### PR TITLE
ci: pass --ignore-verify in native-image smoke test

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -37,6 +37,7 @@ jobs:
           ./modules/cli/target/native-image/spec-to-rest verify fixtures/spec/safe_counter.spec
           ./modules/cli/target/native-image/spec-to-rest compile \
             --target python-fastapi-postgres --out /tmp/native-smoke \
+            --ignore-verify \
             fixtures/spec/url_shortener.spec
           test -f /tmp/native-smoke/pyproject.toml
           test -f /tmp/native-smoke/app/main.py


### PR DESCRIPTION
## Summary
- Native Image CI job has been red since #117 landed verify-as-gate.
- Smoke compiles `fixtures/spec/url_shortener.spec`, which has 6 checks skipped on translator coverage gaps (set-comprehension binder sort mismatch on `U:ShortCode` vs `U:UrlMapping`, `+` on string `ShortCode`). `ExitCodes.forCheckResults` maps any `TranslatorLimitation`-skipped check to exit 2, so `Compile.runGate` aborted before writing project files; the subsequent `test -f /tmp/native-smoke/pyproject.toml` line never ran but the step had already exited with 2.
- The smoke is meant to exercise the native binary end-to-end, not assert the fixture is fully verifiable. Pass `--ignore-verify` (the existing escape hatch from #117) so codegen runs; the existing `test -f pyproject.toml` / `app/main.py` checks remain the smoke gate.

## Test plan
- [ ] Native Image workflow goes green on this branch.
- [ ] `compile --ignore-verify` still emits `pyproject.toml` and `app/main.py` (covered by the existing `test -f` lines).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the native-image smoke test by passing --ignore-verify so the compile step runs and the test validates generated files. Restores the Native Image CI job after verify-as-gate caused early exits on translator limitations.

- **Bug Fixes**
  - Add --ignore-verify to the compile step for `fixtures/spec/url_shortener.spec`.
  - Keep existing gate on file outputs: `/tmp/native-smoke/pyproject.toml` and `/tmp/native-smoke/app/main.py`.

<sup>Written for commit 62f8da973134eb7d89899c922ab0c2f8bc38b38e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

