### PR TITLE
[codex] Add Resource-managed verifier backends

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -66,9 +66,13 @@ object Consistency:
       config: VerificationConfig,
       dump: Option[DumpSink] = None
   ): ConsistencyReport =
-    val alloyBackend = new AlloyBackend
+    var allocated: Option[AlloyBackend] = None
+    lazy val alloyBackend =
+      val backend = new AlloyBackend
+      allocated = Some(backend)
+      backend
     try runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump)
-    finally alloyBackend.close()
+    finally allocated.foreach(_.close())
 
   def runConsistencyChecksIO(
       ir: ServiceIR,
@@ -90,7 +94,7 @@ object Consistency:
   private def runConsistencyChecksWithAlloy(
       ir: ServiceIR,
       backend: WasmBackend,
-      alloyBackend: AlloyBackend,
+      alloyBackend: => AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
   ): ConsistencyReport =

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -1,5 +1,6 @@
 package specrest.verify
 
+import cats.effect.IO
 import specrest.ir.*
 import specrest.verify.alloy.AlloyBackend
 import specrest.verify.alloy.AlloyModule
@@ -65,10 +66,35 @@ object Consistency:
       config: VerificationConfig,
       dump: Option[DumpSink] = None
   ): ConsistencyReport =
-    // Lazy: Z3-only specs never instantiate the Alloy backend. Touching
-    // `alloyBackend` triggers construction once, on first Alloy-routed check.
-    lazy val alloyBackend = new AlloyBackend
-    val checks            = List.newBuilder[CheckResult]
+    val alloyBackend = new AlloyBackend
+    try runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump)
+    finally alloyBackend.close()
+
+  def runConsistencyChecksIO(
+      ir: ServiceIR,
+      backend: WasmBackend,
+      config: VerificationConfig,
+      dump: Option[DumpSink]
+  ): IO[ConsistencyReport] =
+    AlloyBackend.make.use: alloyBackend =>
+      IO.blocking(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
+
+  def runConsistencyChecksIO(
+      ir: ServiceIR,
+      config: VerificationConfig,
+      dump: Option[DumpSink] = None
+  ): IO[ConsistencyReport] =
+    WasmBackend.make.use: backend =>
+      runConsistencyChecksIO(ir, backend, config, dump)
+
+  private def runConsistencyChecksWithAlloy(
+      ir: ServiceIR,
+      backend: WasmBackend,
+      alloyBackend: AlloyBackend,
+      config: VerificationConfig,
+      dump: Option[DumpSink]
+  ): ConsistencyReport =
+    val checks = List.newBuilder[CheckResult]
     checks += runGlobal(ir, backend, alloyBackend, config, dump)
     val ops        = ir.operations.sortBy(_.name.toLowerCase)
     val invariants = enumerateInvariants(ir)

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -1,5 +1,7 @@
 package specrest.verify.alloy
 
+import cats.effect.IO
+import cats.effect.Resource
 import edu.mit.csail.sdg.alloy4.A4Reporter
 import edu.mit.csail.sdg.alloy4.Err
 import edu.mit.csail.sdg.alloy4.Pos
@@ -46,7 +48,20 @@ object AlloyBackend:
   private lazy val coreCapableSolver: Option[SATFactory] =
     SATFactory.find("minisat.prover").toScala.filter(_.isPresent)
 
+  def make: Resource[IO, AlloyBackend] =
+    make(IO.blocking(new AlloyBackend)): backend =>
+      IO.blocking(backend.close())
+
+  private[verify] def make(
+      acquire: IO[AlloyBackend]
+  )(
+      release: AlloyBackend => IO[Unit]
+  ): Resource[IO, AlloyBackend] =
+    Resource.make(acquire)(release)
+
 final class AlloyBackend:
+
+  def close(): Unit = ()
 
   def check(
       source: String,

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -19,8 +19,13 @@ private def dumpIoFail(msg: String, cause: Throwable): VerifyError.Backend =
   cause.printStackTrace(new PrintWriter(sw))
   VerifyError.Backend(s"$msg: ${cause.getMessage}", Some(sw.toString))
 
+private def renderDumpOpenMessage(error: VerifyError.Backend): String =
+  error.cause match
+    case Some(cause) => s"${error.message}\n$cause"
+    case None        => error.message
+
 final private class DumpOpenException(val error: VerifyError.Backend)
-    extends RuntimeException(error.message)
+    extends RuntimeException(renderDumpOpenMessage(error))
 
 final case class DumpEntry(
     id: String,
@@ -88,7 +93,7 @@ final class DumpSink(val dir: Path):
 object DumpSink:
 
   def openResource(dir: Path): Resource[IO, DumpSink] =
-    openResource(acquireIO(dir))(_ => IO.unit)
+    openResource(acquireIO(dir))(sink => IO.blocking(sink.close()))
 
   private[verify] def openResource(
       acquire: IO[DumpSink]
@@ -98,10 +103,9 @@ object DumpSink:
     Resource.make(acquire)(release)
 
   private def acquireIO(dir: Path): IO[DumpSink] =
-    IO.defer:
-      open(dir) match
-        case Right(sink) => IO.pure(sink)
-        case Left(err)   => IO.raiseError(DumpOpenException(err))
+    IO.blocking(open(dir)).flatMap:
+      case Right(sink) => IO.pure(sink)
+      case Left(err)   => IO.raiseError(DumpOpenException(err))
 
   def open(dir: Path): Either[VerifyError.Backend, DumpSink] =
     try

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -1,5 +1,7 @@
 package specrest.verify.certificates
 
+import cats.effect.IO
+import cats.effect.Resource
 import io.circe.Json
 import specrest.ir.VerifyError
 import specrest.verify.CheckOutcome
@@ -17,6 +19,9 @@ private def dumpIoFail(msg: String, cause: Throwable): VerifyError.Backend =
   cause.printStackTrace(new PrintWriter(sw))
   VerifyError.Backend(s"$msg: ${cause.getMessage}", Some(sw.toString))
 
+final private class DumpOpenException(val error: VerifyError.Backend)
+    extends RuntimeException(error.message)
+
 final case class DumpEntry(
     id: String,
     tool: VerifierTool,
@@ -30,6 +35,8 @@ final class DumpSink(val dir: Path):
   private val entries = scala.collection.mutable.ArrayBuffer.empty[DumpEntry]
 
   def entryCount: Int = entries.size
+
+  def close(): Unit = ()
 
   def writeZ3(
       checkId: String,
@@ -79,6 +86,22 @@ final class DumpSink(val dir: Path):
     id.map(c => if c.isLetterOrDigit || c == '.' || c == '_' || c == '-' then c else '_')
 
 object DumpSink:
+
+  def openResource(dir: Path): Resource[IO, DumpSink] =
+    openResource(acquireIO(dir))(_ => IO.unit)
+
+  private[verify] def openResource(
+      acquire: IO[DumpSink]
+  )(
+      release: DumpSink => IO[Unit]
+  ): Resource[IO, DumpSink] =
+    Resource.make(acquire)(release)
+
+  private def acquireIO(dir: Path): IO[DumpSink] =
+    IO.defer:
+      open(dir) match
+        case Right(sink) => IO.pure(sink)
+        case Left(err)   => IO.raiseError(DumpOpenException(err))
 
   def open(dir: Path): Either[VerifyError.Backend, DumpSink] =
     try

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -1,5 +1,7 @@
 package specrest.verify.z3
 
+import cats.effect.IO
+import cats.effect.Resource
 import com.microsoft.z3.ArithExpr
 import com.microsoft.z3.ArrayExpr
 import com.microsoft.z3.ArraySort
@@ -41,6 +43,21 @@ final case class SmokeCheckResult(
     funcMap: Map[String, FuncDecl[?]],
     unsatCoreTrackers: List[String] = Nil
 )
+
+object WasmBackend:
+
+  def apply(): WasmBackend = new WasmBackend()
+
+  def make: Resource[IO, WasmBackend] =
+    make(IO.blocking(WasmBackend())): backend =>
+      IO.blocking(backend.close())
+
+  private[verify] def make(
+      acquire: IO[WasmBackend]
+  )(
+      release: WasmBackend => IO[Unit]
+  ): Resource[IO, WasmBackend] =
+    Resource.make(acquire)(release)
 
 final class WasmBackend:
 

--- a/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
@@ -1,0 +1,84 @@
+package specrest.verify
+
+import cats.effect.IO
+import cats.effect.Ref
+import munit.CatsEffectSuite
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.verify.alloy.AlloyBackend
+import specrest.verify.certificates.DumpSink
+import specrest.verify.z3.WasmBackend
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class ResourceLifecycleTest extends CatsEffectSuite:
+
+  private val releaseCases: List[(String, Ref[IO, Boolean] => IO[Unit])] = List(
+    "WasmBackend.make runs its release action after use" ->
+      (released =>
+        WasmBackend
+          .make(IO.blocking(WasmBackend())): backend =>
+            released.set(true) >> IO.blocking(backend.close())
+          .use(_ => IO.unit)
+      ),
+    "AlloyBackend.make runs its release action after use" ->
+      (released =>
+        AlloyBackend
+          .make(IO.blocking(new AlloyBackend)): backend =>
+            released.set(true) >> IO.blocking(backend.close())
+          .use(_ => IO.unit)
+      ),
+    "DumpSink.openResource runs its release action after use" ->
+      (released =>
+        tempDirResource("dump-resource-release-")
+          .flatMap: dir =>
+            DumpSink.openResource(openSinkIO(dir)): dump =>
+              released.set(true) >> IO.blocking(dump.close())
+          .use: sink =>
+            IO(assert(Files.isDirectory(sink.dir)))
+      )
+  )
+
+  releaseCases.foreach: (name, runCase) =>
+    test(name):
+      assertReleased(runCase)
+
+  test("runConsistencyChecksIO acquires and uses managed backends"):
+    val ir = buildIR("safe_counter")
+    Consistency
+      .runConsistencyChecksIO(ir, VerificationConfig.Default)
+      .map(report => assertEquals(report.ok, true))
+
+  private def assertReleased(runCase: Ref[IO, Boolean] => IO[Unit]): IO[Unit] =
+    for
+      released    <- Ref[IO].of(false)
+      _           <- runCase(released)
+      wasReleased <- released.get
+    yield assertEquals(wasReleased, true)
+
+  private def buildIR(name: String): specrest.ir.ServiceIR =
+    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
+    val parsed = Parse.parseSpec(src)
+    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
+    Builder.buildIR(parsed.tree).toOption.get
+
+  private def tempDirResource(prefix: String): cats.effect.Resource[IO, Path] =
+    cats.effect.Resource.make(IO.blocking(Files.createTempDirectory(prefix))): dir =>
+      IO.blocking(deleteRecursive(dir))
+
+  private def openSinkIO(dir: Path): IO[DumpSink] =
+    IO.defer:
+      DumpSink.open(dir) match
+        case Right(sink) => IO.pure(sink)
+        case Left(err)   => IO.raiseError(RuntimeException(err.message))
+
+  private def deleteRecursive(path: Path): Unit =
+    if Files.isDirectory(path) then
+      val stream = Files.list(path)
+      try
+        val iter = stream.iterator()
+        while iter.hasNext do deleteRecursive(iter.next())
+      finally stream.close()
+    val _ = Files.deleteIfExists(path)


### PR DESCRIPTION
## What changed

This PR adds `Resource[IO, _]` constructors for the verification backends and dump sink while preserving the existing constructor/open usage.

- added `WasmBackend.make: Resource[IO, WasmBackend]`
- added `AlloyBackend.make: Resource[IO, AlloyBackend]`
- added `DumpSink.openResource: Resource[IO, DumpSink]`
- added `Consistency.runConsistencyChecksIO(...)` as the new managed IO entrypoint
- added lifecycle tests using `Ref[IO, Boolean]`
- parameterized the new lifecycle tests to avoid copy-paste

## Why

Issue #98 asks for deterministic backend lifecycle management under Cats Effect without breaking existing synchronous call sites. The verifier still supports the old constructor-based pattern, but now exposes a resource-safe path for later cancellation and parallelism work.

## Impact

- no existing synchronous tests or call sites were removed
- new code can acquire verifier resources through `Resource.use(...)`
- the change is scoped to the verifier resource boundary and does not pull in later IOApp/CLI migration work

## Root cause

Backend and dump-sink lifecycle was still managed manually with constructors and `try/finally`, which blocks the planned CE3 resource/cancellation migration.

## Validation

- `sbt verify/test`
- `sbt test`

Closes #98.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add resource-managed constructors for verifier backends and dump sink, plus IO entrypoints for consistency checks. Also ensures the sync path closes the Alloy backend; lifecycle is deterministic under `cats-effect` while keeping existing sync APIs (addresses #98).

- **New Features**
  - `WasmBackend.make`, `AlloyBackend.make`: `Resource[IO, _]` constructors.
  - `DumpSink.openResource`: resource-safe dump sink; raises `DumpOpenException` on open failure.
  - `Consistency.runConsistencyChecksIO(...)`: managed IO entrypoints that acquire/release backends.
  - Lifecycle tests using `Ref[IO, Boolean]` to confirm release actions run.

- **Bug Fixes**
  - Sync `runConsistencyChecks(...)` now closes `AlloyBackend` when allocated.

<sup>Written for commit 8c39e4ccee2b11ad879bfa8c0f923cd90dd44bb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added async/effect-based APIs for consistency checks and backend management with proper resource scoping

* **Refactor**
  * Enhanced resource lifecycle management across verification backends with guaranteed cleanup semantics
  * Refactored consistency check execution for improved resource handling

* **Tests**
  * Added comprehensive resource lifecycle tests for backend and dump sink components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->