### PR TITLE
Fix generator bugs surfaced by M3.6 golden review

### DIFF
--- a/src/codegen/alembic/migration.ts
+++ b/src/codegen/alembic/migration.ts
@@ -113,7 +113,14 @@ function buildAlembicTable(t: TableSpec): AlembicTable {
     refColumn: fk.refColumn,
     onDelete: fk.onDelete,
   }));
-  const checks = t.checks.map((sql, i) => ({
+  const uniqueCheckSqls: string[] = [];
+  const seenSqls = new Set<string>();
+  for (const sql of t.checks) {
+    if (seenSqls.has(sql)) continue;
+    seenSqls.add(sql);
+    uniqueCheckSqls.push(sql);
+  }
+  const checks = uniqueCheckSqls.map((sql, i) => ({
     name: `ck_${t.name}_${i}`,
     sql,
   }));

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -14,6 +14,7 @@ import type {
 import type { TypeAliasDecl, TypeExpr } from "#ir/types.js";
 import type {
   ProfiledEntity,
+  ProfiledField,
   ProfiledOperation,
   ProfiledService,
 } from "#profile/types.js";
@@ -51,6 +52,12 @@ interface EnrichedOperation {
   readonly serviceReturnAnnotation: string;
   readonly modelLookupColumn: string;
   readonly pathParamName: string;
+  readonly customRequestSchema: CustomRequestSchema | null;
+}
+
+interface CustomRequestSchema {
+  readonly schemaName: string;
+  readonly fields: readonly ProfiledField[];
 }
 
 interface StdlibImport {
@@ -123,17 +130,40 @@ function enrichOperation(
     pythonType: paramPythonType(p, typeLookup),
   }));
 
-  const routeKind = classifyRouteKind(op);
+  let routeKind = classifyRouteKind(op);
   const method = endpoint.method.toLowerCase();
 
   const pathParamCallArgs = pathParamsWithTypes.map((p) => p.name).join(", ");
   const hasRequestBody = routeKind === "create" || endpoint.bodyParams.length > 0;
-  const usesUpdateSchema = op.kind === "partial_update" || op.kind === "replace";
-  const requestBodyType = !hasRequestBody
-    ? ""
-    : usesUpdateSchema
-      ? entity.updateSchemaName
-      : entity.createSchemaName;
+
+  const entityNonIdColumnNames = new Set(
+    entity.fields.filter((f) => f.columnName !== "id").map((f) => f.columnName),
+  );
+  const bodyParamNames = endpoint.bodyParams.map((p) => p.name);
+  const matchesEntityCreateShape =
+    routeKind === "create" &&
+    bodyParamNames.length === entityNonIdColumnNames.size &&
+    bodyParamNames.every((n) => entityNonIdColumnNames.has(n));
+
+  let customRequestSchema: CustomRequestSchema | null = null;
+  let requestBodyType = "";
+  if (hasRequestBody) {
+    if (routeKind === "create" && matchesEntityCreateShape) {
+      requestBodyType = entity.createSchemaName;
+    } else {
+      requestBodyType = `${op.operationName}Request`;
+      const requestBodyByName = new Map(op.requestBodyFields.map((f) => [f.fieldName, f]));
+      const pathParamNames = new Set(endpoint.pathParams.map((p) => p.name));
+      const fields = op.requestBodyFields.filter(
+        (f) => !pathParamNames.has(f.fieldName) && requestBodyByName.has(f.fieldName),
+      );
+      customRequestSchema = { schemaName: requestBodyType, fields };
+    }
+  }
+
+  if (routeKind === "create" && !matchesEntityCreateShape) {
+    routeKind = "other";
+  }
 
   let responseAnnotation: string;
   let serviceCallArgs: string;
@@ -174,6 +204,15 @@ function enrichOperation(
       serviceSignatureExtraArgs = pathParamSignature;
       serviceReturnAnnotation = "bool";
       break;
+    case "redirect":
+      responseAnnotation = "RedirectResponse";
+      serviceCallArgs = pathParamCallArgs;
+      pathParamSignature = pathParamsWithTypes
+        .map((p) => `${p.name}: ${p.pythonType}`)
+        .join(", ");
+      serviceSignatureExtraArgs = pathParamSignature;
+      serviceReturnAnnotation = "str";
+      break;
     default: {
       const args = [
         ...pathParamsWithTypes.map((p) => `${p.name}: ${p.pythonType}`),
@@ -212,6 +251,7 @@ function enrichOperation(
     serviceReturnAnnotation,
     modelLookupColumn,
     pathParamName,
+    customRequestSchema,
   };
 }
 
@@ -220,6 +260,27 @@ function resolveModelLookupColumn(entity: ProfiledEntity, pathParamName: string)
   const entitySnake = toSnakeCase(entity.entityName);
   if (pathParamName === `${entitySnake}_id`) return "id";
   return "id";
+}
+
+const SENSITIVE_EXACT_NAMES: ReadonlySet<string> = new Set([
+  "password",
+  "password_hash",
+  "secret",
+  "token",
+  "api_key",
+]);
+
+const SENSITIVE_SUFFIXES: readonly string[] = [
+  "_hash",
+  "_secret",
+  "_password",
+  "_api_key",
+  "_token",
+];
+
+function isSensitiveFieldName(name: string): boolean {
+  if (SENSITIVE_EXACT_NAMES.has(name)) return true;
+  return SENSITIVE_SUFFIXES.some((s) => name.endsWith(s));
 }
 
 function byPathSpecificity(a: EnrichedOperation, b: EnrichedOperation): number {
@@ -276,10 +337,18 @@ function collectEntityImports(entity: ProfiledEntity): {
   };
 }
 
-function collectSchemaStdlibImports(entity: ProfiledEntity): readonly StdlibImport[] {
+function collectSchemaStdlibImports(
+  entity: ProfiledEntity,
+  customRequestSchemas: readonly CustomRequestSchema[],
+): readonly StdlibImport[] {
   const stdlibByModule = new Map<string, Set<string>>();
   for (const field of entity.fields) {
     mergeStdlibImport(stdlibByModule, field.pythonType);
+  }
+  for (const schema of customRequestSchemas) {
+    for (const field of schema.fields) {
+      mergeStdlibImport(stdlibByModule, field.pythonType);
+    }
   }
   return finalizeStdlibImports(stdlibByModule);
 }
@@ -287,6 +356,7 @@ function collectSchemaStdlibImports(entity: ProfiledEntity): readonly StdlibImpo
 interface RouterTemplateImports {
   readonly needsHttpException: boolean;
   readonly needsResponse: boolean;
+  readonly needsRedirectResponse: boolean;
   readonly schemas: readonly string[];
   readonly stdlibImports: readonly StdlibImport[];
 }
@@ -297,6 +367,7 @@ function collectRouterImports(
 ): RouterTemplateImports {
   let needsHttpException = false;
   let needsResponse = false;
+  let needsRedirectResponse = false;
   const schemaSet = new Set<string>();
   const stdlibByModule = new Map<string, Set<string>>();
 
@@ -306,6 +377,7 @@ function collectRouterImports(
       needsHttpException = true;
       needsResponse = true;
     }
+    if (op.routeKind === "redirect") needsRedirectResponse = true;
     if (op.hasRequestBody && op.requestBodyType) schemaSet.add(op.requestBodyType);
     if (op.routeKind === "create" || op.routeKind === "read" || op.routeKind === "list") {
       schemaSet.add(entity.readSchemaName);
@@ -318,6 +390,7 @@ function collectRouterImports(
   return {
     needsHttpException,
     needsResponse,
+    needsRedirectResponse,
     schemas: [...schemaSet].sort(),
     stdlibImports: finalizeStdlibImports(stdlibByModule),
   };
@@ -326,6 +399,7 @@ function collectRouterImports(
 interface ServiceTemplateImports {
   readonly sqlalchemyCoreImports: readonly string[];
   readonly schemas: readonly string[];
+  readonly needsModelImport: boolean;
 }
 
 function collectServiceImports(
@@ -334,11 +408,19 @@ function collectServiceImports(
 ): ServiceTemplateImports {
   let needsSelect = false;
   let needsSaDelete = false;
+  let needsModelImport = false;
   const schemaSet = new Set<string>();
 
   for (const op of operations) {
-    if (op.routeKind === "read" || op.routeKind === "list") needsSelect = true;
-    if (op.routeKind === "delete") needsSaDelete = true;
+    if (op.routeKind === "read" || op.routeKind === "list") {
+      needsSelect = true;
+      needsModelImport = true;
+    }
+    if (op.routeKind === "delete") {
+      needsSaDelete = true;
+      needsModelImport = true;
+    }
+    if (op.routeKind === "create") needsModelImport = true;
     if (op.routeKind === "create" || op.routeKind === "read" || op.routeKind === "list") {
       schemaSet.add(entity.readSchemaName);
     }
@@ -352,6 +434,7 @@ function collectServiceImports(
   return {
     sqlalchemyCoreImports: coreImports,
     schemas: [...schemaSet].sort(),
+    needsModelImport,
   };
 }
 
@@ -427,7 +510,6 @@ export function emitProject(
       postgresImports,
       stdlibImports,
     } = collectEntityImports(entity);
-    const schemaStdlib = collectSchemaStdlibImports(entity);
     const routerImports = collectRouterImports(entity, entityOperations);
     const serviceImports = collectServiceImports(entity, entityOperations);
 
@@ -435,6 +517,11 @@ export function emitProject(
     const routerSnake = toSnakeCase(pluralize(entity.entityName));
 
     const nonIdFields = entity.fields.filter((f) => f.columnName !== "id");
+    const readFields = nonIdFields.filter((f) => !isSensitiveFieldName(f.columnName));
+    const customRequestSchemas = entityOperations
+      .map((op) => op.customRequestSchema)
+      .filter((s): s is CustomRequestSchema => s !== null);
+    const schemaStdlibWithRequests = collectSchemaStdlibImports(entity, customRequestSchemas);
 
     const modelCtx = {
       ...ctx,
@@ -453,7 +540,9 @@ export function emitProject(
       table,
       entityOperations,
       nonIdFields,
-      stdlibImports: schemaStdlib,
+      readFields,
+      customRequestSchemas,
+      stdlibImports: schemaStdlibWithRequests,
     };
 
     const routerCtx = {

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -11,7 +11,7 @@ import type {
   ParamSpec,
   TableSpec,
 } from "#convention/types.js";
-import type { TypeExpr } from "#ir/types.js";
+import type { TypeAliasDecl, TypeExpr } from "#ir/types.js";
 import type {
   ProfiledEntity,
   ProfiledOperation,
@@ -49,7 +49,8 @@ interface EnrichedOperation {
   readonly pathParamSignature: string;
   readonly serviceSignatureExtraArgs: string;
   readonly serviceReturnAnnotation: string;
-  readonly lookupColumn: string;
+  readonly modelLookupColumn: string;
+  readonly pathParamName: string;
 }
 
 interface StdlibImport {
@@ -78,10 +79,31 @@ function pythonTypeForParam(typeExpr: TypeExpr, typeMap: ReadonlyMap<string, str
   return "str";
 }
 
+function resolveAliasToPython(
+  typeExpr: TypeExpr,
+  base: ReadonlyMap<string, string>,
+  aliasesByName: ReadonlyMap<string, TypeAliasDecl>,
+  visited: Set<string>,
+): string | null {
+  if (typeExpr.kind !== "NamedType") return null;
+  const direct = base.get(typeExpr.name);
+  if (direct !== undefined) return direct;
+  if (visited.has(typeExpr.name)) return null;
+  visited.add(typeExpr.name);
+  const alias = aliasesByName.get(typeExpr.name);
+  if (alias === undefined) return null;
+  return resolveAliasToPython(alias.typeExpr, base, aliasesByName, visited);
+}
+
 function buildTypeLookup(profiled: ProfiledService): ReadonlyMap<string, string> {
   const map = new Map<string, string>();
   for (const [specType, mapping] of profiled.profile.typeMap.entries()) {
     map.set(specType, mapping.python);
+  }
+  const aliasesByName = new Map(profiled.ir.typeAliases.map((a) => [a.name, a]));
+  for (const alias of profiled.ir.typeAliases) {
+    const resolved = resolveAliasToPython(alias.typeExpr, map, aliasesByName, new Set());
+    if (resolved !== null) map.set(alias.name, resolved);
   }
   return map;
 }
@@ -169,7 +191,8 @@ function enrichOperation(
     }
   }
 
-  const lookupColumn = pathParamsWithTypes.length > 0 ? pathParamsWithTypes[0].name : "id";
+  const pathParamName = pathParamsWithTypes.length > 0 ? pathParamsWithTypes[0].name : "id";
+  const modelLookupColumn = resolveModelLookupColumn(entity, pathParamName);
 
   return {
     operationName: op.operationName,
@@ -187,8 +210,23 @@ function enrichOperation(
     pathParamSignature,
     serviceSignatureExtraArgs,
     serviceReturnAnnotation,
-    lookupColumn,
+    modelLookupColumn,
+    pathParamName,
   };
+}
+
+function resolveModelLookupColumn(entity: ProfiledEntity, pathParamName: string): string {
+  if (entity.fields.some((f) => f.columnName === pathParamName)) return pathParamName;
+  const entitySnake = toSnakeCase(entity.entityName);
+  if (pathParamName === `${entitySnake}_id`) return "id";
+  return "id";
+}
+
+function byPathSpecificity(a: EnrichedOperation, b: EnrichedOperation): number {
+  const aParams = (a.path.match(/\{/g) ?? []).length;
+  const bParams = (b.path.match(/\{/g) ?? []).length;
+  if (aParams !== bParams) return aParams - bParams;
+  return 0;
 }
 
 function mergeStdlibImport(
@@ -381,7 +419,8 @@ export function emitProject(
     const table = findTable(ctx.schema.tables, entity.entityName);
     const entityOperations = ctx.operations
       .filter((op) => op.targetEntity === entity.entityName)
-      .map((op) => enrichOperation(op, entity, typeLookup));
+      .map((op) => enrichOperation(op, entity, typeLookup))
+      .sort(byPathSpecificity);
 
     const {
       sqlalchemyImports,

--- a/src/codegen/emit.ts
+++ b/src/codegen/emit.ts
@@ -3,6 +3,7 @@ import { TemplateEngine } from "#codegen/engine.js";
 import { buildOpenApiDocument } from "#codegen/openapi/build.js";
 import { serializeOpenApi } from "#codegen/openapi/serialize.js";
 import { classifyRouteKind, type RouteKind } from "#codegen/route-kind.js";
+import { isSensitiveFieldName } from "#codegen/sensitive-fields.js";
 import { pythonFastapiPostgresTemplates } from "#codegen/templates.js";
 import { buildRenderContext } from "#codegen/types.js";
 import { toSnakeCase, pluralize } from "#convention/naming.js";
@@ -92,14 +93,20 @@ function resolveAliasToPython(
   aliasesByName: ReadonlyMap<string, TypeAliasDecl>,
   visited: Set<string>,
 ): string | null {
-  if (typeExpr.kind !== "NamedType") return null;
-  const direct = base.get(typeExpr.name);
-  if (direct !== undefined) return direct;
-  if (visited.has(typeExpr.name)) return null;
-  visited.add(typeExpr.name);
-  const alias = aliasesByName.get(typeExpr.name);
-  if (alias === undefined) return null;
-  return resolveAliasToPython(alias.typeExpr, base, aliasesByName, visited);
+  if (typeExpr.kind === "NamedType") {
+    const direct = base.get(typeExpr.name);
+    if (direct !== undefined) return direct;
+    if (visited.has(typeExpr.name)) return null;
+    visited.add(typeExpr.name);
+    const alias = aliasesByName.get(typeExpr.name);
+    if (alias === undefined) return null;
+    return resolveAliasToPython(alias.typeExpr, base, aliasesByName, visited);
+  }
+  if (typeExpr.kind === "OptionType") {
+    const inner = resolveAliasToPython(typeExpr.innerType, base, aliasesByName, visited);
+    return inner === null ? null : `${inner} | None`;
+  }
+  return null;
 }
 
 function buildTypeLookup(profiled: ProfiledService): ReadonlyMap<string, string> {
@@ -260,27 +267,6 @@ function resolveModelLookupColumn(entity: ProfiledEntity, pathParamName: string)
   const entitySnake = toSnakeCase(entity.entityName);
   if (pathParamName === `${entitySnake}_id`) return "id";
   return "id";
-}
-
-const SENSITIVE_EXACT_NAMES: ReadonlySet<string> = new Set([
-  "password",
-  "password_hash",
-  "secret",
-  "token",
-  "api_key",
-]);
-
-const SENSITIVE_SUFFIXES: readonly string[] = [
-  "_hash",
-  "_secret",
-  "_password",
-  "_api_key",
-  "_token",
-];
-
-function isSensitiveFieldName(name: string): boolean {
-  if (SENSITIVE_EXACT_NAMES.has(name)) return true;
-  return SENSITIVE_SUFFIXES.some((s) => name.endsWith(s));
 }
 
 function byPathSpecificity(a: EnrichedOperation, b: EnrichedOperation): number {

--- a/src/codegen/openapi/components.ts
+++ b/src/codegen/openapi/components.ts
@@ -1,4 +1,5 @@
 import { fieldToSchema, makeNullable } from "#codegen/openapi/schema.js";
+import { isSensitiveFieldName } from "#codegen/sensitive-fields.js";
 import type { ComponentsObject, SchemaObject } from "#codegen/openapi/types.js";
 import type {
   EntityDecl,
@@ -84,7 +85,7 @@ function readSchemaObject(
   fields: readonly DecoratedField[],
   entity: ProfiledEntity,
 ): SchemaObject {
-  const fs = nonIdFields(fields);
+  const fs = nonIdFields(fields).filter((f) => !isSensitiveFieldName(f.name));
   const props: Record<string, SchemaObject> = { id: { type: "integer" } };
   for (const f of fs) props[f.name] = fieldProperty(f);
   return {

--- a/src/codegen/openapi/schema.ts
+++ b/src/codegen/openapi/schema.ts
@@ -42,7 +42,10 @@ export function makeNullable(schema: SchemaObject): SchemaObject {
   }
   const current: readonly OpenApiSchemaType[] = Array.isArray(type) ? type : [type];
   if (current.includes("null")) return schema;
-  return { ...schema, type: [...current, "null"] };
+  const enumWidened = schema.enum !== undefined && !schema.enum.includes(null)
+    ? { enum: [...schema.enum, null] as readonly (string | null)[] }
+    : {};
+  return { ...schema, type: [...current, "null"], ...enumWidened };
 }
 
 function typeExprToSchema(

--- a/src/codegen/openapi/schema.ts
+++ b/src/codegen/openapi/schema.ts
@@ -42,10 +42,11 @@ export function makeNullable(schema: SchemaObject): SchemaObject {
   }
   const current: readonly OpenApiSchemaType[] = Array.isArray(type) ? type : [type];
   if (current.includes("null")) return schema;
-  const enumWidened = schema.enum !== undefined && !schema.enum.includes(null)
-    ? { enum: [...schema.enum, null] as readonly (string | null)[] }
-    : {};
-  return { ...schema, type: [...current, "null"], ...enumWidened };
+  const widened: SchemaObject = { ...schema, type: [...current, "null"] };
+  if (schema.enum !== undefined && !schema.enum.includes(null)) {
+    return { ...widened, enum: [...schema.enum, null] };
+  }
+  return widened;
 }
 
 function typeExprToSchema(

--- a/src/codegen/openapi/types.ts
+++ b/src/codegen/openapi/types.ts
@@ -19,7 +19,7 @@ export interface SchemaObject {
   readonly minItems?: number;
   readonly maxItems?: number;
   readonly pattern?: string;
-  readonly enum?: readonly string[];
+  readonly enum?: readonly (string | null)[];
   readonly items?: SchemaObject;
   readonly $ref?: string;
   readonly required?: readonly string[];

--- a/src/codegen/route-kind.ts
+++ b/src/codegen/route-kind.ts
@@ -8,13 +8,15 @@ export type RouteKind =
   | "redirect"
   | "other";
 
+const NAVIGATIONAL_REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
+
 export function classifyRouteKind(op: ProfiledOperation): RouteKind {
   const method = op.endpoint.method;
   const status = op.endpoint.successStatus;
   const pathParamCount = op.endpoint.pathParams.length;
   const hasPathParam = pathParamCount > 0;
   const singlePathParam = pathParamCount === 1;
-  if (status >= 300 && status < 400) return "redirect";
+  if (NAVIGATIONAL_REDIRECT_STATUSES.has(status)) return "redirect";
   if (op.kind === "create") return "create";
   if (op.kind === "read" && singlePathParam) return "read";
   if (op.kind === "read" && !hasPathParam) return "list";

--- a/src/codegen/route-kind.ts
+++ b/src/codegen/route-kind.ts
@@ -5,13 +5,16 @@ export type RouteKind =
   | "read"
   | "list"
   | "delete"
+  | "redirect"
   | "other";
 
 export function classifyRouteKind(op: ProfiledOperation): RouteKind {
   const method = op.endpoint.method;
+  const status = op.endpoint.successStatus;
   const pathParamCount = op.endpoint.pathParams.length;
   const hasPathParam = pathParamCount > 0;
   const singlePathParam = pathParamCount === 1;
+  if (status >= 300 && status < 400) return "redirect";
   if (op.kind === "create") return "create";
   if (op.kind === "read" && singlePathParam) return "read";
   if (op.kind === "read" && !hasPathParam) return "list";

--- a/src/codegen/sensitive-fields.ts
+++ b/src/codegen/sensitive-fields.ts
@@ -1,0 +1,20 @@
+const EXACT: ReadonlySet<string> = new Set([
+  "password",
+  "password_hash",
+  "secret",
+  "token",
+  "api_key",
+]);
+
+const SUFFIXES: readonly string[] = [
+  "_hash",
+  "_secret",
+  "_password",
+  "_api_key",
+  "_token",
+];
+
+export function isSensitiveFieldName(name: string): boolean {
+  if (EXACT.has(name)) return true;
+  return SUFFIXES.some((s) => name.endsWith(s));
+}

--- a/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/alembic/env.py.hbs
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/src/codegen/templates/python-fastapi-postgres/pyproject.toml.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/pyproject.toml.hbs
@@ -30,6 +30,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/routers/entity.py.hbs
@@ -2,6 +2,9 @@
 from {{this.module}} import {{join this.names ", "}}
 {{/each}}
 from fastapi import APIRouter, Depends{{#if routerImports.needsHttpException}}, HTTPException{{/if}}{{#if routerImports.needsResponse}}, Response{{/if}}
+{{#if routerImports.needsRedirectResponse}}
+from fastapi.responses import RedirectResponse
+{{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
@@ -39,6 +42,9 @@ async def {{this.handlerName}}(
     if not deleted:
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code={{this.successStatus}})
+{{else if (eq this.routeKind "redirect")}}
+    url = await svc.{{this.handlerName}}({{this.serviceCallArgs}})
+    return RedirectResponse(url=url, status_code={{this.successStatus}})
 {{else}}
     return await svc.{{this.handlerName}}({{this.serviceCallArgs}})
 {{/if}}

--- a/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -16,7 +16,7 @@ class {{entity.readSchemaName}}(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-{{#each nonIdFields}}
+{{#each readFields}}
     {{this.columnName}}: {{this.pydanticType}}{{#if this.nullable}} = None{{/if}}
 {{/each}}
 
@@ -30,4 +30,14 @@ class {{entity.updateSchemaName}}(BaseModel):
 {{/if}}
 {{else}}
     pass
+{{/each}}
+{{#each customRequestSchemas}}
+
+
+class {{this.schemaName}}(BaseModel):
+{{#each this.fields}}
+    {{this.columnName}}: {{this.pydanticType}}{{#if this.nullable}} = None{{/if}}
+{{else}}
+    pass
+{{/each}}
 {{/each}}

--- a/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict
 
 class {{entity.createSchemaName}}(BaseModel):
 {{#each nonIdFields}}
-    {{this.columnName}}: {{this.pydanticType}}
+    {{this.columnName}}: {{this.pydanticType}}{{#if this.nullable}} = None{{/if}}
 {{else}}
     pass
 {{/each}}
@@ -17,7 +17,7 @@ class {{entity.readSchemaName}}(BaseModel):
 
     id: int
 {{#each nonIdFields}}
-    {{this.columnName}}: {{this.pydanticType}}
+    {{this.columnName}}: {{this.pydanticType}}{{#if this.nullable}} = None{{/if}}
 {{/each}}
 
 

--- a/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -18,6 +18,9 @@ class {{entity.entityName}}Service:
         self._session = session
 
 {{#each entityOperations}}
+{{#unless @first}}
+
+{{/unless}}
 {{#if (eq this.routeKind "create")}}
     async def {{this.handlerName}}(self, body: {{../entity.createSchemaName}}) -> {{../entity.readSchemaName}}:
         row = {{../entity.modelClassName}}(**body.model_dump())
@@ -27,7 +30,7 @@ class {{entity.entityName}}Service:
 {{else if (eq this.routeKind "read")}}
     async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> {{../entity.readSchemaName}} | None:
         result = await self._session.execute(
-            select({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
+            select({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.modelLookupColumn}} == {{this.pathParamName}})
         )
         row = result.scalar_one_or_none()
         return {{../entity.readSchemaName}}.model_validate(row) if row is not None else None
@@ -39,7 +42,7 @@ class {{entity.entityName}}Service:
 {{else if (eq this.routeKind "delete")}}
     async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> bool:
         result = await self._session.execute(
-            sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.lookupColumn}} == {{this.lookupColumn}})
+            sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.modelLookupColumn}} == {{this.pathParamName}})
         )
         return result.rowcount > 0
 {{else}}

--- a/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/src/codegen/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -3,7 +3,9 @@ from sqlalchemy import {{join serviceImports.sqlalchemyCoreImports ", "}}
 {{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
+{{#if serviceImports.needsModelImport}}
 from app.models.{{snake_case entity.entityName}} import {{entity.modelClassName}}
+{{/if}}
 {{#if serviceImports.schemas.length}}
 from app.schemas.{{snake_case entity.entityName}} import (
 {{#each serviceImports.schemas}}
@@ -45,6 +47,11 @@ class {{entity.entityName}}Service:
             sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.modelLookupColumn}} == {{this.pathParamName}})
         )
         return result.rowcount > 0
+{{else if (eq this.routeKind "redirect")}}
+    async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> str:
+        raise NotImplementedError(
+            "{{this.kind}} operation '{{this.operationName}}' — implement in M4+"
+        )
 {{else}}
     async def {{this.handlerName}}(self{{#if this.serviceSignatureExtraArgs}}, {{this.serviceSignatureExtraArgs}}{{/if}}) -> {{this.serviceReturnAnnotation}}:
         raise NotImplementedError(

--- a/src/convention/schema.ts
+++ b/src/convention/schema.ts
@@ -15,7 +15,7 @@ import type {
   ForeignKeySpec,
   IndexSpec,
 } from "#convention/types.js";
-import { toTableName, toColumnName } from "#convention/naming.js";
+import { toTableName, toColumnName, toSnakeCase } from "#convention/naming.js";
 import { getConvention } from "#convention/path.js";
 
 export function deriveSchema(ir: ServiceIR): DatabaseSchema {
@@ -208,7 +208,21 @@ function mapFieldToColumn(
   aliasMap: Map<string, TypeAliasDecl>,
 ): MappedField {
   const colName = toColumnName(field.name);
-  return mapTypeToColumn(colName, field.typeExpr, entityNames, enumMap, aliasMap);
+  const mapped = mapTypeToColumn(colName, field.typeExpr, entityNames, enumMap, aliasMap);
+
+  if (mapped.foreignKey === null && colName.endsWith("_id")) {
+    const prefix = colName.slice(0, -"_id".length);
+    const targetEntity = [...entityNames].find((n) => toSnakeCase(n) === prefix);
+    if (targetEntity !== undefined) {
+      return {
+        column: { ...mapped.column, sqlType: "BIGINT" },
+        foreignKey: { column: colName, refTable: toTableName(targetEntity), refColumn: "id", onDelete: "CASCADE" },
+        check: mapped.check,
+      };
+    }
+  }
+
+  return mapped;
 }
 
 function mapTypeToColumn(

--- a/src/convention/schema.ts
+++ b/src/convention/schema.ts
@@ -18,15 +18,21 @@ import type {
 import { toTableName, toColumnName, toSnakeCase } from "#convention/naming.js";
 import { getConvention } from "#convention/path.js";
 
+interface EntityRef {
+  readonly tableName: string;
+  readonly idFkSqlType: string;
+}
+
 export function deriveSchema(ir: ServiceIR): DatabaseSchema {
   const entityNames = new Set(ir.entities.map((e) => e.name));
   const enumMap = new Map(ir.enums.map((e) => [e.name, e]));
   const aliasMap = new Map(ir.typeAliases.map((a) => [a.name, a]));
+  const entityRefs = buildEntityRefMap(ir, entityNames, enumMap, aliasMap);
 
   const tables: TableSpec[] = [];
 
   for (const entity of ir.entities) {
-    tables.push(deriveTable(entity, ir, entityNames, enumMap, aliasMap));
+    tables.push(deriveTable(entity, ir, entityNames, enumMap, aliasMap, entityRefs));
   }
 
   if (ir.state) {
@@ -42,12 +48,36 @@ export function deriveSchema(ir: ServiceIR): DatabaseSchema {
   return { tables };
 }
 
+function buildEntityRefMap(
+  ir: ServiceIR,
+  entityNames: Set<string>,
+  enumMap: Map<string, EnumDecl>,
+  aliasMap: Map<string, TypeAliasDecl>,
+): Map<string, EntityRef> {
+  const map = new Map<string, EntityRef>();
+  for (const entity of ir.entities) {
+    const tableNameOverride = getConvention(ir.conventions, entity.name, "db_table");
+    const tableName = tableNameOverride || toTableName(entity.name);
+    const idField = entity.fields.find((f) => f.name === "id");
+    let idFkSqlType: string;
+    if (idField === undefined) {
+      idFkSqlType = "BIGINT";
+    } else {
+      const mapped = mapTypeToColumn("id", idField.typeExpr, entityNames, enumMap, aliasMap);
+      idFkSqlType = mapped.column.sqlType === "BIGSERIAL" ? "BIGINT" : mapped.column.sqlType;
+    }
+    map.set(entity.name, { tableName, idFkSqlType });
+  }
+  return map;
+}
+
 function deriveTable(
   entity: EntityDecl,
   ir: ServiceIR,
   entityNames: Set<string>,
   enumMap: Map<string, EnumDecl>,
   aliasMap: Map<string, TypeAliasDecl>,
+  entityRefs: Map<string, EntityRef>,
 ): TableSpec {
   const tableNameOverride = getConvention(ir.conventions, entity.name, "db_table");
   const tableName = tableNameOverride || toTableName(entity.name);
@@ -65,7 +95,7 @@ function deriveTable(
 
   for (const field of entity.fields) {
     const colName = toColumnName(field.name);
-    const mapped = mapFieldToColumn(field, entityNames, enumMap, aliasMap);
+    const mapped = mapFieldToColumn(field, entityNames, enumMap, aliasMap, entityRefs);
 
     columns.push(mapped.column);
 
@@ -206,6 +236,7 @@ function mapFieldToColumn(
   entityNames: Set<string>,
   enumMap: Map<string, EnumDecl>,
   aliasMap: Map<string, TypeAliasDecl>,
+  entityRefs: Map<string, EntityRef>,
 ): MappedField {
   const colName = toColumnName(field.name);
   const mapped = mapTypeToColumn(colName, field.typeExpr, entityNames, enumMap, aliasMap);
@@ -214,11 +245,14 @@ function mapFieldToColumn(
     const prefix = colName.slice(0, -"_id".length);
     const targetEntity = [...entityNames].find((n) => toSnakeCase(n) === prefix);
     if (targetEntity !== undefined) {
-      return {
-        column: { ...mapped.column, sqlType: "BIGINT" },
-        foreignKey: { column: colName, refTable: toTableName(targetEntity), refColumn: "id", onDelete: "CASCADE" },
-        check: mapped.check,
-      };
+      const ref = entityRefs.get(targetEntity);
+      if (ref !== undefined) {
+        return {
+          column: { ...mapped.column, sqlType: ref.idFkSqlType },
+          foreignKey: { column: colName, refTable: ref.tableName, refColumn: "id", onDelete: "CASCADE" },
+          check: mapped.check,
+        };
+      }
     }
   }
 

--- a/test/codegen/alembic/env.test.ts
+++ b/test/codegen/alembic/env.test.ts
@@ -50,7 +50,7 @@ describe("alembic/env.py — structural invariants", () => {
     expect(content).not.toContain("+psycopg");
     expect(content).not.toContain("from sqlalchemy import engine_from_config");
     expect(content).toContain(
-      'config.set_main_option("sqlalchemy.url", settings.database_url)',
+      'config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))',
     );
   });
 

--- a/test/codegen/alembic/migration.test.ts
+++ b/test/codegen/alembic/migration.test.ts
@@ -314,6 +314,8 @@ describe("buildAlembicMigration — per-fixture structural coverage", () => {
     let checkCount = 0;
     for (const table of profiled.schema.tables) {
       const uniqueChecks = [...new Set(table.checks)];
+      const actualNames = content.match(new RegExp(`name="ck_${table.name}_\\d+"`, "g")) ?? [];
+      expect(actualNames).toHaveLength(uniqueChecks.length);
       for (let i = 0; i < uniqueChecks.length; i += 1) {
         const name = `ck_${table.name}_${i}`;
         expect(content).toContain(`name="${name}"`);

--- a/test/codegen/alembic/migration.test.ts
+++ b/test/codegen/alembic/migration.test.ts
@@ -313,7 +313,8 @@ describe("buildAlembicMigration — per-fixture structural coverage", () => {
     const content = migrationContent(fixture);
     let checkCount = 0;
     for (const table of profiled.schema.tables) {
-      for (let i = 0; i < table.checks.length; i += 1) {
+      const uniqueChecks = [...new Set(table.checks)];
+      for (let i = 0; i < uniqueChecks.length; i += 1) {
         const name = `ck_${table.name}_${i}`;
         expect(content).toContain(`name="${name}"`);
         checkCount += 1;

--- a/test/codegen/emit.test.ts
+++ b/test/codegen/emit.test.ts
@@ -145,12 +145,13 @@ describe("emitProject — structural markers", () => {
     expect(router.content).toContain("async def shorten(");
   });
 
-  it("service file emits CRUD method bodies and stubs for non-CRUD", () => {
+  it("service file emits CRUD method bodies (delete) and stubs for non-matching creates", () => {
     const files = emitProject(profiledFrom("url_shortener.spec"));
     const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
     expect(svc.content).toContain("class UrlMappingService:");
-    expect(svc.content).toContain("self._session.add(row)");
     expect(svc.content).toContain("sa_delete(UrlMapping).where(UrlMapping.code == code)");
+    expect(svc.content).toMatch(/async def shorten\(self, body: ShortenRequest\)/);
+    expect(svc.content).toMatch(/raise NotImplementedError/);
   });
 
   it("emits NotImplementedError stubs for transition operations (todo_list)", () => {

--- a/test/codegen/emit.test.ts
+++ b/test/codegen/emit.test.ts
@@ -150,8 +150,9 @@ describe("emitProject — structural markers", () => {
     const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
     expect(svc.content).toContain("class UrlMappingService:");
     expect(svc.content).toContain("sa_delete(UrlMapping).where(UrlMapping.code == code)");
-    expect(svc.content).toMatch(/async def shorten\(self, body: ShortenRequest\)/);
-    expect(svc.content).toMatch(/raise NotImplementedError/);
+    expect(svc.content).toMatch(
+      /async def shorten\(self, body: ShortenRequest\) -> None:\n\s+raise NotImplementedError\(/,
+    );
   });
 
   it("emits NotImplementedError stubs for transition operations (todo_list)", () => {

--- a/test/codegen/golden/expected/auth_service/alembic/env.py
+++ b/test/codegen/golden/expected/auth_service/alembic/env.py
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/test/codegen/golden/expected/auth_service/alembic/versions/001_initial_schema.py
+++ b/test/codegen/golden/expected/auth_service/alembic/versions/001_initial_schema.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
     op.create_table(
         "sessions",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
-        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
         sa.Column("access_token", sa.Text(), nullable=False),
         sa.Column("refresh_token", sa.Text(), nullable=False),
         sa.Column("access_expires_at", sa.DateTime(timezone=True), nullable=False),
@@ -42,8 +42,10 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("is_revoked", sa.Boolean(), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE", name="fk_sessions_user_id"),
         sa.CheckConstraint('id > 0', name="ck_sessions_0"),
     )
+    op.create_index("idx_sessions_user_id", "sessions", ["user_id"], unique=False)
 
     op.create_table(
         "login_attempts",
@@ -58,5 +60,6 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("login_attempts")
+    op.drop_index("idx_sessions_user_id", table_name="sessions")
     op.drop_table("sessions")
     op.drop_table("users")

--- a/test/codegen/golden/expected/auth_service/alembic/versions/001_initial_schema.py
+++ b/test/codegen/golden/expected/auth_service/alembic/versions/001_initial_schema.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
     op.create_table(
         "sessions",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
-        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
         sa.Column("access_token", sa.Text(), nullable=False),
         sa.Column("refresh_token", sa.Text(), nullable=False),
         sa.Column("access_expires_at", sa.DateTime(timezone=True), nullable=False),

--- a/test/codegen/golden/expected/auth_service/app/routers/sessions.py
+++ b/test/codegen/golden/expected/auth_service/app/routers/sessions.py
@@ -3,8 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.schemas.session import (
-    SessionCreate,
-    SessionRead,
+    RefreshTokenRequest,
 )
 from app.services.session import SessionService
 
@@ -13,8 +12,8 @@ router = APIRouter(tags=["session"])
 
 @router.post("/auth/refresh", status_code=201)
 async def refresh_token(
-    body: SessionCreate,
+    body: RefreshTokenRequest,
     session: AsyncSession = Depends(get_session),
-) -> SessionRead:
+) -> None:
     svc = SessionService(session)
     return await svc.refresh_token(body)

--- a/test/codegen/golden/expected/auth_service/app/routers/users.py
+++ b/test/codegen/golden/expected/auth_service/app/routers/users.py
@@ -3,9 +3,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.schemas.user import (
-    UserCreate,
-    UserRead,
-    UserUpdate,
+    LoginFailedRequest,
+    LoginRequest,
+    LogoutRequest,
+    RegisterRequest,
+    RequestPasswordResetRequest,
+    ResetPasswordRequest,
 )
 from app.services.user import UserService
 
@@ -14,31 +17,31 @@ router = APIRouter(tags=["user"])
 
 @router.post("/auth/register", status_code=201)
 async def register(
-    body: UserCreate,
+    body: RegisterRequest,
     session: AsyncSession = Depends(get_session),
-) -> UserRead:
+) -> None:
     svc = UserService(session)
     return await svc.register(body)
 
 @router.post("/auth/login", status_code=200)
 async def login(
-    body: UserCreate,
+    body: LoginRequest,
     session: AsyncSession = Depends(get_session),
-) -> UserRead:
+) -> None:
     svc = UserService(session)
     return await svc.login(body)
 
 @router.post("/users", status_code=201)
 async def login_failed(
-    body: UserCreate,
+    body: LoginFailedRequest,
     session: AsyncSession = Depends(get_session),
-) -> UserRead:
+) -> None:
     svc = UserService(session)
     return await svc.login_failed(body)
 
 @router.post("/auth/password-reset", status_code=200)
 async def request_password_reset(
-    body: UserUpdate,
+    body: RequestPasswordResetRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UserService(session)
@@ -46,7 +49,7 @@ async def request_password_reset(
 
 @router.post("/auth/password-reset/confirm", status_code=200)
 async def reset_password(
-    body: UserUpdate,
+    body: ResetPasswordRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UserService(session)
@@ -54,7 +57,7 @@ async def reset_password(
 
 @router.post("/auth/logout", status_code=204)
 async def logout(
-    body: UserUpdate,
+    body: LogoutRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UserService(session)

--- a/test/codegen/golden/expected/auth_service/app/schemas/session.py
+++ b/test/codegen/golden/expected/auth_service/app/schemas/session.py
@@ -17,8 +17,6 @@ class SessionRead(BaseModel):
 
     id: int
     user_id: int
-    access_token: str
-    refresh_token: str
     access_expires_at: datetime
     refresh_expires_at: datetime
     created_at: datetime
@@ -33,3 +31,7 @@ class SessionUpdate(BaseModel):
     refresh_expires_at: datetime | None = None
     created_at: datetime | None = None
     is_revoked: bool | None = None
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str

--- a/test/codegen/golden/expected/auth_service/app/schemas/user.py
+++ b/test/codegen/golden/expected/auth_service/app/schemas/user.py
@@ -7,7 +7,7 @@ class UserCreate(BaseModel):
     password_hash: str
     display_name: str
     created_at: datetime
-    last_login: datetime | None
+    last_login: datetime | None = None
     is_active: bool
 
 
@@ -19,7 +19,7 @@ class UserRead(BaseModel):
     password_hash: str
     display_name: str
     created_at: datetime
-    last_login: datetime | None
+    last_login: datetime | None = None
     is_active: bool
 
 

--- a/test/codegen/golden/expected/auth_service/app/schemas/user.py
+++ b/test/codegen/golden/expected/auth_service/app/schemas/user.py
@@ -16,7 +16,6 @@ class UserRead(BaseModel):
 
     id: int
     email: str
-    password_hash: str
     display_name: str
     created_at: datetime
     last_login: datetime | None = None
@@ -30,3 +29,32 @@ class UserUpdate(BaseModel):
     created_at: datetime | None = None
     last_login: datetime | None = None
     is_active: bool | None = None
+
+
+class RegisterRequest(BaseModel):
+    email: str
+    password: str
+    display_name: str
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class LoginFailedRequest(BaseModel):
+    email: str
+    password: str
+
+
+class RequestPasswordResetRequest(BaseModel):
+    email: str
+
+
+class ResetPasswordRequest(BaseModel):
+    reset_token: str
+    new_password: str
+
+
+class LogoutRequest(BaseModel):
+    access_token: str

--- a/test/codegen/golden/expected/auth_service/app/services/login_attempt.py
+++ b/test/codegen/golden/expected/auth_service/app/services/login_attempt.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.login_attempt import LoginAttempt
 
 
 class LoginAttemptService:

--- a/test/codegen/golden/expected/auth_service/app/services/session.py
+++ b/test/codegen/golden/expected/auth_service/app/services/session.py
@@ -1,9 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.session import Session
 from app.schemas.session import (
-    SessionCreate,
-    SessionRead,
+    RefreshTokenRequest,
 )
 
 
@@ -11,8 +9,7 @@ class SessionService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def refresh_token(self, body: SessionCreate) -> SessionRead:
-        row = Session(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return SessionRead.model_validate(row)
+    async def refresh_token(self, body: RefreshTokenRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'RefreshToken' — implement in M4+"
+        )

--- a/test/codegen/golden/expected/auth_service/app/services/user.py
+++ b/test/codegen/golden/expected/auth_service/app/services/user.py
@@ -1,10 +1,12 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.user import User
 from app.schemas.user import (
-    UserCreate,
-    UserRead,
-    UserUpdate,
+    LoginFailedRequest,
+    LoginRequest,
+    LogoutRequest,
+    RegisterRequest,
+    RequestPasswordResetRequest,
+    ResetPasswordRequest,
 )
 
 
@@ -12,35 +14,32 @@ class UserService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def register(self, body: UserCreate) -> UserRead:
-        row = User(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return UserRead.model_validate(row)
+    async def register(self, body: RegisterRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'Register' — implement in M4+"
+        )
 
-    async def login(self, body: UserCreate) -> UserRead:
-        row = User(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return UserRead.model_validate(row)
+    async def login(self, body: LoginRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'Login' — implement in M4+"
+        )
 
-    async def login_failed(self, body: UserCreate) -> UserRead:
-        row = User(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return UserRead.model_validate(row)
+    async def login_failed(self, body: LoginFailedRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'LoginFailed' — implement in M4+"
+        )
 
-    async def request_password_reset(self, body: UserUpdate) -> None:
+    async def request_password_reset(self, body: RequestPasswordResetRequest) -> None:
         raise NotImplementedError(
             "partial_update operation 'RequestPasswordReset' — implement in M4+"
         )
 
-    async def reset_password(self, body: UserUpdate) -> None:
+    async def reset_password(self, body: ResetPasswordRequest) -> None:
         raise NotImplementedError(
             "partial_update operation 'ResetPassword' — implement in M4+"
         )
 
-    async def logout(self, body: UserUpdate) -> None:
+    async def logout(self, body: LogoutRequest) -> None:
         raise NotImplementedError(
             "partial_update operation 'Logout' — implement in M4+"
         )

--- a/test/codegen/golden/expected/auth_service/app/services/user.py
+++ b/test/codegen/golden/expected/auth_service/app/services/user.py
@@ -17,24 +17,29 @@ class UserService:
         self._session.add(row)
         await self._session.flush()
         return UserRead.model_validate(row)
+
     async def login(self, body: UserCreate) -> UserRead:
         row = User(**body.model_dump())
         self._session.add(row)
         await self._session.flush()
         return UserRead.model_validate(row)
+
     async def login_failed(self, body: UserCreate) -> UserRead:
         row = User(**body.model_dump())
         self._session.add(row)
         await self._session.flush()
         return UserRead.model_validate(row)
+
     async def request_password_reset(self, body: UserUpdate) -> None:
         raise NotImplementedError(
             "partial_update operation 'RequestPasswordReset' — implement in M4+"
         )
+
     async def reset_password(self, body: UserUpdate) -> None:
         raise NotImplementedError(
             "partial_update operation 'ResetPassword' — implement in M4+"
         )
+
     async def logout(self, body: UserUpdate) -> None:
         raise NotImplementedError(
             "partial_update operation 'Logout' — implement in M4+"

--- a/test/codegen/golden/expected/auth_service/openapi.yaml
+++ b/test/codegen/golden/expected/auth_service/openapi.yaml
@@ -247,7 +247,6 @@ components:
       required:
         - id
         - email
-        - password_hash
         - display_name
         - created_at
         - is_active
@@ -257,10 +256,6 @@ components:
         email:
           type: string
           pattern: ^[^@]+@[^@]+\.[^@]+$
-        password_hash:
-          type: string
-          minLength: 64
-          maxLength: 64
         display_name:
           type: string
           minLength: 1
@@ -350,8 +345,6 @@ components:
       required:
         - id
         - user_id
-        - access_token
-        - refresh_token
         - access_expires_at
         - refresh_expires_at
         - created_at
@@ -362,14 +355,6 @@ components:
         user_id:
           type: integer
           exclusiveMinimum: 0
-        access_token:
-          type: string
-          minLength: 128
-          maxLength: 128
-        refresh_token:
-          type: string
-          minLength: 128
-          maxLength: 128
         access_expires_at:
           type: string
           format: date-time

--- a/test/codegen/golden/expected/auth_service/pyproject.toml
+++ b/test/codegen/golden/expected/auth_service/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/test/codegen/golden/expected/ecommerce/alembic/env.py
+++ b/test/codegen/golden/expected/ecommerce/alembic/env.py
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
+++ b/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
@@ -62,15 +62,17 @@ def upgrade() -> None:
     op.create_table(
         "payments",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
-        sa.Column("order_id", sa.Integer(), nullable=False),
+        sa.Column("order_id", sa.BigInteger(), nullable=False),
         sa.Column("amount", sa.Integer(), nullable=False),
         sa.Column("status", sa.Text(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["order_id"], ["orders.id"], ondelete="CASCADE", name="fk_payments_order_id"),
         sa.CheckConstraint('id > 0', name="ck_payments_0"),
         sa.CheckConstraint("status IN ('PENDING', 'AUTHORIZED', 'CAPTURED', 'REFUNDED', 'FAILED')", name="ck_payments_1"),
         sa.CheckConstraint('amount > 0', name="ck_payments_2"),
     )
+    op.create_index("idx_payments_order_id", "payments", ["order_id"], unique=False)
 
     op.create_table(
         "inventory_entries",
@@ -87,6 +89,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("inventory_entries")
+    op.drop_index("idx_payments_order_id", table_name="payments")
     op.drop_table("payments")
     op.drop_table("orders")
     op.drop_table("line_items")

--- a/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
+++ b/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
@@ -82,8 +82,6 @@ def upgrade() -> None:
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
         sa.CheckConstraint('available >= 0', name="ck_inventory_entries_0"),
         sa.CheckConstraint('reserved >= 0', name="ck_inventory_entries_1"),
-        sa.CheckConstraint('available >= 0', name="ck_inventory_entries_2"),
-        sa.CheckConstraint('reserved >= 0', name="ck_inventory_entries_3"),
     )
 
 

--- a/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
+++ b/test/codegen/golden/expected/ecommerce/alembic/versions/001_initial_schema.py
@@ -62,7 +62,7 @@ def upgrade() -> None:
     op.create_table(
         "payments",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
-        sa.Column("order_id", sa.BigInteger(), nullable=False),
+        sa.Column("order_id", sa.Integer(), nullable=False),
         sa.Column("amount", sa.Integer(), nullable=False),
         sa.Column("status", sa.Text(), nullable=False),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),

--- a/test/codegen/golden/expected/ecommerce/app/routers/orders.py
+++ b/test/codegen/golden/expected/ecommerce/app/routers/orders.py
@@ -20,27 +20,25 @@ async def create_draft_order(
     svc = OrderService(session)
     return await svc.create_draft_order(body)
 
+@router.get("/orders", status_code=200)
+async def list_orders(
+    session: AsyncSession = Depends(get_session),
+) -> list[OrderRead]:
+    svc = OrderService(session)
+    return await svc.list_orders()
+
 @router.post("/orders/{order_id}/items", status_code=201)
 async def add_line_item(
-    order_id: str,
+    order_id: int,
     body: OrderUpdate,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
     return await svc.add_line_item(order_id, body)
 
-@router.delete("/orders/{order_id}/items/{item_id}", status_code=204)
-async def remove_line_item(
-    order_id: str,
-    item_id: int,
-    session: AsyncSession = Depends(get_session),
-) -> None:
-    svc = OrderService(session)
-    return await svc.remove_line_item(order_id, item_id)
-
 @router.post("/orders/{order_id}/place", status_code=200)
 async def place_order(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -48,7 +46,7 @@ async def place_order(
 
 @router.post("/orders/{order_id}/payments", status_code=201)
 async def record_payment(
-    order_id: str,
+    order_id: int,
     body: OrderCreate,
     session: AsyncSession = Depends(get_session),
 ) -> None:
@@ -57,7 +55,7 @@ async def record_payment(
 
 @router.post("/orders/{order_id}/ship", status_code=200)
 async def ship_order(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -65,7 +63,7 @@ async def ship_order(
 
 @router.post("/orders/{order_id}/deliver", status_code=200)
 async def confirm_delivery(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -73,7 +71,7 @@ async def confirm_delivery(
 
 @router.post("/orders/{order_id}/cancel", status_code=200)
 async def cancel_order(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -81,7 +79,7 @@ async def cancel_order(
 
 @router.post("/orders/{order_id}/return", status_code=200)
 async def process_return(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -89,7 +87,7 @@ async def process_return(
 
 @router.get("/orders/{order_id}", status_code=200)
 async def get_order(
-    order_id: str,
+    order_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> OrderRead:
     svc = OrderService(session)
@@ -98,9 +96,11 @@ async def get_order(
         raise HTTPException(status_code=404, detail="not found")
     return result
 
-@router.get("/orders", status_code=200)
-async def list_orders(
+@router.delete("/orders/{order_id}/items/{item_id}", status_code=204)
+async def remove_line_item(
+    order_id: int,
+    item_id: int,
     session: AsyncSession = Depends(get_session),
-) -> list[OrderRead]:
+) -> None:
     svc = OrderService(session)
-    return await svc.list_orders()
+    return await svc.remove_line_item(order_id, item_id)

--- a/test/codegen/golden/expected/ecommerce/app/routers/orders.py
+++ b/test/codegen/golden/expected/ecommerce/app/routers/orders.py
@@ -3,9 +3,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.schemas.order import (
-    OrderCreate,
+    AddLineItemRequest,
+    CreateDraftOrderRequest,
     OrderRead,
-    OrderUpdate,
+    RecordPaymentRequest,
 )
 from app.services.order import OrderService
 
@@ -14,9 +15,9 @@ router = APIRouter(tags=["order"])
 
 @router.post("/orders", status_code=201)
 async def create_draft_order(
-    body: OrderCreate,
+    body: CreateDraftOrderRequest,
     session: AsyncSession = Depends(get_session),
-) -> OrderRead:
+) -> None:
     svc = OrderService(session)
     return await svc.create_draft_order(body)
 
@@ -30,7 +31,7 @@ async def list_orders(
 @router.post("/orders/{order_id}/items", status_code=201)
 async def add_line_item(
     order_id: int,
-    body: OrderUpdate,
+    body: AddLineItemRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)
@@ -47,7 +48,7 @@ async def place_order(
 @router.post("/orders/{order_id}/payments", status_code=201)
 async def record_payment(
     order_id: int,
-    body: OrderCreate,
+    body: RecordPaymentRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = OrderService(session)

--- a/test/codegen/golden/expected/ecommerce/app/schemas/order.py
+++ b/test/codegen/golden/expected/ecommerce/app/schemas/order.py
@@ -11,8 +11,8 @@ class OrderCreate(BaseModel):
     total: int
     created_at: datetime
     updated_at: datetime
-    shipped_at: datetime | None
-    delivered_at: datetime | None
+    shipped_at: datetime | None = None
+    delivered_at: datetime | None = None
 
 
 class OrderRead(BaseModel):
@@ -27,8 +27,8 @@ class OrderRead(BaseModel):
     total: int
     created_at: datetime
     updated_at: datetime
-    shipped_at: datetime | None
-    delivered_at: datetime | None
+    shipped_at: datetime | None = None
+    delivered_at: datetime | None = None
 
 
 class OrderUpdate(BaseModel):

--- a/test/codegen/golden/expected/ecommerce/app/schemas/order.py
+++ b/test/codegen/golden/expected/ecommerce/app/schemas/order.py
@@ -42,3 +42,16 @@ class OrderUpdate(BaseModel):
     updated_at: datetime | None = None
     shipped_at: datetime | None = None
     delivered_at: datetime | None = None
+
+
+class CreateDraftOrderRequest(BaseModel):
+    customer_id: int
+
+
+class AddLineItemRequest(BaseModel):
+    sku: str
+    quantity: int
+
+
+class RecordPaymentRequest(BaseModel):
+    amount: int

--- a/test/codegen/golden/expected/ecommerce/app/schemas/product.py
+++ b/test/codegen/golden/expected/ecommerce/app/schemas/product.py
@@ -5,7 +5,7 @@ class ProductCreate(BaseModel):
     sku: str
     name: str
     price: int
-    description: str | None
+    description: str | None = None
 
 
 class ProductRead(BaseModel):
@@ -15,7 +15,7 @@ class ProductRead(BaseModel):
     sku: str
     name: str
     price: int
-    description: str | None
+    description: str | None = None
 
 
 class ProductUpdate(BaseModel):

--- a/test/codegen/golden/expected/ecommerce/app/services/inventory_entry.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/inventory_entry.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.inventory_entry import InventoryEntry
 
 
 class InventoryEntryService:

--- a/test/codegen/golden/expected/ecommerce/app/services/line_item.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/line_item.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.line_item import LineItem
 
 
 class LineItemService:

--- a/test/codegen/golden/expected/ecommerce/app/services/order.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/order.py
@@ -18,45 +18,55 @@ class OrderService:
         self._session.add(row)
         await self._session.flush()
         return OrderRead.model_validate(row)
-    async def add_line_item(self, order_id: str, body: OrderUpdate) -> None:
-        raise NotImplementedError(
-            "partial_update operation 'AddLineItem' — implement in M4+"
-        )
-    async def remove_line_item(self, order_id: str, item_id: int) -> None:
-        raise NotImplementedError(
-            "partial_update operation 'RemoveLineItem' — implement in M4+"
-        )
-    async def place_order(self, order_id: str) -> None:
-        raise NotImplementedError(
-            "transition operation 'PlaceOrder' — implement in M4+"
-        )
-    async def record_payment(self, order_id: str, body: OrderCreate) -> None:
-        raise NotImplementedError(
-            "transition operation 'RecordPayment' — implement in M4+"
-        )
-    async def ship_order(self, order_id: str) -> None:
-        raise NotImplementedError(
-            "transition operation 'ShipOrder' — implement in M4+"
-        )
-    async def confirm_delivery(self, order_id: str) -> None:
-        raise NotImplementedError(
-            "transition operation 'ConfirmDelivery' — implement in M4+"
-        )
-    async def cancel_order(self, order_id: str) -> None:
-        raise NotImplementedError(
-            "transition operation 'CancelOrder' — implement in M4+"
-        )
-    async def process_return(self, order_id: str) -> None:
-        raise NotImplementedError(
-            "transition operation 'ProcessReturn' — implement in M4+"
-        )
-    async def get_order(self, order_id: str) -> OrderRead | None:
-        result = await self._session.execute(
-            select(Order).where(Order.order_id == order_id)
-        )
-        row = result.scalar_one_or_none()
-        return OrderRead.model_validate(row) if row is not None else None
+
     async def list_orders(self) -> list[OrderRead]:
         result = await self._session.execute(select(Order))
         rows = result.scalars().all()
         return [OrderRead.model_validate(row) for row in rows]
+
+    async def add_line_item(self, order_id: int, body: OrderUpdate) -> None:
+        raise NotImplementedError(
+            "partial_update operation 'AddLineItem' — implement in M4+"
+        )
+
+    async def place_order(self, order_id: int) -> None:
+        raise NotImplementedError(
+            "transition operation 'PlaceOrder' — implement in M4+"
+        )
+
+    async def record_payment(self, order_id: int, body: OrderCreate) -> None:
+        raise NotImplementedError(
+            "transition operation 'RecordPayment' — implement in M4+"
+        )
+
+    async def ship_order(self, order_id: int) -> None:
+        raise NotImplementedError(
+            "transition operation 'ShipOrder' — implement in M4+"
+        )
+
+    async def confirm_delivery(self, order_id: int) -> None:
+        raise NotImplementedError(
+            "transition operation 'ConfirmDelivery' — implement in M4+"
+        )
+
+    async def cancel_order(self, order_id: int) -> None:
+        raise NotImplementedError(
+            "transition operation 'CancelOrder' — implement in M4+"
+        )
+
+    async def process_return(self, order_id: int) -> None:
+        raise NotImplementedError(
+            "transition operation 'ProcessReturn' — implement in M4+"
+        )
+
+    async def get_order(self, order_id: int) -> OrderRead | None:
+        result = await self._session.execute(
+            select(Order).where(Order.id == order_id)
+        )
+        row = result.scalar_one_or_none()
+        return OrderRead.model_validate(row) if row is not None else None
+
+    async def remove_line_item(self, order_id: int, item_id: int) -> None:
+        raise NotImplementedError(
+            "partial_update operation 'RemoveLineItem' — implement in M4+"
+        )

--- a/test/codegen/golden/expected/ecommerce/app/services/order.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/order.py
@@ -3,9 +3,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.order import Order
 from app.schemas.order import (
-    OrderCreate,
+    AddLineItemRequest,
+    CreateDraftOrderRequest,
     OrderRead,
-    OrderUpdate,
+    RecordPaymentRequest,
 )
 
 
@@ -13,18 +14,17 @@ class OrderService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def create_draft_order(self, body: OrderCreate) -> OrderRead:
-        row = Order(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return OrderRead.model_validate(row)
+    async def create_draft_order(self, body: CreateDraftOrderRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'CreateDraftOrder' — implement in M4+"
+        )
 
     async def list_orders(self) -> list[OrderRead]:
         result = await self._session.execute(select(Order))
         rows = result.scalars().all()
         return [OrderRead.model_validate(row) for row in rows]
 
-    async def add_line_item(self, order_id: int, body: OrderUpdate) -> None:
+    async def add_line_item(self, order_id: int, body: AddLineItemRequest) -> None:
         raise NotImplementedError(
             "partial_update operation 'AddLineItem' — implement in M4+"
         )
@@ -34,7 +34,7 @@ class OrderService:
             "transition operation 'PlaceOrder' — implement in M4+"
         )
 
-    async def record_payment(self, order_id: int, body: OrderCreate) -> None:
+    async def record_payment(self, order_id: int, body: RecordPaymentRequest) -> None:
         raise NotImplementedError(
             "transition operation 'RecordPayment' — implement in M4+"
         )

--- a/test/codegen/golden/expected/ecommerce/app/services/payment.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/payment.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.payment import Payment
 
 
 class PaymentService:

--- a/test/codegen/golden/expected/ecommerce/app/services/product.py
+++ b/test/codegen/golden/expected/ecommerce/app/services/product.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.product import Product
 
 
 class ProductService:

--- a/test/codegen/golden/expected/ecommerce/openapi.yaml
+++ b/test/codegen/golden/expected/ecommerce/openapi.yaml
@@ -76,6 +76,7 @@ paths:
               - DELIVERED
               - CANCELLED
               - RETURNED
+              - null
   /orders/{order_id}/items:
     post:
       operationId: add_line_item
@@ -668,6 +669,7 @@ components:
             - DELIVERED
             - CANCELLED
             - RETURNED
+            - null
         items:
           type:
             - array
@@ -788,6 +790,7 @@ components:
             - CAPTURED
             - REFUNDED
             - FAILED
+            - null
         created_at:
           type:
             - string

--- a/test/codegen/golden/expected/ecommerce/pyproject.toml
+++ b/test/codegen/golden/expected/ecommerce/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/test/codegen/golden/expected/edge_cases/alembic/env.py
+++ b/test/codegen/golden/expected/edge_cases/alembic/env.py
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/test/codegen/golden/expected/edge_cases/app/services/child.py
+++ b/test/codegen/golden/expected/edge_cases/app/services/child.py
@@ -1,6 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.child import Child
 
 
 class ChildService:

--- a/test/codegen/golden/expected/edge_cases/pyproject.toml
+++ b/test/codegen/golden/expected/edge_cases/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/test/codegen/golden/expected/todo_list/alembic/env.py
+++ b/test/codegen/golden/expected/todo_list/alembic/env.py
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/test/codegen/golden/expected/todo_list/app/routers/todos.py
+++ b/test/codegen/golden/expected/todo_list/app/routers/todos.py
@@ -3,9 +3,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.schemas.todo import (
-    TodoCreate,
+    CreateTodoRequest,
     TodoRead,
-    TodoUpdate,
+    UpdateTodoRequest,
 )
 from app.services.todo import TodoService
 
@@ -14,9 +14,9 @@ router = APIRouter(tags=["todo"])
 
 @router.post("/todos", status_code=201)
 async def create_todo(
-    body: TodoCreate,
+    body: CreateTodoRequest,
     session: AsyncSession = Depends(get_session),
-) -> TodoRead:
+) -> None:
     svc = TodoService(session)
     return await svc.create_todo(body)
 
@@ -41,7 +41,7 @@ async def get_todo(
 @router.patch("/todos/{id}", status_code=200)
 async def update_todo(
     id: int,
-    body: TodoUpdate,
+    body: UpdateTodoRequest,
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = TodoService(session)

--- a/test/codegen/golden/expected/todo_list/app/routers/todos.py
+++ b/test/codegen/golden/expected/todo_list/app/routers/todos.py
@@ -20,6 +20,13 @@ async def create_todo(
     svc = TodoService(session)
     return await svc.create_todo(body)
 
+@router.get("/todos", status_code=200)
+async def list_todos(
+    session: AsyncSession = Depends(get_session),
+) -> list[TodoRead]:
+    svc = TodoService(session)
+    return await svc.list_todos()
+
 @router.get("/todos/{id}", status_code=200)
 async def get_todo(
     id: int,
@@ -30,13 +37,6 @@ async def get_todo(
     if result is None:
         raise HTTPException(status_code=404, detail="not found")
     return result
-
-@router.get("/todos", status_code=200)
-async def list_todos(
-    session: AsyncSession = Depends(get_session),
-) -> list[TodoRead]:
-    svc = TodoService(session)
-    return await svc.list_todos()
 
 @router.patch("/todos/{id}", status_code=200)
 async def update_todo(

--- a/test/codegen/golden/expected/todo_list/app/schemas/todo.py
+++ b/test/codegen/golden/expected/todo_list/app/schemas/todo.py
@@ -36,3 +36,17 @@ class TodoUpdate(BaseModel):
     updated_at: datetime | None = None
     completed_at: datetime | None = None
     tags: list[str] | None = None
+
+
+class CreateTodoRequest(BaseModel):
+    title: str
+    description: str | None = None
+    priority: str
+    tags: list[str]
+
+
+class UpdateTodoRequest(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    priority: str | None = None
+    tags: list[str] | None = None

--- a/test/codegen/golden/expected/todo_list/app/schemas/todo.py
+++ b/test/codegen/golden/expected/todo_list/app/schemas/todo.py
@@ -4,12 +4,12 @@ from pydantic import BaseModel, ConfigDict
 
 class TodoCreate(BaseModel):
     title: str
-    description: str | None
+    description: str | None = None
     status: str
     priority: str
     created_at: datetime
     updated_at: datetime
-    completed_at: datetime | None
+    completed_at: datetime | None = None
     tags: list[str]
 
 
@@ -18,12 +18,12 @@ class TodoRead(BaseModel):
 
     id: int
     title: str
-    description: str | None
+    description: str | None = None
     status: str
     priority: str
     created_at: datetime
     updated_at: datetime
-    completed_at: datetime | None
+    completed_at: datetime | None = None
     tags: list[str]
 
 

--- a/test/codegen/golden/expected/todo_list/app/services/todo.py
+++ b/test/codegen/golden/expected/todo_list/app/services/todo.py
@@ -18,36 +18,44 @@ class TodoService:
         self._session.add(row)
         await self._session.flush()
         return TodoRead.model_validate(row)
+
+    async def list_todos(self) -> list[TodoRead]:
+        result = await self._session.execute(select(Todo))
+        rows = result.scalars().all()
+        return [TodoRead.model_validate(row) for row in rows]
+
     async def get_todo(self, id: int) -> TodoRead | None:
         result = await self._session.execute(
             select(Todo).where(Todo.id == id)
         )
         row = result.scalar_one_or_none()
         return TodoRead.model_validate(row) if row is not None else None
-    async def list_todos(self) -> list[TodoRead]:
-        result = await self._session.execute(select(Todo))
-        rows = result.scalars().all()
-        return [TodoRead.model_validate(row) for row in rows]
+
     async def update_todo(self, id: int, body: TodoUpdate) -> None:
         raise NotImplementedError(
             "partial_update operation 'UpdateTodo' — implement in M4+"
         )
+
     async def start_work(self, id: int) -> None:
         raise NotImplementedError(
             "transition operation 'StartWork' — implement in M4+"
         )
+
     async def complete(self, id: int) -> None:
         raise NotImplementedError(
             "transition operation 'Complete' — implement in M4+"
         )
+
     async def reopen(self, id: int) -> None:
         raise NotImplementedError(
             "transition operation 'Reopen' — implement in M4+"
         )
+
     async def archive(self, id: int) -> None:
         raise NotImplementedError(
             "transition operation 'Archive' — implement in M4+"
         )
+
     async def delete_todo(self, id: int) -> bool:
         result = await self._session.execute(
             sa_delete(Todo).where(Todo.id == id)

--- a/test/codegen/golden/expected/todo_list/app/services/todo.py
+++ b/test/codegen/golden/expected/todo_list/app/services/todo.py
@@ -3,9 +3,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.todo import Todo
 from app.schemas.todo import (
-    TodoCreate,
+    CreateTodoRequest,
     TodoRead,
-    TodoUpdate,
+    UpdateTodoRequest,
 )
 
 
@@ -13,11 +13,10 @@ class TodoService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def create_todo(self, body: TodoCreate) -> TodoRead:
-        row = Todo(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return TodoRead.model_validate(row)
+    async def create_todo(self, body: CreateTodoRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'CreateTodo' — implement in M4+"
+        )
 
     async def list_todos(self) -> list[TodoRead]:
         result = await self._session.execute(select(Todo))
@@ -31,7 +30,7 @@ class TodoService:
         row = result.scalar_one_or_none()
         return TodoRead.model_validate(row) if row is not None else None
 
-    async def update_todo(self, id: int, body: TodoUpdate) -> None:
+    async def update_todo(self, id: int, body: UpdateTodoRequest) -> None:
         raise NotImplementedError(
             "partial_update operation 'UpdateTodo' — implement in M4+"
         )

--- a/test/codegen/golden/expected/todo_list/openapi.yaml
+++ b/test/codegen/golden/expected/todo_list/openapi.yaml
@@ -65,6 +65,7 @@ paths:
               - IN_PROGRESS
               - DONE
               - ARCHIVED
+              - null
         - name: priority_filter
           in: query
           required: false
@@ -77,6 +78,7 @@ paths:
               - MEDIUM
               - HIGH
               - URGENT
+              - null
         - name: tag_filter
           in: query
           required: false
@@ -439,6 +441,7 @@ components:
             - IN_PROGRESS
             - DONE
             - ARCHIVED
+            - null
         priority:
           type:
             - string
@@ -448,6 +451,7 @@ components:
             - MEDIUM
             - HIGH
             - URGENT
+            - null
         created_at:
           type:
             - string

--- a/test/codegen/golden/expected/todo_list/pyproject.toml
+++ b/test/codegen/golden/expected/todo_list/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/test/codegen/golden/expected/url_shortener/alembic/env.py
+++ b/test/codegen/golden/expected/url_shortener/alembic/env.py
@@ -13,7 +13,7 @@ from app.db.base import Base
 
 config = context.config
 
-config.set_main_option("sqlalchemy.url", settings.database_url)
+config.set_main_option("sqlalchemy.url", settings.database_url.replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/test/codegen/golden/expected/url_shortener/app/routers/url_mappings.py
+++ b/test/codegen/golden/expected/url_shortener/app/routers/url_mappings.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
 from app.schemas.url_mapping import (
-    UrlMappingCreate,
+    ShortenRequest,
     UrlMappingRead,
 )
 from app.services.url_mapping import UrlMappingService
@@ -13,9 +14,9 @@ router = APIRouter(tags=["url_mapping"])
 
 @router.post("/shorten", status_code=201)
 async def shorten(
-    body: UrlMappingCreate,
+    body: ShortenRequest,
     session: AsyncSession = Depends(get_session),
-) -> UrlMappingRead:
+) -> None:
     svc = UrlMappingService(session)
     return await svc.shorten(body)
 
@@ -30,9 +31,10 @@ async def list_all(
 async def resolve(
     code: str,
     session: AsyncSession = Depends(get_session),
-) -> None:
+) -> RedirectResponse:
     svc = UrlMappingService(session)
-    return await svc.resolve(code)
+    url = await svc.resolve(code)
+    return RedirectResponse(url=url, status_code=302)
 
 @router.delete("/{code}", status_code=204)
 async def delete(

--- a/test/codegen/golden/expected/url_shortener/app/routers/url_mappings.py
+++ b/test/codegen/golden/expected/url_shortener/app/routers/url_mappings.py
@@ -19,6 +19,13 @@ async def shorten(
     svc = UrlMappingService(session)
     return await svc.shorten(body)
 
+@router.get("/urls", status_code=200)
+async def list_all(
+    session: AsyncSession = Depends(get_session),
+) -> list[UrlMappingRead]:
+    svc = UrlMappingService(session)
+    return await svc.list_all()
+
 @router.get("/{code}", status_code=302)
 async def resolve(
     code: str,
@@ -37,10 +44,3 @@ async def delete(
     if not deleted:
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code=204)
-
-@router.get("/urls", status_code=200)
-async def list_all(
-    session: AsyncSession = Depends(get_session),
-) -> list[UrlMappingRead]:
-    svc = UrlMappingService(session)
-    return await svc.list_all()

--- a/test/codegen/golden/expected/url_shortener/app/schemas/url_mapping.py
+++ b/test/codegen/golden/expected/url_shortener/app/schemas/url_mapping.py
@@ -24,3 +24,7 @@ class UrlMappingUpdate(BaseModel):
     url: str | None = None
     created_at: datetime | None = None
     click_count: int | None = None
+
+
+class ShortenRequest(BaseModel):
+    url: str

--- a/test/codegen/golden/expected/url_shortener/app/services/url_mapping.py
+++ b/test/codegen/golden/expected/url_shortener/app/services/url_mapping.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.url_mapping import UrlMapping
 from app.schemas.url_mapping import (
-    UrlMappingCreate,
+    ShortenRequest,
     UrlMappingRead,
 )
 
@@ -12,18 +12,17 @@ class UrlMappingService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-    async def shorten(self, body: UrlMappingCreate) -> UrlMappingRead:
-        row = UrlMapping(**body.model_dump())
-        self._session.add(row)
-        await self._session.flush()
-        return UrlMappingRead.model_validate(row)
+    async def shorten(self, body: ShortenRequest) -> None:
+        raise NotImplementedError(
+            "create operation 'Shorten' — implement in M4+"
+        )
 
     async def list_all(self) -> list[UrlMappingRead]:
         result = await self._session.execute(select(UrlMapping))
         rows = result.scalars().all()
         return [UrlMappingRead.model_validate(row) for row in rows]
 
-    async def resolve(self, code: str) -> None:
+    async def resolve(self, code: str) -> str:
         raise NotImplementedError(
             "partial_update operation 'Resolve' — implement in M4+"
         )

--- a/test/codegen/golden/expected/url_shortener/app/services/url_mapping.py
+++ b/test/codegen/golden/expected/url_shortener/app/services/url_mapping.py
@@ -17,16 +17,19 @@ class UrlMappingService:
         self._session.add(row)
         await self._session.flush()
         return UrlMappingRead.model_validate(row)
+
+    async def list_all(self) -> list[UrlMappingRead]:
+        result = await self._session.execute(select(UrlMapping))
+        rows = result.scalars().all()
+        return [UrlMappingRead.model_validate(row) for row in rows]
+
     async def resolve(self, code: str) -> None:
         raise NotImplementedError(
             "partial_update operation 'Resolve' — implement in M4+"
         )
+
     async def delete(self, code: str) -> bool:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
         return result.rowcount > 0
-    async def list_all(self) -> list[UrlMappingRead]:
-        result = await self._session.execute(select(UrlMapping))
-        rows = result.scalars().all()
-        return [UrlMappingRead.model_validate(row) for row in rows]

--- a/test/codegen/golden/expected/url_shortener/pyproject.toml
+++ b/test/codegen/golden/expected/url_shortener/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B"]
+extend-ignore = ["B008"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/test/codegen/templates/services.test.ts
+++ b/test/codegen/templates/services.test.ts
@@ -27,8 +27,9 @@ describe("services/entity.py template — via emitProject", () => {
   it("emits a stub for creates whose body does not match the entity create schema", () => {
     const files = emitProject(profiledFrom("url_shortener.spec"));
     const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
-    expect(svc.content).toMatch(/async def shorten\(self, body: ShortenRequest\)/);
-    expect(svc.content).toMatch(/raise NotImplementedError/);
+    expect(svc.content).toMatch(
+      /async def shorten\(self, body: ShortenRequest\) -> None:\n\s+raise NotImplementedError\(/,
+    );
   });
 
   it("emits real SQL for delete against the path-param column", () => {

--- a/test/codegen/templates/services.test.ts
+++ b/test/codegen/templates/services.test.ts
@@ -24,13 +24,11 @@ describe("services/entity.py template — via emitProject", () => {
     expect(svc.content).toContain("self._session = session");
   });
 
-  it("emits real SQL for create (insert via session.add + flush)", () => {
+  it("emits a stub for creates whose body does not match the entity create schema", () => {
     const files = emitProject(profiledFrom("url_shortener.spec"));
     const svc = files.find((f) => f.path === "app/services/url_mapping.py")!;
-    expect(svc.content).toContain("row = UrlMapping(**body.model_dump())");
-    expect(svc.content).toContain("self._session.add(row)");
-    expect(svc.content).toContain("await self._session.flush()");
-    expect(svc.content).toContain("UrlMappingRead.model_validate(row)");
+    expect(svc.content).toMatch(/async def shorten\(self, body: ShortenRequest\)/);
+    expect(svc.content).toMatch(/raise NotImplementedError/);
   });
 
   it("emits real SQL for delete against the path-param column", () => {


### PR DESCRIPTION
## Summary

Scoped subset of #69. Fixes seven generator bugs whose root cause is clear and whose blast radius is contained; defers larger design items (password_hash hiding, FK emission, redirect classification, per-op custom request schemas) which remain open on #69.

## Fixes

| # | Item | Root cause | Where |
|---|------|-----------|-------|
| 1 | `GET /urls` shadowed by `GET /{code}` | Routes registered in spec order; literals must come first | `emit.ts` — sort entity operations by `{` count |
| 2 | `order_id: str` in router despite OpenAPI saying `integer` | `pythonTypeForParam` falls back to `"str"` for user-defined aliases like `OrderId = Int` | `emit.ts` — transitive alias resolution in `buildTypeLookup` |
| 3 | `Order.order_id == order_id` (AttributeError at runtime; `order_id` isn't a column) | Single `lookupColumn` field used for both column and variable | `emit.ts` + service template — split into `modelLookupColumn` / `pathParamName` |
| 4 | `description: str \| None` required in Pydantic even though OpenAPI marks it optional | No default value on nullable Create/Read fields | `schemas/entity.py.hbs` — append `= None` when `nullable` |
| 5 | Methods back-to-back in generated services — fails `ruff check` (PEP 8 E301) | Template had no separator inside `{{#each entityOperations}}` | `services/entity.py.hbs` — blank line via `{{#unless @first}}` |
| 6 | DATABASE_URL with `%` breaks alembic migrations | ConfigParser treats `%` as a substitution prefix | `alembic/env.py.hbs` — wrap `settings.database_url` in `.replace(\"%\", \"%%\")` |
| 7 | Duplicate CHECK constraints (`ck_inventory_entries_0..3` for two unique predicates) | Same invariant SQL derived from multiple paths, no dedup | `migration.ts` — unique-by-SQL before naming |

All visible as golden-tree diffs across 5 fixtures (url_shortener, todo_list, ecommerce, auth_service, edge_cases).

## Deferred on #69

- **password_hash in `UserRead`** — needs a spec-level `@private` annotation or a convention for "secret" field name patterns.
- **Missing FK on `sessions.user_id`** — needs schema-derivation rework to emit `ForeignKeyConstraint` from entity relationships.
- **`302` without `Location` header** — needs redirect classification (status-code-driven RedirectResponse emission).
- **Non-CRUD ops using `OrderUpdate` as body** (`add_line_item`, `/auth/refresh`) — needs per-operation inline request schemas.
- **Nullable enum missing `null` in enum list** (OpenAPI 3.1) — straightforward but in openapi/build.ts, left for a focused openapi PR.
- **Session refresh as plain insert** — genuinely hard; keeps the `NotImplementedError` stub.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1090 / 1090 (2 structural tests updated: env.test.ts for the new `%` escape, migration.test.ts to iterate unique checks)
- [x] Determinism: second `npx vitest run test/codegen/golden/ -u` is a no-op — `git status` clean on golden tree
- [x] `npm run fmt:check` — clean
- [x] Spot-checked url_shortener, ecommerce goldens — `/urls` now before `/{code}`, `Order.id == order_id` (correct direction), `order_id: int` (not str), blank lines between methods, `last_login: datetime \| None = None` defaults, deduped CHECK constraints, `%%`-escaped database_url

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes generator bugs from the M3.6 review and completes the remaining items from #69. Generated routes, types, schemas, migrations, and redirects now align with the spec across all fixtures.

- **Bug Fixes**
  - Routing/redirects: sort routes by path specificity so literals register before params; treat only 301/302/303/307/308 as redirects and return `RedirectResponse`.
  - Types/lookups: resolve type aliases transitively (incl. `Option[...]`) so path params use correct Python types; split model lookup column vs path param so comparisons generate like `Model.id == <param>`; only emit insert bodies for creates that match the entity create shape, otherwise stub.
  - Schemas/OpenAPI: add `= None` for nullable fields in Create/Read; strip sensitive fields from Read in both Pydantic and OpenAPI (`password`, `password_hash`, `token`, `secret`, `api_key`, and *_suffixes); generate per-operation `{OperationName}Request` classes when bodies don’t match the entity create shape; include `null` in `enum` arrays when widening to nullable.
  - Migrations: escape `%` in `alembic/env.py`; deduplicate identical CHECK constraints before naming; derive FKs for `<entity>_id` columns with `ondelete="CASCADE"` and an index, and match the FK column SQL type to the referenced `id` (respecting table overrides; `BIGSERIAL` → `BIGINT`).
  - Codegen quality: insert a blank line between service methods (PEP 8 E301); ignore `ruff` B008 in generated `pyproject.toml` to silence false positives from `Depends(...)`.

<sup>Written for commit 2aaafc72abaac515bc174bd79bf89216040a4d1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for redirect endpoints that return HTTP redirect responses.
  * Introduced custom request schemas for operation-specific request handling.
  * Added automatic foreign key relationships with cascade delete support.

* **Bug Fixes**
  * Fixed percent character escaping in database configuration.
  * Improved duplicate constraint deduplication in migrations.
  * Enhanced sensitive field filtering from generated schemas.

* **Improvements**
  * Better nullable enum support in API specifications.
  * Refined schema generation for non-standard create operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->