### PR TITLE
M_CE.7 — CLI as CommandIOApp (#102)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -60,7 +60,7 @@ CLI output so the attribution is visible.
 | `Consistency.runConsistencyChecks` returns `IO[ConsistencyReport]` (per-check failures remain data inside the report, not in the Either channel) | shipped in M_CE.4 ([#99](https://github.com/HardMax71/spec_to_rest/issues/99)) |
 | Parallel check dispatch (`parTraverseN`, `--parallel <n>`) | shipped in M_CE.5 ([#100](https://github.com/HardMax71/spec_to_rest/issues/100)) |
 | Cancellation + per-check timeout via `IO.timeoutTo` / `Resource` release | shipped in M_CE.6 ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)) |
-| `spec-to-rest` as `CommandIOApp` (removes `unsafeRunSync` bridges from CLI) | [#102](https://github.com/HardMax71/spec_to_rest/issues/102) (pending M_CE.7) |
+| `spec-to-rest` as `CommandIOApp` — structured `IO[ExitCode]` subcommands, SIGINT wired to fiber cancellation | shipped in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)) |
 
 ## Preservation VC shape
 
@@ -505,9 +505,13 @@ typically well under `2 × cfg.timeoutMs`. True mid-call abort via `Context.inte
 is a follow-up ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)); it only
 matters for pathological specs that defeat Z3's own timeout.
 
-SIGINT handling (Ctrl+C) ships in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102))
-when the CLI migrates to `CommandIOApp`, which installs the signal handler that flows
-into the fiber cancellation path described above.
+SIGINT handling (Ctrl+C) ships in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)):
+the CLI runs as `CommandIOApp`, which via the underlying `IOApp` installs a shutdown hook
+(`io-cancel-hook`) that cancels the top-level fiber on SIGINT or SIGTERM. Cancellation then
+flows through the path above — `IO.interruptible` raises `InterruptedException` in the
+Alloy worker thread, `Resource[IO, WasmBackend]` and `Resource[IO, AlloyBackend]` finalizers
+run, Z3 `Context.close()` and Alloy backend pools release, and the JVM exits cleanly.
+The shutdown hook honours a 30 s grace deadline before forcing JVM exit.
 
 ## Parallelism model
 
@@ -532,8 +536,9 @@ with `parTraverseN(maxParallel)`.
   runs under `IO.interruptible`, so an outer deadline or parent cancel releases the fiber,
   tears down the `Resource`-managed backends, and frees native memory. See
   [Timeout semantics](#timeout-semantics) for the two-layer model and the Z3
-  `Thread.interrupt` caveat. Ctrl+C signal handling arrives with the IOApp migration in
-  M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)).
+  `Thread.interrupt` caveat. Ctrl+C signal handling shipped in M_CE.7
+  ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)): `CommandIOApp` installs
+  a JVM shutdown hook that feeds SIGINT / SIGTERM into the fiber cancellation path.
 
 ## Set theory
 

--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -1,6 +1,7 @@
 package specrest.cli
 
-import cats.effect.unsafe.implicits.global
+import cats.effect.ExitCode
+import cats.effect.IO
 import specrest.convention.DiagnosticLevel as ConvDiagLevel
 import specrest.convention.Validate
 import specrest.ir.VerifyError
@@ -13,62 +14,64 @@ import java.nio.file.Paths
 
 object Check:
 
-  def run(specFile: String, log: Logger): Int =
+  def run(specFile: String, log: Logger): IO[ExitCode] =
     readSource(specFile, log) match
-      case Left(code) => code
+      case Left(code) => IO.pure(code)
       case Right(source) =>
-        val t0      = System.nanoTime()
-        val parsedE = Parse.parseSpec(source).unsafeRunSync()
-        val parseMs = (System.nanoTime() - t0) / 1_000_000.0
-        log.verbose(f"Parsed in ${parseMs}%.0fms")
+        val t0 = System.nanoTime()
+        Parse.parseSpec(source).flatMap { parsedE =>
+          val parseMs = (System.nanoTime() - t0) / 1_000_000.0
+          IO.delay(log.verbose(f"Parsed in ${parseMs}%.0fms")) >> (parsedE match
+            case Left(VerifyError.Parse(errors)) =>
+              IO.delay {
+                errors.foreach: e =>
+                  log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+              }.as(ExitCodes.Violations)
+            case Right(parsed) =>
+              val t1 = System.nanoTime()
+              Builder.buildIR(parsed.tree).flatMap:
+                case Left(err) =>
+                  IO.delay(log.error(renderBuildError(specFile, err))).as(ExitCodes.Violations)
+                case Right(ir) =>
+                  IO.delay {
+                    val buildMs = (System.nanoTime() - t1) / 1_000_000.0
+                    log.verbose(f"Built IR in ${buildMs}%.0fms")
 
-        parsedE match
-          case Left(VerifyError.Parse(errors)) =>
-            errors.foreach: e =>
-              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            1
-          case Right(parsed) =>
-            val t1 = System.nanoTime()
-            Builder.buildIR(parsed.tree).unsafeRunSync() match
-              case Left(err) =>
-                log.error(renderBuildError(specFile, err))
-                1
-              case Right(ir) =>
-                val buildMs = (System.nanoTime() - t1) / 1_000_000.0
-                log.verbose(f"Built IR in ${buildMs}%.0fms")
+                    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+                    val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
+                    val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
 
-                val diagnostics = Validate.validateConventions(ir.conventions, ir)
-                val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
-                val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
+                    for w <- warnings do
+                      val loc =
+                        w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                      log.warn(s"${loc}warning: ${w.message}")
+                    for e <- errors do
+                      val loc =
+                        e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+                      log.error(s"${loc}${e.message}")
 
-                for w <- warnings do
-                  val loc =
-                    w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                  log.warn(s"${loc}warning: ${w.message}")
-                for e <- errors do
-                  val loc =
-                    e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                  log.error(s"${loc}${e.message}")
+                    if errors.nonEmpty then ExitCodes.Violations
+                    else
+                      log.success(
+                        s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
+                      )
+                      ExitCodes.Ok
+                  }
+          )
+        }
 
-                if errors.nonEmpty then 1
-                else
-                  log.success(
-                    s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
-                  )
-                  0
-
-  private[cli] def readSource(specFile: String, log: Logger): Either[Int, String] =
+  private[cli] def readSource(specFile: String, log: Logger): Either[ExitCode, String] =
     try Right(Files.readString(Paths.get(specFile)))
     catch
       case _: NoSuchFileException =>
         log.error(s"File not found: $specFile")
-        Left(1)
+        Left(ExitCodes.Violations)
       case e: java.nio.file.FileSystemException =>
         log.error(s"Cannot read $specFile: ${e.getMessage}")
-        Left(1)
+        Left(ExitCodes.Violations)
       case e: RuntimeException =>
         log.error(s"Cannot read $specFile: ${e.getMessage}")
-        Left(1)
+        Left(ExitCodes.Violations)
 
   private[cli] def renderBuildError(specFile: String, e: VerifyError.Build): String =
     e.span match

--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -15,7 +15,7 @@ import java.nio.file.Paths
 object Check:
 
   def run(specFile: String, log: Logger): IO[ExitCode] =
-    readSource(specFile, log) match
+    readSource(specFile, log).flatMap:
       case Left(code) => IO.pure(code)
       case Right(source) =>
         val t0 = System.nanoTime()
@@ -60,18 +60,19 @@ object Check:
           )
         }
 
-  private[cli] def readSource(specFile: String, log: Logger): Either[ExitCode, String] =
-    try Right(Files.readString(Paths.get(specFile)))
-    catch
-      case _: NoSuchFileException =>
-        log.error(s"File not found: $specFile")
-        Left(ExitCodes.Violations)
-      case e: java.nio.file.FileSystemException =>
-        log.error(s"Cannot read $specFile: ${e.getMessage}")
-        Left(ExitCodes.Violations)
-      case e: RuntimeException =>
-        log.error(s"Cannot read $specFile: ${e.getMessage}")
-        Left(ExitCodes.Violations)
+  private[cli] def readSource(specFile: String, log: Logger): IO[Either[ExitCode, String]] =
+    IO.blocking(Files.readString(Paths.get(specFile)))
+      .map(src => Right(src): Either[ExitCode, String])
+      .handleErrorWith:
+        case _: NoSuchFileException =>
+          IO.delay(log.error(s"File not found: $specFile"))
+            .as(Left(ExitCodes.Violations))
+        case e: java.nio.file.FileSystemException =>
+          IO.delay(log.error(s"Cannot read $specFile: ${e.getMessage}"))
+            .as(Left(ExitCodes.Violations))
+        case e: RuntimeException =>
+          IO.delay(log.error(s"Cannot read $specFile: ${e.getMessage}"))
+            .as(Left(ExitCodes.Violations))
 
   private[cli] def renderBuildError(specFile: String, e: VerifyError.Build): String =
     e.span match

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -1,6 +1,7 @@
 package specrest.cli
 
-import cats.effect.unsafe.implicits.global
+import cats.effect.ExitCode
+import cats.effect.IO
 import specrest.codegen.Emit
 import specrest.ir.VerifyError
 import specrest.parser.Builder
@@ -19,22 +20,22 @@ final case class CompileOptions(
 
 object Compile:
 
-  def run(specFile: String, opts: CompileOptions, log: Logger): Int =
+  def run(specFile: String, opts: CompileOptions, log: Logger): IO[ExitCode] =
     Check.readSource(specFile, log) match
-      case Left(code) => code
+      case Left(code) => IO.pure(code)
       case Right(source) =>
-        Parse.parseSpec(source).unsafeRunSync() match
+        Parse.parseSpec(source).flatMap:
           case Left(VerifyError.Parse(errors)) =>
-            errors.foreach: e =>
-              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            1
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitCodes.Violations)
           case Right(parsed) =>
-            Builder.buildIR(parsed.tree).unsafeRunSync() match
+            Builder.buildIR(parsed.tree).flatMap:
               case Left(err) =>
-                log.error(Check.renderBuildError(specFile, err))
-                1
+                IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitCodes.Violations)
               case Right(ir) =>
-                try
+                IO.blocking {
                   val profiled = Annotate.buildProfiledService(ir, opts.target)
                   val files    = Emit.emitProject(profiled)
                   val outRoot  = Paths.get(opts.outDir)
@@ -49,8 +50,10 @@ object Compile:
                       StandardOpenOption.TRUNCATE_EXISTING
                     )
                   log.success(s"wrote ${files.length} files to ${opts.outDir}")
-                  0
-                catch
+                  ExitCodes.Ok
+                }.handleErrorWith:
                   case NonFatal(e) =>
-                    log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
-                    1
+                    IO.delay(
+                      log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
+                    ).as(ExitCodes.Violations)
+                  case e => IO.raiseError(e)

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -21,7 +21,7 @@ final case class CompileOptions(
 object Compile:
 
   def run(specFile: String, opts: CompileOptions, log: Logger): IO[ExitCode] =
-    Check.readSource(specFile, log) match
+    Check.readSource(specFile, log).flatMap:
       case Left(code) => IO.pure(code)
       case Right(source) =>
         Parse.parseSpec(source).flatMap:

--- a/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
+++ b/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
@@ -1,0 +1,35 @@
+package specrest.cli
+
+import cats.effect.ExitCode
+import specrest.ir.VerifyError
+import specrest.verify.CheckOutcome
+import specrest.verify.CheckResult
+import specrest.verify.DiagnosticCategory
+
+object ExitCodes:
+  val Ok: ExitCode         = ExitCode(0)
+  val Violations: ExitCode = ExitCode(1)
+  val Translator: ExitCode = ExitCode(2)
+  val Backend: ExitCode    = ExitCode(3)
+
+  def forVerifyError(e: VerifyError): ExitCode = e match
+    case _: VerifyError.Parse           => Violations
+    case _: VerifyError.Build           => Violations
+    case _: VerifyError.Translator      => Translator
+    case _: VerifyError.AlloyTranslator => Translator
+    case _: VerifyError.Backend         => Backend
+
+  def forCheckResults(checks: List[CheckResult], ok: Boolean): ExitCode =
+    val hasBackendError =
+      checks.exists(_.diagnostic.exists(_.category == DiagnosticCategory.BackendError))
+    val hasViolation =
+      checks.exists(c => c.status == CheckOutcome.Unsat || c.status == CheckOutcome.Unknown)
+    val hasTranslatorLimitation = checks.exists(c =>
+      c.status == CheckOutcome.Skipped &&
+        c.diagnostic.exists(_.category == DiagnosticCategory.TranslatorLimitation)
+    )
+    if hasBackendError then Backend
+    else if hasViolation then Violations
+    else if hasTranslatorLimitation then Translator
+    else if ok then Ok
+    else Violations

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -1,6 +1,7 @@
 package specrest.cli
 
-import cats.effect.unsafe.implicits.global
+import cats.effect.ExitCode
+import cats.effect.IO
 import io.circe.Printer
 import io.circe.syntax.EncoderOps
 import specrest.ir.Serialize
@@ -21,23 +22,22 @@ object InspectFormat:
 
 object Inspect:
 
-  def run(specFile: String, format: InspectFormat, log: Logger): Int =
+  def run(specFile: String, format: InspectFormat, log: Logger): IO[ExitCode] =
     Check.readSource(specFile, log) match
-      case Left(code) => code
+      case Left(code) => IO.pure(code)
       case Right(source) =>
-        Parse.parseSpec(source).unsafeRunSync() match
+        Parse.parseSpec(source).flatMap:
           case Left(VerifyError.Parse(errors)) =>
-            errors.foreach: e =>
-              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            1
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitCodes.Violations)
           case Right(parsed) =>
-            Builder.buildIR(parsed.tree).unsafeRunSync() match
+            Builder.buildIR(parsed.tree).flatMap:
               case Left(err) =>
-                log.error(Check.renderBuildError(specFile, err))
-                1
+                IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitCodes.Violations)
               case Right(ir) =>
-                println(formatIR(ir, format))
-                0
+                IO.blocking(System.out.println(formatIR(ir, format))).as(ExitCodes.Ok)
 
   private def formatIR(ir: specrest.ir.ServiceIR, format: InspectFormat): String = format match
     case InspectFormat.Json =>

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -23,7 +23,7 @@ object InspectFormat:
 object Inspect:
 
   def run(specFile: String, format: InspectFormat, log: Logger): IO[ExitCode] =
-    Check.readSource(specFile, log) match
+    Check.readSource(specFile, log).flatMap:
       case Left(code) => IO.pure(code)
       case Right(source) =>
         Parse.parseSpec(source).flatMap:

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -1,16 +1,23 @@
 package specrest.cli
 
+import cats.effect.ExitCode
+import cats.effect.IO
 import cats.implicits.*
 import com.monovore.decline.*
+import com.monovore.decline.effect.CommandIOApp
 
-object Main:
+object Main
+    extends CommandIOApp(
+      name = "spec-to-rest",
+      header = "Compile formal behavioral specs into verified REST services"
+    ):
 
   private val verbose = Opts.flag("verbose", "show detailed progress", short = "v").orFalse
   private val quiet   = Opts.flag("quiet", "suppress non-error output", short = "q").orFalse
 
   private val specFile = Opts.argument[String]("spec-file")
 
-  private val inspectCmd =
+  private val inspectCmd: Opts[IO[ExitCode]] =
     val format = Opts
       .option[String]("format", "output format (summary, json, ir)", short = "f")
       .withDefault("summary")
@@ -20,16 +27,14 @@ object Main:
           case Left(err) => cats.data.Validated.invalidNel(err)
     Opts.subcommand("inspect", "Print the IR for a spec file"):
       (specFile, format, verbose, quiet).mapN: (spec, fmt, v, q) =>
-        val log = Logger.fromFlags(verbose = v, quiet = q)
-        Inspect.run(spec, fmt, log)
+        Inspect.run(spec, fmt, Logger.fromFlags(verbose = v, quiet = q))
 
-  private val checkCmd =
+  private val checkCmd: Opts[IO[ExitCode]] =
     Opts.subcommand("check", "Parse and validate a spec file"):
       (specFile, verbose, quiet).mapN: (spec, v, q) =>
-        val log = Logger.fromFlags(verbose = v, quiet = q)
-        Check.run(spec, log)
+        Check.run(spec, Logger.fromFlags(verbose = v, quiet = q))
 
-  private val verifyCmd =
+  private val verifyCmd: Opts[IO[ExitCode]] =
     val timeout = Opts
       .option[Long]("timeout", "per-check timeout ms (0 = no timeout)")
       .withDefault(30_000L)
@@ -82,28 +87,20 @@ object Main:
         verbose,
         quiet
       ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, v, q) =>
-        val log = Logger.fromFlags(verbose = v, quiet = q)
-        Verify.run(spec, VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo, par), log)
+        Verify.run(
+          spec,
+          VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo, par),
+          Logger.fromFlags(verbose = v, quiet = q)
+        )
 
-  private val compileCmd =
+  private val compileCmd: Opts[IO[ExitCode]] =
     val target = Opts
       .option[String]("target", "deployment target profile", short = "t")
       .withDefault("python-fastapi-postgres")
     val outDir = Opts.option[String]("out", "output directory", short = "o")
     Opts.subcommand("compile", "Emit project files for a spec"):
       (specFile, target, outDir, verbose, quiet).mapN: (spec, t, o, v, q) =>
-        val log = Logger.fromFlags(verbose = v, quiet = q)
-        Compile.run(spec, CompileOptions(t, o), log)
+        Compile.run(spec, CompileOptions(t, o), Logger.fromFlags(verbose = v, quiet = q))
 
-  private val command = Command(
-    name = "spec-to-rest",
-    header = "Compile formal behavioral specs into verified REST services"
-  )(inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd)
-
-  def main(args: Array[String]): Unit =
-    command.parse(args.toSeq) match
-      case Left(help) =>
-        System.err.println(help)
-        sys.exit(1)
-      case Right(exitCode) =>
-        sys.exit(exitCode)
+  override def main: Opts[IO[ExitCode]] =
+    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -2,6 +2,7 @@ package specrest.cli
 
 import cats.effect.ExitCode
 import cats.effect.IO
+import cats.effect.Resource
 import specrest.ir.ServiceIR
 import specrest.ir.VerifyError
 import specrest.parser.Builder
@@ -51,7 +52,7 @@ object Verify:
         )
       }.as(ExitCodes.Violations)
     else
-      Check.readSource(specFile, log) match
+      Check.readSource(specFile, log).flatMap:
         case Left(code) => IO.pure(code)
         case Right(source) =>
           val tParse0 = System.nanoTime()
@@ -119,7 +120,7 @@ object Verify:
                 .productR(IO.delay(log.success(s"Wrote SMT-LIB to $path")))
                 .as(ExitCodes.Ok)
             case None =>
-              IO.blocking(stdout.print(smt)).as(ExitCodes.Ok)
+              IO.blocking { stdout.print(smt); stdout.flush() }.as(ExitCodes.Ok)
         }
 
   private def dumpAlloyFlow(
@@ -141,23 +142,31 @@ object Verify:
               .productR(IO.delay(log.success(s"Wrote Alloy source to $path")))
               .as(ExitCodes.Ok)
           case None =>
-            IO.blocking(stdout.print(source)).as(ExitCodes.Ok)
+            IO.blocking { stdout.print(source); stdout.flush() }.as(ExitCodes.Ok)
 
+  // Hand-rolled Resource rather than calling DumpSink.openResource directly because
+  // the latter raises DumpOpenException (file-private) on open failure, which we can't
+  // pattern-match on from here. Using DumpSink.open + Resource.make preserves the
+  // clean Left(ExitCode) error channel while still guaranteeing close() on release,
+  // cancellation, or downstream failure.
   private def openDumpSink(
       specFile: String,
       opts: VerifyOptions,
       log: Logger
-  ): IO[Either[ExitCode, Option[DumpSink]]] =
+  ): Resource[IO, Either[ExitCode, Option[DumpSink]]] =
     opts.dumpVc match
-      case None => IO.pure(Right(None))
+      case None => Resource.pure(Right(None))
       case Some(p) =>
-        IO.blocking(DumpSink.open(Paths.get(p))).flatMap:
+        Resource.eval(IO.blocking(DumpSink.open(Paths.get(p)))).flatMap:
           case Left(err) =>
-            IO.delay(log.error(s"$specFile: ${err.message}"))
-              .as(Left(ExitCodes.Backend))
-          case Right(s) =>
-            IO.delay(log.verbose(s"Writing per-check VC artifacts to ${s.dir}"))
-              .as(Right(Some(s)))
+            Resource.eval(
+              IO.delay(log.error(s"$specFile: ${err.message}"))
+                .as(Left(ExitCodes.Backend))
+            )
+          case Right(sink) =>
+            Resource.make(IO.pure(sink))(s => IO.blocking(s.close()))
+              .evalTap(s => IO.delay(log.verbose(s"Writing per-check VC artifacts to ${s.dir}")))
+              .map(s => Right(Some(s)))
 
   private def verifyFlow(
       specFile: String,
@@ -168,7 +177,7 @@ object Verify:
   ): IO[ExitCode] =
     IO.delay(log.verbose(s"Timeout: ${opts.timeoutMs}ms")) >>
       IO.delay(log.verbose(s"Alloy scope: ${opts.alloyScope}")) >>
-      openDumpSink(specFile, opts, log).flatMap:
+      openDumpSink(specFile, opts, log).use:
         case Left(code) => IO.pure(code)
         case Right(sink) =>
           val maxParallel = opts.parallel.getOrElse(VerificationConfig.defaultParallelism)
@@ -216,7 +225,7 @@ object Verify:
         IO.blocking(Files.writeString(Paths.get(path), rendered)).void >>
           IO.delay(log.success(s"Wrote JSON report to $path"))
       case None =>
-        IO.blocking(stdout.print(rendered))
+        IO.blocking { stdout.print(rendered); stdout.flush() }
     write.as(ExitCodes.forCheckResults(report.checks, report.ok))
 
   private def reportConsistency(

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -144,29 +144,22 @@ object Verify:
           case None =>
             IO.blocking { stdout.print(source); stdout.flush() }.as(ExitCodes.Ok)
 
-  // Hand-rolled Resource rather than calling DumpSink.openResource directly because
-  // the latter raises DumpOpenException (file-private) on open failure, which we can't
-  // pattern-match on from here. Using DumpSink.open + Resource.make preserves the
-  // clean Left(ExitCode) error channel while still guaranteeing close() on release,
-  // cancellation, or downstream failure.
   private def openDumpSink(
       specFile: String,
       opts: VerifyOptions,
       log: Logger
   ): Resource[IO, Either[ExitCode, Option[DumpSink]]] =
     opts.dumpVc match
-      case None => Resource.pure(Right(None))
+      case None =>
+        Resource.pure(Right(None))
       case Some(p) =>
-        Resource.eval(IO.blocking(DumpSink.open(Paths.get(p)))).flatMap:
+        DumpSink.openResource(Paths.get(p)).evalMap:
           case Left(err) =>
-            Resource.eval(
-              IO.delay(log.error(s"$specFile: ${err.message}"))
-                .as(Left(ExitCodes.Backend))
-            )
+            IO.delay(log.error(s"$specFile: ${err.message}"))
+              .as(Left(ExitCodes.Backend))
           case Right(sink) =>
-            Resource.make(IO.pure(sink))(s => IO.blocking(s.close()))
-              .evalTap(s => IO.delay(log.verbose(s"Writing per-check VC artifacts to ${s.dir}")))
-              .map(s => Right(Some(s)))
+            IO.delay(log.verbose(s"Writing per-check VC artifacts to ${sink.dir}"))
+              .as(Right(Some(sink)))
 
   private def verifyFlow(
       specFile: String,

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -1,6 +1,7 @@
 package specrest.cli
 
-import cats.effect.unsafe.implicits.global
+import cats.effect.ExitCode
+import cats.effect.IO
 import specrest.ir.ServiceIR
 import specrest.ir.VerifyError
 import specrest.parser.Builder
@@ -13,6 +14,7 @@ import specrest.verify.certificates.DumpSink
 import specrest.verify.z3.SmtLib
 import specrest.verify.z3.Translator
 
+import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -31,120 +33,191 @@ final case class VerifyOptions(
 )
 
 object Verify:
-  val ExitOk: Int         = 0
-  val ExitViolations: Int = 1
-  val ExitTranslator: Int = 2
-  val ExitBackend: Int    = 3
 
-  def run(specFile: String, opts: VerifyOptions, log: Logger): Int =
+  def run(
+      specFile: String,
+      opts: VerifyOptions,
+      log: Logger,
+      stdout: PrintStream = System.out
+  ): IO[ExitCode] =
     val wantsJson = opts.json || opts.jsonOut.isDefined
     val wantsDump =
       opts.dumpSmt || opts.dumpSmtOut.isDefined || opts.dumpAlloy || opts.dumpAlloyOut.isDefined
     if wantsJson && wantsDump then
-      log.error(
-        "--json / --json-out cannot be combined with --dump-smt / --dump-alloy " +
-          "(dump flags short-circuit before checks run; JSON output requires a full run)"
-      )
-      return ExitViolations
-    Check.readSource(specFile, log) match
-      case Left(_) => ExitViolations
-      case Right(source) =>
-        val tParse0 = System.nanoTime()
-        val parsedE = Parse.parseSpec(source).unsafeRunSync()
-        log.verbose(f"Parsed in ${(System.nanoTime() - tParse0) / 1_000_000.0}%.0fms")
-        parsedE match
-          case Left(VerifyError.Parse(errors)) =>
-            errors.foreach: e =>
-              log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
-            ExitViolations
-          case Right(parsed) =>
-            val tBuild0 = System.nanoTime()
-            Builder.buildIR(parsed.tree).unsafeRunSync() match
-              case Left(err) =>
-                log.error(Check.renderBuildError(specFile, err))
-                ExitViolations
-              case Right(ir) =>
-                log.verbose(f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms")
-                runWithIR(specFile, ir, opts, log)
+      IO.delay {
+        log.error(
+          "--json / --json-out cannot be combined with --dump-smt / --dump-alloy " +
+            "(dump flags short-circuit before checks run; JSON output requires a full run)"
+        )
+      }.as(ExitCodes.Violations)
+    else
+      Check.readSource(specFile, log) match
+        case Left(code) => IO.pure(code)
+        case Right(source) =>
+          val tParse0 = System.nanoTime()
+          Parse.parseSpec(source).flatMap { parsedE =>
+            IO.delay(log.verbose(f"Parsed in ${(System.nanoTime() - tParse0) / 1_000_000.0}%.0fms"))
+              .flatMap: _ =>
+                parsedE match
+                  case Left(VerifyError.Parse(errors)) =>
+                    IO.delay {
+                      errors.foreach: e =>
+                        log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+                    }.as(ExitCodes.Violations)
+                  case Right(parsed) =>
+                    val tBuild0 = System.nanoTime()
+                    Builder.buildIR(parsed.tree).flatMap:
+                      case Left(err) =>
+                        IO.delay(log.error(Check.renderBuildError(specFile, err)))
+                          .as(ExitCodes.Violations)
+                      case Right(ir) =>
+                        IO.delay(
+                          log.verbose(
+                            f"Built IR in ${(System.nanoTime() - tBuild0) / 1_000_000.0}%.0fms"
+                          )
+                        ) >> runWithIR(specFile, ir, opts, log, stdout)
+          }
 
   private def runWithIR(
       specFile: String,
       ir: ServiceIR,
       opts: VerifyOptions,
-      log: Logger
-  ): Int =
+      log: Logger,
+      stdout: PrintStream
+  ): IO[ExitCode] =
     if opts.dumpSmt || opts.dumpSmtOut.isDefined then
-      val tTrans0 = System.nanoTime()
-      Translator.translate(ir).unsafeRunSync() match
-        case Left(err) =>
-          log.error(s"$specFile: translator limitation: ${err.message}")
-          ExitTranslator
-        case Right(script) =>
+      dumpSmtFlow(specFile, ir, opts, log, stdout)
+    else if opts.dumpAlloy || opts.dumpAlloyOut.isDefined then
+      dumpAlloyFlow(specFile, ir, opts, log, stdout)
+    else
+      verifyFlow(specFile, ir, opts, log, stdout)
+
+  private def dumpSmtFlow(
+      specFile: String,
+      ir: ServiceIR,
+      opts: VerifyOptions,
+      log: Logger,
+      stdout: PrintStream
+  ): IO[ExitCode] =
+    val tTrans0 = System.nanoTime()
+    Translator.translate(ir).flatMap:
+      case Left(err) =>
+        IO.delay(log.error(s"$specFile: translator limitation: ${err.message}"))
+          .as(ExitCodes.Translator)
+      case Right(script) =>
+        val transMs = (System.nanoTime() - tTrans0) / 1_000_000.0
+        IO.delay(
           log.verbose(
-            f"Translated IR to Z3 script: ${script.sorts.length} sorts, ${script.funcs.length} function decls, ${script.assertions.length} assertions (${(System.nanoTime() - tTrans0) / 1_000_000.0}%.0fms)"
+            f"Translated IR to Z3 script: ${script.sorts.length} sorts, ${script.funcs.length} function decls, ${script.assertions.length} assertions (${transMs}%.0fms)"
           )
+        ) >> {
           val timeout = if opts.timeoutMs > 0 then Some(opts.timeoutMs) else None
           val smt     = SmtLib.renderSmtLib(script, timeout)
           opts.dumpSmtOut match
             case Some(path) =>
-              Files.writeString(Paths.get(path), smt)
-              log.success(s"Wrote SMT-LIB to $path")
+              IO.blocking(Files.writeString(Paths.get(path), smt))
+                .productR(IO.delay(log.success(s"Wrote SMT-LIB to $path")))
+                .as(ExitCodes.Ok)
             case None =>
-              print(smt)
-          ExitOk
-    else if opts.dumpAlloy || opts.dumpAlloyOut.isDefined then
-      AlloyTranslator.translateGlobal(ir, opts.alloyScope).unsafeRunSync() match
-        case Left(err) =>
-          log.error(s"$specFile: alloy translator: ${err.message}")
-          ExitTranslator
-        case Right(module) =>
-          val source = AlloyRender.render(module)
-          opts.dumpAlloyOut match
-            case Some(path) =>
-              Files.writeString(Paths.get(path), source)
-              log.success(s"Wrote Alloy source to $path")
-            case None =>
-              print(source)
-          ExitOk
-    else
-      log.verbose(s"Timeout: ${opts.timeoutMs}ms")
-      log.verbose(s"Alloy scope: ${opts.alloyScope}")
-      val sink: Option[DumpSink] = opts.dumpVc match
-        case None => None
-        case Some(p) =>
-          DumpSink.open(Paths.get(p)) match
-            case Left(err) =>
-              log.error(s"$specFile: ${err.message}")
-              return ExitBackend
-            case Right(s) => Some(s)
-      sink.foreach(s => log.verbose(s"Writing per-check VC artifacts to ${s.dir}"))
-      val maxParallel = opts.parallel.getOrElse(VerificationConfig.defaultParallelism)
-      log.verbose(s"Max parallel: $maxParallel")
-      val tRun0 = System.nanoTime()
-      val report = Consistency.runConsistencyChecks(
-        ir,
-        VerificationConfig(
-          timeoutMs = opts.timeoutMs,
-          alloyScope = opts.alloyScope,
-          captureCore = opts.explain,
-          maxParallel = maxParallel
-        ),
-        sink
-      ).unsafeRunSync()
-      val totalMs = (System.nanoTime() - tRun0) / 1_000_000.0
-      sink.foreach: s =>
-        s.writeIndex(specFile, totalMs, report.ok)
-        log.success(s"Wrote ${s.entryCount} VC artifacts and verdicts.json to ${s.dir}")
-      if opts.json || opts.jsonOut.isDefined then
-        val rendered = JsonReport.render(JsonReport.toJson(specFile, report, totalMs))
-        opts.jsonOut match
+              IO.blocking(stdout.print(smt)).as(ExitCodes.Ok)
+        }
+
+  private def dumpAlloyFlow(
+      specFile: String,
+      ir: ServiceIR,
+      opts: VerifyOptions,
+      log: Logger,
+      stdout: PrintStream
+  ): IO[ExitCode] =
+    AlloyTranslator.translateGlobal(ir, opts.alloyScope).flatMap:
+      case Left(err) =>
+        IO.delay(log.error(s"$specFile: alloy translator: ${err.message}"))
+          .as(ExitCodes.Translator)
+      case Right(module) =>
+        val source = AlloyRender.render(module)
+        opts.dumpAlloyOut match
           case Some(path) =>
-            val _ = Files.writeString(Paths.get(path), rendered)
-            log.success(s"Wrote JSON report to $path")
+            IO.blocking(Files.writeString(Paths.get(path), source))
+              .productR(IO.delay(log.success(s"Wrote Alloy source to $path")))
+              .as(ExitCodes.Ok)
           case None =>
-            print(rendered)
-        exitCodeFor(report.checks, report.ok)
-      else reportConsistency(specFile, report.checks, report.ok, totalMs, log)
+            IO.blocking(stdout.print(source)).as(ExitCodes.Ok)
+
+  private def openDumpSink(
+      specFile: String,
+      opts: VerifyOptions,
+      log: Logger
+  ): IO[Either[ExitCode, Option[DumpSink]]] =
+    opts.dumpVc match
+      case None => IO.pure(Right(None))
+      case Some(p) =>
+        IO.blocking(DumpSink.open(Paths.get(p))).flatMap:
+          case Left(err) =>
+            IO.delay(log.error(s"$specFile: ${err.message}"))
+              .as(Left(ExitCodes.Backend))
+          case Right(s) =>
+            IO.delay(log.verbose(s"Writing per-check VC artifacts to ${s.dir}"))
+              .as(Right(Some(s)))
+
+  private def verifyFlow(
+      specFile: String,
+      ir: ServiceIR,
+      opts: VerifyOptions,
+      log: Logger,
+      stdout: PrintStream
+  ): IO[ExitCode] =
+    IO.delay(log.verbose(s"Timeout: ${opts.timeoutMs}ms")) >>
+      IO.delay(log.verbose(s"Alloy scope: ${opts.alloyScope}")) >>
+      openDumpSink(specFile, opts, log).flatMap:
+        case Left(code) => IO.pure(code)
+        case Right(sink) =>
+          val maxParallel = opts.parallel.getOrElse(VerificationConfig.defaultParallelism)
+          IO.delay(log.verbose(s"Max parallel: $maxParallel")) >> {
+            val tRun0 = System.nanoTime()
+            Consistency.runConsistencyChecks(
+              ir,
+              VerificationConfig(
+                timeoutMs = opts.timeoutMs,
+                alloyScope = opts.alloyScope,
+                captureCore = opts.explain,
+                maxParallel = maxParallel
+              ),
+              sink
+            ).flatMap { report =>
+              val totalMs = (System.nanoTime() - tRun0) / 1_000_000.0
+              val writeIndex = sink match
+                case Some(s) =>
+                  IO.blocking(s.writeIndex(specFile, totalMs, report.ok)) >>
+                    IO.delay(
+                      log.success(
+                        s"Wrote ${s.entryCount} VC artifacts and verdicts.json to ${s.dir}"
+                      )
+                    )
+                case None => IO.unit
+              writeIndex >> {
+                if opts.json || opts.jsonOut.isDefined then
+                  emitJson(specFile, report, totalMs, opts, log, stdout)
+                else reportConsistency(specFile, report.checks, report.ok, totalMs, log)
+              }
+            }
+          }
+
+  private def emitJson(
+      specFile: String,
+      report: ConsistencyReport,
+      totalMs: Double,
+      opts: VerifyOptions,
+      log: Logger,
+      stdout: PrintStream
+  ): IO[ExitCode] =
+    val rendered = JsonReport.render(JsonReport.toJson(specFile, report, totalMs))
+    val write = opts.jsonOut match
+      case Some(path) =>
+        IO.blocking(Files.writeString(Paths.get(path), rendered)).void >>
+          IO.delay(log.success(s"Wrote JSON report to $path"))
+      case None =>
+        IO.blocking(stdout.print(rendered))
+    write.as(ExitCodes.forCheckResults(report.checks, report.ok))
 
   private def reportConsistency(
       specFile: String,
@@ -152,57 +225,43 @@ object Verify:
       ok: Boolean,
       totalMs: Double,
       log: Logger
-  ): Int =
-    val passes   = checks.count(_.status == CheckOutcome.Sat)
-    val skipped  = checks.count(_.status == CheckOutcome.Skipped)
-    val failures = checks.length - passes - skipped
-    val exitCode = exitCodeFor(checks, ok)
+  ): IO[ExitCode] =
+    IO.delay {
+      val passes   = checks.count(_.status == CheckOutcome.Sat)
+      val skipped  = checks.count(_.status == CheckOutcome.Skipped)
+      val failures = checks.length - passes - skipped
+      val exitCode = ExitCodes.forCheckResults(checks, ok)
 
-    if exitCode == ExitOk then
-      log.success(
-        f"$specFile: $passes/${checks.length} consistency checks passed (${totalMs}%.0fms)"
-      )
-      checks.foreach(c => log.verbose(formatCheckLine(c)))
-      exitCode
-    else
-      if failures == 0 && skipped > 0 then
-        log.warn(
-          f"$specFile: $passes/${checks.length} checks passed; $skipped skipped (translator coverage gap) (${totalMs}%.0fms)"
+      if exitCode == ExitCodes.Ok then
+        log.success(
+          f"$specFile: $passes/${checks.length} consistency checks passed (${totalMs}%.0fms)"
         )
+        checks.foreach(c => log.verbose(formatCheckLine(c)))
       else
-        log.error(
-          f"$specFile: $failures failure(s), $skipped skipped in ${checks.length} consistency checks (${totalMs}%.0fms)"
-        )
-
-      checks.foreach: c =>
-        if c.status == CheckOutcome.Sat then log.verbose(formatCheckLine(c))
+        if failures == 0 && skipped > 0 then
+          log.warn(
+            f"$specFile: $passes/${checks.length} checks passed; $skipped skipped (translator coverage gap) (${totalMs}%.0fms)"
+          )
         else
-          c.diagnostic match
-            case Some(diag) =>
-              if c.status == CheckOutcome.Skipped then
-                log.warn("")
-                log.warn(formatDiagnostic(diag, specFile))
-              else
-                log.error("")
-                log.error(formatDiagnostic(diag, specFile))
-            case None =>
-              log.error(formatCheckLine(c))
-      exitCode
+          log.error(
+            f"$specFile: $failures failure(s), $skipped skipped in ${checks.length} consistency checks (${totalMs}%.0fms)"
+          )
 
-  private def exitCodeFor(checks: List[CheckResult], ok: Boolean): Int =
-    val hasBackendError =
-      checks.exists(_.diagnostic.exists(_.category == DiagnosticCategory.BackendError))
-    val hasViolation =
-      checks.exists(c => c.status == CheckOutcome.Unsat || c.status == CheckOutcome.Unknown)
-    val hasTranslatorLimitation = checks.exists(c =>
-      c.status == CheckOutcome.Skipped &&
-        c.diagnostic.exists(_.category == DiagnosticCategory.TranslatorLimitation)
-    )
-    if hasBackendError then ExitBackend
-    else if hasViolation then ExitViolations
-    else if hasTranslatorLimitation then ExitTranslator
-    else if ok then ExitOk
-    else ExitViolations
+        checks.foreach: c =>
+          if c.status == CheckOutcome.Sat then log.verbose(formatCheckLine(c))
+          else
+            c.diagnostic match
+              case Some(diag) =>
+                if c.status == CheckOutcome.Skipped then
+                  log.warn("")
+                  log.warn(formatDiagnostic(diag, specFile))
+                else
+                  log.error("")
+                  log.error(formatDiagnostic(diag, specFile))
+              case None =>
+                log.error(formatCheckLine(c))
+      exitCode
+    }
 
   private def formatCheckLine(c: CheckResult): String =
     val icon = c.status match

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -1,70 +1,75 @@
 package specrest.cli
 
-class CliSmokeTest extends munit.FunSuite:
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CliSmokeTest extends CatsEffectSuite:
 
   private def log: Logger = Logger.fromFlags(verbose = false, quiet = true)
 
   test("check url_shortener is valid"):
-    val exit = Check.run("fixtures/spec/url_shortener.spec", log)
-    assertEquals(exit, 0)
+    Check.run("fixtures/spec/url_shortener.spec", log).assertEquals(ExitCodes.Ok)
 
   test("check on missing file returns 1"):
-    val exit = Check.run("fixtures/does-not-exist.spec", log)
-    assertEquals(exit, 1)
+    Check.run("fixtures/does-not-exist.spec", log).assertEquals(ExitCodes.Violations)
 
   test("inspect --format json returns 0 on valid spec"):
-    val exit = Inspect.run("fixtures/spec/safe_counter.spec", InspectFormat.Json, log)
-    assertEquals(exit, 0)
+    Inspect.run("fixtures/spec/safe_counter.spec", InspectFormat.Json, log)
+      .assertEquals(ExitCodes.Ok)
 
   test("InspectFormat.parse rejects unknown"):
     val err = InspectFormat.parse("yaml").left.toOption
     assert(err.exists(_.contains("unknown format")))
 
   test("verify safe_counter returns exit 0"):
-    val exit = Verify.run(
+    Verify.run(
       "fixtures/spec/safe_counter.spec",
       VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None),
       log
-    )
-    assertEquals(exit, Verify.ExitOk)
+    ).assertEquals(ExitCodes.Ok)
 
   test("verify unsat_invariants returns exit 1 (violations)"):
-    val exit = Verify.run(
+    Verify.run(
       "fixtures/spec/unsat_invariants.spec",
       VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None),
       log
-    )
-    assertEquals(exit, Verify.ExitViolations)
+    ).assertEquals(ExitCodes.Violations)
 
   test("verify --dump-smt writes SMT-LIB (via dumpSmtOut)"):
-    val tmp = java.nio.file.Files.createTempFile("smt-test-", ".smt2")
-    try
-      val exit = Verify.run(
-        "fixtures/spec/safe_counter.spec",
-        VerifyOptions(0L, dumpSmt = false, dumpSmtOut = Some(tmp.toString)),
-        log
-      )
-      assertEquals(exit, Verify.ExitOk)
-      val content = java.nio.file.Files.readString(tmp)
-      assert(content.contains("(set-logic ALL)"))
-      assert(content.contains("(check-sat)"))
-    finally
-      val _ = java.nio.file.Files.deleteIfExists(tmp)
+    val acquire = IO.blocking(java.nio.file.Files.createTempFile("smt-test-", ".smt2"))
+    val release = (tmp: java.nio.file.Path) =>
+      IO.blocking(java.nio.file.Files.deleteIfExists(tmp)).void
+    cats.effect.Resource.make(acquire)(release).use: tmp =>
+      for
+        exit <- Verify.run(
+                  "fixtures/spec/safe_counter.spec",
+                  VerifyOptions(0L, dumpSmt = false, dumpSmtOut = Some(tmp.toString)),
+                  log
+                )
+        content <- IO.blocking(java.nio.file.Files.readString(tmp))
+      yield
+        assertEquals(exit, ExitCodes.Ok)
+        assert(content.contains("(set-logic ALL)"))
+        assert(content.contains("(check-sat)"))
 
   test("compile writes project files to output directory"):
-    val outDir = java.nio.file.Files.createTempDirectory("emit-test-")
-    try
-      val exit = Compile.run(
-        "fixtures/spec/url_shortener.spec",
-        CompileOptions("python-fastapi-postgres", outDir.toString),
-        log
-      )
-      assertEquals(exit, 0)
-      assert(java.nio.file.Files.exists(outDir.resolve("pyproject.toml")))
-      assert(java.nio.file.Files.exists(outDir.resolve("app/main.py")))
-      assert(java.nio.file.Files.exists(outDir.resolve("app/models/url_mapping.py")))
-      assert(java.nio.file.Files.exists(outDir.resolve(".github/workflows/ci.yml")))
-    finally
-      import scala.jdk.StreamConverters.*
-      java.nio.file.Files.walk(outDir).toScala(List).reverse.foreach: p =>
-        val _ = java.nio.file.Files.deleteIfExists(p)
+    val acquire = IO.blocking(java.nio.file.Files.createTempDirectory("emit-test-"))
+    val release = (dir: java.nio.file.Path) =>
+      IO.blocking {
+        import scala.jdk.StreamConverters.*
+        java.nio.file.Files.walk(dir).toScala(List).reverse.foreach: p =>
+          val _ = java.nio.file.Files.deleteIfExists(p)
+      }
+    cats.effect.Resource.make(acquire)(release).use: outDir =>
+      for
+        exit <- Compile.run(
+                  "fixtures/spec/url_shortener.spec",
+                  CompileOptions("python-fastapi-postgres", outDir.toString),
+                  log
+                )
+      yield
+        assertEquals(exit, ExitCodes.Ok)
+        assert(java.nio.file.Files.exists(outDir.resolve("pyproject.toml")))
+        assert(java.nio.file.Files.exists(outDir.resolve("app/main.py")))
+        assert(java.nio.file.Files.exists(outDir.resolve("app/models/url_mapping.py")))
+        assert(java.nio.file.Files.exists(outDir.resolve(".github/workflows/ci.yml")))

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -57,8 +57,9 @@ class CliSmokeTest extends CatsEffectSuite:
     val release = (dir: java.nio.file.Path) =>
       IO.blocking {
         import scala.jdk.StreamConverters.*
-        java.nio.file.Files.walk(dir).toScala(List).reverse.foreach: p =>
-          val _ = java.nio.file.Files.deleteIfExists(p)
+        scala.util.Using.resource(java.nio.file.Files.walk(dir)): stream =>
+          stream.toScala(List).reverse.foreach: p =>
+            val _ = java.nio.file.Files.deleteIfExists(p)
       }
     cats.effect.Resource.make(acquire)(release).use: outDir =>
       for

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -1,71 +1,85 @@
 package specrest.cli
 
+import cats.effect.ExitCode
+import cats.effect.IO
 import io.circe.parser
+import munit.CatsEffectSuite
 
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 import java.nio.file.Files
 
-class VerifyJsonTest extends munit.FunSuite:
+class VerifyJsonTest extends CatsEffectSuite:
 
   private def log: Logger = Logger.fromFlags(verbose = false, quiet = true)
 
-  private def captureStdout(body: => Int): (Int, String) =
-    val buf  = new ByteArrayOutputStream()
-    val ps   = new PrintStream(buf, true, "UTF-8")
-    val exit = Console.withOut(ps)(body)
-    (exit, buf.toString("UTF-8"))
+  private def captureStdout(
+      run: PrintStream => IO[ExitCode]
+  ): IO[(ExitCode, String)] =
+    IO.delay {
+      val buf = new ByteArrayOutputStream()
+      val ps  = new PrintStream(buf, true, "UTF-8")
+      (buf, ps)
+    }.flatMap: (buf, ps) =>
+      run(ps).flatTap(_ => IO.delay(ps.flush()))
+        .map(exit => (exit, buf.toString("UTF-8")))
 
   test("--json emits JSON to stdout and exits 0 on passing spec"):
-    val opts        = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
-    val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
-    assertEquals(exit, Verify.ExitOk)
-    val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
-    val cur    = parsed.hcursor
-    assertEquals(cur.downField("schemaVersion").as[Int].toOption, Some(1))
-    assertEquals(cur.downField("ok").as[Boolean].toOption, Some(true))
-    val checks = cur.downField("checks").values.getOrElse(Vector.empty).toList
-    assert(checks.nonEmpty)
-    // Contract: when outcome is `sat`, the diagnostic field is null — consumers rely on this
-    // to distinguish passing checks from failures without looking at `status` alone.
-    checks.foreach: c =>
-      val status     = c.hcursor.downField("status").as[String].toOption
-      val diagnostic = c.hcursor.downField("diagnostic").focus
-      if status.contains("sat") then
-        assertEquals(diagnostic, Some(io.circe.Json.Null), s"sat check had non-null diagnostic: $c")
+    val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    captureStdout(ps => Verify.run("fixtures/spec/safe_counter.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Ok)
+        val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+        val cur    = parsed.hcursor
+        assertEquals(cur.downField("schemaVersion").as[Int].toOption, Some(1))
+        assertEquals(cur.downField("ok").as[Boolean].toOption, Some(true))
+        val checks = cur.downField("checks").values.getOrElse(Vector.empty).toList
+        assert(checks.nonEmpty)
+        // Contract: when outcome is `sat`, the diagnostic field is null — consumers rely on this
+        // to distinguish passing checks from failures without looking at `status` alone.
+        checks.foreach: c =>
+          val status     = c.hcursor.downField("status").as[String].toOption
+          val diagnostic = c.hcursor.downField("diagnostic").focus
+          if status.contains("sat") then
+            assertEquals(
+              diagnostic,
+              Some(io.circe.Json.Null),
+              s"sat check had non-null diagnostic: $c"
+            )
 
   test("--json exits 1 on failing spec, still emits valid JSON"):
-    val opts        = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
-    val (exit, out) = captureStdout(Verify.run("fixtures/spec/unsat_invariants.spec", opts, log))
-    assertEquals(exit, Verify.ExitViolations)
-    val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
-    assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(false))
-    val categories = parsed.hcursor.downField("checks").values
-      .getOrElse(Vector.empty).toList
-      .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
-    assert(
-      categories.contains("contradictory_invariants"),
-      s"expected contradictory_invariants among $categories"
-    )
+    val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    captureStdout(ps => Verify.run("fixtures/spec/unsat_invariants.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Violations)
+        val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+        assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(false))
+        val categories = parsed.hcursor.downField("checks").values
+          .getOrElse(Vector.empty).toList
+          .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
+        assert(
+          categories.contains("contradictory_invariants"),
+          s"expected contradictory_invariants among $categories"
+        )
 
   test("--json-out writes to file; stdout stays clean"):
-    val tmp = Files.createTempFile("verify-json-", ".json")
-    try
+    val acquire = IO.blocking(Files.createTempFile("verify-json-", ".json"))
+    val release = (p: java.nio.file.Path) => IO.blocking(Files.deleteIfExists(p)).void
+    cats.effect.Resource.make(acquire)(release).use: tmp =>
       val opts = VerifyOptions(
         30_000L,
         dumpSmt = false,
         dumpSmtOut = None,
         jsonOut = Some(tmp.toString)
       )
-      val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
-      assertEquals(exit, Verify.ExitOk)
-      assertEquals(out, "", "stdout should be empty when --json-out is active")
-      val content = Files.readString(tmp)
-      val parsed  = parser.parse(content).toOption.getOrElse(fail("invalid JSON in file"))
-      assertEquals(parsed.hcursor.downField("schemaVersion").as[Int].toOption, Some(1))
-      assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(true))
-    finally
-      val _ = Files.deleteIfExists(tmp)
+      captureStdout(ps => Verify.run("fixtures/spec/safe_counter.spec", opts, log, ps))
+        .flatMap: (exit, out) =>
+          IO.blocking(Files.readString(tmp)).map: content =>
+            assertEquals(exit, ExitCodes.Ok)
+            assertEquals(out, "", "stdout should be empty when --json-out is active")
+            val parsed = parser.parse(content).toOption.getOrElse(fail("invalid JSON in file"))
+            assertEquals(parsed.hcursor.downField("schemaVersion").as[Int].toOption, Some(1))
+            assertEquals(parsed.hcursor.downField("ok").as[Boolean].toOption, Some(true))
 
   test("--json + --dump-smt is rejected with a clear error"):
     val opts = VerifyOptions(
@@ -74,9 +88,10 @@ class VerifyJsonTest extends munit.FunSuite:
       dumpSmtOut = None,
       json = true
     )
-    val (exit, out) = captureStdout(Verify.run("fixtures/spec/safe_counter.spec", opts, log))
-    assertEquals(exit, Verify.ExitViolations)
-    assertEquals(out, "", "no stdout output when the combination is rejected")
+    captureStdout(ps => Verify.run("fixtures/spec/safe_counter.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Violations)
+        assertEquals(out, "", "no stdout output when the combination is rejected")
 
   test("--json with --explain surfaces coreSpans on unsat diagnostics"):
     val opts = VerifyOptions(
@@ -86,10 +101,11 @@ class VerifyJsonTest extends munit.FunSuite:
       json = true,
       explain = true
     )
-    val (exit, out) = captureStdout(Verify.run("fixtures/spec/unsat_invariants.spec", opts, log))
-    assertEquals(exit, Verify.ExitViolations)
-    val parsed = parser.parse(out).toOption.getOrElse(fail("invalid JSON"))
-    val cores = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
-      .flatMap(_.hcursor.downField("diagnostic").downField("coreSpans").values)
-      .flatten
-    assert(cores.nonEmpty, "expected at least one coreSpan entry when --explain is set")
+    captureStdout(ps => Verify.run("fixtures/spec/unsat_invariants.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Violations)
+        val parsed = parser.parse(out).toOption.getOrElse(fail("invalid JSON"))
+        val cores = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
+          .flatMap(_.hcursor.downField("diagnostic").downField("coreSpans").values)
+          .flatten
+        assert(cores.nonEmpty, "expected at least one coreSpan entry when --explain is set")

--- a/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
+++ b/modules/verify/src/main/scala/specrest/verify/certificates/Dump.scala
@@ -19,14 +19,6 @@ private def dumpIoFail(msg: String, cause: Throwable): VerifyError.Backend =
   cause.printStackTrace(new PrintWriter(sw))
   VerifyError.Backend(s"$msg: ${cause.getMessage}", Some(sw.toString))
 
-private def renderDumpOpenMessage(error: VerifyError.Backend): String =
-  error.cause match
-    case Some(cause) => s"${error.message}\n$cause"
-    case None        => error.message
-
-final private class DumpOpenException(val error: VerifyError.Backend)
-    extends RuntimeException(renderDumpOpenMessage(error))
-
 final case class DumpEntry(
     id: String,
     tool: VerifierTool,
@@ -96,8 +88,10 @@ final class DumpSink(val dir: Path):
 
 object DumpSink:
 
-  def openResource(dir: Path): Resource[IO, DumpSink] =
-    openResource(acquireIO(dir))(sink => IO.blocking(sink.close()))
+  def openResource(dir: Path): Resource[IO, Either[VerifyError.Backend, DumpSink]] =
+    Resource.make(IO.blocking(open(dir))):
+      case Right(sink) => IO.blocking(sink.close())
+      case Left(_)     => IO.unit
 
   private[verify] def openResource(
       acquire: IO[DumpSink]
@@ -105,11 +99,6 @@ object DumpSink:
       release: DumpSink => IO[Unit]
   ): Resource[IO, DumpSink] =
     Resource.make(acquire)(release)
-
-  private def acquireIO(dir: Path): IO[DumpSink] =
-    IO.blocking(open(dir)).flatMap:
-      case Right(sink) => IO.pure(sink)
-      case Left(err)   => IO.raiseError(DumpOpenException(err))
 
   def open(dir: Path): Either[VerifyError.Backend, DumpSink] =
     try


### PR DESCRIPTION
Closes #102. Seventh step in the CE3 migration meta ([#95](https://github.com/HardMax71/spec_to_rest/issues/95)); M_CE.1-6 shipped.

## Summary

- **Main** rewritten as `CommandIOApp` (decline-effect 2.6.2). `sys.exit`, `Command.parse`, and the `Either[Help, Int]` match are gone; the base class auto-installs `run` and the JVM shutdown hook.
- Each subcommand runner (`Inspect.run`, `Check.run`, `Verify.run`, `Compile.run`) now returns `IO[ExitCode]`. 11 `unsafeRunSync` bridges in the cli module removed.
- Exit-code mapping centralized in new `ExitCodes` helper (`Ok`/`Violations`/`Translator`/`Backend`, `forVerifyError`, `forCheckResults`). `Verify.Exit*` constants retired.
- `Verify.run` gains a `stdout: PrintStream = System.out` parameter. Resolves the stdout-capture race between parallel CLI test suites by removing the global-state dependency: the test passes its own buffer PrintStream, production path defaults to `System.out`.
- Tests: `CliSmokeTest` + `VerifyJsonTest` migrate to `CatsEffectSuite`; `.assertEquals` on returned IO[ExitCode]. Temp files via `cats.effect.Resource`.

## Cancellation model, now end-to-end

With CE3 migration complete across CLI → verify → backends:

`SIGINT` → `IOApp` shutdown hook (`io-cancel-hook`) → top-level fiber `cancel` → `IO.interruptible` (M_CE.6) sends `Thread.interrupt()` into the solver thread → Alloy raises `InterruptedException`, pool shutdown interrupts Kodkod → `Resource[IO, WasmBackend]` / `Resource[IO, AlloyBackend]` finalizers close Z3 `Context` and Alloy backend → JVM exits within the 30 s grace deadline.

## Verification

- `sbt test` — 136/136 green (121 verify + 15 cli), confirmed 5/5 consecutive runs.
- `sbt scalafmtCheckAll` — clean.
- `sbt \"scalafixAll --check\"` — clean.
- `docs && npm run build` — clean.
- `rg 'sys\.exit|unsafeRunSync' modules/cli/src/main` — zero hits.
- Manual smokes: `inspect`, `check`, `verify` (passing/failing/missing), `verify --timeout 1` (Unknown outcomes fire, ok=false), `compile`, `--help`, bogus subcommand.
- Native-image: **deferred to CI** — local environment is Adoptium JDK 21, not GraalVM. CE 3.7 ships reflect-config in-jar, so no new native-image config is expected; validate on PR CI.

## Behavior delta (intentional)

- `--help` now exits `0` (POSIX convention) instead of `1`. No test/tooling depends on the prior exit code.
- Everything else is bit-identical: exit codes 0/1/2/3 on the same conditions, identical JSON report, identical help text.

## Test plan

- [ ] Full suite green on CI
- [ ] Native-image build succeeds (or PR follow-up with reflect-config additions)
- [ ] Manual: `spec-to-rest verify <heavy-spec>` and Ctrl+C exits cleanly without dangling Z3 Context
- [ ] `scalafmtCheckAll` + `scalafixAll --check` clean
- [ ] Docs build clean

## Deferred follow-ups

- **M_CE.8 (#103)** — migrate `ConsistencyTest`, `JsonReportTest`, etc. off `runConsistencyChecksSync`; delete the Sync entrypoint.
- **M_CE.9 (#104)** — JMH benchmarks; re-measure CommandIOApp cold-start (~30-60ms) on short commands.
- **SIGINT subprocess integration test** — skipped per plan Risk 4; ~40 LoC follow-up if reproducibility becomes an issue.
- **True mid-solver-call abort** via `ctx.interrupt()` — tracked in #113; unchanged by M_CE.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved signal handling (Ctrl+C) with graceful shutdown, including proper resource cleanup and a 30-second grace period before force exit.

* **Improvements**
  * Enhanced CLI exit codes that distinguish between validation violations, translator-related issues, and backend failures for better error diagnostics and scripting integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the CLI to `CommandIOApp` to remove `unsafeRunSync` bridges and wire Ctrl+C to clean fiber cancellation. Subcommands now return `IO[ExitCode]`, exits are consistent, file I/O is cancellation-safe, and tests no longer rely on global stdout.

- **Refactors**
  - Main runs via `decline-effect`’s `CommandIOApp`; no manual `sys.exit` or `Command.parse`.
  - Subcommands (`Inspect.run`, `Check.run`, `Verify.run`, `Compile.run`) return `IO[ExitCode]`.
  - File reads/writes use `IO.blocking`; `Check.readSource` returns `IO[Either[ExitCode, String]]`.
  - New `ExitCodes` helper centralizes exit mapping, plus `forVerifyError` and `forCheckResults`.
  - `Verify.run` takes `stdout: PrintStream` (default `System.out`) to avoid global state; dump/JSON paths flush explicitly.
  - VC dump lifecycle now uses `DumpSink.openResource` (returns `Resource[IO, Either[VerifyError.Backend, DumpSink]]`); removes the custom open wrapper and opaque exception, and guarantees `close()` on success and cancellation.
  - Docs: mark M_CE.7 as shipped and document the SIGINT → cancellation → cleanup path. `--help` now exits 0.

- **Bug Fixes**
  - Fixed stdout-capture race in parallel CLI tests by taking a `PrintStream` instead of rebinding `System.out`.
  - Prevent truncated output by flushing `stdout` after SMT/Alloy/JSON writes.
  - Closed `Files.walk` stream in test cleanup to avoid file-descriptor leaks.

<sup>Written for commit 1bd58e33b17a7ff3d3a4468a6d7126294156e060. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

