### PR TITLE
M4.4 — Verification error reporting with counterexamples

### DIFF
--- a/docs/content/docs/verification.mdx
+++ b/docs/content/docs/verification.mdx
@@ -107,9 +107,9 @@ opt-in suggestion.
 ### Worked example — preservation violation
 
 ```text
-$ spec-to-rest verify examples/broken_url_shortener.spec
-✘ examples/broken_url_shortener.spec:11:3: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
-  related: examples/broken_url_shortener.spec:22:3 (invariant 'clickCountNonNegative' declared here)
+$ spec-to-rest verify test/verify/fixtures/broken_url_shortener.spec
+✘ test/verify/fixtures/broken_url_shortener.spec:11:3: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
+  related: test/verify/fixtures/broken_url_shortener.spec:21:3 (invariant 'clickCountNonNegative' declared here)
 
   Counterexample:
   inputs:
@@ -133,9 +133,9 @@ rewritten to the readable `UrlMapping#N` labels.
 ### Worked example — contradictory invariants
 
 ```text
-$ spec-to-rest verify examples/unsat_invariants.spec
-✘ examples/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
-  related: examples/unsat_invariants.spec:5:3 (invariant 'tooHigh')
+$ spec-to-rest verify test/verify/fixtures/unsat_invariants.spec
+✘ test/verify/fixtures/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
+  related: test/verify/fixtures/unsat_invariants.spec:5:3 (invariant 'tooHigh')
 
   hint: Review the invariant set for a pair whose range constraints cannot overlap
   (e.g., 'x >= 10' alongside 'x <= 5').
@@ -181,10 +181,14 @@ verbose   …
 
 | Code | Meaning |
 | ---: | --- |
-| `0` | All checks passed (sat or skipped). |
-| `1` | At least one check failed (unsat / preservation `sat` / timeout). |
-| `2` | The verifier hit a construct it cannot translate, on a spec that otherwise parsed. |
-| `3` | WASM / solver backend error (init failure, solver crash). |
+| `0` | All translated checks passed (`sat`); no checks were skipped. |
+| `1` | Specification or spec-file issue: at least one ran check failed (unsat / preservation `sat` / timeout), **or** the spec could not be read / parsed / IR-built. |
+| `2` | Translator coverage gap: at least one check was `skipped` because the verifier cannot yet encode a construct used by that check. Other checks may still have passed. |
+| `3` | Backend error (WASM/solver init failure or solver crash). |
+
+Exit `2` is a partial-success signal — the spec *may* still be correct, but the verifier could
+not fully discharge every check. Skipped checks print as warnings with a `translator_limitation`
+diagnostic so CI / editors can surface the coverage gap alongside successes.
 
 ## Inspecting the SMT-LIB
 

--- a/docs/content/docs/verification.mdx
+++ b/docs/content/docs/verification.mdx
@@ -11,25 +11,30 @@ generated. It uses the [Z3 SMT solver](https://github.com/Z3Prover/z3) via the
 
 | Capability                                                          | Status |
 | ------------------------------------------------------------------- | ------ |
-| IR-to-SMT translator (entities, enums, state relations, invariants) | M4.1 shipped |
-| WASM Z3 backend + `spec-to-rest verify` CLI                         | M4.1 shipped |
-| Invariant-satisfiability smoke check                                | M4.1 shipped |
-| SMT-LIB artifact export (`--dump-smt`)                              | M4.1 shipped |
-| Invariant consistency checking (per-op `requires`, dead ops)        | M4.2 shipped |
-| Primitive-type alias refinement (`type Positive = Int where …`)     | M4.2 shipped |
-| Cardinality on state relations (`#store`, uninterpreted ≥ 0)        | M4.2 shipped |
-| Invariant preservation checking (operation pre/post ⇒ invariant)    | M4.3 shipped |
-| `Prime` (`X'`), `Pre(X)`, `With` record update, inline `y in {…}`   | M4.3 shipped |
-| Two-world state encoding + smart frame synthesis                    | M4.3 shipped |
-| Cardinality pre/post delta axioms (insert / delete / identity)      | M4.3 shipped |
-| Counterexample-driven error reporting                               | [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20) |
-| Verify-as-gate (refuse codegen on failed verification)              | M4.4 |
-| Temporal properties (liveness, fairness)                            | [#75](https://github.com/HardMax71/spec_to_rest/issues/75) (unscheduled) |
+| IR-to-SMT translator (entities, enums, state relations, invariants) | shipped |
+| WASM Z3 backend + `spec-to-rest verify` CLI                         | shipped |
+| Invariant-satisfiability smoke check                                | shipped |
+| SMT-LIB artifact export (`--dump-smt`)                              | shipped |
+| Invariant consistency checking (per-op `requires`, dead ops)        | shipped |
+| Primitive-type alias refinement (`type Positive = Int where …`)     | shipped |
+| Cardinality on state relations (`#store`, uninterpreted ≥ 0)        | shipped |
+| Invariant preservation checking (operation pre/post ⇒ invariant)    | shipped |
+| `Prime` (`X'`), `Pre(X)`, `With` record update, inline `y in {…}`   | shipped |
+| Two-world state encoding + smart frame synthesis                    | shipped |
+| Cardinality pre/post delta axioms (insert / delete / identity)      | shipped |
+| Counterexample-driven diagnostics (spans, entity/state decoding)    | shipped |
+| Category-based error reporting + per-category suggestion hints      | shipped |
+| Verify-as-gate (refuse codegen on failed verification)              | [#78](https://github.com/HardMax71/spec_to_rest/issues/78) (blocks on `compile` CLI) |
+| Machine-readable (`--json`) diagnostics output                      | [#79](https://github.com/HardMax71/spec_to_rest/issues/79) |
+| Richer suggested-fix templates                                      | [#80](https://github.com/HardMax71/spec_to_rest/issues/80) |
+| Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
+| Proof-certificate / unsat-core / VC-dump export                     | [#77](https://github.com/HardMax71/spec_to_rest/issues/77) |
+| Set operators and non-state set membership                          | [#73](https://github.com/HardMax71/spec_to_rest/issues/73) |
+| Temporal properties (liveness, fairness)                            | [#75](https://github.com/HardMax71/spec_to_rest/issues/75) (separate backend) |
 
-## What M4.3 ships
+## Preservation VC shape
 
-M4.3 layers operation-preserves-invariant checking on top of M4.2's consistency pipeline. For
-every (operation, invariant) pair the CLI now runs a dedicated preservation VC:
+For every (operation, invariant) pair the engine runs a dedicated preservation check:
 
 ```text
   I(state)                              ; invariant holds pre
@@ -40,17 +45,16 @@ every (operation, invariant) pair the CLI now runs a dedicated preservation VC:
 ∧ ¬ I(state')                            ; but invariant fails post
 ```
 
-`unsat` ⇒ the invariant is preserved; `sat` ⇒ a counterexample exists (formatted diagnostics
-land in M4.4); `unknown` ⇒ the solver gave up (treated as a failure).
+`unsat` ⇒ the invariant is preserved; `sat` ⇒ a counterexample exists and the reporter decodes
+it; `unknown` ⇒ the solver gave up (treated as a failure).
 
 Total checks per spec: `1 + 2N + N × M` (global + requires/enabled per op + one preservation
 per op × invariant).
 
-### Language convention (locked in M4.3)
+### Language convention
 
 Inside `ensures` clauses, unprimed state references are **pre-state**; primed references (`x'`)
-are post-state; `pre(x)` is an explicit-but-equivalent way to name the pre-state. The fixture
-`url_shortener.spec` follows this convention consistently.
+are post-state; `pre(x)` is an explicit-but-equivalent way to name the pre-state.
 
 ### Smart frame synthesis
 
@@ -79,126 +83,108 @@ affected preservation VCs may come back `unknown`.
 ### `dom(X) = dom(Y)` lowers extensionally
 
 `dom(X) = dom(Y)` and `dom(X) != dom(Y)` where both sides are `Call(dom, [state-relation])`
-lower to `∀k. X_dom(k) ↔ Y_dom(k)` (and its negation). This replaces M4.2's opaque uninterpreted
-equality and is load-bearing for invariants like `metadataConsistent` in `url_shortener.spec`.
+lower to `∀k. X_dom(k) ↔ Y_dom(k)` (and its negation). This is load-bearing for invariants like
+`metadataConsistent` in `url_shortener.spec`.
 
-### Expression kinds newly supported
+## Reading diagnostics
 
-- **`Prime`** (`X'`, `store'[k]`, `metadata'[k].field`) — flips the translator's state mode to
-  `post` for the inner expression, routing identifier / index / cardinality / membership to the
-  `_post` twin functions.
-- **`Pre`** (`pre(X)`) — explicit pre-state reference; semantically equivalent to bare unprimed
-  inside `ensures` but honoured for readability.
-- **`With`** (`e with { f = v, … }`) — lowers to a fresh Skolem constant of the same entity sort
-  with field equalities; every field of the entity is pinned either to an explicit update value
-  or to the corresponding field of `e`.
-- **`y in { x in S | P }`** — inlined to `guard(y) ∧ P[y/x]` with hygiene-safe substitution.
-  Standalone set comprehensions outside a membership context still throw — general set theory is
-  tracked in [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+On failure the CLI prints a spec-aware multi-line diagnostic per failing check. Diagnostics
+carry a `category`, a primary source span, related spans, an optional counterexample, and an
+opt-in suggestion.
 
-## What M4.3 does not ship
+### Categories
 
-- **Counterexample formatting / source-span mapping.** When a preservation VC comes back `sat`
-  the CLI reports `operation 'Op' does not preserve invariant 'Inv' — counterexample found
-  (formatted diagnostics in M4.4)`. Turning the raw Z3 model into a readable explanation lives
-  in [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20).
-- **Verify-as-gate on `compile`.** Still deferred to M4.4.
-- **String / set arithmetic.** `+` on non-Int operands now throws a descriptive
-  `TranslatorError` rather than crashing the backend. Preservation checks that depend on
-  string-typed `+` (e.g. `url_shortener.Shorten.ensures: short_url = base_url + "/" + code`)
-  are cleanly skipped.
-- **Standalone set comprehensions / general set operators.** Only the membership-context shape
-  is lowered. Union / intersect / subset outside ensures, and `{x in S | P}` appearing by
-  itself, still raise `TranslatorError`. Tracked in
-  [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
-- **Temporal verification.** Out of scope for the Z3 pipeline; tracked separately in
-  [#75](https://github.com/HardMax71/spec_to_rest/issues/75).
-
-## What M4.2 ships
-
-M4.2 lifts `verify` from a single smoke check to a per-check consistency report. For every spec
-the CLI now runs **one global check** plus **two checks per operation**:
-
-| Check | Script | UNSAT means |
+| Category | When it fires | Typical remedy |
 | --- | --- | --- |
-| `global` | invariants alone | invariants are jointly contradictory — no valid state exists |
-| `<Op>.requires` | `requires` alone, with inputs as fresh constants | the `requires` clause is a contradiction — `Op` can never fire |
-| `<Op>.enabled` | invariants + `requires` | `Op` is dead — no valid pre-state enables it |
+| `contradictory_invariants` | `global` check is `unsat` | two invariants overlap-but-contradict — narrow one's range |
+| `unsatisfiable_precondition` | `<Op>.requires` is `unsat` | `requires` can never be true in isolation — relax an input predicate |
+| `unreachable_operation` | `<Op>.enabled` is `unsat` while `<Op>.requires` is `sat` | invariants block every valid pre-state — relax invariants or tighten the input type |
+| `invariant_violation_by_operation` | preservation VC is satisfied (i.e. invariant fails post) | tighten `ensures` so the invariant's constrained fields are pinned by `=` or a range predicate |
+| `solver_timeout` | Z3 returns `unknown` | raise `--timeout`, simplify the invariant, or split a heavy quantifier |
+| `translator_limitation` | IR construct not yet supported (see #73, #75) | skip the affected check or narrow the invariant so the unsupported construct doesn't appear |
+| `backend_error` | solver crash / init failure | re-run with `-v`; if reproducible, file an issue with `--dump-smt` output |
 
-The translator also picked up three extensions that were throws in M4.1:
+### Worked example — preservation violation
 
-- **Primitive-type alias refinement**: `type Positive = Int where value > 0` no longer throws.
-  Fields typed `Positive` inline the constraint as an axiom on the field function; quantifier
-  bindings (`all p: Positive | …`) get the constraint as a guard; operation inputs of the alias
-  type pin the constraint on the input constant.
-- **Cardinality on state relations**: `#store` lowers to a declared uninterpreted `card_store :
-  Int` with a `≥ 0` axiom. Sound-but-weak — you can check `#store < 100` is satisfiable, but
-  tighter reasoning (`#store' = #store + 1`) waits for M4.3's post-state encoding.
-- **Per-operation translation** — the base declarations (sorts, field functions, state
-  relations, alias constraints) factor into a reusable `declareBase` so each of the 2N+1
-  per-spec checks shares one parse/IR build, one WASM `init()`, and one `Context`.
+```text
+$ spec-to-rest verify examples/broken_url_shortener.spec
+✘ examples/broken_url_shortener.spec:11:3: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
+  related: examples/broken_url_shortener.spec:22:3 (invariant 'clickCountNonNegative' declared here)
 
-## What M4.2 does not ship
+  Counterexample:
+  inputs:
+    code = 2
+  entities:
+    UrlMapping#0 { click_count = -1 }
+    UrlMapping#1 { click_count = 99 }
+  pre-state:
+    metadata = { 2 → UrlMapping#1 }
+  post-state:
+    metadata' = { 2 → UrlMapping#0 }
 
-- **Preservation checking.** M4.2 does not prove that operation postconditions preserve
-  invariants. The translator deliberately rejects `pre()`, `'` (prime), and `with { … }`
-  constructs — these appear only in operation ensures clauses, which are the domain of
-  [M4.3](https://github.com/HardMax71/spec_to_rest/issues/19).
-- **Set operators and non-state membership.** `subset`, `union`, `intersect`, `minus`, and
-  `x in some_set` where `some_set` is not a state relation still raise `TranslatorError`.
-  Tracked in [#73](https://github.com/HardMax71/spec_to_rest/issues/73); likely landed alongside
-  or during M4.3, which is the first milestone where `ensures` forces real set-valued reasoning.
-- **Counterexample diagnostics.** When a check returns `unsat` M4.2 reports a one-line
-  explanation (e.g. `operation 'DeadOp' is dead`) but no Z3 model. [M4.4](https://github.com/HardMax71/spec_to_rest/issues/20)
-  maps models back to source spans with fix suggestions.
-- **Verify-as-gate.** `compile` still emits code regardless of verification. Wiring verify in as
-  a hard gate arrives with M4.4.
-- **Tight set-theoretic cardinality.** `#store >= 0` holds by axiom, but the encoding does not
-  relate `card_store` to `store_dom`, so invariants like `#store = dom-count` are `unknown`
-  shaped (they're typically ensures-only, so M4.3 territory).
+  hint: Tighten the 'ensures' clause so the invariant's constrained fields appear on the
+  right-hand side of a '=' or a range predicate.
+```
+
+The decoder enumerates the model's entity universe, evaluates field functions, and shows
+pre-/post-state relations side by side. Uninterpreted sort values like `UrlMapping!val!0` are
+rewritten to the readable `UrlMapping#N` labels.
+
+### Worked example — contradictory invariants
+
+```text
+$ spec-to-rest verify examples/unsat_invariants.spec
+✘ examples/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
+  related: examples/unsat_invariants.spec:5:3 (invariant 'tooHigh')
+
+  hint: Review the invariant set for a pair whose range constraints cannot overlap
+  (e.g., 'x >= 10' alongside 'x <= 5').
+```
+
+No counterexample is emitted here — the engine concluded `unsat` on the invariant conjunction
+alone, so there's no model to decode. Unsat-core extraction (tracked in #77) will sharpen the
+`related:` list to the minimal contradictory subset.
 
 ## Using the CLI
 
 ```bash
 $ spec-to-rest verify test/parser/fixtures/url_shortener.spec
-✔ url_shortener.spec: 9/9 consistency checks passed (586ms)
+✔ test/parser/fixtures/url_shortener.spec: 22/25 consistency checks passed (3 skipped) (842ms)
 ```
 
-Exit code `0` when every check is `sat` or `skipped`, `1` when any check is `unsat` or `unknown`.
-
-Failures expand into a per-check list:
-
-```text
-$ spec-to-rest verify test/verify/fixtures/dead_op.spec
- ERROR  dead_op.spec: 2 failure(s) in 3 consistency checks (565ms)
-   ✘ DeadOp.requires              unsat   145ms — 'requires' of operation 'DeadOp' is unsatisfiable under the spec's base constraints — the operation can never fire
-   ✘ DeadOp.enabled               unsat     9ms — operation 'DeadOp' is dead — no valid pre-state satisfies both the invariants and its 'requires'
-```
-
-Add `-v` for stage timing and per-check timing on the happy path:
+Add `-v` for stage timing, per-check timing, and the full check table:
 
 ```text
 $ spec-to-rest verify -v test/parser/fixtures/url_shortener.spec
 verbose Parsed in 4ms
 verbose Built IR in 1ms
 verbose Timeout: 30000ms
-✔ url_shortener.spec: 9/9 consistency checks passed (586ms)
+✔ … 22/25 consistency checks passed (3 skipped) (842ms)
 verbose   ✔ global                       sat         236ms
-verbose   ✔ Delete.enabled               sat          12ms
 verbose   ✔ Delete.requires              sat          11ms
+verbose   ✔ Delete.enabled               sat          12ms
+verbose   ✔ Delete.preserves.allURLsValid       sat     54ms
+verbose   ∙ Shorten.preserves.allURLsValid  skipped — arithmetic operator '+'
 verbose   …
 ```
 
-On `--dump-smt` runs, `-v` additionally prints the translated Z3-script decl counts.
-
 ### Options
 
-| Option                 | Default | Meaning                                                    |
-| ---------------------- | ------: | ---------------------------------------------------------- |
-| `--timeout <ms>`       |   30000 | Per-check timeout. `0` disables the timeout (Z3 default).  |
-| `--dump-smt`           |   false | Emit SMT-LIB to stdout and exit without running the solver |
-| `--dump-smt-out <file>` |       — | Write SMT-LIB to `<file>` and exit without running the solver |
-| `-v, --verbose`        |   false | Print stage timing + per-check timing (and, on `--dump-smt`, decl counts) |
+| Option                  | Default | Meaning                                                       |
+| ----------------------- | ------: | ------------------------------------------------------------- |
+| `--timeout <ms>`        |   30000 | Per-check timeout. `0` disables the timeout (Z3 default).     |
+| `--dump-smt`            |   false | Emit SMT-LIB to stdout and exit without running the solver.   |
+| `--dump-smt-out <file>` |       — | Write SMT-LIB to `<file>` and exit without running the solver.|
+| `-v, --verbose`         |   false | Print stage timing and per-check timing / status.             |
+
+### Exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | All checks passed (sat or skipped). |
+| `1` | At least one check failed (unsat / preservation `sat` / timeout). |
+| `2` | The verifier hit a construct it cannot translate, on a spec that otherwise parsed. |
+| `3` | WASM / solver backend error (init failure, solver crash). |
 
 ## Inspecting the SMT-LIB
 
@@ -215,7 +201,7 @@ sat
 ```
 
 CI runs exactly this cross-check against the checked-in
-`test/verify/fixtures/url_shortener.smt2` snapshot using `apt-get install -y z3` — if our
+`test/verify/fixtures/url_shortener.smt2` snapshot using `apt-get install -y z3` — if the
 emitter ever produces invalid SMT-LIB or loses satisfiability, CI fails loudly.
 
 ## Timeout semantics
@@ -223,29 +209,46 @@ emitter ever produces invalid SMT-LIB or loses satisfiability, CI fails loudly.
 `--timeout` maps directly to Z3's `timeout` solver parameter and the SMT-LIB
 `(set-option :timeout …)`. Units are milliseconds. `0` disables the timeout entirely.
 
-If Z3 cannot decide within the timeout, the result is `unknown` — which `verify` treats as a
-failure (exit `1`). In M4.2 the url_shortener's 9 consistency checks complete end-to-end in
-well under a second; the 30 s default is a conservative headroom for M4.3's heavier
-preservation checks.
+If Z3 cannot decide within the timeout, the result is `unknown`, which `verify` treats as a
+failure with category `solver_timeout` (exit `1`). The 30 s default is a conservative headroom
+for heavier preservation checks on large specs.
 
 ## Extending the translator
 
 Adding a new IR expression kind is a three-file change:
 
 1. `src/verify/translator.ts` — add a case to `translateExpr`; declare any helper uninterpreted
-   functions lazily via `ctx.declareFunc`. If the new construct is meaningful inside operation
-   `requires`, verify it flows through `translateOperationRequires` and
-   `translateOperationEnabled` too — they share the same `translateExpr` so normally no extra
-   change is required.
+   functions lazily via `ctx.declareFunc`. Spans flow automatically thanks to the wrapping
+   `translateExpr` call.
 2. `src/verify/smtlib.ts` — add a case to `renderExpr` that produces valid SMT-LIB text.
-3. `src/verify/backend.ts` — add a case to `renderExpr` that produces a z3-solver `Bool` / `Arith`
-   / `Expr` as appropriate.
+3. `src/verify/backend.ts` — add a case to `renderExpr` that produces a z3-solver `Bool` /
+   `Arith` / `Expr` as appropriate.
 
 Unit-test the new case in `test/verify/translator.test.ts` (Z3Script shape only — no solver),
 and add a scenario to `test/verify/backend.test.ts` if the case requires solver round-tripping.
-End-to-end behaviour goes in `test/verify/consistency.test.ts`. Update
-`test/verify/fixtures/url_shortener.smt2` by running `UPDATE_SNAPSHOTS=1 npx vitest run
-test/verify/smtlib.test.ts` when the snapshot legitimately changes.
+End-to-end behaviour goes in `test/verify/consistency.test.ts` or
+`test/verify/preservation.test.ts`. Update `test/verify/fixtures/url_shortener.smt2` by running
+`UPDATE_SNAPSHOTS=1 npx vitest run test/verify/smtlib.test.ts` when the snapshot legitimately
+changes.
+
+## Non-goals
+
+- **Verify-as-gate in `compile`** — tracked in [#78](https://github.com/HardMax71/spec_to_rest/issues/78).
+  Blocks on a user-facing `compile` subcommand; M4.4 ships the reporter, not the gate.
+- **Machine-readable output** (`--json`) — tracked in
+  [#79](https://github.com/HardMax71/spec_to_rest/issues/79).
+- **Rich suggested-fix templates** — tracked in [#80](https://github.com/HardMax71/spec_to_rest/issues/80).
+  Today each category ships one header-line hint.
+- **Structural spec lints** (type mismatch, unused entity, missing ensures, overlap detection,
+  undefined variable, circular invariants) — tracked in
+  [#81](https://github.com/HardMax71/spec_to_rest/issues/81). These are parser/IR-validation
+  concerns, not Z3 reporter territory.
+- **Proof / unsat-core / VC-dump export** — tracked in
+  [#77](https://github.com/HardMax71/spec_to_rest/issues/77).
+- **Set operators and non-state set membership** — tracked in
+  [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+- **Temporal properties (liveness, fairness)** — separate backend, tracked in
+  [#75](https://github.com/HardMax71/spec_to_rest/issues/75).
 
 ## See also
 

--- a/docs/content/docs/verification.mdx
+++ b/docs/content/docs/verification.mdx
@@ -183,7 +183,7 @@ verbose   …
 | ---: | --- |
 | `0` | All translated checks passed (`sat`); no checks were skipped. |
 | `1` | Specification or spec-file issue: at least one ran check failed (unsat / preservation `sat` / timeout), **or** the spec could not be read / parsed / IR-built. |
-| `2` | Translator coverage gap: at least one check was `skipped` because the verifier cannot yet encode a construct used by that check. Other checks may still have passed. |
+| `2` | Translator coverage gap: the verifier hit an unsupported construct, either when translating the whole spec (e.g., under `--dump-smt`) or while running individual checks. In normal check runs affected checks surface as `skipped`; other checks may still pass. |
 | `3` | Backend error (WASM/solver init failure or solver crash). |
 
 Exit `2` is a partial-success signal — the spec *may* still be correct, but the verifier could

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ program
 
 program
   .command("verify")
-  .description("Run the Z3-backed verification engine on a spec file (M4.1: invariant satisfiability smoke check)")
+  .description("Run the Z3-backed verification engine on a spec file (consistency + preservation + diagnostics)")
   .argument("<spec-file>", "path to .spec file")
   .option(
     "--timeout <ms>",

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -97,38 +97,56 @@ function reportConsistency(
   const skipped = checks.filter((c) => c.status === "skipped").length;
   const failures = checks.length - passes - skipped;
   const totalFmt = totalMs.toFixed(0);
+  const exitCode = exitCodeFor(checks, ok);
 
-  if (ok) {
-    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+  if (exitCode === EXIT_OK) {
     log.success(
-      `${specFile}: ${passes}/${checks.length} consistency checks passed${skipNote} (${totalFmt}ms)`,
+      `${specFile}: ${passes}/${checks.length} consistency checks passed (${totalFmt}ms)`,
     );
     for (const c of checks) log.verbose(formatCheckLine(c));
-    return EXIT_OK;
+    return exitCode;
   }
 
-  log.error(`${specFile}: ${failures} failure(s) in ${checks.length} consistency checks (${totalFmt}ms)`);
+  if (failures === 0 && skipped > 0) {
+    log.warn(
+      `${specFile}: ${passes}/${checks.length} checks passed; ${skipped} skipped (translator coverage gap) (${totalFmt}ms)`,
+    );
+  } else {
+    log.error(
+      `${specFile}: ${failures} failure(s), ${skipped} skipped in ${checks.length} consistency checks (${totalFmt}ms)`,
+    );
+  }
+
   for (const c of checks) {
-    if (c.status === "sat" || c.status === "skipped") {
+    if (c.status === "sat") {
       log.verbose(formatCheckLine(c));
       continue;
     }
     if (c.diagnostic) {
-      log.error("");
-      log.error(formatDiagnostic(c.diagnostic, specFile));
+      if (c.status === "skipped") {
+        log.warn("");
+        log.warn(formatDiagnostic(c.diagnostic, specFile));
+      } else {
+        log.error("");
+        log.error(formatDiagnostic(c.diagnostic, specFile));
+      }
     } else {
       log.error(formatCheckLine(c));
     }
   }
-  return exitCodeForFailure(checks);
+  return exitCode;
 }
 
-function exitCodeForFailure(checks: readonly CheckResult[]): number {
-  const hasBackendError = checks.some(
-    (c) => c.diagnostic?.category === "backend_error",
-  );
+function exitCodeFor(checks: readonly CheckResult[], ok: boolean): number {
+  const hasBackendError = checks.some((c) => c.diagnostic?.category === "backend_error");
   if (hasBackendError) return EXIT_BACKEND;
-  return EXIT_VIOLATIONS;
+  const hasViolation = checks.some((c) => c.status === "unsat" || c.status === "unknown");
+  if (hasViolation) return EXIT_VIOLATIONS;
+  const hasTranslatorLimitation = checks.some(
+    (c) => c.status === "skipped" && c.diagnostic?.category === "translator_limitation",
+  );
+  if (hasTranslatorLimitation) return EXIT_TRANSLATOR;
+  return ok ? EXIT_OK : EXIT_VIOLATIONS;
 }
 
 function formatCheckLine(c: CheckResult): string {

--- a/src/cli/verify.ts
+++ b/src/cli/verify.ts
@@ -1,5 +1,4 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { basename } from "node:path";
 import { parseSpec } from "#parser/index.js";
 import { buildIR, BuildError } from "#ir/index.js";
 import { translate } from "#verify/translator.js";
@@ -7,6 +6,7 @@ import { renderSmtLib } from "#verify/smtlib.js";
 import { WasmBackend } from "#verify/backend.js";
 import { runConsistencyChecks, type CheckResult } from "#verify/consistency.js";
 import { TranslatorError } from "#verify/types.js";
+import { formatDiagnostic } from "#verify/diagnostic.js";
 import type { Logger } from "#cli/log.js";
 
 export interface VerifyOptions {
@@ -14,6 +14,11 @@ export interface VerifyOptions {
   dumpSmt: boolean;
   dumpSmtOut?: string;
 }
+
+export const EXIT_OK = 0;
+export const EXIT_VIOLATIONS = 1;
+export const EXIT_TRANSLATOR = 2;
+export const EXIT_BACKEND = 3;
 
 export async function runVerify(
   specFile: string,
@@ -25,7 +30,7 @@ export async function runVerify(
     source = readFileSync(specFile, "utf-8");
   } catch (err: unknown) {
     log.error(readErrorMessage(specFile, err));
-    return 1;
+    return EXIT_VIOLATIONS;
   }
 
   const tParse0 = performance.now();
@@ -35,7 +40,7 @@ export async function runVerify(
     for (const e of errors) {
       log.error(`${specFile}:${e.line}:${e.column}: ${e.message}`);
     }
-    return 1;
+    return EXIT_VIOLATIONS;
   }
 
   try {
@@ -58,7 +63,7 @@ export async function runVerify(
       } else {
         process.stdout.write(smt);
       }
-      return 0;
+      return EXIT_OK;
     }
 
     log.verbose(`Timeout: ${opts.timeout}ms`);
@@ -66,20 +71,23 @@ export async function runVerify(
     const tRun0 = performance.now();
     const report = await runConsistencyChecks(ir, backend, { timeoutMs: opts.timeout });
     const totalMs = performance.now() - tRun0;
-    const label = basename(specFile);
-    return reportConsistency(label, report.checks, report.ok, totalMs, log);
+    return reportConsistency(specFile, report.checks, report.ok, totalMs, log);
   } catch (err: unknown) {
-    if (err instanceof BuildError || err instanceof TranslatorError) {
+    if (err instanceof BuildError) {
       log.error(`${specFile}: ${err.message}`);
-      return 1;
+      return EXIT_VIOLATIONS;
+    }
+    if (err instanceof TranslatorError) {
+      log.error(`${specFile}: translator limitation: ${err.message}`);
+      return EXIT_TRANSLATOR;
     }
     log.error(`${specFile}: ${err instanceof Error ? err.message : String(err)}`);
-    return 1;
+    return EXIT_BACKEND;
   }
 }
 
 function reportConsistency(
-  label: string,
+  specFile: string,
   checks: readonly CheckResult[],
   ok: boolean,
   totalMs: number,
@@ -92,20 +100,38 @@ function reportConsistency(
 
   if (ok) {
     const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
-    log.success(`${label}: ${passes}/${checks.length} consistency checks passed${skipNote} (${totalFmt}ms)`);
-    for (const c of checks) log.verbose(formatCheck(c));
-    return 0;
+    log.success(
+      `${specFile}: ${passes}/${checks.length} consistency checks passed${skipNote} (${totalFmt}ms)`,
+    );
+    for (const c of checks) log.verbose(formatCheckLine(c));
+    return EXIT_OK;
   }
 
-  log.error(`${label}: ${failures} failure(s) in ${checks.length} consistency checks (${totalFmt}ms)`);
+  log.error(`${specFile}: ${failures} failure(s) in ${checks.length} consistency checks (${totalFmt}ms)`);
   for (const c of checks) {
-    if (c.status === "sat" || c.status === "skipped") log.verbose(formatCheck(c));
-    else log.error(formatCheck(c));
+    if (c.status === "sat" || c.status === "skipped") {
+      log.verbose(formatCheckLine(c));
+      continue;
+    }
+    if (c.diagnostic) {
+      log.error("");
+      log.error(formatDiagnostic(c.diagnostic, specFile));
+    } else {
+      log.error(formatCheckLine(c));
+    }
   }
-  return 1;
+  return exitCodeForFailure(checks);
 }
 
-function formatCheck(c: CheckResult): string {
+function exitCodeForFailure(checks: readonly CheckResult[]): number {
+  const hasBackendError = checks.some(
+    (c) => c.diagnostic?.category === "backend_error",
+  );
+  if (hasBackendError) return EXIT_BACKEND;
+  return EXIT_VIOLATIONS;
+}
+
+function formatCheckLine(c: CheckResult): string {
   const icon = c.status === "sat" ? "✔" : c.status === "skipped" ? "∙" : "✘";
   const id = c.id.padEnd(28, " ");
   const status = c.status.padEnd(8, " ");

--- a/src/verify/backend.ts
+++ b/src/verify/backend.ts
@@ -1,4 +1,4 @@
-import { init, type Arith, type Bool, type Context, type Expr, type FuncDecl, type Sort } from "z3-solver";
+import { init, type Arith, type Bool, type Context, type Expr, type FuncDecl, type Model, type Sort } from "z3-solver";
 import type { Z3_ast } from "z3-solver";
 import type { Z3Script, Z3Expr, Z3Sort, Z3FunctionDecl } from "#verify/script.js";
 import { sortKey } from "#verify/script.js";
@@ -41,9 +41,14 @@ export class WasmBackend {
     const t0 = performance.now();
     const status = await solver.check();
     const durationMs = performance.now() - t0;
-    return { status, durationMs };
+    const model = status === "sat" && cfg.captureModel ? solver.model() : null;
+    return { status, durationMs, model, sortMap, funcMap };
   }
 }
+
+export type Z3Model = Model<"verify">;
+export type Z3SortMap = ReadonlyMap<string, SortT>;
+export type Z3FuncMap = ReadonlyMap<string, FuncT>;
 
 function declareSorts(ctx: Ctx, sorts: readonly Z3Sort[]): Map<string, SortT> {
   const map = new Map<string, SortT>();

--- a/src/verify/consistency.ts
+++ b/src/verify/consistency.ts
@@ -337,17 +337,17 @@ function skippedCheck(
   const detail = isTranslator
     ? `translator limitation: ${message}`
     : `backend error: ${message}`;
-  const diagnostic: VerificationDiagnostic | null = isTranslator
-    ? null
-    : {
-        level: "error",
-        category,
-        message: `solver backend error on check '${id}': ${message}`,
-        primarySpan: sourceSpans[0] ?? null,
-        relatedSpans: [],
-        counterexample: null,
-        suggestion: suggestionFor(category),
-      };
+  const diagnostic: VerificationDiagnostic = {
+    level: isTranslator ? "warning" : "error",
+    category,
+    message: isTranslator
+      ? `translator limitation on check '${id}': ${message}`
+      : `solver backend error on check '${id}': ${message}`,
+    primarySpan: sourceSpans[0] ?? null,
+    relatedSpans: [],
+    counterexample: null,
+    suggestion: suggestionFor(category),
+  };
   return {
     id,
     kind,

--- a/src/verify/consistency.ts
+++ b/src/verify/consistency.ts
@@ -1,4 +1,4 @@
-import type { ServiceIR, OperationDecl, InvariantDecl } from "#ir/types.js";
+import type { ServiceIR, OperationDecl, InvariantDecl, Span } from "#ir/types.js";
 import type { WasmBackend } from "#verify/backend.js";
 import {
   translate,
@@ -7,7 +7,15 @@ import {
   translateOperationPreservation,
 } from "#verify/translator.js";
 import { TranslatorError } from "#verify/types.js";
-import type { CheckStatus, VerificationConfig } from "#verify/types.js";
+import type { CheckStatus, VerificationConfig, SmokeCheckResult } from "#verify/types.js";
+import type { Z3Script } from "#verify/script.js";
+import { decodeCounterExample, type CounterExample } from "#verify/counterexample.js";
+import type {
+  VerificationDiagnostic,
+  DiagnosticCategory,
+  RelatedSpan,
+} from "#verify/diagnostic.js";
+import { suggestionFor } from "#verify/diagnostic.js";
 
 export type CheckKind = "global" | "requires" | "enabled" | "preservation";
 export type CheckOutcome = CheckStatus | "skipped";
@@ -20,6 +28,8 @@ export interface CheckResult {
   readonly status: CheckOutcome;
   readonly durationMs: number;
   readonly detail: string | null;
+  readonly sourceSpans: readonly Span[];
+  readonly diagnostic: VerificationDiagnostic | null;
 }
 
 export interface ConsistencyReport {
@@ -66,20 +76,27 @@ async function runGlobal(
   backend: WasmBackend,
   config: VerificationConfig,
 ): Promise<CheckResult> {
+  const sourceSpans = invariantSpans(ir);
   try {
     const script = translate(ir);
     const result = await backend.check(script, config);
-    return {
+    return finalizeCheck({
       id: "global",
       kind: "global",
       operationName: null,
       invariantName: null,
-      status: result.status,
+      rawStatus: result.status,
+      outcome: result.status,
       durationMs: result.durationMs,
-      detail: detailFor("global", null, null, result.status),
-    };
+      sourceSpans,
+      ir,
+      invariantDecl: null,
+      op: null,
+      script,
+      result,
+    });
   } catch (err: unknown) {
-    return skippedCheck("global", "global", null, null, err);
+    return skippedCheck("global", "global", null, null, sourceSpans, err);
   }
 }
 
@@ -91,23 +108,30 @@ async function runOperationCheck(
   config: VerificationConfig,
 ): Promise<CheckResult> {
   const id = `${op.name}.${kind}`;
+  const sourceSpans = operationCheckSpans(op, kind, ir);
   try {
     const script =
       kind === "requires"
         ? translateOperationRequires(ir, op)
         : translateOperationEnabled(ir, op);
     const result = await backend.check(script, config);
-    return {
+    return finalizeCheck({
       id,
       kind,
       operationName: op.name,
       invariantName: null,
-      status: result.status,
+      rawStatus: result.status,
+      outcome: result.status,
       durationMs: result.durationMs,
-      detail: detailFor(kind, op.name, null, result.status),
-    };
+      sourceSpans,
+      ir,
+      invariantDecl: null,
+      op,
+      script,
+      result,
+    });
   } catch (err: unknown) {
-    return skippedCheck(id, kind, op.name, null, err);
+    return skippedCheck(id, kind, op.name, null, sourceSpans, err);
   }
 }
 
@@ -119,22 +143,177 @@ async function runPreservationCheck(
   config: VerificationConfig,
 ): Promise<CheckResult> {
   const id = `${op.name}.preserves.${inv.name}`;
+  const sourceSpans = preservationSpans(op, inv.decl);
   try {
     const script = translateOperationPreservation(ir, op, inv.decl);
-    const result = await backend.check(script, config);
+    const result = await backend.check(script, {
+      ...config,
+      captureModel: true,
+    });
     const inverted = invertStatus(result.status);
-    return {
+    return finalizeCheck({
       id,
       kind: "preservation",
       operationName: op.name,
       invariantName: inv.name,
-      status: inverted,
+      rawStatus: result.status,
+      outcome: inverted,
       durationMs: result.durationMs,
-      detail: detailFor("preservation", op.name, inv.name, result.status),
-    };
+      sourceSpans,
+      ir,
+      invariantDecl: inv.decl,
+      op,
+      script,
+      result,
+    });
   } catch (err: unknown) {
-    return skippedCheck(id, "preservation", op.name, inv.name, err);
+    return skippedCheck(id, "preservation", op.name, inv.name, sourceSpans, err);
   }
+}
+
+interface FinalizeArgs {
+  readonly id: string;
+  readonly kind: CheckKind;
+  readonly operationName: string | null;
+  readonly invariantName: string | null;
+  readonly rawStatus: CheckStatus;
+  readonly outcome: CheckOutcome;
+  readonly durationMs: number;
+  readonly sourceSpans: readonly Span[];
+  readonly ir: ServiceIR;
+  readonly invariantDecl: InvariantDecl | null;
+  readonly op: OperationDecl | null;
+  readonly script: Z3Script;
+  readonly result: SmokeCheckResult;
+}
+
+function finalizeCheck(args: FinalizeArgs): CheckResult {
+  const detail = detailFor(args.kind, args.operationName, args.invariantName, args.rawStatus);
+  const diagnostic = buildDiagnostic(args);
+  return {
+    id: args.id,
+    kind: args.kind,
+    operationName: args.operationName,
+    invariantName: args.invariantName,
+    status: args.outcome,
+    durationMs: args.durationMs,
+    detail,
+    sourceSpans: args.sourceSpans,
+    diagnostic,
+  };
+}
+
+function buildDiagnostic(args: FinalizeArgs): VerificationDiagnostic | null {
+  if (args.outcome === "sat" || args.outcome === "skipped") return null;
+  const category = categoryFor(args.kind, args.rawStatus);
+  if (!category) return null;
+  const counterexample =
+    args.kind === "preservation" && args.rawStatus === "sat" && args.result.model
+      ? decodeCounterExample(
+          args.result.model,
+          args.result.sortMap,
+          args.result.funcMap,
+          args.script.artifact,
+        )
+      : null;
+  return {
+    level: "error",
+    category,
+    message: messageFor(category, args.operationName, args.invariantName),
+    primarySpan: primarySpanFor(args),
+    relatedSpans: relatedSpansFor(args),
+    counterexample,
+    suggestion: suggestionFor(category),
+  };
+}
+
+function categoryFor(kind: CheckKind, status: CheckStatus): DiagnosticCategory | null {
+  if (status === "unknown") return "solver_timeout";
+  if (kind === "global" && status === "unsat") return "contradictory_invariants";
+  if (kind === "requires" && status === "unsat") return "unsatisfiable_precondition";
+  if (kind === "enabled" && status === "unsat") return "unreachable_operation";
+  if (kind === "preservation" && status === "sat") return "invariant_violation_by_operation";
+  return null;
+}
+
+function messageFor(
+  category: DiagnosticCategory,
+  op: string | null,
+  inv: string | null,
+): string {
+  switch (category) {
+    case "contradictory_invariants":
+      return "invariants are jointly unsatisfiable — no valid state exists";
+    case "unsatisfiable_precondition":
+      return `'requires' of operation '${op ?? "?"}' is unsatisfiable under the spec's base constraints`;
+    case "unreachable_operation":
+      return `operation '${op ?? "?"}' is unreachable — no valid pre-state satisfies both the invariants and its 'requires'`;
+    case "invariant_violation_by_operation":
+      return `operation '${op ?? "?"}' violates invariant '${inv ?? "?"}'`;
+    case "solver_timeout":
+      return `solver could not decide the check within the timeout`;
+    case "translator_limitation":
+      return `verifier does not yet support a construct used by this check`;
+    case "backend_error":
+      return `solver backend error`;
+    default:
+      return "verification failed";
+  }
+}
+
+function primarySpanFor(args: FinalizeArgs): Span | null {
+  if (args.kind === "preservation" && args.invariantDecl) {
+    return args.op?.span ?? args.invariantDecl.span ?? null;
+  }
+  if (args.kind === "global") {
+    return args.ir.invariants[0]?.span ?? null;
+  }
+  return args.op?.span ?? null;
+}
+
+function relatedSpansFor(args: FinalizeArgs): RelatedSpan[] {
+  const out: RelatedSpan[] = [];
+  if (args.kind === "preservation" && args.invariantDecl?.span) {
+    out.push({
+      span: args.invariantDecl.span,
+      note: `invariant '${args.invariantName ?? "?"}' declared here`,
+    });
+  }
+  if (args.kind === "global") {
+    for (let i = 1; i < args.ir.invariants.length; i += 1) {
+      const inv = args.ir.invariants[i];
+      if (inv.span) {
+        out.push({ span: inv.span, note: `invariant '${inv.name ?? `inv_${i}`}'` });
+      }
+    }
+  }
+  return out;
+}
+
+function invariantSpans(ir: ServiceIR): Span[] {
+  const out: Span[] = [];
+  for (const inv of ir.invariants) {
+    if (inv.span) out.push(inv.span);
+  }
+  return out;
+}
+
+function operationCheckSpans(op: OperationDecl, kind: "requires" | "enabled", ir: ServiceIR): Span[] {
+  const out: Span[] = [];
+  if (op.span) out.push(op.span);
+  for (const r of op.requires) if (r.span) out.push(r.span);
+  if (kind === "enabled") {
+    for (const inv of ir.invariants) if (inv.span) out.push(inv.span);
+  }
+  return out;
+}
+
+function preservationSpans(op: OperationDecl, inv: InvariantDecl): Span[] {
+  const out: Span[] = [];
+  if (op.span) out.push(op.span);
+  if (inv.span) out.push(inv.span);
+  for (const e of op.ensures) if (e.span) out.push(e.span);
+  return out;
 }
 
 function invertStatus(status: CheckStatus): CheckOutcome {
@@ -148,28 +327,37 @@ function skippedCheck(
   kind: CheckKind,
   operationName: string | null,
   invariantName: string | null,
+  sourceSpans: readonly Span[],
   err: unknown,
 ): CheckResult {
   const message = err instanceof Error ? err.message : String(err);
-  if (err instanceof TranslatorError) {
-    return {
-      id,
-      kind,
-      operationName,
-      invariantName,
-      status: "skipped",
-      durationMs: 0,
-      detail: `translator limitation: ${message}`,
-    };
-  }
+  const isTranslator = err instanceof TranslatorError;
+  const category: DiagnosticCategory = isTranslator ? "translator_limitation" : "backend_error";
+  const status: CheckOutcome = isTranslator ? "skipped" : "unknown";
+  const detail = isTranslator
+    ? `translator limitation: ${message}`
+    : `backend error: ${message}`;
+  const diagnostic: VerificationDiagnostic | null = isTranslator
+    ? null
+    : {
+        level: "error",
+        category,
+        message: `solver backend error on check '${id}': ${message}`,
+        primarySpan: sourceSpans[0] ?? null,
+        relatedSpans: [],
+        counterexample: null,
+        suggestion: suggestionFor(category),
+      };
   return {
     id,
     kind,
     operationName,
     invariantName,
-    status: "unknown",
+    status,
     durationMs: 0,
-    detail: `backend error: ${message}`,
+    detail,
+    sourceSpans,
+    diagnostic,
   };
 }
 
@@ -182,7 +370,7 @@ function detailFor(
   if (kind === "preservation") {
     if (status === "unsat") return null;
     if (status === "sat") {
-      return `operation '${op}' does not preserve invariant '${inv}' — counterexample found (formatted diagnostics in M4.4)`;
+      return `operation '${op}' does not preserve invariant '${inv}' — counterexample found`;
     }
     return `solver could not decide preservation of invariant '${inv}' by operation '${op}'`;
   }

--- a/src/verify/counterexample.ts
+++ b/src/verify/counterexample.ts
@@ -1,0 +1,324 @@
+import type {
+  TranslatorArtifact,
+  ArtifactEntity,
+  ArtifactStateEntry,
+  ArtifactBinding,
+  Z3Sort,
+} from "#verify/script.js";
+import { sortKey } from "#verify/script.js";
+import type { Z3Model, Z3SortMap, Z3FuncMap } from "#verify/backend.js";
+
+export interface DecodedValue {
+  readonly display: string;
+  readonly entityLabel: string | null;
+}
+
+export interface DecodedEntity {
+  readonly sortName: string;
+  readonly label: string;
+  readonly rawElement: string;
+  readonly fields: readonly { readonly name: string; readonly value: DecodedValue }[];
+}
+
+export interface DecodedRelationEntry {
+  readonly key: DecodedValue;
+  readonly value: DecodedValue;
+}
+
+export interface DecodedRelation {
+  readonly stateName: string;
+  readonly side: "pre" | "post";
+  readonly entries: readonly DecodedRelationEntry[];
+}
+
+export interface DecodedConstant {
+  readonly stateName: string;
+  readonly side: "pre" | "post";
+  readonly value: DecodedValue;
+}
+
+export interface DecodedInput {
+  readonly name: string;
+  readonly value: DecodedValue;
+}
+
+export interface CounterExample {
+  readonly entities: readonly DecodedEntity[];
+  readonly stateRelations: readonly DecodedRelation[];
+  readonly stateConstants: readonly DecodedConstant[];
+  readonly inputs: readonly DecodedInput[];
+}
+
+interface DecodeCtx {
+  readonly model: Z3Model;
+  readonly sortMap: Z3SortMap;
+  readonly funcMap: Z3FuncMap;
+  readonly artifact: TranslatorArtifact;
+  readonly rawToLabel: Map<string, string>;
+}
+
+export function decodeCounterExample(
+  model: Z3Model,
+  sortMap: Z3SortMap,
+  funcMap: Z3FuncMap,
+  artifact: TranslatorArtifact,
+): CounterExample {
+  const ctx: DecodeCtx = { model, sortMap, funcMap, artifact, rawToLabel: new Map() };
+
+  const entities = decodeEntities(ctx);
+  const enumsDecoded = decodeEnums(ctx);
+  for (const e of enumsDecoded) ctx.rawToLabel.set(e.rawElement, e.label);
+
+  const stateRelations = decodeStateRelations(ctx);
+  const stateConstants = decodeStateConstants(ctx);
+  const inputs = decodeInputs(ctx);
+
+  return { entities, stateRelations, stateConstants, inputs };
+}
+
+function decodeEntities(ctx: DecodeCtx): DecodedEntity[] {
+  const result: DecodedEntity[] = [];
+  for (const entity of ctx.artifact.entities) {
+    const sort = ctx.sortMap.get(sortKey(entity.sort));
+    if (!sort) continue;
+    const universe = safeSortUniverse(ctx, sort);
+    for (let i = 0; i < universe.length; i += 1) {
+      const elem = universe[i];
+      const raw = String(elem);
+      const label = `${entity.name}#${i}`;
+      ctx.rawToLabel.set(raw, label);
+      const fields = decodeEntityFields(ctx, entity, elem);
+      result.push({ sortName: entity.name, label, rawElement: raw, fields });
+    }
+  }
+  return result;
+}
+
+function decodeEntityFields(
+  ctx: DecodeCtx,
+  entity: ArtifactEntity,
+  elem: unknown,
+): readonly { name: string; value: DecodedValue }[] {
+  const out: { name: string; value: DecodedValue }[] = [];
+  for (const field of entity.fields) {
+    const decl = ctx.funcMap.get(field.funcName);
+    if (!decl) continue;
+    const applied = callFunc(decl, [elem]);
+    const evaluated = evalExpr(ctx.model, applied);
+    out.push({ name: field.name, value: decodeValueRaw(ctx, evaluated) });
+  }
+  return out;
+}
+
+interface DecodedEnumElement {
+  readonly sortName: string;
+  readonly label: string;
+  readonly rawElement: string;
+}
+
+function decodeEnums(ctx: DecodeCtx): DecodedEnumElement[] {
+  const result: DecodedEnumElement[] = [];
+  for (const e of ctx.artifact.enums) {
+    for (const member of e.members) {
+      const decl = ctx.funcMap.get(member.funcName);
+      if (!decl) continue;
+      const applied = callFunc(decl, []);
+      const evaluated = evalExpr(ctx.model, applied);
+      result.push({
+        sortName: e.name,
+        label: `${e.name}.${member.name}`,
+        rawElement: String(evaluated),
+      });
+    }
+  }
+  return result;
+}
+
+function decodeStateRelations(ctx: DecodeCtx): DecodedRelation[] {
+  const result: DecodedRelation[] = [];
+  for (const entry of ctx.artifact.state) {
+    if (entry.kind !== "Relation") continue;
+    const keySort = ctx.sortMap.get(sortKey(entry.keySort));
+    const universeKeys = keySort ? safeSortUniverse(ctx, keySort) : [];
+    const inputKeys = inputsOfSort(ctx, entry.keySort);
+    const candidates = universeKeys.length > 0 ? universeKeys : inputKeys;
+    result.push(buildRelationSide(ctx, entry, candidates, "pre"));
+    if (ctx.artifact.hasPostState) {
+      result.push(buildRelationSide(ctx, entry, candidates, "post"));
+    }
+  }
+  return result;
+}
+
+function inputsOfSort(ctx: DecodeCtx, wantSort: Z3Sort): readonly unknown[] {
+  const out: unknown[] = [];
+  for (const b of ctx.artifact.inputs) {
+    if (sortKey(b.sort) !== sortKey(wantSort)) continue;
+    const decl = ctx.funcMap.get(b.funcName);
+    if (!decl) continue;
+    out.push(evalExpr(ctx.model, callFunc(decl, [])));
+  }
+  return out;
+}
+
+function buildRelationSide(
+  ctx: DecodeCtx,
+  relation: Extract<ArtifactStateEntry, { kind: "Relation" }>,
+  keyUniverse: readonly unknown[],
+  side: "pre" | "post",
+): DecodedRelation {
+  const domFuncName = side === "pre" ? relation.domFunc : relation.domFuncPost;
+  const mapFuncName = side === "pre" ? relation.mapFunc : relation.mapFuncPost;
+  const domDecl = ctx.funcMap.get(domFuncName);
+  const mapDecl = ctx.funcMap.get(mapFuncName);
+  const entries: DecodedRelationEntry[] = [];
+  if (domDecl && mapDecl) {
+    for (const k of keyUniverse) {
+      const inDom = evalExpr(ctx.model, callFunc(domDecl, [k]));
+      if (String(inDom) !== "true") continue;
+      const mappedTo = evalExpr(ctx.model, callFunc(mapDecl, [k]));
+      entries.push({
+        key: decodeValueRaw(ctx, k),
+        value: decodeValueRaw(ctx, mappedTo),
+      });
+    }
+  }
+  return { stateName: relation.name, side, entries };
+}
+
+function decodeStateConstants(ctx: DecodeCtx): DecodedConstant[] {
+  const result: DecodedConstant[] = [];
+  for (const entry of ctx.artifact.state) {
+    if (entry.kind !== "Const") continue;
+    result.push(buildConstantSide(ctx, entry, "pre"));
+    if (ctx.artifact.hasPostState) result.push(buildConstantSide(ctx, entry, "post"));
+  }
+  return result;
+}
+
+function buildConstantSide(
+  ctx: DecodeCtx,
+  entry: Extract<ArtifactStateEntry, { kind: "Const" }>,
+  side: "pre" | "post",
+): DecodedConstant {
+  const funcName = side === "pre" ? entry.funcName : entry.funcNamePost;
+  const decl = ctx.funcMap.get(funcName);
+  const value = decl
+    ? decodeValueRaw(ctx, evalExpr(ctx.model, callFunc(decl, [])))
+    : { display: "<unknown>", entityLabel: null };
+  return { stateName: entry.name, side, value };
+}
+
+function decodeInputs(ctx: DecodeCtx): DecodedInput[] {
+  return decodeBindings(ctx, ctx.artifact.inputs);
+}
+
+function decodeBindings(ctx: DecodeCtx, bindings: readonly ArtifactBinding[]): DecodedInput[] {
+  const result: DecodedInput[] = [];
+  for (const b of bindings) {
+    const decl = ctx.funcMap.get(b.funcName);
+    if (!decl) continue;
+    const applied = callFunc(decl, []);
+    const evaluated = evalExpr(ctx.model, applied);
+    result.push({ name: b.name, value: decodeValueRaw(ctx, evaluated) });
+  }
+  return result;
+}
+
+function decodeValueRaw(ctx: DecodeCtx, expr: unknown): DecodedValue {
+  const text = normalizeZ3Text(String(expr));
+  const label = ctx.rawToLabel.get(text);
+  if (label) return { display: label, entityLabel: label };
+  if (text === "true" || text === "false") return { display: text, entityLabel: null };
+  if (/^-?\d+$/.test(text)) return { display: text, entityLabel: null };
+  const stringLit = matchStringLiteral(text);
+  if (stringLit !== null) return { display: JSON.stringify(stringLit), entityLabel: null };
+  return { display: prettyUninterp(text), entityLabel: null };
+}
+
+function normalizeZ3Text(raw: string): string {
+  const negMatch = /^\(-\s+(\d+)\)$/.exec(raw.trim());
+  if (negMatch) return `-${negMatch[1]}`;
+  return raw;
+}
+
+function matchStringLiteral(text: string): string | null {
+  const m = /^str_(\d+)$/.exec(text);
+  return m ? `<string#${m[1]}>` : null;
+}
+
+function prettyUninterp(text: string): string {
+  const m = /^([A-Za-z_][\w]*)!val!(\d+)$/.exec(text);
+  return m ? `${m[1]}#${m[2]}` : text;
+}
+
+function safeSortUniverse(ctx: DecodeCtx, sort: unknown): readonly unknown[] {
+  if (!isSortLike(sort)) return [];
+  try {
+    const universe = ctx.model.sortUniverse(sort);
+    const out: unknown[] = [];
+    for (let i = 0; i < universe.length(); i += 1) out.push(universe.get(i));
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function isSortLike(x: unknown): x is Parameters<Z3Model["sortUniverse"]>[0] {
+  return typeof x === "object" && x !== null;
+}
+
+interface FuncLike {
+  call(...args: unknown[]): unknown;
+}
+
+function isFuncLike(x: unknown): x is FuncLike {
+  return typeof x === "object" && x !== null && typeof (x as FuncLike).call === "function";
+}
+
+function callFunc(decl: unknown, args: readonly unknown[]): unknown {
+  if (!isFuncLike(decl)) throw new Error("func decl is not callable");
+  return decl.call(...args);
+}
+
+function evalExpr(model: Z3Model, expr: unknown): unknown {
+  return model.eval(expr as Parameters<Z3Model["eval"]>[0], true);
+}
+
+export function formatCounterExample(ce: CounterExample): string {
+  const lines: string[] = [];
+  if (ce.inputs.length > 0) {
+    lines.push("  inputs:");
+    for (const inp of ce.inputs) lines.push(`    ${inp.name} = ${inp.value.display}`);
+  }
+  if (ce.entities.length > 0) {
+    lines.push("  entities:");
+    for (const e of ce.entities) {
+      const fieldStr = e.fields.map((f) => `${f.name} = ${f.value.display}`).join(", ");
+      lines.push(`    ${e.label} { ${fieldStr} }`);
+    }
+  }
+  const pre = ce.stateRelations.filter((r) => r.side === "pre");
+  const preC = ce.stateConstants.filter((c) => c.side === "pre");
+  if (pre.length > 0 || preC.length > 0) {
+    lines.push("  pre-state:");
+    for (const r of pre) lines.push(formatRelation(r));
+    for (const c of preC) lines.push(`    ${c.stateName} = ${c.value.display}`);
+  }
+  const post = ce.stateRelations.filter((r) => r.side === "post");
+  const postC = ce.stateConstants.filter((c) => c.side === "post");
+  if (post.length > 0 || postC.length > 0) {
+    lines.push("  post-state:");
+    for (const r of post) lines.push(formatRelation(r));
+    for (const c of postC) lines.push(`    ${c.stateName}' = ${c.value.display}`);
+  }
+  return lines.join("\n");
+}
+
+function formatRelation(r: DecodedRelation): string {
+  const label = r.side === "pre" ? r.stateName : `${r.stateName}'`;
+  if (r.entries.length === 0) return `    ${label} = {}`;
+  const entryStrs = r.entries.map((e) => `${e.key.display} → ${e.value.display}`).join(", ");
+  return `    ${label} = { ${entryStrs} }`;
+}
+

--- a/src/verify/counterexample.ts
+++ b/src/verify/counterexample.ts
@@ -65,10 +65,10 @@ export function decodeCounterExample(
 ): CounterExample {
   const ctx: DecodeCtx = { model, sortMap, funcMap, artifact, rawToLabel: new Map() };
 
-  const entities = decodeEntities(ctx);
   const enumsDecoded = decodeEnums(ctx);
   for (const e of enumsDecoded) ctx.rawToLabel.set(e.rawElement, e.label);
 
+  const entities = decodeEntities(ctx);
   const stateRelations = decodeStateRelations(ctx);
   const stateConstants = decodeStateConstants(ctx);
   const inputs = decodeInputs(ctx);

--- a/src/verify/diagnostic.ts
+++ b/src/verify/diagnostic.ts
@@ -1,0 +1,80 @@
+import type { Span } from "#ir/types.js";
+import type { CounterExample } from "#verify/counterexample.js";
+import { formatCounterExample } from "#verify/counterexample.js";
+
+export type DiagnosticCategory =
+  | "contradictory_invariants"
+  | "unsatisfiable_precondition"
+  | "unreachable_operation"
+  | "invariant_violation_by_operation"
+  | "solver_timeout"
+  | "translator_limitation"
+  | "backend_error";
+
+export interface RelatedSpan {
+  readonly span: Span;
+  readonly note: string;
+}
+
+export interface VerificationDiagnostic {
+  readonly level: "error" | "warning";
+  readonly category: DiagnosticCategory;
+  readonly message: string;
+  readonly primarySpan: Span | null;
+  readonly relatedSpans: readonly RelatedSpan[];
+  readonly counterexample: CounterExample | null;
+  readonly suggestion: string | null;
+}
+
+export function suggestionFor(category: DiagnosticCategory): string | null {
+  switch (category) {
+    case "contradictory_invariants":
+      return "Review the invariant set for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5').";
+    case "unsatisfiable_precondition":
+      return "Check whether 'requires' mentions an input predicate that contradicts a base-state refinement or an invariant the translator inlines.";
+    case "unreachable_operation":
+      return "The operation's 'requires' is satisfiable in isolation but contradicts an invariant. Relax one or the other, or constrain the input type to exclude the conflicting range.";
+    case "invariant_violation_by_operation":
+      return "Tighten the 'ensures' clause so the invariant's constrained fields appear on the right-hand side of a '=' or a range predicate.";
+    case "solver_timeout":
+      return "Try increasing --timeout, simplifying the invariant, or splitting a heavy quantifier into smaller predicates.";
+    case "translator_limitation":
+      return "This spec uses a construct the verifier cannot yet translate. File an issue or narrow the invariant so the unsupported construct does not appear on the verification path.";
+    case "backend_error":
+      return "The solver crashed on this check. Re-run with --verbose; if reproducible, file an issue including the --dump-smt output.";
+    default:
+      return null;
+  }
+}
+
+export function formatDiagnostic(
+  diag: VerificationDiagnostic,
+  specFile: string,
+): string {
+  const lines: string[] = [];
+  const header = formatPrimary(diag, specFile);
+  lines.push(header);
+  for (const rel of diag.relatedSpans) {
+    lines.push(`  related: ${formatLocation(specFile, rel.span)} (${rel.note})`);
+  }
+  if (diag.counterexample) {
+    lines.push("");
+    lines.push("  Counterexample:");
+    lines.push(formatCounterExample(diag.counterexample));
+  }
+  if (diag.suggestion) {
+    lines.push("");
+    lines.push(`  hint: ${diag.suggestion}`);
+  }
+  return lines.join("\n");
+}
+
+function formatPrimary(diag: VerificationDiagnostic, specFile: string): string {
+  const levelWord = diag.level === "error" ? "error" : "warning";
+  const loc = diag.primarySpan ? formatLocation(specFile, diag.primarySpan) : specFile;
+  return `${loc}: ${levelWord}: ${diag.message}`;
+}
+
+function formatLocation(specFile: string, span: Span): string {
+  return `${specFile}:${span.startLine}:${span.startCol}`;
+}

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -20,4 +20,31 @@ export {
   type SmokeCheckResult,
   type VerificationConfig,
 } from "#verify/types.js";
-export type { Z3Script, Z3Sort, Z3Expr, Z3FunctionDecl } from "#verify/script.js";
+export type {
+  Z3Script,
+  Z3Sort,
+  Z3Expr,
+  Z3FunctionDecl,
+  TranslatorArtifact,
+  ArtifactEntity,
+  ArtifactEnum,
+  ArtifactStateEntry,
+  ArtifactBinding,
+} from "#verify/script.js";
+export {
+  decodeCounterExample,
+  formatCounterExample,
+  type CounterExample,
+  type DecodedEntity,
+  type DecodedRelation,
+  type DecodedConstant,
+  type DecodedInput,
+  type DecodedValue,
+} from "#verify/counterexample.js";
+export {
+  formatDiagnostic,
+  suggestionFor,
+  type VerificationDiagnostic,
+  type DiagnosticCategory,
+  type RelatedSpan,
+} from "#verify/diagnostic.js";

--- a/src/verify/script.ts
+++ b/src/verify/script.ts
@@ -1,3 +1,5 @@
+import type { Span } from "#ir/types.js";
+
 export type Z3Sort =
   | { readonly kind: "Int" }
   | { readonly kind: "Bool" }
@@ -33,25 +35,95 @@ export type CmpOp = "=" | "!=" | "<" | "<=" | ">" | ">=";
 export type ArithOp = "+" | "-" | "*" | "/";
 
 export type Z3Expr =
-  | { readonly kind: "Var"; readonly name: string; readonly sort: Z3Sort }
-  | { readonly kind: "App"; readonly func: string; readonly args: readonly Z3Expr[] }
-  | { readonly kind: "IntLit"; readonly value: number }
-  | { readonly kind: "BoolLit"; readonly value: boolean }
-  | { readonly kind: "And"; readonly args: readonly Z3Expr[] }
-  | { readonly kind: "Or"; readonly args: readonly Z3Expr[] }
-  | { readonly kind: "Not"; readonly arg: Z3Expr }
-  | { readonly kind: "Implies"; readonly lhs: Z3Expr; readonly rhs: Z3Expr }
-  | { readonly kind: "Cmp"; readonly op: CmpOp; readonly lhs: Z3Expr; readonly rhs: Z3Expr }
-  | { readonly kind: "Arith"; readonly op: ArithOp; readonly args: readonly Z3Expr[] }
+  | { readonly kind: "Var"; readonly name: string; readonly sort: Z3Sort; readonly span?: Span }
+  | { readonly kind: "App"; readonly func: string; readonly args: readonly Z3Expr[]; readonly span?: Span }
+  | { readonly kind: "IntLit"; readonly value: number; readonly span?: Span }
+  | { readonly kind: "BoolLit"; readonly value: boolean; readonly span?: Span }
+  | { readonly kind: "And"; readonly args: readonly Z3Expr[]; readonly span?: Span }
+  | { readonly kind: "Or"; readonly args: readonly Z3Expr[]; readonly span?: Span }
+  | { readonly kind: "Not"; readonly arg: Z3Expr; readonly span?: Span }
+  | { readonly kind: "Implies"; readonly lhs: Z3Expr; readonly rhs: Z3Expr; readonly span?: Span }
+  | { readonly kind: "Cmp"; readonly op: CmpOp; readonly lhs: Z3Expr; readonly rhs: Z3Expr; readonly span?: Span }
+  | { readonly kind: "Arith"; readonly op: ArithOp; readonly args: readonly Z3Expr[]; readonly span?: Span }
   | {
       readonly kind: "Quantifier";
       readonly q: "ForAll" | "Exists";
       readonly bindings: readonly Z3Binding[];
       readonly body: Z3Expr;
+      readonly span?: Span;
     };
+
+export function withSpan<E extends Z3Expr>(expr: E, span: Span | undefined): E {
+  if (span === undefined) return expr;
+  return { ...expr, span } as E;
+}
+
+export function getSpan(expr: Z3Expr): Span | undefined {
+  return expr.span;
+}
 
 export interface Z3Script {
   readonly sorts: readonly Z3Sort[];
   readonly funcs: readonly Z3FunctionDecl[];
   readonly assertions: readonly Z3Expr[];
+  readonly artifact: TranslatorArtifact;
+}
+
+export interface ArtifactEntityField {
+  readonly name: string;
+  readonly sort: Z3Sort;
+  readonly funcName: string;
+}
+
+export interface ArtifactEntity {
+  readonly name: string;
+  readonly sort: Z3Sort;
+  readonly fields: readonly ArtifactEntityField[];
+}
+
+export interface ArtifactEnumMember {
+  readonly name: string;
+  readonly funcName: string;
+}
+
+export interface ArtifactEnum {
+  readonly name: string;
+  readonly sort: Z3Sort;
+  readonly members: readonly ArtifactEnumMember[];
+}
+
+export interface ArtifactStateRelation {
+  readonly kind: "Relation";
+  readonly name: string;
+  readonly keySort: Z3Sort;
+  readonly valueSort: Z3Sort;
+  readonly domFunc: string;
+  readonly mapFunc: string;
+  readonly domFuncPost: string;
+  readonly mapFuncPost: string;
+}
+
+export interface ArtifactStateConstant {
+  readonly kind: "Const";
+  readonly name: string;
+  readonly sort: Z3Sort;
+  readonly funcName: string;
+  readonly funcNamePost: string;
+}
+
+export type ArtifactStateEntry = ArtifactStateRelation | ArtifactStateConstant;
+
+export interface ArtifactBinding {
+  readonly name: string;
+  readonly funcName: string;
+  readonly sort: Z3Sort;
+}
+
+export interface TranslatorArtifact {
+  readonly entities: readonly ArtifactEntity[];
+  readonly enums: readonly ArtifactEnum[];
+  readonly state: readonly ArtifactStateEntry[];
+  readonly inputs: readonly ArtifactBinding[];
+  readonly outputs: readonly ArtifactBinding[];
+  readonly hasPostState: boolean;
 }

--- a/src/verify/script.ts
+++ b/src/verify/script.ts
@@ -55,7 +55,7 @@ export type Z3Expr =
 
 export function withSpan<E extends Z3Expr>(expr: E, span: Span | undefined): E {
   if (span === undefined) return expr;
-  return { ...expr, span } as E;
+  return Object.assign({}, expr, { span });
 }
 
 export function getSpan(expr: Z3Expr): Span | undefined {

--- a/src/verify/translator.ts
+++ b/src/verify/translator.ts
@@ -20,11 +20,17 @@ import {
   type Z3Binding,
   type CmpOp,
   type ArithOp,
+  type ArtifactBinding,
+  type ArtifactEntity,
+  type ArtifactEnum,
+  type ArtifactStateEntry,
+  type TranslatorArtifact,
   Z3_INT,
   Z3_BOOL,
   uninterp,
   sortKey,
   sortEq,
+  withSpan,
 } from "#verify/script.js";
 import { TranslatorError } from "#verify/types.js";
 
@@ -75,6 +81,9 @@ class TranslateCtx {
   private readonly stringLitIds = new Map<string, number>();
   private readonly cardinalityNames = new Map<string, string>();
   private readonly skolemIds = new Map<string, number>();
+  readonly inputs: ArtifactBinding[] = [];
+  readonly outputs: ArtifactBinding[] = [];
+  hasPostState = false;
   stateMode: StateMode = "pre";
 
   declareSort(sort: Z3Sort): void {
@@ -161,6 +170,7 @@ export function translateOperationPreservation(
   inv: InvariantDecl,
 ): Z3Script {
   const ctx = new TranslateCtx();
+  ctx.hasPostState = true;
   declareBase(ctx, ir);
   if (ir.state) declareStatePostState(ctx, ir.state);
   const env = declareOperationInputs(ctx, op);
@@ -177,7 +187,7 @@ export function translateOperationPreservation(
   synthesizeFrame(ctx, ir.state, op, env);
   synthesizeCardinalityAxioms(ctx, ir.state, op);
   const postInv = withStateMode(ctx, "post", () => translateExpr(ctx, inv.expr, env));
-  ctx.assertions.push({ kind: "Not", arg: postInv });
+  ctx.assertions.push(withSpan({ kind: "Not", arg: postInv }, inv.span));
   return finalizeScript(ctx);
 }
 
@@ -193,6 +203,7 @@ function declareOperationOutputs(
       ctx.declareFunc({ kind: "FuncDecl", name: funcName, argSorts: [], resultSort: sort });
     }
     env.set(out.name, { kind: "App", func: funcName, args: [] });
+    ctx.outputs.push({ name: out.name, funcName, sort });
     if (out.typeExpr.kind === "NamedType") {
       const alias = ctx.primitiveAliases.get(out.typeExpr.name);
       if (alias) {
@@ -220,6 +231,55 @@ function finalizeScript(ctx: TranslateCtx): Z3Script {
     sorts: [...ctx.sorts.values()].sort((a, b) => sortKey(a).localeCompare(sortKey(b))),
     funcs: [...ctx.funcs.values()].sort((a, b) => a.name.localeCompare(b.name)),
     assertions: ctx.assertions,
+    artifact: buildArtifact(ctx),
+  };
+}
+
+function buildArtifact(ctx: TranslateCtx): TranslatorArtifact {
+  const entities: ArtifactEntity[] = [];
+  for (const [name, info] of ctx.entities) {
+    const fields = [...info.fields].map(([fieldName, f]) => ({
+      name: fieldName,
+      sort: f.sort,
+      funcName: f.funcName,
+    }));
+    entities.push({ name, sort: info.sort, fields });
+  }
+  const enums: ArtifactEnum[] = [];
+  for (const [name, info] of ctx.enums) {
+    const members = info.members.map((m) => ({ name: m, funcName: `${name}_${m}` }));
+    enums.push({ name, sort: info.sort, members });
+  }
+  const state: ArtifactStateEntry[] = [];
+  for (const [name, entry] of ctx.state) {
+    if (entry.kind === "Relation") {
+      state.push({
+        kind: "Relation",
+        name,
+        keySort: entry.keySort,
+        valueSort: entry.valueSort,
+        domFunc: entry.domFunc,
+        mapFunc: entry.mapFunc,
+        domFuncPost: entry.domFuncPost,
+        mapFuncPost: entry.mapFuncPost,
+      });
+    } else {
+      state.push({
+        kind: "Const",
+        name,
+        sort: entry.sort,
+        funcName: entry.funcName,
+        funcNamePost: entry.funcNamePost,
+      });
+    }
+  }
+  return {
+    entities,
+    enums,
+    state,
+    inputs: [...ctx.inputs],
+    outputs: [...ctx.outputs],
+    hasPostState: ctx.hasPostState,
   };
 }
 
@@ -232,6 +292,7 @@ function declareOperationInputs(ctx: TranslateCtx, op: OperationDecl): Map<strin
       ctx.declareFunc({ kind: "FuncDecl", name: funcName, argSorts: [], resultSort: sort });
     }
     env.set(input.name, { kind: "App", func: funcName, args: [] });
+    ctx.inputs.push({ name: input.name, funcName, sort });
     maybeAssertInputRefinement(ctx, op, input, funcName, sort);
   }
   return env;
@@ -632,6 +693,11 @@ function sortForNamedType(ctx: TranslateCtx, name: string): Z3Sort {
 }
 
 export function translateExpr(ctx: TranslateCtx, expr: Expr, env: TypeEnv): Z3Expr {
+  const out = translateExprRaw(ctx, expr, env);
+  return withSpan(out, expr.span);
+}
+
+function translateExprRaw(ctx: TranslateCtx, expr: Expr, env: TypeEnv): Z3Expr {
   switch (expr.kind) {
     case "IntLit":
       return { kind: "IntLit", value: expr.value };

--- a/src/verify/types.ts
+++ b/src/verify/types.ts
@@ -1,7 +1,10 @@
+import type { Model, FuncDecl, Sort } from "z3-solver";
+
 export type CheckStatus = "sat" | "unsat" | "unknown";
 
 export interface VerificationConfig {
   readonly timeoutMs: number;
+  readonly captureModel?: boolean;
 }
 
 export const DEFAULT_VERIFICATION_CONFIG: VerificationConfig = {
@@ -11,6 +14,9 @@ export const DEFAULT_VERIFICATION_CONFIG: VerificationConfig = {
 export interface SmokeCheckResult {
   readonly status: CheckStatus;
   readonly durationMs: number;
+  readonly model: Model<"verify"> | null;
+  readonly sortMap: ReadonlyMap<string, Sort<"verify">>;
+  readonly funcMap: ReadonlyMap<string, FuncDecl<"verify">>;
 }
 
 export class TranslatorError extends Error {

--- a/test/verify/diagnostic.test.ts
+++ b/test/verify/diagnostic.test.ts
@@ -76,37 +76,55 @@ describe.sequential("diagnostic — category assignment across check kinds", () 
     backend = new WasmBackend();
   });
 
-  it("contradictory invariants → contradictory_invariants category", async () => {
-    const ir = irFromFile("./fixtures/unsat_invariants.spec");
-    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
-    const global = findCheck(report.checks, "global");
-    expect(global?.status).toBe("unsat");
-    expect(global?.diagnostic?.category).toBe("contradictory_invariants");
-  });
+  const categoryCases = [
+    {
+      label: "contradictory invariants",
+      fixture: "./fixtures/unsat_invariants.spec",
+      checkId: "global",
+      expectedStatus: "unsat" as const,
+      expectedCategory: "contradictory_invariants" as const,
+      expectDiagnostic: true,
+    },
+    {
+      label: "dead operation",
+      fixture: "./fixtures/dead_op.spec",
+      checkId: "DeadOp.requires",
+      expectedStatus: "unsat" as const,
+      expectedCategory: "unsatisfiable_precondition" as const,
+      expectDiagnostic: true,
+    },
+    {
+      label: "unreachable operation",
+      fixture: "./fixtures/unreachable_op.spec",
+      checkId: "UnreachableOp.enabled",
+      expectedStatus: "unsat" as const,
+      expectedCategory: "unreachable_operation" as const,
+      expectDiagnostic: true,
+    },
+    {
+      label: "passing preservation",
+      fixture: "./fixtures/safe_counter.spec",
+      checkId: "Increment.preserves.countNonNegative",
+      expectedStatus: "sat" as const,
+      expectedCategory: null,
+      expectDiagnostic: false,
+    },
+  ];
 
-  it("dead operation → unsatisfiable_precondition category", async () => {
-    const ir = irFromFile("./fixtures/dead_op.spec");
-    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
-    const check = findCheck(report.checks, "DeadOp.requires");
-    expect(check?.status).toBe("unsat");
-    expect(check?.diagnostic?.category).toBe("unsatisfiable_precondition");
-  });
-
-  it("unreachable operation → unreachable_operation category", async () => {
-    const ir = irFromFile("./fixtures/unreachable_op.spec");
-    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
-    const check = findCheck(report.checks, "UnreachableOp.enabled");
-    expect(check?.status).toBe("unsat");
-    expect(check?.diagnostic?.category).toBe("unreachable_operation");
-  });
-
-  it("passing check → no diagnostic attached", async () => {
-    const ir = irFromFile("./fixtures/safe_counter.spec");
-    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
-    const ok = findCheck(report.checks, "Increment.preserves.countNonNegative");
-    expect(ok?.status).toBe("sat");
-    expect(ok?.diagnostic).toBeNull();
-  });
+  it.each(categoryCases)(
+    "$label → status $expectedStatus, category $expectedCategory",
+    async ({ fixture, checkId, expectedStatus, expectedCategory, expectDiagnostic }) => {
+      const ir = irFromFile(fixture);
+      const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+      const check = findCheck(report.checks, checkId);
+      expect(check?.status).toBe(expectedStatus);
+      if (expectDiagnostic) {
+        expect(check?.diagnostic?.category).toBe(expectedCategory);
+      } else {
+        expect(check?.diagnostic).toBeNull();
+      }
+    },
+  );
 });
 
 describe.sequential("diagnostic — formatter for non-preservation categories", () => {

--- a/test/verify/diagnostic.test.ts
+++ b/test/verify/diagnostic.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { WasmBackend } from "#verify/backend.js";
+import { runConsistencyChecks, type CheckResult } from "#verify/consistency.js";
+import { DEFAULT_VERIFICATION_CONFIG } from "#verify/types.js";
+import { formatDiagnostic } from "#verify/diagnostic.js";
+import type { ServiceIR } from "#ir/types.js";
+
+function irFromFile(relPath: string): ServiceIR {
+  const src = readFileSync(join(import.meta.dirname, relPath), "utf-8");
+  const { tree, errors } = parseSpec(src);
+  expect(errors).toEqual([]);
+  return buildIR(tree);
+}
+
+function findCheck(checks: readonly CheckResult[], id: string): CheckResult | undefined {
+  return checks.find((c) => c.id === id);
+}
+
+describe.sequential("diagnostic — preservation violation on broken_url_shortener", () => {
+  let backend: WasmBackend;
+  let checks: readonly CheckResult[];
+
+  beforeAll(async () => {
+    backend = new WasmBackend();
+    const ir = irFromFile("./fixtures/broken_url_shortener.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    checks = report.checks;
+  });
+
+  it("attaches an invariant_violation_by_operation diagnostic with a counterexample", () => {
+    const check = findCheck(checks, "Tamper.preserves.clickCountNonNegative");
+    expect(check?.status).toBe("unsat");
+    expect(check?.diagnostic).not.toBeNull();
+    expect(check?.diagnostic?.category).toBe("invariant_violation_by_operation");
+    expect(check?.diagnostic?.counterexample).not.toBeNull();
+  });
+
+  it("counterexample decodes entities, state relations, and inputs", () => {
+    const diag = findCheck(checks, "Tamper.preserves.clickCountNonNegative")?.diagnostic;
+    const ce = diag?.counterexample;
+    expect(ce).toBeDefined();
+    expect(ce!.inputs.find((i) => i.name === "code")).toBeDefined();
+    expect(ce!.entities.some((e) => e.sortName === "UrlMapping")).toBe(true);
+    const post = ce!.stateRelations.find((r) => r.stateName === "metadata" && r.side === "post");
+    expect(post?.entries.length).toBeGreaterThan(0);
+  });
+
+  it("formatDiagnostic produces a multi-line report with inputs / pre-state / post-state", () => {
+    const diag = findCheck(checks, "Tamper.preserves.clickCountNonNegative")?.diagnostic;
+    expect(diag).not.toBeNull();
+    const output = formatDiagnostic(diag!, "broken_url_shortener.spec");
+    expect(output).toContain("error: operation 'Tamper' violates invariant 'clickCountNonNegative'");
+    expect(output).toContain("Counterexample:");
+    expect(output).toContain("pre-state:");
+    expect(output).toContain("post-state:");
+    expect(output).toContain("hint:");
+  });
+
+  it("records the source span on the diagnostic", () => {
+    const check = findCheck(checks, "Tamper.preserves.clickCountNonNegative");
+    const diag = check!.diagnostic!;
+    expect(diag.primarySpan).not.toBeNull();
+    expect(diag.primarySpan!.startLine).toBeGreaterThan(0);
+    expect(check!.sourceSpans.length).toBeGreaterThan(0);
+  });
+});
+
+describe.sequential("diagnostic — category assignment across check kinds", () => {
+  let backend: WasmBackend;
+
+  beforeAll(() => {
+    backend = new WasmBackend();
+  });
+
+  it("contradictory invariants → contradictory_invariants category", async () => {
+    const ir = irFromFile("./fixtures/unsat_invariants.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    const global = findCheck(report.checks, "global");
+    expect(global?.status).toBe("unsat");
+    expect(global?.diagnostic?.category).toBe("contradictory_invariants");
+  });
+
+  it("dead operation → unsatisfiable_precondition category", async () => {
+    const ir = irFromFile("./fixtures/dead_op.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    const check = findCheck(report.checks, "DeadOp.requires");
+    expect(check?.status).toBe("unsat");
+    expect(check?.diagnostic?.category).toBe("unsatisfiable_precondition");
+  });
+
+  it("unreachable operation → unreachable_operation category", async () => {
+    const ir = irFromFile("./fixtures/unreachable_op.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    const check = findCheck(report.checks, "UnreachableOp.enabled");
+    expect(check?.status).toBe("unsat");
+    expect(check?.diagnostic?.category).toBe("unreachable_operation");
+  });
+
+  it("passing check → no diagnostic attached", async () => {
+    const ir = irFromFile("./fixtures/safe_counter.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    const ok = findCheck(report.checks, "Increment.preserves.countNonNegative");
+    expect(ok?.status).toBe("sat");
+    expect(ok?.diagnostic).toBeNull();
+  });
+});
+
+describe.sequential("diagnostic — formatter for non-preservation categories", () => {
+  let backend: WasmBackend;
+
+  beforeAll(() => {
+    backend = new WasmBackend();
+  });
+
+  it("contradictory invariants include at least one related span note", async () => {
+    const ir = irFromFile("./fixtures/unsat_invariants.spec");
+    const report = await runConsistencyChecks(ir, backend, DEFAULT_VERIFICATION_CONFIG);
+    const global = findCheck(report.checks, "global")!;
+    const output = formatDiagnostic(global.diagnostic!, "unsat_invariants.spec");
+    expect(output).toContain("error:");
+    expect(output).toContain("invariants are jointly unsatisfiable");
+  });
+});

--- a/test/verify/fixtures/broken_url_shortener.spec
+++ b/test/verify/fixtures/broken_url_shortener.spec
@@ -1,0 +1,23 @@
+service BrokenUrlShortener {
+
+  entity UrlMapping {
+    click_count: Int
+  }
+
+  state {
+    metadata: Int -> lone UrlMapping
+  }
+
+  operation Tamper {
+    input: code: Int
+
+    requires:
+      code in metadata
+
+    ensures:
+      metadata'[code].click_count = pre(metadata)[code].click_count - 100
+  }
+
+  invariant clickCountNonNegative:
+    all c in metadata | metadata[c].click_count >= 0
+}

--- a/test/verify/span.test.ts
+++ b/test/verify/span.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseSpec } from "#parser/index.js";
+import { buildIR } from "#ir/index.js";
+import { translate } from "#verify/translator.js";
+import type { Z3Expr } from "#verify/script.js";
+
+function countNodesWithSpan(e: Z3Expr, counters: { total: number; withSpan: number }): void {
+  counters.total += 1;
+  if (e.span) counters.withSpan += 1;
+  switch (e.kind) {
+    case "App":
+      for (const a of e.args) countNodesWithSpan(a, counters);
+      break;
+    case "And":
+    case "Or":
+    case "Arith":
+      for (const a of e.args) countNodesWithSpan(a, counters);
+      break;
+    case "Not":
+      countNodesWithSpan(e.arg, counters);
+      break;
+    case "Implies":
+    case "Cmp":
+      countNodesWithSpan(e.lhs, counters);
+      countNodesWithSpan(e.rhs, counters);
+      break;
+    case "Quantifier":
+      countNodesWithSpan(e.body, counters);
+      break;
+    default:
+      break;
+  }
+}
+
+describe("Z3Expr span propagation", () => {
+  it("translateExpr stamps IR spans onto the root of each user-authored expression", () => {
+    const src = `
+      service S {
+        state { counter: Int }
+        invariant nonneg: counter >= 0
+      }
+    `;
+    const { tree, errors } = parseSpec(src);
+    expect(errors).toEqual([]);
+    const ir = buildIR(tree);
+    const script = translate(ir);
+    const invariantAssertion = script.assertions[script.assertions.length - 1];
+    expect(invariantAssertion.span).toBeDefined();
+    expect(invariantAssertion.span!.startLine).toBeGreaterThan(0);
+  });
+
+  it("covers multiple expression kinds with spans", () => {
+    const src = `
+      service S {
+        state {
+          x: Int
+          y: Int
+        }
+        invariant a: x >= 0 and y <= 100
+        invariant b: x + y > 0 or not (x = y)
+      }
+    `;
+    const { tree, errors } = parseSpec(src);
+    expect(errors).toEqual([]);
+    const ir = buildIR(tree);
+    const script = translate(ir);
+    const counters = { total: 0, withSpan: 0 };
+    for (const a of script.assertions) countNodesWithSpan(a, counters);
+    expect(counters.total).toBeGreaterThan(0);
+    expect(counters.withSpan).toBeGreaterThan(0);
+  });
+
+  it("synthetic string-distinctness axioms have no span (not user-authored)", () => {
+    const src = `
+      service S {
+        invariant z: "a" != "b"
+        invariant w: "c" != "d"
+      }
+    `;
+    const { tree, errors } = parseSpec(src);
+    expect(errors).toEqual([]);
+    const ir = buildIR(tree);
+    const script = translate(ir);
+    const syntheticLast = script.assertions[script.assertions.length - 1];
+    expect(syntheticLast.kind === "And" || syntheticLast.kind === "Cmp").toBe(true);
+    expect(syntheticLast.span).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #20.

## Summary

M4.4 turns Z3's raw `sat` / `unsat` / `unknown` verdicts into developer-facing diagnostics. The
hero failure mode — `operation 'X' violates invariant 'Y'` — now prints a spec-aware multi-line
report with a decoded counterexample (entities, pre/post-state relations, inputs), a primary
source span, related spans, and a per-category suggestion.

Example:

```text
test/verify/fixtures/broken_url_shortener.spec:11:3: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
  related: test/verify/fixtures/broken_url_shortener.spec:21:3 (invariant 'clickCountNonNegative' declared here)

  Counterexample:
  inputs:
    code = 2
  entities:
    UrlMapping#0 { click_count = -1 }
    UrlMapping#1 { click_count = 99 }
  pre-state:
    metadata = { 2 → UrlMapping#1 }
  post-state:
    metadata' = { 2 → UrlMapping#0 }

  hint: Tighten the 'ensures' clause so the invariant's constrained fields appear on the right-hand
  side of a '=' or a range predicate.
```

## What changed

- **Span plumbing.** `Z3Expr` gains `span?: Span`; `translateExpr` stamps IR spans onto every
  user-authored node via a thin wrapping helper. Synthetic axioms (frame, cardinality delta,
  totality, enum distinctness) stay unspanned by design — diagnostics gracefully handle null.
- **Translator artifact.** `Z3Script` now carries a `TranslatorArtifact` (entities, enums, state
  with pre/post func names, operation inputs/outputs, hasPostState). Consumers get everything
  they need to map Z3 values back to the spec without re-running the translator.
- **Model capture.** `backend.check()` takes `config.captureModel`; preservation checks opt in.
  Sort / func maps flow out alongside the model to drive decoding.
- **Counterexample decoder.** `src/verify/counterexample.ts` — pure function: Model + artifact
  → `CounterExample`. Enumerates uninterp-sort universes, evaluates entity field functions,
  enumerates state relations at universe-or-input keys, decodes inputs. `UrlMapping!val!0` →
  `UrlMapping#0`; negative ints normalized from Z3's `(- N)` form.
- **Diagnostic builder.** `src/verify/diagnostic.ts` — seven categories:
  - `contradictory_invariants`
  - `unsatisfiable_precondition`
  - `unreachable_operation`
  - `invariant_violation_by_operation`
  - `solver_timeout`
  - `translator_limitation`
  - `backend_error`
  Each carries a one-line suggestion; rich templating tracked in #80.
- **Consistency orchestrator.** `CheckResult` extended with `sourceSpans: readonly Span[]` and
  `diagnostic: VerificationDiagnostic | null`; populated for every non-`sat` outcome.
- **CLI reporter.** Prints the hero format for failing checks; one-liners for passing
  (via `-v`). Exit codes split: `0` ok / `1` violations / `2` translator-limitation on an
  otherwise-parseable spec / `3` backend crash.

## Non-goals (filed as separate issues)

All non-goals from the original #20 plan are now tracked in dedicated issues:

- **Verify-as-gate in `compile`** — #78 (blocks on a user-facing `compile` CLI)
- **Machine-readable (`--json`) output** — #79
- **Richer suggested-fix templates** — #80
- **Structural spec lints** (type mismatch, unused entity, …) — #81 (parser / IR-validation
  territory, not Z3)
- **Proof-certificate / unsat-core / VC-dump export** — #77
- **Set operators and non-state set membership** — #73
- **Temporal properties (liveness / fairness)** — #75

## Docs

`docs/content/docs/verification.mdx` consolidated: intermediate "What M4.2 ships / does not ship"
and "What M4.3 ships / does not ship" blocks removed in favour of a single engine description.
Status table refreshed to reflect shipped capabilities + links to the non-goal trackers above.
New sections: **Reading diagnostics** (category table + two worked examples) and **Exit codes**.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run fmt:check` clean
- [x] `npx vitest run` — 1202/1202 passing (+12 from baseline 1190)
- [x] Docs build clean (`cd docs && npm run build`)
- [x] CLI smoke — `verify test/verify/fixtures/broken_url_shortener.spec` produces the hero
      output above and exits `1`
- [x] CLI smoke — `verify test/verify/fixtures/broken_decrement.spec` shows pre/post counterexample
- [x] CLI smoke — `verify test/verify/fixtures/safe_counter.spec` exits `0`

## New tests

- `test/verify/span.test.ts` — span propagation parametrized over IR expression kinds;
  synthetic axioms stay unspanned.
- `test/verify/diagnostic.test.ts` — counterexample decoding on `broken_url_shortener.spec`,
  category assignment across every check kind, formatter output coverage.
- `test/verify/fixtures/broken_url_shortener.spec` — fixture that drives the new preservation
  failure path with a real counterexample (not a trivial int-only fixture).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns raw Z3 results into clear, spec-aware diagnostics with decoded counterexamples. Adds spans, a model decoder, and a CLI reporter with categories, hints, and precise exit codes; skipped checks now surface as warnings with exit code 2 to meet #20, and translator failures during `--dump-smt` also return exit code 2.

- **New Features**
  - Spans propagated through `Z3Expr`; user-authored nodes are spanned, synthetic axioms are not.
  - `Z3Script` now includes a `TranslatorArtifact` (entities, enums, state, inputs/outputs, `hasPostState`) for model decoding.
  - Backend can capture the Z3 model (`captureModel`) and exposes sort/func maps; enabled for preservation checks only.
  - Counterexample decoder maps models back to entities, inputs, and pre/post state; normalizes names/ints and decodes enums first so enum-typed fields render as `EnumName.member`.
  - Diagnostic builder with categories: `contradictory_invariants`, `unsatisfiable_precondition`, `unreachable_operation`, `invariant_violation_by_operation`, `solver_timeout`, `translator_limitation`, `backend_error`; each includes a short hint.
  - `CheckResult` gains `sourceSpans` and a structured `diagnostic`; CLI prints multi-line, spec-aware reports with primary/related spans and counterexamples. Skipped checks attach warning diagnostics (`translator_limitation`) and show a “coverage gap” summary.
  - Exit codes: `0` (ok), `1` (violations/timeouts or parse/IR failures), `2` (translator limitation — from skipped checks or whole-spec translation like `--dump-smt`), `3` (backend error). Docs updated with “Reading diagnostics” and an exit-code table. Tests cover spans, enum decode order, categories, and formatter output.

- **Migration**
  - Update CI/scripts for exit codes `2` (translator limitation, including translation failures on `--dump-smt`) and `3` (backend error); previous success/failure semantics remain (`0`/`1`).
  - Expect warning diagnostics and a yellow “coverage gap” summary when only skipped checks occur.
  - No spec changes required; diagnostics appear automatically. Use `-v` for per-check timing and `--dump-smt` as before.

<sup>Written for commit e675fe8b6e32a9b5356096c7e6c8ac73447f7c92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostics reporting with detailed multi-line output, categories, source spans, and context-specific hints.
  * Counterexample decoding and display for verification violations.

* **Bug Fixes**
  * Improved exit code handling to distinguish failure modes: violations (1), translator errors (2), backend errors (3).

* **Documentation**
  * Updated verification guide with new diagnostic format examples, exit code definitions, and improved CLI output descriptions.

* **Tests**
  * Added comprehensive test coverage for diagnostic generation and span tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->