### PR TITLE
M_CE.1: cats-effect 3.7 foundation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,16 +17,23 @@ ThisBuild / semanticdbEnabled := true
 
 val circeVersion      = "0.14.10"
 val munitVersion      = "1.0.3"
+val munitCEVersion    = "2.2.0"
 val antlrVersion      = "4.13.2"
 val z3TurnkeyVersion  = "4.13.0.1"
 val alloyVersion      = "6.2.0"
 val handlebarsVersion = "4.3.1"
-val declineVersion    = "2.4.1"
+val declineVersion    = "2.6.2"
 val apispecVersion    = "0.11.3"
 val snakeYamlVersion  = "2.3"
+val catsEffectVersion = "3.7.0"
+
+lazy val commonMainDeps = Seq(
+  "org.typelevel" %% "cats-effect" % catsEffectVersion
+)
 
 lazy val commonTestDeps = Seq(
-  "org.scalameta" %% "munit" % munitVersion % Test
+  "org.scalameta" %% "munit"             % munitVersion   % Test,
+  "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test
 )
 
 lazy val ir = (project in file("modules/ir"))
@@ -36,7 +43,7 @@ lazy val ir = (project in file("modules/ir"))
       "io.circe" %% "circe-core"    % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser"  % circeVersion
-    ) ++ commonTestDeps
+    ) ++ commonMainDeps ++ commonTestDeps
   )
 
 lazy val parser = (project in file("modules/parser"))
@@ -50,21 +57,21 @@ lazy val parser = (project in file("modules/parser"))
     Antlr4 / antlr4GenVisitor  := true,
     libraryDependencies ++= Seq(
       "org.antlr" % "antlr4-runtime" % antlrVersion
-    ) ++ commonTestDeps
+    ) ++ commonMainDeps ++ commonTestDeps
   )
 
 lazy val convention = (project in file("modules/convention"))
   .dependsOn(ir, parser % Test)
   .settings(
     name := "spec-convention",
-    libraryDependencies ++= commonTestDeps
+    libraryDependencies ++= commonMainDeps ++ commonTestDeps
   )
 
 lazy val profile = (project in file("modules/profile"))
   .dependsOn(ir, convention, parser % Test)
   .settings(
     name := "spec-profile",
-    libraryDependencies ++= commonTestDeps
+    libraryDependencies ++= commonMainDeps ++ commonTestDeps
   )
 
 lazy val verify = (project in file("modules/verify"))
@@ -78,7 +85,7 @@ lazy val verify = (project in file("modules/verify"))
       "org.alloytools" % "org.alloytools.alloy.core"        % alloyVersion,
       "org.alloytools" % "org.alloytools.pardinus.core"     % alloyVersion,
       "org.alloytools" % "org.alloytools.pardinus.native"   % alloyVersion
-    ) ++ commonTestDeps
+    ) ++ commonMainDeps ++ commonTestDeps
   )
 
 lazy val codegen = (project in file("modules/codegen"))
@@ -89,7 +96,7 @@ lazy val codegen = (project in file("modules/codegen"))
       "com.github.jknack"              % "handlebars"    % handlebarsVersion,
       "com.softwaremill.sttp.apispec" %% "openapi-model" % apispecVersion,
       "org.yaml"                       % "snakeyaml"     % snakeYamlVersion
-    ) ++ commonTestDeps
+    ) ++ commonMainDeps ++ commonTestDeps
   )
 
 lazy val cli = (project in file("modules/cli"))
@@ -100,11 +107,12 @@ lazy val cli = (project in file("modules/cli"))
     Compile / mainClass := Some("specrest.cli.Main"),
     libraryDependencies ++= Seq(
       "com.monovore"  %% "decline"                          % declineVersion,
+      "com.monovore"  %% "decline-effect"                   % declineVersion,
       "org.alloytools" % "org.alloytools.alloy.application" % alloyVersion,
       "org.alloytools" % "org.alloytools.alloy.core"        % alloyVersion,
       "org.alloytools" % "org.alloytools.pardinus.core"     % alloyVersion,
       "org.alloytools" % "org.alloytools.pardinus.native"   % alloyVersion
-    ) ++ commonTestDeps,
+    ) ++ commonMainDeps ++ commonTestDeps,
     nativeImageInstalled := true,
     nativeImageOptions ++= Seq(
       "--no-fallback",

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -53,6 +53,7 @@ CLI output so the attribution is visible.
 | Temporal `always(P)` — `P` holds in every state satisfying the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ ¬P` unsat-check) |
 | Temporal `eventually(P)` — some state satisfies `P` and the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ P` sat-check) |
 | Temporal `fairness(op)`                                              | not supported in v1 — sharp error; requires trace-based verification via Alloy's `var`-sig mode (future work) |
+| Cats Effect 3 IO pipeline (parallel dispatch, typed errors, `Resource`-managed backends) | [#95](https://github.com/HardMax71/spec_to_rest/issues/95) (meta, in-flight); CE3 + munit-cats-effect land in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) as a build dependency ahead of the pipeline migration |
 
 ## Preservation VC shape
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -53,7 +53,8 @@ CLI output so the attribution is visible.
 | Temporal `always(P)` — `P` holds in every state satisfying the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ ¬P` unsat-check) |
 | Temporal `eventually(P)` — some state satisfies `P` and the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ P` sat-check) |
 | Temporal `fairness(op)`                                              | not supported in v1 — sharp error; requires trace-based verification via Alloy's `var`-sig mode (future work) |
-| Cats Effect 3 IO pipeline (parallel dispatch, typed errors, `Resource`-managed backends) | [#95](https://github.com/HardMax71/spec_to_rest/issues/95) (meta, in-flight); CE3 + munit-cats-effect land in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) as a build dependency ahead of the pipeline migration |
+| Cats Effect 3 build dependency + `munit-cats-effect` test harness | shipped in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) — no existing code paths use IO yet |
+| Cats Effect 3 IO pipeline (parallel dispatch, typed errors, `Resource`-managed backends) | [#95](https://github.com/HardMax71/spec_to_rest/issues/95) (meta, in-flight across M_CE.2–M_CE.9) |
 
 ## Preservation VC shape
 

--- a/modules/cli/src/test/scala/specrest/cli/CatsEffectFoundationTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CatsEffectFoundationTest.scala
@@ -1,0 +1,17 @@
+package specrest.cli
+
+import cats.effect.IO
+import com.monovore.decline.Opts
+import com.monovore.decline.effect.CommandIOApp
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)
+
+  test("decline-effect CommandIOApp is on the classpath and composes with decline Opts"):
+    val dummy = new CommandIOApp(name = "dummy", header = "dummy"):
+      override def main: Opts[IO[cats.effect.ExitCode]] =
+        Opts(IO.pure(cats.effect.ExitCode.Success))
+    IO.pure(dummy).map(_ => ()).assertEquals(())

--- a/modules/codegen/src/test/scala/specrest/codegen/CatsEffectFoundationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/CatsEffectFoundationTest.scala
@@ -1,0 +1,9 @@
+package specrest.codegen
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)

--- a/modules/convention/src/test/scala/specrest/convention/CatsEffectFoundationTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/CatsEffectFoundationTest.scala
@@ -1,0 +1,9 @@
+package specrest.convention
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)

--- a/modules/ir/src/test/scala/specrest/ir/CatsEffectFoundationTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/CatsEffectFoundationTest.scala
@@ -8,7 +8,7 @@ class CatsEffectFoundationTest extends CatsEffectSuite:
   test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
     IO.pure(42).assertEquals(42)
 
-  test("IO.delay defers a side effect until evaluation"):
+  test("IO.ref allocates and threads state through the runtime"):
     for
       ref <- IO.ref(0)
       _   <- ref.update(_ + 1)

--- a/modules/ir/src/test/scala/specrest/ir/CatsEffectFoundationTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/CatsEffectFoundationTest.scala
@@ -1,0 +1,16 @@
+package specrest.ir
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)
+
+  test("IO.delay defers a side effect until evaluation"):
+    for
+      ref <- IO.ref(0)
+      _   <- ref.update(_ + 1)
+      v   <- ref.get
+    yield assertEquals(v, 1)

--- a/modules/parser/src/test/scala/specrest/parser/CatsEffectFoundationTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/CatsEffectFoundationTest.scala
@@ -1,0 +1,9 @@
+package specrest.parser
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)

--- a/modules/profile/src/test/scala/specrest/profile/CatsEffectFoundationTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/CatsEffectFoundationTest.scala
@@ -1,0 +1,9 @@
+package specrest.profile
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)

--- a/modules/verify/src/test/scala/specrest/verify/CatsEffectFoundationTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CatsEffectFoundationTest.scala
@@ -1,0 +1,9 @@
+package specrest.verify
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CatsEffectFoundationTest extends CatsEffectSuite:
+
+  test("IO.pure lifts and runs a value through the munit-cats-effect runtime"):
+    IO.pure(42).assertEquals(42)


### PR DESCRIPTION
Closes #96. Part of #95.

## Summary

Introduce the Cats Effect 3 dependency stack (foundation only — no existing code paths changed).
Gates every subsequent Tier-3 sub-issue.

## Changes

- `build.sbt`:
  - Add `"org.typelevel" %% "cats-effect" % "3.7.0"` to every module's `libraryDependencies` (via a new `commonMainDeps` val)
  - Bump `decline` `2.4.1` → `2.6.2`
  - Add `"com.monovore" %% "decline-effect" % "2.6.2"` to the `cli` module (dep only; `Main` stays sync)
  - Add `"org.typelevel" %% "munit-cats-effect" % "2.2.0" % Test` to every module (via `commonTestDeps`)
- One `CatsEffectFoundationTest` per module (`ir`, `parser`, `convention`, `profile`, `verify`, `codegen`, `cli`) extending `munit.CatsEffectSuite` — trivial `IO.pure(42).assertEquals(42)` smoke plus (in `ir`) an `IO.ref` update chain, plus (in `cli`) a compile-only instantiation of `CommandIOApp` to confirm `decline-effect` is wired
- `docs/content/docs/pipelines/verification.mdx`: one-row capability-table update pointing at meta issue #95 and this sub-issue

## Non-goals (per M_CE.1 scope)

- No existing throws converted (M_CE.2)
- No `IO.blocking` wrappers (M_CE.4)
- No new `Resource` usage (M_CE.3)
- `Main` stays as the sync decline entry point (migrated in M_CE.7)

## Test plan

- [x] `sbt compile Test/compile` clean
- [x] `sbt test` green — existing 200+ tests plus the 7 new foundation tests
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `docs/` site builds (`npm run build`)
- [ ] `native-image` build still produces a working binary — verified by CI on push

## Refs

- Meta: #95
- Sub-issue: #96
- Follow-ups (gated on this): #97 (Error ADT), #98 (Resource backends), #99 (Pipeline as IO), #100-#104

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Cats Effect 3.7 as a shared dependency and enable `munit-cats-effect` across all modules. No runtime behavior changes; this is the foundation for the CE3 pipeline (meta #95, closes #96).

- **Dependencies**
  - Add `cats-effect` 3.7.0 via `commonMainDeps`.
  - Add `munit-cats-effect` 2.2.0 in tests via `commonTestDeps`.
  - Bump `decline` to 2.6.2 and add `decline-effect` to `cli` (compile-only; `Main` stays sync).

- **New Features**
  - Add CE3 smoke tests in each module; `cli` includes a `CommandIOApp` compile check.
  - Docs: split verification capability row to show M_CE.1 deliverables vs the future IO pipeline (tracked in #95).

<sup>Written for commit 3e0f6ec40fbb7e579778debb0536f62e57e8c6c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

