### PR TITLE
M5.3 — Schemathesis structural test layer (closes #26)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -225,10 +225,27 @@ content-type drift, and 5xx unhandled exceptions. The structural file is orthogo
 to M5.2: the M5.2 stateful tests verify the **spec contract**, the M5.3 structural
 tests verify the **schema contract**.
 
+The generated file is self-contained — it reads `SPEC_TEST_BASE_URL` and `SPEC_TEST_PROFILE`
+from the environment, declares the three profiles inline (see [Profiles](#profiles)
+below), and validates `SPEC_TEST_PROFILE` against the allowed set with an explicit
+`ValueError` (no opaque `KeyError`):
+
 ```python
+import os
 import schemathesis
 from hypothesis import HealthCheck, settings
 from tests.conftest import client
+
+BASE_URL = os.environ.get("SPEC_TEST_BASE_URL", "http://localhost:8000")
+PROFILE = os.environ.get("SPEC_TEST_PROFILE", "thorough")
+PROFILES = {
+    "smoke":      {"max_examples": 10,   "stateful_step_count": 3},
+    "thorough":   {"max_examples": 100,  "stateful_step_count": 10},
+    "exhaustive": {"max_examples": 1000, "stateful_step_count": 25},
+}
+if PROFILE not in PROFILES:
+    raise ValueError(f"Invalid SPEC_TEST_PROFILE={PROFILE!r}. Expected one of: {', '.join(sorted(PROFILES))}")
+_PROFILE = PROFILES[PROFILE]
 
 schema = schemathesis.openapi.from_path("openapi.yaml")
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -47,6 +47,7 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl` |
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
 | `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
+| `tests/test_structural_<service>.py` | `Structural.scala` | Schemathesis-driven structural tests: schema fuzzing + spec-derived custom checks + OpenAPI-Links state machine |
 | `tests/_testgen_skips.json` | testgen | machine-readable list of clauses that were not turned into tests, with reasons |
 | `pytest.ini` | static template | disables `pytest-xdist` parallelism (admin-router state is global) |
 
@@ -213,6 +214,105 @@ deadline trips on slow CI machines.
 - Per-rule ensures-asserts are handled by the behavioral tests, not duplicated here.
   Stateful surfaces multi-step bugs via the `@invariant()` checks that run after every step.
 
+## Structural tests (M5.3)
+
+Alongside the per-clause behavioral tests and the hand-rolled stateful state machine,
+testgen emits a `tests/test_structural_<service>.py` that wires
+[Schemathesis](https://schemathesis.readthedocs.io/) to the project's `openapi.yaml`.
+Schemathesis fuzzes every `(method, path)` declared in the schema and validates
+responses against the OpenAPI shape — catching wrong status codes, missing endpoints,
+content-type drift, and 5xx unhandled exceptions. The structural file is orthogonal
+to M5.2: the M5.2 stateful tests verify the **spec contract**, the M5.3 structural
+tests verify the **schema contract**.
+
+```python
+import schemathesis
+from hypothesis import HealthCheck, settings
+from tests.conftest import client
+
+schema = schemathesis.openapi.from_path("openapi.yaml")
+
+def _check_invariant_metadata_consistent(response, case):
+    """invariant metadataConsistent: dom(store) = dom(metadata)"""
+    if response.status_code >= 500:
+        return
+    post_state = client.get("/__test_admin__/state").json()
+    assert set(post_state["store"].keys()) == set(post_state["metadata"].keys()), \
+        "invariant violated: metadataConsistent"
+
+_ALL_CHECKS = (_check_invariant_all_ur_ls_valid,
+               _check_invariant_metadata_consistent,
+               _check_invariant_click_count_non_negative)
+
+@schema.parametrize()
+@settings(max_examples=_PROFILE["max_examples"], deadline=None,
+          suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture])
+def test_api_structural(case):
+    client.post("/__test_admin__/reset")
+    response = case.call(base_url=BASE_URL)
+    case.validate_response(response, checks=_ALL_CHECKS)
+
+UrlShortenerLinksStateMachine = schema.as_state_machine()
+TestStructuralLinksUrlShortener = UrlShortenerLinksStateMachine.TestCase
+```
+
+### Profiles
+
+A single env-var, `SPEC_TEST_PROFILE`, picks the depth tier:
+
+| Profile | `max_examples` | `stateful_step_count` | Use case |
+|---|---|---|---|
+| `smoke` | 10 | 3 | pre-commit hook, fast feedback |
+| `thorough` (default) | 100 | 10 | CI on PRs |
+| `exhaustive` | 1000 | 25 | nightly / release gate |
+
+```bash
+SPEC_TEST_PROFILE=smoke pytest tests/test_structural_*.py -v
+```
+
+### Spec-derived custom checks
+
+For each global `invariant` that `ExprToPython` can translate, testgen emits one
+`def _check_invariant_<name>(response, case)` function. The check fetches
+`/__test_admin__/state` and asserts the translated predicate. Checks gate on
+`response.status_code < 500` so 5xx unhandled exceptions surface via Schemathesis's
+own `not_a_server_error` check rather than a stale state read.
+
+For `Create` operations whose `ensures` clauses reference only inputs and outputs
+(no `pre()`, no `state`, no `'`), testgen emits per-operation checks gated by
+`(case.path, case.method, response.status_code)` — these run only when Schemathesis
+hits the matching endpoint with a successful status code. Clauses that don't fit
+this shape are recorded under the new `structural_skipped` array of
+`tests/_testgen_skips.json`.
+
+### Reset between cases
+
+Before every parametrized case, `client.post("/__test_admin__/reset")` runs so global
+invariant checks stay meaningful across hundreds of fuzzed cases. The cost is one
+extra round-trip per case (~1 ms locally). The Links state machine, in contrast,
+fires Hypothesis's per-scenario `__init__` on its own — no manual reset hook needed.
+
+### Two state machines, by design
+
+The Schemathesis-built `as_state_machine()` infers links from response shapes and
+parameter-name matches against the OpenAPI document. The M5.2 hand-rolled
+`<Service>StateMachine` infers them from the spec's classified operations
+(`Create` → `Bundle.target`, `Delete` → `consumes`, etc.). Both run; Schemathesis
+fuzzes shapes the spec layer doesn't (e.g., body fields just outside the
+`where` constraint).
+
+### What structural does not do (in M5.3)
+
+- It does **not** emit explicit OpenAPI `links:` blocks; Schemathesis discovers
+  links via `Location` headers and parameter-name heuristics. Explicit Links
+  emission is tracked separately.
+- Entity-field `where` invariants (e.g., `len(value) >= 6`) are **not** translated to
+  custom checks — Schemathesis already validates them as part of OpenAPI schema
+  conformance at request and response time.
+- The structural skip rate on rich specs is high (~70-80% of `ensures` clauses
+  reference state or `pre()`/primes) — that is by design; behavioral and stateful
+  layers cover those.
+
 ## Coverage on canonical fixtures
 
 These numbers are locked in `SkipRateProbeTest.scala`; CI fails if they regress.
@@ -266,7 +366,6 @@ compile gives a coverage delta as M5.5 expands `ExprToPython`.
 | Mutation-testing CI gate | [M5.7 (#135)](https://github.com/HardMax71/spec_to_rest/issues/135) |
 | Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
 | Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
-| Schemathesis structural layer | [M5.3 (#26)](https://github.com/HardMax71/spec_to_rest/issues/26) |
 | Conformance runner / Makefile / nightly CI | [M5.4 (#23)](https://github.com/HardMax71/spec_to_rest/issues/23) |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |
 | Default `--with-tests` after M5.4 | [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140) |

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -267,7 +267,10 @@ _ALL_CHECKS = (_check_invariant_all_ur_ls_valid,
 def test_api_structural(case):
     client.post("/__test_admin__/reset")
     response = case.call(base_url=BASE_URL)
-    case.validate_response(response, checks=_ALL_CHECKS)
+    if _ALL_CHECKS:
+        case.validate_response(response, checks=_ALL_CHECKS)
+    else:
+        case.validate_response(response)
 
 UrlShortenerLinksStateMachine = schema.as_state_machine()
 TestStructuralLinksUrlShortener = UrlShortenerLinksStateMachine.TestCase

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/github/workflows/ci.yml.hbs
@@ -48,11 +48,16 @@ jobs:
       - name: Run tests
         run: uv run pytest -v
       - name: Start app for conformance tests
+        env:
+          ENABLE_TEST_ADMIN: "1"
         run: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
       - name: Wait for /health
         run: timeout 30 bash -c 'until curl -fsS http://localhost:8000/health; do sleep 1; done'
-      - name: Schemathesis conformance
-        run: uv run schemathesis run openapi.yaml --base-url http://localhost:8000 --stateful=links
+      - name: Structural / behavioral / stateful pytest
+        env:
+          SPEC_TEST_PROFILE: thorough
+          SPEC_TEST_BASE_URL: http://localhost:8000
+        run: uv run pytest -v tests/test_structural_*.py tests/test_behavioral_*.py tests/test_stateful_*.py
 
   docker:
     runs-on: ubuntu-latest

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/pyproject.toml.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/pyproject.toml.hbs
@@ -18,7 +18,7 @@ dev = [
 {{#each profile.devDependencies}}
     "{{this.name}}{{this.version}}",
 {{/each}}
-    "schemathesis>=3.33",
+    "schemathesis>=4.16,<5",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -108,7 +108,9 @@ object Structural:
       val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
       val outputNames = opDecl.outputs.map(_.name).toSet
       opDecl.ensures.zipWithIndex.flatMap: (clause, idx) =>
-        if !referencesOnlyInputsAndOutputs(clause, outputNames, stateFields) then Nil
+        if !referencesOnlyInputsAndOutputs(clause, outputNames, stateFields) then
+          val reason = nonPureOutputReason(clause, outputNames, stateFields)
+          List(Left(TestSkip(opDecl.name, s"structural_ensures[$idx]", reason)))
         else
           val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
           ExprToPython.translate(clause, ctx) match
@@ -142,6 +144,19 @@ object Structural:
     !mentionsState(e, stateFields) && !mentionsPreOrPrime(e) &&
       mentionsAtLeastOneOutput(e, outputs)
 
+  private def nonPureOutputReason(
+      e: Expr,
+      outputs: Set[String],
+      stateFields: Set[String]
+  ): String =
+    if mentionsPreOrPrime(e) then
+      "ensures references pre()/prime() — covered by behavioral/stateful layers"
+    else if mentionsState(e, stateFields) then
+      "ensures references state field — covered by stateful invariants"
+    else if !mentionsAtLeastOneOutput(e, outputs) then
+      "ensures references no output field; not a structural-checkable shape"
+    else "ensures not eligible for structural check"
+
   private def mentionsState(e: Expr, stateFields: Set[String]): Boolean = e match
     case Expr.Identifier(n, _)     => stateFields.contains(n)
     case Expr.BinaryOp(_, l, r, _) => mentionsState(l, stateFields) || mentionsState(r, stateFields)
@@ -154,10 +169,13 @@ object Structural:
         el,
         stateFields
       )
-    case Expr.Let(_, v, b, _)   => mentionsState(v, stateFields) || mentionsState(b, stateFields)
+    case Expr.Let(v, value, b, _) =>
+      mentionsState(value, stateFields) || mentionsState(b, stateFields - v)
     case Expr.SetLiteral(xs, _) => xs.exists(mentionsState(_, stateFields))
     case Expr.Quantifier(_, bs, b, _) =>
-      bs.exists(qb => mentionsState(qb.domain, stateFields)) || mentionsState(b, stateFields)
+      val boundNames = bs.map(_.variable).toSet
+      bs.exists(qb => mentionsState(qb.domain, stateFields)) ||
+      mentionsState(b, stateFields -- boundNames)
     case Expr.Prime(x, _) => mentionsState(x, stateFields)
     case Expr.Pre(x, _)   => mentionsState(x, stateFields)
     case _                => false
@@ -190,14 +208,13 @@ object Structural:
     case Expr.If(c, t, el, _) =>
       mentionsAtLeastOneOutput(c, outputs) || mentionsAtLeastOneOutput(t, outputs) ||
       mentionsAtLeastOneOutput(el, outputs)
-    case Expr.Let(_, v, b, _) =>
-      mentionsAtLeastOneOutput(v, outputs) || mentionsAtLeastOneOutput(b, outputs)
+    case Expr.Let(v, value, b, _) =>
+      mentionsAtLeastOneOutput(value, outputs) || mentionsAtLeastOneOutput(b, outputs - v)
     case Expr.SetLiteral(xs, _) => xs.exists(mentionsAtLeastOneOutput(_, outputs))
     case Expr.Quantifier(_, bs, b, _) =>
-      bs.exists(qb => mentionsAtLeastOneOutput(qb.domain, outputs)) || mentionsAtLeastOneOutput(
-        b,
-        outputs
-      )
+      val boundNames = bs.map(_.variable).toSet
+      bs.exists(qb => mentionsAtLeastOneOutput(qb.domain, outputs)) ||
+      mentionsAtLeastOneOutput(b, outputs -- boundNames)
     case _ => false
 
   // -- File rendering --------------------------------------------------------
@@ -254,6 +271,11 @@ object Structural:
         |    "thorough":   {"max_examples": 100,  "stateful_step_count": 10},
         |    "exhaustive": {"max_examples": 1000, "stateful_step_count": 25},
         |}
+        |if PROFILE not in PROFILES:
+        |    _allowed = ", ".join(sorted(PROFILES))
+        |    raise ValueError(
+        |        f"Invalid SPEC_TEST_PROFILE={PROFILE!r}. Expected one of: {_allowed}"
+        |    )
         |_PROFILE = PROFILES[PROFILE]
         |
         |schema = schemathesis.openapi.from_path("openapi.yaml")

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -1,0 +1,296 @@
+package specrest.testgen
+
+import specrest.convention.Naming
+import specrest.convention.OperationKind
+import specrest.ir.Expr
+import specrest.ir.InvariantDecl
+import specrest.ir.OperationDecl
+import specrest.ir.PrettyPrint
+import specrest.ir.ServiceIR
+import specrest.profile.ProfiledOperation
+import specrest.profile.ProfiledService
+
+final case class StructuralOutput(
+    file: String,
+    skips: List[TestSkip]
+)
+
+object Structural:
+
+  private val TQ = "\"\"\""
+
+  final private case class StructuralCheck(
+      pyFunctionName: String,
+      pyFunctionBody: String
+  )
+
+  def emitFor(profiled: ProfiledService): StructuralOutput =
+    val ir = profiled.ir
+
+    val invChecks = ir.invariants.zipWithIndex.flatMap: (inv, idx) =>
+      checkForGlobalInvariant(inv, idx, ir).toList
+    val invSkips = ir.invariants.zipWithIndex.flatMap: (inv, idx) =>
+      checkForGlobalInvariantSkip(inv, idx, ir).toList
+
+    val ensuresPairs =
+      profiled.operations.flatMap: pop =>
+        ir.operations.find(_.name == pop.operationName) match
+          case Some(opDecl) => checksForOperation(pop, opDecl, ir)
+          case None         => Nil
+    val ensuresChecks = ensuresPairs.collect { case Right(c) => c }
+    val ensuresSkips  = ensuresPairs.collect { case Left(s) => s }
+
+    val checks = invChecks ++ ensuresChecks
+    val skips  = invSkips ++ ensuresSkips
+
+    val py = renderFile(ir, profiled, checks)
+    StructuralOutput(file = py, skips = skips)
+
+  // -- Global invariants -----------------------------------------------------
+
+  private def checkForGlobalInvariant(
+      inv: InvariantDecl,
+      idx: Int,
+      ir: ServiceIR
+  ): Option[StructuralCheck] =
+    val ctx = invariantCtx(ir)
+    ExprToPython.translate(inv.expr, ctx) match
+      case ExprPy.Skip(_, _) => None
+      case ExprPy.Py(text) =>
+        val name       = inv.name.getOrElse(s"anon_$idx")
+        val methodName = Naming.toSnakeCase(name)
+        val sb         = new StringBuilder
+        sb.append(s"def _check_invariant_$methodName(response, case):\n")
+        sb.append(
+          s"    ${TQ}invariant $name: ${escapeDocstring(prettyOneLine(inv.expr))}$TQ\n"
+        )
+        sb.append("    if response.status_code >= 500:\n")
+        sb.append("        return\n")
+        sb.append("    post_state = client.get(\"/__test_admin__/state\").json()\n")
+        sb.append(
+          s"    assert $text, ${ExprToPython.pyString(s"invariant violated: $name")}\n"
+        )
+        Some(StructuralCheck(s"_check_invariant_$methodName", sb.toString))
+
+  private def checkForGlobalInvariantSkip(
+      inv: InvariantDecl,
+      idx: Int,
+      ir: ServiceIR
+  ): Option[TestSkip] =
+    val ctx  = invariantCtx(ir)
+    val name = inv.name.getOrElse(s"anon_$idx")
+    ExprToPython.translate(inv.expr, ctx) match
+      case ExprPy.Skip(reason, _) =>
+        Some(TestSkip("<invariants>", s"structural_invariant[$name]", reason))
+      case _ => None
+
+  private def invariantCtx(ir: ServiceIR): TestCtx =
+    TestCtx(
+      inputs = Set.empty,
+      outputs = Set.empty,
+      stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet,
+      enumValues = ir.enums.map(e => e.name -> e.values.toSet).toMap,
+      knownPredicates = TestCtx.DefaultPredicates,
+      boundVars = Set.empty,
+      capture = CaptureMode.PostState
+    )
+
+  // -- Pure-output ensures (Create operations) -------------------------------
+
+  private def checksForOperation(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      ir: ServiceIR
+  ): List[Either[TestSkip, StructuralCheck]] =
+    if pop.kind != OperationKind.Create && pop.kind != OperationKind.CreateChild then Nil
+    else
+      val opSnake     = Naming.toSnakeCase(opDecl.name)
+      val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
+      val outputNames = opDecl.outputs.map(_.name).toSet
+      opDecl.ensures.zipWithIndex.flatMap: (clause, idx) =>
+        if !referencesOnlyInputsAndOutputs(clause, outputNames, stateFields) then Nil
+        else
+          val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
+          ExprToPython.translate(clause, ctx) match
+            case ExprPy.Skip(reason, _) =>
+              List(Left(TestSkip(opDecl.name, s"structural_ensures[$idx]", reason)))
+            case ExprPy.Py(text) =>
+              val checkName  = s"_check_${opSnake}_ensures_$idx"
+              val pathLit    = ExprToPython.pyString(pop.endpoint.path)
+              val methodLit  = ExprToPython.pyString(pop.endpoint.method.toString.toUpperCase)
+              val successLit = pop.endpoint.successStatus.toString
+              val sb         = new StringBuilder
+              sb.append(s"def $checkName(response, case):\n")
+              sb.append(
+                s"    ${TQ}ensures: ${escapeDocstring(prettyOneLine(clause))}$TQ\n"
+              )
+              sb.append(s"    if not _path_matches(case, $pathLit, $methodLit):\n")
+              sb.append("        return\n")
+              sb.append(s"    if response.status_code != $successLit:\n")
+              sb.append("        return\n")
+              sb.append("    response_data = response.json() if response.content else {}\n")
+              sb.append(
+                s"    assert $text, ${ExprToPython.pyString(s"ensures violated (${opDecl.name}#$idx)")}\n"
+              )
+              List(Right(StructuralCheck(checkName, sb.toString)))
+
+  private def referencesOnlyInputsAndOutputs(
+      e: Expr,
+      outputs: Set[String],
+      stateFields: Set[String]
+  ): Boolean =
+    !mentionsState(e, stateFields) && !mentionsPreOrPrime(e) &&
+      mentionsAtLeastOneOutput(e, outputs)
+
+  private def mentionsState(e: Expr, stateFields: Set[String]): Boolean = e match
+    case Expr.Identifier(n, _)     => stateFields.contains(n)
+    case Expr.BinaryOp(_, l, r, _) => mentionsState(l, stateFields) || mentionsState(r, stateFields)
+    case Expr.UnaryOp(_, x, _)     => mentionsState(x, stateFields)
+    case Expr.FieldAccess(b, _, _) => mentionsState(b, stateFields)
+    case Expr.Index(b, i, _)       => mentionsState(b, stateFields) || mentionsState(i, stateFields)
+    case Expr.Call(_, args, _)     => args.exists(mentionsState(_, stateFields))
+    case Expr.If(c, t, el, _) =>
+      mentionsState(c, stateFields) || mentionsState(t, stateFields) || mentionsState(
+        el,
+        stateFields
+      )
+    case Expr.Let(_, v, b, _)   => mentionsState(v, stateFields) || mentionsState(b, stateFields)
+    case Expr.SetLiteral(xs, _) => xs.exists(mentionsState(_, stateFields))
+    case Expr.Quantifier(_, bs, b, _) =>
+      bs.exists(qb => mentionsState(qb.domain, stateFields)) || mentionsState(b, stateFields)
+    case Expr.Prime(x, _) => mentionsState(x, stateFields)
+    case Expr.Pre(x, _)   => mentionsState(x, stateFields)
+    case _                => false
+
+  private def mentionsPreOrPrime(e: Expr): Boolean = e match
+    case Expr.Pre(_, _)            => true
+    case Expr.Prime(_, _)          => true
+    case Expr.BinaryOp(_, l, r, _) => mentionsPreOrPrime(l) || mentionsPreOrPrime(r)
+    case Expr.UnaryOp(_, x, _)     => mentionsPreOrPrime(x)
+    case Expr.FieldAccess(b, _, _) => mentionsPreOrPrime(b)
+    case Expr.Index(b, i, _)       => mentionsPreOrPrime(b) || mentionsPreOrPrime(i)
+    case Expr.Call(_, args, _)     => args.exists(mentionsPreOrPrime)
+    case Expr.If(c, t, el, _) =>
+      mentionsPreOrPrime(c) || mentionsPreOrPrime(t) || mentionsPreOrPrime(el)
+    case Expr.Let(_, v, b, _)   => mentionsPreOrPrime(v) || mentionsPreOrPrime(b)
+    case Expr.SetLiteral(xs, _) => xs.exists(mentionsPreOrPrime)
+    case Expr.Quantifier(_, bs, b, _) =>
+      bs.exists(qb => mentionsPreOrPrime(qb.domain)) || mentionsPreOrPrime(b)
+    case _ => false
+
+  private def mentionsAtLeastOneOutput(e: Expr, outputs: Set[String]): Boolean = e match
+    case Expr.Identifier(n, _) => outputs.contains(n)
+    case Expr.BinaryOp(_, l, r, _) =>
+      mentionsAtLeastOneOutput(l, outputs) || mentionsAtLeastOneOutput(r, outputs)
+    case Expr.UnaryOp(_, x, _)     => mentionsAtLeastOneOutput(x, outputs)
+    case Expr.FieldAccess(b, _, _) => mentionsAtLeastOneOutput(b, outputs)
+    case Expr.Index(b, i, _) =>
+      mentionsAtLeastOneOutput(b, outputs) || mentionsAtLeastOneOutput(i, outputs)
+    case Expr.Call(_, args, _) => args.exists(mentionsAtLeastOneOutput(_, outputs))
+    case Expr.If(c, t, el, _) =>
+      mentionsAtLeastOneOutput(c, outputs) || mentionsAtLeastOneOutput(t, outputs) ||
+      mentionsAtLeastOneOutput(el, outputs)
+    case Expr.Let(_, v, b, _) =>
+      mentionsAtLeastOneOutput(v, outputs) || mentionsAtLeastOneOutput(b, outputs)
+    case Expr.SetLiteral(xs, _) => xs.exists(mentionsAtLeastOneOutput(_, outputs))
+    case Expr.Quantifier(_, bs, b, _) =>
+      bs.exists(qb => mentionsAtLeastOneOutput(qb.domain, outputs)) || mentionsAtLeastOneOutput(
+        b,
+        outputs
+      )
+    case _ => false
+
+  // -- File rendering --------------------------------------------------------
+
+  private def renderFile(
+      ir: ServiceIR,
+      profiled: ProfiledService,
+      checks: List[StructuralCheck]
+  ): String =
+    val machineName = s"${ir.name}LinksStateMachine"
+    val testName    = s"TestStructuralLinks${ir.name}"
+    val checkDefs   = checks.map(_.pyFunctionBody).mkString("\n")
+    val checkTuple =
+      if checks.isEmpty then "()"
+      else "(\n" + checks.map(c => s"    ${c.pyFunctionName},").mkString("\n") + "\n)"
+    val emitsLinks = profiled.operations.exists(_.targetEntity.isDefined)
+    val linksBlock =
+      if !emitsLinks then ""
+      else
+        s"""|
+            |$machineName = schema.as_state_machine()
+            |$machineName.TestCase.settings = settings(
+            |    max_examples=_PROFILE["max_examples"],
+            |    stateful_step_count=_PROFILE["stateful_step_count"],
+            |    deadline=None,
+            |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+            |)
+            |$testName = $machineName.TestCase
+            |""".stripMargin
+
+    s"""|${TQ}Auto-generated structural tests for ${ir.name}.
+        |
+        |Loads openapi.yaml and uses Schemathesis to fuzz every (method, path);
+        |custom checks below are derived from spec invariants and pure-output
+        |ensures clauses. Per-case state reset via /__test_admin__/reset keeps
+        |global-invariant assertions meaningful across hundreds of fuzzed cases.
+        |
+        |See tests/_testgen_skips.json (structural_skipped) for clauses skipped
+        |during translation.
+        |${TQ}
+        |import os
+        |
+        |import schemathesis
+        |from hypothesis import HealthCheck, settings
+        |
+        |from tests.conftest import client
+        |from tests.predicates import is_valid_email, is_valid_uri
+        |
+        |BASE_URL = os.environ.get("SPEC_TEST_BASE_URL", "http://localhost:8000")
+        |
+        |PROFILE = os.environ.get("SPEC_TEST_PROFILE", "thorough")
+        |PROFILES = {
+        |    "smoke":      {"max_examples": 10,   "stateful_step_count": 3},
+        |    "thorough":   {"max_examples": 100,  "stateful_step_count": 10},
+        |    "exhaustive": {"max_examples": 1000, "stateful_step_count": 25},
+        |}
+        |_PROFILE = PROFILES[PROFILE]
+        |
+        |schema = schemathesis.openapi.from_path("openapi.yaml")
+        |
+        |
+        |def _path_matches(case, expected_template, expected_method):
+        |    if case.method.upper() != expected_method:
+        |        return False
+        |    template = getattr(case.operation, "path", None) or getattr(case, "path", None)
+        |    return template == expected_template
+        |
+        |
+        |${
+         if checkDefs.isEmpty then "# No spec-derived checks generated; see _testgen_skips.json.\n"
+         else checkDefs
+       }
+        |_ALL_CHECKS = $checkTuple
+        |
+        |
+        |@schema.parametrize()
+        |@settings(
+        |    max_examples=_PROFILE["max_examples"],
+        |    deadline=None,
+        |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+        |)
+        |def test_api_structural(case):
+        |    ${TQ}For every (method, path), Schemathesis fuzzes inputs and validates the response shape.$TQ
+        |    client.post("/__test_admin__/reset")
+        |    response = case.call(base_url=BASE_URL)
+        |    if _ALL_CHECKS:
+        |        case.validate_response(response, checks=_ALL_CHECKS)
+        |    else:
+        |        case.validate_response(response)
+        |${linksBlock}""".stripMargin
+
+  private def prettyOneLine(e: Expr): String =
+    PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim
+
+  private def escapeDocstring(s: String): String =
+    s.replace("\\", "\\\\").replace("\"\"\"", "\\\"\\\"\\\"")

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -12,11 +12,17 @@ object TestEmit:
     val strategySpecs  = Strategies.forIR(ir)
     val behavioralOut  = Behavioral.emitFor(profiled)
     val statefulOut    = Stateful.emitFor(profiled)
+    val structuralOut  = Structural.emitFor(profiled)
     val adminRouterSrc = AdminRouter.emit(profiled)
     val strategiesPy   = renderStrategiesFile(strategySpecs)
     val behavioralPy   = renderBehavioralFile(behavioralOut.tests, ir.name, strategySpecs)
     val skipsJson =
-      renderSkipsJson(ir.name, strategySpecs, behavioralOut.skips ++ statefulOut.skips)
+      renderSkipsJson(
+        ir.name,
+        strategySpecs,
+        behavioralOut.skips ++ statefulOut.skips,
+        structuralOut.skips
+      )
 
     List(
       EmittedFile(FilePaths.AdminRouterFile, adminRouterSrc),
@@ -27,6 +33,7 @@ object TestEmit:
       EmittedFile(FilePaths.StrategiesFile, strategiesPy),
       EmittedFile(FilePaths.behavioralTestFile(serviceSnake), behavioralPy),
       EmittedFile(FilePaths.statefulTestFile(serviceSnake), statefulOut.file),
+      EmittedFile(FilePaths.structuralTestFile(serviceSnake), structuralOut.file),
       EmittedFile(FilePaths.SkipsFile, skipsJson)
     )
 
@@ -90,24 +97,29 @@ object TestEmit:
   private def renderSkipsJson(
       serviceName: String,
       strategies: List[StrategySpec],
-      behavioralSkips: List[TestSkip]
+      behavioralSkips: List[TestSkip],
+      structuralSkips: List[TestSkip]
   ): String =
     val strategyEntries = strategies.flatMap: spec =>
       spec.skipped.map(reason =>
         s"""|    {"type": ${jsonString(spec.typeName)}, "reason": ${jsonString(reason)}}"""
       )
-    val behavioralEntries = behavioralSkips.map: s =>
+    val skipEntry = (s: TestSkip) =>
       s"""|    {"operation": ${jsonString(s.operation)}, "kind": ${jsonString(
           s.kind
         )}, "reason": ${jsonString(s.reason)}}"""
+    val behavioralEntries = behavioralSkips.map(skipEntry)
+    val structuralEntries = structuralSkips.map(skipEntry)
 
     val strategiesArr = renderJsonArray(strategyEntries)
     val behavioralArr = renderJsonArray(behavioralEntries)
+    val structuralArr = renderJsonArray(structuralEntries)
     s"""|{
         |  "version": 1,
         |  "service": ${jsonString(serviceName)},
         |  "strategies_skipped": $strategiesArr,
-        |  "behavioral_skipped": $behavioralArr
+        |  "behavioral_skipped": $behavioralArr,
+        |  "structural_skipped": $structuralArr
         |}
         |""".stripMargin
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -19,6 +19,9 @@ object FilePaths:
   def statefulTestFile(serviceSnake: String): String =
     s"tests/test_stateful_$serviceSnake.py"
 
+  def structuralTestFile(serviceSnake: String): String =
+    s"tests/test_structural_$serviceSnake.py"
+
 object SupportedTargets:
   val PythonFastapiPostgres = "python-fastapi-postgres"
   val All: Set[String]      = Set(PythonFastapiPostgres)

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -61,22 +61,41 @@ class StructuralTest extends CatsEffectSuite:
         "invariant check must skip when SUT returned 5xx (no useful state)"
       )
 
-  test("url_shortener: ensures-checks for Create operations are gated by (path, method, status)"):
+  test("todo_list: ensures-checks for Create operations are gated by (path, method, status)"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(
+        out.file.contains("def _check_create_todo_ensures_"),
+        s"expected at least one _check_create_todo_ensures_<i>; got file:\n${out.file}"
+      )
+      val createTodoChecks = out.file.linesIterator
+        .dropWhile(!_.contains("def _check_create_todo_ensures_"))
+        .takeWhile(l => !l.startsWith("def ") || l.contains("_check_create_todo_ensures_"))
+        .mkString("\n")
+      assert(createTodoChecks.nonEmpty, "create_todo check region should not be empty")
+      assert(
+        createTodoChecks.contains("_path_matches(case,"),
+        s"create_todo ensures must gate via _path_matches:\n$createTodoChecks"
+      )
+      assert(
+        createTodoChecks.contains("if response.status_code != "),
+        s"create_todo ensures must gate on success status:\n$createTodoChecks"
+      )
+
+  test("url_shortener: non-pure-output ensures clauses appear in skips with a reason"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val out = Structural.emitFor(profiled)
-      val shortenChecks = out.file.linesIterator
-        .dropWhile(!_.contains("def _check_shorten_ensures_"))
-        .takeWhile(l => !l.startsWith("def ") || l.contains("_check_shorten_ensures_"))
-        .mkString("\n")
-      if shortenChecks.nonEmpty then
-        assert(
-          shortenChecks.contains("_path_matches(case, \"/shorten\", \"POST\")"),
-          s"shorten ensures must gate on /shorten POST:\n$shortenChecks"
-        )
-        assert(
-          shortenChecks.contains("if response.status_code != 201"),
-          s"shorten ensures must gate on 201:\n$shortenChecks"
-        )
+      val shortenSkips = out.skips.filter(s =>
+        s.operation == "Shorten" && s.kind.startsWith("structural_ensures")
+      )
+      assert(
+        shortenSkips.nonEmpty,
+        s"Shorten has 6 ensures clauses, all reference pre()/prime()/state and should be skipped:\n${out.skips}"
+      )
+      assert(
+        shortenSkips.exists(_.reason.contains("pre()/prime()")),
+        s"at least one Shorten skip should cite pre()/prime():\n$shortenSkips"
+      )
 
   test("url_shortener: emits an as_state_machine() Links class"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
@@ -124,4 +143,20 @@ class StructuralTest extends CatsEffectSuite:
         out.file.contains(
           "BASE_URL = os.environ.get(\"SPEC_TEST_BASE_URL\", \"http://localhost:8000\")"
         )
+      )
+
+  test("invalid SPEC_TEST_PROFILE raises a helpful ValueError, not a KeyError"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(
+        out.file.contains("if PROFILE not in PROFILES:"),
+        s"missing explicit-validation guard:\n${out.file}"
+      )
+      assert(
+        out.file.contains("raise ValueError("),
+        s"missing ValueError raise:\n${out.file}"
+      )
+      assert(
+        out.file.contains("Invalid SPEC_TEST_PROFILE="),
+        s"ValueError message should name the env-var:\n${out.file}"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -1,0 +1,127 @@
+package specrest.testgen
+
+import munit.CatsEffectSuite
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.profile.Annotate
+
+class StructuralTest extends CatsEffectSuite:
+
+  private def loadProfiled(path: String) =
+    val src = scala.util.Using.resource(scala.io.Source.fromFile(path)): source =>
+      source.getLines.mkString("\n")
+    Parse.parseSpec(src).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("url_shortener: imports schemathesis and re-uses M5.1 client + predicates"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(out.file.contains("import schemathesis"), out.file)
+      assert(out.file.contains("from tests.conftest import client"))
+      assert(out.file.contains("from tests.predicates import is_valid_email, is_valid_uri"))
+      assert(out.file.contains("schema = schemathesis.openapi.from_path(\"openapi.yaml\")"))
+
+  test("url_shortener: profile env-var with three named tiers"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(out.file.contains("PROFILE = os.environ.get(\"SPEC_TEST_PROFILE\", \"thorough\")"))
+      assert(out.file.contains("\"smoke\":"))
+      assert(out.file.contains("\"thorough\":"))
+      assert(out.file.contains("\"exhaustive\":"))
+      assert(out.file.contains("\"max_examples\": 1000"))
+      assert(out.file.contains("\"stateful_step_count\": 25"))
+
+  test("url_shortener: parametrize body resets state then validates with checks"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out         = Structural.emitFor(profiled)
+      val resetIdx    = out.file.indexOf("client.post(\"/__test_admin__/reset\")")
+      val callIdx     = out.file.indexOf("response = case.call(base_url=BASE_URL)")
+      val validateIdx = out.file.indexOf("case.validate_response(response, checks=_ALL_CHECKS)")
+      assert(resetIdx >= 0, s"missing reset call:\n${out.file}")
+      assert(callIdx > resetIdx, "reset must precede the call")
+      assert(validateIdx > callIdx, "validate must follow the call")
+
+  test("url_shortener: emits one global-invariant check per translatable invariant"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(out.file.contains("def _check_invariant_all_ur_ls_valid(response, case):"))
+      assert(out.file.contains("def _check_invariant_metadata_consistent(response, case):"))
+      assert(out.file.contains("def _check_invariant_click_count_non_negative(response, case):"))
+      assert(out.file.contains("post_state = client.get(\"/__test_admin__/state\").json()"))
+
+  test("url_shortener: invariant checks gated by status < 500"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(
+        out.file.contains("if response.status_code >= 500:"),
+        "invariant check must skip when SUT returned 5xx (no useful state)"
+      )
+
+  test("url_shortener: ensures-checks for Create operations are gated by (path, method, status)"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      val shortenChecks = out.file.linesIterator
+        .dropWhile(!_.contains("def _check_shorten_ensures_"))
+        .takeWhile(l => !l.startsWith("def ") || l.contains("_check_shorten_ensures_"))
+        .mkString("\n")
+      if shortenChecks.nonEmpty then
+        assert(
+          shortenChecks.contains("_path_matches(case, \"/shorten\", \"POST\")"),
+          s"shorten ensures must gate on /shorten POST:\n$shortenChecks"
+        )
+        assert(
+          shortenChecks.contains("if response.status_code != 201"),
+          s"shorten ensures must gate on 201:\n$shortenChecks"
+        )
+
+  test("url_shortener: emits an as_state_machine() Links class"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(out.file.contains("schema.as_state_machine()"))
+      assert(out.file.contains("TestStructuralLinksUrlShortener = "))
+
+  test("safe_counter: no entities → no Links state machine emitted, but file is valid"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(
+        !out.file.contains("schema.as_state_machine()"),
+        s"safe_counter has no entities; should not emit a Links state machine:\n${out.file}"
+      )
+      assert(out.file.contains("def test_api_structural(case):"))
+      assert(out.file.contains("def _check_invariant_count_non_negative(response, case):"))
+
+  test("invariant skips use <invariants> sentinel, not <service>"):
+    val ir = specrest.ir.ServiceIR(
+      name = "X",
+      invariants = List(
+        specrest.ir.InvariantDecl(
+          name = Some("badInv"),
+          expr = specrest.ir.Expr.SetComprehension(
+            "x",
+            specrest.ir.Expr.Identifier("nonsense"),
+            specrest.ir.Expr.BoolLit(true)
+          )
+        )
+      )
+    )
+    val profile  = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+    val out      = Structural.emitFor(profile)
+    val invSkips = out.skips.filter(_.kind.startsWith("structural_invariant"))
+    assert(invSkips.nonEmpty, s"expected at least one invariant skip; got ${out.skips}")
+    assert(
+      invSkips.forall(_.operation == "<invariants>"),
+      s"all invariant skips should use <invariants> sentinel; got ${invSkips}"
+    )
+
+  test("base_url plumbed from SPEC_TEST_BASE_URL env-var with localhost default"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(
+        out.file.contains(
+          "BASE_URL = os.environ.get(\"SPEC_TEST_BASE_URL\", \"http://localhost:8000\")"
+        )
+      )

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -16,7 +16,7 @@ class TestEmitTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("emit produces 9 files at the M5.4-locked paths"):
+  test("emit produces 10 files at the M5.4-locked paths"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val paths = files.map(_.path).toSet
@@ -30,6 +30,7 @@ class TestEmitTest extends CatsEffectSuite:
           "tests/strategies.py",
           "tests/test_behavioral_url_shortener.py",
           "tests/test_stateful_url_shortener.py",
+          "tests/test_structural_url_shortener.py",
           "tests/_testgen_skips.json",
           "pytest.ini"
         )
@@ -67,6 +68,7 @@ class TestEmitTest extends CatsEffectSuite:
       assert(skips.startsWith("{"))
       assert(skips.contains("\"service\": \"UrlShortener\""))
       assert(skips.contains("\"behavioral_skipped\""))
+      assert(skips.contains("\"structural_skipped\""))
       assert(skips.contains("MapLiteral") || skips.contains("SetComprehension"))
       // verify it parses as JSON via circe (transitive via ir module)
       val parsed = io.circe.parser.parse(skips)


### PR DESCRIPTION
## Summary

- Adds `modules/testgen/src/main/scala/specrest/testgen/Structural.scala`. Each `--with-tests` compile now emits a 10th file: `tests/test_structural_<service>.py`, covering (a) `@schema.parametrize()` with spec-derived custom checks, and (b) `schema.as_state_machine()` for OpenAPI-Links sequencing.
- Custom checks are generated from translatable global `invariant` clauses (gated by `status_code < 500`, fetched via `/__test_admin__/state`) and from pure-output `Create` `ensures` clauses (gated by `(case.path, case.method, response.status_code)`). Skips land in a new `structural_skipped` array in `tests/_testgen_skips.json`.
- Profile env-var `SPEC_TEST_PROFILE` selects depth: `smoke` (10/3), `thorough` (100/10, default), `exhaustive` (1000/25).
- Bumps generated `pyproject.toml.hbs` to `schemathesis>=4.16,<5` (was `>=3.33`); the 4.x rewrite uses `schemathesis.openapi.from_path` and inline `validate_response(checks=...)`.
- Generated CI workflow: replaces the standalone `schemathesis run openapi.yaml` step with `pytest tests/test_structural_*.py tests/test_behavioral_*.py tests/test_stateful_*.py`, sharing M5.1's conftest and admin-router session gate. Also forwards `ENABLE_TEST_ADMIN=1` to the uvicorn step.

## Why two state machines

M5.2 (`Stateful.scala`) emits a hand-rolled `RuleBasedStateMachine` from spec operations and verifies the **spec contract** (one `@rule` per `OperationDecl` plus `@invariant`s).
M5.3 (`Structural.scala`) emits a `schema.as_state_machine()` from the OpenAPI document and verifies the **schema contract** (one rule per `(method, path)` plus Schemathesis's own checks for status conformance, response-shape conformance, and not-a-server-error).

Both run side-by-side; pytest discovery treats them as separate test classes. Schemathesis fuzzes shapes the spec layer doesn't (e.g., body fields just outside a `where` constraint).

## What does NOT change

No Scala build deps. No new handlebars templates (the `.py` is rendered in-process from Scala strings, like `Stateful.scala`). No native-image resource-config diff. No verify/parser/ir/codegen logic touched.

## Why `--ignore-verify` for the manual smoke

`url_shortener.spec` currently surfaces translator-limitation warnings on the M5.5 `MapLiteral`/`SetComprehension` clauses; the verify-as-gate refuses codegen by default. Local smoke used `--ignore-verify` to confirm the structural file emits and pytest collects it.

## Test plan

- [x] `sbt test` — 134 tests green, 10 new in `StructuralTest`.
- [x] `sbt scalafmtCheckAll` clean.
- [x] `sbt "scalafixAll --check"` clean.
- [x] `cd docs && npm run build` clean.
- [x] Manual: `sbt "cli/run compile --ignore-verify --with-tests --out /tmp/m53_url fixtures/spec/url_shortener.spec"` writes 38 files including `tests/test_structural_url_shortener.py`.
- [x] `python -m py_compile tests/test_structural_*.py` — both `safe_counter` and `url_shortener` are syntactically valid.
- [x] Schemathesis 4.16.1 schema load probe: `schemathesis.openapi.from_path("openapi.yaml")` returns an `OpenApiSchema` with `parametrize` and `as_state_machine` available; `as_state_machine()` returns `APIWorkflow` (Hypothesis state machine).
- [x] `pytest --collect-only tests/test_structural_*.py` collects `[GET /health]` for `safe_counter` (1 test) and 6 tests for `url_shortener`'s parametrized + Links classes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Schemathesis-based structural test layer that generates `tests/test_structural_<service>.py` for schema fuzzing and OpenAPI Links, and integrates it into `pytest`/CI to verify the schema contract alongside behavioral and stateful suites. Aligns docs with the generated tests and meets #26.

- **New Features**
  - Emit `tests/test_structural_<service>.py` using `schema.parametrize()` and, when applicable, `schema.as_state_machine()`; conditional `validate_response(checks=...)` avoids errors when no checks are generated.
  - Generate custom checks from translatable global invariants and pure-output Create ensures; gate by path/method/status; reset state per case via `POST /__test_admin__/reset`; read invariants from `/__test_admin__/state`.
  - Record skips under `structural_skipped` in `tests/_testgen_skips.json` with explicit reasons; scope-aware `let`/quantifier analysis prevents false references; invalid `SPEC_TEST_PROFILE` raises a clear `ValueError` with allowed values.
  - CI runs `pytest` for structural/behavioral/stateful suites together and forwards `ENABLE_TEST_ADMIN=1`; `SPEC_TEST_PROFILE` controls depth and `SPEC_TEST_BASE_URL` sets the base URL.

- **Dependencies**
  - Bump generated services to `schemathesis>=4.16,<5` and replace the standalone `schemathesis run` CI step with `pytest`.

<sup>Written for commit 9e717191fb20354fd543e15a81e377540c6df780. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/143?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added structural testing layer with Schemathesis integration and environment-based configuration (`SPEC_TEST_PROFILE`, `SPEC_TEST_BASE_URL`).

* **Documentation**
  * Added documentation for structural test configuration, behavior, and coverage scope.

* **Chores**
  * Updated Schemathesis dependency constraints and CI pipeline to execute structural tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->