### PR TITLE
M3.1 — Template engine setup

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,17 @@
   instead of `./` or `../` paths. The mappings are defined in `package.json` `imports` field.
   Exception: auto-generated files (`src/parser/generated/`) use relative imports internally.
 
+## Type Safety
+
+- **No `unknown` in public function signatures.** Use concrete types or union types
+  (`string | number | boolean`). `unknown` is only acceptable when wrapping third-party library
+  boundaries (e.g., `Handlebars.HelperDelegate`), never in exported functions.
+- **No `as` type casts.** Use type guards, discriminated unions, or restructure code so TypeScript
+  can infer types. Exception: conforming to third-party library types at FFI boundaries (typed as
+  `HelperDelegate`, etc.).
+- **No `any`.** Do not introduce `any` into project code. If a dependency's types use `any`, contain
+  it at the boundary and expose concrete types to the rest of the codebase.
+
 ## Testing
 
 - **Prefer test parametrization over code duplication.** Use `it.each` / `describe.each` or

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "antlr4ng": "^3.0.16",
         "commander": "^14.0.3",
-        "consola": "^3.4.2"
+        "consola": "^3.4.2",
+        "handlebars": "^4.7.9"
       },
       "bin": {
         "spec-to-rest": "dist/cli.js"
@@ -1204,6 +1205,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1495,6 +1517,15 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1513,6 +1544,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -1655,6 +1692,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1790,6 +1836,19 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -1997,6 +2056,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "#ir/*.js": "./src/ir/*.js",
     "#cli/*.js": "./src/cli/*.js",
     "#convention/*.js": "./src/convention/*.js",
-    "#profile/*.js": "./src/profile/*.js"
+    "#profile/*.js": "./src/profile/*.js",
+    "#codegen/*.js": "./src/codegen/*.js"
   },
   "dependencies": {
     "antlr4ng": "^3.0.16",
     "commander": "^14.0.3",
-    "consola": "^3.4.2"
+    "consola": "^3.4.2",
+    "handlebars": "^4.7.9"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/src/codegen/engine.ts
+++ b/src/codegen/engine.ts
@@ -1,0 +1,25 @@
+import Handlebars from "handlebars";
+import { registerHelpers } from "#codegen/helpers.js";
+import type { RenderContext } from "#codegen/types.js";
+
+export class TemplateEngine {
+  private readonly hbs: typeof Handlebars;
+
+  constructor() {
+    this.hbs = Handlebars.create();
+    registerHelpers(this.hbs);
+  }
+
+  render(templateSource: string, context: RenderContext): string {
+    const compiled = this.hbs.compile(templateSource, { noEscape: true });
+    return compiled(context);
+  }
+
+  compileTemplate(source: string): HandlebarsTemplateDelegate {
+    return this.hbs.compile(source, { noEscape: true });
+  }
+
+  registerPartial(name: string, source: string): void {
+    this.hbs.registerPartial(name, source);
+  }
+}

--- a/src/codegen/engine.ts
+++ b/src/codegen/engine.ts
@@ -1,6 +1,5 @@
 import Handlebars from "handlebars";
 import { registerHelpers } from "#codegen/helpers.js";
-import type { RenderContext } from "#codegen/types.js";
 
 export class TemplateEngine {
   private readonly hbs: typeof Handlebars;
@@ -10,7 +9,10 @@ export class TemplateEngine {
     registerHelpers(this.hbs);
   }
 
-  render(templateSource: string, context: RenderContext): string {
+  render<T extends Record<string, unknown> = Record<string, unknown>>(
+    templateSource: string,
+    context: T,
+  ): string {
     const compiled = this.hbs.compile(templateSource, { noEscape: true });
     return compiled(context);
   }

--- a/src/codegen/helpers.ts
+++ b/src/codegen/helpers.ts
@@ -1,0 +1,116 @@
+import Handlebars from "handlebars";
+import {
+  toSnakeCase,
+  toKebabCase,
+  splitCamelCase,
+  pluralize as conventionPluralize,
+} from "#convention/naming.js";
+
+export function snakeCaseHelper(value: string): string {
+  return toSnakeCase(value);
+}
+
+export function camelCaseHelper(value: string): string {
+  const parts = splitCamelCase(value);
+  return parts
+    .map((w, i) =>
+      i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1).toLowerCase(),
+    )
+    .join("");
+}
+
+export function pascalCaseHelper(value: string): string {
+  const parts = splitCamelCase(value);
+  return parts.map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase()).join("");
+}
+
+export function kebabCaseHelper(value: string): string {
+  return toKebabCase(value);
+}
+
+export function pluralizeHelper(value: string): string {
+  return conventionPluralize(value);
+}
+
+export function upperHelper(value: string): string {
+  return value.toUpperCase();
+}
+
+export function lowerHelper(value: string): string {
+  return value.toLowerCase();
+}
+
+export function concatHelper(...args: unknown[]): string {
+  const parts = args.slice(0, -1);
+  return parts.map(String).join("");
+}
+
+export function joinHelper(array: readonly unknown[], separator: string): string {
+  if (!Array.isArray(array)) return String(array);
+  return array.join(separator);
+}
+
+export function indentHelper(
+  this: unknown,
+  contentOrSpaces: unknown,
+  maybeSpaces?: unknown,
+): string {
+  if (typeof contentOrSpaces === "number" || typeof contentOrSpaces === "string" && maybeSpaces && typeof (maybeSpaces as Record<string, unknown>).fn === "function") {
+    const spaces = Number(contentOrSpaces);
+    const options = maybeSpaces as Handlebars.HelperOptions;
+    const content = options.fn(this);
+    return indentString(content, spaces);
+  }
+
+  const content = String(contentOrSpaces);
+  const spaces = Number(maybeSpaces);
+  return indentString(content, spaces);
+}
+
+function indentString(content: string, spaces: number): string {
+  const pad = " ".repeat(spaces);
+  return content
+    .split("\n")
+    .map((line) => (line.trim() === "" ? "" : pad + line))
+    .join("\n");
+}
+
+export function eqHelper(a: unknown, b: unknown): boolean {
+  return a === b;
+}
+
+export function neHelper(a: unknown, b: unknown): boolean {
+  return a !== b;
+}
+
+export function andHelper(...args: unknown[]): boolean {
+  const values = args.slice(0, -1);
+  return values.every(Boolean);
+}
+
+export function orHelper(...args: unknown[]): boolean {
+  const values = args.slice(0, -1);
+  return values.some(Boolean);
+}
+
+export function notHelper(value: unknown): boolean {
+  return !value;
+}
+
+export function registerHelpers(hbs: typeof Handlebars): void {
+  hbs.registerHelper("snake_case", (v: string) => snakeCaseHelper(v));
+  hbs.registerHelper("camel_case", (v: string) => camelCaseHelper(v));
+  hbs.registerHelper("pascal_case", (v: string) => pascalCaseHelper(v));
+  hbs.registerHelper("kebab_case", (v: string) => kebabCaseHelper(v));
+  hbs.registerHelper("pluralize", (v: string) => pluralizeHelper(v));
+  hbs.registerHelper("upper", (v: string) => upperHelper(v));
+  hbs.registerHelper("lower", (v: string) => lowerHelper(v));
+  hbs.registerHelper("concat", concatHelper);
+  hbs.registerHelper("join", joinHelper);
+  hbs.registerHelper("indent", indentHelper);
+  hbs.registerHelper("eq", eqHelper);
+  hbs.registerHelper("ne", neHelper);
+  hbs.registerHelper("and", andHelper);
+  hbs.registerHelper("or", orHelper);
+  hbs.registerHelper("not", notHelper);
+}

--- a/src/codegen/helpers.ts
+++ b/src/codegen/helpers.ts
@@ -6,12 +6,14 @@ import {
   pluralize as conventionPluralize,
 } from "#convention/naming.js";
 
+export type Primitive = string | number | boolean;
+
 export function snakeCaseHelper(value: string): string {
   return toSnakeCase(value);
 }
 
 export function camelCaseHelper(value: string): string {
-  const parts = splitCamelCase(value);
+  const parts = splitCamelCase(value).filter((w) => w.length > 0);
   return parts
     .map((w, i) =>
       i === 0 ? w.toLowerCase() : w[0].toUpperCase() + w.slice(1).toLowerCase(),
@@ -20,7 +22,7 @@ export function camelCaseHelper(value: string): string {
 }
 
 export function pascalCaseHelper(value: string): string {
-  const parts = splitCamelCase(value);
+  const parts = splitCamelCase(value).filter((w) => w.length > 0);
   return parts.map((w) => w[0].toUpperCase() + w.slice(1).toLowerCase()).join("");
 }
 
@@ -40,34 +42,15 @@ export function lowerHelper(value: string): string {
   return value.toLowerCase();
 }
 
-export function concatHelper(...args: unknown[]): string {
-  const parts = args.slice(0, -1);
-  return parts.map(String).join("");
+export function concatHelper(...parts: string[]): string {
+  return parts.join("");
 }
 
-export function joinHelper(array: readonly unknown[], separator: string): string {
-  if (!Array.isArray(array)) return String(array);
+export function joinHelper(array: readonly string[], separator: string = ","): string {
   return array.join(separator);
 }
 
-export function indentHelper(
-  this: unknown,
-  contentOrSpaces: unknown,
-  maybeSpaces?: unknown,
-): string {
-  if (typeof contentOrSpaces === "number" || typeof contentOrSpaces === "string" && maybeSpaces && typeof (maybeSpaces as Record<string, unknown>).fn === "function") {
-    const spaces = Number(contentOrSpaces);
-    const options = maybeSpaces as Handlebars.HelperOptions;
-    const content = options.fn(this);
-    return indentString(content, spaces);
-  }
-
-  const content = String(contentOrSpaces);
-  const spaces = Number(maybeSpaces);
-  return indentString(content, spaces);
-}
-
-function indentString(content: string, spaces: number): string {
+export function indentString(content: string, spaces: number): string {
   const pad = " ".repeat(spaces);
   return content
     .split("\n")
@@ -75,25 +58,23 @@ function indentString(content: string, spaces: number): string {
     .join("\n");
 }
 
-export function eqHelper(a: unknown, b: unknown): boolean {
+export function eqHelper(a: Primitive, b: Primitive): boolean {
   return a === b;
 }
 
-export function neHelper(a: unknown, b: unknown): boolean {
+export function neHelper(a: Primitive, b: Primitive): boolean {
   return a !== b;
 }
 
-export function andHelper(...args: unknown[]): boolean {
-  const values = args.slice(0, -1);
-  return values.every(Boolean);
+export function andHelper(a: Primitive, b: Primitive): boolean {
+  return !!a && !!b;
 }
 
-export function orHelper(...args: unknown[]): boolean {
-  const values = args.slice(0, -1);
-  return values.some(Boolean);
+export function orHelper(a: Primitive, b: Primitive): boolean {
+  return !!a || !!b;
 }
 
-export function notHelper(value: unknown): boolean {
+export function notHelper(value: Primitive): boolean {
   return !value;
 }
 
@@ -105,12 +86,29 @@ export function registerHelpers(hbs: typeof Handlebars): void {
   hbs.registerHelper("pluralize", (v: string) => pluralizeHelper(v));
   hbs.registerHelper("upper", (v: string) => upperHelper(v));
   hbs.registerHelper("lower", (v: string) => lowerHelper(v));
-  hbs.registerHelper("concat", concatHelper);
-  hbs.registerHelper("join", joinHelper);
-  hbs.registerHelper("indent", indentHelper);
-  hbs.registerHelper("eq", eqHelper);
-  hbs.registerHelper("ne", neHelper);
-  hbs.registerHelper("and", andHelper);
-  hbs.registerHelper("or", orHelper);
-  hbs.registerHelper("not", notHelper);
+  hbs.registerHelper("eq", (a: Primitive, b: Primitive) => eqHelper(a, b));
+  hbs.registerHelper("ne", (a: Primitive, b: Primitive) => neHelper(a, b));
+  hbs.registerHelper("and", (a: Primitive, b: Primitive) => andHelper(a, b));
+  hbs.registerHelper("or", (a: Primitive, b: Primitive) => orHelper(a, b));
+  hbs.registerHelper("not", (v: Primitive) => notHelper(v));
+
+  const concatAdapter: Handlebars.HelperDelegate = (a, b, c, d, e) =>
+    concatHelper(...[a, b, c, d, e].filter((s): s is string => typeof s === "string"));
+  hbs.registerHelper("concat", concatAdapter);
+
+  const joinAdapter: Handlebars.HelperDelegate = (array, separator) =>
+    joinHelper(array, typeof separator === "string" ? separator : ",");
+  hbs.registerHelper("join", joinAdapter);
+
+  const indentAdapter: Handlebars.HelperDelegate = function (
+    this: Record<string, string>,
+    first,
+    second,
+  ) {
+    if (second && typeof second.fn === "function") {
+      return indentString(second.fn(this), Number(first));
+    }
+    return indentString(String(first), Number(second));
+  };
+  hbs.registerHelper("indent", indentAdapter);
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,0 +1,27 @@
+export type {
+  RenderContext,
+  RenderProfile,
+  RenderResult,
+  TemplateSource,
+  TypeMappingEntry,
+} from "#codegen/types.js";
+export { buildRenderContext } from "#codegen/types.js";
+export { TemplateEngine } from "#codegen/engine.js";
+export {
+  registerHelpers,
+  snakeCaseHelper,
+  camelCaseHelper,
+  pascalCaseHelper,
+  kebabCaseHelper,
+  pluralizeHelper,
+  upperHelper,
+  lowerHelper,
+  concatHelper,
+  joinHelper,
+  indentHelper,
+  eqHelper,
+  neHelper,
+  andHelper,
+  orHelper,
+  notHelper,
+} from "#codegen/helpers.js";

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5,6 +5,7 @@ export type {
   TemplateSource,
   TypeMappingEntry,
 } from "#codegen/types.js";
+export type { Primitive } from "#codegen/helpers.js";
 export { buildRenderContext } from "#codegen/types.js";
 export { TemplateEngine } from "#codegen/engine.js";
 export {
@@ -18,7 +19,7 @@ export {
   lowerHelper,
   concatHelper,
   joinHelper,
-  indentHelper,
+  indentString,
   eqHelper,
   neHelper,
   andHelper,

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -1,0 +1,106 @@
+import { toSnakeCase } from "#convention/naming.js";
+import type { EndpointSpec, DatabaseSchema } from "#convention/types.js";
+import type {
+  ProfiledService,
+  ProfiledEntity,
+  ProfiledOperation,
+  DeploymentProfile,
+  TypeMapping,
+} from "#profile/types.js";
+
+export interface TypeMappingEntry {
+  readonly specType: string;
+  readonly python: string;
+  readonly pydantic: string;
+  readonly sqlalchemyColumn: string;
+}
+
+export interface RenderProfile {
+  readonly name: string;
+  readonly displayName: string;
+  readonly language: string;
+  readonly framework: string;
+  readonly database: string;
+  readonly orm: string;
+  readonly migrationTool: string;
+  readonly validation: string;
+  readonly packageManager: string;
+  readonly httpServer: string;
+  readonly dbDriver: string;
+  readonly async: boolean;
+  readonly pythonVersion: string;
+  readonly modelDir: string;
+  readonly schemaDir: string;
+  readonly routerDir: string;
+  readonly directories: readonly string[];
+  readonly typeMap: readonly TypeMappingEntry[];
+  readonly dependencies: DeploymentProfile["dependencies"];
+  readonly devDependencies: DeploymentProfile["devDependencies"];
+}
+
+export interface RenderContext {
+  readonly service: { readonly name: string; readonly snakeName: string };
+  readonly profile: RenderProfile;
+  readonly entities: readonly ProfiledEntity[];
+  readonly operations: readonly ProfiledOperation[];
+  readonly endpoints: readonly EndpointSpec[];
+  readonly schema: DatabaseSchema;
+}
+
+export interface RenderResult {
+  readonly fileName: string;
+  readonly content: string;
+}
+
+export interface TemplateSource {
+  readonly name: string;
+  readonly content: string;
+}
+
+function convertTypeMap(typeMap: ReadonlyMap<string, TypeMapping>): readonly TypeMappingEntry[] {
+  return [...typeMap.entries()].map(([specType, mapping]) => ({
+    specType,
+    python: mapping.python,
+    pydantic: mapping.pydantic,
+    sqlalchemyColumn: mapping.sqlalchemyColumn,
+  }));
+}
+
+function convertProfile(profile: DeploymentProfile): RenderProfile {
+  return {
+    name: profile.name,
+    displayName: profile.displayName,
+    language: profile.language,
+    framework: profile.framework,
+    database: profile.database,
+    orm: profile.orm,
+    migrationTool: profile.migrationTool,
+    validation: profile.validation,
+    packageManager: profile.packageManager,
+    httpServer: profile.httpServer,
+    dbDriver: profile.dbDriver,
+    async: profile.async,
+    pythonVersion: profile.pythonVersion,
+    modelDir: profile.modelDir,
+    schemaDir: profile.schemaDir,
+    routerDir: profile.routerDir,
+    directories: profile.directories,
+    typeMap: convertTypeMap(profile.typeMap),
+    dependencies: profile.dependencies,
+    devDependencies: profile.devDependencies,
+  };
+}
+
+export function buildRenderContext(profiled: ProfiledService): RenderContext {
+  return {
+    service: {
+      name: profiled.ir.name,
+      snakeName: toSnakeCase(profiled.ir.name),
+    },
+    profile: convertProfile(profiled.profile),
+    entities: profiled.entities,
+    operations: profiled.operations,
+    endpoints: profiled.endpoints,
+    schema: profiled.schema,
+  };
+}

--- a/test/codegen/engine.test.ts
+++ b/test/codegen/engine.test.ts
@@ -90,6 +90,16 @@ describe("TemplateEngine", () => {
     );
     expect(result).toContain("Shorten");
   });
+
+  it("uses indent block helper for Python indentation", () => {
+    const engine = new TemplateEngine();
+    const result = engine.render(
+      "class Foo:\n{{#indent 4}}name: str\nage: int\n{{/indent}}",
+      {} as Record<string, never>,
+    );
+    expect(result).toContain("    name: str");
+    expect(result).toContain("    age: int");
+  });
 });
 
 describe("TemplateEngine — PoC schema rendering", () => {

--- a/test/codegen/engine.test.ts
+++ b/test/codegen/engine.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { TemplateEngine } from "#codegen/engine.js";
+import { buildRenderContext } from "#codegen/types.js";
+import type { RenderContext } from "#codegen/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../parser/fixtures");
+
+function contextFrom(name: string): RenderContext {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  const ir = buildIR(tree);
+  const profiled = buildProfiledService(ir, "python-fastapi-postgres");
+  return buildRenderContext(profiled);
+}
+
+const SCHEMA_TEMPLATE = `from pydantic import BaseModel
+
+
+class {{entity.createSchemaName}}(BaseModel):
+{{#each entity.fields}}
+    {{snake_case this.fieldName}}: {{this.pydanticType}}
+{{/each}}
+
+
+class {{entity.readSchemaName}}(BaseModel):
+    id: int
+{{#each entity.fields}}
+    {{snake_case this.fieldName}}: {{this.pydanticType}}
+{{/each}}
+
+    model_config = {"from_attributes": True}
+`;
+
+describe("TemplateEngine", () => {
+  it("renders simple variable substitution", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render("Service: {{service.name}}", ctx);
+    expect(result).toBe("Service: UrlShortener");
+  });
+
+  it("renders snake_case service name", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render("{{service.snakeName}}", ctx);
+    expect(result).toBe("url_shortener");
+  });
+
+  it("renders profile fields", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render("{{profile.framework}} + {{profile.orm}}", ctx);
+    expect(result).toBe("fastapi + sqlalchemy");
+  });
+
+  it("iterates over entities", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render(
+      "{{#each entities}}{{this.entityName}} {{/each}}",
+      ctx,
+    );
+    expect(result).toContain("UrlMapping");
+  });
+
+  it("iterates over operations with helpers", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render(
+      "{{#each operations}}{{snake_case this.operationName}}\n{{/each}}",
+      ctx,
+    );
+    expect(result).toContain("shorten");
+    expect(result).toContain("resolve");
+    expect(result).toContain("delete");
+  });
+
+  it("uses eq helper in conditional", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const result = engine.render(
+      '{{#each operations}}{{#if (eq this.endpoint.method "POST")}}{{this.operationName}} {{/if}}{{/each}}',
+      ctx,
+    );
+    expect(result).toContain("Shorten");
+  });
+});
+
+describe("TemplateEngine — PoC schema rendering", () => {
+  it("renders valid Python schema for url_shortener", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const entity = ctx.entities[0];
+    const result = engine.render(SCHEMA_TEMPLATE, { ...ctx, entity });
+    expect(result).toContain("from pydantic import BaseModel");
+    expect(result).toContain("class UrlMappingCreate(BaseModel):");
+    expect(result).toContain("class UrlMappingRead(BaseModel):");
+    expect(result).toContain('model_config = {"from_attributes": True}');
+  });
+
+  it("renders fields with snake_case names and Python types", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const entity = ctx.entities[0];
+    const result = engine.render(SCHEMA_TEMPLATE, { ...ctx, entity });
+    for (const field of entity.fields) {
+      expect(result).toContain(`${field.columnName}: ${field.pydanticType}`);
+    }
+  });
+
+  it("renders consistent 4-space indentation", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("url_shortener.spec");
+    const entity = ctx.entities[0];
+    const result = engine.render(SCHEMA_TEMPLATE, { ...ctx, entity });
+    const indentedLines = result.split("\n").filter((l) => l.startsWith(" "));
+    for (const line of indentedLines) {
+      const leadingSpaces = line.match(/^( +)/)![1].length;
+      expect(leadingSpaces % 4).toBe(0);
+    }
+  });
+
+  it("renders todo_list schema with nullable fields", () => {
+    const engine = new TemplateEngine();
+    const ctx = contextFrom("todo_list.spec");
+    const todo = ctx.entities.find((e) => e.entityName === "Todo")!;
+    const result = engine.render(SCHEMA_TEMPLATE, { ...ctx, entity: todo });
+    expect(result).toContain("class TodoCreate(BaseModel):");
+    const description = todo.fields.find((f) => f.fieldName === "description");
+    if (description?.nullable) {
+      expect(result).toContain("| None");
+    }
+  });
+});
+
+describe("TemplateEngine — partials", () => {
+  it("registers and renders a partial", () => {
+    const engine = new TemplateEngine();
+    engine.registerPartial(
+      "field_line",
+      "    {{snake_case fieldName}}: {{pydanticType}}",
+    );
+    const ctx = contextFrom("url_shortener.spec");
+    const field = ctx.entities[0].fields[0];
+    const result = engine.render("{{> field_line}}", field as never);
+    expect(result).toContain(`: ${field.pydanticType}`);
+  });
+});
+
+describe("TemplateEngine — compileTemplate", () => {
+  it("compiles template for reuse with different contexts", () => {
+    const engine = new TemplateEngine();
+    const compiled = engine.compileTemplate("Entity: {{entityName}}");
+    const ctx = contextFrom("ecommerce.spec");
+    const results = ctx.entities.map((e) => compiled(e));
+    expect(results.length).toBeGreaterThan(1);
+    for (const [i, result] of results.entries()) {
+      expect(result).toBe(`Entity: ${ctx.entities[i].entityName}`);
+    }
+  });
+});
+
+describe("buildRenderContext", () => {
+  it("converts profile typeMap to array", () => {
+    const ctx = contextFrom("url_shortener.spec");
+    expect(Array.isArray(ctx.profile.typeMap)).toBe(true);
+    expect(ctx.profile.typeMap.length).toBeGreaterThan(0);
+    const strEntry = ctx.profile.typeMap.find((t) => t.specType === "String");
+    expect(strEntry).toBeDefined();
+    expect(strEntry!.python).toBe("str");
+  });
+
+  it("populates service snakeName", () => {
+    const ctx = contextFrom("url_shortener.spec");
+    expect(ctx.service.name).toBe("UrlShortener");
+    expect(ctx.service.snakeName).toBe("url_shortener");
+  });
+
+  it("preserves all entities and operations", () => {
+    const ctx = contextFrom("ecommerce.spec");
+    expect(ctx.entities.length).toBe(5);
+    expect(ctx.operations.length).toBe(11);
+  });
+});

--- a/test/codegen/helpers.test.ts
+++ b/test/codegen/helpers.test.ts
@@ -9,7 +9,7 @@ import {
   lowerHelper,
   concatHelper,
   joinHelper,
-  indentHelper,
+  indentString,
   eqHelper,
   neHelper,
   andHelper,
@@ -41,6 +41,10 @@ describe("camelCaseHelper", () => {
   it.each(cases)("%s -> %s", (input, expected) => {
     expect(camelCaseHelper(input)).toBe(expected);
   });
+
+  it("handles empty string", () => {
+    expect(camelCaseHelper("")).toBe("");
+  });
 });
 
 describe("pascalCaseHelper", () => {
@@ -52,6 +56,10 @@ describe("pascalCaseHelper", () => {
 
   it.each(cases)("%s -> %s", (input, expected) => {
     expect(pascalCaseHelper(input)).toBe(expected);
+  });
+
+  it("handles empty string", () => {
+    expect(pascalCaseHelper("")).toBe("");
   });
 });
 
@@ -91,12 +99,12 @@ describe("lowerHelper", () => {
 });
 
 describe("concatHelper", () => {
-  it("concatenates strings (ignoring Handlebars options arg)", () => {
-    expect(concatHelper("hello", " ", "world", {})).toBe("hello world");
+  it("concatenates strings", () => {
+    expect(concatHelper("hello", " ", "world")).toBe("hello world");
   });
 
   it("concatenates two strings", () => {
-    expect(concatHelper("a", "b", {})).toBe("ab");
+    expect(concatHelper("a", "b")).toBe("ab");
   });
 });
 
@@ -108,73 +116,93 @@ describe("joinHelper", () => {
   it("handles single-element array", () => {
     expect(joinHelper(["a"], ", ")).toBe("a");
   });
+
+  it("defaults to comma separator", () => {
+    expect(joinHelper(["a", "b"])).toBe("a,b");
+  });
 });
 
-describe("indentHelper", () => {
-  it("indents each line by N spaces (inline mode)", () => {
-    const result = indentHelper.call({}, "line1\nline2", 4);
-    expect(result).toBe("    line1\n    line2");
+describe("indentString", () => {
+  it("indents each line by N spaces", () => {
+    expect(indentString("line1\nline2", 4)).toBe("    line1\n    line2");
   });
 
   it("does not indent empty lines", () => {
-    const result = indentHelper.call({}, "line1\n\nline2", 4);
-    expect(result).toBe("    line1\n\n    line2");
+    expect(indentString("line1\n\nline2", 4)).toBe("    line1\n\n    line2");
   });
 
   it("preserves relative indentation", () => {
-    const result = indentHelper.call({}, "def foo():\n    pass", 4);
-    expect(result).toBe("    def foo():\n        pass");
-  });
-
-  it("works as block helper", () => {
-    const options = { fn: () => "line1\nline2\n" } as unknown as Handlebars.HelperOptions;
-    const result = indentHelper.call({}, 4, options);
-    expect(result).toContain("    line1");
-    expect(result).toContain("    line2");
+    expect(indentString("def foo():\n    pass", 4)).toBe(
+      "    def foo():\n        pass",
+    );
   });
 });
 
-describe("logic helpers", () => {
-  const eqCases = [
+describe("eqHelper", () => {
+  const cases: [string | number | boolean, string | number | boolean, boolean][] = [
     ["a", "a", true],
     ["a", "b", false],
     [1, 1, true],
-    [1, "1", false],
-  ] as const;
+    [true, true, true],
+    [true, false, false],
+  ];
 
-  it.each(eqCases)("eq(%s, %s) -> %s", (a, b, expected) => {
+  it.each(cases)("eq(%s, %s) -> %s", (a, b, expected) => {
     expect(eqHelper(a, b)).toBe(expected);
   });
+});
 
-  const neCases = [
+describe("neHelper", () => {
+  const cases: [string | number, string | number, boolean][] = [
     ["a", "b", true],
     ["a", "a", false],
-  ] as const;
+    [1, 2, true],
+  ];
 
-  it.each(neCases)("ne(%s, %s) -> %s", (a, b, expected) => {
+  it.each(cases)("ne(%s, %s) -> %s", (a, b, expected) => {
     expect(neHelper(a, b)).toBe(expected);
   });
+});
 
-  it("and returns true when all truthy", () => {
-    expect(andHelper(true, true, {})).toBe(true);
+describe("andHelper", () => {
+  it("returns true when both truthy", () => {
+    expect(andHelper(true, true)).toBe(true);
   });
 
-  it("and returns false when any falsy", () => {
-    expect(andHelper(true, false, {})).toBe(false);
+  it("returns false when any falsy", () => {
+    expect(andHelper(true, false)).toBe(false);
   });
 
-  it("or returns true when any truthy", () => {
-    expect(orHelper(false, true, {})).toBe(true);
+  it("treats non-empty string as truthy", () => {
+    expect(andHelper("a", "b")).toBe(true);
   });
 
-  it("or returns false when all falsy", () => {
-    expect(orHelper(false, false, {})).toBe(false);
+  it("treats empty string as falsy", () => {
+    expect(andHelper("a", "")).toBe(false);
+  });
+});
+
+describe("orHelper", () => {
+  it("returns true when any truthy", () => {
+    expect(orHelper(false, true)).toBe(true);
   });
 
-  it("not inverts truthiness", () => {
+  it("returns false when all falsy", () => {
+    expect(orHelper(false, false)).toBe(false);
+  });
+});
+
+describe("notHelper", () => {
+  it("inverts boolean", () => {
     expect(notHelper(true)).toBe(false);
     expect(notHelper(false)).toBe(true);
+  });
+
+  it("treats empty string as falsy", () => {
     expect(notHelper("")).toBe(true);
+  });
+
+  it("treats non-empty string as truthy", () => {
     expect(notHelper("x")).toBe(false);
   });
 });

--- a/test/codegen/helpers.test.ts
+++ b/test/codegen/helpers.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  snakeCaseHelper,
+  camelCaseHelper,
+  pascalCaseHelper,
+  kebabCaseHelper,
+  pluralizeHelper,
+  upperHelper,
+  lowerHelper,
+  concatHelper,
+  joinHelper,
+  indentHelper,
+  eqHelper,
+  neHelper,
+  andHelper,
+  orHelper,
+  notHelper,
+} from "#codegen/helpers.js";
+
+describe("snakeCaseHelper", () => {
+  const cases = [
+    ["OrderItem", "order_item"],
+    ["UrlMapping", "url_mapping"],
+    ["User", "user"],
+    ["CreateDraftOrder", "create_draft_order"],
+  ] as const;
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(snakeCaseHelper(input)).toBe(expected);
+  });
+});
+
+describe("camelCaseHelper", () => {
+  const cases = [
+    ["OrderItem", "orderItem"],
+    ["UrlMapping", "urlMapping"],
+    ["User", "user"],
+    ["CreateDraftOrder", "createDraftOrder"],
+  ] as const;
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(camelCaseHelper(input)).toBe(expected);
+  });
+});
+
+describe("pascalCaseHelper", () => {
+  const cases = [
+    ["OrderItem", "OrderItem"],
+    ["urlMapping", "UrlMapping"],
+    ["user", "User"],
+  ] as const;
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(pascalCaseHelper(input)).toBe(expected);
+  });
+});
+
+describe("kebabCaseHelper", () => {
+  const cases = [
+    ["OrderItem", "order-item"],
+    ["UrlMapping", "url-mapping"],
+  ] as const;
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(kebabCaseHelper(input)).toBe(expected);
+  });
+});
+
+describe("pluralizeHelper", () => {
+  const cases = [
+    ["order", "orders"],
+    ["person", "people"],
+    ["status", "statuses"],
+  ] as const;
+
+  it.each(cases)("%s -> %s", (input, expected) => {
+    expect(pluralizeHelper(input)).toBe(expected);
+  });
+});
+
+describe("upperHelper", () => {
+  it("converts to uppercase", () => {
+    expect(upperHelper("hello")).toBe("HELLO");
+  });
+});
+
+describe("lowerHelper", () => {
+  it("converts to lowercase", () => {
+    expect(lowerHelper("HELLO")).toBe("hello");
+  });
+});
+
+describe("concatHelper", () => {
+  it("concatenates strings (ignoring Handlebars options arg)", () => {
+    expect(concatHelper("hello", " ", "world", {})).toBe("hello world");
+  });
+
+  it("concatenates two strings", () => {
+    expect(concatHelper("a", "b", {})).toBe("ab");
+  });
+});
+
+describe("joinHelper", () => {
+  it("joins array with separator", () => {
+    expect(joinHelper(["a", "b", "c"], ", ")).toBe("a, b, c");
+  });
+
+  it("handles single-element array", () => {
+    expect(joinHelper(["a"], ", ")).toBe("a");
+  });
+});
+
+describe("indentHelper", () => {
+  it("indents each line by N spaces (inline mode)", () => {
+    const result = indentHelper.call({}, "line1\nline2", 4);
+    expect(result).toBe("    line1\n    line2");
+  });
+
+  it("does not indent empty lines", () => {
+    const result = indentHelper.call({}, "line1\n\nline2", 4);
+    expect(result).toBe("    line1\n\n    line2");
+  });
+
+  it("preserves relative indentation", () => {
+    const result = indentHelper.call({}, "def foo():\n    pass", 4);
+    expect(result).toBe("    def foo():\n        pass");
+  });
+
+  it("works as block helper", () => {
+    const options = { fn: () => "line1\nline2\n" } as unknown as Handlebars.HelperOptions;
+    const result = indentHelper.call({}, 4, options);
+    expect(result).toContain("    line1");
+    expect(result).toContain("    line2");
+  });
+});
+
+describe("logic helpers", () => {
+  const eqCases = [
+    ["a", "a", true],
+    ["a", "b", false],
+    [1, 1, true],
+    [1, "1", false],
+  ] as const;
+
+  it.each(eqCases)("eq(%s, %s) -> %s", (a, b, expected) => {
+    expect(eqHelper(a, b)).toBe(expected);
+  });
+
+  const neCases = [
+    ["a", "b", true],
+    ["a", "a", false],
+  ] as const;
+
+  it.each(neCases)("ne(%s, %s) -> %s", (a, b, expected) => {
+    expect(neHelper(a, b)).toBe(expected);
+  });
+
+  it("and returns true when all truthy", () => {
+    expect(andHelper(true, true, {})).toBe(true);
+  });
+
+  it("and returns false when any falsy", () => {
+    expect(andHelper(true, false, {})).toBe(false);
+  });
+
+  it("or returns true when any truthy", () => {
+    expect(orHelper(false, true, {})).toBe(true);
+  });
+
+  it("or returns false when all falsy", () => {
+    expect(orHelper(false, false, {})).toBe(false);
+  });
+
+  it("not inverts truthiness", () => {
+    expect(notHelper(true)).toBe(false);
+    expect(notHelper(false)).toBe(true);
+    expect(notHelper("")).toBe(true);
+    expect(notHelper("x")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Handlebars-based template engine (`src/codegen/`) with 15 custom helpers for code generation
- Helpers wrap existing `naming.ts` functions (snake_case, pluralize, kebab_case) — no logic duplication
- Engine uses isolated `Handlebars.create()` instance, string-in/string-out (no filesystem I/O)
- PoC Pydantic schema template renders valid Python source from profiled IR
- 52 new tests (37 helper unit tests + 15 engine integration tests), 620 total passing

## New files
| File | Purpose |
|---|---|
| `src/codegen/types.ts` | `RenderContext`, `buildRenderContext()` — converts `Map` to plain objects for Handlebars |
| `src/codegen/helpers.ts` | 15 helpers: naming, string, indent, logic (eq/ne/and/or/not) |
| `src/codegen/engine.ts` | `TemplateEngine` class with isolated Handlebars instance |
| `src/codegen/index.ts` | Barrel exports |
| `test/codegen/helpers.test.ts` | Each helper tested independently as pure function |
| `test/codegen/engine.test.ts` | Full pipeline: parse → IR → profile → render → valid Python |

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — 620/620 tests pass (20 files)
- [x] Helper unit tests verify each helper independently (acceptance criterion 1)
- [x] PoC template renders valid Python with correct indentation (acceptance criterion 2)

Closes #17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `handlebars`-based template engine for code generation with 15 typed helpers and an isolated runtime. Proves end-to-end by rendering valid, correctly indented Pydantic schemas from the profiled IR, with improved typing and edge-case handling.

- **New Features**
  - `TemplateEngine` with generic `render`, `compileTemplate`, and `registerPartial`; isolated `Handlebars.create()`; no filesystem I/O.
  - 15 helpers: naming, string, `indent` (via pure `indentString`), and logic; no duplicated naming logic.
  - `buildRenderContext` flattens `typeMap` to an array and adds `service.snakeName`.
  - PoC template renders valid Python Pydantic schemas; 52 new tests passing.
  - Typing and edge cases: concrete helper types (no casts), safer camel/pascal on empty segments, `join` default separator when Handlebars options are passed, correct `indent` block/inline detection; type-safety rules documented in `.claude/CLAUDE.md` (no `unknown` in public APIs, no `as` casts except FFI, no `any`).

- **Dependencies**
  - Add `handlebars@^4.7.9`.

<sup>Written for commit bfc507b4245b10c3b0d03841b80baf13de13031e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

