### PR TITLE
M_CE.6 — Per-check IO.timeoutTo + cancel-aware Resource lifecycle (#101)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -491,11 +491,15 @@ The 30 s default is conservative headroom for heavier preservation checks on lar
 
 The solver-call IOs use `IO.interruptible` (not `IO.blocking`), so a cancelled fiber —
 whether via the outer timeout or a parent cancel — sends `Thread.interrupt()` into the
-blocking pool. Alloy's `Future.get(timeout)` honours the interrupt (it calls
-`future.cancel(true)` on the Kodkod thread), so Alloy aborts promptly. Z3's native
-`solver.check()` does *not* observe `Thread.isInterrupted`; on outer timeout the fiber's
-fallback fires and `Resource` finalizers close the Z3 `Context`, but the solver thread
-itself may continue briefly until it honours its own inner `timeout` parameter. Practical
+blocking pool. Alloy aborts cleanly: on `Thread.interrupt()`, the thread blocked in
+`Future.get(timeout, …)` throws `InterruptedException`, and the backend's
+`finally pool.shutdownNow()` propagates an interrupt into the Kodkod SAT thread,
+which honours it. (The distinct *wall-clock timeout* path is separate: on
+`TimeoutException`, the backend itself calls `future.cancel(true)`; both paths
+converge on a stopped Kodkod thread.) Z3's native `solver.check()` does *not* observe
+`Thread.isInterrupted`; on outer timeout the fiber's fallback fires and `Resource`
+finalizers close the Z3 `Context`, but the solver thread itself may continue briefly
+until it honours its own inner `timeout` parameter. Practical
 bound: worst-case native CPU-time after timeout is `cfg.timeoutMs + solver_slack`,
 typically well under `2 × cfg.timeoutMs`. True mid-call abort via `Context.interrupt()`
 is a follow-up ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)); it only

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -59,7 +59,7 @@ CLI output so the attribution is visible.
 | Pipeline entries (`Parse.parseSpec`, `Builder.buildIR`, Z3/Alloy `Translator.*`, `WasmBackend.check`, `AlloyBackend.check`) return `IO[Either[VerifyError, _]]` | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
 | `Consistency.runConsistencyChecks` returns `IO[ConsistencyReport]` (per-check failures remain data inside the report, not in the Either channel) | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
 | Parallel check dispatch (`parTraverseN`, `--parallel <n>`) | shipped in M_CE.5 ([#100](https://github.com/HardMax71/spec_to_rest/issues/100)) |
-| Cancellation + per-check timeout via `IO.timeout` / `Resource` release | [#101](https://github.com/HardMax71/spec_to_rest/issues/101) (pending M_CE.6) |
+| Cancellation + per-check timeout via `IO.timeoutTo` / `Resource` release | shipped in M_CE.6 ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)) |
 | `spec-to-rest` as `CommandIOApp` (removes `unsafeRunSync` bridges from CLI) | [#102](https://github.com/HardMax71/spec_to_rest/issues/102) (pending M_CE.7) |
 
 ## Preservation VC shape
@@ -469,12 +469,41 @@ is unsettled and there is no concrete consumer today. Tracked separately in
 
 ## Timeout semantics
 
-`--timeout` maps directly to Z3's `timeout` solver parameter and the SMT-LIB
-`(set-option :timeout …)`. Units are milliseconds. `0` disables the timeout entirely.
+`--timeout` maps to two layers, both driven by the same value in milliseconds:
 
-If Z3 cannot decide within the timeout, the result is `unknown`, which `verify` treats as a
-failure with category `solver_timeout` (exit `1`). The 30 s default is a conservative headroom
-for heavier preservation checks on large specs.
+1. **Inner (solver-native)**: Z3's `timeout` solver parameter (and the SMT-LIB
+   `(set-option :timeout …)` the emitter renders for `--dump-smt`); Alloy's
+   `Future.get(timeout, MILLISECONDS)` on the Kodkod solver thread.
+2. **Outer (`IO.timeoutTo`)**: the orchestrator wraps each check's IO with
+   `io.timeoutTo(cfg.timeoutMs.millis, fallback)`. The fallback produces a
+   `CheckOutcome.Unknown` result carrying a `solver_timeout` diagnostic with detail
+   `outer timeout: <ms>ms`.
+
+`0` disables both layers (standard Z3 "no timeout" semantics). In practice whichever
+layer fires first determines the result; the outer layer is the hard deadline — if the
+solver misbehaves and ignores its inner timeout, the fiber still releases, the
+`Resource[IO, WasmBackend]` / `Resource[IO, AlloyBackend]` finalizers run, and the report
+returns in bounded time.
+
+The 30 s default is conservative headroom for heavier preservation checks on large specs.
+
+### Cancellation
+
+The solver-call IOs use `IO.interruptible` (not `IO.blocking`), so a cancelled fiber —
+whether via the outer timeout or a parent cancel — sends `Thread.interrupt()` into the
+blocking pool. Alloy's `Future.get(timeout)` honours the interrupt (it calls
+`future.cancel(true)` on the Kodkod thread), so Alloy aborts promptly. Z3's native
+`solver.check()` does *not* observe `Thread.isInterrupted`; on outer timeout the fiber's
+fallback fires and `Resource` finalizers close the Z3 `Context`, but the solver thread
+itself may continue briefly until it honours its own inner `timeout` parameter. Practical
+bound: worst-case native CPU-time after timeout is `cfg.timeoutMs + solver_slack`,
+typically well under `2 × cfg.timeoutMs`. True mid-call abort via `Context.interrupt()`
+is a follow-up ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)); it only
+matters for pathological specs that defeat Z3's own timeout.
+
+SIGINT handling (Ctrl+C) ships in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102))
+when the CLI migrates to `CommandIOApp`, which installs the signal handler that flows
+into the fiber cancellation path described above.
 
 ## Parallelism model
 
@@ -495,9 +524,12 @@ with `parTraverseN(maxParallel)`.
   `--parallel 8` or lower to bound peak native memory.
 - **Determinism**: `parTraverseN` preserves input order in the result list, so the report
   order is identical across runs regardless of the fiber-completion order.
-- **Cancellation**: the `IO.timeout` wrapping and Ctrl+C handling land in M_CE.6
-  ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)). The `Resource`-managed
-  backends will then release native memory on signal.
+- **Cancellation**: each check is wrapped in `IO.timeoutTo(cfg.timeoutMs.millis, …)` and
+  runs under `IO.interruptible`, so an outer deadline or parent cancel releases the fiber,
+  tears down the `Resource`-managed backends, and frees native memory. See
+  [Timeout semantics](#timeout-semantics) for the two-layer model and the Z3
+  `Thread.interrupt` caveat. Ctrl+C signal handling arrives with the IOApp migration in
+  M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)).
 
 ## Set theory
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -498,7 +498,7 @@ fallback fires and `Resource` finalizers close the Z3 `Context`, but the solver 
 itself may continue briefly until it honours its own inner `timeout` parameter. Practical
 bound: worst-case native CPU-time after timeout is `cfg.timeoutMs + solver_slack`,
 typically well under `2 × cfg.timeoutMs`. True mid-call abort via `Context.interrupt()`
-is a follow-up ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)); it only
+is a follow-up ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)); it only
 matters for pathological specs that defeat Z3's own timeout.
 
 SIGINT handling (Ctrl+C) ships in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102))

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -3,7 +3,6 @@ package specrest.verify
 import cats.effect.IO
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
-import scala.concurrent.duration.*
 import specrest.ir.*
 import specrest.verify.alloy.AlloyBackend
 import specrest.verify.alloy.AlloyModule
@@ -17,6 +16,8 @@ import specrest.verify.z3.TranslatorArtifact
 import specrest.verify.z3.WasmBackend
 import specrest.verify.z3.Z3CounterExample
 import specrest.verify.z3.Z3Script
+
+import scala.concurrent.duration.*
 
 enum CheckKind:
   case Global, Requires, Enabled, Preservation, Temporal

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -3,6 +3,7 @@ package specrest.verify
 import cats.effect.IO
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
+import scala.concurrent.duration.*
 import specrest.ir.*
 import specrest.verify.alloy.AlloyBackend
 import specrest.verify.alloy.AlloyModule
@@ -86,12 +87,23 @@ object Consistency:
     val results: IO[List[CheckResult]] =
       if config.maxParallel <= 1 then
         backendsResource.use: (wasm, alloy) =>
-          plans.traverse(p => IO.blocking(executePlan(p, wasm, alloy, config, dump)))
+          plans.traverse(p => runOne(p, wasm, alloy, config, dump))
       else
         plans.parTraverseN(config.maxParallel): plan =>
           backendsResource.use: (wasm, alloy) =>
-            IO.blocking(executePlan(plan, wasm, alloy, config, dump))
+            runOne(plan, wasm, alloy, config, dump)
     results.map(reportFromResults)
+
+  private def runOne(
+      plan: CheckPlan,
+      backend: WasmBackend,
+      alloyBackend: AlloyBackend,
+      config: VerificationConfig,
+      dump: Option[DumpSink]
+  ): IO[CheckResult] =
+    val io = IO.interruptible(executePlan(plan, backend, alloyBackend, config, dump))
+    if config.timeoutMs <= 0 then io
+    else io.timeoutTo(config.timeoutMs.millis, IO.pure(timeoutFallback(plan, config)))
 
   private def backendsResource: cats.effect.Resource[IO, (WasmBackend, AlloyBackend)] =
     for
@@ -159,6 +171,67 @@ object Consistency:
       c.status == CheckOutcome.Sat || c.status == CheckOutcome.Skipped
     )
     ConsistencyReport(results, ok)
+
+  private def timeoutFallback(plan: CheckPlan, config: VerificationConfig): CheckResult =
+    val (id, kind, tool, operationName, invariantName, sourceSpans) = plan match
+      case CheckPlan.Global(ir) =>
+        (
+          "global",
+          CheckKind.Global,
+          Classifier.classifyGlobal(ir),
+          None,
+          None,
+          ir.invariants.flatMap(_.span)
+        )
+      case CheckPlan.Op(ir, op, k) =>
+        val kindStr = k match
+          case CheckKind.Requires => "requires"
+          case CheckKind.Enabled  => "enabled"
+          case _                  => "?"
+        val t = k match
+          case CheckKind.Requires => Classifier.classifyRequires(op)
+          case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
+          case _                  => VerifierTool.Z3
+        (s"${op.name}.$kindStr", k, t, Some(op.name), None, operationCheckSpans(op, k, ir))
+      case CheckPlan.Preservation(_, op, inv) =>
+        (
+          s"${op.name}.preserves.${inv.name}",
+          CheckKind.Preservation,
+          Classifier.classifyPreservation(op, inv.decl),
+          Some(op.name),
+          Some(inv.name),
+          preservationSpans(op, inv.decl)
+        )
+      case CheckPlan.Temporal(_, decl) =>
+        (
+          s"temporal.${decl.name}",
+          CheckKind.Temporal,
+          VerifierTool.Alloy,
+          None,
+          Some(decl.name),
+          decl.span.toList
+        )
+    val diagnostic = VerificationDiagnostic(
+      level = DiagnosticLevel.Error,
+      category = DiagnosticCategory.SolverTimeout,
+      message = s"outer timeout on check '$id': fired at ${config.timeoutMs}ms",
+      primarySpan = sourceSpans.headOption,
+      relatedSpans = Nil,
+      counterexample = None,
+      suggestion = Diagnostic.suggestionFor(DiagnosticCategory.SolverTimeout)
+    )
+    CheckResult(
+      id = id,
+      kind = kind,
+      tool = tool,
+      operationName = operationName,
+      invariantName = invariantName,
+      status = CheckOutcome.Unknown,
+      durationMs = config.timeoutMs.toDouble,
+      detail = Some(s"outer timeout: ${config.timeoutMs}ms"),
+      sourceSpans = sourceSpans,
+      diagnostic = Some(diagnostic)
+    )
 
   private def dumpZ3(
       dump: Option[DumpSink],

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -70,6 +70,64 @@ object Consistency:
     case Preservation(ir: ServiceIR, op: OperationDecl, inv: NamedInvariant)
     case Temporal(ir: ServiceIR, decl: TemporalDecl)
 
+  final private case class PlanMetadata(
+      id: String,
+      kind: CheckKind,
+      tool: VerifierTool,
+      operationName: Option[String],
+      invariantName: Option[String],
+      sourceSpans: List[Span]
+  )
+
+  // Single source of truth for plan → (id, kind, tool, op, inv, spans). The run* methods
+  // below redundantly derive matching values inline; keep both in sync. TimeoutTest's
+  // parity assertions exercise the cross-path agreement.
+  private def metadataFor(plan: CheckPlan): PlanMetadata = plan match
+    case CheckPlan.Global(ir) =>
+      PlanMetadata(
+        id = "global",
+        kind = CheckKind.Global,
+        tool = Classifier.classifyGlobal(ir),
+        operationName = None,
+        invariantName = None,
+        sourceSpans = ir.invariants.flatMap(_.span)
+      )
+    case CheckPlan.Op(ir, op, k) =>
+      val kindStr = k match
+        case CheckKind.Requires => "requires"
+        case CheckKind.Enabled  => "enabled"
+        case _                  => "?"
+      val tool = k match
+        case CheckKind.Requires => Classifier.classifyRequires(op)
+        case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
+        case _                  => VerifierTool.Z3
+      PlanMetadata(
+        id = s"${op.name}.$kindStr",
+        kind = k,
+        tool = tool,
+        operationName = Some(op.name),
+        invariantName = None,
+        sourceSpans = operationCheckSpans(op, k, ir)
+      )
+    case CheckPlan.Preservation(_, op, inv) =>
+      PlanMetadata(
+        id = s"${op.name}.preserves.${inv.name}",
+        kind = CheckKind.Preservation,
+        tool = Classifier.classifyPreservation(op, inv.decl),
+        operationName = Some(op.name),
+        invariantName = Some(inv.name),
+        sourceSpans = preservationSpans(op, inv.decl)
+      )
+    case CheckPlan.Temporal(_, decl) =>
+      PlanMetadata(
+        id = s"temporal.${decl.name}",
+        kind = CheckKind.Temporal,
+        tool = VerifierTool.Alloy,
+        operationName = None,
+        invariantName = Some(decl.name),
+        sourceSpans = decl.span.toList
+      )
+
   def runConsistencyChecks(
       ir: ServiceIR,
       backend: WasmBackend,
@@ -87,8 +145,18 @@ object Consistency:
     val plans = planChecks(ir)
     val results: IO[List[CheckResult]] =
       if config.maxParallel <= 1 then
-        backendsResource.use: (wasm, alloy) =>
-          plans.traverse(p => runOne(p, wasm, alloy, config, dump))
+        if config.timeoutMs <= 0 then
+          backendsResource.use: (wasm, alloy) =>
+            plans.traverse(p => runOne(p, wasm, alloy, config, dump))
+        else
+          // With per-check timeouts, a cancelled IO.interruptible may leave a native
+          // solver thread still running on its Z3 Context (Z3's solver.check does not
+          // observe Thread.isInterrupted). Allocating backends per plan guarantees the
+          // next plan uses a fresh, uncontested Context instead of racing with the
+          // timed-out thread on a shared one (Context is not thread-safe).
+          plans.traverse: plan =>
+            backendsResource.use: (wasm, alloy) =>
+              runOne(plan, wasm, alloy, config, dump)
       else
         plans.parTraverseN(config.maxParallel): plan =>
           backendsResource.use: (wasm, alloy) =>
@@ -174,63 +242,26 @@ object Consistency:
     ConsistencyReport(results, ok)
 
   private def timeoutFallback(plan: CheckPlan, config: VerificationConfig): CheckResult =
-    val (id, kind, tool, operationName, invariantName, sourceSpans) = plan match
-      case CheckPlan.Global(ir) =>
-        (
-          "global",
-          CheckKind.Global,
-          Classifier.classifyGlobal(ir),
-          None,
-          None,
-          ir.invariants.flatMap(_.span)
-        )
-      case CheckPlan.Op(ir, op, k) =>
-        val kindStr = k match
-          case CheckKind.Requires => "requires"
-          case CheckKind.Enabled  => "enabled"
-          case _                  => "?"
-        val t = k match
-          case CheckKind.Requires => Classifier.classifyRequires(op)
-          case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
-          case _                  => VerifierTool.Z3
-        (s"${op.name}.$kindStr", k, t, Some(op.name), None, operationCheckSpans(op, k, ir))
-      case CheckPlan.Preservation(_, op, inv) =>
-        (
-          s"${op.name}.preserves.${inv.name}",
-          CheckKind.Preservation,
-          Classifier.classifyPreservation(op, inv.decl),
-          Some(op.name),
-          Some(inv.name),
-          preservationSpans(op, inv.decl)
-        )
-      case CheckPlan.Temporal(_, decl) =>
-        (
-          s"temporal.${decl.name}",
-          CheckKind.Temporal,
-          VerifierTool.Alloy,
-          None,
-          Some(decl.name),
-          decl.span.toList
-        )
+    val meta = metadataFor(plan)
     val diagnostic = VerificationDiagnostic(
       level = DiagnosticLevel.Error,
       category = DiagnosticCategory.SolverTimeout,
-      message = s"outer timeout on check '$id': fired at ${config.timeoutMs}ms",
-      primarySpan = sourceSpans.headOption,
+      message = s"outer timeout on check '${meta.id}': fired at ${config.timeoutMs}ms",
+      primarySpan = meta.sourceSpans.headOption,
       relatedSpans = Nil,
       counterexample = None,
       suggestion = Diagnostic.suggestionFor(DiagnosticCategory.SolverTimeout)
     )
     CheckResult(
-      id = id,
-      kind = kind,
-      tool = tool,
-      operationName = operationName,
-      invariantName = invariantName,
+      id = meta.id,
+      kind = meta.kind,
+      tool = meta.tool,
+      operationName = meta.operationName,
+      invariantName = meta.invariantName,
       status = CheckOutcome.Unknown,
       durationMs = config.timeoutMs.toDouble,
       detail = Some(s"outer timeout: ${config.timeoutMs}ms"),
-      sourceSpans = sourceSpans,
+      sourceSpans = meta.sourceSpans,
       diagnostic = Some(diagnostic)
     )
 

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -63,14 +63,6 @@ final class AlloyBackend:
 
   def close(): Unit = ()
 
-  def check(
-      source: String,
-      commandIdx: Int,
-      timeoutMs: Long,
-      captureCore: Boolean = false
-  ): IO[Either[VerifyError.Backend, AlloyCheckResult]] =
-    IO.interruptible(checkSync(source, commandIdx, timeoutMs, captureCore))
-
   private[specrest] def checkSync(
       source: String,
       commandIdx: Int,

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -69,7 +69,7 @@ final class AlloyBackend:
       timeoutMs: Long,
       captureCore: Boolean = false
   ): IO[Either[VerifyError.Backend, AlloyCheckResult]] =
-    IO.blocking(checkSync(source, commandIdx, timeoutMs, captureCore))
+    IO.interruptible(checkSync(source, commandIdx, timeoutMs, captureCore))
 
   private[specrest] def checkSync(
       source: String,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -69,7 +69,7 @@ final class WasmBackend:
       script: Z3Script,
       cfg: VerificationConfig
   ): IO[Either[VerifyError.Backend, SmokeCheckResult]] =
-    IO.blocking(checkSync(script, cfg))
+    IO.interruptible(checkSync(script, cfg))
 
   private[specrest] def checkSync(
       script: Z3Script,
@@ -80,10 +80,10 @@ final class WasmBackend:
         val sortMap = declareSorts(ctx, script.sorts)
         val funcMap = declareFuncs(ctx, script.funcs, sortMap)
         val solver  = ctx.mkSolver()
-        if cfg.timeoutMs > 0 then
-          val params = ctx.mkParams()
-          params.add("timeout", cfg.timeoutMs.toInt)
-          solver.setParameters(params)
+        val params  = ctx.mkParams()
+        params.add("random_seed", 0)
+        if cfg.timeoutMs > 0 then params.add("timeout", cfg.timeoutMs.toInt)
+        solver.setParameters(params)
         val rctx         = new RenderCtx(ctx, sortMap, funcMap, summon[BackendBoundary])
         val trackerNames = scala.collection.mutable.ArrayBuffer.empty[String]
         if cfg.captureCore then

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -65,12 +65,6 @@ final class WasmBackend:
 
   def close(): Unit = ctx.close()
 
-  def check(
-      script: Z3Script,
-      cfg: VerificationConfig
-  ): IO[Either[VerifyError.Backend, SmokeCheckResult]] =
-    IO.interruptible(checkSync(script, cfg))
-
   private[specrest] def checkSync(
       script: Z3Script,
       cfg: VerificationConfig

--- a/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
@@ -18,22 +18,24 @@ class TimeoutTest extends CatsEffectSuite:
     val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
     val parsed = Parse.parseSpecSync(src)
     assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+    Builder.buildIRSync(parsed.tree) match
+      case Right(ir) => ir
+      case Left(err) => fail(s"build errors for $name: $err")
 
   List(1, 4).foreach: maxPar =>
-    test(s"tight timeout on set_ops (parallel=$maxPar) yields only Unknown/Skipped outcomes"):
+    test(s"tight timeout on set_ops (parallel=$maxPar) triggers the timeout fallback"):
       val ir  = buildIR("set_ops")
       val cfg = VerificationConfig(timeoutMs = 1L, maxParallel = maxPar)
       Consistency.runConsistencyChecks(ir, cfg).map: report =>
-        val bad = report.checks.filter: c =>
-          c.status != CheckOutcome.Unknown && c.status != CheckOutcome.Skipped
+        // Fast hardware can race a trivial Z3 check through in under 1 ms, so we do
+        // not assert that every check times out. We do assert (a) the fallback path
+        // fires on at least one non-skipped check, and (b) the run ends not-ok because
+        // of those timeouts (skipped-only would still flip ok=true).
+        val timedOut = report.checks.count(_.status == CheckOutcome.Unknown)
         assert(
-          bad.isEmpty,
-          s"unexpected non-timeout outcomes: ${bad.map(c => s"${c.id}=${c.status}").mkString(", ")}"
-        )
-        assert(
-          report.checks.exists(_.status == CheckOutcome.Unknown),
-          "no Unknown outcomes — outer timeout fallback did not fire on any check"
+          timedOut > 0,
+          s"no Unknown outcomes — outer timeout fallback did not fire. " +
+            s"Statuses: ${report.checks.groupBy(_.status).view.mapValues(_.size).toMap}"
         )
         assertEquals(report.ok, false)
 

--- a/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
@@ -1,0 +1,79 @@
+package specrest.verify
+
+import cats.effect.IO
+import cats.effect.Ref
+import munit.CatsEffectSuite
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.verify.alloy.AlloyBackend
+import specrest.verify.z3.WasmBackend
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.concurrent.duration.*
+
+class TimeoutTest extends CatsEffectSuite:
+
+  private def buildIR(name: String): specrest.ir.ServiceIR =
+    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
+    val parsed = Parse.parseSpecSync(src)
+    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
+    Builder.buildIRSync(parsed.tree).toOption.get
+
+  List(1, 4).foreach: maxPar =>
+    test(s"tight timeout on set_ops (parallel=$maxPar) yields only Unknown/Skipped outcomes"):
+      val ir  = buildIR("set_ops")
+      val cfg = VerificationConfig(timeoutMs = 1L, maxParallel = maxPar)
+      Consistency.runConsistencyChecks(ir, cfg).map: report =>
+        val bad = report.checks.filter: c =>
+          c.status != CheckOutcome.Unknown && c.status != CheckOutcome.Skipped
+        assert(
+          bad.isEmpty,
+          s"unexpected non-timeout outcomes: ${bad.map(c => s"${c.id}=${c.status}").mkString(", ")}"
+        )
+        assert(
+          report.checks.exists(_.status == CheckOutcome.Unknown),
+          "no Unknown outcomes — outer timeout fallback did not fire on any check"
+        )
+        assertEquals(report.ok, false)
+
+  test("serial and parallel produce identical outcomes under tight timeout"):
+    val ir   = buildIR("set_ops")
+    val cfgS = VerificationConfig(timeoutMs = 1L, maxParallel = 1)
+    val cfgP = VerificationConfig(timeoutMs = 1L, maxParallel = 4)
+    for
+      serial   <- Consistency.runConsistencyChecks(ir, cfgS)
+      parallel <- Consistency.runConsistencyChecks(ir, cfgP)
+    yield
+      assertEquals(
+        serial.checks.map(c => c.id -> c.status),
+        parallel.checks.map(c => c.id -> c.status)
+      )
+      assertEquals(serial.ok, parallel.ok)
+
+  test("timeoutMs=0 disables outer timeout (safe_counter parity vs 30s default)"):
+    val ir      = buildIR("safe_counter")
+    val cfgZero = VerificationConfig(timeoutMs = 0L, maxParallel = 1)
+    val cfgDef  = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
+    for
+      zero <- Consistency.runConsistencyChecks(ir, cfgZero)
+      dflt <- Consistency.runConsistencyChecks(ir, cfgDef)
+    yield
+      assertEquals(
+        zero.checks.map(c => c.id -> c.status),
+        dflt.checks.map(c => c.id -> c.status)
+      )
+      assertEquals(zero.ok, dflt.ok)
+
+  test("Resource release fires when the using IO is timed out"):
+    Ref[IO].of(0).flatMap: released =>
+      val wasmRes = WasmBackend
+        .make(IO.blocking(WasmBackend())): backend =>
+          released.update(_ + 1) >> IO.blocking(backend.close())
+      val alloyRes = AlloyBackend
+        .make(IO.blocking(new AlloyBackend)): backend =>
+          released.update(_ + 1) >> IO.blocking(backend.close())
+      val combined = wasmRes.flatMap(w => alloyRes.map(a => (w, a)))
+      combined.use(_ => IO.sleep(10.seconds)).timeoutTo(50.millis, IO.unit) >>
+        released.get.map: count =>
+          assertEquals(count, 2, "both backend Resources should have released after timeout")


### PR DESCRIPTION
## Summary

Sixth sub-issue of the CE3 migration meta (#95). Closes #101 (except the SIGINT subprocess integration test, which depends on `CommandIOApp` landing in M_CE.7).

- Wrap each `CheckPlan` in `IO.timeoutTo(cfg.timeoutMs.millis, fallback)` inside `Consistency.runConsistencyChecks`. Both serial and parallel orchestrator branches go through a single `runOne` helper that applies the timeout uniformly. `timeoutMs=0` keeps the existing "no outer timeout" semantics.
- Switch solver IOs from `IO.blocking` to `IO.interruptible`. Alloy's `Future.get(timeout)` already honours `Thread.interrupt()`; Z3's native `solver.check()` does not — documented — but the fiber still releases, the `Resource[IO, WasmBackend]` finalizer closes the `Context`, and the fallback fires cleanly.
- Timeout fallback returns `CheckOutcome.Unknown` with a `SolverTimeout` diagnostic (detail: `outer timeout: <ms>ms`). `Unknown` is reused rather than adding a `TimedOut` variant — same user meaning, zero churn to JSON tokens / CLI rendering / parity tests.
- Pin `random_seed=0` on the Z3 solver for reproducible counterexamples across versions (Z3's default is 0 today, but explicit is better than implicit).
- Docs: flip status-table row to shipped-in-M_CE.6; expand "Timeout semantics" into a two-layer (inner solver + outer `IO.timeoutTo`) section; add "Cancellation" subsection covering the `Thread.interrupt` caveat for Z3 and the SIGINT pointer to M_CE.7.

## Test plan

- [x] `sbt verify/testOnly *TimeoutTest` — 5/5 pass (parametrized over `parallel=1,4` plus standalone cases).
- [x] `sbt test` — full suite green across 24 consecutive runs (measured locally to rule out flakiness).
- [x] `sbt scalafmtCheckAll` — clean.
- [x] `cd docs && npm run build` — clean.
- [x] CLI smoke: `verify fixtures/spec/set_ops.spec --timeout 1 --parallel 1|4` produces 29 `outer timeout` diagnostics and exits non-zero.
- [x] CLI parity smoke: `verify fixtures/spec/url_shortener.spec --timeout 0` vs `--timeout 30000` produce byte-identical JSON reports (only `durationMs`/`totalMs` timing fields differ).

## Deferred

- SIGINT subprocess integration test → M_CE.7 (#102); needs `CommandIOApp` signal handling.
- True Z3 `Context.interrupt()` mid-solver-call abort → follow-up if real users hit solver-CPU-burn after Ctrl+C in M_CE.7.
- JMH validation of `IO.interruptible` overhead → M_CE.9 (#104).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-check timeouts and cancel-aware resource handling to the verification orchestrator. Each check now has an outer deadline; timeouts cancel work and free resources safely, and serial runs allocate per-plan backends when timeouts are enabled to avoid Z3 `Context` races.

- **New Features**
  - Wrap each `CheckPlan` with `IO.timeoutTo(cfg.timeoutMs.millis, fallback)` via a shared `runOne`; `timeoutMs=0` preserves “no outer timeout”.
  - Switch solver calls to `IO.interruptible`; Alloy aborts cleanly on interrupt, Z3 ignores thread interrupts but `Resource` finalizers close the `Context`.
  - On outer timeout, return `CheckOutcome.Unknown` with `solver_timeout` (detail: `outer timeout: <ms>ms`).
  - Pin Z3 `random_seed=0` for reproducible counterexamples; docs updated with the two-layer timeout model and a clearer Alloy cancel vs wall‑clock timeout explanation (M_CE.6 marked shipped).

- **Refactors**
  - When `timeoutMs > 0`, allocate backends per plan in the serial path to avoid non-thread-safe Z3 `Context` races with timed-out threads.
  - Removed dead `WasmBackend.check`/`AlloyBackend.check`; added `PlanMetadata` used by `timeoutFallback`; minor import tidy.

<sup>Written for commit a21c4962655020db65aa8a95712fdfae5455dd68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced timeout control with two-layer model and clearer diagnostics distinguishing outer timeout scenarios.
  * Improved interruption support for better Ctrl+C handling during verification.

* **Bug Fixes**
  * Z3 now executes deterministically with fixed random seed.

* **Documentation**
  * Updated verification documentation covering revised timeout and cancellation control flow.

* **Tests**
  * Added comprehensive timeout behavior validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->