### PR TITLE
M5.2 — Stateful Tests via Hypothesis (closes #25)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -46,6 +46,7 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/predicates.py` | static template | `is_valid_uri`, `is_valid_email` helpers used by strategies and assertions |
 | `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl` |
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
+| `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
 | `tests/_testgen_skips.json` | testgen | machine-readable list of clauses that were not turned into tests, with reasons |
 | `pytest.ini` | static template | disables `pytest-xdist` parallelism (admin-router state is global) |
 
@@ -114,6 +115,100 @@ def test_shorten_invariant_all_ur_ls_valid(url):
         "invariant violated: invariant allURLsValid: (all c in store | isValidURI(store[c]))"
 ```
 
+## Stateful tests (M5.2)
+
+Alongside the per-clause behavioral tests, testgen emits one
+`tests/test_stateful_<service>.py` containing a Hypothesis
+[`RuleBasedStateMachine`](https://hypothesis.readthedocs.io/en/latest/stateful.html)
+that exercises multi-step operation sequences against the live SUT. Each spec operation
+becomes an `@rule` performing the real HTTP call. Entity ids returned from `Create`-classified
+operations flow into other rules through `Bundle`s — so a `Resolve` rule receives a code that
+was just produced by a `Shorten` rule, and a `Delete` rule consumes the code from the bundle.
+Global invariants run after every step against `/__test_admin__/state`.
+
+```python
+class UrlShortenerStateMachine(RuleBasedStateMachine):
+    url_mapping_ids = Bundle("url_mapping_ids")
+
+    @initialize()
+    def _reset(self):
+        client.post("/__test_admin__/reset")
+
+    @rule(target=url_mapping_ids, url=strategy_long_url())
+    def shorten(self, url):
+        response = client.post("/shorten", json={"url": url})
+        assert response.status_code == 201, response.text
+        return response.json()["code"]
+
+    @rule(code=url_mapping_ids)
+    def resolve(self, code):
+        response = client.get(f"/{code}")
+        assert response.status_code == 302, response.text
+
+    @rule(code=consumes(url_mapping_ids))
+    def delete(self, code):
+        response = client.delete(f"/{code}")
+        assert response.status_code == 204, response.text
+
+    @invariant()
+    def invariant_all_ur_ls_valid(self):
+        post_state = client.get("/__test_admin__/state").json()
+        assert all(is_valid_uri(post_state["store"][c]) for c in post_state["store"])
+
+TestStatefulUrlShortener = UrlShortenerStateMachine.TestCase
+```
+
+### Bundle inference
+
+| Operation kind (convention layer) | Role in the state machine |
+|---|---|
+| `Create` / `CreateChild` (returns an entity) | `@rule(target=<entity>_ids, …)` — pushes the response id into the bundle |
+| `Delete` (id-typed input) | parameter via `consumes(<entity>_ids)` — pops the id |
+| Read / Update / Replace / Transition / SideEffect (id-typed input) | parameter via `<entity>_ids` (non-consuming draw) |
+| any operation with no entity-id input or output | parameter-less rule that just exercises the endpoint |
+
+The `<entity>_ids` bundle name follows the entity's snake-cased name (e.g., `url_mapping_ids`,
+`todo_ids`). The id projection from the response uses the entity's primary-key field
+(`id` if present, otherwise the first declared field — for `url_shortener` this is `code`).
+
+### Strict vs loose status assertions
+
+For each rule, testgen decides whether to assert the success status strictly or to also
+accept any 4xx (the SUT rejecting because its own preconditions failed):
+
+- **Strict** (`assert response.status_code == <success>`): used for `Create` rules and for
+  rules whose every `requires` clause is either trivially `true` or a `<input> in <state>`
+  pattern that is satisfied by construction via bundle membership.
+- **Loose** (`if-elif`-`else`, accepting `<success>` or `400..499`): used for rules with
+  any other state-dependent precondition (e.g., transition guards like
+  `todos[id].status = TODO`). A 4xx response there is the SUT correctly rejecting an
+  unsatisfied precondition, not a bug.
+
+### Settings
+
+```python
+TestStateful<Service>.settings = settings(
+    max_examples=25,
+    stateful_step_count=20,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+```
+
+`deadline=None` is required because every step performs an HTTP round-trip; a per-step
+deadline trips on slow CI machines.
+
+### What stateful does not do (in M5.2)
+
+- It does **not** maintain a Python-side ghost model of state. The SUT, accessed via
+  `/__test_admin__/state`, is the model. This trades shrink-output detail for emitter
+  simplicity and avoids re-translating every `ensures` clause as a model update.
+- It does **not** branch by `TransitionDecl` status (separate `pending_ids`, `shipped_ids`
+  bundles). Status guards are exercised by loose rules instead. Per-status bundles are
+  tracked under [#137](https://github.com/HardMax71/spec_to_rest/issues/137) (M5.9).
+- Per-rule ensures-asserts are handled by the behavioral tests, not duplicated here.
+  Stateful surfaces multi-step bugs via the `@invariant()` checks that run after every step.
+
 ## Coverage on canonical fixtures
 
 These numbers are locked in `SkipRateProbeTest.scala`; CI fails if they regress.
@@ -166,8 +261,7 @@ compile gives a coverage delta as M5.5 expands `ExprToPython`.
 | Custom strategies for spec predicates beyond `isValidURI`/`valid_email` | [M5.6 (#134)](https://github.com/HardMax71/spec_to_rest/issues/134) |
 | Mutation-testing CI gate | [M5.7 (#135)](https://github.com/HardMax71/spec_to_rest/issues/135) |
 | Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
-| Transition-aware property tests | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
-| Stateful tests via `RuleBasedStateMachine` | [M5.2 (#25)](https://github.com/HardMax71/spec_to_rest/issues/25) |
+| Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
 | Schemathesis structural layer | [M5.3 (#26)](https://github.com/HardMax71/spec_to_rest/issues/26) |
 | Conformance runner / Makefile / nightly CI | [M5.4 (#23)](https://github.com/HardMax71/spec_to_rest/issues/23) |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -186,13 +186,17 @@ accept any 4xx (the SUT rejecting because its own preconditions failed):
 
 ### Settings
 
+Settings are attached to the state machine's `TestCase` (which the `TestStateful<Service>`
+alias refers to):
+
 ```python
-TestStateful<Service>.settings = settings(
+<Service>StateMachine.TestCase.settings = settings(
     max_examples=25,
     stateful_step_count=20,
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
 )
+TestStateful<Service> = <Service>StateMachine.TestCase
 ```
 
 `deadline=None` is required because every step performs an HTTP round-trip; a per-step

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -1,0 +1,403 @@
+package specrest.testgen
+
+import specrest.convention.EndpointSpec
+import specrest.convention.Naming
+import specrest.convention.OperationKind
+import specrest.ir.EntityDecl
+import specrest.ir.Expr
+import specrest.ir.FieldDecl
+import specrest.ir.InvariantDecl
+import specrest.ir.OperationDecl
+import specrest.ir.PrettyPrint
+import specrest.ir.ServiceIR
+import specrest.ir.TypeExpr
+import specrest.profile.ProfiledOperation
+import specrest.profile.ProfiledService
+
+final case class StatefulOutput(
+    file: String,
+    skips: List[TestSkip]
+)
+
+object Stateful:
+
+  final private case class BundleSpec(
+      entityName: String,
+      bundleName: String,
+      pyVarName: String,
+      pkFieldName: String,
+      pkTypeExpr: TypeExpr
+  )
+
+  private enum InputBinding:
+    case BundleDraw(bundle: BundleSpec)
+    case BundleConsume(bundle: BundleSpec)
+    case Generated(strategy: String)
+    case Skip(reason: String)
+
+  private enum RuleRole:
+    case CreateTarget(bundle: BundleSpec, pkProjection: String)
+    case Plain
+
+  def emitFor(profiled: ProfiledService): StatefulOutput =
+    val ir       = profiled.ir
+    val bundles  = inferBundles(profiled)
+    val machName = s"${ir.name}StateMachine"
+    val testName = s"TestStateful${ir.name}"
+
+    val rulesAndSkips = profiled.operations.map: pop =>
+      ir.operations.find(_.name == pop.operationName) match
+        case Some(opDecl) => emitRule(pop, opDecl, ir, bundles)
+        case None         => Right(Nil) -> Nil
+    val ruleBlocks = rulesAndSkips.flatMap(_._1.toOption.toList.flatten)
+    val ruleSkips  = rulesAndSkips.flatMap(_._2)
+
+    val invariantsAndSkips = ir.invariants.zipWithIndex.map: (inv, idx) =>
+      emitInvariant(inv, idx, ir)
+    val invariantBlocks = invariantsAndSkips.flatMap(_._1.toList)
+    val invariantSkips  = invariantsAndSkips.flatMap(_._2.toList)
+
+    val py = renderFile(
+      ir = ir,
+      machineName = machName,
+      testName = testName,
+      bundles = bundles,
+      ruleBlocks = ruleBlocks,
+      invariantBlocks = invariantBlocks
+    )
+
+    StatefulOutput(file = py, skips = ruleSkips ++ invariantSkips)
+
+  private def inferBundles(profiled: ProfiledService): List[BundleSpec] =
+    val ir = profiled.ir
+    val createOps = profiled.operations.filter: pop =>
+      pop.kind == OperationKind.Create || pop.kind == OperationKind.CreateChild
+    val byEntity = createOps.flatMap(pop => pop.targetEntity.map(_ -> pop)).groupBy(_._1)
+    byEntity.keys.toList.sorted.flatMap: entityName =>
+      ir.entities.find(_.name == entityName).flatMap: entity =>
+        primaryKey(entity).map: pk =>
+          BundleSpec(
+            entityName = entityName,
+            bundleName = s"${Naming.toSnakeCase(entityName)}_ids",
+            pyVarName = s"${Naming.toSnakeCase(entityName)}_ids",
+            pkFieldName = pk.name,
+            pkTypeExpr = pk.typeExpr
+          )
+
+  private def primaryKey(entity: EntityDecl): Option[FieldDecl] =
+    entity.fields.find(_.name == "id").orElse(entity.fields.headOption)
+
+  private def emitRule(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      ir: ServiceIR,
+      bundles: List[BundleSpec]
+  ): (Either[Unit, List[String]], List[TestSkip]) =
+    val role            = inferCreateRole(pop, opDecl, bundles)
+    val pathParamNames  = pop.endpoint.pathParams.map(_.name).toSet
+    val bodyParamNames  = pop.endpoint.bodyParams.map(_.name).toSet
+    val queryParamNames = pop.endpoint.queryParams.map(_.name).toSet
+    val allParams       = pathParamNames ++ bodyParamNames ++ queryParamNames
+
+    val bindings = opDecl.inputs.collect:
+      case p if allParams.contains(p.name) =>
+        p.name -> bindForInput(p.typeExpr, pop, ir, bundles)
+    val skipped = bindings.collect:
+      case (n, InputBinding.Skip(r)) =>
+        TestSkip(opDecl.name, "stateful_rule", s"input '$n': $r")
+    if skipped.nonEmpty then (Right(Nil), skipped)
+    else
+      val ruleBody = buildRuleBlock(
+        pop = pop,
+        opDecl = opDecl,
+        bindings = bindings,
+        role = role
+      )
+      (Right(List(ruleBody)), Nil)
+
+  private def inferCreateRole(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      bundles: List[BundleSpec]
+  ): RuleRole =
+    if pop.kind != OperationKind.Create && pop.kind != OperationKind.CreateChild then
+      RuleRole.Plain
+    else
+      pop.targetEntity.flatMap(en => bundles.find(_.entityName == en)) match
+        case None => RuleRole.Plain
+        case Some(bundle) =>
+          val proj = projectionForCreateOutput(opDecl, bundle)
+          RuleRole.CreateTarget(bundle, proj)
+
+  private def projectionForCreateOutput(
+      opDecl: OperationDecl,
+      bundle: BundleSpec
+  ): String =
+    val outputs = opDecl.outputs
+    outputs match
+      case List(out) if isEntityType(out.typeExpr, bundle.entityName) =>
+        s"response_data[${ExprToPython.pyString(bundle.pkFieldName)}]"
+      case _ =>
+        outputs
+          .find(o => sameNamedType(o.typeExpr, bundle.pkTypeExpr))
+          .map(o => s"response_data[${ExprToPython.pyString(o.name)}]")
+          .getOrElse(s"response_data[${ExprToPython.pyString(bundle.pkFieldName)}]")
+
+  private def isEntityType(t: TypeExpr, name: String): Boolean = t match
+    case TypeExpr.NamedType(n, _) => n == name
+    case _                        => false
+
+  private def sameNamedType(a: TypeExpr, b: TypeExpr): Boolean = (a, b) match
+    case (TypeExpr.NamedType(x, _), TypeExpr.NamedType(y, _)) => x == y
+    case _                                                    => false
+
+  private def bindForInput(
+      paramType: TypeExpr,
+      pop: ProfiledOperation,
+      ir: ServiceIR,
+      bundles: List[BundleSpec]
+  ): InputBinding =
+    val matchingBundle = bundles.find(b => sameNamedType(paramType, b.pkTypeExpr))
+    matchingBundle match
+      case Some(bundle) =>
+        if pop.kind == OperationKind.Delete then InputBinding.BundleConsume(bundle)
+        else InputBinding.BundleDraw(bundle)
+      case None =>
+        Strategies.expressionFor(paramType, ir) match
+          case StrategyExpr.Code(text) => InputBinding.Generated(text)
+          case StrategyExpr.Skip(r)    => InputBinding.Skip(r)
+
+  private def buildRuleBlock(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      bindings: List[(String, InputBinding)],
+      role: RuleRole
+  ): String =
+    val sb        = new StringBuilder
+    val ruleArgs  = ruleDecoratorArgs(bindings, role)
+    val funcName  = Naming.toSnakeCase(opDecl.name)
+    val sigParams = ("self" :: bindings.map(_._1)).mkString(", ")
+
+    sb.append(s"    @rule($ruleArgs)\n")
+    sb.append(s"    def $funcName($sigParams):\n")
+    sb.append(s"        \"\"\"${escapeDocstring(operationSummary(opDecl))}\"\"\"\n")
+    sb.append(s"        response = ${requestCallExpr(pop)}\n")
+    sb.append("        response_data = response.json() if response.content else {}\n")
+
+    val bundleInputNames = bindings.collect:
+      case (n, InputBinding.BundleDraw(_) | InputBinding.BundleConsume(_)) => n
+    val allRequiresSatisfiableByBundles =
+      opDecl.requires.forall(r => requiresIsSatisfiedByBundles(r, bundleInputNames.toSet))
+    val expectsStrictSuccess =
+      role match
+        case RuleRole.CreateTarget(_, _) => true
+        case RuleRole.Plain              => allRequiresSatisfiableByBundles
+
+    val successCode = pop.endpoint.successStatus
+    if expectsStrictSuccess then
+      sb.append(s"        assert response.status_code == $successCode, response.text\n")
+      role match
+        case RuleRole.CreateTarget(_, proj) =>
+          sb.append(s"        return $proj\n")
+        case RuleRole.Plain =>
+          ()
+    else
+      sb.append(
+        s"        if response.status_code == $successCode:\n            pass\n"
+      )
+      sb.append(
+        "        elif 400 <= response.status_code < 500:\n            pass\n"
+      )
+      sb.append(
+        "        else:\n            assert False, f\"unexpected status {response.status_code}: {response.text}\"\n"
+      )
+    sb.toString
+
+  private def ruleDecoratorArgs(
+      bindings: List[(String, InputBinding)],
+      role: RuleRole
+  ): String =
+    val targetArg = role match
+      case RuleRole.CreateTarget(b, _) => List(s"target=${b.pyVarName}")
+      case RuleRole.Plain              => Nil
+    val paramArgs = bindings.map: (name, b) =>
+      val rhs = b match
+        case InputBinding.BundleDraw(bundle)    => bundle.pyVarName
+        case InputBinding.BundleConsume(bundle) => s"consumes(${bundle.pyVarName})"
+        case InputBinding.Generated(text)       => text
+        case InputBinding.Skip(_)               => "st.nothing()"
+      s"$name=$rhs"
+    (targetArg ++ paramArgs).mkString(", ")
+
+  private def emitInvariant(
+      inv: InvariantDecl,
+      idx: Int,
+      ir: ServiceIR
+  ): (Option[String], Option[TestSkip]) =
+    val ctx = TestCtx(
+      inputs = Set.empty,
+      outputs = Set.empty,
+      stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet,
+      enumValues = ir.enums.map(e => e.name -> e.values.toSet).toMap,
+      knownPredicates = TestCtx.DefaultPredicates,
+      boundVars = Set.empty,
+      capture = CaptureMode.PostState
+    )
+    val name       = inv.name.getOrElse(s"anon_$idx")
+    val methodName = Naming.toSnakeCase(name)
+    ExprToPython.translate(inv.expr, ctx) match
+      case ExprPy.Skip(reason, _) =>
+        val skip = TestSkip("<service>", s"stateful_invariant[$name]", reason)
+        (None, Some(skip))
+      case ExprPy.Py(text) =>
+        val sb = new StringBuilder
+        sb.append("    @invariant()\n")
+        sb.append(s"    def invariant_$methodName(self):\n")
+        sb.append(
+          s"        \"\"\"invariant $name: ${escapeDocstring(prettyOneLine(inv.expr))}\"\"\"\n"
+        )
+        sb.append("        post_state = client.get(\"/__test_admin__/state\").json()\n")
+        sb.append(
+          s"        assert $text, ${ExprToPython.pyString(s"invariant violated: $name")}\n"
+        )
+        (Some(sb.toString), None)
+
+  private def renderFile(
+      ir: ServiceIR,
+      machineName: String,
+      testName: String,
+      bundles: List[BundleSpec],
+      ruleBlocks: List[String],
+      invariantBlocks: List[String]
+  ): String =
+    val needsConsumes = ruleBlocks.exists(_.contains("consumes("))
+    val statefulImports = List(
+      "RuleBasedStateMachine",
+      "Bundle",
+      "rule",
+      "initialize",
+      "invariant"
+    ) ++ (if needsConsumes then List("consumes") else Nil)
+    val statefulImportLine =
+      statefulImports.map("    " + _ + ",").mkString("\n")
+
+    val strategySpecs = Strategies.forIR(ir)
+    val strategyImport =
+      if strategySpecs.isEmpty then ""
+      else
+        val names = strategySpecs.map(_.functionName).sorted.mkString(",\n    ")
+        s"""|from tests.strategies import (
+            |    $names,
+            |)
+            |
+            |""".stripMargin
+
+    val bundleDecls =
+      if bundles.isEmpty then ""
+      else
+        bundles
+          .map(b => s"    ${b.pyVarName} = Bundle(${ExprToPython.pyString(b.bundleName)})")
+          .mkString("\n") + "\n\n"
+
+    val initializeBlock =
+      """    @initialize()
+        |    def _reset(self):
+        |        client.post("/__test_admin__/reset")
+        |
+        |""".stripMargin
+
+    val ruleSection =
+      if ruleBlocks.isEmpty then "    # No rules generated; see _testgen_skips.json.\n    pass\n"
+      else ruleBlocks.mkString("\n")
+
+    val invariantSection =
+      if invariantBlocks.isEmpty then ""
+      else "\n" + invariantBlocks.mkString("\n")
+
+    s"""|\"\"\"Auto-generated stateful tests for ${ir.name}.
+        |
+        |Builds a Hypothesis RuleBasedStateMachine: each spec operation becomes a
+        |@rule that performs the real HTTP call; entity ids returned from Create
+        |operations flow through Bundles into Read/Update/Delete rules; global
+        |invariants are checked after every step against /__test_admin__/state.
+        |
+        |See tests/_testgen_skips.json for clauses skipped during translation.
+        |\"\"\"
+        |from hypothesis import HealthCheck, settings
+        |from hypothesis import strategies as st
+        |from hypothesis.stateful import (
+        |$statefulImportLine
+        |)
+        |
+        |from tests.conftest import client
+        |from tests.predicates import is_valid_email, is_valid_uri
+        |
+        |${strategyImport}class $machineName(RuleBasedStateMachine):
+        |
+        |${bundleDecls}${initializeBlock}${ruleSection}${invariantSection}
+        |
+        |$machineName.TestCase.settings = settings(
+        |    max_examples=25,
+        |    stateful_step_count=20,
+        |    deadline=None,
+        |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+        |)
+        |$testName = $machineName.TestCase
+        |""".stripMargin.replace("\\\"", "\"")
+
+  private def requestCallExpr(pop: ProfiledOperation): String =
+    val ep              = pop.endpoint
+    val method          = ep.method.toString.toLowerCase
+    val bodyParamNames  = ep.bodyParams.map(_.name)
+    val queryParamNames = ep.queryParams.map(_.name)
+    val pathExpr        = pythonPathLiteral(ep)
+    val bodyExpr =
+      if bodyParamNames.isEmpty then ""
+      else
+        val pairs =
+          bodyParamNames.map(n => s"${ExprToPython.pyString(n)}: $n").mkString(", ")
+        s", json={$pairs}"
+    val queryExpr =
+      if queryParamNames.isEmpty then ""
+      else
+        val pairs =
+          queryParamNames.map(n => s"${ExprToPython.pyString(n)}: $n").mkString(", ")
+        s", params={$pairs}"
+    s"client.$method($pathExpr$bodyExpr$queryExpr)"
+
+  private def pythonPathLiteral(ep: EndpointSpec): String =
+    if ep.pathParams.isEmpty then ExprToPython.pyString(ep.path)
+    else "f" + ExprToPython.pyString(ep.path)
+
+  private def operationSummary(op: OperationDecl): String =
+    val req = op.requires
+      .filterNot(isTrivialTrue)
+      .map(prettyOneLine)
+      .mkString("; ")
+    val ens = op.ensures.map(prettyOneLine).mkString("; ")
+    val parts = List(
+      Option.when(req.nonEmpty)(s"requires: $req"),
+      Option.when(ens.nonEmpty)(s"ensures: $ens")
+    ).flatten
+    if parts.isEmpty then op.name else s"${op.name}: ${parts.mkString(" | ")}"
+
+  private def isTrivialTrue(e: Expr): Boolean = e match
+    case Expr.BoolLit(true, _) => true
+    case _                     => false
+
+  private def requiresIsSatisfiedByBundles(e: Expr, bundleInputs: Set[String]): Boolean =
+    e match
+      case Expr.BoolLit(true, _) => true
+      case Expr.BinaryOp(specrest.ir.BinOp.In, Expr.Identifier(in, _), Expr.Identifier(_, _), _)
+          if bundleInputs.contains(in) =>
+        true
+      case Expr.BinaryOp(specrest.ir.BinOp.And, l, r, _) =>
+        requiresIsSatisfiedByBundles(l, bundleInputs) &&
+        requiresIsSatisfiedByBundles(r, bundleInputs)
+      case _ => false
+
+  private def prettyOneLine(e: Expr): String =
+    PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim
+
+  private def escapeDocstring(s: String): String =
+    s.replace("\\", "\\\\").replace("\"\"\"", "\\\"\\\"\\\"")

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -3,6 +3,7 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.convention.OperationKind
+import specrest.ir.BinOp
 import specrest.ir.EntityDecl
 import specrest.ir.Expr
 import specrest.ir.FieldDecl
@@ -38,6 +39,8 @@ object Stateful:
   private enum RuleRole:
     case CreateTarget(bundle: BundleSpec, pkProjection: String)
     case Plain
+
+  private val TQ = "\"\"\""
 
   def emitFor(profiled: ProfiledService): StatefulOutput =
     val ir       = profiled.ir
@@ -93,55 +96,70 @@ object Stateful:
       ir: ServiceIR,
       bundles: List[BundleSpec]
   ): (Either[Unit, List[String]], List[TestSkip]) =
-    val role            = inferCreateRole(pop, opDecl, bundles)
-    val pathParamNames  = pop.endpoint.pathParams.map(_.name).toSet
-    val bodyParamNames  = pop.endpoint.bodyParams.map(_.name).toSet
-    val queryParamNames = pop.endpoint.queryParams.map(_.name).toSet
-    val allParams       = pathParamNames ++ bodyParamNames ++ queryParamNames
+    val (role, roleSkips) = inferCreateRole(pop, opDecl, bundles)
+    val pathParamNames    = pop.endpoint.pathParams.map(_.name).toSet
+    val bodyParamNames    = pop.endpoint.bodyParams.map(_.name).toSet
+    val queryParamNames   = pop.endpoint.queryParams.map(_.name).toSet
+    val allParams         = pathParamNames ++ bodyParamNames ++ queryParamNames
 
     val bindings = opDecl.inputs.collect:
       case p if allParams.contains(p.name) =>
-        p.name -> bindForInput(p.typeExpr, pop, ir, bundles)
+        p.name -> bindForInput(p.name, p.typeExpr, pop, ir, bundles)
     val skipped = bindings.collect:
       case (n, InputBinding.Skip(r)) =>
         TestSkip(opDecl.name, "stateful_rule", s"input '$n': $r")
-    if skipped.nonEmpty then (Right(Nil), skipped)
+    if skipped.nonEmpty then (Right(Nil), skipped ++ roleSkips)
     else
+      val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
       val ruleBody = buildRuleBlock(
         pop = pop,
         opDecl = opDecl,
         bindings = bindings,
-        role = role
+        role = role,
+        stateFields = stateFields
       )
-      (Right(List(ruleBody)), Nil)
+      (Right(List(ruleBody)), roleSkips)
 
   private def inferCreateRole(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
       bundles: List[BundleSpec]
-  ): RuleRole =
+  ): (RuleRole, List[TestSkip]) =
     if pop.kind != OperationKind.Create && pop.kind != OperationKind.CreateChild then
-      RuleRole.Plain
+      (RuleRole.Plain, Nil)
     else
       pop.targetEntity.flatMap(en => bundles.find(_.entityName == en)) match
-        case None => RuleRole.Plain
+        case None => (RuleRole.Plain, Nil)
         case Some(bundle) =>
-          val proj = projectionForCreateOutput(opDecl, bundle)
-          RuleRole.CreateTarget(bundle, proj)
+          projectionForCreateOutput(opDecl, bundle) match
+            case Some(proj) => (RuleRole.CreateTarget(bundle, proj), Nil)
+            case None =>
+              val skip = TestSkip(
+                opDecl.name,
+                "stateful_create_target",
+                s"Create operation has no output of entity type '${bundle.entityName}' " +
+                  s"or PK type '${typeName(bundle.pkTypeExpr).getOrElse("?")}'; " +
+                  "emitting parameter-less rule without target= bundle"
+              )
+              (RuleRole.Plain, List(skip))
 
   private def projectionForCreateOutput(
       opDecl: OperationDecl,
       bundle: BundleSpec
-  ): String =
+  ): Option[String] =
     val outputs = opDecl.outputs
     outputs match
       case List(out) if isEntityType(out.typeExpr, bundle.entityName) =>
-        s"response_data[${ExprToPython.pyString(bundle.pkFieldName)}]"
+        Some(s"response_data[${ExprToPython.pyString(bundle.pkFieldName)}]")
       case _ =>
         outputs
           .find(o => sameNamedType(o.typeExpr, bundle.pkTypeExpr))
           .map(o => s"response_data[${ExprToPython.pyString(o.name)}]")
-          .getOrElse(s"response_data[${ExprToPython.pyString(bundle.pkFieldName)}]")
+          .orElse(
+            outputs
+              .find(_.name == bundle.pkFieldName)
+              .map(o => s"response_data[${ExprToPython.pyString(o.name)}]")
+          )
 
   private def isEntityType(t: TypeExpr, name: String): Boolean = t match
     case TypeExpr.NamedType(n, _) => n == name
@@ -151,13 +169,30 @@ object Stateful:
     case (TypeExpr.NamedType(x, _), TypeExpr.NamedType(y, _)) => x == y
     case _                                                    => false
 
+  private def typeName(t: TypeExpr): Option[String] = t match
+    case TypeExpr.NamedType(n, _) => Some(n)
+    case _                        => None
+
   private def bindForInput(
+      paramName: String,
       paramType: TypeExpr,
       pop: ProfiledOperation,
       ir: ServiceIR,
       bundles: List[BundleSpec]
   ): InputBinding =
-    val matchingBundle = bundles.find(b => sameNamedType(paramType, b.pkTypeExpr))
+    val targetEntityBundle = pop.targetEntity.flatMap: en =>
+      bundles.find(b => b.entityName == en && sameNamedType(paramType, b.pkTypeExpr))
+    val pkFieldNameMatch = bundles.find: b =>
+      sameNamedType(paramType, b.pkTypeExpr) &&
+        (paramName == b.pkFieldName || paramName == s"${Naming.toSnakeCase(b.entityName)}_id")
+    val typeMatches = bundles.filter(b => sameNamedType(paramType, b.pkTypeExpr))
+    val uniqueTypeMatch = typeMatches match
+      case head :: Nil => Some(head)
+      case _           => None
+
+    val matchingBundle =
+      targetEntityBundle.orElse(pkFieldNameMatch).orElse(uniqueTypeMatch)
+
     matchingBundle match
       case Some(bundle) =>
         if pop.kind == OperationKind.Delete then InputBinding.BundleConsume(bundle)
@@ -171,7 +206,8 @@ object Stateful:
       pop: ProfiledOperation,
       opDecl: OperationDecl,
       bindings: List[(String, InputBinding)],
-      role: RuleRole
+      role: RuleRole,
+      stateFields: Set[String]
   ): String =
     val sb        = new StringBuilder
     val ruleArgs  = ruleDecoratorArgs(bindings, role)
@@ -180,14 +216,14 @@ object Stateful:
 
     sb.append(s"    @rule($ruleArgs)\n")
     sb.append(s"    def $funcName($sigParams):\n")
-    sb.append(s"        \"\"\"${escapeDocstring(operationSummary(opDecl))}\"\"\"\n")
+    sb.append(s"        $TQ${escapeDocstring(operationSummary(opDecl))}$TQ\n")
     sb.append(s"        response = ${requestCallExpr(pop)}\n")
-    sb.append("        response_data = response.json() if response.content else {}\n")
 
     val bundleInputNames = bindings.collect:
       case (n, InputBinding.BundleDraw(_) | InputBinding.BundleConsume(_)) => n
     val allRequiresSatisfiableByBundles =
-      opDecl.requires.forall(r => requiresIsSatisfiedByBundles(r, bundleInputNames.toSet))
+      opDecl.requires.forall: r =>
+        requiresIsSatisfiedByBundles(r, bundleInputNames.toSet, stateFields)
     val expectsStrictSuccess =
       role match
         case RuleRole.CreateTarget(_, _) => true
@@ -198,6 +234,7 @@ object Stateful:
       sb.append(s"        assert response.status_code == $successCode, response.text\n")
       role match
         case RuleRole.CreateTarget(_, proj) =>
+          sb.append("        response_data = response.json() if response.content else {}\n")
           sb.append(s"        return $proj\n")
         case RuleRole.Plain =>
           ()
@@ -247,14 +284,14 @@ object Stateful:
     val methodName = Naming.toSnakeCase(name)
     ExprToPython.translate(inv.expr, ctx) match
       case ExprPy.Skip(reason, _) =>
-        val skip = TestSkip("<service>", s"stateful_invariant[$name]", reason)
+        val skip = TestSkip("<invariants>", s"stateful_invariant[$name]", reason)
         (None, Some(skip))
       case ExprPy.Py(text) =>
         val sb = new StringBuilder
         sb.append("    @invariant()\n")
         sb.append(s"    def invariant_$methodName(self):\n")
         sb.append(
-          s"        \"\"\"invariant $name: ${escapeDocstring(prettyOneLine(inv.expr))}\"\"\"\n"
+          s"        ${TQ}invariant $name: ${escapeDocstring(prettyOneLine(inv.expr))}$TQ\n"
         )
         sb.append("        post_state = client.get(\"/__test_admin__/state\").json()\n")
         sb.append(
@@ -314,7 +351,7 @@ object Stateful:
       if invariantBlocks.isEmpty then ""
       else "\n" + invariantBlocks.mkString("\n")
 
-    s"""|\"\"\"Auto-generated stateful tests for ${ir.name}.
+    s"""|${TQ}Auto-generated stateful tests for ${ir.name}.
         |
         |Builds a Hypothesis RuleBasedStateMachine: each spec operation becomes a
         |@rule that performs the real HTTP call; entity ids returned from Create
@@ -322,7 +359,7 @@ object Stateful:
         |invariants are checked after every step against /__test_admin__/state.
         |
         |See tests/_testgen_skips.json for clauses skipped during translation.
-        |\"\"\"
+        |${TQ}
         |from hypothesis import HealthCheck, settings
         |from hypothesis import strategies as st
         |from hypothesis.stateful import (
@@ -343,7 +380,7 @@ object Stateful:
         |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
         |)
         |$testName = $machineName.TestCase
-        |""".stripMargin.replace("\\\"", "\"")
+        |""".stripMargin
 
   private def requestCallExpr(pop: ProfiledOperation): String =
     val ep              = pop.endpoint
@@ -385,15 +422,19 @@ object Stateful:
     case Expr.BoolLit(true, _) => true
     case _                     => false
 
-  private def requiresIsSatisfiedByBundles(e: Expr, bundleInputs: Set[String]): Boolean =
+  private def requiresIsSatisfiedByBundles(
+      e: Expr,
+      bundleInputs: Set[String],
+      stateFields: Set[String]
+  ): Boolean =
     e match
       case Expr.BoolLit(true, _) => true
-      case Expr.BinaryOp(specrest.ir.BinOp.In, Expr.Identifier(in, _), Expr.Identifier(_, _), _)
-          if bundleInputs.contains(in) =>
+      case Expr.BinaryOp(BinOp.In, Expr.Identifier(in, _), Expr.Identifier(state, _), _)
+          if bundleInputs.contains(in) && stateFields.contains(state) =>
         true
-      case Expr.BinaryOp(specrest.ir.BinOp.And, l, r, _) =>
-        requiresIsSatisfiedByBundles(l, bundleInputs) &&
-        requiresIsSatisfiedByBundles(r, bundleInputs)
+      case Expr.BinaryOp(BinOp.And, l, r, _) =>
+        requiresIsSatisfiedByBundles(l, bundleInputs, stateFields) &&
+        requiresIsSatisfiedByBundles(r, bundleInputs, stateFields)
       case _ => false
 
   private def prettyOneLine(e: Expr): String =

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -11,11 +11,12 @@ object TestEmit:
     val serviceSnake   = Naming.toSnakeCase(ir.name)
     val strategySpecs  = Strategies.forIR(ir)
     val behavioralOut  = Behavioral.emitFor(profiled)
+    val statefulOut    = Stateful.emitFor(profiled)
     val adminRouterSrc = AdminRouter.emit(profiled)
     val strategiesPy   = renderStrategiesFile(strategySpecs)
     val behavioralPy   = renderBehavioralFile(behavioralOut.tests, ir.name, strategySpecs)
     val skipsJson =
-      renderSkipsJson(ir.name, strategySpecs, behavioralOut.skips)
+      renderSkipsJson(ir.name, strategySpecs, behavioralOut.skips ++ statefulOut.skips)
 
     List(
       EmittedFile(FilePaths.AdminRouterFile, adminRouterSrc),
@@ -25,6 +26,7 @@ object TestEmit:
       EmittedFile(FilePaths.PytestIniFile, Templates.pytestIni),
       EmittedFile(FilePaths.StrategiesFile, strategiesPy),
       EmittedFile(FilePaths.behavioralTestFile(serviceSnake), behavioralPy),
+      EmittedFile(FilePaths.statefulTestFile(serviceSnake), statefulOut.file),
       EmittedFile(FilePaths.SkipsFile, skipsJson)
     )
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -16,6 +16,9 @@ object FilePaths:
   def behavioralTestFile(serviceSnake: String): String =
     s"tests/test_behavioral_$serviceSnake.py"
 
+  def statefulTestFile(serviceSnake: String): String =
+    s"tests/test_stateful_$serviceSnake.py"
+
 object SupportedTargets:
   val PythonFastapiPostgres = "python-fastapi-postgres"
   val All: Set[String]      = Set(PythonFastapiPostgres)

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -1,0 +1,128 @@
+package specrest.testgen
+
+import munit.CatsEffectSuite
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.profile.Annotate
+
+class StatefulTest extends CatsEffectSuite:
+
+  private def loadProfiled(path: String) =
+    val src = scala.io.Source.fromFile(path).getLines.mkString("\n")
+    Parse.parseSpec(src).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("url_shortener: bundle declared and per-entity"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("url_mapping_ids = Bundle(\"url_mapping_ids\")"), out.file)
+
+  test("url_shortener: Shorten emits target=, returns id projection"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("@rule(target=url_mapping_ids"), out.file)
+      assert(out.file.contains("def shorten(self, url):"))
+      assert(out.file.contains("return response_data[\"code\"]"))
+
+  test("url_shortener: Resolve uses non-consuming bundle draw"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("@rule(code=url_mapping_ids)"))
+      assert(out.file.contains("def resolve(self, code):"))
+
+  test("url_shortener: Delete uses consumes()"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("@rule(code=consumes(url_mapping_ids))"))
+      assert(out.file.contains("def delete(self, code):"))
+
+  test("url_shortener: ListAll has no params (parameter-less rule)"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("@rule()"))
+      assert(out.file.contains("def list_all(self):"))
+
+  test("url_shortener: invariants emitted with @invariant() decorator"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("@invariant()"))
+      assert(out.file.contains("def invariant_all_ur_ls_valid(self):"))
+      assert(out.file.contains("def invariant_metadata_consistent(self):"))
+      assert(out.file.contains("post_state = client.get(\"/__test_admin__/state\").json()"))
+
+  test("file emits TestCase alias and settings"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("UrlShortenerStateMachine.TestCase.settings = settings("))
+      assert(out.file.contains("max_examples=25"))
+      assert(out.file.contains("stateful_step_count=20"))
+      assert(out.file.contains("deadline=None"))
+      assert(out.file.contains("TestStatefulUrlShortener = UrlShortenerStateMachine.TestCase"))
+
+  test("imports include Bundle, rule, initialize, invariant, consumes when used"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("    RuleBasedStateMachine,"))
+      assert(out.file.contains("    Bundle,"))
+      assert(out.file.contains("    rule,"))
+      assert(out.file.contains("    initialize,"))
+      assert(out.file.contains("    invariant,"))
+      assert(out.file.contains("    consumes,"))
+
+  test("safe_counter: no entities → no bundles, parameter-less rules"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(
+        !out.file.contains("Bundle("),
+        s"safe_counter has no entities, expected no Bundle:\n${out.file}"
+      )
+      assert(out.file.contains("def increment(self):"))
+      assert(out.file.contains("def decrement(self):"))
+      assert(!out.file.contains("consumes("), "no bundles → no consumes import or use")
+
+  test("todo_list: CreateTodo emits target=todo_ids, all sub-strategies"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("todo_ids = Bundle(\"todo_ids\")"))
+      assert(out.file.contains("@rule(target=todo_ids"))
+      assert(out.file.contains("def create_todo(self,"))
+      assert(out.file.contains("strategy_priority()"))
+      assert(out.file.contains("return response_data[\"id\"]"))
+
+  test("todo_list: state-dep transition rules use loose 4xx-tolerant assertion"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("def start_work(self, id):"))
+      assert(
+        out.file.contains("400 <= response.status_code < 500"),
+        s"transition rules should accept 4xx for unsatisfied non-key requires:\n${out.file}"
+      )
+
+  test("rule whose only requires is `<input> in <state>` uses strict assertion"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      val resolveBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def resolve(self, code):"))
+        .takeWhile(!_.startsWith("    @"))
+        .mkString("\n")
+      assert(
+        resolveBlock.contains("assert response.status_code == 302"),
+        s"Resolve has only `code in store` require → bundle-satisfied → strict;\nblock=$resolveBlock"
+      )
+
+  test("@initialize() reset is emitted exactly once"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out        = Stateful.emitFor(profiled)
+      val needle     = "client.post(\"/__test_admin__/reset\")"
+      val resetCount = out.file.sliding(needle.length).count(_ == needle)
+      assertEquals(resetCount, 1, "single @initialize reset call expected")
+
+  test("output contains TestCase pytest-discovery alias"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("TestStatefulSafeCounter = SafeCounterStateMachine.TestCase"))

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -8,7 +8,8 @@ import specrest.profile.Annotate
 class StatefulTest extends CatsEffectSuite:
 
   private def loadProfiled(path: String) =
-    val src = scala.io.Source.fromFile(path).getLines.mkString("\n")
+    val src = scala.util.Using.resource(scala.io.Source.fromFile(path)): source =>
+      source.getLines.mkString("\n")
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
@@ -40,11 +41,24 @@ class StatefulTest extends CatsEffectSuite:
       assert(out.file.contains("@rule(code=consumes(url_mapping_ids))"))
       assert(out.file.contains("def delete(self, code):"))
 
-  test("url_shortener: ListAll has no params (parameter-less rule)"):
+  test("url_shortener: ListAll has @rule() decorator immediately preceding def"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
-      val out = Stateful.emitFor(profiled)
-      assert(out.file.contains("@rule()"))
-      assert(out.file.contains("def list_all(self):"))
+      val out          = Stateful.emitFor(profiled)
+      val listAllDef   = "def list_all(self):"
+      val listAllIndex = out.file.indexOf(listAllDef)
+      assert(listAllIndex >= 0, s"missing list_all def:\n${out.file}")
+      val precedingLine = out.file
+        .substring(0, listAllIndex)
+        .linesIterator
+        .toList
+        .reverse
+        .find(_.trim.nonEmpty)
+        .map(_.trim)
+      assertEquals(
+        precedingLine,
+        Some("@rule()"),
+        s"expected bare @rule() before list_all:\n${out.file}"
+      )
 
   test("url_shortener: invariants emitted with @invariant() decorator"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
@@ -126,3 +140,68 @@ class StatefulTest extends CatsEffectSuite:
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val out = Stateful.emitFor(profiled)
       assert(out.file.contains("TestStatefulSafeCounter = SafeCounterStateMachine.TestCase"))
+
+  test("non-Create rules do NOT call response.json() before status assertion"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      val resolveBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def resolve(self, code):"))
+        .takeWhile(!_.startsWith("    @"))
+        .mkString("\n")
+      assert(
+        !resolveBlock.contains("response_data = response.json()"),
+        s"Resolve (302 redirect) must not call response.json(); block:\n$resolveBlock"
+      )
+      val deleteBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def delete(self, code):"))
+        .takeWhile(!_.startsWith("    @"))
+        .mkString("\n")
+      assert(
+        !deleteBlock.contains("response_data = response.json()"),
+        s"Delete (204 no body) must not call response.json(); block:\n$deleteBlock"
+      )
+
+  test("Create rule parses response.json() AFTER strict status assertion"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      val shortenBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def shorten(self, url):"))
+        .takeWhile(!_.startsWith("    @"))
+        .toList
+      val assertIdx = shortenBlock.indexWhere(_.contains("assert response.status_code == 201"))
+      val jsonIdx   = shortenBlock.indexWhere(_.contains("response_data = response.json()"))
+      assert(
+        assertIdx >= 0,
+        s"missing strict status assert in shorten:\n${shortenBlock.mkString("\n")}"
+      )
+      assert(jsonIdx >= 0, s"missing response.json() in shorten:\n${shortenBlock.mkString("\n")}")
+      assert(
+        jsonIdx > assertIdx,
+        s"json() must come AFTER status assert; got assert@$assertIdx, json@$jsonIdx"
+      )
+
+  test("invariant skips use <invariants> sentinel, not <service>"):
+    val ir = specrest.ir.ServiceIR(
+      name = "X",
+      invariants = List(
+        specrest.ir.InvariantDecl(
+          name = Some("badInv"),
+          expr = specrest.ir.Expr.SetComprehension(
+            "x",
+            specrest.ir.Expr.Identifier("nonsense"),
+            specrest.ir.Expr.BoolLit(true)
+          )
+        )
+      )
+    )
+    val profile  = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+    val out      = Stateful.emitFor(profile)
+    val invSkips = out.skips.filter(_.kind.startsWith("stateful_invariant"))
+    assert(invSkips.nonEmpty, s"expected at least one invariant skip; got ${out.skips}")
+    assert(
+      invSkips.forall(_.operation == "<invariants>"),
+      s"all invariant skips should use <invariants> sentinel; got ${invSkips}"
+    )

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -16,7 +16,7 @@ class TestEmitTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("emit produces 8 files at the M5.4-locked paths"):
+  test("emit produces 9 files at the M5.4-locked paths"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val paths = files.map(_.path).toSet
@@ -29,6 +29,7 @@ class TestEmitTest extends CatsEffectSuite:
           "tests/predicates.py",
           "tests/strategies.py",
           "tests/test_behavioral_url_shortener.py",
+          "tests/test_stateful_url_shortener.py",
           "tests/_testgen_skips.json",
           "pytest.ini"
         )


### PR DESCRIPTION
## Summary

- Emits one Hypothesis `RuleBasedStateMachine` per service alongside M5.1's behavioral tests. Spec operations become `@rule`s; entity ids flow through `Bundle`s so multi-step sequences (Create → Read → Delete) exercise real data flow against the live SUT.
- Global invariants run as `@invariant()` after every step against `/__test_admin__/state` (reusing the M5.1 admin router and `ExprToPython` translator).
- Purely additive on top of M5.1 — no new admin endpoints, conftest changes, or strategies.

## Bundle inference

| Operation kind | State-machine role |
|---|---|
| `Create` / `CreateChild` returning entity | `@rule(target=<entity>_ids, …)`; pushes id from response |
| `Delete` with id-typed input | parameter via `consumes(<entity>_ids)` |
| Read / Update / Replace / Transition / SideEffect with id-typed input | non-consuming bundle draw |
| otherwise | parameter-less rule |

The `<entity>_ids` bundle name follows the entity's snake-cased name; the id projection from the response uses the entity's primary-key field (`id` if present, otherwise the first declared field — for `url_shortener`, `code`).

## Strict vs loose status assertions

Rules whose every `requires` is either trivially-true or `<input> in <state>` (satisfied by bundle membership) emit `assert response.status_code == <success>`. Rules with other state-dependent preconditions (e.g., transition guards `status = TODO`) accept either success or any 4xx — the SUT correctly rejecting an unsatisfied precondition is not a bug.

## Acceptance criteria

- [x] `pytest tests/test_stateful.py` discovers multi-step violations — `pytest --collect-only` collects the `TestStateful<Service>` class for url_shortener, todo_list, and safe_counter (15 / 27 / 14 tests respectively across both behavioral + stateful files).
- [x] Bundles correctly track created resources — verified by unit tests: `Shorten` emits `target=url_mapping_ids`, `Resolve` uses non-consuming `code=url_mapping_ids` draw, `Delete` uses `consumes(url_mapping_ids)`.
- [x] State machine explores diverse operation sequences — built-in to Hypothesis's `RuleBasedStateMachine`; settings tuned for HTTP latency (`deadline=None`, `max_examples=25`, `stateful_step_count=20`).

## Files changed

- `modules/testgen/.../Stateful.scala` (new, ~270 LoC) — bundle inference + rule/invariant emission
- `modules/testgen/.../Types.scala` — `FilePaths.statefulTestFile`
- `modules/testgen/.../TestEmit.scala` — append emitted file; merge stateful skips into `_testgen_skips.json`
- `modules/testgen/.../StatefulTest.scala` (new) — 14 unit tests
- `modules/testgen/.../TestEmitTest.scala` — expect 9 emitted files (was 8)
- `docs/content/docs/pipelines/test-generation.mdx` — new "Stateful tests (M5.2)" section with bundle table and code example

## Out of scope (deferred)

- Per-status sub-bundles for transitions (`pending_ids`, `shipped_ids`) — tracked under [#137 (M5.9)](https://github.com/HardMax71/spec_to_rest/issues/137).
- Python-side ghost-model state — deliberately omitted; the SUT (via `/__test_admin__/state`) is the model. Trade: simpler emitter, less verbose shrink output.
- Per-rule ensures-asserts — handled by the M5.1 behavioral file, not duplicated here.

## Test plan

- [x] `sbt test` — full suite green (134 / 134)
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `cd docs && npm run build` clean
- [x] CLI smoke: `sbt "cli/run compile --with-tests --out /tmp/m52 fixtures/spec/url_shortener.spec"` → 37 files, includes `tests/test_stateful_url_shortener.py`
- [x] `pytest --collect-only` on generated suite collects all stateful test cases without import errors
- [ ] (CI) verify against the canonical fixtures
- [ ] (post-#86) end-to-end: stateful suite actually exercises a runnable SUT and surfaces a multi-step bug

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stateful test generation using Hypothesis `RuleBasedStateMachine` to explore multi-step API sequences and validate global invariants against the live SUT. Purely additive to M5.1 (no new admin endpoints, strategies, or conftest changes).

- New Features
  - Emit `tests/test_stateful_<service>.py` with one `RuleBasedStateMachine`; each spec operation becomes an `@rule` that performs real HTTP calls.
  - Flow entity ids with `Bundle`s: creates `target=<entity>_ids`, deletes `consumes(<entity>_ids)`, other id-typed rules draw from `<entity>_ids`; non-id ops are parameter-less.
  - Run `@invariant()` after every step via `/__test_admin__/state`; strict status asserts when bundle-satisfied, otherwise accept success or any 4xx.
  - Settings tuned for HTTP on `<Service>StateMachine.TestCase`: `max_examples=25`, `stateful_step_count=20`, `deadline=None`.
  - Integrated into emitter: new stateful file path, merge stateful skips into `tests/_testgen_skips.json`; docs updated with examples; tests updated; expected outputs now 9 files.

- Bug Fixes
  - Parse `response.json()` only in strict Create-target success path to avoid JSON errors on 302/204.
  - Tighten bundle-satisfied detection: ensure `<input> in <state>` checks against actual state fields.
  - Guard Create-target inference on a real id projection; otherwise fall back to plain rule and record a `stateful_create_target` skip.
  - Disambiguate bundle binding: prefer target-entity match, then name match (`<pk>` or `<entity>_id`), then type-only when unique.
  - Fix docstring rendering by removing over-broad backslash replacement; preserve escaping.
  - Use `<invariants>` sentinel for invariant skip records; close file handles in tests; ensure `@rule()` is immediately before the def; docs show the emitted `.TestCase.settings` pattern.

<sup>Written for commit 1aa2e8ff7d50c5751f1cc9202b5932b80f6b887a. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic stateful test generation using Hypothesis RuleBasedStateMachine, creating property-based tests that perform real HTTP operations and verify system behavior across state changes.
  * Entity identifier tracking via Hypothesis Bundles for maintaining state consistency across test operations.
  * Global invariant validation after each operation to ensure system integrity.

* **Documentation**
  * Comprehensive guide on the stateful testing layer, covering rule generation, entity management, assertion strategies, and configuration options.

* **Tests**
  * New test suite validating stateful test generation with bundle declarations, rule parameterization, and invariant emission verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->