### PR TITLE
M3.4 — SQL migration generation

### DIFF
--- a/src/codegen/alembic/migration.ts
+++ b/src/codegen/alembic/migration.ts
@@ -74,21 +74,33 @@ export function buildAlembicMigration(
   };
 }
 
+type TopoColor = "white" | "gray" | "black";
+
 function topoSortTables(tables: readonly TableSpec[]): TableSpec[] {
   const byName = new Map(tables.map((t) => [t.name, t]));
-  const visited = new Set<string>();
+  const color = new Map<string, TopoColor>();
+  for (const t of tables) color.set(t.name, "white");
   const result: TableSpec[] = [];
 
-  function visit(t: TableSpec): void {
-    if (visited.has(t.name)) return;
-    visited.add(t.name);
+  function visit(t: TableSpec, stack: string[]): void {
+    const c = color.get(t.name);
+    if (c === "black") return;
+    if (c === "gray") {
+      const cycleStart = stack.indexOf(t.name);
+      const cycle = [...stack.slice(cycleStart), t.name].join(" -> ");
+      throw new Error(`Foreign-key cycle detected: ${cycle}`);
+    }
+    color.set(t.name, "gray");
+    stack.push(t.name);
     for (const fk of t.foreignKeys) {
       const target = byName.get(fk.refTable);
-      if (target !== undefined && target !== t) visit(target);
+      if (target !== undefined && target !== t) visit(target, stack);
     }
+    stack.pop();
+    color.set(t.name, "black");
     result.push(t);
   }
-  for (const t of tables) visit(t);
+  for (const t of tables) visit(t, []);
   return result;
 }
 
@@ -143,11 +155,13 @@ function buildColumn(c: ColumnSpec, t: TableSpec): AlembicColumn {
 function mapSqlTypeToSa(sqlType: string): string {
   const direct = DIRECT_SA_TYPES.get(sqlType);
   if (direct !== undefined) return direct;
-  const numericMatch = sqlType.match(/^NUMERIC\((\d+)\s*,\s*(\d+)\)$/);
-  if (numericMatch) return `sa.Numeric(${numericMatch[1]}, ${numericMatch[2]})`;
+  const numericWithScale = sqlType.match(/^NUMERIC\((\d+)\s*,\s*(\d+)\)$/);
+  if (numericWithScale) return `sa.Numeric(${numericWithScale[1]}, ${numericWithScale[2]})`;
+  const numericNoScale = sqlType.match(/^NUMERIC\((\d+)\)$/);
+  if (numericNoScale) return `sa.Numeric(${numericNoScale[1]})`;
   const varcharMatch = sqlType.match(/^VARCHAR\((\d+)\)$/);
   if (varcharMatch) return `sa.String(length=${varcharMatch[1]})`;
-  return "sa.Text()";
+  throw new Error(`Unsupported SQL type in Alembic migration: ${sqlType}`);
 }
 
 const DIRECT_SA_TYPES: ReadonlyMap<string, string> = new Map([
@@ -172,9 +186,14 @@ function mapServerDefault(value: string | null): string | null {
 }
 
 function pythonStringLiteral(s: string): string {
-  if (!s.includes("'")) return `'${s}'`;
-  if (!s.includes('"')) return `"${s}"`;
-  return `"${s.replace(/"/g, '\\"')}"`;
+  const escaped = s
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+  if (!escaped.includes("'")) return `'${escaped}'`;
+  if (!escaped.includes('"')) return `"${escaped}"`;
+  return `"${escaped.replace(/"/g, '\\"')}"`;
 }
 
 function renderColumnCall(c: AlembicColumn): string {

--- a/src/codegen/alembic/migration.ts
+++ b/src/codegen/alembic/migration.ts
@@ -1,0 +1,195 @@
+import type {
+  DatabaseSchema,
+  TableSpec,
+  ColumnSpec,
+} from "#convention/types.js";
+
+export interface AlembicColumn {
+  readonly name: string;
+  readonly saType: string;
+  readonly nullable: boolean;
+  readonly primaryKey: boolean;
+  readonly autoincrement: boolean;
+  readonly serverDefault: string | null;
+}
+
+export interface AlembicForeignKey {
+  readonly name: string;
+  readonly column: string;
+  readonly refTable: string;
+  readonly refColumn: string;
+  readonly onDelete: string;
+}
+
+export interface AlembicCheck {
+  readonly name: string;
+  readonly sql: string;
+}
+
+export interface AlembicIndex {
+  readonly name: string;
+  readonly table: string;
+  readonly columns: readonly string[];
+  readonly unique: boolean;
+}
+
+export interface AlembicTable {
+  readonly name: string;
+  readonly entityName: string;
+  readonly columns: readonly AlembicColumn[];
+  readonly foreignKeys: readonly AlembicForeignKey[];
+  readonly checks: readonly AlembicCheck[];
+  readonly indexes: readonly AlembicIndex[];
+  readonly tableArgs: readonly string[];
+}
+
+export interface AlembicMigration {
+  readonly revision: string;
+  readonly createdDate: string;
+  readonly tables: readonly AlembicTable[];
+  readonly tablesReversed: readonly AlembicTable[];
+  readonly needsPostgresDialect: boolean;
+}
+
+export interface BuildMigrationOptions {
+  readonly revision?: string;
+  readonly createdDate?: string;
+}
+
+export function buildAlembicMigration(
+  schema: DatabaseSchema,
+  opts: BuildMigrationOptions = {},
+): AlembicMigration {
+  const sorted = topoSortTables(schema.tables);
+  const tables = sorted.map((t) => buildAlembicTable(t));
+  const needsPostgresDialect = tables.some((t) =>
+    t.columns.some((c) => c.saType.startsWith("postgresql.")),
+  );
+  return {
+    revision: opts.revision ?? "001",
+    createdDate: opts.createdDate ?? new Date().toISOString().slice(0, 10),
+    tables,
+    tablesReversed: [...tables].reverse(),
+    needsPostgresDialect,
+  };
+}
+
+function topoSortTables(tables: readonly TableSpec[]): TableSpec[] {
+  const byName = new Map(tables.map((t) => [t.name, t]));
+  const visited = new Set<string>();
+  const result: TableSpec[] = [];
+
+  function visit(t: TableSpec): void {
+    if (visited.has(t.name)) return;
+    visited.add(t.name);
+    for (const fk of t.foreignKeys) {
+      const target = byName.get(fk.refTable);
+      if (target !== undefined && target !== t) visit(target);
+    }
+    result.push(t);
+  }
+  for (const t of tables) visit(t);
+  return result;
+}
+
+function buildAlembicTable(t: TableSpec): AlembicTable {
+  const columns = t.columns.map((c) => buildColumn(c, t));
+  const foreignKeys = t.foreignKeys.map((fk) => ({
+    name: `fk_${t.name}_${fk.column}`,
+    column: fk.column,
+    refTable: fk.refTable,
+    refColumn: fk.refColumn,
+    onDelete: fk.onDelete,
+  }));
+  const checks = t.checks.map((sql, i) => ({
+    name: `ck_${t.name}_${i}`,
+    sql,
+  }));
+  const indexes = t.indexes.map((ix) => ({
+    name: ix.name,
+    table: t.name,
+    columns: ix.columns,
+    unique: ix.unique,
+  }));
+  const tableArgs = [
+    ...columns.map(renderColumnCall),
+    ...foreignKeys.map(renderForeignKeyCall),
+    ...checks.map(renderCheckCall),
+  ];
+  return {
+    name: t.name,
+    entityName: t.entityName,
+    columns,
+    foreignKeys,
+    checks,
+    indexes,
+    tableArgs,
+  };
+}
+
+function buildColumn(c: ColumnSpec, t: TableSpec): AlembicColumn {
+  const isPk = c.name === t.primaryKey;
+  const isSerial = c.sqlType === "BIGSERIAL" || c.sqlType === "SERIAL";
+  return {
+    name: c.name,
+    saType: mapSqlTypeToSa(c.sqlType),
+    nullable: c.nullable,
+    primaryKey: isPk,
+    autoincrement: isSerial,
+    serverDefault: mapServerDefault(c.defaultValue),
+  };
+}
+
+function mapSqlTypeToSa(sqlType: string): string {
+  const direct = DIRECT_SA_TYPES.get(sqlType);
+  if (direct !== undefined) return direct;
+  const numericMatch = sqlType.match(/^NUMERIC\((\d+)\s*,\s*(\d+)\)$/);
+  if (numericMatch) return `sa.Numeric(${numericMatch[1]}, ${numericMatch[2]})`;
+  const varcharMatch = sqlType.match(/^VARCHAR\((\d+)\)$/);
+  if (varcharMatch) return `sa.String(length=${varcharMatch[1]})`;
+  return "sa.Text()";
+}
+
+const DIRECT_SA_TYPES: ReadonlyMap<string, string> = new Map([
+  ["TEXT", "sa.Text()"],
+  ["BIGSERIAL", "sa.BigInteger()"],
+  ["BIGINT", "sa.BigInteger()"],
+  ["INTEGER", "sa.Integer()"],
+  ["SERIAL", "sa.Integer()"],
+  ["BOOLEAN", "sa.Boolean()"],
+  ["DOUBLE PRECISION", "sa.Float()"],
+  ["DATE", "sa.Date()"],
+  ["TIMESTAMPTZ", "sa.DateTime(timezone=True)"],
+  ["UUID", "sa.Uuid()"],
+  ["BYTEA", "sa.LargeBinary()"],
+  ["JSONB", "postgresql.JSONB()"],
+]);
+
+function mapServerDefault(value: string | null): string | null {
+  if (value === null) return null;
+  if (value === "NOW()") return "sa.func.now()";
+  return `sa.text(${pythonStringLiteral(value)})`;
+}
+
+function pythonStringLiteral(s: string): string {
+  if (!s.includes("'")) return `'${s}'`;
+  if (!s.includes('"')) return `"${s}"`;
+  return `"${s.replace(/"/g, '\\"')}"`;
+}
+
+function renderColumnCall(c: AlembicColumn): string {
+  const parts: string[] = [`"${c.name}"`, c.saType];
+  if (c.primaryKey) parts.push("primary_key=True");
+  if (c.autoincrement) parts.push("autoincrement=True");
+  if (c.serverDefault !== null) parts.push(`server_default=${c.serverDefault}`);
+  parts.push(`nullable=${c.nullable ? "True" : "False"}`);
+  return `sa.Column(${parts.join(", ")})`;
+}
+
+function renderForeignKeyCall(fk: AlembicForeignKey): string {
+  return `sa.ForeignKeyConstraint(["${fk.column}"], ["${fk.refTable}.${fk.refColumn}"], ondelete="${fk.onDelete}", name="${fk.name}")`;
+}
+
+function renderCheckCall(c: AlembicCheck): string {
+  return `sa.CheckConstraint(${pythonStringLiteral(c.sql)}, name="${c.name}")`;
+}

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -1,3 +1,4 @@
+import { buildAlembicMigration } from "#codegen/alembic/migration.js";
 import { TemplateEngine } from "#codegen/engine.js";
 import { buildOpenApiDocument } from "#codegen/openapi/build.js";
 import { serializeOpenApi } from "#codegen/openapi/serialize.js";
@@ -441,6 +442,21 @@ export function emitProject(profiled: ProfiledService): EmittedFile[] {
   files.push({
     path: "openapi.yaml",
     content: serializeOpenApi(buildOpenApiDocument(profiled)),
+  });
+
+  const migration = buildAlembicMigration(profiled.schema);
+  const alembicCtx = { ...ctx, migration };
+  files.push({
+    path: "alembic.ini",
+    content: engine.render(templates.alembicIni, ctx),
+  });
+  files.push({
+    path: "alembic/env.py",
+    content: engine.render(templates.alembicEnv, ctx),
+  });
+  files.push({
+    path: `alembic/versions/${migration.revision}_initial_schema.py`,
+    content: engine.render(templates.alembicMigration, alembicCtx),
   });
 
   return files;

--- a/src/codegen/templates.ts
+++ b/src/codegen/templates.ts
@@ -25,6 +25,9 @@ export const pythonFastapiPostgresTemplates = Object.freeze({
   routerInit: loadTemplate("routers/__init__.py.hbs"),
   serviceEntity: loadTemplate("services/entity.py.hbs"),
   serviceInit: loadTemplate("services/__init__.py.hbs"),
+  alembicIni: loadTemplate("alembic.ini.hbs"),
+  alembicEnv: loadTemplate("alembic/env.py.hbs"),
+  alembicMigration: loadTemplate("alembic/versions/001_initial_schema.py.hbs"),
 });
 
 export type PythonFastapiPostgresTemplates = typeof pythonFastapiPostgresTemplates;

--- a/src/codegen/templates/python-fastapi-postgres/alembic.ini.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic.ini.hbs
@@ -1,0 +1,40 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+file_template = %%(rev)s_%%(slug)s
+version_path_separator = os
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
@@ -1,6 +1,9 @@
+import asyncio
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
 
@@ -10,8 +13,7 @@ from app.models.base import Base
 
 config = context.config
 
-_database_url = settings.database_url.replace("+asyncpg", "+psycopg")
-config.set_main_option("sqlalchemy.url", _database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
@@ -30,20 +32,25 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
-def run_migrations_online() -> None:
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
     section = config.get_section(config.config_ini_section) or {}
-    connectable = engine_from_config(
+    connectable = async_engine_from_config(
         section,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )
-    with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
-        with context.begin_transaction():
-            context.run_migrations()
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
 
 
 if context.is_offline_mode():
     run_migrations_offline()
 else:
-    run_migrations_online()
+    asyncio.run(run_migrations_online())

--- a/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
@@ -1,0 +1,49 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+import app.models  # noqa: F401  -- populate Base.metadata
+from app.config import settings
+from app.models.base import Base
+
+config = context.config
+
+_database_url = settings.database_url.replace("+asyncpg", "+psycopg")
+config.set_main_option("sqlalchemy.url", _database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=config.get_main_option("sqlalchemy.url"),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    section = config.get_section(config.config_ini_section) or {}
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/src/codegen/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
@@ -30,6 +30,8 @@ def upgrade() -> None:
     op.create_index("{{this.name}}", "{{this.table}}", [{{#each this.columns}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}], unique={{#if this.unique}}True{{else}}False{{/if}})
 {{/each}}
 
+{{else}}
+    pass
 {{/each}}
 
 def downgrade() -> None:
@@ -38,4 +40,6 @@ def downgrade() -> None:
     op.drop_index("{{this.name}}", table_name="{{this.table}}")
 {{/each}}
     op.drop_table("{{this.name}}")
+{{else}}
+    pass
 {{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
@@ -1,0 +1,41 @@
+"""Initial schema for {{service.name}}.
+
+Revision ID: {{migration.revision}}
+Create Date: {{migration.createdDate}}
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+{{#if migration.needsPostgresDialect}}
+from sqlalchemy.dialects import postgresql
+{{/if}}
+
+
+revision: str = "{{migration.revision}}"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+{{#each migration.tables}}
+    op.create_table(
+        "{{this.name}}",
+{{#each this.tableArgs}}
+        {{{this}}},
+{{/each}}
+    )
+{{#each this.indexes}}
+    op.create_index("{{this.name}}", "{{this.table}}", [{{#each this.columns}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}], unique={{#if this.unique}}True{{else}}False{{/if}})
+{{/each}}
+
+{{/each}}
+
+def downgrade() -> None:
+{{#each migration.tablesReversed}}
+{{#each this.indexes}}
+    op.drop_index("{{this.name}}", table_name="{{this.table}}")
+{{/each}}
+    op.drop_table("{{this.name}}")
+{{/each}}

--- a/src/profile/python-fastapi.ts
+++ b/src/profile/python-fastapi.ts
@@ -52,7 +52,7 @@ export const PYTHON_FASTAPI_POSTGRES: DeploymentProfile = {
     { name: "mypy", version: ">=1.13" },
   ],
 
-  pythonVersion: ">=3.12",
+  pythonVersion: ">=3.10",
 
   directories: [
     "app",

--- a/test/codegen/alembic/env.test.ts
+++ b/test/codegen/alembic/env.test.ts
@@ -37,18 +37,27 @@ describe("alembic/env.py — structural invariants", () => {
     expect(content).toContain("target_metadata = Base.metadata");
   });
 
-  it("swaps +asyncpg -> +psycopg so alembic uses a sync driver", () => {
+  it("uses the async alembic pattern (asyncio.run + async_engine_from_config)", () => {
     const content = emittedFile("url_shortener.spec", "alembic/env.py");
+    expect(content).toContain("import asyncio");
+    expect(content).toContain("from sqlalchemy.ext.asyncio import async_engine_from_config");
+    expect(content).toContain("asyncio.run(run_migrations_online())");
+    expect(content).toContain("await connection.run_sync(do_run_migrations)");
+  });
+
+  it("does not swap the async driver (runs alembic on asyncpg directly)", () => {
+    const content = emittedFile("url_shortener.spec", "alembic/env.py");
+    expect(content).not.toContain("+psycopg");
+    expect(content).not.toContain("from sqlalchemy import engine_from_config");
     expect(content).toContain(
-      'settings.database_url.replace("+asyncpg", "+psycopg")',
+      'config.set_main_option("sqlalchemy.url", settings.database_url)',
     );
-    expect(content).toContain("config.set_main_option(\"sqlalchemy.url\"");
   });
 
   it("defines both offline and online migration entry points", () => {
     const content = emittedFile("url_shortener.spec", "alembic/env.py");
     expect(content).toContain("def run_migrations_offline() -> None:");
-    expect(content).toContain("def run_migrations_online() -> None:");
+    expect(content).toContain("async def run_migrations_online() -> None:");
     expect(content).toContain("if context.is_offline_mode():");
   });
 

--- a/test/codegen/alembic/env.test.ts
+++ b/test/codegen/alembic/env.test.ts
@@ -1,0 +1,87 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { emitProject } from "#codegen/emit.js";
+import { buildIR } from "#ir/index.js";
+import { parseSpec } from "#parser/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+function emittedFile(fixture: string, path: string): string {
+  const files = emitProject(profiledFrom(fixture));
+  const file = files.find((f) => f.path === path);
+  expect(file, `${path} not emitted for ${fixture}`).toBeDefined();
+  return file!.content;
+}
+
+function python3Available(): boolean {
+  const probe = spawnSync("python3", ["--version"], { encoding: "utf-8" });
+  return probe.status === 0;
+}
+
+describe("alembic/env.py — structural invariants", () => {
+  it("imports the app models so Base.metadata is populated before alembic runs", () => {
+    const content = emittedFile("url_shortener.spec", "alembic/env.py");
+    expect(content).toContain("import app.models");
+    expect(content).toContain("from app.models.base import Base");
+    expect(content).toContain("target_metadata = Base.metadata");
+  });
+
+  it("swaps +asyncpg -> +psycopg so alembic uses a sync driver", () => {
+    const content = emittedFile("url_shortener.spec", "alembic/env.py");
+    expect(content).toContain(
+      'settings.database_url.replace("+asyncpg", "+psycopg")',
+    );
+    expect(content).toContain("config.set_main_option(\"sqlalchemy.url\"");
+  });
+
+  it("defines both offline and online migration entry points", () => {
+    const content = emittedFile("url_shortener.spec", "alembic/env.py");
+    expect(content).toContain("def run_migrations_offline() -> None:");
+    expect(content).toContain("def run_migrations_online() -> None:");
+    expect(content).toContain("if context.is_offline_mode():");
+  });
+
+  const maybeIt = python3Available() ? it : it.skip;
+  maybeIt.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+  ])("parses as valid Python via ast.parse (%s)", (fixture) => {
+    const content = emittedFile(fixture, "alembic/env.py");
+    const proc = spawnSync(
+      "python3",
+      ["-c", "import ast, sys; ast.parse(sys.stdin.read())"],
+      { input: content, encoding: "utf-8" },
+    );
+    if (proc.status !== 0) {
+      throw new Error(`env.py for ${fixture} failed ast.parse:\n${proc.stderr}`);
+    }
+  });
+});
+
+describe("alembic.ini — structural invariants", () => {
+  it("points script_location at alembic and leaves sqlalchemy.url blank (env.py sets it)", () => {
+    const content = emittedFile("url_shortener.spec", "alembic.ini");
+    expect(content).toMatch(/script_location\s*=\s*alembic/);
+    expect(content).toMatch(/sqlalchemy\.url\s*=\s*$/m);
+  });
+
+  it("defines the standard alembic logger config blocks", () => {
+    const content = emittedFile("url_shortener.spec", "alembic.ini");
+    expect(content).toContain("[loggers]");
+    expect(content).toContain("[logger_alembic]");
+    expect(content).toContain("[logger_sqlalchemy]");
+    expect(content).toContain("[handler_console]");
+  });
+});

--- a/test/codegen/alembic/migration.test.ts
+++ b/test/codegen/alembic/migration.test.ts
@@ -1,0 +1,262 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildAlembicMigration } from "#codegen/alembic/migration.js";
+import { emitProject } from "#codegen/emit.js";
+import { buildIR } from "#ir/index.js";
+import { parseSpec } from "#parser/index.js";
+import { buildProfiledService } from "#profile/annotate.js";
+import type { ProfiledService } from "#profile/types.js";
+
+const fixtureDir = join(import.meta.dirname, "../../parser/fixtures");
+
+function profiledFrom(name: string): ProfiledService {
+  const src = readFileSync(join(fixtureDir, name), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildProfiledService(buildIR(tree), "python-fastapi-postgres");
+}
+
+function migrationContent(fixture: string): string {
+  const files = emitProject(profiledFrom(fixture));
+  const file = files.find((f) =>
+    f.path === "alembic/versions/001_initial_schema.py",
+  );
+  expect(file).toBeDefined();
+  return file!.content;
+}
+
+function python3Available(): boolean {
+  const probe = spawnSync("python3", ["--version"], { encoding: "utf-8" });
+  return probe.status === 0;
+}
+
+describe("buildAlembicMigration — render context shape", () => {
+  it("stamps revision 001 and a YYYY-MM-DD created date by default", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const migration = buildAlembicMigration(profiled.schema);
+    expect(migration.revision).toBe("001");
+    expect(migration.createdDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("exposes options for deterministic output in tests", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const migration = buildAlembicMigration(profiled.schema, {
+      revision: "007",
+      createdDate: "2026-04-18",
+    });
+    expect(migration.revision).toBe("007");
+    expect(migration.createdDate).toBe("2026-04-18");
+  });
+
+  it("topo-sorts tables so FK targets come before referrers", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const migration = buildAlembicMigration(profiled.schema);
+    const position = new Map(
+      migration.tables.map((t, i) => [t.name, i] as const),
+    );
+    for (const table of migration.tables) {
+      for (const fk of table.foreignKeys) {
+        const targetPos = position.get(fk.refTable);
+        if (targetPos === undefined) continue;
+        expect(targetPos).toBeLessThan(position.get(table.name)!);
+      }
+    }
+  });
+
+  it("tablesReversed reverses tables (for downgrade drop order)", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const migration = buildAlembicMigration(profiled.schema);
+    expect(migration.tablesReversed.map((t) => t.name)).toEqual(
+      [...migration.tables].reverse().map((t) => t.name),
+    );
+  });
+
+  it("sets needsPostgresDialect only when a JSONB column exists", () => {
+    const withJsonb = profiledFrom("ecommerce.spec");
+    const hasJsonbColumn = withJsonb.schema.tables.some((t) =>
+      t.columns.some((c) => c.sqlType === "JSONB"),
+    );
+    expect(buildAlembicMigration(withJsonb.schema).needsPostgresDialect).toBe(
+      hasJsonbColumn,
+    );
+
+    const noJsonb = profiledFrom("url_shortener.spec");
+    const urlShortenerHasJsonb = noJsonb.schema.tables.some((t) =>
+      t.columns.some((c) => c.sqlType === "JSONB"),
+    );
+    expect(buildAlembicMigration(noJsonb.schema).needsPostgresDialect).toBe(
+      urlShortenerHasJsonb,
+    );
+  });
+});
+
+describe("buildAlembicMigration — SQL-type → SQLAlchemy mapping", () => {
+  it("maps convention PG types to SQLAlchemy type expressions", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const migration = buildAlembicMigration(profiled.schema);
+    const urlMappings = migration.tables.find((t) => t.name === "url_mappings");
+    expect(urlMappings).toBeDefined();
+    const columns = new Map(urlMappings!.columns.map((c) => [c.name, c]));
+
+    expect(columns.get("id")?.saType).toBe("sa.BigInteger()");
+    expect(columns.get("id")?.primaryKey).toBe(true);
+    expect(columns.get("id")?.autoincrement).toBe(true);
+    expect(columns.get("code")?.saType).toBe("sa.Text()");
+    expect(columns.get("click_count")?.saType).toBe("sa.Integer()");
+    expect(columns.get("created_at")?.saType).toBe("sa.DateTime(timezone=True)");
+  });
+
+  it("translates convention defaults to SQLAlchemy expressions", () => {
+    const migration = buildAlembicMigration({
+      tables: [
+        {
+          name: "t",
+          entityName: "T",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "created_at", sqlType: "TIMESTAMPTZ", nullable: false, defaultValue: "NOW()" },
+            { name: "payload", sqlType: "JSONB", nullable: false, defaultValue: "'[]'::jsonb" },
+          ],
+          primaryKey: "id",
+          foreignKeys: [],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    });
+    const cols = new Map(migration.tables[0].columns.map((c) => [c.name, c]));
+    expect(cols.get("id")?.serverDefault).toBeNull();
+    expect(cols.get("created_at")?.serverDefault).toBe("sa.func.now()");
+    expect(cols.get("payload")?.serverDefault).toBe("sa.text(\"'[]'::jsonb\")");
+  });
+});
+
+describe("buildAlembicMigration — per-fixture structural coverage", () => {
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+    "edge_cases.spec",
+  ])("includes every derived table as op.create_table in %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const content = migrationContent(fixture);
+    for (const table of profiled.schema.tables) {
+      expect(content).toContain(`op.create_table(\n        "${table.name}",`);
+    }
+  });
+
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+  ])("every derived CHECK constraint surfaces as a named CheckConstraint in %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const content = migrationContent(fixture);
+    let checkCount = 0;
+    for (const table of profiled.schema.tables) {
+      for (let i = 0; i < table.checks.length; i += 1) {
+        const name = `ck_${table.name}_${i}`;
+        expect(content).toContain(`name="${name}"`);
+        checkCount += 1;
+      }
+    }
+    if (checkCount > 0) expect(content).toContain("sa.CheckConstraint(");
+  });
+
+  it.each([
+    "ecommerce.spec",
+    "todo_list.spec",
+  ])("every derived foreign key surfaces as ForeignKeyConstraint in %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const content = migrationContent(fixture);
+    let fkCount = 0;
+    for (const table of profiled.schema.tables) {
+      for (const fk of table.foreignKeys) {
+        const fkRef = `["${fk.column}"], ["${fk.refTable}.${fk.refColumn}"]`;
+        expect(content).toContain(fkRef);
+        expect(content).toContain(`ondelete="${fk.onDelete}"`);
+        fkCount += 1;
+      }
+    }
+    if (fkCount > 0) expect(content).toContain("sa.ForeignKeyConstraint(");
+  });
+
+  it.each([
+    "url_shortener.spec",
+    "ecommerce.spec",
+  ])("every derived index surfaces as op.create_index in %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const content = migrationContent(fixture);
+    for (const table of profiled.schema.tables) {
+      for (const ix of table.indexes) {
+        expect(content).toContain(`op.create_index("${ix.name}", "${table.name}",`);
+        expect(content).toContain(`unique=${ix.unique ? "True" : "False"}`);
+      }
+    }
+  });
+
+  it.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+  ])("downgrade drops tables in reverse topological order for %s", (fixture) => {
+    const profiled = profiledFrom(fixture);
+    const migration = buildAlembicMigration(profiled.schema);
+    const content = migrationContent(fixture);
+    const downgrade = content.split("def downgrade()")[1] ?? "";
+    const positions = migration.tablesReversed.map((t) => ({
+      name: t.name,
+      pos: downgrade.indexOf(`op.drop_table("${t.name}")`),
+    }));
+    for (const entry of positions) expect(entry.pos).toBeGreaterThan(-1);
+    for (let i = 1; i < positions.length; i += 1) {
+      expect(positions[i].pos).toBeGreaterThan(positions[i - 1].pos);
+    }
+  });
+});
+
+describe("001_initial_schema.py — PostgreSQL dialect import", () => {
+  it("imports the postgresql dialect when any JSONB column is emitted", () => {
+    const content = migrationContent("ecommerce.spec");
+    const hasJsonb = profiledFrom("ecommerce.spec").schema.tables.some((t) =>
+      t.columns.some((c) => c.sqlType === "JSONB"),
+    );
+    if (hasJsonb) {
+      expect(content).toContain("from sqlalchemy.dialects import postgresql");
+    }
+  });
+
+  it("omits the postgresql import when no JSONB column exists", () => {
+    const content = migrationContent("url_shortener.spec");
+    const hasJsonb = profiledFrom("url_shortener.spec").schema.tables.some((t) =>
+      t.columns.some((c) => c.sqlType === "JSONB"),
+    );
+    if (!hasJsonb) {
+      expect(content).not.toContain("from sqlalchemy.dialects import postgresql");
+    }
+  });
+});
+
+describe("001_initial_schema.py — Python syntactic validity", () => {
+  const maybeIt = python3Available() ? it : it.skip;
+  maybeIt.each([
+    "url_shortener.spec",
+    "todo_list.spec",
+    "ecommerce.spec",
+    "auth_service.spec",
+    "edge_cases.spec",
+  ])("parses as valid Python via ast.parse (%s)", (fixture) => {
+    const content = migrationContent(fixture);
+    const proc = spawnSync(
+      "python3",
+      ["-c", "import ast, sys; ast.parse(sys.stdin.read())"],
+      { input: content, encoding: "utf-8" },
+    );
+    if (proc.status !== 0) {
+      throw new Error(`Migration for ${fixture} failed ast.parse:\n${proc.stderr}\n--- content ---\n${content}`);
+    }
+  });
+});

--- a/test/codegen/alembic/migration.test.ts
+++ b/test/codegen/alembic/migration.test.ts
@@ -59,10 +59,73 @@ describe("buildAlembicMigration — render context shape", () => {
     for (const table of migration.tables) {
       for (const fk of table.foreignKeys) {
         const targetPos = position.get(fk.refTable);
-        if (targetPos === undefined) continue;
-        expect(targetPos).toBeLessThan(position.get(table.name)!);
+        expect(
+          targetPos,
+          `FK target ${fk.refTable} missing from migration.tables`,
+        ).toBeDefined();
+        expect(targetPos!).toBeLessThan(position.get(table.name)!);
       }
     }
+  });
+
+  it("throws on foreign-key cycles instead of silently producing an invalid order", () => {
+    const cyclicSchema = {
+      tables: [
+        {
+          name: "a",
+          entityName: "A",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "b_id", sqlType: "BIGINT", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [
+            { column: "b_id", refTable: "b", refColumn: "id", onDelete: "CASCADE" },
+          ],
+          checks: [],
+          indexes: [],
+        },
+        {
+          name: "b",
+          entityName: "B",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "a_id", sqlType: "BIGINT", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [
+            { column: "a_id", refTable: "a", refColumn: "id", onDelete: "CASCADE" },
+          ],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    };
+    expect(() => buildAlembicMigration(cyclicSchema)).toThrow(
+      /Foreign-key cycle detected/,
+    );
+  });
+
+  it("accepts self-referential FKs without mistaking them for a cycle", () => {
+    const selfRefSchema = {
+      tables: [
+        {
+          name: "nodes",
+          entityName: "Node",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "parent_id", sqlType: "BIGINT", nullable: true, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [
+            { column: "parent_id", refTable: "nodes", refColumn: "id", onDelete: "CASCADE" },
+          ],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    };
+    expect(() => buildAlembicMigration(selfRefSchema)).not.toThrow();
   });
 
   it("tablesReversed reverses tables (for downgrade drop order)", () => {
@@ -73,22 +136,44 @@ describe("buildAlembicMigration — render context shape", () => {
     );
   });
 
-  it("sets needsPostgresDialect only when a JSONB column exists", () => {
-    const withJsonb = profiledFrom("ecommerce.spec");
-    const hasJsonbColumn = withJsonb.schema.tables.some((t) =>
-      t.columns.some((c) => c.sqlType === "JSONB"),
-    );
-    expect(buildAlembicMigration(withJsonb.schema).needsPostgresDialect).toBe(
-      hasJsonbColumn,
-    );
+  it("needsPostgresDialect is true when any column is JSONB", () => {
+    const migration = buildAlembicMigration({
+      tables: [
+        {
+          name: "t",
+          entityName: "T",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "payload", sqlType: "JSONB", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    });
+    expect(migration.needsPostgresDialect).toBe(true);
+  });
 
-    const noJsonb = profiledFrom("url_shortener.spec");
-    const urlShortenerHasJsonb = noJsonb.schema.tables.some((t) =>
-      t.columns.some((c) => c.sqlType === "JSONB"),
-    );
-    expect(buildAlembicMigration(noJsonb.schema).needsPostgresDialect).toBe(
-      urlShortenerHasJsonb,
-    );
+  it("needsPostgresDialect is false when no column is JSONB", () => {
+    const migration = buildAlembicMigration({
+      tables: [
+        {
+          name: "t",
+          entityName: "T",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "name", sqlType: "TEXT", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    });
+    expect(migration.needsPostgresDialect).toBe(false);
   });
 });
 
@@ -106,6 +191,77 @@ describe("buildAlembicMigration — SQL-type → SQLAlchemy mapping", () => {
     expect(columns.get("code")?.saType).toBe("sa.Text()");
     expect(columns.get("click_count")?.saType).toBe("sa.Integer()");
     expect(columns.get("created_at")?.saType).toBe("sa.DateTime(timezone=True)");
+  });
+
+  it("handles NUMERIC(p) without a scale argument", () => {
+    const migration = buildAlembicMigration({
+      tables: [
+        {
+          name: "t",
+          entityName: "T",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+            { name: "amount_p", sqlType: "NUMERIC(10)", nullable: false, defaultValue: null },
+            { name: "amount_ps", sqlType: "NUMERIC(19,4)", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [],
+          checks: [],
+          indexes: [],
+        },
+      ],
+    });
+    const cols = new Map(migration.tables[0].columns.map((c) => [c.name, c]));
+    expect(cols.get("amount_p")?.saType).toBe("sa.Numeric(10)");
+    expect(cols.get("amount_ps")?.saType).toBe("sa.Numeric(19, 4)");
+  });
+
+  it("throws on a truly unsupported SQL type instead of silently degrading to sa.Text()", () => {
+    expect(() =>
+      buildAlembicMigration({
+        tables: [
+          {
+            name: "t",
+            entityName: "T",
+            columns: [
+              { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+              { name: "odd", sqlType: "MONEY_EXT", nullable: false, defaultValue: null },
+            ],
+            primaryKey: "id",
+            foreignKeys: [],
+            checks: [],
+            indexes: [],
+          },
+        ],
+      }),
+    ).toThrow(/Unsupported SQL type in Alembic migration: MONEY_EXT/);
+  });
+
+  it("escapes backslashes and control chars so Python literals stay valid", () => {
+    const migration = buildAlembicMigration({
+      tables: [
+        {
+          name: "t",
+          entityName: "T",
+          columns: [
+            { name: "id", sqlType: "BIGSERIAL", nullable: false, defaultValue: null },
+          ],
+          primaryKey: "id",
+          foreignKeys: [],
+          checks: [
+            // regex with backslash and a newline — both must be escaped
+            "code ~ '^\\d+$'",
+            "note != 'line-1\nline-2'",
+          ],
+          indexes: [],
+        },
+      ],
+    });
+    const args = migration.tables[0].tableArgs.filter((a) =>
+      a.includes("CheckConstraint"),
+    );
+    expect(args[0]).toContain("^\\\\d+$");
+    expect(args[1]).toContain("line-1\\nline-2");
   });
 
   it("translates convention defaults to SQLAlchemy expressions", () => {
@@ -219,26 +375,63 @@ describe("buildAlembicMigration — per-fixture structural coverage", () => {
 });
 
 describe("001_initial_schema.py — PostgreSQL dialect import", () => {
-  it("imports the postgresql dialect when any JSONB column is emitted", () => {
-    const content = migrationContent("ecommerce.spec");
-    const hasJsonb = profiledFrom("ecommerce.spec").schema.tables.some((t) =>
+  it("imports postgresql dialect for the ecommerce fixture (JSONB fields present)", () => {
+    const profiled = profiledFrom("ecommerce.spec");
+    const hasJsonb = profiled.schema.tables.some((t) =>
       t.columns.some((c) => c.sqlType === "JSONB"),
     );
-    if (hasJsonb) {
-      expect(content).toContain("from sqlalchemy.dialects import postgresql");
-    }
+    expect(hasJsonb, "ecommerce fixture must have a JSONB column for this test to be meaningful").toBe(true);
+    expect(migrationContent("ecommerce.spec")).toContain(
+      "from sqlalchemy.dialects import postgresql",
+    );
   });
 
-  it("omits the postgresql import when no JSONB column exists", () => {
-    const content = migrationContent("url_shortener.spec");
-    const hasJsonb = profiledFrom("url_shortener.spec").schema.tables.some((t) =>
+  it("omits postgresql dialect for the url_shortener fixture (no JSONB)", () => {
+    const profiled = profiledFrom("url_shortener.spec");
+    const hasJsonb = profiled.schema.tables.some((t) =>
       t.columns.some((c) => c.sqlType === "JSONB"),
     );
-    if (!hasJsonb) {
-      expect(content).not.toContain("from sqlalchemy.dialects import postgresql");
+    expect(hasJsonb, "url_shortener fixture must NOT have a JSONB column for this test to be meaningful").toBe(false);
+    expect(migrationContent("url_shortener.spec")).not.toContain(
+      "from sqlalchemy.dialects import postgresql",
+    );
+  });
+});
+
+describe("001_initial_schema.py — empty-schema fallback", () => {
+  it("emits `pass` in upgrade/downgrade when the schema has no tables", () => {
+    const content = emitEmptySchemaMigration();
+    expect(content).toMatch(/def upgrade\(\) -> None:\s*\n\s+pass/);
+    expect(content).toMatch(/def downgrade\(\) -> None:\s*\n\s+pass/);
+  });
+
+  const maybeIt = python3Available() ? it : it.skip;
+  maybeIt("parses as valid Python when the schema is empty", () => {
+    const proc = spawnSync(
+      "python3",
+      ["-c", "import ast, sys; ast.parse(sys.stdin.read())"],
+      { input: emitEmptySchemaMigration(), encoding: "utf-8" },
+    );
+    if (proc.status !== 0) {
+      throw new Error(`empty-schema migration failed ast.parse:\n${proc.stderr}`);
     }
   });
 });
+
+function emitEmptySchemaMigration(): string {
+  const profiled = profiledFrom("url_shortener.spec");
+  const stripped: ProfiledService = {
+    ...profiled,
+    schema: { tables: [] },
+    entities: [],
+  };
+  const files = emitProject(stripped);
+  const file = files.find((f) =>
+    f.path === "alembic/versions/001_initial_schema.py",
+  );
+  expect(file).toBeDefined();
+  return file!.content;
+}
 
 describe("001_initial_schema.py — Python syntactic validity", () => {
   const maybeIt = python3Available() ? it : it.skip;

--- a/test/codegen/emit.test.ts
+++ b/test/codegen/emit.test.ts
@@ -28,6 +28,9 @@ describe("emitProject — file paths", () => {
     const files = emitProject(profiledFrom("url_shortener.spec"));
     const paths = files.map((f) => f.path).sort();
     expect(paths).toEqual([
+      "alembic.ini",
+      "alembic/env.py",
+      "alembic/versions/001_initial_schema.py",
       "app/__init__.py",
       "app/config.py",
       "app/database.py",


### PR DESCRIPTION
## Summary

- Emits `alembic.ini`, `alembic/env.py`, and `alembic/versions/001_initial_schema.py` from `DatabaseSchema` (already derived in M2.2).
- New `src/codegen/alembic/migration.ts` maps convention-engine PG SQL types to SQLAlchemy `Column` expressions, topologically sorts tables so FK targets come before referrers (reversed in `downgrade`), and translates `server_default` (`NOW()` → `sa.func.now()`; `'[]'::jsonb`/`'{}'::jsonb` → `sa.text(...)`).
- `env.py` swaps `+asyncpg` → `+psycopg` so alembic runs with a sync driver; imports `app.models` so `Base.metadata` is populated before the migration runs.
- JSONB columns trigger the `from sqlalchemy.dialects import postgresql` import automatically.

## Acceptance criteria (issue #16)

| AC | Status |
|---|---|
| `alembic upgrade head` creates correct schema | ✅ — `op.create_table` per table with columns, PK, FKs, named CHECK constraints; `op.create_index` for every derived index. Python `ast.parse` gate proves the migration is syntactically valid for all 5 fixtures. End-to-end `alembic upgrade head` will be exercised by M3.5 (docker-compose up). |
| CHECK constraints from invariants present | ✅ — every `TableSpec.checks` entry surfaces as `sa.CheckConstraint(sql, name="ck_<table>_<i>")`. Parametrized test `every derived CHECK constraint surfaces as a named CheckConstraint` covers 3 fixtures. |
| Foreign keys from relations correct | ✅ — every `TableSpec.foreignKeys` surfaces as `sa.ForeignKeyConstraint([col], [refTable.refCol], ondelete=..., name=fk_<table>_<col>)`. Topo sort verified by `topo-sorts tables so FK targets come before referrers` test. |

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — **780 passed** (37 new Alembic tests: 29 in `migration.test.ts`, 8 in `env.test.ts`)
- [x] Python `ast.parse` sweep — valid Python for `alembic/env.py` + `001_initial_schema.py` across all 5 fixtures
- [x] Manual render of `url_shortener` and `ecommerce` fixtures — correct topo order, JSONB dialect import triggered, check-constraint naming stable

## Deferred (tracked)

Follow-up issues filed under Phase 7 before this PR:

- **#56** — **M7.5 Diff migrations** (`002_`, `003_`, … on spec changes)
- **#57** — **M7.6 Schema derivation polish** (triggers from aggregate invariants + partial indexes)
- **#58** — **M7.7 Alt database dialects** (SQLite, MySQL)

Closes #16.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generates `alembic` scaffolding and an initial migration from the derived `DatabaseSchema`, so `alembic upgrade head` creates the full schema with correct tables, constraints, and indexes. Meets #16 by emitting CHECKs, FKs, and indexes, and enforcing a valid, ordered migration.

- **New Features**
  - Emits `alembic.ini`, `alembic/env.py`, and `alembic/versions/001_initial_schema.py`.
  - Maps PG types to `SQLAlchemy` (including `NUMERIC(p[,s])`, `postgresql.JSONB()`), and translates `server_default` (`NOW()` → `sa.func.now()`, JSONB literals → `sa.text(...)`).
  - Topologically sorts table creation; throws on FK cycles; drops in reverse. Adds named FKs, CHECKs, and `op.create_index` for derived indexes.
  - `env.py` uses Alembic’s async pattern (`asyncio.run`, `async_engine_from_config`), imports `app.models` to populate `Base.metadata`, and conditionally imports the PostgreSQL dialect only when JSONB is present.
  - Escapes backslashes/control chars in emitted Python strings and emits `pass` for empty schemas.

- **Dependencies**
  - Set Python version floor to `>=3.10` to match type hints in the migration header.

<sup>Written for commit 36c9bf0a1b8b26f7778def0b56a05c22827db7a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Generated Python FastAPI/PostgreSQL projects now automatically include database migrations using Alembic, capturing complete database schemas with support for tables, columns, indexes, constraints, and foreign keys. Migrations include reversible upgrade and downgrade paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->