### PR TITLE
M3.2 — Python/FastAPI Templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "generate": "antlr-ng -Dlanguage=TypeScript -v -o src/parser/generated src/parser/Spec.g4",
-    "build": "npm run generate && tsc",
+    "build": "npm run generate && tsc && node -e \"require('node:fs').cpSync('src/codegen/templates', 'dist/codegen/templates', {recursive: true})\"",
     "test": "npm run generate && vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -400,11 +400,14 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
     const entitySnake = toSnakeCase(entity.entityName);
     const routerSnake = toSnakeCase(pluralize(entity.entityName));
 
+    const nonIdFields = entity.fields.filter((f) => f.columnName !== "id");
+
     const modelCtx = {
       ...ctx,
       entity,
       table,
       entityOperations,
+      nonIdFields,
       sqlalchemyImports,
       postgresImports,
       stdlibImports,
@@ -415,6 +418,7 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
       entity,
       table,
       entityOperations,
+      nonIdFields,
       stdlibImports: schemaStdlib,
     };
 

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -59,8 +59,10 @@ const STDLIB_TYPE_SOURCES: ReadonlyMap<string, StdlibImport> = new Map([
   ["datetime", { module: "datetime", names: ["datetime"] }],
   ["date", { module: "datetime", names: ["date"] }],
   ["Decimal", { module: "decimal", names: ["Decimal"] }],
-  ["uuid.UUID", { module: "uuid", names: ["UUID"] }],
+  ["UUID", { module: "uuid", names: ["UUID"] }],
 ]);
+
+const POSTGRES_DIALECT_TYPES: ReadonlySet<string> = new Set(["JSONB"]);
 
 function pythonTypeForParam(typeExpr: TypeExpr, typeMap: ReadonlyMap<string, string>): string {
   if (typeExpr.kind === "NamedType") {
@@ -76,12 +78,14 @@ function pythonTypeForParam(typeExpr: TypeExpr, typeMap: ReadonlyMap<string, str
 
 function classifyRouteKind(op: ProfiledOperation): RouteKind {
   const method = op.endpoint.method;
-  const hasPathParam = op.endpoint.pathParams.length > 0;
+  const pathParamCount = op.endpoint.pathParams.length;
+  const hasPathParam = pathParamCount > 0;
+  const singlePathParam = pathParamCount === 1;
   if (op.kind === "create") return "create";
-  if (op.kind === "read" && hasPathParam) return "read";
+  if (op.kind === "read" && singlePathParam) return "read";
   if (op.kind === "read" && !hasPathParam) return "list";
   if (op.kind === "filtered_read" && !hasPathParam) return "list";
-  if (op.kind === "delete") return "delete";
+  if (op.kind === "delete" && singlePathParam) return "delete";
   if (method === "GET" && !hasPathParam) return "list";
   return "other";
 }
@@ -114,7 +118,12 @@ function enrichOperation(
 
   const pathParamCallArgs = pathParamsWithTypes.map((p) => p.name).join(", ");
   const hasRequestBody = routeKind === "create" || endpoint.bodyParams.length > 0;
-  const requestBodyType = hasRequestBody ? entity.createSchemaName : "";
+  const usesUpdateSchema = op.kind === "partial_update" || op.kind === "replace";
+  const requestBodyType = !hasRequestBody
+    ? ""
+    : usesUpdateSchema
+      ? entity.updateSchemaName
+      : entity.createSchemaName;
 
   let responseAnnotation: string;
   let serviceCallArgs: string;
@@ -158,7 +167,7 @@ function enrichOperation(
     default: {
       const args = [
         ...pathParamsWithTypes.map((p) => `${p.name}: ${p.pythonType}`),
-        ...(hasRequestBody ? [`body: ${entity.createSchemaName}`] : []),
+        ...(hasRequestBody ? [`body: ${requestBodyType}`] : []),
       ];
       responseAnnotation = "None";
       serviceCallArgs = [
@@ -194,51 +203,130 @@ function enrichOperation(
   };
 }
 
+function mergeStdlibImport(
+  byModule: Map<string, Set<string>>,
+  pythonType: string,
+): void {
+  const key = pythonType.replace(/\s*\|\s*None$/, "");
+  const stdlib = STDLIB_TYPE_SOURCES.get(key);
+  if (stdlib === undefined) return;
+  const existing = byModule.get(stdlib.module) ?? new Set<string>();
+  for (const n of stdlib.names) existing.add(n);
+  byModule.set(stdlib.module, existing);
+}
+
+function finalizeStdlibImports(byModule: Map<string, Set<string>>): readonly StdlibImport[] {
+  const result: StdlibImport[] = [];
+  for (const [module, names] of byModule) {
+    result.push({ module, names: [...names].sort() });
+  }
+  result.sort((a, b) => a.module.localeCompare(b.module));
+  return result;
+}
+
 function collectEntityImports(entity: ProfiledEntity): {
   sqlalchemyImports: readonly string[];
+  postgresImports: readonly string[];
   stdlibImports: readonly StdlibImport[];
 } {
   const sqlSet = new Set<string>();
+  const pgSet = new Set<string>();
   const stdlibByModule = new Map<string, Set<string>>();
 
   for (const field of entity.fields) {
-    sqlSet.add(field.sqlalchemyColumnType);
-    const stdlib = STDLIB_TYPE_SOURCES.get(field.pythonType);
-    if (stdlib !== undefined) {
-      const existing = stdlibByModule.get(stdlib.module) ?? new Set<string>();
-      for (const n of stdlib.names) existing.add(n);
-      stdlibByModule.set(stdlib.module, existing);
+    const colType = field.sqlalchemyColumnType;
+    if (POSTGRES_DIALECT_TYPES.has(colType)) {
+      pgSet.add(colType);
+    } else {
+      sqlSet.add(colType);
     }
+    mergeStdlibImport(stdlibByModule, field.pythonType);
   }
-
-  const stdlibImports: StdlibImport[] = [];
-  for (const [module, names] of stdlibByModule) {
-    stdlibImports.push({ module, names: [...names].sort() });
-  }
-  stdlibImports.sort((a, b) => a.module.localeCompare(b.module));
 
   return {
     sqlalchemyImports: [...sqlSet].sort(),
-    stdlibImports,
+    postgresImports: [...pgSet].sort(),
+    stdlibImports: finalizeStdlibImports(stdlibByModule),
   };
 }
 
 function collectSchemaStdlibImports(entity: ProfiledEntity): readonly StdlibImport[] {
   const stdlibByModule = new Map<string, Set<string>>();
   for (const field of entity.fields) {
-    const stdlib = STDLIB_TYPE_SOURCES.get(field.pythonType);
-    if (stdlib !== undefined) {
-      const existing = stdlibByModule.get(stdlib.module) ?? new Set<string>();
-      for (const n of stdlib.names) existing.add(n);
-      stdlibByModule.set(stdlib.module, existing);
+    mergeStdlibImport(stdlibByModule, field.pythonType);
+  }
+  return finalizeStdlibImports(stdlibByModule);
+}
+
+interface RouterTemplateImports {
+  readonly needsHttpException: boolean;
+  readonly needsResponse: boolean;
+  readonly schemas: readonly string[];
+  readonly stdlibImports: readonly StdlibImport[];
+}
+
+function collectRouterImports(
+  entity: ProfiledEntity,
+  operations: readonly EnrichedOperation[],
+): RouterTemplateImports {
+  let needsHttpException = false;
+  let needsResponse = false;
+  const schemaSet = new Set<string>();
+  const stdlibByModule = new Map<string, Set<string>>();
+
+  for (const op of operations) {
+    if (op.routeKind === "read") needsHttpException = true;
+    if (op.routeKind === "delete") {
+      needsHttpException = true;
+      needsResponse = true;
+    }
+    if (op.hasRequestBody && op.requestBodyType) schemaSet.add(op.requestBodyType);
+    if (op.routeKind === "create" || op.routeKind === "read" || op.routeKind === "list") {
+      schemaSet.add(entity.readSchemaName);
+    }
+    for (const p of op.pathParamsWithTypes) {
+      mergeStdlibImport(stdlibByModule, p.pythonType);
     }
   }
-  const result: StdlibImport[] = [];
-  for (const [module, names] of stdlibByModule) {
-    result.push({ module, names: [...names].sort() });
+
+  return {
+    needsHttpException,
+    needsResponse,
+    schemas: [...schemaSet].sort(),
+    stdlibImports: finalizeStdlibImports(stdlibByModule),
+  };
+}
+
+interface ServiceTemplateImports {
+  readonly sqlalchemyCoreImports: readonly string[];
+  readonly schemas: readonly string[];
+}
+
+function collectServiceImports(
+  entity: ProfiledEntity,
+  operations: readonly EnrichedOperation[],
+): ServiceTemplateImports {
+  let needsSelect = false;
+  let needsSaDelete = false;
+  const schemaSet = new Set<string>();
+
+  for (const op of operations) {
+    if (op.routeKind === "read" || op.routeKind === "list") needsSelect = true;
+    if (op.routeKind === "delete") needsSaDelete = true;
+    if (op.routeKind === "create" || op.routeKind === "read" || op.routeKind === "list") {
+      schemaSet.add(entity.readSchemaName);
+    }
+    if (op.hasRequestBody && op.requestBodyType) schemaSet.add(op.requestBodyType);
   }
-  result.sort((a, b) => a.module.localeCompare(b.module));
-  return result;
+
+  const coreImports: string[] = [];
+  if (needsSaDelete) coreImports.push("delete as sa_delete");
+  if (needsSelect) coreImports.push("select");
+
+  return {
+    sqlalchemyCoreImports: coreImports,
+    schemas: [...schemaSet].sort(),
+  };
 }
 
 function findTable(
@@ -300,8 +388,14 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
       .filter((op) => op.targetEntity === entity.entityName)
       .map((op) => enrichOperation(op, entity, typeLookup));
 
-    const { sqlalchemyImports, stdlibImports } = collectEntityImports(entity);
+    const {
+      sqlalchemyImports,
+      postgresImports,
+      stdlibImports,
+    } = collectEntityImports(entity);
     const schemaStdlib = collectSchemaStdlibImports(entity);
+    const routerImports = collectRouterImports(entity, entityOperations);
+    const serviceImports = collectServiceImports(entity, entityOperations);
 
     const entitySnake = toSnakeCase(entity.entityName);
     const routerSnake = toSnakeCase(pluralize(entity.entityName));
@@ -312,6 +406,7 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
       table,
       entityOperations,
       sqlalchemyImports,
+      postgresImports,
       stdlibImports,
     };
 
@@ -320,8 +415,23 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
       entity,
       table,
       entityOperations,
-      sqlalchemyImports: [] as readonly string[],
       stdlibImports: schemaStdlib,
+    };
+
+    const routerCtx = {
+      ...ctx,
+      entity,
+      table,
+      entityOperations,
+      routerImports,
+    };
+
+    const serviceCtx = {
+      ...ctx,
+      entity,
+      table,
+      entityOperations,
+      serviceImports,
     };
 
     files.push({
@@ -334,11 +444,11 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
     });
     files.push({
       path: `app/routers/${routerSnake}.py`,
-      content: engine.render(templates.routerEntity, modelCtx),
+      content: engine.render(templates.routerEntity, routerCtx),
     });
     files.push({
       path: `app/services/${entitySnake}.py`,
-      content: engine.render(templates.serviceEntity, modelCtx),
+      content: engine.render(templates.serviceEntity, serviceCtx),
     });
   }
 

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -1,0 +1,346 @@
+import { TemplateEngine } from "#codegen/engine.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+import { buildRenderContext } from "#codegen/types.js";
+import { toSnakeCase, pluralize } from "#convention/naming.js";
+import type {
+  EndpointSpec,
+  ParamSpec,
+  TableSpec,
+} from "#convention/types.js";
+import type { TypeExpr } from "#ir/types.js";
+import type {
+  ProfiledEntity,
+  ProfiledOperation,
+  ProfiledService,
+} from "#profile/types.js";
+
+export interface EmittedFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+type RouteKind =
+  | "create"
+  | "read"
+  | "list"
+  | "delete"
+  | "other";
+
+interface EnrichedPathParam {
+  readonly name: string;
+  readonly pythonType: string;
+}
+
+interface EnrichedOperation {
+  readonly operationName: string;
+  readonly handlerName: string;
+  readonly kind: string;
+  readonly method: string;
+  readonly path: string;
+  readonly successStatus: number;
+  readonly pathParamsWithTypes: readonly EnrichedPathParam[];
+  readonly hasRequestBody: boolean;
+  readonly requestBodyType: string;
+  readonly responseAnnotation: string;
+  readonly serviceCallArgs: string;
+  readonly routeKind: RouteKind;
+  readonly pathParamSignature: string;
+  readonly serviceSignatureExtraArgs: string;
+  readonly serviceReturnAnnotation: string;
+  readonly lookupColumn: string;
+}
+
+interface StdlibImport {
+  readonly module: string;
+  readonly names: readonly string[];
+}
+
+const STDLIB_TYPE_SOURCES: ReadonlyMap<string, StdlibImport> = new Map([
+  ["datetime", { module: "datetime", names: ["datetime"] }],
+  ["date", { module: "datetime", names: ["date"] }],
+  ["Decimal", { module: "decimal", names: ["Decimal"] }],
+  ["uuid.UUID", { module: "uuid", names: ["UUID"] }],
+]);
+
+function pythonTypeForParam(typeExpr: TypeExpr, typeMap: ReadonlyMap<string, string>): string {
+  if (typeExpr.kind === "NamedType") {
+    const mapped = typeMap.get(typeExpr.name);
+    if (mapped !== undefined) return mapped;
+    return "str";
+  }
+  if (typeExpr.kind === "OptionType") {
+    return `${pythonTypeForParam(typeExpr.innerType, typeMap)} | None`;
+  }
+  return "str";
+}
+
+function classifyRouteKind(op: ProfiledOperation): RouteKind {
+  const method = op.endpoint.method;
+  const hasPathParam = op.endpoint.pathParams.length > 0;
+  if (op.kind === "create") return "create";
+  if (op.kind === "read" && hasPathParam) return "read";
+  if (op.kind === "read" && !hasPathParam) return "list";
+  if (op.kind === "filtered_read" && !hasPathParam) return "list";
+  if (op.kind === "delete") return "delete";
+  if (method === "GET" && !hasPathParam) return "list";
+  return "other";
+}
+
+function buildTypeLookup(profiled: ProfiledService): ReadonlyMap<string, string> {
+  const map = new Map<string, string>();
+  for (const [specType, mapping] of profiled.profile.typeMap.entries()) {
+    map.set(specType, mapping.python);
+  }
+  return map;
+}
+
+function paramPythonType(param: ParamSpec, typeLookup: ReadonlyMap<string, string>): string {
+  return pythonTypeForParam(param.typeExpr, typeLookup);
+}
+
+function enrichOperation(
+  op: ProfiledOperation,
+  entity: ProfiledEntity,
+  typeLookup: ReadonlyMap<string, string>,
+): EnrichedOperation {
+  const endpoint: EndpointSpec = op.endpoint;
+  const pathParamsWithTypes: EnrichedPathParam[] = endpoint.pathParams.map((p) => ({
+    name: p.name,
+    pythonType: paramPythonType(p, typeLookup),
+  }));
+
+  const routeKind = classifyRouteKind(op);
+  const method = endpoint.method.toLowerCase();
+
+  const pathParamCallArgs = pathParamsWithTypes.map((p) => p.name).join(", ");
+  const hasRequestBody = routeKind === "create" || endpoint.bodyParams.length > 0;
+  const requestBodyType = hasRequestBody ? entity.createSchemaName : "";
+
+  let responseAnnotation: string;
+  let serviceCallArgs: string;
+  let pathParamSignature: string;
+  let serviceSignatureExtraArgs: string;
+  let serviceReturnAnnotation: string;
+
+  switch (routeKind) {
+    case "create":
+      responseAnnotation = entity.readSchemaName;
+      serviceCallArgs = hasRequestBody ? "body" : "";
+      pathParamSignature = "";
+      serviceSignatureExtraArgs = "";
+      serviceReturnAnnotation = entity.readSchemaName;
+      break;
+    case "read":
+      responseAnnotation = entity.readSchemaName;
+      serviceCallArgs = pathParamCallArgs;
+      pathParamSignature = pathParamsWithTypes
+        .map((p) => `${p.name}: ${p.pythonType}`)
+        .join(", ");
+      serviceSignatureExtraArgs = pathParamSignature;
+      serviceReturnAnnotation = `${entity.readSchemaName} | None`;
+      break;
+    case "list":
+      responseAnnotation = `list[${entity.readSchemaName}]`;
+      serviceCallArgs = "";
+      pathParamSignature = "";
+      serviceSignatureExtraArgs = "";
+      serviceReturnAnnotation = `list[${entity.readSchemaName}]`;
+      break;
+    case "delete":
+      responseAnnotation = "Response";
+      serviceCallArgs = pathParamCallArgs;
+      pathParamSignature = pathParamsWithTypes
+        .map((p) => `${p.name}: ${p.pythonType}`)
+        .join(", ");
+      serviceSignatureExtraArgs = pathParamSignature;
+      serviceReturnAnnotation = "bool";
+      break;
+    default: {
+      const args = [
+        ...pathParamsWithTypes.map((p) => `${p.name}: ${p.pythonType}`),
+        ...(hasRequestBody ? [`body: ${entity.createSchemaName}`] : []),
+      ];
+      responseAnnotation = "None";
+      serviceCallArgs = [
+        ...pathParamsWithTypes.map((p) => p.name),
+        ...(hasRequestBody ? ["body"] : []),
+      ].join(", ");
+      pathParamSignature = "";
+      serviceSignatureExtraArgs = args.join(", ");
+      serviceReturnAnnotation = "None";
+      break;
+    }
+  }
+
+  const lookupColumn = pathParamsWithTypes.length > 0 ? pathParamsWithTypes[0].name : "id";
+
+  return {
+    operationName: op.operationName,
+    handlerName: op.handlerName,
+    kind: op.kind,
+    method,
+    path: endpoint.path,
+    successStatus: endpoint.successStatus,
+    pathParamsWithTypes,
+    hasRequestBody,
+    requestBodyType,
+    responseAnnotation,
+    serviceCallArgs,
+    routeKind,
+    pathParamSignature,
+    serviceSignatureExtraArgs,
+    serviceReturnAnnotation,
+    lookupColumn,
+  };
+}
+
+function collectEntityImports(entity: ProfiledEntity): {
+  sqlalchemyImports: readonly string[];
+  stdlibImports: readonly StdlibImport[];
+} {
+  const sqlSet = new Set<string>();
+  const stdlibByModule = new Map<string, Set<string>>();
+
+  for (const field of entity.fields) {
+    sqlSet.add(field.sqlalchemyColumnType);
+    const stdlib = STDLIB_TYPE_SOURCES.get(field.pythonType);
+    if (stdlib !== undefined) {
+      const existing = stdlibByModule.get(stdlib.module) ?? new Set<string>();
+      for (const n of stdlib.names) existing.add(n);
+      stdlibByModule.set(stdlib.module, existing);
+    }
+  }
+
+  const stdlibImports: StdlibImport[] = [];
+  for (const [module, names] of stdlibByModule) {
+    stdlibImports.push({ module, names: [...names].sort() });
+  }
+  stdlibImports.sort((a, b) => a.module.localeCompare(b.module));
+
+  return {
+    sqlalchemyImports: [...sqlSet].sort(),
+    stdlibImports,
+  };
+}
+
+function collectSchemaStdlibImports(entity: ProfiledEntity): readonly StdlibImport[] {
+  const stdlibByModule = new Map<string, Set<string>>();
+  for (const field of entity.fields) {
+    const stdlib = STDLIB_TYPE_SOURCES.get(field.pythonType);
+    if (stdlib !== undefined) {
+      const existing = stdlibByModule.get(stdlib.module) ?? new Set<string>();
+      for (const n of stdlib.names) existing.add(n);
+      stdlibByModule.set(stdlib.module, existing);
+    }
+  }
+  const result: StdlibImport[] = [];
+  for (const [module, names] of stdlibByModule) {
+    result.push({ module, names: [...names].sort() });
+  }
+  result.sort((a, b) => a.module.localeCompare(b.module));
+  return result;
+}
+
+function findTable(
+  tables: readonly TableSpec[],
+  entityName: string,
+): TableSpec | null {
+  return tables.find((t) => t.entityName === entityName) ?? null;
+}
+
+export function emitProject(profiled: ProfiledService): EmittedFile[] {
+  const ctx = buildRenderContext(profiled);
+  const engine = new TemplateEngine();
+  const typeLookup = buildTypeLookup(profiled);
+  const templates = pythonFastapiPostgresTemplates;
+  const files: EmittedFile[] = [];
+
+  files.push({
+    path: "app/__init__.py",
+    content: "",
+  });
+
+  files.push({
+    path: "app/main.py",
+    content: engine.render(templates.main, ctx),
+  });
+  files.push({
+    path: "app/config.py",
+    content: engine.render(templates.config, ctx),
+  });
+  files.push({
+    path: "app/database.py",
+    content: engine.render(templates.database, ctx),
+  });
+
+  files.push({
+    path: "app/models/base.py",
+    content: engine.render(templates.modelBase, ctx),
+  });
+  files.push({
+    path: "app/models/__init__.py",
+    content: engine.render(templates.modelInit, ctx),
+  });
+  files.push({
+    path: "app/schemas/__init__.py",
+    content: engine.render(templates.schemaInit, ctx),
+  });
+  files.push({
+    path: "app/routers/__init__.py",
+    content: engine.render(templates.routerInit, ctx),
+  });
+  files.push({
+    path: "app/services/__init__.py",
+    content: engine.render(templates.serviceInit, ctx),
+  });
+
+  for (const entity of ctx.entities) {
+    const table = findTable(ctx.schema.tables, entity.entityName);
+    const entityOperations = ctx.operations
+      .filter((op) => op.targetEntity === entity.entityName)
+      .map((op) => enrichOperation(op, entity, typeLookup));
+
+    const { sqlalchemyImports, stdlibImports } = collectEntityImports(entity);
+    const schemaStdlib = collectSchemaStdlibImports(entity);
+
+    const entitySnake = toSnakeCase(entity.entityName);
+    const routerSnake = toSnakeCase(pluralize(entity.entityName));
+
+    const modelCtx = {
+      ...ctx,
+      entity,
+      table,
+      entityOperations,
+      sqlalchemyImports,
+      stdlibImports,
+    };
+
+    const schemaCtx = {
+      ...ctx,
+      entity,
+      table,
+      entityOperations,
+      sqlalchemyImports: [] as readonly string[],
+      stdlibImports: schemaStdlib,
+    };
+
+    files.push({
+      path: `app/models/${entitySnake}.py`,
+      content: engine.render(templates.modelEntity, modelCtx),
+    });
+    files.push({
+      path: `app/schemas/${entitySnake}.py`,
+      content: engine.render(templates.schemaEntity, schemaCtx),
+    });
+    files.push({
+      path: `app/routers/${routerSnake}.py`,
+      content: engine.render(templates.routerEntity, modelCtx),
+    });
+    files.push({
+      path: `app/services/${entitySnake}.py`,
+      content: engine.render(templates.serviceEntity, modelCtx),
+    });
+  }
+
+  return files;
+}

--- a/src/codegen/engine.ts
+++ b/src/codegen/engine.ts
@@ -9,10 +9,7 @@ export class TemplateEngine {
     registerHelpers(this.hbs);
   }
 
-  render<T extends Record<string, unknown> = Record<string, unknown>>(
-    templateSource: string,
-    context: T,
-  ): string {
+  render<T extends object = object>(templateSource: string, context: T): string {
     const compiled = this.hbs.compile(templateSource, { noEscape: true });
     return compiled(context);
   }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6,8 +6,11 @@ export type {
   TypeMappingEntry,
 } from "#codegen/types.js";
 export type { Primitive } from "#codegen/helpers.js";
+export type { EmittedFile } from "#codegen/emit.js";
 export { buildRenderContext } from "#codegen/types.js";
 export { TemplateEngine } from "#codegen/engine.js";
+export { emitProject } from "#codegen/emit.js";
+export { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
 export {
   registerHelpers,
   snakeCaseHelper,

--- a/src/codegen/templates.ts
+++ b/src/codegen/templates.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const templateRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "templates",
+  "python-fastapi-postgres",
+);
+
+function loadTemplate(relPath: string): string {
+  return readFileSync(join(templateRoot, relPath), "utf-8");
+}
+
+export const pythonFastapiPostgresTemplates = Object.freeze({
+  main: loadTemplate("main.py.hbs"),
+  config: loadTemplate("config.py.hbs"),
+  database: loadTemplate("database.py.hbs"),
+  modelBase: loadTemplate("models/base.py.hbs"),
+  modelEntity: loadTemplate("models/entity.py.hbs"),
+  modelInit: loadTemplate("models/__init__.py.hbs"),
+  schemaEntity: loadTemplate("schemas/entity.py.hbs"),
+  schemaInit: loadTemplate("schemas/__init__.py.hbs"),
+  routerEntity: loadTemplate("routers/entity.py.hbs"),
+  routerInit: loadTemplate("routers/__init__.py.hbs"),
+  serviceEntity: loadTemplate("services/entity.py.hbs"),
+  serviceInit: loadTemplate("services/__init__.py.hbs"),
+});
+
+export type PythonFastapiPostgresTemplates = typeof pythonFastapiPostgresTemplates;

--- a/src/codegen/templates/python-fastapi-postgres/config.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/config.py.hbs
@@ -1,0 +1,12 @@
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    database_url: str = "postgresql+asyncpg://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}"
+    base_url: str = "http://localhost:8000"
+    log_level: str = "info"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+settings = Settings()

--- a/src/codegen/templates/python-fastapi-postgres/config.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/config.py.hbs
@@ -2,11 +2,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    database_url: str = "postgresql+asyncpg://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}"
+    database_url: str = (
+        "postgresql+asyncpg://{{service.snakeName}}:{{service.snakeName}}"
+        "@localhost:5432/{{service.snakeName}}"
+    )
     base_url: str = "http://localhost:8000"
     log_level: str = "info"
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
 
 settings = Settings()

--- a/src/codegen/templates/python-fastapi-postgres/database.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/database.py.hbs
@@ -1,0 +1,25 @@
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+
+engine = create_async_engine(
+    settings.database_url,
+    echo=False,
+    pool_size=10,
+    max_overflow=20,
+    pool_pre_ping=True,
+)
+
+async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/src/codegen/templates/python-fastapi-postgres/main.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/main.py.hbs
@@ -20,7 +20,12 @@ app = FastAPI(title="{{service.name}}", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "http://127.0.0.1:3000",
+        "http://127.0.0.1:5173",
+    ],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/src/codegen/templates/python-fastapi-postgres/main.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/main.py.hbs
@@ -1,0 +1,36 @@
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.database import engine
+{{#each entities}}
+from app.routers import {{snake_case (pluralize this.entityName)}}
+{{/each}}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    yield
+    await engine.dispose()
+
+
+app = FastAPI(title="{{service.name}}", version="0.1.0", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+{{#each entities}}
+app.include_router({{snake_case (pluralize this.entityName)}}.router)
+{{/each}}
+
+
+@app.get("/health", tags=["infrastructure"])
+async def health_check() -> dict[str, str]:
+    return {"status": "ok"}

--- a/src/codegen/templates/python-fastapi-postgres/models/__init__.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/models/__init__.py.hbs
@@ -1,0 +1,11 @@
+from app.models.base import Base
+{{#each entities}}
+from app.models.{{snake_case this.entityName}} import {{this.modelClassName}}
+{{/each}}
+
+__all__ = [
+    "Base",
+{{#each entities}}
+    "{{this.modelClassName}}",
+{{/each}}
+]

--- a/src/codegen/templates/python-fastapi-postgres/models/base.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/models/base.py.hbs
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
@@ -1,0 +1,16 @@
+{{#each stdlibImports}}
+from {{this.module}} import {{join this.names ", "}}
+{{/each}}
+from sqlalchemy import {{join sqlalchemyImports ", "}}
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class {{entity.modelClassName}}(Base):
+    __tablename__ = "{{entity.tableName}}"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+{{#each entity.fields}}
+    {{this.columnName}}: {{this.sqlalchemyType}} = mapped_column({{this.sqlalchemyColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
+{{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
@@ -1,7 +1,12 @@
 {{#each stdlibImports}}
 from {{this.module}} import {{join this.names ", "}}
 {{/each}}
+{{#if sqlalchemyImports.length}}
 from sqlalchemy import {{join sqlalchemyImports ", "}}
+{{/if}}
+{{#if postgresImports.length}}
+from sqlalchemy.dialects.postgresql import {{join postgresImports ", "}}
+{{/if}}
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
@@ -12,5 +17,7 @@ class {{entity.modelClassName}}(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
 {{#each entity.fields}}
+{{#if (ne this.columnName "id")}}
     {{this.columnName}}: {{this.sqlalchemyType}} = mapped_column({{this.sqlalchemyColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
+{{/if}}
 {{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/models/entity.py.hbs
@@ -16,8 +16,6 @@ class {{entity.modelClassName}}(Base):
     __tablename__ = "{{entity.tableName}}"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-{{#each entity.fields}}
-{{#if (ne this.columnName "id")}}
+{{#each nonIdFields}}
     {{this.columnName}}: {{this.sqlalchemyType}} = mapped_column({{this.sqlalchemyColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
-{{/if}}
 {{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/routers/__init__.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/routers/__init__.py.hbs
@@ -1,0 +1,9 @@
+{{#each entities}}
+from app.routers import {{snake_case (pluralize this.entityName)}}
+{{/each}}
+
+__all__ = [
+{{#each entities}}
+    "{{snake_case (pluralize this.entityName)}}",
+{{/each}}
+]

--- a/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.schemas.{{snake_case entity.entityName}} import (
+    {{entity.createSchemaName}},
+    {{entity.readSchemaName}},
+    {{entity.updateSchemaName}},
+)
+from app.services.{{snake_case entity.entityName}} import {{entity.entityName}}Service
+
+router = APIRouter(tags=["{{snake_case entity.entityName}}"])
+
+{{#each entityOperations}}
+
+@router.{{this.method}}("{{this.path}}", status_code={{this.successStatus}})
+async def {{this.handlerName}}(
+{{#each this.pathParamsWithTypes}}
+    {{this.name}}: {{this.pythonType}},
+{{/each}}
+{{#if this.hasRequestBody}}
+    body: {{this.requestBodyType}},
+{{/if}}
+    session: AsyncSession = Depends(get_session),
+) -> {{this.responseAnnotation}}:
+    svc = {{../entity.entityName}}Service(session)
+{{#if (eq this.routeKind "read")}}
+    result = await svc.{{this.handlerName}}({{this.serviceCallArgs}})
+    if result is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return result
+{{else if (eq this.routeKind "delete")}}
+    deleted = await svc.{{this.handlerName}}({{this.serviceCallArgs}})
+    if not deleted:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(status_code={{this.successStatus}})
+{{else}}
+    return await svc.{{this.handlerName}}({{this.serviceCallArgs}})
+{{/if}}
+{{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
@@ -1,12 +1,17 @@
-from fastapi import APIRouter, Depends, HTTPException, Response
+{{#each routerImports.stdlibImports}}
+from {{this.module}} import {{join this.names ", "}}
+{{/each}}
+from fastapi import APIRouter, Depends{{#if routerImports.needsHttpException}}, HTTPException{{/if}}{{#if routerImports.needsResponse}}, Response{{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
+{{#if routerImports.schemas.length}}
 from app.schemas.{{snake_case entity.entityName}} import (
-    {{entity.createSchemaName}},
-    {{entity.readSchemaName}},
-    {{entity.updateSchemaName}},
+{{#each routerImports.schemas}}
+    {{this}},
+{{/each}}
 )
+{{/if}}
 from app.services.{{snake_case entity.entityName}} import {{entity.entityName}}Service
 
 router = APIRouter(tags=["{{snake_case entity.entityName}}"])

--- a/src/codegen/templates/python-fastapi-postgres/schemas/__init__.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/__init__.py.hbs
@@ -1,0 +1,11 @@
+{{#each entities}}
+from app.schemas.{{snake_case this.entityName}} import {{this.createSchemaName}}, {{this.readSchemaName}}, {{this.updateSchemaName}}
+{{/each}}
+
+__all__ = [
+{{#each entities}}
+    "{{this.createSchemaName}}",
+    "{{this.readSchemaName}}",
+    "{{this.updateSchemaName}}",
+{{/each}}
+]

--- a/src/codegen/templates/python-fastapi-postgres/schemas/__init__.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/__init__.py.hbs
@@ -1,5 +1,9 @@
 {{#each entities}}
-from app.schemas.{{snake_case this.entityName}} import {{this.createSchemaName}}, {{this.readSchemaName}}, {{this.updateSchemaName}}
+from app.schemas.{{snake_case this.entityName}} import (
+    {{this.createSchemaName}},
+    {{this.readSchemaName}},
+    {{this.updateSchemaName}},
+)
 {{/each}}
 
 __all__ = [

--- a/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -5,10 +5,8 @@ from pydantic import BaseModel, ConfigDict
 
 
 class {{entity.createSchemaName}}(BaseModel):
-{{#each entity.fields}}
-{{#if (ne this.columnName "id")}}
+{{#each nonIdFields}}
     {{this.columnName}}: {{this.pydanticType}}
-{{/if}}
 {{else}}
     pass
 {{/each}}
@@ -18,21 +16,17 @@ class {{entity.readSchemaName}}(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-{{#each entity.fields}}
-{{#if (ne this.columnName "id")}}
+{{#each nonIdFields}}
     {{this.columnName}}: {{this.pydanticType}}
-{{/if}}
 {{/each}}
 
 
 class {{entity.updateSchemaName}}(BaseModel):
-{{#each entity.fields}}
-{{#if (ne this.columnName "id")}}
+{{#each nonIdFields}}
 {{#if this.nullable}}
     {{this.columnName}}: {{this.pydanticType}} = None
 {{else}}
     {{this.columnName}}: {{this.pydanticType}} | None = None
-{{/if}}
 {{/if}}
 {{else}}
     pass

--- a/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -1,0 +1,29 @@
+{{#each stdlibImports}}
+from {{this.module}} import {{join this.names ", "}}
+{{/each}}
+from pydantic import BaseModel, ConfigDict
+
+
+class {{entity.createSchemaName}}(BaseModel):
+{{#each entity.fields}}
+    {{this.columnName}}: {{this.pydanticType}}
+{{else}}
+    pass
+{{/each}}
+
+
+class {{entity.readSchemaName}}(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+{{#each entity.fields}}
+    {{this.columnName}}: {{this.pydanticType}}
+{{/each}}
+
+
+class {{entity.updateSchemaName}}(BaseModel):
+{{#each entity.fields}}
+    {{this.columnName}}: {{this.pydanticType}} | None = None
+{{else}}
+    pass
+{{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -6,7 +6,9 @@ from pydantic import BaseModel, ConfigDict
 
 class {{entity.createSchemaName}}(BaseModel):
 {{#each entity.fields}}
+{{#if (ne this.columnName "id")}}
     {{this.columnName}}: {{this.pydanticType}}
+{{/if}}
 {{else}}
     pass
 {{/each}}
@@ -17,13 +19,21 @@ class {{entity.readSchemaName}}(BaseModel):
 
     id: int
 {{#each entity.fields}}
+{{#if (ne this.columnName "id")}}
     {{this.columnName}}: {{this.pydanticType}}
+{{/if}}
 {{/each}}
 
 
 class {{entity.updateSchemaName}}(BaseModel):
 {{#each entity.fields}}
+{{#if (ne this.columnName "id")}}
+{{#if this.nullable}}
+    {{this.columnName}}: {{this.pydanticType}} = None
+{{else}}
     {{this.columnName}}: {{this.pydanticType}} | None = None
+{{/if}}
+{{/if}}
 {{else}}
     pass
 {{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/services/__init__.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/services/__init__.py.hbs
@@ -1,0 +1,9 @@
+{{#each entities}}
+from app.services.{{snake_case this.entityName}} import {{this.entityName}}Service
+{{/each}}
+
+__all__ = [
+{{#each entities}}
+    "{{this.entityName}}Service",
+{{/each}}
+]

--- a/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -1,12 +1,16 @@
-from sqlalchemy import delete as sa_delete, select
+{{#if serviceImports.sqlalchemyCoreImports.length}}
+from sqlalchemy import {{join serviceImports.sqlalchemyCoreImports ", "}}
+{{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.{{snake_case entity.entityName}} import {{entity.modelClassName}}
+{{#if serviceImports.schemas.length}}
 from app.schemas.{{snake_case entity.entityName}} import (
-    {{entity.createSchemaName}},
-    {{entity.readSchemaName}},
-    {{entity.updateSchemaName}},
+{{#each serviceImports.schemas}}
+    {{this}},
+{{/each}}
 )
+{{/if}}
 
 
 class {{entity.entityName}}Service:
@@ -21,7 +25,7 @@ class {{entity.entityName}}Service:
         await self._session.flush()
         return {{../entity.readSchemaName}}.model_validate(row)
 {{else if (eq this.routeKind "read")}}
-    async def {{this.handlerName}}(self, {{this.pathParamSignature}}) -> {{../entity.readSchemaName}} | None:
+    async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> {{../entity.readSchemaName}} | None:
         result = await self._session.execute(
             select({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
         )
@@ -33,7 +37,7 @@ class {{entity.entityName}}Service:
         rows = result.scalars().all()
         return [{{../entity.readSchemaName}}.model_validate(row) for row in rows]
 {{else if (eq this.routeKind "delete")}}
-    async def {{this.handlerName}}(self, {{this.pathParamSignature}}) -> bool:
+    async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> bool:
         result = await self._session.execute(
             sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
         )

--- a/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -1,0 +1,47 @@
+from sqlalchemy import delete as sa_delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.{{snake_case entity.entityName}} import {{entity.modelClassName}}
+from app.schemas.{{snake_case entity.entityName}} import (
+    {{entity.createSchemaName}},
+    {{entity.readSchemaName}},
+    {{entity.updateSchemaName}},
+)
+
+
+class {{entity.entityName}}Service:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+{{#each entityOperations}}
+{{#if (eq this.routeKind "create")}}
+    async def {{this.handlerName}}(self, body: {{../entity.createSchemaName}}) -> {{../entity.readSchemaName}}:
+        row = {{../entity.modelClassName}}(**body.model_dump())
+        self._session.add(row)
+        await self._session.flush()
+        return {{../entity.readSchemaName}}.model_validate(row)
+{{else if (eq this.routeKind "read")}}
+    async def {{this.handlerName}}(self, {{this.pathParamSignature}}) -> {{../entity.readSchemaName}} | None:
+        result = await self._session.execute(
+            select({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
+        )
+        row = result.scalar_one_or_none()
+        return {{../entity.readSchemaName}}.model_validate(row) if row is not None else None
+{{else if (eq this.routeKind "list")}}
+    async def {{this.handlerName}}(self) -> list[{{../entity.readSchemaName}}]:
+        result = await self._session.execute(select({{../entity.modelClassName}}))
+        rows = result.scalars().all()
+        return [{{../entity.readSchemaName}}.model_validate(row) for row in rows]
+{{else if (eq this.routeKind "delete")}}
+    async def {{this.handlerName}}(self, {{this.pathParamSignature}}) -> bool:
+        result = await self._session.execute(
+            sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
+        )
+        return result.rowcount > 0
+{{else}}
+    async def {{this.handlerName}}(self{{#if this.serviceSignatureExtraArgs}}, {{this.serviceSignatureExtraArgs}}{{/if}}) -> {{this.serviceReturnAnnotation}}:
+        raise NotImplementedError(
+            "{{this.kind}} operation '{{this.operationName}}' — implement in M4+"
+        )
+{{/if}}
+{{/each}}

--- a/src/profile/python-fastapi.ts
+++ b/src/profile/python-fastapi.ts
@@ -8,7 +8,7 @@ const TYPE_MAP = new Map<string, TypeMapping>([
   ["Boolean",  { python: "bool",        pydantic: "bool",        sqlalchemyColumn: "Boolean"    }],
   ["DateTime", { python: "datetime",    pydantic: "datetime",    sqlalchemyColumn: "DateTime"   }],
   ["Date",     { python: "date",        pydantic: "date",        sqlalchemyColumn: "Date"       }],
-  ["UUID",     { python: "uuid.UUID",   pydantic: "uuid.UUID",   sqlalchemyColumn: "Uuid"       }],
+  ["UUID",     { python: "UUID",        pydantic: "UUID",        sqlalchemyColumn: "Uuid"       }],
   ["Decimal",  { python: "Decimal",     pydantic: "Decimal",     sqlalchemyColumn: "Numeric"    }],
   ["Bytes",    { python: "bytes",       pydantic: "bytes",       sqlalchemyColumn: "LargeBinary"}],
   ["Money",    { python: "int",         pydantic: "int",         sqlalchemyColumn: "Integer"    }],

--- a/test/codegen/emit.test.ts
+++ b/test/codegen/emit.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { emitProject } from "#codegen/emit.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  const ir = buildIR(tree);
+  return buildProfiledService(ir, "python-fastapi-postgres");
+}
+
+function python3Available(): boolean {
+  const probe = spawnSync("python3", ["--version"], { encoding: "utf-8" });
+  return probe.status === 0;
+}
+
+describe("emitProject — file paths", () => {
+  it("produces the expected file tree for url_shortener", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const paths = files.map((f) => f.path).sort();
+    expect(paths).toEqual([
+      "app/__init__.py",
+      "app/config.py",
+      "app/database.py",
+      "app/main.py",
+      "app/models/__init__.py",
+      "app/models/base.py",
+      "app/models/url_mapping.py",
+      "app/routers/__init__.py",
+      "app/routers/url_mappings.py",
+      "app/schemas/__init__.py",
+      "app/schemas/url_mapping.py",
+      "app/services/__init__.py",
+      "app/services/url_mapping.py",
+    ]);
+  });
+
+  it("produces one model/schema/router/service file per entity for ecommerce", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    const paths = new Set(files.map((f) => f.path));
+    for (const entity of profiled.entities) {
+      const snake = entity.modelFileName.replace(/\.py$/, "");
+      const routerSnake = entity.routerFileName.replace(/\.py$/, "");
+      expect(paths).toContain(`app/models/${snake}.py`);
+      expect(paths).toContain(`app/schemas/${snake}.py`);
+      expect(paths).toContain(`app/routers/${routerSnake}.py`);
+      expect(paths).toContain(`app/services/${snake}.py`);
+    }
+  });
+
+  it.each(["url_shortener.spec", "todo_list.spec", "ecommerce.spec"])(
+    "returns non-empty content for every file — %s",
+    (fixture) => {
+      const files = emitProject(profiledFrom(fixture));
+      expect(files.length).toBeGreaterThan(0);
+      for (const f of files) {
+        if (f.path.endsWith("__init__.py") && f.path === "app/__init__.py") continue;
+        expect(f.content.length).toBeGreaterThan(0);
+      }
+    },
+  );
+});
+
+describe("emitProject — syntactic validity", () => {
+  const py3 = python3Available();
+  const maybeIt = py3 ? it : it.skip;
+
+  maybeIt.each(["url_shortener.spec", "todo_list.spec", "ecommerce.spec"])(
+    "every generated .py file is valid Python — %s",
+    (fixture) => {
+      const files = emitProject(profiledFrom(fixture));
+      for (const f of files) {
+        if (!f.path.endsWith(".py")) continue;
+        const proc = spawnSync(
+          "python3",
+          ["-c", "import ast, sys; ast.parse(sys.stdin.read())"],
+          { input: f.content, encoding: "utf-8" },
+        );
+        if (proc.status !== 0) {
+          throw new Error(`SyntaxError in ${f.path}:\n${proc.stderr}\n--- content ---\n${f.content}`);
+        }
+      }
+    },
+  );
+});
+
+describe("emitProject — structural markers", () => {
+  it("main.py imports each entity router and registers it", () => {
+    const files = emitProject(profiledFrom("ecommerce.spec"));
+    const main = files.find((f) => f.path === "app/main.py")!;
+    expect(main.content).toMatch(/from app\.routers import products/);
+    expect(main.content).toMatch(/app\.include_router\(products\.router\)/);
+    expect(main.content).toContain("@app.get(\"/health\"");
+  });
+
+  it("model file emits SQLAlchemy 2.0 Mapped columns", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const model = files.find((f) => f.path === "app/models/url_mapping.py")!;
+    expect(model.content).toContain("class UrlMapping(Base):");
+    expect(model.content).toContain('__tablename__ = "url_mappings"');
+    expect(model.content).toContain("id: Mapped[int] = mapped_column(primary_key=True)");
+    expect(model.content).toContain("from sqlalchemy.orm import Mapped, mapped_column");
+    expect(model.content).toMatch(/code: Mapped\[str\] = mapped_column\(String\)/);
+  });
+
+  it("schema file emits Create/Read/Update classes", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const schema = files.find((f) => f.path === "app/schemas/url_mapping.py")!;
+    expect(schema.content).toContain("class UrlMappingCreate(BaseModel):");
+    expect(schema.content).toContain("class UrlMappingRead(BaseModel):");
+    expect(schema.content).toContain("class UrlMappingUpdate(BaseModel):");
+    expect(schema.content).toContain("ConfigDict(from_attributes=True)");
+  });
+
+  it("router file emits @router.{method} decorators with correct status codes", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const router = files.find((f) => f.path === "app/routers/url_mappings.py")!;
+    expect(router.content).toContain('@router.post("/shorten", status_code=201)');
+    expect(router.content).toContain('@router.delete("/{code}", status_code=204)');
+    expect(router.content).toContain("async def shorten(");
+  });
+
+  it("service file emits CRUD method bodies and stubs for non-CRUD", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
+    expect(svc.content).toContain("class UrlMappingService:");
+    expect(svc.content).toContain("self._session.add(row)");
+    expect(svc.content).toContain("sa_delete(UrlMapping).where(UrlMapping.code == code)");
+  });
+
+  it("emits NotImplementedError stubs for transition operations (todo_list)", () => {
+    const files = emitProject(profiledFrom("todo_list.spec"));
+    const svc = files.find((f) => f.path === "app/services/todo.py")!;
+    expect(svc.content).toMatch(/raise NotImplementedError/);
+  });
+});

--- a/test/codegen/templates/config.test.ts
+++ b/test/codegen/templates/config.test.ts
@@ -33,10 +33,11 @@ describe("config.py template", () => {
     ["todo_list.spec", "todo_list"],
     ["ecommerce.spec", "order_service"],
   ])(
-    "default database_url uses service snake-cased name as db/user — %s",
+    "default database_url references service snake-cased name as db/user — %s",
     (fixture, snake) => {
       const out = engine.render(pythonFastapiPostgresTemplates.config, ctxFrom(fixture));
-      expect(out).toContain(`postgresql+asyncpg://${snake}:${snake}@localhost:5432/${snake}`);
+      expect(out).toContain(`postgresql+asyncpg://${snake}:${snake}`);
+      expect(out).toContain(`@localhost:5432/${snake}`);
     },
   );
 

--- a/test/codegen/templates/config.test.ts
+++ b/test/codegen/templates/config.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { TemplateEngine } from "#codegen/engine.js";
+import { buildRenderContext } from "#codegen/types.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function ctxFrom(name: string) {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildRenderContext(buildProfiledService(buildIR(tree), "python-fastapi-postgres"));
+}
+
+describe("config.py template", () => {
+  const engine = new TemplateEngine();
+
+  it.each(["url_shortener.spec", "todo_list.spec", "ecommerce.spec"])(
+    "renders a Settings class for %s",
+    (fixture) => {
+      const out = engine.render(pythonFastapiPostgresTemplates.config, ctxFrom(fixture));
+      expect(out).toContain("class Settings(BaseSettings):");
+      expect(out).toContain("settings = Settings()");
+    },
+  );
+
+  it.each([
+    ["url_shortener.spec", "url_shortener"],
+    ["todo_list.spec", "todo_list"],
+    ["ecommerce.spec", "order_service"],
+  ])(
+    "default database_url uses service snake-cased name as db/user — %s",
+    (fixture, snake) => {
+      const out = engine.render(pythonFastapiPostgresTemplates.config, ctxFrom(fixture));
+      expect(out).toContain(`postgresql+asyncpg://${snake}:${snake}@localhost:5432/${snake}`);
+    },
+  );
+
+  it("declares required settings fields with defaults", () => {
+    const out = engine.render(pythonFastapiPostgresTemplates.config, ctxFrom("url_shortener.spec"));
+    expect(out).toMatch(/database_url: str = /);
+    expect(out).toMatch(/base_url: str = /);
+    expect(out).toMatch(/log_level: str = /);
+  });
+});

--- a/test/codegen/templates/database.test.ts
+++ b/test/codegen/templates/database.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { TemplateEngine } from "#codegen/engine.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+
+describe("database.py template", () => {
+  const engine = new TemplateEngine();
+  const out = engine.render(pythonFastapiPostgresTemplates.database, {});
+
+  it("creates an async engine reading settings.database_url", () => {
+    expect(out).toContain("create_async_engine(");
+    expect(out).toContain("settings.database_url");
+  });
+
+  it("exports get_session with commit/rollback lifecycle", () => {
+    expect(out).toContain("async def get_session() -> AsyncIterator[AsyncSession]:");
+    expect(out).toContain("await session.commit()");
+    expect(out).toContain("await session.rollback()");
+  });
+
+  it("declares async_session_factory from async_sessionmaker", () => {
+    expect(out).toContain("async_session_factory = async_sessionmaker(");
+  });
+});

--- a/test/codegen/templates/main.test.ts
+++ b/test/codegen/templates/main.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { TemplateEngine } from "#codegen/engine.js";
+import { buildRenderContext } from "#codegen/types.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function ctxFrom(name: string) {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildRenderContext(buildProfiledService(buildIR(tree), "python-fastapi-postgres"));
+}
+
+describe("main.py template", () => {
+  const engine = new TemplateEngine();
+
+  it.each(["url_shortener.spec", "todo_list.spec", "ecommerce.spec"])(
+    "renders without throwing for %s",
+    (fixture) => {
+      expect(() => engine.render(pythonFastapiPostgresTemplates.main, ctxFrom(fixture))).not.toThrow();
+    },
+  );
+
+  it.each([
+    ["url_shortener.spec", "UrlShortener"],
+    ["todo_list.spec", "TodoList"],
+    ["ecommerce.spec", "OrderService"],
+  ])("uses the service name in FastAPI title — %s", (fixture, serviceName) => {
+    const out = engine.render(pythonFastapiPostgresTemplates.main, ctxFrom(fixture));
+    expect(out).toContain(`title="${serviceName}"`);
+  });
+
+  it("imports one router per entity for multi-entity services", () => {
+    const ctx = ctxFrom("ecommerce.spec");
+    const out = engine.render(pythonFastapiPostgresTemplates.main, ctx);
+    for (const entity of ctx.entities) {
+      const snake = entity.routerFileName.replace(/\.py$/, "");
+      expect(out).toContain(`from app.routers import ${snake}`);
+      expect(out).toContain(`app.include_router(${snake}.router)`);
+    }
+  });
+
+  it("always emits a /health endpoint and CORS middleware", () => {
+    const out = engine.render(pythonFastapiPostgresTemplates.main, ctxFrom("url_shortener.spec"));
+    expect(out).toContain('@app.get("/health"');
+    expect(out).toContain("CORSMiddleware");
+    expect(out).toContain("lifespan=lifespan");
+  });
+});

--- a/test/codegen/templates/models.test.ts
+++ b/test/codegen/templates/models.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { emitProject } from "#codegen/emit.js";
+import { TemplateEngine } from "#codegen/engine.js";
+import { buildRenderContext } from "#codegen/types.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+describe("models/base.py template", () => {
+  it("declares a single Base(DeclarativeBase) class", () => {
+    const engine = new TemplateEngine();
+    const ctx = buildRenderContext(profiledFrom("url_shortener.spec"));
+    const out = engine.render(pythonFastapiPostgresTemplates.modelBase, ctx);
+    expect(out).toContain("class Base(DeclarativeBase):");
+    expect(out).toContain("from sqlalchemy.orm import DeclarativeBase");
+  });
+});
+
+describe("models/__init__.py template", () => {
+  it.each(["url_shortener.spec", "todo_list.spec", "ecommerce.spec"])(
+    "re-exports every entity model class for %s",
+    (fixture) => {
+      const engine = new TemplateEngine();
+      const ctx = buildRenderContext(profiledFrom(fixture));
+      const out = engine.render(pythonFastapiPostgresTemplates.modelInit, ctx);
+      for (const entity of ctx.entities) {
+        expect(out).toContain(`import ${entity.modelClassName}`);
+      }
+      expect(out).toContain('"Base"');
+    },
+  );
+});
+
+describe("models/entity.py template — via emitProject", () => {
+  it.each([
+    ["url_shortener.spec", "UrlMapping", "url_mappings"],
+    ["todo_list.spec", "Todo", "todos"],
+  ])(
+    "emits class + __tablename__ for %s",
+    (fixture, entityName, tableName) => {
+      const files = emitProject(profiledFrom(fixture));
+      const snake = entityName.replace(/([A-Z])/g, "_$1").replace(/^_/, "").toLowerCase();
+      const model = files.find((f) => f.path === `app/models/${snake}.py`)!;
+      expect(model.content).toContain(`class ${entityName}(Base):`);
+      expect(model.content).toContain(`__tablename__ = "${tableName}"`);
+    },
+  );
+
+  it("emits Mapped[T] = mapped_column(ColType) for every entity field", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const files = emitProject(profiled);
+    const entity = profiled.entities[0];
+    const model = files.find((f) => f.path === `app/models/${entity.modelFileName}`)!;
+    for (const field of entity.fields) {
+      expect(model.content).toContain(`${field.columnName}: ${field.sqlalchemyType}`);
+      expect(model.content).toContain(field.sqlalchemyColumnType);
+    }
+  });
+
+  it("always declares `id: Mapped[int] = mapped_column(primary_key=True)`", () => {
+    const files = emitProject(profiledFrom("ecommerce.spec"));
+    const modelFiles = files.filter((f) => f.path.startsWith("app/models/") && !f.path.endsWith("__init__.py") && !f.path.endsWith("base.py"));
+    expect(modelFiles.length).toBeGreaterThan(0);
+    for (const f of modelFiles) {
+      expect(f.content).toContain("id: Mapped[int] = mapped_column(primary_key=True)");
+    }
+  });
+
+  it("collects stdlib imports only for types that need them", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const files = emitProject(profiled);
+    const model = files.find((f) => f.path === "app/models/url_mapping.py")!;
+    expect(model.content).toContain("from datetime import datetime");
+  });
+});

--- a/test/codegen/templates/routers.test.ts
+++ b/test/codegen/templates/routers.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { emitProject } from "#codegen/emit.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+describe("routers/entity.py template — via emitProject", () => {
+  it("creates APIRouter + imports schemas + imports service", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const router = files.find((f) => f.path === "app/routers/url_mappings.py")!;
+    expect(router.content).toContain("from fastapi import APIRouter");
+    expect(router.content).toContain("from app.schemas.url_mapping import");
+    expect(router.content).toContain("from app.services.url_mapping import UrlMappingService");
+    expect(router.content).toMatch(/router = APIRouter\(tags=\["url_mapping"\]\)/);
+  });
+
+  it.each([
+    ["Shorten", "post", "/shorten", 201],
+    ["Delete", "delete", "/{code}", 204],
+    ["ListAll", "get", "/urls", 200],
+  ])(
+    "emits @router.%s for operation %s with path %s and status %s",
+    (handler, method, path, status) => {
+      const files = emitProject(profiledFrom("url_shortener.spec"));
+      const router = files.find((f) => f.path === "app/routers/url_mappings.py")!;
+      expect(router.content).toContain(`@router.${method}("${path}", status_code=${status})`);
+      const expectedHandler = handler
+        .replace(/([A-Z])/g, "_$1")
+        .replace(/^_/, "")
+        .toLowerCase();
+      expect(router.content).toContain(`async def ${expectedHandler}(`);
+    },
+  );
+
+  it("uses Depends(get_session) for every handler", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const router = files.find((f) => f.path === "app/routers/url_mappings.py")!;
+    const handlerCount = (router.content.match(/async def /g) ?? []).length;
+    const dependsCount = (router.content.match(/Depends\(get_session\)/g) ?? []).length;
+    expect(handlerCount).toBeGreaterThan(0);
+    expect(dependsCount).toBe(handlerCount);
+  });
+
+  it("typed-parameterizes path params using resolved Python types", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const router = files.find((f) => f.path === "app/routers/url_mappings.py")!;
+    expect(router.content).toMatch(/code: str,/);
+  });
+
+  it("ecommerce generates one router file per entity", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    for (const entity of profiled.entities) {
+      const f = files.find((x) => x.path === `app/routers/${entity.routerFileName}`);
+      expect(f).toBeDefined();
+      expect(f!.content).toContain("router = APIRouter(");
+    }
+  });
+});
+
+describe("routers/__init__.py template", () => {
+  it("imports each entity's router module", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    const init = files.find((f) => f.path === "app/routers/__init__.py")!;
+    for (const entity of profiled.entities) {
+      const mod = entity.routerFileName.replace(/\.py$/, "");
+      expect(init.content).toContain(`from app.routers import ${mod}`);
+    }
+  });
+});

--- a/test/codegen/templates/schemas.test.ts
+++ b/test/codegen/templates/schemas.test.ts
@@ -5,6 +5,8 @@ import { parseSpec } from "#parser/index.js";
 import { buildIR } from "#ir/index.js";
 import { buildProfiledService } from "#profile/annotate.js";
 import { emitProject } from "#codegen/emit.js";
+import { TemplateEngine } from "#codegen/engine.js";
+import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
 import type { ProfiledService } from "#profile/types.js";
 
 const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
@@ -52,6 +54,25 @@ describe("schemas/entity.py template — via emitProject", () => {
     for (const field of entity.fields) {
       expect(updateBlock).toContain(`${field.columnName}: ${field.pydanticType} | None = None`);
     }
+  });
+});
+
+describe("schemas/entity.py template — id-only entity", () => {
+  it("renders `pass` for Create/Update when there are no non-id fields", () => {
+    const engine = new TemplateEngine();
+    const ctx = {
+      entity: {
+        createSchemaName: "FooCreate",
+        readSchemaName: "FooRead",
+        updateSchemaName: "FooUpdate",
+      },
+      nonIdFields: [],
+      stdlibImports: [],
+    };
+    const out = engine.render(pythonFastapiPostgresTemplates.schemaEntity, ctx);
+    expect(out).toMatch(/class FooCreate\(BaseModel\):\s+pass/);
+    expect(out).toMatch(/class FooUpdate\(BaseModel\):\s+pass/);
+    expect(out).toMatch(/class FooRead\(BaseModel\):[\s\S]*?id: int/);
   });
 });
 

--- a/test/codegen/templates/schemas.test.ts
+++ b/test/codegen/templates/schemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { emitProject } from "#codegen/emit.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+describe("schemas/entity.py template — via emitProject", () => {
+  it.each([
+    ["url_shortener.spec", "UrlMapping"],
+    ["todo_list.spec", "Todo"],
+  ])(
+    "emits Create/Read/Update classes for %s.%s",
+    (fixture, entityName) => {
+      const files = emitProject(profiledFrom(fixture));
+      const snake = entityName.replace(/([A-Z])/g, "_$1").replace(/^_/, "").toLowerCase();
+      const schema = files.find((f) => f.path === `app/schemas/${snake}.py`)!;
+      expect(schema.content).toContain(`class ${entityName}Create(BaseModel):`);
+      expect(schema.content).toContain(`class ${entityName}Read(BaseModel):`);
+      expect(schema.content).toContain(`class ${entityName}Update(BaseModel):`);
+      expect(schema.content).toContain("ConfigDict(from_attributes=True)");
+    },
+  );
+
+  it("Read schema includes `id: int` and all entity fields", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const files = emitProject(profiled);
+    const entity = profiled.entities[0];
+    const schema = files.find((f) => f.path === "app/schemas/url_mapping.py")!;
+    expect(schema.content).toMatch(/class UrlMappingRead\(BaseModel\):[\s\S]*?id: int/);
+    for (const field of entity.fields) {
+      expect(schema.content).toContain(`${field.columnName}: ${field.pydanticType}`);
+    }
+  });
+
+  it("Update schema types every field as `T | None = None`", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const files = emitProject(profiled);
+    const entity = profiled.entities[0];
+    const schema = files.find((f) => f.path === "app/schemas/url_mapping.py")!;
+    const updateBlock = schema.content.split("class UrlMappingUpdate(BaseModel):")[1];
+    for (const field of entity.fields) {
+      expect(updateBlock).toContain(`${field.columnName}: ${field.pydanticType} | None = None`);
+    }
+  });
+});
+
+describe("schemas/__init__.py template", () => {
+  it("re-exports Create/Read/Update for every entity", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    const init = files.find((f) => f.path === "app/schemas/__init__.py")!;
+    for (const entity of profiled.entities) {
+      expect(init.content).toContain(entity.createSchemaName);
+      expect(init.content).toContain(entity.readSchemaName);
+      expect(init.content).toContain(entity.updateSchemaName);
+    }
+  });
+});

--- a/test/codegen/templates/services.test.ts
+++ b/test/codegen/templates/services.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import { emitProject } from "#codegen/emit.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+describe("services/entity.py template — via emitProject", () => {
+  it("declares a service class that wraps AsyncSession", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
+    expect(svc.content).toContain("class UrlMappingService:");
+    expect(svc.content).toContain("def __init__(self, session: AsyncSession) -> None:");
+    expect(svc.content).toContain("self._session = session");
+  });
+
+  it("emits real SQL for create (insert via session.add + flush)", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
+    expect(svc.content).toContain("row = UrlMapping(**body.model_dump())");
+    expect(svc.content).toContain("self._session.add(row)");
+    expect(svc.content).toContain("await self._session.flush()");
+    expect(svc.content).toContain("UrlMappingRead.model_validate(row)");
+  });
+
+  it("emits real SQL for delete against the path-param column", () => {
+    const files = emitProject(profiledFrom("url_shortener.spec"));
+    const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
+    expect(svc.content).toContain("sa_delete(UrlMapping).where(UrlMapping.code == code)");
+    expect(svc.content).toContain("return result.rowcount > 0");
+  });
+
+  it("emits a NotImplementedError stub for non-CRUD operations (transitions)", () => {
+    const files = emitProject(profiledFrom("todo_list.spec"));
+    const svc = files.find((f) => f.path === "app/services/todo.py")!;
+    expect(svc.content).toMatch(/raise NotImplementedError\(/);
+  });
+
+  it("ecommerce produces one service file per entity, each with a class", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    for (const entity of profiled.entities) {
+      const snake = entity.modelFileName.replace(/\.py$/, "");
+      const svc = files.find((f) => f.path === `app/services/${snake}.py`);
+      expect(svc).toBeDefined();
+      expect(svc!.content).toContain(`class ${entity.entityName}Service:`);
+    }
+  });
+});
+
+describe("services/__init__.py template", () => {
+  it("re-exports every entity's *Service class", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const files = emitProject(profiled);
+    const init = files.find((f) => f.path === "app/services/__init__.py")!;
+    for (const entity of profiled.entities) {
+      expect(init.content).toContain(`${entity.entityName}Service`);
+    }
+  });
+});

--- a/test/profile/type-map.test.ts
+++ b/test/profile/type-map.test.ts
@@ -39,7 +39,7 @@ describe("primitive type mapping", () => {
     { spec: "Boolean",  python: "bool",      pydantic: "bool",      sqlalchemy: "Mapped[bool]" },
     { spec: "DateTime", python: "datetime",  pydantic: "datetime",  sqlalchemy: "Mapped[datetime]" },
     { spec: "Date",     python: "date",      pydantic: "date",      sqlalchemy: "Mapped[date]" },
-    { spec: "UUID",     python: "uuid.UUID", pydantic: "uuid.UUID", sqlalchemy: "Mapped[uuid.UUID]" },
+    { spec: "UUID",     python: "UUID",      pydantic: "UUID",      sqlalchemy: "Mapped[UUID]"     },
     { spec: "Decimal",  python: "Decimal",   pydantic: "Decimal",   sqlalchemy: "Mapped[Decimal]" },
     { spec: "Bytes",    python: "bytes",     pydantic: "bytes",     sqlalchemy: "Mapped[bytes]" },
     { spec: "Money",    python: "int",       pydantic: "int",       sqlalchemy: "Mapped[int]" },


### PR DESCRIPTION
## Summary

Closes #14. First complete template suite for the `python-fastapi-postgres` profile, built on the M3.1 engine.

- **12 `.hbs` templates** under `src/codegen/templates/python-fastapi-postgres/` covering `main.py`, `config.py`, `database.py`, per-entity `models/schemas/routers/services` + `__init__.py` re-exports
- **`emitProject(profiled: ProfiledService) → EmittedFile[]`** — library entry point, no CLI wiring yet (mirrors M3.1)
- **`src/codegen/templates.ts`** — template loader, synchronous at module init, resolves path via `import.meta.url`; build script copies `.hbs` into `dist/` so it works post-compile

### Service layer dispatch
Per-operation `routeKind` classification:
- `create` → real `session.add(row); await flush(); return Read.model_validate(row)`
- `read` / `delete` → real `select(...).where(Model.{pathParam} == {pathParam})`
- `filtered_read` / `list` → `select(Model); scalars().all()`
- `replace`, `partial_update`, `side_effect`, `transition`, `batch_mutation`, `create_child` → typed `NotImplementedError` stubs (per issue: "TODO stubs for complex ops")

### Deferred per roadmap (with issue comments)
| Concern | Ticket |
|---|---|
| alembic / migrations | #16 (M3.4) |
| Dockerfile, docker-compose, pyproject.toml, Makefile, CI | #15 (M3.5) |
| OpenAPI spec | #13 (M3.3) |
| Golden-file snapshot tests | #18 (M3.6) |
| `generate` CLI command | future |

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vitest run` — 689 tests pass (60 new: 46 per-template + 14 end-to-end)
- [x] `npm run build` — templates copy to `dist/codegen/templates/`
- [x] Python `ast.parse` subprocess check — all 55 generated `.py` files (across `url_shortener`, `todo_list`, `ecommerce` fixtures) are syntactically valid Python
- [x] `npm run cli -- inspect ...` — CLI unaffected by build-script tweak

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the first complete template suite for the `python-fastapi-postgres` profile and a library entry to emit a FastAPI + SQLAlchemy app from a spec (call `emitProject(profiled)`). Closes #14. Also improves CORS, imports, UUID/JSONB handling, and fixes id-only schema edge cases.

- **New Features**
  - 12 `.hbs` templates for `main.py`, `config.py`, `database.py`, and per-entity `models/schemas/routers/services` with `__init__.py` re-exports.
  - `emitProject(profiled: ProfiledService) → EmittedFile[]` generates an `app/` tree (library-only, no CLI).
  - Runtime template loader (`src/codegen/templates.ts`); build step copies templates to `dist/`.
  - Services: real async SQL for create/read/list/delete; other kinds emit typed `NotImplementedError` stubs.
  - Tests: per-template unit tests and end-to-end emit with Python `ast.parse` validation.

- **Bug Fixes**
  - Pre-filter `nonIdFields` to avoid empty class bodies in Create/Update schemas for id-only entities; model template updated for consistency.
  - CORS uses explicit localhost origins; `Settings` adds `extra="ignore"` and wraps `database_url` for line length.
  - Import hygiene: conditional imports for schemas, `HTTPException`/`Response`, and `select`/`sa_delete`; path-param stdlib imports; JSONB from `sqlalchemy.dialects.postgresql`.
  - Types: normalize `UUID` mapping and stdlib import (`from uuid import UUID`).
  - Template logic: avoid duplicate `id` fields; correct `Update` optionality; better route kind classification and request-body schema selection.

<sup>Written for commit 1ee521497b5b38e294a6256735cc1985e31402f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating complete Python FastAPI projects with PostgreSQL database integration, including models, schemas, routers, and service layers.
  * Generated code uses async/await patterns and modern SQLAlchemy 2.0 conventions.
  * Build process now includes template assets in distribution output.

* **Tests**
  * Added comprehensive test coverage for code generation functionality, including template rendering and generated Python syntax validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->