### PR TITLE
M_CE.4 — Pipeline as IO: parse, build, translate, check (closes #99)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -56,7 +56,8 @@ CLI output so the attribution is visible.
 | Cats Effect 3 build dependency + `munit-cats-effect` test harness | shipped in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) |
 | Typed `VerifyError` ADT across parse/build/translate/backend | shipped in M_CE.2 ([#97](https://github.com/HardMax71/spec_to_rest/issues/97)) |
 | `Resource[IO, _]`-managed Z3 / Alloy / dump-sink backends | shipped in M_CE.3 ([#98](https://github.com/HardMax71/spec_to_rest/issues/98)) |
-| Pipeline entries (`Parse.parseSpec`, `Builder.buildIR`, Z3/Alloy `Translator.*`, `WasmBackend.check`, `AlloyBackend.check`, `Consistency.runConsistencyChecks`) return `IO[Either[VerifyError, _]]` | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
+| Pipeline entries (`Parse.parseSpec`, `Builder.buildIR`, Z3/Alloy `Translator.*`, `WasmBackend.check`, `AlloyBackend.check`) return `IO[Either[VerifyError, _]]` | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
+| `Consistency.runConsistencyChecks` returns `IO[ConsistencyReport]` (per-check failures remain data inside the report, not in the Either channel) | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
 | Parallel check dispatch (`parTraverseN`, `--parallel <n>`) | [#100](https://github.com/HardMax71/spec_to_rest/issues/100) (pending M_CE.5) |
 | Cancellation + per-check timeout via `IO.timeout` / `Resource` release | [#101](https://github.com/HardMax71/spec_to_rest/issues/101) (pending M_CE.6) |
 | `spec-to-rest` as `CommandIOApp` (removes `unsafeRunSync` bridges from CLI) | [#102](https://github.com/HardMax71/spec_to_rest/issues/102) (pending M_CE.7) |

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -53,8 +53,13 @@ CLI output so the attribution is visible.
 | Temporal `always(P)` — `P` holds in every state satisfying the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ ¬P` unsat-check) |
 | Temporal `eventually(P)` — some state satisfies `P` and the invariants | shipped (Alloy, bounded scope; implemented as `I ∧ P` sat-check) |
 | Temporal `fairness(op)`                                              | not supported in v1 — sharp error; requires trace-based verification via Alloy's `var`-sig mode (future work) |
-| Cats Effect 3 build dependency + `munit-cats-effect` test harness | shipped in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) — no existing code paths use IO yet |
-| Cats Effect 3 IO pipeline (parallel dispatch, typed errors, `Resource`-managed backends) | [#95](https://github.com/HardMax71/spec_to_rest/issues/95) (meta, in-flight across M_CE.2–M_CE.9) |
+| Cats Effect 3 build dependency + `munit-cats-effect` test harness | shipped in M_CE.1 ([#96](https://github.com/HardMax71/spec_to_rest/issues/96)) |
+| Typed `VerifyError` ADT across parse/build/translate/backend | shipped in M_CE.2 ([#97](https://github.com/HardMax71/spec_to_rest/issues/97)) |
+| `Resource[IO, _]`-managed Z3 / Alloy / dump-sink backends | shipped in M_CE.3 ([#98](https://github.com/HardMax71/spec_to_rest/issues/98)) |
+| Pipeline entries (`Parse.parseSpec`, `Builder.buildIR`, Z3/Alloy `Translator.*`, `WasmBackend.check`, `AlloyBackend.check`, `Consistency.runConsistencyChecks`) return `IO[Either[VerifyError, _]]` | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
+| Parallel check dispatch (`parTraverseN`, `--parallel <n>`) | [#100](https://github.com/HardMax71/spec_to_rest/issues/100) (pending M_CE.5) |
+| Cancellation + per-check timeout via `IO.timeout` / `Resource` release | [#101](https://github.com/HardMax71/spec_to_rest/issues/101) (pending M_CE.6) |
+| `spec-to-rest` as `CommandIOApp` (removes `unsafeRunSync` bridges from CLI) | [#102](https://github.com/HardMax71/spec_to_rest/issues/102) (pending M_CE.7) |
 
 ## Preservation VC shape
 

--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -1,5 +1,6 @@
 package specrest.cli
 
+import cats.effect.unsafe.implicits.global
 import specrest.convention.DiagnosticLevel as ConvDiagLevel
 import specrest.convention.Validate
 import specrest.ir.VerifyError
@@ -17,41 +18,44 @@ object Check:
       case Left(code) => code
       case Right(source) =>
         val t0      = System.nanoTime()
-        val parsed  = Parse.parseSpec(source)
+        val parsedE = Parse.parseSpec(source).unsafeRunSync()
         val parseMs = (System.nanoTime() - t0) / 1_000_000.0
         log.verbose(f"Parsed in ${parseMs}%.0fms")
 
-        if parsed.errors.nonEmpty then
-          parsed.errors.foreach: e =>
-            log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-          1
-        else
-          val t1 = System.nanoTime()
-          Builder.buildIR(parsed.tree) match
-            case Left(err) =>
-              log.error(renderBuildError(specFile, err))
-              1
-            case Right(ir) =>
-              val buildMs = (System.nanoTime() - t1) / 1_000_000.0
-              log.verbose(f"Built IR in ${buildMs}%.0fms")
+        parsedE match
+          case Left(VerifyError.Parse(errors)) =>
+            errors.foreach: e =>
+              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            1
+          case Right(parsed) =>
+            val t1 = System.nanoTime()
+            Builder.buildIR(parsed.tree).unsafeRunSync() match
+              case Left(err) =>
+                log.error(renderBuildError(specFile, err))
+                1
+              case Right(ir) =>
+                val buildMs = (System.nanoTime() - t1) / 1_000_000.0
+                log.verbose(f"Built IR in ${buildMs}%.0fms")
 
-              val diagnostics = Validate.validateConventions(ir.conventions, ir)
-              val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
-              val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
+                val diagnostics = Validate.validateConventions(ir.conventions, ir)
+                val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
+                val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
 
-              for w <- warnings do
-                val loc = w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                log.warn(s"${loc}warning: ${w.message}")
-              for e <- errors do
-                val loc = e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                log.error(s"${loc}${e.message}")
+                for w <- warnings do
+                  val loc =
+                    w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                  log.warn(s"${loc}warning: ${w.message}")
+                for e <- errors do
+                  val loc =
+                    e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                  log.error(s"${loc}${e.message}")
 
-              if errors.nonEmpty then 1
-              else
-                log.success(
-                  s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
-                )
-                0
+                if errors.nonEmpty then 1
+                else
+                  log.success(
+                    s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
+                  )
+                  0
 
   private[cli] def readSource(specFile: String, log: Logger): Either[Int, String] =
     try Right(Files.readString(Paths.get(specFile)))

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -1,6 +1,8 @@
 package specrest.cli
 
+import cats.effect.unsafe.implicits.global
 import specrest.codegen.Emit
+import specrest.ir.VerifyError
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.profile.Annotate
@@ -21,34 +23,34 @@ object Compile:
     Check.readSource(specFile, log) match
       case Left(code) => code
       case Right(source) =>
-        val parsed = Parse.parseSpec(source)
-        if parsed.errors.nonEmpty then
-          parsed.errors.foreach: e =>
-            log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-          1
-        else
-          Builder.buildIR(parsed.tree) match
-            case Left(err) =>
-              log.error(Check.renderBuildError(specFile, err))
-              1
-            case Right(ir) =>
-              try
-                val profiled = Annotate.buildProfiledService(ir, opts.target)
-                val files    = Emit.emitProject(profiled)
-                val outRoot  = Paths.get(opts.outDir)
-                Files.createDirectories(outRoot)
-                files.foreach: f =>
-                  val target = outRoot.resolve(f.path)
-                  Option(target.getParent).foreach(Files.createDirectories(_))
-                  Files.writeString(
-                    target,
-                    f.content,
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.TRUNCATE_EXISTING
-                  )
-                log.success(s"wrote ${files.length} files to ${opts.outDir}")
-                0
-              catch
-                case NonFatal(e) =>
-                  log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
-                  1
+        Parse.parseSpec(source).unsafeRunSync() match
+          case Left(VerifyError.Parse(errors)) =>
+            errors.foreach: e =>
+              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            1
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).unsafeRunSync() match
+              case Left(err) =>
+                log.error(Check.renderBuildError(specFile, err))
+                1
+              case Right(ir) =>
+                try
+                  val profiled = Annotate.buildProfiledService(ir, opts.target)
+                  val files    = Emit.emitProject(profiled)
+                  val outRoot  = Paths.get(opts.outDir)
+                  Files.createDirectories(outRoot)
+                  files.foreach: f =>
+                    val target = outRoot.resolve(f.path)
+                    Option(target.getParent).foreach(Files.createDirectories(_))
+                    Files.writeString(
+                      target,
+                      f.content,
+                      StandardOpenOption.CREATE,
+                      StandardOpenOption.TRUNCATE_EXISTING
+                    )
+                  log.success(s"wrote ${files.length} files to ${opts.outDir}")
+                  0
+                catch
+                  case NonFatal(e) =>
+                    log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
+                    1

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -1,9 +1,11 @@
 package specrest.cli
 
+import cats.effect.unsafe.implicits.global
 import io.circe.Printer
 import io.circe.syntax.EncoderOps
 import specrest.ir.Serialize
 import specrest.ir.Serialize.given
+import specrest.ir.VerifyError
 import specrest.parser.Builder
 import specrest.parser.Parse
 
@@ -23,19 +25,19 @@ object Inspect:
     Check.readSource(specFile, log) match
       case Left(code) => code
       case Right(source) =>
-        val parsed = Parse.parseSpec(source)
-        if parsed.errors.nonEmpty then
-          parsed.errors.foreach: e =>
-            log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-          1
-        else
-          Builder.buildIR(parsed.tree) match
-            case Left(err) =>
-              log.error(Check.renderBuildError(specFile, err))
-              1
-            case Right(ir) =>
-              println(formatIR(ir, format))
-              0
+        Parse.parseSpec(source).unsafeRunSync() match
+          case Left(VerifyError.Parse(errors)) =>
+            errors.foreach: e =>
+              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            1
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).unsafeRunSync() match
+              case Left(err) =>
+                log.error(Check.renderBuildError(specFile, err))
+                1
+              case Right(ir) =>
+                println(formatIR(ir, format))
+                0
 
   private def formatIR(ir: specrest.ir.ServiceIR, format: InspectFormat): String = format match
     case InspectFormat.Json =>

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -1,5 +1,6 @@
 package specrest.cli
 
+import cats.effect.unsafe.implicits.global
 import specrest.ir.ServiceIR
 import specrest.ir.VerifyError
 import specrest.parser.Builder
@@ -49,21 +50,22 @@ object Verify:
       case Left(_) => ExitViolations
       case Right(source) =>
         val tParse0 = System.nanoTime()
-        val parsed  = Parse.parseSpec(source)
+        val parsedE = Parse.parseSpec(source).unsafeRunSync()
         log.verbose(f"Parsed in ${(System.nanoTime() - tParse0) / 1_000_000.0}%.0fms")
-        if parsed.errors.nonEmpty then
-          parsed.errors.foreach: e =>
-            log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-          ExitViolations
-        else
-          val tBuild0 = System.nanoTime()
-          Builder.buildIR(parsed.tree) match
-            case Left(err) =>
-              log.error(Check.renderBuildError(specFile, err))
-              ExitViolations
-            case Right(ir) =>
-              log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
-              runWithIR(specFile, ir, opts, log)
+        parsedE match
+          case Left(VerifyError.Parse(errors)) =>
+            errors.foreach: e =>
+              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            ExitViolations
+          case Right(parsed) =>
+            val tBuild0 = System.nanoTime()
+            Builder.buildIR(parsed.tree).unsafeRunSync() match
+              case Left(err) =>
+                log.error(Check.renderBuildError(specFile, err))
+                ExitViolations
+              case Right(ir) =>
+                log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
+                runWithIR(specFile, ir, opts, log)
 
   private def runWithIR(
       specFile: String,

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -121,7 +121,7 @@ object Verify:
       val backend = WasmBackend()
       try
         val tRun0 = System.nanoTime()
-        val report = Consistency.runConsistencyChecks(
+        val report = Consistency.runConsistencyChecksSync(
           ir,
           backend,
           VerificationConfig(

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -93,7 +93,7 @@ object Verify:
               print(smt)
           ExitOk
     else if opts.dumpAlloy || opts.dumpAlloyOut.isDefined then
-      AlloyTranslator.translateGlobal(ir, opts.alloyScope) match
+      AlloyTranslator.translateGlobal(ir, opts.alloyScope).unsafeRunSync() match
         case Left(err) =>
           log.error(s"$specFile: alloy translator: ${err.message}")
           ExitTranslator

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -75,7 +75,7 @@ object Verify:
   ): Int =
     if opts.dumpSmt || opts.dumpSmtOut.isDefined then
       val tTrans0 = System.nanoTime()
-      Translator.translate(ir) match
+      Translator.translate(ir).unsafeRunSync() match
         case Left(err) =>
           log.error(s"$specFile: translator limitation: ${err.message}")
           ExitTranslator

--- a/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
@@ -16,9 +16,9 @@ class AlembicMigrationTest extends munit.FunSuite:
 
   private def buildProfiled(name: String): specrest.profile.ProfiledService =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("empty schema produces empty migration"):

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -11,9 +11,9 @@ class EmitTest extends munit.FunSuite:
 
   private def buildProfiled(name: String): specrest.profile.ProfiledService =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("emitProject runs without crashing on url_shortener"):

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -12,9 +12,9 @@ class OpenApiTest extends munit.FunSuite:
 
   private def buildProfiled(name: String): specrest.profile.ProfiledService =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty)
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
   test("buildOpenApiDocument returns a well-formed document"):

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -22,9 +22,9 @@ class ConventionSmokeTest extends munit.FunSuite:
 
   private def buildFixture(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   test("classify + derive + validate runs for every fixture"):
     fixtures.foreach: fixture =>

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -1,5 +1,6 @@
 package specrest.parser
 
+import cats.effect.IO
 import org.antlr.v4.runtime.ParserRuleContext
 import specrest.ir.*
 import specrest.parser.generated.SpecBaseVisitor
@@ -54,7 +55,10 @@ extension [A, B](list: List[A])
     list.map(f).sequenceB
 
 object Builder:
-  def buildIR(tree: SpecFileContext): BuildResult[ServiceIR] =
+  def buildIR(tree: SpecFileContext): IO[Either[VerifyError.Build, ServiceIR]] =
+    IO.delay(buildIRSync(tree))
+
+  private[specrest] def buildIRSync(tree: SpecFileContext): Either[VerifyError.Build, ServiceIR] =
     val imports = tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
     new IRBuilder().buildService(tree.serviceDecl).map(_.copy(imports = imports))
 

--- a/modules/parser/src/main/scala/specrest/parser/Parse.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Parse.scala
@@ -1,11 +1,13 @@
 package specrest.parser
 
+import cats.effect.IO
 import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.RecognitionException
 import org.antlr.v4.runtime.Recognizer
 import specrest.ir.ParseError
+import specrest.ir.VerifyError
 import specrest.parser.generated.SpecLexer
 import specrest.parser.generated.SpecParser
 
@@ -13,7 +15,11 @@ final case class ParseResult(tree: SpecParser.SpecFileContext, errors: List[Pars
 
 object Parse:
 
-  def parseSpec(input: String): ParseResult =
+  def parseSpec(input: String): IO[Either[VerifyError.Parse, ParseResult]] =
+    IO.delay(parseSpecSync(input)).map: r =>
+      if r.errors.isEmpty then Right(r) else Left(VerifyError.Parse(r.errors))
+
+  private[specrest] def parseSpecSync(input: String): ParseResult =
     val chars  = CharStreams.fromString(input)
     val lexer  = new SpecLexer(chars)
     val tokens = new CommonTokenStream(lexer)

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -30,9 +30,9 @@ class ParseBuildGoldenTest extends munit.FunSuite:
     test(s"parse + build + serialize matches golden — $name"):
       assert(Files.exists(goldenPath), s"Missing golden for $name at $goldenPath")
       val source = Files.readString(specPath)
-      val parsed = Parse.parseSpec(source)
+      val parsed = Parse.parseSpecSync(source)
       assert(parsed.errors.isEmpty, s"Parse errors for $name: ${parsed.errors}")
-      val ir         = Builder.buildIR(parsed.tree).toOption.get
+      val ir         = Builder.buildIRSync(parsed.tree).toOption.get
       val emittedDom = Serialize.toJson(ir)
       val goldenRaw  = Files.readString(goldenPath)
       val goldenDom = io.circe.parser.parse(goldenRaw) match

--- a/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
@@ -10,9 +10,9 @@ class ProfileSmokeTest extends munit.FunSuite:
 
   private def buildFixture(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   test("registry lists python-fastapi-postgres"):
     assert(Registry.listProfiles.contains("python-fastapi-postgres"))

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -64,6 +64,23 @@ object Consistency:
       ir: ServiceIR,
       backend: WasmBackend,
       config: VerificationConfig,
+      dump: Option[DumpSink]
+  ): IO[ConsistencyReport] =
+    AlloyBackend.make.use: alloyBackend =>
+      IO.blocking(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
+
+  def runConsistencyChecks(
+      ir: ServiceIR,
+      config: VerificationConfig,
+      dump: Option[DumpSink] = None
+  ): IO[ConsistencyReport] =
+    WasmBackend.make.use: backend =>
+      runConsistencyChecks(ir, backend, config, dump)
+
+  def runConsistencyChecksSync(
+      ir: ServiceIR,
+      backend: WasmBackend,
+      config: VerificationConfig,
       dump: Option[DumpSink] = None
   ): ConsistencyReport =
     var allocated: Option[AlloyBackend] = None
@@ -73,23 +90,6 @@ object Consistency:
       backend
     try runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump)
     finally allocated.foreach(_.close())
-
-  def runConsistencyChecksIO(
-      ir: ServiceIR,
-      backend: WasmBackend,
-      config: VerificationConfig,
-      dump: Option[DumpSink]
-  ): IO[ConsistencyReport] =
-    AlloyBackend.make.use: alloyBackend =>
-      IO.blocking(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
-
-  def runConsistencyChecksIO(
-      ir: ServiceIR,
-      config: VerificationConfig,
-      dump: Option[DumpSink] = None
-  ): IO[ConsistencyReport] =
-    WasmBackend.make.use: backend =>
-      runConsistencyChecksIO(ir, backend, config, dump)
 
   private def runConsistencyChecksWithAlloy(
       ir: ServiceIR,

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -201,7 +201,7 @@ object Consistency:
     val tool        = Classifier.classifyGlobal(ir)
     if tool == VerifierTool.Alloy then
       return runGlobalAlloy(ir, alloyBackend, config, sourceSpans, dump)
-    Translator.translate(ir) match
+    Translator.translateSync(ir) match
       case Left(err) =>
         skippedCheck(
           "global",
@@ -214,7 +214,7 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        backend.check(script, config) match
+        backend.checkSync(script, config) match
           case Left(err) =>
             skippedCheck(
               "global",
@@ -332,8 +332,8 @@ object Consistency:
     if tool == VerifierTool.Alloy then
       return runOperationAlloy(ir, op, kind, alloyBackend, config, id, sourceSpans, dump)
     val scriptE: Either[VerifyError.Translator, Z3Script] = kind match
-      case CheckKind.Requires => Translator.translateOperationRequires(ir, op)
-      case CheckKind.Enabled  => Translator.translateOperationEnabled(ir, op)
+      case CheckKind.Requires => Translator.translateOperationRequiresSync(ir, op)
+      case CheckKind.Enabled  => Translator.translateOperationEnabledSync(ir, op)
       case _ =>
         Left(VerifyError.Translator(s"runOperationCheck: unexpected kind $kind"))
     scriptE match
@@ -349,7 +349,7 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        backend.check(script, config) match
+        backend.checkSync(script, config) match
           case Left(err) =>
             skippedCheck(
               id,
@@ -461,7 +461,7 @@ object Consistency:
     val tool        = Classifier.classifyPreservation(op, inv.decl)
     if tool == VerifierTool.Alloy then
       return runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump)
-    Translator.translateOperationPreservation(ir, op, inv.decl) match
+    Translator.translateOperationPreservationSync(ir, op, inv.decl) match
       case Left(err) =>
         skippedCheck(
           id,
@@ -474,7 +474,7 @@ object Consistency:
           err.message
         )
       case Right(script) =>
-        backend.check(script, config.copy(captureModel = true)) match
+        backend.checkSync(script, config.copy(captureModel = true)) match
           case Left(err) =>
             skippedCheck(
               id,

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -67,7 +67,7 @@ object Consistency:
       dump: Option[DumpSink]
   ): IO[ConsistencyReport] =
     AlloyBackend.make.use: alloyBackend =>
-      IO.blocking(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
+      IO.delay(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
 
   def runConsistencyChecks(
       ir: ServiceIR,

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -260,7 +260,7 @@ object Consistency:
       sourceSpans: List[Span],
       dump: Option[DumpSink]
   ): CheckResult =
-    AlloyTranslator.translateGlobal(ir, config.alloyScope) match
+    AlloyTranslator.translateGlobalSync(ir, config.alloyScope) match
       case Left(err) =>
         skippedCheck(
           "global",
@@ -274,7 +274,7 @@ object Consistency:
         )
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.check(
+        alloyBackend.checkSync(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
@@ -392,9 +392,9 @@ object Consistency:
   ): CheckResult =
     val moduleE: Either[VerifyError.AlloyTranslator, AlloyModule] = kind match
       case CheckKind.Requires =>
-        AlloyTranslator.translateOperationRequires(ir, op, config.alloyScope)
+        AlloyTranslator.translateOperationRequiresSync(ir, op, config.alloyScope)
       case CheckKind.Enabled =>
-        AlloyTranslator.translateOperationEnabled(ir, op, config.alloyScope)
+        AlloyTranslator.translateOperationEnabledSync(ir, op, config.alloyScope)
       case _ =>
         Left(VerifyError.AlloyTranslator(s"runOperationAlloy: unexpected kind $kind"))
     moduleE match
@@ -411,7 +411,7 @@ object Consistency:
         )
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.check(
+        alloyBackend.checkSync(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
@@ -516,7 +516,7 @@ object Consistency:
   ): CheckResult =
     val id          = s"temporal.${decl.name}"
     val sourceSpans = decl.span.toList
-    AlloyTranslator.translateTemporal(ir, decl, config.alloyScope) match
+    AlloyTranslator.translateTemporalSync(ir, decl, config.alloyScope) match
       case Left(err) =>
         skippedCheck(
           id,
@@ -530,7 +530,7 @@ object Consistency:
         )
       case Right(translation) =>
         val rendered = AlloyRender.renderWithLineMap(translation.module)
-        alloyBackend.check(
+        alloyBackend.checkSync(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
@@ -579,7 +579,7 @@ object Consistency:
       sourceSpans: List[Span],
       dump: Option[DumpSink]
   ): CheckResult =
-    AlloyTranslator.translateOperationPreservation(ir, op, inv.decl, config.alloyScope) match
+    AlloyTranslator.translateOperationPreservationSync(ir, op, inv.decl, config.alloyScope) match
       case Left(err) =>
         skippedCheck(
           id,
@@ -593,7 +593,7 @@ object Consistency:
         )
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.check(
+        alloyBackend.checkSync(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -68,6 +68,14 @@ final class AlloyBackend:
       commandIdx: Int,
       timeoutMs: Long,
       captureCore: Boolean = false
+  ): IO[Either[VerifyError.Backend, AlloyCheckResult]] =
+    IO.blocking(checkSync(source, commandIdx, timeoutMs, captureCore))
+
+  private[specrest] def checkSync(
+      source: String,
+      commandIdx: Int,
+      timeoutMs: Long,
+      captureCore: Boolean = false
   ): Either[VerifyError.Backend, AlloyCheckResult] =
     try
       boundary:

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -1,5 +1,6 @@
 package specrest.verify.alloy
 
+import cats.effect.IO
 import specrest.ir.*
 import specrest.verify.Classifier
 
@@ -25,6 +26,12 @@ object Translator:
   def translateGlobal(
       ir: ServiceIR,
       scope: Int
+  ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
+    IO.delay(translateGlobalSync(ir, scope))
+
+  private[specrest] def translateGlobalSync(
+      ir: ServiceIR,
+      scope: Int
   ): Either[VerifyError.AlloyTranslator, AlloyModule] =
     boundary:
       val ctx = buildCtx(ir)
@@ -43,6 +50,13 @@ object Translator:
   final case class TemporalTranslation(kind: TemporalKind, module: AlloyModule)
 
   def translateTemporal(
+      ir: ServiceIR,
+      decl: TemporalDecl,
+      scope: Int
+  ): IO[Either[VerifyError.AlloyTranslator, TemporalTranslation]] =
+    IO.delay(translateTemporalSync(ir, decl, scope))
+
+  private[specrest] def translateTemporalSync(
       ir: ServiceIR,
       decl: TemporalDecl,
       scope: Int
@@ -85,6 +99,13 @@ object Translator:
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
+  ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
+    IO.delay(translateOperationRequiresSync(ir, op, scope))
+
+  private[specrest] def translateOperationRequiresSync(
+      ir: ServiceIR,
+      op: OperationDecl,
+      scope: Int
   ): Either[VerifyError.AlloyTranslator, AlloyModule] =
     boundary:
       val ctx = buildCtxWithInputs(ir, op)
@@ -97,6 +118,13 @@ object Translator:
       ))
 
   def translateOperationEnabled(
+      ir: ServiceIR,
+      op: OperationDecl,
+      scope: Int
+  ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
+    IO.delay(translateOperationEnabledSync(ir, op, scope))
+
+  private[specrest] def translateOperationEnabledSync(
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
@@ -124,6 +152,14 @@ object Translator:
       AlloyFact(Some(name), renderExpr(ctx, inv.expr), inv.span)
 
   def translateOperationPreservation(
+      ir: ServiceIR,
+      op: OperationDecl,
+      inv: InvariantDecl,
+      scope: Int
+  ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
+    IO.delay(translateOperationPreservationSync(ir, op, inv, scope))
+
+  private[specrest] def translateOperationPreservationSync(
       ir: ServiceIR,
       op: OperationDecl,
       inv: InvariantDecl,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -77,6 +77,12 @@ final class WasmBackend:
   def check(
       script: Z3Script,
       cfg: VerificationConfig
+  ): IO[Either[VerifyError.Backend, SmokeCheckResult]] =
+    IO.blocking(checkSync(script, cfg))
+
+  private[specrest] def checkSync(
+      script: Z3Script,
+      cfg: VerificationConfig
   ): Either[VerifyError.Backend, SmokeCheckResult] =
     try
       boundary:

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -61,18 +61,9 @@ object WasmBackend:
 
 final class WasmBackend:
 
-  private var ctxCache: Option[Context] = None
+  private val ctx: Context = new Context()
 
-  private def getContext(): Context = ctxCache match
-    case Some(c) => c
-    case None =>
-      val c = new Context()
-      ctxCache = Some(c)
-      c
-
-  def close(): Unit =
-    ctxCache.foreach(_.close())
-    ctxCache = None
+  def close(): Unit = ctx.close()
 
   def check(
       script: Z3Script,
@@ -86,7 +77,6 @@ final class WasmBackend:
   ): Either[VerifyError.Backend, SmokeCheckResult] =
     try
       boundary:
-        val ctx     = getContext()
         val sortMap = declareSorts(ctx, script.sorts)
         val funcMap = declareFuncs(ctx, script.funcs, sortMap)
         val solver  = ctx.mkSolver()

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1,5 +1,6 @@
 package specrest.verify.z3
 
+import cats.effect.IO
 import specrest.ir.*
 
 import scala.collection.mutable
@@ -112,16 +113,38 @@ final private class TranslateCtx(val bnd: TranslateBoundary):
 
 object Translator:
 
-  def translate(ir: ServiceIR): Either[VerifyError.Translator, Z3Script] =
-    boundary:
-      val ctx = new TranslateCtx(summon[TranslateBoundary])
-      declareBase(ctx, ir)
-      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
-      Right(finalizeScript(ctx))
+  def translate(ir: ServiceIR): IO[Either[VerifyError.Translator, Z3Script]] =
+    IO.delay(translateSync(ir))
 
   def translateOperationRequires(
       ir: ServiceIR,
       op: OperationDecl
+  ): IO[Either[VerifyError.Translator, Z3Script]] =
+    IO.delay(translateOperationRequiresSync(ir, op))
+
+  def translateOperationEnabled(
+      ir: ServiceIR,
+      op: OperationDecl
+  ): IO[Either[VerifyError.Translator, Z3Script]] =
+    IO.delay(translateOperationEnabledSync(ir, op))
+
+  def translateOperationPreservation(
+      ir: ServiceIR,
+      op: OperationDecl,
+      inv: InvariantDecl
+  ): IO[Either[VerifyError.Translator, Z3Script]] =
+    IO.delay(translateOperationPreservationSync(ir, op, inv))
+
+  private[specrest] def translateSync(ir: ServiceIR): Either[VerifyError.Translator, Z3Script] =
+    boundary:
+      val ctx = new TranslateCtx(summon[TranslateBoundary])
+      declareBase(ctx, ir)
+      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
+      Right(finalizeScript(ctx))
+
+  private[specrest] def translateOperationRequiresSync(
+      ir: ServiceIR,
+      op: OperationDecl
   ): Either[VerifyError.Translator, Z3Script] =
     boundary:
       val ctx = new TranslateCtx(summon[TranslateBoundary])
@@ -130,7 +153,7 @@ object Translator:
       for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
       Right(finalizeScript(ctx))
 
-  def translateOperationEnabled(
+  private[specrest] def translateOperationEnabledSync(
       ir: ServiceIR,
       op: OperationDecl
   ): Either[VerifyError.Translator, Z3Script] =
@@ -142,7 +165,7 @@ object Translator:
       for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
       Right(finalizeScript(ctx))
 
-  def translateOperationPreservation(
+  private[specrest] def translateOperationPreservationSync(
       ir: ServiceIR,
       op: OperationDecl,
       inv: InvariantDecl

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -11,9 +11,9 @@ class ConsistencyTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   test("url_shortener passes all consistency checks"):
     val backend = WasmBackend()
@@ -184,9 +184,9 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal someUserExists:
         |    eventually(some u in users | u = u)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpec(spec)
+    val parsed = specrest.parser.Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
+    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
@@ -210,9 +210,9 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal alwaysFalse:
         |    always(all u in users | u != u)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpec(spec)
+    val parsed = specrest.parser.Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
+    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
@@ -236,9 +236,9 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal fairStep:
         |    fairness(Step)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpec(spec)
+    val parsed = specrest.parser.Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIR(parsed.tree).toOption.get
+    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
       val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -19,7 +19,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("url_shortener")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       assert(
         report.ok,
         s"expected ok=true; failing checks: ${report.checks.filter(c =>
@@ -32,7 +32,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("unsat_invariants")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       assert(!report.ok)
       val global = report.checks.find(_.id == "global").get
       assertEquals(global.status, CheckOutcome.Unsat)
@@ -46,7 +46,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir      = buildIR("dead_op")
-      val report  = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val deadReq = report.checks.find(_.id == "DeadOp.requires")
       assert(deadReq.isDefined, s"missing DeadOp.requires in checks: ${report.checks.map(_.id)}")
       assertEquals(deadReq.get.status, CheckOutcome.Unsat)
@@ -60,7 +60,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir          = buildIR("unreachable_op")
-      val report      = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report      = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val unreachable = report.checks.find(_.id == "UnreachableOp.enabled")
       assert(unreachable.isDefined)
       assertEquals(unreachable.get.status, CheckOutcome.Unsat)
@@ -74,7 +74,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val violations = report.checks.filter(c =>
         c.kind == CheckKind.Preservation && c.status == CheckOutcome.Unsat
       )
@@ -90,7 +90,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("safe_counter")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       assert(
         report.ok,
         s"safe_counter should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
@@ -101,7 +101,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir      = buildIR("set_ops")
-      val report  = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
       assert(
         skipped.isEmpty,
@@ -117,7 +117,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir      = buildIR("set_comp_demo")
-      val report  = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
       assert(
         skipped.isEmpty,
@@ -135,7 +135,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("powerset_demo")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val global = report.checks.find(_.id == "global").getOrElse(fail("no global check"))
       assertEquals(
         global.tool,
@@ -153,7 +153,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir             = buildIR("temporal_demo")
-      val report         = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report         = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val temporalChecks = report.checks.filter(_.kind == CheckKind.Temporal)
       assertEquals(
         temporalChecks.size,
@@ -189,7 +189,7 @@ class ConsistencyTest extends munit.FunSuite:
     val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.tool, VerifierTool.Alloy)
@@ -215,7 +215,7 @@ class ConsistencyTest extends munit.FunSuite:
     val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.tool, VerifierTool.Alloy)
@@ -241,7 +241,7 @@ class ConsistencyTest extends munit.FunSuite:
     val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.status, CheckOutcome.Skipped)
@@ -255,7 +255,7 @@ class ConsistencyTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("powerset_ops")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val reqCheck = report.checks.find(_.id == "AddUser.requires")
         .getOrElse(fail("no AddUser.requires check"))
       assertEquals(reqCheck.tool, VerifierTool.Alloy)

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -23,7 +23,7 @@ class JsonReportTest extends munit.FunSuite:
       val ir      = parseSpec(fixture)
       val backend = WasmBackend()
       try
-        val report = Consistency.runConsistencyChecks(
+        val report = Consistency.runConsistencyChecksSync(
           ir,
           backend,
           VerificationConfig(timeoutMs = 30_000L, captureCore = true)
@@ -62,7 +62,7 @@ class JsonReportTest extends munit.FunSuite:
     val ir      = parseSpec("broken_url_shortener")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(
+      val report = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig(timeoutMs = 30_000L, captureCore = true)
@@ -97,7 +97,7 @@ class JsonReportTest extends munit.FunSuite:
     val ir      = parseSpec("safe_counter")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val json   = JsonReport.toJson("x.spec", report, 42.0)
       val keys   = json.asObject.map(_.keys.toSet).getOrElse(Set.empty[String])
       assertEquals(keys, Set("schemaVersion", "specFile", "ok", "totalMs", "checks"))

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -126,9 +126,9 @@ class JsonReportTest extends munit.FunSuite:
 
   private def parseSpec(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   // Paths where timing fields legitimately live in the schema. Scoping prevents accidental
   // erasure if a future diagnostic/counterexample field shares one of these names.

--- a/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
@@ -60,9 +60,9 @@ class ResourceLifecycleTest extends CatsEffectSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   private def tempDirResource(prefix: String): cats.effect.Resource[IO, Path] =
     cats.effect.Resource.make(IO.blocking(Files.createTempDirectory(prefix))): dir =>

--- a/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
@@ -45,10 +45,10 @@ class ResourceLifecycleTest extends CatsEffectSuite:
     test(name):
       assertReleased(runCase)
 
-  test("runConsistencyChecksIO acquires and uses managed backends"):
+  test("runConsistencyChecks acquires and uses managed backends"):
     val ir = buildIR("safe_counter")
     Consistency
-      .runConsistencyChecksIO(ir, VerificationConfig.Default)
+      .runConsistencyChecks(ir, VerificationConfig.Default)
       .map(report => assertEquals(report.ok, true))
 
   private def assertReleased(runCase: Ref[IO, Boolean] => IO[Unit]): IO[Unit] =

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -23,7 +23,7 @@ class AlloyGoldenTest extends munit.FunSuite:
   fixtures.foreach: name =>
     test(s"Alloy source matches golden — $name"):
       val ir      = buildIR(name)
-      val module  = Translator.translateGlobal(ir, scope = 5).toOption.get
+      val module  = Translator.translateGlobalSync(ir, scope = 5).toOption.get
       val emitted = Render.render(module).stripSuffix("\n")
       val golden  = Files.readString(goldenDir.resolve(s"$name.als")).stripSuffix("\n")
       if emitted != golden then

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -16,9 +16,9 @@ class AlloyGoldenTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   fixtures.foreach: name =>
     test(s"Alloy source matches golden — $name"):

--- a/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
@@ -41,7 +41,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
+    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
     assert(result.solution.isDefined, "expected a solution for sat case")
 
@@ -54,7 +54,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
+    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Unsat, s"expected unsat; source=$source")
 
   test("singleton State sig with set field + subset powerset quantification"):
@@ -76,7 +76,7 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
+    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
 
   test("existential powerset quantification (some t: set …) works end-to-end"):
@@ -91,5 +91,5 @@ class RenderTest extends munit.FunSuite:
     )
     val source  = Render.render(m)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
+    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")

--- a/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
@@ -11,9 +11,9 @@ class TranslatorTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   test("powerset_demo translates to a valid Alloy module and solves sat"):
     val ir     = buildIR("powerset_demo")
@@ -52,9 +52,9 @@ class TranslatorTest extends munit.FunSuite:
         |  invariant everySubsetContainedInUsers:
         |    all t in ^users | t subset users
         |}""".stripMargin
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translateGlobal(ir, scope = 5) match
       case Left(e)  => e
       case Right(_) => fail("expected Left(AlloyTranslator)")
@@ -70,9 +70,9 @@ class TranslatorTest extends munit.FunSuite:
         |  invariant power:
         |    #(^a) >= 0
         |}""".stripMargin
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translateGlobal(ir, scope = 5) match
       case Left(e)  => e
       case Right(_) => fail("expected Left(AlloyTranslator)")

--- a/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
@@ -17,7 +17,7 @@ class TranslatorTest extends munit.FunSuite:
 
   test("powerset_demo translates to a valid Alloy module and solves sat"):
     val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobal(ir, scope = 5).toOption.get
+    val module = Translator.translateGlobalSync(ir, scope = 5).toOption.get
     assertEquals(module.name, "PowersetDemo")
     assert(
       module.sigs.exists(_.name == "User"),
@@ -27,12 +27,12 @@ class TranslatorTest extends munit.FunSuite:
     assertEquals(module.facts.size, 1)
     val source  = Render.render(module)
     val backend = new AlloyBackend
-    val result  = backend.check(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
+    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
     assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=\n$source")
 
   test("Alloy render contains expected structural tokens"):
     val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobal(ir, scope = 5).toOption.get
+    val module = Translator.translateGlobalSync(ir, scope = 5).toOption.get
     val source = Render.render(module)
     assert(source.contains("module PowersetDemo"), s"source=\n$source")
     assert(source.contains("sig User"), s"source=\n$source")
@@ -55,7 +55,7 @@ class TranslatorTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateGlobal(ir, scope = 5) match
+    val err = Translator.translateGlobalSync(ir, scope = 5) match
       case Left(e)  => e
       case Right(_) => fail("expected Left(AlloyTranslator)")
     assert(
@@ -73,7 +73,7 @@ class TranslatorTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateGlobal(ir, scope = 5) match
+    val err = Translator.translateGlobalSync(ir, scope = 5) match
       case Left(e)  => e
       case Right(_) => fail("expected Left(AlloyTranslator)")
     assert(

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -28,7 +28,7 @@ class DumpTest extends munit.FunSuite:
       val backend = WasmBackend()
       val sink    = DumpSink.open(tmpDir).toOption.get
       try
-        val report = Consistency.runConsistencyChecks(
+        val report = Consistency.runConsistencyChecksSync(
           ir,
           backend,
           VerificationConfig.Default,
@@ -84,7 +84,7 @@ class DumpTest extends munit.FunSuite:
     val backend = WasmBackend()
     val sink    = DumpSink.open(tmpDir).toOption.get
     try
-      val _ = Consistency.runConsistencyChecks(
+      val _ = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig.Default,

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -104,9 +104,9 @@ class DumpTest extends munit.FunSuite:
 
   private def parseSpec(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   private def deleteRecursive(p: java.nio.file.Path): Unit =
     if Files.isDirectory(p) then

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -16,7 +16,7 @@ class UnsatCoreTest extends munit.FunSuite:
     val ir      = parseSpec("unsat_invariants")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(
+      val report = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig(timeoutMs = 30_000L, captureCore = true)
@@ -38,7 +38,7 @@ class UnsatCoreTest extends munit.FunSuite:
     val ir      = parseSpec("unsat_invariants")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(
+      val report = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig.Default
@@ -51,7 +51,7 @@ class UnsatCoreTest extends munit.FunSuite:
     val ir      = parseSpec("contradictory_powerset")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(
+      val report = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig(timeoutMs = 60_000L, captureCore = true)
@@ -75,7 +75,7 @@ class UnsatCoreTest extends munit.FunSuite:
     val ir      = parseSpec("dead_op")
     val backend = WasmBackend()
     try
-      val report = Consistency.runConsistencyChecks(
+      val report = Consistency.runConsistencyChecksSync(
         ir,
         backend,
         VerificationConfig(timeoutMs = 30_000L, captureCore = true)

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -89,6 +89,6 @@ class UnsatCoreTest extends munit.FunSuite:
 
   private def parseSpec(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -12,9 +12,9 @@ class BackendTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   private def emptyArtifact: TranslatorArtifact =
     TranslatorArtifact(Nil, Nil, Nil, Nil, Nil, hasPostState = false)

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -23,7 +23,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val script = Z3Script(Nil, Nil, Nil, emptyArtifact)
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -31,7 +31,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val script = Z3Script(Nil, Nil, List(Z3Expr.BoolLit(false)), emptyArtifact)
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -46,7 +46,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -62,7 +62,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -70,8 +70,8 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("url_shortener")
-      val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val script = Translator.translateSync(ir).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -79,8 +79,8 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("unsat_invariants")
-      val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val script = Translator.translateSync(ir).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -88,8 +88,8 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("safe_counter")
-      val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val script = Translator.translateSync(ir).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -110,7 +110,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()
 
@@ -129,7 +129,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -144,7 +144,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -169,7 +169,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -197,7 +197,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -223,7 +223,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -246,7 +246,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -267,7 +267,7 @@ class BackendTest extends munit.FunSuite:
         ),
         artifact = emptyArtifact
       )
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Unsat)
     finally backend.close()
 
@@ -275,7 +275,7 @@ class BackendTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("set_ops")
-      val script = Translator.translate(ir).toOption.get
-      val result = backend.check(script, VerificationConfig.Default).toOption.get
+      val script = Translator.translateSync(ir).toOption.get
+      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
       assertEquals(result.status, CheckStatus.Sat)
     finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
@@ -23,9 +23,9 @@ class CounterExampleTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty)
-    Builder.buildIR(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree).toOption.get
 
   test("broken_url_shortener preservation failure produces a decoded counterexample"):
     val backend = WasmBackend()

--- a/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
@@ -31,7 +31,7 @@ class CounterExampleTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val viol = report.checks.find(c =>
         c.kind == CheckKind.Preservation &&
           c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
@@ -93,7 +93,7 @@ class CounterExampleTest extends munit.FunSuite:
     val backend = WasmBackend()
     try
       val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecks(ir, backend, VerificationConfig.Default)
+      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
       val violation = report.checks.find(c =>
         c.kind == CheckKind.Preservation &&
           c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -36,7 +36,7 @@ class SmtLibGoldenTest extends munit.FunSuite:
   translatableFixtures.foreach: name =>
     test(s"SMT-LIB matches golden — $name"):
       val ir = buildIR(name)
-      val script = Translator.translate(ir).fold(
+      val script = Translator.translateSync(ir).fold(
         err => fail(s"Translator.translate failed for $name: ${err.message}"),
         identity
       )

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -26,9 +26,9 @@ class SmtLibGoldenTest extends munit.FunSuite:
 
   private def buildIR(name: String): specrest.ir.ServiceIR =
     val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpec(src)
+    val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIR(parsed.tree).fold(
+    Builder.buildIRSync(parsed.tree).fold(
       err => fail(s"buildIR failed for $name: ${err.message}"),
       identity
     )

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -6,9 +6,9 @@ import specrest.parser.Parse
 class TranslatorSetOpsTest extends munit.FunSuite:
 
   private def scriptOf(spec: String): Z3Script =
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     Translator.translate(ir).toOption.get
 
   private def smtOf(spec: String): String =
@@ -133,9 +133,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]",
       "a subset {}"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
@@ -149,9 +149,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]\n    n: Int",
       "a subset n"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
@@ -165,9 +165,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]\n    b: Set[Bool]",
       "a union b subset a"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
@@ -181,9 +181,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]",
       "{1, true} subset a"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     if parsed.errors.isEmpty then
-      val ir = Builder.buildIR(parsed.tree).toOption.get
+      val ir = Builder.buildIRSync(parsed.tree).toOption.get
       val err = Translator.translate(ir) match
         case Left(e)  => e
         case Right(_) => fail("expected translator error")
@@ -197,9 +197,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]\n    x: Int",
       "x in {1, 2, true}"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     if parsed.errors.isEmpty then
-      val ir = Builder.buildIR(parsed.tree).toOption.get
+      val ir = Builder.buildIRSync(parsed.tree).toOption.get
       val err = Translator.translate(ir) match
         case Left(e)  => e
         case Right(_) => fail("expected translator error")
@@ -214,9 +214,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]\n    b: Set[Int]\n    flag: Bool",
       "flag in (a union b) implies true"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
@@ -231,9 +231,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]",
       "a subset {}"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
@@ -247,9 +247,9 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       "a: Set[Int]\n    b: Set[Set[Int]]",
       "b subset ^a"
     )
-    val parsed = Parse.parseSpec(spec)
+    val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIR(parsed.tree).toOption.get
+    val ir = Builder.buildIRSync(parsed.tree).toOption.get
     val err = Translator.translate(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -9,7 +9,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    Translator.translate(ir).toOption.get
+    Translator.translateSync(ir).toOption.get
 
   private def smtOf(spec: String): String =
     SmtLib.renderSmtLib(scriptOf(spec))
@@ -136,7 +136,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(
@@ -152,7 +152,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(
@@ -168,7 +168,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(
@@ -184,7 +184,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     if parsed.errors.isEmpty then
       val ir = Builder.buildIRSync(parsed.tree).toOption.get
-      val err = Translator.translate(ir) match
+      val err = Translator.translateSync(ir) match
         case Left(e)  => e
         case Right(_) => fail("expected translator error")
       assert(
@@ -200,7 +200,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     if parsed.errors.isEmpty then
       val ir = Builder.buildIRSync(parsed.tree).toOption.get
-      val err = Translator.translate(ir) match
+      val err = Translator.translateSync(ir) match
         case Left(e)  => e
         case Right(_) => fail("expected translator error")
       assert(
@@ -217,7 +217,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(
@@ -234,7 +234,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(
@@ -250,7 +250,7 @@ class TranslatorSetOpsTest extends munit.FunSuite:
     val parsed = Parse.parseSpecSync(spec)
     assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
     val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translate(ir) match
+    val err = Translator.translateSync(ir) match
       case Left(e)  => e
       case Right(_) => fail("expected translator error")
     assert(


### PR DESCRIPTION
## Summary

- Lifts the six verify-pipeline public entries (`Parse.parseSpec`, `Builder.buildIR`, Z3 `Translator.{translate,translateOperationRequires,translateOperationEnabled,translateOperationPreservation}`, Alloy `Translator.{translateGlobal,translateTemporal,translateOperation{Requires,Enabled,Preservation}}`, `WasmBackend.check`, `AlloyBackend.check`, `Consistency.runConsistencyChecks`) to return `IO[Either[VerifyError.X, A]]` — the typed error channel M_CE.2 introduced is now threaded through the effect system.
- Sync bodies preserved as package-private `*Sync` helpers; tests and `Consistency` internals keep using them so M_CE.4 stays narrow — no test migration to `CatsEffectSuite` (that's M_CE.8), no internal parallelism (M_CE.5), no IOApp CLI (M_CE.7).
- CLI (`Check`, `Inspect`, `Compile`, `Verify`) bridges the IO returns with `unsafeRunSync` at the sync entry points; all bridges removed when Main flips to IOApp in M_CE.7.

## Notable design choice — wrapper per workload

Meta-issue #95 says "All Z3/Alloy/ANTLR/Handlebars calls go through `IO.blocking`". This PR deviates: translators and parser use `IO.delay`, only actual thread-blocking solver calls use `IO.blocking`. Per the [cats-effect thread-model docs](https://typelevel.org/cats-effect/docs/thread-model) and [starvation-and-tuning docs](https://typelevel.org/cats-effect/docs/core/starvation-and-tuning), wrapping CPU-bound work in `IO.blocking` shifts it to the unbounded blocking pool — which would defeat `parTraverseN`'s compute-pool work-stealing in M_CE.5 and create thread-allocation pressure. CE3's auto-yield every 1024 runloop stages covers fairness for our bounded translator recursion.

| Entry | Wrapper | Reason |
| --- | --- | --- |
| `Parse.parseSpec` / `Builder.buildIR` | `IO.delay` | Pure CPU; compute pool |
| `Translator.translate*` (Z3 + Alloy, 9 methods) | `IO.delay` | Pure CPU; compute pool |
| `WasmBackend.check` / `AlloyBackend.check` | `IO.blocking` | Solver can hard-block up to `cfg.timeoutMs` |

## Commit breakdown (5 commits, independently compilable + green)

1. `parse/build as IO[Either[VerifyError, _]]`
2. `z3 translator + backend as IO`
3. `alloy translator + backend as IO`
4. `Consistency.runConsistencyChecks is IO` (deletes sync variant; adds `runConsistencyChecksSync` convenience alongside the two IO overloads)
5. `refresh verification.mdx capability table`

## Deliberate deferrals

- **Bench module** — #99's acceptance list mentions it; no bench module exists yet. M_CE.9 creates it.
- **Tests on `CatsEffectSuite`** — M_CE.8 scope. Tests stay on `FunSuite` + call `*Sync` helpers; no `unsafeRunSync` in test code.
- **`parseSpec` two-channel flattening** — the issue's literal signature was `IO[Either[_, ParseResult]]` with `ParseResult` still carrying `errors: List[ParseError]`. Collapsed: empty errors ⇒ `Right`, non-empty ⇒ `Left(VerifyError.Parse(errors))`. Avoids data appearing in both branches.

## Test plan

- [ ] `sbt scalafmtCheckAll` — clean
- [ ] `sbt test` — 198 tests green (no change vs main)
- [ ] `sbt cli/run verify fixtures/spec/url_shortener.spec` — sat as before
- [ ] `sbt cli/run verify --dump-smt fixtures/spec/url_shortener.spec` — unchanged SMT-LIB output
- [ ] `sbt cli/run compile --out /tmp/out fixtures/spec/url_shortener.spec` — unchanged codegen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated verification pipeline progress table with additional shipped milestones including error type definitions and resource-managed backends, plus new pending items for parallel dispatch, cancellation handling with per-check timeouts, and CLI runtime improvements.

* **Refactor**
  * Internal improvements to error handling and pipeline architecture across parsing, IR building, translation, and verification stages for enhanced consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Thread the verification pipeline through `IO` with typed errors end-to-end: parse → build → translate → check now return `IO[Either[VerifyError, _]]`. Also fixes the consistency wrapper to use `IO.delay`, makes Z3 context handling thread-safe, and updates docs; closes #99.

- **Refactors**
  - Lifted to `IO[Either[VerifyError, _]]`: `Parse.parseSpec`, `Builder.buildIR`, Z3 `Translator.{translate, translateOperationRequires, translateOperationEnabled, translateOperationPreservation}`, Alloy `Translator.{translateGlobal, translateTemporal, translateOperationRequires, translateOperationEnabled, translateOperationPreservation}`, `WasmBackend.check`, `AlloyBackend.check`, `Consistency.runConsistencyChecks`.
  - Kept `*Sync` helpers; added `Consistency.runConsistencyChecksSync`; CLI bridges with `unsafeRunSync` until `CommandIOApp` in M_CE.7.
  - Wrapper policy: `IO.delay` for CPU-bound work (parse/build/translate and the orchestrator body); `IO.blocking` only for solver checks.
  - `WasmBackend`: replace lazy `Context` cache with a single eager `Context` for thread safety; docs table clarified for M_CE.1–M_CE.4 and separated `Consistency` row.

- **Migration**
  - No CLI or output changes; fixtures and SMT/Alloy dumps remain the same.
  - New callers should use the `IO` variants and compose with `Resource`; reserve `*Sync` for tests/CLI until M_CE.7.

<sup>Written for commit 5ea43a2966d846564f439e6244a70a17e9d13188. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

