### PR TITLE
Add Mermaid diagram rendering

### DIFF
--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,9 +1,11 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { Mermaid } from "@/components/mdx/mermaid";
 
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    Mermaid,
     ...components,
   };
 }

--- a/docs/components/mdx/mermaid.tsx
+++ b/docs/components/mdx/mermaid.tsx
@@ -1,0 +1,15 @@
+import { renderMermaidSVG } from "beautiful-mermaid";
+
+export async function Mermaid({ chart }: { chart: string }) {
+  try {
+    const svg = renderMermaidSVG(chart, {
+      bg: "var(--color-fd-background)",
+      fg: "var(--color-fd-foreground)",
+      interactive: true,
+      transparent: true,
+    });
+    return <div dangerouslySetInnerHTML={{ __html: svg }} />;
+  } catch {
+    return <pre>{chart}</pre>;
+  }
+}

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@orama/orama": "^3.1.8",
+        "beautiful-mermaid": "^1.1.3",
         "fumadocs-core": "^16.7.10",
         "fumadocs-mdx": "^14.2.11",
         "fumadocs-ui": "^16.7.10",
@@ -2627,6 +2628,28 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/beautiful-mermaid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/beautiful-mermaid/-/beautiful-mermaid-1.1.3.tgz",
+      "integrity": "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==",
+      "license": "MIT",
+      "dependencies": {
+        "elkjs": "^0.11.0",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/beautiful-mermaid/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001786",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
@@ -2851,6 +2874,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@orama/orama": "^3.1.8",
+    "beautiful-mermaid": "^1.1.3",
     "fumadocs-core": "^16.7.10",
     "fumadocs-mdx": "^14.2.11",
     "fumadocs-ui": "^16.7.10",

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
+import { remarkMdxMermaid } from "fumadocs-core/mdx-plugins";
 
 export const docs = defineDocs({
   dir: "content/docs",
@@ -7,5 +8,6 @@ export const docs = defineDocs({
 export default defineConfig({
   mdxOptions: {
     format: "md",
+    remarkPlugins: [remarkMdxMermaid],
   },
 });


### PR DESCRIPTION
## Summary
- Mermaid code blocks were rendering as raw text instead of diagrams
- Added `beautiful-mermaid` for build-time SVG rendering (no client JS)
- Added `remarkMdxMermaid` plugin from fumadocs-core to transform code blocks
- All 15 Mermaid diagrams now render as SVGs in the static export

## Test plan
- [x] `npm run build` in `docs/` succeeds
- [x] HTML output contains SVG elements for Mermaid diagrams
- [x] Verify diagrams render correctly on deployed site

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Mermaid code blocks rendering as plain text by adding build-time SVG rendering. All 15 diagrams now render as theme-aware SVGs with no client JavaScript.

- **New Features**
  - Added `remarkMdxMermaid` from `fumadocs-core` to convert Mermaid code blocks to a `Mermaid` component.
  - Added and registered a `Mermaid` component that renders SVG via `beautiful-mermaid` (uses CSS vars for colors, interactive, falls back to text on error).

- **Dependencies**
  - Added `beautiful-mermaid@^1.1.3`.

<sup>Written for commit 224fbc739a12c9bd6483c80ff4feea8619c48b78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Documentation now supports Mermaid diagram rendering, enabling visual representation of flowcharts, diagrams, and other chart types directly within documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->