### PR TITLE
verify: first-class set theory (closes #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,8 @@ jobs:
         run: |
           timeout 60s z3 -T:30 fixtures/golden/smt/url_shortener.smt2 \
             | head -n1 | grep -Fxq sat
+
+      - name: Cross-check set_ops SMT snapshot against native Z3
+        run: |
+          timeout 60s z3 -T:30 fixtures/golden/smt/set_ops.smt2 \
+            | head -n1 | grep -Fxq sat

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -30,7 +30,9 @@ natively per-platform so no system install is required.
 | Richer suggested-fix templates                                      | [#80](https://github.com/HardMax71/spec_to_rest/issues/80) |
 | Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
 | Proof-certificate / unsat-core / VC-dump export                     | [#77](https://github.com/HardMax71/spec_to_rest/issues/77) |
-| Set operators and non-state set membership                          | [#73](https://github.com/HardMax71/spec_to_rest/issues/73) |
+| Set-literal membership (`x in {A, B, C}`), set algebra (`union`, `intersect`, `minus`, `subset`), non-state set membership via `(select ...)` | shipped |
+| Standalone set comprehension as equality RHS (`s = {x in D \| P}`)   | [#73](https://github.com/HardMax71/spec_to_rest/issues/73) (deferred — element-sort ambiguity vs. the receiver's declared type) |
+| Powerset (`^s`)                                                     | not planned — undecidable in first-order SMT |
 | Temporal properties (liveness, fairness)                            | [#75](https://github.com/HardMax71/spec_to_rest/issues/75) (separate backend) |
 
 ## Preservation VC shape
@@ -102,7 +104,7 @@ opt-in suggestion.
 | `unreachable_operation` | `<Op>.enabled` is `unsat` while `<Op>.requires` is `sat` | invariants block every valid pre-state — relax invariants or tighten the input type |
 | `invariant_violation_by_operation` | preservation VC is satisfied (i.e. invariant fails post) | tighten `ensures` so the invariant's constrained fields are pinned by `=` or a range predicate |
 | `solver_timeout` | Z3 returns `unknown` | raise `--timeout`, simplify the invariant, or split a heavy quantifier |
-| `translator_limitation` | IR construct not yet supported (see #73, #75) | skip the affected check or narrow the invariant so the unsupported construct doesn't appear |
+| `translator_limitation` | IR construct not yet supported (see #75, remaining #73 slice) | skip the affected check or narrow the invariant so the unsupported construct doesn't appear |
 | `backend_error` | solver crash / init failure | re-run with `-v`; if reproducible, file an issue with `--dump-smt` output |
 
 ### Worked example — preservation violation
@@ -218,6 +220,36 @@ If Z3 cannot decide within the timeout, the result is `unknown`, which `verify` 
 failure with category `solver_timeout` (exit `1`). The 30 s default is a conservative headroom
 for heavier preservation checks on large specs.
 
+## Set theory
+
+`Set[T]` maps to Z3's built-in set theory (extensional `Array T Bool` under the hood). The
+SMT-LIB emitter and the Z3 Java backend agree on the same surface:
+
+| Spec form                       | SMT-LIB                                                  |
+| ------------------------------- | -------------------------------------------------------- |
+| `Set[Int]` type                 | `(Set Int)`                                              |
+| `x in {A, B, C}`                | `(or (= x A) (= x B) (= x C))` — exact lowering          |
+| `x not in {A, B, C}`            | `(not (or ...))`                                         |
+| `x in (a union b)` etc.         | `(select <expr> x)`                                      |
+| `a union b`                     | `(union a b)`                                            |
+| `a intersect b`                 | `(intersection a b)`                                     |
+| `a minus b`                     | `(setminus a b)`                                         |
+| `a subset b`                    | `(subset a b)`                                           |
+| `{ }` (empty set)               | `((as const (Set T)) false)` — requires receiver context |
+| `{ e1, e2 }` (non-empty lit)    | `(store (store ((as const (Set T)) false) e1 true) e2 true)` |
+
+Set-literal membership (`in {A, B, C}`) lowers to a disjunction of equalities rather than a
+`select` against a skolem set; this is exact and avoids introducing uninterpreted
+infrastructure for the common enum-membership pattern.
+
+`{}` as a standalone expression is rejected (the element sort can't be inferred from the
+literal itself) — assign it to a typed receiver or constrain it by equality.
+
+Standalone set comprehensions (`entries = { x in D | P }`) remain a translator throw: the
+comprehension's element sort is the *binder's* sort (e.g. a relation's key sort), which
+typically mismatches the receiver's declared type and would produce a sort-mismatch rather
+than a useful verdict. See [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+
 ## Extending the translator
 
 Adding a new IR expression kind is a three-file change:
@@ -251,8 +283,13 @@ when the snapshot legitimately changes.
   concerns, not Z3 reporter territory.
 - **Proof / unsat-core / VC-dump export** — tracked in
   [#77](https://github.com/HardMax71/spec_to_rest/issues/77).
-- **Set operators and non-state set membership** — tracked in
-  [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+- **Standalone set comprehensions as equality RHS** (`entries = { x in D | P }`) — the
+  comprehension's element sort is the *binder's* sort (e.g. the key sort of a state
+  relation), not the receiver's declared type, so a naive lowering would produce a
+  sort-mismatch crash. Kept as a throw in the translator pending a spec-language
+  clarification; see [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+- **Powerset** (`^s`) — undecidable in first-order SMT; not planned. If a spec truly needs
+  powerset, use a higher-order model checker (Alloy, Quint).
 - **Temporal properties (liveness, fairness)** — separate backend, tracked in
   [#75](https://github.com/HardMax71/spec_to_rest/issues/75).
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -31,7 +31,7 @@ natively per-platform so no system install is required.
 | Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
 | Proof-certificate / unsat-core / VC-dump export                     | [#77](https://github.com/HardMax71/spec_to_rest/issues/77) |
 | Set-literal membership (`x in {A, B, C}`), set algebra (`union`, `intersect`, `minus`, `subset`), non-state set membership via `(select ...)` | shipped |
-| Standalone set comprehension as equality RHS (`s = {x in D \| P}`)   | [#73](https://github.com/HardMax71/spec_to_rest/issues/73) (deferred — element-sort ambiguity vs. the receiver's declared type) |
+| Standalone set comprehension as equality RHS (`s = {x in D \| P}`)   | not supported — the binder's element sort typically mismatches the receiver's declared type; use an inline membership form |
 | Powerset (`^s`)                                                     | not planned — undecidable in first-order SMT |
 | Temporal properties (liveness, fairness)                            | [#75](https://github.com/HardMax71/spec_to_rest/issues/75) (separate backend) |
 
@@ -104,7 +104,7 @@ opt-in suggestion.
 | `unreachable_operation` | `<Op>.enabled` is `unsat` while `<Op>.requires` is `sat` | invariants block every valid pre-state — relax invariants or tighten the input type |
 | `invariant_violation_by_operation` | preservation VC is satisfied (i.e. invariant fails post) | tighten `ensures` so the invariant's constrained fields are pinned by `=` or a range predicate |
 | `solver_timeout` | Z3 returns `unknown` | raise `--timeout`, simplify the invariant, or split a heavy quantifier |
-| `translator_limitation` | IR construct not yet supported (see #75, remaining #73 slice) | skip the affected check or narrow the invariant so the unsupported construct doesn't appear |
+| `translator_limitation` | IR construct not yet supported by the verifier | skip the affected check or narrow the invariant so the unsupported construct doesn't appear |
 | `backend_error` | solver crash / init failure | re-run with `-v`; if reproducible, file an issue with `--dump-smt` output |
 
 ### Worked example — preservation violation
@@ -248,7 +248,7 @@ literal itself) — assign it to a typed receiver or constrain it by equality.
 Standalone set comprehensions (`entries = { x in D | P }`) remain a translator throw: the
 comprehension's element sort is the *binder's* sort (e.g. a relation's key sort), which
 typically mismatches the receiver's declared type and would produce a sort-mismatch rather
-than a useful verdict. See [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+than a useful verdict. Use the inline membership form instead: `y in { x in S | P }`.
 
 ## Extending the translator
 
@@ -286,8 +286,8 @@ when the snapshot legitimately changes.
 - **Standalone set comprehensions as equality RHS** (`entries = { x in D | P }`) — the
   comprehension's element sort is the *binder's* sort (e.g. the key sort of a state
   relation), not the receiver's declared type, so a naive lowering would produce a
-  sort-mismatch crash. Kept as a throw in the translator pending a spec-language
-  clarification; see [#73](https://github.com/HardMax71/spec_to_rest/issues/73).
+  sort-mismatch crash. Kept as a translator throw; use the inline membership form
+  `y in { x in S | P }` instead.
 - **Powerset** (`^s`) — undecidable in first-order SMT; not planned. If a spec truly needs
   powerset, use a higher-order model checker (Alloy, Quint).
 - **Temporal properties (liveness, fairness)** — separate backend, tracked in

--- a/fixtures/golden/ir/set_ops.json
+++ b/fixtures/golden/ir/set_ops.json
@@ -1,0 +1,1573 @@
+{
+  "kind" : "Service",
+  "name" : "SetOpsDemo",
+  "imports" : [
+  ],
+  "entities" : [
+  ],
+  "enums" : [
+  ],
+  "typeAliases" : [
+  ],
+  "state" : {
+    "kind" : "State",
+    "fields" : [
+      {
+        "kind" : "StateField",
+        "name" : "counters",
+        "typeExpr" : {
+          "kind" : "RelationType",
+          "fromType" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 4,
+              "startCol" : 14,
+              "endLine" : 4,
+              "endCol" : 17
+            }
+          },
+          "multiplicity" : "lone",
+          "toType" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 4,
+              "startCol" : 26,
+              "endLine" : 4,
+              "endCol" : 29
+            }
+          },
+          "span" : {
+            "startLine" : 4,
+            "startCol" : 14,
+            "endLine" : 4,
+            "endCol" : 29
+          }
+        },
+        "span" : {
+          "startLine" : 4,
+          "startCol" : 4,
+          "endLine" : 4,
+          "endCol" : 29
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 3,
+      "startCol" : 2,
+      "endLine" : 5,
+      "endCol" : 3
+    }
+  },
+  "operations" : [
+    {
+      "kind" : "Operation",
+      "name" : "Bump",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "id",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 14,
+              "startCol" : 15,
+              "endLine" : 14,
+              "endCol" : 18
+            }
+          },
+          "span" : {
+            "startLine" : 14,
+            "startCol" : 11,
+            "endLine" : 14,
+            "endCol" : 18
+          }
+        }
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "id",
+            "span" : {
+              "startLine" : 16,
+              "startCol" : 6,
+              "endLine" : 16,
+              "endCol" : 8
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "counters",
+            "span" : {
+              "startLine" : 16,
+              "startCol" : 12,
+              "endLine" : 16,
+              "endCol" : 20
+            }
+          },
+          "span" : {
+            "startLine" : 16,
+            "startCol" : 6,
+            "endLine" : 16,
+            "endCol" : 20
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Index",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 17,
+                "startCol" : 6,
+                "endLine" : 17,
+                "endCol" : 14
+              }
+            },
+            "index" : {
+              "kind" : "Identifier",
+              "name" : "id",
+              "span" : {
+                "startLine" : 17,
+                "startCol" : 15,
+                "endLine" : 17,
+                "endCol" : 17
+              }
+            },
+            "span" : {
+              "startLine" : 17,
+              "startCol" : 6,
+              "endLine" : 17,
+              "endCol" : 18
+            }
+          },
+          "right" : {
+            "kind" : "SetLiteral",
+            "elements" : [
+              {
+                "kind" : "IntLit",
+                "value" : 0,
+                "span" : {
+                  "startLine" : 17,
+                  "startCol" : 23,
+                  "endLine" : 17,
+                  "endCol" : 24
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 1,
+                "span" : {
+                  "startLine" : 17,
+                  "startCol" : 26,
+                  "endLine" : 17,
+                  "endCol" : 27
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 2,
+                "span" : {
+                  "startLine" : 17,
+                  "startCol" : 29,
+                  "endLine" : 17,
+                  "endCol" : 30
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 17,
+              "startCol" : 22,
+              "endLine" : 17,
+              "endCol" : 31
+            }
+          },
+          "span" : {
+            "startLine" : 17,
+            "startCol" : 6,
+            "endLine" : 17,
+            "endCol" : 31
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 19,
+                "startCol" : 6,
+                "endLine" : 19,
+                "endCol" : 14
+              }
+            },
+            "span" : {
+              "startLine" : 19,
+              "startCol" : 6,
+              "endLine" : 19,
+              "endCol" : 15
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "counters",
+                "span" : {
+                  "startLine" : 19,
+                  "startCol" : 22,
+                  "endLine" : 19,
+                  "endCol" : 30
+                }
+              },
+              "span" : {
+                "startLine" : 19,
+                "startCol" : 18,
+                "endLine" : 19,
+                "endCol" : 31
+              }
+            },
+            "right" : {
+              "kind" : "MapLiteral",
+              "entries" : [
+                {
+                  "key" : {
+                    "kind" : "Identifier",
+                    "name" : "id",
+                    "span" : {
+                      "startLine" : 19,
+                      "startCol" : 35,
+                      "endLine" : 19,
+                      "endCol" : 37
+                    }
+                  },
+                  "value" : {
+                    "kind" : "IntLit",
+                    "value" : 5,
+                    "span" : {
+                      "startLine" : 19,
+                      "startCol" : 41,
+                      "endLine" : 19,
+                      "endCol" : 42
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 19,
+                    "startCol" : 35,
+                    "endLine" : 19,
+                    "endCol" : 37
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 19,
+                "startCol" : 34,
+                "endLine" : 19,
+                "endCol" : 43
+              }
+            },
+            "span" : {
+              "startLine" : 19,
+              "startCol" : 18,
+              "endLine" : 19,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 19,
+            "startCol" : 6,
+            "endLine" : 19,
+            "endCol" : 43
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 13,
+        "startCol" : 2,
+        "endLine" : 20,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "Touch",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "id",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 23,
+              "startCol" : 15,
+              "endLine" : 23,
+              "endCol" : 18
+            }
+          },
+          "span" : {
+            "startLine" : 23,
+            "startCol" : 11,
+            "endLine" : 23,
+            "endCol" : 18
+          }
+        }
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "id",
+            "span" : {
+              "startLine" : 25,
+              "startCol" : 6,
+              "endLine" : 25,
+              "endCol" : 8
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "counters",
+            "span" : {
+              "startLine" : 25,
+              "startCol" : 12,
+              "endLine" : 25,
+              "endCol" : 20
+            }
+          },
+          "span" : {
+            "startLine" : 25,
+            "startCol" : 6,
+            "endLine" : 25,
+            "endCol" : 20
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "not_in",
+          "left" : {
+            "kind" : "Index",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 26,
+                "startCol" : 6,
+                "endLine" : 26,
+                "endCol" : 14
+              }
+            },
+            "index" : {
+              "kind" : "Identifier",
+              "name" : "id",
+              "span" : {
+                "startLine" : 26,
+                "startCol" : 15,
+                "endLine" : 26,
+                "endCol" : 17
+              }
+            },
+            "span" : {
+              "startLine" : 26,
+              "startCol" : 6,
+              "endLine" : 26,
+              "endCol" : 18
+            }
+          },
+          "right" : {
+            "kind" : "SetLiteral",
+            "elements" : [
+              {
+                "kind" : "IntLit",
+                "value" : 5,
+                "span" : {
+                  "startLine" : 26,
+                  "startCol" : 27,
+                  "endLine" : 26,
+                  "endCol" : 28
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 26,
+              "startCol" : 26,
+              "endLine" : 26,
+              "endCol" : 29
+            }
+          },
+          "span" : {
+            "startLine" : 26,
+            "startCol" : 6,
+            "endLine" : 26,
+            "endCol" : 29
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 28,
+                "startCol" : 6,
+                "endLine" : 28,
+                "endCol" : 14
+              }
+            },
+            "span" : {
+              "startLine" : 28,
+              "startCol" : 6,
+              "endLine" : 28,
+              "endCol" : 15
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "counters",
+                "span" : {
+                  "startLine" : 28,
+                  "startCol" : 22,
+                  "endLine" : 28,
+                  "endCol" : 30
+                }
+              },
+              "span" : {
+                "startLine" : 28,
+                "startCol" : 18,
+                "endLine" : 28,
+                "endCol" : 31
+              }
+            },
+            "right" : {
+              "kind" : "MapLiteral",
+              "entries" : [
+                {
+                  "key" : {
+                    "kind" : "Identifier",
+                    "name" : "id",
+                    "span" : {
+                      "startLine" : 28,
+                      "startCol" : 35,
+                      "endLine" : 28,
+                      "endCol" : 37
+                    }
+                  },
+                  "value" : {
+                    "kind" : "IntLit",
+                    "value" : 3,
+                    "span" : {
+                      "startLine" : 28,
+                      "startCol" : 41,
+                      "endLine" : 28,
+                      "endCol" : 42
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 28,
+                    "startCol" : 35,
+                    "endLine" : 28,
+                    "endCol" : 37
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 28,
+                "startCol" : 34,
+                "endLine" : 28,
+                "endCol" : 43
+              }
+            },
+            "span" : {
+              "startLine" : 28,
+              "startCol" : 18,
+              "endLine" : 28,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 28,
+            "startCol" : 6,
+            "endLine" : 28,
+            "endCol" : 43
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 22,
+        "startCol" : 2,
+        "endLine" : 29,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "Merge",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "a",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 18,
+                "endLine" : 32,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 14,
+              "endLine" : 32,
+              "endCol" : 22
+            }
+          },
+          "span" : {
+            "startLine" : 32,
+            "startCol" : 11,
+            "endLine" : 32,
+            "endCol" : 22
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "b",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 31,
+                "endLine" : 32,
+                "endCol" : 34
+              }
+            },
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 27,
+              "endLine" : 32,
+              "endCol" : 35
+            }
+          },
+          "span" : {
+            "startLine" : 32,
+            "startCol" : 24,
+            "endLine" : 32,
+            "endCol" : 35
+          }
+        }
+      ],
+      "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "u",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 33,
+                "startCol" : 19,
+                "endLine" : 33,
+                "endCol" : 22
+              }
+            },
+            "span" : {
+              "startLine" : 33,
+              "startCol" : 15,
+              "endLine" : 33,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 33,
+            "startCol" : 12,
+            "endLine" : 33,
+            "endCol" : 23
+          }
+        }
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 36,
+            "startCol" : 6,
+            "endLine" : 36,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "u",
+            "span" : {
+              "startLine" : 39,
+              "startCol" : 6,
+              "endLine" : 39,
+              "endCol" : 7
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "union",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "a",
+              "span" : {
+                "startLine" : 39,
+                "startCol" : 10,
+                "endLine" : 39,
+                "endCol" : 11
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 39,
+                "startCol" : 18,
+                "endLine" : 39,
+                "endCol" : 19
+              }
+            },
+            "span" : {
+              "startLine" : 39,
+              "startCol" : 10,
+              "endLine" : 39,
+              "endCol" : 19
+            }
+          },
+          "span" : {
+            "startLine" : 39,
+            "startCol" : 6,
+            "endLine" : 39,
+            "endCol" : 19
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 31,
+        "startCol" : 2,
+        "endLine" : 40,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "Common",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "a",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 43,
+                "startCol" : 18,
+                "endLine" : 43,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 43,
+              "startCol" : 14,
+              "endLine" : 43,
+              "endCol" : 22
+            }
+          },
+          "span" : {
+            "startLine" : 43,
+            "startCol" : 11,
+            "endLine" : 43,
+            "endCol" : 22
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "b",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 43,
+                "startCol" : 31,
+                "endLine" : 43,
+                "endCol" : 34
+              }
+            },
+            "span" : {
+              "startLine" : 43,
+              "startCol" : 27,
+              "endLine" : 43,
+              "endCol" : 35
+            }
+          },
+          "span" : {
+            "startLine" : 43,
+            "startCol" : 24,
+            "endLine" : 43,
+            "endCol" : 35
+          }
+        }
+      ],
+      "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "i",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 44,
+                "startCol" : 19,
+                "endLine" : 44,
+                "endCol" : 22
+              }
+            },
+            "span" : {
+              "startLine" : 44,
+              "startCol" : 15,
+              "endLine" : 44,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 44,
+            "startCol" : 12,
+            "endLine" : 44,
+            "endCol" : 23
+          }
+        }
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 47,
+            "startCol" : 6,
+            "endLine" : 47,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "i",
+            "span" : {
+              "startLine" : 50,
+              "startCol" : 6,
+              "endLine" : 50,
+              "endCol" : 7
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "intersect",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "a",
+              "span" : {
+                "startLine" : 50,
+                "startCol" : 10,
+                "endLine" : 50,
+                "endCol" : 11
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 50,
+                "startCol" : 22,
+                "endLine" : 50,
+                "endCol" : 23
+              }
+            },
+            "span" : {
+              "startLine" : 50,
+              "startCol" : 10,
+              "endLine" : 50,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 50,
+            "startCol" : 6,
+            "endLine" : 50,
+            "endCol" : 23
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 42,
+        "startCol" : 2,
+        "endLine" : 51,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "OnlyA",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "a",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 54,
+                "startCol" : 18,
+                "endLine" : 54,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 54,
+              "startCol" : 14,
+              "endLine" : 54,
+              "endCol" : 22
+            }
+          },
+          "span" : {
+            "startLine" : 54,
+            "startCol" : 11,
+            "endLine" : 54,
+            "endCol" : 22
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "b",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 54,
+                "startCol" : 31,
+                "endLine" : 54,
+                "endCol" : 34
+              }
+            },
+            "span" : {
+              "startLine" : 54,
+              "startCol" : 27,
+              "endLine" : 54,
+              "endCol" : 35
+            }
+          },
+          "span" : {
+            "startLine" : 54,
+            "startCol" : 24,
+            "endLine" : 54,
+            "endCol" : 35
+          }
+        }
+      ],
+      "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "d",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 55,
+                "startCol" : 19,
+                "endLine" : 55,
+                "endCol" : 22
+              }
+            },
+            "span" : {
+              "startLine" : 55,
+              "startCol" : 15,
+              "endLine" : 55,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 55,
+            "startCol" : 12,
+            "endLine" : 55,
+            "endCol" : 23
+          }
+        }
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 58,
+            "startCol" : 6,
+            "endLine" : 58,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "d",
+            "span" : {
+              "startLine" : 61,
+              "startCol" : 6,
+              "endLine" : 61,
+              "endCol" : 7
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "minus",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "a",
+              "span" : {
+                "startLine" : 61,
+                "startCol" : 10,
+                "endLine" : 61,
+                "endCol" : 11
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 61,
+                "startCol" : 18,
+                "endLine" : 61,
+                "endCol" : 19
+              }
+            },
+            "span" : {
+              "startLine" : 61,
+              "startCol" : 10,
+              "endLine" : 61,
+              "endCol" : 19
+            }
+          },
+          "span" : {
+            "startLine" : 61,
+            "startCol" : 6,
+            "endLine" : 61,
+            "endCol" : 19
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 53,
+        "startCol" : 2,
+        "endLine" : 62,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "Included",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "a",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 65,
+                "startCol" : 18,
+                "endLine" : 65,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 65,
+              "startCol" : 14,
+              "endLine" : 65,
+              "endCol" : 22
+            }
+          },
+          "span" : {
+            "startLine" : 65,
+            "startCol" : 11,
+            "endLine" : 65,
+            "endCol" : 22
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "b",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 65,
+                "startCol" : 31,
+                "endLine" : 65,
+                "endCol" : 34
+              }
+            },
+            "span" : {
+              "startLine" : 65,
+              "startCol" : 27,
+              "endLine" : 65,
+              "endCol" : 35
+            }
+          },
+          "span" : {
+            "startLine" : 65,
+            "startCol" : 24,
+            "endLine" : 65,
+            "endCol" : 35
+          }
+        }
+      ],
+      "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "result",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Bool",
+            "span" : {
+              "startLine" : 66,
+              "startCol" : 20,
+              "endLine" : 66,
+              "endCol" : 24
+            }
+          },
+          "span" : {
+            "startLine" : 66,
+            "startCol" : 12,
+            "endLine" : 66,
+            "endCol" : 24
+          }
+        }
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 69,
+            "startCol" : 6,
+            "endLine" : 69,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "result",
+            "span" : {
+              "startLine" : 72,
+              "startCol" : 6,
+              "endLine" : 72,
+              "endCol" : 12
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "subset",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "a",
+              "span" : {
+                "startLine" : 72,
+                "startCol" : 16,
+                "endLine" : 72,
+                "endCol" : 17
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 72,
+                "startCol" : 25,
+                "endLine" : 72,
+                "endCol" : 26
+              }
+            },
+            "span" : {
+              "startLine" : 72,
+              "startCol" : 16,
+              "endLine" : 72,
+              "endCol" : 26
+            }
+          },
+          "span" : {
+            "startLine" : 72,
+            "startCol" : 6,
+            "endLine" : 72,
+            "endCol" : 27
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 64,
+        "startCol" : 2,
+        "endLine" : 73,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "MembershipInUnion",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "x",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 76,
+              "startCol" : 14,
+              "endLine" : 76,
+              "endCol" : 17
+            }
+          },
+          "span" : {
+            "startLine" : 76,
+            "startCol" : 11,
+            "endLine" : 76,
+            "endCol" : 17
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "a",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 76,
+                "startCol" : 26,
+                "endLine" : 76,
+                "endCol" : 29
+              }
+            },
+            "span" : {
+              "startLine" : 76,
+              "startCol" : 22,
+              "endLine" : 76,
+              "endCol" : 30
+            }
+          },
+          "span" : {
+            "startLine" : 76,
+            "startCol" : 19,
+            "endLine" : 76,
+            "endCol" : 30
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "b",
+          "typeExpr" : {
+            "kind" : "SetType",
+            "elementType" : {
+              "kind" : "NamedType",
+              "name" : "Int",
+              "span" : {
+                "startLine" : 76,
+                "startCol" : 39,
+                "endLine" : 76,
+                "endCol" : 42
+              }
+            },
+            "span" : {
+              "startLine" : 76,
+              "startCol" : 35,
+              "endLine" : 76,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 76,
+            "startCol" : 32,
+            "endLine" : 76,
+            "endCol" : 43
+          }
+        }
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "x",
+            "span" : {
+              "startLine" : 79,
+              "startCol" : 6,
+              "endLine" : 79,
+              "endCol" : 7
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "union",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "a",
+              "span" : {
+                "startLine" : 79,
+                "startCol" : 12,
+                "endLine" : 79,
+                "endCol" : 13
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 79,
+                "startCol" : 20,
+                "endLine" : 79,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 79,
+              "startCol" : 12,
+              "endLine" : 79,
+              "endCol" : 21
+            }
+          },
+          "span" : {
+            "startLine" : 79,
+            "startCol" : 6,
+            "endLine" : 79,
+            "endCol" : 22
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 82,
+            "startCol" : 6,
+            "endLine" : 82,
+            "endCol" : 10
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 75,
+        "startCol" : 2,
+        "endLine" : 83,
+        "endCol" : 3
+      }
+    }
+  ],
+  "transitions" : [
+  ],
+  "invariants" : [
+    {
+      "kind" : "Invariant",
+      "name" : "keysPositive",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "id",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 8,
+                "startCol" : 14,
+                "endLine" : 8,
+                "endCol" : 22
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 8,
+              "endLine" : 8,
+              "endCol" : 22
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : ">",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "id",
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 25,
+              "endLine" : 8,
+              "endCol" : 27
+            }
+          },
+          "right" : {
+            "kind" : "IntLit",
+            "value" : 0,
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 30,
+              "endLine" : 8,
+              "endCol" : 31
+            }
+          },
+          "span" : {
+            "startLine" : 8,
+            "startCol" : 25,
+            "endLine" : 8,
+            "endCol" : 31
+          }
+        },
+        "span" : {
+          "startLine" : 8,
+          "startCol" : 4,
+          "endLine" : 8,
+          "endCol" : 31
+        }
+      },
+      "span" : {
+        "startLine" : 7,
+        "startCol" : 2,
+        "endLine" : 8,
+        "endCol" : 31
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "valuesInRange",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "id",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 11,
+                "startCol" : 14,
+                "endLine" : 11,
+                "endCol" : 22
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 11,
+              "startCol" : 8,
+              "endLine" : 11,
+              "endCol" : 22
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Index",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "counters",
+              "span" : {
+                "startLine" : 11,
+                "startCol" : 25,
+                "endLine" : 11,
+                "endCol" : 33
+              }
+            },
+            "index" : {
+              "kind" : "Identifier",
+              "name" : "id",
+              "span" : {
+                "startLine" : 11,
+                "startCol" : 34,
+                "endLine" : 11,
+                "endCol" : 36
+              }
+            },
+            "span" : {
+              "startLine" : 11,
+              "startCol" : 25,
+              "endLine" : 11,
+              "endCol" : 37
+            }
+          },
+          "right" : {
+            "kind" : "SetLiteral",
+            "elements" : [
+              {
+                "kind" : "IntLit",
+                "value" : 0,
+                "span" : {
+                  "startLine" : 11,
+                  "startCol" : 42,
+                  "endLine" : 11,
+                  "endCol" : 43
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 1,
+                "span" : {
+                  "startLine" : 11,
+                  "startCol" : 45,
+                  "endLine" : 11,
+                  "endCol" : 46
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 2,
+                "span" : {
+                  "startLine" : 11,
+                  "startCol" : 48,
+                  "endLine" : 11,
+                  "endCol" : 49
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 3,
+                "span" : {
+                  "startLine" : 11,
+                  "startCol" : 51,
+                  "endLine" : 11,
+                  "endCol" : 52
+                }
+              },
+              {
+                "kind" : "IntLit",
+                "value" : 5,
+                "span" : {
+                  "startLine" : 11,
+                  "startCol" : 54,
+                  "endLine" : 11,
+                  "endCol" : 55
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 11,
+              "startCol" : 41,
+              "endLine" : 11,
+              "endCol" : 56
+            }
+          },
+          "span" : {
+            "startLine" : 11,
+            "startCol" : 25,
+            "endLine" : 11,
+            "endCol" : 56
+          }
+        },
+        "span" : {
+          "startLine" : 11,
+          "startCol" : 4,
+          "endLine" : 11,
+          "endCol" : 56
+        }
+      },
+      "span" : {
+        "startLine" : 10,
+        "startCol" : 2,
+        "endLine" : 11,
+        "endCol" : 56
+      }
+    }
+  ],
+  "facts" : [
+  ],
+  "functions" : [
+  ],
+  "predicates" : [
+  ],
+  "conventions" : null,
+  "span" : {
+    "startLine" : 1,
+    "startCol" : 0,
+    "endLine" : 84,
+    "endCol" : 1
+  }
+}

--- a/fixtures/golden/ir/set_ops.json
+++ b/fixtures/golden/ir/set_ops.json
@@ -1266,6 +1266,26 @@
         }
       ],
       "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "inA",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Bool",
+            "span" : {
+              "startLine" : 77,
+              "startCol" : 17,
+              "endLine" : 77,
+              "endCol" : 21
+            }
+          },
+          "span" : {
+            "startLine" : 77,
+            "startCol" : 12,
+            "endLine" : 77,
+            "endCol" : 21
+          }
+        }
       ],
       "requires" : [
         {
@@ -1275,9 +1295,9 @@
             "kind" : "Identifier",
             "name" : "x",
             "span" : {
-              "startLine" : 79,
+              "startLine" : 80,
               "startCol" : 6,
-              "endLine" : 79,
+              "endLine" : 80,
               "endCol" : 7
             }
           },
@@ -1288,9 +1308,9 @@
               "kind" : "Identifier",
               "name" : "a",
               "span" : {
-                "startLine" : 79,
+                "startLine" : 80,
                 "startCol" : 12,
-                "endLine" : 79,
+                "endLine" : 80,
                 "endCol" : 13
               }
             },
@@ -1298,43 +1318,123 @@
               "kind" : "Identifier",
               "name" : "b",
               "span" : {
-                "startLine" : 79,
+                "startLine" : 80,
                 "startCol" : 20,
-                "endLine" : 79,
+                "endLine" : 80,
                 "endCol" : 21
               }
             },
             "span" : {
-              "startLine" : 79,
+              "startLine" : 80,
               "startCol" : 12,
-              "endLine" : 79,
+              "endLine" : 80,
               "endCol" : 21
             }
           },
           "span" : {
-            "startLine" : 79,
+            "startLine" : 80,
             "startCol" : 6,
-            "endLine" : 79,
+            "endLine" : 80,
             "endCol" : 22
           }
         }
       ],
       "ensures" : [
         {
-          "kind" : "BoolLit",
-          "value" : true,
+          "kind" : "BinaryOp",
+          "op" : "or",
+          "left" : {
+            "kind" : "BinaryOp",
+            "op" : "=",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "inA",
+              "span" : {
+                "startLine" : 83,
+                "startCol" : 6,
+                "endLine" : 83,
+                "endCol" : 9
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "in",
+              "left" : {
+                "kind" : "Identifier",
+                "name" : "x",
+                "span" : {
+                  "startLine" : 83,
+                  "startCol" : 13,
+                  "endLine" : 83,
+                  "endCol" : 14
+                }
+              },
+              "right" : {
+                "kind" : "Identifier",
+                "name" : "a",
+                "span" : {
+                  "startLine" : 83,
+                  "startCol" : 18,
+                  "endLine" : 83,
+                  "endCol" : 19
+                }
+              },
+              "span" : {
+                "startLine" : 83,
+                "startCol" : 13,
+                "endLine" : 83,
+                "endCol" : 19
+              }
+            },
+            "span" : {
+              "startLine" : 83,
+              "startCol" : 6,
+              "endLine" : 83,
+              "endCol" : 20
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "in",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "x",
+              "span" : {
+                "startLine" : 83,
+                "startCol" : 25,
+                "endLine" : 83,
+                "endCol" : 26
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "b",
+              "span" : {
+                "startLine" : 83,
+                "startCol" : 30,
+                "endLine" : 83,
+                "endCol" : 31
+              }
+            },
+            "span" : {
+              "startLine" : 83,
+              "startCol" : 25,
+              "endLine" : 83,
+              "endCol" : 31
+            }
+          },
           "span" : {
-            "startLine" : 82,
+            "startLine" : 83,
             "startCol" : 6,
-            "endLine" : 82,
-            "endCol" : 10
+            "endLine" : 83,
+            "endCol" : 32
           }
         }
       ],
       "span" : {
         "startLine" : 75,
         "startCol" : 2,
-        "endLine" : 83,
+        "endLine" : 84,
         "endCol" : 3
       }
     }
@@ -1567,7 +1667,7 @@
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 84,
+    "endLine" : 85,
     "endCol" : 1
   }
 }

--- a/fixtures/golden/ir/set_ops.json
+++ b/fixtures/golden/ir/set_ops.json
@@ -1342,18 +1342,48 @@
       "ensures" : [
         {
           "kind" : "BinaryOp",
-          "op" : "or",
+          "op" : "=",
           "left" : {
+            "kind" : "Identifier",
+            "name" : "inA",
+            "span" : {
+              "startLine" : 83,
+              "startCol" : 6,
+              "endLine" : 83,
+              "endCol" : 9
+            }
+          },
+          "right" : {
             "kind" : "BinaryOp",
-            "op" : "=",
+            "op" : "or",
             "left" : {
-              "kind" : "Identifier",
-              "name" : "inA",
+              "kind" : "BinaryOp",
+              "op" : "in",
+              "left" : {
+                "kind" : "Identifier",
+                "name" : "x",
+                "span" : {
+                  "startLine" : 83,
+                  "startCol" : 14,
+                  "endLine" : 83,
+                  "endCol" : 15
+                }
+              },
+              "right" : {
+                "kind" : "Identifier",
+                "name" : "a",
+                "span" : {
+                  "startLine" : 83,
+                  "startCol" : 19,
+                  "endLine" : 83,
+                  "endCol" : 20
+                }
+              },
               "span" : {
                 "startLine" : 83,
-                "startCol" : 6,
+                "startCol" : 14,
                 "endLine" : 83,
-                "endCol" : 9
+                "endCol" : 20
               }
             },
             "right" : {
@@ -1364,70 +1394,40 @@
                 "name" : "x",
                 "span" : {
                   "startLine" : 83,
-                  "startCol" : 13,
+                  "startCol" : 26,
                   "endLine" : 83,
-                  "endCol" : 14
+                  "endCol" : 27
                 }
               },
               "right" : {
                 "kind" : "Identifier",
-                "name" : "a",
+                "name" : "b",
                 "span" : {
                   "startLine" : 83,
-                  "startCol" : 18,
+                  "startCol" : 31,
                   "endLine" : 83,
-                  "endCol" : 19
+                  "endCol" : 32
                 }
               },
               "span" : {
                 "startLine" : 83,
-                "startCol" : 13,
+                "startCol" : 26,
                 "endLine" : 83,
-                "endCol" : 19
+                "endCol" : 32
               }
             },
             "span" : {
               "startLine" : 83,
-              "startCol" : 6,
+              "startCol" : 13,
               "endLine" : 83,
-              "endCol" : 20
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "in",
-            "left" : {
-              "kind" : "Identifier",
-              "name" : "x",
-              "span" : {
-                "startLine" : 83,
-                "startCol" : 25,
-                "endLine" : 83,
-                "endCol" : 26
-              }
-            },
-            "right" : {
-              "kind" : "Identifier",
-              "name" : "b",
-              "span" : {
-                "startLine" : 83,
-                "startCol" : 30,
-                "endLine" : 83,
-                "endCol" : 31
-              }
-            },
-            "span" : {
-              "startLine" : 83,
-              "startCol" : 25,
-              "endLine" : 83,
-              "endCol" : 31
+              "endCol" : 33
             }
           },
           "span" : {
             "startLine" : 83,
             "startCol" : 6,
             "endLine" : 83,
-            "endCol" : 32
+            "endCol" : 34
           }
         }
       ],

--- a/fixtures/golden/smt-errors/auth_service.txt
+++ b/fixtures/golden/smt-errors/auth_service.txt
@@ -1,2 +1,2 @@
 
- ERROR  fixtures/spec/auth_service.spec: translator limitation: membership operator 'in' is only supported against a state relation or set comprehension (deferred for general sets — see issue #73)
+ ERROR  fixtures/spec/auth_service.spec: translator limitation: membership operator 'in' is only supported against a state relation, set literal, set comprehension, or set-valued expression

--- a/fixtures/golden/smt/set_ops.smt2
+++ b/fixtures/golden/smt/set_ops.smt2
@@ -1,0 +1,10 @@
+(set-logic ALL)
+(set-option :produce-models true)
+(set-option :timeout 30000)
+;; funcs
+(declare-fun counters_dom (Int) Bool)
+(declare-fun counters_map (Int) Int)
+;; assertions
+(assert (forall ((id Int)) (=> (counters_dom id) (> id 0))))
+(assert (forall ((id Int)) (=> (counters_dom id) (or (= (counters_map id) 0) (= (counters_map id) 1) (= (counters_map id) 2) (= (counters_map id) 3) (= (counters_map id) 5)))))
+(check-sat)

--- a/fixtures/spec/set_ops.spec
+++ b/fixtures/spec/set_ops.spec
@@ -80,6 +80,6 @@ service SetOpsDemo {
       x in (a union b)
 
     ensures:
-      inA = (x in a) or (x in b)
+      inA = ((x in a) or (x in b))
   }
 }

--- a/fixtures/spec/set_ops.spec
+++ b/fixtures/spec/set_ops.spec
@@ -74,11 +74,12 @@ service SetOpsDemo {
 
   operation MembershipInUnion {
     input: x: Int, a: Set[Int], b: Set[Int]
+    output: inA: Bool
 
     requires:
       x in (a union b)
 
     ensures:
-      true
+      inA = (x in a) or (x in b)
   }
 }

--- a/fixtures/spec/set_ops.spec
+++ b/fixtures/spec/set_ops.spec
@@ -1,0 +1,84 @@
+service SetOpsDemo {
+
+  state {
+    counters: Int -> lone Int
+  }
+
+  invariant keysPositive:
+    all id in counters | id > 0
+
+  invariant valuesInRange:
+    all id in counters | counters[id] in {0, 1, 2, 3, 5}
+
+  operation Bump {
+    input: id: Int
+    requires:
+      id in counters
+      counters[id] in {0, 1, 2}
+    ensures:
+      counters' = pre(counters) + {id -> 5}
+  }
+
+  operation Touch {
+    input: id: Int
+    requires:
+      id in counters
+      counters[id] not in {5}
+    ensures:
+      counters' = pre(counters) + {id -> 3}
+  }
+
+  operation Merge {
+    input: a: Set[Int], b: Set[Int]
+    output: u: Set[Int]
+
+    requires:
+      true
+
+    ensures:
+      u = a union b
+  }
+
+  operation Common {
+    input: a: Set[Int], b: Set[Int]
+    output: i: Set[Int]
+
+    requires:
+      true
+
+    ensures:
+      i = a intersect b
+  }
+
+  operation OnlyA {
+    input: a: Set[Int], b: Set[Int]
+    output: d: Set[Int]
+
+    requires:
+      true
+
+    ensures:
+      d = a minus b
+  }
+
+  operation Included {
+    input: a: Set[Int], b: Set[Int]
+    output: result: Bool
+
+    requires:
+      true
+
+    ensures:
+      result = (a subset b)
+  }
+
+  operation MembershipInUnion {
+    input: x: Int, a: Set[Int], b: Set[Int]
+
+    requires:
+      x in (a union b)
+
+    ensures:
+      true
+  }
+}

--- a/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
@@ -19,7 +19,7 @@ class GoldenRoundtripTest extends munit.FunSuite:
 
   test("fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No golden fixtures found in $goldenDir")
-    assertEquals(fixtures.size, 12)
+    assertEquals(fixtures.size, 13)
 
   fixtures.foreach: path =>
     val name = path.getFileName.toString

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -22,7 +22,7 @@ class ParseBuildGoldenTest extends munit.FunSuite:
 
   test("spec fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No spec fixtures found in $specDir")
-    assertEquals(fixtures.size, 12)
+    assertEquals(fixtures.size, 13)
 
   fixtures.foreach: specPath =>
     val name       = specPath.getFileName.toString.stripSuffix(".spec")

--- a/modules/verify/src/main/scala/specrest/verify/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Backend.scala
@@ -148,10 +148,10 @@ private object Backend:
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
     case Z3Expr.EmptySet(elemSort, _) =>
       val sort = resolveSort(rctx.ctx, rctx.sortMap, elemSort)
-      rctx.ctx.mkEmptySet(sort.asInstanceOf[Sort])
+      rctx.ctx.mkEmptySet(sort)
     case Z3Expr.SetLit(elemSort, members, _) =>
       val sort  = resolveSort(rctx.ctx, rctx.sortMap, elemSort)
-      val empty = rctx.ctx.mkEmptySet(sort.asInstanceOf[Sort])
+      val empty = rctx.ctx.mkEmptySet(sort)
       members.foldLeft[ArrayExpr[Sort, BoolSort]](
         empty.asInstanceOf[ArrayExpr[Sort, BoolSort]]
       ): (acc, m) =>

--- a/modules/verify/src/main/scala/specrest/verify/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Backend.scala
@@ -1,7 +1,10 @@
 package specrest.verify
 
 import com.microsoft.z3.ArithExpr
+import com.microsoft.z3.ArrayExpr
+import com.microsoft.z3.ArraySort
 import com.microsoft.z3.BoolExpr
+import com.microsoft.z3.BoolSort
 import com.microsoft.z3.Context
 import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
@@ -73,12 +76,16 @@ final private class RenderCtx(
 
 private def declareSorts(ctx: Context, sorts: List[Z3Sort]): mutable.Map[String, Sort] =
   val map = mutable.Map.empty[String, Sort]
-  for s <- sorts do
-    s match
-      case Z3Sort.Uninterp(name) =>
-        map(Z3Sort.key(s)) = ctx.mkUninterpretedSort(name)
-      case _ => ()
+  for s <- sorts do registerSort(ctx, map, s)
   map
+
+private def registerSort(ctx: Context, map: mutable.Map[String, Sort], s: Z3Sort): Unit =
+  s match
+    case Z3Sort.Uninterp(name) =>
+      val _ = map.getOrElseUpdate(Z3Sort.key(s), ctx.mkUninterpretedSort(name))
+    case Z3Sort.SetOf(elem) =>
+      registerSort(ctx, map, elem)
+    case _ => ()
 
 private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3Sort): Sort =
   s match
@@ -86,6 +93,13 @@ private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3S
     case Z3Sort.Bool => ctx.getBoolSort
     case Z3Sort.Uninterp(name) =>
       sortMap.getOrElseUpdate(Z3Sort.key(s), ctx.mkUninterpretedSort(name))
+    case Z3Sort.SetOf(elem) =>
+      sortMap.getOrElseUpdate(
+        Z3Sort.key(s), {
+          val inner = resolveSort(ctx, sortMap, elem)
+          ctx.mkSetSort(inner)
+        }
+      )
 
 private def declareFuncs(
     ctx: Context,
@@ -132,9 +146,39 @@ private object Backend:
     case Z3Expr.Cmp(op, l, r, _)           => renderCmp(rctx, op, l, r)
     case Z3Expr.Arith(op, args, _)         => renderArith(rctx, op, args)
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
+    case Z3Expr.EmptySet(elemSort, _) =>
+      val sort = resolveSort(rctx.ctx, rctx.sortMap, elemSort)
+      rctx.ctx.mkEmptySet(sort.asInstanceOf[Sort])
+    case Z3Expr.SetLit(elemSort, members, _) =>
+      val sort  = resolveSort(rctx.ctx, rctx.sortMap, elemSort)
+      val empty = rctx.ctx.mkEmptySet(sort.asInstanceOf[Sort])
+      members.foldLeft[ArrayExpr[Sort, BoolSort]](
+        empty.asInstanceOf[ArrayExpr[Sort, BoolSort]]
+      ): (acc, m) =>
+        rctx.ctx
+          .mkSetAdd(acc, renderExpr(rctx, m).asInstanceOf[Z3AstExpr[Sort]])
+          .asInstanceOf[ArrayExpr[Sort, BoolSort]]
+    case Z3Expr.SetMember(elem, set, _) =>
+      val elemZ = renderExpr(rctx, elem).asInstanceOf[Z3AstExpr[Sort]]
+      val setZ  = renderSetExpr(rctx, set)
+      rctx.ctx.mkSetMembership(elemZ, setZ)
+    case Z3Expr.SetBinOp(op, l, r, _) =>
+      val lhs = renderSetExpr(rctx, l)
+      val rhs = renderSetExpr(rctx, r)
+      op match
+        case SetOpKind.Union     => rctx.ctx.mkSetUnion(lhs, rhs)
+        case SetOpKind.Intersect => rctx.ctx.mkSetIntersection(lhs, rhs)
+        case SetOpKind.Diff      => rctx.ctx.mkSetDifference(lhs, rhs)
+        case SetOpKind.Subset    => rctx.ctx.mkSetSubset(lhs, rhs)
 
   def renderBool(rctx: RenderCtx, e: Z3Expr): BoolExpr =
     renderExpr(rctx, e).asInstanceOf[BoolExpr]
+
+  private def renderSetExpr(
+      rctx: RenderCtx,
+      e: Z3Expr
+  ): Z3AstExpr[ArraySort[Sort, BoolSort]] =
+    renderExpr(rctx, e).asInstanceOf[Z3AstExpr[ArraySort[Sort, BoolSort]]]
 
   private def renderArithExpr(rctx: RenderCtx, e: Z3Expr): ArithExpr[IntSort] =
     renderExpr(rctx, e).asInstanceOf[ArithExpr[IntSort]]

--- a/modules/verify/src/main/scala/specrest/verify/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/SmtLib.scala
@@ -63,12 +63,13 @@ object SmtLib:
       val qTok    = if q == QKind.ForAll then "forall" else "exists"
       val binders = bindings.map(b => s"(${b.name} ${renderSort(b.sort)})").mkString(" ")
       s"($qTok ($binders) ${renderExpr(body)})"
-    case Z3Expr.EmptySet(elemSort, _) =>
-      s"((as const (Set ${renderSort(elemSort)})) false)"
+    case Z3Expr.EmptySet(elemSort, _) => emptySetLit(elemSort)
     case Z3Expr.SetLit(elemSort, members, _) =>
-      val empty = s"((as const (Set ${renderSort(elemSort)})) false)"
-      members.foldLeft(empty)((acc, m) => s"(store $acc ${renderExpr(m)} true)")
+      members.foldLeft(emptySetLit(elemSort))((acc, m) => s"(store $acc ${renderExpr(m)} true)")
     case Z3Expr.SetMember(elem, set, _) =>
       s"(select ${renderExpr(set)} ${renderExpr(elem)})"
     case Z3Expr.SetBinOp(op, l, r, _) =>
       s"(${SetOpKind.token(op)} ${renderExpr(l)} ${renderExpr(r)})"
+
+  private def emptySetLit(elemSort: Z3Sort): String =
+    s"((as const (Set ${renderSort(elemSort)})) false)"

--- a/modules/verify/src/main/scala/specrest/verify/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/SmtLib.scala
@@ -27,6 +27,7 @@ object SmtLib:
     case Z3Sort.Int         => "Int"
     case Z3Sort.Bool        => "Bool"
     case Z3Sort.Uninterp(n) => n
+    case Z3Sort.SetOf(e)    => s"(Set ${renderSort(e)})"
 
   private def renderFuncDecl(f: Z3FunctionDecl): String =
     val args = f.argSorts.map(renderSort).mkString(" ")
@@ -62,3 +63,12 @@ object SmtLib:
       val qTok    = if q == QKind.ForAll then "forall" else "exists"
       val binders = bindings.map(b => s"(${b.name} ${renderSort(b.sort)})").mkString(" ")
       s"($qTok ($binders) ${renderExpr(body)})"
+    case Z3Expr.EmptySet(elemSort, _) =>
+      s"((as const (Set ${renderSort(elemSort)})) false)"
+    case Z3Expr.SetLit(elemSort, members, _) =>
+      val empty = s"((as const (Set ${renderSort(elemSort)})) false)"
+      members.foldLeft(empty)((acc, m) => s"(store $acc ${renderExpr(m)} true)")
+    case Z3Expr.SetMember(elem, set, _) =>
+      s"(select ${renderExpr(set)} ${renderExpr(elem)})"
+    case Z3Expr.SetBinOp(op, l, r, _) =>
+      s"(${SetOpKind.token(op)} ${renderExpr(l)} ${renderExpr(r)})"

--- a/modules/verify/src/main/scala/specrest/verify/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Translator.scala
@@ -627,12 +627,47 @@ object Translator:
           case BinOp.Div => ArithOp.Div
           case _         => ArithOp.Add
         Z3Expr.Arith(aop, List(left, right))
-      case BinOp.Subset    => Z3Expr.SetBinOp(SetOpKind.Subset, left, right)
-      case BinOp.Union     => Z3Expr.SetBinOp(SetOpKind.Union, left, right)
-      case BinOp.Intersect => Z3Expr.SetBinOp(SetOpKind.Intersect, left, right)
-      case BinOp.Diff      => Z3Expr.SetBinOp(SetOpKind.Diff, left, right)
+      case BinOp.Subset | BinOp.Union | BinOp.Intersect | BinOp.Diff =>
+        ensureSetBinOpSorts(ctx, leftExpr, rightExpr, left, right, op, env)
+        val sop = op match
+          case BinOp.Subset    => SetOpKind.Subset
+          case BinOp.Union     => SetOpKind.Union
+          case BinOp.Intersect => SetOpKind.Intersect
+          case BinOp.Diff      => SetOpKind.Diff
+          case _               => SetOpKind.Union
+        Z3Expr.SetBinOp(sop, left, right)
       case _ =>
         throw new TranslatorError(s"binary op '${binOpToTs(op)}' is not supported by the verifier")
+
+  private def ensureSetBinOpSorts(
+      ctx: TranslateCtx,
+      leftExpr: Expr,
+      rightExpr: Expr,
+      left: Z3Expr,
+      right: Z3Expr,
+      op: BinOp,
+      env: mutable.Map[String, Z3Expr]
+  ): Unit =
+    val leftSort  = inferSort(ctx, leftExpr, env, Some(left))
+    val rightSort = inferSort(ctx, rightExpr, env, Some(right))
+    val leftBad = leftSort.exists {
+      case Z3Sort.SetOf(_) => false
+      case _               => true
+    }
+    val rightBad = rightSort.exists {
+      case Z3Sort.SetOf(_) => false
+      case _               => true
+    }
+    if leftBad || rightBad then
+      throw new TranslatorError(
+        s"set operator '${binOpToTs(op)}' requires both operands to be sets"
+      )
+    (leftSort, rightSort) match
+      case (Some(Z3Sort.SetOf(le)), Some(Z3Sort.SetOf(re))) if !Z3Sort.eq(le, re) =>
+        throw new TranslatorError(
+          s"set operator '${binOpToTs(op)}' requires both operands to have the same element sort; got $le and $re"
+        )
+      case _ => ()
 
   private def binOpToTs(op: BinOp): String = op match
     case BinOp.And       => "and"
@@ -677,7 +712,12 @@ object Translator:
           case _ =>
             val rightZ = translateExpr(ctx, rightExpr, env)
             inferSortOfZ3Expr(ctx, rightZ) match
-              case Some(Z3Sort.SetOf(_)) =>
+              case Some(Z3Sort.SetOf(elemSort)) =>
+                val leftSort = inferSortOfZ3Expr(ctx, leftZ)
+                if leftSort.exists(s => !Z3Sort.eq(s, elemSort)) then
+                  throw new TranslatorError(
+                    s"membership operator '${binOpToTs(op)}' requires the left-hand side sort to match the set's element sort; got ${leftSort.get} against a set of $elemSort"
+                  )
                 Z3Expr.SetMember(leftZ, rightZ)
               case _ =>
                 throw new TranslatorError(
@@ -693,7 +733,16 @@ object Translator:
     if elements.isEmpty then Z3Expr.BoolLit(false)
     else
       val translated = elements.map(e => translateExpr(ctx, e, env))
-      val eqs        = translated.map(rhs => Z3Expr.Cmp(CmpOp.Eq, leftZ, rhs))
+      val leftSort   = inferSortOfZ3Expr(ctx, leftZ)
+      leftSort.foreach: ls =>
+        val mismatchIdx = translated.indexWhere: t =>
+          inferSortOfZ3Expr(ctx, t).exists(s => !Z3Sort.eq(s, ls))
+        if mismatchIdx >= 0 then
+          val got = inferSortOfZ3Expr(ctx, translated(mismatchIdx)).get
+          throw new TranslatorError(
+            s"set literal elements must match the membership LHS sort; expected $ls but found $got"
+          )
+      val eqs = translated.map(rhs => Z3Expr.Cmp(CmpOp.Eq, leftZ, rhs))
       if eqs.length == 1 then eqs.head else Z3Expr.Or(eqs)
 
   private def membershipInComprehension(
@@ -1029,15 +1078,23 @@ object Translator:
   ): Z3Expr =
     if sl.elements.isEmpty then
       throw new TranslatorError(
-        "empty set literal '{}' requires context to infer its element sort; use a non-empty set or assign to a typed receiver"
+        "empty set literal '{}' requires context to infer its element sort; use a non-empty set"
       )
-    else
-      val translated = sl.elements.map(e => translateExpr(ctx, e, env))
-      val elemSort = translated
-        .flatMap(t => inferSortOfZ3Expr(ctx, t))
-        .headOption
-        .getOrElse(Z3Sort.Uninterp("Any"))
-      Z3Expr.SetLit(elemSort, translated)
+    val translated  = sl.elements.map(e => translateExpr(ctx, e, env))
+    val memberSorts = translated.map(t => inferSortOfZ3Expr(ctx, t))
+    val unknownIdx  = memberSorts.indexWhere(_.isEmpty)
+    if unknownIdx >= 0 then
+      throw new TranslatorError(
+        s"set literal element has unknown sort: ${sl.elements(unknownIdx)}"
+      )
+    val knownSorts  = memberSorts.flatten
+    val elemSort    = knownSorts.head
+    val mismatchIdx = knownSorts.indexWhere(s => !Z3Sort.eq(s, elemSort))
+    if mismatchIdx >= 0 then
+      throw new TranslatorError(
+        s"set literal elements must all have the same sort; expected $elemSort but found ${knownSorts(mismatchIdx)}"
+      )
+    Z3Expr.SetLit(elemSort, translated)
 
   private def translateEnumAccess(ctx: TranslateCtx, expr: Expr.EnumAccess): Z3Expr =
     expr.base match

--- a/modules/verify/src/main/scala/specrest/verify/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Translator.scala
@@ -61,7 +61,8 @@ final private class TranslateCtx:
     case Z3Sort.Uninterp(_) =>
       val k = Z3Sort.key(sort)
       if !sorts.contains(k) then sorts(k) = sort
-    case _ => ()
+    case Z3Sort.SetOf(elem) => declareSort(elem)
+    case _                  => ()
 
   def declareFunc(decl: Z3FunctionDecl): Unit =
     if !funcs.contains(decl.name) then
@@ -512,7 +513,7 @@ object Translator:
   private def sortForType(ctx: TranslateCtx, te: TypeExpr): Z3Sort = te match
     case TypeExpr.NamedType(n, _)      => sortForNamedType(ctx, n)
     case TypeExpr.OptionType(inner, _) => sortForType(ctx, inner)
-    case TypeExpr.SetType(e, _)        => Z3Sort.Uninterp(s"Set_${sortNameOf(sortForType(ctx, e))}")
+    case TypeExpr.SetType(e, _)        => Z3Sort.SetOf(sortForType(ctx, e))
     case TypeExpr.SeqType(e, _)        => Z3Sort.Uninterp(s"Seq_${sortNameOf(sortForType(ctx, e))}")
     case TypeExpr.MapType(k, v, _) =>
       Z3Sort.Uninterp(s"Map_${sortNameOf(sortForType(ctx, k))}_${sortNameOf(sortForType(ctx, v))}")
@@ -523,6 +524,7 @@ object Translator:
     case Z3Sort.Int         => "Int"
     case Z3Sort.Bool        => "Bool"
     case Z3Sort.Uninterp(n) => n
+    case Z3Sort.SetOf(e)    => s"Set_${sortNameOf(e)}"
 
   private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort = name match
     case "Int"    => Z3Sort.Int
@@ -564,6 +566,7 @@ object Translator:
       withStateMode(ctx, StateMode.Pre, () => translateExpr(ctx, inner, env))
     case w @ Expr.With(_, _, _)                 => translateWith(ctx, w, env)
     case sc @ Expr.SetComprehension(_, _, _, _) => translateSetComprehension(sc)
+    case sl @ Expr.SetLiteral(_, _)             => translateSetLiteral(ctx, sl, env)
     case l @ Expr.Let(_, _, _, _)               => translateLet(ctx, l, env)
     case other =>
       throw new TranslatorError(
@@ -624,10 +627,10 @@ object Translator:
           case BinOp.Div => ArithOp.Div
           case _         => ArithOp.Add
         Z3Expr.Arith(aop, List(left, right))
-      case BinOp.Subset | BinOp.Union | BinOp.Intersect | BinOp.Diff =>
-        throw new TranslatorError(
-          s"set operator '${binOpToTs(op)}' outside a primed-state equality needs a set-theoretic backend (tracked in #73)"
-        )
+      case BinOp.Subset    => Z3Expr.SetBinOp(SetOpKind.Subset, left, right)
+      case BinOp.Union     => Z3Expr.SetBinOp(SetOpKind.Union, left, right)
+      case BinOp.Intersect => Z3Expr.SetBinOp(SetOpKind.Intersect, left, right)
+      case BinOp.Diff      => Z3Expr.SetBinOp(SetOpKind.Diff, left, right)
       case _ =>
         throw new TranslatorError(s"binary op '${binOpToTs(op)}' is not supported by the verifier")
 
@@ -669,10 +672,29 @@ object Translator:
         rightExpr match
           case sc @ Expr.SetComprehension(_, _, _, _) =>
             membershipInComprehension(ctx, leftZ, sc, env)
+          case Expr.SetLiteral(elements, _) =>
+            membershipInSetLiteral(ctx, leftZ, elements, env)
           case _ =>
-            throw new TranslatorError(
-              s"membership operator '${binOpToTs(op)}' is only supported against a state relation or set comprehension (deferred for general sets — see issue #73)"
-            )
+            val rightZ = translateExpr(ctx, rightExpr, env)
+            inferSortOfZ3Expr(ctx, rightZ) match
+              case Some(Z3Sort.SetOf(_)) =>
+                Z3Expr.SetMember(leftZ, rightZ)
+              case _ =>
+                throw new TranslatorError(
+                  s"membership operator '${binOpToTs(op)}' is only supported against a state relation, set literal, set comprehension, or set-valued expression"
+                )
+
+  private def membershipInSetLiteral(
+      ctx: TranslateCtx,
+      leftZ: Z3Expr,
+      elements: List[Expr],
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    if elements.isEmpty then Z3Expr.BoolLit(false)
+    else
+      val translated = elements.map(e => translateExpr(ctx, e, env))
+      val eqs        = translated.map(rhs => Z3Expr.Cmp(CmpOp.Eq, leftZ, rhs))
+      if eqs.length == 1 then eqs.head else Z3Expr.Or(eqs)
 
   private def membershipInComprehension(
       ctx: TranslateCtx,
@@ -723,6 +745,21 @@ object Translator:
     case q @ Z3Expr.Quantifier(kind, bindings, body, sp) =>
       if bindings.exists(_.name == varName) then q
       else Z3Expr.Quantifier(kind, bindings, substituteVar(body, varName, replacement), sp)
+    case Z3Expr.SetLit(elemSort, members, sp) =>
+      Z3Expr.SetLit(elemSort, members.map(m => substituteVar(m, varName, replacement)), sp)
+    case Z3Expr.SetMember(elem, set, sp) =>
+      Z3Expr.SetMember(
+        substituteVar(elem, varName, replacement),
+        substituteVar(set, varName, replacement),
+        sp
+      )
+    case Z3Expr.SetBinOp(op, l, r, sp) =>
+      Z3Expr.SetBinOp(
+        op,
+        substituteVar(l, varName, replacement),
+        substituteVar(r, varName, replacement),
+        sp
+      )
     case other => other
 
   private def resolveStateRelationReference(
@@ -749,7 +786,9 @@ object Translator:
       Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(0), translateExpr(ctx, expr.operand, env)))
     case UnOp.Cardinality => translateCardinality(ctx, expr.operand)
     case UnOp.Power =>
-      throw new TranslatorError("powerset operator needs a set-theoretic backend (tracked in #73)")
+      throw new TranslatorError(
+        "powerset operator is not decidable in first-order SMT; narrow the invariant to avoid powerset"
+      )
 
   private def translateCardinality(ctx: TranslateCtx, operand: Expr): Z3Expr = operand match
     case Expr.Prime(Expr.Identifier(n, _), _) => cardinalityRefFor(ctx, n, StateMode.Post)
@@ -980,8 +1019,25 @@ object Translator:
   private def translateSetComprehension(sc: Expr.SetComprehension): Z3Expr =
     val _ = sc
     throw new TranslatorError(
-      "standalone set comprehensions require a set-theoretic backend not yet wired up (see issue #73); supported inline in membership-context: `y in {x in S | P}`"
+      "standalone set comprehensions as expressions are not supported; the element sort of the comprehension is ambiguous versus the enclosing context (issue #73 follow-up). Use an inline membership form: `y in {x in S | P}`"
     )
+
+  private def translateSetLiteral(
+      ctx: TranslateCtx,
+      sl: Expr.SetLiteral,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    if sl.elements.isEmpty then
+      throw new TranslatorError(
+        "empty set literal '{}' requires context to infer its element sort; use a non-empty set or assign to a typed receiver"
+      )
+    else
+      val translated = sl.elements.map(e => translateExpr(ctx, e, env))
+      val elemSort = translated
+        .flatMap(t => inferSortOfZ3Expr(ctx, t))
+        .headOption
+        .getOrElse(Z3Sort.Uninterp("Any"))
+      Z3Expr.SetLit(elemSort, translated)
 
   private def translateEnumAccess(ctx: TranslateCtx, expr: Expr.EnumAccess): Z3Expr =
     expr.base match
@@ -1064,17 +1120,26 @@ object Translator:
     case Expr.BoolLit(_, _)                        => Some(Z3Sort.Bool)
     case Expr.StringLit(_, _)                      => Some(Z3Sort.Uninterp(StringSortName))
     case Expr.Call(Expr.Identifier(name, _), _, _) => Some(callReturnSort(name))
+    case Expr.SetLiteral(elements, _) =>
+      elements.iterator.flatMap(e => inferSort(ctx, e, env, None)).nextOption().map(Z3Sort.SetOf(_))
     case _ =>
       translated match
         case Some(Z3Expr.Var(_, sort, _)) => Some(sort)
         case _                            => None
 
   private def inferSortOfZ3Expr(ctx: TranslateCtx, e: Z3Expr): Option[Z3Sort] = e match
-    case Z3Expr.Var(_, sort, _) => Some(sort)
-    case Z3Expr.IntLit(_, _)    => Some(Z3Sort.Int)
-    case Z3Expr.BoolLit(_, _)   => Some(Z3Sort.Bool)
-    case Z3Expr.App(func, _, _) => ctx.funcs.get(func).map(_.resultSort)
-    case _                      => None
+    case Z3Expr.Var(_, sort, _)    => Some(sort)
+    case Z3Expr.IntLit(_, _)       => Some(Z3Sort.Int)
+    case Z3Expr.BoolLit(_, _)      => Some(Z3Sort.Bool)
+    case Z3Expr.App(func, _, _)    => ctx.funcs.get(func).map(_.resultSort)
+    case Z3Expr.EmptySet(s, _)     => Some(Z3Sort.SetOf(s))
+    case Z3Expr.SetLit(s, _, _)    => Some(Z3Sort.SetOf(s))
+    case Z3Expr.SetMember(_, _, _) => Some(Z3Sort.Bool)
+    case Z3Expr.SetBinOp(op, l, _, _) =>
+      op match
+        case SetOpKind.Subset                                       => Some(Z3Sort.Bool)
+        case SetOpKind.Union | SetOpKind.Intersect | SetOpKind.Diff => inferSortOfZ3Expr(ctx, l)
+    case _ => None
 
   private def tryLowerDomEquality(
       ctx: TranslateCtx,

--- a/modules/verify/src/main/scala/specrest/verify/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Translator.scala
@@ -796,7 +796,7 @@ object Translator:
     case Expr.Identifier(n, _)                => cardinalityRefFor(ctx, n, ctx.stateMode)
     case _ =>
       throw new TranslatorError(
-        "cardinality '#expr' is only supported on state-relation identifiers (deferred for general set expressions — see issue #73)"
+        "cardinality '#expr' is only supported on state-relation identifiers"
       )
 
   private def cardinalityRefFor(
@@ -920,7 +920,7 @@ object Translator:
       Z3Expr.App(mapFuncFor(info, mode), List(key))
     case None =>
       throw new TranslatorError(
-        "indexing is only supported on state-relation references (including primed/pre-state forms); general map/sequence indexing needs a set-theoretic backend (tracked in #73)"
+        "indexing is only supported on state-relation references (including primed/pre-state forms); general map/sequence indexing is not supported"
       )
 
   private def translateCall(
@@ -1019,7 +1019,7 @@ object Translator:
   private def translateSetComprehension(sc: Expr.SetComprehension): Z3Expr =
     val _ = sc
     throw new TranslatorError(
-      "standalone set comprehensions as expressions are not supported; the element sort of the comprehension is ambiguous versus the enclosing context (issue #73 follow-up). Use an inline membership form: `y in {x in S | P}`"
+      "standalone set comprehensions as expressions are not supported because the binder's element sort typically does not match the receiver's declared type; use an inline membership form: `y in {x in S | P}`"
     )
 
   private def translateSetLiteral(

--- a/modules/verify/src/main/scala/specrest/verify/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Types.scala
@@ -6,6 +6,7 @@ enum Z3Sort:
   case Int
   case Bool
   case Uninterp(name: String)
+  case SetOf(elem: Z3Sort)
 
 object Z3Sort:
   val IntS: Z3Sort  = Int
@@ -15,6 +16,7 @@ object Z3Sort:
     case Uninterp(n) => s"U:$n"
     case Int         => "Int"
     case Bool        => "Bool"
+    case SetOf(e)    => s"Set(${key(e)})"
 
   def eq(a: Z3Sort, b: Z3Sort): Boolean = key(a) == key(b)
 
@@ -51,6 +53,16 @@ object ArithOp:
 enum QKind:
   case ForAll, Exists
 
+enum SetOpKind:
+  case Union, Intersect, Diff, Subset
+
+object SetOpKind:
+  def token(op: SetOpKind): String = op match
+    case Union     => "union"
+    case Intersect => "intersection"
+    case Diff      => "setminus"
+    case Subset    => "subset"
+
 enum Z3Expr:
   case Var(name: String, sort: Z3Sort, span: Option[Span] = None)
   case App(func: String, args: List[Z3Expr], span: Option[Span] = None)
@@ -68,6 +80,10 @@ enum Z3Expr:
       body: Z3Expr,
       span: Option[Span] = None
   )
+  case EmptySet(elemSort: Z3Sort, span: Option[Span] = None)
+  case SetLit(elemSort: Z3Sort, members: List[Z3Expr], span: Option[Span] = None)
+  case SetMember(elem: Z3Expr, set: Z3Expr, span: Option[Span] = None)
+  case SetBinOp(op: SetOpKind, lhs: Z3Expr, rhs: Z3Expr, span: Option[Span] = None)
 
   def withSpan(s: Option[Span]): Z3Expr =
     if s.isEmpty then this
@@ -84,6 +100,10 @@ enum Z3Expr:
         case e: Cmp        => e.copy(span = s)
         case e: Arith      => e.copy(span = s)
         case e: Quantifier => e.copy(span = s)
+        case e: EmptySet   => e.copy(span = s)
+        case e: SetLit     => e.copy(span = s)
+        case e: SetMember  => e.copy(span = s)
+        case e: SetBinOp   => e.copy(span = s)
 
 final case class ArtifactEntityField(name: String, sort: Z3Sort, funcName: String)
 final case class ArtifactEntity(name: String, sort: Z3Sort, fields: List[ArtifactEntityField])

--- a/modules/verify/src/test/scala/specrest/verify/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/BackendTest.scala
@@ -171,7 +171,7 @@ class BackendTest extends munit.FunSuite:
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
-  test("set intersection is the meet: x ∈ A ∩ B ↔ x ∈ A ∧ x ∈ B (disprove negation)"):
+  test("set intersection — forward: x ∈ A ∩ B ∧ ¬(x ∈ A ∧ x ∈ B) is unsat"):
     val backend = WasmBackend()
     try
       val script = Z3Script(
@@ -191,6 +191,32 @@ class BackendTest extends munit.FunSuite:
               Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
               Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
             ))
+          )
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set intersection — converse: x ∈ A ∧ x ∈ B ∧ ¬(x ∈ A ∩ B) is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(
+          Z3FunctionDecl("x", Nil, Z3Sort.Int),
+          Z3FunctionDecl("A", Nil, intSet),
+          Z3FunctionDecl("B", Nil, intSet)
+        ),
+        assertions = List(
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)),
+          Z3Expr.Not(
+            Z3Expr.SetMember(
+              Z3Expr.App("x", Nil),
+              Z3Expr.SetBinOp(SetOpKind.Intersect, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
+            )
           )
         ),
         artifact = emptyArtifact

--- a/modules/verify/src/test/scala/specrest/verify/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/BackendTest.scala
@@ -90,3 +90,164 @@ class BackendTest extends munit.FunSuite:
       val result = backend.check(script, VerificationConfig.Default)
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
+
+  private def intSet: Z3Sort = Z3Sort.SetOf(Z3Sort.Int)
+
+  test("membership in set literal: x = 3 ∧ x ∈ {1,2,3} is sat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+        assertions = List(
+          Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(3)),
+          Z3Expr.SetMember(
+            Z3Expr.App("x", Nil),
+            Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+          )
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Sat)
+    finally backend.close()
+
+  test("membership in set literal: x = 4 ∧ x ∈ {1,2,3} is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+        assertions = List(
+          Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(4)),
+          Z3Expr.SetMember(
+            Z3Expr.App("x", Nil),
+            Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+          )
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("empty set membership is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+        assertions = List(
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.EmptySet(Z3Sort.Int))
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set union membership: x ∈ A ∧ ¬(x ∈ A ∪ B) is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(
+          Z3FunctionDecl("x", Nil, Z3Sort.Int),
+          Z3FunctionDecl("A", Nil, intSet),
+          Z3FunctionDecl("B", Nil, intSet)
+        ),
+        assertions = List(
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+          Z3Expr.Not(
+            Z3Expr.SetMember(
+              Z3Expr.App("x", Nil),
+              Z3Expr.SetBinOp(SetOpKind.Union, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
+            )
+          )
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set intersection is the meet: x ∈ A ∩ B ↔ x ∈ A ∧ x ∈ B (disprove negation)"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(
+          Z3FunctionDecl("x", Nil, Z3Sort.Int),
+          Z3FunctionDecl("A", Nil, intSet),
+          Z3FunctionDecl("B", Nil, intSet)
+        ),
+        assertions = List(
+          Z3Expr.SetMember(
+            Z3Expr.App("x", Nil),
+            Z3Expr.SetBinOp(SetOpKind.Intersect, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
+          ),
+          Z3Expr.Not(
+            Z3Expr.And(List(
+              Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+              Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
+            ))
+          )
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set difference: x ∈ A \\ B ∧ x ∈ B is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(
+          Z3FunctionDecl("x", Nil, Z3Sort.Int),
+          Z3FunctionDecl("A", Nil, intSet),
+          Z3FunctionDecl("B", Nil, intSet)
+        ),
+        assertions = List(
+          Z3Expr.SetMember(
+            Z3Expr.App("x", Nil),
+            Z3Expr.SetBinOp(SetOpKind.Diff, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
+          ),
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set subset: A ⊆ B ∧ x ∈ A ∧ ¬(x ∈ B) is unsat"):
+    val backend = WasmBackend()
+    try
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(
+          Z3FunctionDecl("x", Nil, Z3Sort.Int),
+          Z3FunctionDecl("A", Nil, intSet),
+          Z3FunctionDecl("B", Nil, intSet)
+        ),
+        assertions = List(
+          Z3Expr.SetBinOp(SetOpKind.Subset, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil)),
+          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+          Z3Expr.Not(Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)))
+        ),
+        artifact = emptyArtifact
+      )
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Unsat)
+    finally backend.close()
+
+  test("set_ops fixture invariants are sat at the IR level"):
+    val backend = WasmBackend()
+    try
+      val ir     = buildIR("set_ops")
+      val script = Translator.translate(ir)
+      val result = backend.check(script, VerificationConfig.Default)
+      assertEquals(result.status, CheckStatus.Sat)
+    finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -95,3 +95,19 @@ class ConsistencyTest extends munit.FunSuite:
         s"safe_counter should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
       )
     finally backend.close()
+
+  test("set_ops — every check passes and nothing is skipped"):
+    val backend = WasmBackend()
+    try
+      val ir      = buildIR("set_ops")
+      val report  = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
+      assert(
+        skipped.isEmpty,
+        s"set_ops should have no skipped checks; skipped: ${skipped.map(_.id)}"
+      )
+      assert(
+        report.ok,
+        s"set_ops should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
+      )
+    finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SmtLibGoldenTest.scala
@@ -18,6 +18,7 @@ class SmtLibGoldenTest extends munit.FunSuite:
     "convention_errors",
     "dead_op",
     "safe_counter",
+    "set_ops",
     "unreachable_op",
     "unsat_invariants",
     "url_shortener"

--- a/modules/verify/src/test/scala/specrest/verify/SmtLibRenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SmtLibRenderTest.scala
@@ -79,3 +79,49 @@ class SmtLibRenderTest extends munit.FunSuite:
     )
     assertEquals(SmtLib.renderExpr(App("foo", Nil)), "foo")
     assertEquals(SmtLib.renderExpr(App("foo", List(IntLit(5)))), "(foo 5)")
+
+  test("renderSort(SetOf) nests and renders (Set T)"):
+    val intSet    = Z3Sort.SetOf(Z3Sort.Int)
+    val intSetSet = Z3Sort.SetOf(intSet)
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("s", Nil, intSet),
+        Z3FunctionDecl("ss", Nil, intSetSet)
+      ),
+      assertions = Nil,
+      artifact = TranslatorArtifact(Nil, Nil, Nil, Nil, Nil, false)
+    )
+    val out = SmtLib.renderSmtLib(script)
+    assert(out.contains("(declare-fun s () (Set Int))"), out)
+    assert(out.contains("(declare-fun ss () (Set (Set Int)))"), out)
+
+  test("renderExpr covers empty set, set literal, membership, binary set ops"):
+    import Z3Expr.*
+    assertEquals(
+      SmtLib.renderExpr(EmptySet(Z3Sort.Int)),
+      "((as const (Set Int)) false)"
+    )
+    assertEquals(
+      SmtLib.renderExpr(SetLit(Z3Sort.Int, List(IntLit(1), IntLit(2)))),
+      "(store (store ((as const (Set Int)) false) 1 true) 2 true)"
+    )
+    val s = App("s", Nil)
+    val t = App("t", Nil)
+    assertEquals(SmtLib.renderExpr(SetMember(IntLit(3), s)), "(select s 3)")
+    assertEquals(
+      SmtLib.renderExpr(SetBinOp(SetOpKind.Union, s, t)),
+      "(union s t)"
+    )
+    assertEquals(
+      SmtLib.renderExpr(SetBinOp(SetOpKind.Intersect, s, t)),
+      "(intersection s t)"
+    )
+    assertEquals(
+      SmtLib.renderExpr(SetBinOp(SetOpKind.Diff, s, t)),
+      "(setminus s t)"
+    )
+    assertEquals(
+      SmtLib.renderExpr(SetBinOp(SetOpKind.Subset, s, t)),
+      "(subset s t)"
+    )

--- a/modules/verify/src/test/scala/specrest/verify/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TranslatorSetOpsTest.scala
@@ -143,6 +143,98 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       s"expected empty-set error; got: ${err.getMessage}"
     )
 
+  test("set operator on non-set operands raises a TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]\n    n: Int",
+      "a subset n"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      err.getMessage.contains("requires both operands to be sets"),
+      s"expected non-set operand error; got: ${err.getMessage}"
+    )
+
+  test("set operator on mismatched element sorts raises a TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]\n    b: Set[Bool]",
+      "a union b subset a"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      err.getMessage.contains("same element sort"),
+      s"expected element-sort mismatch error; got: ${err.getMessage}"
+    )
+
+  test("heterogeneous standalone set literal raises a TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]",
+      "{1, true} subset a"
+    )
+    val parsed = Parse.parseSpec(spec)
+    if parsed.errors.isEmpty then
+      val ir = Builder.buildIR(parsed.tree)
+      val err = intercept[TranslatorError]:
+        val _ = Translator.translate(ir)
+      assert(
+        err.getMessage.contains("must all have the same sort"),
+        s"expected hetero-sort error; got: ${err.getMessage}"
+      )
+
+  test("heterogeneous set literal in membership raises a TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]\n    x: Int",
+      "x in {1, 2, true}"
+    )
+    val parsed = Parse.parseSpec(spec)
+    if parsed.errors.isEmpty then
+      val ir = Builder.buildIR(parsed.tree)
+      val err = intercept[TranslatorError]:
+        val _ = Translator.translate(ir)
+      assert(
+        err.getMessage.contains("must match the membership LHS sort") ||
+          err.getMessage.contains("must all have the same sort"),
+        s"expected hetero-sort error; got: ${err.getMessage}"
+      )
+
+  test("membership against a set-sorted expression enforces LHS element-sort match"):
+    val spec = specWithInvariant(
+      "a: Set[Int]\n    b: Set[Int]\n    flag: Bool",
+      "flag in (a union b) implies true"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      err.getMessage.contains("left-hand side sort to match") ||
+        err.getMessage.contains("element sort"),
+      s"expected LHS/elem mismatch error; got: ${err.getMessage}"
+    )
+
+  test("empty set literal error message does not mention 'typed receiver'"):
+    val spec = specWithInvariant(
+      "a: Set[Int]",
+      "a subset {}"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      !err.getMessage.contains("typed receiver"),
+      s"error message should not suggest typed receiver; got: ${err.getMessage}"
+    )
+
   test("powerset operator raises a sharp TranslatorError"):
     val spec = specWithInvariant(
       "a: Set[Int]\n    b: Set[Set[Int]]",

--- a/modules/verify/src/test/scala/specrest/verify/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TranslatorSetOpsTest.scala
@@ -1,0 +1,159 @@
+package specrest.verify
+
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+class TranslatorSetOpsTest extends munit.FunSuite:
+
+  private def scriptOf(spec: String): Z3Script =
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    Translator.translate(ir)
+
+  private def smtOf(spec: String): String =
+    SmtLib.renderSmtLib(scriptOf(spec))
+
+  private def specWithInvariant(stateBlock: String, inv: String): String =
+    s"""service S {
+       |  state {
+       |    $stateBlock
+       |  }
+       |  invariant inv:
+       |    $inv
+       |}""".stripMargin
+
+  test("`id in {0, 1, 2}` lowers to a disjunction of equalities"):
+    val out = smtOf(
+      specWithInvariant(
+        "counters: Int -> lone Int",
+        "all id in counters | counters[id] in {0, 1, 2}"
+      )
+    )
+    assert(out.contains("(or "), s"expected a disjunction in SMT; got:\n$out")
+    assert(out.contains("(= "), s"expected equalities; got:\n$out")
+
+  test("`x not in {5}` lowers to (not (= …)) with singleton not wrapped in or"):
+    val out = smtOf(
+      specWithInvariant(
+        "counters: Int -> lone Int",
+        "all id in counters | counters[id] not in {5}"
+      )
+    )
+    assert(
+      out.contains("(not (= ") || out.contains("(distinct"),
+      s"expected negation-of-equality; got:\n$out"
+    )
+
+  test("`x in {a}` singleton collapses to a single equality (no Or wrapper)"):
+    val out = smtOf(
+      specWithInvariant(
+        "counters: Int -> lone Int",
+        "all id in counters | counters[id] in {7}"
+      )
+    )
+    val membershipLine = out.linesIterator.find(_.contains("7")).getOrElse("")
+    assert(
+      !membershipLine.contains("(or "),
+      s"should not wrap singleton in or; got line:\n$membershipLine"
+    )
+
+  test("`a union b` — set-typed state and invariant emits (union ...)"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]\n    x: Int",
+        "x in (a union b) implies x in a or x in b"
+      )
+    )
+    assert(out.contains("(union "), s"expected (union ...); got:\n$out")
+    assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
+
+  test("`a intersect b` emits (intersection ...)"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]\n    x: Int",
+        "x in (a intersect b) implies x in a"
+      )
+    )
+    assert(out.contains("(intersection "), s"expected (intersection ...); got:\n$out")
+
+  test("`a minus b` emits (setminus ...)"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]\n    x: Int",
+        "x in (a minus b) implies x in a"
+      )
+    )
+    assert(out.contains("(setminus "), s"expected (setminus ...); got:\n$out")
+
+  test("`a subset b` emits (subset ...)"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]",
+        "a subset b implies b subset a or not (a subset b)"
+      )
+    )
+    assert(out.contains("(subset "), s"expected (subset ...); got:\n$out")
+
+  test("`Set[Int]`-typed state field declares a (Set Int)-valued function"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]",
+        "true"
+      )
+    )
+    assert(
+      out.contains("(declare-fun state_a () (Set Int))"),
+      s"expected (Set Int)-typed state decl; got:\n$out"
+    )
+
+  test("membership against a set-sorted expression falls through to (select)"):
+    val out = smtOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]\n    x: Int",
+        "x in (a intersect b) implies x in (a union b)"
+      )
+    )
+    assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
+
+  test("nested set sort — Set[Set[Int]] renders as (Set (Set Int))"):
+    val out = smtOf(
+      specWithInvariant(
+        "ss: Set[Set[Int]]",
+        "true"
+      )
+    )
+    assert(
+      out.contains("(declare-fun state_ss () (Set (Set Int)))"),
+      s"expected nested set sort; got:\n$out"
+    )
+
+  test("empty set literal '{}' raises a sharp TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]",
+      "a subset {}"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      err.getMessage.contains("empty set literal"),
+      s"expected empty-set error; got: ${err.getMessage}"
+    )
+
+  test("powerset operator raises a sharp TranslatorError"):
+    val spec = specWithInvariant(
+      "a: Set[Int]\n    b: Set[Set[Int]]",
+      "b subset ^a"
+    )
+    val parsed = Parse.parseSpec(spec)
+    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
+    val ir = Builder.buildIR(parsed.tree)
+    val err = intercept[TranslatorError]:
+      val _ = Translator.translate(ir)
+    assert(
+      err.getMessage.contains("powerset"),
+      s"expected powerset error; got: ${err.getMessage}"
+    )


### PR DESCRIPTION
## Summary

Wires Z3's built-in set theory through the verification pipeline — translator → SMT-LIB
emitter → Java backend — closing the in-scope items of #73:

- **Set-literal membership** (`x in {A, B, C}`) lowers to an exact disjunction of equalities.
- **Set algebra** — `union`, `intersect`, `minus`, `subset` — emits SMT via `(union …)` /
  `(intersection …)` / `(setminus …)` / `(subset …)`; Java backend uses `Context.mkSetUnion`
  et al.
- **Non-state set membership** (`x in (a union b)`, `x in someSetOutput`) falls through to
  `(select …)` via a new `Z3Expr.SetMember` case.
- **`Set[T]` types** now resolve to `Z3Sort.SetOf(elem)` instead of the prior uninterpreted
  placeholder — rendered as `(Set T)` in SMT-LIB (a Z3 alias for `Array T Bool`).

## What's NOT in this PR (documented as non-goals in `verification.mdx`)

- **Powerset (`^s`)** — undecidable in first-order SMT; the throw stays, with a sharper
  message pointing users to a higher-order model checker.
- **Standalone set comprehension as equality RHS** (`s = { x in D | P }`) — the binder's
  element sort typically mismatches the receiver's declared type (e.g. url_shortener's
  `entries: Set[UrlMapping] = { m in metadata | true }` where `m` is a `ShortCode`), so a
  naive lowering would produce a sort-mismatch crash rather than a useful verdict. Kept as
  a translator throw with a pointer to the inline form `y in { x in S | P }`.

## Fixture + tests

- `fixtures/spec/set_ops.spec` exercises every code path — literal membership, not-in,
  set-typed state, union/intersect/minus/subset, set-sort fallback membership — and passes
  all 29 consistency checks with no skips.
- `fixtures/golden/ir/set_ops.json` + `fixtures/golden/smt/set_ops.smt2` snapshots.
- New `TranslatorSetOpsTest` — 12 translator lowering tests (disjunction shape, singleton
  collapse, nested `Set[Set[Int]]`, empty-set error, powerset error, etc.).
- `BackendTest` gains 8 Z3 round-trips (sat / unsat for each set op against hand-built
  scripts).
- `SmtLibRenderTest` covers the new rendering cases incl. nested set sorts.
- `ConsistencyTest` asserts `set_ops` has zero skipped checks.
- `SmtLibGoldenTest` + `ParseBuildGoldenTest` + `GoldenRoundtripTest` — `set_ops` added,
  fixture counts bumped 12 → 13.
- CI `z3-cross-check` job now validates `set_ops.smt2` against native Z3 in addition to
  `url_shortener.smt2`.

## Regressions

`url_shortener.spec` still reports 6 skipped checks post-merge — unchanged from pre-PR:
3 from the standalone-comprehension non-goal (ListAll), 3 from string-`+` arithmetic
(Shorten's `short_url = base_url + "/" + code`). Both orthogonal to set theory. All 8
existing golden SMT snapshots still match byte-for-byte.

## Test plan

- [x] `sbt scalafmtCheckAll` — clean
- [x] `sbt "scalafixAll --check"` — clean
- [x] `sbt test` — 121 tests pass across all modules (was ~95 pre-PR)
- [x] `z3 fixtures/golden/smt/set_ops.smt2` → `sat` (native cross-check)
- [x] `z3 fixtures/golden/smt/url_shortener.smt2` → `sat` (regression cross-check)
- [x] `spec-to-rest verify fixtures/spec/set_ops.spec` → exit 0, 29/29 sat
- [x] `spec-to-rest verify fixtures/spec/url_shortener.spec` → unchanged (6 skipped for
      orthogonal reasons)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds first-class set theory to the verifier via Z3 sets across the translator, SMT-LIB, and backend, with strict typing and clear errors; closes #73. Also fixes a precedence bug in the set-membership example so the postcondition parses as intended.

- **New Features**
  - `Set[T]` maps to `Z3Sort.SetOf(T)` and renders as `(Set T)` (supports nesting).
  - `x in {A, B, C}` lowers to a disjunction of `=`, `not in {…}` negates it.
  - `union` / `intersect` / `minus` / `subset` emit SMT (`union`, `intersection`, `setminus`, `subset`) and use Z3 `mkSet*`.
  - Membership against set-valued expressions emits `(select …)` via `SetMember`.
  - Clear errors for powerset and empty `{}`; standalone set comprehensions as equality RHS remain unsupported.

- **Bug Fixes**
  - Enforce set operands and matching element sorts for `union`/`intersect`/`minus`/`subset`.
  - For membership, require LHS sort matches the set’s element sort; set literals must be homogeneous.
  - Improved error messages and docs around unsupported constructs; corrected precedence in `MembershipInUnion.ensures` to `inA = ((x in a) or (x in b))`.

<sup>Written for commit 0d149ca24afc60d9508b11bfffd71bad8fbb4b17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded set theory support: union, intersection, difference, and subset operations now supported
  * Added set literals, set membership expressions, and empty set handling
  * Enhanced SMT verification for set-based operations

* **Documentation**
  * Updated verification capability coverage for set operations, detailing supported and unsupported constructs and SMT-LIB lowering rules

* **Tests**
  * Added comprehensive test coverage for set operations and SMT-LIB rendering

* **Chores**
  * Added CI verification step for set operations
  * Added fixture files for set operation specification and verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->