### PR TITLE
Add alloy-cross-check CI job mirroring z3-cross-check (closes #91)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,14 +108,16 @@ jobs:
       - name: Cross-check per-check VC dumps against native Alloy
         run: |
           set -euo pipefail
+          any_alloy_entries=0
           any_checked=0
           for verdicts in fixtures/golden/vc/*/verdicts.json; do
             dir=$(dirname "$verdicts")
             mapfile -t alloy_ids < <(jq -r '.entries[] | select(.tool == "alloy") | .id' "$verdicts")
             [ "${#alloy_ids[@]}" -gt 0 ] || { echo "skip $dir (no alloy entries)"; continue; }
+            any_alloy_entries=1
             for id in "${alloy_ids[@]}"; do
-              file=$(jq -r --arg id "$id" '.entries[] | select(.id == $id) | .file' "$verdicts")
-              expected=$(jq -r --arg id "$id" '.entries[] | select(.id == $id) | .rawStatus' "$verdicts")
+              file=$(jq -r --arg id "$id" '.entries[] | select(.tool == "alloy" and .id == $id) | .file' "$verdicts")
+              expected=$(jq -r --arg id "$id" '.entries[] | select(.tool == "alloy" and .id == $id) | .rawStatus' "$verdicts")
               case "$expected" in
                 sat|unsat) ;;
                 *) echo "skip $id (rawStatus=$expected)"; continue ;;
@@ -139,7 +141,11 @@ jobs:
               any_checked=1
             done
           done
-          if [ "$any_checked" -eq 0 ]; then
+          if [ "$any_alloy_entries" -eq 0 ]; then
             echo "no alloy-tool entries found under fixtures/golden/vc/ — refusing to pass vacuously" >&2
+            exit 1
+          fi
+          if [ "$any_checked" -eq 0 ]; then
+            echo "alloy-tool entries exist but all had non-sat/unsat rawStatus — nothing was cross-checked" >&2
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,68 @@ jobs:
               echo "ok $id ($expected)"
             done
           done
+
+  alloy-cross-check:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Alloy 6.2.0 CLI jar
+        id: alloy-cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/alloy/alloy.jar
+          key: alloy-6.2.0
+
+      - name: Download Alloy 6.2.0 CLI jar
+        if: steps.alloy-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/alloy
+          curl -fsSL -o ~/.cache/alloy/alloy.jar \
+            https://github.com/AlloyTools/org.alloytools.alloy/releases/download/v6.2.0/org.alloytools.alloy.dist.jar
+
+      - name: Cross-check per-check VC dumps against native Alloy
+        run: |
+          set -euo pipefail
+          any_checked=0
+          for verdicts in fixtures/golden/vc/*/verdicts.json; do
+            dir=$(dirname "$verdicts")
+            mapfile -t alloy_ids < <(jq -r '.entries[] | select(.tool == "alloy") | .id' "$verdicts")
+            [ "${#alloy_ids[@]}" -gt 0 ] || { echo "skip $dir (no alloy entries)"; continue; }
+            for id in "${alloy_ids[@]}"; do
+              file=$(jq -r --arg id "$id" '.entries[] | select(.id == $id) | .file' "$verdicts")
+              expected=$(jq -r --arg id "$id" '.entries[] | select(.id == $id) | .rawStatus' "$verdicts")
+              case "$expected" in
+                sat|unsat) ;;
+                *) echo "skip $id (rawStatus=$expected)"; continue ;;
+              esac
+              workdir=$(mktemp -d)
+              cp "$dir/$file" "$workdir/$(basename "$file")"
+              ( cd "$workdir" && timeout 60s java -jar ~/.cache/alloy/alloy.jar exec -q -f -s sat4j "$(basename "$file")" >/dev/null )
+              stem="${file%.als}"
+              receipt="$workdir/$stem/receipt.json"
+              if [ ! -f "$receipt" ]; then
+                echo "no receipt.json for $id at $receipt" >&2
+                exit 1
+              fi
+              actual=$(jq -r '.commands | to_entries[0].value | if has("solution") then "sat" else "unsat" end' "$receipt")
+              if [ "$actual" != "$expected" ]; then
+                echo "DISAGREEMENT in $dir/$file: in-process=$expected, native=$actual" >&2
+                exit 1
+              fi
+              echo "ok $dir/$id ($expected)"
+              rm -rf "$workdir"
+              any_checked=1
+            done
+          done
+          if [ "$any_checked" -eq 0 ]; then
+            echo "no alloy-tool entries found under fixtures/golden/vc/ — refusing to pass vacuously" >&2
+            exit 1
+          fi

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -43,7 +43,7 @@ CLI output so the attribution is visible.
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
 | Unsat-core extraction (`--explain`) — surface contributing spec spans on `unsat` diagnostics | shipped (Z3 always; Alloy when `minisat.prover` is bundled) |
 | Full Z3 proof-term export (Alethe / Z3-native)                      | [#90](https://github.com/HardMax71/spec_to_rest/issues/90) |
-| Native Alloy CLI cross-check job in CI                              | [#91](https://github.com/HardMax71/spec_to_rest/issues/91) |
+| Native Alloy CLI cross-check job in CI                              | shipped |
 | Set-literal membership (`x in {A, B, C}`), set algebra (`union`, `intersect`, `minus`, `subset`), non-state set membership via `(select ...)` | shipped (Z3) |
 | Standalone set comprehension as equality RHS (`s = {x in D \| P}`)   | shipped (Z3, via extensional sort-coerced quantifier axiom; requires binder element sort to match receiver element sort) |
 | Powerset (`^s`) — existential binder (`some t in ^s \| P(t)`)        | shipped (Alloy, bounded scope; default 5) |
@@ -423,7 +423,12 @@ CLI to re-derive the verdict against an independent solver / version. The `verdi
 index records the verdict, duration, and tool for each check.
 
 The optional `z3-cross-check` CI job iterates `fixtures/golden/vc/**/*.smt2`, replays each
-through native Z3, and asserts agreement with the `rawStatus` field in `verdicts.json`.
+through native Z3, and asserts agreement with the `rawStatus` field in `verdicts.json`. The
+symmetric `alloy-cross-check` job iterates `fixtures/golden/vc/**/*.als`, replays each
+through the native Alloy 6.2.0 CLI (`java -jar org.alloytools.alloy.dist.jar exec`), parses
+`receipt.json` (presence of a `solution` key on the single `run` command = `sat`, absence =
+`unsat`), and asserts the same agreement. Regenerate the goldens by running
+`sbt "cli/run verify <spec> --dump-vc fixtures/golden/vc/<name>"`.
 
 `rawStatus` records what the solver actually returned for the SMT-LIB (sat / unsat /
 unknown). `outcome` records the user-facing verdict after preservation-style inversion (a

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -422,12 +422,14 @@ input** that was passed to the live backend — replayable with a fresh `z3 -in`
 CLI to re-derive the verdict against an independent solver / version. The `verdicts.json`
 index records the verdict, duration, and tool for each check.
 
-The optional `z3-cross-check` CI job iterates `fixtures/golden/vc/**/*.smt2`, replays each
-through native Z3, and asserts agreement with the `rawStatus` field in `verdicts.json`. The
-symmetric `alloy-cross-check` job iterates `fixtures/golden/vc/**/*.als`, replays each
-through the native Alloy 6.2.0 CLI (`java -jar org.alloytools.alloy.dist.jar exec`), parses
-`receipt.json` (presence of a `solution` key on the single `run` command = `sat`, absence =
-`unsat`), and asserts the same agreement. Regenerate the goldens by running
+The optional `z3-cross-check` CI job iterates `fixtures/golden/vc/*/verdicts.json`,
+replays each `.smt2` file listed under an entry with `tool == "z3"` through native Z3,
+and asserts agreement with the entry's `rawStatus`. The symmetric `alloy-cross-check`
+job iterates the same `verdicts.json` files, selects entries with `tool == "alloy"`,
+replays each entry's `.file` through the native Alloy 6.2.0 CLI (`java -jar
+org.alloytools.alloy.dist.jar exec`), parses `receipt.json` (presence of a `solution`
+key on the single `run` command = `sat`, absence = `unsat`), and asserts the same
+agreement. Regenerate the goldens by running
 `sbt "cli/run verify <spec> --dump-vc fixtures/golden/vc/<name>"`.
 
 `rawStatus` records what the solver actually returned for the SMT-LIB (sat / unsat /

--- a/fixtures/golden/vc/contradictory_powerset/global.als
+++ b/fixtures/golden/vc/contradictory_powerset/global.als
@@ -1,0 +1,17 @@
+module ContradictoryPowerset
+
+sig User {}
+
+one sig State {
+  users: set User
+}
+
+fact trivialPowersetAnchor {
+  (some t: set User | (t in State.users) and ((t = State.users)))
+}
+
+fact userNotEqualSelf {
+  (some u: User | (u in State.users) and ((u != u)))
+}
+
+run global {  } for 5

--- a/fixtures/golden/vc/contradictory_powerset/verdicts.json
+++ b/fixtures/golden/vc/contradictory_powerset/verdicts.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion" : 1,
+  "specFile" : "fixtures/spec/contradictory_powerset.spec",
+  "totalMs" : 535.30673,
+  "ok" : false,
+  "entries" : [
+    {
+      "id" : "global",
+      "tool" : "alloy",
+      "outcome" : "unsat",
+      "rawStatus" : "unsat",
+      "durationMs" : 104.196557,
+      "file" : "global.als"
+    }
+  ]
+}

--- a/fixtures/golden/vc/powerset_demo/global.als
+++ b/fixtures/golden/vc/powerset_demo/global.als
@@ -1,0 +1,15 @@
+module PowersetDemo
+
+sig User {
+  id: one Int
+}
+
+one sig State {
+  users: set User
+}
+
+fact someEmptySubsetExists {
+  (some t: set User | (t in State.users) and ((#(t) = 0)))
+}
+
+run global {  } for 5

--- a/fixtures/golden/vc/powerset_demo/verdicts.json
+++ b/fixtures/golden/vc/powerset_demo/verdicts.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion" : 1,
+  "specFile" : "fixtures/spec/powerset_demo.spec",
+  "totalMs" : 629.513242,
+  "ok" : true,
+  "entries" : [
+    {
+      "id" : "global",
+      "tool" : "alloy",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 143.06451,
+      "file" : "global.als"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes #91. Adds a symmetric `alloy-cross-check` CI job that replays the per-check `.als`
VC dumps through the native Alloy 6.2.0 CLI and asserts agreement with the `rawStatus`
recorded by the in-process Java Alloy backend in `verdicts.json`. Catches translator /
renderer regressions that the in-process backend would silently swallow (since both run
against the same JVM jars).

## What the issue got wrong (verified while implementing)

1. **CLI flag shape.** No `-batch`, no "Instance found" grep line. Alloy 6.2.0's CLI is
   `java -jar org.alloytools.alloy.dist.jar exec -q -f -s sat4j <file>`, which writes a
   `<stem>/receipt.json`.
2. **Exit code is always 0** — even on syntax errors. So the verdict must come from
   `receipt.json`, not `$?`: presence of a `solution: [...]` key on the single `run`
   command = `sat`, absence = `unsat`. This is the same mapping the in-process backend
   already uses (`AlloyBackend.scala:140` — `solution.satisfiable`).
3. **Jar size** is ~21 MB, not ~30 MB (asset: `org.alloytools.alloy.dist.jar`).

## What was missing from the repo

The existing `fixtures/golden/vc/` dirs (`url_shortener`, `unsat_invariants`) are **100%
Z3-routed** — they contain zero `.als` files. A naive iteration would have passed
vacuously. Two new goldens added here fix that:

- `fixtures/golden/vc/powerset_demo/` — one check, `sat` (existential over `^users`).
- `fixtures/golden/vc/contradictory_powerset/` — one check, `unsat` (contradictory
  invariants). Satisfies AC "≥1 sat, ≥1 unsat".

The job fails hard if it finds zero `tool == "alloy"` entries across the tree, so any
future goldens regression surfaces immediately.

## Design notes

- **Cache key `alloy-6.2.0`.** Matches the in-process pin in `build.sbt:23`. Jar is
  immutable per release; cache hit is essentially always.
- **Isolated workdir per check.** `exec` writes its output dir **next to the input
  file**; copying each `.als` into a fresh tmpdir avoids colliding `<stem>/` outputs when
  multiple VCs live in one golden dir.
- **`-s sat4j` pinned.** Reproducible against the pure-Java solver — no native libs to
  bootstrap, no variance between runners.
- **`.als` filter via `.tool == "alloy"` from `verdicts.json`.** Mixed-routing fixtures
  (future) will just work — no file-extension dance needed.
- **`tempoeral_demo` intentionally not added** — temporals are an additional encoding
  axis; keep the golden set minimal for the first landing, extend in a follow-up if a
  regression suggests it.

## AC mapping (#91)

- [x] CI job runs after `build-and-test`, gates by solver-agreement.
- [x] ≥1 sat case + ≥1 unsat case covered by snapshots (the two new goldens).
- [x] Job timeout 5 min.

## Non-goals respected

- No bundling Alloy in the artifact (just download-per-CI, cached).
- No cross-version matrix — pinned to 6.2.0 to match the in-process jar.

## Verification

```bash
sbt "verify/testOnly *DumpTest"          # 7 tests green (regenerated goldens match)
(cd docs && npm run build)               # clean
# CI cross-check script, run locally against the jar cached at ~/.cache/alloy/alloy.jar:
# -> ok fixtures/golden/vc/contradictory_powerset/global (unsat)
# -> ok fixtures/golden/vc/powerset_demo/global (sat)
# -> skip fixtures/golden/vc/unsat_invariants (no alloy entries)
# -> skip fixtures/golden/vc/url_shortener (no alloy entries)
```

## Regenerating goldens

```bash
sbt "cli/run verify <spec> --dump-vc fixtures/golden/vc/<name>"
```

Documented in the verification docs page.

## Test plan

- [x] Local CI-script dry-run: passes on both new goldens; correctly skips Z3-only dirs.
- [x] `sbt "verify/testOnly *DumpTest"` — 7/7 green.
- [x] `(cd docs && npm run build)` clean.
- [x] Docs: flipped #91 row, expanded cross-check subsection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `alloy-cross-check` CI job that replays `.als` VC dumps with the Alloy 6.2.0 CLI and checks they match `rawStatus` in `verdicts.json`. Closes #91 and guards against translator/renderer regressions by comparing with an independent run.

- **New Features**
  - New `alloy-cross-check` job runs after `build-and-test` with a 5‑minute timeout.
  - Replays `.als` via the Alloy 6.2.0 CLI and parses `receipt.json` (`solution` present = `sat`, absent = `unsat`); asserts agreement with `rawStatus`.
  - Selects entries via `verdicts.json` with `tool == "alloy"` and scopes lookups by both `tool` and `id`; uses isolated temp dirs; fails on any mismatch.
  - Vacuous-pass guards: fails if no Alloy entries exist anywhere, and also if entries exist but none had `sat/unsat` statuses to replay (distinct messages).
  - Adds Alloy goldens: `powerset_demo` (sat) and `contradictory_powerset` (unsat).
  - Docs: mark #91 shipped and clarify that cross-checks iterate `verdicts.json` (not `**/*.als`), plus document CLI flow and verdict mapping.

- **Dependencies**
  - Downloads and caches `org.alloytools.alloy.dist.jar` under key `alloy-6.2.0`.
  - Pins solver to `sat4j` for reproducible runs.

<sup>Written for commit 87c52a372af97e03b6b3f5df80a0edfcd9a7096b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

