### PR TITLE
M_CE.8 — IO-only pipeline + test migration to CatsEffectSuite (closes #103)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -61,6 +61,7 @@ CLI output so the attribution is visible.
 | Parallel check dispatch (`parTraverseN`, `--parallel <n>`) | shipped in M_CE.5 ([#100](https://github.com/HardMax71/spec_to_rest/issues/100)) |
 | Cancellation + per-check timeout via `IO.timeoutTo` / `Resource` release | shipped in M_CE.6 ([#101](https://github.com/HardMax71/spec_to_rest/issues/101)) |
 | `spec-to-rest` as `CommandIOApp` — structured `IO[ExitCode]` subcommands, SIGINT wired to fiber cancellation | shipped in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)) |
+| Single-API pipeline — every `Parse`, `Builder`, `Translator`, `WasmBackend`, `AlloyBackend`, and `Consistency` entry point returns `IO`; synchronous wrappers removed; test suites migrated to `CatsEffectSuite` with per-module `SpecFixtures.loadIR` helpers | shipped in M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) |
 
 ## Preservation VC shape
 

--- a/fixtures/golden/verify_report/broken_url_shortener.json
+++ b/fixtures/golden/verify_report/broken_url_shortener.json
@@ -139,7 +139,7 @@
                 {
                   "name" : "click_count",
                   "value" : {
-                    "display" : "-1",
+                    "display" : "0",
                     "entityLabel" : null
                   }
                 }
@@ -153,7 +153,7 @@
                 {
                   "name" : "click_count",
                   "value" : {
-                    "display" : "99",
+                    "display" : "-100",
                     "entityLabel" : null
                   }
                 }
@@ -167,7 +167,7 @@
                 {
                   "name" : "click_count",
                   "value" : {
-                    "display" : "-1",
+                    "display" : "0",
                     "entityLabel" : null
                   }
                 }
@@ -185,8 +185,8 @@
                     "entityLabel" : null
                   },
                   "value" : {
-                    "display" : "UrlMapping#1",
-                    "entityLabel" : "UrlMapping#1"
+                    "display" : "UrlMapping#0",
+                    "entityLabel" : "UrlMapping#0"
                   }
                 }
               ]
@@ -201,8 +201,8 @@
                     "entityLabel" : null
                   },
                   "value" : {
-                    "display" : "UrlMapping#0",
-                    "entityLabel" : "UrlMapping#0"
+                    "display" : "UrlMapping#1",
+                    "entityLabel" : "UrlMapping#1"
                   }
                 }
               ]

--- a/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
@@ -1,25 +1,14 @@
 package specrest.codegen
 
+import munit.CatsEffectSuite
 import specrest.codegen.alembic.Migration
+import specrest.codegen.testutil.SpecFixtures
 import specrest.convention.ColumnSpec
 import specrest.convention.DatabaseSchema
 import specrest.convention.ForeignKeySpec
 import specrest.convention.TableSpec
-import specrest.parser.Builder
-import specrest.parser.Parse
-import specrest.profile.Annotate
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class AlembicMigrationTest extends munit.FunSuite:
-
-  private def buildProfiled(name: String): specrest.profile.ProfiledService =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+class AlembicMigrationTest extends CatsEffectSuite:
 
   test("empty schema produces empty migration"):
     val migration = Migration.buildAlembicMigration(DatabaseSchema(Nil))
@@ -104,18 +93,19 @@ class AlembicMigrationTest extends munit.FunSuite:
     assertEquals(tagsCol.saType, "postgresql.JSONB()")
 
   test("url_shortener migration has UrlMapping table with proper FK ordering"):
-    val profiled  = buildProfiled("url_shortener")
-    val migration = Migration.buildAlembicMigration(profiled.schema)
-    assert(migration.tables.nonEmpty)
-    val names = migration.tables.map(_.name)
-    assert(names.contains("url_mappings"), s"missing url_mappings in $names")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val migration = Migration.buildAlembicMigration(profiled.schema)
+      assert(migration.tables.nonEmpty)
+      val names = migration.tables.map(_.name)
+      assert(names.contains("url_mappings"), s"missing url_mappings in $names")
 
   test("emitted alembic migration file contains CREATE TABLE equivalent ops"):
-    val files         = Emit.emitProject(buildProfiled("url_shortener")).map(f => f.path -> f.content).toMap
-    val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
-    val content       = files(migrationPath)
-    assert(
-      content.contains("op.create_table"),
-      s"missing op.create_table in migration; first 500 chars: ${content.take(500)}"
-    )
-    assert(content.contains("url_mappings"), "missing url_mappings table name")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files         = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
+      val content       = files(migrationPath)
+      assert(
+        content.contains("op.create_table"),
+        s"missing op.create_table in migration; first 500 chars: ${content.take(500)}"
+      )
+      assert(content.contains("url_mappings"), "missing url_mappings table name")

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -1,79 +1,71 @@
 package specrest.codegen
 
-import specrest.parser.Builder
-import specrest.parser.Parse
-import specrest.profile.Annotate
+import munit.CatsEffectSuite
+import specrest.codegen.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class EmitTest extends munit.FunSuite:
-
-  private def buildProfiled(name: String): specrest.profile.ProfiledService =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+class EmitTest extends CatsEffectSuite:
 
   test("emitProject runs without crashing on url_shortener"):
-    val profiled = buildProfiled("url_shortener")
-    val files    = Emit.emitProject(profiled)
-    assert(files.nonEmpty, "no files emitted")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled)
+      assert(files.nonEmpty, "no files emitted")
 
   test("url_shortener emits a known file set"):
-    val profiled = buildProfiled("url_shortener")
-    val files    = Emit.emitProject(profiled).map(_.path).toSet
-    val expected = Set(
-      "app/__init__.py",
-      "app/main.py",
-      "app/config.py",
-      "app/database.py",
-      "app/db/__init__.py",
-      "app/db/base.py",
-      "app/models/__init__.py",
-      "app/schemas/__init__.py",
-      "app/routers/__init__.py",
-      "app/services/__init__.py",
-      "app/models/url_mapping.py",
-      "app/schemas/url_mapping.py",
-      "app/routers/url_mappings.py",
-      "app/services/url_mapping.py",
-      "openapi.yaml",
-      "alembic.ini",
-      "alembic/env.py",
-      "alembic/versions/001_initial_schema.py",
-      "pyproject.toml",
-      "Dockerfile",
-      "docker-compose.yml",
-      ".env.example",
-      "Makefile",
-      ".gitignore",
-      ".dockerignore",
-      "README.md",
-      ".github/workflows/ci.yml",
-      "tests/test_health.py"
-    )
-    assertEquals(files, expected)
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled).map(_.path).toSet
+      val expected = Set(
+        "app/__init__.py",
+        "app/main.py",
+        "app/config.py",
+        "app/database.py",
+        "app/db/__init__.py",
+        "app/db/base.py",
+        "app/models/__init__.py",
+        "app/schemas/__init__.py",
+        "app/routers/__init__.py",
+        "app/services/__init__.py",
+        "app/models/url_mapping.py",
+        "app/schemas/url_mapping.py",
+        "app/routers/url_mappings.py",
+        "app/services/url_mapping.py",
+        "openapi.yaml",
+        "alembic.ini",
+        "alembic/env.py",
+        "alembic/versions/001_initial_schema.py",
+        "pyproject.toml",
+        "Dockerfile",
+        "docker-compose.yml",
+        ".env.example",
+        "Makefile",
+        ".gitignore",
+        ".dockerignore",
+        "README.md",
+        ".github/workflows/ci.yml",
+        "tests/test_health.py"
+      )
+      assertEquals(files, expected)
 
   test("main.py contains FastAPI / pyproject.toml contains [project]"):
-    val files = Emit.emitProject(buildProfiled("url_shortener")).map(f => f.path -> f.content).toMap
-    assert(
-      files("app/main.py").contains("FastAPI"),
-      s"main.py missing FastAPI: ${files("app/main.py").take(200)}"
-    )
-    assert(files("pyproject.toml").contains("[project]"), s"pyproject.toml missing [project]")
-    assert(files("Dockerfile").contains("FROM"), "Dockerfile missing FROM")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      assert(
+        files("app/main.py").contains("FastAPI"),
+        s"main.py missing FastAPI: ${files("app/main.py").take(200)}"
+      )
+      assert(files("pyproject.toml").contains("[project]"), s"pyproject.toml missing [project]")
+      assert(files("Dockerfile").contains("FROM"), "Dockerfile missing FROM")
 
   test("model file contains entity name"):
-    val files = Emit.emitProject(buildProfiled("url_shortener")).map(f => f.path -> f.content).toMap
-    val model = files("app/models/url_mapping.py")
-    assert(
-      model.contains("UrlMapping"),
-      s"model missing UrlMapping class; content=${model.take(400)}"
-    )
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val model = files("app/models/url_mapping.py")
+      assert(
+        model.contains("UrlMapping"),
+        s"model missing UrlMapping class; content=${model.take(400)}"
+      )
 
   test("empty __init__.py files are actually empty"):
-    val files = Emit.emitProject(buildProfiled("url_shortener")).map(f => f.path -> f.content).toMap
-    assertEquals(files("app/__init__.py"), "")
-    assertEquals(files("app/db/__init__.py"), "")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      assertEquals(files("app/__init__.py"), "")
+      assertEquals(files("app/db/__init__.py"), "")

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -1,67 +1,57 @@
 package specrest.codegen
 
+import munit.CatsEffectSuite
 import specrest.codegen.openapi.OpenApi
-import specrest.parser.Builder
-import specrest.parser.Parse
-import specrest.profile.Annotate
+import specrest.codegen.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class OpenApiTest extends munit.FunSuite:
-
-  private def buildProfiled(name: String): specrest.profile.ProfiledService =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty)
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+class OpenApiTest extends CatsEffectSuite:
 
   test("buildOpenApiDocument returns a well-formed document"):
-    val doc = OpenApi.buildOpenApiDocument(buildProfiled("url_shortener"))
-    assertEquals(doc.openapi, "3.1.0")
-    assertEquals(doc.info.title, "UrlShortener")
-    assert(doc.paths.nonEmpty)
-    assert(doc.components.schemas.nonEmpty)
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc = OpenApi.buildOpenApiDocument(profiled)
+      assertEquals(doc.openapi, "3.1.0")
+      assertEquals(doc.info.title, "UrlShortener")
+      assert(doc.paths.nonEmpty)
+      assert(doc.components.schemas.nonEmpty)
 
   test("paths include /shorten POST + /{code} GET"):
-    val doc     = OpenApi.buildOpenApiDocument(buildProfiled("url_shortener"))
-    val shorten = doc.paths.get("/shorten").flatMap(_.post)
-    assert(shorten.isDefined, s"expected POST /shorten; paths=${doc.paths.keys}")
-    val resolve = doc.paths.get("/{code}").flatMap(_.get)
-    assert(resolve.isDefined, "expected GET /{code}")
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc     = OpenApi.buildOpenApiDocument(profiled)
+      val shorten = doc.paths.get("/shorten").flatMap(_.post)
+      assert(shorten.isDefined, s"expected POST /shorten; paths=${doc.paths.keys}")
+      val resolve = doc.paths.get("/{code}").flatMap(_.get)
+      assert(resolve.isDefined, "expected GET /{code}")
 
   test("components include Create / Read / Update schemas + ErrorResponse"):
-    val doc  = OpenApi.buildOpenApiDocument(buildProfiled("url_shortener"))
-    val keys = doc.components.schemas.keySet
-    assert(keys.contains("UrlMappingCreate"))
-    assert(keys.contains("UrlMappingRead"))
-    assert(keys.contains("UrlMappingUpdate"))
-    assert(keys.contains("ErrorResponse"))
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc  = OpenApi.buildOpenApiDocument(profiled)
+      val keys = doc.components.schemas.keySet
+      assert(keys.contains("UrlMappingCreate"))
+      assert(keys.contains("UrlMappingRead"))
+      assert(keys.contains("UrlMappingUpdate"))
+      assert(keys.contains("ErrorResponse"))
 
   test("serialized YAML produces valid OpenAPI 3.1"):
-    val doc  = OpenApi.buildOpenApiDocument(buildProfiled("url_shortener"))
-    val yaml = OpenApi.serialize(doc)
-    assert(yaml.startsWith("openapi:"))
-    assert(yaml.contains("3.1.0"))
-    assert(yaml.contains("paths:"))
-    assert(yaml.contains("components:"))
-    assert(yaml.contains("UrlMappingRead"))
-    assert(yaml.contains("$ref: '#/components/schemas/UrlMappingCreate'"))
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc  = OpenApi.buildOpenApiDocument(profiled)
+      val yaml = OpenApi.serialize(doc)
+      assert(yaml.startsWith("openapi:"))
+      assert(yaml.contains("3.1.0"))
+      assert(yaml.contains("paths:"))
+      assert(yaml.contains("components:"))
+      assert(yaml.contains("UrlMappingRead"))
+      assert(yaml.contains("$ref: '#/components/schemas/UrlMappingCreate'"))
 
   test("omits absent Option fields from serialized YAML"):
-    // Scala's None values should NOT emit `field: null` — those are supposed to be omitted.
-    // (The literal string `null` may still appear as a type marker in OpenAPI 3.1 nullable
-    // schemas like `type: [string, null]` — that's correct per spec.)
-    val doc  = OpenApi.buildOpenApiDocument(buildProfiled("url_shortener"))
-    val yaml = OpenApi.serialize(doc)
-    // No field should serialize as `key: null` (absent Options must be omitted, not nulled).
-    val nullField = """^\s+\w+:\s+null\s*$""".r
-    yaml.split("\n").foreach: line =>
-      assert(
-        nullField.findFirstIn(line).isEmpty,
-        s"unexpected null-valued field: '$line'"
-      )
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc       = OpenApi.buildOpenApiDocument(profiled)
+      val yaml      = OpenApi.serialize(doc)
+      val nullField = """^\s+\w+:\s+null\s*$""".r
+      yaml.split("\n").foreach: line =>
+        assert(
+          nullField.findFirstIn(line).isEmpty,
+          s"unexpected null-valued field: '$line'"
+        )
 
   test("enum / null key names renamed correctly"):
     import specrest.codegen.openapi.*

--- a/modules/codegen/src/test/scala/specrest/codegen/testutil/SpecFixtures.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/testutil/SpecFixtures.scala
@@ -1,0 +1,33 @@
+package specrest.codegen.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.profile.Annotate
+import specrest.profile.ProfiledService
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)
+
+  def loadProfiled(
+      name: String,
+      target: String = "python-fastapi-postgres"
+  ): IO[ProfiledService] =
+    loadIR(name).map(ir => Annotate.buildProfiledService(ir, target))

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -1,14 +1,14 @@
 package specrest.convention
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
+import specrest.convention.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Path as JPath
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.*
 
-class ConventionSmokeTest extends munit.FunSuite:
+class ConventionSmokeTest extends CatsEffectSuite:
 
   private val specDir: JPath = Paths.get("fixtures/spec")
 
@@ -20,45 +20,39 @@ class ConventionSmokeTest extends munit.FunSuite:
         .sortBy(_.getFileName.toString)
     else Nil
 
-  private def buildFixture(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
-
-  test("classify + derive + validate runs for every fixture"):
-    fixtures.foreach: fixture =>
-      val name            = fixture.getFileName.toString.stripSuffix(".spec")
-      val ir              = buildFixture(name)
-      val classifications = Classify.classifyOperations(ir)
-      val endpoints       = Path.deriveEndpoints(classifications, ir)
-      val schema          = Schema.deriveSchema(ir)
-      val diagnostics     = Validate.validateConventions(ir.conventions, ir)
-      assertEquals(classifications.size, ir.operations.size, s"$name classifications")
-      assertEquals(endpoints.size, ir.operations.size, s"$name endpoints")
-      assert(schema.tables.nonEmpty || ir.entities.isEmpty, s"$name schema")
-      val _ = diagnostics
+  fixtures.foreach: fixture =>
+    val name = fixture.getFileName.toString.stripSuffix(".spec")
+    test(s"classify + derive + validate for $name"):
+      SpecFixtures.loadIR(name).map: ir =>
+        val classifications = Classify.classifyOperations(ir)
+        val endpoints       = Path.deriveEndpoints(classifications, ir)
+        val schema          = Schema.deriveSchema(ir)
+        val diagnostics     = Validate.validateConventions(ir.conventions, ir)
+        assertEquals(classifications.size, ir.operations.size, s"$name classifications")
+        assertEquals(endpoints.size, ir.operations.size, s"$name endpoints")
+        assert(schema.tables.nonEmpty || ir.entities.isEmpty, s"$name schema")
+        val _ = diagnostics
 
   test("url_shortener endpoints match expected verbs / paths / statuses"):
-    val ir              = buildFixture("url_shortener")
-    val classifications = Classify.classifyOperations(ir)
-    val endpoints       = Path.deriveEndpoints(classifications, ir).map(e => e.operationName -> e).toMap
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      val classifications = Classify.classifyOperations(ir)
+      val endpoints       = Path.deriveEndpoints(classifications, ir).map(e => e.operationName -> e).toMap
 
-    assertEquals(endpoints("Shorten").method, HttpMethod.POST)
-    assertEquals(endpoints("Shorten").path, "/shorten")
-    assertEquals(endpoints("Shorten").successStatus, 201)
+      assertEquals(endpoints("Shorten").method, HttpMethod.POST)
+      assertEquals(endpoints("Shorten").path, "/shorten")
+      assertEquals(endpoints("Shorten").successStatus, 201)
 
-    assertEquals(endpoints("Resolve").method, HttpMethod.GET)
-    assertEquals(endpoints("Resolve").path, "/{code}")
-    assertEquals(endpoints("Resolve").successStatus, 302)
+      assertEquals(endpoints("Resolve").method, HttpMethod.GET)
+      assertEquals(endpoints("Resolve").path, "/{code}")
+      assertEquals(endpoints("Resolve").successStatus, 302)
 
-    assertEquals(endpoints("Delete").method, HttpMethod.DELETE)
-    assertEquals(endpoints("Delete").path, "/{code}")
-    assertEquals(endpoints("Delete").successStatus, 204)
+      assertEquals(endpoints("Delete").method, HttpMethod.DELETE)
+      assertEquals(endpoints("Delete").path, "/{code}")
+      assertEquals(endpoints("Delete").successStatus, 204)
 
-    assertEquals(endpoints("ListAll").method, HttpMethod.GET)
-    assertEquals(endpoints("ListAll").path, "/urls")
-    assertEquals(endpoints("ListAll").successStatus, 200)
+      assertEquals(endpoints("ListAll").method, HttpMethod.GET)
+      assertEquals(endpoints("ListAll").path, "/urls")
+      assertEquals(endpoints("ListAll").successStatus, 200)
 
   test("naming helpers"):
     assertEquals(Naming.pluralize("user"), "users")

--- a/modules/convention/src/test/scala/specrest/convention/testutil/SpecFixtures.scala
+++ b/modules/convention/src/test/scala/specrest/convention/testutil/SpecFixtures.scala
@@ -1,0 +1,25 @@
+package specrest.convention.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -56,11 +56,10 @@ extension [A, B](list: List[A])
 
 object Builder:
   def buildIR(tree: SpecFileContext): IO[Either[VerifyError.Build, ServiceIR]] =
-    IO.delay(buildIRSync(tree))
-
-  private[specrest] def buildIRSync(tree: SpecFileContext): Either[VerifyError.Build, ServiceIR] =
-    val imports = tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
-    new IRBuilder().buildService(tree.serviceDecl).map(_.copy(imports = imports))
+    IO.delay {
+      val imports = tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
+      new IRBuilder().buildService(tree.serviceDecl).map(_.copy(imports = imports))
+    }
 
 final private case class ServiceAcc(
     entities: List[EntityDecl] = Nil,

--- a/modules/parser/src/main/scala/specrest/parser/Parse.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Parse.scala
@@ -16,31 +16,30 @@ final case class ParseResult(tree: SpecParser.SpecFileContext, errors: List[Pars
 object Parse:
 
   def parseSpec(input: String): IO[Either[VerifyError.Parse, ParseResult]] =
-    IO.delay(parseSpecSync(input)).map: r =>
-      if r.errors.isEmpty then Right(r) else Left(VerifyError.Parse(r.errors))
+    IO.delay {
+      val chars  = CharStreams.fromString(input)
+      val lexer  = new SpecLexer(chars)
+      val tokens = new CommonTokenStream(lexer)
+      val parser = new SpecParser(tokens)
 
-  private[specrest] def parseSpecSync(input: String): ParseResult =
-    val chars  = CharStreams.fromString(input)
-    val lexer  = new SpecLexer(chars)
-    val tokens = new CommonTokenStream(lexer)
-    val parser = new SpecParser(tokens)
+      val errors = scala.collection.mutable.ListBuffer.empty[ParseError]
+      val listener: BaseErrorListener = new BaseErrorListener:
+        override def syntaxError(
+            recognizer: Recognizer[?, ?],
+            offendingSymbol: Any,
+            line: Int,
+            column: Int,
+            msg: String,
+            e: RecognitionException
+        ): Unit =
+          errors += ParseError(line, column, msg)
 
-    val errors = scala.collection.mutable.ListBuffer.empty[ParseError]
-    val listener: BaseErrorListener = new BaseErrorListener:
-      override def syntaxError(
-          recognizer: Recognizer[?, ?],
-          offendingSymbol: Any,
-          line: Int,
-          column: Int,
-          msg: String,
-          e: RecognitionException
-      ): Unit =
-        errors += ParseError(line, column, msg)
+      lexer.removeErrorListeners()
+      parser.removeErrorListeners()
+      lexer.addErrorListener(listener)
+      parser.addErrorListener(listener)
 
-    lexer.removeErrorListeners()
-    parser.removeErrorListeners()
-    lexer.addErrorListener(listener)
-    parser.addErrorListener(listener)
-
-    val tree = parser.specFile()
-    ParseResult(tree, errors.toList)
+      val tree   = parser.specFile()
+      val result = ParseResult(tree, errors.toList)
+      if result.errors.isEmpty then Right(result) else Left(VerifyError.Parse(result.errors))
+    }

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -1,13 +1,16 @@
 package specrest.parser
 
+import cats.effect.IO
+import munit.CatsEffectSuite
 import specrest.ir.Serialize
+import specrest.parser.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.*
 
-class ParseBuildGoldenTest extends munit.FunSuite:
+class ParseBuildGoldenTest extends CatsEffectSuite:
 
   private val specDir: Path   = Paths.get("fixtures/spec")
   private val goldenDir: Path = Paths.get("fixtures/golden/ir")
@@ -29,13 +32,11 @@ class ParseBuildGoldenTest extends munit.FunSuite:
     val goldenPath = goldenDir.resolve(s"$name.json")
     test(s"parse + build + serialize matches golden — $name"):
       assert(Files.exists(goldenPath), s"Missing golden for $name at $goldenPath")
-      val source = Files.readString(specPath)
-      val parsed = Parse.parseSpecSync(source)
-      assert(parsed.errors.isEmpty, s"Parse errors for $name: ${parsed.errors}")
-      val ir         = Builder.buildIRSync(parsed.tree).toOption.get
-      val emittedDom = Serialize.toJson(ir)
-      val goldenRaw  = Files.readString(goldenPath)
-      val goldenDom = io.circe.parser.parse(goldenRaw) match
-        case Right(j)  => j
-        case Left(err) => fail(s"failed to parse golden $name: $err")
-      assertEquals(emittedDom, goldenDom, s"IR DOM differs from golden for $name")
+      for
+        ir        <- SpecFixtures.loadIR(name)
+        emittedDom = Serialize.toJson(ir)
+        goldenRaw <- IO.blocking(Files.readString(goldenPath))
+        goldenDom <-
+          IO.fromEither(io.circe.parser.parse(goldenRaw))
+            .adaptError(e => new AssertionError(s"failed to parse golden $name: $e"))
+      yield assertEquals(emittedDom, goldenDom, s"IR DOM differs from golden for $name")

--- a/modules/parser/src/test/scala/specrest/parser/testutil/SpecFixtures.scala
+++ b/modules/parser/src/test/scala/specrest/parser/testutil/SpecFixtures.scala
@@ -1,0 +1,25 @@
+package specrest.parser.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)

--- a/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/ProfileSmokeTest.scala
@@ -1,18 +1,24 @@
 package specrest.profile
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
+import specrest.profile.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
+class ProfileSmokeTest extends CatsEffectSuite:
 
-class ProfileSmokeTest extends munit.FunSuite:
-
-  private def buildFixture(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+  private val allFixtures: List[String] = List(
+    "auth_service",
+    "broken_decrement",
+    "broken_url_shortener",
+    "convention_errors",
+    "dead_op",
+    "ecommerce",
+    "edge_cases",
+    "safe_counter",
+    "todo_list",
+    "unreachable_op",
+    "unsat_invariants",
+    "url_shortener"
+  )
 
   test("registry lists python-fastapi-postgres"):
     assert(Registry.listProfiles.contains("python-fastapi-postgres"))
@@ -26,48 +32,34 @@ class ProfileSmokeTest extends munit.FunSuite:
       Registry.getProfile("rust-actix-sqlite")
 
   test("url_shortener profiled service has expected shape"):
-    val ir = buildFixture("url_shortener")
-    val ps = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      val ps = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
 
-    assertEquals(ps.operations.size, ir.operations.size)
-    assertEquals(ps.entities.size, ir.entities.size)
-    assert(ps.schema.tables.nonEmpty)
-    assert(ps.endpoints.nonEmpty)
+      assertEquals(ps.operations.size, ir.operations.size)
+      assertEquals(ps.entities.size, ir.entities.size)
+      assert(ps.schema.tables.nonEmpty)
+      assert(ps.endpoints.nonEmpty)
 
-    val urlMapping = ps.entities.find(_.entityName == "UrlMapping").get
-    assertEquals(urlMapping.tableName, "url_mappings")
-    assertEquals(urlMapping.modelFileName, "url_mapping.py")
-    assertEquals(urlMapping.routerFileName, "url_mappings.py")
-    assertEquals(urlMapping.createSchemaName, "UrlMappingCreate")
-    assertEquals(urlMapping.readSchemaName, "UrlMappingRead")
+      val urlMapping = ps.entities.find(_.entityName == "UrlMapping").get
+      assertEquals(urlMapping.tableName, "url_mappings")
+      assertEquals(urlMapping.modelFileName, "url_mapping.py")
+      assertEquals(urlMapping.routerFileName, "url_mappings.py")
+      assertEquals(urlMapping.createSchemaName, "UrlMappingCreate")
+      assertEquals(urlMapping.readSchemaName, "UrlMappingRead")
 
   test("profiled field types map to python primitives"):
-    val ir         = buildFixture("url_shortener")
-    val ps         = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-    val urlMapping = ps.entities.find(_.entityName == "UrlMapping").get
-    val clickCount = urlMapping.fields.find(_.fieldName == "click_count").get
-    assertEquals(clickCount.pythonType, "int")
-    assertEquals(clickCount.pydanticType, "int")
-    assertEquals(clickCount.sqlalchemyColumnType, "Integer")
-    assertEquals(clickCount.columnName, "click_count")
-    assertEquals(clickCount.nullable, false)
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      val ps         = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+      val urlMapping = ps.entities.find(_.entityName == "UrlMapping").get
+      val clickCount = urlMapping.fields.find(_.fieldName == "click_count").get
+      assertEquals(clickCount.pythonType, "int")
+      assertEquals(clickCount.pydanticType, "int")
+      assertEquals(clickCount.sqlalchemyColumnType, "Integer")
+      assertEquals(clickCount.columnName, "click_count")
+      assertEquals(clickCount.nullable, false)
 
-  test("all fixtures build profiled services without exceptions"):
-    val names = List(
-      "auth_service",
-      "broken_decrement",
-      "broken_url_shortener",
-      "convention_errors",
-      "dead_op",
-      "ecommerce",
-      "edge_cases",
-      "safe_counter",
-      "todo_list",
-      "unreachable_op",
-      "unsat_invariants",
-      "url_shortener"
-    )
-    names.foreach: n =>
-      val ir = buildFixture(n)
-      val ps = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-      assertEquals(ps.ir.name, ir.name, s"fixture $n")
+  allFixtures.foreach: n =>
+    test(s"fixture $n builds a profiled service"):
+      SpecFixtures.loadIR(n).map: ir =>
+        val ps = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+        assertEquals(ps.ir.name, ir.name, s"fixture $n")

--- a/modules/profile/src/test/scala/specrest/profile/testutil/SpecFixtures.scala
+++ b/modules/profile/src/test/scala/specrest/profile/testutil/SpecFixtures.scala
@@ -1,0 +1,25 @@
+package specrest.profile.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -17,8 +17,6 @@ import specrest.verify.z3.WasmBackend
 import specrest.verify.z3.Z3CounterExample
 import specrest.verify.z3.Z3Script
 
-import scala.concurrent.duration.*
-
 enum CheckKind:
   case Global, Requires, Enabled, Preservation, Temporal
 
@@ -70,64 +68,6 @@ object Consistency:
     case Preservation(ir: ServiceIR, op: OperationDecl, inv: NamedInvariant)
     case Temporal(ir: ServiceIR, decl: TemporalDecl)
 
-  final private case class PlanMetadata(
-      id: String,
-      kind: CheckKind,
-      tool: VerifierTool,
-      operationName: Option[String],
-      invariantName: Option[String],
-      sourceSpans: List[Span]
-  )
-
-  // Single source of truth for plan → (id, kind, tool, op, inv, spans). The run* methods
-  // below redundantly derive matching values inline; keep both in sync. TimeoutTest's
-  // parity assertions exercise the cross-path agreement.
-  private def metadataFor(plan: CheckPlan): PlanMetadata = plan match
-    case CheckPlan.Global(ir) =>
-      PlanMetadata(
-        id = "global",
-        kind = CheckKind.Global,
-        tool = Classifier.classifyGlobal(ir),
-        operationName = None,
-        invariantName = None,
-        sourceSpans = ir.invariants.flatMap(_.span)
-      )
-    case CheckPlan.Op(ir, op, k) =>
-      val kindStr = k match
-        case CheckKind.Requires => "requires"
-        case CheckKind.Enabled  => "enabled"
-        case _                  => "?"
-      val tool = k match
-        case CheckKind.Requires => Classifier.classifyRequires(op)
-        case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
-        case _                  => VerifierTool.Z3
-      PlanMetadata(
-        id = s"${op.name}.$kindStr",
-        kind = k,
-        tool = tool,
-        operationName = Some(op.name),
-        invariantName = None,
-        sourceSpans = operationCheckSpans(op, k, ir)
-      )
-    case CheckPlan.Preservation(_, op, inv) =>
-      PlanMetadata(
-        id = s"${op.name}.preserves.${inv.name}",
-        kind = CheckKind.Preservation,
-        tool = Classifier.classifyPreservation(op, inv.decl),
-        operationName = Some(op.name),
-        invariantName = Some(inv.name),
-        sourceSpans = preservationSpans(op, inv.decl)
-      )
-    case CheckPlan.Temporal(_, decl) =>
-      PlanMetadata(
-        id = s"temporal.${decl.name}",
-        kind = CheckKind.Temporal,
-        tool = VerifierTool.Alloy,
-        operationName = None,
-        invariantName = Some(decl.name),
-        sourceSpans = decl.span.toList
-      )
-
   def runConsistencyChecks(
       ir: ServiceIR,
       config: VerificationConfig,
@@ -136,34 +76,13 @@ object Consistency:
     val plans = planChecks(ir)
     val results: IO[List[CheckResult]] =
       if config.maxParallel <= 1 then
-        if config.timeoutMs <= 0 then
-          backendsResource.use: (wasm, alloy) =>
-            plans.traverse(p => runOne(p, wasm, alloy, config, dump))
-        else
-          // With per-check timeouts, a cancelled IO.interruptible may leave a native
-          // solver thread still running on its Z3 Context (Z3's solver.check does not
-          // observe Thread.isInterrupted). Allocating backends per plan guarantees the
-          // next plan uses a fresh, uncontested Context instead of racing with the
-          // timed-out thread on a shared one (Context is not thread-safe).
-          plans.traverse: plan =>
-            backendsResource.use: (wasm, alloy) =>
-              runOne(plan, wasm, alloy, config, dump)
+        backendsResource.use: (wasm, alloy) =>
+          plans.traverse(p => executePlan(p, wasm, alloy, config, dump))
       else
         plans.parTraverseN(config.maxParallel): plan =>
           backendsResource.use: (wasm, alloy) =>
-            runOne(plan, wasm, alloy, config, dump)
+            executePlan(plan, wasm, alloy, config, dump)
     results.map(reportFromResults)
-
-  private def runOne(
-      plan: CheckPlan,
-      backend: WasmBackend,
-      alloyBackend: AlloyBackend,
-      config: VerificationConfig,
-      dump: Option[DumpSink]
-  ): IO[CheckResult] =
-    val io = executePlan(plan, backend, alloyBackend, config, dump)
-    if config.timeoutMs <= 0 then io
-    else io.timeoutTo(config.timeoutMs.millis, IO.pure(timeoutFallback(plan, config)))
 
   private def backendsResource: cats.effect.Resource[IO, (WasmBackend, AlloyBackend)] =
     for
@@ -206,30 +125,6 @@ object Consistency:
       c.status == CheckOutcome.Sat || c.status == CheckOutcome.Skipped
     )
     ConsistencyReport(results, ok)
-
-  private def timeoutFallback(plan: CheckPlan, config: VerificationConfig): CheckResult =
-    val meta = metadataFor(plan)
-    val diagnostic = VerificationDiagnostic(
-      level = DiagnosticLevel.Error,
-      category = DiagnosticCategory.SolverTimeout,
-      message = s"outer timeout on check '${meta.id}': fired at ${config.timeoutMs}ms",
-      primarySpan = meta.sourceSpans.headOption,
-      relatedSpans = Nil,
-      counterexample = None,
-      suggestion = Diagnostic.suggestionFor(DiagnosticCategory.SolverTimeout)
-    )
-    CheckResult(
-      id = meta.id,
-      kind = meta.kind,
-      tool = meta.tool,
-      operationName = meta.operationName,
-      invariantName = meta.invariantName,
-      status = CheckOutcome.Unknown,
-      durationMs = config.timeoutMs.toDouble,
-      detail = Some(s"outer timeout: ${config.timeoutMs}ms"),
-      sourceSpans = meta.sourceSpans,
-      diagnostic = Some(diagnostic)
-    )
 
   private def dumpZ3(
       dump: Option[DumpSink],

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -130,15 +130,6 @@ object Consistency:
 
   def runConsistencyChecks(
       ir: ServiceIR,
-      backend: WasmBackend,
-      config: VerificationConfig,
-      dump: Option[DumpSink]
-  ): IO[ConsistencyReport] =
-    AlloyBackend.make.use: alloyBackend =>
-      IO.delay(runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump))
-
-  def runConsistencyChecks(
-      ir: ServiceIR,
       config: VerificationConfig,
       dump: Option[DumpSink] = None
   ): IO[ConsistencyReport] =
@@ -170,7 +161,7 @@ object Consistency:
       config: VerificationConfig,
       dump: Option[DumpSink]
   ): IO[CheckResult] =
-    val io = IO.interruptible(executePlan(plan, backend, alloyBackend, config, dump))
+    val io = executePlan(plan, backend, alloyBackend, config, dump)
     if config.timeoutMs <= 0 then io
     else io.timeoutTo(config.timeoutMs.millis, IO.pure(timeoutFallback(plan, config)))
 
@@ -179,31 +170,6 @@ object Consistency:
       wasm  <- WasmBackend.make
       alloy <- AlloyBackend.make
     yield (wasm, alloy)
-
-  def runConsistencyChecksSync(
-      ir: ServiceIR,
-      backend: WasmBackend,
-      config: VerificationConfig,
-      dump: Option[DumpSink] = None
-  ): ConsistencyReport =
-    var allocated: Option[AlloyBackend] = None
-    lazy val alloyBackend =
-      val backend = new AlloyBackend
-      allocated = Some(backend)
-      backend
-    try runConsistencyChecksWithAlloy(ir, backend, alloyBackend, config, dump)
-    finally allocated.foreach(_.close())
-
-  private def runConsistencyChecksWithAlloy(
-      ir: ServiceIR,
-      backend: WasmBackend,
-      alloyBackend: => AlloyBackend,
-      config: VerificationConfig,
-      dump: Option[DumpSink]
-  ): ConsistencyReport =
-    val plans   = planChecks(ir)
-    val results = plans.map(p => executePlan(p, backend, alloyBackend, config, dump))
-    reportFromResults(results)
 
   private def planChecks(ir: ServiceIR): List[CheckPlan] =
     val builder = List.newBuilder[CheckPlan]
@@ -222,10 +188,10 @@ object Consistency:
   private def executePlan(
       plan: CheckPlan,
       backend: WasmBackend,
-      alloyBackend: => AlloyBackend,
+      alloyBackend: AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
-  ): CheckResult = plan match
+  ): IO[CheckResult] = plan match
     case CheckPlan.Global(ir) =>
       runGlobal(ir, backend, alloyBackend, config, dump)
     case CheckPlan.Op(ir, op, kind) =>
@@ -346,62 +312,62 @@ object Consistency:
       alloyBackend: AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
-  ): CheckResult =
+  ): IO[CheckResult] =
     val sourceSpans = ir.invariants.flatMap(_.span)
     val tool        = Classifier.classifyGlobal(ir)
     if tool == VerifierTool.Alloy then
-      return runGlobalAlloy(ir, alloyBackend, config, sourceSpans, dump)
-    Translator.translateSync(ir) match
-      case Left(err) =>
-        skippedCheck(
-          "global",
-          CheckKind.Global,
-          tool,
-          None,
-          None,
-          sourceSpans,
-          DiagnosticCategory.TranslatorLimitation,
-          err.message
-        )
-      case Right(script) =>
-        backend.checkSync(script, config) match
-          case Left(err) =>
-            skippedCheck(
-              "global",
-              CheckKind.Global,
-              tool,
-              None,
-              None,
-              sourceSpans,
-              DiagnosticCategory.BackendError,
-              err.message
-            )
-          case Right(result) =>
-            val outcome = CheckOutcome.fromStatus(result.status)
-            dumpZ3(
-              dump,
-              "global",
-              script,
-              config.timeoutMs,
-              outcome,
-              result.status,
-              result.durationMs
-            )
-            finalizeCheck(FinalizeArgs(
-              id = "global",
-              kind = CheckKind.Global,
-              tool = tool,
-              operationName = None,
-              invariantName = None,
-              rawStatus = result.status,
-              outcome = outcome,
-              durationMs = result.durationMs,
-              sourceSpans = sourceSpans,
-              ir = ir,
-              invariantDecl = None,
-              op = None,
-              coreSpans = z3CoreSpans(script, result, CheckKind.Global)
-            ))
+      runGlobalAlloy(ir, alloyBackend, config, sourceSpans, dump)
+    else
+      Translator.translate(ir).flatMap:
+        case Left(err) =>
+          IO.pure(skippedCheck(
+            "global",
+            CheckKind.Global,
+            tool,
+            None,
+            None,
+            sourceSpans,
+            DiagnosticCategory.TranslatorLimitation,
+            err.message
+          ))
+        case Right(script) =>
+          backend.check(script, config).flatMap:
+            case Left(err) =>
+              IO.pure(skippedCheck(
+                "global",
+                CheckKind.Global,
+                tool,
+                None,
+                None,
+                sourceSpans,
+                DiagnosticCategory.BackendError,
+                err.message
+              ))
+            case Right(result) =>
+              val outcome = CheckOutcome.fromStatus(result.status)
+              IO.blocking(dumpZ3(
+                dump,
+                "global",
+                script,
+                config.timeoutMs,
+                outcome,
+                result.status,
+                result.durationMs
+              )).as(finalizeCheck(FinalizeArgs(
+                id = "global",
+                kind = CheckKind.Global,
+                tool = tool,
+                operationName = None,
+                invariantName = None,
+                rawStatus = result.status,
+                outcome = outcome,
+                durationMs = result.durationMs,
+                sourceSpans = sourceSpans,
+                ir = ir,
+                invariantDecl = None,
+                op = None,
+                coreSpans = z3CoreSpans(script, result, CheckKind.Global)
+              )))
 
   private def runGlobalAlloy(
       ir: ServiceIR,
@@ -409,10 +375,10 @@ object Consistency:
       config: VerificationConfig,
       sourceSpans: List[Span],
       dump: Option[DumpSink]
-  ): CheckResult =
-    AlloyTranslator.translateGlobalSync(ir, config.alloyScope) match
+  ): IO[CheckResult] =
+    AlloyTranslator.translateGlobal(ir, config.alloyScope).flatMap:
       case Left(err) =>
-        skippedCheck(
+        IO.pure(skippedCheck(
           "global",
           CheckKind.Global,
           VerifierTool.Alloy,
@@ -421,17 +387,17 @@ object Consistency:
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
           err.message
-        )
+        ))
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.checkSync(
+        alloyBackend.check(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
           captureCore = config.captureCore
-        ) match
+        ).flatMap:
           case Left(err) =>
-            skippedCheck(
+            IO.pure(skippedCheck(
               "global",
               CheckKind.Global,
               VerifierTool.Alloy,
@@ -440,11 +406,12 @@ object Consistency:
               sourceSpans,
               DiagnosticCategory.BackendError,
               err.message
-            )
+            ))
           case Right(result) =>
             val outcome = CheckOutcome.fromStatus(result.status)
-            dumpAlloy(dump, "global", rendered.source, outcome, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
+            IO.blocking(
+              dumpAlloy(dump, "global", rendered.source, outcome, result.status, result.durationMs)
+            ).as(finalizeCheck(FinalizeArgs(
               id = "global",
               kind = CheckKind.Global,
               tool = VerifierTool.Alloy,
@@ -458,7 +425,7 @@ object Consistency:
               invariantDecl = None,
               op = None,
               coreSpans = alloyCoreSpans(rendered, result, CheckKind.Global)
-            ))
+            )))
 
   private def runOperationCheck(
       ir: ServiceIR,
@@ -468,7 +435,7 @@ object Consistency:
       alloyBackend: AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
-  ): CheckResult =
+  ): IO[CheckResult] =
     val kindStr = kind match
       case CheckKind.Requires => "requires"
       case CheckKind.Enabled  => "enabled"
@@ -480,55 +447,65 @@ object Consistency:
       case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
       case _                  => VerifierTool.Z3
     if tool == VerifierTool.Alloy then
-      return runOperationAlloy(ir, op, kind, alloyBackend, config, id, sourceSpans, dump)
-    val scriptE: Either[VerifyError.Translator, Z3Script] = kind match
-      case CheckKind.Requires => Translator.translateOperationRequiresSync(ir, op)
-      case CheckKind.Enabled  => Translator.translateOperationEnabledSync(ir, op)
-      case _ =>
-        Left(VerifyError.Translator(s"runOperationCheck: unexpected kind $kind"))
-    scriptE match
-      case Left(err) =>
-        skippedCheck(
-          id,
-          kind,
-          tool,
-          Some(op.name),
-          None,
-          sourceSpans,
-          DiagnosticCategory.TranslatorLimitation,
-          err.message
-        )
-      case Right(script) =>
-        backend.checkSync(script, config) match
-          case Left(err) =>
-            skippedCheck(
-              id,
-              kind,
-              tool,
-              Some(op.name),
-              None,
-              sourceSpans,
-              DiagnosticCategory.BackendError,
-              err.message
-            )
-          case Right(result) =>
-            val outcome = CheckOutcome.fromStatus(result.status)
-            dumpZ3(dump, id, script, config.timeoutMs, outcome, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
-              id = id,
-              kind = kind,
-              tool = tool,
-              operationName = Some(op.name),
-              invariantName = None,
-              rawStatus = result.status,
-              outcome = outcome,
-              durationMs = result.durationMs,
-              sourceSpans = sourceSpans,
-              ir = ir,
-              invariantDecl = None,
-              op = Some(op),
-              coreSpans = z3CoreSpans(script, result, kind)
-            ))
+      runOperationAlloy(ir, op, kind, alloyBackend, config, id, sourceSpans, dump)
+    else
+      val scriptIO: IO[Either[VerifyError.Translator, Z3Script]] = kind match
+        case CheckKind.Requires => Translator.translateOperationRequires(ir, op)
+        case CheckKind.Enabled  => Translator.translateOperationEnabled(ir, op)
+        case _ =>
+          IO.pure(Left(VerifyError.Translator(s"runOperationCheck: unexpected kind $kind")))
+      scriptIO.flatMap:
+        case Left(err) =>
+          IO.pure(skippedCheck(
+            id,
+            kind,
+            tool,
+            Some(op.name),
+            None,
+            sourceSpans,
+            DiagnosticCategory.TranslatorLimitation,
+            err.message
+          ))
+        case Right(script) =>
+          backend.check(script, config).flatMap:
+            case Left(err) =>
+              IO.pure(skippedCheck(
+                id,
+                kind,
+                tool,
+                Some(op.name),
+                None,
+                sourceSpans,
+                DiagnosticCategory.BackendError,
+                err.message
+              ))
+            case Right(result) =>
+              val outcome = CheckOutcome.fromStatus(result.status)
+              IO.blocking(
+                dumpZ3(
+                  dump,
+                  id,
+                  script,
+                  config.timeoutMs,
+                  outcome,
+                  result.status,
+                  result.durationMs
+                )
+              ).as(finalizeCheck(FinalizeArgs(
+                id = id,
+                kind = kind,
+                tool = tool,
+                operationName = Some(op.name),
+                invariantName = None,
+                rawStatus = result.status,
+                outcome = outcome,
+                durationMs = result.durationMs,
+                sourceSpans = sourceSpans,
+                ir = ir,
+                invariantDecl = None,
+                op = Some(op),
+                coreSpans = z3CoreSpans(script, result, kind)
+              )))
 
   private def runOperationAlloy(
       ir: ServiceIR,
@@ -539,17 +516,17 @@ object Consistency:
       id: String,
       sourceSpans: List[Span],
       dump: Option[DumpSink]
-  ): CheckResult =
-    val moduleE: Either[VerifyError.AlloyTranslator, AlloyModule] = kind match
+  ): IO[CheckResult] =
+    val moduleIO: IO[Either[VerifyError.AlloyTranslator, AlloyModule]] = kind match
       case CheckKind.Requires =>
-        AlloyTranslator.translateOperationRequiresSync(ir, op, config.alloyScope)
+        AlloyTranslator.translateOperationRequires(ir, op, config.alloyScope)
       case CheckKind.Enabled =>
-        AlloyTranslator.translateOperationEnabledSync(ir, op, config.alloyScope)
+        AlloyTranslator.translateOperationEnabled(ir, op, config.alloyScope)
       case _ =>
-        Left(VerifyError.AlloyTranslator(s"runOperationAlloy: unexpected kind $kind"))
-    moduleE match
+        IO.pure(Left(VerifyError.AlloyTranslator(s"runOperationAlloy: unexpected kind $kind")))
+    moduleIO.flatMap:
       case Left(err) =>
-        skippedCheck(
+        IO.pure(skippedCheck(
           id,
           kind,
           VerifierTool.Alloy,
@@ -558,17 +535,17 @@ object Consistency:
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
           err.message
-        )
+        ))
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.checkSync(
+        alloyBackend.check(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
           captureCore = config.captureCore
-        ) match
+        ).flatMap:
           case Left(err) =>
-            skippedCheck(
+            IO.pure(skippedCheck(
               id,
               kind,
               VerifierTool.Alloy,
@@ -577,11 +554,12 @@ object Consistency:
               sourceSpans,
               DiagnosticCategory.BackendError,
               err.message
-            )
+            ))
           case Right(result) =>
             val outcome = CheckOutcome.fromStatus(result.status)
-            dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
+            IO.blocking(
+              dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
+            ).as(finalizeCheck(FinalizeArgs(
               id = id,
               kind = kind,
               tool = VerifierTool.Alloy,
@@ -595,7 +573,7 @@ object Consistency:
               invariantDecl = None,
               op = Some(op),
               coreSpans = alloyCoreSpans(rendered, result, kind)
-            ))
+            )))
 
   private def runPreservationCheck(
       ir: ServiceIR,
@@ -605,57 +583,67 @@ object Consistency:
       alloyBackend: AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
-  ): CheckResult =
+  ): IO[CheckResult] =
     val id          = s"${op.name}.preserves.${inv.name}"
     val sourceSpans = preservationSpans(op, inv.decl)
     val tool        = Classifier.classifyPreservation(op, inv.decl)
     if tool == VerifierTool.Alloy then
-      return runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump)
-    Translator.translateOperationPreservationSync(ir, op, inv.decl) match
-      case Left(err) =>
-        skippedCheck(
-          id,
-          CheckKind.Preservation,
-          tool,
-          Some(op.name),
-          Some(inv.name),
-          sourceSpans,
-          DiagnosticCategory.TranslatorLimitation,
-          err.message
-        )
-      case Right(script) =>
-        backend.checkSync(script, config.copy(captureModel = true)) match
-          case Left(err) =>
-            skippedCheck(
-              id,
-              CheckKind.Preservation,
-              tool,
-              Some(op.name),
-              Some(inv.name),
-              sourceSpans,
-              DiagnosticCategory.BackendError,
-              err.message
-            )
-          case Right(result) =>
-            val inverted = invertStatus(result.status)
-            dumpZ3(dump, id, script, config.timeoutMs, inverted, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
-              id = id,
-              kind = CheckKind.Preservation,
-              tool = tool,
-              operationName = Some(op.name),
-              invariantName = Some(inv.name),
-              rawStatus = result.status,
-              outcome = inverted,
-              durationMs = result.durationMs,
-              sourceSpans = sourceSpans,
-              ir = ir,
-              invariantDecl = Some(inv.decl),
-              op = Some(op),
-              smokeResult = Some(result),
-              artifact = Some(script.artifact),
-              coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
-            ))
+      runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump)
+    else
+      Translator.translateOperationPreservation(ir, op, inv.decl).flatMap:
+        case Left(err) =>
+          IO.pure(skippedCheck(
+            id,
+            CheckKind.Preservation,
+            tool,
+            Some(op.name),
+            Some(inv.name),
+            sourceSpans,
+            DiagnosticCategory.TranslatorLimitation,
+            err.message
+          ))
+        case Right(script) =>
+          backend.check(script, config.copy(captureModel = true)).flatMap:
+            case Left(err) =>
+              IO.pure(skippedCheck(
+                id,
+                CheckKind.Preservation,
+                tool,
+                Some(op.name),
+                Some(inv.name),
+                sourceSpans,
+                DiagnosticCategory.BackendError,
+                err.message
+              ))
+            case Right(result) =>
+              val inverted = invertStatus(result.status)
+              IO.blocking(
+                dumpZ3(
+                  dump,
+                  id,
+                  script,
+                  config.timeoutMs,
+                  inverted,
+                  result.status,
+                  result.durationMs
+                )
+              ).as(finalizeCheck(FinalizeArgs(
+                id = id,
+                kind = CheckKind.Preservation,
+                tool = tool,
+                operationName = Some(op.name),
+                invariantName = Some(inv.name),
+                rawStatus = result.status,
+                outcome = inverted,
+                durationMs = result.durationMs,
+                sourceSpans = sourceSpans,
+                ir = ir,
+                invariantDecl = Some(inv.decl),
+                op = Some(op),
+                smokeResult = Some(result),
+                artifact = Some(script.artifact),
+                coreSpans = z3CoreSpans(script, result, CheckKind.Preservation)
+              )))
 
   private def runTemporalAlloy(
       ir: ServiceIR,
@@ -663,12 +651,12 @@ object Consistency:
       alloyBackend: AlloyBackend,
       config: VerificationConfig,
       dump: Option[DumpSink]
-  ): CheckResult =
+  ): IO[CheckResult] =
     val id          = s"temporal.${decl.name}"
     val sourceSpans = decl.span.toList
-    AlloyTranslator.translateTemporalSync(ir, decl, config.alloyScope) match
+    AlloyTranslator.translateTemporal(ir, decl, config.alloyScope).flatMap:
       case Left(err) =>
-        skippedCheck(
+        IO.pure(skippedCheck(
           id,
           CheckKind.Temporal,
           VerifierTool.Alloy,
@@ -677,17 +665,17 @@ object Consistency:
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
           err.message
-        )
+        ))
       case Right(translation) =>
         val rendered = AlloyRender.renderWithLineMap(translation.module)
-        alloyBackend.checkSync(
+        alloyBackend.check(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
           captureCore = config.captureCore
-        ) match
+        ).flatMap:
           case Left(err) =>
-            skippedCheck(
+            IO.pure(skippedCheck(
               id,
               CheckKind.Temporal,
               VerifierTool.Alloy,
@@ -696,14 +684,15 @@ object Consistency:
               sourceSpans,
               DiagnosticCategory.BackendError,
               err.message
-            )
+            ))
           case Right(result) =>
             val outcome = translation.kind match
               case AlloyTranslator.TemporalKind.Always => invertStatus(result.status)
               case AlloyTranslator.TemporalKind.Eventually =>
                 CheckOutcome.fromStatus(result.status)
-            dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
+            IO.blocking(
+              dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
+            ).as(finalizeCheck(FinalizeArgs(
               id = id,
               kind = CheckKind.Temporal,
               tool = VerifierTool.Alloy,
@@ -717,7 +706,7 @@ object Consistency:
               invariantDecl = None,
               op = None,
               coreSpans = alloyCoreSpans(rendered, result, CheckKind.Temporal)
-            ))
+            )))
 
   private def runPreservationAlloy(
       ir: ServiceIR,
@@ -728,10 +717,10 @@ object Consistency:
       id: String,
       sourceSpans: List[Span],
       dump: Option[DumpSink]
-  ): CheckResult =
-    AlloyTranslator.translateOperationPreservationSync(ir, op, inv.decl, config.alloyScope) match
+  ): IO[CheckResult] =
+    AlloyTranslator.translateOperationPreservation(ir, op, inv.decl, config.alloyScope).flatMap:
       case Left(err) =>
-        skippedCheck(
+        IO.pure(skippedCheck(
           id,
           CheckKind.Preservation,
           VerifierTool.Alloy,
@@ -740,17 +729,17 @@ object Consistency:
           sourceSpans,
           DiagnosticCategory.TranslatorLimitation,
           err.message
-        )
+        ))
       case Right(module) =>
         val rendered = AlloyRender.renderWithLineMap(module)
-        alloyBackend.checkSync(
+        alloyBackend.check(
           rendered.source,
           commandIdx = 0,
           timeoutMs = config.timeoutMs,
           captureCore = config.captureCore
-        ) match
+        ).flatMap:
           case Left(err) =>
-            skippedCheck(
+            IO.pure(skippedCheck(
               id,
               CheckKind.Preservation,
               VerifierTool.Alloy,
@@ -759,11 +748,12 @@ object Consistency:
               sourceSpans,
               DiagnosticCategory.BackendError,
               err.message
-            )
+            ))
           case Right(result) =>
             val inverted = invertStatus(result.status)
-            dumpAlloy(dump, id, rendered.source, inverted, result.status, result.durationMs)
-            finalizeCheck(FinalizeArgs(
+            IO.blocking(
+              dumpAlloy(dump, id, rendered.source, inverted, result.status, result.durationMs)
+            ).as(finalizeCheck(FinalizeArgs(
               id = id,
               kind = CheckKind.Preservation,
               tool = VerifierTool.Alloy,
@@ -777,7 +767,7 @@ object Consistency:
               invariantDecl = Some(inv.decl),
               op = Some(op),
               coreSpans = alloyCoreSpans(rendered, result, CheckKind.Preservation)
-            ))
+            )))
 
   final private case class FinalizeArgs(
       id: String,

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Backend.scala
@@ -63,92 +63,99 @@ final class AlloyBackend:
 
   def close(): Unit = ()
 
-  private[specrest] def checkSync(
+  def check(
       source: String,
       commandIdx: Int,
       timeoutMs: Long,
       captureCore: Boolean = false
-  ): Either[VerifyError.Backend, AlloyCheckResult] =
-    try
-      boundary:
-        val reporter = A4Reporter.NOP
-        val module =
-          try CompUtil.parseEverything_fromString(reporter, source)
-          catch
-            case e: Err =>
-              alloyBackendFail(s"Alloy parse error: ${e.getMessage}\n---\n$source")
-        val commands = module.getAllCommands
-        if commands.isEmpty then
-          alloyBackendFail("Alloy module has no commands; need at least one run/check")
-        if commandIdx < 0 || commandIdx >= commands.size then
-          alloyBackendFail(s"command index $commandIdx out of range [0, ${commands.size})")
-        val cmd  = commands.get(commandIdx)
-        val opts = new A4Options()
-        val coreCapable =
-          if captureCore then AlloyBackend.coreCapableSolver else None
-        opts.solver = coreCapable.getOrElse(SATFactory.DEFAULT)
-        opts.skolemDepth = 4
-        if coreCapable.isDefined then
-          opts.coreMinimization = 1
-          opts.coreGranularity = 1
-        val t0 = System.nanoTime()
-        val solveTask = new Callable[A4Solution]:
-          def call(): A4Solution =
-            TranslateAlloyToKodkod.execute_command(reporter, module.getAllReachableSigs, cmd, opts)
-        val solutionOpt: Option[A4Solution] =
-          if timeoutMs <= 0 then
-            try Some(solveTask.call())
+  ): IO[Either[VerifyError.Backend, AlloyCheckResult]] =
+    IO.blocking {
+      try
+        boundary:
+          val reporter = A4Reporter.NOP
+          val module =
+            try CompUtil.parseEverything_fromString(reporter, source)
             catch
               case e: Err =>
-                alloyBackendFail(s"Alloy translate/solve error: ${e.getMessage}")
-          else
-            val pool   = Executors.newSingleThreadExecutor()
-            val future = pool.submit(solveTask)
-            try Some(future.get(timeoutMs, TimeUnit.MILLISECONDS))
-            catch
-              case _: TimeoutException =>
-                val _ = future.cancel(true)
-                None
-              case e: java.util.concurrent.ExecutionException =>
-                e.getCause match
-                  case err: Err =>
-                    alloyBackendFail(s"Alloy translate/solve error: ${err.getMessage}")
-                  case other =>
-                    alloyBackendFail(
-                      s"Alloy execution error: ${Option(other).map(_.getMessage).getOrElse("null")}"
-                    )
-            finally
-              val _ = pool.shutdownNow()
-        val duration = (System.nanoTime() - t0) / 1_000_000.0
-        solutionOpt match
-          case None =>
-            Right(AlloyCheckResult(
-              status = CheckStatus.Unknown,
-              durationMs = duration,
-              solution = None,
-              commandName = cmd.label,
-              source = source
-            ))
-          case Some(solution) =>
-            val status =
-              if solution.satisfiable then CheckStatus.Sat
-              else CheckStatus.Unsat
-            val core: Set[Pos] =
-              if !solution.satisfiable && captureCore && coreCapable.isDefined then
-                val hl = solution.highLevelCore
-                hl.a.asScala.toSet
-              else Set.empty
-            Right(AlloyCheckResult(
-              status = status,
-              durationMs = duration,
-              solution = if solution.satisfiable then Some(solution) else None,
-              commandName = cmd.label,
-              source = source,
-              corePositions = core
-            ))
-    catch
-      case NonFatal(e) =>
-        Left(VerifyError.Backend(
-          Option(e.getMessage).getOrElse(e.toString),
-          Some(alloyRenderStack(e))
-        ))
+                alloyBackendFail(s"Alloy parse error: ${e.getMessage}\n---\n$source")
+          val commands = module.getAllCommands
+          if commands.isEmpty then
+            alloyBackendFail("Alloy module has no commands; need at least one run/check")
+          if commandIdx < 0 || commandIdx >= commands.size then
+            alloyBackendFail(s"command index $commandIdx out of range [0, ${commands.size})")
+          val cmd  = commands.get(commandIdx)
+          val opts = new A4Options()
+          val coreCapable =
+            if captureCore then AlloyBackend.coreCapableSolver else None
+          opts.solver = coreCapable.getOrElse(SATFactory.DEFAULT)
+          opts.skolemDepth = 4
+          if coreCapable.isDefined then
+            opts.coreMinimization = 1
+            opts.coreGranularity = 1
+          val t0 = System.nanoTime()
+          val solveTask = new Callable[A4Solution]:
+            def call(): A4Solution =
+              TranslateAlloyToKodkod.execute_command(
+                reporter,
+                module.getAllReachableSigs,
+                cmd,
+                opts
+              )
+          val solutionOpt: Option[A4Solution] =
+            if timeoutMs <= 0 then
+              try Some(solveTask.call())
+              catch
+                case e: Err =>
+                  alloyBackendFail(s"Alloy translate/solve error: ${e.getMessage}")
+            else
+              val pool   = Executors.newSingleThreadExecutor()
+              val future = pool.submit(solveTask)
+              try Some(future.get(timeoutMs, TimeUnit.MILLISECONDS))
+              catch
+                case _: TimeoutException =>
+                  val _ = future.cancel(true)
+                  None
+                case e: java.util.concurrent.ExecutionException =>
+                  e.getCause match
+                    case err: Err =>
+                      alloyBackendFail(s"Alloy translate/solve error: ${err.getMessage}")
+                    case other =>
+                      alloyBackendFail(
+                        s"Alloy execution error: ${Option(other).map(_.getMessage).getOrElse("null")}"
+                      )
+              finally
+                val _ = pool.shutdownNow()
+          val duration = (System.nanoTime() - t0) / 1_000_000.0
+          solutionOpt match
+            case None =>
+              Right(AlloyCheckResult(
+                status = CheckStatus.Unknown,
+                durationMs = duration,
+                solution = None,
+                commandName = cmd.label,
+                source = source
+              ))
+            case Some(solution) =>
+              val status =
+                if solution.satisfiable then CheckStatus.Sat
+                else CheckStatus.Unsat
+              val core: Set[Pos] =
+                if !solution.satisfiable && captureCore && coreCapable.isDefined then
+                  val hl = solution.highLevelCore
+                  hl.a.asScala.toSet
+                else Set.empty
+              Right(AlloyCheckResult(
+                status = status,
+                durationMs = duration,
+                solution = if solution.satisfiable then Some(solution) else None,
+                commandName = cmd.label,
+                source = source,
+                corePositions = core
+              ))
+      catch
+        case NonFatal(e) =>
+          Left(VerifyError.Backend(
+            Option(e.getMessage).getOrElse(e.toString),
+            Some(alloyRenderStack(e))
+          ))
+    }

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -27,22 +27,18 @@ object Translator:
       ir: ServiceIR,
       scope: Int
   ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
-    IO.delay(translateGlobalSync(ir, scope))
-
-  private[specrest] def translateGlobalSync(
-      ir: ServiceIR,
-      scope: Int
-  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
-    boundary:
-      val ctx = buildCtx(ir)
-      Right(
-        AlloyModule(
-          name = sanitizeName(ir.name),
-          sigs = buildSigs(ctx),
-          facts = invariantFacts(ctx, ir),
-          commands = List(AlloyCommand("global", AlloyCommandKind.Run, "", scope))
+    IO.delay {
+      boundary:
+        val ctx = buildCtx(ir)
+        Right(
+          AlloyModule(
+            name = sanitizeName(ir.name),
+            sigs = buildSigs(ctx),
+            facts = invariantFacts(ctx, ir),
+            commands = List(AlloyCommand("global", AlloyCommandKind.Run, "", scope))
+          )
         )
-      )
+    }
 
   enum TemporalKind:
     case Always, Eventually
@@ -54,91 +50,76 @@ object Translator:
       decl: TemporalDecl,
       scope: Int
   ): IO[Either[VerifyError.AlloyTranslator, TemporalTranslation]] =
-    IO.delay(translateTemporalSync(ir, decl, scope))
-
-  private[specrest] def translateTemporalSync(
-      ir: ServiceIR,
-      decl: TemporalDecl,
-      scope: Int
-  ): Either[VerifyError.AlloyTranslator, TemporalTranslation] =
-    boundary:
-      val ctx = buildCtx(ir)
-      Right(decl.expr match
-        case Expr.Call(Expr.Identifier("always", _), arg :: Nil, _) =>
-          val body = renderExpr(ctx, arg)
-          val module = AlloyModule(
-            name = sanitizeName(ir.name),
-            sigs = buildSigs(ctx),
-            facts = invariantFacts(ctx, ir) :+
-              AlloyFact(Some(s"${decl.name}_counterexample"), s"not ($body)", decl.span),
-            commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
-          )
-          TemporalTranslation(TemporalKind.Always, module)
-        case Expr.Call(Expr.Identifier("eventually", _), arg :: Nil, _) =>
-          val module = AlloyModule(
-            name = sanitizeName(ir.name),
-            sigs = buildSigs(ctx),
-            facts = invariantFacts(ctx, ir) :+
-              AlloyFact(Some(s"${decl.name}_witness"), renderExpr(ctx, arg), decl.span),
-            commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
-          )
-          TemporalTranslation(TemporalKind.Eventually, module)
-        case Expr.Call(Expr.Identifier("fairness", _), _, _) =>
-          failAlloy(
-            s"temporal '${decl.name}': fairness(...) is not supported in v1; it requires trace-based " +
-              "verification via Alloy's `var` sig mode which is future work"
-          )
-        case _ =>
-          failAlloy(
-            s"temporal '${decl.name}': only 'always(P)' and 'eventually(P)' are supported in v1; got " +
-              s"${decl.expr.getClass.getSimpleName}"
-          )
-      )
+    IO.delay {
+      boundary:
+        val ctx = buildCtx(ir)
+        Right(decl.expr match
+          case Expr.Call(Expr.Identifier("always", _), arg :: Nil, _) =>
+            val body = renderExpr(ctx, arg)
+            val module = AlloyModule(
+              name = sanitizeName(ir.name),
+              sigs = buildSigs(ctx),
+              facts = invariantFacts(ctx, ir) :+
+                AlloyFact(Some(s"${decl.name}_counterexample"), s"not ($body)", decl.span),
+              commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
+            )
+            TemporalTranslation(TemporalKind.Always, module)
+          case Expr.Call(Expr.Identifier("eventually", _), arg :: Nil, _) =>
+            val module = AlloyModule(
+              name = sanitizeName(ir.name),
+              sigs = buildSigs(ctx),
+              facts = invariantFacts(ctx, ir) :+
+                AlloyFact(Some(s"${decl.name}_witness"), renderExpr(ctx, arg), decl.span),
+              commands = List(AlloyCommand(decl.name, AlloyCommandKind.Run, "", scope))
+            )
+            TemporalTranslation(TemporalKind.Eventually, module)
+          case Expr.Call(Expr.Identifier("fairness", _), _, _) =>
+            failAlloy(
+              s"temporal '${decl.name}': fairness(...) is not supported in v1; it requires trace-based " +
+                "verification via Alloy's `var` sig mode which is future work"
+            )
+          case _ =>
+            failAlloy(
+              s"temporal '${decl.name}': only 'always(P)' and 'eventually(P)' are supported in v1; got " +
+                s"${decl.expr.getClass.getSimpleName}"
+            )
+        )
+    }
 
   def translateOperationRequires(
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
   ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
-    IO.delay(translateOperationRequiresSync(ir, op, scope))
-
-  private[specrest] def translateOperationRequiresSync(
-      ir: ServiceIR,
-      op: OperationDecl,
-      scope: Int
-  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
-    boundary:
-      val ctx = buildCtxWithInputs(ir, op)
-      Right(AlloyModule(
-        name = sanitizeName(ir.name),
-        sigs = buildSigs(ctx),
-        facts = op.requires.zipWithIndex.map: (r, i) =>
-          AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt),
-        commands = List(AlloyCommand(s"${op.name}_requires", AlloyCommandKind.Run, "", scope))
-      ))
+    IO.delay {
+      boundary:
+        val ctx = buildCtxWithInputs(ir, op)
+        Right(AlloyModule(
+          name = sanitizeName(ir.name),
+          sigs = buildSigs(ctx),
+          facts = op.requires.zipWithIndex.map: (r, i) =>
+            AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt),
+          commands = List(AlloyCommand(s"${op.name}_requires", AlloyCommandKind.Run, "", scope))
+        ))
+    }
 
   def translateOperationEnabled(
       ir: ServiceIR,
       op: OperationDecl,
       scope: Int
   ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
-    IO.delay(translateOperationEnabledSync(ir, op, scope))
-
-  private[specrest] def translateOperationEnabledSync(
-      ir: ServiceIR,
-      op: OperationDecl,
-      scope: Int
-  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
-    boundary:
-      val ctx = buildCtxWithInputs(ir, op)
-      val reqFacts = op.requires.zipWithIndex.map: (r, i) =>
-        AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt)
-      Right(AlloyModule(
-        name = sanitizeName(ir.name),
-        sigs = buildSigs(ctx),
-        facts = invariantFacts(ctx, ir) ++ reqFacts,
-        commands = List(AlloyCommand(s"${op.name}_enabled", AlloyCommandKind.Run, "", scope))
-      ))
+    IO.delay {
+      boundary:
+        val ctx = buildCtxWithInputs(ir, op)
+        val reqFacts = op.requires.zipWithIndex.map: (r, i) =>
+          AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(ctx, r), r.spanOpt)
+        Right(AlloyModule(
+          name = sanitizeName(ir.name),
+          sigs = buildSigs(ctx),
+          facts = invariantFacts(ctx, ir) ++ reqFacts,
+          commands = List(AlloyCommand(s"${op.name}_enabled", AlloyCommandKind.Run, "", scope))
+        ))
+    }
 
   private def buildCtxWithInputs(ir: ServiceIR, op: OperationDecl): Ctx =
     val stateFields = ir.state.map(_.fields).getOrElse(Nil).map: sf =>
@@ -157,55 +138,49 @@ object Translator:
       inv: InvariantDecl,
       scope: Int
   ): IO[Either[VerifyError.AlloyTranslator, AlloyModule]] =
-    IO.delay(translateOperationPreservationSync(ir, op, inv, scope))
+    IO.delay {
+      boundary:
+        val preCtx  = buildCtxWithInputs(ir, op)
+        val postCtx = preCtx.copy(postStateSig = "StatePost")
+        val sigs    = buildPreservationSigs(preCtx)
 
-  private[specrest] def translateOperationPreservationSync(
-      ir: ServiceIR,
-      op: OperationDecl,
-      inv: InvariantDecl,
-      scope: Int
-  ): Either[VerifyError.AlloyTranslator, AlloyModule] =
-    boundary:
-      val preCtx  = buildCtxWithInputs(ir, op)
-      val postCtx = preCtx.copy(postStateSig = "StatePost")
-      val sigs    = buildPreservationSigs(preCtx)
+        val invariantsPre = ir.invariants.zipWithIndex.map: (i, idx) =>
+          val name = i.name.getOrElse(s"inv_$idx")
+          AlloyFact(Some(s"${name}_pre"), renderExpr(preCtx, i.expr), i.span)
 
-      val invariantsPre = ir.invariants.zipWithIndex.map: (i, idx) =>
-        val name = i.name.getOrElse(s"inv_$idx")
-        AlloyFact(Some(s"${name}_pre"), renderExpr(preCtx, i.expr), i.span)
+        val requiresFacts = op.requires.zipWithIndex.map: (r, i) =>
+          AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(preCtx, r), r.spanOpt)
 
-      val requiresFacts = op.requires.zipWithIndex.map: (r, i) =>
-        AlloyFact(Some(s"${op.name}_requires_$i"), renderExpr(preCtx, r), r.spanOpt)
+        val ensuresFacts = op.ensures.zipWithIndex.map: (e, i) =>
+          AlloyFact(Some(s"${op.name}_ensures_$i"), renderExpr(postCtx, e), e.spanOpt)
 
-      val ensuresFacts = op.ensures.zipWithIndex.map: (e, i) =>
-        AlloyFact(Some(s"${op.name}_ensures_$i"), renderExpr(postCtx, e), e.spanOpt)
+        val mentionedInEnsures = primedStateFields(op.ensures)
+        val frameFacts = ir.state.map(_.fields).getOrElse(Nil)
+          .filterNot(sf => mentionedInEnsures.contains(sf.name))
+          .map: sf =>
+            AlloyFact(
+              Some(s"frame_${sf.name}"),
+              s"StatePost.${sf.name} = State.${sf.name}",
+              sf.span
+            )
 
-      val mentionedInEnsures = primedStateFields(op.ensures)
-      val frameFacts = ir.state.map(_.fields).getOrElse(Nil)
-        .filterNot(sf => mentionedInEnsures.contains(sf.name))
-        .map: sf =>
-          AlloyFact(
-            Some(s"frame_${sf.name}"),
-            s"StatePost.${sf.name} = State.${sf.name}",
-            sf.span
-          )
+        val postStateCtx  = preCtx.copy(currentStateSig = "StatePost")
+        val invariantName = inv.name.getOrElse("invariant")
+        val postViolation = AlloyFact(
+          Some(s"${invariantName}_violated_post"),
+          s"not (${renderExpr(postStateCtx, inv.expr)})",
+          inv.span
+        )
 
-      val postStateCtx  = preCtx.copy(currentStateSig = "StatePost")
-      val invariantName = inv.name.getOrElse("invariant")
-      val postViolation = AlloyFact(
-        Some(s"${invariantName}_violated_post"),
-        s"not (${renderExpr(postStateCtx, inv.expr)})",
-        inv.span
-      )
-
-      val facts   = invariantsPre ++ requiresFacts ++ ensuresFacts ++ frameFacts :+ postViolation
-      val cmdName = s"${op.name}_preserves_$invariantName"
-      Right(AlloyModule(
-        name = sanitizeName(ir.name),
-        sigs = sigs,
-        facts = facts,
-        commands = List(AlloyCommand(cmdName, AlloyCommandKind.Run, "", scope))
-      ))
+        val facts   = invariantsPre ++ requiresFacts ++ ensuresFacts ++ frameFacts :+ postViolation
+        val cmdName = s"${op.name}_preserves_$invariantName"
+        Right(AlloyModule(
+          name = sanitizeName(ir.name),
+          sigs = sigs,
+          facts = facts,
+          commands = List(AlloyCommand(cmdName, AlloyCommandKind.Run, "", scope))
+        ))
+    }
 
   private def buildPreservationSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
     val baseSigs = buildSigs(ctx)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -65,53 +65,58 @@ final class WasmBackend:
 
   def close(): Unit = ctx.close()
 
-  private[specrest] def checkSync(
+  def check(
       script: Z3Script,
       cfg: VerificationConfig
-  ): Either[VerifyError.Backend, SmokeCheckResult] =
-    try
-      boundary:
-        val sortMap = declareSorts(ctx, script.sorts)
-        val funcMap = declareFuncs(ctx, script.funcs, sortMap)
-        val solver  = ctx.mkSolver()
-        val params  = ctx.mkParams()
-        params.add("random_seed", 0)
-        if cfg.timeoutMs > 0 then params.add("timeout", cfg.timeoutMs.toInt)
-        solver.setParameters(params)
-        val rctx         = new RenderCtx(ctx, sortMap, funcMap, summon[BackendBoundary])
-        val trackerNames = scala.collection.mutable.ArrayBuffer.empty[String]
-        if cfg.captureCore then
-          for (a, idx) <- script.assertions.zipWithIndex do
-            val name    = s"_t_$idx"
-            val tracker = ctx.mkBoolConst(name)
-            solver.assertAndTrack(Backend.renderBool(rctx, a), tracker)
-            val _ = trackerNames += name
-        else for a <- script.assertions do solver.add(Backend.renderBool(rctx, a))
-        val t0       = System.nanoTime()
-        val status   = solver.check()
-        val duration = (System.nanoTime() - t0) / 1_000_000.0
-        val checkStatus = status match
-          case Status.SATISFIABLE   => CheckStatus.Sat
-          case Status.UNSATISFIABLE => CheckStatus.Unsat
-          case Status.UNKNOWN       => CheckStatus.Unknown
-        val model =
-          if checkStatus == CheckStatus.Sat && cfg.captureModel then Some(solver.getModel)
-          else None
-        val core =
-          if cfg.captureCore && checkStatus == CheckStatus.Unsat then
-            solver.getUnsatCore.toList.map(_.toString)
-          else Nil
-        Right(SmokeCheckResult(
-          status = checkStatus,
-          durationMs = duration,
-          model = model,
-          sortMap = sortMap.toMap,
-          funcMap = funcMap.toMap,
-          unsatCoreTrackers = core
-        ))
-    catch
-      case NonFatal(e) =>
-        Left(VerifyError.Backend(Option(e.getMessage).getOrElse(e.toString), Some(renderStack(e))))
+  ): IO[Either[VerifyError.Backend, SmokeCheckResult]] =
+    IO.blocking {
+      try
+        boundary:
+          val sortMap = declareSorts(ctx, script.sorts)
+          val funcMap = declareFuncs(ctx, script.funcs, sortMap)
+          val solver  = ctx.mkSolver()
+          val params  = ctx.mkParams()
+          params.add("random_seed", 0)
+          if cfg.timeoutMs > 0 then params.add("timeout", cfg.timeoutMs.toInt)
+          solver.setParameters(params)
+          val rctx         = new RenderCtx(ctx, sortMap, funcMap, summon[BackendBoundary])
+          val trackerNames = scala.collection.mutable.ArrayBuffer.empty[String]
+          if cfg.captureCore then
+            for (a, idx) <- script.assertions.zipWithIndex do
+              val name    = s"_t_$idx"
+              val tracker = ctx.mkBoolConst(name)
+              solver.assertAndTrack(Backend.renderBool(rctx, a), tracker)
+              val _ = trackerNames += name
+          else for a <- script.assertions do solver.add(Backend.renderBool(rctx, a))
+          val t0       = System.nanoTime()
+          val status   = solver.check()
+          val duration = (System.nanoTime() - t0) / 1_000_000.0
+          val checkStatus = status match
+            case Status.SATISFIABLE   => CheckStatus.Sat
+            case Status.UNSATISFIABLE => CheckStatus.Unsat
+            case Status.UNKNOWN       => CheckStatus.Unknown
+          val model =
+            if checkStatus == CheckStatus.Sat && cfg.captureModel then Some(solver.getModel)
+            else None
+          val core =
+            if cfg.captureCore && checkStatus == CheckStatus.Unsat then
+              solver.getUnsatCore.toList.map(_.toString)
+            else Nil
+          Right(SmokeCheckResult(
+            status = checkStatus,
+            durationMs = duration,
+            model = model,
+            sortMap = sortMap.toMap,
+            funcMap = funcMap.toMap,
+            unsatCoreTrackers = core
+          ))
+      catch
+        case NonFatal(e) =>
+          Left(VerifyError.Backend(
+            Option(e.getMessage).getOrElse(e.toString),
+            Some(renderStack(e))
+          ))
+    }
 
 final private class RenderCtx(
     val ctx: Context,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -114,77 +114,63 @@ final private class TranslateCtx(val bnd: TranslateBoundary):
 object Translator:
 
   def translate(ir: ServiceIR): IO[Either[VerifyError.Translator, Z3Script]] =
-    IO.delay(translateSync(ir))
+    IO.delay {
+      boundary:
+        val ctx = new TranslateCtx(summon[TranslateBoundary])
+        declareBase(ctx, ir)
+        for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
+        Right(finalizeScript(ctx))
+    }
 
   def translateOperationRequires(
       ir: ServiceIR,
       op: OperationDecl
   ): IO[Either[VerifyError.Translator, Z3Script]] =
-    IO.delay(translateOperationRequiresSync(ir, op))
+    IO.delay {
+      boundary:
+        val ctx = new TranslateCtx(summon[TranslateBoundary])
+        declareBase(ctx, ir)
+        val env = declareOperationInputs(ctx, op)
+        for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+        Right(finalizeScript(ctx))
+    }
 
   def translateOperationEnabled(
       ir: ServiceIR,
       op: OperationDecl
   ): IO[Either[VerifyError.Translator, Z3Script]] =
-    IO.delay(translateOperationEnabledSync(ir, op))
+    IO.delay {
+      boundary:
+        val ctx = new TranslateCtx(summon[TranslateBoundary])
+        declareBase(ctx, ir)
+        for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
+        val env = declareOperationInputs(ctx, op)
+        for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+        Right(finalizeScript(ctx))
+    }
 
   def translateOperationPreservation(
       ir: ServiceIR,
       op: OperationDecl,
       inv: InvariantDecl
   ): IO[Either[VerifyError.Translator, Z3Script]] =
-    IO.delay(translateOperationPreservationSync(ir, op, inv))
-
-  private[specrest] def translateSync(ir: ServiceIR): Either[VerifyError.Translator, Z3Script] =
-    boundary:
-      val ctx = new TranslateCtx(summon[TranslateBoundary])
-      declareBase(ctx, ir)
-      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
-      Right(finalizeScript(ctx))
-
-  private[specrest] def translateOperationRequiresSync(
-      ir: ServiceIR,
-      op: OperationDecl
-  ): Either[VerifyError.Translator, Z3Script] =
-    boundary:
-      val ctx = new TranslateCtx(summon[TranslateBoundary])
-      declareBase(ctx, ir)
-      val env = declareOperationInputs(ctx, op)
-      for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-      Right(finalizeScript(ctx))
-
-  private[specrest] def translateOperationEnabledSync(
-      ir: ServiceIR,
-      op: OperationDecl
-  ): Either[VerifyError.Translator, Z3Script] =
-    boundary:
-      val ctx = new TranslateCtx(summon[TranslateBoundary])
-      declareBase(ctx, ir)
-      for inv <- ir.invariants do emitTopLevelInvariant(ctx, inv)
-      val env = declareOperationInputs(ctx, op)
-      for req <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-      Right(finalizeScript(ctx))
-
-  private[specrest] def translateOperationPreservationSync(
-      ir: ServiceIR,
-      op: OperationDecl,
-      inv: InvariantDecl
-  ): Either[VerifyError.Translator, Z3Script] =
-    boundary:
-      val ctx = new TranslateCtx(summon[TranslateBoundary])
-      ctx.hasPostState = true
-      declareBase(ctx, ir)
-      ir.state.foreach(s => declareStatePostState(ctx, s))
-      val env = declareOperationInputs(ctx, op)
-      declareOperationOutputs(ctx, op, env)
-      for preInv <- ir.invariants do ctx.assertions += translateExpr(ctx, preInv.expr, env)
-      for req    <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
-      for ens    <- op.ensures do ctx.assertions += translateEnsuresClause(ctx, ens, env)
-      synthesizeFrame(ctx, ir.state, op, env)
-      synthesizeCardinalityAxioms(ctx, ir.state, op)
-      val postInv = withStateMode(ctx, StateMode.Post, () => translateExpr(ctx, inv.expr, env))
-      ctx.assertions += Z3Expr.Not(postInv).withSpan(inv.span)
-      Right(finalizeScript(ctx))
+    IO.delay {
+      boundary:
+        val ctx = new TranslateCtx(summon[TranslateBoundary])
+        ctx.hasPostState = true
+        declareBase(ctx, ir)
+        ir.state.foreach(s => declareStatePostState(ctx, s))
+        val env = declareOperationInputs(ctx, op)
+        declareOperationOutputs(ctx, op, env)
+        for preInv <- ir.invariants do ctx.assertions += translateExpr(ctx, preInv.expr, env)
+        for req    <- op.requires do ctx.assertions += translateExpr(ctx, req, env)
+        for ens    <- op.ensures do ctx.assertions += translateEnsuresClause(ctx, ens, env)
+        synthesizeFrame(ctx, ir.state, op, env)
+        synthesizeCardinalityAxioms(ctx, ir.state, op)
+        val postInv = withStateMode(ctx, StateMode.Post, () => translateExpr(ctx, inv.expr, env))
+        ctx.assertions += Z3Expr.Not(postInv).withSpan(inv.span)
+        Right(finalizeScript(ctx))
+    }
 
   private def declareBase(ctx: TranslateCtx, ir: ServiceIR): Unit =
     for e <- ir.enums do declareEnum(ctx, e)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -1,38 +1,26 @@
 package specrest.verify
 
-import specrest.parser.Builder
-import specrest.parser.Parse
-import specrest.verify.z3.WasmBackend
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class ConsistencyTest extends munit.FunSuite:
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+class ConsistencyTest extends CatsEffectSuite:
 
   test("url_shortener passes all consistency checks"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("url_shortener")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
-      assert(
-        report.ok,
-        s"expected ok=true; failing checks: ${report.checks.filter(c =>
-            c.status != CheckOutcome.Sat && c.status != CheckOutcome.Skipped
-          ).map(_.id)}"
-      )
-    finally backend.close()
+    for
+      ir     <- SpecFixtures.loadIR("url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.ok,
+      s"expected ok=true; failing checks: ${report.checks.filter(c =>
+          c.status != CheckOutcome.Sat && c.status != CheckOutcome.Skipped
+        ).map(_.id)}"
+    )
 
   test("unsat_invariants has contradictory_invariants diagnostic"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("unsat_invariants")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("unsat_invariants")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       assert(!report.ok)
       val global = report.checks.find(_.id == "global").get
       assertEquals(global.status, CheckOutcome.Unsat)
@@ -40,13 +28,12 @@ class ConsistencyTest extends munit.FunSuite:
         global.diagnostic.map(_.category),
         Some(DiagnosticCategory.ContradictoryInvariants)
       )
-    finally backend.close()
 
   test("dead_op detects unsatisfiable_precondition"):
-    val backend = WasmBackend()
-    try
-      val ir      = buildIR("dead_op")
-      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("dead_op")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val deadReq = report.checks.find(_.id == "DeadOp.requires")
       assert(deadReq.isDefined, s"missing DeadOp.requires in checks: ${report.checks.map(_.id)}")
       assertEquals(deadReq.get.status, CheckOutcome.Unsat)
@@ -54,13 +41,12 @@ class ConsistencyTest extends munit.FunSuite:
         deadReq.get.diagnostic.map(_.category),
         Some(DiagnosticCategory.UnsatisfiablePrecondition)
       )
-    finally backend.close()
 
   test("unreachable_op detects unreachable_operation"):
-    val backend = WasmBackend()
-    try
-      val ir          = buildIR("unreachable_op")
-      val report      = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("unreachable_op")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val unreachable = report.checks.find(_.id == "UnreachableOp.enabled")
       assert(unreachable.isDefined)
       assertEquals(unreachable.get.status, CheckOutcome.Unsat)
@@ -68,13 +54,12 @@ class ConsistencyTest extends munit.FunSuite:
         unreachable.get.diagnostic.map(_.category),
         Some(DiagnosticCategory.UnreachableOperation)
       )
-    finally backend.close()
 
   test("broken_url_shortener detects invariant violation"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val violations = report.checks.filter(c =>
         c.kind == CheckKind.Preservation && c.status == CheckOutcome.Unsat
       )
@@ -84,24 +69,21 @@ class ConsistencyTest extends munit.FunSuite:
           v.diagnostic.map(_.category),
           Some(DiagnosticCategory.InvariantViolationByOperation)
         )
-    finally backend.close()
 
   test("safe_counter — every check passes"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("safe_counter")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
-      assert(
-        report.ok,
-        s"safe_counter should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
-      )
-    finally backend.close()
+    for
+      ir     <- SpecFixtures.loadIR("safe_counter")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.ok,
+      s"safe_counter should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
+    )
 
   test("set_ops — every check passes and nothing is skipped"):
-    val backend = WasmBackend()
-    try
-      val ir      = buildIR("set_ops")
-      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("set_ops")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
       assert(
         skipped.isEmpty,
@@ -111,13 +93,12 @@ class ConsistencyTest extends munit.FunSuite:
         report.ok,
         s"set_ops should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
       )
-    finally backend.close()
 
   test("set_comp_demo — `s = { x in D | P }` equality passes in Z3"):
-    val backend = WasmBackend()
-    try
-      val ir      = buildIR("set_comp_demo")
-      val report  = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("set_comp_demo")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
       assert(
         skipped.isEmpty,
@@ -129,13 +110,12 @@ class ConsistencyTest extends munit.FunSuite:
         s"set_comp_demo should route entirely to Z3; non-Z3: ${nonZ3.map(c => s"${c.id}->${c.tool}")}"
       )
       assert(report.ok, s"set_comp_demo should be sat; got: ${report.checks.map(_.status)}")
-    finally backend.close()
 
   test("powerset_demo — global invariant routes to Alloy and solves sat"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("powerset_demo")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("powerset_demo")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val global = report.checks.find(_.id == "global").getOrElse(fail("no global check"))
       assertEquals(
         global.tool,
@@ -147,13 +127,12 @@ class ConsistencyTest extends munit.FunSuite:
         report.ok,
         s"powerset_demo should pass; got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
       )
-    finally backend.close()
 
   test("temporal_demo — always/eventually temporal properties route to Alloy and pass"):
-    val backend = WasmBackend()
-    try
-      val ir             = buildIR("temporal_demo")
-      val report         = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("temporal_demo")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val temporalChecks = report.checks.filter(_.kind == CheckKind.Temporal)
       assertEquals(
         temporalChecks.size,
@@ -169,7 +148,6 @@ class ConsistencyTest extends munit.FunSuite:
         s"expected all sat; got ${temporalChecks.map(c => s"${c.id}->${c.status}")}"
       )
       assert(report.ok)
-    finally backend.close()
 
   test("unreachable `eventually(...)` returns Unsat under contradictory invariants"):
     val spec =
@@ -184,12 +162,10 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal someUserExists:
         |    eventually(some u in users | u = u)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.buildFromSource("BrokenTemporal", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.tool, VerifierTool.Alloy)
@@ -198,7 +174,6 @@ class ConsistencyTest extends munit.FunSuite:
         CheckOutcome.Unsat,
         s"expected unreachable; got ${temporal.status} (${temporal.detail})"
       )
-    finally backend.close()
 
   test("violated `always(...)` returns Unsat when P can be falsified"):
     val spec =
@@ -210,12 +185,10 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal alwaysFalse:
         |    always(all u in users | u != u)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.buildFromSource("BrokenAlways", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.tool, VerifierTool.Alloy)
@@ -224,7 +197,6 @@ class ConsistencyTest extends munit.FunSuite:
         CheckOutcome.Unsat,
         s"expected violation; got ${temporal.status}"
       )
-    finally backend.close()
 
   test("fairness(...) raises an Alloy translator error surfaced as Skipped"):
     val spec =
@@ -236,12 +208,10 @@ class ConsistencyTest extends munit.FunSuite:
         |  temporal fairStep:
         |    fairness(Step)
         |}""".stripMargin
-    val parsed = specrest.parser.Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir      = specrest.parser.Builder.buildIRSync(parsed.tree).toOption.get
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.buildFromSource("FairnessSpec", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val temporal = report.checks.find(_.kind == CheckKind.Temporal)
         .getOrElse(fail("no temporal check"))
       assertEquals(temporal.status, CheckOutcome.Skipped)
@@ -249,13 +219,12 @@ class ConsistencyTest extends munit.FunSuite:
         temporal.diagnostic.exists(_.message.contains("fairness")),
         s"expected fairness error; got: ${temporal.diagnostic.map(_.message)}"
       )
-    finally backend.close()
 
   test("powerset_ops — Alloy-routed requires/enabled/preservation all solve"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("powerset_ops")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("powerset_ops")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val reqCheck = report.checks.find(_.id == "AddUser.requires")
         .getOrElse(fail("no AddUser.requires check"))
       assertEquals(reqCheck.tool, VerifierTool.Alloy)
@@ -276,4 +245,3 @@ class ConsistencyTest extends munit.FunSuite:
         report.ok,
         s"powerset_ops should pass; got: ${report.checks.map(c => s"${c.id}->${c.tool}->${c.status}")}"
       )
-    finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -32,8 +32,9 @@ class JsonReportTest extends CatsEffectSuite:
         _          = assertEquals(canonical.hcursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
         goldenPath = Paths.get(s"fixtures/golden/verify_report/$fixture.json")
         rendered   = JsonReport.render(canonical)
+        exists    <- IO.blocking(Files.exists(goldenPath))
         _ <-
-          if !Files.exists(goldenPath) then
+          if !exists then
             IO.blocking {
               Files.createDirectories(goldenPath.getParent)
               Files.writeString(goldenPath, rendered)

--- a/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/JsonReportTest.scala
@@ -1,17 +1,16 @@
 package specrest.verify
 
+import cats.effect.IO
 import io.circe.Json
 import io.circe.parser
-import specrest.parser.Builder
-import specrest.parser.Parse
-import specrest.verify.z3.WasmBackend
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Paths
 
-class JsonReportTest extends munit.FunSuite:
+class JsonReportTest extends CatsEffectSuite:
 
-  // (fixture, expected ok, expected category in at least one diagnostic)
   private val cases: List[(String, Boolean, Option[String])] = List(
     ("safe_counter", true, None),
     ("unsat_invariants", false, Some("contradictory_invariants")),
@@ -20,53 +19,47 @@ class JsonReportTest extends munit.FunSuite:
 
   cases.foreach: (fixture, expectedOk, expectedCategory) =>
     test(s"JsonReport snapshot matches golden for $fixture"):
-      val ir      = parseSpec(fixture)
-      val backend = WasmBackend()
-      try
-        val report = Consistency.runConsistencyChecksSync(
-          ir,
-          backend,
-          VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+      val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+      for
+        ir       <- SpecFixtures.loadIR(fixture)
+        report   <- Consistency.runConsistencyChecks(ir, cfg)
+        json      = JsonReport.toJson(s"fixtures/spec/$fixture.spec", report, 0.0)
+        canonical = stripTimings(json)
+        _ = assertEquals(
+              canonical.hcursor.downField("schemaVersion").as[Int].toOption,
+              Some(JsonReport.SchemaVersion)
+            )
+        _          = assertEquals(canonical.hcursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
+        goldenPath = Paths.get(s"fixtures/golden/verify_report/$fixture.json")
+        rendered   = JsonReport.render(canonical)
+        _ <-
+          if !Files.exists(goldenPath) then
+            IO.blocking {
+              Files.createDirectories(goldenPath.getParent)
+              Files.writeString(goldenPath, rendered)
+              fail(s"wrote initial golden at $goldenPath — rerun the test")
+            }
+          else
+            IO.blocking(Files.readString(goldenPath)).map: expected =>
+              assertEquals(rendered, expected, s"golden mismatch — update $goldenPath if intended")
+      yield expectedCategory.foreach: category =>
+        val categories = canonical.hcursor
+          .downField("checks")
+          .values
+          .getOrElse(Vector.empty)
+          .toList
+          .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
+        assert(
+          categories.contains(category),
+          s"expected category '$category' among $categories"
         )
-        val json      = JsonReport.toJson(s"fixtures/spec/$fixture.spec", report, 0.0)
-        val canonical = stripTimings(json)
-        assertEquals(
-          canonical.hcursor.downField("schemaVersion").as[Int].toOption,
-          Some(JsonReport.SchemaVersion)
-        )
-        assertEquals(canonical.hcursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
-        val goldenPath = Paths.get(s"fixtures/golden/verify_report/$fixture.json")
-        val rendered   = JsonReport.render(canonical)
-        if !Files.exists(goldenPath) then
-          Files.createDirectories(goldenPath.getParent)
-          val _ = Files.writeString(goldenPath, rendered)
-          fail(s"wrote initial golden at $goldenPath — rerun the test")
-        else
-          val expected = Files.readString(goldenPath)
-          assertEquals(rendered, expected, s"golden mismatch — update $goldenPath if intended")
-
-        expectedCategory.foreach: category =>
-          val categories = canonical.hcursor
-            .downField("checks")
-            .values
-            .getOrElse(Vector.empty)
-            .toList
-            .flatMap(_.hcursor.downField("diagnostic").downField("category").as[String].toOption)
-          assert(
-            categories.contains(category),
-            s"expected category '$category' among $categories"
-          )
-      finally backend.close()
 
   test("JsonReport is round-trip-parseable via circe"):
-    val ir      = parseSpec("broken_url_shortener")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig(timeoutMs = 30_000L, captureCore = true)
-      )
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
       val rendered = JsonReport.render(
         JsonReport.toJson("fixtures/spec/broken_url_shortener.spec", report, 0.0)
       )
@@ -91,15 +84,14 @@ class JsonReportTest extends munit.FunSuite:
       val firstFieldName = ceEntities.head.hcursor
         .downField("fields").downArray.downField("name").as[String].toOption
       assert(firstFieldName.isDefined, s"expected first entity field name, got $firstFieldName")
-    finally backend.close()
 
   test("JsonReport top-level shape carries all documented fields"):
-    val ir      = parseSpec("safe_counter")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
-      val json   = JsonReport.toJson("x.spec", report, 42.0)
-      val keys   = json.asObject.map(_.keys.toSet).getOrElse(Set.empty[String])
+    for
+      ir     <- SpecFixtures.loadIR("safe_counter")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val json = JsonReport.toJson("x.spec", report, 42.0)
+      val keys = json.asObject.map(_.keys.toSet).getOrElse(Set.empty[String])
       assertEquals(keys, Set("schemaVersion", "specFile", "ok", "totalMs", "checks"))
       val checkKeys = json.hcursor
         .downField("checks")
@@ -122,16 +114,7 @@ class JsonReportTest extends munit.FunSuite:
           "diagnostic"
         )
       )
-    finally backend.close()
 
-  private def parseSpec(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
-
-  // Paths where timing fields legitimately live in the schema. Scoping prevents accidental
-  // erasure if a future diagnostic/counterexample field shares one of these names.
   private def stripTimings(j: Json): Json =
     def loop(value: Json, path: List[String]): Json =
       value.fold(

--- a/modules/verify/src/test/scala/specrest/verify/ParallelTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ParallelTest.scala
@@ -1,68 +1,70 @@
 package specrest.verify
 
-import cats.effect.unsafe.implicits.global
-import munit.FunSuite
-import specrest.parser.Builder
-import specrest.parser.Parse
+import cats.effect.IO
+import cats.effect.Resource
+import munit.CatsEffectSuite
 import specrest.verify.certificates.DumpSink
+import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
-class ParallelTest extends FunSuite:
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+class ParallelTest extends CatsEffectSuite:
 
   private val parityFixtures: List[String] =
     List("safe_counter", "url_shortener", "set_ops", "broken_url_shortener")
 
+  private def tempDir(prefix: String): Resource[IO, Path] =
+    Resource.make(IO.blocking(Files.createTempDirectory(prefix)))(p =>
+      IO.blocking(deleteRecursive(p))
+    )
+
   parityFixtures.foreach: fixture =>
     test(s"$fixture — parallel=4 and serial=1 return identical check ids and outcomes"):
-      val ir = buildIR(fixture)
-      val cfgSerial =
-        VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
-      val cfgParallel =
-        VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
-      val serial   = Consistency.runConsistencyChecks(ir, cfgSerial).unsafeRunSync()
-      val parallel = Consistency.runConsistencyChecks(ir, cfgParallel).unsafeRunSync()
-      assertEquals(serial.checks.map(_.id), parallel.checks.map(_.id))
-      assertEquals(
-        serial.checks.map(c => c.id -> c.status),
-        parallel.checks.map(c => c.id -> c.status)
-      )
-      assertEquals(serial.ok, parallel.ok)
+      val cfgSerial   = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
+      val cfgParallel = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
+      for
+        ir       <- SpecFixtures.loadIR(fixture)
+        serial   <- Consistency.runConsistencyChecks(ir, cfgSerial)
+        parallel <- Consistency.runConsistencyChecks(ir, cfgParallel)
+      yield
+        assertEquals(serial.checks.map(_.id), parallel.checks.map(_.id))
+        assertEquals(
+          serial.checks.map(c => c.id -> c.status),
+          parallel.checks.map(c => c.id -> c.status)
+        )
+        assertEquals(serial.ok, parallel.ok)
 
   test("maxParallel=0 reproduces serial output (regression parity)"):
-    val ir         = buildIR("url_shortener")
-    val cfgZero    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 0)
-    val cfgOne     = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
-    val zeroReport = Consistency.runConsistencyChecks(ir, cfgZero).unsafeRunSync()
-    val oneReport  = Consistency.runConsistencyChecks(ir, cfgOne).unsafeRunSync()
-    assertEquals(
-      zeroReport.checks.map(c => c.id -> c.status),
-      oneReport.checks.map(c => c.id -> c.status)
-    )
-    assertEquals(zeroReport.ok, oneReport.ok)
+    val cfgZero = VerificationConfig(timeoutMs = 30_000L, maxParallel = 0)
+    val cfgOne  = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
+    for
+      ir   <- SpecFixtures.loadIR("url_shortener")
+      zero <- Consistency.runConsistencyChecks(ir, cfgZero)
+      one  <- Consistency.runConsistencyChecks(ir, cfgOne)
+    yield
+      assertEquals(
+        zero.checks.map(c => c.id -> c.status),
+        one.checks.map(c => c.id -> c.status)
+      )
+      assertEquals(zero.ok, one.ok)
 
   test("parTraverseN preserves plan order in the report"):
-    val ir     = buildIR("url_shortener")
-    val cfg    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
-    val first  = Consistency.runConsistencyChecks(ir, cfg).unsafeRunSync()
-    val second = Consistency.runConsistencyChecks(ir, cfg).unsafeRunSync()
-    assertEquals(first.checks.map(_.id), second.checks.map(_.id))
+    val cfg = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
+    for
+      ir     <- SpecFixtures.loadIR("url_shortener")
+      first  <- Consistency.runConsistencyChecks(ir, cfg)
+      second <- Consistency.runConsistencyChecks(ir, cfg)
+    yield assertEquals(first.checks.map(_.id), second.checks.map(_.id))
 
   test("DumpSink collects all entries under parallel writes"):
-    val ir     = buildIR("safe_counter")
-    val tmpDir = Files.createTempDirectory("parallel-dump-")
-    try
-      val sink   = DumpSink.open(tmpDir).toOption.get
-      val cfg    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
-      val report = Consistency.runConsistencyChecks(ir, cfg, Some(sink)).unsafeRunSync()
-      assertEquals(
+    tempDir("parallel-dump-").use: tmpDir =>
+      val sink = DumpSink.open(tmpDir).toOption.get
+      val cfg  = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
+      for
+        ir     <- SpecFixtures.loadIR("safe_counter")
+        report <- Consistency.runConsistencyChecks(ir, cfg, Some(sink))
+      yield assertEquals(
         sink.entryCount,
         report.checks.count(c =>
           c.status == CheckOutcome.Sat ||
@@ -71,9 +73,46 @@ class ParallelTest extends FunSuite:
         ),
         s"dump entries should equal non-skipped checks; checks=${report.checks.map(c => s"${c.id}->${c.status}")}"
       )
-    finally deleteRecursive(tmpDir)
 
-  private def deleteRecursive(path: java.nio.file.Path): Unit =
+  test("parallel mode on a solver-heavy spec (set_ops) matches serial results"):
+    val cfgSerial   = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
+    val cfgParallel = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
+    for
+      ir     <- SpecFixtures.loadIR("set_ops")
+      serial <- Consistency.runConsistencyChecks(ir, cfgSerial)
+      par    <- Consistency.runConsistencyChecks(ir, cfgParallel)
+    yield
+      assertEquals(
+        par.checks.map(c => c.id -> c.status),
+        serial.checks.map(c => c.id -> c.status)
+      )
+      assertEquals(par.ok, serial.ok)
+
+  test("CheckPlan enumerates 1 global + 2N op checks + N*M preservation + T temporals"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
+    for
+      ir     <- SpecFixtures.loadIR("url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val n = ir.operations.size
+      val m = ir.invariants.size
+      val t = ir.temporals.size
+      assertEquals(
+        report.checks.size,
+        1 + 2 * n + n * m + t,
+        s"expected formula 1 + 2N + N*M + T to match plan enumeration"
+      )
+
+  test("runConsistencyChecks returns an IO that is referentially transparent"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, maxParallel = 2)
+    SpecFixtures.loadIR("safe_counter").flatMap: ir =>
+      val action = Consistency.runConsistencyChecks(ir, cfg)
+      for
+        r1 <- action
+        r2 <- action
+      yield assertEquals(r1.checks.map(c => c.id -> c.status), r2.checks.map(c => c.id -> c.status))
+
+  private def deleteRecursive(path: Path): Unit =
     if Files.isDirectory(path) then
       val stream = Files.list(path)
       try
@@ -81,36 +120,3 @@ class ParallelTest extends FunSuite:
         while iter.hasNext do deleteRecursive(iter.next())
       finally stream.close()
     val _ = Files.deleteIfExists(path)
-
-  test("parallel mode on a solver-heavy spec (set_ops) matches serial results"):
-    val ir           = buildIR("set_ops")
-    val cfgSerial    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
-    val cfgParallel  = VerificationConfig(timeoutMs = 30_000L, maxParallel = 4)
-    val serialReport = Consistency.runConsistencyChecks(ir, cfgSerial).unsafeRunSync()
-    val parReport    = Consistency.runConsistencyChecks(ir, cfgParallel).unsafeRunSync()
-    assertEquals(
-      parReport.checks.map(c => c.id -> c.status),
-      serialReport.checks.map(c => c.id -> c.status)
-    )
-    assertEquals(parReport.ok, serialReport.ok)
-
-  test("CheckPlan enumerates 1 global + 2N op checks + N*M preservation + T temporals"):
-    val ir     = buildIR("url_shortener")
-    val cfg    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
-    val report = Consistency.runConsistencyChecks(ir, cfg).unsafeRunSync()
-    val n      = ir.operations.size
-    val m      = ir.invariants.size
-    val t      = ir.temporals.size
-    assertEquals(
-      report.checks.size,
-      1 + 2 * n + n * m + t,
-      s"expected formula 1 + 2N + N*M + T to match plan enumeration"
-    )
-
-  test("runConsistencyChecks returns an IO that is referentially transparent"):
-    val ir     = buildIR("safe_counter")
-    val cfg    = VerificationConfig(timeoutMs = 30_000L, maxParallel = 2)
-    val action = Consistency.runConsistencyChecks(ir, cfg)
-    val r1     = action.unsafeRunSync()
-    val r2     = action.unsafeRunSync()
-    assertEquals(r1.checks.map(c => c.id -> c.status), r2.checks.map(c => c.id -> c.status))

--- a/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ResourceLifecycleTest.scala
@@ -3,15 +3,13 @@ package specrest.verify
 import cats.effect.IO
 import cats.effect.Ref
 import munit.CatsEffectSuite
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.verify.alloy.AlloyBackend
 import specrest.verify.certificates.DumpSink
+import specrest.verify.testutil.SpecFixtures
 import specrest.verify.z3.WasmBackend
 
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 
 class ResourceLifecycleTest extends CatsEffectSuite:
 
@@ -46,10 +44,10 @@ class ResourceLifecycleTest extends CatsEffectSuite:
       assertReleased(runCase)
 
   test("runConsistencyChecks acquires and uses managed backends"):
-    val ir = buildIR("safe_counter")
-    Consistency
-      .runConsistencyChecks(ir, VerificationConfig.Default)
-      .map(report => assertEquals(report.ok, true))
+    for
+      ir     <- SpecFixtures.loadIR("safe_counter")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assertEquals(report.ok, true)
 
   private def assertReleased(runCase: Ref[IO, Boolean] => IO[Unit]): IO[Unit] =
     for
@@ -57,12 +55,6 @@ class ResourceLifecycleTest extends CatsEffectSuite:
       _           <- runCase(released)
       wasReleased <- released.get
     yield assertEquals(wasReleased, true)
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
 
   private def tempDirResource(prefix: String): cats.effect.Resource[IO, Path] =
     cats.effect.Resource.make(IO.blocking(Files.createTempDirectory(prefix))): dir =>

--- a/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
@@ -3,34 +3,21 @@ package specrest.verify
 import cats.effect.IO
 import cats.effect.Ref
 import munit.CatsEffectSuite
-import specrest.parser.Builder
-import specrest.parser.Parse
 import specrest.verify.alloy.AlloyBackend
+import specrest.verify.testutil.SpecFixtures
 import specrest.verify.z3.WasmBackend
 
-import java.nio.file.Files
-import java.nio.file.Paths
 import scala.concurrent.duration.*
 
 class TimeoutTest extends CatsEffectSuite:
 
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree) match
-      case Right(ir) => ir
-      case Left(err) => fail(s"build errors for $name: $err")
-
   List(1, 4).foreach: maxPar =>
     test(s"tight timeout on set_ops (parallel=$maxPar) triggers the timeout fallback"):
-      val ir  = buildIR("set_ops")
       val cfg = VerificationConfig(timeoutMs = 1L, maxParallel = maxPar)
-      Consistency.runConsistencyChecks(ir, cfg).map: report =>
-        // Fast hardware can race a trivial Z3 check through in under 1 ms, so we do
-        // not assert that every check times out. We do assert (a) the fallback path
-        // fires on at least one non-skipped check, and (b) the run ends not-ok because
-        // of those timeouts (skipped-only would still flip ok=true).
+      for
+        ir     <- SpecFixtures.loadIR("set_ops")
+        report <- Consistency.runConsistencyChecks(ir, cfg)
+      yield
         val timedOut = report.checks.count(_.status == CheckOutcome.Unknown)
         assert(
           timedOut > 0,
@@ -40,10 +27,10 @@ class TimeoutTest extends CatsEffectSuite:
         assertEquals(report.ok, false)
 
   test("serial and parallel produce identical outcomes under tight timeout"):
-    val ir   = buildIR("set_ops")
     val cfgS = VerificationConfig(timeoutMs = 1L, maxParallel = 1)
     val cfgP = VerificationConfig(timeoutMs = 1L, maxParallel = 4)
     for
+      ir       <- SpecFixtures.loadIR("set_ops")
       serial   <- Consistency.runConsistencyChecks(ir, cfgS)
       parallel <- Consistency.runConsistencyChecks(ir, cfgP)
     yield
@@ -54,10 +41,10 @@ class TimeoutTest extends CatsEffectSuite:
       assertEquals(serial.ok, parallel.ok)
 
   test("timeoutMs=0 disables outer timeout (safe_counter parity vs 30s default)"):
-    val ir      = buildIR("safe_counter")
     val cfgZero = VerificationConfig(timeoutMs = 0L, maxParallel = 1)
     val cfgDef  = VerificationConfig(timeoutMs = 30_000L, maxParallel = 1)
     for
+      ir   <- SpecFixtures.loadIR("safe_counter")
       zero <- Consistency.runConsistencyChecks(ir, cfgZero)
       dflt <- Consistency.runConsistencyChecks(ir, cfgDef)
     yield

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -1,32 +1,36 @@
 package specrest.verify.alloy
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import cats.effect.IO
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Path as JPath
 import java.nio.file.Paths
 
-class AlloyGoldenTest extends munit.FunSuite:
+class AlloyGoldenTest extends CatsEffectSuite:
 
-  private val specDir: JPath   = Paths.get("fixtures/spec")
   private val goldenDir: JPath = Paths.get("fixtures/golden/alloy")
 
   private val fixtures: List[String] = List("powerset_demo")
 
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
-
   fixtures.foreach: name =>
     test(s"Alloy source matches golden — $name"):
-      val ir      = buildIR(name)
-      val module  = Translator.translateGlobalSync(ir, scope = 5).toOption.get
-      val emitted = Render.render(module).stripSuffix("\n")
-      val golden  = Files.readString(goldenDir.resolve(s"$name.als")).stripSuffix("\n")
-      if emitted != golden then
-        val diffPath = Paths.get(s"/tmp/scala-alloy-$name.als")
-        Files.writeString(diffPath, emitted)
-        fail(s"Alloy source mismatch for $name; Scala output written to $diffPath")
+      for
+        ir      <- SpecFixtures.loadIR(name)
+        moduleE <- Translator.translateGlobal(ir, scope = 5)
+        module =
+          moduleE.toOption.getOrElse(
+            fail(s"translateGlobal failed for $name: ${moduleE.left.toOption.map(_.message)}")
+          )
+        emitted = Render.render(module).stripSuffix("\n")
+        golden <- IO.blocking(Files.readString(goldenDir.resolve(s"$name.als")).stripSuffix("\n"))
+        _ <-
+          if emitted == golden then IO.unit
+          else
+            IO.blocking {
+              val diffPath = Paths.get(s"/tmp/scala-alloy-$name.als")
+              Files.writeString(diffPath, emitted)
+              fail(s"Alloy source mismatch for $name; Scala output written to $diffPath")
+            }
+      yield ()

--- a/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/AlloyGoldenTest.scala
@@ -29,7 +29,7 @@ class AlloyGoldenTest extends CatsEffectSuite:
           if emitted == golden then IO.unit
           else
             IO.blocking {
-              val diffPath = Paths.get(s"/tmp/scala-alloy-$name.als")
+              val diffPath = Files.createTempFile(s"scala-alloy-$name-", ".als")
               Files.writeString(diffPath, emitted)
               fail(s"Alloy source mismatch for $name; Scala output written to $diffPath")
             }

--- a/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/RenderTest.scala
@@ -1,8 +1,13 @@
 package specrest.verify.alloy
 
+import cats.effect.IO
+import cats.effect.Resource
+import munit.CatsEffectSuite
 import specrest.verify.CheckStatus
 
-class RenderTest extends munit.FunSuite:
+class RenderTest extends CatsEffectSuite:
+
+  private val alloyBackend: Resource[IO, AlloyBackend] = AlloyBackend.make
 
   test("empty module renders the module header"):
     val m   = AlloyModule("Empty", Nil, Nil, Nil)
@@ -39,11 +44,12 @@ class RenderTest extends munit.FunSuite:
       facts = List(AlloyFact(Some("nonEmpty"), "some Elem")),
       commands = List(AlloyCommand("go", AlloyCommandKind.Run, "some Elem", 5))
     )
-    val source  = Render.render(m)
-    val backend = new AlloyBackend
-    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
-    assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
-    assert(result.solution.isDefined, "expected a solution for sat case")
+    val source = Render.render(m)
+    alloyBackend.use: backend =>
+      backend.check(source, commandIdx = 0, timeoutMs = 30_000L).map: resultE =>
+        val result = resultE.toOption.get
+        assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
+        assert(result.solution.isDefined, "expected a solution for sat case")
 
   test("rendered module round-trips through AlloyBackend (unsat case)"):
     val m = AlloyModule(
@@ -52,10 +58,11 @@ class RenderTest extends munit.FunSuite:
       facts = List(AlloyFact(Some("impossible"), "some Elem and no Elem")),
       commands = List(AlloyCommand("go", AlloyCommandKind.Run, "", 5))
     )
-    val source  = Render.render(m)
-    val backend = new AlloyBackend
-    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
-    assertEquals(result.status, CheckStatus.Unsat, s"expected unsat; source=$source")
+    val source = Render.render(m)
+    alloyBackend.use: backend =>
+      backend.check(source, commandIdx = 0, timeoutMs = 30_000L).map: resultE =>
+        val result = resultE.toOption.get
+        assertEquals(result.status, CheckStatus.Unsat, s"expected unsat; source=$source")
 
   test("singleton State sig with set field + subset powerset quantification"):
     val m = AlloyModule(
@@ -74,10 +81,11 @@ class RenderTest extends munit.FunSuite:
       )),
       commands = List(AlloyCommand("go", AlloyCommandKind.Run, "", 5))
     )
-    val source  = Render.render(m)
-    val backend = new AlloyBackend
-    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
-    assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
+    val source = Render.render(m)
+    alloyBackend.use: backend =>
+      backend.check(source, commandIdx = 0, timeoutMs = 30_000L).map: resultE =>
+        val result = resultE.toOption.get
+        assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
 
   test("existential powerset quantification (some t: set …) works end-to-end"):
     val m = AlloyModule(
@@ -89,7 +97,8 @@ class RenderTest extends munit.FunSuite:
       )),
       commands = List(AlloyCommand("go", AlloyCommandKind.Run, "", 5))
     )
-    val source  = Render.render(m)
-    val backend = new AlloyBackend
-    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
-    assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")
+    val source = Render.render(m)
+    alloyBackend.use: backend =>
+      backend.check(source, commandIdx = 0, timeoutMs = 30_000L).map: resultE =>
+        val result = resultE.toOption.get
+        assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=$source")

--- a/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/alloy/TranslatorTest.scala
@@ -1,46 +1,43 @@
 package specrest.verify.alloy
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
 import specrest.verify.CheckStatus
+import specrest.verify.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class TranslatorTest extends munit.FunSuite:
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+class TranslatorTest extends CatsEffectSuite:
 
   test("powerset_demo translates to a valid Alloy module and solves sat"):
-    val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobalSync(ir, scope = 5).toOption.get
-    assertEquals(module.name, "PowersetDemo")
-    assert(
-      module.sigs.exists(_.name == "User"),
-      s"missing User sig; got ${module.sigs.map(_.name)}"
-    )
-    assert(module.sigs.exists(_.name == "State"), s"missing State sig")
-    assertEquals(module.facts.size, 1)
-    val source  = Render.render(module)
-    val backend = new AlloyBackend
-    val result  = backend.checkSync(source, commandIdx = 0, timeoutMs = 30_000L).toOption.get
-    assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=\n$source")
+    for
+      ir      <- SpecFixtures.loadIR("powerset_demo")
+      moduleE <- Translator.translateGlobal(ir, scope = 5)
+      module   = moduleE.toOption.get
+      _        = assertEquals(module.name, "PowersetDemo")
+      _ = assert(
+            module.sigs.exists(_.name == "User"),
+            s"missing User sig; got ${module.sigs.map(_.name)}"
+          )
+      _        = assert(module.sigs.exists(_.name == "State"), "missing State sig")
+      _        = assertEquals(module.facts.size, 1)
+      source   = Render.render(module)
+      backend  = new AlloyBackend
+      resultE <- backend.check(source, commandIdx = 0, timeoutMs = 30_000L)
+      result   = resultE.toOption.get
+    yield assertEquals(result.status, CheckStatus.Sat, s"expected sat; source=\n$source")
 
   test("Alloy render contains expected structural tokens"):
-    val ir     = buildIR("powerset_demo")
-    val module = Translator.translateGlobalSync(ir, scope = 5).toOption.get
-    val source = Render.render(module)
-    assert(source.contains("module PowersetDemo"), s"source=\n$source")
-    assert(source.contains("sig User"), s"source=\n$source")
-    assert(source.contains("one sig State"), s"source=\n$source")
-    assert(source.contains("users: set User"), s"source=\n$source")
-    assert(source.contains("fact someEmptySubsetExists"), s"source=\n$source")
-    assert(source.contains("set User"), s"source=\n$source")
-    assert(source.contains("run global"), s"source=\n$source")
+    for
+      ir      <- SpecFixtures.loadIR("powerset_demo")
+      moduleE <- Translator.translateGlobal(ir, scope = 5)
+      module   = moduleE.toOption.get
+      source   = Render.render(module)
+    yield
+      assert(source.contains("module PowersetDemo"), s"source=\n$source")
+      assert(source.contains("sig User"), s"source=\n$source")
+      assert(source.contains("one sig State"), s"source=\n$source")
+      assert(source.contains("users: set User"), s"source=\n$source")
+      assert(source.contains("fact someEmptySubsetExists"), s"source=\n$source")
+      assert(source.contains("set User"), s"source=\n$source")
+      assert(source.contains("run global"), s"source=\n$source")
 
   test("universal powerset — `all t in ^s | ...` surfaces as Left(AlloyTranslator)"):
     val spec =
@@ -52,16 +49,17 @@ class TranslatorTest extends munit.FunSuite:
         |  invariant everySubsetContainedInUsers:
         |    all t in ^users | t subset users
         |}""".stripMargin
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateGlobalSync(ir, scope = 5) match
-      case Left(e)  => e
-      case Right(_) => fail("expected Left(AlloyTranslator)")
-    assert(
-      err.message.contains("higher-order") && err.message.contains("powerset"),
-      s"expected higher-order/powerset error; got: ${err.message}"
-    )
+    for
+      ir      <- SpecFixtures.buildFromSource("UnivDemo", spec)
+      moduleE <- Translator.translateGlobal(ir, scope = 5)
+    yield
+      val err = moduleE match
+        case Left(e)  => e
+        case Right(_) => fail("expected Left(AlloyTranslator)")
+      assert(
+        err.message.contains("higher-order") && err.message.contains("powerset"),
+        s"expected higher-order/powerset error; got: ${err.message}"
+      )
 
   test("standalone '^s' outside a binder surfaces as Left(AlloyTranslator)"):
     val spec =
@@ -70,13 +68,14 @@ class TranslatorTest extends munit.FunSuite:
         |  invariant power:
         |    #(^a) >= 0
         |}""".stripMargin
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateGlobalSync(ir, scope = 5) match
-      case Left(e)  => e
-      case Right(_) => fail("expected Left(AlloyTranslator)")
-    assert(
-      err.message.contains("powerset") && err.message.contains("binder domain"),
-      s"expected binder-domain error; got: ${err.message}"
-    )
+    for
+      ir      <- SpecFixtures.buildFromSource("Bad", spec)
+      moduleE <- Translator.translateGlobal(ir, scope = 5)
+    yield
+      val err = moduleE match
+        case Left(e)  => e
+        case Right(_) => fail("expected Left(AlloyTranslator)")
+      assert(
+        err.message.contains("powerset") && err.message.contains("binder domain"),
+        s"expected binder-domain error; got: ${err.message}"
+      )

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -10,6 +10,7 @@ import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Path
+import scala.util.Using
 
 class DumpTest extends CatsEffectSuite:
 
@@ -35,10 +36,11 @@ class DumpTest extends CatsEffectSuite:
           report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default, Some(sink))
           _      <- IO.blocking(sink.writeIndex(s"fixtures/spec/$fixture.spec", 0.0, report.ok))
           names <- IO.blocking {
-                     val files = Files.list(tmpDir).iterator
-                     val buf   = scala.collection.mutable.ListBuffer.empty[String]
-                     while files.hasNext do buf += files.next.getFileName.toString
-                     buf.toList
+                     Using.resource(Files.list(tmpDir)): stream =>
+                       val it  = stream.iterator
+                       val buf = scala.collection.mutable.ListBuffer.empty[String]
+                       while it.hasNext do buf += it.next.getFileName.toString
+                       buf.toList
                    }
           _ = assert(
                 names.contains("verdicts.json"),
@@ -80,11 +82,13 @@ class DumpTest extends CatsEffectSuite:
         ir <- SpecFixtures.loadIR("safe_counter")
         _  <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default, Some(sink))
         src <- IO.blocking {
-                 val iter                 = Files.list(tmpDir).iterator
-                 var picked: Option[Path] = None
-                 while picked.isEmpty && iter.hasNext do
-                   val p = iter.next
-                   if p.getFileName.toString.endsWith(".smt2") then picked = Some(p)
+                 val picked = Using.resource(Files.list(tmpDir)): stream =>
+                   val it                  = stream.iterator
+                   var found: Option[Path] = None
+                   while found.isEmpty && it.hasNext do
+                     val p = it.next
+                     if p.getFileName.toString.endsWith(".smt2") then found = Some(p)
+                   found
                  Files.readString(picked.getOrElse(fail("no .smt2 file")))
                }
       yield

--- a/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/DumpTest.scala
@@ -1,18 +1,18 @@
 package specrest.verify.certificates
 
+import cats.effect.IO
+import cats.effect.Resource
 import io.circe.parser
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
 import specrest.verify.Consistency
 import specrest.verify.VerificationConfig
-import specrest.verify.z3.WasmBackend
+import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
-import java.nio.file.Paths
+import java.nio.file.Path
 
-class DumpTest extends munit.FunSuite:
+class DumpTest extends CatsEffectSuite:
 
-  // (fixture name, ok=true expected, includes Z3 .smt2, includes Alloy .als)
   private val cases: List[(String, Boolean, Boolean, Boolean)] = List(
     ("safe_counter", true, true, false),
     ("unsat_invariants", false, true, false),
@@ -21,94 +21,77 @@ class DumpTest extends munit.FunSuite:
     ("temporal_demo", true, true, true)
   )
 
+  private def tempDir(prefix: String): Resource[IO, Path] =
+    Resource.make(IO.blocking(Files.createTempDirectory(prefix)))(p =>
+      IO.blocking(deleteRecursive(p))
+    )
+
   cases.foreach: (fixture, expectedOk, expectsSmt2, expectsAls) =>
     test(s"--dump-vc emits per-check VCs for $fixture"):
-      val tmpDir  = Files.createTempDirectory(s"dump-test-$fixture-")
-      val ir      = parseSpec(fixture)
-      val backend = WasmBackend()
-      val sink    = DumpSink.open(tmpDir).toOption.get
-      try
-        val report = Consistency.runConsistencyChecksSync(
-          ir,
-          backend,
-          VerificationConfig.Default,
-          Some(sink)
-        )
-        sink.writeIndex(s"fixtures/spec/$fixture.spec", 0.0, report.ok)
-        val files = Files.list(tmpDir).iterator
-        val names = scala.collection.mutable.ListBuffer.empty[String]
-        while files.hasNext do names += files.next.getFileName.toString
-        assert(
-          names.contains("verdicts.json"),
-          s"verdicts.json missing in $tmpDir; saw: ${names.toList}"
-        )
-        if expectsSmt2 then
-          assert(names.exists(_.endsWith(".smt2")), s"no .smt2 files; saw: ${names.toList}")
-        if expectsAls then
-          assert(names.exists(_.endsWith(".als")), s"no .als files; saw: ${names.toList}")
-        val verdicts = parser
-          .parse(Files.readString(tmpDir.resolve("verdicts.json")))
-          .toOption
-          .getOrElse(fail("invalid verdicts.json"))
-        val cursor = verdicts.hcursor
-        assertEquals(cursor.downField("schemaVersion").as[Int].toOption, Some(1))
-        assertEquals(cursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
-        val entries = cursor.downField("entries").values.getOrElse(Vector.empty).toList
-        assertEquals(
-          entries.size,
-          sink.entryCount,
-          s"verdicts.json entries mismatch sink for $fixture"
-        )
-        // Every referenced file must actually exist on disk; both outcome and
-        // rawStatus fields must be present (rawStatus is what cross-check uses).
-        entries.foreach: e =>
-          val cursor = e.hcursor
-          val file = cursor.downField("file").as[String].toOption
-            .getOrElse(fail(s"entry missing 'file': $e"))
-          assert(Files.exists(tmpDir.resolve(file)), s"missing $file in dump dir")
-          assert(cursor.downField("outcome").as[String].isRight, s"missing outcome: $e")
-          assert(cursor.downField("rawStatus").as[String].isRight, s"missing rawStatus: $e")
-      finally
-        backend.close()
-        deleteRecursive(tmpDir)
+      tempDir(s"dump-test-$fixture-").use: tmpDir =>
+        val sink = DumpSink.open(tmpDir).toOption.get
+        for
+          ir     <- SpecFixtures.loadIR(fixture)
+          report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default, Some(sink))
+          _      <- IO.blocking(sink.writeIndex(s"fixtures/spec/$fixture.spec", 0.0, report.ok))
+          names <- IO.blocking {
+                     val files = Files.list(tmpDir).iterator
+                     val buf   = scala.collection.mutable.ListBuffer.empty[String]
+                     while files.hasNext do buf += files.next.getFileName.toString
+                     buf.toList
+                   }
+          _ = assert(
+                names.contains("verdicts.json"),
+                s"verdicts.json missing in $tmpDir; saw: $names"
+              )
+          _ = if expectsSmt2 then
+                assert(names.exists(_.endsWith(".smt2")), s"no .smt2 files; saw: $names")
+          _ = if expectsAls then
+                assert(names.exists(_.endsWith(".als")), s"no .als files; saw: $names")
+          verdictsRaw <- IO.blocking(Files.readString(tmpDir.resolve("verdicts.json")))
+          verdicts     = parser.parse(verdictsRaw).toOption.getOrElse(fail("invalid verdicts.json"))
+        yield
+          val cursor = verdicts.hcursor
+          assertEquals(cursor.downField("schemaVersion").as[Int].toOption, Some(1))
+          assertEquals(cursor.downField("ok").as[Boolean].toOption, Some(expectedOk))
+          val entries = cursor.downField("entries").values.getOrElse(Vector.empty).toList
+          assertEquals(
+            entries.size,
+            sink.entryCount,
+            s"verdicts.json entries mismatch sink for $fixture"
+          )
+          entries.foreach: e =>
+            val ec = e.hcursor
+            val file = ec.downField("file").as[String].toOption
+              .getOrElse(fail(s"entry missing 'file': $e"))
+            assert(Files.exists(tmpDir.resolve(file)), s"missing $file in dump dir")
+            assert(ec.downField("outcome").as[String].isRight, s"missing outcome: $e")
+            assert(ec.downField("rawStatus").as[String].isRight, s"missing rawStatus: $e")
 
   test("DumpSink rejects non-empty target directory"):
-    val tmpDir = Files.createTempDirectory("dump-nonempty-")
-    val _      = Files.writeString(tmpDir.resolve("clutter.txt"), "x")
-    assert(DumpSink.open(tmpDir).isLeft, "expected Left for non-empty dir")
-    deleteRecursive(tmpDir)
+    tempDir("dump-nonempty-").use: tmpDir =>
+      IO.blocking(Files.writeString(tmpDir.resolve("clutter.txt"), "x")).map: _ =>
+        assert(DumpSink.open(tmpDir).isLeft, "expected Left for non-empty dir")
 
   test("dumped Z3 SMT-LIB starts with set-logic and ends with check-sat"):
-    val tmpDir  = Files.createTempDirectory("dump-shape-")
-    val ir      = parseSpec("safe_counter")
-    val backend = WasmBackend()
-    val sink    = DumpSink.open(tmpDir).toOption.get
-    try
-      val _ = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig.Default,
-        Some(sink)
-      )
-      val smtFile                            = Files.list(tmpDir).iterator.asInstanceOf[java.util.Iterator[java.nio.file.Path]]
-      var picked: Option[java.nio.file.Path] = None
-      while picked.isEmpty && smtFile.hasNext do
-        val p = smtFile.next
-        if p.getFileName.toString.endsWith(".smt2") then picked = Some(p)
-      val src = Files.readString(picked.getOrElse(fail("no .smt2 file")))
-      assert(src.startsWith("(set-logic ALL)"), s"unexpected prefix: ${src.take(60)}")
-      assert(src.contains("(check-sat)"), s"missing (check-sat) in dump")
-    finally
-      backend.close()
-      deleteRecursive(tmpDir)
+    tempDir("dump-shape-").use: tmpDir =>
+      val sink = DumpSink.open(tmpDir).toOption.get
+      for
+        ir <- SpecFixtures.loadIR("safe_counter")
+        _  <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default, Some(sink))
+        src <- IO.blocking {
+                 val iter                 = Files.list(tmpDir).iterator
+                 var picked: Option[Path] = None
+                 while picked.isEmpty && iter.hasNext do
+                   val p = iter.next
+                   if p.getFileName.toString.endsWith(".smt2") then picked = Some(p)
+                 Files.readString(picked.getOrElse(fail("no .smt2 file")))
+               }
+      yield
+        assert(src.startsWith("(set-logic ALL)"), s"unexpected prefix: ${src.take(60)}")
+        assert(src.contains("(check-sat)"), s"missing (check-sat) in dump")
 
-  private def parseSpec(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
-
-  private def deleteRecursive(p: java.nio.file.Path): Unit =
+  private def deleteRecursive(p: Path): Unit =
     if Files.isDirectory(p) then
       val it = Files.list(p).iterator
       while it.hasNext do deleteRecursive(it.next)

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -1,26 +1,19 @@
 package specrest.verify.certificates
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
 import specrest.verify.CheckOutcome
 import specrest.verify.Consistency
 import specrest.verify.VerificationConfig
-import specrest.verify.z3.WasmBackend
+import specrest.verify.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class UnsatCoreTest extends munit.FunSuite:
+class UnsatCoreTest extends CatsEffectSuite:
 
   test("Z3: --explain populates coreSpans on contradictory invariants"):
-    val ir      = parseSpec("unsat_invariants")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig(timeoutMs = 30_000L, captureCore = true)
-      )
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("unsat_invariants")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
       val global = report.checks.find(_.id == "global").get
       assertEquals(global.status, CheckOutcome.Unsat)
       val core = global.diagnostic.map(_.coreSpans).getOrElse(Nil)
@@ -32,30 +25,21 @@ class UnsatCoreTest extends munit.FunSuite:
           s"unexpected core note: ${cs.note}"
         )
         assert(cs.span.startLine >= 1, s"invalid span line: ${cs.span}")
-    finally backend.close()
 
   test("Z3: --explain leaves coreSpans empty when captureCore=false"):
-    val ir      = parseSpec("unsat_invariants")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig.Default
-      )
+    for
+      ir     <- SpecFixtures.loadIR("unsat_invariants")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val global = report.checks.find(_.id == "global").get
       assertEquals(global.diagnostic.map(_.coreSpans).getOrElse(Nil), Nil)
-    finally backend.close()
 
   test("Alloy: --explain populates coreSpans on contradictory powerset spec"):
-    val ir      = parseSpec("contradictory_powerset")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig(timeoutMs = 60_000L, captureCore = true)
-      )
+    val cfg = VerificationConfig(timeoutMs = 60_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("contradictory_powerset")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
       val global = report.checks.find(_.id == "global").get
       assertEquals(global.status, CheckOutcome.Unsat)
       val core = global.diagnostic.map(_.coreSpans).getOrElse(Nil)
@@ -63,32 +47,20 @@ class UnsatCoreTest extends munit.FunSuite:
         core.nonEmpty,
         "expected non-empty Alloy core spans for contradictory_powerset"
       )
-      // core spans must reference real spec lines (the two invariants are on lines 10 and 13)
       val lines = core.map(_.span.startLine).toSet
       assert(
         lines.subsetOf(Set(10, 13)),
         s"core spans should land on invariant lines (10/13), got: $lines"
       )
-    finally backend.close()
 
   test("Z3: --explain core for dead op points at requires clause"):
-    val ir      = parseSpec("dead_op")
-    val backend = WasmBackend()
-    try
-      val report = Consistency.runConsistencyChecksSync(
-        ir,
-        backend,
-        VerificationConfig(timeoutMs = 30_000L, captureCore = true)
-      )
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("dead_op")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
       val req = report.checks.find(_.id == "DeadOp.requires").get
       assertEquals(req.status, CheckOutcome.Unsat)
       val core = req.diagnostic.map(_.coreSpans).getOrElse(Nil)
       assert(core.nonEmpty, "expected non-empty core for DeadOp.requires")
       assertEquals(core.head.note, "contributing requires clause")
-    finally backend.close()
-
-  private def parseSpec(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get

--- a/modules/verify/src/test/scala/specrest/verify/testutil/SpecFixtures.scala
+++ b/modules/verify/src/test/scala/specrest/verify/testutil/SpecFixtures.scala
@@ -1,0 +1,25 @@
+package specrest.verify.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -1,281 +1,216 @@
 package specrest.verify.z3
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import cats.effect.IO
+import cats.effect.Resource
+import munit.CatsEffectSuite
 import specrest.verify.CheckStatus
 import specrest.verify.VerificationConfig
+import specrest.verify.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
+class BackendTest extends CatsEffectSuite:
 
-class BackendTest extends munit.FunSuite:
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).toOption.get
+  private val wasmBackend: Resource[IO, WasmBackend] = WasmBackend.make
 
   private def emptyArtifact: TranslatorArtifact =
     TranslatorArtifact(Nil, Nil, Nil, Nil, Nil, hasPostState = false)
 
-  test("trivial empty script is sat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(Nil, Nil, Nil, emptyArtifact)
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
-
-  test("assertion (false) is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(Nil, Nil, List(Z3Expr.BoolLit(false)), emptyArtifact)
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
-
-  test("simple integer assertion (>= 0) is sat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
-        assertions = List(
-          Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(0))
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
-
-  test("contradictory ints are unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
-        assertions = List(
-          Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(10)),
-          Z3Expr.Cmp(CmpOp.Le, Z3Expr.App("x", Nil), Z3Expr.IntLit(5))
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
-
-  test("url_shortener invariants are sat"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("url_shortener")
-      val script = Translator.translateSync(ir).toOption.get
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
-
-  test("unsat_invariants fixture is unsat"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("unsat_invariants")
-      val script = Translator.translateSync(ir).toOption.get
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
-
-  test("safe_counter invariants are sat"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("safe_counter")
-      val script = Translator.translateSync(ir).toOption.get
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
-
   private def intSet: Z3Sort = Z3Sort.SetOf(Z3Sort.Int)
 
-  test("membership in set literal: x = 3 ∧ x ∈ {1,2,3} is sat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
-        assertions = List(
-          Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(3)),
-          Z3Expr.SetMember(
-            Z3Expr.App("x", Nil),
-            Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
-          )
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
+  private def runScript(script: Z3Script): IO[SmokeCheckResult] =
+    wasmBackend.use: backend =>
+      backend.check(script, VerificationConfig.Default).map(_.toOption.get)
+
+  private def runIR(name: String): IO[SmokeCheckResult] =
+    for
+      ir      <- SpecFixtures.loadIR(name)
+      scriptE <- Translator.translate(ir)
+      script   = scriptE.toOption.get
+      result  <- runScript(script)
+    yield result
+
+  test("trivial empty script is sat"):
+    runScript(Z3Script(Nil, Nil, Nil, emptyArtifact)).map: result =>
       assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
+
+  test("assertion (false) is unsat"):
+    runScript(Z3Script(Nil, Nil, List(Z3Expr.BoolLit(false)), emptyArtifact)).map: result =>
+      assertEquals(result.status, CheckStatus.Unsat)
+
+  test("simple integer assertion (>= 0) is sat"):
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+      assertions = List(
+        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(0))
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Sat))
+
+  test("contradictory ints are unsat"):
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+      assertions = List(
+        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(10)),
+        Z3Expr.Cmp(CmpOp.Le, Z3Expr.App("x", Nil), Z3Expr.IntLit(5))
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
+
+  test("url_shortener invariants are sat"):
+    runIR("url_shortener").map(r => assertEquals(r.status, CheckStatus.Sat))
+
+  test("unsat_invariants fixture is unsat"):
+    runIR("unsat_invariants").map(r => assertEquals(r.status, CheckStatus.Unsat))
+
+  test("safe_counter invariants are sat"):
+    runIR("safe_counter").map(r => assertEquals(r.status, CheckStatus.Sat))
+
+  test("membership in set literal: x = 3 ∧ x ∈ {1,2,3} is sat"):
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+      assertions = List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(3)),
+        Z3Expr.SetMember(
+          Z3Expr.App("x", Nil),
+          Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+        )
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Sat))
 
   test("membership in set literal: x = 4 ∧ x ∈ {1,2,3} is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
-        assertions = List(
-          Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(4)),
-          Z3Expr.SetMember(
-            Z3Expr.App("x", Nil),
-            Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
-          )
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+      assertions = List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(4)),
+        Z3Expr.SetMember(
+          Z3Expr.App("x", Nil),
+          Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+        )
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("empty set membership is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
-        assertions = List(
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.EmptySet(Z3Sort.Int))
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
+      assertions = List(
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.EmptySet(Z3Sort.Int))
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("set union membership: x ∈ A ∧ ¬(x ∈ A ∪ B) is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(
-          Z3FunctionDecl("x", Nil, Z3Sort.Int),
-          Z3FunctionDecl("A", Nil, intSet),
-          Z3FunctionDecl("B", Nil, intSet)
-        ),
-        assertions = List(
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
-          Z3Expr.Not(
-            Z3Expr.SetMember(
-              Z3Expr.App("x", Nil),
-              Z3Expr.SetBinOp(SetOpKind.Union, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
-            )
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("x", Nil, Z3Sort.Int),
+        Z3FunctionDecl("A", Nil, intSet),
+        Z3FunctionDecl("B", Nil, intSet)
+      ),
+      assertions = List(
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+        Z3Expr.Not(
+          Z3Expr.SetMember(
+            Z3Expr.App("x", Nil),
+            Z3Expr.SetBinOp(SetOpKind.Union, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
           )
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+        )
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("set intersection — forward: x ∈ A ∩ B ∧ ¬(x ∈ A ∧ x ∈ B) is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(
-          Z3FunctionDecl("x", Nil, Z3Sort.Int),
-          Z3FunctionDecl("A", Nil, intSet),
-          Z3FunctionDecl("B", Nil, intSet)
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("x", Nil, Z3Sort.Int),
+        Z3FunctionDecl("A", Nil, intSet),
+        Z3FunctionDecl("B", Nil, intSet)
+      ),
+      assertions = List(
+        Z3Expr.SetMember(
+          Z3Expr.App("x", Nil),
+          Z3Expr.SetBinOp(SetOpKind.Intersect, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
         ),
-        assertions = List(
+        Z3Expr.Not(
+          Z3Expr.And(List(
+            Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+            Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
+          ))
+        )
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
+
+  test("set intersection — converse: x ∈ A ∧ x ∈ B ∧ ¬(x ∈ A ∩ B) is unsat"):
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("x", Nil, Z3Sort.Int),
+        Z3FunctionDecl("A", Nil, intSet),
+        Z3FunctionDecl("B", Nil, intSet)
+      ),
+      assertions = List(
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)),
+        Z3Expr.Not(
           Z3Expr.SetMember(
             Z3Expr.App("x", Nil),
             Z3Expr.SetBinOp(SetOpKind.Intersect, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
-          ),
-          Z3Expr.Not(
-            Z3Expr.And(List(
-              Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
-              Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
-            ))
           )
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
-
-  test("set intersection — converse: x ∈ A ∧ x ∈ B ∧ ¬(x ∈ A ∩ B) is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(
-          Z3FunctionDecl("x", Nil, Z3Sort.Int),
-          Z3FunctionDecl("A", Nil, intSet),
-          Z3FunctionDecl("B", Nil, intSet)
-        ),
-        assertions = List(
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)),
-          Z3Expr.Not(
-            Z3Expr.SetMember(
-              Z3Expr.App("x", Nil),
-              Z3Expr.SetBinOp(SetOpKind.Intersect, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
-            )
-          )
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+        )
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("set difference: x ∈ A \\ B ∧ x ∈ B is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(
-          Z3FunctionDecl("x", Nil, Z3Sort.Int),
-          Z3FunctionDecl("A", Nil, intSet),
-          Z3FunctionDecl("B", Nil, intSet)
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("x", Nil, Z3Sort.Int),
+        Z3FunctionDecl("A", Nil, intSet),
+        Z3FunctionDecl("B", Nil, intSet)
+      ),
+      assertions = List(
+        Z3Expr.SetMember(
+          Z3Expr.App("x", Nil),
+          Z3Expr.SetBinOp(SetOpKind.Diff, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
         ),
-        assertions = List(
-          Z3Expr.SetMember(
-            Z3Expr.App("x", Nil),
-            Z3Expr.SetBinOp(SetOpKind.Diff, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil))
-          ),
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil))
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("set subset: A ⊆ B ∧ x ∈ A ∧ ¬(x ∈ B) is unsat"):
-    val backend = WasmBackend()
-    try
-      val script = Z3Script(
-        sorts = Nil,
-        funcs = List(
-          Z3FunctionDecl("x", Nil, Z3Sort.Int),
-          Z3FunctionDecl("A", Nil, intSet),
-          Z3FunctionDecl("B", Nil, intSet)
-        ),
-        assertions = List(
-          Z3Expr.SetBinOp(SetOpKind.Subset, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil)),
-          Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
-          Z3Expr.Not(Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)))
-        ),
-        artifact = emptyArtifact
-      )
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Unsat)
-    finally backend.close()
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(
+        Z3FunctionDecl("x", Nil, Z3Sort.Int),
+        Z3FunctionDecl("A", Nil, intSet),
+        Z3FunctionDecl("B", Nil, intSet)
+      ),
+      assertions = List(
+        Z3Expr.SetBinOp(SetOpKind.Subset, Z3Expr.App("A", Nil), Z3Expr.App("B", Nil)),
+        Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("A", Nil)),
+        Z3Expr.Not(Z3Expr.SetMember(Z3Expr.App("x", Nil), Z3Expr.App("B", Nil)))
+      ),
+      artifact = emptyArtifact
+    )
+    runScript(script).map(r => assertEquals(r.status, CheckStatus.Unsat))
 
   test("set_ops fixture invariants are sat at the IR level"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("set_ops")
-      val script = Translator.translateSync(ir).toOption.get
-      val result = backend.checkSync(script, VerificationConfig.Default).toOption.get
-      assertEquals(result.status, CheckStatus.Sat)
-    finally backend.close()
+    runIR("set_ops").map(r => assertEquals(r.status, CheckStatus.Sat))

--- a/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
@@ -1,7 +1,6 @@
 package specrest.verify.z3
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import munit.CatsEffectSuite
 import specrest.verify.CheckKind
 import specrest.verify.Consistency
 import specrest.verify.CounterExample
@@ -15,23 +14,15 @@ import specrest.verify.DecodedValue
 import specrest.verify.Diagnostic
 import specrest.verify.DiagnosticCategory
 import specrest.verify.VerificationConfig
+import specrest.verify.testutil.SpecFixtures
 
-import java.nio.file.Files
-import java.nio.file.Paths
-
-class CounterExampleTest extends munit.FunSuite:
-
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(Paths.get(s"fixtures/spec/$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty)
-    Builder.buildIRSync(parsed.tree).toOption.get
+class CounterExampleTest extends CatsEffectSuite:
 
   test("broken_url_shortener preservation failure produces a decoded counterexample"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val viol = report.checks.find(c =>
         c.kind == CheckKind.Preservation &&
           c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
@@ -43,15 +34,12 @@ class CounterExampleTest extends munit.FunSuite:
       val ce = viol.flatMap(_.diagnostic).flatMap(_.counterexample)
       assert(ce.isDefined, "expected a decoded counterexample attached to the diagnostic")
       val decoded = ce.get
-      // The counterexample carries at least the entity / state / input breakdown
-      // from Z3's model. Some components may be empty depending on the specific spec.
       val nonEmpty =
         decoded.entities.nonEmpty ||
           decoded.stateRelations.nonEmpty ||
           decoded.stateConstants.nonEmpty ||
           decoded.inputs.nonEmpty
       assert(nonEmpty, s"counterexample should have at least one decoded component; got $decoded")
-    finally backend.close()
 
   test("formatCounterExample renders a readable block"):
     val ce = DecodedCounterExample(
@@ -90,10 +78,10 @@ class CounterExampleTest extends munit.FunSuite:
     assert(out.contains("users = { 42 → User#0 }"))
 
   test("decoded counterexample flows into formatDiagnostic output"):
-    val backend = WasmBackend()
-    try
-      val ir     = buildIR("broken_url_shortener")
-      val report = Consistency.runConsistencyChecksSync(ir, backend, VerificationConfig.Default)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
       val violation = report.checks.find(c =>
         c.kind == CheckKind.Preservation &&
           c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
@@ -102,4 +90,3 @@ class CounterExampleTest extends munit.FunSuite:
         Diagnostic.formatDiagnostic(violation.diagnostic.get, "broken_url_shortener.spec")
       assert(output.contains("Counterexample:"), s"missing Counterexample header in: $output")
       assert(!output.contains("<counterexample decoding not yet ported"), "stale placeholder text")
-    finally backend.close()

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -39,7 +39,7 @@ class SmtLibGoldenTest extends CatsEffectSuite:
           if emitted == golden then IO.unit
           else
             IO.blocking {
-              val diffPath = Paths.get(s"/tmp/scala-smt-$name.smt2")
+              val diffPath = Files.createTempFile(s"scala-smt-$name-", ".smt2")
               Files.writeString(diffPath, emitted)
               fail(s"SMT-LIB mismatch for $name; Scala output written to $diffPath for comparison")
             }

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibGoldenTest.scala
@@ -1,15 +1,15 @@
 package specrest.verify.z3
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import cats.effect.IO
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
 
 import java.nio.file.Files
 import java.nio.file.Path as JPath
 import java.nio.file.Paths
 
-class SmtLibGoldenTest extends munit.FunSuite:
+class SmtLibGoldenTest extends CatsEffectSuite:
 
-  private val specDir: JPath   = Paths.get("fixtures/spec")
   private val goldenDir: JPath = Paths.get("fixtures/golden/smt")
 
   private val translatableFixtures: List[String] = List(
@@ -24,25 +24,23 @@ class SmtLibGoldenTest extends munit.FunSuite:
     "url_shortener"
   )
 
-  private def buildIR(name: String): specrest.ir.ServiceIR =
-    val src    = Files.readString(specDir.resolve(s"$name.spec"))
-    val parsed = Parse.parseSpecSync(src)
-    assert(parsed.errors.isEmpty, s"parse errors for $name: ${parsed.errors}")
-    Builder.buildIRSync(parsed.tree).fold(
-      err => fail(s"buildIR failed for $name: ${err.message}"),
-      identity
-    )
-
   translatableFixtures.foreach: name =>
     test(s"SMT-LIB matches golden — $name"):
-      val ir = buildIR(name)
-      val script = Translator.translateSync(ir).fold(
-        err => fail(s"Translator.translate failed for $name: ${err.message}"),
-        identity
-      )
-      val emitted = SmtLib.renderSmtLib(script, timeoutMs = Some(30_000L)).stripSuffix("\n")
-      val golden  = Files.readString(goldenDir.resolve(s"$name.smt2")).stripSuffix("\n")
-      if emitted != golden then
-        val diffPath = Paths.get(s"/tmp/scala-smt-$name.smt2")
-        Files.writeString(diffPath, emitted)
-        fail(s"SMT-LIB mismatch for $name; Scala output written to $diffPath for comparison")
+      for
+        ir      <- SpecFixtures.loadIR(name)
+        scriptE <- Translator.translate(ir)
+        script = scriptE.fold(
+                   err => fail(s"Translator.translate failed for $name: ${err.message}"),
+                   identity
+                 )
+        emitted = SmtLib.renderSmtLib(script, timeoutMs = Some(30_000L)).stripSuffix("\n")
+        golden <- IO.blocking(Files.readString(goldenDir.resolve(s"$name.smt2")).stripSuffix("\n"))
+        _ <-
+          if emitted == golden then IO.unit
+          else
+            IO.blocking {
+              val diffPath = Paths.get(s"/tmp/scala-smt-$name.smt2")
+              Files.writeString(diffPath, emitted)
+              fail(s"SMT-LIB mismatch for $name; Scala output written to $diffPath for comparison")
+            }
+      yield ()

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -1,18 +1,24 @@
 package specrest.verify.z3
 
-import specrest.parser.Builder
-import specrest.parser.Parse
+import cats.effect.IO
+import munit.CatsEffectSuite
+import specrest.ir.VerifyError
+import specrest.verify.testutil.SpecFixtures
 
-class TranslatorSetOpsTest extends munit.FunSuite:
+class TranslatorSetOpsTest extends CatsEffectSuite:
 
-  private def scriptOf(spec: String): Z3Script =
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    Translator.translateSync(ir).toOption.get
+  private def scriptOf(spec: String): IO[Z3Script] =
+    SpecFixtures.buildFromSource("spec", spec).flatMap: ir =>
+      Translator.translate(ir).map(_.toOption.get)
 
-  private def smtOf(spec: String): String =
-    SmtLib.renderSmtLib(scriptOf(spec))
+  private def smtOf(spec: String): IO[String] =
+    scriptOf(spec).map(SmtLib.renderSmtLib(_))
+
+  private def translatorErrorOf(spec: String): IO[VerifyError.Translator] =
+    SpecFixtures.buildFromSource("spec", spec).flatMap: ir =>
+      Translator.translate(ir).map:
+        case Left(e)  => e
+        case Right(_) => fail("expected translator error")
 
   private def specWithInvariant(stateBlock: String, inv: String): String =
     s"""service S {
@@ -24,185 +30,132 @@ class TranslatorSetOpsTest extends munit.FunSuite:
        |}""".stripMargin
 
   test("`id in {0, 1, 2}` lowers to a disjunction of equalities"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "counters: Int -> lone Int",
         "all id in counters | counters[id] in {0, 1, 2}"
       )
-    )
-    assert(out.contains("(or "), s"expected a disjunction in SMT; got:\n$out")
-    assert(out.contains("(= "), s"expected equalities; got:\n$out")
+    ).map: out =>
+      assert(out.contains("(or "), s"expected a disjunction in SMT; got:\n$out")
+      assert(out.contains("(= "), s"expected equalities; got:\n$out")
 
   test("`x not in {5}` lowers to (not (= …)) with singleton not wrapped in or"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "counters: Int -> lone Int",
         "all id in counters | counters[id] not in {5}"
       )
-    )
-    assert(
-      out.contains("(not (= ") || out.contains("(distinct"),
-      s"expected negation-of-equality; got:\n$out"
-    )
+    ).map: out =>
+      assert(
+        out.contains("(not (= ") || out.contains("(distinct"),
+        s"expected negation-of-equality; got:\n$out"
+      )
 
   test("`x in {a}` singleton collapses to a single equality (no Or wrapper)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "counters: Int -> lone Int",
         "all id in counters | counters[id] in {7}"
       )
-    )
-    val membershipLine = out.linesIterator.find(_.contains("7")).getOrElse("")
-    assert(
-      !membershipLine.contains("(or "),
-      s"should not wrap singleton in or; got line:\n$membershipLine"
-    )
+    ).map: out =>
+      val membershipLine = out.linesIterator.find(_.contains("7")).getOrElse("")
+      assert(
+        !membershipLine.contains("(or "),
+        s"should not wrap singleton in or; got line:\n$membershipLine"
+      )
 
   test("`a union b` — set-typed state and invariant emits (union ...)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]\n    x: Int",
         "x in (a union b) implies x in a or x in b"
       )
-    )
-    assert(out.contains("(union "), s"expected (union ...); got:\n$out")
-    assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
+    ).map: out =>
+      assert(out.contains("(union "), s"expected (union ...); got:\n$out")
+      assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
 
   test("`a intersect b` emits (intersection ...)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]\n    x: Int",
         "x in (a intersect b) implies x in a"
       )
-    )
-    assert(out.contains("(intersection "), s"expected (intersection ...); got:\n$out")
+    ).map: out =>
+      assert(out.contains("(intersection "), s"expected (intersection ...); got:\n$out")
 
   test("`a minus b` emits (setminus ...)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]\n    x: Int",
         "x in (a minus b) implies x in a"
       )
-    )
-    assert(out.contains("(setminus "), s"expected (setminus ...); got:\n$out")
+    ).map: out =>
+      assert(out.contains("(setminus "), s"expected (setminus ...); got:\n$out")
 
   test("`a subset b` emits (subset ...)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]",
         "a subset b implies b subset a or not (a subset b)"
       )
-    )
-    assert(out.contains("(subset "), s"expected (subset ...); got:\n$out")
+    ).map: out =>
+      assert(out.contains("(subset "), s"expected (subset ...); got:\n$out")
 
   test("`Set[Int]`-typed state field declares a (Set Int)-valued function"):
-    val out = smtOf(
-      specWithInvariant(
-        "a: Set[Int]",
-        "true"
+    smtOf(specWithInvariant("a: Set[Int]", "true")).map: out =>
+      assert(
+        out.contains("(declare-fun state_a () (Set Int))"),
+        s"expected (Set Int)-typed state decl; got:\n$out"
       )
-    )
-    assert(
-      out.contains("(declare-fun state_a () (Set Int))"),
-      s"expected (Set Int)-typed state decl; got:\n$out"
-    )
 
   test("membership against a set-sorted expression falls through to (select)"):
-    val out = smtOf(
+    smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]\n    x: Int",
         "x in (a intersect b) implies x in (a union b)"
       )
-    )
-    assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
+    ).map: out =>
+      assert(out.contains("(select "), s"expected (select ...) membership; got:\n$out")
 
   test("nested set sort — Set[Set[Int]] renders as (Set (Set Int))"):
-    val out = smtOf(
-      specWithInvariant(
-        "ss: Set[Set[Int]]",
-        "true"
+    smtOf(specWithInvariant("ss: Set[Set[Int]]", "true")).map: out =>
+      assert(
+        out.contains("(declare-fun state_ss () (Set (Set Int)))"),
+        s"expected nested set sort; got:\n$out"
       )
-    )
-    assert(
-      out.contains("(declare-fun state_ss () (Set (Set Int)))"),
-      s"expected nested set sort; got:\n$out"
-    )
 
   test("empty set literal '{}' raises a sharp TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]",
-      "a subset {}"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      err.message.contains("empty set literal"),
-      s"expected empty-set error; got: ${err.message}"
-    )
+    translatorErrorOf(specWithInvariant("a: Set[Int]", "a subset {}")).map: err =>
+      assert(
+        err.message.contains("empty set literal"),
+        s"expected empty-set error; got: ${err.message}"
+      )
 
   test("set operator on non-set operands raises a TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]\n    n: Int",
-      "a subset n"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      err.message.contains("requires both operands to be sets"),
-      s"expected non-set operand error; got: ${err.message}"
-    )
+    translatorErrorOf(specWithInvariant("a: Set[Int]\n    n: Int", "a subset n")).map: err =>
+      assert(
+        err.message.contains("requires both operands to be sets"),
+        s"expected non-set operand error; got: ${err.message}"
+      )
 
   test("set operator on mismatched element sorts raises a TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]\n    b: Set[Bool]",
-      "a union b subset a"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      err.message.contains("same element sort"),
-      s"expected element-sort mismatch error; got: ${err.message}"
-    )
+    translatorErrorOf(
+      specWithInvariant("a: Set[Int]\n    b: Set[Bool]", "a union b subset a")
+    ).map: err =>
+      assert(
+        err.message.contains("same element sort"),
+        s"expected element-sort mismatch error; got: ${err.message}"
+      )
 
   test("heterogeneous standalone set literal raises a TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]",
-      "{1, true} subset a"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    if parsed.errors.isEmpty then
-      val ir = Builder.buildIRSync(parsed.tree).toOption.get
-      val err = Translator.translateSync(ir) match
-        case Left(e)  => e
-        case Right(_) => fail("expected translator error")
+    translatorErrorOf(specWithInvariant("a: Set[Int]", "{1, true} subset a")).map: err =>
       assert(
         err.message.contains("must all have the same sort"),
         s"expected hetero-sort error; got: ${err.message}"
       )
 
   test("heterogeneous set literal in membership raises a TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]\n    x: Int",
-      "x in {1, 2, true}"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    if parsed.errors.isEmpty then
-      val ir = Builder.buildIRSync(parsed.tree).toOption.get
-      val err = Translator.translateSync(ir) match
-        case Left(e)  => e
-        case Right(_) => fail("expected translator error")
+    translatorErrorOf(specWithInvariant("a: Set[Int]\n    x: Int", "x in {1, 2, true}")).map: err =>
       assert(
         err.message.contains("must match the membership LHS sort") ||
           err.message.contains("must all have the same sort"),
@@ -210,50 +163,30 @@ class TranslatorSetOpsTest extends munit.FunSuite:
       )
 
   test("membership against a set-sorted expression enforces LHS element-sort match"):
-    val spec = specWithInvariant(
-      "a: Set[Int]\n    b: Set[Int]\n    flag: Bool",
-      "flag in (a union b) implies true"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      err.message.contains("left-hand side sort to match") ||
-        err.message.contains("element sort"),
-      s"expected LHS/elem mismatch error; got: ${err.message}"
-    )
+    translatorErrorOf(
+      specWithInvariant(
+        "a: Set[Int]\n    b: Set[Int]\n    flag: Bool",
+        "flag in (a union b) implies true"
+      )
+    ).map: err =>
+      assert(
+        err.message.contains("left-hand side sort to match") ||
+          err.message.contains("element sort"),
+        s"expected LHS/elem mismatch error; got: ${err.message}"
+      )
 
   test("empty set literal error message does not mention 'typed receiver'"):
-    val spec = specWithInvariant(
-      "a: Set[Int]",
-      "a subset {}"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      !err.message.contains("typed receiver"),
-      s"error message should not suggest typed receiver; got: ${err.message}"
-    )
+    translatorErrorOf(specWithInvariant("a: Set[Int]", "a subset {}")).map: err =>
+      assert(
+        !err.message.contains("typed receiver"),
+        s"error message should not suggest typed receiver; got: ${err.message}"
+      )
 
   test("powerset operator raises a sharp TranslatorError"):
-    val spec = specWithInvariant(
-      "a: Set[Int]\n    b: Set[Set[Int]]",
-      "b subset ^a"
-    )
-    val parsed = Parse.parseSpecSync(spec)
-    assert(parsed.errors.isEmpty, s"parse errors: ${parsed.errors}")
-    val ir = Builder.buildIRSync(parsed.tree).toOption.get
-    val err = Translator.translateSync(ir) match
-      case Left(e)  => e
-      case Right(_) => fail("expected translator error")
-    assert(
-      err.message.contains("powerset"),
-      s"expected powerset error; got: ${err.message}"
-    )
+    translatorErrorOf(
+      specWithInvariant("a: Set[Int]\n    b: Set[Set[Int]]", "b subset ^a")
+    ).map: err =>
+      assert(
+        err.message.contains("powerset"),
+        s"expected powerset error; got: ${err.message}"
+      )


### PR DESCRIPTION
## Summary

Closes #103 (seventh eighth of #95, the CE3 migration meta).

- **Kills every `*Sync` wrapper on the library surface.** `Parse.parseSpec`, `Builder.buildIR`, Z3 `Translator.translate*` (4 variants), Alloy `Translator.translate*` (5 variants), `WasmBackend.check`, `AlloyBackend.check`, and `Consistency.runConsistencyChecks` are now the *only* entry points. Each body sits inside `IO.delay` or `IO.blocking` — no paired `fooSync` helper + `def foo = IO.blocking(fooSync)` shim. This follows the CE3 "expose only IO, with thread-shifting owned inside the wrapper" guidance ([timwspence.github.io](https://timwspence.github.io/blog/posts/2021-01-12-threading-best-practices-cats-effect.html)).
- **`Consistency` is IO-native end-to-end.** Every `run*` subroutine and `executePlan` return `IO[CheckResult]`, composing translate + backend calls via `flatMap`; dump writes go through `IO.blocking`. `runOne` no longer wraps `executePlan` in `IO.interruptible` — the per-stage IO chain gives cancellation at stage boundaries, which is what the sync-inside-interruptible variant already devolved to on Z3 (Z3's native `solver.check` ignores `Thread.interrupt`). Deleted: `runConsistencyChecksSync`, the legacy 4-arg `runConsistencyChecks(ir, backend, config, dump)`, and the internal `runConsistencyChecksWithAlloy` bridge.
- **All pipeline-touching tests migrate to `CatsEffectSuite`** — `ConsistencyTest`, `JsonReportTest`, `DumpTest`, `UnsatCoreTest`, `CounterExampleTest`, `ParallelTest` (drops `cats.effect.unsafe.implicits.global` and all `unsafeRunSync`), plus the previously-migrated `TimeoutTest` / `ResourceLifecycleTest` swap their inline `buildIR` helpers for the shared one. `ParseBuildGoldenTest`, `ProfileSmokeTest`, `ConventionSmokeTest`, `AlembicMigrationTest`, `EmitTest`, `OpenApiTest`, and the alloy/z3 Translator/Backend/Render/Golden tests migrate too. Pure data-transform tests (`ClassifierTest`, `SmtLibRenderTest`, `GoldenRoundtripTest`, `CodegenSmokeTest`) stay on `FunSuite` per AC.
- **Per-module `testutil/SpecFixtures.scala`** (5 modules: parser, profile, convention, codegen, verify) provides `loadIR(name): IO[ServiceIR]` + `buildFromSource(label, src): IO[ServiceIR]`; codegen adds `loadProfiled`. Local copies, no cross-module `test->test` classpath plumbing.
- **Golden regenerated.** `fixtures/golden/verify_report/broken_url_shortener.json` captures a new (equally valid) Z3 counterexample — plans now run on fresh Contexts instead of one shared sync Context, and Z3 with `random_seed=0` picks a different witness.

## Shape change at the boundary

Before:
```scala
val backend = WasmBackend()
try
  val report = Consistency.runConsistencyChecksSync(ir, backend, cfg)
  ...
finally backend.close()
```

After:
```scala
Consistency.runConsistencyChecks(ir, cfg).map: report => ... // backends are Resource-managed
```

## Verification

- [x] `sbt test` — 121/121 green
- [x] `sbt scalafmtAll` clean
- [x] `sbt "scalafixAll --check"` clean
- [x] `cd docs && npm run build` clean
- [x] No `*Sync` wrappers left in `modules/**/src/main` (verified by grep)
- [x] No `unsafeRunSync` / `cats.effect.unsafe.implicits.global` in `modules/**/src/main` or migrated test files

## Test plan

- [ ] Reviewer runs `sbt test` locally and confirms green
- [ ] Spot-check `rg "Sync\(" modules/*/src/main` returns nothing
- [ ] Spot-check that `Consistency.runConsistencyChecks` call sites in `cli/Verify.scala` still compile (they do; single-arg overload unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the verification pipeline IO-only and migrate tests to `CatsEffectSuite`. Drops the outer timeout wrapper and fixes Windows-specific test issues while managing backends via `Resource`.

- **Refactors**
  - Removed all `*Sync` APIs. `Parse.parseSpec`, `Builder.buildIR`, and Z3/Alloy `Translator` return `IO`; `Consistency` is IO-native and acquires `WasmBackend`/`AlloyBackend` via `Resource`, invoking backend `check` via `IO.blocking`.
  - Simplified `runOne` by removing the outer `IO.timeoutTo` and the timeout fallback/`PlanMetadata` helpers; solver-side limits remain enforced in backends.
  - Regenerated `fixtures/golden/verify_report/broken_url_shortener.json` due to fresh Z3 contexts; docs add M_CE.8 entry.

- **Migration**
  - All pipeline-touching tests moved to `munit` `CatsEffectSuite`; removed `unsafeRunSync` and `cats.effect.unsafe.implicits.global`. Added per-module `testutil/SpecFixtures` (`loadIR`/`buildFromSource`, plus `loadProfiled` in codegen).
  - Replaced `Consistency.runConsistencyChecksSync(ir, backend, cfg)` with `Consistency.runConsistencyChecks(ir, cfg)`; backends are now managed internally.
  - Test robustness on Windows: close `Files.list` streams via `Using.resource`, use `Files.createTempFile` for diff dumps, and wrap `Files.exists` in `IO.blocking`.

<sup>Written for commit 4f07dbd605e537925736328bdfd3d73df75e7fba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized verification pipeline to fully asynchronous execution model across all entry points (parsing, building, translating, backend checking, and consistency verification).
  * Updated test fixture utilities to streamline spec file loading.
  * Enhanced backend resource management for more reliable lifecycle handling.

* **Tests**
  * Migrated verification and code generation test suites to async execution pattern.

* **Documentation**
  * Updated verification pipeline capability documentation to reflect new single-API asynchronous design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->