### PR TITLE
M4.2 — Invariant consistency checking

### DIFF
--- a/docs/content/docs/verification.mdx
+++ b/docs/content/docs/verification.mdx
@@ -79,11 +79,11 @@ Failures expand into a per-check list:
 ```text
 $ spec-to-rest verify test/verify/fixtures/dead_op.spec
  ERROR  dead_op.spec: 2 failure(s) in 3 consistency checks (565ms)
-   ✘ DeadOp.requires              unsat   145ms — 'requires' clause of operation 'DeadOp' is contradictory — the operation can never fire
+   ✘ DeadOp.requires              unsat   145ms — 'requires' of operation 'DeadOp' is unsatisfiable under the spec's base constraints — the operation can never fire
    ✘ DeadOp.enabled               unsat     9ms — operation 'DeadOp' is dead — no valid pre-state satisfies both the invariants and its 'requires'
 ```
 
-Add `-v` for per-check timing on the happy path and full decl counts:
+Add `-v` for stage timing and per-check timing on the happy path:
 
 ```text
 $ spec-to-rest verify -v test/parser/fixtures/url_shortener.spec
@@ -97,6 +97,8 @@ verbose   ✔ Delete.requires              sat          11ms
 verbose   …
 ```
 
+On `--dump-smt` runs, `-v` additionally prints the translated Z3-script decl counts.
+
 ### Options
 
 | Option                 | Default | Meaning                                                    |
@@ -104,7 +106,7 @@ verbose   …
 | `--timeout <ms>`       |   30000 | Per-check timeout. `0` disables the timeout (Z3 default).  |
 | `--dump-smt`           |   false | Emit SMT-LIB to stdout and exit without running the solver |
 | `--dump-smt-out <file>` |       — | Write SMT-LIB to `<file>` and exit without running the solver |
-| `-v, --verbose`        |   false | Print decl counts and timing                               |
+| `-v, --verbose`        |   false | Print stage timing + per-check timing (and, on `--dump-smt`, decl counts) |
 
 ## Inspecting the SMT-LIB
 

--- a/docs/content/docs/verification.mdx
+++ b/docs/content/docs/verification.mdx
@@ -15,58 +15,86 @@ generated. It uses the [Z3 SMT solver](https://github.com/Z3Prover/z3) via the
 | WASM Z3 backend + `spec-to-rest verify` CLI                         | M4.1 shipped |
 | Invariant-satisfiability smoke check                                | M4.1 shipped |
 | SMT-LIB artifact export (`--dump-smt`)                              | M4.1 shipped |
-| Invariant consistency checking (per-op `requires`, dead ops)        | [M4.2](https://github.com/HardMax71/spec_to_rest/issues/21) |
+| Invariant consistency checking (per-op `requires`, dead ops)        | M4.2 shipped |
+| Primitive-type alias refinement (`type Positive = Int where …`)     | M4.2 shipped |
+| Cardinality on state relations (`#store`, uninterpreted ≥ 0)        | M4.2 shipped |
 | Invariant preservation checking (operation pre/post ⇒ invariant)    | [M4.3](https://github.com/HardMax71/spec_to_rest/issues/19) |
 | Counterexample-driven error reporting                               | [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20) |
 | Verify-as-gate (refuse codegen on failed verification)              | M4.4 |
 
-## What M4.1 ships
+## What M4.2 ships
 
-M4.1 lands the plumbing: an IR-to-SMT translator, a WASM Z3 backend, and a `verify` CLI that
-runs a single satisfiability smoke check on the conjunction of a spec's invariants and
-entity/type-alias `where` constraints. Reading `sat` back confirms the encoding is well-formed
-end-to-end; reading `unsat` indicates contradictory constraints (exactly the kind of error
-[M4.2](https://github.com/HardMax71/spec_to_rest/issues/21) will surface with a proper
-diagnostic).
+M4.2 lifts `verify` from a single smoke check to a per-check consistency report. For every spec
+the CLI now runs **one global check** plus **two checks per operation**:
 
-The translator covers the subset of the IR used by `url_shortener.spec` — entity fields,
-state-relation `dom` / `map` functions, entity-level and top-level invariants, type-alias `where`
-constraints, bounded quantifiers, enum distinctness axioms. External predicates (`isValidURI`,
-`len`, regex `matches`) are modelled as uninterpreted functions, sound but pessimistic —
-M4.2/M4.3 will tighten these as needed.
+| Check | Script | UNSAT means |
+| --- | --- | --- |
+| `global` | invariants alone | invariants are jointly contradictory — no valid state exists |
+| `<Op>.requires` | `requires` alone, with inputs as fresh constants | the `requires` clause is a contradiction — `Op` can never fire |
+| `<Op>.enabled` | invariants + `requires` | `Op` is dead — no valid pre-state enables it |
 
-## What M4.1 does not ship
+The translator also picked up three extensions that were throws in M4.1:
 
-- **Consistency checking.** M4.1 does not check that each operation's `requires` is satisfiable,
-  or that an operation is ever reachable. See [M4.2](https://github.com/HardMax71/spec_to_rest/issues/21).
-- **Preservation checking.** M4.1 does not prove that operation postconditions preserve
+- **Primitive-type alias refinement**: `type Positive = Int where value > 0` no longer throws.
+  Fields typed `Positive` inline the constraint as an axiom on the field function; quantifier
+  bindings (`all p: Positive | …`) get the constraint as a guard; operation inputs of the alias
+  type pin the constraint on the input constant.
+- **Cardinality on state relations**: `#store` lowers to a declared uninterpreted `card_store :
+  Int` with a `≥ 0` axiom. Sound-but-weak — you can check `#store < 100` is satisfiable, but
+  tighter reasoning (`#store' = #store + 1`) waits for M4.3's post-state encoding.
+- **Per-operation translation** — the base declarations (sorts, field functions, state
+  relations, alias constraints) factor into a reusable `declareBase` so each of the 2N+1
+  per-spec checks shares one parse/IR build, one WASM `init()`, and one `Context`.
+
+## What M4.2 does not ship
+
+- **Preservation checking.** M4.2 does not prove that operation postconditions preserve
   invariants. The translator deliberately rejects `pre()`, `'` (prime), and `with { … }`
   constructs — these appear only in operation ensures clauses, which are the domain of
   [M4.3](https://github.com/HardMax71/spec_to_rest/issues/19).
-- **Human-readable diagnostics.** M4.1 reports a raw `sat`/`unsat`/`unknown` verdict.
-  [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20) will map counterexamples back to
-  source spans with fix suggestions.
+- **Set operators and non-state membership.** `subset`, `union`, `intersect`, `minus`, and
+  `x in some_set` where `some_set` is not a state relation still raise `TranslatorError`.
+  Tracked in [#73](https://github.com/HardMax71/spec_to_rest/issues/73); likely landed alongside
+  or during M4.3, which is the first milestone where `ensures` forces real set-valued reasoning.
+- **Counterexample diagnostics.** When a check returns `unsat` M4.2 reports a one-line
+  explanation (e.g. `operation 'DeadOp' is dead`) but no Z3 model. [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20)
+  maps models back to source spans with fix suggestions.
 - **Verify-as-gate.** `compile` still emits code regardless of verification. Wiring verify in as
   a hard gate arrives with M4.4.
+- **Tight set-theoretic cardinality.** `#store >= 0` holds by axiom, but the encoding does not
+  relate `card_store` to `store_dom`, so invariants like `#store = dom-count` are `unknown`
+  shaped (they're typically ensures-only, so M4.3 territory).
 
 ## Using the CLI
 
 ```bash
 $ spec-to-rest verify test/parser/fixtures/url_shortener.spec
-url_shortener.spec: sat (invariant satisfiability, 238ms)
+✔ url_shortener.spec: 9/9 consistency checks passed (586ms)
 ```
 
-Exit code `0` on `sat`, `1` on `unsat`/`unknown`/parser error.
+Exit code `0` when every check is `sat` or `skipped`, `1` when any check is `unsat` or `unknown`.
 
-Add `-v` for timing and decl counts:
+Failures expand into a per-check list:
 
-```bash
+```text
+$ spec-to-rest verify test/verify/fixtures/dead_op.spec
+ ERROR  dead_op.spec: 2 failure(s) in 3 consistency checks (565ms)
+   ✘ DeadOp.requires              unsat   145ms — 'requires' clause of operation 'DeadOp' is contradictory — the operation can never fire
+   ✘ DeadOp.enabled               unsat     9ms — operation 'DeadOp' is dead — no valid pre-state satisfies both the invariants and its 'requires'
+```
+
+Add `-v` for per-check timing on the happy path and full decl counts:
+
+```text
 $ spec-to-rest verify -v test/parser/fixtures/url_shortener.spec
 verbose Parsed in 4ms
 verbose Built IR in 1ms
-verbose Translated IR to Z3 script: 8 sorts, 18 function decls, 8 assertions (3ms)
 verbose Timeout: 30000ms
-✔ url_shortener.spec: sat (invariant satisfiability, 238ms)
+✔ url_shortener.spec: 9/9 consistency checks passed (586ms)
+verbose   ✔ global                       sat         236ms
+verbose   ✔ Delete.enabled               sat          12ms
+verbose   ✔ Delete.requires              sat          11ms
+verbose   …
 ```
 
 ### Options
@@ -102,22 +130,28 @@ emitter ever produces invalid SMT-LIB or loses satisfiability, CI fails loudly.
 `(set-option :timeout …)`. Units are milliseconds. `0` disables the timeout entirely.
 
 If Z3 cannot decide within the timeout, the result is `unknown` — which `verify` treats as a
-failure (exit `1`). In M4.1 the url_shortener smoke check completes in well under a second; the
-30 s default is a conservative headroom for M4.2/M4.3's heavier quantifier checks.
+failure (exit `1`). In M4.2 the url_shortener's 9 consistency checks complete end-to-end in
+well under a second; the 30 s default is a conservative headroom for M4.3's heavier
+preservation checks.
 
 ## Extending the translator
 
 Adding a new IR expression kind is a three-file change:
 
 1. `src/verify/translator.ts` — add a case to `translateExpr`; declare any helper uninterpreted
-   functions lazily via `ctx.declareFunc`.
+   functions lazily via `ctx.declareFunc`. If the new construct is meaningful inside operation
+   `requires`, verify it flows through `translateOperationRequires` and
+   `translateOperationEnabled` too — they share the same `translateExpr` so normally no extra
+   change is required.
 2. `src/verify/smtlib.ts` — add a case to `renderExpr` that produces valid SMT-LIB text.
 3. `src/verify/backend.ts` — add a case to `renderExpr` that produces a z3-solver `Bool` / `Arith`
    / `Expr` as appropriate.
 
 Unit-test the new case in `test/verify/translator.test.ts` (Z3Script shape only — no solver),
 and add a scenario to `test/verify/backend.test.ts` if the case requires solver round-tripping.
-Update `test/verify/fixtures/url_shortener.smt2` by deleting and re-running the snapshot test.
+End-to-end behaviour goes in `test/verify/consistency.test.ts`. Update
+`test/verify/fixtures/url_shortener.smt2` by running `UPDATE_SNAPSHOTS=1 npx vitest run
+test/verify/smtlib.test.ts` when the snapshot legitimately changes.
 
 ## See also
 

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -5,6 +5,7 @@ import { buildIR, BuildError } from "#ir/index.js";
 import { translate } from "#verify/translator.js";
 import { renderSmtLib } from "#verify/smtlib.js";
 import { WasmBackend } from "#verify/backend.js";
+import { runConsistencyChecks, type CheckResult } from "#verify/consistency.js";
 import { TranslatorError } from "#verify/types.js";
 import type { Logger } from "#cli/log.js";
 
@@ -42,15 +43,14 @@ export async function runVerify(
     const ir = buildIR(tree);
     log.verbose(`Built IR in ${(performance.now() - tBuild0).toFixed(0)}ms`);
 
-    const tTrans0 = performance.now();
-    const script = translate(ir);
-    log.verbose(
-      `Translated IR to Z3 script: ${script.sorts.length} sorts, ` +
-        `${script.funcs.length} function decls, ${script.assertions.length} assertions ` +
-        `(${(performance.now() - tTrans0).toFixed(0)}ms)`,
-    );
-
     if (opts.dumpSmt || opts.dumpSmtOut) {
+      const tTrans0 = performance.now();
+      const script = translate(ir);
+      log.verbose(
+        `Translated IR to Z3 script: ${script.sorts.length} sorts, ` +
+          `${script.funcs.length} function decls, ${script.assertions.length} assertions ` +
+          `(${(performance.now() - tTrans0).toFixed(0)}ms)`,
+      );
       const smt = renderSmtLib(script, opts.timeout > 0 ? opts.timeout : undefined);
       if (opts.dumpSmtOut) {
         writeFileSync(opts.dumpSmtOut, smt);
@@ -63,15 +63,11 @@ export async function runVerify(
 
     log.verbose(`Timeout: ${opts.timeout}ms`);
     const backend = new WasmBackend();
-    const result = await backend.check(script, { timeoutMs: opts.timeout });
+    const tRun0 = performance.now();
+    const report = await runConsistencyChecks(ir, backend, { timeoutMs: opts.timeout });
+    const totalMs = performance.now() - tRun0;
     const label = basename(specFile);
-    const durationFmt = result.durationMs.toFixed(0);
-    if (result.status === "sat") {
-      log.success(`${label}: sat (invariant satisfiability, ${durationFmt}ms)`);
-      return 0;
-    }
-    log.error(`${label}: ${result.status} (invariant satisfiability, ${durationFmt}ms)`);
-    return 1;
+    return reportConsistency(label, report.checks, report.ok, totalMs, log);
   } catch (err: unknown) {
     if (err instanceof BuildError || err instanceof TranslatorError) {
       log.error(`${specFile}: ${err.message}`);
@@ -80,6 +76,42 @@ export async function runVerify(
     log.error(`${specFile}: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
   }
+}
+
+function reportConsistency(
+  label: string,
+  checks: readonly CheckResult[],
+  ok: boolean,
+  totalMs: number,
+  log: Logger,
+): number {
+  const passes = checks.filter((c) => c.status === "sat").length;
+  const skipped = checks.filter((c) => c.status === "skipped").length;
+  const failures = checks.length - passes - skipped;
+  const totalFmt = totalMs.toFixed(0);
+
+  if (ok) {
+    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+    log.success(`${label}: ${passes}/${checks.length} consistency checks passed${skipNote} (${totalFmt}ms)`);
+    for (const c of checks) log.verbose(formatCheck(c));
+    return 0;
+  }
+
+  log.error(`${label}: ${failures} failure(s) in ${checks.length} consistency checks (${totalFmt}ms)`);
+  for (const c of checks) {
+    if (c.status === "sat" || c.status === "skipped") log.verbose(formatCheck(c));
+    else log.error(formatCheck(c));
+  }
+  return 1;
+}
+
+function formatCheck(c: CheckResult): string {
+  const icon = c.status === "sat" ? "✔" : c.status === "skipped" ? "∙" : "✘";
+  const id = c.id.padEnd(28, " ");
+  const status = c.status.padEnd(8, " ");
+  const duration = `${c.durationMs.toFixed(0)}ms`.padStart(8, " ");
+  const detail = c.detail ? ` — ${c.detail}` : "";
+  return `  ${icon} ${id} ${status} ${duration}${detail}`;
 }
 
 function readErrorMessage(specFile: string, err: unknown): string {

--- a/src/verify/backend.ts
+++ b/src/verify/backend.ts
@@ -19,9 +19,17 @@ interface RenderCtx {
 }
 
 export class WasmBackend {
+  private ctxPromise: Promise<Ctx> | null = null;
+
+  private async getContext(): Promise<Ctx> {
+    if (!this.ctxPromise) {
+      this.ctxPromise = init().then((high) => high.Context("verify"));
+    }
+    return this.ctxPromise;
+  }
+
   async check(script: Z3Script, cfg: VerificationConfig): Promise<SmokeCheckResult> {
-    const high = await init();
-    const ctx = high.Context("verify");
+    const ctx = await this.getContext();
     const sortMap = declareSorts(ctx, script.sorts);
     const funcMap = declareFuncs(ctx, script.funcs, sortMap);
     const solver = new ctx.Solver();

--- a/src/verify/consistency.ts
+++ b/src/verify/consistency.ts
@@ -91,18 +91,24 @@ function skippedCheck(
   operationName: string | null,
   err: unknown,
 ): CheckResult {
-  const message = err instanceof TranslatorError
-    ? err.message
-    : err instanceof Error
-      ? err.message
-      : String(err);
+  const message = err instanceof Error ? err.message : String(err);
+  if (err instanceof TranslatorError) {
+    return {
+      id,
+      kind,
+      operationName,
+      status: "skipped",
+      durationMs: 0,
+      detail: `translator limitation: ${message}`,
+    };
+  }
   return {
     id,
     kind,
     operationName,
-    status: "skipped",
+    status: "unknown",
     durationMs: 0,
-    detail: `translator limitation: ${message}`,
+    detail: `backend error: ${message}`,
   };
 }
 
@@ -114,7 +120,7 @@ function detailFor(kind: CheckKind, op: string | null, status: CheckStatus): str
   }
   if (kind === "requires") {
     if (status === "unsat") {
-      return `'requires' clause of operation '${op}' is contradictory — the operation can never fire`;
+      return `'requires' of operation '${op}' is unsatisfiable under the spec's base constraints — the operation can never fire`;
     }
     return `solver could not decide 'requires' satisfiability for operation '${op}'`;
   }

--- a/src/verify/consistency.ts
+++ b/src/verify/consistency.ts
@@ -1,0 +1,125 @@
+import type { ServiceIR, OperationDecl } from "#ir/types.js";
+import type { WasmBackend } from "#verify/backend.js";
+import { translate, translateOperationRequires, translateOperationEnabled } from "#verify/translator.js";
+import { TranslatorError } from "#verify/types.js";
+import type { CheckStatus, VerificationConfig } from "#verify/types.js";
+
+export type CheckKind = "global" | "requires" | "enabled";
+export type CheckOutcome = CheckStatus | "skipped";
+
+export interface CheckResult {
+  readonly id: string;
+  readonly kind: CheckKind;
+  readonly operationName: string | null;
+  readonly status: CheckOutcome;
+  readonly durationMs: number;
+  readonly detail: string | null;
+}
+
+export interface ConsistencyReport {
+  readonly checks: readonly CheckResult[];
+  readonly ok: boolean;
+}
+
+export async function runConsistencyChecks(
+  ir: ServiceIR,
+  backend: WasmBackend,
+  config: VerificationConfig,
+): Promise<ConsistencyReport> {
+  const checks: CheckResult[] = [];
+  checks.push(await runGlobal(ir, backend, config));
+  const ops = [...ir.operations].sort((a, b) => a.name.localeCompare(b.name));
+  for (const op of ops) {
+    checks.push(await runOperationCheck(ir, op, "requires", backend, config));
+    checks.push(await runOperationCheck(ir, op, "enabled", backend, config));
+  }
+  const ok = checks.every((c) => c.status === "sat" || c.status === "skipped");
+  return { checks, ok };
+}
+
+async function runGlobal(
+  ir: ServiceIR,
+  backend: WasmBackend,
+  config: VerificationConfig,
+): Promise<CheckResult> {
+  try {
+    const script = translate(ir);
+    const result = await backend.check(script, config);
+    return {
+      id: "global",
+      kind: "global",
+      operationName: null,
+      status: result.status,
+      durationMs: result.durationMs,
+      detail: detailFor("global", null, result.status),
+    };
+  } catch (err: unknown) {
+    return skippedCheck("global", "global", null, err);
+  }
+}
+
+async function runOperationCheck(
+  ir: ServiceIR,
+  op: OperationDecl,
+  kind: "requires" | "enabled",
+  backend: WasmBackend,
+  config: VerificationConfig,
+): Promise<CheckResult> {
+  const id = `${op.name}.${kind}`;
+  try {
+    const script =
+      kind === "requires"
+        ? translateOperationRequires(ir, op)
+        : translateOperationEnabled(ir, op);
+    const result = await backend.check(script, config);
+    return {
+      id,
+      kind,
+      operationName: op.name,
+      status: result.status,
+      durationMs: result.durationMs,
+      detail: detailFor(kind, op.name, result.status),
+    };
+  } catch (err: unknown) {
+    return skippedCheck(id, kind, op.name, err);
+  }
+}
+
+function skippedCheck(
+  id: string,
+  kind: CheckKind,
+  operationName: string | null,
+  err: unknown,
+): CheckResult {
+  const message = err instanceof TranslatorError
+    ? err.message
+    : err instanceof Error
+      ? err.message
+      : String(err);
+  return {
+    id,
+    kind,
+    operationName,
+    status: "skipped",
+    durationMs: 0,
+    detail: `translator limitation: ${message}`,
+  };
+}
+
+function detailFor(kind: CheckKind, op: string | null, status: CheckStatus): string | null {
+  if (status === "sat") return null;
+  if (kind === "global") {
+    if (status === "unsat") return "invariants are jointly contradictory — no valid state exists";
+    return "solver could not decide invariant satisfiability within the timeout";
+  }
+  if (kind === "requires") {
+    if (status === "unsat") {
+      return `'requires' clause of operation '${op}' is contradictory — the operation can never fire`;
+    }
+    return `solver could not decide 'requires' satisfiability for operation '${op}'`;
+  }
+  if (status === "unsat") {
+    return `operation '${op}' is dead — no valid pre-state satisfies both the invariants and its 'requires'`;
+  }
+  return `solver could not decide enablement for operation '${op}'`;
+}

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -1,6 +1,17 @@
-export { translate } from "#verify/translator.js";
+export {
+  translate,
+  translateOperationRequires,
+  translateOperationEnabled,
+} from "#verify/translator.js";
 export { renderSmtLib } from "#verify/smtlib.js";
 export { WasmBackend } from "#verify/backend.js";
+export { runConsistencyChecks } from "#verify/consistency.js";
+export type {
+  CheckKind,
+  CheckOutcome,
+  CheckResult,
+  ConsistencyReport,
+} from "#verify/consistency.js";
 export {
   DEFAULT_VERIFICATION_CONFIG,
   TranslatorError,

--- a/src/verify/translator.ts
+++ b/src/verify/translator.ts
@@ -336,14 +336,48 @@ function emitStateRefinement(ctx: TranslateCtx, sf: StateFieldDecl): void {
     return;
   }
   if (sf.typeExpr.kind !== "RelationType" && sf.typeExpr.kind !== "MapType") return;
+  const keyType = sf.typeExpr.kind === "RelationType" ? sf.typeExpr.fromType : sf.typeExpr.keyType;
   const valueType = sf.typeExpr.kind === "RelationType" ? sf.typeExpr.toType : sf.typeExpr.valueType;
-  const aliasConstraint = refinementConstraintFor(ctx, valueType);
-  if (!aliasConstraint) return;
-  const varName = `k_${sf.name}`;
+  const keyConstraint = refinementConstraintFor(ctx, keyType);
+  const valueConstraint = refinementConstraintFor(ctx, valueType);
+  if (keyConstraint) emitRelationKeyRefinement(ctx, info, sf.name, keyConstraint);
+  if (valueConstraint) emitRelationValueRefinement(ctx, info, sf.name, valueConstraint);
+}
+
+function emitRelationKeyRefinement(
+  ctx: TranslateCtx,
+  info: StateInfo,
+  fieldName: string,
+  keyConstraint: Expr,
+): void {
+  const varName = `k_${fieldName}_key`;
+  const keyVar: Z3Expr = { kind: "Var", name: varName, sort: info.keySort };
+  const env = new Map<string, Z3Expr>();
+  env.set("value", keyVar);
+  const pred = translateExpr(ctx, keyConstraint, env);
+  ctx.assertions.push({
+    kind: "Quantifier",
+    q: "ForAll",
+    bindings: [{ name: varName, sort: info.keySort }],
+    body: {
+      kind: "Implies",
+      lhs: { kind: "App", func: info.domFunc, args: [keyVar] },
+      rhs: pred,
+    },
+  });
+}
+
+function emitRelationValueRefinement(
+  ctx: TranslateCtx,
+  info: StateInfo,
+  fieldName: string,
+  valueConstraint: Expr,
+): void {
+  const varName = `k_${fieldName}`;
   const keyVar: Z3Expr = { kind: "Var", name: varName, sort: info.keySort };
   const env = new Map<string, Z3Expr>();
   env.set("value", { kind: "App", func: info.mapFunc, args: [keyVar] });
-  const body = translateExpr(ctx, aliasConstraint, env);
+  const body = translateExpr(ctx, valueConstraint, env);
   const guarded: Z3Expr = info.isTotal
     ? body
     : {

--- a/src/verify/translator.ts
+++ b/src/verify/translator.ts
@@ -6,6 +6,7 @@ import type {
   StateDecl,
   StateFieldDecl,
   InvariantDecl,
+  OperationDecl,
   TypeExpr,
   Expr,
   BinaryOp,
@@ -59,9 +60,14 @@ class TranslateCtx {
   readonly entities = new Map<string, EntityInfo>();
   readonly enums = new Map<string, { readonly sort: Z3Sort; readonly members: readonly string[] }>();
   readonly typeAliases = new Map<string, { readonly sort: Z3Sort }>();
+  readonly primitiveAliases = new Map<
+    string,
+    { readonly underlyingSort: Z3Sort; readonly constraint: Expr }
+  >();
   readonly state = new Map<string, StateEntry>();
   private readonly matchesIds = new Map<string, number>();
   private readonly stringLitIds = new Map<string, number>();
+  private readonly cardinalityNames = new Map<string, string>();
 
   declareSort(sort: Z3Sort): void {
     if (sort.kind !== "Uninterp") return;
@@ -96,11 +102,45 @@ class TranslateCtx {
   stringLitCount(): number {
     return this.stringLitIds.size;
   }
+
+  cardinalityNameFor(targetName: string): string {
+    const existing = this.cardinalityNames.get(targetName);
+    if (existing !== undefined) return existing;
+    const name = `card_${targetName}`;
+    this.cardinalityNames.set(targetName, name);
+    return name;
+  }
 }
 
 export function translate(ir: ServiceIR): Z3Script {
   const ctx = new TranslateCtx();
+  declareBase(ctx, ir);
+  for (const inv of ir.invariants) emitTopLevelInvariant(ctx, inv);
+  return finalizeScript(ctx);
+}
 
+export function translateOperationRequires(ir: ServiceIR, op: OperationDecl): Z3Script {
+  const ctx = new TranslateCtx();
+  declareBase(ctx, ir);
+  const env = declareOperationInputs(ctx, op);
+  for (const req of op.requires) {
+    ctx.assertions.push(translateExpr(ctx, req, env));
+  }
+  return finalizeScript(ctx);
+}
+
+export function translateOperationEnabled(ir: ServiceIR, op: OperationDecl): Z3Script {
+  const ctx = new TranslateCtx();
+  declareBase(ctx, ir);
+  for (const inv of ir.invariants) emitTopLevelInvariant(ctx, inv);
+  const env = declareOperationInputs(ctx, op);
+  for (const req of op.requires) {
+    ctx.assertions.push(translateExpr(ctx, req, env));
+  }
+  return finalizeScript(ctx);
+}
+
+function declareBase(ctx: TranslateCtx, ir: ServiceIR): void {
   for (const e of ir.enums) declareEnum(ctx, e);
   for (const t of ir.typeAliases) declareTypeAlias(ctx, t);
   for (const e of ir.entities) declareEntity(ctx, e);
@@ -108,14 +148,46 @@ export function translate(ir: ServiceIR): Z3Script {
 
   for (const t of ir.typeAliases) emitTypeAliasConstraint(ctx, t);
   for (const e of ir.entities) emitEntityAssertions(ctx, e);
-  for (const inv of ir.invariants) emitTopLevelInvariant(ctx, inv);
-  emitStringLiteralDistinctness(ctx);
+}
 
+function finalizeScript(ctx: TranslateCtx): Z3Script {
+  emitStringLiteralDistinctness(ctx);
   return {
     sorts: [...ctx.sorts.values()].sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
     funcs: [...ctx.funcs.values()].sort((a, b) => a.name.localeCompare(b.name)),
     assertions: ctx.assertions,
   };
+}
+
+function declareOperationInputs(ctx: TranslateCtx, op: OperationDecl): Map<string, Z3Expr> {
+  const env = new Map<string, Z3Expr>();
+  for (const input of op.inputs) {
+    const sort = sortForType(ctx, input.typeExpr);
+    const funcName = `input_${op.name}_${input.name}`;
+    if (!ctx.funcs.has(funcName)) {
+      ctx.declareFunc({ kind: "FuncDecl", name: funcName, argSorts: [], resultSort: sort });
+    }
+    env.set(input.name, { kind: "App", func: funcName, args: [] });
+    maybeAssertInputRefinement(ctx, op, input, funcName, sort);
+  }
+  return env;
+}
+
+function maybeAssertInputRefinement(
+  ctx: TranslateCtx,
+  op: OperationDecl,
+  input: { readonly name: string; readonly typeExpr: TypeExpr },
+  funcName: string,
+  sort: Z3Sort,
+): void {
+  void op;
+  void sort;
+  if (input.typeExpr.kind !== "NamedType") return;
+  const alias = ctx.primitiveAliases.get(input.typeExpr.name);
+  if (!alias) return;
+  const env = new Map<string, Z3Expr>();
+  env.set("value", { kind: "App", func: funcName, args: [] });
+  ctx.assertions.push(translateExpr(ctx, alias.constraint, env));
 }
 
 function declareEnum(ctx: TranslateCtx, e: EnumDecl): void {
@@ -143,28 +215,29 @@ function declareEnum(ctx: TranslateCtx, e: EnumDecl): void {
 }
 
 function declareTypeAlias(ctx: TranslateCtx, t: TypeAliasDecl): void {
-  const sort = aliasUnderlyingSort(t);
+  const primitiveSort = primitiveUnderlyingSort(t);
+  if (primitiveSort && t.constraint) {
+    ctx.primitiveAliases.set(t.name, {
+      underlyingSort: primitiveSort,
+      constraint: t.constraint,
+    });
+    return;
+  }
+  const sort = primitiveSort ?? uninterp(t.name);
   ctx.declareSort(sort);
   ctx.typeAliases.set(t.name, { sort });
 }
 
-function aliasUnderlyingSort(t: TypeAliasDecl): Z3Sort {
-  if (t.typeExpr.kind === "NamedType") {
-    const name = t.typeExpr.name;
-    if (name === "Int" || name === "Bool") {
-      if (t.constraint) {
-        throw new TranslatorError(
-          `type alias '${t.name}' wraps primitive '${name}' with a where-clause — unwrap modeling is out of M4.1 scope (deferred to M4.2+)`,
-        );
-      }
-      return name === "Int" ? Z3_INT : Z3_BOOL;
-    }
-  }
-  return uninterp(t.name);
+function primitiveUnderlyingSort(t: TypeAliasDecl): Z3Sort | null {
+  if (t.typeExpr.kind !== "NamedType") return null;
+  if (t.typeExpr.name === "Int") return Z3_INT;
+  if (t.typeExpr.name === "Bool") return Z3_BOOL;
+  return null;
 }
 
 function emitTypeAliasConstraint(ctx: TranslateCtx, t: TypeAliasDecl): void {
   if (!t.constraint) return;
+  if (ctx.primitiveAliases.has(t.name)) return;
   const sort = ctx.typeAliases.get(t.name)!.sort;
   const varName = `self_${t.name}`;
   const selfRef: Z3Expr = { kind: "Var", name: varName, sort };
@@ -198,17 +271,29 @@ function emitEntityAssertions(ctx: TranslateCtx, e: EntityDecl): void {
   const selfRef: Z3Expr = { kind: "Var", name: varName, sort: info.sort };
 
   for (const f of e.fields) {
-    if (!f.constraint) continue;
     const fieldInfo = info.fields.get(f.name)!;
-    const env = new Map<string, Z3Expr>();
-    env.set("value", { kind: "App", func: fieldInfo.funcName, args: [selfRef] });
-    const body = translateExpr(ctx, f.constraint, env);
-    ctx.assertions.push({
-      kind: "Quantifier",
-      q: "ForAll",
-      bindings: [{ name: varName, sort: info.sort }],
-      body,
-    });
+    const aliasConstraint = refinementConstraintFor(ctx, f.typeExpr);
+    const fieldRead: Z3Expr = { kind: "App", func: fieldInfo.funcName, args: [selfRef] };
+    const bodies: Z3Expr[] = [];
+    if (aliasConstraint) {
+      const env = new Map<string, Z3Expr>();
+      env.set("value", fieldRead);
+      bodies.push(translateExpr(ctx, aliasConstraint, env));
+    }
+    if (f.constraint) {
+      const env = new Map<string, Z3Expr>();
+      env.set("value", fieldRead);
+      bodies.push(translateExpr(ctx, f.constraint, env));
+    }
+    if (bodies.length > 0) {
+      const body: Z3Expr = bodies.length === 1 ? bodies[0] : { kind: "And", args: bodies };
+      ctx.assertions.push({
+        kind: "Quantifier",
+        q: "ForAll",
+        bindings: [{ name: varName, sort: info.sort }],
+        body,
+      });
+    }
   }
 
   for (const inv of e.invariants) {
@@ -225,6 +310,12 @@ function emitEntityAssertions(ctx: TranslateCtx, e: EntityDecl): void {
       body,
     });
   }
+}
+
+function refinementConstraintFor(ctx: TranslateCtx, te: TypeExpr): Expr | null {
+  if (te.kind !== "NamedType") return null;
+  const prim = ctx.primitiveAliases.get(te.name);
+  return prim ? prim.constraint : null;
 }
 
 function declareState(ctx: TranslateCtx, state: StateDecl): void {
@@ -341,6 +432,8 @@ function sortForNamedType(ctx: TranslateCtx, name: string): Z3Sort {
   if (entity) return entity.sort;
   const enumSort = ctx.enums.get(name);
   if (enumSort) return enumSort.sort;
+  const primAlias = ctx.primitiveAliases.get(name);
+  if (primAlias) return primAlias.underlyingSort;
   const alias = ctx.typeAliases.get(name);
   if (alias) return alias.sort;
   return uninterp(name);
@@ -463,9 +556,7 @@ function translateUnaryOp(
         args: [{ kind: "IntLit", value: 0 }, translateExpr(ctx, expr.operand, env)],
       };
     case "cardinality":
-      throw new TranslatorError(
-        `cardinality operator '#' is out of M4.1 scope (deferred to M4.2+)`,
-      );
+      return translateCardinality(ctx, expr.operand);
     case "power":
       throw new TranslatorError(
         `powerset operator is out of M4.1 scope (deferred to M4.2+)`,
@@ -473,6 +564,31 @@ function translateUnaryOp(
     default:
       throw new TranslatorError(`unary op '${expr.op}' is out of M4.1 scope`);
   }
+}
+
+function translateCardinality(ctx: TranslateCtx, operand: Expr): Z3Expr {
+  if (operand.kind !== "Identifier") {
+    throw new TranslatorError(
+      "cardinality '#expr' is only supported on state-relation identifiers in M4.2 (deferred for general set expressions — see issue #73)",
+    );
+  }
+  const state = ctx.state.get(operand.name);
+  if (!state || state.kind !== "Relation") {
+    throw new TranslatorError(
+      `cardinality '#${operand.name}' requires a state relation; '${operand.name}' is not declared as one`,
+    );
+  }
+  const funcName = ctx.cardinalityNameFor(operand.name);
+  if (!ctx.funcs.has(funcName)) {
+    ctx.declareFunc({ kind: "FuncDecl", name: funcName, argSorts: [], resultSort: Z3_INT });
+    ctx.assertions.push({
+      kind: "Cmp",
+      op: ">=",
+      lhs: { kind: "App", func: funcName, args: [] },
+      rhs: { kind: "IntLit", value: 0 },
+    });
+  }
+  return { kind: "App", func: funcName, args: [] };
 }
 
 function translateQuantifier(
@@ -526,6 +642,17 @@ function resolveBindingDomain(ctx: TranslateCtx, b: QuantifierBinding): BindingR
     if (entity) return { sort: entity.sort, guard: null };
     const alias = ctx.typeAliases.get(name);
     if (alias) return { sort: alias.sort, guard: null };
+    const primAlias = ctx.primitiveAliases.get(name);
+    if (primAlias) {
+      return {
+        sort: primAlias.underlyingSort,
+        guard: (vn) => {
+          const env = new Map<string, Z3Expr>();
+          env.set("value", { kind: "Var", name: vn, sort: primAlias.underlyingSort });
+          return translateExpr(ctx, primAlias.constraint, env);
+        },
+      };
+    }
     const enumDecl = ctx.enums.get(name);
     if (enumDecl) return { sort: enumDecl.sort, guard: null };
     const state = ctx.state.get(name);

--- a/src/verify/translator.ts
+++ b/src/verify/translator.ts
@@ -321,6 +321,42 @@ function refinementConstraintFor(ctx: TranslateCtx, te: TypeExpr): Expr | null {
 function declareState(ctx: TranslateCtx, state: StateDecl): void {
   for (const sf of state.fields) declareStateField(ctx, sf);
   for (const sf of state.fields) emitStateTotality(ctx, sf);
+  for (const sf of state.fields) emitStateRefinement(ctx, sf);
+}
+
+function emitStateRefinement(ctx: TranslateCtx, sf: StateFieldDecl): void {
+  const info = ctx.state.get(sf.name);
+  if (!info) return;
+  if (info.kind === "Const") {
+    const aliasConstraint = refinementConstraintFor(ctx, sf.typeExpr);
+    if (!aliasConstraint) return;
+    const env = new Map<string, Z3Expr>();
+    env.set("value", { kind: "App", func: info.funcName, args: [] });
+    ctx.assertions.push(translateExpr(ctx, aliasConstraint, env));
+    return;
+  }
+  if (sf.typeExpr.kind !== "RelationType" && sf.typeExpr.kind !== "MapType") return;
+  const valueType = sf.typeExpr.kind === "RelationType" ? sf.typeExpr.toType : sf.typeExpr.valueType;
+  const aliasConstraint = refinementConstraintFor(ctx, valueType);
+  if (!aliasConstraint) return;
+  const varName = `k_${sf.name}`;
+  const keyVar: Z3Expr = { kind: "Var", name: varName, sort: info.keySort };
+  const env = new Map<string, Z3Expr>();
+  env.set("value", { kind: "App", func: info.mapFunc, args: [keyVar] });
+  const body = translateExpr(ctx, aliasConstraint, env);
+  const guarded: Z3Expr = info.isTotal
+    ? body
+    : {
+        kind: "Implies",
+        lhs: { kind: "App", func: info.domFunc, args: [keyVar] },
+        rhs: body,
+      };
+  ctx.assertions.push({
+    kind: "Quantifier",
+    q: "ForAll",
+    bindings: [{ name: varName, sort: info.keySort }],
+    body: guarded,
+  });
 }
 
 function declareStateField(ctx: TranslateCtx, sf: StateFieldDecl): void {

--- a/test/verify/backend.test.ts
+++ b/test/verify/backend.test.ts
@@ -123,3 +123,20 @@ describe.sequential("WasmBackend — trivial check-sat scenarios", () => {
     expect(DEFAULT_VERIFICATION_CONFIG.timeoutMs).toBe(30_000);
   });
 });
+
+describe.sequential("WasmBackend — context reuse across checks", () => {
+  it("runs two independent checks on one backend without crosstalk", async () => {
+    const reuseBackend = new WasmBackend();
+    const first = await reuseBackend.check(
+      { sorts: [], funcs: [], assertions: [{ kind: "BoolLit", value: false }] },
+      { timeoutMs: 30_000 },
+    );
+    expect(first.status).toBe("unsat");
+
+    const second = await reuseBackend.check(
+      { sorts: [], funcs: [], assertions: [] },
+      { timeoutMs: 30_000 },
+    );
+    expect(second.status).toBe("sat");
+  });
+});

--- a/test/verify/consistency.test.ts
+++ b/test/verify/consistency.test.ts
@@ -65,6 +65,22 @@ describe.sequential("consistency — dead and unreachable operations", () => {
   });
 });
 
+describe.sequential("consistency — backend errors are reported as unknown, not skipped", () => {
+  it("a throwing backend produces an unknown check with a 'backend error' detail, not a skip", async () => {
+    const ir = irFromFile("../parser/fixtures/url_shortener.spec");
+    const brokenBackend = {
+      async check(): Promise<never> {
+        throw new Error("simulated solver crash");
+      },
+    } as unknown as WasmBackend;
+    const report = await runConsistencyChecks(ir, brokenBackend, DEFAULT_VERIFICATION_CONFIG);
+    expect(report.ok).toBe(false);
+    const global = findCheck(report.checks, "global");
+    expect(global?.status).toBe("unknown");
+    expect(global?.detail).toContain("backend error");
+  });
+});
+
 describe.sequential("consistency — contradictory invariants still caught", () => {
   let backend: WasmBackend;
 

--- a/test/verify/consistency.test.ts
+++ b/test/verify/consistency.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { WasmBackend } from "#verify/backend.js";
+import { runConsistencyChecks, type CheckResult } from "#verify/consistency.js";
+import { DEFAULT_VERIFICATION_CONFIG } from "#verify/types.js";
+import type { ServiceIR } from "#ir/types.js";
+
+function irFromFile(relPath: string): ServiceIR {
+  const src = readFileSync(join(import.meta.dirname, relPath), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildIR(tree);
+}
+
+function findCheck(checks: readonly CheckResult[], id: string): CheckResult | undefined {
+  return checks.find((c) => c.id === id);
+}
+
+describe.sequential("consistency — url_shortener happy path", () => {
+  let backend: WasmBackend;
+
+  beforeAll(() => {
+    backend = new WasmBackend();
+  });
+
+  it("all consistency checks pass on the url_shortener fixture", async () => {
+    const ir = irFromFile("../parser/fixtures/url_shortener.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    expect(report.ok).toBe(true);
+    const global = findCheck(report.checks, "global");
+    expect(global?.status).toBe("sat");
+    for (const op of ["Shorten", "Resolve", "Delete", "ListAll"]) {
+      expect(findCheck(report.checks, `${op}.requires`)?.status).toBe("sat");
+      expect(findCheck(report.checks, `${op}.enabled`)?.status).toBe("sat");
+    }
+  });
+});
+
+describe.sequential("consistency — dead and unreachable operations", () => {
+  let backend: WasmBackend;
+
+  beforeAll(() => {
+    backend = new WasmBackend();
+  });
+
+  it("detects a dead operation (requires itself is contradictory)", async () => {
+    const ir = irFromFile("./fixtures/dead_op.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    expect(report.ok).toBe(false);
+    expect(findCheck(report.checks, "global")?.status).toBe("sat");
+    expect(findCheck(report.checks, "DeadOp.requires")?.status).toBe("unsat");
+    expect(findCheck(report.checks, "DeadOp.enabled")?.status).toBe("unsat");
+  });
+
+  it("detects an unreachable operation (requires contradicts the invariants)", async () => {
+    const ir = irFromFile("./fixtures/unreachable_op.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    expect(report.ok).toBe(false);
+    expect(findCheck(report.checks, "global")?.status).toBe("sat");
+    expect(findCheck(report.checks, "UnreachableOp.requires")?.status).toBe("sat");
+    expect(findCheck(report.checks, "UnreachableOp.enabled")?.status).toBe("unsat");
+  });
+});
+
+describe.sequential("consistency — contradictory invariants still caught", () => {
+  let backend: WasmBackend;
+
+  beforeAll(() => {
+    backend = new WasmBackend();
+  });
+
+  it("unsat_invariants.spec fails the global check", async () => {
+    const ir = irFromFile("./fixtures/unsat_invariants.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    expect(report.ok).toBe(false);
+    expect(findCheck(report.checks, "global")?.status).toBe("unsat");
+  });
+});

--- a/test/verify/fixtures/dead_op.spec
+++ b/test/verify/fixtures/dead_op.spec
@@ -1,0 +1,10 @@
+service T {
+  entity E { n: Int }
+  state { x: Int }
+
+  operation DeadOp {
+    input: y: Int
+    requires:
+      y > 10 and y < 5
+  }
+}

--- a/test/verify/fixtures/unreachable_op.spec
+++ b/test/verify/fixtures/unreachable_op.spec
@@ -1,0 +1,10 @@
+service T {
+  state { x: Int }
+
+  operation UnreachableOp {
+    requires:
+      x < 5
+  }
+
+  invariant: x > 100
+}

--- a/test/verify/translator.test.ts
+++ b/test/verify/translator.test.ts
@@ -3,14 +3,21 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseSpec } from "#parser/index.js";
 import { buildIR } from "#ir/index.js";
-import { translate } from "#verify/translator.js";
+import { translate, translateOperationRequires, translateOperationEnabled } from "#verify/translator.js";
 import type { Z3Expr, Z3FunctionDecl, Z3Script } from "#verify/script.js";
 import { TranslatorError } from "#verify/types.js";
+import type { ServiceIR } from "#ir/types.js";
 
 function scriptFrom(src: string): Z3Script {
   const { tree, errors } = parseSpec(src);
   expect(errors).toEqual([]);
   return translate(buildIR(tree));
+}
+
+function irFrom(src: string): ServiceIR {
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildIR(tree);
 }
 
 function service(body: string): string {
@@ -226,16 +233,42 @@ describe("translator — enums", () => {
 });
 
 describe("translator — primitive-underlying type aliases", () => {
-  it("type Positive = Int where value > 0 throws (deferred to M4.2)", () => {
+  it("type Positive = Int where value > 0 translates without throwing", () => {
     expect(() =>
       scriptFrom(service(`type Positive = Int where value > 0`)),
-    ).toThrow(TranslatorError);
+    ).not.toThrow();
   });
 
-  it("type Flag = Bool where value = true throws (deferred to M4.2)", () => {
-    expect(() =>
-      scriptFrom(service(`type Flag = Bool where value = true`)),
-    ).toThrow(TranslatorError);
+  it("entity field of primitive-alias type inlines the alias refinement as an axiom", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        entity E { n: Positive }
+      `),
+    );
+    const en = findFunc(script, "E_n");
+    expect(en?.resultSort.kind).toBe("Int");
+    const refinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.q === "ForAll" &&
+        a.body.kind === "Cmp" &&
+        a.body.op === ">" &&
+        a.body.lhs.kind === "App" &&
+        a.body.lhs.func === "E_n",
+    );
+    expect(refinement).toBeDefined();
+  });
+
+  it("type Flag = Bool where value = true translates to Bool underlying sort", () => {
+    const script = scriptFrom(
+      service(`
+        type Flag = Bool where value = true
+        entity E { f: Flag }
+      `),
+    );
+    const ef = findFunc(script, "E_f");
+    expect(ef?.resultSort.kind).toBe("Bool");
   });
 
   it("type Wrapper = Int without a where-clause uses Int sort directly", () => {
@@ -306,6 +339,111 @@ describe("translator — out-of-scope kinds throw TranslatorError", () => {
         `),
       ),
     ).toThrow(TranslatorError);
+  });
+});
+
+describe("translator — cardinality", () => {
+  it("cardinality on a state relation declares an uninterpreted Int with a ≥ 0 axiom", () => {
+    const script = scriptFrom(
+      service(`
+        entity V { value: Int }
+        state { store: Int -> lone V }
+        invariant: #store >= 0
+      `),
+    );
+    const cardFunc = script.funcs.find((f) => f.name === "card_store");
+    expect(cardFunc).toBeDefined();
+    expect(cardFunc?.resultSort.kind).toBe("Int");
+    const geZero = script.assertions.find(
+      (a) =>
+        a.kind === "Cmp" &&
+        a.op === ">=" &&
+        a.lhs.kind === "App" &&
+        a.lhs.func === "card_store" &&
+        a.rhs.kind === "IntLit" &&
+        a.rhs.value === 0,
+    );
+    expect(geZero).toBeDefined();
+  });
+
+  it("cardinality on a non-state identifier throws", () => {
+    expect(() =>
+      scriptFrom(
+        service(`
+          entity V { value: Int }
+          invariant: #V >= 0
+        `),
+      ),
+    ).toThrow(TranslatorError);
+  });
+});
+
+describe("translator — operation requires", () => {
+  const src = `service T {
+    entity Item { value: Int }
+    state { store: Int -> lone Item }
+    operation Put {
+      input: key: Int
+      requires: key > 0
+    }
+    operation Fetch {
+      input: key: Int
+      requires: key in store
+    }
+    invariant: true
+  }`;
+
+  it("translateOperationRequires declares typed input constants", () => {
+    const ir = irFrom(src);
+    const op = ir.operations.find((o) => o.name === "Put")!;
+    const script = translateOperationRequires(ir, op);
+    const input = script.funcs.find((f) => f.name === "input_Put_key");
+    expect(input).toBeDefined();
+    expect(input?.resultSort.kind).toBe("Int");
+    expect(input?.argSorts.length).toBe(0);
+  });
+
+  it("translateOperationRequires omits top-level invariants", () => {
+    const ir = irFrom(src);
+    const op = ir.operations.find((o) => o.name === "Put")!;
+    const script = translateOperationRequires(ir, op);
+    const hasTopLevelTrue = script.assertions.some(
+      (a) => a.kind === "BoolLit" && a.value === true,
+    );
+    expect(hasTopLevelTrue).toBe(false);
+  });
+
+  it("translateOperationEnabled includes top-level invariants plus requires", () => {
+    const ir = irFrom(src);
+    const op = ir.operations.find((o) => o.name === "Put")!;
+    const script = translateOperationEnabled(ir, op);
+    const hasTopLevelTrue = script.assertions.some(
+      (a) => a.kind === "BoolLit" && a.value === true,
+    );
+    expect(hasTopLevelTrue).toBe(true);
+    const requiresCmp = script.assertions.some(
+      (a) =>
+        a.kind === "Cmp" &&
+        a.op === ">" &&
+        a.lhs.kind === "App" &&
+        a.lhs.func === "input_Put_key",
+    );
+    expect(requiresCmp).toBe(true);
+  });
+
+  it("operation requires can reference state-relation membership", () => {
+    const ir = irFrom(src);
+    const op = ir.operations.find((o) => o.name === "Fetch")!;
+    const script = translateOperationRequires(ir, op);
+    const membership = script.assertions.some(
+      (a) =>
+        a.kind === "App" &&
+        a.func === "store_dom" &&
+        a.args.length === 1 &&
+        a.args[0].kind === "App" &&
+        a.args[0].func === "input_Fetch_key",
+    );
+    expect(membership).toBe(true);
   });
 });
 

--- a/test/verify/translator.test.ts
+++ b/test/verify/translator.test.ts
@@ -380,6 +380,49 @@ describe("translator — state refinement for primitive aliases", () => {
     expect(refinement).toBeDefined();
   });
 
+  it("state relation with primitive-alias key type asserts the key refinement under dom", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        state { r: Positive -> lone Int }
+      `),
+    );
+    const keyRefinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.q === "ForAll" &&
+        a.bindings[0].name === "k_r_key" &&
+        a.body.kind === "Implies" &&
+        a.body.lhs.kind === "App" &&
+        a.body.lhs.func === "r_dom" &&
+        a.body.rhs.kind === "Cmp" &&
+        a.body.rhs.op === ">",
+    );
+    expect(keyRefinement).toBeDefined();
+  });
+
+  it("state relation with primitive-alias key and value emits both refinements", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        type Percent = Int where value >= 0 and value <= 100
+        state { r: Positive -> lone Percent }
+      `),
+    );
+    const keyRefinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.bindings[0].name === "k_r_key",
+    );
+    const valueRefinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.bindings[0].name === "k_r",
+    );
+    expect(keyRefinement).toBeDefined();
+    expect(valueRefinement).toBeDefined();
+  });
+
   it("total state relation (multiplicity one) of primitive-alias type drops the dom guard", () => {
     const script = scriptFrom(
       service(`

--- a/test/verify/translator.test.ts
+++ b/test/verify/translator.test.ts
@@ -342,6 +342,64 @@ describe("translator — out-of-scope kinds throw TranslatorError", () => {
   });
 });
 
+describe("translator — state refinement for primitive aliases", () => {
+  it("state const of primitive-alias type asserts the alias constraint", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        state { x: Positive }
+      `),
+    );
+    const refinement = script.assertions.find(
+      (a) =>
+        a.kind === "Cmp" &&
+        a.op === ">" &&
+        a.lhs.kind === "App" &&
+        a.lhs.func === "state_x",
+    );
+    expect(refinement).toBeDefined();
+  });
+
+  it("state relation map of primitive-alias value type asserts the alias constraint under dom", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        state { r: Int -> lone Positive }
+      `),
+    );
+    const refinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.q === "ForAll" &&
+        a.body.kind === "Implies" &&
+        a.body.lhs.kind === "App" &&
+        a.body.lhs.func === "r_dom" &&
+        a.body.rhs.kind === "Cmp" &&
+        a.body.rhs.op === ">",
+    );
+    expect(refinement).toBeDefined();
+  });
+
+  it("total state relation (multiplicity one) of primitive-alias type drops the dom guard", () => {
+    const script = scriptFrom(
+      service(`
+        type Positive = Int where value > 0
+        state { r: Int -> one Positive }
+      `),
+    );
+    const refinement = script.assertions.find(
+      (a) =>
+        a.kind === "Quantifier" &&
+        a.q === "ForAll" &&
+        a.body.kind === "Cmp" &&
+        a.body.op === ">" &&
+        a.body.lhs.kind === "App" &&
+        a.body.lhs.func === "r_map",
+    );
+    expect(refinement).toBeDefined();
+  });
+});
+
 describe("translator — cardinality", () => {
   it("cardinality on a state relation declares an uninterpreted Int with a ≥ 0 axiom", () => {
     const script = scriptFrom(


### PR DESCRIPTION
## Summary

- Lifts `verify` from a single global satisfiability check into a per-check consistency report: one `global` check plus `<Op>.requires` and `<Op>.enabled` for each operation. On the `url_shortener` fixture that's 9 checks in ~600 ms end-to-end.
- Adds two translator extensions: **primitive-type alias refinement** (`type Positive = Int where value > 0` inlines the constraint at every introduction site — fields, quantifier bindings, operation inputs) and **state-relation cardinality** (`#store` declares an uninterpreted `Int` with a `≥ 0` axiom; sound-but-weak).
- Factors the existing translation pipeline through `declareBase` so the three new entry points (`translate`, `translateOperationRequires`, `translateOperationEnabled`) share sort/func declarations without duplication. The M4.1 `translate(ir)` output is byte-identical — the `url_shortener.smt2` snapshot still matches.
- `WasmBackend` now memoizes `init()` so the CLI's 2N+1 checks share one WASM load and one `Context`.
- CLI output swaps the single-line status for a per-check table; exit code is 0 when every check is `sat` / `skipped`, 1 otherwise. `--dump-smt` still emits the original global script.

## Closes

Closes #21.

## Related

- #22 (M4.1) — built directly on this plumbing; no regressions.
- #19 (M4.3) — `ensures` / `Prime` / `Pre` / `With` still deliberately throw; those are the next milestone's territory.
- #20 (M4.4) — failures report one-line explanations only; Z3 model → source-span diagnostics ship with M4.4.
- #73 (new) — set operators and non-state membership split out of this PR; will land alongside or during M4.3 when `ensures` forces the design.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 1169 passed, 0 failed (adds 12 new tests across `translator.test.ts`, `backend.test.ts`, `consistency.test.ts`).
- [x] `npm run fmt:check` — clean.
- [x] `cd docs && npm run build` — docs build clean.
- [x] `npm run cli -- verify test/parser/fixtures/url_shortener.spec` — 9/9 checks sat, exit 0.
- [x] `npm run cli -- verify test/verify/fixtures/dead_op.spec` — 2 failures, exit 1.
- [x] `npm run cli -- verify test/verify/fixtures/unreachable_op.spec` — 1 failure (`<Op>.enabled` unsat, `<Op>.requires` sat), exit 1.
- [x] `test/verify/fixtures/url_shortener.smt2` snapshot unchanged — CI cross-check against native Z3 still green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `verify` from a single smoke check to a full consistency report: one `global` invariants check plus per-operation `requires` and `enabled` checks, with clearer CLI output and faster runs via context reuse.

- **New Features**
  - Per-op consistency: runs `global`, `<Op>.requires`, `<Op>.enabled`. `global` unsat → invariants contradict. `requires` unsat → op can never fire (under base axioms). `enabled` unsat → op is dead.
  - CLI: per-check table with timings; exit code `0` only if all checks are `sat`/`skipped`. Translator limits → `skipped` (ok); backend/runtime errors → `unknown` (fail). `--dump-smt` still exports the original global script; `-v` shows stage + per-check timing, and decl counts only on `--dump-smt`.
  - Primitive alias refinement: `type Positive = Int where value > 0` is inlined at fields, quantifier bindings, operation inputs, state consts, state-relation map values (guarded by `dom` when partial), and state-relation keys (`dom(k) ⇒ P(k)`).
  - Cardinality on state relations: `#store` lowers to an uninterpreted `Int` with a `≥ 0` axiom (limited to state relations; sound but weak).

- **Refactors**
  - Translator factored through `declareBase`; added `translateOperationRequires` and `translateOperationEnabled` to reuse declarations.
  - `WasmBackend` memoizes `init()` and reuses a single Z3 `Context` across all checks.
  - `translate(ir)` output is unchanged; existing SMT snapshots still match.

<sup>Written for commit b149736b4b949642afcf13a25189c4ac3d40aa0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

