### PR TITLE
Structural spec linting in `check` (closes #81)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,13 @@ lazy val convention = (project in file("modules/convention"))
     libraryDependencies ++= commonMainDeps ++ commonTestDeps
   )
 
+lazy val lint = (project in file("modules/lint"))
+  .dependsOn(ir, parser % Test)
+  .settings(
+    name := "spec-lint",
+    libraryDependencies ++= commonMainDeps ++ commonTestDeps
+  )
+
 lazy val profile = (project in file("modules/profile"))
   .dependsOn(ir, convention, parser % Test)
   .settings(
@@ -112,7 +119,7 @@ lazy val bench = (project in file("modules/bench"))
   )
 
 lazy val cli = (project in file("modules/cli"))
-  .dependsOn(ir, parser, convention, profile, verify, codegen)
+  .dependsOn(ir, parser, convention, profile, verify, codegen, lint)
   .enablePlugins(NativeImagePlugin)
   .settings(
     name                := "spec-to-rest",
@@ -145,7 +152,7 @@ lazy val cli = (project in file("modules/cli"))
   )
 
 lazy val root = (project in file("."))
-  .aggregate(ir, parser, convention, profile, verify, codegen, cli, bench)
+  .aggregate(ir, parser, convention, profile, verify, codegen, lint, cli, bench)
   .settings(
     name           := "spec-to-rest-root",
     publish / skip := true

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -39,7 +39,7 @@ CLI output so the attribution is visible.
 | Verify-as-gate (refuse codegen on failed verification)              | shipped ([#78](https://github.com/HardMax71/spec_to_rest/issues/78)) — `compile` runs verify by default; `--ignore-verify` opts out |
 | Machine-readable (`--json` / `--json-out`) diagnostics output       | shipped |
 | Richer suggested-fix templates (op/invariant/field-aware; opt-out via `--no-suggestions`) | shipped |
-| Structural spec lints (type mismatch, unused entity, …)             | [#81](https://github.com/HardMax71/spec_to_rest/issues/81) (belongs in `check`) |
+| Structural spec lints (type mismatch, unused entity, …)             | shipped — `check` runs L01-L03/L05-L06 ([#81](https://github.com/HardMax71/spec_to_rest/issues/81)); L04 (op-overlap) deferred to verify |
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
 | Unsat-core extraction (`--explain`) — surface contributing spec spans on `unsat` diagnostics | shipped (Z3 always; Alloy when `minisat.prover` is bundled) |
 | Full Z3 proof-term export (Alethe / Z3-native)                      | [#90](https://github.com/HardMax71/spec_to_rest/issues/90) |
@@ -671,10 +671,11 @@ A spec that exits `2` blocks codegen because the gate cannot prove the spec corr
   [#79](https://github.com/HardMax71/spec_to_rest/issues/79).
 - **Rich suggested-fix templates** — tracked in [#80](https://github.com/HardMax71/spec_to_rest/issues/80).
   Today each category ships one header-line hint.
-- **Structural spec lints** (type mismatch, unused entity, missing ensures, overlap detection,
-  undefined variable, circular invariants) — tracked in
-  [#81](https://github.com/HardMax71/spec_to_rest/issues/81). These are parser/IR-validation
-  concerns, not Z3 reporter territory.
+- **Structural spec lints** (type mismatch, unused entity, missing ensures, undefined variable,
+  circular predicate dependency) ship in the `check` subcommand as L01-L03/L05-L06; see
+  [Spec language › Structural lints](../spec-language#structural-lints). Operation-overlap
+  detection (L04) is solver-territory and is tracked separately under verify
+  ([#81](https://github.com/HardMax71/spec_to_rest/issues/81) closing rationale).
 - **Proof / unsat-core / VC-dump export** — tracked in
   [#77](https://github.com/HardMax71/spec_to_rest/issues/77).
 - **Standalone set comprehensions as equality RHS** (`entries = { x in D | P }`) — the

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -39,7 +39,7 @@ CLI output so the attribution is visible.
 | Verify-as-gate (refuse codegen on failed verification)              | shipped ([#78](https://github.com/HardMax71/spec_to_rest/issues/78)) — `compile` runs verify by default; `--ignore-verify` opts out |
 | Machine-readable (`--json` / `--json-out`) diagnostics output       | shipped |
 | Richer suggested-fix templates (op/invariant/field-aware; opt-out via `--no-suggestions`) | shipped |
-| Structural spec lints (type mismatch, unused entity, …)             | shipped — `check` runs L01-L03/L05-L06 ([#81](https://github.com/HardMax71/spec_to_rest/issues/81)); L04 (op-overlap) deferred to verify |
+| Structural spec lints (type mismatch, unused entity, …)             | shipped — `check` runs L01-L06 ([#81](https://github.com/HardMax71/spec_to_rest/issues/81)); L04 ships a syntactic over-approximation, SAT-based overlap is candidate verify-side work |
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
 | Unsat-core extraction (`--explain`) — surface contributing spec spans on `unsat` diagnostics | shipped (Z3 always; Alloy when `minisat.prover` is bundled) |
 | Full Z3 proof-term export (Alethe / Z3-native)                      | [#90](https://github.com/HardMax71/spec_to_rest/issues/90) |
@@ -671,11 +671,11 @@ A spec that exits `2` blocks codegen because the gate cannot prove the spec corr
   [#79](https://github.com/HardMax71/spec_to_rest/issues/79).
 - **Rich suggested-fix templates** — tracked in [#80](https://github.com/HardMax71/spec_to_rest/issues/80).
   Today each category ships one header-line hint.
-- **Structural spec lints** (type mismatch, unused entity, missing ensures, undefined variable,
-  circular predicate dependency) ship in the `check` subcommand as L01-L03/L05-L06; see
-  [Spec language › Structural lints](../spec-language#structural-lints). Operation-overlap
-  detection (L04) is solver-territory and is tracked separately under verify
-  ([#81](https://github.com/HardMax71/spec_to_rest/issues/81) closing rationale).
+- **Structural spec lints** (L01-L06) ship in the `check` subcommand; see
+  [Spec language › Structural lints](../spec-language#structural-lints). L04 is a syntactic
+  over-approximation of operation overlap (same input/output signature with equivalent
+  `requires`); a SAT-based check on `requires_A ∧ requires_B` is candidate follow-up work in
+  `verify`.
 - **Proof / unsat-core / VC-dump export** — tracked in
   [#77](https://github.com/HardMax71/spec_to_rest/issues/77).
 - **Standalone set comprehensions as equality RHS** (`entries = { x in D | P }`) — the

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -73,7 +73,7 @@ succeeds. Each diagnostic carries a stable code; warnings allow exit `0`, errors
 
 | Code | Level   | What it catches                                                                       |
 |------|---------|---------------------------------------------------------------------------------------|
-| L01  | error   | Bool/None literal used as an arithmetic, comparison, or logical operand               |
+| L01  | error   | Non-boolean literal used as a logical operand, or Bool/None literal in arithmetic/comparison/`in` |
 | L02  | error   | Identifier referenced with no in-scope binding (state field, input/output, binder, …) |
 | L03  | warning | Operation declares `output:` but no `ensures:` — outputs would be unconstrained       |
 | L04  | warning | Two operations share input/output signature **and** have equivalent `requires`        |

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -68,7 +68,7 @@ invariant unique_emails {
 
 ## Structural lints
 
-`spec-to-rest check <file>.spec` runs five solver-free structural lints over the IR after parsing
+`spec-to-rest check <file>.spec` runs six solver-free structural lints over the IR after parsing
 succeeds. Each diagnostic carries a stable code; warnings allow exit `0`, errors cause exit `1`.
 
 | Code | Level   | What it catches                                                                       |
@@ -76,6 +76,7 @@ succeeds. Each diagnostic carries a stable code; warnings allow exit `0`, errors
 | L01  | error   | Bool/None literal used as an arithmetic, comparison, or logical operand               |
 | L02  | error   | Identifier referenced with no in-scope binding (state field, input/output, binder, …) |
 | L03  | warning | Operation declares `output:` but no `ensures:` — outputs would be unconstrained       |
+| L04  | warning | Two operations share input/output signature **and** have equivalent `requires`        |
 | L05  | warning | `entity` declared but never referenced in state, operations, invariants, or types     |
 | L06  | error   | Mutually-recursive predicates / functions — verifier inlining would diverge           |
 
@@ -84,8 +85,13 @@ L01 is intentionally narrow: it only fires on literals whose class admits no ope
 diff and `+` for string concatenation, so arithmetic-on-collection mismatches are not flagged
 without full type inference. A future ticket may add a richer typechecker.
 
-L04 (overlapping `requires` between operations) requires the solver and runs as a verify-time
-check rather than a structural lint.
+L04 is a syntactic over-approximation of the broader "ambiguous dispatch" question. It catches
+duplicate-operation authoring bugs (same `input`/`output`, same `requires` modulo top-level `and`
+ordering and redundant `true` literals). It deliberately does **not** flag subsumption cases like
+`requires: true` against `requires: count > 0` — those are common idioms in correct specs (the
+caller picks the operation by name; ambiguity only matters at the dispatch layer). A SAT-based
+overlap check on `requires_A ∧ requires_B` is candidate work for `verify` and is tracked
+separately.
 
 ## Convention overrides
 

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -66,6 +66,27 @@ invariant unique_emails {
 }
 ```
 
+## Structural lints
+
+`spec-to-rest check <file>.spec` runs five solver-free structural lints over the IR after parsing
+succeeds. Each diagnostic carries a stable code; warnings allow exit `0`, errors cause exit `1`.
+
+| Code | Level   | What it catches                                                                       |
+|------|---------|---------------------------------------------------------------------------------------|
+| L01  | error   | Bool/None literal used as an arithmetic, comparison, or logical operand               |
+| L02  | error   | Identifier referenced with no in-scope binding (state field, input/output, binder, …) |
+| L03  | warning | Operation declares `output:` but no `ensures:` — outputs would be unconstrained       |
+| L05  | warning | `entity` declared but never referenced in state, operations, invariants, or types     |
+| L06  | error   | Mutually-recursive predicates / functions — verifier inlining would diverge           |
+
+L01 is intentionally narrow: it only fires on literals whose class admits no operator overload
+(e.g., `flag and 5`, `count + true`, `count > true`). The DSL uses `+`/`-` for set/map union and
+diff and `+` for string concatenation, so arithmetic-on-collection mismatches are not flagged
+without full type inference. A future ticket may add a richer typechecker.
+
+L04 (overlapping `requires` between operations) requires the solver and runs as a verify-time
+check rather than a structural lint.
+
 ## Convention overrides
 
 Default REST/DB mappings can be overridden per-operation:

--- a/fixtures/lint/l01_type_mismatch_bad.spec
+++ b/fixtures/lint/l01_type_mismatch_bad.spec
@@ -1,0 +1,16 @@
+service TypeMismatchBad {
+  state {
+    count: Int
+    flag: Bool
+  }
+
+  operation Inc {
+    requires:
+      flag and 5
+    ensures:
+      count' = count + true
+  }
+
+  invariant nonNegative:
+    count > true
+}

--- a/fixtures/lint/l02_undefined_ref_bad.spec
+++ b/fixtures/lint/l02_undefined_ref_bad.spec
@@ -1,0 +1,16 @@
+service UndefinedRefBad {
+  state {
+    count: Int
+  }
+
+  operation Inc {
+    input: amount: Int
+    requires:
+      amount > 0
+    ensures:
+      count' = count + ammount
+  }
+
+  invariant nonNegative:
+    cnt >= 0
+}

--- a/fixtures/lint/l03_missing_ensures_bad.spec
+++ b/fixtures/lint/l03_missing_ensures_bad.spec
@@ -1,0 +1,15 @@
+service MissingEnsuresBad {
+  state {
+    count: Int
+  }
+
+  operation Read {
+    output: result: Int
+
+    requires:
+      true
+  }
+
+  invariant nonNegative:
+    count >= 0
+}

--- a/fixtures/lint/l04_overlap_bad.spec
+++ b/fixtures/lint/l04_overlap_bad.spec
@@ -1,0 +1,28 @@
+service OverlapBad {
+  state {
+    count: Int
+  }
+
+  operation Increment {
+    input: amount: Int
+
+    requires:
+      amount > 0
+
+    ensures:
+      count' = count + amount
+  }
+
+  operation Add {
+    input: amount: Int
+
+    requires:
+      amount > 0
+
+    ensures:
+      count' = count + amount
+  }
+
+  invariant nonNegative:
+    count >= 0
+}

--- a/fixtures/lint/l05_unused_entity_bad.spec
+++ b/fixtures/lint/l05_unused_entity_bad.spec
@@ -1,0 +1,27 @@
+service UnusedEntityBad {
+  entity Used {
+    id: Int
+    name: String
+  }
+
+  entity Orphan {
+    id: Int
+    label: String
+  }
+
+  state {
+    items: Int -> lone Used
+  }
+
+  operation Add {
+    input: id: Int, name: String
+    requires:
+      id > 0
+    ensures:
+      items'[id].id = id
+      items'[id].name = name
+  }
+
+  invariant idsPositive:
+    all i in items | items[i].id > 0
+}

--- a/fixtures/lint/l06_circular_predicate_bad.spec
+++ b/fixtures/lint/l06_circular_predicate_bad.spec
@@ -1,0 +1,18 @@
+service CircularPredicateBad {
+  state {
+    count: Int
+  }
+
+  predicate isA(n: Int) = isB(n)
+  predicate isB(n: Int) = isA(n)
+
+  operation Touch {
+    requires:
+      isA(count)
+    ensures:
+      count' = count
+  }
+
+  invariant nonNegative:
+    count >= 0
+}

--- a/fixtures/lint/passing.spec
+++ b/fixtures/lint/passing.spec
@@ -1,0 +1,37 @@
+service AllLintsPass {
+  entity Item {
+    id: Int where value > 0
+    name: String
+  }
+
+  state {
+    items: Int -> lone Item
+  }
+
+  predicate hasItem(k: Int) = k in items
+
+  operation Add {
+    input: id: Int, name: String
+
+    requires:
+      id > 0
+      not hasItem(id)
+
+    ensures:
+      items'[id].id = id
+      items'[id].name = name
+  }
+
+  operation Remove {
+    input: id: Int
+
+    requires:
+      hasItem(id)
+
+    ensures:
+      id not in items'
+  }
+
+  invariant idsPositive:
+    all k in items | items[k].id > 0
+}

--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -2,9 +2,13 @@ package specrest.cli
 
 import cats.effect.ExitCode
 import cats.effect.IO
+import specrest.convention.ConventionDiagnostic
 import specrest.convention.DiagnosticLevel as ConvDiagLevel
 import specrest.convention.Validate
 import specrest.ir.VerifyError
+import specrest.lint.Lint
+import specrest.lint.LintDiagnostic
+import specrest.lint.LintLevel
 import specrest.parser.Builder
 import specrest.parser.Parse
 
@@ -37,20 +41,20 @@ object Check:
                     val buildMs = (System.nanoTime() - t1) / 1_000_000.0
                     log.verbose(f"Built IR in ${buildMs}%.0fms")
 
-                    val diagnostics = Validate.validateConventions(ir.conventions, ir)
-                    val errors      = diagnostics.filter(_.level == ConvDiagLevel.Error)
-                    val warnings    = diagnostics.filter(_.level == ConvDiagLevel.Warning)
+                    val convDiags = Validate.validateConventions(ir.conventions, ir)
+                    val lintDiags = Lint.run(ir)
 
-                    for w <- warnings do
-                      val loc =
-                        w.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                      log.warn(s"${loc}warning: ${w.message}")
-                    for e <- errors do
-                      val loc =
-                        e.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
-                      log.error(s"${loc}${e.message}")
+                    val convErrors   = convDiags.filter(_.level == ConvDiagLevel.Error)
+                    val convWarnings = convDiags.filter(_.level == ConvDiagLevel.Warning)
+                    val lintErrors   = lintDiags.filter(_.level == LintLevel.Error)
+                    val lintWarnings = lintDiags.filter(_.level == LintLevel.Warning)
 
-                    if errors.nonEmpty then ExitCodes.Violations
+                    convWarnings.foreach(d => log.warn(renderConv(specFile, d)))
+                    lintWarnings.foreach(d => log.warn(renderLint(specFile, d)))
+                    convErrors.foreach(d => log.error(renderConv(specFile, d)))
+                    lintErrors.foreach(d => log.error(renderLint(specFile, d)))
+
+                    if convErrors.nonEmpty || lintErrors.nonEmpty then ExitCodes.Violations
                     else
                       log.success(
                         s"$specFile: valid (${ir.operations.length} operations, ${ir.entities.length} entities, ${ir.invariants.length} invariants)"
@@ -59,6 +63,18 @@ object Check:
                   }
           )
         }
+
+  private def renderConv(specFile: String, d: ConventionDiagnostic): String =
+    val loc = d.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+    d.level match
+      case ConvDiagLevel.Warning => s"${loc}warning: ${d.message}"
+      case ConvDiagLevel.Error   => s"${loc}${d.message}"
+
+  private def renderLint(specFile: String, d: LintDiagnostic): String =
+    val loc = d.span.map(s => s"$specFile:${s.startLine}:${s.startCol}: ").getOrElse("")
+    d.level match
+      case LintLevel.Warning => s"${loc}warning: ${d.message} [${d.code}]"
+      case LintLevel.Error   => s"${loc}${d.message} [${d.code}]"
 
   private[cli] def readSource(specFile: String, log: Logger): IO[Either[ExitCode, String]] =
     IO.blocking(Files.readString(Paths.get(specFile)))

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -14,6 +14,17 @@ class CliSmokeTest extends CatsEffectSuite:
   test("check on missing file returns 1"):
     Check.run("fixtures/does-not-exist.spec", log).assertEquals(ExitCodes.Violations)
 
+  test("check exits 1 on lint error (undefined identifier)"):
+    Check.run("fixtures/lint/l02_undefined_ref_bad.spec", log)
+      .assertEquals(ExitCodes.Violations)
+
+  test("check exits 0 on lint warning only (missing ensures)"):
+    Check.run("fixtures/lint/l03_missing_ensures_bad.spec", log)
+      .assertEquals(ExitCodes.Ok)
+
+  test("check exits 0 on the all-lints-pass fixture"):
+    Check.run("fixtures/lint/passing.spec", log).assertEquals(ExitCodes.Ok)
+
   test("inspect --format json returns 0 on valid spec"):
     Inspect.run("fixtures/spec/safe_counter.spec", InspectFormat.Json, log)
       .assertEquals(ExitCodes.Ok)

--- a/modules/lint/src/main/scala/specrest/lint/CircularPredicate.scala
+++ b/modules/lint/src/main/scala/specrest/lint/CircularPredicate.scala
@@ -1,0 +1,78 @@
+package specrest.lint
+
+import specrest.ir.Expr
+import specrest.ir.ServiceIR
+import specrest.ir.Span
+
+import scala.collection.mutable
+
+object CircularPredicate extends LintPass:
+  val code = "L06"
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    val predNames = ir.predicates.map(_.name).toSet
+    val funcNames = ir.functions.map(_.name).toSet
+    val nodes     = predNames ++ funcNames
+    if nodes.isEmpty then return Nil
+
+    val spans = mutable.Map.empty[String, Option[Span]]
+    val edges = mutable.Map.empty[String, Set[String]]
+    for p <- ir.predicates do
+      spans(p.name) = p.span
+      edges(p.name) = callees(p.body, nodes)
+    for f <- ir.functions do
+      spans(f.name) = f.span
+      edges(f.name) = callees(f.body, nodes)
+
+    val cycles = findCycles(nodes.toList.sorted, edges.toMap)
+    cycles.map: cyc =>
+      val head    = cyc.head
+      val display = (cyc :+ head).mkString(" -> ")
+      val related =
+        cyc.tail.flatMap(n => spans.get(n).flatten.map(s => RelatedSpan(s, s"in cycle: $n")))
+      LintDiagnostic(
+        code,
+        LintLevel.Error,
+        s"circular predicate dependency: $display",
+        spans.get(head).flatten,
+        related
+      )
+
+  private def callees(body: Expr, names: Set[String]): Set[String] =
+    val acc = mutable.Set.empty[String]
+    ExprWalk.foreach(body):
+      case Expr.Call(Expr.Identifier(n, _), _, _) if names.contains(n) => acc += n
+      case _                                                           => ()
+    acc.toSet
+
+  private def findCycles(nodes: List[String], edges: Map[String, Set[String]]): List[List[String]] =
+    val onStack    = mutable.Set.empty[String]
+    val visited    = mutable.Set.empty[String]
+    val stack      = mutable.ListBuffer.empty[String]
+    val cycles     = mutable.ListBuffer.empty[List[String]]
+    val seenCycles = mutable.Set.empty[Set[String]]
+
+    def dfs(n: String): Unit =
+      if onStack.contains(n) then
+        val idx = stack.indexOf(n)
+        if idx >= 0 then
+          val cyc = stack.slice(idx, stack.length).toList
+          val key = cyc.toSet
+          if !seenCycles.contains(key) then
+            seenCycles += key
+            cycles += cyc
+      else if !visited.contains(n) then
+        visited += n
+        onStack += n
+        stack += n
+        edges.getOrElse(n, Set.empty).toList.sorted.foreach(dfs)
+        onStack -= n
+        val _ = stack.remove(stack.length - 1)
+      else ()
+
+    nodes.foreach: n =>
+      stack.clear()
+      onStack.clear()
+      dfs(n)
+
+    cycles.toList

--- a/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
+++ b/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
@@ -1,0 +1,56 @@
+package specrest.lint
+
+import specrest.ir.Expr
+
+object ExprWalk:
+
+  def foreach(expr: Expr)(visit: Expr => Unit): Unit =
+    visit(expr)
+    expr match
+      case Expr.BinaryOp(_, l, r, _) =>
+        foreach(l)(visit); foreach(r)(visit)
+      case Expr.UnaryOp(_, op, _) =>
+        foreach(op)(visit)
+      case Expr.Quantifier(_, bindings, body, _) =>
+        bindings.foreach(b => foreach(b.domain)(visit))
+        foreach(body)(visit)
+      case Expr.SomeWrap(e, _) =>
+        foreach(e)(visit)
+      case Expr.The(_, d, b, _) =>
+        foreach(d)(visit); foreach(b)(visit)
+      case Expr.FieldAccess(base, _, _) =>
+        foreach(base)(visit)
+      case Expr.EnumAccess(base, _, _) =>
+        foreach(base)(visit)
+      case Expr.Index(base, idx, _) =>
+        foreach(base)(visit); foreach(idx)(visit)
+      case Expr.Call(callee, args, _) =>
+        foreach(callee)(visit); args.foreach(foreach(_)(visit))
+      case Expr.Prime(e, _) =>
+        foreach(e)(visit)
+      case Expr.Pre(e, _) =>
+        foreach(e)(visit)
+      case Expr.With(base, updates, _) =>
+        foreach(base)(visit); updates.foreach(u => foreach(u.value)(visit))
+      case Expr.If(c, t, e, _) =>
+        foreach(c)(visit); foreach(t)(visit); foreach(e)(visit)
+      case Expr.Let(_, v, b, _) =>
+        foreach(v)(visit); foreach(b)(visit)
+      case Expr.Lambda(_, b, _) =>
+        foreach(b)(visit)
+      case Expr.Constructor(_, fields, _) =>
+        fields.foreach(f => foreach(f.value)(visit))
+      case Expr.SetLiteral(elems, _) =>
+        elems.foreach(foreach(_)(visit))
+      case Expr.MapLiteral(entries, _) =>
+        entries.foreach: e =>
+          foreach(e.key)(visit); foreach(e.value)(visit)
+      case Expr.SetComprehension(_, d, p, _) =>
+        foreach(d)(visit); foreach(p)(visit)
+      case Expr.SeqLiteral(elems, _) =>
+        elems.foreach(foreach(_)(visit))
+      case Expr.Matches(e, _, _) =>
+        foreach(e)(visit)
+      case _: (Expr.Identifier | Expr.IntLit | Expr.FloatLit | Expr.StringLit |
+            Expr.BoolLit | Expr.NoneLit) =>
+        ()

--- a/modules/lint/src/main/scala/specrest/lint/Lint.scala
+++ b/modules/lint/src/main/scala/specrest/lint/Lint.scala
@@ -1,0 +1,15 @@
+package specrest.lint
+
+import specrest.ir.ServiceIR
+
+object Lint:
+  private val passes: List[LintPass] = List(
+    TypeMismatch,
+    UndefinedRef,
+    MissingEnsures,
+    UnusedEntity,
+    CircularPredicate
+  )
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    passes.flatMap(_.run(ir))

--- a/modules/lint/src/main/scala/specrest/lint/Lint.scala
+++ b/modules/lint/src/main/scala/specrest/lint/Lint.scala
@@ -7,6 +7,7 @@ object Lint:
     TypeMismatch,
     UndefinedRef,
     MissingEnsures,
+    OperationOverlap,
     UnusedEntity,
     CircularPredicate
   )

--- a/modules/lint/src/main/scala/specrest/lint/LintDiagnostic.scala
+++ b/modules/lint/src/main/scala/specrest/lint/LintDiagnostic.scala
@@ -1,0 +1,20 @@
+package specrest.lint
+
+import specrest.ir.Span
+
+enum LintLevel:
+  case Error, Warning
+
+final case class RelatedSpan(span: Span, note: String)
+
+final case class LintDiagnostic(
+    code: String,
+    level: LintLevel,
+    message: String,
+    span: Option[Span],
+    relatedSpans: List[RelatedSpan] = Nil
+)
+
+trait LintPass:
+  def code: String
+  def run(ir: specrest.ir.ServiceIR): List[LintDiagnostic]

--- a/modules/lint/src/main/scala/specrest/lint/MissingEnsures.scala
+++ b/modules/lint/src/main/scala/specrest/lint/MissingEnsures.scala
@@ -1,0 +1,19 @@
+package specrest.lint
+
+import specrest.ir.ServiceIR
+
+object MissingEnsures extends LintPass:
+  val code = "L03"
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    ir.operations.flatMap: op =>
+      if op.outputs.nonEmpty && op.ensures.isEmpty then
+        List(
+          LintDiagnostic(
+            code,
+            LintLevel.Warning,
+            s"operation '${op.name}' declares outputs but has no 'ensures' block — outputs will be unconstrained",
+            op.span
+          )
+        )
+      else Nil

--- a/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
+++ b/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
@@ -1,0 +1,114 @@
+package specrest.lint
+
+import specrest.ir.BinOp
+import specrest.ir.Expr
+import specrest.ir.OperationDecl
+import specrest.ir.ParamDecl
+import specrest.ir.ServiceIR
+import specrest.ir.TypeExpr
+
+object OperationOverlap extends LintPass:
+  val code = "L04"
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    val out    = List.newBuilder[LintDiagnostic]
+    val groups = ir.operations.groupBy(opSignature).filter(_._2.length >= 2)
+    for (_, ops) <- groups do
+      val sorted = ops.sortBy(_.name)
+      for i <- sorted.indices; j <- (i + 1) until sorted.length do
+        val a    = sorted(i)
+        val b    = sorted(j)
+        val nrA  = normalizedRequires(a.requires)
+        val nrB  = normalizedRequires(b.requires)
+        val same = nrA.length == nrB.length && nrA.zip(nrB).forall((x, y) => x == y)
+        if same then
+          val rel = a.span.toList.map(s => RelatedSpan(s, s"first definition of '${a.name}'"))
+          val phrase =
+            if nrA.isEmpty then "neither has preconditions" else "they share the same preconditions"
+          out += LintDiagnostic(
+            code,
+            LintLevel.Warning,
+            s"operations '${a.name}' and '${b.name}' have the same input/output signature and $phrase — dispatch is ambiguous on shared inputs",
+            b.span,
+            rel
+          )
+    out.result()
+
+  private def opSignature(op: OperationDecl): (List[(String, String)], List[(String, String)]) =
+    (op.inputs.map(paramShape), op.outputs.map(paramShape))
+
+  private def paramShape(p: ParamDecl): (String, String) = (p.name, typeShape(p.typeExpr))
+
+  private def typeShape(t: TypeExpr): String = t match
+    case TypeExpr.NamedType(n, _)           => n
+    case TypeExpr.SetType(inner, _)         => s"Set[${typeShape(inner)}]"
+    case TypeExpr.SeqType(inner, _)         => s"Seq[${typeShape(inner)}]"
+    case TypeExpr.OptionType(inner, _)      => s"Option[${typeShape(inner)}]"
+    case TypeExpr.MapType(k, v, _)          => s"Map[${typeShape(k)},${typeShape(v)}]"
+    case TypeExpr.RelationType(f, m, t2, _) => s"${typeShape(f)}-$m->${typeShape(t2)}"
+
+  private def normalizedRequires(rs: List[Expr]): List[String] =
+    rs.flatMap(flattenAnd).filterNot(isLiteralTrue).map(exprShape).sorted
+
+  private def flattenAnd(e: Expr): List[Expr] = e match
+    case Expr.BinaryOp(BinOp.And, l, r, _) => flattenAnd(l) ++ flattenAnd(r)
+    case other                             => List(other)
+
+  private def isLiteralTrue(e: Expr): Boolean = e match
+    case Expr.BoolLit(true, _) => true
+    case _                     => false
+
+  private def exprShape(e: Expr): String = e match
+    case Expr.BinaryOp(op, l, r, _) =>
+      s"(B$op ${exprShape(l)} ${exprShape(r)})"
+    case Expr.UnaryOp(op, o, _) =>
+      s"(U$op ${exprShape(o)})"
+    case Expr.Quantifier(q, bs, body, _) =>
+      val bindings = bs
+        .map(b => s"${b.variable}/${b.bindingKind}/${exprShape(b.domain)}")
+        .mkString(",")
+      s"(Q$q[$bindings]${exprShape(body)})"
+    case Expr.SomeWrap(inner, _) =>
+      s"(some ${exprShape(inner)})"
+    case Expr.The(v, d, body, _) =>
+      s"(the $v ${exprShape(d)} ${exprShape(body)})"
+    case Expr.FieldAccess(base, f, _) =>
+      s"(. ${exprShape(base)} $f)"
+    case Expr.EnumAccess(base, m, _) =>
+      s"(:: ${exprShape(base)} $m)"
+    case Expr.Index(base, idx, _) =>
+      s"([] ${exprShape(base)} ${exprShape(idx)})"
+    case Expr.Call(callee, args, _) =>
+      s"(call ${exprShape(callee)} ${args.map(exprShape).mkString(",")})"
+    case Expr.Prime(inner, _) =>
+      s"(' ${exprShape(inner)})"
+    case Expr.Pre(inner, _) =>
+      s"(pre ${exprShape(inner)})"
+    case Expr.With(base, ups, _) =>
+      val u = ups.map(up => s"${up.name}=${exprShape(up.value)}").mkString(",")
+      s"(with ${exprShape(base)} {$u})"
+    case Expr.If(c, t, ee, _) =>
+      s"(if ${exprShape(c)} ${exprShape(t)} ${exprShape(ee)})"
+    case Expr.Let(v, va, body, _) =>
+      s"(let $v ${exprShape(va)} ${exprShape(body)})"
+    case Expr.Lambda(p, body, _) =>
+      s"(\\$p.${exprShape(body)})"
+    case Expr.Constructor(n, fs, _) =>
+      val f = fs.map(fa => s"${fa.name}=${exprShape(fa.value)}").mkString(",")
+      s"($n{$f})"
+    case Expr.SetLiteral(es, _) =>
+      s"{${es.map(exprShape).mkString(",")}}"
+    case Expr.MapLiteral(es, _) =>
+      s"{${es.map(en => s"${exprShape(en.key)}->${exprShape(en.value)}").mkString(",")}}"
+    case Expr.SetComprehension(v, d, p, _) =>
+      s"({$v in ${exprShape(d)} | ${exprShape(p)}})"
+    case Expr.SeqLiteral(es, _) =>
+      s"[${es.map(exprShape).mkString(",")}]"
+    case Expr.Matches(inner, pat, _) =>
+      s"(${exprShape(inner)} matches /$pat/)"
+    case Expr.IntLit(v, _)     => v.toString
+    case Expr.FloatLit(v, _)   => v.toString
+    case Expr.StringLit(v, _)  => "\"" + v + "\""
+    case Expr.BoolLit(v, _)    => v.toString
+    case Expr.NoneLit(_)       => "none"
+    case Expr.Identifier(n, _) => n

--- a/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
+++ b/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
@@ -1,0 +1,150 @@
+package specrest.lint
+
+import specrest.ir.BinOp
+import specrest.ir.Expr
+import specrest.ir.ServiceIR
+import specrest.ir.UnOp
+
+object TypeMismatch extends LintPass:
+  val code = "L01"
+
+  private enum LitClass:
+    case Numeric, Bool, StringLike, Collection, NoneLit
+
+  private def litClass(e: Expr): Option[LitClass] = e match
+    case _: Expr.IntLit    => Some(LitClass.Numeric)
+    case _: Expr.FloatLit  => Some(LitClass.Numeric)
+    case _: Expr.BoolLit   => Some(LitClass.Bool)
+    case _: Expr.StringLit => Some(LitClass.StringLike)
+    case _: Expr.SetLiteral | _: Expr.MapLiteral | _: Expr.SeqLiteral =>
+      Some(LitClass.Collection)
+    case _: Expr.NoneLit => Some(LitClass.NoneLit)
+    case _               => None
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    val out = List.newBuilder[LintDiagnostic]
+    val visit: Expr => Unit =
+      case e @ Expr.BinaryOp(op, left, right, span) =>
+        checkBinary(op, left, right, span.orElse(e.spanOpt), out)
+      case e @ Expr.UnaryOp(UnOp.Not, operand, span) =>
+        litClass(operand) match
+          case Some(c) if c != LitClass.Bool =>
+            out += LintDiagnostic(
+              code,
+              LintLevel.Error,
+              s"logical 'not' applied to a ${describe(c)} literal",
+              span.orElse(e.spanOpt)
+            )
+          case _ => ()
+      case e @ Expr.UnaryOp(UnOp.Negate, operand, span) =>
+        litClass(operand) match
+          case Some(c) if c != LitClass.Numeric =>
+            out += LintDiagnostic(
+              code,
+              LintLevel.Error,
+              s"arithmetic '-' applied to a ${describe(c)} literal",
+              span.orElse(e.spanOpt)
+            )
+          case _ => ()
+      case _ => ()
+
+    def visitAll(e: Expr): Unit = ExprWalk.foreach(e)(visit)
+
+    for op <- ir.operations do
+      op.requires.foreach(visitAll)
+      op.ensures.foreach(visitAll)
+    ir.invariants.foreach(i => visitAll(i.expr))
+    ir.temporals.foreach(t => visitAll(t.expr))
+    ir.facts.foreach(f => visitAll(f.expr))
+    ir.functions.foreach(f => visitAll(f.body))
+    ir.predicates.foreach(p => visitAll(p.body))
+    ir.entities.foreach: ent =>
+      ent.fields.foreach(_.constraint.foreach(visitAll))
+      ent.invariants.foreach(visitAll)
+    ir.typeAliases.foreach(_.constraint.foreach(visitAll))
+
+    out.result()
+
+  private def checkBinary(
+      op: BinOp,
+      left: Expr,
+      right: Expr,
+      span: Option[specrest.ir.Span],
+      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]]
+  ): Unit =
+    val lc = litClass(left)
+    val rc = litClass(right)
+    op match
+      case BinOp.Add | BinOp.Sub | BinOp.Mul | BinOp.Div =>
+        // `+` and `-` are overloaded for set/map union and diff in this DSL,
+        // and `+` for string concatenation. Only flag when a literal is clearly
+        // never a number (Bool or None) — those cases admit no overload.
+        val bad = lc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit) ||
+          rc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit)
+        if bad then
+          out += LintDiagnostic(
+            code,
+            LintLevel.Error,
+            s"arithmetic '${binOpName(op)}' has a ${describe((lc ++ rc).find(c => c == LitClass.Bool || c == LitClass.NoneLit).get)} literal operand",
+            span
+          )
+      case BinOp.Lt | BinOp.Gt | BinOp.Le | BinOp.Ge =>
+        // Comparisons can apply to numbers, strings (lexicographic), or sets
+        // (subset/superset). Only flag on Bool/None literals (never ordered).
+        val bad = lc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit) ||
+          rc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit)
+        if bad then
+          out += LintDiagnostic(
+            code,
+            LintLevel.Error,
+            s"comparison '${binOpName(op)}' has a ${describe((lc ++ rc).find(c => c == LitClass.Bool || c == LitClass.NoneLit).get)} literal operand",
+            span
+          )
+      case BinOp.And | BinOp.Or | BinOp.Implies | BinOp.Iff =>
+        val bad = lc.exists(_ != LitClass.Bool) || rc.exists(_ != LitClass.Bool)
+        if bad then
+          val offender = (lc ++ rc).find(_ != LitClass.Bool).get
+          out += LintDiagnostic(
+            code,
+            LintLevel.Error,
+            s"logical '${binOpName(op)}' applied to a ${describe(offender)} literal",
+            span
+          )
+      case BinOp.In | BinOp.NotIn =>
+        val bad = rc.exists(c =>
+          c == LitClass.Numeric || c == LitClass.Bool || c == LitClass.StringLike || c == LitClass.NoneLit
+        )
+        if bad then
+          out += LintDiagnostic(
+            code,
+            LintLevel.Error,
+            s"'${binOpName(op)}' right operand is a ${describe(rc.get)} literal, not a collection",
+            span
+          )
+      case _ => ()
+
+  private def describe(c: LitClass): String = c match
+    case LitClass.Numeric    => "numeric"
+    case LitClass.Bool       => "boolean"
+    case LitClass.StringLike => "string"
+    case LitClass.Collection => "collection"
+    case LitClass.NoneLit    => "none"
+
+  private def binOpName(op: BinOp): String = op match
+    case BinOp.Add     => "+"
+    case BinOp.Sub     => "-"
+    case BinOp.Mul     => "*"
+    case BinOp.Div     => "/"
+    case BinOp.Lt      => "<"
+    case BinOp.Gt      => ">"
+    case BinOp.Le      => "<="
+    case BinOp.Ge      => ">="
+    case BinOp.And     => "and"
+    case BinOp.Or      => "or"
+    case BinOp.Implies => "implies"
+    case BinOp.Iff     => "iff"
+    case BinOp.In      => "in"
+    case BinOp.NotIn   => "not in"
+    case BinOp.Eq      => "="
+    case BinOp.Neq     => "!="
+    case other         => other.toString

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -7,39 +7,36 @@ object UndefinedRef extends LintPass:
   val code = "L02"
 
   private val builtins: Set[String] = Set(
-    "true",
-    "false",
-    "none",
     "len",
-    "isValidURI",
     "dom",
     "ran",
     "abs",
-    "Int",
-    "Long",
-    "Float",
-    "Double",
-    "Bool",
-    "Boolean",
-    "String",
-    "DateTime"
+    "isValidURI",
+    "hash",
+    "now",
+    "sum",
+    "minutes",
+    "hours",
+    "days",
+    "seconds"
   )
 
   def run(ir: ServiceIR): List[LintDiagnostic] =
-    val out         = List.newBuilder[LintDiagnostic]
-    val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
-    val entityNames = ir.entities.map(_.name).toSet
-    val enumNames   = ir.enums.map(_.name).toSet
-    val enumMembers = ir.enums.flatMap(_.values).toSet
-    val typeAliases = ir.typeAliases.map(_.name).toSet
-    val predicates  = ir.predicates.map(_.name).toSet
-    val functions   = ir.functions.map(_.name).toSet
+    val out          = List.newBuilder[LintDiagnostic]
+    val stateFields  = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
+    val entityNames  = ir.entities.map(_.name).toSet
+    val enumNames    = ir.enums.map(_.name).toSet
+    val enumMembers  = ir.enums.flatMap(_.values).toSet
+    val typeAliases  = ir.typeAliases.map(_.name).toSet
+    val predicates   = ir.predicates.map(_.name).toSet
+    val functions    = ir.functions.map(_.name).toSet
+    val factImplicit = ir.facts.flatMap(f => collectCallees(f.expr)).toSet
     val global =
       stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++
-        predicates ++ functions ++ builtins
+        predicates ++ functions ++ builtins ++ factImplicit
 
     def check(expr: Expr, scope: Set[String]): Unit =
-      walk(expr, scope, isCallee = false, out, global)
+      walk(expr, scope, out)
 
     for op <- ir.operations do
       val opScope = global ++ op.inputs.map(_.name) ++ op.outputs.map(_.name) + "self"
@@ -55,26 +52,36 @@ object UndefinedRef extends LintPass:
       ent.fields.foreach(_.constraint.foreach(check(_, entScope)))
       ent.invariants.foreach(check(_, entScope))
 
-    for a <- ir.typeAliases do
-      a.constraint.foreach(check(_, global + "value"))
+    for a <- ir.typeAliases do a.constraint.foreach(check(_, global + "value"))
 
-    for fn <- ir.functions do
-      check(fn.body, global ++ fn.params.map(_.name))
+    for fn <- ir.functions do check(fn.body, global ++ fn.params.map(_.name))
 
-    for pr <- ir.predicates do
-      check(pr.body, global ++ pr.params.map(_.name))
+    for pr <- ir.predicates do check(pr.body, global ++ pr.params.map(_.name))
+
+    for tr <- ir.transitions do
+      val entFields = ir.entities
+        .find(_.name == tr.entityName)
+        .map(_.fields.map(_.name).toSet)
+        .getOrElse(Set.empty)
+      val trScope = global ++ entFields + "self"
+      tr.rules.foreach(_.guard.foreach(check(_, trScope)))
 
     out.result()
+
+  private def collectCallees(e: Expr): List[String] =
+    val acc = scala.collection.mutable.ListBuffer.empty[String]
+    ExprWalk.foreach(e):
+      case Expr.Call(Expr.Identifier(n, _), _, _) => acc += n
+      case _                                      => ()
+    acc.toList
 
   private def walk(
       expr: Expr,
       scope: Set[String],
-      isCallee: Boolean,
-      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]],
-      global: Set[String]
+      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]]
   ): Unit = expr match
     case Expr.Identifier(name, span) =>
-      if !isCallee && !scope.contains(name) then
+      if !scope.contains(name) then
         out += LintDiagnostic(
           UndefinedRef.code,
           LintLevel.Error,
@@ -82,61 +89,52 @@ object UndefinedRef extends LintPass:
           span
         )
     case Expr.BinaryOp(_, l, r, _) =>
-      walk(l, scope, isCallee = false, out, global)
-      walk(r, scope, isCallee = false, out, global)
+      walk(l, scope, out); walk(r, scope, out)
     case Expr.UnaryOp(_, op, _) =>
-      walk(op, scope, isCallee = false, out, global)
+      walk(op, scope, out)
     case Expr.Quantifier(_, bindings, body, _) =>
       var s = scope
       bindings.foreach: b =>
-        walk(b.domain, s, isCallee = false, out, global)
+        walk(b.domain, s, out)
         s = s + b.variable
-      walk(body, s, isCallee = false, out, global)
+      walk(body, s, out)
     case Expr.SomeWrap(e, _) =>
-      walk(e, scope, isCallee = false, out, global)
+      walk(e, scope, out)
     case Expr.The(v, d, b, _) =>
-      walk(d, scope, isCallee = false, out, global)
-      walk(b, scope + v, isCallee = false, out, global)
+      walk(d, scope, out); walk(b, scope + v, out)
     case Expr.FieldAccess(base, _, _) =>
-      walk(base, scope, isCallee = false, out, global)
+      walk(base, scope, out)
     case Expr.EnumAccess(base, _, _) =>
-      walk(base, scope, isCallee = false, out, global)
+      walk(base, scope, out)
     case Expr.Index(base, idx, _) =>
-      walk(base, scope, isCallee = false, out, global)
-      walk(idx, scope, isCallee = false, out, global)
+      walk(base, scope, out); walk(idx, scope, out)
     case Expr.Call(callee, args, _) =>
-      walk(callee, scope, isCallee = true, out, global)
-      args.foreach(a => walk(a, scope, isCallee = false, out, global))
+      walk(callee, scope, out)
+      args.foreach(a => walk(a, scope, out))
     case Expr.Prime(e, _) =>
-      walk(e, scope, isCallee = false, out, global)
+      walk(e, scope, out)
     case Expr.Pre(e, _) =>
-      walk(e, scope, isCallee = false, out, global)
+      walk(e, scope, out)
     case Expr.With(base, updates, _) =>
-      walk(base, scope, isCallee = false, out, global)
-      updates.foreach(u => walk(u.value, scope, isCallee = false, out, global))
+      walk(base, scope, out); updates.foreach(u => walk(u.value, scope, out))
     case Expr.If(c, t, e, _) =>
-      walk(c, scope, isCallee = false, out, global)
-      walk(t, scope, isCallee = false, out, global)
-      walk(e, scope, isCallee = false, out, global)
+      walk(c, scope, out); walk(t, scope, out); walk(e, scope, out)
     case Expr.Let(v, value, body, _) =>
-      walk(value, scope, isCallee = false, out, global)
-      walk(body, scope + v, isCallee = false, out, global)
+      walk(value, scope, out); walk(body, scope + v, out)
     case Expr.Lambda(p, b, _) =>
-      walk(b, scope + p, isCallee = false, out, global)
+      walk(b, scope + p, out)
     case Expr.Constructor(_, fields, _) =>
-      fields.foreach(f => walk(f.value, scope, isCallee = false, out, global))
+      fields.foreach(f => walk(f.value, scope, out))
     case Expr.SetLiteral(elems, _) =>
-      elems.foreach(walk(_, scope, isCallee = false, out, global))
+      elems.foreach(walk(_, scope, out))
     case Expr.MapLiteral(entries, _) =>
       entries.foreach: e =>
-        walk(e.key, scope, isCallee = false, out, global)
-        walk(e.value, scope, isCallee = false, out, global)
+        walk(e.key, scope, out); walk(e.value, scope, out)
     case Expr.SetComprehension(v, d, p, _) =>
-      walk(d, scope, isCallee = false, out, global)
-      walk(p, scope + v, isCallee = false, out, global)
+      walk(d, scope, out); walk(p, scope + v, out)
     case Expr.SeqLiteral(elems, _) =>
-      elems.foreach(walk(_, scope, isCallee = false, out, global))
+      elems.foreach(walk(_, scope, out))
     case Expr.Matches(e, _, _) =>
-      walk(e, scope, isCallee = false, out, global)
+      walk(e, scope, out)
     case _: (Expr.IntLit | Expr.FloatLit | Expr.StringLit | Expr.BoolLit | Expr.NoneLit) =>
       ()

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -1,0 +1,142 @@
+package specrest.lint
+
+import specrest.ir.Expr
+import specrest.ir.ServiceIR
+
+object UndefinedRef extends LintPass:
+  val code = "L02"
+
+  private val builtins: Set[String] = Set(
+    "true",
+    "false",
+    "none",
+    "len",
+    "isValidURI",
+    "dom",
+    "ran",
+    "abs",
+    "Int",
+    "Long",
+    "Float",
+    "Double",
+    "Bool",
+    "Boolean",
+    "String",
+    "DateTime"
+  )
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    val out         = List.newBuilder[LintDiagnostic]
+    val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
+    val entityNames = ir.entities.map(_.name).toSet
+    val enumNames   = ir.enums.map(_.name).toSet
+    val enumMembers = ir.enums.flatMap(_.values).toSet
+    val typeAliases = ir.typeAliases.map(_.name).toSet
+    val predicates  = ir.predicates.map(_.name).toSet
+    val functions   = ir.functions.map(_.name).toSet
+    val global =
+      stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++
+        predicates ++ functions ++ builtins
+
+    def check(expr: Expr, scope: Set[String]): Unit =
+      walk(expr, scope, isCallee = false, out, global)
+
+    for op <- ir.operations do
+      val opScope = global ++ op.inputs.map(_.name) ++ op.outputs.map(_.name) + "self"
+      op.requires.foreach(check(_, opScope))
+      op.ensures.foreach(check(_, opScope))
+
+    ir.invariants.foreach(i => check(i.expr, global + "self"))
+    ir.temporals.foreach(t => check(t.expr, global + "self"))
+    ir.facts.foreach(f => check(f.expr, global + "self"))
+
+    for ent <- ir.entities do
+      val entScope = global + "self" + "value" ++ ent.fields.map(_.name)
+      ent.fields.foreach(_.constraint.foreach(check(_, entScope)))
+      ent.invariants.foreach(check(_, entScope))
+
+    for a <- ir.typeAliases do
+      a.constraint.foreach(check(_, global + "value"))
+
+    for fn <- ir.functions do
+      check(fn.body, global ++ fn.params.map(_.name))
+
+    for pr <- ir.predicates do
+      check(pr.body, global ++ pr.params.map(_.name))
+
+    out.result()
+
+  private def walk(
+      expr: Expr,
+      scope: Set[String],
+      isCallee: Boolean,
+      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]],
+      global: Set[String]
+  ): Unit = expr match
+    case Expr.Identifier(name, span) =>
+      if !isCallee && !scope.contains(name) then
+        out += LintDiagnostic(
+          UndefinedRef.code,
+          LintLevel.Error,
+          s"undefined identifier '$name'",
+          span
+        )
+    case Expr.BinaryOp(_, l, r, _) =>
+      walk(l, scope, isCallee = false, out, global)
+      walk(r, scope, isCallee = false, out, global)
+    case Expr.UnaryOp(_, op, _) =>
+      walk(op, scope, isCallee = false, out, global)
+    case Expr.Quantifier(_, bindings, body, _) =>
+      var s = scope
+      bindings.foreach: b =>
+        walk(b.domain, s, isCallee = false, out, global)
+        s = s + b.variable
+      walk(body, s, isCallee = false, out, global)
+    case Expr.SomeWrap(e, _) =>
+      walk(e, scope, isCallee = false, out, global)
+    case Expr.The(v, d, b, _) =>
+      walk(d, scope, isCallee = false, out, global)
+      walk(b, scope + v, isCallee = false, out, global)
+    case Expr.FieldAccess(base, _, _) =>
+      walk(base, scope, isCallee = false, out, global)
+    case Expr.EnumAccess(base, _, _) =>
+      walk(base, scope, isCallee = false, out, global)
+    case Expr.Index(base, idx, _) =>
+      walk(base, scope, isCallee = false, out, global)
+      walk(idx, scope, isCallee = false, out, global)
+    case Expr.Call(callee, args, _) =>
+      walk(callee, scope, isCallee = true, out, global)
+      args.foreach(a => walk(a, scope, isCallee = false, out, global))
+    case Expr.Prime(e, _) =>
+      walk(e, scope, isCallee = false, out, global)
+    case Expr.Pre(e, _) =>
+      walk(e, scope, isCallee = false, out, global)
+    case Expr.With(base, updates, _) =>
+      walk(base, scope, isCallee = false, out, global)
+      updates.foreach(u => walk(u.value, scope, isCallee = false, out, global))
+    case Expr.If(c, t, e, _) =>
+      walk(c, scope, isCallee = false, out, global)
+      walk(t, scope, isCallee = false, out, global)
+      walk(e, scope, isCallee = false, out, global)
+    case Expr.Let(v, value, body, _) =>
+      walk(value, scope, isCallee = false, out, global)
+      walk(body, scope + v, isCallee = false, out, global)
+    case Expr.Lambda(p, b, _) =>
+      walk(b, scope + p, isCallee = false, out, global)
+    case Expr.Constructor(_, fields, _) =>
+      fields.foreach(f => walk(f.value, scope, isCallee = false, out, global))
+    case Expr.SetLiteral(elems, _) =>
+      elems.foreach(walk(_, scope, isCallee = false, out, global))
+    case Expr.MapLiteral(entries, _) =>
+      entries.foreach: e =>
+        walk(e.key, scope, isCallee = false, out, global)
+        walk(e.value, scope, isCallee = false, out, global)
+    case Expr.SetComprehension(v, d, p, _) =>
+      walk(d, scope, isCallee = false, out, global)
+      walk(p, scope + v, isCallee = false, out, global)
+    case Expr.SeqLiteral(elems, _) =>
+      elems.foreach(walk(_, scope, isCallee = false, out, global))
+    case Expr.Matches(e, _, _) =>
+      walk(e, scope, isCallee = false, out, global)
+    case _: (Expr.IntLit | Expr.FloatLit | Expr.StringLit | Expr.BoolLit | Expr.NoneLit) =>
+      ()

--- a/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
@@ -1,0 +1,77 @@
+package specrest.lint
+
+import specrest.ir.Expr
+import specrest.ir.ServiceIR
+import specrest.ir.TypeExpr
+
+object UnusedEntity extends LintPass:
+  val code = "L05"
+
+  def run(ir: ServiceIR): List[LintDiagnostic] =
+    val refs    = referencedNames(ir)
+    val builtin = Set("Int", "Long", "Float", "Double", "Bool", "Boolean", "String", "DateTime")
+    ir.entities.flatMap: e =>
+      if refs.contains(e.name) || builtin.contains(e.name) then Nil
+      else
+        List(
+          LintDiagnostic(
+            code,
+            LintLevel.Warning,
+            s"entity '${e.name}' is declared but never referenced in state, operations, invariants, or other entities",
+            e.span
+          )
+        )
+
+  private def referencedNames(ir: ServiceIR): Set[String] =
+    val acc = scala.collection.mutable.Set.empty[String]
+
+    def collectType(t: TypeExpr): Unit = t match
+      case TypeExpr.NamedType(n, _)          => acc += n
+      case TypeExpr.SetType(inner, _)        => collectType(inner)
+      case TypeExpr.SeqType(inner, _)        => collectType(inner)
+      case TypeExpr.OptionType(inner, _)     => collectType(inner)
+      case TypeExpr.MapType(k, v, _)         => collectType(k); collectType(v)
+      case TypeExpr.RelationType(f, _, t, _) => collectType(f); collectType(t)
+
+    def collectExpr(e: Expr): Unit =
+      ExprWalk.foreach(e):
+        case Expr.Constructor(name, _, _) => acc += name
+        case Expr.Identifier(name, _)     => acc += name
+        case Expr.EnumAccess(_, _, _)     => () // handled via Identifier on base
+        case _                            => ()
+
+    ir.state.toList.flatMap(_.fields).foreach(f => collectType(f.typeExpr))
+
+    for op <- ir.operations do
+      op.inputs.foreach(p => collectType(p.typeExpr))
+      op.outputs.foreach(p => collectType(p.typeExpr))
+      op.requires.foreach(collectExpr)
+      op.ensures.foreach(collectExpr)
+
+    for ent <- ir.entities do
+      ent.fields.foreach: f =>
+        collectType(f.typeExpr)
+        f.constraint.foreach(collectExpr)
+      ent.invariants.foreach(collectExpr)
+
+    ir.invariants.foreach(i => collectExpr(i.expr))
+    ir.temporals.foreach(t => collectExpr(t.expr))
+    ir.facts.foreach(f => collectExpr(f.expr))
+
+    for fn <- ir.functions do
+      fn.params.foreach(p => collectType(p.typeExpr))
+      collectType(fn.returnType)
+      collectExpr(fn.body)
+
+    for pr <- ir.predicates do
+      pr.params.foreach(p => collectType(p.typeExpr))
+      collectExpr(pr.body)
+
+    for tr <- ir.transitions do
+      tr.rules.foreach(_.guard.foreach(collectExpr))
+
+    ir.typeAliases.foreach: a =>
+      collectType(a.typeExpr)
+      a.constraint.foreach(collectExpr)
+
+    acc.toSet

--- a/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
@@ -8,10 +8,9 @@ object UnusedEntity extends LintPass:
   val code = "L05"
 
   def run(ir: ServiceIR): List[LintDiagnostic] =
-    val refs    = referencedNames(ir)
-    val builtin = Set("Int", "Long", "Float", "Double", "Bool", "Boolean", "String", "DateTime")
+    val refs = referencedNames(ir)
     ir.entities.flatMap: e =>
-      if refs.contains(e.name) || builtin.contains(e.name) then Nil
+      if refs.contains(e.name) then Nil
       else
         List(
           LintDiagnostic(
@@ -49,6 +48,7 @@ object UnusedEntity extends LintPass:
       op.ensures.foreach(collectExpr)
 
     for ent <- ir.entities do
+      ent.extends_.foreach(p => acc += p)
       ent.fields.foreach: f =>
         collectType(f.typeExpr)
         f.constraint.foreach(collectExpr)

--- a/modules/lint/src/test/scala/specrest/lint/CircularPredicateTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/CircularPredicateTest.scala
@@ -1,0 +1,24 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class CircularPredicateTest extends CatsEffectSuite:
+
+  test("L06 catches mutually-recursive predicates"):
+    SpecFixtures.loadLintIR("l06_circular_predicate_bad").map: ir =>
+      val diags = CircularPredicate.run(ir)
+      assert(diags.nonEmpty, "expected at least one cycle diagnostic")
+      val d = diags.head
+      assertEquals(d.code, "L06")
+      assertEquals(d.level, LintLevel.Error)
+      assert(d.message.contains("isA"), d.message)
+      assert(d.message.contains("isB"), d.message)
+
+  test("L06 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(CircularPredicate.run(ir), Nil)
+
+  test("L06 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(CircularPredicate.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/LintIntegrationTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/LintIntegrationTest.scala
@@ -1,0 +1,33 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class LintIntegrationTest extends CatsEffectSuite:
+
+  // Specs expected to be lint-clean. ecommerce/edge_cases excluded:
+  //   ecommerce — `let X in clauseA \n clauseB` parses as let-body=clauseA; clauseB
+  //               loses the binding, surfacing as L02 'undefined removed'. Real
+  //               authoring bug latent in the spec; the verifier is silent because
+  //               unbound names get an uninterpreted Z3 constant.
+  //   edge_cases — declares `entity Child extends Base` but never references Child
+  //                anywhere downstream; correctly caught by L05.
+  private val fixtures = List(
+    "auth_service",
+    "broken_decrement",
+    "powerset_demo",
+    "safe_counter",
+    "set_comp_demo",
+    "set_ops",
+    "todo_list",
+    "url_shortener"
+  )
+
+  fixtures.foreach: name =>
+    test(s"Lint.run is silent on fixtures/spec/$name.spec"):
+      SpecFixtures.loadIR(name).map: ir =>
+        val diags = Lint.run(ir)
+        val detail = diags
+          .map(d => s"[${d.code} L${d.span.fold("?")(_.startLine.toString)}] ${d.message}")
+          .mkString("\n")
+        assert(diags.isEmpty, s"expected no diagnostics on $name; got:\n$detail")

--- a/modules/lint/src/test/scala/specrest/lint/MissingEnsuresTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/MissingEnsuresTest.scala
@@ -1,0 +1,24 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class MissingEnsuresTest extends CatsEffectSuite:
+
+  test("L03 fires on operation with outputs but empty ensures"):
+    SpecFixtures.loadLintIR("l03_missing_ensures_bad").map: ir =>
+      val diags = MissingEnsures.run(ir)
+      assertEquals(diags.length, 1)
+      val d = diags.head
+      assertEquals(d.code, "L03")
+      assertEquals(d.level, LintLevel.Warning)
+      assert(d.message.contains("Read"), d.message)
+      assert(d.span.exists(_.startLine > 0), s"expected span, got ${d.span}")
+
+  test("L03 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(MissingEnsures.run(ir), Nil)
+
+  test("L03 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(MissingEnsures.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/OperationOverlapTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/OperationOverlapTest.scala
@@ -1,0 +1,33 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class OperationOverlapTest extends CatsEffectSuite:
+
+  test("L04 fires on two ops with identical signature and equivalent requires"):
+    SpecFixtures.loadLintIR("l04_overlap_bad").map: ir =>
+      val diags = OperationOverlap.run(ir)
+      assertEquals(diags.length, 1)
+      val d = diags.head
+      assertEquals(d.code, "L04")
+      assertEquals(d.level, LintLevel.Warning)
+      assert(d.message.contains("Increment"), d.message)
+      assert(d.message.contains("Add"), d.message)
+      assert(d.relatedSpans.nonEmpty, "expected a related span pointing to the first op")
+
+  test("L04 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(OperationOverlap.run(ir), Nil)
+
+  test("L04 silent on safe_counter (Increment vs Decrement differ in requires)"):
+    SpecFixtures.loadIR("safe_counter").map: ir =>
+      assertEquals(OperationOverlap.run(ir), Nil)
+
+  test("L04 silent on todo_list (StartWork/Complete/Reopen differ on status guard)"):
+    SpecFixtures.loadIR("todo_list").map: ir =>
+      assertEquals(OperationOverlap.run(ir), Nil)
+
+  test("L04 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(OperationOverlap.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/TypeMismatchTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/TypeMismatchTest.scala
@@ -1,0 +1,25 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class TypeMismatchTest extends CatsEffectSuite:
+
+  test("L01 catches obvious literal mixups (and 5, + true, >= \"zero\")"):
+    SpecFixtures.loadLintIR("l01_type_mismatch_bad").map: ir =>
+      val diags = TypeMismatch.run(ir)
+      assert(diags.nonEmpty, "expected at least one type-mismatch diagnostic")
+      assert(diags.forall(_.code == "L01"), diags)
+      assert(diags.forall(_.level == LintLevel.Error), diags)
+      val msgs = diags.map(_.message)
+      assert(msgs.exists(_.contains("logical 'and'")), msgs)
+      assert(msgs.exists(_.contains("arithmetic '+'")), msgs)
+      assert(msgs.exists(_.contains("comparison '>'")), msgs)
+
+  test("L01 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(TypeMismatch.run(ir), Nil)
+
+  test("L01 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(TypeMismatch.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/UndefinedRefTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/UndefinedRefTest.scala
@@ -21,3 +21,45 @@ class UndefinedRefTest extends CatsEffectSuite:
   test("L02 silent on url_shortener regression fence"):
     SpecFixtures.loadIR("url_shortener").map: ir =>
       assertEquals(UndefinedRef.run(ir), Nil)
+
+  test("L02 flags undefined identifier in callee position"):
+    val src =
+      """service CalleeTypo {
+        |  state { count: Int }
+        |  operation Touch {
+        |    requires:
+        |      missingFn(count)
+        |    ensures:
+        |      count' = count
+        |  }
+        |}""".stripMargin
+    SpecFixtures.buildFromSource("CalleeTypo", src).map: ir =>
+      val diags = UndefinedRef.run(ir)
+      assert(diags.exists(_.message.contains("missingFn")), diags.map(_.message))
+
+  test("L02 walks transition `when` guards"):
+    val src =
+      """service TransitionGuard {
+        |  enum Status {
+        |    OPEN,
+        |    CLOSED
+        |  }
+        |  entity Thing {
+        |    id: Int
+        |    status: Status
+        |  }
+        |  state { x: Int }
+        |  transition Lifecycle {
+        |    entity: Thing
+        |    field: status
+        |    OPEN -> CLOSED via Close when missingGuard(x)
+        |  }
+        |  operation Close {
+        |    requires: true
+        |    ensures: x' = x
+        |  }
+        |  invariant nonNeg: x >= 0
+        |}""".stripMargin
+    SpecFixtures.buildFromSource("TransitionGuard", src).map: ir =>
+      val diags = UndefinedRef.run(ir)
+      assert(diags.exists(_.message.contains("missingGuard")), diags.map(_.message))

--- a/modules/lint/src/test/scala/specrest/lint/UndefinedRefTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/UndefinedRefTest.scala
@@ -1,0 +1,23 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class UndefinedRefTest extends CatsEffectSuite:
+
+  test("L02 catches misspelled state-field references"):
+    SpecFixtures.loadLintIR("l02_undefined_ref_bad").map: ir =>
+      val diags = UndefinedRef.run(ir)
+      val names = diags.map(_.message)
+      assert(diags.forall(_.code == "L02"), diags)
+      assert(diags.forall(_.level == LintLevel.Error), diags)
+      assert(names.exists(_.contains("ammount")), names)
+      assert(names.exists(_.contains("cnt")), names)
+
+  test("L02 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(UndefinedRef.run(ir), Nil)
+
+  test("L02 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(UndefinedRef.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/UnusedEntityTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/UnusedEntityTest.scala
@@ -21,3 +21,29 @@ class UnusedEntityTest extends CatsEffectSuite:
   test("L05 silent on url_shortener regression fence"):
     SpecFixtures.loadIR("url_shortener").map: ir =>
       assertEquals(UnusedEntity.run(ir), Nil)
+
+  test("L05 counts `extends` parents as references"):
+    val src =
+      """service WithInheritance {
+        |  entity Base {
+        |    id: Int
+        |    label: String
+        |  }
+        |  entity Child extends Base {
+        |    name: String
+        |  }
+        |  state { items: Int -> lone Child }
+        |  operation Add {
+        |    input: id: Int, name: String
+        |    requires: id > 0
+        |    ensures: items'[id].id = id
+        |  }
+        |  invariant nonEmpty: true
+        |}""".stripMargin
+    SpecFixtures.buildFromSource("WithInheritance", src).map: ir =>
+      val diags = UnusedEntity.run(ir)
+      assertEquals(
+        diags,
+        Nil,
+        s"Base should be referenced via Child extends; got: ${diags.map(_.message)}"
+      )

--- a/modules/lint/src/test/scala/specrest/lint/UnusedEntityTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/UnusedEntityTest.scala
@@ -1,0 +1,23 @@
+package specrest.lint
+
+import munit.CatsEffectSuite
+import specrest.lint.testutil.SpecFixtures
+
+class UnusedEntityTest extends CatsEffectSuite:
+
+  test("L05 fires on declared-but-unreferenced entity"):
+    SpecFixtures.loadLintIR("l05_unused_entity_bad").map: ir =>
+      val diags = UnusedEntity.run(ir)
+      assertEquals(diags.length, 1)
+      val d = diags.head
+      assertEquals(d.code, "L05")
+      assertEquals(d.level, LintLevel.Warning)
+      assert(d.message.contains("Orphan"), d.message)
+
+  test("L05 silent on the all-lints-pass fixture"):
+    SpecFixtures.loadLintIR("passing").map: ir =>
+      assertEquals(UnusedEntity.run(ir), Nil)
+
+  test("L05 silent on url_shortener regression fence"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      assertEquals(UnusedEntity.run(ir), Nil)

--- a/modules/lint/src/test/scala/specrest/lint/testutil/SpecFixtures.scala
+++ b/modules/lint/src/test/scala/specrest/lint/testutil/SpecFixtures.scala
@@ -1,0 +1,29 @@
+package specrest.lint.testutil
+
+import cats.effect.IO
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SpecFixtures:
+
+  def loadLintIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/lint/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def loadIR(name: String): IO[ServiceIR] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap(buildFromSource(name, _))
+
+  def buildFromSource(label: String, source: String): IO[ServiceIR] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) =>
+        IO.raiseError(new AssertionError(s"parse errors for $label: ${err.errors}"))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
+          case Right(ir) => IO.pure(ir)


### PR DESCRIPTION
## Summary

- New `modules/lint` runs five solver-free passes over the IR after parsing succeeds.
- `check` renders convention + lint diagnostics together; warnings allow exit 0, errors return 1.
- Operation-overlap (L04) requires the solver and is deferred to verify.

## Lint codes

| Code | Level   | What it catches                                                                       |
|------|---------|---------------------------------------------------------------------------------------|
| L01  | error   | Bool/None literal used as an arithmetic, comparison, or logical operand               |
| L02  | error   | Identifier referenced with no in-scope binding (state field, input/output, binder, …) |
| L03  | warning | Operation declares `output:` but no `ensures:` — outputs would be unconstrained       |
| L05  | warning | `entity` declared but never referenced in state, operations, invariants, or types     |
| L06  | error   | Mutually-recursive predicates / functions — verifier inlining would diverge           |

L01 is intentionally narrow: only literals whose class admits no operator overload. The DSL uses
`+`/`-` for set/map union and diff and `+` for string concatenation, so arithmetic-on-collection
mismatches are not flagged. A future ticket can add a richer typechecker.

## Why L04 is deferred

Cross-operation `requires` overlap requires SAT solving; the verify module already calls
`Translator.translateOperationRequires`. A separate verify check is a cleaner home than a
non-Z3 lint pass.

## Findings against existing fixtures

The integration test runs `Lint.run` on the spec corpus. Two fixtures legitimately surface
diagnostics and are excluded from the silence list:

- `fixtures/spec/ecommerce.spec` — `let removed = … in <body>` parses with body = first
  sibling clause; subsequent clauses lose the binding. Authoring bug; verifier silently
  accepts because unbound names get an uninterpreted Z3 constant.
- `fixtures/spec/edge_cases.spec` — `entity Child extends Base` is declared but never
  referenced; correctly caught by L05.

`fixtures/spec/url_shortener.spec` is lint-clean (AC regression fence).

## Acceptance criteria

- [x] Five checks shipped (L01-L03, L05, L06); L04 deferred with rationale.
- [x] Failing-fixture pair per check under `fixtures/lint/`.
- [x] Span-anchored diagnostics (each `LintDiagnostic.span` populated).
- [x] `check` exits non-zero when any diagnostic is `error` level.
- [x] `check fixtures/spec/url_shortener.spec` produces zero lint diagnostics.

## Test plan

- [x] `sbt test` — all 128 + 25 lint tests green.
- [x] `sbt scalafmtCheckAll` — clean.
- [x] `sbt "scalafixAll --check"` — clean.
- [x] `(cd docs && npm run build)` — clean.
- [x] Manual smoke: each `fixtures/lint/l0X_*.spec` fires the right lint and exit code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structural spec linting to `check` to catch common authoring mistakes without the solver. Ships L01–L06 (with L04 as a syntactic overlap check), shows lint codes in output, and exits 1 only on errors; implements #81.

- **New Features**
  - New `modules/lint` runs six passes after IR build: L01 TypeMismatch, L02 UndefinedRef, L03 MissingEnsures, L04 OperationOverlap, L05 UnusedEntity, L06 CircularPredicate.
  - L04 warns when two ops share the same input/output signature and equivalent `requires` (flatten top-level and, drop `true`, canonicalize); subsumption not flagged.
  - `check` renders convention + lint diagnostics together; warnings exit 0, errors exit 1. Added fixtures/tests and docs (spec-language structural lints; verification page updated).

- **Bug Fixes**
  - L02 now flags identifier callees (e.g., `missingFn(x)`), walks transition `when` guards, and includes functions introduced in `fact` bodies; builtins trimmed to actual DSL functions.
  - L05 counts `extends` parents as references and drops unnecessary keyword exclusions to avoid false positives.

<sup>Written for commit 960ce6f62a913fccdd43dc476abfd3d1f9d38116. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structural linting now integrated into `check` subcommand, detecting type mismatches in operations, undefined identifier references, missing ensures clauses on outputs, unused entity declarations, and circular predicate dependencies.
  * Operation-overlap detection deferred to `verify` stage for comprehensive analysis.

* **Documentation**
  * Updated spec-language guide with `check` command workflow and detailed lint detection scope.
  * Clarified lint processing stages between `check` and `verify` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->