### PR TITLE
M_CE.2 — Error ADT: full-FP VerifyError channel

### DIFF
--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -2,7 +2,7 @@ package specrest.cli
 
 import specrest.convention.DiagnosticLevel as ConvDiagLevel
 import specrest.convention.Validate
-import specrest.parser.BuildError
+import specrest.ir.VerifyError
 import specrest.parser.Builder
 import specrest.parser.Parse
 
@@ -26,36 +26,32 @@ object Check:
             log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
           1
         else
-          try
-            val t1      = System.nanoTime()
-            val ir      = Builder.buildIR(parsed.tree)
-            val buildMs = (System.nanoTime() - t1) / 1_000_000.0
-            log.verbose(f"Built IR in ${buildMs}%.0fms")
-
-            val diagnostics = Validate.validateConventions(ir.conventions, ir)
-            val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
-            val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
-
-            for w <- warnings do
-              val loc = w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-              log.warn(s"${loc}warning: ${w.message}")
-            for e <- errors do
-              val loc = e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-              log.error(s"${loc}${e.message}")
-
-            if errors.nonEmpty then 1
-            else
-              log.success(
-                s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
-              )
-              0
-          catch
-            case e: BuildError =>
-              log.error(s"$specFile: ${e.getMessage}")
+          val t1 = System.nanoTime()
+          Builder.buildIR(parsed.tree) match
+            case Left(err) =>
+              log.error(renderBuildError(specFile, err))
               1
-            case e: RuntimeException =>
-              log.error(s"$specFile: ${e.getMessage}")
-              1
+            case Right(ir) =>
+              val buildMs = (System.nanoTime() - t1) / 1_000_000.0
+              log.verbose(f"Built IR in ${buildMs}%.0fms")
+
+              val diagnostics = Validate.validateConventions(ir.conventions, ir)
+              val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
+              val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
+
+              for w <- warnings do
+                val loc = w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                log.warn(s"${loc}warning: ${w.message}")
+              for e <- errors do
+                val loc = e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                log.error(s"${loc}${e.message}")
+
+              if errors.nonEmpty then 1
+              else
+                log.success(
+                  s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
+                )
+                0
 
   private[cli] def readSource(specFile: String, log: Logger): Either[Int, String] =
     try Right(Files.readString(Paths.get(specFile)))
@@ -69,3 +65,8 @@ object Check:
       case e: RuntimeException =>
         log.error(s"Cannot read $specFile: ${e.getMessage}")
         Left(1)
+
+  private[cli] def renderBuildError(specFile: String, e: VerifyError.Build): String =
+    e.span match
+      case Some(s) => s"$specFile:${s.startLine}:${s.startCol}: Build error: ${e.message}"
+      case None    => s"$specFile: Build error: ${e.message}"

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -8,6 +8,7 @@ import specrest.profile.Annotate
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
+import scala.util.control.NonFatal
 
 final case class CompileOptions(
     target: String,
@@ -48,6 +49,6 @@ object Compile:
                 log.success(s"wrote ${files.length} files to ${opts.outDir}")
                 0
               catch
-                case e: RuntimeException =>
-                  log.error(s"$specFile: ${e.getMessage}")
+                case NonFatal(e) =>
+                  log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
                   1

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -1,7 +1,6 @@
 package specrest.cli
 
 import specrest.codegen.Emit
-import specrest.parser.BuildError
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.profile.Annotate
@@ -27,27 +26,28 @@ object Compile:
             log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
           1
         else
-          try
-            val ir       = Builder.buildIR(parsed.tree)
-            val profiled = Annotate.buildProfiledService(ir, opts.target)
-            val files    = Emit.emitProject(profiled)
-            val outRoot  = Paths.get(opts.outDir)
-            Files.createDirectories(outRoot)
-            files.foreach: f =>
-              val target = outRoot.resolve(f.path)
-              Option(target.getParent).foreach(Files.createDirectories(_))
-              Files.writeString(
-                target,
-                f.content,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING
-              )
-            log.success(s"wrote ${files.length} files to ${opts.outDir}")
-            0
-          catch
-            case e: BuildError =>
-              log.error(s"$specFile: ${e.getMessage}")
+          Builder.buildIR(parsed.tree) match
+            case Left(err) =>
+              log.error(Check.renderBuildError(specFile, err))
               1
-            case e: RuntimeException =>
-              log.error(s"$specFile: ${e.getMessage}")
-              1
+            case Right(ir) =>
+              try
+                val profiled = Annotate.buildProfiledService(ir, opts.target)
+                val files    = Emit.emitProject(profiled)
+                val outRoot  = Paths.get(opts.outDir)
+                Files.createDirectories(outRoot)
+                files.foreach: f =>
+                  val target = outRoot.resolve(f.path)
+                  Option(target.getParent).foreach(Files.createDirectories(_))
+                  Files.writeString(
+                    target,
+                    f.content,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING
+                  )
+                log.success(s"wrote ${files.length} files to ${opts.outDir}")
+                0
+              catch
+                case e: RuntimeException =>
+                  log.error(s"$specFile: ${e.getMessage}")
+                  1

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -4,7 +4,6 @@ import io.circe.Printer
 import io.circe.syntax.EncoderOps
 import specrest.ir.Serialize
 import specrest.ir.Serialize.given
-import specrest.parser.BuildError
 import specrest.parser.Builder
 import specrest.parser.Parse
 
@@ -30,18 +29,13 @@ object Inspect:
             log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
           1
         else
-          try
-            val ir     = Builder.buildIR(parsed.tree)
-            val output = formatIR(ir, format)
-            println(output)
-            0
-          catch
-            case e: BuildError =>
-              log.error(s"$specFile: ${e.getMessage}")
+          Builder.buildIR(parsed.tree) match
+            case Left(err) =>
+              log.error(Check.renderBuildError(specFile, err))
               1
-            case e: RuntimeException =>
-              log.error(s"$specFile: ${e.getMessage}")
-              1
+            case Right(ir) =>
+              println(formatIR(ir, format))
+              0
 
   private def formatIR(ir: specrest.ir.ServiceIR, format: InspectFormat): String = format match
     case InspectFormat.Json =>

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -63,11 +63,7 @@ object Verify:
               ExitViolations
             case Right(ir) =>
               log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
-              try runWithIR(specFile, ir, opts, log)
-              catch
-                case e: RuntimeException =>
-                  log.error(s"$specFile: ${e.getMessage}")
-                  ExitBackend
+              runWithIR(specFile, ir, opts, log)
 
   private def runWithIR(
       specFile: String,
@@ -95,19 +91,30 @@ object Verify:
               print(smt)
           ExitOk
     else if opts.dumpAlloy || opts.dumpAlloyOut.isDefined then
-      val module = AlloyTranslator.translateGlobal(ir, opts.alloyScope)
-      val source = AlloyRender.render(module)
-      opts.dumpAlloyOut match
-        case Some(path) =>
-          Files.writeString(Paths.get(path), source)
-          log.success(s"Wrote Alloy source to $path")
-        case None =>
-          print(source)
-      ExitOk
+      AlloyTranslator.translateGlobal(ir, opts.alloyScope) match
+        case Left(err) =>
+          log.error(s"$specFile: alloy translator: ${err.message}")
+          ExitTranslator
+        case Right(module) =>
+          val source = AlloyRender.render(module)
+          opts.dumpAlloyOut match
+            case Some(path) =>
+              Files.writeString(Paths.get(path), source)
+              log.success(s"Wrote Alloy source to $path")
+            case None =>
+              print(source)
+          ExitOk
     else
       log.verbose(s"Timeout: ${opts.timeoutMs}ms")
       log.verbose(s"Alloy scope: ${opts.alloyScope}")
-      val sink = opts.dumpVc.map(p => DumpSink.open(Paths.get(p)))
+      val sink: Option[DumpSink] = opts.dumpVc match
+        case None => None
+        case Some(p) =>
+          DumpSink.open(Paths.get(p)) match
+            case Left(err) =>
+              log.error(s"$specFile: ${err.message}")
+              return ExitBackend
+            case Right(s) => Some(s)
       sink.foreach(s => log.verbose(s"Writing per-check VC artifacts to ${s.dir}"))
       val backend = WasmBackend()
       try

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -1,6 +1,7 @@
 package specrest.cli
 
-import specrest.parser.BuildError
+import specrest.ir.ServiceIR
+import specrest.ir.VerifyError
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.verify.*
@@ -55,28 +56,28 @@ object Verify:
             log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
           ExitViolations
         else
-          try runWithIR(specFile, parsed.tree, opts, log)
-          catch
-            case e: BuildError =>
-              log.error(s"$specFile: ${e.getMessage}")
+          val tBuild0 = System.nanoTime()
+          Builder.buildIR(parsed.tree) match
+            case Left(err) =>
+              log.error(Check.renderBuildError(specFile, err))
               ExitViolations
-            case e: TranslatorError =>
-              log.error(s"$specFile: translator limitation: ${e.getMessage}")
-              ExitTranslator
-            case e: RuntimeException =>
-              log.error(s"$specFile: ${e.getMessage}")
-              ExitBackend
+            case Right(ir) =>
+              log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
+              try runWithIR(specFile, ir, opts, log)
+              catch
+                case e: TranslatorError =>
+                  log.error(s"$specFile: translator limitation: ${e.getMessage}")
+                  ExitTranslator
+                case e: RuntimeException =>
+                  log.error(s"$specFile: ${e.getMessage}")
+                  ExitBackend
 
   private def runWithIR(
       specFile: String,
-      tree: specrest.parser.generated.SpecParser.SpecFileContext,
+      ir: ServiceIR,
       opts: VerifyOptions,
       log: Logger
   ): Int =
-    val tBuild0 = System.nanoTime()
-    val ir      = Builder.buildIR(tree)
-    log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
-
     if opts.dumpSmt || opts.dumpSmtOut.isDefined then
       val tTrans0 = System.nanoTime()
       val script  = Translator.translate(ir)

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -65,9 +65,6 @@ object Verify:
               log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
               try runWithIR(specFile, ir, opts, log)
               catch
-                case e: TranslatorError =>
-                  log.error(s"$specFile: translator limitation: ${e.getMessage}")
-                  ExitTranslator
                 case e: RuntimeException =>
                   log.error(s"$specFile: ${e.getMessage}")
                   ExitBackend
@@ -80,19 +77,23 @@ object Verify:
   ): Int =
     if opts.dumpSmt || opts.dumpSmtOut.isDefined then
       val tTrans0 = System.nanoTime()
-      val script  = Translator.translate(ir)
-      log.verbose(
-        f"Translated IR to Z3 script: ${script.sorts.length} sorts, ${script.funcs.length} function decls, ${script.assertions.length} assertions (${(System.nanoTime() - tTrans0) / 1_000_000.0}%.0fms)"
-      )
-      val timeout = if opts.timeoutMs > 0 then Some(opts.timeoutMs) else None
-      val smt     = SmtLib.renderSmtLib(script, timeout)
-      opts.dumpSmtOut match
-        case Some(path) =>
-          Files.writeString(Paths.get(path), smt)
-          log.success(s"Wrote SMT-LIB to $path")
-        case None =>
-          print(smt)
-      ExitOk
+      Translator.translate(ir) match
+        case Left(err) =>
+          log.error(s"$specFile: translator limitation: ${err.message}")
+          ExitTranslator
+        case Right(script) =>
+          log.verbose(
+            f"Translated IR to Z3 script: ${script.sorts.length} sorts, ${script.funcs.length} function decls, ${script.assertions.length} assertions (${(System.nanoTime() - tTrans0) / 1_000_000.0}%.0fms)"
+          )
+          val timeout = if opts.timeoutMs > 0 then Some(opts.timeoutMs) else None
+          val smt     = SmtLib.renderSmtLib(script, timeout)
+          opts.dumpSmtOut match
+            case Some(path) =>
+              Files.writeString(Paths.get(path), smt)
+              log.success(s"Wrote SMT-LIB to $path")
+            case None =>
+              print(smt)
+          ExitOk
     else if opts.dumpAlloy || opts.dumpAlloyOut.isDefined then
       val module = AlloyTranslator.translateGlobal(ir, opts.alloyScope)
       val source = AlloyRender.render(module)

--- a/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
@@ -18,7 +18,7 @@ class AlembicMigrationTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("empty schema produces empty migration"):

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -13,7 +13,7 @@ class EmitTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("emitProject runs without crashing on url_shortener"):

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -14,7 +14,7 @@ class OpenApiTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty)
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("buildOpenApiDocument returns a well-formed document"):

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -24,7 +24,7 @@ class ConventionSmokeTest extends munit.FunSuite:
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   test("classify + derive + validate runs for every fixture"):
     fixtures.foreach: fixture =>

--- a/modules/ir/src/main/scala/specrest/ir/VerifyError.scala
+++ b/modules/ir/src/main/scala/specrest/ir/VerifyError.scala
@@ -1,0 +1,11 @@
+package specrest.ir
+
+sealed trait VerifyError derives CanEqual
+object VerifyError:
+  final case class Parse(errors: List[ParseError])                 extends VerifyError
+  final case class Build(message: String, span: Option[Span])      extends VerifyError
+  final case class Translator(message: String)                     extends VerifyError
+  final case class AlloyTranslator(message: String)                extends VerifyError
+  final case class Backend(message: String, cause: Option[String]) extends VerifyError
+
+final case class ParseError(line: Int, column: Int, message: String)

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -7,12 +7,7 @@ import specrest.parser.generated.SpecParser.*
 
 import scala.jdk.CollectionConverters.*
 
-final class BuildError(msg: String, ctx: ParserRuleContext)
-    extends RuntimeException({
-      val line = Option(ctx.getStart).map(_.getLine).getOrElse(0)
-      val col  = Option(ctx.getStart).map(_.getCharPositionInLine).getOrElse(0)
-      s"Build error at $line:$col: $msg"
-    })
+private type BuildResult[A] = Either[VerifyError.Build, A]
 
 private def spanFrom(ctx: ParserRuleContext): Span =
   val start = ctx.getStart
@@ -25,6 +20,9 @@ private def spanFrom(ctx: ParserRuleContext): Span =
   )
 
 private def sp(ctx: ParserRuleContext): Option[Span] = Some(spanFrom(ctx))
+
+private def buildErr(msg: String, ctx: ParserRuleContext): VerifyError.Build =
+  VerifyError.Build(msg, sp(ctx))
 
 private def unquote(raw: String): String =
   val inner = raw.substring(1, raw.length - 1)
@@ -46,395 +44,483 @@ private def unquote(raw: String): String =
 
 private def unslashRegex(raw: String): String = raw.substring(1, raw.length - 1)
 
+extension [A](list: List[BuildResult[A]])
+  private def sequenceB: BuildResult[List[A]] =
+    list.foldRight[BuildResult[List[A]]](Right(Nil)):
+      case (eh, et) => eh.flatMap(h => et.map(h :: _))
+
+extension [A, B](list: List[A])
+  private def traverseB(f: A => BuildResult[B]): BuildResult[List[B]] =
+    list.map(f).sequenceB
+
 object Builder:
-  def buildIR(tree: SpecFileContext): ServiceIR =
-    val imports =
-      tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
-    val ir = new IRBuilder().buildService(tree.serviceDecl)
-    ir.copy(imports = imports)
+  def buildIR(tree: SpecFileContext): BuildResult[ServiceIR] =
+    val imports = tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
+    new IRBuilder().buildService(tree.serviceDecl).map(_.copy(imports = imports))
 
-final private class IRBuilder extends SpecBaseVisitor[Expr]:
+final private case class ServiceAcc(
+    entities: List[EntityDecl] = Nil,
+    enums: List[EnumDecl] = Nil,
+    typeAliases: List[TypeAliasDecl] = Nil,
+    state: Option[StateDecl] = None,
+    operations: List[OperationDecl] = Nil,
+    transitions: List[TransitionDecl] = Nil,
+    invariants: List[InvariantDecl] = Nil,
+    temporals: List[TemporalDecl] = Nil,
+    facts: List[FactDecl] = Nil,
+    functions: List[FunctionDecl] = Nil,
+    predicates: List[PredicateDecl] = Nil,
+    conventions: Option[ConventionsDecl] = None
+)
 
-  override def defaultResult(): Expr =
-    throw new RuntimeException("IRBuilder: unhandled expression node")
+final private class IRBuilder extends SpecBaseVisitor[BuildResult[Expr]]:
 
-  private def expr(ctx: ExprContext): Expr = visit(ctx)
+  override def defaultResult(): BuildResult[Expr] =
+    Left(VerifyError.Build("IRBuilder: unhandled expression node", None))
 
-  private def binOp(ctx: ParserRuleContext, l: ExprContext, r: ExprContext, op: BinOp): Expr =
-    Expr.BinaryOp(op, expr(l), expr(r), sp(ctx))
+  private def expr(ctx: ExprContext): BuildResult[Expr] = visit(ctx)
 
-  private def unaryOp(ctx: ParserRuleContext, arg: ExprContext, op: UnOp): Expr =
-    Expr.UnaryOp(op, expr(arg), sp(ctx))
+  private def binOp(
+      ctx: ParserRuleContext,
+      l: ExprContext,
+      r: ExprContext,
+      op: BinOp
+  ): BuildResult[Expr] =
+    for
+      lE <- expr(l)
+      rE <- expr(r)
+    yield Expr.BinaryOp(op, lE, rE, sp(ctx))
 
-  // ═══ Declarations ═══
+  private def unaryOp(ctx: ParserRuleContext, arg: ExprContext, op: UnOp): BuildResult[Expr] =
+    expr(arg).map(a => Expr.UnaryOp(op, a, sp(ctx)))
 
-  def buildService(ctx: ServiceDeclContext): ServiceIR =
-    val name                                 = ctx.UPPER_IDENT.getText
-    val entities                             = List.newBuilder[EntityDecl]
-    val enums                                = List.newBuilder[EnumDecl]
-    val typeAliases                          = List.newBuilder[TypeAliasDecl]
-    var state: Option[StateDecl]             = None
-    val operations                           = List.newBuilder[OperationDecl]
-    val transitions                          = List.newBuilder[TransitionDecl]
-    val invariants                           = List.newBuilder[InvariantDecl]
-    val temporals                            = List.newBuilder[TemporalDecl]
-    val facts                                = List.newBuilder[FactDecl]
-    val functions                            = List.newBuilder[FunctionDecl]
-    val predicates                           = List.newBuilder[PredicateDecl]
-    var conventions: Option[ConventionsDecl] = None
+  def buildService(ctx: ServiceDeclContext): BuildResult[ServiceIR] =
+    val name = ctx.UPPER_IDENT.getText
+    val finalAcc = ctx.serviceMember.asScala.toList
+      .foldLeft[BuildResult[ServiceAcc]](Right(ServiceAcc())):
+        case (accE, member) => accE.flatMap(acc => processMember(acc, member))
+    finalAcc.map: acc =>
+      ServiceIR(
+        name = name,
+        imports = Nil,
+        entities = acc.entities.reverse,
+        enums = acc.enums.reverse,
+        typeAliases = acc.typeAliases.reverse,
+        state = acc.state,
+        operations = acc.operations.reverse,
+        transitions = acc.transitions.reverse,
+        invariants = acc.invariants.reverse,
+        temporals = acc.temporals.reverse,
+        facts = acc.facts.reverse,
+        functions = acc.functions.reverse,
+        predicates = acc.predicates.reverse,
+        conventions = acc.conventions,
+        span = sp(ctx)
+      )
 
-    for member <- ctx.serviceMember.asScala do
-      if member.entityDecl != null then entities += buildEntity(member.entityDecl)
-      else if member.enumDecl != null then enums += buildEnum(member.enumDecl)
-      else if member.typeAlias != null then typeAliases += buildTypeAlias(member.typeAlias)
-      else if member.stateDecl != null then
-        if state.isDefined then throw new BuildError("duplicate state block", member.stateDecl)
-        state = Some(buildState(member.stateDecl))
-      else if member.operationDecl != null then operations += buildOperation(member.operationDecl)
-      else if member.transitionDecl != null then
-        transitions += buildTransition(member.transitionDecl)
-      else if member.invariantDecl != null then invariants += buildInvariant(member.invariantDecl)
-      else if member.temporalDecl != null then temporals += buildTemporal(member.temporalDecl)
-      else if member.factDecl != null then facts += buildFact(member.factDecl)
-      else if member.functionDecl != null then functions += buildFunction(member.functionDecl)
-      else if member.predicateDecl != null then predicates += buildPredicate(member.predicateDecl)
-      else if member.conventionBlock != null then
-        if conventions.isDefined then
-          throw new BuildError("duplicate conventions block", member.conventionBlock)
-        conventions = Some(buildConventions(member.conventionBlock))
+  private def processMember(acc: ServiceAcc, m: ServiceMemberContext): BuildResult[ServiceAcc] =
+    if m.entityDecl != null then
+      buildEntity(m.entityDecl).map(e => acc.copy(entities = e :: acc.entities))
+    else if m.enumDecl != null then
+      Right(acc.copy(enums = buildEnum(m.enumDecl) :: acc.enums))
+    else if m.typeAlias != null then
+      buildTypeAlias(m.typeAlias).map(t => acc.copy(typeAliases = t :: acc.typeAliases))
+    else if m.stateDecl != null then
+      if acc.state.isDefined then Left(buildErr("duplicate state block", m.stateDecl))
+      else buildState(m.stateDecl).map(s => acc.copy(state = Some(s)))
+    else if m.operationDecl != null then
+      buildOperation(m.operationDecl).map(o => acc.copy(operations = o :: acc.operations))
+    else if m.transitionDecl != null then
+      buildTransition(m.transitionDecl).map(t => acc.copy(transitions = t :: acc.transitions))
+    else if m.invariantDecl != null then
+      buildInvariant(m.invariantDecl).map(i => acc.copy(invariants = i :: acc.invariants))
+    else if m.temporalDecl != null then
+      buildTemporal(m.temporalDecl).map(t => acc.copy(temporals = t :: acc.temporals))
+    else if m.factDecl != null then
+      buildFact(m.factDecl).map(f => acc.copy(facts = f :: acc.facts))
+    else if m.functionDecl != null then
+      buildFunction(m.functionDecl).map(f => acc.copy(functions = f :: acc.functions))
+    else if m.predicateDecl != null then
+      buildPredicate(m.predicateDecl).map(p => acc.copy(predicates = p :: acc.predicates))
+    else if m.conventionBlock != null then
+      if acc.conventions.isDefined then
+        Left(buildErr("duplicate conventions block", m.conventionBlock))
+      else buildConventions(m.conventionBlock).map(c => acc.copy(conventions = Some(c)))
+    else Right(acc)
 
-    ServiceIR(
-      name = name,
-      imports = Nil,
-      entities = entities.result(),
-      enums = enums.result(),
-      typeAliases = typeAliases.result(),
-      state = state,
-      operations = operations.result(),
-      transitions = transitions.result(),
-      invariants = invariants.result(),
-      temporals = temporals.result(),
-      facts = facts.result(),
-      functions = functions.result(),
-      predicates = predicates.result(),
-      conventions = conventions,
-      span = sp(ctx)
-    )
-
-  private def buildEntity(ctx: EntityDeclContext): EntityDecl =
+  private def buildEntity(ctx: EntityDeclContext): BuildResult[EntityDecl] =
     val idents     = ctx.UPPER_IDENT
     val name       = idents.get(0).getText
     val extendsOpt = if ctx.EXTENDS != null then Some(idents.get(1).getText) else None
-    val fields     = List.newBuilder[FieldDecl]
-    val invariants = List.newBuilder[Expr]
-    for member <- ctx.entityMember.asScala do
-      if member.fieldDecl != null then fields += buildField(member.fieldDecl)
-      else if member.entityInvariant != null then
-        invariants += expr(member.entityInvariant.expr)
-    EntityDecl(name, extendsOpt, fields.result(), invariants.result(), sp(ctx))
+    val members    = ctx.entityMember.asScala.toList
+    val parts = members.foldLeft[BuildResult[(List[FieldDecl], List[Expr])]](Right((Nil, Nil))):
+      case (accE, member) =>
+        accE.flatMap: (fs, invs) =>
+          if member.fieldDecl != null then
+            buildField(member.fieldDecl).map(f => (f :: fs, invs))
+          else if member.entityInvariant != null then
+            expr(member.entityInvariant.expr).map(e => (fs, e :: invs))
+          else Right((fs, invs))
+    parts.map: (fs, invs) =>
+      EntityDecl(name, extendsOpt, fs.reverse, invs.reverse, sp(ctx))
 
-  private def buildField(ctx: FieldDeclContext): FieldDecl =
-    val name       = ctx.lowerIdent.getText
-    val typeExprV  = buildTypeExpr(ctx.typeExpr)
-    val constraint = if ctx.WHERE != null then Some(expr(ctx.expr)) else None
-    FieldDecl(name, typeExprV, constraint, sp(ctx))
+  private def buildField(ctx: FieldDeclContext): BuildResult[FieldDecl] =
+    val name      = ctx.lowerIdent.getText
+    val typeExprV = buildTypeExpr(ctx.typeExpr)
+    val constraintE: BuildResult[Option[Expr]] =
+      if ctx.WHERE != null then expr(ctx.expr).map(Some(_)) else Right(None)
+    for
+      t <- typeExprV
+      c <- constraintE
+    yield FieldDecl(name, t, c, sp(ctx))
 
   private def buildEnum(ctx: EnumDeclContext): EnumDecl =
     val name   = ctx.UPPER_IDENT.getText
     val values = ctx.enumValue.asScala.map(_.UPPER_IDENT.getText).toList
     EnumDecl(name, values, sp(ctx))
 
-  private def buildTypeAlias(ctx: TypeAliasContext): TypeAliasDecl =
-    val name       = ctx.UPPER_IDENT.getText
-    val typeExprV  = buildTypeExpr(ctx.typeExpr)
-    val constraint = if ctx.WHERE != null then Some(expr(ctx.expr)) else None
-    TypeAliasDecl(name, typeExprV, constraint, sp(ctx))
+  private def buildTypeAlias(ctx: TypeAliasContext): BuildResult[TypeAliasDecl] =
+    val name      = ctx.UPPER_IDENT.getText
+    val typeExprV = buildTypeExpr(ctx.typeExpr)
+    val constraintE: BuildResult[Option[Expr]] =
+      if ctx.WHERE != null then expr(ctx.expr).map(Some(_)) else Right(None)
+    for
+      t <- typeExprV
+      c <- constraintE
+    yield TypeAliasDecl(name, t, c, sp(ctx))
 
-  private def buildState(ctx: StateDeclContext): StateDecl =
-    val fields = ctx.stateField.asScala.map(buildStateField).toList
-    StateDecl(fields, sp(ctx))
+  private def buildState(ctx: StateDeclContext): BuildResult[StateDecl] =
+    ctx.stateField.asScala.toList
+      .traverseB(buildStateField)
+      .map(fields => StateDecl(fields, sp(ctx)))
 
-  private def buildStateField(ctx: StateFieldContext): StateFieldDecl =
-    StateFieldDecl(ctx.lowerIdent.getText, buildTypeExpr(ctx.typeExpr), sp(ctx))
+  private def buildStateField(ctx: StateFieldContext): BuildResult[StateFieldDecl] =
+    buildTypeExpr(ctx.typeExpr).map(t => StateFieldDecl(ctx.lowerIdent.getText, t, sp(ctx)))
 
-  private def buildOperation(ctx: OperationDeclContext): OperationDecl =
-    val name     = ctx.UPPER_IDENT.getText
-    val inputs   = List.newBuilder[ParamDecl]
-    val outputs  = List.newBuilder[ParamDecl]
-    val requires = List.newBuilder[Expr]
-    val ensures  = List.newBuilder[Expr]
-    for clause <- ctx.operationClause.asScala do
-      if clause.inputClause != null then
-        for p <- clause.inputClause.paramList.param.asScala do inputs += buildParam(p)
-      else if clause.outputClause != null then
-        for p <- clause.outputClause.paramList.param.asScala do outputs += buildParam(p)
-      else if clause.requiresClause != null then
-        for e <- clause.requiresClause.expr.asScala do requires += expr(e)
-      else if clause.ensuresClause != null then
-        for e <- clause.ensuresClause.expr.asScala do ensures += expr(e)
-    OperationDecl(
-      name,
-      inputs.result(),
-      outputs.result(),
-      requires.result(),
-      ensures.result(),
-      sp(ctx)
-    )
+  private def buildOperation(ctx: OperationDeclContext): BuildResult[OperationDecl] =
+    val name    = ctx.UPPER_IDENT.getText
+    val clauses = ctx.operationClause.asScala.toList
+    val acc0: BuildResult[(List[ParamDecl], List[ParamDecl], List[Expr], List[Expr])] =
+      Right((Nil, Nil, Nil, Nil))
+    val collected = clauses.foldLeft(acc0):
+      case (accE, clause) =>
+        accE.flatMap: (ins, outs, reqs, ens) =>
+          if clause.inputClause != null then
+            clause.inputClause.paramList.param.asScala.toList
+              .traverseB(buildParam)
+              .map(ps => (ins ++ ps, outs, reqs, ens))
+          else if clause.outputClause != null then
+            clause.outputClause.paramList.param.asScala.toList
+              .traverseB(buildParam)
+              .map(ps => (ins, outs ++ ps, reqs, ens))
+          else if clause.requiresClause != null then
+            clause.requiresClause.expr.asScala.toList
+              .traverseB(expr)
+              .map(es => (ins, outs, reqs ++ es, ens))
+          else if clause.ensuresClause != null then
+            clause.ensuresClause.expr.asScala.toList
+              .traverseB(expr)
+              .map(es => (ins, outs, reqs, ens ++ es))
+          else Right((ins, outs, reqs, ens))
+    collected.map: (ins, outs, reqs, ens) =>
+      OperationDecl(name, ins, outs, reqs, ens, sp(ctx))
 
-  private def buildParam(ctx: ParamContext): ParamDecl =
-    ParamDecl(ctx.lowerIdent.getText, buildTypeExpr(ctx.typeExpr), sp(ctx))
+  private def buildParam(ctx: ParamContext): BuildResult[ParamDecl] =
+    buildTypeExpr(ctx.typeExpr).map(t => ParamDecl(ctx.lowerIdent.getText, t, sp(ctx)))
 
-  private def buildTransition(ctx: TransitionDeclContext): TransitionDecl =
+  private def buildTransition(ctx: TransitionDeclContext): BuildResult[TransitionDecl] =
     val idents     = ctx.UPPER_IDENT
     val name       = idents.get(0).getText
     val entityName = idents.get(1).getText
     val fieldName  = ctx.lowerIdent.getText
-    val rules      = ctx.transitionRule.asScala.map(buildTransitionRule).toList
-    TransitionDecl(name, entityName, fieldName, rules, sp(ctx))
+    ctx.transitionRule.asScala.toList
+      .traverseB(buildTransitionRule)
+      .map(rules => TransitionDecl(name, entityName, fieldName, rules, sp(ctx)))
 
-  private def buildTransitionRule(ctx: TransitionRuleContext): TransitionRule =
+  private def buildTransitionRule(ctx: TransitionRuleContext): BuildResult[TransitionRule] =
     val idents = ctx.UPPER_IDENT
     val from   = idents.get(0).getText
     val to     = idents.get(1).getText
     val via    = idents.get(2).getText
-    val guard  = if ctx.WHEN != null then Some(expr(ctx.expr)) else None
-    TransitionRule(from, to, via, guard, sp(ctx))
+    val guardE: BuildResult[Option[Expr]] =
+      if ctx.WHEN != null then expr(ctx.expr).map(Some(_)) else Right(None)
+    guardE.map(g => TransitionRule(from, to, via, g, sp(ctx)))
 
-  private def buildInvariant(ctx: InvariantDeclContext): InvariantDecl =
+  private def buildInvariant(ctx: InvariantDeclContext): BuildResult[InvariantDecl] =
     val name = Option(ctx.lowerIdent).map(_.getText)
-    InvariantDecl(name, expr(ctx.expr), sp(ctx))
+    expr(ctx.expr).map(e => InvariantDecl(name, e, sp(ctx)))
 
-  private def buildTemporal(ctx: TemporalDeclContext): TemporalDecl =
+  private def buildTemporal(ctx: TemporalDeclContext): BuildResult[TemporalDecl] =
     val name = ctx.lowerIdent.getText
-    TemporalDecl(name, expr(ctx.expr), sp(ctx))
+    expr(ctx.expr).map(e => TemporalDecl(name, e, sp(ctx)))
 
-  private def buildFact(ctx: FactDeclContext): FactDecl =
+  private def buildFact(ctx: FactDeclContext): BuildResult[FactDecl] =
     val name = Option(ctx.lowerIdent).map(_.getText)
-    FactDecl(name, expr(ctx.expr), sp(ctx))
+    expr(ctx.expr).map(e => FactDecl(name, e, sp(ctx)))
 
-  private def buildFunction(ctx: FunctionDeclContext): FunctionDecl =
+  private def buildFunction(ctx: FunctionDeclContext): BuildResult[FunctionDecl] =
     val name       = ctx.lowerIdent.getText
-    val params     = Option(ctx.paramList).map(_.param.asScala.map(buildParam).toList).getOrElse(Nil)
     val returnType = buildTypeExpr(ctx.typeExpr)
-    val body       = expr(ctx.expr)
-    FunctionDecl(name, params, returnType, body, sp(ctx))
+    val paramsE: BuildResult[List[ParamDecl]] =
+      Option(ctx.paramList).map(_.param.asScala.toList.traverseB(buildParam)).getOrElse(Right(Nil))
+    for
+      ps <- paramsE
+      rt <- returnType
+      b  <- expr(ctx.expr)
+    yield FunctionDecl(name, ps, rt, b, sp(ctx))
 
-  private def buildPredicate(ctx: PredicateDeclContext): PredicateDecl =
-    val name   = ctx.lowerIdent.getText
-    val params = Option(ctx.paramList).map(_.param.asScala.map(buildParam).toList).getOrElse(Nil)
-    val body   = expr(ctx.expr)
-    PredicateDecl(name, params, body, sp(ctx))
+  private def buildPredicate(ctx: PredicateDeclContext): BuildResult[PredicateDecl] =
+    val name = ctx.lowerIdent.getText
+    val paramsE: BuildResult[List[ParamDecl]] =
+      Option(ctx.paramList).map(_.param.asScala.toList.traverseB(buildParam)).getOrElse(Right(Nil))
+    for
+      ps <- paramsE
+      b  <- expr(ctx.expr)
+    yield PredicateDecl(name, ps, b, sp(ctx))
 
-  private def buildConventions(ctx: ConventionBlockContext): ConventionsDecl =
-    val rules = ctx.conventionRule.asScala.map(buildConventionRule).toList
-    ConventionsDecl(rules, sp(ctx))
+  private def buildConventions(ctx: ConventionBlockContext): BuildResult[ConventionsDecl] =
+    ctx.conventionRule.asScala.toList
+      .traverseB(buildConventionRule)
+      .map(rules => ConventionsDecl(rules, sp(ctx)))
 
-  private def buildConventionRule(ctx: ConventionRuleContext): ConventionRule =
+  private def buildConventionRule(ctx: ConventionRuleContext): BuildResult[ConventionRule] =
     val target    = ctx.UPPER_IDENT.getText
     val property  = ctx.lowerIdent.getText
     val qualifier = Option(ctx.STRING_LIT).map(s => unquote(s.getText))
-    val value     = expr(ctx.expr)
-    ConventionRule(target, property, qualifier, value, sp(ctx))
+    expr(ctx.expr).map(v => ConventionRule(target, property, qualifier, v, sp(ctx)))
 
-  // ═══ Type expressions ═══
-
-  private def buildTypeExpr(ctx: TypeExprContext): TypeExpr =
+  private def buildTypeExpr(ctx: TypeExprContext): BuildResult[TypeExpr] =
     val baseTypes = ctx.baseType
     if ctx.ARROW != null then
-      val fromType = buildBaseType(baseTypes.get(0))
-      val multiplicity = Option(ctx.multiplicity) match
-        case None => Multiplicity.One
-        case Some(m) =>
-          m.getText match
-            case "one"  => Multiplicity.One
-            case "lone" => Multiplicity.Lone
-            case "some" => Multiplicity.Some
-            case "set"  => Multiplicity.Set
-            case other  => throw new BuildError(s"unknown multiplicity: $other", m)
-      val toType = buildBaseType(baseTypes.get(1))
-      TypeExpr.RelationType(fromType, multiplicity, toType, sp(ctx))
+      for
+        fromType <- buildBaseType(baseTypes.get(0))
+        toType   <- buildBaseType(baseTypes.get(1))
+        mult <- Option(ctx.multiplicity) match
+                  case None => Right(Multiplicity.One)
+                  case Some(m) =>
+                    m.getText match
+                      case "one"  => Right(Multiplicity.One)
+                      case "lone" => Right(Multiplicity.Lone)
+                      case "some" => Right(Multiplicity.Some)
+                      case "set"  => Right(Multiplicity.Set)
+                      case other  => Left(buildErr(s"unknown multiplicity: $other", m))
+      yield TypeExpr.RelationType(fromType, mult, toType, sp(ctx))
     else buildBaseType(baseTypes.get(0))
 
-  private def buildBaseType(ctx: BaseTypeContext): TypeExpr =
+  private def buildBaseType(ctx: BaseTypeContext): BuildResult[TypeExpr] =
     if ctx.primitiveType != null then
-      TypeExpr.NamedType(ctx.primitiveType.getText, sp(ctx))
+      Right(TypeExpr.NamedType(ctx.primitiveType.getText, sp(ctx)))
     else if ctx.SET != null then
-      TypeExpr.SetType(buildTypeExpr(ctx.typeExpr(0)), sp(ctx))
+      buildTypeExpr(ctx.typeExpr(0)).map(t => TypeExpr.SetType(t, sp(ctx)))
     else if ctx.MAP != null then
-      TypeExpr.MapType(buildTypeExpr(ctx.typeExpr(0)), buildTypeExpr(ctx.typeExpr(1)), sp(ctx))
+      for
+        k <- buildTypeExpr(ctx.typeExpr(0))
+        v <- buildTypeExpr(ctx.typeExpr(1))
+      yield TypeExpr.MapType(k, v, sp(ctx))
     else if ctx.SEQ != null then
-      TypeExpr.SeqType(buildTypeExpr(ctx.typeExpr(0)), sp(ctx))
+      buildTypeExpr(ctx.typeExpr(0)).map(t => TypeExpr.SeqType(t, sp(ctx)))
     else if ctx.OPTION != null then
-      TypeExpr.OptionType(buildTypeExpr(ctx.typeExpr(0)), sp(ctx))
-    else TypeExpr.NamedType(ctx.UPPER_IDENT.getText, sp(ctx))
+      buildTypeExpr(ctx.typeExpr(0)).map(t => TypeExpr.OptionType(t, sp(ctx)))
+    else Right(TypeExpr.NamedType(ctx.UPPER_IDENT.getText, sp(ctx)))
 
-  // ═══ Expression visitor overrides ═══
-
-  override def visitMulExpr(ctx: MulExprContext): Expr =
+  override def visitMulExpr(ctx: MulExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Mul)
-  override def visitDivExpr(ctx: DivExprContext): Expr =
+  override def visitDivExpr(ctx: DivExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Div)
-  override def visitAddExpr(ctx: AddExprContext): Expr =
+  override def visitAddExpr(ctx: AddExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Add)
-  override def visitSubExpr(ctx: SubExprContext): Expr =
+  override def visitSubExpr(ctx: SubExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Sub)
-  override def visitUnionExpr(ctx: UnionExprContext): Expr =
+  override def visitUnionExpr(ctx: UnionExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Union)
-  override def visitIntersectExpr(ctx: IntersectExprContext): Expr =
+  override def visitIntersectExpr(ctx: IntersectExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Intersect)
-  override def visitMinusExpr(ctx: MinusExprContext): Expr =
+  override def visitMinusExpr(ctx: MinusExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Diff)
-  override def visitEqExpr(ctx: EqExprContext): Expr =
+  override def visitEqExpr(ctx: EqExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Eq)
-  override def visitNeqExpr(ctx: NeqExprContext): Expr =
+  override def visitNeqExpr(ctx: NeqExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Neq)
-  override def visitLtExpr(ctx: LtExprContext): Expr =
+  override def visitLtExpr(ctx: LtExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Lt)
-  override def visitGtExpr(ctx: GtExprContext): Expr =
+  override def visitGtExpr(ctx: GtExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Gt)
-  override def visitLteExpr(ctx: LteExprContext): Expr =
+  override def visitLteExpr(ctx: LteExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Le)
-  override def visitGteExpr(ctx: GteExprContext): Expr =
+  override def visitGteExpr(ctx: GteExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Ge)
-  override def visitInExpr(ctx: InExprContext): Expr =
+  override def visitInExpr(ctx: InExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.In)
-  override def visitNotInExpr(ctx: NotInExprContext): Expr =
+  override def visitNotInExpr(ctx: NotInExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.NotIn)
-  override def visitSubsetExpr(ctx: SubsetExprContext): Expr =
+  override def visitSubsetExpr(ctx: SubsetExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Subset)
-  override def visitImpliesExpr(ctx: ImpliesExprContext): Expr =
+  override def visitImpliesExpr(ctx: ImpliesExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Implies)
-  override def visitIffExpr(ctx: IffExprContext): Expr =
+  override def visitIffExpr(ctx: IffExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Iff)
-  override def visitAndExpr(ctx: AndExprContext): Expr =
+  override def visitAndExpr(ctx: AndExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.And)
-  override def visitOrExpr(ctx: OrExprContext): Expr =
+  override def visitOrExpr(ctx: OrExprContext): BuildResult[Expr] =
     binOp(ctx, ctx.expr(0), ctx.expr(1), BinOp.Or)
 
-  override def visitCardinalityExpr(ctx: CardinalityExprContext): Expr =
+  override def visitCardinalityExpr(ctx: CardinalityExprContext): BuildResult[Expr] =
     unaryOp(ctx, ctx.expr, UnOp.Cardinality)
-  override def visitNegExpr(ctx: NegExprContext): Expr     = unaryOp(ctx, ctx.expr, UnOp.Negate)
-  override def visitPowerExpr(ctx: PowerExprContext): Expr = unaryOp(ctx, ctx.expr, UnOp.Power)
-  override def visitNotExpr(ctx: NotExprContext): Expr     = unaryOp(ctx, ctx.expr, UnOp.Not)
+  override def visitNegExpr(ctx: NegExprContext): BuildResult[Expr] =
+    unaryOp(ctx, ctx.expr, UnOp.Negate)
+  override def visitPowerExpr(ctx: PowerExprContext): BuildResult[Expr] =
+    unaryOp(ctx, ctx.expr, UnOp.Power)
+  override def visitNotExpr(ctx: NotExprContext): BuildResult[Expr] =
+    unaryOp(ctx, ctx.expr, UnOp.Not)
 
-  override def visitPrimeExpr(ctx: PrimeExprContext): Expr =
-    Expr.Prime(expr(ctx.expr), sp(ctx))
+  override def visitPrimeExpr(ctx: PrimeExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.Prime(e, sp(ctx)))
 
-  override def visitFieldAccessExpr(ctx: FieldAccessExprContext): Expr =
-    Expr.FieldAccess(expr(ctx.expr), ctx.lowerIdent.getText, sp(ctx))
+  override def visitFieldAccessExpr(ctx: FieldAccessExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.FieldAccess(e, ctx.lowerIdent.getText, sp(ctx)))
 
-  override def visitEnumAccessExpr(ctx: EnumAccessExprContext): Expr =
-    Expr.EnumAccess(expr(ctx.expr), ctx.UPPER_IDENT.getText, sp(ctx))
+  override def visitEnumAccessExpr(ctx: EnumAccessExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.EnumAccess(e, ctx.UPPER_IDENT.getText, sp(ctx)))
 
-  override def visitIndexExpr(ctx: IndexExprContext): Expr =
-    Expr.Index(expr(ctx.expr(0)), expr(ctx.expr(1)), sp(ctx))
+  override def visitIndexExpr(ctx: IndexExprContext): BuildResult[Expr] =
+    for
+      a <- expr(ctx.expr(0))
+      b <- expr(ctx.expr(1))
+    yield Expr.Index(a, b, sp(ctx))
 
-  override def visitCallExpr(ctx: CallExprContext): Expr =
-    val args = Option(ctx.argList).map(_.expr.asScala.map(expr).toList).getOrElse(Nil)
-    Expr.Call(expr(ctx.expr), args, sp(ctx))
+  override def visitCallExpr(ctx: CallExprContext): BuildResult[Expr] =
+    val argsE: BuildResult[List[Expr]] =
+      Option(ctx.argList).map(_.expr.asScala.toList.traverseB(expr)).getOrElse(Right(Nil))
+    for
+      fn   <- expr(ctx.expr)
+      args <- argsE
+    yield Expr.Call(fn, args, sp(ctx))
 
-  override def visitWithExpr(ctx: WithExprContext): Expr =
-    val updates = ctx.fieldAssign.asScala.map(buildFieldAssign).toList
-    Expr.With(expr(ctx.expr), updates, sp(ctx))
+  override def visitWithExpr(ctx: WithExprContext): BuildResult[Expr] =
+    for
+      base    <- expr(ctx.expr)
+      updates <- ctx.fieldAssign.asScala.toList.traverseB(buildFieldAssign)
+    yield Expr.With(base, updates, sp(ctx))
 
-  override def visitMatchesExpr(ctx: MatchesExprContext): Expr =
-    Expr.Matches(expr(ctx.expr), unslashRegex(ctx.REGEX_LIT.getText), sp(ctx))
+  override def visitMatchesExpr(ctx: MatchesExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.Matches(e, unslashRegex(ctx.REGEX_LIT.getText), sp(ctx)))
 
-  override def visitParenExpr(ctx: ParenExprContext): Expr = expr(ctx.expr)
-  override def visitQuantExpr(ctx: QuantExprContext): Expr = buildQuantifier(ctx.quantifierExpr)
-  override def visitSomeWrapE(ctx: SomeWrapEContext): Expr = buildSomeWrap(ctx.someWrapExpr)
-  override def visitTheE(ctx: TheEContext): Expr           = buildThe(ctx.theExpr)
-  override def visitIfE(ctx: IfEContext): Expr             = buildIf(ctx.ifExpr)
-  override def visitLetE(ctx: LetEContext): Expr           = buildLet(ctx.letExpr)
-  override def visitLambdaE(ctx: LambdaEContext): Expr     = buildLambda(ctx.lambdaExpr)
-  override def visitConstructorE(ctx: ConstructorEContext): Expr =
+  override def visitParenExpr(ctx: ParenExprContext): BuildResult[Expr] = expr(ctx.expr)
+  override def visitQuantExpr(ctx: QuantExprContext): BuildResult[Expr] =
+    buildQuantifier(ctx.quantifierExpr)
+  override def visitSomeWrapE(ctx: SomeWrapEContext): BuildResult[Expr] =
+    buildSomeWrap(ctx.someWrapExpr)
+  override def visitTheE(ctx: TheEContext): BuildResult[Expr]       = buildThe(ctx.theExpr)
+  override def visitIfE(ctx: IfEContext): BuildResult[Expr]         = buildIf(ctx.ifExpr)
+  override def visitLetE(ctx: LetEContext): BuildResult[Expr]       = buildLet(ctx.letExpr)
+  override def visitLambdaE(ctx: LambdaEContext): BuildResult[Expr] = buildLambda(ctx.lambdaExpr)
+  override def visitConstructorE(ctx: ConstructorEContext): BuildResult[Expr] =
     buildConstructor(ctx.constructorExpr)
-  override def visitSetOrMapE(ctx: SetOrMapEContext): Expr = buildSetOrMap(ctx.setOrMapLiteral)
-  override def visitSeqE(ctx: SeqEContext): Expr           = buildSeq(ctx.seqLiteral)
+  override def visitSetOrMapE(ctx: SetOrMapEContext): BuildResult[Expr] =
+    buildSetOrMap(ctx.setOrMapLiteral)
+  override def visitSeqE(ctx: SeqEContext): BuildResult[Expr] = buildSeq(ctx.seqLiteral)
 
-  override def visitPreExpr(ctx: PreExprContext): Expr =
-    Expr.Pre(expr(ctx.expr), sp(ctx))
+  override def visitPreExpr(ctx: PreExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.Pre(e, sp(ctx)))
 
-  override def visitIntLitExpr(ctx: IntLitExprContext): Expr =
-    Expr.IntLit(ctx.INT_LIT.getText.toLong, sp(ctx))
+  override def visitIntLitExpr(ctx: IntLitExprContext): BuildResult[Expr] =
+    Right(Expr.IntLit(ctx.INT_LIT.getText.toLong, sp(ctx)))
 
-  override def visitFloatLitExpr(ctx: FloatLitExprContext): Expr =
-    Expr.FloatLit(ctx.FLOAT_LIT.getText.toDouble, sp(ctx))
+  override def visitFloatLitExpr(ctx: FloatLitExprContext): BuildResult[Expr] =
+    Right(Expr.FloatLit(ctx.FLOAT_LIT.getText.toDouble, sp(ctx)))
 
-  override def visitStringLitExpr(ctx: StringLitExprContext): Expr =
-    Expr.StringLit(unquote(ctx.STRING_LIT.getText), sp(ctx))
+  override def visitStringLitExpr(ctx: StringLitExprContext): BuildResult[Expr] =
+    Right(Expr.StringLit(unquote(ctx.STRING_LIT.getText), sp(ctx)))
 
-  override def visitTrueLitExpr(ctx: TrueLitExprContext): Expr   = Expr.BoolLit(true, sp(ctx))
-  override def visitFalseLitExpr(ctx: FalseLitExprContext): Expr = Expr.BoolLit(false, sp(ctx))
-  override def visitNoneLitExpr(ctx: NoneLitExprContext): Expr   = Expr.NoneLit(sp(ctx))
+  override def visitTrueLitExpr(ctx: TrueLitExprContext): BuildResult[Expr] =
+    Right(Expr.BoolLit(true, sp(ctx)))
+  override def visitFalseLitExpr(ctx: FalseLitExprContext): BuildResult[Expr] =
+    Right(Expr.BoolLit(false, sp(ctx)))
+  override def visitNoneLitExpr(ctx: NoneLitExprContext): BuildResult[Expr] =
+    Right(Expr.NoneLit(sp(ctx)))
 
-  override def visitUpperIdentExpr(ctx: UpperIdentExprContext): Expr =
-    Expr.Identifier(ctx.UPPER_IDENT.getText, sp(ctx))
+  override def visitUpperIdentExpr(ctx: UpperIdentExprContext): BuildResult[Expr] =
+    Right(Expr.Identifier(ctx.UPPER_IDENT.getText, sp(ctx)))
 
-  override def visitLowerIdentExpr(ctx: LowerIdentExprContext): Expr =
-    Expr.Identifier(ctx.lowerIdent.getText, sp(ctx))
+  override def visitLowerIdentExpr(ctx: LowerIdentExprContext): BuildResult[Expr] =
+    Right(Expr.Identifier(ctx.lowerIdent.getText, sp(ctx)))
 
-  // ═══ Expression sub-rules ═══
-
-  private def buildQuantifier(ctx: QuantifierExprContext): Expr =
+  private def buildQuantifier(ctx: QuantifierExprContext): BuildResult[Expr] =
     val qCtx = ctx.quantifier
     val quantifier: QuantKind =
       if qCtx.ALL != null then QuantKind.All
       else if qCtx.SOME != null then QuantKind.Some
       else if qCtx.NO != null then QuantKind.No
       else QuantKind.Exists
-    val bindings = ctx.quantBinding.asScala.map: b =>
-      val bk = if b.IN != null then BindingKind.In else BindingKind.Colon
-      QuantifierBinding(b.lowerIdent.getText, expr(b.expr), bk, sp(b))
-    .toList
-    Expr.Quantifier(quantifier, bindings, expr(ctx.expr), sp(ctx))
+    val bindingsE: BuildResult[List[QuantifierBinding]] =
+      ctx.quantBinding.asScala.toList.traverseB: b =>
+        val bk = if b.IN != null then BindingKind.In else BindingKind.Colon
+        expr(b.expr).map(d => QuantifierBinding(b.lowerIdent.getText, d, bk, sp(b)))
+    for
+      bs   <- bindingsE
+      body <- expr(ctx.expr)
+    yield Expr.Quantifier(quantifier, bs, body, sp(ctx))
 
-  private def buildSomeWrap(ctx: SomeWrapExprContext): Expr =
-    Expr.SomeWrap(expr(ctx.expr), sp(ctx))
+  private def buildSomeWrap(ctx: SomeWrapExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(e => Expr.SomeWrap(e, sp(ctx)))
 
-  private def buildThe(ctx: TheExprContext): Expr =
+  private def buildThe(ctx: TheExprContext): BuildResult[Expr] =
     val exprs = ctx.expr
-    Expr.The(ctx.lowerIdent.getText, expr(exprs.get(0)), expr(exprs.get(1)), sp(ctx))
+    for
+      a <- expr(exprs.get(0))
+      b <- expr(exprs.get(1))
+    yield Expr.The(ctx.lowerIdent.getText, a, b, sp(ctx))
 
-  private def buildIf(ctx: IfExprContext): Expr =
+  private def buildIf(ctx: IfExprContext): BuildResult[Expr] =
     val exprs = ctx.expr
-    Expr.If(expr(exprs.get(0)), expr(exprs.get(1)), expr(exprs.get(2)), sp(ctx))
+    for
+      c <- expr(exprs.get(0))
+      t <- expr(exprs.get(1))
+      e <- expr(exprs.get(2))
+    yield Expr.If(c, t, e, sp(ctx))
 
-  private def buildLet(ctx: LetExprContext): Expr =
+  private def buildLet(ctx: LetExprContext): BuildResult[Expr] =
     val exprs = ctx.expr
-    Expr.Let(ctx.lowerIdent.getText, expr(exprs.get(0)), expr(exprs.get(1)), sp(ctx))
+    for
+      v <- expr(exprs.get(0))
+      b <- expr(exprs.get(1))
+    yield Expr.Let(ctx.lowerIdent.getText, v, b, sp(ctx))
 
-  private def buildLambda(ctx: LambdaExprContext): Expr =
-    Expr.Lambda(ctx.lowerIdent.getText, expr(ctx.expr), sp(ctx))
+  private def buildLambda(ctx: LambdaExprContext): BuildResult[Expr] =
+    expr(ctx.expr).map(b => Expr.Lambda(ctx.lowerIdent.getText, b, sp(ctx)))
 
-  private def buildConstructor(ctx: ConstructorExprContext): Expr =
-    val fields = ctx.fieldAssign.asScala.map(buildFieldAssign).toList
-    Expr.Constructor(ctx.UPPER_IDENT.getText, fields, sp(ctx))
+  private def buildConstructor(ctx: ConstructorExprContext): BuildResult[Expr] =
+    ctx.fieldAssign.asScala.toList
+      .traverseB(buildFieldAssign)
+      .map(fs => Expr.Constructor(ctx.UPPER_IDENT.getText, fs, sp(ctx)))
 
-  private def buildSetOrMap(ctx: SetOrMapLiteralContext): Expr =
+  private def buildSetOrMap(ctx: SetOrMapLiteralContext): BuildResult[Expr] =
     val exprs = ctx.expr
     val span  = sp(ctx)
-    if exprs.isEmpty && ctx.lowerIdent == null then Expr.SetLiteral(Nil, span)
+    if exprs.isEmpty && ctx.lowerIdent == null then Right(Expr.SetLiteral(Nil, span))
     else if ctx.PIPE != null then
-      Expr.SetComprehension(
-        ctx.lowerIdent.getText,
-        expr(exprs.get(0)),
-        expr(exprs.get(1)),
-        span
-      )
+      for
+        dom  <- expr(exprs.get(0))
+        body <- expr(exprs.get(1))
+      yield Expr.SetComprehension(ctx.lowerIdent.getText, dom, body, span)
     else if !ctx.ARROW.isEmpty then
       if exprs.size % 2 != 0 then
-        throw new BuildError("map literal requires key/value pairs", ctx)
-      val entries = List.newBuilder[MapEntry]
-      var i       = 0
-      while i < exprs.size do
-        entries += MapEntry(expr(exprs.get(i)), expr(exprs.get(i + 1)), sp(exprs.get(i)))
-        i += 2
-      Expr.MapLiteral(entries.result(), span)
-    else Expr.SetLiteral(exprs.asScala.map(expr).toList, span)
+        Left(buildErr("map literal requires key/value pairs", ctx))
+      else
+        val pairs: List[(ExprContext, ExprContext)] =
+          (0 until exprs.size by 2).map(i => (exprs.get(i), exprs.get(i + 1))).toList
+        pairs
+          .traverseB: (kc, vc) =>
+            for
+              k <- expr(kc)
+              v <- expr(vc)
+            yield MapEntry(k, v, sp(kc))
+          .map(entries => Expr.MapLiteral(entries, span))
+    else
+      exprs.asScala.toList.traverseB(expr).map(es => Expr.SetLiteral(es, span))
 
-  private def buildSeq(ctx: SeqLiteralContext): Expr =
-    Expr.SeqLiteral(ctx.expr.asScala.map(expr).toList, sp(ctx))
+  private def buildSeq(ctx: SeqLiteralContext): BuildResult[Expr] =
+    ctx.expr.asScala.toList.traverseB(expr).map(es => Expr.SeqLiteral(es, sp(ctx)))
 
-  private def buildFieldAssign(ctx: FieldAssignContext): FieldAssign =
-    FieldAssign(ctx.lowerIdent.getText, expr(ctx.expr), sp(ctx))
+  private def buildFieldAssign(ctx: FieldAssignContext): BuildResult[FieldAssign] =
+    expr(ctx.expr).map(e => FieldAssign(ctx.lowerIdent.getText, e, sp(ctx)))

--- a/modules/parser/src/main/scala/specrest/parser/Parse.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Parse.scala
@@ -5,10 +5,9 @@ import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
+import specrest.ir.ParseError
 import specrest.parser.generated.SpecLexer
 import specrest.parser.generated.SpecParser
-
-final case class ParseError(line: Int, column: Int, message: String)
 
 final case class ParseResult(tree: SpecParser.SpecFileContext, errors: List[ParseError])
 

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -32,7 +32,7 @@ class ParseBuildGoldenTest extends munit.FunSuite:
       val source = Files.readString(specPath)
       val parsed = Parse.parseSpec(source)
       assert(parsed.errors.isEmpty, s"Parse errors for $name: ${parsed.errors}")
-      val ir         = Builder.buildIR(parsed.tree)
+      val ir         = Builder.buildIR(parsed.tree).toOption.get
       val emittedDom = Serialize.toJson(ir)
       val goldenRaw  = Files.readString(goldenPath)
       val goldenDom = io.circe.parser.parse(goldenRaw) match

--- a/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
@@ -12,7 +12,7 @@ class ProfileSmokeTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   test("registry lists python-fastapi-postgres"):
     assert(Registry.listProfiles.contains("python-fastapi-postgres"))

--- a/modules/verify/src/main/scala/specrest/verify/Config.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Config.scala
@@ -18,5 +18,3 @@ final case class VerificationConfig(
 
 object VerificationConfig:
   val Default: VerificationConfig = VerificationConfig(timeoutMs = 30_000L)
-
-final class TranslatorError(message: String) extends RuntimeException(message)

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -184,35 +184,8 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        try
-          val result  = backend.check(script, config)
-          val outcome = CheckOutcome.fromStatus(result.status)
-          dumpZ3(
-            dump,
-            "global",
-            script,
-            config.timeoutMs,
-            outcome,
-            result.status,
-            result.durationMs
-          )
-          finalizeCheck(FinalizeArgs(
-            id = "global",
-            kind = CheckKind.Global,
-            tool = tool,
-            operationName = None,
-            invariantName = None,
-            rawStatus = result.status,
-            outcome = outcome,
-            durationMs = result.durationMs,
-            sourceSpans = sourceSpans,
-            ir = ir,
-            invariantDecl = None,
-            op = None,
-            coreSpans = z3CoreSpans(script, result, CheckKind.Global)
-          ))
-        catch
-          case e: Throwable =>
+        backend.check(script, config) match
+          case Left(err) =>
             skippedCheck(
               "global",
               CheckKind.Global,
@@ -221,8 +194,34 @@ object Consistency:
               None,
               sourceSpans,
               DiagnosticCategory.BackendError,
-              backendMsg(e)
+              err.message
             )
+          case Right(result) =>
+            val outcome = CheckOutcome.fromStatus(result.status)
+            dumpZ3(
+              dump,
+              "global",
+              script,
+              config.timeoutMs,
+              outcome,
+              result.status,
+              result.durationMs
+            )
+            finalizeCheck(FinalizeArgs(
+              id = "global",
+              kind = CheckKind.Global,
+              tool = tool,
+              operationName = None,
+              invariantName = None,
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = None,
+              coreSpans = z3CoreSpans(script, result, CheckKind.Global)
+            ))
 
   private def runGlobalAlloy(
       ir: ServiceIR,
@@ -320,27 +319,8 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        try
-          val result  = backend.check(script, config)
-          val outcome = CheckOutcome.fromStatus(result.status)
-          dumpZ3(dump, id, script, config.timeoutMs, outcome, result.status, result.durationMs)
-          finalizeCheck(FinalizeArgs(
-            id = id,
-            kind = kind,
-            tool = tool,
-            operationName = Some(op.name),
-            invariantName = None,
-            rawStatus = result.status,
-            outcome = outcome,
-            durationMs = result.durationMs,
-            sourceSpans = sourceSpans,
-            ir = ir,
-            invariantDecl = None,
-            op = Some(op),
-            coreSpans = z3CoreSpans(script, result, kind)
-          ))
-        catch
-          case e: Throwable =>
+        backend.check(script, config) match
+          case Left(err) =>
             skippedCheck(
               id,
               kind,
@@ -349,8 +329,26 @@ object Consistency:
               None,
               sourceSpans,
               DiagnosticCategory.BackendError,
-              backendMsg(e)
+              err.message
             )
+          case Right(result) =>
+            val outcome = CheckOutcome.fromStatus(result.status)
+            dumpZ3(dump, id, script, config.timeoutMs, outcome, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = kind,
+              tool = tool,
+              operationName = Some(op.name),
+              invariantName = None,
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = Some(op),
+              coreSpans = z3CoreSpans(script, result, kind)
+            ))
 
   private def runOperationAlloy(
       ir: ServiceIR,
@@ -445,29 +443,8 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        try
-          val result   = backend.check(script, config.copy(captureModel = true))
-          val inverted = invertStatus(result.status)
-          dumpZ3(dump, id, script, config.timeoutMs, inverted, result.status, result.durationMs)
-          finalizeCheck(FinalizeArgs(
-            id = id,
-            kind = CheckKind.Preservation,
-            tool = tool,
-            operationName = Some(op.name),
-            invariantName = Some(inv.name),
-            rawStatus = result.status,
-            outcome = inverted,
-            durationMs = result.durationMs,
-            sourceSpans = sourceSpans,
-            ir = ir,
-            invariantDecl = Some(inv.decl),
-            op = Some(op),
-            smokeResult = Some(result),
-            artifact = Some(script.artifact),
-            coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
-          ))
-        catch
-          case e: Throwable =>
+        backend.check(script, config.copy(captureModel = true)) match
+          case Left(err) =>
             skippedCheck(
               id,
               CheckKind.Preservation,
@@ -476,8 +453,28 @@ object Consistency:
               Some(inv.name),
               sourceSpans,
               DiagnosticCategory.BackendError,
-              backendMsg(e)
+              err.message
             )
+          case Right(result) =>
+            val inverted = invertStatus(result.status)
+            dumpZ3(dump, id, script, config.timeoutMs, inverted, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = CheckKind.Preservation,
+              tool = tool,
+              operationName = Some(op.name),
+              invariantName = Some(inv.name),
+              rawStatus = result.status,
+              outcome = inverted,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = Some(inv.decl),
+              op = Some(op),
+              smokeResult = Some(result),
+              artifact = Some(script.artifact),
+              coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
+            ))
 
   private def runTemporalAlloy(
       ir: ServiceIR,

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -171,29 +171,58 @@ object Consistency:
     val tool        = Classifier.classifyGlobal(ir)
     if tool == VerifierTool.Alloy then
       return runGlobalAlloy(ir, alloyBackend, config, sourceSpans, dump)
-    try
-      val script  = Translator.translate(ir)
-      val result  = backend.check(script, config)
-      val outcome = CheckOutcome.fromStatus(result.status)
-      dumpZ3(dump, "global", script, config.timeoutMs, outcome, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = "global",
-        kind = CheckKind.Global,
-        tool = tool,
-        operationName = None,
-        invariantName = None,
-        rawStatus = result.status,
-        outcome = outcome,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = None,
-        op = None,
-        coreSpans = z3CoreSpans(script, result, CheckKind.Global)
-      ))
-    catch
-      case e: Throwable =>
-        skippedCheck("global", CheckKind.Global, tool, None, None, sourceSpans, e)
+    Translator.translate(ir) match
+      case Left(err) =>
+        skippedCheck(
+          "global",
+          CheckKind.Global,
+          tool,
+          None,
+          None,
+          sourceSpans,
+          DiagnosticCategory.TranslatorLimitation,
+          err.message
+        )
+      case Right(script) =>
+        try
+          val result  = backend.check(script, config)
+          val outcome = CheckOutcome.fromStatus(result.status)
+          dumpZ3(
+            dump,
+            "global",
+            script,
+            config.timeoutMs,
+            outcome,
+            result.status,
+            result.durationMs
+          )
+          finalizeCheck(FinalizeArgs(
+            id = "global",
+            kind = CheckKind.Global,
+            tool = tool,
+            operationName = None,
+            invariantName = None,
+            rawStatus = result.status,
+            outcome = outcome,
+            durationMs = result.durationMs,
+            sourceSpans = sourceSpans,
+            ir = ir,
+            invariantDecl = None,
+            op = None,
+            coreSpans = z3CoreSpans(script, result, CheckKind.Global)
+          ))
+        catch
+          case e: Throwable =>
+            skippedCheck(
+              "global",
+              CheckKind.Global,
+              tool,
+              None,
+              None,
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              backendMsg(e)
+            )
 
   private def runGlobalAlloy(
       ir: ServiceIR,
@@ -237,7 +266,8 @@ object Consistency:
           None,
           None,
           sourceSpans,
-          new TranslatorError(e.getMessage)
+          DiagnosticCategory.TranslatorLimitation,
+          backendMsg(e)
         )
       case e: Throwable =>
         skippedCheck(
@@ -247,7 +277,8 @@ object Consistency:
           None,
           None,
           sourceSpans,
-          e
+          DiagnosticCategory.BackendError,
+          backendMsg(e)
         )
 
   private def runOperationCheck(
@@ -271,33 +302,55 @@ object Consistency:
       case _                  => VerifierTool.Z3
     if tool == VerifierTool.Alloy then
       return runOperationAlloy(ir, op, kind, alloyBackend, config, id, sourceSpans, dump)
-    try
-      val script = kind match
-        case CheckKind.Requires => Translator.translateOperationRequires(ir, op)
-        case CheckKind.Enabled  => Translator.translateOperationEnabled(ir, op)
-        case _ =>
-          throw new TranslatorError(s"runOperationCheck: unexpected kind $kind")
-      val result  = backend.check(script, config)
-      val outcome = CheckOutcome.fromStatus(result.status)
-      dumpZ3(dump, id, script, config.timeoutMs, outcome, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = id,
-        kind = kind,
-        tool = tool,
-        operationName = Some(op.name),
-        invariantName = None,
-        rawStatus = result.status,
-        outcome = outcome,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = None,
-        op = Some(op),
-        coreSpans = z3CoreSpans(script, result, kind)
-      ))
-    catch
-      case e: Throwable =>
-        skippedCheck(id, kind, tool, Some(op.name), None, sourceSpans, e)
+    val scriptE: Either[VerifyError.Translator, Z3Script] = kind match
+      case CheckKind.Requires => Translator.translateOperationRequires(ir, op)
+      case CheckKind.Enabled  => Translator.translateOperationEnabled(ir, op)
+      case _ =>
+        Left(VerifyError.Translator(s"runOperationCheck: unexpected kind $kind"))
+    scriptE match
+      case Left(err) =>
+        skippedCheck(
+          id,
+          kind,
+          tool,
+          Some(op.name),
+          None,
+          sourceSpans,
+          DiagnosticCategory.TranslatorLimitation,
+          err.message
+        )
+      case Right(script) =>
+        try
+          val result  = backend.check(script, config)
+          val outcome = CheckOutcome.fromStatus(result.status)
+          dumpZ3(dump, id, script, config.timeoutMs, outcome, result.status, result.durationMs)
+          finalizeCheck(FinalizeArgs(
+            id = id,
+            kind = kind,
+            tool = tool,
+            operationName = Some(op.name),
+            invariantName = None,
+            rawStatus = result.status,
+            outcome = outcome,
+            durationMs = result.durationMs,
+            sourceSpans = sourceSpans,
+            ir = ir,
+            invariantDecl = None,
+            op = Some(op),
+            coreSpans = z3CoreSpans(script, result, kind)
+          ))
+        catch
+          case e: Throwable =>
+            skippedCheck(
+              id,
+              kind,
+              tool,
+              Some(op.name),
+              None,
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              backendMsg(e)
+            )
 
   private def runOperationAlloy(
       ir: ServiceIR,
@@ -350,10 +403,20 @@ object Consistency:
           Some(op.name),
           None,
           sourceSpans,
-          new TranslatorError(e.getMessage)
+          DiagnosticCategory.TranslatorLimitation,
+          backendMsg(e)
         )
       case e: Throwable =>
-        skippedCheck(id, kind, VerifierTool.Alloy, Some(op.name), None, sourceSpans, e)
+        skippedCheck(
+          id,
+          kind,
+          VerifierTool.Alloy,
+          Some(op.name),
+          None,
+          sourceSpans,
+          DiagnosticCategory.BackendError,
+          backendMsg(e)
+        )
 
   private def runPreservationCheck(
       ir: ServiceIR,
@@ -369,30 +432,8 @@ object Consistency:
     val tool        = Classifier.classifyPreservation(op, inv.decl)
     if tool == VerifierTool.Alloy then
       return runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump)
-    try
-      val script   = Translator.translateOperationPreservation(ir, op, inv.decl)
-      val result   = backend.check(script, config.copy(captureModel = true))
-      val inverted = invertStatus(result.status)
-      dumpZ3(dump, id, script, config.timeoutMs, inverted, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = id,
-        kind = CheckKind.Preservation,
-        tool = tool,
-        operationName = Some(op.name),
-        invariantName = Some(inv.name),
-        rawStatus = result.status,
-        outcome = inverted,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = Some(inv.decl),
-        op = Some(op),
-        smokeResult = Some(result),
-        artifact = Some(script.artifact),
-        coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
-      ))
-    catch
-      case e: Throwable =>
+    Translator.translateOperationPreservation(ir, op, inv.decl) match
+      case Left(err) =>
         skippedCheck(
           id,
           CheckKind.Preservation,
@@ -400,8 +441,43 @@ object Consistency:
           Some(op.name),
           Some(inv.name),
           sourceSpans,
-          e
+          DiagnosticCategory.TranslatorLimitation,
+          err.message
         )
+      case Right(script) =>
+        try
+          val result   = backend.check(script, config.copy(captureModel = true))
+          val inverted = invertStatus(result.status)
+          dumpZ3(dump, id, script, config.timeoutMs, inverted, result.status, result.durationMs)
+          finalizeCheck(FinalizeArgs(
+            id = id,
+            kind = CheckKind.Preservation,
+            tool = tool,
+            operationName = Some(op.name),
+            invariantName = Some(inv.name),
+            rawStatus = result.status,
+            outcome = inverted,
+            durationMs = result.durationMs,
+            sourceSpans = sourceSpans,
+            ir = ir,
+            invariantDecl = Some(inv.decl),
+            op = Some(op),
+            smokeResult = Some(result),
+            artifact = Some(script.artifact),
+            coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
+          ))
+        catch
+          case e: Throwable =>
+            skippedCheck(
+              id,
+              CheckKind.Preservation,
+              tool,
+              Some(op.name),
+              Some(inv.name),
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              backendMsg(e)
+            )
 
   private def runTemporalAlloy(
       ir: ServiceIR,
@@ -449,7 +525,8 @@ object Consistency:
           None,
           Some(decl.name),
           sourceSpans,
-          new TranslatorError(e.getMessage)
+          DiagnosticCategory.TranslatorLimitation,
+          backendMsg(e)
         )
       case e: Throwable =>
         skippedCheck(
@@ -459,7 +536,8 @@ object Consistency:
           None,
           Some(decl.name),
           sourceSpans,
-          e
+          DiagnosticCategory.BackendError,
+          backendMsg(e)
         )
 
   private def runPreservationAlloy(
@@ -508,7 +586,8 @@ object Consistency:
           Some(op.name),
           Some(inv.name),
           sourceSpans,
-          new TranslatorError(e.getMessage)
+          DiagnosticCategory.TranslatorLimitation,
+          backendMsg(e)
         )
       case e: Throwable =>
         skippedCheck(
@@ -518,7 +597,8 @@ object Consistency:
           Some(op.name),
           Some(inv.name),
           sourceSpans,
-          e
+          DiagnosticCategory.BackendError,
+          backendMsg(e)
         )
 
   final private case class FinalizeArgs(
@@ -660,13 +740,10 @@ object Consistency:
       operationName: Option[String],
       invariantName: Option[String],
       sourceSpans: List[Span],
-      err: Throwable
+      category: DiagnosticCategory,
+      message: String
   ): CheckResult =
-    val message      = Option(err.getMessage).getOrElse(err.toString)
-    val isTranslator = err.isInstanceOf[TranslatorError]
-    val category =
-      if isTranslator then DiagnosticCategory.TranslatorLimitation
-      else DiagnosticCategory.BackendError
+    val isTranslator = category == DiagnosticCategory.TranslatorLimitation
     val status: CheckOutcome =
       if isTranslator then CheckOutcome.Skipped else CheckOutcome.Unknown
     val detail =
@@ -695,6 +772,8 @@ object Consistency:
       sourceSpans = sourceSpans,
       diagnostic = Some(diagnostic)
     )
+
+  private def backendMsg(e: Throwable): String = Option(e.getMessage).getOrElse(e.toString)
 
   private def detailFor(
       kind: CheckKind,

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -2,7 +2,7 @@ package specrest.verify
 
 import specrest.ir.*
 import specrest.verify.alloy.AlloyBackend
-import specrest.verify.alloy.AlloyTranslatorError
+import specrest.verify.alloy.AlloyModule
 import specrest.verify.alloy.Render as AlloyRender
 import specrest.verify.alloy.Translator as AlloyTranslator
 import specrest.verify.certificates.DumpSink
@@ -230,34 +230,8 @@ object Consistency:
       sourceSpans: List[Span],
       dump: Option[DumpSink]
   ): CheckResult =
-    try
-      val module   = AlloyTranslator.translateGlobal(ir, config.alloyScope)
-      val rendered = AlloyRender.renderWithLineMap(module)
-      val result = alloyBackend.check(
-        rendered.source,
-        commandIdx = 0,
-        timeoutMs = config.timeoutMs,
-        captureCore = config.captureCore
-      )
-      val outcome = CheckOutcome.fromStatus(result.status)
-      dumpAlloy(dump, "global", rendered.source, outcome, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = "global",
-        kind = CheckKind.Global,
-        tool = VerifierTool.Alloy,
-        operationName = None,
-        invariantName = None,
-        rawStatus = result.status,
-        outcome = outcome,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = None,
-        op = None,
-        coreSpans = alloyCoreSpans(rendered, result, CheckKind.Global)
-      ))
-    catch
-      case e: AlloyTranslatorError =>
+    AlloyTranslator.translateGlobal(ir, config.alloyScope) match
+      case Left(err) =>
         skippedCheck(
           "global",
           CheckKind.Global,
@@ -266,19 +240,45 @@ object Consistency:
           None,
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
-          backendMsg(e)
+          err.message
         )
-      case e: Throwable =>
-        skippedCheck(
-          "global",
-          CheckKind.Global,
-          VerifierTool.Alloy,
-          None,
-          None,
-          sourceSpans,
-          DiagnosticCategory.BackendError,
-          backendMsg(e)
-        )
+      case Right(module) =>
+        val rendered = AlloyRender.renderWithLineMap(module)
+        alloyBackend.check(
+          rendered.source,
+          commandIdx = 0,
+          timeoutMs = config.timeoutMs,
+          captureCore = config.captureCore
+        ) match
+          case Left(err) =>
+            skippedCheck(
+              "global",
+              CheckKind.Global,
+              VerifierTool.Alloy,
+              None,
+              None,
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              err.message
+            )
+          case Right(result) =>
+            val outcome = CheckOutcome.fromStatus(result.status)
+            dumpAlloy(dump, "global", rendered.source, outcome, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = "global",
+              kind = CheckKind.Global,
+              tool = VerifierTool.Alloy,
+              operationName = None,
+              invariantName = None,
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = None,
+              coreSpans = alloyCoreSpans(rendered, result, CheckKind.Global)
+            ))
 
   private def runOperationCheck(
       ir: ServiceIR,
@@ -360,40 +360,15 @@ object Consistency:
       sourceSpans: List[Span],
       dump: Option[DumpSink]
   ): CheckResult =
-    try
-      val module = kind match
-        case CheckKind.Requires =>
-          AlloyTranslator.translateOperationRequires(ir, op, config.alloyScope)
-        case CheckKind.Enabled =>
-          AlloyTranslator.translateOperationEnabled(ir, op, config.alloyScope)
-        case _ =>
-          throw new AlloyTranslatorError(s"runOperationAlloy: unexpected kind $kind")
-      val rendered = AlloyRender.renderWithLineMap(module)
-      val result = alloyBackend.check(
-        rendered.source,
-        commandIdx = 0,
-        timeoutMs = config.timeoutMs,
-        captureCore = config.captureCore
-      )
-      val outcome = CheckOutcome.fromStatus(result.status)
-      dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = id,
-        kind = kind,
-        tool = VerifierTool.Alloy,
-        operationName = Some(op.name),
-        invariantName = None,
-        rawStatus = result.status,
-        outcome = outcome,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = None,
-        op = Some(op),
-        coreSpans = alloyCoreSpans(rendered, result, kind)
-      ))
-    catch
-      case e: AlloyTranslatorError =>
+    val moduleE: Either[VerifyError.AlloyTranslator, AlloyModule] = kind match
+      case CheckKind.Requires =>
+        AlloyTranslator.translateOperationRequires(ir, op, config.alloyScope)
+      case CheckKind.Enabled =>
+        AlloyTranslator.translateOperationEnabled(ir, op, config.alloyScope)
+      case _ =>
+        Left(VerifyError.AlloyTranslator(s"runOperationAlloy: unexpected kind $kind"))
+    moduleE match
+      case Left(err) =>
         skippedCheck(
           id,
           kind,
@@ -402,19 +377,45 @@ object Consistency:
           None,
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
-          backendMsg(e)
+          err.message
         )
-      case e: Throwable =>
-        skippedCheck(
-          id,
-          kind,
-          VerifierTool.Alloy,
-          Some(op.name),
-          None,
-          sourceSpans,
-          DiagnosticCategory.BackendError,
-          backendMsg(e)
-        )
+      case Right(module) =>
+        val rendered = AlloyRender.renderWithLineMap(module)
+        alloyBackend.check(
+          rendered.source,
+          commandIdx = 0,
+          timeoutMs = config.timeoutMs,
+          captureCore = config.captureCore
+        ) match
+          case Left(err) =>
+            skippedCheck(
+              id,
+              kind,
+              VerifierTool.Alloy,
+              Some(op.name),
+              None,
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              err.message
+            )
+          case Right(result) =>
+            val outcome = CheckOutcome.fromStatus(result.status)
+            dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = kind,
+              tool = VerifierTool.Alloy,
+              operationName = Some(op.name),
+              invariantName = None,
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = Some(op),
+              coreSpans = alloyCoreSpans(rendered, result, kind)
+            ))
 
   private def runPreservationCheck(
       ir: ServiceIR,
@@ -485,36 +486,8 @@ object Consistency:
   ): CheckResult =
     val id          = s"temporal.${decl.name}"
     val sourceSpans = decl.span.toList
-    try
-      val translation = AlloyTranslator.translateTemporal(ir, decl, config.alloyScope)
-      val rendered    = AlloyRender.renderWithLineMap(translation.module)
-      val result = alloyBackend.check(
-        rendered.source,
-        commandIdx = 0,
-        timeoutMs = config.timeoutMs,
-        captureCore = config.captureCore
-      )
-      val outcome = translation.kind match
-        case AlloyTranslator.TemporalKind.Always     => invertStatus(result.status)
-        case AlloyTranslator.TemporalKind.Eventually => CheckOutcome.fromStatus(result.status)
-      dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = id,
-        kind = CheckKind.Temporal,
-        tool = VerifierTool.Alloy,
-        operationName = None,
-        invariantName = Some(decl.name),
-        rawStatus = result.status,
-        outcome = outcome,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = None,
-        op = None,
-        coreSpans = alloyCoreSpans(rendered, result, CheckKind.Temporal)
-      ))
-    catch
-      case e: AlloyTranslatorError =>
+    AlloyTranslator.translateTemporal(ir, decl, config.alloyScope) match
+      case Left(err) =>
         skippedCheck(
           id,
           CheckKind.Temporal,
@@ -523,19 +496,48 @@ object Consistency:
           Some(decl.name),
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
-          backendMsg(e)
+          err.message
         )
-      case e: Throwable =>
-        skippedCheck(
-          id,
-          CheckKind.Temporal,
-          VerifierTool.Alloy,
-          None,
-          Some(decl.name),
-          sourceSpans,
-          DiagnosticCategory.BackendError,
-          backendMsg(e)
-        )
+      case Right(translation) =>
+        val rendered = AlloyRender.renderWithLineMap(translation.module)
+        alloyBackend.check(
+          rendered.source,
+          commandIdx = 0,
+          timeoutMs = config.timeoutMs,
+          captureCore = config.captureCore
+        ) match
+          case Left(err) =>
+            skippedCheck(
+              id,
+              CheckKind.Temporal,
+              VerifierTool.Alloy,
+              None,
+              Some(decl.name),
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              err.message
+            )
+          case Right(result) =>
+            val outcome = translation.kind match
+              case AlloyTranslator.TemporalKind.Always => invertStatus(result.status)
+              case AlloyTranslator.TemporalKind.Eventually =>
+                CheckOutcome.fromStatus(result.status)
+            dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = CheckKind.Temporal,
+              tool = VerifierTool.Alloy,
+              operationName = None,
+              invariantName = Some(decl.name),
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = None,
+              coreSpans = alloyCoreSpans(rendered, result, CheckKind.Temporal)
+            ))
 
   private def runPreservationAlloy(
       ir: ServiceIR,
@@ -547,35 +549,8 @@ object Consistency:
       sourceSpans: List[Span],
       dump: Option[DumpSink]
   ): CheckResult =
-    try
-      val module =
-        AlloyTranslator.translateOperationPreservation(ir, op, inv.decl, config.alloyScope)
-      val rendered = AlloyRender.renderWithLineMap(module)
-      val result = alloyBackend.check(
-        rendered.source,
-        commandIdx = 0,
-        timeoutMs = config.timeoutMs,
-        captureCore = config.captureCore
-      )
-      val inverted = invertStatus(result.status)
-      dumpAlloy(dump, id, rendered.source, inverted, result.status, result.durationMs)
-      finalizeCheck(FinalizeArgs(
-        id = id,
-        kind = CheckKind.Preservation,
-        tool = VerifierTool.Alloy,
-        operationName = Some(op.name),
-        invariantName = Some(inv.name),
-        rawStatus = result.status,
-        outcome = inverted,
-        durationMs = result.durationMs,
-        sourceSpans = sourceSpans,
-        ir = ir,
-        invariantDecl = Some(inv.decl),
-        op = Some(op),
-        coreSpans = alloyCoreSpans(rendered, result, CheckKind.Preservation)
-      ))
-    catch
-      case e: AlloyTranslatorError =>
+    AlloyTranslator.translateOperationPreservation(ir, op, inv.decl, config.alloyScope) match
+      case Left(err) =>
         skippedCheck(
           id,
           CheckKind.Preservation,
@@ -584,19 +559,45 @@ object Consistency:
           Some(inv.name),
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
-          backendMsg(e)
+          err.message
         )
-      case e: Throwable =>
-        skippedCheck(
-          id,
-          CheckKind.Preservation,
-          VerifierTool.Alloy,
-          Some(op.name),
-          Some(inv.name),
-          sourceSpans,
-          DiagnosticCategory.BackendError,
-          backendMsg(e)
-        )
+      case Right(module) =>
+        val rendered = AlloyRender.renderWithLineMap(module)
+        alloyBackend.check(
+          rendered.source,
+          commandIdx = 0,
+          timeoutMs = config.timeoutMs,
+          captureCore = config.captureCore
+        ) match
+          case Left(err) =>
+            skippedCheck(
+              id,
+              CheckKind.Preservation,
+              VerifierTool.Alloy,
+              Some(op.name),
+              Some(inv.name),
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              err.message
+            )
+          case Right(result) =>
+            val inverted = invertStatus(result.status)
+            dumpAlloy(dump, id, rendered.source, inverted, result.status, result.durationMs)
+            finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = CheckKind.Preservation,
+              tool = VerifierTool.Alloy,
+              operationName = Some(op.name),
+              invariantName = Some(inv.name),
+              rawStatus = result.status,
+              outcome = inverted,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = Some(inv.decl),
+              op = Some(op),
+              coreSpans = alloyCoreSpans(rendered, result, CheckKind.Preservation)
+            ))
 
   final private case class FinalizeArgs(
       id: String,
@@ -769,8 +770,6 @@ object Consistency:
       sourceSpans = sourceSpans,
       diagnostic = Some(diagnostic)
     )
-
-  private def backendMsg(e: Throwable): String = Option(e.getMessage).getOrElse(e.toString)
 
   private def detailFor(
       kind: CheckKind,

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -8,6 +8,7 @@ import edu.mit.csail.sdg.translator.A4Options
 import edu.mit.csail.sdg.translator.A4Solution
 import edu.mit.csail.sdg.translator.TranslateAlloyToKodkod
 import kodkod.engine.satlab.SATFactory
+import specrest.ir.VerifyError
 import specrest.verify.CheckStatus
 
 import java.util.concurrent.Callable
@@ -16,6 +17,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
+import scala.util.boundary
+import scala.util.control.NonFatal
 
 final case class AlloyCheckResult(
     status: CheckStatus,
@@ -26,8 +29,13 @@ final case class AlloyCheckResult(
     corePositions: Set[Pos] = Set.empty
 )
 
+private type AlloyBackendLabel =
+  boundary.Label[Either[VerifyError.Backend, AlloyCheckResult]]
+
+private def alloyBackendFail(msg: String)(using AlloyBackendLabel): Nothing =
+  boundary.break(Left(VerifyError.Backend(msg, None)))
+
 object AlloyBackend:
-  // Cached lookup; SATFactory.find is a list scan.
   private lazy val coreCapableSolver: Option[SATFactory] =
     SATFactory.find("minisat.prover").toScala.filter(_.isPresent)
 
@@ -38,78 +46,84 @@ final class AlloyBackend:
       commandIdx: Int,
       timeoutMs: Long,
       captureCore: Boolean = false
-  ): AlloyCheckResult =
-    val reporter = A4Reporter.NOP
-    val module =
-      try CompUtil.parseEverything_fromString(reporter, source)
+  ): Either[VerifyError.Backend, AlloyCheckResult] =
+    boundary:
+      try
+        val reporter = A4Reporter.NOP
+        val module =
+          try CompUtil.parseEverything_fromString(reporter, source)
+          catch
+            case e: Err =>
+              alloyBackendFail(s"Alloy parse error: ${e.getMessage}\n---\n$source")
+        val commands = module.getAllCommands
+        if commands.isEmpty then
+          alloyBackendFail("Alloy module has no commands; need at least one run/check")
+        if commandIdx < 0 || commandIdx >= commands.size then
+          alloyBackendFail(s"command index $commandIdx out of range [0, ${commands.size})")
+        val cmd  = commands.get(commandIdx)
+        val opts = new A4Options()
+        val coreCapable =
+          if captureCore then AlloyBackend.coreCapableSolver else None
+        opts.solver = coreCapable.getOrElse(SATFactory.DEFAULT)
+        opts.skolemDepth = 4
+        if coreCapable.isDefined then
+          opts.coreMinimization = 1
+          opts.coreGranularity = 1
+        val t0 = System.nanoTime()
+        val solveTask = new Callable[A4Solution]:
+          def call(): A4Solution =
+            TranslateAlloyToKodkod.execute_command(reporter, module.getAllReachableSigs, cmd, opts)
+        val solutionOpt: Option[A4Solution] =
+          if timeoutMs <= 0 then
+            try Some(solveTask.call())
+            catch
+              case e: Err =>
+                alloyBackendFail(s"Alloy translate/solve error: ${e.getMessage}")
+          else
+            val pool   = Executors.newSingleThreadExecutor()
+            val future = pool.submit(solveTask)
+            try Some(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+            catch
+              case _: TimeoutException =>
+                val _ = future.cancel(true)
+                None
+              case e: java.util.concurrent.ExecutionException =>
+                e.getCause match
+                  case err: Err =>
+                    alloyBackendFail(s"Alloy translate/solve error: ${err.getMessage}")
+                  case other =>
+                    alloyBackendFail(
+                      s"Alloy execution error: ${Option(other).map(_.getMessage).getOrElse("null")}"
+                    )
+            finally
+              val _ = pool.shutdownNow()
+        val duration = (System.nanoTime() - t0) / 1_000_000.0
+        solutionOpt match
+          case None =>
+            Right(AlloyCheckResult(
+              status = CheckStatus.Unknown,
+              durationMs = duration,
+              solution = None,
+              commandName = cmd.label,
+              source = source
+            ))
+          case Some(solution) =>
+            val status =
+              if solution.satisfiable then CheckStatus.Sat
+              else CheckStatus.Unsat
+            val core: Set[Pos] =
+              if !solution.satisfiable && captureCore && coreCapable.isDefined then
+                val hl = solution.highLevelCore
+                hl.a.asScala.toSet
+              else Set.empty
+            Right(AlloyCheckResult(
+              status = status,
+              durationMs = duration,
+              solution = if solution.satisfiable then Some(solution) else None,
+              commandName = cmd.label,
+              source = source,
+              corePositions = core
+            ))
       catch
-        case e: Err =>
-          throw new AlloyTranslatorError(s"Alloy parse error: ${e.getMessage}\n---\n$source")
-    val commands = module.getAllCommands
-    if commands.isEmpty then
-      throw new AlloyTranslatorError("Alloy module has no commands; need at least one run/check")
-    if commandIdx < 0 || commandIdx >= commands.size then
-      throw new AlloyTranslatorError(
-        s"command index $commandIdx out of range [0, ${commands.size})"
-      )
-    val cmd  = commands.get(commandIdx)
-    val opts = new A4Options()
-    val coreCapable =
-      if captureCore then AlloyBackend.coreCapableSolver else None
-    opts.solver = coreCapable.getOrElse(SATFactory.DEFAULT)
-    opts.skolemDepth = 4
-    if coreCapable.isDefined then
-      opts.coreMinimization = 1
-      opts.coreGranularity = 1
-    val t0 = System.nanoTime()
-    val solveTask = new Callable[A4Solution]:
-      def call(): A4Solution =
-        TranslateAlloyToKodkod.execute_command(reporter, module.getAllReachableSigs, cmd, opts)
-    val solutionOpt: Option[A4Solution] =
-      if timeoutMs <= 0 then
-        try Some(solveTask.call())
-        catch
-          case e: Err =>
-            throw new AlloyTranslatorError(s"Alloy translate/solve error: ${e.getMessage}")
-      else
-        val pool   = Executors.newSingleThreadExecutor()
-        val future = pool.submit(solveTask)
-        try Some(future.get(timeoutMs, TimeUnit.MILLISECONDS))
-        catch
-          case _: TimeoutException =>
-            val _ = future.cancel(true)
-            None
-          case e: java.util.concurrent.ExecutionException =>
-            e.getCause match
-              case err: Err =>
-                throw new AlloyTranslatorError(s"Alloy translate/solve error: ${err.getMessage}")
-              case other => throw other
-        finally
-          val _ = pool.shutdownNow()
-    val duration = (System.nanoTime() - t0) / 1_000_000.0
-    solutionOpt match
-      case None =>
-        AlloyCheckResult(
-          status = CheckStatus.Unknown,
-          durationMs = duration,
-          solution = None,
-          commandName = cmd.label,
-          source = source
-        )
-      case Some(solution) =>
-        val status =
-          if solution.satisfiable then CheckStatus.Sat
-          else CheckStatus.Unsat
-        val core: Set[Pos] =
-          if !solution.satisfiable && captureCore && coreCapable.isDefined then
-            val hl = solution.highLevelCore
-            hl.a.asScala.toSet
-          else Set.empty
-        AlloyCheckResult(
-          status = status,
-          durationMs = duration,
-          solution = if solution.satisfiable then Some(solution) else None,
-          commandName = cmd.label,
-          source = source,
-          corePositions = core
-        )
+        case NonFatal(e) =>
+          Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(e.toString)))

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -11,6 +11,8 @@ import kodkod.engine.satlab.SATFactory
 import specrest.ir.VerifyError
 import specrest.verify.CheckStatus
 
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.util.concurrent.Callable
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -19,6 +21,11 @@ import scala.jdk.CollectionConverters.*
 import scala.jdk.OptionConverters.RichOptional
 import scala.util.boundary
 import scala.util.control.NonFatal
+
+private def alloyRenderStack(e: Throwable): String =
+  val sw = new StringWriter
+  e.printStackTrace(new PrintWriter(sw))
+  sw.toString
 
 final case class AlloyCheckResult(
     status: CheckStatus,
@@ -47,8 +54,8 @@ final class AlloyBackend:
       timeoutMs: Long,
       captureCore: Boolean = false
   ): Either[VerifyError.Backend, AlloyCheckResult] =
-    boundary:
-      try
+    try
+      boundary:
         val reporter = A4Reporter.NOP
         val module =
           try CompUtil.parseEverything_fromString(reporter, source)
@@ -124,6 +131,9 @@ final class AlloyBackend:
               source = source,
               corePositions = core
             ))
-      catch
-        case NonFatal(e) =>
-          Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(e.toString)))
+    catch
+      case NonFatal(e) =>
+        Left(VerifyError.Backend(
+          Option(e.getMessage).getOrElse(e.toString),
+          Some(alloyRenderStack(e))
+        ))

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -4,6 +4,12 @@ import specrest.ir.*
 import specrest.verify.Classifier
 
 import scala.collection.mutable
+import scala.util.boundary
+
+private type AlloyLabel = boundary.Label[Either[VerifyError.AlloyTranslator, Nothing]]
+
+private def failAlloy(msg: String)(using AlloyLabel): Nothing =
+  boundary.break(Left(VerifyError.AlloyTranslator(msg)))
 
 object Translator:
 
@@ -16,14 +22,20 @@ object Translator:
       boundVars: Set[String] = Set.empty
   )
 
-  def translateGlobal(ir: ServiceIR, scope: Int): AlloyModule =
-    val ctx = buildCtx(ir)
-    AlloyModule(
-      name = sanitizeName(ir.name),
-      sigs = buildSigs(ctx),
-      facts = invariantFacts(ctx, ir),
-      commands = List(AlloyCommand("global", AlloyCommandKind.Run, "", scope))
-    )
+  def translateGlobal(
+      ir: ServiceIR,
+      scope: Int
+  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
+    boundary:
+      val ctx = buildCtx(ir)
+      Right(
+        AlloyModule(
+          name = sanitizeName(ir.name),
+          sigs = buildSigs(ctx),
+          facts = invariantFacts(ctx, ir),
+          commands = List(AlloyCommand("global", AlloyCommandKind.Run, "", scope))
+        )
+      )
 
   enum TemporalKind:
     case Always, Eventually
@@ -34,67 +46,71 @@ object Translator:
       ir: ServiceIR,
       decl: TemporalDecl,
       scope: Int
-  ): TemporalTranslation =
-    val ctx = buildCtx(ir)
-    decl.expr match
-      case Expr.Call(Expr.Identifier("always", _), arg :: Nil, _) =>
-        val body = renderExpr(ctx, arg)
-        val module = AlloyModule(
-          name = sanitizeName(ir.name),
-          sigs = buildSigs(ctx),
-          facts = invariantFacts(ctx, ir) :+
-            AlloyFact(Some(s"${decl.name}_counterexample"), s"not ($body)", decl.span),
-          commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
-        )
-        TemporalTranslation(TemporalKind.Always, module)
-      case Expr.Call(Expr.Identifier("eventually", _), arg :: Nil, _) =>
-        val module = AlloyModule(
-          name = sanitizeName(ir.name),
-          sigs = buildSigs(ctx),
-          facts = invariantFacts(ctx, ir) :+
-            AlloyFact(Some(s"${decl.name}_witness"), renderExpr(ctx, arg), decl.span),
-          commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
-        )
-        TemporalTranslation(TemporalKind.Eventually, module)
-      case Expr.Call(Expr.Identifier("fairness", _), _, _) =>
-        throw new AlloyTranslatorError(
-          s"temporal '${decl.name}': fairness(...) is not supported in v1; it requires trace-based " +
-            "verification via Alloy's `var` sig mode which is future work"
-        )
-      case _ =>
-        throw new AlloyTranslatorError(
-          s"temporal '${decl.name}': only 'always(P)' and 'eventually(P)' are supported in v1; got " +
-            s"${decl.expr.getClass.getSimpleName}"
-        )
+  ): Either[VerifyError.AlloyTranslator, TemporalTranslation] =
+    boundary:
+      val ctx = buildCtx(ir)
+      Right(decl.expr match
+        case Expr.Call(Expr.Identifier("always", _), arg :: Nil, _) =>
+          val body = renderExpr(ctx, arg)
+          val module = AlloyModule(
+            name = sanitizeName(ir.name),
+            sigs = buildSigs(ctx),
+            facts = invariantFacts(ctx, ir) :+
+              AlloyFact(Some(s"${decl.name}_counterexample"), s"not ($body)", decl.span),
+            commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
+          )
+          TemporalTranslation(TemporalKind.Always, module)
+        case Expr.Call(Expr.Identifier("eventually", _), arg :: Nil, _) =>
+          val module = AlloyModule(
+            name = sanitizeName(ir.name),
+            sigs = buildSigs(ctx),
+            facts = invariantFacts(ctx, ir) :+
+              AlloyFact(Some(s"${decl.name}_witness"), renderExpr(ctx, arg), decl.span),
+            commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
+          )
+          TemporalTranslation(TemporalKind.Eventually, module)
+        case Expr.Call(Expr.Identifier("fairness", _), _, _) =>
+          failAlloy(
+            s"temporal '${decl.name}': fairness(...) is not supported in v1; it requires trace-based " +
+              "verification via Alloy's `var` sig mode which is future work"
+          )
+        case _ =>
+          failAlloy(
+            s"temporal '${decl.name}': only 'always(P)' and 'eventually(P)' are supported in v1; got " +
+              s"${decl.expr.getClass.getSimpleName}"
+          )
+      )
 
   def translateOperationRequires(
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
-  ): AlloyModule =
-    val ctx = buildCtxWithInputs(ir, op)
-    AlloyModule(
-      name = sanitizeName(ir.name),
-      sigs = buildSigs(ctx),
-      facts = op.requires.zipWithIndex.map: (r, i) =>
-        AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt),
-      commands = List(AlloyCommand(s"${op.name}_requires", AlloyCommandKind.Run, "", scope))
-    )
+  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
+    boundary:
+      val ctx = buildCtxWithInputs(ir, op)
+      Right(AlloyModule(
+        name = sanitizeName(ir.name),
+        sigs = buildSigs(ctx),
+        facts = op.requires.zipWithIndex.map: (r, i) =>
+          AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt),
+        commands = List(AlloyCommand(s"${op.name}_requires", AlloyCommandKind.Run, "", scope))
+      ))
 
   def translateOperationEnabled(
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
-  ): AlloyModule =
-    val ctx = buildCtxWithInputs(ir, op)
-    val reqFacts = op.requires.zipWithIndex.map: (r, i) =>
-      AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt)
-    AlloyModule(
-      name = sanitizeName(ir.name),
-      sigs = buildSigs(ctx),
-      facts = invariantFacts(ctx, ir) ++ reqFacts,
-      commands = List(AlloyCommand(s"${op.name}_enabled", AlloyCommandKind.Run, "", scope))
-    )
+  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
+    boundary:
+      val ctx = buildCtxWithInputs(ir, op)
+      val reqFacts = op.requires.zipWithIndex.map: (r, i) =>
+        AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt)
+      Right(AlloyModule(
+        name = sanitizeName(ir.name),
+        sigs = buildSigs(ctx),
+        facts = invariantFacts(ctx, ir) ++ reqFacts,
+        commands = List(AlloyCommand(s"${op.name}_enabled", AlloyCommandKind.Run, "", scope))
+      ))
 
   private def buildCtxWithInputs(ir: ServiceIR, op: OperationDecl): Ctx =
     val stateFields = ir.state.map(_.fields).getOrElse(Nil).map: sf =>
@@ -102,7 +118,7 @@ object Translator:
     val inputFields = op.inputs.map(p => p.name -> p.typeExpr)
     Ctx(ir, stateFields.toMap, inputFields.toMap)
 
-  private def invariantFacts(ctx: Ctx, ir: ServiceIR): List[AlloyFact] =
+  private def invariantFacts(ctx: Ctx, ir: ServiceIR)(using AlloyLabel): List[AlloyFact] =
     ir.invariants.zipWithIndex.map: (inv, i) =>
       val name = inv.name.getOrElse(s"inv_$i")
       AlloyFact(Some(name), renderExpr(ctx, inv.expr), inv.span)
@@ -112,49 +128,50 @@ object Translator:
       op: OperationDecl,
       inv: InvariantDecl,
       scope: Int
-  ): AlloyModule =
-    val preCtx  = buildCtxWithInputs(ir, op)
-    val postCtx = preCtx.copy(postStateSig = "StatePost")
-    val sigs    = buildPreservationSigs(preCtx)
+  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
+    boundary:
+      val preCtx  = buildCtxWithInputs(ir, op)
+      val postCtx = preCtx.copy(postStateSig = "StatePost")
+      val sigs    = buildPreservationSigs(preCtx)
 
-    val invariantsPre = ir.invariants.zipWithIndex.map: (i, idx) =>
-      val name = i.name.getOrElse(s"inv_$idx")
-      AlloyFact(Some(s"${name}_pre"), renderExpr(preCtx, i.expr), i.span)
+      val invariantsPre = ir.invariants.zipWithIndex.map: (i, idx) =>
+        val name = i.name.getOrElse(s"inv_$idx")
+        AlloyFact(Some(s"${name}_pre"), renderExpr(preCtx, i.expr), i.span)
 
-    val requiresFacts = op.requires.zipWithIndex.map: (r, i) =>
-      AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(preCtx, r), r.spanOpt)
+      val requiresFacts = op.requires.zipWithIndex.map: (r, i) =>
+        AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(preCtx, r), r.spanOpt)
 
-    val ensuresFacts = op.ensures.zipWithIndex.map: (e, i) =>
-      AlloyFact(Some(s"${op.name}_ensures_$i"), renderExpr(postCtx, e), e.spanOpt)
+      val ensuresFacts = op.ensures.zipWithIndex.map: (e, i) =>
+        AlloyFact(Some(s"${op.name}_ensures_$i"), renderExpr(postCtx, e), e.spanOpt)
 
-    val mentionedInEnsures = primedStateFields(op.ensures)
-    val frameFacts = ir.state.map(_.fields).getOrElse(Nil)
-      .filterNot(sf => mentionedInEnsures.contains(sf.name))
-      .map: sf =>
-        AlloyFact(
-          Some(s"frame_${sf.name}"),
-          s"StatePost.${sf.name} = State.${sf.name}",
-          sf.span
-        )
+      val mentionedInEnsures = primedStateFields(op.ensures)
+      val frameFacts = ir.state.map(_.fields).getOrElse(Nil)
+        .filterNot(sf => mentionedInEnsures.contains(sf.name))
+        .map: sf =>
+          AlloyFact(
+            Some(s"frame_${sf.name}"),
+            s"StatePost.${sf.name} = State.${sf.name}",
+            sf.span
+          )
 
-    val postStateCtx  = preCtx.copy(currentStateSig = "StatePost")
-    val invariantName = inv.name.getOrElse("invariant")
-    val postViolation = AlloyFact(
-      Some(s"${invariantName}_violated_post"),
-      s"not (${renderExpr(postStateCtx, inv.expr)})",
-      inv.span
-    )
+      val postStateCtx  = preCtx.copy(currentStateSig = "StatePost")
+      val invariantName = inv.name.getOrElse("invariant")
+      val postViolation = AlloyFact(
+        Some(s"${invariantName}_violated_post"),
+        s"not (${renderExpr(postStateCtx, inv.expr)})",
+        inv.span
+      )
 
-    val facts   = invariantsPre ++ requiresFacts ++ ensuresFacts ++ frameFacts :+ postViolation
-    val cmdName = s"${op.name}_preserves_$invariantName"
-    AlloyModule(
-      name = sanitizeName(ir.name),
-      sigs = sigs,
-      facts = facts,
-      commands = List(AlloyCommand(cmdName, AlloyCommandKind.Run, "", scope))
-    )
+      val facts   = invariantsPre ++ requiresFacts ++ ensuresFacts ++ frameFacts :+ postViolation
+      val cmdName = s"${op.name}_preserves_$invariantName"
+      Right(AlloyModule(
+        name = sanitizeName(ir.name),
+        sigs = sigs,
+        facts = facts,
+        commands = List(AlloyCommand(cmdName, AlloyCommandKind.Run, "", scope))
+      ))
 
-  private def buildPreservationSigs(ctx: Ctx): List[AlloySig] =
+  private def buildPreservationSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
     val baseSigs = buildSigs(ctx)
     if ctx.stateFields.nonEmpty then
       val stateFields = ctx.stateFields.toList.map: (name, typ) =>
@@ -164,9 +181,6 @@ object Translator:
     else baseSigs
 
   private def primedStateFields(ensures: List[Expr]): Set[String] =
-    // Any state identifier appearing under any Prime(...) subtree is considered
-    // mentioned by ensures — so the frame generator does NOT pin that field.
-    // Entering a Prime flips `underPrime` for the whole subtree; Pre() flips it back.
     val mentioned = mutable.Set.empty[String]
     def walk(e: Expr, underPrime: Boolean): Unit = e match
       case Expr.Prime(inner, _) => walk(inner, underPrime = true)
@@ -183,7 +197,7 @@ object Translator:
       sf.name -> sf.typeExpr
     Ctx(ir, stateFields.toMap)
 
-  private def buildSigs(ctx: Ctx): List[AlloySig] =
+  private def buildSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
     val sigs = mutable.ArrayBuffer.empty[AlloySig]
     if needsBoolSig(ctx) then
       sigs += AlloySig("Bool", abstract_ = true)
@@ -231,25 +245,24 @@ object Translator:
         )
     inFields || inExprs
 
-  private def alloyFieldTypeOf(t: TypeExpr): (AlloyFieldMultiplicity, String) = t match
-    case TypeExpr.NamedType(name, _) =>
-      (AlloyFieldMultiplicity.One, mapPrimitive(name))
-    case TypeExpr.SetType(inner, _) =>
-      val elem = typeToSigName(inner)
-      (AlloyFieldMultiplicity.Set, elem)
-    case TypeExpr.OptionType(inner, _) =>
-      (AlloyFieldMultiplicity.Lone, typeToSigName(inner))
-    case other =>
-      throw new AlloyTranslatorError(
-        s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $other"
-      )
+  private def alloyFieldTypeOf(t: TypeExpr)(using AlloyLabel): (AlloyFieldMultiplicity, String) =
+    t match
+      case TypeExpr.NamedType(name, _) =>
+        (AlloyFieldMultiplicity.One, mapPrimitive(name))
+      case TypeExpr.SetType(inner, _) =>
+        val elem = typeToSigName(inner)
+        (AlloyFieldMultiplicity.Set, elem)
+      case TypeExpr.OptionType(inner, _) =>
+        (AlloyFieldMultiplicity.Lone, typeToSigName(inner))
+      case other =>
+        failAlloy(
+          s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $other"
+        )
 
-  private def typeToSigName(t: TypeExpr): String = t match
+  private def typeToSigName(t: TypeExpr)(using AlloyLabel): String = t match
     case TypeExpr.NamedType(name, _) => mapPrimitive(name)
     case other =>
-      throw new AlloyTranslatorError(
-        s"nested type not supported as Alloy element sort: $other"
-      )
+      failAlloy(s"nested type not supported as Alloy element sort: $other")
 
   private def mapPrimitive(name: String): String = name match
     case "Int"    => "Int"
@@ -257,13 +270,13 @@ object Translator:
     case "String" => "String"
     case other    => other
 
-  private def renderExpr(ctx: Ctx, e: Expr): String = e match
+  private def renderExpr(ctx: Ctx, e: Expr)(using AlloyLabel): String = e match
     case Expr.BinaryOp(op, l, r, _)           => renderBinaryOp(ctx, op, l, r)
     case Expr.UnaryOp(UnOp.Not, x, _)         => s"not (${renderExpr(ctx, x)})"
     case Expr.UnaryOp(UnOp.Cardinality, x, _) => s"#(${renderExpr(ctx, x)})"
     case Expr.UnaryOp(UnOp.Negate, x, _)      => s"minus[0, ${renderExpr(ctx, x)}]"
     case Expr.UnaryOp(UnOp.Power, _, _) =>
-      throw new AlloyTranslatorError(
+      failAlloy(
         "standalone powerset '^s' is only supported as a binder domain (e.g. 'some t in ^s | ...')"
       )
     case q @ Expr.Quantifier(_, _, _, _) => renderQuantifier(ctx, q)
@@ -278,23 +291,19 @@ object Translator:
       renderExpr(ctx.copy(currentStateSig = ctx.postStateSig), inner)
     case Expr.Pre(inner, _) =>
       renderExpr(ctx.copy(currentStateSig = "State"), inner)
-    case Expr.IntLit(v, _)  => v.toString
+    case Expr.IntLit(v, _) => v.toString
     case Expr.BoolLit(v, _) =>
-      // Universe-independent: (True = True) is always-true, (True = False) always-false.
-      // Requires the Bool/True/False sigs emitted by buildSigs when BoolLit is used.
       if v then "(True = True)" else "(True = False)"
     case Expr.StringLit(s, _) =>
-      throw new AlloyTranslatorError(s"string literal '$s' is not supported in Alloy translation")
+      failAlloy(s"string literal '$s' is not supported in Alloy translation")
     case Expr.SetLiteral(Nil, _)    => "none"
     case Expr.SetLiteral(elems, _)  => elems.map(renderExpr(ctx, _)).mkString(" + ")
     case Expr.Index(b, i, _)        => s"(${renderExpr(ctx, b)})[${renderExpr(ctx, i)}]"
     case Expr.Call(callee, args, _) => renderCall(ctx, callee, args)
     case other =>
-      throw new AlloyTranslatorError(
-        s"Alloy translator does not support expression: ${other.getClass.getSimpleName}"
-      )
+      failAlloy(s"Alloy translator does not support expression: ${other.getClass.getSimpleName}")
 
-  private def renderBinaryOp(ctx: Ctx, op: BinOp, l: Expr, r: Expr): String =
+  private def renderBinaryOp(ctx: Ctx, op: BinOp, l: Expr, r: Expr)(using AlloyLabel): String =
     val lr = renderExpr(ctx, l)
     val rr = renderExpr(ctx, r)
     op match
@@ -319,19 +328,19 @@ object Translator:
       case BinOp.Mul       => s"mul[$lr, $rr]"
       case BinOp.Div       => s"div[$lr, $rr]"
 
-  private def renderQuantifier(ctx: Ctx, q: Expr.Quantifier): String =
+  private def renderQuantifier(ctx: Ctx, q: Expr.Quantifier)(using AlloyLabel): String =
     val hasPowersetBinder = q.bindings.exists(_.domain match
       case Expr.UnaryOp(UnOp.Power, _, _) => true
       case _                              => false
     )
     if hasPowersetBinder && q.quantifier == QuantKind.All then
-      throw new AlloyTranslatorError(
+      failAlloy(
         "universal quantification over a powerset ('all t in ^s | ...') requires higher-order " +
           "reasoning that Alloy rejects as non-skolemizable. Rewrite as an existential " +
           "('some t in ^s | ...') or as a first-order statement about s (e.g. 'all x in s | ...')."
       )
     if hasPowersetBinder && q.quantifier == QuantKind.No then
-      throw new AlloyTranslatorError(
+      failAlloy(
         "'no t in ^s | ...' is a negated universal over a powerset; Alloy rejects it as " +
           "higher-order for the same reason as 'all'. Rewrite to a first-order statement."
       )
@@ -355,7 +364,9 @@ object Translator:
         s"($guard)$joiner($bodyInner)"
     s"($keyword $bindings | $body)"
 
-  private def buildBinding(ctx: Ctx, b: QuantifierBinding): (String, Option[String]) =
+  private def buildBinding(ctx: Ctx, b: QuantifierBinding)(using
+      AlloyLabel
+  ): (String, Option[String]) =
     b.domain match
       case Expr.UnaryOp(UnOp.Power, inner, _) =>
         val innerType   = domainSigName(ctx, inner)
@@ -367,8 +378,7 @@ object Translator:
           .orElse(ctx.ir.enums.find(_.name == name).map(_.name))
         t match
           case Some(sigName) => (s"${b.variable}: $sigName", None)
-          case None          =>
-            // Field-typed domains (state or op input): bind to the element sig, guard via `in <field>`.
+          case None =>
             if ctx.stateFields.contains(name) || ctx.inputFields.contains(name) then
               val elem = domainSigName(ctx, b.domain)
               (s"${b.variable}: $elem", Some(s"${b.variable} in ${renderExpr(ctx, b.domain)}"))
@@ -376,7 +386,7 @@ object Translator:
       case _ =>
         (s"${b.variable}: ${renderExpr(ctx, b.domain)}", None)
 
-  private def domainSigName(ctx: Ctx, e: Expr): String = e match
+  private def domainSigName(ctx: Ctx, e: Expr)(using AlloyLabel): String = e match
     case Expr.Identifier(name, _) =>
       ctx.stateFields.get(name).orElse(ctx.inputFields.get(name)) match
         case Some(t) => fieldElementSigName(t)
@@ -385,28 +395,24 @@ object Translator:
             .orElse(ctx.ir.enums.find(_.name == name).map(_.name))
             .getOrElse(name)
     case _ =>
-      throw new AlloyTranslatorError(
+      failAlloy(
         s"powerset binder domain must be an identifier referring to an entity or set-typed state"
       )
 
-  private def fieldElementSigName(t: TypeExpr): String = t match
+  private def fieldElementSigName(t: TypeExpr)(using AlloyLabel): String = t match
     case TypeExpr.NamedType(name, _)                         => mapPrimitive(name)
     case TypeExpr.SetType(TypeExpr.NamedType(name, _), _)    => mapPrimitive(name)
     case TypeExpr.OptionType(TypeExpr.NamedType(name, _), _) => mapPrimitive(name)
     case other =>
-      throw new AlloyTranslatorError(
-        s"unsupported quantifier domain field type: $other"
-      )
+      failAlloy(s"unsupported quantifier domain field type: $other")
 
-  private def renderCall(ctx: Ctx, callee: Expr, args: List[Expr]): String =
+  private def renderCall(ctx: Ctx, callee: Expr, args: List[Expr])(using AlloyLabel): String =
     callee match
       case Expr.Identifier(name, _) =>
         val rendered = args.map(renderExpr(ctx, _)).mkString(", ")
         s"$name[$rendered]"
       case _ =>
-        throw new AlloyTranslatorError(
-          s"Alloy translator only supports identifier-called functions; got $callee"
-        )
+        failAlloy(s"Alloy translator only supports identifier-called functions; got $callee")
 
   private def sanitizeName(name: String): String =
     name.filter(c => c.isLetterOrDigit || c == '_')

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
@@ -48,5 +48,3 @@ final case class AlloyModule(
     facts: List[AlloyFact],
     commands: List[AlloyCommand]
 )
-
-final class AlloyTranslatorError(message: String) extends RuntimeException(message)

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -1,6 +1,7 @@
 package specrest.verify.certificates
 
 import io.circe.Json
+import specrest.ir.VerifyError
 import specrest.verify.CheckOutcome
 import specrest.verify.CheckStatus
 import specrest.verify.VerifierTool
@@ -71,17 +72,21 @@ final class DumpSink(val dir: Path):
 
 object DumpSink:
 
-  def open(dir: Path): DumpSink =
+  def open(dir: Path): Either[VerifyError.Backend, DumpSink] =
     if Files.exists(dir) then
       if !Files.isDirectory(dir) then
-        throw new RuntimeException(s"--dump-vc target is not a directory: $dir")
-      val isEmpty =
-        val s = Files.list(dir)
-        try !s.iterator.hasNext
-        finally s.close()
-      if !isEmpty then
-        throw new RuntimeException(
-          s"--dump-vc target directory is non-empty: $dir (refusing to overwrite)"
-        )
-    else Files.createDirectories(dir)
-    new DumpSink(dir)
+        Left(VerifyError.Backend(s"--dump-vc target is not a directory: $dir", None))
+      else
+        val isEmpty =
+          val s = Files.list(dir)
+          try !s.iterator.hasNext
+          finally s.close()
+        if !isEmpty then
+          Left(VerifyError.Backend(
+            s"--dump-vc target directory is non-empty: $dir (refusing to overwrite)",
+            None
+          ))
+        else Right(new DumpSink(dir))
+    else
+      val _ = Files.createDirectories(dir)
+      Right(new DumpSink(dir))

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -6,8 +6,16 @@ import specrest.verify.CheckOutcome
 import specrest.verify.CheckStatus
 import specrest.verify.VerifierTool
 
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.nio.file.Files
 import java.nio.file.Path
+import scala.util.control.NonFatal
+
+private def dumpIoFail(msg: String, cause: Throwable): VerifyError.Backend =
+  val sw = new StringWriter
+  cause.printStackTrace(new PrintWriter(sw))
+  VerifyError.Backend(s"$msg: ${cause.getMessage}", Some(sw.toString))
 
 final case class DumpEntry(
     id: String,
@@ -73,20 +81,24 @@ final class DumpSink(val dir: Path):
 object DumpSink:
 
   def open(dir: Path): Either[VerifyError.Backend, DumpSink] =
-    if Files.exists(dir) then
-      if !Files.isDirectory(dir) then
-        Left(VerifyError.Backend(s"--dump-vc target is not a directory: $dir", None))
+    try
+      if Files.exists(dir) then
+        if !Files.isDirectory(dir) then
+          Left(VerifyError.Backend(s"--dump-vc target is not a directory: $dir", None))
+        else
+          val isEmpty =
+            val s = Files.list(dir)
+            try !s.iterator.hasNext
+            finally s.close()
+          if !isEmpty then
+            Left(VerifyError.Backend(
+              s"--dump-vc target directory is non-empty: $dir (refusing to overwrite)",
+              None
+            ))
+          else Right(new DumpSink(dir))
       else
-        val isEmpty =
-          val s = Files.list(dir)
-          try !s.iterator.hasNext
-          finally s.close()
-        if !isEmpty then
-          Left(VerifyError.Backend(
-            s"--dump-vc target directory is non-empty: $dir (refusing to overwrite)",
-            None
-          ))
-        else Right(new DumpSink(dir))
-    else
-      val _ = Files.createDirectories(dir)
-      Right(new DumpSink(dir))
+        val _ = Files.createDirectories(dir)
+        Right(new DumpSink(dir))
+    catch
+      case NonFatal(e) =>
+        Left(dumpIoFail(s"--dump-vc failed accessing $dir", e))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -16,6 +16,8 @@ import specrest.ir.VerifyError
 import specrest.verify.CheckStatus
 import specrest.verify.VerificationConfig
 
+import java.io.PrintWriter
+import java.io.StringWriter
 import scala.collection.mutable
 import scala.util.boundary
 import scala.util.control.NonFatal
@@ -25,6 +27,11 @@ private type BackendBoundary =
 
 private def backendFail(rctx: RenderCtx, msg: String): Nothing =
   boundary.break(Left(VerifyError.Backend(msg, None)))(using rctx.bnd)
+
+private[z3] def renderStack(e: Throwable): String =
+  val sw = new StringWriter
+  e.printStackTrace(new PrintWriter(sw))
+  sw.toString
 
 final case class SmokeCheckResult(
     status: CheckStatus,
@@ -54,8 +61,8 @@ final class WasmBackend:
       script: Z3Script,
       cfg: VerificationConfig
   ): Either[VerifyError.Backend, SmokeCheckResult] =
-    boundary:
-      try
+    try
+      boundary:
         val ctx     = getContext()
         val sortMap = declareSorts(ctx, script.sorts)
         val funcMap = declareFuncs(ctx, script.funcs, sortMap)
@@ -95,9 +102,9 @@ final class WasmBackend:
           funcMap = funcMap.toMap,
           unsatCoreTrackers = core
         ))
-      catch
-        case NonFatal(e) =>
-          Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(e.toString)))
+    catch
+      case NonFatal(e) =>
+        Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(renderStack(e))))
 
 final private class RenderCtx(
     val ctx: Context,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -12,10 +12,19 @@ import com.microsoft.z3.IntSort
 import com.microsoft.z3.Model
 import com.microsoft.z3.Sort
 import com.microsoft.z3.Status
+import specrest.ir.VerifyError
 import specrest.verify.CheckStatus
 import specrest.verify.VerificationConfig
 
 import scala.collection.mutable
+import scala.util.boundary
+import scala.util.control.NonFatal
+
+private type BackendBoundary =
+  boundary.Label[Either[VerifyError.Backend, SmokeCheckResult]]
+
+private def backendFail(rctx: RenderCtx, msg: String): Nothing =
+  boundary.break(Left(VerifyError.Backend(msg, None)))(using rctx.bnd)
 
 final case class SmokeCheckResult(
     status: CheckStatus,
@@ -41,51 +50,60 @@ final class WasmBackend:
     ctxCache.foreach(_.close())
     ctxCache = None
 
-  def check(script: Z3Script, cfg: VerificationConfig): SmokeCheckResult =
-    val ctx     = getContext()
-    val sortMap = declareSorts(ctx, script.sorts)
-    val funcMap = declareFuncs(ctx, script.funcs, sortMap)
-    val solver  = ctx.mkSolver()
-    if cfg.timeoutMs > 0 then
-      val params = ctx.mkParams()
-      params.add("timeout", cfg.timeoutMs.toInt)
-      solver.setParameters(params)
-    val rctx         = new RenderCtx(ctx, sortMap, funcMap)
-    val trackerNames = scala.collection.mutable.ArrayBuffer.empty[String]
-    if cfg.captureCore then
-      for (a, idx) <- script.assertions.zipWithIndex do
-        val name    = s"_t_$idx"
-        val tracker = ctx.mkBoolConst(name)
-        solver.assertAndTrack(Backend.renderBool(rctx, a), tracker)
-        val _ = trackerNames += name
-    else for a <- script.assertions do solver.add(Backend.renderBool(rctx, a))
-    val t0       = System.nanoTime()
-    val status   = solver.check()
-    val duration = (System.nanoTime() - t0) / 1_000_000.0
-    val checkStatus = status match
-      case Status.SATISFIABLE   => CheckStatus.Sat
-      case Status.UNSATISFIABLE => CheckStatus.Unsat
-      case Status.UNKNOWN       => CheckStatus.Unknown
-    val model =
-      if checkStatus == CheckStatus.Sat && cfg.captureModel then Some(solver.getModel)
-      else None
-    val core =
-      if cfg.captureCore && checkStatus == CheckStatus.Unsat then
-        solver.getUnsatCore.toList.map(_.toString)
-      else Nil
-    SmokeCheckResult(
-      status = checkStatus,
-      durationMs = duration,
-      model = model,
-      sortMap = sortMap.toMap,
-      funcMap = funcMap.toMap,
-      unsatCoreTrackers = core
-    )
+  def check(
+      script: Z3Script,
+      cfg: VerificationConfig
+  ): Either[VerifyError.Backend, SmokeCheckResult] =
+    boundary:
+      try
+        val ctx     = getContext()
+        val sortMap = declareSorts(ctx, script.sorts)
+        val funcMap = declareFuncs(ctx, script.funcs, sortMap)
+        val solver  = ctx.mkSolver()
+        if cfg.timeoutMs > 0 then
+          val params = ctx.mkParams()
+          params.add("timeout", cfg.timeoutMs.toInt)
+          solver.setParameters(params)
+        val rctx         = new RenderCtx(ctx, sortMap, funcMap, summon[BackendBoundary])
+        val trackerNames = scala.collection.mutable.ArrayBuffer.empty[String]
+        if cfg.captureCore then
+          for (a, idx) <- script.assertions.zipWithIndex do
+            val name    = s"_t_$idx"
+            val tracker = ctx.mkBoolConst(name)
+            solver.assertAndTrack(Backend.renderBool(rctx, a), tracker)
+            val _ = trackerNames += name
+        else for a <- script.assertions do solver.add(Backend.renderBool(rctx, a))
+        val t0       = System.nanoTime()
+        val status   = solver.check()
+        val duration = (System.nanoTime() - t0) / 1_000_000.0
+        val checkStatus = status match
+          case Status.SATISFIABLE   => CheckStatus.Sat
+          case Status.UNSATISFIABLE => CheckStatus.Unsat
+          case Status.UNKNOWN       => CheckStatus.Unknown
+        val model =
+          if checkStatus == CheckStatus.Sat && cfg.captureModel then Some(solver.getModel)
+          else None
+        val core =
+          if cfg.captureCore && checkStatus == CheckStatus.Unsat then
+            solver.getUnsatCore.toList.map(_.toString)
+          else Nil
+        Right(SmokeCheckResult(
+          status = checkStatus,
+          durationMs = duration,
+          model = model,
+          sortMap = sortMap.toMap,
+          funcMap = funcMap.toMap,
+          unsatCoreTrackers = core
+        ))
+      catch
+        case NonFatal(e) =>
+          Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(e.toString)))
 
 final private class RenderCtx(
     val ctx: Context,
     val sortMap: mutable.Map[String, Sort],
-    val funcMap: mutable.Map[String, FuncDecl[?]]
+    val funcMap: mutable.Map[String, FuncDecl[?]],
+    val bnd: BackendBoundary
 ):
   val varStack: mutable.ArrayBuffer[mutable.Map[String, Z3AstExpr[?]]] = mutable.ArrayBuffer.empty
 
@@ -141,12 +159,10 @@ private object Backend:
 
   def renderExpr(rctx: RenderCtx, e: Z3Expr): Z3AstExpr[?] = e match
     case Z3Expr.Var(name, _, _) =>
-      lookupVar(rctx, name).getOrElse(
-        throw new RuntimeException(s"unbound Z3 variable '$name'")
-      )
+      lookupVar(rctx, name).getOrElse(backendFail(rctx, s"unbound Z3 variable '$name'"))
     case Z3Expr.App(func, args, _) =>
       rctx.funcMap.get(func) match
-        case None => throw new RuntimeException(s"undeclared Z3 function '$func'")
+        case None => backendFail(rctx, s"undeclared Z3 function '$func'")
         case Some(decl) =>
           val rendered = args.map(a => renderExpr(rctx, a)).toArray
           decl.asInstanceOf[FuncDecl[Sort]]
@@ -212,14 +228,14 @@ private object Backend:
         case CmpOp.Le => rctx.ctx.mkLe(l, r)
         case CmpOp.Gt => rctx.ctx.mkGt(l, r)
         case CmpOp.Ge => rctx.ctx.mkGe(l, r)
-        case _        => throw new RuntimeException(s"unreachable CmpOp: $op")
+        case _        => backendFail(rctx, s"unreachable CmpOp: $op")
 
   private def renderArith(
       rctx: RenderCtx,
       op: ArithOp,
       args: List[Z3Expr]
   ): ArithExpr[IntSort] =
-    if args.isEmpty then throw new RuntimeException("Arith with no args")
+    if args.isEmpty then backendFail(rctx, "Arith with no args")
     val rendered = args.map(a => renderArithExpr(rctx, a))
     op match
       case ArithOp.Add => rctx.ctx.mkAdd(rendered*)
@@ -232,7 +248,7 @@ private object Backend:
 
   private def renderQuantifier(rctx: RenderCtx, e: Z3Expr.Quantifier): BoolExpr =
     if e.bindings.isEmpty then
-      throw new RuntimeException(s"Quantifier must have at least one binding (got 0 for ${e.q})")
+      backendFail(rctx, s"Quantifier must have at least one binding (got 0 for ${e.q})")
     val frame  = mutable.Map.empty[String, Z3AstExpr[?]]
     val consts = mutable.ArrayBuffer.empty[Z3AstExpr[?]]
     for b <- e.bindings do

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -170,10 +170,7 @@ object Z3CounterExample:
       case None    => text
 
   private def safeSortUniverse(model: Model, sort: Sort): List[Z3AstExpr[?]] =
-    try
-      val universe = model.getSortUniverse(sort)
-      universe.toList
-    catch case _: Throwable => Nil
+    scala.util.Try(model.getSortUniverse(sort).toList).toOption.getOrElse(Nil)
 
   private def applyDecl(decl: FuncDecl[?], args: List[Z3AstExpr[?]]): Z3AstExpr[?] =
     decl

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1,9 +1,15 @@
 package specrest.verify.z3
 
 import specrest.ir.*
-import specrest.verify.TranslatorError
 
 import scala.collection.mutable
+import scala.util.boundary
+
+private type TranslateBoundary =
+  boundary.Label[Either[VerifyError.Translator, Z3Script]]
+
+private def fail(ctx: TranslateCtx, msg: String): Nothing =
+  boundary.break(Left(VerifyError.Translator(msg)))(using ctx.bnd)
 
 private val StringSortName = "String"
 
@@ -39,7 +45,7 @@ final private case class StateConstInfo(
     funcNamePost: String
 ) extends StateEntry
 
-final private class TranslateCtx:
+final private class TranslateCtx(val bnd: TranslateBoundary):
   val sorts: mutable.LinkedHashMap[String, Z3Sort]              = mutable.LinkedHashMap.empty
   val funcs: mutable.LinkedHashMap[String, Z3FunctionDecl]      = mutable.LinkedHashMap.empty
   val assertions: mutable.ArrayBuffer[Z3Expr]                   = mutable.ArrayBuffer.empty
@@ -106,46 +112,56 @@ final private class TranslateCtx:
 
 object Translator:
 
-  def translate(ir: ServiceIR): Z3Script =
-    val ctx = new TranslateCtx
-    declareBase(ctx, ir)
-    for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
-    finalizeScript(ctx)
+  def translate(ir: ServiceIR): Either[VerifyError.Translator, Z3Script] =
+    boundary:
+      val ctx = new TranslateCtx(summon[TranslateBoundary])
+      declareBase(ctx, ir)
+      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
+      Right(finalizeScript(ctx))
 
-  def translateOperationRequires(ir: ServiceIR, op: OperationDecl): Z3Script =
-    val ctx = new TranslateCtx
-    declareBase(ctx, ir)
-    val env = declareOperationInputs(ctx, op)
-    for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-    finalizeScript(ctx)
+  def translateOperationRequires(
+      ir: ServiceIR,
+      op: OperationDecl
+  ): Either[VerifyError.Translator, Z3Script] =
+    boundary:
+      val ctx = new TranslateCtx(summon[TranslateBoundary])
+      declareBase(ctx, ir)
+      val env = declareOperationInputs(ctx, op)
+      for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+      Right(finalizeScript(ctx))
 
-  def translateOperationEnabled(ir: ServiceIR, op: OperationDecl): Z3Script =
-    val ctx = new TranslateCtx
-    declareBase(ctx, ir)
-    for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
-    val env = declareOperationInputs(ctx, op)
-    for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-    finalizeScript(ctx)
+  def translateOperationEnabled(
+      ir: ServiceIR,
+      op: OperationDecl
+  ): Either[VerifyError.Translator, Z3Script] =
+    boundary:
+      val ctx = new TranslateCtx(summon[TranslateBoundary])
+      declareBase(ctx, ir)
+      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
+      val env = declareOperationInputs(ctx, op)
+      for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+      Right(finalizeScript(ctx))
 
   def translateOperationPreservation(
       ir: ServiceIR,
       op: OperationDecl,
       inv: InvariantDecl
-  ): Z3Script =
-    val ctx = new TranslateCtx
-    ctx.hasPostState = true
-    declareBase(ctx, ir)
-    ir.state.foreach(s => declareStatePostState(ctx, s))
-    val env = declareOperationInputs(ctx, op)
-    declareOperationOutputs(ctx, op, env)
-    for preInv <- ir.invariants do ctx.assertions += translateExpr(ctx, preInv.expr, env)
-    for req    <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-    for ens    <- op.ensures do ctx.assertions += translateEnsuresClause(ctx, ens, env)
-    synthesizeFrame(ctx, ir.state, op, env)
-    synthesizeCardinalityAxioms(ctx, ir.state, op)
-    val postInv = withStateMode(ctx, StateMode.Post, () => translateExpr(ctx, inv.expr, env))
-    ctx.assertions += Z3Expr.Not(postInv).withSpan(inv.span)
-    finalizeScript(ctx)
+  ): Either[VerifyError.Translator, Z3Script] =
+    boundary:
+      val ctx = new TranslateCtx(summon[TranslateBoundary])
+      ctx.hasPostState = true
+      declareBase(ctx, ir)
+      ir.state.foreach(s => declareStatePostState(ctx, s))
+      val env = declareOperationInputs(ctx, op)
+      declareOperationOutputs(ctx, op, env)
+      for preInv <- ir.invariants do ctx.assertions += translateExpr(ctx, preInv.expr, env)
+      for req    <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+      for ens    <- op.ensures do ctx.assertions += translateEnsuresClause(ctx, ens, env)
+      synthesizeFrame(ctx, ir.state, op, env)
+      synthesizeCardinalityAxioms(ctx, ir.state, op)
+      val postInv = withStateMode(ctx, StateMode.Post, () => translateExpr(ctx, inv.expr, env))
+      ctx.assertions += Z3Expr.Not(postInv).withSpan(inv.span)
+      Right(finalizeScript(ctx))
 
   private def declareBase(ctx: TranslateCtx, ir: ServiceIR): Unit =
     for e <- ir.enums do declareEnum(ctx, e)
@@ -566,11 +582,12 @@ object Translator:
     case Expr.Pre(inner, _) =>
       withStateMode(ctx, StateMode.Pre, () => translateExpr(ctx, inner, env))
     case w @ Expr.With(_, _, _)                 => translateWith(ctx, w, env)
-    case sc @ Expr.SetComprehension(_, _, _, _) => translateSetComprehension(sc)
+    case sc @ Expr.SetComprehension(_, _, _, _) => translateSetComprehension(ctx, sc)
     case sl @ Expr.SetLiteral(_, _)             => translateSetLiteral(ctx, sl, env)
     case l @ Expr.Let(_, _, _, _)               => translateLet(ctx, l, env)
     case other =>
-      throw new TranslatorError(
+      fail(
+        ctx,
         s"expression kind '${other.getClass.getSimpleName}' is not yet supported by the verifier"
       )
 
@@ -621,7 +638,8 @@ object Translator:
         val leftBad   = leftSort.exists(_ != Z3Sort.Int)
         val rightBad  = rightSort.exists(_ != Z3Sort.Int)
         if leftBad || rightBad then
-          throw new TranslatorError(
+          fail(
+            ctx,
             s"arithmetic operator '${binOpToTs(op)}' is only supported on integers (deferred for string/set arithmetic)"
           )
         val aop = op match
@@ -641,7 +659,7 @@ object Translator:
           case _               => SetOpKind.Union
         Z3Expr.SetBinOp(sop, left, right)
       case _ =>
-        throw new TranslatorError(s"binary op '${binOpToTs(op)}' is not supported by the verifier")
+        fail(ctx, s"binary op '${binOpToTs(op)}' is not supported by the verifier")
 
   private def ensureSetBinOpSorts(
       ctx: TranslateCtx,
@@ -663,12 +681,11 @@ object Translator:
       case _               => true
     }
     if leftBad || rightBad then
-      throw new TranslatorError(
-        s"set operator '${binOpToTs(op)}' requires both operands to be sets"
-      )
+      fail(ctx, s"set operator '${binOpToTs(op)}' requires both operands to be sets")
     (leftSort, rightSort) match
       case (Some(Z3Sort.SetOf(le)), Some(Z3Sort.SetOf(re))) if !Z3Sort.eq(le, re) =>
-        throw new TranslatorError(
+        fail(
+          ctx,
           s"set operator '${binOpToTs(op)}' requires both operands to have the same element sort; got $le and $re"
         )
       case _ => ()
@@ -719,12 +736,14 @@ object Translator:
               case Some(Z3Sort.SetOf(elemSort)) =>
                 val leftSort = inferSortOfZ3Expr(ctx, leftZ)
                 if leftSort.exists(s => !Z3Sort.eq(s, elemSort)) then
-                  throw new TranslatorError(
+                  fail(
+                    ctx,
                     s"membership operator '${binOpToTs(op)}' requires the left-hand side sort to match the set's element sort; got ${leftSort.get} against a set of $elemSort"
                   )
                 Z3Expr.SetMember(leftZ, rightZ)
               case _ =>
-                throw new TranslatorError(
+                fail(
+                  ctx,
                   s"membership operator '${binOpToTs(op)}' is only supported against a state relation, set literal, set comprehension, or set-valued expression"
                 )
 
@@ -743,7 +762,8 @@ object Translator:
           inferSortOfZ3Expr(ctx, t).exists(s => !Z3Sort.eq(s, ls))
         if mismatchIdx >= 0 then
           val got = inferSortOfZ3Expr(ctx, translated(mismatchIdx)).get
-          throw new TranslatorError(
+          fail(
+            ctx,
             s"set literal elements must match the membership LHS sort; expected $ls but found $got"
           )
       val eqs = translated.map(rhs => Z3Expr.Cmp(CmpOp.Eq, leftZ, rhs))
@@ -839,7 +859,8 @@ object Translator:
       Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(0), translateExpr(ctx, expr.operand, env)))
     case UnOp.Cardinality => translateCardinality(ctx, expr.operand)
     case UnOp.Power =>
-      throw new TranslatorError(
+      fail(
+        ctx,
         "powerset operator is not decidable in first-order SMT; narrow the invariant to avoid powerset"
       )
 
@@ -848,9 +869,7 @@ object Translator:
     case Expr.Pre(Expr.Identifier(n, _), _)   => cardinalityRefFor(ctx, n, StateMode.Pre)
     case Expr.Identifier(n, _)                => cardinalityRefFor(ctx, n, ctx.stateMode)
     case _ =>
-      throw new TranslatorError(
-        "cardinality '#expr' is only supported on state-relation identifiers"
-      )
+      fail(ctx, "cardinality '#expr' is only supported on state-relation identifiers")
 
   private def cardinalityRefFor(
       ctx: TranslateCtx,
@@ -869,7 +888,8 @@ object Translator:
           )
         Z3Expr.App(funcName, Nil)
       case _ =>
-        throw new TranslatorError(
+        fail(
+          ctx,
           s"cardinality '#$targetName' requires a state relation; '$targetName' is not declared as one"
         )
 
@@ -953,13 +973,15 @@ object Translator:
             entity.fields.get(expr.field) match
               case Some((_, funcName)) => Z3Expr.App(funcName, List(base))
               case None =>
-                throw new TranslatorError(s"entity '$name' has no field '${expr.field}'")
+                fail(ctx, s"entity '$name' has no field '${expr.field}'")
           case None =>
-            throw new TranslatorError(
+            fail(
+              ctx,
               s"field access '.${expr.field}' requires an entity-typed base; inferred sort is not an entity"
             )
       case _ =>
-        throw new TranslatorError(
+        fail(
+          ctx,
           s"field access '.${expr.field}' requires an entity-typed base; inferred sort is not an entity"
         )
 
@@ -972,7 +994,8 @@ object Translator:
       val key = translateExpr(ctx, expr.index, env)
       Z3Expr.App(mapFuncFor(info, mode), List(key))
     case None =>
-      throw new TranslatorError(
+      fail(
+        ctx,
         "indexing is only supported on state-relation references (including primed/pre-state forms); general map/sequence indexing is not supported"
       )
 
@@ -992,9 +1015,7 @@ object Translator:
           ctx.declareFunc(Z3FunctionDecl(funcName, argSorts, resultSort))
         Z3Expr.App(funcName, args)
       case _ =>
-        throw new TranslatorError(
-          "higher-order call (non-identifier callee) is not supported by the verifier"
-        )
+        fail(ctx, "higher-order call (non-identifier callee) is not supported by the verifier")
 
   private def callReturnSort(name: String): Z3Sort = name match
     case "len"        => Z3Sort.Int
@@ -1038,9 +1059,7 @@ object Translator:
       case Some(Z3Sort.Uninterp(name)) =>
         ctx.entities.get(name) match
           case None =>
-            throw new TranslatorError(
-              s"'with' expression requires an entity sort; '$name' is not an entity"
-            )
+            fail(ctx, s"'with' expression requires an entity sort; '$name' is not an entity")
           case Some(entity) =>
             val baseZ      = translateExpr(ctx, expr.base, env)
             val skolemName = ctx.freshSkolem(s"with_$name")
@@ -1057,7 +1076,7 @@ object Translator:
             for update <- expr.updates do
               entity.fields.get(update.name) match
                 case None =>
-                  throw new TranslatorError(s"entity '$name' has no field '${update.name}'")
+                  fail(ctx, s"entity '$name' has no field '${update.name}'")
                 case Some((_, funcName)) =>
                   val value = translateExpr(ctx, update.value, env)
                   ctx.assertions += Z3Expr.Cmp(
@@ -1067,11 +1086,12 @@ object Translator:
                   )
             skolemRef
       case _ =>
-        throw new TranslatorError("'with' expression requires a known entity sort")
+        fail(ctx, "'with' expression requires a known entity sort")
 
-  private def translateSetComprehension(sc: Expr.SetComprehension): Z3Expr =
+  private def translateSetComprehension(ctx: TranslateCtx, sc: Expr.SetComprehension): Z3Expr =
     val _ = sc
-    throw new TranslatorError(
+    fail(
+      ctx,
       "standalone set comprehensions as expressions are not supported because the binder's element sort typically does not match the receiver's declared type; use an inline membership form: `y in {x in S | P}`"
     )
 
@@ -1081,21 +1101,21 @@ object Translator:
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
     if sl.elements.isEmpty then
-      throw new TranslatorError(
+      fail(
+        ctx,
         "empty set literal '{}' requires context to infer its element sort; use a non-empty set"
       )
     val translated  = sl.elements.map(e => translateExpr(ctx, e, env))
     val memberSorts = translated.map(t => inferSortOfZ3Expr(ctx, t))
     val unknownIdx  = memberSorts.indexWhere(_.isEmpty)
     if unknownIdx >= 0 then
-      throw new TranslatorError(
-        s"set literal element has unknown sort: ${sl.elements(unknownIdx)}"
-      )
+      fail(ctx, s"set literal element has unknown sort: ${sl.elements(unknownIdx)}")
     val knownSorts  = memberSorts.flatten
     val elemSort    = knownSorts.head
     val mismatchIdx = knownSorts.indexWhere(s => !Z3Sort.eq(s, elemSort))
     if mismatchIdx >= 0 then
-      throw new TranslatorError(
+      fail(
+        ctx,
         s"set literal elements must all have the same sort; expected $elemSort but found ${knownSorts(mismatchIdx)}"
       )
     Z3Expr.SetLit(elemSort, translated)
@@ -1110,7 +1130,7 @@ object Translator:
           ctx.declareFunc(Z3FunctionDecl(funcName, Nil, resultSort))
         Z3Expr.App(funcName, Nil)
       case _ =>
-        throw new TranslatorError("enum access base must be an identifier")
+        fail(ctx, "enum access base must be an identifier")
 
   private def stringLiteralConst(ctx: TranslateCtx, value: String): Z3Expr =
     val name = ctx.stringLitNameFor(value)
@@ -1259,19 +1279,19 @@ object Translator:
     val elemSort = inferSortOfZ3Expr(ctx, setZ) match
       case Some(Z3Sort.SetOf(e)) => e
       case Some(other) =>
-        throw new TranslatorError(
+        fail(
+          ctx,
           s"set-comprehension equality requires a set-sorted receiver; got ${Z3Sort.key(other)}"
         )
       case None =>
-        throw new TranslatorError(
-          "set-comprehension equality requires a receiver with an inferrable set sort"
-        )
+        fail(ctx, "set-comprehension equality requires a receiver with an inferrable set sort")
     val resolved = resolveBindingDomain(
       ctx,
       QuantifierBinding(sc.variable, sc.domain, BindingKind.In)
     )
     if !Z3Sort.eq(resolved.sort, elemSort) then
-      throw new TranslatorError(
+      fail(
+        ctx,
         s"set-comprehension binder sort ${Z3Sort.key(resolved.sort)} does not match receiver element sort ${Z3Sort.key(elemSort)}"
       )
     // Use a fresh binder so we don't capture an outer identifier that shadows

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -13,7 +13,7 @@ class ConsistencyTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   test("url_shortener passes all consistency checks"):
     val backend = WasmBackend()
@@ -186,7 +186,7 @@ class ConsistencyTest extends munit.FunSuite:
         |}""".stripMargin
     val parsed = specrest.parser.Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree)
+    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
@@ -212,7 +212,7 @@ class ConsistencyTest extends munit.FunSuite:
         |}""".stripMargin
     val parsed = specrest.parser.Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree)
+    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
@@ -238,7 +238,7 @@ class ConsistencyTest extends munit.FunSuite:
         |}""".stripMargin
     val parsed = specrest.parser.Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree)
+    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -128,7 +128,7 @@ class JsonReportTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   // Paths where timing fields legitimately live in the schema. Scoping prevents accidental
   // erasure if a future diagnostic/counterexample field shares one of these names.

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -23,7 +23,7 @@ class AlloyGoldenTest extends munit.FunSuite:
   fixtures.foreach: name =>
     test(s"Alloy source matches golden — $name"):
       val ir      = buildIR(name)
-      val module  = Translator.translateGlobal(ir, scope = 5)
+      val module  = Translator.translateGlobal(ir, scope = 5).toOption.get
       val emitted = Render.render(module).stripSuffix("\n")
       val golden  = Files.readString(goldenDir.resolve(s"$name.als")).stripSuffix("\n")
       if emitted != golden then

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -18,7 +18,7 @@ class AlloyGoldenTest extends munit.FunSuite:
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   fixtures.foreach: name =>
     test(s"Alloy source matches golden — $name"):

--- a/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
@@ -41,7 +41,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
     assert(result.solution.isDefined, "expected a solution for sat case")
 
@@ -54,7 +54,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Unsat, s"expected unsat; source=$source")
 
   test("singleton State sig with set field + subset powerset quantification"):
@@ -76,7 +76,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
 
   test("existential powerset quantification (some t: set …) works end-to-end"):
@@ -91,5 +91,5 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")

--- a/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
@@ -13,7 +13,7 @@ class TranslatorTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   test("powerset_demo translates to a valid Alloy module and solves sat"):
     val ir     = buildIR("powerset_demo")
@@ -54,7 +54,7 @@ class TranslatorTest extends munit.FunSuite:
         |}""".stripMargin
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[AlloyTranslatorError]:
       val m = Translator.translateGlobal(ir, scope = 5)
       Render.render(m)
@@ -72,7 +72,7 @@ class TranslatorTest extends munit.FunSuite:
         |}""".stripMargin
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[AlloyTranslatorError]:
       val m = Translator.translateGlobal(ir, scope = 5)
       Render.render(m)

--- a/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
@@ -17,7 +17,7 @@ class TranslatorTest extends munit.FunSuite:
 
   test("powerset_demo translates to a valid Alloy module and solves sat"):
     val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobal(ir, scope = 5)
+    val module = Translator.translateGlobal(ir, scope = 5).toOption.get
     assertEquals(module.name, "PowersetDemo")
     assert(
       module.sigs.exists(_.name == "User"),
@@ -27,12 +27,12 @@ class TranslatorTest extends munit.FunSuite:
     assertEquals(module.facts.size, 1)
     val source  = Render.render(module)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=\n$source")
 
   test("Alloy render contains expected structural tokens"):
     val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobal(ir, scope = 5)
+    val module = Translator.translateGlobal(ir, scope = 5).toOption.get
     val source = Render.render(module)
     assert(source.contains("module PowersetDemo"), s"source=\n$source")
     assert(source.contains("sig User"), s"source=\n$source")
@@ -42,7 +42,7 @@ class TranslatorTest extends munit.FunSuite:
     assert(source.contains("set User"), s"source=\n$source")
     assert(source.contains("run global"), s"source=\n$source")
 
-  test("universal powerset — `all t in ^s | ...` raises a sharp AlloyTranslatorError"):
+  test("universal powerset — `all t in ^s | ...` surfaces as Left(AlloyTranslator)"):
     val spec =
       """service UnivDemo {
         |  entity User {
@@ -55,15 +55,15 @@ class TranslatorTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[AlloyTranslatorError]:
-      val m = Translator.translateGlobal(ir, scope = 5)
-      Render.render(m)
+    val err = Translator.translateGlobal(ir, scope = 5) match
+      case Left(e)  => e
+      case Right(_) => fail("expected Left(AlloyTranslator)")
     assert(
-      err.getMessage.contains("higher-order") && err.getMessage.contains("powerset"),
-      s"expected higher-order/powerset error; got: ${err.getMessage}"
+      err.message.contains("higher-order") && err.message.contains("powerset"),
+      s"expected higher-order/powerset error; got: ${err.message}"
     )
 
-  test("standalone '^s' outside a binder raises AlloyTranslatorError"):
+  test("standalone '^s' outside a binder surfaces as Left(AlloyTranslator)"):
     val spec =
       """service Bad {
         |  state { a: Set[Int] }
@@ -73,10 +73,10 @@ class TranslatorTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[AlloyTranslatorError]:
-      val m = Translator.translateGlobal(ir, scope = 5)
-      Render.render(m)
+    val err = Translator.translateGlobal(ir, scope = 5) match
+      case Left(e)  => e
+      case Right(_) => fail("expected Left(AlloyTranslator)")
     assert(
-      err.getMessage.contains("powerset") && err.getMessage.contains("binder domain"),
-      s"expected binder-domain error; got: ${err.getMessage}"
+      err.message.contains("powerset") && err.message.contains("binder domain"),
+      s"expected binder-domain error; got: ${err.message}"
     )

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -26,7 +26,7 @@ class DumpTest extends munit.FunSuite:
       val tmpDir  = Files.createTempDirectory(s"dump-test-$fixture-")
       val ir      = parseSpec(fixture)
       val backend = WasmBackend()
-      val sink    = DumpSink.open(tmpDir)
+      val sink    = DumpSink.open(tmpDir).toOption.get
       try
         val report = Consistency.runConsistencyChecks(
           ir,
@@ -75,14 +75,14 @@ class DumpTest extends munit.FunSuite:
   test("DumpSink rejects non-empty target directory"):
     val tmpDir = Files.createTempDirectory("dump-nonempty-")
     val _      = Files.writeString(tmpDir.resolve("clutter.txt"), "x")
-    val _      = intercept[RuntimeException](DumpSink.open(tmpDir))
+    assert(DumpSink.open(tmpDir).isLeft, "expected Left for non-empty dir")
     deleteRecursive(tmpDir)
 
   test("dumped Z3 SMT-LIB starts with set-logic and ends with check-sat"):
     val tmpDir  = Files.createTempDirectory("dump-shape-")
     val ir      = parseSpec("safe_counter")
     val backend = WasmBackend()
-    val sink    = DumpSink.open(tmpDir)
+    val sink    = DumpSink.open(tmpDir).toOption.get
     try
       val _ = Consistency.runConsistencyChecks(
         ir,

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -106,7 +106,7 @@ class DumpTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   private def deleteRecursive(p: java.nio.file.Path): Unit =
     if Files.isDirectory(p) then

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -91,4 +91,4 @@ class UnsatCoreTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -23,7 +23,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val script = Z3Script(Nil, Nil, Nil, emptyArtifact)
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -31,7 +31,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val script = Z3Script(Nil, Nil, List(Z3Expr.BoolLit(false)), emptyArtifact)
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -46,7 +46,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -62,7 +62,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -71,7 +71,7 @@ class BackendTest extends munit.FunSuite:
     try
       val ir     = buildIR("url_shortener")
       val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -80,7 +80,7 @@ class BackendTest extends munit.FunSuite:
     try
       val ir     = buildIR("unsat_invariants")
       val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -89,7 +89,7 @@ class BackendTest extends munit.FunSuite:
     try
       val ir     = buildIR("safe_counter")
       val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -110,7 +110,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -129,7 +129,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -144,7 +144,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -169,7 +169,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -197,7 +197,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -223,7 +223,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -246,7 +246,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -267,7 +267,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -276,6 +276,6 @@ class BackendTest extends munit.FunSuite:
     try
       val ir     = buildIR("set_ops")
       val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default)
+      val result = backend.check(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -14,7 +14,7 @@ class BackendTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   private def emptyArtifact: TranslatorArtifact =
     TranslatorArtifact(Nil, Nil, Nil, Nil, Nil, hasPostState = false)

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -70,7 +70,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("url_shortener")
-      val script = Translator.translate(ir)
+      val script = Translator.translate(ir).toOption.get
       val result = backend.check(script, VerificationConfig.Default)
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
@@ -79,7 +79,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("unsat_invariants")
-      val script = Translator.translate(ir)
+      val script = Translator.translate(ir).toOption.get
       val result = backend.check(script, VerificationConfig.Default)
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
@@ -88,7 +88,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("safe_counter")
-      val script = Translator.translate(ir)
+      val script = Translator.translate(ir).toOption.get
       val result = backend.check(script, VerificationConfig.Default)
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
@@ -275,7 +275,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("set_ops")
-      val script = Translator.translate(ir)
+      val script = Translator.translate(ir).toOption.get
       val result = backend.check(script, VerificationConfig.Default)
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
@@ -25,7 +25,7 @@ class CounterExampleTest extends munit.FunSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty)
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   test("broken_url_shortener preservation failure produces a decoded counterexample"):
     val backend = WasmBackend()

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -28,7 +28,7 @@ class SmtLibGoldenTest extends munit.FunSuite:
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree)
+    Builder.buildIR(parsed.tree).toOption.get
 
   translatableFixtures.foreach: name =>
     test(s"SMT-LIB matches golden — $name"):

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -33,7 +33,7 @@ class SmtLibGoldenTest extends munit.FunSuite:
   translatableFixtures.foreach: name =>
     test(s"SMT-LIB matches golden — $name"):
       val ir      = buildIR(name)
-      val script  = Translator.translate(ir)
+      val script  = Translator.translate(ir).toOption.get
       val emitted = SmtLib.renderSmtLib(script, timeoutMs = Some(30_000L)).stripSuffix("\n")
       val golden  = Files.readString(goldenDir.resolve(s"$name.smt2")).stripSuffix("\n")
       if emitted != golden then

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -28,12 +28,18 @@ class SmtLibGoldenTest extends munit.FunSuite:
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
     val parsed = Parse.parseSpec(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIR(parsed.tree).fold(
+      err => fail(s"buildIR failed for $name: ${err.message}"),
+      identity
+    )
 
   translatableFixtures.foreach: name =>
     test(s"SMT-LIB matches golden — $name"):
-      val ir      = buildIR(name)
-      val script  = Translator.translate(ir).toOption.get
+      val ir = buildIR(name)
+      val script = Translator.translate(ir).fold(
+        err => fail(s"Translator.translate failed for $name: ${err.message}"),
+        identity
+      )
       val emitted = SmtLib.renderSmtLib(script, timeoutMs = Some(30_000L)).stripSuffix("\n")
       val golden  = Files.readString(goldenDir.resolve(s"$name.smt2")).stripSuffix("\n")
       if emitted != golden then

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -9,7 +9,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
   private def scriptOf(spec: String): Z3Script =
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     Translator.translate(ir)
 
   private def smtOf(spec: String): String =
@@ -136,7 +136,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(
@@ -151,7 +151,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(
@@ -166,7 +166,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(
@@ -181,7 +181,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     if parsed.errors.isEmpty then
-      val ir = Builder.buildIR(parsed.tree)
+      val ir = Builder.buildIR(parsed.tree).toOption.get
       val err = intercept[TranslatorError]:
         val _ = Translator.translate(ir)
       assert(
@@ -196,7 +196,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     if parsed.errors.isEmpty then
-      val ir = Builder.buildIR(parsed.tree)
+      val ir = Builder.buildIR(parsed.tree).toOption.get
       val err = intercept[TranslatorError]:
         val _ = Translator.translate(ir)
       assert(
@@ -212,7 +212,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(
@@ -228,7 +228,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(
@@ -243,7 +243,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     )
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree)
+    val ir = Builder.buildIR(parsed.tree).toOption.get
     val err = intercept[TranslatorError]:
       val _ = Translator.translate(ir)
     assert(

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -2,7 +2,6 @@ package specrest.verify.z3
 
 import specrest.parser.Builder
 import specrest.parser.Parse
-import specrest.verify.TranslatorError
 
 class TranslatorSetOpsTest extends munit.FunSuite:
 
@@ -10,7 +9,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    Translator.translate(ir)
+    Translator.translate(ir).toOption.get
 
   private def smtOf(spec: String): String =
     SmtLib.renderSmtLib(scriptOf(spec))
@@ -137,11 +136,12 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      err.getMessage.contains("empty set literal"),
-      s"expected empty-set error; got: ${err.getMessage}"
+      err.message.contains("empty set literal"),
+      s"expected empty-set error; got: ${err.message}"
     )
 
   test("set operator on non-set operands raises a TranslatorError"):
@@ -152,11 +152,12 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      err.getMessage.contains("requires both operands to be sets"),
-      s"expected non-set operand error; got: ${err.getMessage}"
+      err.message.contains("requires both operands to be sets"),
+      s"expected non-set operand error; got: ${err.message}"
     )
 
   test("set operator on mismatched element sorts raises a TranslatorError"):
@@ -167,11 +168,12 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      err.getMessage.contains("same element sort"),
-      s"expected element-sort mismatch error; got: ${err.getMessage}"
+      err.message.contains("same element sort"),
+      s"expected element-sort mismatch error; got: ${err.message}"
     )
 
   test("heterogeneous standalone set literal raises a TranslatorError"):
@@ -182,11 +184,12 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     if parsed.errors.isEmpty then
       val ir = Builder.buildIR(parsed.tree).toOption.get
-      val err = intercept[TranslatorError]:
-        val _ = Translator.translate(ir)
+      val err = Translator.translate(ir) match
+        case Left(e)  => e
+        case Right(_) => fail("expected translator error")
       assert(
-        err.getMessage.contains("must all have the same sort"),
-        s"expected hetero-sort error; got: ${err.getMessage}"
+        err.message.contains("must all have the same sort"),
+        s"expected hetero-sort error; got: ${err.message}"
       )
 
   test("heterogeneous set literal in membership raises a TranslatorError"):
@@ -197,12 +200,13 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     if parsed.errors.isEmpty then
       val ir = Builder.buildIR(parsed.tree).toOption.get
-      val err = intercept[TranslatorError]:
-        val _ = Translator.translate(ir)
+      val err = Translator.translate(ir) match
+        case Left(e)  => e
+        case Right(_) => fail("expected translator error")
       assert(
-        err.getMessage.contains("must match the membership LHS sort") ||
-          err.getMessage.contains("must all have the same sort"),
-        s"expected hetero-sort error; got: ${err.getMessage}"
+        err.message.contains("must match the membership LHS sort") ||
+          err.message.contains("must all have the same sort"),
+        s"expected hetero-sort error; got: ${err.message}"
       )
 
   test("membership against a set-sorted expression enforces LHS element-sort match"):
@@ -213,12 +217,13 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      err.getMessage.contains("left-hand side sort to match") ||
-        err.getMessage.contains("element sort"),
-      s"expected LHS/elem mismatch error; got: ${err.getMessage}"
+      err.message.contains("left-hand side sort to match") ||
+        err.message.contains("element sort"),
+      s"expected LHS/elem mismatch error; got: ${err.message}"
     )
 
   test("empty set literal error message does not mention 'typed receiver'"):
@@ -229,11 +234,12 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      !err.getMessage.contains("typed receiver"),
-      s"error message should not suggest typed receiver; got: ${err.getMessage}"
+      !err.message.contains("typed receiver"),
+      s"error message should not suggest typed receiver; got: ${err.message}"
     )
 
   test("powerset operator raises a sharp TranslatorError"):
@@ -244,9 +250,10 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpec(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIR(parsed.tree).toOption.get
-    val err = intercept[TranslatorError]:
-      val _ = Translator.translate(ir)
+    val err = Translator.translate(ir) match
+      case Left(e)  => e
+      case Right(_) => fail("expected translator error")
     assert(
-      err.getMessage.contains("powerset"),
-      s"expected powerset error; got: ${err.getMessage}"
+      err.message.contains("powerset"),
+      s"expected powerset error; got: ${err.message}"
     )


### PR DESCRIPTION
Closes #97 · Parent: #95 (Cats Effect migration meta)

## Summary

Full-FP `VerifyError` channel for the verify pipeline. Zero `throw` keyword, zero `fromThrowable`/`toExitCode` adapters, three exception classes deleted. All verify-path public surfaces return `Either[VerifyError, A]`; internal non-local short-circuit uses `scala.util.boundary.break` — the Scala 3 stdlib typed escape, not a `throw`.

## Commits (4 logical stages)

| Stage | Commit | Scope |
|---|---|---|
| 1 | `893308a` | `VerifyError` ADT in `ir` module; `Builder.buildIR` flipped to Either, 5 throw sites → `Left(Build)`; ANTLR visitor returns Either via for-comprehensions; `BuildError` class deleted |
| 2a | `f5d9bc4` | `Translator.translate*` (z3, 1888 LoC) flipped; ~25 throws → `fail(ctx, msg)` via boundary; `TranslatorError` class deleted; Consistency's `skippedCheck` refactored from `Throwable`-dispatch to `(category, message)` |
| 2b | `e9c1229` | `WasmBackend.check` flipped; 5 invariant throws → `backendFail`; Z3 Java lib exceptions captured once at the FFI boundary via `NonFatal` |
| 3 | `7a594dd` | `AlloyTranslator.*` flipped (threads `(using AlloyLabel)`); `AlloyBackend.check` flipped; `AlloyTranslatorError` class deleted; `DumpSink.open` flipped; CounterExample's try/catch → `Try().toOption.getOrElse` |

## The ADT (pure data, no methods)

```scala
sealed trait VerifyError derives CanEqual
object VerifyError:
  final case class Parse(errors: List[ParseError])                 extends VerifyError
  final case class Build(message: String, span: Option[Span])      extends VerifyError
  final case class Translator(message: String)                     extends VerifyError
  final case class AlloyTranslator(message: String)                extends VerifyError
  final case class Backend(message: String, cause: Option[String]) extends VerifyError
```

No `InvariantInput` (no throw sites existed). No `UserCancelled` (arrives with cancellation infra in M_CE.6 / #101). No companion helpers — every consumer exhaustively matches at its use site.

## AC verification (all green)

```text
$ grep -RE '\bthrow\s+new' modules/parser/src/main modules/verify/src/main modules/cli/src/main
(no matches)

$ grep -RnE 'fromThrowable|toExitCode' modules/
(no matches)

$ grep -RnE 'intercept\[(BuildError|TranslatorError|AlloyTranslatorError)' modules/*/src/test
(no matches)

$ grep -RnE 'class (BuildError|TranslatorError|AlloyTranslatorError)' modules/*/src/main
(no matches — all deleted)
```

All 194 tests green (`sbt test`). Full suite timings comparable to pre-migration baseline.

## On `scala.util.boundary`

The z3 Translator (1888 LoC) and Alloy Translator (412 LoC) have deeply-recursive structure where threading `Either` through every recursive call would inflate code 3× with `for`-comprehensions at every node. Instead, internal short-circuit uses `boundary.break` — Scala 3.3+ stdlib primitive for typed non-local escape. Public entries wrap bodies in `boundary:` blocks and return `Either`. The `break` keyword is not syntactically a `throw`; under the hood it uses a stackless control-flow object, invisible at source level. This is idiomatic Scala 3 and used across the Typelevel ecosystem since 3.3.

## Remaining catches (scope-limited, documented)

- `alloy/Backend.check` — 4 catches inside the single FFI boundary (Alloy library `Err` + `NonFatal`). Single-module capture, no dispatch.
- `z3/Backend.check` — 1 `NonFatal` wrapping Z3 Java lib calls. Single-site FFI capture.
- `cli/Check.readSource` — Java NIO `IOException`, `NoSuchFileException`. File I/O FFI.
- `cli/Compile.run` — wraps codegen which still throws in profile/codegen/convention (**out of M_CE.2 scope** per issue). Transitional; follow-up sibling ADTs (`ProfileError`, `CodegenError`) will address.

## Follow-ups

- Sibling ADTs for `profile/Registry`, `codegen/Templates`, `codegen/Migration`, `convention/Path`, `cli/Check.readSource` — tracked under a follow-up issue.
- Single exhaustive `match` on `VerifyError` at CLI entry (currently folded per-operation due to multiple branches in `runWithIR`: dump-smt, dump-alloy, consistency) — cosmetic refactor.
- Test names still say "raises a sharp TranslatorError"; strings only, tests assert Either.Left content correctly.
- M_CE.4 (#99) pipeline-as-IO will trivially lift the `catchNonFatal` pattern to `IO.blocking(...).attempt.map(_.leftMap(...))`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the verify pipeline under a typed `specrest.ir.VerifyError` channel and removes throwable errors. All verify and dump paths now return `Either` and use `scala.util.boundary`; FFI and I/O failures are captured with full stack traces.

- **Refactors**
  - Added `VerifyError` ADT; moved `ParseError` to `specrest.ir`.
  - Flipped `Builder.buildIR`, Z3 `Translator.translate*`/`WasmBackend.check`, Alloy `Translator.translateGlobal`/`AlloyBackend.check`, and `DumpSink.open` to return `Either`; internal short-circuits use `boundary`; FFI errors captured once per backend.
  - CLI (`check`, `verify`, `inspect`) folds `Either` and renders errors; deleted `BuildError`, `TranslatorError`, `AlloyTranslatorError`; tests updated.

- **Bug Fixes**
  - Corrected `boundary`/`NonFatal` ordering in both backends so `break` payloads aren’t swallowed.
  - Wrapped `DumpSink.open` and CLI `Compile` file I/O in `NonFatal` and map to `VerifyError.Backend`.
  - Backend error `cause` now includes full stack traces for easier debugging.
  - Improved tests to surface `Either.Left` messages (e.g., in SMT golden checks).

<sup>Written for commit da0936c1e85b7ffd0f3f2843c8c0bb0984291ae8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced error reporting for build failures, translation issues, and backend verification problems with structured error diagnostics

* **Refactor**
  - Consolidated error handling patterns across CLI and verification modules for improved consistency and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->