### PR TITLE
M5.4 — Conformance test runner (closes #23)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -18,19 +18,19 @@ layers, conformance runner, mutation testing)? See
 ```bash
 sbt "cli/run compile --with-tests --out /tmp/my-service fixtures/spec/url_shortener.spec"
 cd /tmp/my-service
+cp .env.example .env
 
-# Forward ENABLE_TEST_ADMIN into the FastAPI container. The host env-var alone
-# does NOT propagate via docker-compose unless the compose file declares it; add:
-#   environment:
-#     ENABLE_TEST_ADMIN: ${ENABLE_TEST_ADMIN:-}
-# to the api service in docker-compose.yml, then:
-ENABLE_TEST_ADMIN=1 docker-compose up -d
+# Full docker-compose pipeline (boot, run all 3 layers, tear down):
+make test-conformance-docker PROFILE=smoke
 
-# Or run the service directly without docker:
-ENABLE_TEST_ADMIN=1 uvicorn app.main:app --host 0.0.0.0 --port 8000
-
-uv run --no-project --with hypothesis --with httpx --with pytest pytest tests/
+# Or against an already-running service:
+ENABLE_TEST_ADMIN=1 uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+make test-conformance PROFILE=smoke
 ```
+
+The generated `docker-compose.yml` already forwards `ENABLE_TEST_ADMIN` from the host
+to the app container, so `ENABLE_TEST_ADMIN=1 docker compose up` works without manual
+edits.
 
 The `ENABLE_TEST_ADMIN=1` env var is required: tests use a small admin router
 (`/__test_admin__/reset` and `/__test_admin__/state`) to control state and read it back.
@@ -48,6 +48,7 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
 | `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
 | `tests/test_structural_<service>.py` | `Structural.scala` | Schemathesis-driven structural tests: schema fuzzing + spec-derived custom checks + OpenAPI-Links state machine |
+| `tests/run_conformance.py` | static template | three-phase orchestrator (structural → behavioral → stateful) with JUnit XML output and a unified exit code |
 | `tests/_testgen_skips.json` | testgen | machine-readable list of clauses that were not turned into tests, with reasons |
 | `pytest.ini` | static template | disables `pytest-xdist` parallelism (admin-router state is global) |
 
@@ -333,6 +334,50 @@ fuzzes shapes the spec layer doesn't (e.g., body fields just outside the
   reference state or `pre()`/primes) — that is by design; behavioral and stateful
   layers cover those.
 
+## Conformance runner (M5.4)
+
+`tests/run_conformance.py` is a static Python orchestrator that runs the three layers
+sequentially against an already-running service, emits JUnit XML per phase, and
+aggregates a single exit code. The Makefile wraps it with two targets:
+
+```bash
+# Service must already be reachable at SPEC_TEST_BASE_URL
+make test-conformance PROFILE=smoke
+
+# Brings up docker compose, waits for /health, runs, tears down
+make test-conformance-docker PROFILE=thorough
+```
+
+Phase order is structural → behavioral → stateful. Each phase begins with
+`POST /__test_admin__/reset` (on top of the per-case resets in the test files
+themselves) so a wedged state from one phase cannot poison the next. The phase
+glob is expanded inside the runner — pytest receives concrete paths, so `pytest`'s
+own collection-error path doesn't trigger when a phase has no matching files (a
+service with no entities legitimately has no stateful tests).
+
+| Profile | `max_examples` | Use case |
+|---|---|---|
+| `smoke` | 10 | pre-commit / fast feedback |
+| `thorough` (default) | 100 | CI on PRs |
+| `exhaustive` | 1000 | nightly cron |
+
+JUnit XML lands under `results/<phase>-<profile>.xml`. The generated GitHub Actions
+workflow (`.github/workflows/ci.yml`) calls `make test-conformance` after starting the
+service, picks the profile from the event type
+(`exhaustive` on `schedule`, `thorough` otherwise), and uploads `results/` as an
+artifact. Cron is wired at `0 2 * * *` for the nightly exhaustive run.
+
+Exit codes:
+
+- `0` — all three phases passed
+- `1` — at least one phase failed
+- `2` — service unreachable, admin router disabled, or invalid `PROFILE`
+
+The generated `docker-compose.yml` forwards `ENABLE_TEST_ADMIN` from the host
+environment to the app container, so `ENABLE_TEST_ADMIN=1 docker compose up` is
+sufficient — no manual edit required (the M5.1 caveat in the quick-start above is
+historical; M5.4 plumbs this for you).
+
 ## Coverage on canonical fixtures
 
 These numbers are locked in `SkipRateProbeTest.scala`; CI fails if they regress.
@@ -386,6 +431,5 @@ compile gives a coverage delta as M5.5 expands `ExprToPython`.
 | Mutation-testing CI gate | [M5.7 (#135)](https://github.com/HardMax71/spec_to_rest/issues/135) |
 | Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
 | Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
-| Conformance runner / Makefile / nightly CI | [M5.4 (#23)](https://github.com/HardMax71/spec_to_rest/issues/23) |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |
 | Default `--with-tests` after M5.4 | [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140) |

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/Makefile.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/Makefile.hbs
@@ -1,31 +1,45 @@
-.PHONY: help install run test lint typecheck migrate docker-up docker-down clean
+.PHONY: help install run test lint typecheck migrate docker-up docker-down test-conformance test-conformance-docker clean
 
-help:         ## Show available commands
-	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+PROFILE ?= thorough
 
-install:      ## Install dependencies with uv
+help:                    ## Show available commands
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*?##/ {printf "  %-24s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+install:                 ## Install dependencies with uv
 	uv sync --all-extras
 
-run:          ## Run dev server on :8000
+run:                     ## Run dev server on :8000
 	uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 
-test:         ## Run pytest
+test:                    ## Run pytest
 	uv run pytest
 
-lint:         ## Run ruff
+lint:                    ## Run ruff
 	uv run ruff check app/ tests/
 
-typecheck:    ## Run mypy
+typecheck:               ## Run mypy
 	uv run mypy app/
 
-migrate:      ## Apply alembic migrations
+migrate:                 ## Apply alembic migrations
 	uv run alembic upgrade head
 
-docker-up:    ## Bring up all services
+docker-up:               ## Bring up all services
 	docker compose up --build -d
 
-docker-down:  ## Stop all services and remove volumes
+docker-down:             ## Stop all services and remove volumes
 	docker compose down -v
 
-clean:        ## Remove caches
-	rm -rf .ruff_cache .mypy_cache .pytest_cache __pycache__
+test-conformance:        ## Run all 3 test layers against an already-running service (PROFILE=smoke|thorough|exhaustive)
+	uv run python tests/run_conformance.py $(PROFILE)
+
+test-conformance-docker: ## Boot service via docker compose, run conformance, tear down (PROFILE=...)
+	@set -e; \
+	cleanup() { docker compose down -v >/dev/null 2>&1 || true; }; \
+	trap cleanup EXIT; \
+	uv sync --all-extras; \
+	ENABLE_TEST_ADMIN=1 docker compose up --build -d; \
+	timeout 60 bash -c 'until curl -fsS http://localhost:8000/health >/dev/null; do sleep 2; done'; \
+	$(MAKE) test-conformance PROFILE=$(PROFILE)
+
+clean:                   ## Remove caches
+	rm -rf .ruff_cache .mypy_cache .pytest_cache __pycache__ results/

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/docker-compose.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/docker-compose.yml.hbs
@@ -26,6 +26,8 @@ services:
     ports:
       - "8000:8000"
     env_file: .env
+    environment:
+      ENABLE_TEST_ADMIN: ${ENABLE_TEST_ADMIN:-}
     depends_on:
       db:
         condition: service_healthy

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/github/workflows/ci.yml.hbs
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: "0 2 * * *"
 
 jobs:
   test:
@@ -28,6 +30,8 @@ jobs:
     env:
       DATABASE_URL: postgresql+asyncpg://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}
       BASE_URL: http://localhost:8000
+      SPEC_TEST_BASE_URL: http://localhost:8000
+      SPEC_TEST_PROFILE: $\{{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -45,19 +49,22 @@ jobs:
         run: uv run mypy app/
       - name: Run migrations
         run: uv run alembic upgrade head
-      - name: Run tests
-        run: uv run pytest -v
+      - name: Run unit tests
+        run: uv run pytest -v tests/test_health.py
       - name: Start app for conformance tests
         env:
           ENABLE_TEST_ADMIN: "1"
         run: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 &
       - name: Wait for /health
         run: timeout 30 bash -c 'until curl -fsS http://localhost:8000/health; do sleep 1; done'
-      - name: Structural / behavioral / stateful pytest
-        env:
-          SPEC_TEST_PROFILE: thorough
-          SPEC_TEST_BASE_URL: http://localhost:8000
-        run: uv run pytest -v tests/test_structural_*.py tests/test_behavioral_*.py tests/test_stateful_*.py
+      - name: Conformance suite (structural / behavioral / stateful)
+        run: make test-conformance PROFILE=$SPEC_TEST_PROFILE
+      - name: Upload JUnit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-results-$\{{ env.SPEC_TEST_PROFILE }}
+          path: results/
 
   docker:
     runs-on: ubuntu-latest

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/gitignore.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/gitignore.hbs
@@ -22,6 +22,9 @@ dist/
 .coverage
 htmlcov/
 
+# Conformance test artifacts
+results/
+
 # Environment
 .env
 .env.*

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -69,3 +69,22 @@ class EmitTest extends CatsEffectSuite:
       val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
       assertEquals(files("app/__init__.py"), "")
       assertEquals(files("app/db/__init__.py"), "")
+
+  test(
+    "ci.yml renders GitHub Actions ${{ ... }} expressions literally (not Handlebars-substituted)"
+  ):
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val ci    = files(".github/workflows/ci.yml")
+      assert(
+        ci.contains("${{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}"),
+        s"ci.yml profile expression not rendered as a literal GitHub expression:\n$ci"
+      )
+      assert(
+        ci.contains("${{ env.SPEC_TEST_PROFILE }}"),
+        s"ci.yml artifact-name expression not rendered as a literal GitHub expression:\n$ci"
+      )
+      assert(
+        !ci.contains("$\\{{"),
+        s"Handlebars escape leaked into rendered output:\n$ci"
+      )

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/run_conformance.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/run_conformance.py
@@ -8,19 +8,25 @@ the service up and tearing it down; this script only owns the phase orchestratio
 Usage:
     python tests/run_conformance.py [smoke|thorough|exhaustive]
 
+Profile selection (highest priority first):
+    1. argv[1] if present
+    2. SPEC_TEST_PROFILE environment variable
+    3. "thorough" (default)
+
 Environment:
     SPEC_TEST_BASE_URL  base URL for the SUT (default: http://localhost:8000)
-    SPEC_TEST_PROFILE   forwarded to each phase; overrides argv[1] if set already
+    SPEC_TEST_PROFILE   used when argv[1] is not given; forwarded to each phase
 
 Exit codes:
     0   all phases passed
-    1   one or more phases failed
-    2   service unreachable / admin router disabled
+    1   one or more pytest phases reported test failures
+    2   service unreachable / admin router disabled / invalid profile
 """
 import glob
 import os
 import subprocess
 import sys
+from enum import Enum
 from pathlib import Path
 
 import httpx
@@ -36,6 +42,12 @@ PHASES = (
     ("behavioral", "tests/test_behavioral_*.py", "--tb=short"),
     ("stateful",   "tests/test_stateful_*.py",   "--tb=long"),
 )
+
+
+class Outcome(Enum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    INFRA = "INFRA"
 
 
 def select_profile() -> str:
@@ -73,14 +85,14 @@ def reset_state() -> bool:
     return True
 
 
-def run_phase(name: str, pattern: str, tb_flag: str, profile: str) -> bool:
+def run_phase(name: str, pattern: str, tb_flag: str, profile: str) -> Outcome:
     print(f"\n{'=' * 60}\nPHASE: {name} ({profile})\n{'=' * 60}\n", flush=True)
     matches = sorted(glob.glob(pattern))
     if not matches:
         print(f"{name}: SKIPPED (no files match {pattern!r})", flush=True)
-        return True
+        return Outcome.PASS
     if not reset_state():
-        return False
+        return Outcome.INFRA
     junit = RESULTS_DIR / f"{name}-{profile}.xml"
     cmd = [
         sys.executable, "-m", "pytest",
@@ -90,10 +102,9 @@ def run_phase(name: str, pattern: str, tb_flag: str, profile: str) -> bool:
     ]
     env = {**os.environ, "SPEC_TEST_PROFILE": profile, "SPEC_TEST_BASE_URL": BASE_URL}
     result = subprocess.run(cmd, env=env)
-    passed = result.returncode == 0
-    status = "PASSED" if passed else "FAILED"
-    print(f"\n{name}: {status} (junit: {junit})", flush=True)
-    return passed
+    outcome = Outcome.PASS if result.returncode == 0 else Outcome.FAIL
+    print(f"\n{name}: {outcome.value} (junit: {junit})", flush=True)
+    return outcome
 
 
 def main() -> int:
@@ -101,16 +112,23 @@ def main() -> int:
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     print(f"Running conformance tests against {BASE_URL} (profile: {profile})")
 
-    results: dict[str, bool] = {}
-    for name, glob, tb_flag in PHASES:
-        results[name] = run_phase(name, glob, tb_flag, profile)
+    results: dict[str, Outcome] = {}
+    for name, pattern, tb_flag in PHASES:
+        results[name] = run_phase(name, pattern, tb_flag, profile)
 
     print(f"\n{'=' * 60}\nCONFORMANCE TEST SUMMARY\n{'=' * 60}")
-    for phase, passed in results.items():
-        print(f"  {phase:12s} {'PASS' if passed else 'FAIL'}")
-    overall = all(results.values())
-    print(f"\nOverall: {'ALL PASSED' if overall else 'FAILURES DETECTED'}")
-    return 0 if overall else 1
+    for phase, outcome in results.items():
+        print(f"  {phase:12s} {outcome.value}")
+    has_infra = any(o is Outcome.INFRA for o in results.values())
+    has_fail = any(o is Outcome.FAIL for o in results.values())
+    if has_infra:
+        print("\nOverall: INFRA FAILURE")
+        return 2
+    if has_fail:
+        print("\nOverall: FAILURES DETECTED")
+        return 1
+    print("\nOverall: ALL PASSED")
+    return 0
 
 
 if __name__ == "__main__":

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/run_conformance.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/run_conformance.py
@@ -1,0 +1,117 @@
+"""Auto-generated conformance test runner. Do not edit by hand.
+
+Runs the three test layers (structural, behavioral, stateful) sequentially against
+an already-running service, emitting JUnit XML per phase and aggregating an exit
+code. The Makefile target `test-conformance-docker` is responsible for bringing
+the service up and tearing it down; this script only owns the phase orchestration.
+
+Usage:
+    python tests/run_conformance.py [smoke|thorough|exhaustive]
+
+Environment:
+    SPEC_TEST_BASE_URL  base URL for the SUT (default: http://localhost:8000)
+    SPEC_TEST_PROFILE   forwarded to each phase; overrides argv[1] if set already
+
+Exit codes:
+    0   all phases passed
+    1   one or more phases failed
+    2   service unreachable / admin router disabled
+"""
+import glob
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import httpx
+
+PROFILES = ("smoke", "thorough", "exhaustive")
+DEFAULT_PROFILE = "thorough"
+
+BASE_URL = os.environ.get("SPEC_TEST_BASE_URL", "http://localhost:8000")
+RESULTS_DIR = Path("results")
+
+PHASES = (
+    ("structural", "tests/test_structural_*.py", "--tb=short"),
+    ("behavioral", "tests/test_behavioral_*.py", "--tb=short"),
+    ("stateful",   "tests/test_stateful_*.py",   "--tb=long"),
+)
+
+
+def select_profile() -> str:
+    if len(sys.argv) > 1:
+        candidate = sys.argv[1]
+    else:
+        candidate = os.environ.get("SPEC_TEST_PROFILE", DEFAULT_PROFILE)
+    if candidate not in PROFILES:
+        allowed = ", ".join(PROFILES)
+        sys.stderr.write(
+            f"ERROR: invalid profile {candidate!r}; expected one of: {allowed}\n"
+        )
+        sys.exit(2)
+    return candidate
+
+
+def reset_state() -> bool:
+    try:
+        r = httpx.post(f"{BASE_URL}/__test_admin__/reset", timeout=5.0)
+    except httpx.HTTPError as e:
+        sys.stderr.write(f"ERROR: service unreachable at {BASE_URL}: {e}\n")
+        return False
+    if r.status_code == 403:
+        sys.stderr.write(
+            "ERROR: /__test_admin__/reset returned 403; "
+            "start the service with ENABLE_TEST_ADMIN=1\n"
+        )
+        return False
+    if r.status_code != 204:
+        sys.stderr.write(
+            f"ERROR: /__test_admin__/reset returned {r.status_code}; "
+            f"expected 204\n"
+        )
+        return False
+    return True
+
+
+def run_phase(name: str, pattern: str, tb_flag: str, profile: str) -> bool:
+    print(f"\n{'=' * 60}\nPHASE: {name} ({profile})\n{'=' * 60}\n", flush=True)
+    matches = sorted(glob.glob(pattern))
+    if not matches:
+        print(f"{name}: SKIPPED (no files match {pattern!r})", flush=True)
+        return True
+    if not reset_state():
+        return False
+    junit = RESULTS_DIR / f"{name}-{profile}.xml"
+    cmd = [
+        sys.executable, "-m", "pytest",
+        "-v", tb_flag,
+        f"--junitxml={junit}",
+        *matches,
+    ]
+    env = {**os.environ, "SPEC_TEST_PROFILE": profile, "SPEC_TEST_BASE_URL": BASE_URL}
+    result = subprocess.run(cmd, env=env)
+    passed = result.returncode == 0
+    status = "PASSED" if passed else "FAILED"
+    print(f"\n{name}: {status} (junit: {junit})", flush=True)
+    return passed
+
+
+def main() -> int:
+    profile = select_profile()
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Running conformance tests against {BASE_URL} (profile: {profile})")
+
+    results: dict[str, bool] = {}
+    for name, glob, tb_flag in PHASES:
+        results[name] = run_phase(name, glob, tb_flag, profile)
+
+    print(f"\n{'=' * 60}\nCONFORMANCE TEST SUMMARY\n{'=' * 60}")
+    for phase, passed in results.items():
+        print(f"  {phase:12s} {'PASS' if passed else 'FAIL'}")
+    overall = all(results.values())
+    print(f"\nOverall: {'ALL PASSED' if overall else 'FAILURES DETECTED'}")
+    return 0 if overall else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
@@ -7,9 +7,10 @@ object Templates:
 
   private val Root = "testgen-templates/python-fastapi-postgres"
 
-  lazy val conftest: String   = loadResource("tests/conftest.py")
-  lazy val predicates: String = loadResource("tests/predicates.py")
-  lazy val pytestIni: String  = loadResource("tests/pytest.ini")
+  lazy val conftest: String       = loadResource("tests/conftest.py")
+  lazy val predicates: String     = loadResource("tests/predicates.py")
+  lazy val pytestIni: String      = loadResource("tests/pytest.ini")
+  lazy val runConformance: String = loadResource("tests/run_conformance.py")
 
   private def loadResource(relPath: String): String =
     val resourcePath = s"$Root/$relPath"

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -34,6 +34,7 @@ object TestEmit:
       EmittedFile(FilePaths.behavioralTestFile(serviceSnake), behavioralPy),
       EmittedFile(FilePaths.statefulTestFile(serviceSnake), statefulOut.file),
       EmittedFile(FilePaths.structuralTestFile(serviceSnake), structuralOut.file),
+      EmittedFile(FilePaths.RunConformanceFile, Templates.runConformance),
       EmittedFile(FilePaths.SkipsFile, skipsJson)
     )
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -5,13 +5,14 @@ import specrest.ir.ServiceIR
 import specrest.ir.Span
 
 object FilePaths:
-  val TestsInitFile   = "tests/__init__.py"
-  val ConftestFile    = "tests/conftest.py"
-  val StrategiesFile  = "tests/strategies.py"
-  val PredicatesFile  = "tests/predicates.py"
-  val SkipsFile       = "tests/_testgen_skips.json"
-  val AdminRouterFile = "app/routers/test_admin.py"
-  val PytestIniFile   = "pytest.ini"
+  val TestsInitFile      = "tests/__init__.py"
+  val ConftestFile       = "tests/conftest.py"
+  val StrategiesFile     = "tests/strategies.py"
+  val PredicatesFile     = "tests/predicates.py"
+  val SkipsFile          = "tests/_testgen_skips.json"
+  val AdminRouterFile    = "app/routers/test_admin.py"
+  val PytestIniFile      = "pytest.ini"
+  val RunConformanceFile = "tests/run_conformance.py"
 
   def behavioralTestFile(serviceSnake: String): String =
     s"tests/test_behavioral_$serviceSnake.py"

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -16,7 +16,7 @@ class TestEmitTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("emit produces 10 files at the M5.4-locked paths"):
+  test("emit produces 11 files at the M5.4-locked paths"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val paths = files.map(_.path).toSet
@@ -31,6 +31,7 @@ class TestEmitTest extends CatsEffectSuite:
           "tests/test_behavioral_url_shortener.py",
           "tests/test_stateful_url_shortener.py",
           "tests/test_structural_url_shortener.py",
+          "tests/run_conformance.py",
           "tests/_testgen_skips.json",
           "pytest.ini"
         )
@@ -81,12 +82,27 @@ class TestEmitTest extends CatsEffectSuite:
       assert(admin.contains("prefix=\"/__test_admin__\""))
       assert(admin.contains("ENABLE_TEST_ADMIN"))
 
-  test("conftest, predicates, pytest.ini are byte-identical to bundled templates"):
+  test("conftest, predicates, pytest.ini, run_conformance are byte-identical to bundled templates"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       assertEquals(files.find(_.path == "tests/conftest.py").get.content, Templates.conftest)
       assertEquals(files.find(_.path == "tests/predicates.py").get.content, Templates.predicates)
       assertEquals(files.find(_.path == "pytest.ini").get.content, Templates.pytestIni)
+      assertEquals(
+        files.find(_.path == "tests/run_conformance.py").get.content,
+        Templates.runConformance
+      )
+
+  test("run_conformance.py orchestrates all three phases with JUnit XML"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val files  = TestEmit.emit(profiled)
+      val runner = files.find(_.path == "tests/run_conformance.py").get.content
+      assert(runner.contains("tests/test_structural_*.py"))
+      assert(runner.contains("tests/test_behavioral_*.py"))
+      assert(runner.contains("tests/test_stateful_*.py"))
+      assert(runner.contains("--junitxml="))
+      assert(runner.contains("SPEC_TEST_PROFILE"))
+      assert(runner.contains("/__test_admin__/reset"))
 
   test("safe_counter has no strategies (no type aliases or enums)"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -104,6 +104,16 @@ class TestEmitTest extends CatsEffectSuite:
       assert(runner.contains("SPEC_TEST_PROFILE"))
       assert(runner.contains("/__test_admin__/reset"))
 
+  test("run_conformance.py distinguishes infra failures (exit 2) from test failures (exit 1)"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val files  = TestEmit.emit(profiled)
+      val runner = files.find(_.path == "tests/run_conformance.py").get.content
+      assert(runner.contains("class Outcome"))
+      assert(runner.contains("INFRA"))
+      assert(runner.contains("return 2"))
+      assert(runner.contains("return 1"))
+      assert(runner.contains("return 0"))
+
   test("safe_counter has no strategies (no type aliases or enums)"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val files      = TestEmit.emit(profiled)


### PR DESCRIPTION
## Summary

- Emits `tests/run_conformance.py` (static template, gated by `--with-tests`) — a three-phase orchestrator (structural → behavioral → stateful) that expands phase globs in-process so pytest receives concrete paths, writes JUnit XML per phase to `results/<phase>-<profile>.xml`, and aggregates a unified exit code (0 all-pass / 1 any-fail / 2 unreachable or invalid profile).
- Adds `make test-conformance` (assumes service running) and `make test-conformance-docker` (boots `docker compose`, waits for `/health`, runs, tears down with a trap on exit). Both accept `PROFILE=smoke|thorough|exhaustive`.
- Forwards `ENABLE_TEST_ADMIN` from the host into the app container in the generated `docker-compose.yml`, retiring the M5.1 manual-edit caveat documented in the test-generation page.
- Reworks the generated CI workflow to call the runner, picks the profile by GitHub event (`exhaustive` on `schedule`, `thorough` otherwise), adds a nightly cron at `0 2 * * *`, and uploads `results/` as an artifact. Ignores `results/` in the project's gitignore.

## Acceptance criteria (from #23)

- [x] `make test-conformance` runs all 3 layers
- [x] JUnit XML report produced per phase
- [x] Clean exit on success, non-zero on any failure (0/1/2 semantics)

## Test plan

- [x] `sbt test` — 134 passing across all modules
- [x] `sbt scalafmtCheckAll` and `sbt scalafixAll` clean
- [x] `cd docs && npm run build` clean
- [x] Manual end-to-end smoke against `safe_counter.spec`:
  - `cli/run compile --with-tests --ignore-verify --out /tmp/m54-smoke fixtures/spec/safe_counter.spec`
  - `make test-conformance-docker PROFILE=smoke` boots compose, runs all 3 phases, writes `results/{structural,behavioral,stateful}-smoke.xml`, tears down. Exit 1 (real M4-stage stub failures and a Schemathesis 4.x API drift in `_check_invariant_*` signatures — both pre-existing M5.3 issues, not M5.4).
- [x] Runner exit-code paths verified: invalid profile → 2, unreachable service → 1, no matching glob → phase skipped (true)

## Notes

- The runner expands phase globs via `glob.glob` in Python before passing to pytest; subprocess args don't shell-expand, so passing the literal `tests/test_*_*.py` would have made pytest fail with "file or directory not found." This also gives the runner a graceful no-files path (a service with zero entities legitimately has no stateful tests).
- Per-phase reset (`POST /__test_admin__/reset`) sits on top of the per-case resets in the test files themselves; cost is three extra round-trips, value is "a wedged DB after a stateful failure does not poison the next phase."
- M5.12 (#140) — flipping `--with-tests` to default-on — is now unblocked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a conformance test runner that executes structural, behavioral, and stateful suites with JUnit output and stable exit codes, wired into `make`, `docker compose`, and CI. Clarifies exit-code semantics (infra vs test failures) and fixes CI expression rendering, with nightly exhaustive runs.

- **Bug Fixes**
  - Runner now distinguishes infra failures (exit 2) from test failures (exit 1) via a tri-state Outcome; profile precedence is `argv > SPEC_TEST_PROFILE > thorough`.
  - GitHub Actions expressions (`${{ ... }}`) render literally in `ci.yml`; tests lock this to prevent Handlebars escapes.
  - Docs and templates updated: `docker-compose.yml` forwards `ENABLE_TEST_ADMIN`, `make test-conformance-docker` waits for `/health`, CI uploads `results/`, and `results/` is ignored in `.gitignore`.

<sup>Written for commit 4f990695a35ef229c082f02c87c707aa06558ef0. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conformance testing framework with configurable profiles (`smoke`, `thorough`, `exhaustive`)
  * Introduced Makefile targets for running conformance tests locally and in Docker
  * GitHub Actions CI now includes daily scheduled test runs
  * JUnit XML test results are automatically generated and uploaded as artifacts

* **Documentation**
  * Updated quick start guide with Makefile-driven conformance testing instructions
  * Added comprehensive documentation for conformance runner phases and configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->