### PR TITLE
Richer suggested-fix templates for verification diagnostics (closes #80)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -237,9 +237,9 @@ $ spec-to-rest verify fixtures/spec/unsat_invariants.spec
 ✘ fixtures/spec/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
   related: fixtures/spec/unsat_invariants.spec:5:3 (invariant 'tooHigh')
 
-  hint: Invariants 'inv_0', 'inv_1', 'inv_2' are jointly unsatisfiable. Look for a
-  pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5');
-  narrow one or drop it.
+  hint: The invariant set is jointly unsatisfiable; for example, review 'inv_0',
+  'inv_1', 'inv_2' for a pair whose range constraints cannot overlap (e.g.,
+  'x >= 10' alongside 'x <= 5'); narrow or drop one.
 ```
 
 No counterexample is emitted here — the engine concluded `unsat` on the invariant conjunction

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -38,7 +38,7 @@ CLI output so the attribution is visible.
 | Category-based error reporting + per-category suggestion hints      | shipped |
 | Verify-as-gate (refuse codegen on failed verification)              | shipped ([#78](https://github.com/HardMax71/spec_to_rest/issues/78)) — `compile` runs verify by default; `--ignore-verify` opts out |
 | Machine-readable (`--json` / `--json-out`) diagnostics output       | shipped |
-| Richer suggested-fix templates                                      | [#80](https://github.com/HardMax71/spec_to_rest/issues/80) |
+| Richer suggested-fix templates (op/invariant/field-aware; opt-out via `--no-suggestions`) | shipped |
 | Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
 | Unsat-core extraction (`--explain`) — surface contributing spec spans on `unsat` diagnostics | shipped (Z3 always; Alloy when `minisat.prover` is bundled) |
@@ -214,9 +214,17 @@ $ spec-to-rest verify fixtures/spec/broken_url_shortener.spec
   post-state:
     metadata' = { 2 → UrlMapping#0 }
 
-  hint: Tighten the 'ensures' clause so the invariant's constrained fields appear on the
-  right-hand side of a '=' or a range predicate.
+  hint: 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see
+  counterexample. Tighten 'ensures' with a range predicate or a constructor that
+  initialises click_count correctly.
 ```
+
+The hint names the violating operation, the violated invariant, and the field(s) the
+invariant constrains — extracted from the IR rather than re-rendered. Suggestions are
+capped at 200 chars and can be turned off entirely with `--no-suggestions` (the
+`suggestion` field then comes back as `null` in JSON output as well). The phrasing is
+intentionally non-stable text intended for humans; downstream tooling should switch on
+the `category` enum, not on the suggestion string.
 
 The decoder enumerates the model's entity universe, evaluates field functions, and shows
 pre-/post-state relations side by side. Uninterpreted sort values like `UrlMapping!val!0` are
@@ -229,8 +237,9 @@ $ spec-to-rest verify fixtures/spec/unsat_invariants.spec
 ✘ fixtures/spec/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
   related: fixtures/spec/unsat_invariants.spec:5:3 (invariant 'tooHigh')
 
-  hint: Review the invariant set for a pair whose range constraints cannot overlap
-  (e.g., 'x >= 10' alongside 'x <= 5').
+  hint: Invariants 'inv_0', 'inv_1', 'inv_2' are jointly unsatisfiable. Look for a
+  pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5');
+  narrow one or drop it.
 ```
 
 No counterexample is emitted here — the engine concluded `unsat` on the invariant conjunction
@@ -270,6 +279,7 @@ verbose   …
 | `--json`                |   false | Emit machine-readable JSON report to stdout (suppresses text).|
 | `--json-out <file>`     |       — | Write machine-readable JSON report to `<file>` (suppresses text). |
 | `--parallel <n>`        |    auto | Max concurrent checks. Default: host `availableProcessors`. `0` = serial (regression parity). |
+| `--no-suggestions`      |   false | Suppress per-diagnostic `hint:` text in CLI and `suggestion` in JSON output. |
 | `-v, --verbose`         |   false | Print stage timing and per-check timing / status.             |
 
 ### Exit codes

--- a/fixtures/golden/verify_report/broken_url_shortener.json
+++ b/fixtures/golden/verify_report/broken_url_shortener.json
@@ -220,7 +220,7 @@
             }
           ]
         },
-        "suggestion" : "Tighten the 'ensures' clause so the invariant's constrained fields appear on the right-hand side of a '=' or a range predicate.",
+        "suggestion" : "'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises click_count correctly.",
         "coreSpans" : [
         ]
       }

--- a/fixtures/golden/verify_report/unsat_invariants.json
+++ b/fixtures/golden/verify_report/unsat_invariants.json
@@ -64,7 +64,7 @@
           }
         ],
         "counterexample" : null,
-        "suggestion" : "Review the invariant set for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5').",
+        "suggestion" : "Invariants 'inv_0', 'inv_1', 'inv_2' are jointly unsatisfiable. Look for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow one or drop it.",
         "coreSpans" : [
           {
             "span" : {

--- a/fixtures/golden/verify_report/unsat_invariants.json
+++ b/fixtures/golden/verify_report/unsat_invariants.json
@@ -64,7 +64,7 @@
           }
         ],
         "counterexample" : null,
-        "suggestion" : "Invariants 'inv_0', 'inv_1', 'inv_2' are jointly unsatisfiable. Look for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow one or drop it.",
+        "suggestion" : "The invariant set is jointly unsatisfiable; for example, review 'inv_0', 'inv_1', 'inv_2' for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow or drop one.",
         "coreSpans" : [
           {
             "span" : {

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -70,6 +70,9 @@ object Main
         if n >= 0 then cats.data.Validated.valid(n)
         else cats.data.Validated.invalidNel(s"--parallel must be >= 0 (got $n)")
       .orNone
+    val noSuggestions = Opts
+      .flag("no-suggestions", "suppress per-diagnostic 'hint:' suggestions in CLI and JSON output")
+      .orFalse
     Opts.subcommand("verify", "Run the Z3/Alloy-backed verification engine on a spec file"):
       (
         specFile,
@@ -84,12 +87,13 @@ object Main
         json,
         jsonOut,
         parallel,
+        noSuggestions,
         verbose,
         quiet
-      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, v, q) =>
+      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, ns, v, q) =>
         Verify.run(
           spec,
-          VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo, par),
+          VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo, par, suggestions = !ns),
           Logger.fromFlags(verbose = v, quiet = q)
         )
 

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -30,7 +30,8 @@ final case class VerifyOptions(
     explain: Boolean = false,
     json: Boolean = false,
     jsonOut: Option[String] = None,
-    parallel: Option[Int] = None
+    parallel: Option[Int] = None,
+    suggestions: Boolean = true
 )
 
 object Verify:
@@ -182,7 +183,8 @@ object Verify:
                 timeoutMs = opts.timeoutMs,
                 alloyScope = opts.alloyScope,
                 captureCore = opts.explain,
-                maxParallel = maxParallel
+                maxParallel = maxParallel,
+                suggestions = opts.suggestions
               ),
               sink
             ).flatMap { report =>

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -93,6 +93,42 @@ class VerifyJsonTest extends CatsEffectSuite:
         assertEquals(exit, ExitCodes.Violations)
         assertEquals(out, "", "no stdout output when the combination is rejected")
 
+  test("--no-suggestions sets diagnostic.suggestion to null in JSON"):
+    val opts = VerifyOptions(
+      30_000L,
+      dumpSmt = false,
+      dumpSmtOut = None,
+      json = true,
+      suggestions = false
+    )
+    captureStdout(ps => Verify.run("fixtures/spec/unsat_invariants.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Violations)
+        val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+        val suggestions = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
+          .flatMap(_.hcursor.downField("diagnostic").focus)
+          .filterNot(_.isNull)
+          .flatMap(_.hcursor.downField("suggestion").focus)
+        assert(suggestions.nonEmpty, "expected at least one diagnostic in the report")
+        suggestions.foreach: s =>
+          assertEquals(
+            s,
+            io.circe.Json.Null,
+            s"expected null suggestion when --no-suggestions; got: $s"
+          )
+
+  test("default run produces a non-null diagnostic.suggestion"):
+    val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    captureStdout(ps => Verify.run("fixtures/spec/unsat_invariants.spec", opts, log, ps))
+      .map: (_, out) =>
+        val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+        val nonEmpty = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
+          .flatMap(_.hcursor.downField("diagnostic").focus)
+          .filterNot(_.isNull)
+          .flatMap(_.hcursor.downField("suggestion").as[String].toOption)
+          .filter(_.nonEmpty)
+        assert(nonEmpty.nonEmpty, s"expected at least one non-empty suggestion; got: $out")
+
   test("--json with --explain surfaces coreSpans on unsat diagnostics"):
     val opts = VerifyOptions(
       30_000L,

--- a/modules/verify/src/main/scala/specrest/verify/Config.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Config.scala
@@ -14,7 +14,8 @@ final case class VerificationConfig(
     captureModel: Boolean = false,
     alloyScope: Int = 5,
     captureCore: Boolean = false,
-    maxParallel: Int = VerificationConfig.defaultParallelism
+    maxParallel: Int = VerificationConfig.defaultParallelism,
+    suggestions: Boolean = true
 )
 
 object VerificationConfig:

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -82,7 +82,40 @@ object Consistency:
         plans.parTraverseN(config.maxParallel): plan =>
           backendsResource.use: (wasm, alloy) =>
             executePlan(plan, wasm, alloy, config, dump)
-    results.map(reportFromResults)
+    results.map(rs => reportFromResults(rs.map(c => enrichSuggestion(c, ir, config))))
+
+  private def enrichSuggestion(
+      check: CheckResult,
+      ir: ServiceIR,
+      config: VerificationConfig
+  ): CheckResult =
+    check.diagnostic match
+      case None => check
+      case Some(diag) =>
+        val newSuggestion: Option[String] =
+          if !config.suggestions then None
+          else
+            diag.category match
+              case DiagnosticCategory.TranslatorLimitation | DiagnosticCategory.BackendError =>
+                diag.suggestion
+              case _ =>
+                val op = check.operationName.flatMap(n => ir.operations.find(_.name == n))
+                val invDecl = check.invariantName.flatMap: n =>
+                  ir.invariants.find(_.name.contains(n))
+                Diagnostic.suggestionFor(
+                  diag.category,
+                  Diagnostic.SuggestionContext(
+                    ir = ir,
+                    op = op,
+                    invariantDecl = invDecl,
+                    operationName = check.operationName,
+                    invariantName = check.invariantName,
+                    counterexample = diag.counterexample,
+                    checkId = check.id,
+                    timeoutMs = config.timeoutMs
+                  )
+                )
+        check.copy(diagnostic = Some(diag.copy(suggestion = newSuggestion)))
 
   private def backendsResource: cats.effect.Resource[IO, (WasmBackend, AlloyBackend)] =
     for

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -99,9 +99,16 @@ object Consistency:
               case DiagnosticCategory.TranslatorLimitation | DiagnosticCategory.BackendError =>
                 diag.suggestion
               case _ =>
-                val op = check.operationName.flatMap(n => ir.operations.find(_.name == n))
-                val invDecl = check.invariantName.flatMap: n =>
-                  ir.invariants.find(_.name.contains(n))
+                val op               = check.operationName.flatMap(n => ir.operations.find(_.name == n))
+                val isInvariantBound = check.kind == CheckKind.Preservation
+                val invDecl =
+                  if !isInvariantBound then None
+                  else
+                    check.invariantName.flatMap: n =>
+                      ir.invariants
+                        .find(_.name.contains(n))
+                        .orElse(n.stripPrefix("inv_").toIntOption.flatMap(ir.invariants.lift))
+                val invName = if isInvariantBound then check.invariantName else None
                 Diagnostic.suggestionFor(
                   diag.category,
                   Diagnostic.SuggestionContext(
@@ -109,7 +116,7 @@ object Consistency:
                     op = op,
                     invariantDecl = invDecl,
                     operationName = check.operationName,
-                    invariantName = check.invariantName,
+                    invariantName = invName,
                     counterexample = diag.counterexample,
                     checkId = check.id,
                     timeoutMs = config.timeoutMs

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -101,12 +101,17 @@ object Diagnostic:
 
   private def contradictoryInvariantsSuggestion(ctx: SuggestionContext): Option[String] =
     val names = invariantDisplayNames(ctx.ir)
-    if names.isEmpty then suggestionFor(DiagnosticCategory.ContradictoryInvariants)
-    else
-      val list = formatNameList(names, max = 3)
-      Some(
-        s"Invariants $list are jointly unsatisfiable. Look for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow one or drop it."
-      )
+    names match
+      case Nil => suggestionFor(DiagnosticCategory.ContradictoryInvariants)
+      case one :: Nil =>
+        Some(
+          s"Invariant '$one' is unsatisfiable on its own — its range constraints cannot be met by any state. Narrow the predicate or drop it."
+        )
+      case many =>
+        val list = formatNameList(many, max = 3)
+        Some(
+          s"The invariant set is jointly unsatisfiable; for example, review $list for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow or drop one."
+        )
 
   private def unsatisfiablePreconditionSuggestion(ctx: SuggestionContext): Option[String] =
     ctx.operationName match
@@ -121,11 +126,12 @@ object Diagnostic:
       case None => suggestionFor(DiagnosticCategory.UnreachableOperation)
       case Some(op) =>
         val invs = invariantDisplayNames(ctx.ir)
-        val invList =
-          if invs.isEmpty then "the invariants"
-          else s"invariants ${formatNameList(invs, max = 3)}"
+        val invClause =
+          if invs.isEmpty then "the invariants conflict on every valid pre-state"
+          else
+            s"the invariants conflict on every valid pre-state (e.g., ${formatNameList(invs, max = 3)})"
         Some(
-          s"'$op' is unreachable: its 'requires' is satisfiable alone, but $invList block every valid pre-state. Relax one invariant, or tighten '$op''s input type to exclude the conflicting range."
+          s"'$op' is unreachable: 'requires' is satisfiable alone, but $invClause. Relax one invariant, or tighten the input type of '$op' to exclude the conflicting range."
         )
 
   private def invariantViolationSuggestion(ctx: SuggestionContext): Option[String] =
@@ -204,7 +210,7 @@ object Diagnostic:
     val out = List.newBuilder[String]
     def walk(x: Expr, depthQuant: Int): Unit = x match
       case Expr.Quantifier(_, bs, body, _) =>
-        if depthQuant >= 1 then out += "quantifier alternation"
+        if depthQuant >= 1 then out += "nested quantifiers"
         bs.foreach(b => walk(b.domain, depthQuant))
         walk(body, depthQuant + 1)
       case Expr.SetComprehension(_, d, p, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -127,11 +127,10 @@ object Diagnostic:
       case Some(op) =>
         val invs = invariantDisplayNames(ctx.ir)
         val invClause =
-          if invs.isEmpty then "the invariants conflict on every valid pre-state"
-          else
-            s"the invariants conflict on every valid pre-state (e.g., ${formatNameList(invs, max = 3)})"
+          if invs.isEmpty then "the invariants"
+          else s"the invariants (e.g., ${formatNameList(invs, max = 3)})"
         Some(
-          s"'$op' is unreachable: 'requires' is satisfiable alone, but $invClause. Relax one invariant, or tighten the input type of '$op' to exclude the conflicting range."
+          s"'$op' is unreachable: 'requires' is satisfiable alone but conflicts with $invClause on every valid pre-state. Relax an invariant or tighten the input type."
         )
 
   private def invariantViolationSuggestion(ctx: SuggestionContext): Option[String] =

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -1,6 +1,11 @@
 package specrest.verify
 
+import specrest.ir.Expr
+import specrest.ir.InvariantDecl
+import specrest.ir.OperationDecl
+import specrest.ir.ServiceIR
 import specrest.ir.Span
+import specrest.ir.UnOp
 
 enum DiagnosticCategory:
   case ContradictoryInvariants, UnsatisfiablePrecondition, UnreachableOperation,
@@ -39,6 +44,31 @@ final case class VerificationDiagnostic(
 
 object Diagnostic:
 
+  private val MaxSuggestionLength = 200
+
+  final case class SuggestionContext(
+      ir: ServiceIR,
+      op: Option[OperationDecl],
+      invariantDecl: Option[InvariantDecl],
+      operationName: Option[String],
+      invariantName: Option[String],
+      counterexample: Option[DecodedCounterExample],
+      checkId: String,
+      timeoutMs: Long
+  )
+
+  def suggestionFor(category: DiagnosticCategory, ctx: SuggestionContext): Option[String] =
+    val raw = category match
+      case DiagnosticCategory.ContradictoryInvariants   => contradictoryInvariantsSuggestion(ctx)
+      case DiagnosticCategory.UnsatisfiablePrecondition => unsatisfiablePreconditionSuggestion(ctx)
+      case DiagnosticCategory.UnreachableOperation      => unreachableOperationSuggestion(ctx)
+      case DiagnosticCategory.InvariantViolationByOperation =>
+        invariantViolationSuggestion(ctx)
+      case DiagnosticCategory.SolverTimeout        => solverTimeoutSuggestion(ctx)
+      case DiagnosticCategory.TranslatorLimitation => suggestionFor(category)
+      case DiagnosticCategory.BackendError         => suggestionFor(category)
+    raw.map(cap)
+
   def suggestionFor(category: DiagnosticCategory): Option[String] = category match
     case DiagnosticCategory.ContradictoryInvariants =>
       Some(
@@ -68,6 +98,147 @@ object Diagnostic:
       Some(
         "The solver crashed on this check. Re-run with --verbose; if reproducible, file an issue including the --dump-smt output."
       )
+
+  private def contradictoryInvariantsSuggestion(ctx: SuggestionContext): Option[String] =
+    val names = invariantDisplayNames(ctx.ir)
+    if names.isEmpty then suggestionFor(DiagnosticCategory.ContradictoryInvariants)
+    else
+      val list = formatNameList(names, max = 3)
+      Some(
+        s"Invariants $list are jointly unsatisfiable. Look for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow one or drop it."
+      )
+
+  private def unsatisfiablePreconditionSuggestion(ctx: SuggestionContext): Option[String] =
+    ctx.operationName match
+      case None => suggestionFor(DiagnosticCategory.UnsatisfiablePrecondition)
+      case Some(op) =>
+        Some(
+          s"'$op.requires' is unsatisfiable on its own — its conjuncts contradict each other. Inspect the listed spans for a pair like 'y > 10' ∧ 'y < 5', or relax the input-type refinement."
+        )
+
+  private def unreachableOperationSuggestion(ctx: SuggestionContext): Option[String] =
+    ctx.operationName match
+      case None => suggestionFor(DiagnosticCategory.UnreachableOperation)
+      case Some(op) =>
+        val invs = invariantDisplayNames(ctx.ir)
+        val invList =
+          if invs.isEmpty then "the invariants"
+          else s"invariants ${formatNameList(invs, max = 3)}"
+        Some(
+          s"'$op' is unreachable: its 'requires' is satisfiable alone, but $invList block every valid pre-state. Relax one invariant, or tighten '$op''s input type to exclude the conflicting range."
+        )
+
+  private def invariantViolationSuggestion(ctx: SuggestionContext): Option[String] =
+    (ctx.operationName, ctx.invariantName, ctx.invariantDecl) match
+      case (Some(op), Some(inv), Some(decl)) =>
+        val fields = collectFieldNames(decl.expr)
+        if fields.isEmpty then
+          Some(
+            s"'$op' violates '$inv'. Tighten 'ensures' so the fields '$inv' constrains are pinned by '=' or a range predicate; see counterexample."
+          )
+        else
+          val fieldList = formatNameList(fields, max = 2)
+          Some(
+            s"'$op' violates '$inv' on field(s) $fieldList — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises ${fields.head} correctly."
+          )
+      case _ => suggestionFor(DiagnosticCategory.InvariantViolationByOperation)
+
+  private def solverTimeoutSuggestion(ctx: SuggestionContext): Option[String] =
+    val features = ctx.invariantDecl.map(_.expr).toList.flatMap(featureSummary).distinct
+    val featureClause =
+      if features.isEmpty then ""
+      else s" (uses ${features.mkString(", ")})"
+    val invClause = ctx.invariantName match
+      case Some(name) => s"; simplify invariant '$name'$featureClause"
+      case None       => ""
+    Some(
+      s"Solver timed out on '${ctx.checkId}' after ${ctx.timeoutMs}ms. Increase --timeout$invClause, or split a heavy quantifier into smaller predicates."
+    )
+
+  private def invariantDisplayNames(ir: ServiceIR): List[String] =
+    ir.invariants.zipWithIndex.map: (inv, i) =>
+      inv.name.getOrElse(s"inv_$i")
+
+  private def formatNameList(names: List[String], max: Int): String =
+    val quoted = names.map(n => s"'$n'")
+    if quoted.size <= max then quoted.mkString(", ")
+    else quoted.take(max).mkString(", ") + ", …"
+
+  private def cap(s: String): String =
+    if s.length <= MaxSuggestionLength then s
+    else s.take(MaxSuggestionLength - 1) + "…"
+
+  private def collectFieldNames(e: Expr): List[String] =
+    val out = List.newBuilder[String]
+    def walk(x: Expr): Unit = x match
+      case Expr.FieldAccess(base, field, _) =>
+        out += field
+        walk(base)
+      case Expr.BinaryOp(_, l, r, _)       => walk(l); walk(r)
+      case Expr.UnaryOp(_, op, _)          => walk(op)
+      case Expr.Quantifier(_, bs, body, _) => bs.foreach(b => walk(b.domain)); walk(body)
+      case Expr.SomeWrap(x, _)             => walk(x)
+      case Expr.The(_, d, b, _)            => walk(d); walk(b)
+      case Expr.EnumAccess(b, _, _)        => walk(b)
+      case Expr.Index(b, i, _)             => walk(b); walk(i)
+      case Expr.Call(c, args, _)           => walk(c); args.foreach(walk)
+      case Expr.Prime(x, _)                => walk(x)
+      case Expr.Pre(x, _)                  => walk(x)
+      case Expr.With(b, ups, _)            => walk(b); ups.foreach(u => walk(u.value))
+      case Expr.If(c, t, e, _)             => walk(c); walk(t); walk(e)
+      case Expr.Let(_, v, b, _)            => walk(v); walk(b)
+      case Expr.Lambda(_, b, _)            => walk(b)
+      case Expr.Constructor(_, fs, _)      => fs.foreach(f => walk(f.value))
+      case Expr.SetLiteral(es, _)          => es.foreach(walk)
+      case Expr.MapLiteral(es, _) => es.foreach { e =>
+          walk(e.key); walk(e.value)
+        }
+      case Expr.SetComprehension(_, d, p, _) => walk(d); walk(p)
+      case Expr.SeqLiteral(es, _)            => es.foreach(walk)
+      case Expr.Matches(x, _, _)             => walk(x)
+      case _                                 => ()
+    walk(e)
+    out.result().distinct
+
+  private def featureSummary(e: Expr): List[String] =
+    val out = List.newBuilder[String]
+    def walk(x: Expr, depthQuant: Int): Unit = x match
+      case Expr.Quantifier(_, bs, body, _) =>
+        if depthQuant >= 1 then out += "quantifier alternation"
+        bs.foreach(b => walk(b.domain, depthQuant))
+        walk(body, depthQuant + 1)
+      case Expr.SetComprehension(_, d, p, _) =>
+        out += "set comprehension"
+        walk(d, depthQuant); walk(p, depthQuant)
+      case Expr.UnaryOp(UnOp.Power, op, _) =>
+        out += "powerset"
+        walk(op, depthQuant)
+      case Expr.BinaryOp(_, l, r, _) => walk(l, depthQuant); walk(r, depthQuant)
+      case Expr.UnaryOp(_, op, _)    => walk(op, depthQuant)
+      case Expr.SomeWrap(x, _)       => walk(x, depthQuant)
+      case Expr.The(_, d, b, _)      => walk(d, depthQuant); walk(b, depthQuant)
+      case Expr.FieldAccess(b, _, _) => walk(b, depthQuant)
+      case Expr.EnumAccess(b, _, _)  => walk(b, depthQuant)
+      case Expr.Index(b, i, _)       => walk(b, depthQuant); walk(i, depthQuant)
+      case Expr.Call(c, args, _)     => walk(c, depthQuant); args.foreach(walk(_, depthQuant))
+      case Expr.Prime(x, _)          => walk(x, depthQuant)
+      case Expr.Pre(x, _)            => walk(x, depthQuant)
+      case Expr.With(b, ups, _) =>
+        walk(b, depthQuant); ups.foreach(u => walk(u.value, depthQuant))
+      case Expr.If(c, t, e, _)        => walk(c, depthQuant); walk(t, depthQuant); walk(e, depthQuant)
+      case Expr.Let(_, v, b, _)       => walk(v, depthQuant); walk(b, depthQuant)
+      case Expr.Lambda(_, b, _)       => walk(b, depthQuant)
+      case Expr.Constructor(_, fs, _) => fs.foreach(f => walk(f.value, depthQuant))
+      case Expr.SetLiteral(es, _)     => es.foreach(walk(_, depthQuant))
+      case Expr.MapLiteral(es, _) =>
+        es.foreach { e =>
+          walk(e.key, depthQuant); walk(e.value, depthQuant)
+        }
+      case Expr.SeqLiteral(es, _) => es.foreach(walk(_, depthQuant))
+      case Expr.Matches(x, _, _)  => walk(x, depthQuant)
+      case _                      => ()
+    walk(e, 0)
+    out.result().distinct
 
   def formatDiagnostic(diag: VerificationDiagnostic, specFile: String): String =
     val lines = List.newBuilder[String]

--- a/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
@@ -60,20 +60,56 @@ class SuggestionTemplateTest extends CatsEffectSuite:
       assert(hint.contains("click_count"), s"expected field name; got: $hint")
       assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
 
-  test("solver_timeout suggestion mentions check id and timeout"):
-    val tinyTimeout = VerificationConfig.Default.copy(timeoutMs = 1L, captureModel = true)
-    for
-      ir     <- SpecFixtures.loadIR("set_ops")
-      report <- Consistency.runConsistencyChecks(ir, tinyTimeout)
-    yield
-      val timedOut = report.checks.find(c =>
-        c.diagnostic.exists(_.category == DiagnosticCategory.SolverTimeout)
+  test("solver_timeout suggestion mentions check id and timeout (direct template)"):
+    SpecFixtures.loadIR("broken_url_shortener").map: ir =>
+      val invDecl = ir.invariants.headOption.getOrElse(fail("expected an invariant"))
+      val ctx = Diagnostic.SuggestionContext(
+        ir = ir,
+        op = ir.operations.headOption,
+        invariantDecl = Some(invDecl),
+        operationName = ir.operations.headOption.map(_.name),
+        invariantName = invDecl.name,
+        counterexample = None,
+        checkId = "Tamper.preserves.clickCountNonNegative",
+        timeoutMs = 1L
       )
-      assume(timedOut.isDefined, "expected at least one SolverTimeout diagnostic under 1ms timeout")
-      val hint = timedOut.get.diagnostic.flatMap(_.suggestion).getOrElse("")
+      val hint = Diagnostic
+        .suggestionFor(DiagnosticCategory.SolverTimeout, ctx)
+        .getOrElse(fail("expected a suggestion"))
       assert(hint.contains("timed out"), s"hint=$hint")
       assert(hint.contains("1ms"), s"expected '1ms' in hint; got: $hint")
+      assert(
+        hint.contains("Tamper.preserves.clickCountNonNegative"),
+        s"expected check id in hint; got: $hint"
+      )
       assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("synthetic 'inv_<idx>' resolves invariantDecl by position for unnamed invariants"):
+    val spec =
+      """service UnnamedInv {
+        |  state { x: Int }
+        |  operation Bump {
+        |    requires: x = 0
+        |    ensures: x' = -1
+        |  }
+        |  invariant: x >= 0
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("UnnamedInv", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val violation = report.checks
+        .find(c =>
+          c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
+        )
+        .getOrElse(fail("expected a preservation violation"))
+      val hint = violation.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("Bump"), s"expected 'Bump' in hint; got: $hint")
+      // Without the positional `inv_<idx>` fallback in enrichSuggestion, invariantDecl would
+      // be None and the template would fall back to the no-context generic text ("the
+      // invariant's constrained fields"). Asserting on `'inv_0'` proves the rich template
+      // fired against the resolved declaration.
+      assert(hint.contains("'inv_0'"), s"expected 'inv_0' in hint (synthetic lookup); got: $hint")
 
   test("--no-suggestions suppresses suggestion in diagnostic"):
     val cfg = VerificationConfig.Default.copy(suggestions = false)

--- a/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
@@ -1,0 +1,93 @@
+package specrest.verify
+
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
+
+class SuggestionTemplateTest extends CatsEffectSuite:
+
+  private val MaxLen = 200
+
+  test("contradictory_invariants suggestion names the conflicting invariants"):
+    for
+      ir     <- SpecFixtures.loadIR("unsat_invariants")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val global = report.checks.find(_.id == "global").get
+      val hint   = global.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("jointly unsatisfiable"), s"hint=$hint")
+      assert(
+        hint.contains("inv_0") || hint.contains("inv_1") || hint.contains("inv_2"),
+        s"expected one of inv_0/1/2 in hint; got: $hint"
+      )
+      assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("unsatisfiable_precondition suggestion names the operation"):
+    for
+      ir     <- SpecFixtures.loadIR("dead_op")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val deadReq = report.checks.find(_.id == "DeadOp.requires").get
+      val hint    = deadReq.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("DeadOp"), s"expected 'DeadOp' in hint; got: $hint")
+      assert(hint.contains("unsatisfiable"), s"hint=$hint")
+      assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("unreachable_operation suggestion names the operation and invariants"):
+    for
+      ir     <- SpecFixtures.loadIR("unreachable_op")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val unreachable = report.checks.find(_.id == "UnreachableOp.enabled").get
+      val hint        = unreachable.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("UnreachableOp"), s"expected 'UnreachableOp' in hint; got: $hint")
+      assert(hint.contains("unreachable"), s"hint=$hint")
+      assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("invariant_violation_by_operation suggestion names op, invariant, and field"):
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val violation = report.checks
+        .find(c =>
+          c.kind == CheckKind.Preservation &&
+            c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
+        )
+        .getOrElse(fail("no preservation violation found"))
+      val hint = violation.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("Tamper"), s"expected 'Tamper' in hint; got: $hint")
+      assert(hint.contains("clickCountNonNegative"), s"expected invariant name; got: $hint")
+      assert(hint.contains("click_count"), s"expected field name; got: $hint")
+      assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("solver_timeout suggestion mentions check id and timeout"):
+    val tinyTimeout = VerificationConfig.Default.copy(timeoutMs = 1L, captureModel = true)
+    for
+      ir     <- SpecFixtures.loadIR("set_ops")
+      report <- Consistency.runConsistencyChecks(ir, tinyTimeout)
+    yield
+      val timedOut = report.checks.find(c =>
+        c.diagnostic.exists(_.category == DiagnosticCategory.SolverTimeout)
+      )
+      assume(timedOut.isDefined, "expected at least one SolverTimeout diagnostic under 1ms timeout")
+      val hint = timedOut.get.diagnostic.flatMap(_.suggestion).getOrElse("")
+      assert(hint.contains("timed out"), s"hint=$hint")
+      assert(hint.contains("1ms"), s"expected '1ms' in hint; got: $hint")
+      assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
+
+  test("--no-suggestions suppresses suggestion in diagnostic"):
+    val cfg = VerificationConfig.Default.copy(suggestions = false)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val violations = report.checks.filter(c =>
+        c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
+      )
+      assert(violations.nonEmpty, "expected at least one preservation violation")
+      violations.foreach: v =>
+        assertEquals(
+          v.diagnostic.flatMap(_.suggestion),
+          None,
+          s"expected no suggestion when suggestions=false; got: ${v.diagnostic.flatMap(_.suggestion)}"
+        )


### PR DESCRIPTION
## Summary

Closes #80. Replaces the per-category one-line suggestion strings with situation-aware templates that name the specific operation, invariant, field, and (where applicable) the timeout/check-id involved.

## What changes

Five spec-failure categories produce richer hints. Examples (post-fix):

- **contradictory_invariants** (`unsat_invariants` fixture):
  > Invariants 'inv_0', 'inv_1', 'inv_2' are jointly unsatisfiable. Look for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow one or drop it.

- **invariant_violation_by_operation** (`broken_url_shortener` fixture):
  > 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises click_count correctly.

- **unsatisfiable_precondition** (`dead_op`):
  > 'DeadOp.requires' is unsatisfiable on its own — its conjuncts contradict each other. Inspect the listed spans for a pair like 'y > 10' ∧ 'y < 5', or relax the input-type refinement.

- **unreachable_operation** (`unreachable_op`):
  > 'UnreachableOp' is unreachable: its 'requires' is satisfiable alone, but invariants 'inv_0' block every valid pre-state. Relax one invariant, or tighten 'UnreachableOp''s input type to exclude the conflicting range.

- **solver_timeout**:
  > Solver timed out on '\<id\>' after \<T\>ms. Increase --timeout; simplify invariant '\<name\>' (uses set comprehension), or split a heavy quantifier into smaller predicates.

`TranslatorLimitation` and `BackendError` keep the original generic strings — those are infrastructure failures with no useful per-spec template.

Field name extraction walks `InvariantDecl.expr` collecting `FieldAccess.field` references. Feature summary detects nested quantifiers (alternation), `SetComprehension`, and `UnOp.Power`.

## Plumbing

- `VerificationConfig.suggestions: Boolean = true`.
- `--no-suggestions` flag on `verify` suppresses both the CLI `hint:` line and the JSON `suggestion` field.
- Suggestions hard-capped at 200 chars; templates fit cleanly under the cap on every fixture (no mid-word truncation).
- `Diagnostic.suggestionFor` gains a `(category, ctx)` overload; the legacy `(category)` overload remains as the fallback for `skippedCheck` and for diagnostics where context is missing.
- `Consistency.runConsistencyChecks` post-processes the report with `enrichSuggestion` to keep the change off the ~24 `FinalizeArgs` call sites.

## Tests

- `SuggestionTemplateTest` — 6 new tests, one per category + `--no-suggestions` opt-out, asserting the rich wording mentions the expected names and stays under 200 chars.
- `VerifyJsonTest` — 2 new tests: `--no-suggestions` sets `suggestion` to `null` in JSON; default run produces a non-null suggestion.
- JSON goldens at `fixtures/golden/verify_report/{unsat_invariants,broken_url_shortener}.json` regenerated to reflect the new wording.

## Docs

- Status row #80 → shipped.
- "Reading diagnostics" worked examples refreshed.
- New `--no-suggestions` row in the options table.
- Note that suggestion text is non-stable; downstream tooling should switch on the `category` enum.

## Test plan

- [x] `sbt test` — 127/127 green.
- [x] `sbt scalafmtCheckAll` — clean.
- [x] `sbt "scalafixAll --check"` — clean.
- [x] `(cd docs && npm run build)` — clean.
- [x] Manual smoke: `cli/run verify fixtures/spec/broken_url_shortener.spec` shows the rich hint; `--no-suggestions` suppresses it.

## Out of scope (deferred)

- Rule-driven (style 2) AST-pattern templates — the issue says start with template-driven (style 1) and promote to rule-driven only if v1 user feedback shows it's needed.
- Auto-apply rewrites (explicit non-goal in #80).
- Alloy counterexample decoding for richer Alloy-routed preservation hints (separate workstream; today Alloy preservation diagnostics carry no model).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Richer, context-aware suggested-fix templates for verification diagnostics, with a `--no-suggestions` opt-out (implements #80). Hints now name the operation, invariant, and fields to make failures easier to fix.

- **New Features**
  - Context-aware hints for contradictory invariants, unsatisfiable precondition, unreachable operation, invariant violation by operation, and solver timeout. Names op/invariant/fields; references the counterexample when available.
  - Field names come from the IR; timeout hints include check id, timeout, and structural features (set comprehension, powerset, nested quantifiers). 200-char cap.
  - New `--no-suggestions` flag and `VerificationConfig.suggestions`; suppresses CLI `hint:` and sets JSON `suggestion` to null.
  - Template polish and correctness: unreachable-operation wording now says "'requires' is satisfiable alone but conflicts with the invariants" (avoids the possessive glitch); softened claims; fallback for unnamed invariants via synthetic `inv_<idx>`; “nested quantifiers” label; only attach invariant context for preservation checks.

- **Migration**
  - Downstream tools should key off `category`, not the suggestion text (wording is non-stable).
  - When suggestions are disabled, expect `suggestion: null` in JSON.

<sup>Written for commit 972bbea92b4efd8c74c60e79d341f363c1e8e8a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--no-suggestions` CLI flag to suppress diagnostic suggestions; JSON output sets `suggestion` to `null` when used.
  * Enhanced diagnostic suggestions now include operation name, violated invariant, and affected field information.
  * Suggestions capped at 200 characters.

* **Documentation**
  * Updated verification guide with examples showing operation/invariant/field-aware suggestions and new opt-out flag.

* **Tests**
  * Added test coverage for suggestion generation and suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->