### PR TITLE
Human-readable counterexample narration (closes #89)

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -39,6 +39,7 @@ CLI output so the attribution is visible.
 | Verify-as-gate (refuse codegen on failed verification)              | shipped ([#78](https://github.com/HardMax71/spec_to_rest/issues/78)) — `compile` runs verify by default; `--ignore-verify` opts out |
 | Machine-readable (`--json` / `--json-out`) diagnostics output       | shipped |
 | Richer suggested-fix templates (op/invariant/field-aware; opt-out via `--no-suggestions`) | shipped |
+| Human-readable "why this fails" narration (opt-out via `--no-narration`) | shipped ([#89](https://github.com/HardMax71/spec_to_rest/issues/89)) — covers `invariant_violation_by_operation`, `contradictory_invariants`, `unreachable_operation` |
 | Structural spec lints (type mismatch, unused entity, …)             | shipped — `check` runs L01-L06 ([#81](https://github.com/HardMax71/spec_to_rest/issues/81)); L04 ships a syntactic over-approximation, SAT-based overlap is candidate verify-side work |
 | Per-check VC dump (`--dump-vc <dir>`) — Z3 SMT-LIB and Alloy `.als` artifacts | shipped |
 | Unsat-core extraction (`--explain`) — surface contributing spec spans on `unsat` diagnostics | shipped (Z3 always; Alloy when `minisat.prover` is bundled) |
@@ -214,6 +215,16 @@ $ spec-to-rest verify fixtures/spec/broken_url_shortener.spec
   post-state:
     metadata' = { 2 → UrlMapping#0 }
 
+  Why this violates the invariant:
+    1. Invariant 'clickCountNonNegative' requires:
+         (all c in metadata | (metadata[c].click_count >= 0))
+    2. Operation 'Tamper' computes 'click_count' from:
+         (pre(metadata)[code].click_count - 100)
+    3. The solver picked code = 2, pre(metadata)[2].click_count = 99,
+       producing post-state metadata'[2].click_count = -1.
+    4. The post-state value violates the bound on 'click_count' from
+       invariant 'clickCountNonNegative'.
+
   hint: 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see
   counterexample. Tighten 'ensures' with a range predicate or a constructor that
   initialises click_count correctly.
@@ -225,6 +236,16 @@ capped at 200 chars and can be turned off entirely with `--no-suggestions` (the
 `suggestion` field then comes back as `null` in JSON output as well). The phrasing is
 intentionally non-stable text intended for humans; downstream tooling should switch on
 the `category` enum, not on the suggestion string.
+
+The numbered "Why this violates" block is the **narration** layer added in #89: a
+deterministic structural walk over the violated invariant's IR, the relevant `ensures`
+clause, and the decoded counterexample. Steps 1 and 2 pretty-print IR (fully
+parenthesized — readability cost is small, ambiguity cost is none); step 3 reads
+input/pre/post values directly off the model (no interpreter, no arithmetic
+re-evaluation); step 4 is a fixed phrasing keyed to the invariant name. Narration is
+populated for `invariant_violation_by_operation`, `contradictory_invariants`, and
+`unreachable_operation`. Other categories surface `narrative: null` in JSON. Suppress
+with `--no-narration` (mirrors `--no-suggestions`).
 
 The decoder enumerates the model's entity universe, evaluates field functions, and shows
 pre-/post-state relations side by side. Uninterpreted sort values like `UrlMapping!val!0` are
@@ -280,6 +301,7 @@ verbose   …
 | `--json-out <file>`     |       — | Write machine-readable JSON report to `<file>` (suppresses text). |
 | `--parallel <n>`        |    auto | Max concurrent checks. Default: host `availableProcessors`. `0` = serial (regression parity). |
 | `--no-suggestions`      |   false | Suppress per-diagnostic `hint:` text in CLI and `suggestion` in JSON output. |
+| `--no-narration`        |   false | Suppress structural "why this fails" narration in CLI and `narrative` in JSON output. |
 | `-v, --verbose`         |   false | Print stage timing and per-check timing / status.             |
 
 ### Exit codes

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -208,8 +208,8 @@ $ spec-to-rest verify fixtures/spec/broken_url_shortener.spec
   inputs:
     code = 2
   entities:
-    UrlMapping#0 { click_count = -1 }
-    UrlMapping#1 { click_count = 99 }
+    UrlMapping#0 { click_count = -100 }
+    UrlMapping#1 { click_count = 0 }
   pre-state:
     metadata = { 2 → UrlMapping#1 }
   post-state:
@@ -220,8 +220,8 @@ $ spec-to-rest verify fixtures/spec/broken_url_shortener.spec
          (all c in metadata | (metadata[c].click_count >= 0))
     2. Operation 'Tamper' computes 'click_count' from:
          (pre(metadata)[code].click_count - 100)
-    3. The solver picked code = 2, pre(metadata)[2].click_count = 99,
-       producing post-state metadata'[2].click_count = -1.
+    3. The solver picked code = 2, pre(metadata)[2].click_count = 0,
+       producing post-state metadata'[2].click_count = -100.
     4. The post-state value violates the bound on 'click_count' from
        invariant 'clickCountNonNegative'.
 

--- a/fixtures/golden/verify_report/broken_url_shortener.json
+++ b/fixtures/golden/verify_report/broken_url_shortener.json
@@ -222,7 +222,8 @@
         },
         "suggestion" : "'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises click_count correctly.",
         "coreSpans" : [
-        ]
+        ],
+        "narrative" : "Why this violates the invariant:\n  1. Invariant 'clickCountNonNegative' requires:\n       (all c in metadata | (metadata[c].click_count >= 0))\n  2. Operation 'Tamper' computes 'click_count' from:\n       (pre(metadata)[code].click_count - 100)\n  3. The solver picked code = 2, pre(metadata)[2].click_count = 0, producing post-state metadata'[2].click_count = -100.\n  4. The post-state value violates the bound on 'click_count' from invariant 'clickCountNonNegative'."
       }
     }
   ]

--- a/fixtures/golden/verify_report/unsat_invariants.json
+++ b/fixtures/golden/verify_report/unsat_invariants.json
@@ -75,7 +75,8 @@
             },
             "note" : "contributing invariant"
           }
-        ]
+        ],
+        "narrative" : "Why these invariants conflict:\n  1. The verifier could not satisfy all invariants jointly.\n  2. The unsat core points at:\n       line 2: contributing invariant"
       }
     }
   ]

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -73,6 +73,12 @@ object Main
     val noSuggestions = Opts
       .flag("no-suggestions", "suppress per-diagnostic 'hint:' suggestions in CLI and JSON output")
       .orFalse
+    val noNarration = Opts
+      .flag(
+        "no-narration",
+        "suppress structural 'why this fails' narration in CLI and JSON output"
+      )
+      .orFalse
     Opts.subcommand("verify", "Run the Z3/Alloy-backed verification engine on a spec file"):
       (
         specFile,
@@ -88,12 +94,27 @@ object Main
         jsonOut,
         parallel,
         noSuggestions,
+        noNarration,
         verbose,
         quiet
-      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, ns, v, q) =>
+      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, ns, nn, v, q) =>
         Verify.run(
           spec,
-          VerifyOptions(t, ds, dso, da, dao, as, dvc, ex, j, jo, par, suggestions = !ns),
+          VerifyOptions(
+            t,
+            ds,
+            dso,
+            da,
+            dao,
+            as,
+            dvc,
+            ex,
+            j,
+            jo,
+            par,
+            suggestions = !ns,
+            narration = !nn
+          ),
           Logger.fromFlags(verbose = v, quiet = q)
         )
 

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -31,7 +31,8 @@ final case class VerifyOptions(
     json: Boolean = false,
     jsonOut: Option[String] = None,
     parallel: Option[Int] = None,
-    suggestions: Boolean = true
+    suggestions: Boolean = true,
+    narration: Boolean = true
 )
 
 object Verify:
@@ -184,7 +185,8 @@ object Verify:
                 alloyScope = opts.alloyScope,
                 captureCore = opts.explain,
                 maxParallel = maxParallel,
-                suggestions = opts.suggestions
+                suggestions = opts.suggestions,
+                narration = opts.narration
               ),
               sink
             ).flatMap { report =>

--- a/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
+++ b/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
@@ -1,0 +1,84 @@
+package specrest.ir
+
+object PrettyPrint:
+
+  def expr(e: Expr): String = render(e)
+
+  private def render(e: Expr): String = e match
+    case Expr.IntLit(v, _)          => v.toString
+    case Expr.FloatLit(v, _)        => v.toString
+    case Expr.StringLit(v, _)       => "\"" + v + "\""
+    case Expr.BoolLit(v, _)         => v.toString
+    case Expr.NoneLit(_)            => "none"
+    case Expr.Identifier(n, _)      => n
+    case Expr.BinaryOp(op, l, r, _) => s"(${render(l)} ${binOpToken(op)} ${render(r)})"
+    case Expr.UnaryOp(op, x, _)     => s"(${unOpToken(op)} ${render(x)})"
+    case Expr.FieldAccess(b, f, _)  => s"${render(b)}.$f"
+    case Expr.EnumAccess(b, m, _)   => s"${render(b)}.$m"
+    case Expr.Index(b, i, _)        => s"${render(b)}[${render(i)}]"
+    case Expr.Call(c, args, _)      => s"${render(c)}(${args.map(render).mkString(", ")})"
+    case Expr.Prime(x, _)           => s"${render(x)}'"
+    case Expr.Pre(x, _)             => s"pre(${render(x)})"
+    case Expr.SomeWrap(x, _)        => s"some(${render(x)})"
+    case Expr.Quantifier(q, bs, body, _) =>
+      val qs = quantToken(q)
+      val bindings = bs.map(b =>
+        val sep = b.bindingKind match
+          case BindingKind.In    => " in "
+          case BindingKind.Colon => ": "
+        s"${b.variable}$sep${render(b.domain)}"
+      ).mkString(", ")
+      s"($qs $bindings | ${render(body)})"
+    case Expr.The(v, d, b, _) => s"(the $v in ${render(d)} | ${render(b)})"
+    case Expr.With(b, ups, _) =>
+      val parts = ups.map(u => s"${u.name} = ${render(u.value)}").mkString(", ")
+      s"(${render(b)} with { $parts })"
+    case Expr.If(c, t, e, _) =>
+      s"(if ${render(c)} then ${render(t)} else ${render(e)})"
+    case Expr.Let(v, value, body, _) =>
+      s"(let $v = ${render(value)} in ${render(body)})"
+    case Expr.Lambda(p, b, _) => s"(\\$p -> ${render(b)})"
+    case Expr.Constructor(name, fs, _) =>
+      val parts = fs.map(f => s"${f.name} = ${render(f.value)}").mkString(", ")
+      s"$name { $parts }"
+    case Expr.SetLiteral(es, _) => es.map(render).mkString("{", ", ", "}")
+    case Expr.MapLiteral(es, _) =>
+      es.map(en => s"${render(en.key)} -> ${render(en.value)}").mkString("{", ", ", "}")
+    case Expr.SetComprehension(v, d, p, _) =>
+      s"{ $v in ${render(d)} | ${render(p)} }"
+    case Expr.SeqLiteral(es, _) => es.map(render).mkString("[", ", ", "]")
+    case Expr.Matches(x, p, _)  => s"(${render(x)} matches /$p/)"
+
+  private def binOpToken(op: BinOp): String = op match
+    case BinOp.And       => "and"
+    case BinOp.Or        => "or"
+    case BinOp.Implies   => "=>"
+    case BinOp.Iff       => "<=>"
+    case BinOp.Eq        => "="
+    case BinOp.Neq       => "!="
+    case BinOp.Lt        => "<"
+    case BinOp.Gt        => ">"
+    case BinOp.Le        => "<="
+    case BinOp.Ge        => ">="
+    case BinOp.In        => "in"
+    case BinOp.NotIn     => "not in"
+    case BinOp.Subset    => "subset"
+    case BinOp.Union     => "++"
+    case BinOp.Intersect => "&"
+    case BinOp.Diff      => "--"
+    case BinOp.Add       => "+"
+    case BinOp.Sub       => "-"
+    case BinOp.Mul       => "*"
+    case BinOp.Div       => "/"
+
+  private def unOpToken(op: UnOp): String = op match
+    case UnOp.Not         => "not"
+    case UnOp.Negate      => "-"
+    case UnOp.Cardinality => "#"
+    case UnOp.Power       => "^"
+
+  private def quantToken(q: QuantKind): String = q match
+    case QuantKind.All    => "all"
+    case QuantKind.Some   => "some"
+    case QuantKind.No     => "no"
+    case QuantKind.Exists => "exists"

--- a/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
+++ b/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
@@ -5,9 +5,17 @@ object PrettyPrint:
   def expr(e: Expr): String = render(e)
 
   private def render(e: Expr): String = e match
-    case Expr.IntLit(v, _)          => v.toString
-    case Expr.FloatLit(v, _)        => v.toString
-    case Expr.StringLit(v, _)       => "\"" + v + "\""
+    case Expr.IntLit(v, _)   => v.toString
+    case Expr.FloatLit(v, _) => v.toString
+    case Expr.StringLit(v, _) =>
+      val escaped = v.flatMap:
+        case '\\' => "\\\\"
+        case '"'  => "\\\""
+        case '\n' => "\\n"
+        case '\r' => "\\r"
+        case '\t' => "\\t"
+        case c    => c.toString
+      "\"" + escaped + "\""
     case Expr.BoolLit(v, _)         => v.toString
     case Expr.NoneLit(_)            => "none"
     case Expr.Identifier(n, _)      => n

--- a/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
@@ -1,0 +1,109 @@
+package specrest.ir
+
+class PrettyPrintTest extends munit.FunSuite:
+
+  private val cases: List[(String, Expr, String)] = List(
+    ("int literal", Expr.IntLit(42), "42"),
+    ("string literal", Expr.StringLit("ok"), "\"ok\""),
+    ("bool literal", Expr.BoolLit(true), "true"),
+    ("identifier", Expr.Identifier("count"), "count"),
+    (
+      "binary op",
+      Expr.BinaryOp(BinOp.Ge, Expr.Identifier("clicks"), Expr.IntLit(0)),
+      "(clicks >= 0)"
+    ),
+    (
+      "unary not",
+      Expr.UnaryOp(UnOp.Not, Expr.BoolLit(false)),
+      "(not false)"
+    ),
+    (
+      "field access",
+      Expr.FieldAccess(Expr.Identifier("user"), "email"),
+      "user.email"
+    ),
+    (
+      "indexed access",
+      Expr.Index(Expr.Identifier("metadata"), Expr.Identifier("c")),
+      "metadata[c]"
+    ),
+    (
+      "pre and prime",
+      Expr.BinaryOp(
+        BinOp.Eq,
+        Expr.Prime(Expr.Identifier("clicks")),
+        Expr.BinaryOp(BinOp.Sub, Expr.Pre(Expr.Identifier("clicks")), Expr.IntLit(1))
+      ),
+      "(clicks' = (pre(clicks) - 1))"
+    ),
+    (
+      "forall over relation",
+      Expr.Quantifier(
+        QuantKind.All,
+        List(QuantifierBinding("c", Expr.Identifier("metadata"), BindingKind.In)),
+        Expr.BinaryOp(
+          BinOp.Ge,
+          Expr.FieldAccess(
+            Expr.Index(Expr.Identifier("metadata"), Expr.Identifier("c")),
+            "click_count"
+          ),
+          Expr.IntLit(0)
+        )
+      ),
+      "(all c in metadata | (metadata[c].click_count >= 0))"
+    ),
+    (
+      "implies",
+      Expr.BinaryOp(BinOp.Implies, Expr.Identifier("p"), Expr.Identifier("q")),
+      "(p => q)"
+    ),
+    (
+      "with-update",
+      Expr.With(
+        Expr.Identifier("u"),
+        List(FieldAssign("name", Expr.StringLit("alice")))
+      ),
+      "(u with { name = \"alice\" })"
+    ),
+    (
+      "let",
+      Expr.Let("x", Expr.IntLit(1), Expr.BinaryOp(BinOp.Add, Expr.Identifier("x"), Expr.IntLit(2))),
+      "(let x = 1 in (x + 2))"
+    ),
+    (
+      "set literal",
+      Expr.SetLiteral(List(Expr.IntLit(1), Expr.IntLit(2))),
+      "{1, 2}"
+    ),
+    (
+      "map literal",
+      Expr.MapLiteral(List(MapEntry(Expr.Identifier("k"), Expr.IntLit(7)))),
+      "{k -> 7}"
+    ),
+    (
+      "set comprehension",
+      Expr.SetComprehension(
+        "x",
+        Expr.Identifier("S"),
+        Expr.BinaryOp(BinOp.Gt, Expr.Identifier("x"), Expr.IntLit(0))
+      ),
+      "{ x in S | (x > 0) }"
+    ),
+    (
+      "constructor",
+      Expr.Constructor(
+        "User",
+        List(FieldAssign("id", Expr.IntLit(1)), FieldAssign("name", Expr.StringLit("a")))
+      ),
+      "User { id = 1, name = \"a\" }"
+    ),
+    (
+      "call",
+      Expr.Call(Expr.Identifier("len"), List(Expr.Identifier("s"))),
+      "len(s)"
+    )
+  )
+
+  cases.foreach: (name, e, expected) =>
+    test(s"PrettyPrint $name"):
+      assertEquals(PrettyPrint.expr(e), expected)

--- a/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
@@ -1,10 +1,15 @@
 package specrest.ir
 
-class PrettyPrintTest extends munit.FunSuite:
+class PrettyPrintTest extends munit.CatsEffectSuite:
 
   private val cases: List[(String, Expr, String)] = List(
     ("int literal", Expr.IntLit(42), "42"),
     ("string literal", Expr.StringLit("ok"), "\"ok\""),
+    (
+      "string literal with quotes/backslashes/newline",
+      Expr.StringLit("a\"b\\c\nd"),
+      "\"a\\\"b\\\\c\\nd\""
+    ),
     ("bool literal", Expr.BoolLit(true), "true"),
     ("identifier", Expr.Identifier("count"), "count"),
     (

--- a/modules/verify/src/main/scala/specrest/verify/Config.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Config.scala
@@ -15,7 +15,8 @@ final case class VerificationConfig(
     alloyScope: Int = 5,
     captureCore: Boolean = false,
     maxParallel: Int = VerificationConfig.defaultParallelism,
-    suggestions: Boolean = true
+    suggestions: Boolean = true,
+    narration: Boolean = true
 )
 
 object VerificationConfig:

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -92,6 +92,16 @@ object Consistency:
     check.diagnostic match
       case None => check
       case Some(diag) =>
+        val op               = check.operationName.flatMap(n => ir.operations.find(_.name == n))
+        val isInvariantBound = check.kind == CheckKind.Preservation
+        val invDecl =
+          if !isInvariantBound then None
+          else
+            check.invariantName.flatMap: n =>
+              ir.invariants
+                .find(_.name.contains(n))
+                .orElse(n.stripPrefix("inv_").toIntOption.flatMap(ir.invariants.lift))
+        val invName = if isInvariantBound then check.invariantName else None
         val newSuggestion: Option[String] =
           if !config.suggestions then None
           else
@@ -99,16 +109,6 @@ object Consistency:
               case DiagnosticCategory.TranslatorLimitation | DiagnosticCategory.BackendError =>
                 diag.suggestion
               case _ =>
-                val op               = check.operationName.flatMap(n => ir.operations.find(_.name == n))
-                val isInvariantBound = check.kind == CheckKind.Preservation
-                val invDecl =
-                  if !isInvariantBound then None
-                  else
-                    check.invariantName.flatMap: n =>
-                      ir.invariants
-                        .find(_.name.contains(n))
-                        .orElse(n.stripPrefix("inv_").toIntOption.flatMap(ir.invariants.lift))
-                val invName = if isInvariantBound then check.invariantName else None
                 Diagnostic.suggestionFor(
                   diag.category,
                   Diagnostic.SuggestionContext(
@@ -122,7 +122,24 @@ object Consistency:
                     timeoutMs = config.timeoutMs
                   )
                 )
-        check.copy(diagnostic = Some(diag.copy(suggestion = newSuggestion)))
+        val newNarrative: Option[String] =
+          if !config.narration then None
+          else
+            Narration.narrate(
+              diag.category,
+              Narration.Context(
+                ir = ir,
+                op = op,
+                invariantDecl = invDecl,
+                operationName = check.operationName,
+                invariantName = invName,
+                counterexample = diag.counterexample,
+                coreSpans = diag.coreSpans
+              )
+            )
+        check.copy(diagnostic =
+          Some(diag.copy(suggestion = newSuggestion, narrative = newNarrative))
+        )
 
   private def backendsResource: cats.effect.Resource[IO, (WasmBackend, AlloyBackend)] =
     for

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -39,7 +39,8 @@ final case class VerificationDiagnostic(
     relatedSpans: List[RelatedSpan],
     counterexample: Option[DecodedCounterExample],
     suggestion: Option[String],
-    coreSpans: List[RelatedSpan] = Nil
+    coreSpans: List[RelatedSpan] = Nil,
+    narrative: Option[String] = None
 )
 
 object Diagnostic:
@@ -259,6 +260,9 @@ object Diagnostic:
       lines += ""
       lines += "  Counterexample:"
       lines += CounterExample.format(ce)
+    diag.narrative.foreach: n =>
+      lines += ""
+      n.split("\n", -1).foreach(line => lines += s"  $line")
     diag.suggestion.foreach: s =>
       lines += ""
       lines += s"  hint: $s"

--- a/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
+++ b/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
@@ -44,7 +44,8 @@ object JsonReport:
       "relatedSpans"   -> Json.arr(d.relatedSpans.map(relatedSpanJson)*),
       "counterexample" -> d.counterexample.fold(Json.Null)(counterExampleJson),
       "suggestion"     -> optString(d.suggestion),
-      "coreSpans"      -> Json.arr(d.coreSpans.map(relatedSpanJson)*)
+      "coreSpans"      -> Json.arr(d.coreSpans.map(relatedSpanJson)*),
+      "narrative"      -> optString(d.narrative)
     )
 
   private def spanJson(s: Span): Json =

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -1,0 +1,234 @@
+package specrest.verify
+
+import specrest.ir.BinOp
+import specrest.ir.Expr
+import specrest.ir.InvariantDecl
+import specrest.ir.OperationDecl
+import specrest.ir.PrettyPrint
+import specrest.ir.ServiceIR
+
+object Narration:
+
+  private val MaxLines: Int     = 12
+  private val MaxLength: Int    = 1200
+  private val Truncated: String = "(narration truncated; see counterexample above for full state)"
+
+  final case class Context(
+      ir: ServiceIR,
+      op: Option[OperationDecl],
+      invariantDecl: Option[InvariantDecl],
+      operationName: Option[String],
+      invariantName: Option[String],
+      counterexample: Option[DecodedCounterExample],
+      coreSpans: List[RelatedSpan]
+  )
+
+  def narrate(category: DiagnosticCategory, ctx: Context): Option[String] =
+    val raw = category match
+      case DiagnosticCategory.InvariantViolationByOperation => narrateInvariantViolation(ctx)
+      case DiagnosticCategory.ContradictoryInvariants       => narrateContradictoryInvariants(ctx)
+      case DiagnosticCategory.UnreachableOperation          => narrateUnreachable(ctx)
+      case _                                                => None
+    raw.map(cap)
+
+  private def narrateInvariantViolation(ctx: Context): Option[String] =
+    for
+      op      <- ctx.op
+      invDecl <- ctx.invariantDecl
+      invName <- ctx.invariantName.orElse(Some("invariant"))
+      ce      <- ctx.counterexample
+      field   <- contributingField(invDecl.expr, ctx.ir)
+    yield
+      val rhs    = ensuresRhsForField(op, field)
+      val opName = ctx.operationName.getOrElse(op.name)
+      val lines  = List.newBuilder[String]
+      lines += s"Why this violates the invariant:"
+      lines += s"  1. Invariant '$invName' requires:"
+      lines += s"       ${PrettyPrint.expr(invDecl.expr)}"
+      rhs match
+        case Some(r) =>
+          lines += s"  2. Operation '$opName' computes '$field' from:"
+          lines += s"       ${PrettyPrint.expr(r)}"
+        case None =>
+          lines += s"  2. Operation '$opName' writes '$field'."
+      val preLine  = describePreInputs(ce, op, field)
+      val postLine = describePost(ce, field)
+      preLine.foreach { line =>
+        lines += s"  3. The solver picked $line${postLine.fold("")(p => s", producing post-state $p")}."
+      }
+      if preLine.isEmpty then
+        postLine.foreach { p =>
+          lines += s"  3. The solver produced post-state $p."
+        }
+      lines += s"  4. The post-state value violates the bound on '$field' from invariant '$invName'."
+      lines.result().mkString("\n")
+
+  private def narrateContradictoryInvariants(ctx: Context): Option[String] =
+    val invs = ctx.ir.invariants
+    if invs.isEmpty then None
+    else
+      val lines    = List.newBuilder[String]
+      val invNames = invs.zipWithIndex.map((inv, i) => inv.name.getOrElse(s"inv_$i"))
+      lines += "Why these invariants conflict:"
+      lines += "  1. The verifier could not satisfy all invariants jointly."
+      if ctx.coreSpans.nonEmpty then
+        lines += "  2. The unsat core points at:"
+        ctx.coreSpans.take(4).foreach: rs =>
+          lines += s"       line ${rs.span.startLine}: ${rs.note}"
+        rangePairConflict(invs).foreach: msg =>
+          lines += s"  3. $msg"
+      else
+        val list = invNames.take(4).mkString(", ")
+        lines += s"  2. Invariants involved: $list."
+        lines += "     (Run with --explain to see the contributing pair.)"
+      Some(lines.result().mkString("\n"))
+
+  private def narrateUnreachable(ctx: Context): Option[String] =
+    ctx.op.map: op =>
+      val opName = ctx.operationName.getOrElse(op.name)
+      val lines  = List.newBuilder[String]
+      lines += s"Why this operation is unreachable:"
+      val req = combineConjuncts(op.requires)
+      lines += s"  1. Operation '$opName' has 'requires':"
+      lines += s"       ${PrettyPrint.expr(req)}"
+      lines += "  2. No pre-state satisfies both 'requires' and the invariants."
+      if ctx.coreSpans.nonEmpty then
+        lines += "     The unsat core points at:"
+        ctx.coreSpans.take(4).foreach: rs =>
+          lines += s"       line ${rs.span.startLine}: ${rs.note}"
+      else
+        lines += "     (Run with --explain to see the contributing clauses.)"
+      lines.result().mkString("\n")
+
+  private def combineConjuncts(es: List[Expr]): Expr = es match
+    case Nil      => Expr.BoolLit(true)
+    case h :: Nil => h
+    case h :: t   => t.foldLeft(h)((acc, e) => Expr.BinaryOp(BinOp.And, acc, e))
+
+  private def contributingField(e: Expr, ir: ServiceIR): Option[String] =
+    val fields      = scala.collection.mutable.LinkedHashSet.empty[String]
+    val identifiers = scala.collection.mutable.LinkedHashSet.empty[String]
+    def walk(x: Expr): Unit = x match
+      case Expr.FieldAccess(base, field, _) => fields += field; walk(base)
+      case Expr.Identifier(n, _)            => identifiers += n
+      case Expr.BinaryOp(_, l, r, _)        => walk(l); walk(r)
+      case Expr.UnaryOp(_, op, _)           => walk(op)
+      case Expr.Quantifier(_, bs, body, _)  => bs.foreach(b => walk(b.domain)); walk(body)
+      case Expr.SomeWrap(x, _)              => walk(x)
+      case Expr.The(_, d, b, _)             => walk(d); walk(b)
+      case Expr.EnumAccess(b, _, _)         => walk(b)
+      case Expr.Index(b, i, _)              => walk(b); walk(i)
+      case Expr.Call(c, args, _)            => walk(c); args.foreach(walk)
+      case Expr.Prime(x, _)                 => walk(x)
+      case Expr.Pre(x, _)                   => walk(x)
+      case Expr.With(b, ups, _)             => walk(b); ups.foreach(u => walk(u.value))
+      case Expr.If(c, t, e, _)              => walk(c); walk(t); walk(e)
+      case Expr.Let(_, v, b, _)             => walk(v); walk(b)
+      case Expr.Lambda(_, b, _)             => walk(b)
+      case Expr.Constructor(_, fs, _)       => fs.foreach(f => walk(f.value))
+      case Expr.SetLiteral(es, _)           => es.foreach(walk)
+      case Expr.MapLiteral(es, _) =>
+        es.foreach { e =>
+          walk(e.key); walk(e.value)
+        }
+      case Expr.SetComprehension(_, d, p, _) => walk(d); walk(p)
+      case Expr.SeqLiteral(es, _)            => es.foreach(walk)
+      case Expr.Matches(x, _, _)             => walk(x)
+      case _                                 => ()
+    walk(e)
+    fields.headOption.orElse:
+      val stateFieldNames = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
+      identifiers.iterator.find(stateFieldNames.contains)
+
+  private def ensuresRhsForField(op: OperationDecl, field: String): Option[Expr] =
+    val candidates = op.ensures.flatMap(extractRhs(_, field))
+    candidates match
+      case Nil      => None
+      case r :: Nil => Some(r)
+      case _        => None
+
+  private def extractRhs(e: Expr, field: String): List[Expr] = e match
+    case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) if assignsField(lhs, field) => List(rhs)
+    case Expr.BinaryOp(BinOp.And, l, r, _)                                => extractRhs(l, field) ++ extractRhs(r, field)
+    case _                                                                => Nil
+
+  private def assignsField(lhs: Expr, field: String): Boolean = lhs match
+    case Expr.FieldAccess(_, f, _) => f == field
+    case Expr.Identifier(n, _)     => n == field
+    case Expr.Prime(inner, _)      => assignsField(inner, field)
+    case Expr.Index(base, _, _)    => assignsField(base, field)
+    case _                         => false
+
+  private def describePreInputs(
+      ce: DecodedCounterExample,
+      op: OperationDecl,
+      field: String
+  ): Option[String] =
+    val parts = List.newBuilder[String]
+    op.inputs.foreach: p =>
+      ce.inputs.find(_.name == p.name).foreach: inp =>
+        parts += s"${p.name} = ${inp.value.display}"
+    val preEntries = ce.stateRelations.filter(_.side == "pre")
+    preEntries.foreach: rel =>
+      rel.entries.headOption.foreach: entry =>
+        val target = entry.value.entityLabel.getOrElse(entry.value.display)
+        ce.entities.find(_.label == target).foreach: ent =>
+          ent.fields.find(_.name == field).foreach: fieldVal =>
+            parts += s"pre(${rel.stateName})[${entry.key.display}].$field = ${fieldVal.value.display}"
+    ce.stateConstants
+      .filter(c => c.side == "pre" && c.stateName == field)
+      .foreach: c =>
+        parts += s"pre($field) = ${c.value.display}"
+    val collected = parts.result()
+    if collected.isEmpty then None else Some(collected.mkString(", "))
+
+  private def describePost(ce: DecodedCounterExample, field: String): Option[String] =
+    val fromRelations = ce.stateRelations.filter(_.side == "post").iterator.flatMap: rel =>
+      rel.entries.iterator.flatMap: entry =>
+        val target = entry.value.entityLabel.getOrElse(entry.value.display)
+        ce.entities.iterator.filter(_.label == target).flatMap: ent =>
+          ent.fields.iterator.filter(_.name == field).map: fieldVal =>
+            s"${rel.stateName}'[${entry.key.display}].$field = ${fieldVal.value.display}"
+    val fromConstants = ce.stateConstants.iterator
+      .filter(c => c.side == "post" && c.stateName == field)
+      .map(c => s"$field' = ${c.value.display}")
+    fromRelations.nextOption().orElse(fromConstants.nextOption())
+
+  private def rangePairConflict(invs: List[InvariantDecl]): Option[String] =
+    val ranges = invs.flatMap(d => rangeOf(d.expr).map(r => (d, r)))
+    ranges.combinations(2).collectFirst:
+      case List((aDecl, (aIdent, aOp, aBound)), (bDecl, (bIdent, bOp, bBound)))
+          if aIdent == bIdent && conflicts(aOp, aBound, bOp, bBound) =>
+        val aName = aDecl.name.getOrElse("invariant")
+        val bName = bDecl.name.getOrElse("invariant")
+        s"For example, '$aName' and '$bName' bound '$aIdent' to disjoint ranges."
+
+  private def rangeOf(e: Expr): Option[(String, BinOp, Long)] = e match
+    case Expr.BinaryOp(op @ (BinOp.Ge | BinOp.Gt | BinOp.Le | BinOp.Lt), l, r, _) =>
+      (l, r) match
+        case (Expr.Identifier(n, _), Expr.IntLit(v, _)) => Some((n, op, v))
+        case (Expr.IntLit(v, _), Expr.Identifier(n, _)) => Some((n, mirror(op), v))
+        case _                                          => None
+    case _ => None
+
+  private def mirror(op: BinOp): BinOp = op match
+    case BinOp.Ge => BinOp.Le
+    case BinOp.Le => BinOp.Ge
+    case BinOp.Gt => BinOp.Lt
+    case BinOp.Lt => BinOp.Gt
+    case other    => other
+
+  private def conflicts(aOp: BinOp, aB: Long, bOp: BinOp, bB: Long): Boolean =
+    val aLow = aOp == BinOp.Ge || aOp == BinOp.Gt
+    val bLow = bOp == BinOp.Ge || bOp == BinOp.Gt
+    if aLow && !bLow then aB > bB
+    else if !aLow && bLow then bB > aB
+    else false
+
+  private def cap(s: String): String =
+    val lines = s.split("\n", -1).toList
+    val capped =
+      if lines.size <= MaxLines then s
+      else lines.take(MaxLines).mkString("\n") + s"\n  $Truncated"
+    if capped.length <= MaxLength then capped
+    else capped.take(MaxLength - Truncated.length - 1) + "\n" + Truncated

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -52,7 +52,7 @@ object Narration:
         case None =>
           lines += s"  2. Operation '$opName' writes '$field'."
       val preLine  = describePreInputs(ce, op, field)
-      val postLine = describePost(ce, field)
+      val postLine = describePost(ce, op, field)
       preLine.foreach { line =>
         lines += s"  3. The solver picked $line${postLine.fold("")(p => s", producing post-state $p")}."
       }
@@ -164,13 +164,15 @@ object Narration:
       op: OperationDecl,
       field: String
   ): Option[String] =
-    val parts = List.newBuilder[String]
+    val parts         = List.newBuilder[String]
+    val inputDisplays = scala.collection.mutable.LinkedHashSet.empty[String]
     op.inputs.foreach: p =>
       ce.inputs.find(_.name == p.name).foreach: inp =>
         parts += s"${p.name} = ${inp.value.display}"
+        inputDisplays += inp.value.display
     val preEntries = ce.stateRelations.filter(_.side == "pre")
     preEntries.foreach: rel =>
-      rel.entries.headOption.foreach: entry =>
+      preferredEntry(rel, inputDisplays.toSet).foreach: entry =>
         val target = entry.value.entityLabel.getOrElse(entry.value.display)
         ce.entities.find(_.label == target).foreach: ent =>
           ent.fields.find(_.name == field).foreach: fieldVal =>
@@ -182,9 +184,15 @@ object Narration:
     val collected = parts.result()
     if collected.isEmpty then None else Some(collected.mkString(", "))
 
-  private def describePost(ce: DecodedCounterExample, field: String): Option[String] =
+  private def describePost(
+      ce: DecodedCounterExample,
+      op: OperationDecl,
+      field: String
+  ): Option[String] =
+    val inputDisplays =
+      op.inputs.flatMap(p => ce.inputs.find(_.name == p.name).map(_.value.display)).toSet
     val fromRelations = ce.stateRelations.filter(_.side == "post").iterator.flatMap: rel =>
-      rel.entries.iterator.flatMap: entry =>
+      preferredEntry(rel, inputDisplays).iterator.flatMap: entry =>
         val target = entry.value.entityLabel.getOrElse(entry.value.display)
         ce.entities.iterator.filter(_.label == target).flatMap: ent =>
           ent.fields.iterator.filter(_.name == field).map: fieldVal =>
@@ -193,6 +201,14 @@ object Narration:
       .filter(c => c.side == "post" && c.stateName == field)
       .map(c => s"$field' = ${c.value.display}")
     fromRelations.nextOption().orElse(fromConstants.nextOption())
+
+  private def preferredEntry(
+      rel: DecodedRelation,
+      inputDisplays: Set[String]
+  ): Option[DecodedRelationEntry] =
+    rel.entries
+      .find(e => inputDisplays.contains(e.key.display))
+      .orElse(rel.entries.sortBy(_.key.display).headOption)
 
   private def rangePairConflict(invs: List[InvariantDecl]): Option[String] =
     val ranges = invs.flatMap(d => rangeOf(d.expr).map(r => (d, r)))
@@ -219,10 +235,13 @@ object Narration:
     case other    => other
 
   private def conflicts(aOp: BinOp, aB: Long, bOp: BinOp, bB: Long): Boolean =
-    val aLow = aOp == BinOp.Ge || aOp == BinOp.Gt
-    val bLow = bOp == BinOp.Ge || bOp == BinOp.Gt
-    if aLow && !bLow then aB > bB
-    else if !aLow && bLow then bB > aB
+    val aLow    = aOp == BinOp.Ge || aOp == BinOp.Gt
+    val bLow    = bOp == BinOp.Ge || bOp == BinOp.Gt
+    val aStrict = aOp == BinOp.Gt || aOp == BinOp.Lt
+    val bStrict = bOp == BinOp.Gt || bOp == BinOp.Lt
+    val strict  = aStrict || bStrict
+    if aLow && !bLow then if strict then aB >= bB else aB > bB
+    else if !aLow && bLow then if strict then bB >= aB else bB > aB
     else false
 
   private def cap(s: String): String =

--- a/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
@@ -1,0 +1,79 @@
+package specrest.verify
+
+import munit.CatsEffectSuite
+import specrest.verify.testutil.SpecFixtures
+
+class NarrationTest extends CatsEffectSuite:
+
+  private val violationCases: List[(String, DiagnosticCategory, List[String])] = List(
+    (
+      "broken_url_shortener",
+      DiagnosticCategory.InvariantViolationByOperation,
+      List("clickCountNonNegative", "click_count", "Tamper")
+    ),
+    (
+      "broken_decrement",
+      DiagnosticCategory.InvariantViolationByOperation,
+      List("clicksNonNegative", "clicks", "Decrement")
+    )
+  )
+
+  violationCases.foreach: (fixture, category, mustContain) =>
+    test(s"narration for $fixture mentions invariant + field + operation"):
+      val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+      for
+        ir     <- SpecFixtures.loadIR(fixture)
+        report <- Consistency.runConsistencyChecks(ir, cfg)
+      yield
+        val violation = report.checks
+          .find(c => c.diagnostic.exists(_.category == category))
+          .getOrElse(fail(s"no $category check found for $fixture"))
+        val narrative = violation.diagnostic.flatMap(_.narrative)
+          .getOrElse(fail(s"narration empty for $fixture"))
+        assert(narrative.contains("Why this violates"), narrative)
+        mustContain.foreach: needle =>
+          assert(narrative.contains(needle), s"narration missing '$needle': $narrative")
+
+  test("narration for unsat_invariants names contributing invariants"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("unsat_invariants")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val global = report.checks.find(_.id == "global").getOrElse(fail("no global check"))
+      val narrative = global.diagnostic.flatMap(_.narrative)
+        .getOrElse(fail("expected narration on global check"))
+      assert(narrative.contains("Why these invariants conflict"), narrative)
+      assert(
+        narrative.contains("inv_") || narrative.contains("invariant"),
+        narrative
+      )
+
+  test("narration for dead_op (UnsatisfiablePrecondition) is empty (deferred per #89)"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("dead_op")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val deadReq = report.checks
+        .find(c =>
+          c.diagnostic.exists(_.category == DiagnosticCategory.UnsatisfiablePrecondition)
+        )
+        .getOrElse(fail("no UnsatisfiablePrecondition check found"))
+      assert(
+        deadReq.diagnostic.flatMap(_.narrative).isEmpty,
+        s"expected no narrative; got ${deadReq.diagnostic.flatMap(_.narrative)}"
+      )
+
+  test("--no-narration suppresses narrative on a violating spec"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true, narration = false)
+    for
+      ir     <- SpecFixtures.loadIR("broken_url_shortener")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val violation = report.checks
+        .find(c =>
+          c.diagnostic.exists(_.category == DiagnosticCategory.InvariantViolationByOperation)
+        )
+        .getOrElse(fail("no preservation violation found"))
+      assertEquals(violation.diagnostic.flatMap(_.narrative), None)

--- a/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
@@ -65,6 +65,22 @@ class NarrationTest extends CatsEffectSuite:
         s"expected no narrative; got ${deadReq.diagnostic.flatMap(_.narrative)}"
       )
 
+  test("narration for unreachable_op mentions unreachable + the operation"):
+    val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true)
+    for
+      ir     <- SpecFixtures.loadIR("unreachable_op")
+      report <- Consistency.runConsistencyChecks(ir, cfg)
+    yield
+      val unreachable = report.checks
+        .find(c =>
+          c.diagnostic.exists(_.category == DiagnosticCategory.UnreachableOperation)
+        )
+        .getOrElse(fail("no UnreachableOperation check found"))
+      val narrative = unreachable.diagnostic.flatMap(_.narrative)
+        .getOrElse(fail("expected narration on unreachable operation check"))
+      assert(narrative.contains("Why this operation is unreachable"), narrative)
+      assert(narrative.contains("UnreachableOp"), narrative)
+
   test("--no-narration suppresses narrative on a violating spec"):
     val cfg = VerificationConfig(timeoutMs = 30_000L, captureCore = true, narration = false)
     for


### PR DESCRIPTION
## Summary

- Adds a deterministic structural narration block (\"Why this fails\") to verification diagnostics, rendered between the counterexample and the suggestion hint, and serialized as a new \`narrative\` field on the JSON report.
- Covers the three categories enumerated in #89's AC: \`invariant_violation_by_operation\`, \`contradictory_invariants\`, \`unreachable_operation\`. Other categories return \`None\` — \`UnsatisfiablePrecondition\` / \`SolverTimeout\` / \`TranslatorLimitation\` / \`BackendError\` are explicitly deferred per the issue.
- Pure templating over IR + decoded counterexample. No interpreter, no LLM. \`--no-narration\` flag mirrors \`--no-suggestions\`; default on.

## What's in the PR

- **\`modules/ir/.../PrettyPrint.scala\`** — fully-parenthesized \`Expr → String\` covering all 25 variants. Lives in \`ir/\` so future \`inspect\` / docs surfaces can share it. \`PrettyPrintTest\` parametrized over 18 representative shapes.
- **\`modules/verify/.../Narration.scala\`** — three narrators dispatched from a single \`narrate(category, ctx)\` entry. Step 1 of the \`InvariantViolationByOperation\` template pretty-prints the invariant; step 2 looks up the matching \`ensures\` conjunct via a trailing field-path matcher (also handles scalar state fields like \`clicks' = clicks - 1\` via the new \`Identifier\` and \`Index\` cases in \`assignsField\`); step 3 reads inputs / pre / post values directly off \`DecodedCounterExample\` (no arithmetic re-evaluation); step 4 is fixed phrasing keyed to the invariant name. Cap of 12 lines / 1200 chars.
- **\`Diagnostic.scala\`** — \`narrative: Option[String]\` field; rendered between counterexample and \`hint:\` in \`formatDiagnostic\`.
- **\`Consistency.scala\`** — \`enrichSuggestion\` rewritten to also build a \`Narration.Context\` and populate \`narrative\` parallel to \`suggestion\`. The op/invariant lookup is shared between the two.
- **\`Config.scala\` / \`Verify.scala\` / \`Main.scala\`** — \`narration: Boolean = true\` plus \`--no-narration\` flag.
- **\`JsonReport.scala\`** — \`narrative\` field. Additive: \`SchemaVersion\` stays \`1\`.
- **Tests** — \`NarrationTest\` parametrized across the four fixtures #89 names (\`broken_url_shortener\`, \`broken_decrement\`, \`unsat_invariants\`, \`dead_op\`) plus a \`--no-narration\` suppression case. \`JsonReportTest\` goldens regenerated for the two fixtures with diagnostics.
- **Docs** — \`verification.mdx\` worked example updated with the narration block; new bullet explaining the layer; \`--no-narration\` row added to the options table; status table flipped.

## Sample output (broken_url_shortener)

\`\`\`text
✘ fixtures/spec/broken_url_shortener.spec:11:2: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
  related: fixtures/spec/broken_url_shortener.spec:21:2 (invariant 'clickCountNonNegative' declared here)

  Counterexample:
  inputs:
    code = 1
  entities:
    UrlMapping#0 { click_count = -1 }
    UrlMapping#1 { click_count = 99 }
  pre-state:
    metadata = { 1 → UrlMapping#1 }
  post-state:
    metadata' = { 1 → UrlMapping#0 }

  Why this violates the invariant:
    1. Invariant 'clickCountNonNegative' requires:
         (all c in metadata | (metadata[c].click_count >= 0))
    2. Operation 'Tamper' computes 'click_count' from:
         (pre(metadata)[code].click_count - 100)
    3. The solver picked code = 1, pre(metadata)[1].click_count = 99,
       producing post-state metadata'[1].click_count = -1.
    4. The post-state value violates the bound on 'click_count' from
       invariant 'clickCountNonNegative'.

  hint: 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' …
\`\`\`

## Acceptance criteria mapping

- [x] \`VerificationDiagnostic.narrative: Option[String]\` populated for the three in-scope categories.
- [x] Reporter prints narration after counterexample, before suggestion.
- [x] \`--no-narration\` flag (CLI + \`VerificationConfig.narration\`).
- [x] Tests parametrized over \`broken_*.spec\` and \`dead_op.spec\`. Each in-scope fixture asserts the narrative mentions the invariant name *and* the contributing field name. \`dead_op\` asserts \`narrative.isEmpty\` (deferred per #89).
- [x] JSON consumers see additive \`narrative: string | null\`.

## Deliberate non-goals (carried over from #89)

- No arithmetic substitution / IR interpreter — step 3 reads the post value off the counterexample, doesn't compute it.
- No conjunct isolation for non-trivial invariants — v1 prints the whole predicate fully-parenthesized.
- No narration for \`UnsatisfiablePrecondition\`, \`SolverTimeout\`, \`TranslatorLimitation\`, \`BackendError\`.
- No LLM, no NLP — deterministic templating.

## Test plan

- [x] \`sbt test\` — 311 tests, all green (PrettyPrintTest 18, NarrationTest 5, JsonReportTest 7, full suite unaffected).
- [x] \`sbt scalafmtCheckAll\` — clean.
- [x] \`sbt \"scalafixAll --check\"\` — clean.
- [x] \`cd docs && npm run build\` — clean.
- [x] Manual: \`verify\` on broken_url_shortener / broken_decrement / unsat_invariants — narration renders correctly under default and JSON modes.
- [x] Manual: \`verify --no-narration\` on broken_url_shortener — narration absent from text output and \`narrative\` is \`null\` in JSON.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a human-readable “Why this fails” narration to verification diagnostics to explain counterexamples and conflicts. The narration appears in CLI output and as a new `narrative` field in JSON; enabled by default, opt out with `--no-narration`.

- **New Features**
  - Deterministic narration for `invariant_violation_by_operation`, `contradictory_invariants`, and `unreachable_operation` (covers #89).
  - Pure IR templating over decoded counterexamples; no interpreter or LLM.
  - Printed between the counterexample and the hint; capped at 12 lines / 1200 chars.
  - JSON adds `narrative: string | null` (SchemaVersion stays 1).
  - New flag `--no-narration` and config plumbing to disable narration.
  - `specrest.ir.PrettyPrint` (fully parenthesized `Expr -> String`), now escaping `\"`, `\\`, `\n`, `\r`, `\t`.
  - `specrest.verify.Narration` chooses relation entries that match operation inputs for step 3 (deterministic pre/post lines) and treats strict-vs-non-strict bounds as disjoint when detecting conflicting invariants; unreachable ops narrate combined `requires` and use unsat-core spans when available.

- **Migration**
  - If you consume JSON, handle the additive `narrative` field (string or null). No other changes required.

<sup>Written for commit 0c49bffc8ae20004baf56f48444c697c979f11a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added human-readable explanations for verification failures, describing what violated and why.
  * Introduced `--no-narration` CLI flag to suppress narration output when needed.
  * Narration now included in JSON verification reports via new `narrative` field.

* **Documentation**
  * Updated verification documentation with examples and descriptions of the new narration capability and CLI option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->