### PR TITLE
Wire Z3 Context.interrupt() into WasmBackend.check onCancel (closes #113)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,30 +6,58 @@
   flowcharts instead of hand-drawn ASCII boxes and arrows.
 - **All fenced code blocks must specify a language.** Use ` ```text ` when no specific language
   applies. Never leave the language identifier empty after the opening triple backticks.
-- **No comments at the top of files.** No JSDoc preambles, no block comments, no single-line
+- **No comments at the top of files.** No Scaladoc preambles, no block comments, no single-line
   summaries. The file name and exports are the documentation.
+- **No inline comments that restate the code.** Only add a comment when the _why_ is non-obvious (a
+  hidden invariant, a workaround for a specific library bug, a surprising constraint). If removing
+  the comment would not confuse a future reader, do not write it.
 
 ## Imports
 
-- **No relative imports.** Use Node.js subpath imports (`#parser/...`, `#ir/...`, `#cli/...`)
-  instead of `./` or `../` paths. The mappings are defined in `package.json` `imports` field.
-  Exception: auto-generated files (`src/parser/generated/`) use relative imports internally.
+- **One import per line.** Follow the existing convention of explicit imports
+  (`import cats.effect.IO`, `import cats.effect.Resource`) rather than wildcard imports. Exception:
+  package-level alias imports already in use (e.g., `import scala.jdk.CollectionConverters.*`).
+- **Scalafix `OrganizeImports` runs in CI.** After edits that add or rename imports, run
+  `sbt scalafixAll` locally before pushing — CI rejects unorganized imports.
 
-## Type Safety
+## Type Safety (Scala 3)
 
-- **No `unknown` in public function signatures.** Use concrete types or union types
-  (`string | number | boolean`). `unknown` is only acceptable when wrapping third-party library
-  boundaries (e.g., `Handlebars.HelperDelegate`), never in exported functions.
-- **No `as` type casts.** Use type guards, discriminated unions, or restructure code so TypeScript
-  can infer types. Exception: conforming to third-party library types at FFI boundaries (typed as
-  `HelperDelegate`, etc.).
-- **No `any`.** Do not introduce `any` into project code. If a dependency's types use `any`, contain
-  it at the boundary and expose concrete types to the rest of the codebase.
+- **No `asInstanceOf` in application code.** Use pattern matching, `match` on sealed hierarchies, or
+  restructure types so the compiler can infer them. Exception: conforming to Java/third-party APIs
+  at FFI boundaries (e.g., `com.microsoft.z3.*` generic type erasure in
+  `modules/verify/.../z3/Backend.scala`).
+- **No `Any` in public signatures.** Use concrete types or union types. `Any` is only acceptable
+  when interoperating with Java reflection / generic erasure at the FFI boundary.
+- **No `null` in domain code.** Use `Option[A]`. `null` is only acceptable when calling Java APIs
+  that accept `null` as a sentinel (e.g., Z3's `mkForall(..., null, null, null, null)`).
+- **No defensive throws.** Do not add `require`/`assert`/`throw` guards for conditions that cannot
+  happen given the type system's guarantees. Structural solutions (ADTs, `Either`,
+  `boundary`/`break`) over speculative runtime checks.
+
+## Cats Effect idioms (CE3)
+
+- **Prefer `IO.blocking(body).onCancel(finalizer)` over `IO.async { cb => new Thread(...) }`** when
+  all you need is an external-signal cancel hook. `onCancel` on `IO.blocking` fires concurrently
+  with the still-blocked thread — sufficient for wrapping native code that has a thread-safe
+  interrupt API (e.g., `ctx.interrupt()`).
+- **Do not factor a private sync helper just to reduce nesting.** Inline the body inside
+  `IO.blocking { ... }`. A 40-line block is fine; an artificial `private def checkSync` is not.
+- **Single source of truth for config defaults.** `VerificationConfig.Default` is the only place
+  timeout/scope/parallelism defaults live. Do not duplicate them at call sites.
+- **Do not weaken test assertions to paper over flakiness.** Find and fix the root cause. If a
+  test's invariant is already covered deterministically elsewhere, delete the redundant test rather
+  than relaxing it.
 
 ## Testing
 
-- **Prefer test parametrization over code duplication.** Use `it.each` / `describe.each` or
-  loop-driven test generation instead of copy-pasting nearly identical test cases.
+- **Prefer test parametrization over code duplication.** Use munit's
+  `List(...).foreach: case => test(name): ...` pattern (see `modules/verify/.../ParallelTest.scala`,
+  `modules/cli/.../CliSmokeTest.scala`) instead of copy-pasting nearly identical test cases.
+- **Every new test extends `CatsEffectSuite`** (munit-cats-effect). Return `IO[Unit]` from test
+  bodies; use `.assertEquals(...)` on `IO[A]` directly. No `unsafeRunSync` in test code.
+- **Wall-clock / timing tests use generous tolerances.** CI machines vary — a test that passes in
+  200 ms locally should assert `< 2000 ms`, not `< 250 ms`. Assert the _qualitative_ property
+  (bounded, not unbounded), not the exact latency.
 
 ## Attribution
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -489,26 +489,35 @@ The 30 s default is conservative headroom for heavier preservation checks on lar
 
 ### Cancellation
 
-The solver-call IOs live inside `IO.blocking`, which is uncancelable until natural
-completion — a cancelled parent fiber waits for the in-flight blocking call to return
-(bounded by the solver's own inner timeout) before cancellation proceeds and `Resource`
-finalizers fire. That's the contract: no asynchronous mid-call abort, but a deterministic
-shutdown order with bounded latency.
+Fiber cancellation of an in-flight Z3 `solver.check()` is wired through
+`Context.interrupt()` on the Z3 side
+([#113](https://github.com/HardMax71/spec_to_rest/issues/113)):
 
-Z3's native `solver.check()` does *not* observe `Thread.isInterrupted`, and because the
-call runs inside `IO.blocking` we wouldn't send an interrupt anyway. On cancel the solver
-thread continues until it honours its own inner `timeout` parameter; then `Resource`
-finalizers close the Z3 `Context`. True mid-call abort via `Context.interrupt()` is a
-follow-up ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)); it only matters
-for pathological specs that defeat Z3's own timeout.
+```scala
+IO.blocking(checkSync(...)).onCancel(IO.blocking(ctx.interrupt()))
+```
+
+`Context.interrupt()` is the only Z3 API designed to be called from a thread other than
+the one running the solver. On cancel, CE3 fires the `onCancel` finalizer concurrently
+with the still-blocked solver thread; Z3 observes the interrupt, `solver.check()` returns
+`Status.UNKNOWN` promptly, the blocking body completes, and `Resource[IO, WasmBackend]`
+finalizers close the `Context`. Practical mid-call abort latency is a few ms on top of
+whatever Z3 takes to unwind the current rewriting pass — well under the inner `timeout`
+parameter's slack window.
+
+Alloy's backend uses an internal `Future.get(timeout)` pool for its inner deadline, and
+the `Resource` finalizer shuts the pool down on cancel; its equivalent of
+`Context.interrupt()` is `future.cancel(true)`, which is already in the timeout path but
+not yet in the `onCancel` path. A symmetric fix is filed as a follow-up if demand
+materializes.
 
 SIGINT handling (Ctrl+C) ships in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)):
 the CLI runs as `CommandIOApp`, which via the underlying `IOApp` installs a shutdown hook
-(`io-cancel-hook`) that cancels the top-level fiber on SIGINT or SIGTERM. Cancellation then
-flows through the path above — in-flight `IO.blocking` calls complete naturally,
-`Resource[IO, WasmBackend]` and `Resource[IO, AlloyBackend]` finalizers run, Z3
-`Context.close()` and Alloy backend pools release, and the JVM exits cleanly. The shutdown
-hook honours a 30 s grace deadline before forcing JVM exit.
+(`io-cancel-hook`) that cancels the top-level fiber on SIGINT or SIGTERM. Cancellation
+flows into the path above — the Z3 `onCancel` finalizer runs, in-flight solver calls
+abort, `Resource[IO, WasmBackend]` and `Resource[IO, AlloyBackend]` finalizers fire, Z3
+`Context.close()` and Alloy backend pools release, and the JVM exits cleanly. The
+shutdown hook honours a 30 s grace deadline before forcing JVM exit.
 
 ## Parallelism model
 
@@ -529,13 +538,14 @@ with `parTraverseN(maxParallel)`.
   `--parallel 8` or lower to bound peak native memory.
 - **Determinism**: `parTraverseN` preserves input order in the result list, so the report
   order is identical across runs regardless of the fiber-completion order.
-- **Cancellation**: solver calls run inside `IO.blocking`, which completes naturally before
-  cancellation proceeds. A parent cancel or `CheckOutcome.Unknown` from the inner timeout
-  both release the fiber, tear down the `Resource`-managed backends, and free native memory.
-  See [Timeout semantics](#timeout-semantics) for the inner-solver deadline model and the
-  Z3 `Thread.interrupt` caveat. Ctrl+C signal handling shipped in M_CE.7
-  ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)): `CommandIOApp` installs
-  a JVM shutdown hook that feeds SIGINT / SIGTERM into the fiber cancellation path.
+- **Cancellation**: Z3's `WasmBackend.check` wires `ctx.interrupt()` into its `onCancel`
+  finalizer ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)), so a parent
+  cancel aborts the in-flight `solver.check()` within milliseconds instead of waiting for
+  Z3's inner timeout. `Resource`-managed backends then tear down and free native memory.
+  See [Cancellation](#cancellation) for the full path. Ctrl+C signal handling shipped in
+  M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)): `CommandIOApp`
+  installs a JVM shutdown hook that feeds SIGINT / SIGTERM into the fiber cancellation
+  path.
 
 ## Set theory
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -494,16 +494,19 @@ Fiber cancellation of an in-flight Z3 `solver.check()` is wired through
 ([#113](https://github.com/HardMax71/spec_to_rest/issues/113)):
 
 ```scala
-IO.blocking(checkSync(...)).onCancel(IO.blocking(ctx.interrupt()))
+IO.blocking {
+  // declare sorts/funcs, build solver, solver.check(), decode result, …
+}.onCancel(IO.blocking(ctx.interrupt()))
 ```
 
 `Context.interrupt()` is the only Z3 API designed to be called from a thread other than
 the one running the solver. On cancel, CE3 fires the `onCancel` finalizer concurrently
-with the still-blocked solver thread; Z3 observes the interrupt, `solver.check()` returns
-`Status.UNKNOWN` promptly, the blocking body completes, and `Resource[IO, WasmBackend]`
-finalizers close the `Context`. Practical mid-call abort latency is a few ms on top of
-whatever Z3 takes to unwind the current rewriting pass — well under the inner `timeout`
-parameter's slack window.
+with the still-blocked solver thread; Z3 observes the interrupt, `solver.check()` aborts
+promptly (typically returning `Status.UNKNOWN`, though the result is discarded by the
+cancelled fiber), the blocking body completes, and `Resource[IO, WasmBackend]`
+finalizers close the `Context`. Practical native mid-call abort is single-digit ms; the
+`TimeoutTest` regression bound is looser (~2 s) to absorb JIT / GC / CI noise without
+flaking on slower runners.
 
 Alloy's backend uses an internal `Future.get(timeout)` pool for its inner deadline, and
 the `Resource` finalizer shuts the pool down on cancel; its equivalent of

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -116,7 +116,7 @@ final class WasmBackend:
             Option(e.getMessage).getOrElse(e.toString),
             Some(renderStack(e))
           ))
-    }
+    }.onCancel(IO.blocking(ctx.interrupt()))
 
 final private class RenderCtx(
     val ctx: Context,

--- a/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
@@ -40,6 +40,24 @@ class TimeoutTest extends CatsEffectSuite:
       )
       assertEquals(zero.ok, dflt.ok)
 
+  test("ctx.interrupt() aborts solver.check() promptly on fiber cancel"):
+    val cfg       = VerificationConfig(timeoutMs = 0L, maxParallel = 1)
+    val outerMs   = 100L
+    val tolerance = 2_000L
+    for
+      ir <- SpecFixtures.loadIR("set_ops")
+      t0 <- IO.monotonic
+      _  <- Consistency.runConsistencyChecks(ir, cfg).timeoutTo(outerMs.millis, IO.unit)
+      t1 <- IO.monotonic
+    yield
+      val elapsed = (t1 - t0).toMillis
+      assert(
+        elapsed < outerMs + tolerance,
+        s"expected prompt cancel (< ${outerMs + tolerance}ms); got ${elapsed}ms. " +
+          s"Without ctx.interrupt(), a ${outerMs}ms outer cancel would be held by Z3 " +
+          s"until solver.check() returns naturally on the solver-heavy set_ops fixture."
+      )
+
   test("Resource release fires when the using IO is timed out"):
     Ref[IO].of(0).flatMap: released =>
       val wasmRes = WasmBackend

--- a/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TimeoutTest.scala
@@ -41,22 +41,34 @@ class TimeoutTest extends CatsEffectSuite:
       assertEquals(zero.ok, dflt.ok)
 
   test("ctx.interrupt() aborts solver.check() promptly on fiber cancel"):
+    // #113: cfg.timeoutMs = 0 disables Z3's inner deadline, so if ctx.interrupt()
+    // regresses this test hangs on set_ops until solver.check() returns naturally
+    // — the desired regression signal. The 2s tolerance covers JIT warmup, GC,
+    // CI noise, and the time Z3 takes to unwind its current rewriting pass after
+    // the interrupt; mid-call abort itself is single-digit ms. Do not tighten
+    // below ~1s without validating on slow CI runners, and do not loosen past
+    // 2s without first confirming the regression is still caught.
     val cfg       = VerificationConfig(timeoutMs = 0L, maxParallel = 1)
     val outerMs   = 100L
     val tolerance = 2_000L
-    for
-      ir <- SpecFixtures.loadIR("set_ops")
-      t0 <- IO.monotonic
-      _  <- Consistency.runConsistencyChecks(ir, cfg).timeoutTo(outerMs.millis, IO.unit)
-      t1 <- IO.monotonic
-    yield
-      val elapsed = (t1 - t0).toMillis
-      assert(
-        elapsed < outerMs + tolerance,
-        s"expected prompt cancel (< ${outerMs + tolerance}ms); got ${elapsed}ms. " +
-          s"Without ctx.interrupt(), a ${outerMs}ms outer cancel would be held by Z3 " +
-          s"until solver.check() returns naturally on the solver-heavy set_ops fixture."
-      )
+    Ref[IO].of(false).flatMap: fired =>
+      for
+        ir <- SpecFixtures.loadIR("set_ops")
+        t0 <- IO.monotonic
+        _ <- Consistency
+               .runConsistencyChecks(ir, cfg)
+               .timeoutTo(outerMs.millis, fired.set(true))
+        t1      <- IO.monotonic
+        didFire <- fired.get
+        elapsed  = (t1 - t0).toMillis
+      yield
+        assert(didFire, "timeoutTo fallback did not fire — test did not exercise the cancel path")
+        assert(
+          elapsed < outerMs + tolerance,
+          s"expected prompt cancel (< ${outerMs + tolerance}ms); got ${elapsed}ms. " +
+            s"Without ctx.interrupt(), a ${outerMs}ms outer cancel would be held by Z3 " +
+            s"until solver.check() returns naturally on the solver-heavy set_ops fixture."
+        )
 
   test("Resource release fires when the using IO is timed out"):
     Ref[IO].of(0).flatMap: released =>


### PR DESCRIPTION
## Summary

Closes #113.

Z3's native `solver.check()` ignores `Thread.isInterrupted`, so fiber cancellation
on an in-flight Z3 check used to be held by the parent fiber until the solver
returned naturally (or hit its inner `timeout` parameter). `Context.interrupt()`
is the only Z3 API safe to call from a thread other than the one running the
solver, and CE3's `onCancel` finalizer on `IO.blocking` runs **concurrently**
with the still-blocked thread — wiring the two gives prompt mid-call abort at
fiber cancellation.

Core change is one line on the existing `IO.blocking`:

```scala
IO.blocking { ...sync body... }.onCancel(IO.blocking(ctx.interrupt()))
```

No raw `Thread`, no `IO.async`, no factored-out sync method — the idiomatic CE3
pattern, confirmed by the Typelevel discussion on blocking-with-`onCancel`
semantics ([cats-effect #1979](https://github.com/typelevel/cats-effect/discussions/1979)).

## Why this wasn't done in M_CE.6

M_CE.6 wired `Resource[IO, WasmBackend]` finalizers + per-check outer timeout,
so the `Context` was guaranteed to close on cancel. But the in-flight
`solver.check()` itself still ran to natural completion — practical worst-case
native CPU was `cfg.timeoutMs + solver_slack`. #113 closes that last gap.

## Test plan

- [x] New wall-clock test in `TimeoutTest.scala`: outer `timeoutTo(100ms)` on
      `Consistency.runConsistencyChecks(set_ops, cfg=timeoutMs=0)`. With the fix,
      cancel-to-completion is bounded (< 2100ms on my box). Without the fix,
      Z3's internal timeout is disabled and `IO.blocking` is uncancelable, so
      cancel would be held by Z3 indefinitely.
- [x] `sbt test` — 121/121 verify, 12/12 cli, all others green.
- [x] `sbt scalafmtCheckAll` — clean.
- [x] `sbt scalafixAll --check` — clean.
- [x] `(cd docs && npm run build)` — clean.

## Docs

Rewrote the Cancellation subsection of `docs/content/docs/pipelines/verification.mdx`
to reflect the fix; updated the parallelism-model Cancellation bullet to point at
it. Removed the prior "follow-up (#113)" caveat.

## Non-goals / follow-ups

- **Alloy symmetric fix.** The Alloy backend already cancels its internal
  `Future.get(timeout)` pool in the timeout path, but not in the `onCancel` path.
  Filed as a noted follow-up in the docs; no concrete consumer today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when cancelling verification solver operations; cancellations now abort promptly rather than waiting for natural completion.

* **Documentation**
  * Updated verification pipeline documentation to reflect current cancellation behavior and semantics.

* **Tests**
  * Added test coverage verifying cancellation timing for solver operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires Z3 `Context.interrupt()` into `WasmBackend.check` via `onCancel` so canceling a fiber aborts an in-flight `solver.check()` promptly instead of waiting for Z3’s inner timeout. Closes #113.

- **Bug Fixes**
  - Wrapped `IO.blocking(solver.check())` with `.onCancel(IO.blocking(ctx.interrupt()))` to enable mid-call abort.
  - Added a wall-clock test for bounded cancel latency with `timeoutMs=0` and a 100 ms outer timeout; now asserts the timeout path was exercised and documents the 2 s tolerance.

- **Docs**
  - Updated verification docs: fixed the code snippet to match the inlined `onCancel` shape, clarified that cancelled results are discarded (status not contractual), and reconciled native latency with the test bound.
  - Rewrote `CLAUDE.md` for the Scala 3 / CE3 codebase (imports, type-safety, Cats Effect cancellation idioms, and testing guidance).

<sup>Written for commit 6744664558df41800f678a74a6fddc70bf9c0ad8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

