### PR TITLE
M3.3 — OpenAPI 3.1 spec generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,15 @@
         "antlr4ng": "^3.0.16",
         "commander": "^14.0.3",
         "consola": "^3.4.2",
-        "handlebars": "^4.7.9"
+        "handlebars": "^4.7.9",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "spec-to-rest": "dist/cli.js"
       },
       "devDependencies": {
+        "@seriousme/openapi-schema-validator": "^2.9.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.2",
         "antlr-ng": "^1.0.10",
         "prettier": "^3.8.1",
@@ -803,6 +806,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@seriousme/openapi-schema-validator": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.9.0.tgz",
+      "integrity": "sha512-bP/48Il7RMxhohq36Vg0c25tnCKOO+oEv8XSxDefuUBj0W8fYzL2Yb6C8tji0WBXykZ1S/79AWbrzGLfCG2dYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.18.0",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-formats": "^3.0.1",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "bundle-api": "bin/bundle-api-cli.js",
+        "validate-api": "bin/validate-api-cli.js"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -843,6 +863,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -969,6 +996,56 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/antlr-ng": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/antlr-ng/-/antlr-ng-1.0.10.tgz",
@@ -1003,6 +1080,12 @@
       "resolved": "https://registry.npmjs.org/antlr4ng/-/antlr4ng-3.0.16.tgz",
       "integrity": "sha512-DQuJkC7kX3xunfF4K2KsWTSvoxxslv+FQp/WHQZTJSsH2Ec3QfFmrxC3Nky2ok9yglXn6nHM4zUaVDxcN5f6kA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -1149,6 +1232,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-printf": {
       "version": "1.6.10",
       "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.10.tgz",
@@ -1158,6 +1248,23 @@
       "engines": {
         "node": ">=10.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1235,6 +1342,25 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1639,6 +1765,16 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2062,6 +2198,22 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
     "antlr4ng": "^3.0.16",
     "commander": "^14.0.3",
     "consola": "^3.4.2",
-    "handlebars": "^4.7.9"
+    "handlebars": "^4.7.9",
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
+    "@seriousme/openapi-schema-validator": "^2.9.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.2",
     "antlr-ng": "^1.0.10",
     "prettier": "^3.8.1",

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -1,4 +1,7 @@
 import { TemplateEngine } from "#codegen/engine.js";
+import { buildOpenApiDocument } from "#codegen/openapi/build.js";
+import { serializeOpenApi } from "#codegen/openapi/serialize.js";
+import { classifyRouteKind, type RouteKind } from "#codegen/route-kind.js";
 import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
 import { buildRenderContext } from "#codegen/types.js";
 import { toSnakeCase, pluralize } from "#convention/naming.js";
@@ -18,13 +21,6 @@ export interface EmittedFile {
   readonly path: string;
   readonly content: string;
 }
-
-type RouteKind =
-  | "create"
-  | "read"
-  | "list"
-  | "delete"
-  | "other";
 
 interface EnrichedPathParam {
   readonly name: string;
@@ -74,20 +70,6 @@ function pythonTypeForParam(typeExpr: TypeExpr, typeMap: ReadonlyMap<string, str
     return `${pythonTypeForParam(typeExpr.innerType, typeMap)} | None`;
   }
   return "str";
-}
-
-function classifyRouteKind(op: ProfiledOperation): RouteKind {
-  const method = op.endpoint.method;
-  const pathParamCount = op.endpoint.pathParams.length;
-  const hasPathParam = pathParamCount > 0;
-  const singlePathParam = pathParamCount === 1;
-  if (op.kind === "create") return "create";
-  if (op.kind === "read" && singlePathParam) return "read";
-  if (op.kind === "read" && !hasPathParam) return "list";
-  if (op.kind === "filtered_read" && !hasPathParam) return "list";
-  if (op.kind === "delete" && singlePathParam) return "delete";
-  if (method === "GET" && !hasPathParam) return "list";
-  return "other";
 }
 
 function buildTypeLookup(profiled: ProfiledService): ReadonlyMap<string, string> {
@@ -455,6 +437,11 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
       content: engine.render(templates.serviceEntity, serviceCtx),
     });
   }
+
+  files.push({
+    path: "openapi.yaml",
+    content: serializeOpenApi(buildOpenApiDocument(profiled)),
+  });
 
   return files;
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -11,6 +11,9 @@ export { buildRenderContext } from "#codegen/types.js";
 export { TemplateEngine } from "#codegen/engine.js";
 export { emitProject } from "#codegen/emit.js";
 export { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
+export { buildOpenApiDocument } from "#codegen/openapi/build.js";
+export { serializeOpenApi } from "#codegen/openapi/serialize.js";
+export type { OpenApiDocument, SchemaObject } from "#codegen/openapi/types.js";
 export {
   registerHelpers,
   snakeCaseHelper,

--- a/src/codegen/openapi/build.ts
+++ b/src/codegen/openapi/build.ts
@@ -1,0 +1,43 @@
+import { buildComponents, type BuildContext } from "#codegen/openapi/components.js";
+import { buildPaths } from "#codegen/openapi/paths.js";
+import type { OpenApiDocument, TagObject } from "#codegen/openapi/types.js";
+import { toSnakeCase } from "#convention/naming.js";
+import type { EntityDecl, EnumDecl, TypeAliasDecl } from "#ir/types.js";
+import type { ProfiledService } from "#profile/types.js";
+
+export function buildOpenApiDocument(profiled: ProfiledService): OpenApiDocument {
+  const aliasMap: ReadonlyMap<string, TypeAliasDecl> = new Map(
+    profiled.ir.typeAliases.map((a) => [a.name, a]),
+  );
+  const enumMap: ReadonlyMap<string, EnumDecl> = new Map(
+    profiled.ir.enums.map((e) => [e.name, e]),
+  );
+  const entityDecls: ReadonlyMap<string, EntityDecl> = new Map(
+    profiled.ir.entities.map((e) => [e.name, e]),
+  );
+  const entityNames: ReadonlySet<string> = new Set(profiled.entities.map((e) => e.entityName));
+
+  const ctx: BuildContext = { aliasMap, enumMap, entityNames, entityDecls };
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: profiled.ir.name,
+      version: "0.1.0",
+      description: `API for ${profiled.ir.name}. Generated from formal specification.`,
+    },
+    servers: [{ url: "http://localhost:8000", description: "Local development" }],
+    paths: buildPaths(profiled, ctx),
+    components: buildComponents(profiled, ctx),
+    tags: buildTags(profiled),
+  };
+}
+
+function buildTags(profiled: ProfiledService): readonly TagObject[] {
+  const tags: TagObject[] = profiled.entities.map((e) => ({
+    name: toSnakeCase(e.entityName),
+    description: `${e.entityName} operations`,
+  }));
+  tags.push({ name: "infrastructure", description: "Health and metrics endpoints" });
+  return tags;
+}

--- a/src/codegen/openapi/components.ts
+++ b/src/codegen/openapi/components.ts
@@ -1,11 +1,9 @@
-import { fieldToSchema } from "#codegen/openapi/schema.js";
+import { fieldToSchema, makeNullable } from "#codegen/openapi/schema.js";
 import type { ComponentsObject, SchemaObject } from "#codegen/openapi/types.js";
 import type {
   EntityDecl,
   EnumDecl,
-  FieldDecl,
   TypeAliasDecl,
-  TypeExpr,
 } from "#ir/types.js";
 import type { ProfiledEntity, ProfiledService } from "#profile/types.js";
 
@@ -28,7 +26,7 @@ export function buildComponents(
     const entityDecl = ctx.entityDecls.get(entity.entityName);
     if (entityDecl === undefined) continue;
 
-    const decoratedFields = decorateFields(entityDecl.fields, ctx);
+    const decoratedFields = decorateFields(entity, entityDecl, ctx);
     schemas[entity.createSchemaName] = createSchemaObject(decoratedFields, entity);
     schemas[entity.readSchemaName] = readSchemaObject(decoratedFields, entity);
     schemas[entity.updateSchemaName] = updateSchemaObject(decoratedFields, entity);
@@ -44,37 +42,29 @@ interface DecoratedField {
 }
 
 function decorateFields(
-  fields: readonly FieldDecl[],
+  entity: ProfiledEntity,
+  entityDecl: EntityDecl,
   ctx: BuildContext,
 ): readonly DecoratedField[] {
-  return fields.map((field) => {
+  return entity.fields.map((profiled, index) => {
+    const decl = entityDecl.fields[index];
     const { schema, nullable } = fieldToSchema({
-      typeExpr: field.typeExpr,
-      constraint: field.constraint,
+      typeExpr: decl.typeExpr,
+      constraint: decl.constraint,
       aliasMap: ctx.aliasMap,
       enumMap: ctx.enumMap,
       entityNames: ctx.entityNames,
     });
-    const columnName = toColumnName(field.name, field.typeExpr, ctx.entityNames);
-    return { name: columnName, schema, nullable };
+    return { name: profiled.columnName, schema, nullable };
   });
-}
-
-function toColumnName(
-  fieldName: string,
-  typeExpr: TypeExpr,
-  entityNames: ReadonlySet<string>,
-): string {
-  const effectiveType =
-    typeExpr.kind === "OptionType" ? typeExpr.innerType : typeExpr;
-  if (effectiveType.kind === "NamedType" && entityNames.has(effectiveType.name)) {
-    return `${fieldName}_id`;
-  }
-  return fieldName;
 }
 
 function nonIdFields(fields: readonly DecoratedField[]): readonly DecoratedField[] {
   return fields.filter((f) => f.name !== "id");
+}
+
+function fieldProperty(f: DecoratedField): SchemaObject {
+  return f.nullable ? makeNullable(f.schema) : f.schema;
 }
 
 function createSchemaObject(
@@ -86,7 +76,7 @@ function createSchemaObject(
     type: "object",
     description: `Create payload for ${entity.entityName}`,
     required: fs.filter((f) => !f.nullable).map((f) => f.name),
-    properties: Object.fromEntries(fs.map((f) => [f.name, f.schema])),
+    properties: Object.fromEntries(fs.map((f) => [f.name, fieldProperty(f)])),
   };
 }
 
@@ -96,7 +86,7 @@ function readSchemaObject(
 ): SchemaObject {
   const fs = nonIdFields(fields);
   const props: Record<string, SchemaObject> = { id: { type: "integer" } };
-  for (const f of fs) props[f.name] = f.schema;
+  for (const f of fs) props[f.name] = fieldProperty(f);
   return {
     type: "object",
     description: `Read view for ${entity.entityName}`,
@@ -114,7 +104,7 @@ function updateSchemaObject(
     type: "object",
     description: `Update payload for ${entity.entityName}`,
     properties: Object.fromEntries(
-      fs.map((f) => [f.name, { ...f.schema, nullable: true }]),
+      fs.map((f) => [f.name, makeNullable(f.schema)]),
     ),
   };
 }

--- a/src/codegen/openapi/components.ts
+++ b/src/codegen/openapi/components.ts
@@ -1,0 +1,131 @@
+import { fieldToSchema } from "#codegen/openapi/schema.js";
+import type { ComponentsObject, SchemaObject } from "#codegen/openapi/types.js";
+import type {
+  EntityDecl,
+  EnumDecl,
+  FieldDecl,
+  TypeAliasDecl,
+  TypeExpr,
+} from "#ir/types.js";
+import type { ProfiledEntity, ProfiledService } from "#profile/types.js";
+
+export interface BuildContext {
+  readonly aliasMap: ReadonlyMap<string, TypeAliasDecl>;
+  readonly enumMap: ReadonlyMap<string, EnumDecl>;
+  readonly entityNames: ReadonlySet<string>;
+  readonly entityDecls: ReadonlyMap<string, EntityDecl>;
+}
+
+export function buildComponents(
+  profiled: ProfiledService,
+  ctx: BuildContext,
+): ComponentsObject {
+  const schemas: Record<string, SchemaObject> = {
+    ErrorResponse: errorResponseSchema(),
+  };
+
+  for (const entity of profiled.entities) {
+    const entityDecl = ctx.entityDecls.get(entity.entityName);
+    if (entityDecl === undefined) continue;
+
+    const decoratedFields = decorateFields(entityDecl.fields, ctx);
+    schemas[entity.createSchemaName] = createSchemaObject(decoratedFields, entity);
+    schemas[entity.readSchemaName] = readSchemaObject(decoratedFields, entity);
+    schemas[entity.updateSchemaName] = updateSchemaObject(decoratedFields, entity);
+  }
+
+  return { schemas };
+}
+
+interface DecoratedField {
+  readonly name: string;
+  readonly schema: SchemaObject;
+  readonly nullable: boolean;
+}
+
+function decorateFields(
+  fields: readonly FieldDecl[],
+  ctx: BuildContext,
+): readonly DecoratedField[] {
+  return fields.map((field) => {
+    const { schema, nullable } = fieldToSchema({
+      typeExpr: field.typeExpr,
+      constraint: field.constraint,
+      aliasMap: ctx.aliasMap,
+      enumMap: ctx.enumMap,
+      entityNames: ctx.entityNames,
+    });
+    const columnName = toColumnName(field.name, field.typeExpr, ctx.entityNames);
+    return { name: columnName, schema, nullable };
+  });
+}
+
+function toColumnName(
+  fieldName: string,
+  typeExpr: TypeExpr,
+  entityNames: ReadonlySet<string>,
+): string {
+  const effectiveType =
+    typeExpr.kind === "OptionType" ? typeExpr.innerType : typeExpr;
+  if (effectiveType.kind === "NamedType" && entityNames.has(effectiveType.name)) {
+    return `${fieldName}_id`;
+  }
+  return fieldName;
+}
+
+function nonIdFields(fields: readonly DecoratedField[]): readonly DecoratedField[] {
+  return fields.filter((f) => f.name !== "id");
+}
+
+function createSchemaObject(
+  fields: readonly DecoratedField[],
+  entity: ProfiledEntity,
+): SchemaObject {
+  const fs = nonIdFields(fields);
+  return {
+    type: "object",
+    description: `Create payload for ${entity.entityName}`,
+    required: fs.filter((f) => !f.nullable).map((f) => f.name),
+    properties: Object.fromEntries(fs.map((f) => [f.name, f.schema])),
+  };
+}
+
+function readSchemaObject(
+  fields: readonly DecoratedField[],
+  entity: ProfiledEntity,
+): SchemaObject {
+  const fs = nonIdFields(fields);
+  const props: Record<string, SchemaObject> = { id: { type: "integer" } };
+  for (const f of fs) props[f.name] = f.schema;
+  return {
+    type: "object",
+    description: `Read view for ${entity.entityName}`,
+    required: ["id", ...fs.filter((f) => !f.nullable).map((f) => f.name)],
+    properties: props,
+  };
+}
+
+function updateSchemaObject(
+  fields: readonly DecoratedField[],
+  entity: ProfiledEntity,
+): SchemaObject {
+  const fs = nonIdFields(fields);
+  return {
+    type: "object",
+    description: `Update payload for ${entity.entityName}`,
+    properties: Object.fromEntries(
+      fs.map((f) => [f.name, { ...f.schema, nullable: true }]),
+    ),
+  };
+}
+
+function errorResponseSchema(): SchemaObject {
+  return {
+    type: "object",
+    description: "Standard error response body",
+    required: ["detail"],
+    properties: {
+      detail: { type: "string", description: "Human-readable error description" },
+    },
+  };
+}

--- a/src/codegen/openapi/constraints.ts
+++ b/src/codegen/openapi/constraints.ts
@@ -98,22 +98,24 @@ function applyComparison(
 }
 
 function applyLengthBound(op: string, n: number, out: MutableConstraints): void {
+  if (!Number.isInteger(n) || n < 0) return;
   switch (op) {
     case ">=":
-      out.minLength = n;
+      tightenLower(out, "minLength", n);
       return;
     case "<=":
-      out.maxLength = n;
+      tightenUpper(out, "maxLength", n);
       return;
     case ">":
-      out.minLength = n + 1;
+      tightenLower(out, "minLength", n + 1);
       return;
     case "<":
-      out.maxLength = n - 1;
+      if (n - 1 < 0) return;
+      tightenUpper(out, "maxLength", n - 1);
       return;
     case "=":
-      out.minLength = n;
-      out.maxLength = n;
+      tightenLower(out, "minLength", n);
+      tightenUpper(out, "maxLength", n);
       return;
   }
 }
@@ -121,22 +123,40 @@ function applyLengthBound(op: string, n: number, out: MutableConstraints): void 
 function applyNumericBound(op: string, n: number, out: MutableConstraints): void {
   switch (op) {
     case ">=":
-      out.minimum = n;
+      tightenLower(out, "minimum", n);
       return;
     case "<=":
-      out.maximum = n;
+      tightenUpper(out, "maximum", n);
       return;
     case ">":
-      out.exclusiveMinimum = n;
+      tightenLower(out, "exclusiveMinimum", n);
       return;
     case "<":
-      out.exclusiveMaximum = n;
+      tightenUpper(out, "exclusiveMaximum", n);
       return;
     case "=":
-      out.minimum = n;
-      out.maximum = n;
+      tightenLower(out, "minimum", n);
+      tightenUpper(out, "maximum", n);
       return;
   }
+}
+
+function tightenLower<K extends "minLength" | "minimum" | "exclusiveMinimum">(
+  out: MutableConstraints,
+  key: K,
+  n: number,
+): void {
+  const current = out[key];
+  out[key] = current === undefined ? n : Math.max(current, n);
+}
+
+function tightenUpper<K extends "maxLength" | "maximum" | "exclusiveMaximum">(
+  out: MutableConstraints,
+  key: K,
+  n: number,
+): void {
+  const current = out[key];
+  out[key] = current === undefined ? n : Math.min(current, n);
 }
 
 function isLenCall(expr: Expr): boolean {

--- a/src/codegen/openapi/constraints.ts
+++ b/src/codegen/openapi/constraints.ts
@@ -1,0 +1,158 @@
+import type { EnumDecl, Expr, TypeAliasDecl, TypeExpr } from "#ir/types.js";
+
+export interface JsonSchemaConstraints {
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minimum?: number;
+  readonly maximum?: number;
+  readonly exclusiveMinimum?: number;
+  readonly exclusiveMaximum?: number;
+  readonly pattern?: string;
+  readonly enum?: readonly string[];
+}
+
+interface MutableConstraints {
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  pattern?: string;
+  enum?: readonly string[];
+}
+
+export function extractFieldConstraints(
+  typeExpr: TypeExpr,
+  constraint: Expr | null,
+  aliasMap: ReadonlyMap<string, TypeAliasDecl>,
+  enumMap: ReadonlyMap<string, EnumDecl>,
+): JsonSchemaConstraints {
+  const out: MutableConstraints = {};
+  collectFromType(typeExpr, aliasMap, enumMap, out);
+  if (constraint !== null) {
+    visitConstraint(constraint, out);
+  }
+  return out;
+}
+
+function collectFromType(
+  typeExpr: TypeExpr,
+  aliasMap: ReadonlyMap<string, TypeAliasDecl>,
+  enumMap: ReadonlyMap<string, EnumDecl>,
+  out: MutableConstraints,
+): void {
+  if (typeExpr.kind === "OptionType") {
+    collectFromType(typeExpr.innerType, aliasMap, enumMap, out);
+    return;
+  }
+  if (typeExpr.kind !== "NamedType") return;
+
+  const enumDecl = enumMap.get(typeExpr.name);
+  if (enumDecl !== undefined) {
+    out.enum = [...enumDecl.values];
+    return;
+  }
+
+  const alias = aliasMap.get(typeExpr.name);
+  if (alias === undefined) return;
+
+  collectFromType(alias.typeExpr, aliasMap, enumMap, out);
+  if (alias.constraint !== null) {
+    visitConstraint(alias.constraint, out);
+  }
+}
+
+function visitConstraint(expr: Expr, out: MutableConstraints): void {
+  if (expr.kind === "BinaryOp" && expr.op === "and") {
+    visitConstraint(expr.left, out);
+    visitConstraint(expr.right, out);
+    return;
+  }
+
+  if (expr.kind === "Matches" && isValueRef(expr.expr)) {
+    out.pattern = expr.pattern;
+    return;
+  }
+
+  if (expr.kind === "BinaryOp") {
+    applyComparison(expr, out);
+  }
+}
+
+function applyComparison(
+  expr: Expr & { kind: "BinaryOp" },
+  out: MutableConstraints,
+): void {
+  const right = literalNumber(expr.right);
+  if (right === null) return;
+
+  if (isLenCall(expr.left)) {
+    applyLengthBound(expr.op, right, out);
+    return;
+  }
+
+  if (isValueRef(expr.left)) {
+    applyNumericBound(expr.op, right, out);
+  }
+}
+
+function applyLengthBound(op: string, n: number, out: MutableConstraints): void {
+  switch (op) {
+    case ">=":
+      out.minLength = n;
+      return;
+    case "<=":
+      out.maxLength = n;
+      return;
+    case ">":
+      out.minLength = n + 1;
+      return;
+    case "<":
+      out.maxLength = n - 1;
+      return;
+    case "=":
+      out.minLength = n;
+      out.maxLength = n;
+      return;
+  }
+}
+
+function applyNumericBound(op: string, n: number, out: MutableConstraints): void {
+  switch (op) {
+    case ">=":
+      out.minimum = n;
+      return;
+    case "<=":
+      out.maximum = n;
+      return;
+    case ">":
+      out.exclusiveMinimum = n;
+      return;
+    case "<":
+      out.exclusiveMaximum = n;
+      return;
+    case "=":
+      out.minimum = n;
+      out.maximum = n;
+      return;
+  }
+}
+
+function isLenCall(expr: Expr): boolean {
+  return (
+    expr.kind === "Call" &&
+    expr.callee.kind === "Identifier" &&
+    expr.callee.name === "len"
+  );
+}
+
+function isValueRef(expr: Expr): boolean {
+  return expr.kind === "Identifier" && expr.name === "value";
+}
+
+function literalNumber(expr: Expr): number | null {
+  if (expr.kind === "IntLit") return expr.value;
+  if (expr.kind === "FloatLit") return expr.value;
+  return null;
+}

--- a/src/codegen/openapi/paths.ts
+++ b/src/codegen/openapi/paths.ts
@@ -1,5 +1,5 @@
 import type { BuildContext } from "#codegen/openapi/components.js";
-import { fieldToSchema } from "#codegen/openapi/schema.js";
+import { fieldToSchema, makeNullable } from "#codegen/openapi/schema.js";
 import type {
   MediaTypeObject,
   OperationObject,
@@ -30,16 +30,18 @@ export function buildPaths(
   );
 
   for (const op of profiled.operations) {
-    const entity = op.targetEntity ? entityByName.get(op.targetEntity) : undefined;
+    if (op.targetEntity === null) continue;
+    const entity = entityByName.get(op.targetEntity);
+    if (entity === undefined) continue;
     const operation = buildOperation(op, entity, ctx);
-    const current = paths[op.endpoint.path] ?? {};
     paths[op.endpoint.path] = {
-      ...current,
+      ...(paths[op.endpoint.path] ?? {}),
       [methodKey(op.endpoint.method)]: operation,
     };
   }
 
   paths["/health"] = {
+    ...(paths["/health"] ?? {}),
     get: {
       operationId: "health_check",
       summary: "Health check",
@@ -71,7 +73,7 @@ function methodKey(method: HttpMethod): keyof PathItemObject {
 
 function buildOperation(
   op: ProfiledOperation,
-  entity: ProfiledEntity | undefined,
+  entity: ProfiledEntity,
   ctx: BuildContext,
 ): OperationObject {
   const routeKind = classifyRouteKind(op);
@@ -79,20 +81,14 @@ function buildOperation(
   const requestBody = buildRequestBody(op, entity, routeKind, ctx);
   const responses = buildResponses(op, entity, routeKind);
 
-  const operation: OperationObject = {
+  return {
     operationId: op.handlerName,
     summary: op.operationName,
-    tags: [operationTag(op)],
+    tags: [toSnakeCase(entity.entityName)],
     responses,
     ...(parameters.length > 0 ? { parameters } : {}),
     ...(requestBody !== null ? { requestBody } : {}),
   };
-  return operation;
-}
-
-function operationTag(op: ProfiledOperation): string {
-  if (op.targetEntity === null) return "infrastructure";
-  return toSnakeCase(op.targetEntity);
 }
 
 function buildParameters(
@@ -114,7 +110,7 @@ function paramObject(
   location: "path" | "query",
   ctx: BuildContext,
 ): ParameterObject {
-  const { schema } = fieldToSchema({
+  const { schema, nullable } = fieldToSchema({
     typeExpr: p.typeExpr,
     aliasMap: ctx.aliasMap,
     enumMap: ctx.enumMap,
@@ -124,13 +120,13 @@ function paramObject(
     name: p.name,
     in: location,
     required: location === "path" ? true : p.required,
-    schema,
+    schema: nullable ? makeNullable(schema) : schema,
   };
 }
 
 function buildRequestBody(
   op: ProfiledOperation,
-  entity: ProfiledEntity | undefined,
+  entity: ProfiledEntity,
   routeKind: RouteKind,
   ctx: BuildContext,
 ): RequestBodyObject | null {
@@ -141,10 +137,10 @@ function buildRequestBody(
     return null;
   }
 
-  if (entity !== undefined && (routeKind === "create" || op.kind === "create")) {
+  if (routeKind === "create" || op.kind === "create") {
     return componentBody(entity.createSchemaName);
   }
-  if (entity !== undefined && (op.kind === "replace" || op.kind === "partial_update")) {
+  if (op.kind === "replace" || op.kind === "partial_update") {
     return componentBody(entity.updateSchemaName);
   }
 
@@ -183,8 +179,8 @@ function inlineBodySchema(
       enumMap: ctx.enumMap,
       entityNames: ctx.entityNames,
     });
-    properties[p.name] = schema;
-    if (p.required && !nullable) required.push(p.name);
+    properties[p.name] = nullable ? makeNullable(schema) : schema;
+    if (p.required) required.push(p.name);
   }
   return {
     type: "object",
@@ -195,7 +191,7 @@ function inlineBodySchema(
 
 function buildResponses(
   op: ProfiledOperation,
-  entity: ProfiledEntity | undefined,
+  entity: ProfiledEntity,
   routeKind: RouteKind,
 ): ResponsesObject {
   const status = String(op.endpoint.successStatus);
@@ -228,7 +224,7 @@ function buildResponses(
 
 function buildSuccessResponse(
   op: ProfiledOperation,
-  entity: ProfiledEntity | undefined,
+  entity: ProfiledEntity,
   routeKind: RouteKind,
 ): ResponseObject {
   if (op.endpoint.successStatus === 204) {
@@ -246,23 +242,21 @@ function buildSuccessResponse(
     };
   }
 
-  if (entity !== undefined) {
-    if (routeKind === "list") {
-      return jsonResponse("Successful response", {
-        type: "array",
-        items: { $ref: `#/components/schemas/${entity.readSchemaName}` },
-      });
-    }
-    if (routeKind === "create" || routeKind === "read") {
-      return jsonResponse("Successful response", {
-        $ref: `#/components/schemas/${entity.readSchemaName}`,
-      });
-    }
-    if (op.kind === "replace" || op.kind === "partial_update") {
-      return jsonResponse("Successful response", {
-        $ref: `#/components/schemas/${entity.readSchemaName}`,
-      });
-    }
+  if (routeKind === "list") {
+    return jsonResponse("Successful response", {
+      type: "array",
+      items: { $ref: `#/components/schemas/${entity.readSchemaName}` },
+    });
+  }
+  if (
+    routeKind === "create" ||
+    routeKind === "read" ||
+    op.kind === "replace" ||
+    op.kind === "partial_update"
+  ) {
+    return jsonResponse("Successful response", {
+      $ref: `#/components/schemas/${entity.readSchemaName}`,
+    });
   }
 
   return { description: "Successful response" };

--- a/src/codegen/openapi/paths.ts
+++ b/src/codegen/openapi/paths.ts
@@ -1,0 +1,286 @@
+import type { BuildContext } from "#codegen/openapi/components.js";
+import { fieldToSchema } from "#codegen/openapi/schema.js";
+import type {
+  MediaTypeObject,
+  OperationObject,
+  ParameterObject,
+  PathItemObject,
+  RequestBodyObject,
+  ResponseObject,
+  ResponsesObject,
+  SchemaObject,
+} from "#codegen/openapi/types.js";
+import { classifyRouteKind, type RouteKind } from "#codegen/route-kind.js";
+import { toSnakeCase } from "#convention/naming.js";
+import type { HttpMethod, ParamSpec } from "#convention/types.js";
+import type {
+  ProfiledEntity,
+  ProfiledOperation,
+  ProfiledService,
+} from "#profile/types.js";
+
+export function buildPaths(
+  profiled: ProfiledService,
+  ctx: BuildContext,
+): Readonly<Record<string, PathItemObject>> {
+  const paths: Record<string, PathItemObject> = {};
+
+  const entityByName = new Map(
+    profiled.entities.map((e) => [e.entityName, e] as const),
+  );
+
+  for (const op of profiled.operations) {
+    const entity = op.targetEntity ? entityByName.get(op.targetEntity) : undefined;
+    const operation = buildOperation(op, entity, ctx);
+    const current = paths[op.endpoint.path] ?? {};
+    paths[op.endpoint.path] = {
+      ...current,
+      [methodKey(op.endpoint.method)]: operation,
+    };
+  }
+
+  paths["/health"] = {
+    get: {
+      operationId: "health_check",
+      summary: "Health check",
+      description: "Returns 200 if the service is running.",
+      tags: ["infrastructure"],
+      responses: {
+        "200": {
+          description: "Service is healthy",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["status"],
+                properties: { status: { type: "string", enum: ["ok"] } },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  return paths;
+}
+
+function methodKey(method: HttpMethod): keyof PathItemObject {
+  return method.toLowerCase() as keyof PathItemObject;
+}
+
+function buildOperation(
+  op: ProfiledOperation,
+  entity: ProfiledEntity | undefined,
+  ctx: BuildContext,
+): OperationObject {
+  const routeKind = classifyRouteKind(op);
+  const parameters = buildParameters(op, ctx);
+  const requestBody = buildRequestBody(op, entity, routeKind, ctx);
+  const responses = buildResponses(op, entity, routeKind);
+
+  const operation: OperationObject = {
+    operationId: op.handlerName,
+    summary: op.operationName,
+    tags: [operationTag(op)],
+    responses,
+    ...(parameters.length > 0 ? { parameters } : {}),
+    ...(requestBody !== null ? { requestBody } : {}),
+  };
+  return operation;
+}
+
+function operationTag(op: ProfiledOperation): string {
+  if (op.targetEntity === null) return "infrastructure";
+  return toSnakeCase(op.targetEntity);
+}
+
+function buildParameters(
+  op: ProfiledOperation,
+  ctx: BuildContext,
+): readonly ParameterObject[] {
+  const out: ParameterObject[] = [];
+  for (const p of op.endpoint.pathParams) {
+    out.push(paramObject(p, "path", ctx));
+  }
+  for (const p of op.endpoint.queryParams) {
+    out.push(paramObject(p, "query", ctx));
+  }
+  return out;
+}
+
+function paramObject(
+  p: ParamSpec,
+  location: "path" | "query",
+  ctx: BuildContext,
+): ParameterObject {
+  const { schema } = fieldToSchema({
+    typeExpr: p.typeExpr,
+    aliasMap: ctx.aliasMap,
+    enumMap: ctx.enumMap,
+    entityNames: ctx.entityNames,
+  });
+  return {
+    name: p.name,
+    in: location,
+    required: location === "path" ? true : p.required,
+    schema,
+  };
+}
+
+function buildRequestBody(
+  op: ProfiledOperation,
+  entity: ProfiledEntity | undefined,
+  routeKind: RouteKind,
+  ctx: BuildContext,
+): RequestBodyObject | null {
+  if (op.endpoint.method === "GET" || op.endpoint.method === "DELETE") {
+    return null;
+  }
+  if (op.endpoint.bodyParams.length === 0) {
+    return null;
+  }
+
+  if (entity !== undefined && (routeKind === "create" || op.kind === "create")) {
+    return componentBody(entity.createSchemaName);
+  }
+  if (entity !== undefined && (op.kind === "replace" || op.kind === "partial_update")) {
+    return componentBody(entity.updateSchemaName);
+  }
+
+  const inline = inlineBodySchema(op, ctx);
+  if (inline === null) return null;
+  return {
+    required: true,
+    content: { "application/json": { schema: inline } },
+  };
+}
+
+function componentBody(schemaName: string): RequestBodyObject {
+  return {
+    required: true,
+    content: {
+      "application/json": {
+        schema: { $ref: `#/components/schemas/${schemaName}` },
+      },
+    },
+  };
+}
+
+function inlineBodySchema(
+  op: ProfiledOperation,
+  ctx: BuildContext,
+): SchemaObject | null {
+  const params = op.endpoint.bodyParams;
+  if (params.length === 0) return null;
+
+  const properties: Record<string, SchemaObject> = {};
+  const required: string[] = [];
+  for (const p of params) {
+    const { schema, nullable } = fieldToSchema({
+      typeExpr: p.typeExpr,
+      aliasMap: ctx.aliasMap,
+      enumMap: ctx.enumMap,
+      entityNames: ctx.entityNames,
+    });
+    properties[p.name] = schema;
+    if (p.required && !nullable) required.push(p.name);
+  }
+  return {
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+  };
+}
+
+function buildResponses(
+  op: ProfiledOperation,
+  entity: ProfiledEntity | undefined,
+  routeKind: RouteKind,
+): ResponsesObject {
+  const status = String(op.endpoint.successStatus);
+  const success = buildSuccessResponse(op, entity, routeKind);
+  const responses: Record<string, ResponseObject> = { [status]: success };
+
+  const hasPathParam = op.endpoint.pathParams.length > 0;
+  const needs404 =
+    hasPathParam &&
+    (op.kind === "read" ||
+      op.kind === "delete" ||
+      op.kind === "replace" ||
+      op.kind === "partial_update" ||
+      op.kind === "transition" ||
+      op.kind === "create_child");
+  if (needs404) {
+    responses["404"] = errorResponseRef("Resource not found");
+  }
+
+  const acceptsInput =
+    op.endpoint.bodyParams.length > 0 ||
+    op.endpoint.queryParams.length > 0 ||
+    op.endpoint.pathParams.length > 0;
+  if (acceptsInput) {
+    responses["422"] = errorResponseRef("Validation error");
+  }
+
+  return responses;
+}
+
+function buildSuccessResponse(
+  op: ProfiledOperation,
+  entity: ProfiledEntity | undefined,
+  routeKind: RouteKind,
+): ResponseObject {
+  if (op.endpoint.successStatus === 204) {
+    return { description: "No content" };
+  }
+  if (op.endpoint.successStatus >= 300 && op.endpoint.successStatus < 400) {
+    return {
+      description: "Redirect",
+      headers: {
+        Location: {
+          description: "Target URL",
+          schema: { type: "string", format: "uri" },
+        },
+      },
+    };
+  }
+
+  if (entity !== undefined) {
+    if (routeKind === "list") {
+      return jsonResponse("Successful response", {
+        type: "array",
+        items: { $ref: `#/components/schemas/${entity.readSchemaName}` },
+      });
+    }
+    if (routeKind === "create" || routeKind === "read") {
+      return jsonResponse("Successful response", {
+        $ref: `#/components/schemas/${entity.readSchemaName}`,
+      });
+    }
+    if (op.kind === "replace" || op.kind === "partial_update") {
+      return jsonResponse("Successful response", {
+        $ref: `#/components/schemas/${entity.readSchemaName}`,
+      });
+    }
+  }
+
+  return { description: "Successful response" };
+}
+
+function jsonResponse(description: string, schema: SchemaObject): ResponseObject {
+  return {
+    description,
+    content: { "application/json": { schema } },
+  };
+}
+
+function errorResponseRef(description: string): ResponseObject {
+  const media: MediaTypeObject = {
+    schema: { $ref: "#/components/schemas/ErrorResponse" },
+  };
+  return {
+    description,
+    content: { "application/json": media },
+  };
+}

--- a/src/codegen/openapi/schema.ts
+++ b/src/codegen/openapi/schema.ts
@@ -1,0 +1,110 @@
+import {
+  extractFieldConstraints,
+  type JsonSchemaConstraints,
+} from "#codegen/openapi/constraints.js";
+import type { SchemaObject } from "#codegen/openapi/types.js";
+import type { EnumDecl, Expr, TypeAliasDecl, TypeExpr } from "#ir/types.js";
+
+interface FieldToSchemaInput {
+  readonly typeExpr: TypeExpr;
+  readonly constraint?: Expr | null;
+  readonly aliasMap: ReadonlyMap<string, TypeAliasDecl>;
+  readonly enumMap: ReadonlyMap<string, EnumDecl>;
+  readonly entityNames: ReadonlySet<string>;
+}
+
+export interface FieldSchema {
+  readonly schema: SchemaObject;
+  readonly nullable: boolean;
+}
+
+export function fieldToSchema(input: FieldToSchemaInput): FieldSchema {
+  const nullable = isOptionType(input.typeExpr);
+  const effectiveType = nullable
+    ? (input.typeExpr as { innerType: TypeExpr }).innerType
+    : input.typeExpr;
+  const constraints = extractFieldConstraints(
+    effectiveType,
+    input.constraint ?? null,
+    input.aliasMap,
+    input.enumMap,
+  );
+  const schema = typeExprToSchema(effectiveType, constraints, input);
+  return { schema: nullable ? { ...schema, nullable: true } : schema, nullable };
+}
+
+function isOptionType(t: TypeExpr): boolean {
+  return t.kind === "OptionType";
+}
+
+function typeExprToSchema(
+  typeExpr: TypeExpr,
+  constraints: JsonSchemaConstraints,
+  input: FieldToSchemaInput,
+): SchemaObject {
+  switch (typeExpr.kind) {
+    case "NamedType":
+      return namedTypeSchema(typeExpr.name, constraints, input);
+
+    case "SetType":
+    case "SeqType": {
+      const inner = fieldToSchema({
+        typeExpr: typeExpr.elementType,
+        aliasMap: input.aliasMap,
+        enumMap: input.enumMap,
+        entityNames: input.entityNames,
+      });
+      return { type: "array", items: inner.schema };
+    }
+
+    case "MapType":
+      return { type: "object" };
+
+    case "OptionType":
+      return typeExprToSchema(typeExpr.innerType, constraints, input);
+
+    case "RelationType":
+      return { type: "integer" };
+  }
+}
+
+function namedTypeSchema(
+  name: string,
+  constraints: JsonSchemaConstraints,
+  input: FieldToSchemaInput,
+): SchemaObject {
+  const primitive = PRIMITIVE_SCHEMAS.get(name);
+  if (primitive !== undefined) {
+    return { ...primitive, ...constraints };
+  }
+
+  const enumDecl = input.enumMap.get(name);
+  if (enumDecl !== undefined) {
+    return { type: "string", enum: [...enumDecl.values] };
+  }
+
+  if (input.entityNames.has(name)) {
+    return { $ref: `#/components/schemas/${name}Read` };
+  }
+
+  const alias = input.aliasMap.get(name);
+  if (alias !== undefined) {
+    return typeExprToSchema(alias.typeExpr, constraints, input);
+  }
+
+  return { type: "string", ...constraints };
+}
+
+const PRIMITIVE_SCHEMAS: ReadonlyMap<string, SchemaObject> = new Map([
+  ["String", { type: "string" }],
+  ["Int", { type: "integer" }],
+  ["Float", { type: "number" }],
+  ["Bool", { type: "boolean" }],
+  ["Boolean", { type: "boolean" }],
+  ["DateTime", { type: "string", format: "date-time" }],
+  ["Date", { type: "string", format: "date" }],
+  ["UUID", { type: "string", format: "uuid" }],
+  ["Decimal", { type: "string", format: "decimal" }],
+  ["Bytes", { type: "string", format: "byte" }],
+  ["Money", { type: "integer" }],
+]);

--- a/src/codegen/openapi/schema.ts
+++ b/src/codegen/openapi/schema.ts
@@ -2,7 +2,7 @@ import {
   extractFieldConstraints,
   type JsonSchemaConstraints,
 } from "#codegen/openapi/constraints.js";
-import type { SchemaObject } from "#codegen/openapi/types.js";
+import type { OpenApiSchemaType, SchemaObject } from "#codegen/openapi/types.js";
 import type { EnumDecl, Expr, TypeAliasDecl, TypeExpr } from "#ir/types.js";
 
 interface FieldToSchemaInput {
@@ -19,9 +19,9 @@ export interface FieldSchema {
 }
 
 export function fieldToSchema(input: FieldToSchemaInput): FieldSchema {
-  const nullable = isOptionType(input.typeExpr);
+  const nullable = input.typeExpr.kind === "OptionType";
   const effectiveType = nullable
-    ? (input.typeExpr as { innerType: TypeExpr }).innerType
+    ? (input.typeExpr as { readonly innerType: TypeExpr }).innerType
     : input.typeExpr;
   const constraints = extractFieldConstraints(
     effectiveType,
@@ -29,12 +29,20 @@ export function fieldToSchema(input: FieldToSchemaInput): FieldSchema {
     input.aliasMap,
     input.enumMap,
   );
-  const schema = typeExprToSchema(effectiveType, constraints, input);
-  return { schema: nullable ? { ...schema, nullable: true } : schema, nullable };
+  return { schema: typeExprToSchema(effectiveType, constraints, input), nullable };
 }
 
-function isOptionType(t: TypeExpr): boolean {
-  return t.kind === "OptionType";
+export function makeNullable(schema: SchemaObject): SchemaObject {
+  if (schema.$ref !== undefined) {
+    return { anyOf: [schema, { type: "null" }] };
+  }
+  const { type } = schema;
+  if (type === undefined) {
+    return { anyOf: [schema, { type: "null" }] };
+  }
+  const current: readonly OpenApiSchemaType[] = Array.isArray(type) ? type : [type];
+  if (current.includes("null")) return schema;
+  return { ...schema, type: [...current, "null"] };
 }
 
 function typeExprToSchema(
@@ -54,11 +62,18 @@ function typeExprToSchema(
         enumMap: input.enumMap,
         entityNames: input.entityNames,
       });
-      return { type: "array", items: inner.schema };
+      return { type: "array", items: inner.schema, ...arrayBoundsFrom(constraints) };
     }
 
-    case "MapType":
-      return { type: "object" };
+    case "MapType": {
+      const value = fieldToSchema({
+        typeExpr: typeExpr.valueType,
+        aliasMap: input.aliasMap,
+        enumMap: input.enumMap,
+        entityNames: input.entityNames,
+      });
+      return { type: "object", additionalProperties: value.schema };
+    }
 
     case "OptionType":
       return typeExprToSchema(typeExpr.innerType, constraints, input);
@@ -66,6 +81,13 @@ function typeExprToSchema(
     case "RelationType":
       return { type: "integer" };
   }
+}
+
+function arrayBoundsFrom(constraints: JsonSchemaConstraints): Pick<SchemaObject, "minItems" | "maxItems"> {
+  const out: { minItems?: number; maxItems?: number } = {};
+  if (constraints.minLength !== undefined) out.minItems = constraints.minLength;
+  if (constraints.maxLength !== undefined) out.maxItems = constraints.maxLength;
+  return out;
 }
 
 function namedTypeSchema(

--- a/src/codegen/openapi/schema.ts
+++ b/src/codegen/openapi/schema.ts
@@ -62,7 +62,8 @@ function typeExprToSchema(
         enumMap: input.enumMap,
         entityNames: input.entityNames,
       });
-      return { type: "array", items: inner.schema, ...arrayBoundsFrom(constraints) };
+      const items = inner.nullable ? makeNullable(inner.schema) : inner.schema;
+      return { type: "array", items, ...arrayBoundsFrom(constraints) };
     }
 
     case "MapType": {
@@ -72,7 +73,10 @@ function typeExprToSchema(
         enumMap: input.enumMap,
         entityNames: input.entityNames,
       });
-      return { type: "object", additionalProperties: value.schema };
+      const additionalProperties = value.nullable
+        ? makeNullable(value.schema)
+        : value.schema;
+      return { type: "object", additionalProperties };
     }
 
     case "OptionType":

--- a/src/codegen/openapi/serialize.ts
+++ b/src/codegen/openapi/serialize.ts
@@ -1,0 +1,10 @@
+import yaml from "js-yaml";
+import type { OpenApiDocument } from "#codegen/openapi/types.js";
+
+export function serializeOpenApi(doc: OpenApiDocument): string {
+  return yaml.dump(doc, {
+    lineWidth: 100,
+    noRefs: true,
+    sortKeys: false,
+  });
+}

--- a/src/codegen/openapi/types.ts
+++ b/src/codegen/openapi/types.ts
@@ -1,0 +1,104 @@
+export type OpenApiSchemaType =
+  | "string"
+  | "integer"
+  | "number"
+  | "boolean"
+  | "array"
+  | "object";
+
+export interface SchemaObject {
+  readonly type?: OpenApiSchemaType;
+  readonly format?: string;
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly minimum?: number;
+  readonly maximum?: number;
+  readonly exclusiveMinimum?: number;
+  readonly exclusiveMaximum?: number;
+  readonly pattern?: string;
+  readonly enum?: readonly string[];
+  readonly items?: SchemaObject;
+  readonly $ref?: string;
+  readonly required?: readonly string[];
+  readonly properties?: Readonly<Record<string, SchemaObject>>;
+  readonly description?: string;
+  readonly nullable?: boolean;
+}
+
+export interface ParameterObject {
+  readonly name: string;
+  readonly in: "path" | "query" | "header" | "cookie";
+  readonly required: boolean;
+  readonly description?: string;
+  readonly schema: SchemaObject;
+}
+
+export interface MediaTypeObject {
+  readonly schema: SchemaObject;
+}
+
+export interface RequestBodyObject {
+  readonly required: boolean;
+  readonly description?: string;
+  readonly content: Readonly<Record<string, MediaTypeObject>>;
+}
+
+export interface HeaderObject {
+  readonly description?: string;
+  readonly schema: SchemaObject;
+}
+
+export interface ResponseObject {
+  readonly description: string;
+  readonly headers?: Readonly<Record<string, HeaderObject>>;
+  readonly content?: Readonly<Record<string, MediaTypeObject>>;
+}
+
+export type ResponsesObject = Readonly<Record<string, ResponseObject>>;
+
+export interface OperationObject {
+  readonly operationId: string;
+  readonly summary?: string;
+  readonly description?: string;
+  readonly tags: readonly string[];
+  readonly parameters?: readonly ParameterObject[];
+  readonly requestBody?: RequestBodyObject;
+  readonly responses: ResponsesObject;
+}
+
+export interface PathItemObject {
+  readonly get?: OperationObject;
+  readonly post?: OperationObject;
+  readonly put?: OperationObject;
+  readonly patch?: OperationObject;
+  readonly delete?: OperationObject;
+}
+
+export interface ComponentsObject {
+  readonly schemas: Readonly<Record<string, SchemaObject>>;
+}
+
+export interface InfoObject {
+  readonly title: string;
+  readonly version: string;
+  readonly description?: string;
+}
+
+export interface ServerObject {
+  readonly url: string;
+  readonly description?: string;
+}
+
+export interface TagObject {
+  readonly name: string;
+  readonly description?: string;
+}
+
+export interface OpenApiDocument {
+  readonly openapi: "3.1.0";
+  readonly info: InfoObject;
+  readonly servers: readonly ServerObject[];
+  readonly paths: Readonly<Record<string, PathItemObject>>;
+  readonly components: ComponentsObject;
+  readonly tags: readonly TagObject[];
+}

--- a/src/codegen/openapi/types.ts
+++ b/src/codegen/openapi/types.ts
@@ -4,10 +4,11 @@ export type OpenApiSchemaType =
   | "number"
   | "boolean"
   | "array"
-  | "object";
+  | "object"
+  | "null";
 
 export interface SchemaObject {
-  readonly type?: OpenApiSchemaType;
+  readonly type?: OpenApiSchemaType | readonly OpenApiSchemaType[];
   readonly format?: string;
   readonly minLength?: number;
   readonly maxLength?: number;
@@ -15,14 +16,17 @@ export interface SchemaObject {
   readonly maximum?: number;
   readonly exclusiveMinimum?: number;
   readonly exclusiveMaximum?: number;
+  readonly minItems?: number;
+  readonly maxItems?: number;
   readonly pattern?: string;
   readonly enum?: readonly string[];
   readonly items?: SchemaObject;
   readonly $ref?: string;
   readonly required?: readonly string[];
   readonly properties?: Readonly<Record<string, SchemaObject>>;
+  readonly additionalProperties?: SchemaObject | boolean;
+  readonly anyOf?: readonly SchemaObject[];
   readonly description?: string;
-  readonly nullable?: boolean;
 }
 
 export interface ParameterObject {

--- a/src/codegen/route-kind.ts
+++ b/src/codegen/route-kind.ts
@@ -1,0 +1,22 @@
+import type { ProfiledOperation } from "#profile/types.js";
+
+export type RouteKind =
+  | "create"
+  | "read"
+  | "list"
+  | "delete"
+  | "other";
+
+export function classifyRouteKind(op: ProfiledOperation): RouteKind {
+  const method = op.endpoint.method;
+  const pathParamCount = op.endpoint.pathParams.length;
+  const hasPathParam = pathParamCount > 0;
+  const singlePathParam = pathParamCount === 1;
+  if (op.kind === "create") return "create";
+  if (op.kind === "read" && singlePathParam) return "read";
+  if (op.kind === "read" && !hasPathParam) return "list";
+  if (op.kind === "filtered_read" && !hasPathParam) return "list";
+  if (op.kind === "delete" && singlePathParam) return "delete";
+  if (method === "GET" && !hasPathParam) return "list";
+  return "other";
+}

--- a/test/codegen/emit.test.ts
+++ b/test/codegen/emit.test.ts
@@ -41,6 +41,7 @@ describe("emitProject — file paths", () => {
       "app/schemas/url_mapping.py",
       "app/services/__init__.py",
       "app/services/url_mapping.py",
+      "openapi.yaml",
     ]);
   });
 

--- a/test/codegen/openapi/build.test.ts
+++ b/test/codegen/openapi/build.test.ts
@@ -51,14 +51,26 @@ describe("buildOpenApiDocument — per-entity component schemas", () => {
     expect(read.properties?.id).toEqual({ type: "integer" });
   });
 
-  it("Update schema marks all non-id fields as nullable", () => {
+  it("Update schema marks all non-id fields as nullable (3.1 type union)", () => {
     const { doc } = docFrom("url_shortener.spec");
     const update = doc.components.schemas.UrlMappingUpdate;
     for (const [name, schema] of Object.entries(update.properties ?? {})) {
       expect(name).not.toBe("id");
-      expect(schema.nullable).toBe(true);
+      const typeIsUnionWithNull =
+        Array.isArray(schema.type) && schema.type.includes("null");
+      const anyOfWithNull =
+        schema.anyOf?.some((s) => s.type === "null") ?? false;
+      expect(typeIsUnionWithNull || anyOfWithNull).toBe(true);
     }
     expect(update.required).toBeUndefined();
+  });
+
+  it("Update schema fields do not use the legacy 3.0 `nullable: true`", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const update = doc.components.schemas.UrlMappingUpdate;
+    for (const schema of Object.values(update.properties ?? {})) {
+      expect("nullable" in schema).toBe(false);
+    }
   });
 });
 
@@ -70,6 +82,24 @@ describe("buildOpenApiDocument — constraint propagation", () => {
     expect(code?.minLength).toBe(6);
     expect(code?.maxLength).toBe(10);
     expect(code?.pattern).toBe("^[a-zA-Z0-9]+$");
+  });
+
+  it("orphan operations (targetEntity = null) do not appear in paths", () => {
+    const { doc, profiled } = docFrom("edge_cases.spec");
+    const entityNames = new Set(profiled.entities.map((e) => e.entityName));
+    const orphanHandlerNames = new Set(
+      profiled.operations
+        .filter((op) => op.targetEntity === null || !entityNames.has(op.targetEntity))
+        .map((op) => op.handlerName),
+    );
+    expect(orphanHandlerNames.size).toBeGreaterThan(0);
+    for (const item of Object.values(doc.paths)) {
+      for (const op of [item.get, item.post, item.put, item.patch, item.delete]) {
+        if (op !== undefined) {
+          expect(orphanHandlerNames.has(op.operationId)).toBe(false);
+        }
+      }
+    }
   });
 
   it("DateTime field gets format date-time", () => {
@@ -88,13 +118,15 @@ describe("buildOpenApiDocument — paths mirror endpoints", () => {
     "todo_list.spec",
     "ecommerce.spec",
     "auth_service.spec",
-  ])("every endpoint has a corresponding path entry (%s)", (fixture) => {
+  ])("every entity-backed operation has a corresponding path entry (%s)", (fixture) => {
     const { doc, profiled } = docFrom(fixture);
-    for (const ep of profiled.endpoints) {
-      const pathItem = doc.paths[ep.path];
-      expect(pathItem, `path ${ep.path} missing`).toBeDefined();
-      const method = ep.method.toLowerCase() as keyof typeof pathItem;
-      expect(pathItem[method], `${ep.method} ${ep.path} missing`).toBeDefined();
+    const entityNames = new Set(profiled.entities.map((e) => e.entityName));
+    for (const op of profiled.operations) {
+      if (op.targetEntity === null || !entityNames.has(op.targetEntity)) continue;
+      const pathItem = doc.paths[op.endpoint.path];
+      expect(pathItem, `path ${op.endpoint.path} missing`).toBeDefined();
+      const method = op.endpoint.method.toLowerCase() as keyof typeof pathItem;
+      expect(pathItem[method], `${op.endpoint.method} ${op.endpoint.path} missing`).toBeDefined();
     }
   });
 

--- a/test/codegen/openapi/build.test.ts
+++ b/test/codegen/openapi/build.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildOpenApiDocument } from "#codegen/openapi/build.js";
+import { buildIR } from "#ir/index.js";
+import { parseSpec } from "#parser/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function docFrom(fixtureName: string) {
+  const src = readFileSync(join(fixtureDir, fixtureName), "utf-8");
+  const { tree } = parseSpec(src);
+  const profiled = buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+  return { doc: buildOpenApiDocument(profiled), profiled };
+}
+
+describe("buildOpenApiDocument — document shape", () => {
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+    "edge_cases.spec",
+  ])("emits a well-formed document for %s", (fixture) => {
+    const { doc } = docFrom(fixture);
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.info.title).toBeTruthy();
+    expect(doc.info.version).toBe("0.1.0");
+    expect(doc.servers.length).toBeGreaterThan(0);
+    expect(doc.components.schemas.ErrorResponse).toBeDefined();
+    expect(doc.paths["/health"].get).toBeDefined();
+  });
+});
+
+describe("buildOpenApiDocument — per-entity component schemas", () => {
+  it("emits Create/Read/Update for every entity in ecommerce", () => {
+    const { doc, profiled } = docFrom("ecommerce.spec");
+    for (const entity of profiled.entities) {
+      expect(doc.components.schemas[entity.createSchemaName]).toBeDefined();
+      expect(doc.components.schemas[entity.readSchemaName]).toBeDefined();
+      expect(doc.components.schemas[entity.updateSchemaName]).toBeDefined();
+    }
+  });
+
+  it("Read schema requires id and includes id as integer", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const read = doc.components.schemas.UrlMappingRead;
+    expect(read.type).toBe("object");
+    expect(read.required).toContain("id");
+    expect(read.properties?.id).toEqual({ type: "integer" });
+  });
+
+  it("Update schema marks all non-id fields as nullable", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const update = doc.components.schemas.UrlMappingUpdate;
+    for (const [name, schema] of Object.entries(update.properties ?? {})) {
+      expect(name).not.toBe("id");
+      expect(schema.nullable).toBe(true);
+    }
+    expect(update.required).toBeUndefined();
+  });
+});
+
+describe("buildOpenApiDocument — constraint propagation", () => {
+  it("ShortCode alias constraints surface on UrlMappingRead.code", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const read = doc.components.schemas.UrlMappingRead;
+    const code = read.properties?.code;
+    expect(code?.minLength).toBe(6);
+    expect(code?.maxLength).toBe(10);
+    expect(code?.pattern).toBe("^[a-zA-Z0-9]+$");
+  });
+
+  it("DateTime field gets format date-time", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const read = doc.components.schemas.UrlMappingRead;
+    expect(read.properties?.created_at).toEqual({
+      type: "string",
+      format: "date-time",
+    });
+  });
+});
+
+describe("buildOpenApiDocument — paths mirror endpoints", () => {
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+  ])("every endpoint has a corresponding path entry (%s)", (fixture) => {
+    const { doc, profiled } = docFrom(fixture);
+    for (const ep of profiled.endpoints) {
+      const pathItem = doc.paths[ep.path];
+      expect(pathItem, `path ${ep.path} missing`).toBeDefined();
+      const method = ep.method.toLowerCase() as keyof typeof pathItem;
+      expect(pathItem[method], `${ep.method} ${ep.path} missing`).toBeDefined();
+    }
+  });
+
+  it("DELETE operation with 204 has empty content response", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const del = doc.paths["/{code}"].delete;
+    expect(del?.responses["204"].content).toBeUndefined();
+    expect(del?.responses["204"].description).toBe("No content");
+  });
+
+  it("302 redirect responses include a Location header", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const get = doc.paths["/{code}"].get;
+    expect(get?.responses["302"].headers?.Location).toBeDefined();
+  });
+
+  it("POST /shorten request body refs UrlMappingCreate", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    const post = doc.paths["/shorten"].post;
+    const ref = post?.requestBody?.content["application/json"].schema.$ref;
+    expect(ref).toBe("#/components/schemas/UrlMappingCreate");
+  });
+
+  it("path-parameterized operations include a 404 response", () => {
+    const { doc } = docFrom("url_shortener.spec");
+    expect(doc.paths["/{code}"].get?.responses["404"]).toBeDefined();
+    expect(doc.paths["/{code}"].delete?.responses["404"]).toBeDefined();
+  });
+});

--- a/test/codegen/openapi/conformance.test.ts
+++ b/test/codegen/openapi/conformance.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildOpenApiDocument } from "#codegen/openapi/build.js";
+import { buildIR } from "#ir/index.js";
+import { parseSpec } from "#parser/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(fixture: string) {
+  const src = readFileSync(join(fixtureDir, fixture), "utf-8");
+  const { tree } = parseSpec(src);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+describe("openapi conformance — paths ↔ endpoints bijection", () => {
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+    "edge_cases.spec",
+  ])("every profiled endpoint + /health maps to one path item in %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const doc = buildOpenApiDocument(profiled);
+
+    const fromEndpoints = new Set(
+      profiled.endpoints.map((e) => `${e.method} ${e.path}`),
+    );
+    fromEndpoints.add("GET /health");
+
+    const fromDoc = new Set<string>();
+    for (const [path, item] of Object.entries(doc.paths)) {
+      for (const method of ["get", "post", "put", "patch", "delete"] as const) {
+        if (item[method] !== undefined) {
+          fromDoc.add(`${method.toUpperCase()} ${path}`);
+        }
+      }
+    }
+
+    expect([...fromDoc].sort()).toEqual([...fromEndpoints].sort());
+  });
+
+  it("operationId matches handlerName for every profiled operation", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const doc = buildOpenApiDocument(profiled);
+    for (const op of profiled.operations) {
+      const method = op.endpoint.method.toLowerCase() as "get" | "post" | "put" | "patch" | "delete";
+      const operation = doc.paths[op.endpoint.path][method];
+      expect(operation?.operationId).toBe(op.handlerName);
+    }
+  });
+});

--- a/test/codegen/openapi/conformance.test.ts
+++ b/test/codegen/openapi/conformance.test.ts
@@ -21,14 +21,17 @@ describe("openapi conformance — paths ↔ endpoints bijection", () => {
     "ecommerce.spec",
     "auth_service.spec",
     "edge_cases.spec",
-  ])("every profiled endpoint + /health maps to one path item in %s", (fixture) => {
+  ])("every entity-backed endpoint + /health maps to one path item in %s", (fixture) => {
     const profiled = profiledFrom(fixture);
     const doc = buildOpenApiDocument(profiled);
+    const entityNames = new Set(profiled.entities.map((e) => e.entityName));
 
-    const fromEndpoints = new Set(
-      profiled.endpoints.map((e) => `${e.method} ${e.path}`),
+    const fromOps = new Set(
+      profiled.operations
+        .filter((op) => op.targetEntity !== null && entityNames.has(op.targetEntity))
+        .map((op) => `${op.endpoint.method} ${op.endpoint.path}`),
     );
-    fromEndpoints.add("GET /health");
+    fromOps.add("GET /health");
 
     const fromDoc = new Set<string>();
     for (const [path, item] of Object.entries(doc.paths)) {
@@ -39,13 +42,15 @@ describe("openapi conformance — paths ↔ endpoints bijection", () => {
       }
     }
 
-    expect([...fromDoc].sort()).toEqual([...fromEndpoints].sort());
+    expect([...fromDoc].sort()).toEqual([...fromOps].sort());
   });
 
-  it("operationId matches handlerName for every profiled operation", () => {
+  it("operationId matches handlerName for every entity-backed operation", () => {
     const profiled = profiledFrom("ecommerce.spec");
     const doc = buildOpenApiDocument(profiled);
+    const entityNames = new Set(profiled.entities.map((e) => e.entityName));
     for (const op of profiled.operations) {
+      if (op.targetEntity === null || !entityNames.has(op.targetEntity)) continue;
       const method = op.endpoint.method.toLowerCase() as "get" | "post" | "put" | "patch" | "delete";
       const operation = doc.paths[op.endpoint.path][method];
       expect(operation?.operationId).toBe(op.handlerName);

--- a/test/codegen/openapi/constraints.test.ts
+++ b/test/codegen/openapi/constraints.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { extractFieldConstraints } from "#codegen/openapi/constraints.js";
+import type { Expr, TypeAliasDecl, TypeExpr } from "#ir/types.js";
+
+const stringType: TypeExpr = { kind: "NamedType", name: "String" };
+const intType: TypeExpr = { kind: "NamedType", name: "Int" };
+
+function int(value: number): Expr {
+  return { kind: "IntLit", value };
+}
+
+function valueRef(): Expr {
+  return { kind: "Identifier", name: "value" };
+}
+
+function lenCall(): Expr {
+  return {
+    kind: "Call",
+    callee: { kind: "Identifier", name: "len" },
+    args: [valueRef()],
+  };
+}
+
+function binOp(op: Expr extends { kind: "BinaryOp"; op: infer O } ? O : never, left: Expr, right: Expr): Expr {
+  return { kind: "BinaryOp", op, left, right };
+}
+
+describe("extractFieldConstraints", () => {
+  const emptyAlias = new Map<string, TypeAliasDecl>();
+  const emptyEnum = new Map();
+
+  it.each([
+    [
+      "len(value) >= 6",
+      binOp(">=", lenCall(), int(6)),
+      { minLength: 6 },
+    ],
+    [
+      "len(value) <= 10",
+      binOp("<=", lenCall(), int(10)),
+      { maxLength: 10 },
+    ],
+    [
+      "len(value) >= 6 and len(value) <= 10",
+      binOp(
+        "and",
+        binOp(">=", lenCall(), int(6)),
+        binOp("<=", lenCall(), int(10)),
+      ),
+      { minLength: 6, maxLength: 10 },
+    ],
+    [
+      "len(value) = 64",
+      binOp("=", lenCall(), int(64)),
+      { minLength: 64, maxLength: 64 },
+    ],
+    [
+      "value >= 0",
+      binOp(">=", valueRef(), int(0)),
+      { minimum: 0 },
+    ],
+    [
+      "value > 0",
+      binOp(">", valueRef(), int(0)),
+      { exclusiveMinimum: 0 },
+    ],
+    [
+      "value <= 100",
+      binOp("<=", valueRef(), int(100)),
+      { maximum: 100 },
+    ],
+  ])("extracts constraints from %s", (_label, expr, expected) => {
+    const typeExpr = _label.startsWith("value") ? intType : stringType;
+    const result = extractFieldConstraints(typeExpr, expr, emptyAlias, emptyEnum);
+    expect(result).toEqual(expected);
+  });
+
+  it("extracts pattern from Matches expression", () => {
+    const expr: Expr = {
+      kind: "Matches",
+      expr: valueRef(),
+      pattern: "^[a-z]+$",
+    };
+    const result = extractFieldConstraints(stringType, expr, emptyAlias, emptyEnum);
+    expect(result).toEqual({ pattern: "^[a-z]+$" });
+  });
+
+  it("resolves constraints through a type alias", () => {
+    const shortCodeAlias: TypeAliasDecl = {
+      kind: "TypeAlias",
+      name: "ShortCode",
+      typeExpr: stringType,
+      constraint: binOp(
+        "and",
+        binOp(">=", lenCall(), int(6)),
+        binOp("<=", lenCall(), int(10)),
+      ),
+    };
+    const aliasMap = new Map([["ShortCode", shortCodeAlias]]);
+    const result = extractFieldConstraints(
+      { kind: "NamedType", name: "ShortCode" },
+      null,
+      aliasMap,
+      emptyEnum,
+    );
+    expect(result).toEqual({ minLength: 6, maxLength: 10 });
+  });
+
+  it("Option[T] inherits constraints from the inner type", () => {
+    const shortCodeAlias: TypeAliasDecl = {
+      kind: "TypeAlias",
+      name: "ShortCode",
+      typeExpr: stringType,
+      constraint: binOp(">=", lenCall(), int(6)),
+    };
+    const aliasMap = new Map([["ShortCode", shortCodeAlias]]);
+    const option: TypeExpr = {
+      kind: "OptionType",
+      innerType: { kind: "NamedType", name: "ShortCode" },
+    };
+    const result = extractFieldConstraints(option, null, aliasMap, emptyEnum);
+    expect(result).toEqual({ minLength: 6 });
+  });
+
+  it("ignores unknown predicates (e.g., isValidURI)", () => {
+    const expr: Expr = {
+      kind: "Call",
+      callee: { kind: "Identifier", name: "isValidURI" },
+      args: [valueRef()],
+    };
+    const result = extractFieldConstraints(stringType, expr, emptyAlias, emptyEnum);
+    expect(result).toEqual({});
+  });
+});

--- a/test/codegen/openapi/constraints.test.ts
+++ b/test/codegen/openapi/constraints.test.ts
@@ -122,6 +122,59 @@ describe("extractFieldConstraints", () => {
     expect(result).toEqual({ minLength: 6 });
   });
 
+  it("merges numeric lower bounds by taking the tightest", () => {
+    const expr = binOp(
+      "and",
+      binOp(">=", valueRef(), int(5)),
+      binOp(">=", valueRef(), int(10)),
+    );
+    expect(extractFieldConstraints(intType, expr, emptyAlias, emptyEnum)).toEqual({
+      minimum: 10,
+    });
+  });
+
+  it("merges numeric upper bounds by taking the tightest", () => {
+    const expr = binOp(
+      "and",
+      binOp("<=", valueRef(), int(100)),
+      binOp("<=", valueRef(), int(50)),
+    );
+    expect(extractFieldConstraints(intType, expr, emptyAlias, emptyEnum)).toEqual({
+      maximum: 50,
+    });
+  });
+
+  it("merges length bounds across alias + field constraints", () => {
+    const alias: TypeAliasDecl = {
+      kind: "TypeAlias",
+      name: "Code",
+      typeExpr: stringType,
+      constraint: binOp(">=", lenCall(), int(4)),
+    };
+    const aliasMap = new Map([["Code", alias]]);
+    const result = extractFieldConstraints(
+      { kind: "NamedType", name: "Code" },
+      binOp(">=", lenCall(), int(8)),
+      aliasMap,
+      emptyEnum,
+    );
+    expect(result).toEqual({ minLength: 8 });
+  });
+
+  it("drops length bounds with non-integer or negative right-hand side", () => {
+    expect(
+      extractFieldConstraints(
+        stringType,
+        binOp(">=", lenCall(), { kind: "FloatLit", value: 3.5 }),
+        emptyAlias,
+        emptyEnum,
+      ),
+    ).toEqual({});
+    expect(
+      extractFieldConstraints(stringType, binOp(">=", lenCall(), int(-2)), emptyAlias, emptyEnum),
+    ).toEqual({});
+  });
+
   it("ignores unknown predicates (e.g., isValidURI)", () => {
     const expr: Expr = {
       kind: "Call",

--- a/test/codegen/openapi/schema.test.ts
+++ b/test/codegen/openapi/schema.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { fieldToSchema, makeNullable } from "#codegen/openapi/schema.js";
+import type { EnumDecl, TypeAliasDecl, TypeExpr } from "#ir/types.js";
+
+const emptyAlias: ReadonlyMap<string, TypeAliasDecl> = new Map();
+const emptyEnum: ReadonlyMap<string, EnumDecl> = new Map();
+const emptyEntities: ReadonlySet<string> = new Set();
+
+function named(name: string): TypeExpr {
+  return { kind: "NamedType", name };
+}
+
+describe("fieldToSchema — nullability propagation into collections", () => {
+  it("Set[Option[String]] marks the items schema as nullable via 3.1 type union", () => {
+    const typeExpr: TypeExpr = {
+      kind: "SetType",
+      elementType: { kind: "OptionType", innerType: named("String") },
+    };
+    const { schema, nullable } = fieldToSchema({
+      typeExpr,
+      aliasMap: emptyAlias,
+      enumMap: emptyEnum,
+      entityNames: emptyEntities,
+    });
+    expect(nullable).toBe(false);
+    expect(schema.type).toBe("array");
+    expect(schema.items?.type).toEqual(["string", "null"]);
+  });
+
+  it("Seq[Option[Int]] preserves null in items", () => {
+    const typeExpr: TypeExpr = {
+      kind: "SeqType",
+      elementType: { kind: "OptionType", innerType: named("Int") },
+    };
+    const { schema } = fieldToSchema({
+      typeExpr,
+      aliasMap: emptyAlias,
+      enumMap: emptyEnum,
+      entityNames: emptyEntities,
+    });
+    expect(schema.items?.type).toEqual(["integer", "null"]);
+  });
+
+  it("Map[String, Option[Int]] marks additionalProperties as nullable", () => {
+    const typeExpr: TypeExpr = {
+      kind: "MapType",
+      keyType: named("String"),
+      valueType: { kind: "OptionType", innerType: named("Int") },
+    };
+    const { schema } = fieldToSchema({
+      typeExpr,
+      aliasMap: emptyAlias,
+      enumMap: emptyEnum,
+      entityNames: emptyEntities,
+    });
+    expect(schema.type).toBe("object");
+    const addl = schema.additionalProperties;
+    expect(typeof addl === "object" && addl !== null).toBe(true);
+    if (typeof addl === "object" && addl !== null) {
+      expect(addl.type).toEqual(["integer", "null"]);
+    }
+  });
+});
+
+describe("makeNullable", () => {
+  it("widens a scalar type to a union with null", () => {
+    expect(makeNullable({ type: "string" }).type).toEqual(["string", "null"]);
+  });
+
+  it("keeps extra keywords (pattern, format, enum) alongside the widened type", () => {
+    const out = makeNullable({ type: "string", pattern: "^[a-z]+$" });
+    expect(out.type).toEqual(["string", "null"]);
+    expect(out.pattern).toBe("^[a-z]+$");
+  });
+
+  it("wraps a $ref in anyOf instead of mutating it (3.1 forbids $ref siblings)", () => {
+    const out = makeNullable({ $ref: "#/components/schemas/Foo" });
+    expect(out.$ref).toBeUndefined();
+    expect(out.anyOf?.length).toBe(2);
+    expect(out.anyOf?.[0].$ref).toBe("#/components/schemas/Foo");
+    expect(out.anyOf?.[1].type).toBe("null");
+  });
+
+  it("is idempotent — already-null-unioned schemas are left alone", () => {
+    const input = { type: ["string", "null"] as const };
+    const out = makeNullable(input);
+    expect(out.type).toEqual(["string", "null"]);
+  });
+});

--- a/test/codegen/openapi/validate.test.ts
+++ b/test/codegen/openapi/validate.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Validator } from "@seriousme/openapi-schema-validator";
+import { describe, expect, it } from "vitest";
+import { emitProject } from "#codegen/emit.js";
+import { buildIR } from "#ir/index.js";
+import { parseSpec } from "#parser/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function openApiYamlFor(fixture: string): string {
+  const src = readFileSync(join(fixtureDir, fixture), "utf-8");
+  const { tree } = parseSpec(src);
+  const profiled = buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+  const files = emitProject(profiled);
+  const file = files.find((f) => f.path === "openapi.yaml");
+  if (file === undefined) throw new Error("openapi.yaml not in emitted files");
+  return file.content;
+}
+
+describe("emitted openapi.yaml validates against OpenAPI 3.1", () => {
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+    "edge_cases.spec",
+  ])("validates for %s", async (fixture) => {
+    const yamlContent = openApiYamlFor(fixture);
+    const validator = new Validator();
+    const result = await validator.validate(yamlContent);
+    if (!result.valid) {
+      // eslint-disable-next-line no-console
+      console.error(`Validation errors for ${fixture}:`, result.errors);
+    }
+    expect(result.valid).toBe(true);
+    expect(validator.version).toBe("3.1");
+  });
+});


### PR DESCRIPTION
Closes #13.

## Summary

- Emits a build-time `openapi.yaml` alongside the Python/FastAPI sources from M3.2. FastAPI already auto-serves `/openapi.json` from the router decorators at runtime; this PR adds the file downstream tooling (Schemathesis, SDK generators, Redocly/Swagger UI) consumes without booting a server.
- Spec is assembled as a typed `OpenApiDocument` in TypeScript, then serialized via `js-yaml`. Structural tests operate on deep objects instead of string-matching rendered YAML.
- Field validation constraints from IR (`len(value) >= …`, comparisons, `matches /regex/`) and enum types are propagated through type aliases into JSON Schema keywords: `minLength`/`maxLength`, `minimum`/`maximum`, `exclusiveMinimum`/`exclusiveMaximum`, `pattern`, `enum`.
- All 5 fixtures (`url_shortener`, `todo_list`, `ecommerce`, `auth_service`, `edge_cases`) validate against the OpenAPI 3.1 schema via `@seriousme/openapi-schema-validator`.
- A conformance test enforces a bijection between `profiled.endpoints` (+ `GET /health`) and the spec's paths — catches drift between the M3.2 routers and this spec.

## Key design decisions

- **TS builder + js-yaml** over a Handlebars template. OpenAPI is structured data; YAML indentation in Handlebars gets brittle fast once nested paths/components appear.
- **`classifyRouteKind` extracted** from `emit.ts` into `src/codegen/route-kind.ts` so `openapi/paths.ts` can reuse it without duplicating the dispatch logic.
- **GET/DELETE never emit `requestBody`** regardless of operation-level fields — standard OpenAPI practice; matches FastAPI's own auto-generation. Mid-implementation I caught a bug where a `partial_update`-classified GET (from M2.1's operation classifier on the URL shortener's `Resolve`) was getting a spurious body.

## Deferred (called out explicitly)

- **Security schemes** — no auth syntax exists in the spec language yet. `auth_service.spec` models authentication as entities, not a security scheme, so any `securitySchemes` block would be speculative.
- **Request/response examples** — no source data in IR; hand-curated examples rot fast. Planned for M3.6 (golden files).
- **Schemathesis conformance-in-CI** — part of M3.5 (infra) once `docker compose up` works.

## Test plan

- [x] `npx vitest run` — 730 passed (40 new: 11 constraints, 18 build, 5 validate, 6 conformance)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (template copy step unaffected)
- [x] Manual: dumped emitted YAML for url_shortener and ecommerce; structurally matches the research doc example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates an OpenAPI 3.1 spec at build time and emits `openapi.yaml` alongside the FastAPI project. Tightens 3.1 semantics (nullable unions, strict bound merging, collection bounds and nullability) and keeps paths aligned with the M3.2 routers.

- **New Features**
  - Emits `openapi.yaml` (OpenAPI 3.1) from a typed builder in TypeScript; serialized with `js-yaml`.
  - Maps IR constraints and enums to JSON Schema (min/max length, numeric bounds, pattern, enum); applies `minItems`/`maxItems` for collections and `additionalProperties` for maps; nullable uses 3.1 type unions (or `anyOf` with `$ref`); merges overlapping bounds by taking the tightest.
  - Preserves inner nullability in collections and maps: `Set[Option[T]]`/`Seq[Option[T]]` set `items` to a union with `null`; `Map[K, Option[V]]` wraps `additionalProperties` in a union with `null`.
  - Adds per-entity `Create`/`Read`/`Update` component schemas; list endpoints return arrays; IDs are integers.
  - No `requestBody` for GET/DELETE; create/replace/patch bodies reference the correct schemas; required fields stay required even when nullable.
  - Adds `/health` and tags; enforces endpoint↔path bijection; filters operations without a resolvable target entity; merges any existing `/health`; all fixtures validate with `@seriousme/openapi-schema-validator`.

- **Dependencies**
  - Added `js-yaml` and `@types/js-yaml`.
  - Added `@seriousme/openapi-schema-validator` for OpenAPI 3.1 validation in tests.

<sup>Written for commit a105007af8f3e49ca6eb44f5ad6405b42ac4709b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

