### PR TITLE
verify: machine-readable --json / --json-out diagnostics (closes #79)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -258,7 +258,7 @@ verbose   …
 | `--dump-smt`            |   false | Emit SMT-LIB to stdout and exit without running the solver.   |
 | `--dump-smt-out <file>` |       — | Write SMT-LIB to `<file>` and exit without running the solver.|
 | `--json`                |   false | Emit machine-readable JSON report to stdout (suppresses text).|
-| `--json-out <file>`     |       — | Write JSON report to `<file>`.                                |
+| `--json-out <file>`     |       — | Write machine-readable JSON report to `<file>` (suppresses text). |
 | `-v, --verbose`         |   false | Print stage timing and per-check timing / status.             |
 
 ### Exit codes
@@ -301,6 +301,9 @@ JSON) and `--dump-vc <dir>` (VC artifacts go to the dir, JSON to stdout/file).
 
 Exit codes are **identical** to text mode (`0` pass, `1` violation, `2` translator gap, `3`
 backend error) — the JSON complements the exit signal rather than replacing it.
+
+Combining `--json` / `--json-out` with `--dump-smt` / `--dump-alloy` is rejected with a clear
+error: the dump flags short-circuit before any checks run, so there is no report to serialize.
 
 ### Top-level schema
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -37,7 +37,7 @@ CLI output so the attribution is visible.
 | Counterexample-driven diagnostics (spans, entity/state decoding)    | shipped |
 | Category-based error reporting + per-category suggestion hints      | shipped |
 | Verify-as-gate (refuse codegen on failed verification)              | [#78](https://github.com/HardMax71/spec_to_rest/issues/78) (blocks on `compile` CLI) |
-| Machine-readable (`--json`) diagnostics output                      | [#79](https://github.com/HardMax71/spec_to_rest/issues/79) |
+| Machine-readable (`--json` / `--json-out`) diagnostics output       | shipped |
 | Richer suggested-fix templates                                      | [#80](https://github.com/HardMax71/spec_to_rest/issues/80) |
 | Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
@@ -257,6 +257,8 @@ verbose   …
 | `--timeout <ms>`        |   30000 | Per-check timeout. `0` disables the timeout (Z3 default).     |
 | `--dump-smt`            |   false | Emit SMT-LIB to stdout and exit without running the solver.   |
 | `--dump-smt-out <file>` |       — | Write SMT-LIB to `<file>` and exit without running the solver.|
+| `--json`                |   false | Emit machine-readable JSON report to stdout (suppresses text).|
+| `--json-out <file>`     |       — | Write JSON report to `<file>`.                                |
 | `-v, --verbose`         |   false | Print stage timing and per-check timing / status.             |
 
 ### Exit codes
@@ -289,6 +291,98 @@ sat
 CI runs exactly this cross-check against the checked-in
 `fixtures/golden/smt/url_shortener.smt2` snapshot using `apt-get install -y z3` — if the
 emitter ever produces invalid SMT-LIB or loses satisfiability, CI fails loudly.
+
+## Machine-readable output (`--json` / `--json-out`)
+
+`spec-to-rest verify --json <spec>` runs the full engine and emits a structured JSON report
+to stdout instead of the human-readable text. `--json-out <file>` writes the same JSON to a
+file and keeps stdout clean. Either flag can compose with `--explain` (core spans land in the
+JSON) and `--dump-vc <dir>` (VC artifacts go to the dir, JSON to stdout/file).
+
+Exit codes are **identical** to text mode (`0` pass, `1` violation, `2` translator gap, `3`
+backend error) — the JSON complements the exit signal rather than replacing it.
+
+### Top-level schema
+
+```json
+{
+  "schemaVersion": 1,
+  "specFile": "fixtures/spec/url_shortener.spec",
+  "ok": false,
+  "totalMs": 842.0,
+  "checks": [ /* … */ ]
+}
+```
+
+Each entry in `checks` mirrors the internal `CheckResult` 1:1:
+
+```json
+{
+  "id": "Tamper.preserves.clickCountNonNegative",
+  "kind": "preservation",
+  "tool": "z3",
+  "operationName": "Tamper",
+  "invariantName": "clickCountNonNegative",
+  "status": "unsat",
+  "durationMs": 142.0,
+  "detail": "operation 'Tamper' does not preserve invariant '…' — counterexample found",
+  "sourceSpans": [{ "startLine": 11, "startCol": 2, "endLine": 19, "endCol": 3 }],
+  "diagnostic": {
+    "level": "error",
+    "category": "invariant_violation_by_operation",
+    "message": "operation 'Tamper' violates invariant 'clickCountNonNegative'",
+    "primarySpan": { "startLine": 11, "startCol": 2, "endLine": 19, "endCol": 3 },
+    "relatedSpans": [{ "span": {…}, "note": "invariant '…' declared here" }],
+    "counterexample": {
+      "entities": [{ "sortName": "UrlMapping", "label": "UrlMapping#0",
+                     "rawElement": "UrlMapping!val!0",
+                     "fields": [{ "name": "click_count",
+                                  "value": { "display": "-1", "entityLabel": null } }] }],
+      "stateRelations": [{ "stateName": "metadata", "side": "pre",
+                           "entries": [{ "key": {…}, "value": {…} }] }],
+      "stateConstants": [],
+      "inputs": [{ "name": "code", "value": { "display": "2", "entityLabel": null } }]
+    },
+    "suggestion": "Tighten the 'ensures' clause so…",
+    "coreSpans": []
+  }
+}
+```
+
+Passing checks have `diagnostic: null`. Checks without a counterexample (e.g. global
+`unsat`) have `counterexample: null`. `coreSpans` is an empty array when `--explain` is off
+or the backend can't provide a core.
+
+### Stable enum tokens
+
+These snake_case strings are the contract consumers depend on. Breaking changes bump
+`schemaVersion`.
+
+| Field      | Values |
+| ---------- | ------ |
+| `kind`     | `global`, `requires`, `enabled`, `preservation`, `temporal` |
+| `status`   | `sat`, `unsat`, `unknown`, `skipped` |
+| `tool`     | `z3`, `alloy` |
+| `level`    | `error`, `warning` |
+| `category` | `contradictory_invariants`, `unsatisfiable_precondition`, `unreachable_operation`, `invariant_violation_by_operation`, `solver_timeout`, `translator_limitation`, `backend_error` |
+
+### Example consumer queries
+
+```bash
+# Did verification pass?
+spec-to-rest verify --json spec.spec | jq .ok
+
+# List every failing check ID.
+spec-to-rest verify --json spec.spec | jq '.checks[] | select(.status != "sat" and .status != "skipped") | .id'
+
+# Extract the first preservation counterexample's inputs.
+spec-to-rest verify --json spec.spec \
+  | jq '.checks[] | select(.diagnostic.category == "invariant_violation_by_operation") | .diagnostic.counterexample.inputs'
+```
+
+The JSON is *complementary* to [`--dump-vc`](#per-check-vc-dump---dump-vc): `--dump-vc` emits
+the raw solver inputs for replay; `--json` emits the decoded diagnostic data for consumption
+by editors, CI bots, and aggregators.
 
 ## Verification certificates
 

--- a/fixtures/golden/verify_report/broken_url_shortener.json
+++ b/fixtures/golden/verify_report/broken_url_shortener.json
@@ -1,0 +1,229 @@
+{
+  "schemaVersion" : 1,
+  "specFile" : "fixtures/spec/broken_url_shortener.spec",
+  "ok" : false,
+  "totalMs" : 0.0,
+  "checks" : [
+    {
+      "id" : "global",
+      "kind" : "global",
+      "tool" : "z3",
+      "operationName" : null,
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 21,
+          "startCol" : 2,
+          "endLine" : 22,
+          "endCol" : 52
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Tamper.requires",
+      "kind" : "requires",
+      "tool" : "z3",
+      "operationName" : "Tamper",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 11,
+          "startCol" : 2,
+          "endLine" : 19,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 15,
+          "startCol" : 6,
+          "endLine" : 15,
+          "endCol" : 22
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Tamper.enabled",
+      "kind" : "enabled",
+      "tool" : "z3",
+      "operationName" : "Tamper",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 11,
+          "startCol" : 2,
+          "endLine" : 19,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 15,
+          "startCol" : 6,
+          "endLine" : 15,
+          "endCol" : 22
+        },
+        {
+          "startLine" : 21,
+          "startCol" : 2,
+          "endLine" : 22,
+          "endCol" : 52
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Tamper.preserves.clickCountNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "operationName" : "Tamper",
+      "invariantName" : "clickCountNonNegative",
+      "status" : "unsat",
+      "durationMs" : 0.0,
+      "detail" : "operation 'Tamper' does not preserve invariant 'clickCountNonNegative' — counterexample found",
+      "sourceSpans" : [
+        {
+          "startLine" : 11,
+          "startCol" : 2,
+          "endLine" : 19,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 21,
+          "startCol" : 2,
+          "endLine" : 22,
+          "endCol" : 52
+        },
+        {
+          "startLine" : 18,
+          "startCol" : 6,
+          "endLine" : 18,
+          "endCol" : 73
+        }
+      ],
+      "diagnostic" : {
+        "level" : "error",
+        "category" : "invariant_violation_by_operation",
+        "message" : "operation 'Tamper' violates invariant 'clickCountNonNegative'",
+        "primarySpan" : {
+          "startLine" : 11,
+          "startCol" : 2,
+          "endLine" : 19,
+          "endCol" : 3
+        },
+        "relatedSpans" : [
+          {
+            "span" : {
+              "startLine" : 21,
+              "startCol" : 2,
+              "endLine" : 22,
+              "endCol" : 52
+            },
+            "note" : "invariant 'clickCountNonNegative' declared here"
+          }
+        ],
+        "counterexample" : {
+          "entities" : [
+            {
+              "sortName" : "UrlMapping",
+              "label" : "UrlMapping#0",
+              "rawElement" : "UrlMapping!val!0",
+              "fields" : [
+                {
+                  "name" : "click_count",
+                  "value" : {
+                    "display" : "-1",
+                    "entityLabel" : null
+                  }
+                }
+              ]
+            },
+            {
+              "sortName" : "UrlMapping",
+              "label" : "UrlMapping#1",
+              "rawElement" : "UrlMapping!val!1",
+              "fields" : [
+                {
+                  "name" : "click_count",
+                  "value" : {
+                    "display" : "99",
+                    "entityLabel" : null
+                  }
+                }
+              ]
+            },
+            {
+              "sortName" : "UrlMapping",
+              "label" : "UrlMapping#2",
+              "rawElement" : "UrlMapping!val!2",
+              "fields" : [
+                {
+                  "name" : "click_count",
+                  "value" : {
+                    "display" : "-1",
+                    "entityLabel" : null
+                  }
+                }
+              ]
+            }
+          ],
+          "stateRelations" : [
+            {
+              "stateName" : "metadata",
+              "side" : "pre",
+              "entries" : [
+                {
+                  "key" : {
+                    "display" : "2",
+                    "entityLabel" : null
+                  },
+                  "value" : {
+                    "display" : "UrlMapping#1",
+                    "entityLabel" : "UrlMapping#1"
+                  }
+                }
+              ]
+            },
+            {
+              "stateName" : "metadata",
+              "side" : "post",
+              "entries" : [
+                {
+                  "key" : {
+                    "display" : "2",
+                    "entityLabel" : null
+                  },
+                  "value" : {
+                    "display" : "UrlMapping#0",
+                    "entityLabel" : "UrlMapping#0"
+                  }
+                }
+              ]
+            }
+          ],
+          "stateConstants" : [
+          ],
+          "inputs" : [
+            {
+              "name" : "code",
+              "value" : {
+                "display" : "2",
+                "entityLabel" : null
+              }
+            }
+          ]
+        },
+        "suggestion" : "Tighten the 'ensures' clause so the invariant's constrained fields appear on the right-hand side of a '=' or a range predicate.",
+        "coreSpans" : [
+        ]
+      }
+    }
+  ]
+}

--- a/fixtures/golden/verify_report/safe_counter.json
+++ b/fixtures/golden/verify_report/safe_counter.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion" : 1,
+  "specFile" : "fixtures/spec/safe_counter.spec",
+  "ok" : true,
+  "totalMs" : 0.0,
+  "checks" : [
+    {
+      "id" : "global",
+      "kind" : "global",
+      "tool" : "z3",
+      "operationName" : null,
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 23,
+          "endCol" : 14
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Decrement.requires",
+      "kind" : "requires",
+      "tool" : "z3",
+      "operationName" : "Decrement",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 14,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 16,
+          "startCol" : 6,
+          "endLine" : 16,
+          "endCol" : 15
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Decrement.enabled",
+      "kind" : "enabled",
+      "tool" : "z3",
+      "operationName" : "Decrement",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 14,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 16,
+          "startCol" : 6,
+          "endLine" : 16,
+          "endCol" : 15
+        },
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 23,
+          "endCol" : 14
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Decrement.preserves.countNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "operationName" : "Decrement",
+      "invariantName" : "countNonNegative",
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 14,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 23,
+          "endCol" : 14
+        },
+        {
+          "startLine" : 19,
+          "startCol" : 6,
+          "endLine" : 19,
+          "endCol" : 24
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Increment.requires",
+      "kind" : "requires",
+      "tool" : "z3",
+      "operationName" : "Increment",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 6,
+          "startCol" : 2,
+          "endLine" : 12,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 8,
+          "startCol" : 6,
+          "endLine" : 8,
+          "endCol" : 10
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Increment.enabled",
+      "kind" : "enabled",
+      "tool" : "z3",
+      "operationName" : "Increment",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 6,
+          "startCol" : 2,
+          "endLine" : 12,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 8,
+          "startCol" : 6,
+          "endLine" : 8,
+          "endCol" : 10
+        },
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 23,
+          "endCol" : 14
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Increment.preserves.countNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "operationName" : "Increment",
+      "invariantName" : "countNonNegative",
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 6,
+          "startCol" : 2,
+          "endLine" : 12,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 23,
+          "endCol" : 14
+        },
+        {
+          "startLine" : 11,
+          "startCol" : 6,
+          "endLine" : 11,
+          "endCol" : 24
+        }
+      ],
+      "diagnostic" : null
+    }
+  ]
+}

--- a/fixtures/golden/verify_report/unsat_invariants.json
+++ b/fixtures/golden/verify_report/unsat_invariants.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion" : 1,
+  "specFile" : "fixtures/spec/unsat_invariants.spec",
+  "ok" : false,
+  "totalMs" : 0.0,
+  "checks" : [
+    {
+      "id" : "global",
+      "kind" : "global",
+      "tool" : "z3",
+      "operationName" : null,
+      "invariantName" : null,
+      "status" : "unsat",
+      "durationMs" : 0.0,
+      "detail" : "invariants are jointly contradictory — no valid state exists",
+      "sourceSpans" : [
+        {
+          "startLine" : 2,
+          "startCol" : 2,
+          "endLine" : 2,
+          "endCol" : 20
+        },
+        {
+          "startLine" : 3,
+          "startCol" : 2,
+          "endLine" : 3,
+          "endCol" : 19
+        },
+        {
+          "startLine" : 4,
+          "startCol" : 2,
+          "endLine" : 4,
+          "endCol" : 31
+        }
+      ],
+      "diagnostic" : {
+        "level" : "error",
+        "category" : "contradictory_invariants",
+        "message" : "invariants are jointly unsatisfiable — no valid state exists",
+        "primarySpan" : {
+          "startLine" : 2,
+          "startCol" : 2,
+          "endLine" : 2,
+          "endCol" : 20
+        },
+        "relatedSpans" : [
+          {
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 2,
+              "endLine" : 3,
+              "endCol" : 19
+            },
+            "note" : "invariant 'inv_1'"
+          },
+          {
+            "span" : {
+              "startLine" : 4,
+              "startCol" : 2,
+              "endLine" : 4,
+              "endCol" : 31
+            },
+            "note" : "invariant 'inv_2'"
+          }
+        ],
+        "counterexample" : null,
+        "suggestion" : "Review the invariant set for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5').",
+        "coreSpans" : [
+          {
+            "span" : {
+              "startLine" : 2,
+              "startCol" : 13,
+              "endLine" : 2,
+              "endCol" : 20
+            },
+            "note" : "contributing invariant"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -53,7 +53,9 @@ object Main:
       .orFalse
     val json =
       Opts.flag("json", "emit machine-readable JSON report to stdout (suppresses text)").orFalse
-    val jsonOut = Opts.option[String]("json-out", "write JSON report to file").orNone
+    val jsonOut = Opts
+      .option[String]("json-out", "write JSON report to file (implies JSON mode; suppresses text)")
+      .orNone
     Opts.subcommand("verify", "Run the Z3/Alloy-backed verification engine on a spec file"):
       (
         specFile,

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -51,6 +51,9 @@ object Main:
     val explain = Opts
       .flag("explain", "extract unsat cores; surface contributing spec spans on unsat diagnostics")
       .orFalse
+    val json =
+      Opts.flag("json", "emit machine-readable JSON report to stdout (suppresses text)").orFalse
+    val jsonOut = Opts.option[String]("json-out", "write JSON report to file").orNone
     Opts.subcommand("verify", "Run the Z3/Alloy-backed verification engine on a spec file"):
       (
         specFile,
@@ -62,11 +65,13 @@ object Main:
         alloyScope,
         dumpVc,
         explain,
+        json,
+        jsonOut,
         verbose,
         quiet
-      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, v, q) =>
+      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, v, q) =>
         val log = Logger.fromFlags(verbose = v, quiet = q)
-        Verify.run(spec, VerifyOptions(t, ds, dso, da, dao, as, dvc, ex), log)
+        Verify.run(spec, VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo), log)
 
   private val compileCmd =
     val target = Opts

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -35,6 +35,15 @@ object Verify:
   val ExitBackend: Int    = 3
 
   def run(specFile: String, opts: VerifyOptions, log: Logger): Int =
+    val wantsJson = opts.json || opts.jsonOut.isDefined
+    val wantsDump =
+      opts.dumpSmt || opts.dumpSmtOut.isDefined || opts.dumpAlloy || opts.dumpAlloyOut.isDefined
+    if wantsJson && wantsDump then
+      log.error(
+        "--json / --json-out cannot be combined with --dump-smt / --dump-alloy " +
+          "(dump flags short-circuit before checks run; JSON output requires a full run)"
+      )
+      return ExitViolations
     Check.readSource(specFile, log) match
       case Left(_) => ExitViolations
       case Right(source) =>

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -23,7 +23,9 @@ final case class VerifyOptions(
     dumpAlloyOut: Option[String] = None,
     alloyScope: Int = 5,
     dumpVc: Option[String] = None,
-    explain: Boolean = false
+    explain: Boolean = false,
+    json: Boolean = false,
+    jsonOut: Option[String] = None
 )
 
 object Verify:
@@ -113,7 +115,16 @@ object Verify:
         sink.foreach: s =>
           s.writeIndex(specFile, totalMs, report.ok)
           log.success(s"Wrote ${s.entryCount} VC artifacts and verdicts.json to ${s.dir}")
-        reportConsistency(specFile, report.checks, report.ok, totalMs, log)
+        if opts.json || opts.jsonOut.isDefined then
+          val rendered = JsonReport.render(JsonReport.toJson(specFile, report, totalMs))
+          opts.jsonOut match
+            case Some(path) =>
+              val _ = Files.writeString(Paths.get(path), rendered)
+              log.success(s"Wrote JSON report to $path")
+            case None =>
+              print(rendered)
+          exitCodeFor(report.checks, report.ok)
+        else reportConsistency(specFile, report.checks, report.ok, totalMs, log)
       finally backend.close()
 
   private def reportConsistency(

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -24,7 +24,15 @@ class VerifyJsonTest extends munit.FunSuite:
     val cur    = parsed.hcursor
     assertEquals(cur.downField("schemaVersion").as[Int].toOption, Some(1))
     assertEquals(cur.downField("ok").as[Boolean].toOption, Some(true))
-    assert(cur.downField("checks").values.exists(_.nonEmpty))
+    val checks = cur.downField("checks").values.getOrElse(Vector.empty).toList
+    assert(checks.nonEmpty)
+    // Contract: when outcome is `sat`, the diagnostic field is null — consumers rely on this
+    // to distinguish passing checks from failures without looking at `status` alone.
+    checks.foreach: c =>
+      val status     = c.hcursor.downField("status").as[String].toOption
+      val diagnostic = c.hcursor.downField("diagnostic").focus
+      if status.contains("sat") then
+        assertEquals(diagnostic, Some(io.circe.Json.Null), s"sat check had non-null diagnostic: $c")
 
   test("--json exits 1 on failing spec, still emits valid JSON"):
     val opts        = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
@@ -58,6 +66,17 @@ class VerifyJsonTest extends munit.FunSuite:
       assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(true))
     finally
       val _ = Files.deleteIfExists(tmp)
+
+  test("--json + --dump-smt is rejected with a clear error"):
+    val opts = VerifyOptions(
+      30_000L,
+      dumpSmt = true,
+      dumpSmtOut = None,
+      json = true
+    )
+    val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
+    assertEquals(exit, Verify.ExitViolations)
+    assertEquals(out, "", "no stdout output when the combination is rejected")
 
   test("--json with --explain surfaces coreSpans on unsat diagnostics"):
     val opts = VerifyOptions(

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -1,0 +1,76 @@
+package specrest.cli
+
+import io.circe.parser
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+
+class VerifyJsonTest extends munit.FunSuite:
+
+  private def log: Logger = Logger.fromFlags(verbose = false, quiet = true)
+
+  private def captureStdout(body: => Int): (Int, String) =
+    val buf  = new ByteArrayOutputStream()
+    val ps   = new PrintStream(buf, true, "UTF-8")
+    val exit = Console.withOut(ps)(body)
+    (exit, buf.toString("UTF-8"))
+
+  test("--json emits JSON to stdout and exits 0 on passing spec"):
+    val opts        = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
+    assertEquals(exit, Verify.ExitOk)
+    val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+    val cur    = parsed.hcursor
+    assertEquals(cur.downField("schemaVersion").as[Int].toOption, Some(1))
+    assertEquals(cur.downField("ok").as[Boolean].toOption, Some(true))
+    assert(cur.downField("checks").values.exists(_.nonEmpty))
+
+  test("--json exits 1 on failing spec, still emits valid JSON"):
+    val opts        = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    val (exit, out) = captureStdout(Verify.run("fixtures/spec/unsat_invariants.spec", opts, log))
+    assertEquals(exit, Verify.ExitViolations)
+    val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+    assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(false))
+    val categories = parsed.hcursor.downField("checks").values
+      .getOrElse(Vector.empty).toList
+      .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
+    assert(
+      categories.contains("contradictory_invariants"),
+      s"expected contradictory_invariants among $categories"
+    )
+
+  test("--json-out writes to file; stdout stays clean"):
+    val tmp = Files.createTempFile("verify-json-", ".json")
+    try
+      val opts = VerifyOptions(
+        30_000L,
+        dumpSmt = false,
+        dumpSmtOut = None,
+        jsonOut = Some(tmp.toString)
+      )
+      val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
+      assertEquals(exit, Verify.ExitOk)
+      assertEquals(out, "", "stdout should be empty when --json-out is active")
+      val content = Files.readString(tmp)
+      val parsed  = parser.parse(content).toOption.getOrElse(fail("invalid JSON in file"))
+      assertEquals(parsed.hcursor.downField("schemaVersion").as[Int].toOption, Some(1))
+      assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(true))
+    finally
+      val _ = Files.deleteIfExists(tmp)
+
+  test("--json with --explain surfaces coreSpans on unsat diagnostics"):
+    val opts = VerifyOptions(
+      30_000L,
+      dumpSmt = false,
+      dumpSmtOut = None,
+      json = true,
+      explain = true
+    )
+    val (exit, out) = captureStdout(Verify.run("fixtures/spec/unsat_invariants.spec", opts, log))
+    assertEquals(exit, Verify.ExitViolations)
+    val parsed = parser.parse(out).toOption.getOrElse(fail("invalid JSON"))
+    val cores = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
+      .flatMap(_.hcursor.downField("diagnostic").downField("coreSpans").values)
+      .flatten
+    assert(cores.nonEmpty, "expected at least one coreSpan entry when --explain is set")

--- a/modules/verify/src/main/scala/specrest/verify/Config.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Config.scala
@@ -4,7 +4,7 @@ enum CheckStatus:
   case Sat, Unsat, Unknown
 
 object CheckStatus:
-  def tokenLower(s: CheckStatus): String = s match
+  def token(s: CheckStatus): String = s match
     case Sat     => "sat"
     case Unsat   => "unsat"
     case Unknown => "unknown"

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -17,6 +17,14 @@ import specrest.verify.z3.Z3Script
 enum CheckKind:
   case Global, Requires, Enabled, Preservation, Temporal
 
+object CheckKind:
+  def token(k: CheckKind): String = k match
+    case Global       => "global"
+    case Requires     => "requires"
+    case Enabled      => "enabled"
+    case Preservation => "preservation"
+    case Temporal     => "temporal"
+
 enum CheckOutcome:
   case Sat, Unsat, Unknown, Skipped
 
@@ -25,6 +33,12 @@ object CheckOutcome:
     case CheckStatus.Sat     => Sat
     case CheckStatus.Unsat   => Unsat
     case CheckStatus.Unknown => Unknown
+
+  def token(o: CheckOutcome): String = o match
+    case Sat     => "sat"
+    case Unsat   => "unsat"
+    case Unknown => "unknown"
+    case Skipped => "skipped"
 
 final case class CheckResult(
     id: String,

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -6,8 +6,23 @@ enum DiagnosticCategory:
   case ContradictoryInvariants, UnsatisfiablePrecondition, UnreachableOperation,
     InvariantViolationByOperation, SolverTimeout, TranslatorLimitation, BackendError
 
+object DiagnosticCategory:
+  def token(c: DiagnosticCategory): String = c match
+    case ContradictoryInvariants       => "contradictory_invariants"
+    case UnsatisfiablePrecondition     => "unsatisfiable_precondition"
+    case UnreachableOperation          => "unreachable_operation"
+    case InvariantViolationByOperation => "invariant_violation_by_operation"
+    case SolverTimeout                 => "solver_timeout"
+    case TranslatorLimitation          => "translator_limitation"
+    case BackendError                  => "backend_error"
+
 enum DiagnosticLevel:
   case Error, Warning
+
+object DiagnosticLevel:
+  def token(l: DiagnosticLevel): String = l match
+    case Error   => "error"
+    case Warning => "warning"
 
 final case class RelatedSpan(span: Span, note: String)
 

--- a/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
+++ b/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
@@ -1,0 +1,145 @@
+package specrest.verify
+
+import io.circe.Json
+import io.circe.Printer
+import specrest.ir.Span
+
+object JsonReport:
+
+  val SchemaVersion: Int = 1
+
+  private val printer: Printer = Printer.spaces2.copy(dropNullValues = false)
+
+  def toJson(specFile: String, report: ConsistencyReport, totalMs: Double): Json =
+    Json.obj(
+      "schemaVersion" -> Json.fromInt(SchemaVersion),
+      "specFile"      -> Json.fromString(specFile),
+      "ok"            -> Json.fromBoolean(report.ok),
+      "totalMs"       -> Json.fromDoubleOrNull(totalMs),
+      "checks"        -> Json.arr(report.checks.map(checkJson)*)
+    )
+
+  def render(json: Json): String = printer.print(json) + "\n"
+
+  private def checkJson(c: CheckResult): Json =
+    Json.obj(
+      "id"            -> Json.fromString(c.id),
+      "kind"          -> Json.fromString(checkKindToken(c.kind)),
+      "tool"          -> Json.fromString(VerifierTool.token(c.tool)),
+      "operationName" -> optString(c.operationName),
+      "invariantName" -> optString(c.invariantName),
+      "status"        -> Json.fromString(outcomeToken(c.status)),
+      "durationMs"    -> Json.fromDoubleOrNull(c.durationMs),
+      "detail"        -> optString(c.detail),
+      "sourceSpans"   -> Json.arr(c.sourceSpans.map(spanJson)*),
+      "diagnostic"    -> c.diagnostic.fold(Json.Null)(diagnosticJson)
+    )
+
+  private def diagnosticJson(d: VerificationDiagnostic): Json =
+    Json.obj(
+      "level"          -> Json.fromString(levelToken(d.level)),
+      "category"       -> Json.fromString(categoryToken(d.category)),
+      "message"        -> Json.fromString(d.message),
+      "primarySpan"    -> d.primarySpan.fold(Json.Null)(spanJson),
+      "relatedSpans"   -> Json.arr(d.relatedSpans.map(relatedSpanJson)*),
+      "counterexample" -> d.counterexample.fold(Json.Null)(counterExampleJson),
+      "suggestion"     -> optString(d.suggestion),
+      "coreSpans"      -> Json.arr(d.coreSpans.map(relatedSpanJson)*)
+    )
+
+  private def spanJson(s: Span): Json =
+    Json.obj(
+      "startLine" -> Json.fromInt(s.startLine),
+      "startCol"  -> Json.fromInt(s.startCol),
+      "endLine"   -> Json.fromInt(s.endLine),
+      "endCol"    -> Json.fromInt(s.endCol)
+    )
+
+  private def relatedSpanJson(r: RelatedSpan): Json =
+    Json.obj(
+      "span" -> spanJson(r.span),
+      "note" -> Json.fromString(r.note)
+    )
+
+  private def counterExampleJson(ce: DecodedCounterExample): Json =
+    Json.obj(
+      "entities"       -> Json.arr(ce.entities.map(entityJson)*),
+      "stateRelations" -> Json.arr(ce.stateRelations.map(relationJson)*),
+      "stateConstants" -> Json.arr(ce.stateConstants.map(constantJson)*),
+      "inputs"         -> Json.arr(ce.inputs.map(inputJson)*)
+    )
+
+  private def entityJson(e: DecodedEntity): Json =
+    Json.obj(
+      "sortName"   -> Json.fromString(e.sortName),
+      "label"      -> Json.fromString(e.label),
+      "rawElement" -> Json.fromString(e.rawElement),
+      "fields"     -> Json.arr(e.fields.map(fieldJson)*)
+    )
+
+  private def fieldJson(f: DecodedEntityField): Json =
+    Json.obj(
+      "name"  -> Json.fromString(f.name),
+      "value" -> valueJson(f.value)
+    )
+
+  private def valueJson(v: DecodedValue): Json =
+    Json.obj(
+      "display"     -> Json.fromString(v.display),
+      "entityLabel" -> optString(v.entityLabel)
+    )
+
+  private def relationJson(r: DecodedRelation): Json =
+    Json.obj(
+      "stateName" -> Json.fromString(r.stateName),
+      "side"      -> Json.fromString(r.side),
+      "entries"   -> Json.arr(r.entries.map(relationEntryJson)*)
+    )
+
+  private def relationEntryJson(e: DecodedRelationEntry): Json =
+    Json.obj(
+      "key"   -> valueJson(e.key),
+      "value" -> valueJson(e.value)
+    )
+
+  private def constantJson(c: DecodedConstant): Json =
+    Json.obj(
+      "stateName" -> Json.fromString(c.stateName),
+      "side"      -> Json.fromString(c.side),
+      "value"     -> valueJson(c.value)
+    )
+
+  private def inputJson(i: DecodedInput): Json =
+    Json.obj(
+      "name"  -> Json.fromString(i.name),
+      "value" -> valueJson(i.value)
+    )
+
+  private def optString(o: Option[String]): Json =
+    o.fold(Json.Null)(Json.fromString)
+
+  private def checkKindToken(k: CheckKind): String = k match
+    case CheckKind.Global       => "global"
+    case CheckKind.Requires     => "requires"
+    case CheckKind.Enabled      => "enabled"
+    case CheckKind.Preservation => "preservation"
+    case CheckKind.Temporal     => "temporal"
+
+  private def outcomeToken(o: CheckOutcome): String = o match
+    case CheckOutcome.Sat     => "sat"
+    case CheckOutcome.Unsat   => "unsat"
+    case CheckOutcome.Unknown => "unknown"
+    case CheckOutcome.Skipped => "skipped"
+
+  private def levelToken(l: DiagnosticLevel): String = l match
+    case DiagnosticLevel.Error   => "error"
+    case DiagnosticLevel.Warning => "warning"
+
+  private def categoryToken(c: DiagnosticCategory): String = c match
+    case DiagnosticCategory.ContradictoryInvariants       => "contradictory_invariants"
+    case DiagnosticCategory.UnsatisfiablePrecondition     => "unsatisfiable_precondition"
+    case DiagnosticCategory.UnreachableOperation          => "unreachable_operation"
+    case DiagnosticCategory.InvariantViolationByOperation => "invariant_violation_by_operation"
+    case DiagnosticCategory.SolverTimeout                 => "solver_timeout"
+    case DiagnosticCategory.TranslatorLimitation          => "translator_limitation"
+    case DiagnosticCategory.BackendError                  => "backend_error"

--- a/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
+++ b/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
@@ -24,11 +24,11 @@ object JsonReport:
   private def checkJson(c: CheckResult): Json =
     Json.obj(
       "id"            -> Json.fromString(c.id),
-      "kind"          -> Json.fromString(checkKindToken(c.kind)),
+      "kind"          -> Json.fromString(CheckKind.token(c.kind)),
       "tool"          -> Json.fromString(VerifierTool.token(c.tool)),
       "operationName" -> optString(c.operationName),
       "invariantName" -> optString(c.invariantName),
-      "status"        -> Json.fromString(outcomeToken(c.status)),
+      "status"        -> Json.fromString(CheckOutcome.token(c.status)),
       "durationMs"    -> Json.fromDoubleOrNull(c.durationMs),
       "detail"        -> optString(c.detail),
       "sourceSpans"   -> Json.arr(c.sourceSpans.map(spanJson)*),
@@ -37,8 +37,8 @@ object JsonReport:
 
   private def diagnosticJson(d: VerificationDiagnostic): Json =
     Json.obj(
-      "level"          -> Json.fromString(levelToken(d.level)),
-      "category"       -> Json.fromString(categoryToken(d.category)),
+      "level"          -> Json.fromString(DiagnosticLevel.token(d.level)),
+      "category"       -> Json.fromString(DiagnosticCategory.token(d.category)),
       "message"        -> Json.fromString(d.message),
       "primarySpan"    -> d.primarySpan.fold(Json.Null)(spanJson),
       "relatedSpans"   -> Json.arr(d.relatedSpans.map(relatedSpanJson)*),
@@ -117,29 +117,3 @@ object JsonReport:
 
   private def optString(o: Option[String]): Json =
     o.fold(Json.Null)(Json.fromString)
-
-  private def checkKindToken(k: CheckKind): String = k match
-    case CheckKind.Global       => "global"
-    case CheckKind.Requires     => "requires"
-    case CheckKind.Enabled      => "enabled"
-    case CheckKind.Preservation => "preservation"
-    case CheckKind.Temporal     => "temporal"
-
-  private def outcomeToken(o: CheckOutcome): String = o match
-    case CheckOutcome.Sat     => "sat"
-    case CheckOutcome.Unsat   => "unsat"
-    case CheckOutcome.Unknown => "unknown"
-    case CheckOutcome.Skipped => "skipped"
-
-  private def levelToken(l: DiagnosticLevel): String = l match
-    case DiagnosticLevel.Error   => "error"
-    case DiagnosticLevel.Warning => "warning"
-
-  private def categoryToken(c: DiagnosticCategory): String = c match
-    case DiagnosticCategory.ContradictoryInvariants       => "contradictory_invariants"
-    case DiagnosticCategory.UnsatisfiablePrecondition     => "unsatisfiable_precondition"
-    case DiagnosticCategory.UnreachableOperation          => "unreachable_operation"
-    case DiagnosticCategory.InvariantViolationByOperation => "invariant_violation_by_operation"
-    case DiagnosticCategory.SolverTimeout                 => "solver_timeout"
-    case DiagnosticCategory.TranslatorLimitation          => "translator_limitation"
-    case DiagnosticCategory.BackendError                  => "backend_error"

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -51,8 +51,8 @@ final class DumpSink(val dir: Path):
       Json.obj(
         "id"         -> Json.fromString(e.id),
         "tool"       -> Json.fromString(VerifierTool.token(e.tool)),
-        "outcome"    -> Json.fromString(outcomeToken(e.outcome)),
-        "rawStatus"  -> Json.fromString(rawStatusToken(e.rawStatus)),
+        "outcome"    -> Json.fromString(CheckOutcome.token(e.outcome)),
+        "rawStatus"  -> Json.fromString(CheckStatus.token(e.rawStatus)),
         "durationMs" -> Json.fromDoubleOrNull(e.durationMs),
         "file"       -> Json.fromString(e.file)
       )
@@ -68,17 +68,6 @@ final class DumpSink(val dir: Path):
 
   private def sanitize(id: String): String =
     id.map(c => if c.isLetterOrDigit || c == '.' || c == '_' || c == '-' then c else '_')
-
-  private def outcomeToken(s: CheckOutcome): String = s match
-    case CheckOutcome.Sat     => "sat"
-    case CheckOutcome.Unsat   => "unsat"
-    case CheckOutcome.Unknown => "unknown"
-    case CheckOutcome.Skipped => "skipped"
-
-  private def rawStatusToken(s: CheckStatus): String = s match
-    case CheckStatus.Sat     => "sat"
-    case CheckStatus.Unsat   => "unsat"
-    case CheckStatus.Unknown => "unknown"
 
 object DumpSink:
 

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -1,0 +1,143 @@
+package specrest.verify
+
+import io.circe.Json
+import io.circe.parser
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.verify.z3.WasmBackend
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class JsonReportTest extends munit.FunSuite:
+
+  // (fixture, expected ok, expected category in at least one diagnostic)
+  private val cases: List[(String, Boolean, Option[String])] = List(
+    ("safe_counter", true, None),
+    ("unsat_invariants", false, Some("contradictory_invariants")),
+    ("broken_url_shortener", false, Some("invariant_violation_by_operation"))
+  )
+
+  cases.foreach: (fixture, expectedOk, expectedCategory) =>
+    test(s"JsonReport snapshot matches golden for $fixture"):
+      val ir      = parseSpec(fixture)
+      val backend = WasmBackend()
+      try
+        val report = Consistency.runConsistencyChecks(
+          ir,
+          backend,
+          VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+        )
+        val json      = JsonReport.toJson(s"fixtures/spec/$fixture.spec", report, 0.0)
+        val canonical = stripTimings(json)
+        assertEquals(
+          canonical.hcursor.downField("schemaVersion").as[Int].toOption,
+          Some(JsonReport.SchemaVersion)
+        )
+        assertEquals(canonical.hcursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
+        val goldenPath = Paths.get(s"fixtures/golden/verify_report/$fixture.json")
+        val rendered   = JsonReport.render(canonical)
+        if !Files.exists(goldenPath) then
+          Files.createDirectories(goldenPath.getParent)
+          val _ = Files.writeString(goldenPath, rendered)
+          fail(s"wrote initial golden at $goldenPath — rerun the test")
+        else
+          val expected = Files.readString(goldenPath)
+          assertEquals(rendered, expected, s"golden mismatch — update $goldenPath if intended")
+
+        expectedCategory.foreach: category =>
+          val categories = canonical.hcursor
+            .downField("checks")
+            .values
+            .getOrElse(Vector.empty)
+            .toList
+            .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
+          assert(
+            categories.contains(category),
+            s"expected category '$category' among $categories"
+          )
+      finally backend.close()
+
+  test("JsonReport is round-trip-parseable via circe"):
+    val ir      = parseSpec("broken_url_shortener")
+    val backend = WasmBackend()
+    try
+      val report = Consistency.runConsistencyChecks(
+        ir,
+        backend,
+        VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+      )
+      val rendered = JsonReport.render(
+        JsonReport.toJson("fixtures/spec/broken_url_shortener.spec", report, 0.0)
+      )
+      val parsed = parser.parse(rendered).toOption.getOrElse(fail("re-parse failed"))
+      val cur    = parsed.hcursor
+      assertEquals(cur.downField("schemaVersion").as[Int].toOption, Some(1))
+      val checks = cur.downField("checks").values.getOrElse(Vector.empty).toList
+      assert(checks.nonEmpty, "expected non-empty checks array")
+      val preservation = checks.find: c =>
+        c.hcursor.downField("kind").as[String].toOption.contains("preservation") &&
+          c.hcursor.downField("diagnostic").downField("category").as[String]
+            .toOption.contains("invariant_violation_by_operation")
+      assert(
+        preservation.isDefined,
+        "expected an invariant_violation_by_operation preservation check"
+      )
+      val ceEntities = preservation
+        .flatMap(_.hcursor.downField("diagnostic").downField("counterexample")
+          .downField("entities").values)
+        .getOrElse(Vector.empty)
+      assert(ceEntities.nonEmpty, "expected decoded counterexample entities")
+      val firstFieldName = ceEntities.head.hcursor
+        .downField("fields").downArray.downField("name").as[String].toOption
+      assert(firstFieldName.isDefined, s"expected first entity field name, got $firstFieldName")
+    finally backend.close()
+
+  test("JsonReport top-level shape carries all documented fields"):
+    val ir      = parseSpec("safe_counter")
+    val backend = WasmBackend()
+    try
+      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val json   = JsonReport.toJson("x.spec", report, 42.0)
+      val keys   = json.asObject.map(_.keys.toList).getOrElse(Nil)
+      assertEquals(keys, List("schemaVersion", "specFile", "ok", "totalMs", "checks"))
+      val checkKeys = json.hcursor.downField("checks").downArray.focus
+        .flatMap(_.asObject.map(_.keys.toList)).getOrElse(Nil)
+      assertEquals(
+        checkKeys,
+        List(
+          "id",
+          "kind",
+          "tool",
+          "operationName",
+          "invariantName",
+          "status",
+          "durationMs",
+          "detail",
+          "sourceSpans",
+          "diagnostic"
+        )
+      )
+    finally backend.close()
+
+  private def parseSpec(name: String): specrest.ir.ServiceIR =
+    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
+    val parsed = Parse.parseSpec(src)
+    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
+    Builder.buildIR(parsed.tree)
+
+  private def stripTimings(j: Json): Json =
+    j.fold(
+      jsonNull = Json.Null,
+      jsonBoolean = Json.fromBoolean,
+      jsonNumber = n => Json.fromJsonNumber(n),
+      jsonString = Json.fromString,
+      jsonArray = arr => Json.arr(arr.map(stripTimings)*),
+      jsonObject = obj =>
+        val patched = obj.toMap.map: (k, v) =>
+          val mapped =
+            if k == "totalMs" || k == "durationMs" then Json.fromDoubleOrNull(0.0)
+            else stripTimings(v)
+          k -> mapped
+        Json.fromFields(obj.keys.map(k => k -> patched(k)))
+    )

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -99,13 +99,17 @@ class JsonReportTest extends munit.FunSuite:
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
       val json   = JsonReport.toJson("x.spec", report, 42.0)
-      val keys   = json.asObject.map(_.keys.toList).getOrElse(Nil)
-      assertEquals(keys, List("schemaVersion", "specFile", "ok", "totalMs", "checks"))
-      val checkKeys = json.hcursor.downField("checks").downArray.focus
-        .flatMap(_.asObject.map(_.keys.toList)).getOrElse(Nil)
+      val keys   = json.asObject.map(_.keys.toSet).getOrElse(Set.empty[String])
+      assertEquals(keys, Set("schemaVersion", "specFile", "ok", "totalMs", "checks"))
+      val checkKeys = json.hcursor
+        .downField("checks")
+        .downArray
+        .focus
+        .flatMap(_.asObject.map(_.keys.toSet))
+        .getOrElse(Set.empty[String])
       assertEquals(
         checkKeys,
-        List(
+        Set(
           "id",
           "kind",
           "tool",
@@ -126,18 +130,24 @@ class JsonReportTest extends munit.FunSuite:
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
     Builder.buildIR(parsed.tree)
 
+  // Paths where timing fields legitimately live in the schema. Scoping prevents accidental
+  // erasure if a future diagnostic/counterexample field shares one of these names.
   private def stripTimings(j: Json): Json =
-    j.fold(
-      jsonNull = Json.Null,
-      jsonBoolean = Json.fromBoolean,
-      jsonNumber = n => Json.fromJsonNumber(n),
-      jsonString = Json.fromString,
-      jsonArray = arr => Json.arr(arr.map(stripTimings)*),
-      jsonObject = obj =>
-        val patched = obj.toMap.map: (k, v) =>
-          val mapped =
-            if k == "totalMs" || k == "durationMs" then Json.fromDoubleOrNull(0.0)
-            else stripTimings(v)
-          k -> mapped
-        Json.fromFields(obj.keys.map(k => k -> patched(k)))
-    )
+    def loop(value: Json, path: List[String]): Json =
+      value.fold(
+        jsonNull = Json.Null,
+        jsonBoolean = Json.fromBoolean,
+        jsonNumber = n => Json.fromJsonNumber(n),
+        jsonString = Json.fromString,
+        jsonArray = arr => Json.arr(arr.map(loop(_, path :+ "[]"))*),
+        jsonObject = obj =>
+          val patched = obj.toMap.map: (k, v) =>
+            val isTopTotal   = path.isEmpty && k == "totalMs"
+            val isCheckTotal = path == List("checks", "[]") && k == "durationMs"
+            val mapped =
+              if isTopTotal || isCheckTotal then Json.fromDoubleOrNull(0.0)
+              else loop(v, path :+ k)
+            k -> mapped
+          Json.fromFields(obj.keys.map(k => k -> patched(k)))
+      )
+    loop(j, Nil)


### PR DESCRIPTION
## Summary

Adds a `--json` / `--json-out <file>` flag to `spec-to-rest verify` that emits the full
verification report as structured JSON — enabling editor plugins, CI bots, and aggregators
to consume check results programmatically. Closes #79.

The serializer is a pure `ConsistencyReport → Json` function mirroring the internal
`CheckResult` / `VerificationDiagnostic` data 1:1, so consumers see categories, primary /
related / core spans, decoded counterexamples (entities, pre / post-state relations, inputs),
and suggestion hints — not a derived subset. No separate schema type hierarchy to maintain.

**Top-level shape:**

```json
{
  "schemaVersion": 1,
  "specFile": "fixtures/spec/url_shortener.spec",
  "ok": false,
  "totalMs": 842.0,
  "checks": [ /* CheckResult 1:1 */ ]
}
```

**Stable enum tokens** (documented in `verification.mdx`):

- `kind` — `global | requires | enabled | preservation | temporal`
- `status` — `sat | unsat | unknown | skipped`
- `tool` — `z3 | alloy`
- `level` — `error | warning`
- `category` — `contradictory_invariants | unsatisfiable_precondition | unreachable_operation | invariant_violation_by_operation | solver_timeout | translator_limitation | backend_error`

**Exit codes unchanged.** `--json` is an output-format selector, not a contract change — a
CI pipeline can still key on the 0 / 1 / 2 / 3 exit signal while parsing the structured
report off the same invocation.

## Design notes

- Two-flag pattern (`--json` for stdout, `--json-out <file>` for file) mirrors the existing
  `--dump-smt` / `--dump-smt-out` convention rather than the `--json [optional-file]` shape
  in the issue — the two-flag form composes more cleanly with `decline` and is consistent
  with the rest of the CLI.
- `schemaVersion` is an integer (`1`), matching the `verdicts.json` emitted by `--dump-vc`.
  The issue body showed a string `"1"`; integer is more idiomatic and consistent with the
  sibling dump format.
- `--json` composes with `--explain` (core spans land in JSON) and `--dump-vc <dir>` (VC
  artifacts go to the dir, JSON to stdout/file). It does **not** compose with `--dump-smt`
  / `--dump-alloy`, which short-circuit before running any checks.

## Testing

- **`JsonReportTest.scala`** — parametrized snapshot tests across three fixtures covering
  the distinct diagnostic shapes: `safe_counter` (all pass, no diagnostics),
  `unsat_invariants` (global `unsat` with populated `coreSpans`), `broken_url_shortener`
  (preservation violation with decoded counterexample: entities, pre/post-state relations,
  inputs). Timing fields zeroed before diff; goldens are checked in.
- **Round-trip test** — re-parses emitted JSON via circe, cursor-navigates to find a
  preservation check by `category === "invariant_violation_by_operation"`, asserts CE
  entity fields are reachable. Covers the AC's "small consumer" scenario.
- **`VerifyJsonTest.scala`** — CLI integration tests: stdout mode, file mode, exit code
  on failing spec (`ExitViolations`), `--explain` compatibility.

All 101 tests green locally. sbt scalafmtCheckAll clean. scalafix --check clean. Docs build
clean.

## Test plan

- [ ] `sbt "all compile Test/compile"`
- [ ] `sbt test` — 101 tests pass
- [ ] `sbt scalafmtCheckAll`
- [ ] `sbt "scalafixAll --check"`
- [ ] `cd docs && npm run build`
- [ ] CI z3-cross-check still passes (no VC-dump artifacts changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--json` flag to the verify command for JSON output to stdout
  * Added `--json-out <file>` flag to write verification results as JSON to a specified file

* **Documentation**
  * Updated verification CLI documentation with detailed JSON schema, flag descriptions, and output structure details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds machine-readable JSON output to `spec-to-rest verify` via `--json` and `--json-out`, so editors and CI can consume full diagnostics. Exit codes stay the same; closes #79.

- **New Features**
  - `--json` prints the report to stdout; `--json-out <file>` writes to a file. Both suppress text output.
  - Report mirrors internal checks and diagnostics 1:1 (spans, counterexamples, suggestions) with `schemaVersion: 1` and stable enum tokens for `kind`, `status`, `tool`, `level`, and `category`.
  - Works with `--explain` and `--dump-vc`. Combining with `--dump-smt`/`--dump-alloy` is explicitly rejected with a clear error.

- **Refactors**
  - Centralized enum token emitters on `CheckKind`, `CheckOutcome`, `DiagnosticLevel`, `DiagnosticCategory`, and `CheckStatus`, shared by JSON and `Dump`.
  - Tests lock the contract that SAT checks have `diagnostic: null`, and only top-level `totalMs` and per-check `durationMs` are scrubbed in snapshots.

<sup>Written for commit 524e0172de0fd864ab6e920535aad616a3b02261. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

