### PR TITLE
M5.6 — User-supplied custom Hypothesis strategies (closes #134)

### DIFF
--- a/docs/content/docs/design/convention-engine.mdx
+++ b/docs/content/docs/design/convention-engine.mdx
@@ -42,6 +42,21 @@ operation Resolve(code: String) -> Url
 }
 ```
 
+A service-wide `conventions { ... }` block also targets entities, type aliases,
+and enums:
+
+```
+conventions {
+  Url.db_table = "url_mappings"
+  LongURL.strategy = "tests.strategies_user:valid_url"
+  Status.strategy = "tests.strategies_user:realistic_status"
+}
+```
+
+The `strategy` property is wired by the test-generation pipeline; see
+[Test Generation — Custom strategies](/pipelines/test-generation) for the
+end-to-end flow including the `--strict-strategies` CI gate.
+
 ## Deployment profiles
 
 The engine supports 4 built-in profiles that adjust conventions for different environments:

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -475,18 +475,24 @@ The generated `tests/strategies.py` automatically imports the symbols and routes
 ### `--strict-strategies` CI gate
 
 Pass `--strict-strategies` to `compile --with-tests` to fail the build if any
-type alias has unhandled `where` constraints AND no convention override is
-registered. Use it as a CI guard against silently-too-permissive strategies:
+type alias or enum has an incomplete synthesized strategy AND no convention
+override is registered. Use it as a CI guard against silently-broken strategies:
 
 ```bash
 sbt "cli/run compile --with-tests --strict-strategies --out /tmp/svc fixtures/spec/auth_service.spec"
-# Exit 1 if any alias falls back to st.text() / st.integers() with un-honoured `where`
+# Exit 1 if any strategy falls back to st.text() / st.integers() / st.nothing() with no override
 ```
 
-Without an override, an alias whose `where` includes a custom predicate (e.g.,
-`where custom_pred(value)`) emits a comment-tagged skip in `strategies.py` and
-appears in `_testgen_skips.json`'s `strategies_skipped` array. With
-`--strict-strategies`, that becomes a compile error.
+Two synthesis gaps trip the gate:
+
+1. **Unhandled `where` constraint** — e.g., `type Code = String where custom_pred(value)`
+   produces `st.text()` plus a `# testgen-skip:` note. The synthesized strategy
+   is too permissive (custom_pred is not enforced).
+2. **Unsupported base type** — e.g., `type Mapping = Map<String, Int>` falls
+   through to `st.nothing()`. The synthesized strategy is unusable.
+
+Both cases land in `_testgen_skips.json`'s `strategies_skipped` array and
+become compile errors under `--strict-strategies`.
 
 ## Limitations and follow-up issues
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -45,6 +45,7 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/conftest.py` | static template | `httpx` client + session-scoped fixture that **skips the whole suite** with a clear message if the service is unreachable or the admin router isn't enabled |
 | `tests/predicates.py` | static template | `is_valid_uri`, `is_valid_email` helpers used by strategies and assertions |
 | `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl` |
+| `tests/strategies_user.py` | static template | empty stub for user-supplied strategy functions referenced from `<Type>.strategy = "module:symbol"` convention rules. Preserved across re-compile. |
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
 | `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
 | `tests/test_structural_<service>.py` | `Structural.scala` | Schemathesis-driven structural tests: schema fuzzing + spec-derived custom checks + OpenAPI-Links state machine |
@@ -430,12 +431,68 @@ is outside the recognized negative-test pattern; (c) a real user error in the sp
   runtime requires [#86](https://github.com/HardMax71/spec_to_rest/issues/86)
   (runtime invariant enforcement). The two issues are designed to compose.
 
+## Custom strategies (M5.6)
+
+`Strategies.scala` synthesizes a Hypothesis strategy from each `TypeAliasDecl`'s
+`where` clause — recognised shapes are length bounds, regex (`matches /…/`), numeric
+range, and the `is_valid_uri` / `is_valid_email` predicate filters. Anything outside
+that set lands in `_testgen_skips.json` under `strategies_skipped`, with the synth
+falling back to an unconstrained base strategy (`st.text()`, `st.integers()`).
+
+To override the synthesized strategy with a hand-written one, declare a `strategy`
+convention rule whose value is a `module:symbol` reference:
+
+```text
+service AuthService {
+  type Email = String where value matches /^[^@]+@[^@]+\.[^@]+$/
+  type PasswordHash = String where len(value) = 64
+
+  conventions {
+    Email.strategy = "tests.strategies_user:valid_email"
+    PasswordHash.strategy = "tests.strategies_user:strong_password_hash"
+  }
+}
+```
+
+Then implement the symbols in `tests/strategies_user.py` (stub emitted on first
+compile, preserved across re-compile):
+
+```python
+from hypothesis import strategies as st
+
+def valid_email():
+    return st.from_regex(r"^[^@]+@[^@]+\.[^@]+$", fullmatch=True)
+
+def strong_password_hash():
+    return st.text(alphabet="0123456789abcdef", min_size=64, max_size=64)
+```
+
+The generated `tests/strategies.py` automatically imports the symbols and routes
+`def strategy_<type>(): return <symbol>()` to the override. Downstream test files
+(`test_behavioral_*.py`, `test_stateful_*.py`) keep calling
+`strategy_<type>()` unchanged — only the body of that function is swapped.
+
+### `--strict-strategies` CI gate
+
+Pass `--strict-strategies` to `compile --with-tests` to fail the build if any
+type alias has unhandled `where` constraints AND no convention override is
+registered. Use it as a CI guard against silently-too-permissive strategies:
+
+```bash
+sbt "cli/run compile --with-tests --strict-strategies --out /tmp/svc fixtures/spec/auth_service.spec"
+# Exit 1 if any alias falls back to st.text() / st.integers() with un-honoured `where`
+```
+
+Without an override, an alias whose `where` includes a custom predicate (e.g.,
+`where custom_pred(value)`) emits a comment-tagged skip in `strategies.py` and
+appears in `_testgen_skips.json`'s `strategies_skipped` array. With
+`--strict-strategies`, that becomes a compile error.
+
 ## Limitations and follow-up issues
 
 | Limit | Tracked under |
 |---|---|
 | State-dependent preconditions skip ensures tests | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) — TransitionDecl-aware state-machine setup |
-| Custom strategies for spec predicates beyond `isValidURI`/`valid_email` | [M5.6 (#134)](https://github.com/HardMax71/spec_to_rest/issues/134) |
 | Mutation-testing CI gate | [M5.7 (#135)](https://github.com/HardMax71/spec_to_rest/issues/135) |
 | Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
 | Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -143,4 +143,24 @@ operation Resolve(code: String) -> Url
 }
 ```
 
+A service-wide `conventions { ... }` block targets operations, entities, type
+aliases, and enums by name. Each property is valid against a specific target
+kind:
+
+| Property              | Valid targets        |
+|-----------------------|----------------------|
+| `http_method`         | operation            |
+| `http_path`           | operation            |
+| `http_status_success` | operation            |
+| `http_header`         | operation            |
+| `db_table`            | entity               |
+| `db_timestamps`       | entity               |
+| `plural`              | entity               |
+| `strategy`            | type alias, enum     |
+
+The `strategy` property points testgen at a user-supplied Hypothesis strategy:
+`<TypeAliasOrEnum>.strategy = "module:symbol"`. See
+[Test Generation pipeline — Custom strategies](/pipelines/test-generation) for
+the integration with `--with-tests` and the `--strict-strategies` CI gate.
+
 See [Convention Engine](/design/convention-engine) for the full mapping rules.

--- a/fixtures/golden/ir/strict_strategies_negative.json
+++ b/fixtures/golden/ir/strict_strategies_negative.json
@@ -1,0 +1,242 @@
+{
+  "kind" : "Service",
+  "name" : "StrictStrategiesNeg",
+  "imports" : [
+  ],
+  "entities" : [
+  ],
+  "enums" : [
+  ],
+  "typeAliases" : [
+    {
+      "kind" : "TypeAlias",
+      "name" : "CustomCode",
+      "typeExpr" : {
+        "kind" : "NamedType",
+        "name" : "String",
+        "span" : {
+          "startLine" : 2,
+          "startCol" : 20,
+          "endLine" : 2,
+          "endCol" : 26
+        }
+      },
+      "constraint" : {
+        "kind" : "Call",
+        "callee" : {
+          "kind" : "Identifier",
+          "name" : "custom_pred",
+          "span" : {
+            "startLine" : 2,
+            "startCol" : 33,
+            "endLine" : 2,
+            "endCol" : 44
+          }
+        },
+        "args" : [
+          {
+            "kind" : "Identifier",
+            "name" : "value",
+            "span" : {
+              "startLine" : 2,
+              "startCol" : 45,
+              "endLine" : 2,
+              "endCol" : 50
+            }
+          }
+        ],
+        "span" : {
+          "startLine" : 2,
+          "startCol" : 33,
+          "endLine" : 2,
+          "endCol" : 51
+        }
+      },
+      "span" : {
+        "startLine" : 2,
+        "startCol" : 2,
+        "endLine" : 2,
+        "endCol" : 51
+      }
+    }
+  ],
+  "state" : {
+    "kind" : "State",
+    "fields" : [
+      {
+        "kind" : "StateField",
+        "name" : "counter",
+        "typeExpr" : {
+          "kind" : "NamedType",
+          "name" : "Int",
+          "span" : {
+            "startLine" : 5,
+            "startCol" : 13,
+            "endLine" : 5,
+            "endCol" : 16
+          }
+        },
+        "span" : {
+          "startLine" : 5,
+          "startCol" : 4,
+          "endLine" : 5,
+          "endCol" : 16
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 4,
+      "startCol" : 2,
+      "endLine" : 6,
+      "endCol" : 3
+    }
+  },
+  "operations" : [
+    {
+      "kind" : "Operation",
+      "name" : "Increment",
+      "inputs" : [
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 10,
+            "startCol" : 6,
+            "endLine" : 10,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "counter",
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 6,
+                "endLine" : 13,
+                "endCol" : 13
+              }
+            },
+            "span" : {
+              "startLine" : 13,
+              "startCol" : 6,
+              "endLine" : 13,
+              "endCol" : 14
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "counter",
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 17,
+                "endLine" : 13,
+                "endCol" : 24
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 27,
+                "endLine" : 13,
+                "endCol" : 28
+              }
+            },
+            "span" : {
+              "startLine" : 13,
+              "startCol" : 17,
+              "endLine" : 13,
+              "endCol" : 28
+            }
+          },
+          "span" : {
+            "startLine" : 13,
+            "startCol" : 6,
+            "endLine" : 13,
+            "endCol" : 28
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 8,
+        "startCol" : 2,
+        "endLine" : 14,
+        "endCol" : 3
+      }
+    }
+  ],
+  "transitions" : [
+  ],
+  "invariants" : [
+    {
+      "kind" : "Invariant",
+      "name" : "counterNonNegative",
+      "expr" : {
+        "kind" : "BinaryOp",
+        "op" : ">=",
+        "left" : {
+          "kind" : "Identifier",
+          "name" : "counter",
+          "span" : {
+            "startLine" : 17,
+            "startCol" : 4,
+            "endLine" : 17,
+            "endCol" : 11
+          }
+        },
+        "right" : {
+          "kind" : "IntLit",
+          "value" : 0,
+          "span" : {
+            "startLine" : 17,
+            "startCol" : 15,
+            "endLine" : 17,
+            "endCol" : 16
+          }
+        },
+        "span" : {
+          "startLine" : 17,
+          "startCol" : 4,
+          "endLine" : 17,
+          "endCol" : 16
+        }
+      },
+      "span" : {
+        "startLine" : 16,
+        "startCol" : 2,
+        "endLine" : 17,
+        "endCol" : 16
+      }
+    }
+  ],
+  "temporals" : [
+  ],
+  "facts" : [
+  ],
+  "functions" : [
+  ],
+  "predicates" : [
+  ],
+  "conventions" : null,
+  "span" : {
+    "startLine" : 1,
+    "startCol" : 0,
+    "endLine" : 18,
+    "endCol" : 1
+  }
+}

--- a/fixtures/golden/ir/strict_strategies_positive.json
+++ b/fixtures/golden/ir/strict_strategies_positive.json
@@ -1,0 +1,274 @@
+{
+  "kind" : "Service",
+  "name" : "StrictStrategiesPos",
+  "imports" : [
+  ],
+  "entities" : [
+  ],
+  "enums" : [
+  ],
+  "typeAliases" : [
+    {
+      "kind" : "TypeAlias",
+      "name" : "CustomCode",
+      "typeExpr" : {
+        "kind" : "NamedType",
+        "name" : "String",
+        "span" : {
+          "startLine" : 2,
+          "startCol" : 20,
+          "endLine" : 2,
+          "endCol" : 26
+        }
+      },
+      "constraint" : {
+        "kind" : "Call",
+        "callee" : {
+          "kind" : "Identifier",
+          "name" : "custom_pred",
+          "span" : {
+            "startLine" : 2,
+            "startCol" : 33,
+            "endLine" : 2,
+            "endCol" : 44
+          }
+        },
+        "args" : [
+          {
+            "kind" : "Identifier",
+            "name" : "value",
+            "span" : {
+              "startLine" : 2,
+              "startCol" : 45,
+              "endLine" : 2,
+              "endCol" : 50
+            }
+          }
+        ],
+        "span" : {
+          "startLine" : 2,
+          "startCol" : 33,
+          "endLine" : 2,
+          "endCol" : 51
+        }
+      },
+      "span" : {
+        "startLine" : 2,
+        "startCol" : 2,
+        "endLine" : 2,
+        "endCol" : 51
+      }
+    }
+  ],
+  "state" : {
+    "kind" : "State",
+    "fields" : [
+      {
+        "kind" : "StateField",
+        "name" : "counter",
+        "typeExpr" : {
+          "kind" : "NamedType",
+          "name" : "Int",
+          "span" : {
+            "startLine" : 5,
+            "startCol" : 13,
+            "endLine" : 5,
+            "endCol" : 16
+          }
+        },
+        "span" : {
+          "startLine" : 5,
+          "startCol" : 4,
+          "endLine" : 5,
+          "endCol" : 16
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 4,
+      "startCol" : 2,
+      "endLine" : 6,
+      "endCol" : 3
+    }
+  },
+  "operations" : [
+    {
+      "kind" : "Operation",
+      "name" : "Increment",
+      "inputs" : [
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 10,
+            "startCol" : 6,
+            "endLine" : 10,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "counter",
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 6,
+                "endLine" : 13,
+                "endCol" : 13
+              }
+            },
+            "span" : {
+              "startLine" : 13,
+              "startCol" : 6,
+              "endLine" : 13,
+              "endCol" : 14
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "counter",
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 17,
+                "endLine" : 13,
+                "endCol" : 24
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 13,
+                "startCol" : 27,
+                "endLine" : 13,
+                "endCol" : 28
+              }
+            },
+            "span" : {
+              "startLine" : 13,
+              "startCol" : 17,
+              "endLine" : 13,
+              "endCol" : 28
+            }
+          },
+          "span" : {
+            "startLine" : 13,
+            "startCol" : 6,
+            "endLine" : 13,
+            "endCol" : 28
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 8,
+        "startCol" : 2,
+        "endLine" : 14,
+        "endCol" : 3
+      }
+    }
+  ],
+  "transitions" : [
+  ],
+  "invariants" : [
+    {
+      "kind" : "Invariant",
+      "name" : "counterNonNegative",
+      "expr" : {
+        "kind" : "BinaryOp",
+        "op" : ">=",
+        "left" : {
+          "kind" : "Identifier",
+          "name" : "counter",
+          "span" : {
+            "startLine" : 17,
+            "startCol" : 4,
+            "endLine" : 17,
+            "endCol" : 11
+          }
+        },
+        "right" : {
+          "kind" : "IntLit",
+          "value" : 0,
+          "span" : {
+            "startLine" : 17,
+            "startCol" : 15,
+            "endLine" : 17,
+            "endCol" : 16
+          }
+        },
+        "span" : {
+          "startLine" : 17,
+          "startCol" : 4,
+          "endLine" : 17,
+          "endCol" : 16
+        }
+      },
+      "span" : {
+        "startLine" : 16,
+        "startCol" : 2,
+        "endLine" : 17,
+        "endCol" : 16
+      }
+    }
+  ],
+  "temporals" : [
+  ],
+  "facts" : [
+  ],
+  "functions" : [
+  ],
+  "predicates" : [
+  ],
+  "conventions" : {
+    "kind" : "Conventions",
+    "rules" : [
+      {
+        "kind" : "ConventionRule",
+        "target" : "CustomCode",
+        "property" : "strategy",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "StringLit",
+          "value" : "tests.strategies_user:custom_code",
+          "span" : {
+            "startLine" : 20,
+            "startCol" : 26,
+            "endLine" : 20,
+            "endCol" : 61
+          }
+        },
+        "span" : {
+          "startLine" : 20,
+          "startCol" : 4,
+          "endLine" : 20,
+          "endCol" : 61
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 19,
+      "startCol" : 2,
+      "endLine" : 21,
+      "endCol" : 3
+    }
+  },
+  "span" : {
+    "startLine" : 1,
+    "startCol" : 0,
+    "endLine" : 22,
+    "endCol" : 1
+  }
+}

--- a/fixtures/spec/strict_strategies_negative.spec
+++ b/fixtures/spec/strict_strategies_negative.spec
@@ -1,0 +1,18 @@
+service StrictStrategiesNeg {
+  type CustomCode = String where custom_pred(value)
+
+  state {
+    counter: Int
+  }
+
+  operation Increment {
+    requires:
+      true
+
+    ensures:
+      counter' = counter + 1
+  }
+
+  invariant counterNonNegative:
+    counter >= 0
+}

--- a/fixtures/spec/strict_strategies_positive.spec
+++ b/fixtures/spec/strict_strategies_positive.spec
@@ -1,0 +1,22 @@
+service StrictStrategiesPos {
+  type CustomCode = String where custom_pred(value)
+
+  state {
+    counter: Int
+  }
+
+  operation Increment {
+    requires:
+      true
+
+    ensures:
+      counter' = counter + 1
+  }
+
+  invariant counterNonNegative:
+    counter >= 0
+
+  conventions {
+    CustomCode.strategy = "tests.strategies_user:custom_code"
+  }
+}

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -76,7 +76,7 @@ object Compile:
                         else
                           IO.delay {
                             log.error(
-                              "--strict-strategies: type aliases with unhandled `where` constraints (no convention override registered):"
+                              "--strict-strategies: type aliases / enums with incomplete strategy synthesis (no convention override registered):"
                             )
                             unhandled.foreach: s =>
                               log.error(s"  ${s.typeName}: ${s.skipped.mkString("; ")}")

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -7,6 +7,8 @@ import specrest.ir.VerifyError
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.profile.Annotate
+import specrest.testgen.FilePaths
+import specrest.testgen.Strategies
 import specrest.testgen.SupportedTargets
 import specrest.testgen.TestEmit
 import specrest.verify.VerificationConfig
@@ -20,7 +22,8 @@ final case class CompileOptions(
     target: String,
     outDir: String,
     ignoreVerify: Boolean = false,
-    withTests: Boolean = false
+    withTests: Boolean = false,
+    strictStrategies: Boolean = false
 )
 
 object Compile:
@@ -33,7 +36,16 @@ object Compile:
             s"(got --target=${opts.target})"
         )
       ).as(ExitCodes.Violations)
-    else runImpl(specFile, opts, log)
+    else
+      val warnIfStrictWithoutTests =
+        if opts.strictStrategies && !opts.withTests then
+          IO.delay(
+            log.warn(
+              "--strict-strategies has no effect without --with-tests; ignoring"
+            )
+          )
+        else IO.unit
+      warnIfStrictWithoutTests *> runImpl(specFile, opts, log)
 
   private def runImpl(specFile: String, opts: CompileOptions, log: Logger): IO[ExitCode] =
     Check.readSource(specFile, log).flatMap:
@@ -57,28 +69,48 @@ object Compile:
                   else Verify.runGate(specFile, ir, VerificationConfig.Default, log)
                 gate.flatMap:
                   case ok if ok == ExitCodes.Ok =>
-                    IO.blocking {
-                      val profiled  = Annotate.buildProfiledService(ir, opts.target)
-                      val baseFiles = Emit.emitProject(profiled)
-                      val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
-                      val files     = baseFiles ++ testFiles
-                      val outRoot   = Paths.get(opts.outDir)
-                      Files.createDirectories(outRoot)
-                      files.foreach: f =>
-                        val target = outRoot.resolve(f.path)
-                        Option(target.getParent).foreach(Files.createDirectories(_))
-                        Files.writeString(
-                          target,
-                          f.content,
-                          StandardOpenOption.CREATE,
-                          StandardOpenOption.TRUNCATE_EXISTING
-                        )
-                      log.success(s"wrote ${files.length} files to ${opts.outDir}")
-                      ExitCodes.Ok
-                    }.handleErrorWith:
-                      case NonFatal(e) =>
-                        IO.delay(
-                          log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
-                        ).as(ExitCodes.Violations)
-                      case e => IO.raiseError(e)
+                    val strictGate =
+                      if opts.withTests && opts.strictStrategies then
+                        val unhandled = Strategies.forIR(ir).filter(_.skipped.nonEmpty)
+                        if unhandled.isEmpty then IO.pure(ExitCodes.Ok)
+                        else
+                          IO.delay {
+                            log.error(
+                              "--strict-strategies: type aliases with unhandled `where` constraints (no convention override registered):"
+                            )
+                            unhandled.foreach: s =>
+                              log.error(s"  ${s.typeName}: ${s.skipped.mkString("; ")}")
+                          }.as(ExitCodes.Violations)
+                      else IO.pure(ExitCodes.Ok)
+
+                    strictGate.flatMap:
+                      case strictOk if strictOk == ExitCodes.Ok =>
+                        IO.blocking {
+                          val profiled  = Annotate.buildProfiledService(ir, opts.target)
+                          val baseFiles = Emit.emitProject(profiled)
+                          val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
+                          val files     = baseFiles ++ testFiles
+                          val outRoot   = Paths.get(opts.outDir)
+                          Files.createDirectories(outRoot)
+                          files.foreach: f =>
+                            val target = outRoot.resolve(f.path)
+                            Option(target.getParent).foreach(Files.createDirectories(_))
+                            val isUserStrategies = f.path == FilePaths.StrategiesUserFile
+                            if isUserStrategies && Files.exists(target) then ()
+                            else
+                              Files.writeString(
+                                target,
+                                f.content,
+                                StandardOpenOption.CREATE,
+                                StandardOpenOption.TRUNCATE_EXISTING
+                              )
+                          log.success(s"wrote ${files.length} files to ${opts.outDir}")
+                          ExitCodes.Ok
+                        }.handleErrorWith:
+                          case NonFatal(e) =>
+                            IO.delay(
+                              log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
+                            ).as(ExitCodes.Violations)
+                          case e => IO.raiseError(e)
+                      case strictCode => IO.pure(strictCode)
                   case gateCode => IO.pure(gateCode)

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -135,7 +135,7 @@ object Main
     val strictStrategies = Opts
       .flag(
         "strict-strategies",
-        "fail compile if any entity-typed strategy has unhandled `where` constraints and no convention override registered (requires --with-tests)"
+        "fail compile if any synthesized strategy is incomplete (unhandled `where` constraint or unsupported base type) and no convention override is registered (requires --with-tests)"
       )
       .orFalse
     Opts.subcommand("compile", "Emit project files for a spec"):

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -132,12 +132,18 @@ object Main
         "also emit Hypothesis property tests + admin router (python-fastapi-postgres only)"
       )
       .orFalse
+    val strictStrategies = Opts
+      .flag(
+        "strict-strategies",
+        "fail compile if any entity-typed strategy has unhandled `where` constraints and no convention override registered (requires --with-tests)"
+      )
+      .orFalse
     Opts.subcommand("compile", "Emit project files for a spec"):
-      (specFile, target, outDir, ignoreVerify, withTests, verbose, quiet).mapN:
-        (spec, t, o, iv, wt, v, q) =>
+      (specFile, target, outDir, ignoreVerify, withTests, strictStrategies, verbose, quiet).mapN:
+        (spec, t, o, iv, wt, ss, v, q) =>
           Compile.run(
             spec,
-            CompileOptions(t, o, iv, wt),
+            CompileOptions(t, o, iv, wt, ss),
             Logger.fromFlags(verbose = v, quiet = q)
           )
 

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -167,3 +167,73 @@ class CliSmokeTest extends CatsEffectSuite:
             c.expectFiles,
             s"gate failure should leave the output directory uncreated (${c.name})"
           )
+
+  test("--strict-strategies fails when type alias has unhandled `where` and no override"):
+    tempOutPath.use: outDir =>
+      Compile.run(
+        "fixtures/spec/strict_strategies_negative.spec",
+        CompileOptions(
+          "python-fastapi-postgres",
+          outDir.toString,
+          ignoreVerify = true,
+          withTests = true,
+          strictStrategies = true
+        ),
+        log
+      ).map: exit =>
+        assertEquals(exit, ExitCodes.Violations)
+        assert(
+          !java.nio.file.Files.exists(outDir.resolve("pyproject.toml")),
+          "no files should be written when strict-strategies fails"
+        )
+
+  test("--strict-strategies passes when override is registered for the unhandled type"):
+    tempOutPath.use: outDir =>
+      Compile.run(
+        "fixtures/spec/strict_strategies_positive.spec",
+        CompileOptions(
+          "python-fastapi-postgres",
+          outDir.toString,
+          ignoreVerify = true,
+          withTests = true,
+          strictStrategies = true
+        ),
+        log
+      ).map: exit =>
+        assertEquals(exit, ExitCodes.Ok)
+        val strategiesPy =
+          java.nio.file.Files.readString(outDir.resolve("tests/strategies.py"))
+        assert(
+          strategiesPy.contains("from tests.strategies_user import custom_code"),
+          s"strategies.py should import the override:\n$strategiesPy"
+        )
+        assert(
+          strategiesPy.contains("def strategy_custom_code():\n    return custom_code()"),
+          s"strategies.py should call the override:\n$strategiesPy"
+        )
+        assert(
+          java.nio.file.Files.exists(outDir.resolve("tests/strategies_user.py")),
+          "strategies_user.py stub must be emitted"
+        )
+
+  test("strategies_user.py is not overwritten by re-compile"):
+    tempOutPath.use: outDir =>
+      val opts = CompileOptions(
+        "python-fastapi-postgres",
+        outDir.toString,
+        ignoreVerify = true,
+        withTests = true
+      )
+      for
+        firstExit <- Compile.run("fixtures/spec/strict_strategies_positive.spec", opts, log)
+        userPath   = outDir.resolve("tests/strategies_user.py")
+        _ <- IO.blocking {
+               val edited = java.nio.file.Files.readString(userPath) + "\n# USER EDIT\n"
+               java.nio.file.Files.writeString(userPath, edited)
+             }
+        secondExit   <- Compile.run("fixtures/spec/strict_strategies_positive.spec", opts, log)
+        finalContent <- IO.blocking(java.nio.file.Files.readString(userPath))
+      yield
+        assertEquals(firstExit, ExitCodes.Ok)
+        assertEquals(secondExit, ExitCodes.Ok)
+        assert(finalContent.contains("# USER EDIT"), s"user edit was overwritten:\n$finalContent")

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -17,6 +17,8 @@ object Validate:
     "plural"
   )
 
+  private val AliasOrEnumProperties: Set[String] = Set("strategy")
+
   def validateConventions(
       conventions: Option[ConventionsDecl],
       ir: ServiceIR
@@ -26,6 +28,8 @@ object Validate:
       case Some(c) =>
         val opNames     = ir.operations.map(_.name).toSet
         val entityNames = ir.entities.map(_.name).toSet
+        val aliasNames  = ir.typeAliases.map(_.name).toSet
+        val enumNames   = ir.enums.map(_.name).toSet
         val diagnostics = List.newBuilder[ConventionDiagnostic]
         val seen        = scala.collection.mutable.Map.empty[String, ConventionRule]
 
@@ -52,13 +56,15 @@ object Validate:
           val targetKind =
             if opNames.contains(rule.target) then Some("operation")
             else if entityNames.contains(rule.target) then Some("entity")
+            else if aliasNames.contains(rule.target) then Some("alias")
+            else if enumNames.contains(rule.target) then Some("enum")
             else None
 
           targetKind match
             case None =>
               diagnostics += ConventionDiagnostic(
                 DiagnosticLevel.Error,
-                s"no operation or entity named '${rule.target}'",
+                s"no operation, entity, type alias, or enum named '${rule.target}'",
                 rule.span,
                 rule.target,
                 rule.property
@@ -71,6 +77,14 @@ object Validate:
                 rule.target,
                 rule.property
               )
+            case Some("operation") if AliasOrEnumProperties.contains(rule.property) =>
+              diagnostics += ConventionDiagnostic(
+                DiagnosticLevel.Error,
+                s"property '${rule.property}' is not valid for operation '${rule.target}'; it applies to type aliases and enums",
+                rule.span,
+                rule.target,
+                rule.property
+              )
             case Some("entity") if OperationProperties.contains(rule.property) =>
               diagnostics += ConventionDiagnostic(
                 DiagnosticLevel.Error,
@@ -79,9 +93,26 @@ object Validate:
                 rule.target,
                 rule.property
               )
+            case Some("entity") if AliasOrEnumProperties.contains(rule.property) =>
+              diagnostics += ConventionDiagnostic(
+                DiagnosticLevel.Error,
+                s"property '${rule.property}' is not valid for entity '${rule.target}'; it applies to type aliases and enums",
+                rule.span,
+                rule.target,
+                rule.property
+              )
+            case Some("alias" | "enum") if !AliasOrEnumProperties.contains(rule.property) =>
+              diagnostics += ConventionDiagnostic(
+                DiagnosticLevel.Error,
+                s"property '${rule.property}' is not valid for type alias / enum '${rule.target}'; only 'strategy' applies",
+                rule.span,
+                rule.target,
+                rule.property
+              )
             case Some(_)
                 if !OperationProperties.contains(rule.property) &&
-                  !EntityProperties.contains(rule.property) =>
+                  !EntityProperties.contains(rule.property) &&
+                  !AliasOrEnumProperties.contains(rule.property) =>
               diagnostics += ConventionDiagnostic(
                 DiagnosticLevel.Error,
                 s"unknown convention property '${rule.property}'",
@@ -108,6 +139,7 @@ object Validate:
     case "db_table"            => validateDbTable(rule, diagnostics)
     case "db_timestamps"       => validateDbTimestamps(rule, diagnostics)
     case "plural"              => validatePlural(rule, diagnostics)
+    case "strategy"            => validateStrategy(rule, diagnostics)
     case _                     => ()
 
   private def err(
@@ -262,3 +294,22 @@ object Validate:
     case Expr.StringLit(_, _) => ()
     case _ =>
       err(rule, s"invalid value for ${rule.target}.plural — expected a string", diagnostics)
+
+  private def validateStrategy(
+      rule: ConventionRule,
+      diagnostics: scala.collection.mutable.Builder[
+        ConventionDiagnostic,
+        List[ConventionDiagnostic]
+      ]
+  ): Unit = rule.value match
+    case Expr.StringLit(v, _) =>
+      v.split(':') match
+        case Array(m, s) if m.nonEmpty && s.nonEmpty => ()
+        case _ =>
+          err(
+            rule,
+            s"""invalid value for ${rule.target}.strategy — expected "module:symbol" (e.g., "tests.strategies_user:valid_url"), got "$v"""",
+            diagnostics
+          )
+    case _ =>
+      err(rule, s"invalid value for ${rule.target}.strategy — expected a string", diagnostics)

--- a/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
@@ -1,0 +1,125 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.ir.*
+
+class StrategyOverrideTest extends CatsEffectSuite:
+
+  private def rule(target: String, property: String, value: Expr): ConventionRule =
+    ConventionRule(target = target, property = property, qualifier = None, value = value)
+
+  private def stringRule(target: String, property: String, v: String): ConventionRule =
+    rule(target, property, Expr.StringLit(v))
+
+  private def baseIR(
+      operations: List[OperationDecl] = Nil,
+      entities: List[EntityDecl] = Nil,
+      typeAliases: List[TypeAliasDecl] = Nil,
+      enums: List[EnumDecl] = Nil,
+      rules: List[ConventionRule] = Nil
+  ): ServiceIR =
+    ServiceIR(
+      name = "Demo",
+      operations = operations,
+      entities = entities,
+      typeAliases = typeAliases,
+      enums = enums,
+      conventions = if rules.isEmpty then None else Some(ConventionsDecl(rules))
+    )
+
+  test("strategy on type alias is accepted"):
+    val ir = baseIR(
+      typeAliases = List(TypeAliasDecl("LongURL", TypeExpr.NamedType("String"))),
+      rules = List(stringRule("LongURL", "strategy", "tests.strategies_user:valid_url"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assertEquals(diagnostics, Nil)
+
+  test("strategy on enum is accepted"):
+    val ir = baseIR(
+      enums = List(EnumDecl("Color", List("RED", "BLUE"))),
+      rules = List(stringRule("Color", "strategy", "tests.strategies_user:valid_color"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assertEquals(diagnostics, Nil)
+
+  test("strategy on operation is rejected"):
+    val ir = baseIR(
+      operations = List(OperationDecl(name = "Shorten")),
+      rules = List(stringRule("Shorten", "strategy", "tests.strategies_user:foo"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d =>
+        d.message.contains("type aliases and enums") && d.target == "Shorten"
+      ),
+      s"diagnostics=$diagnostics"
+    )
+
+  test("strategy on entity is rejected"):
+    val ir = baseIR(
+      entities = List(EntityDecl(name = "Url")),
+      rules = List(stringRule("Url", "strategy", "tests.strategies_user:foo"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d => d.message.contains("type aliases and enums") && d.target == "Url"),
+      s"diagnostics=$diagnostics"
+    )
+
+  test("non-strategy property on type alias is rejected"):
+    val ir = baseIR(
+      typeAliases = List(TypeAliasDecl("LongURL", TypeExpr.NamedType("String"))),
+      rules = List(stringRule("LongURL", "http_method", "GET"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d => d.message.contains("only 'strategy' applies")),
+      s"diagnostics=$diagnostics"
+    )
+
+  test("strategy without colon is rejected"):
+    val ir = baseIR(
+      typeAliases = List(TypeAliasDecl("LongURL", TypeExpr.NamedType("String"))),
+      rules = List(stringRule("LongURL", "strategy", "no_colon_here"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d => d.message.contains("module:symbol")),
+      s"diagnostics=$diagnostics"
+    )
+
+  test("strategy with empty module or symbol is rejected"):
+    val ir = baseIR(
+      typeAliases = List(
+        TypeAliasDecl("A", TypeExpr.NamedType("String")),
+        TypeAliasDecl("B", TypeExpr.NamedType("String"))
+      ),
+      rules = List(
+        stringRule("A", "strategy", ":symbol_only"),
+        stringRule("B", "strategy", "module_only:")
+      )
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assertEquals(diagnostics.count(_.property == "strategy"), 2, s"diagnostics=$diagnostics")
+
+  test("strategy with non-string value is rejected"):
+    val ir = baseIR(
+      typeAliases = List(TypeAliasDecl("LongURL", TypeExpr.NamedType("String"))),
+      rules = List(rule("LongURL", "strategy", Expr.IntLit(42)))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d => d.message.contains("expected a string") && d.target == "LongURL"),
+      s"diagnostics=$diagnostics"
+    )
+
+  test("unknown target name (not op/entity/alias/enum) reports updated message"):
+    val ir = baseIR(
+      rules = List(stringRule("MysteryThing", "strategy", "m:s"))
+    )
+    val diagnostics = Validate.validateConventions(ir.conventions, ir)
+    assert(
+      diagnostics.exists(d => d.message.contains("type alias, or enum")),
+      s"diagnostics=$diagnostics"
+    )

--- a/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
@@ -19,7 +19,7 @@ class GoldenRoundtripTest extends munit.FunSuite:
 
   test("fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No golden fixtures found in $goldenDir")
-    assertEquals(fixtures.size, 18)
+    assertEquals(fixtures.size, 20)
 
   fixtures.foreach: path =>
     val name = path.getFileName.toString

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -25,7 +25,7 @@ class ParseBuildGoldenTest extends CatsEffectSuite:
 
   test("spec fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No spec fixtures found in $specDir")
-    assertEquals(fixtures.size, 18)
+    assertEquals(fixtures.size, 20)
 
   fixtures.foreach: specPath =>
     val name       = specPath.getFileName.toString.stripSuffix(".spec")

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/strategies_user.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/strategies_user.py
@@ -1,0 +1,17 @@
+"""User-supplied Hypothesis strategies referenced from spec convention rules.
+
+Override an entity-typed strategy in the spec:
+
+    conventions {
+      LongURL.strategy = "tests.strategies_user:valid_url"
+    }
+
+Then define `valid_url` here as a zero-argument function that returns a Hypothesis
+strategy. The generated `tests/strategies.py` will import it automatically.
+
+This file is preserved across `spec-to-rest compile` runs — your edits are not
+overwritten. Reset it by deleting it before re-running compile.
+"""
+from hypothesis import strategies as st  # noqa: F401
+
+# Add your strategies below.

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/strategies_user.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/strategies_user.py
@@ -1,6 +1,6 @@
 """User-supplied Hypothesis strategies referenced from spec convention rules.
 
-Override an entity-typed strategy in the spec:
+Override a type-alias or enum strategy in the spec:
 
     conventions {
       LongURL.strategy = "tests.strategies_user:valid_url"

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -2,17 +2,21 @@ package specrest.testgen
 
 import specrest.convention.Naming
 import specrest.ir.BinOp
+import specrest.ir.ConventionRule
 import specrest.ir.EnumDecl
 import specrest.ir.Expr
 import specrest.ir.ServiceIR
 import specrest.ir.TypeAliasDecl
 import specrest.ir.TypeExpr
 
+final case class StrategyImport(module: String, symbol: String)
+
 final case class StrategySpec(
     typeName: String,
     functionName: String,
     body: String,
-    skipped: List[String]
+    skipped: List[String],
+    imports: List[StrategyImport] = Nil
 )
 
 enum StrategyExpr:
@@ -58,9 +62,20 @@ final private case class IntConstraint(
 object Strategies:
 
   def forIR(ir: ServiceIR): List[StrategySpec] =
-    val aliasSpecs = ir.typeAliases.map(specForAlias(_, ir))
-    val enumSpecs  = ir.enums.map(specForEnum)
+    val overrides  = strategyOverrides(ir)
+    val aliasSpecs = ir.typeAliases.map(specForAlias(_, ir, overrides))
+    val enumSpecs  = ir.enums.map(specForEnum(_, overrides))
     aliasSpecs ++ enumSpecs
+
+  private def strategyOverrides(ir: ServiceIR): Map[String, StrategyImport] =
+    ir.conventions.toList.flatMap(_.rules).flatMap:
+      case ConventionRule(target, "strategy", _, Expr.StringLit(v, _), _) =>
+        v.split(':') match
+          case Array(m, s) if m.nonEmpty && s.nonEmpty =>
+            Some(target -> StrategyImport(m, s))
+          case _ => None
+      case _ => None
+    .toMap
 
   def expressionFor(t: TypeExpr, ir: ServiceIR): StrategyExpr = t match
     case TypeExpr.NamedType("String", _) => StrategyExpr.Code("st.text()")
@@ -93,23 +108,50 @@ object Strategies:
   private[testgen] def strategyFunctionName(typeName: String): String =
     s"strategy_${Naming.toSnakeCase(typeName)}"
 
-  private def specForAlias(alias: TypeAliasDecl, ir: ServiceIR): StrategySpec =
-    val (body, skipped) = renderAlias(alias, ir)
-    StrategySpec(
-      typeName = alias.name,
-      functionName = strategyFunctionName(alias.name),
-      body = body,
-      skipped = skipped
-    )
+  private def specForAlias(
+      alias: TypeAliasDecl,
+      ir: ServiceIR,
+      overrides: Map[String, StrategyImport]
+  ): StrategySpec =
+    overrides.get(alias.name) match
+      case Some(imp) =>
+        StrategySpec(
+          typeName = alias.name,
+          functionName = strategyFunctionName(alias.name),
+          body = s"${imp.symbol}()",
+          skipped = Nil,
+          imports = List(imp)
+        )
+      case None =>
+        val (body, skipped) = renderAlias(alias, ir)
+        StrategySpec(
+          typeName = alias.name,
+          functionName = strategyFunctionName(alias.name),
+          body = body,
+          skipped = skipped
+        )
 
-  private def specForEnum(decl: EnumDecl): StrategySpec =
-    val literals = decl.values.map(v => ExprToPython.pyString(v)).mkString(", ")
-    StrategySpec(
-      typeName = decl.name,
-      functionName = strategyFunctionName(decl.name),
-      body = s"st.sampled_from([$literals])",
-      skipped = Nil
-    )
+  private def specForEnum(
+      decl: EnumDecl,
+      overrides: Map[String, StrategyImport]
+  ): StrategySpec =
+    overrides.get(decl.name) match
+      case Some(imp) =>
+        StrategySpec(
+          typeName = decl.name,
+          functionName = strategyFunctionName(decl.name),
+          body = s"${imp.symbol}()",
+          skipped = Nil,
+          imports = List(imp)
+        )
+      case None =>
+        val literals = decl.values.map(v => ExprToPython.pyString(v)).mkString(", ")
+        StrategySpec(
+          typeName = decl.name,
+          functionName = strategyFunctionName(decl.name),
+          body = s"st.sampled_from([$literals])",
+          skipped = Nil
+        )
 
   private def renderAlias(alias: TypeAliasDecl, ir: ServiceIR): (String, List[String]) =
     alias.typeExpr match

--- a/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
@@ -16,6 +16,7 @@ object Templates:
   lazy val predicatesStaticTemplate: String = loadResource("tests/predicates.py")
   lazy val pytestIni: String                = loadResource("tests/pytest.ini")
   lazy val runConformance: String           = loadResource("tests/run_conformance.py")
+  lazy val strategiesUser: String           = loadResource("tests/strategies_user.py")
 
   def predicates(ir: ServiceIR): String =
     val userBlock = renderUserDefinitions(ir)

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -31,6 +31,7 @@ object TestEmit:
       EmittedFile(FilePaths.PredicatesFile, Templates.predicates(ir)),
       EmittedFile(FilePaths.PytestIniFile, Templates.pytestIni),
       EmittedFile(FilePaths.StrategiesFile, strategiesPy),
+      EmittedFile(FilePaths.StrategiesUserFile, Templates.strategiesUser),
       EmittedFile(FilePaths.behavioralTestFile(serviceSnake), behavioralPy),
       EmittedFile(FilePaths.statefulTestFile(serviceSnake), statefulOut.file),
       EmittedFile(FilePaths.structuralTestFile(serviceSnake), structuralOut.file),
@@ -39,13 +40,27 @@ object TestEmit:
     )
 
   private def renderStrategiesFile(specs: List[StrategySpec]): String =
-    val header =
+    val baseHeader =
       """|\"\"\"Auto-generated Hypothesis strategies. Do not edit by hand.\"\"\"
          |from hypothesis import strategies as st
          |
          |from tests.predicates import is_valid_email, is_valid_uri
-         |
          |""".stripMargin.replace("\\\"", "\"")
+
+    val userImports = specs.flatMap(_.imports).distinct
+    val userImportsBlock =
+      userImports
+        .groupBy(_.module)
+        .toList
+        .sortBy(_._1)
+        .map: (module, imps) =>
+          val syms = imps.map(_.symbol).distinct.sorted.mkString(", ")
+          s"from $module import $syms"
+        .mkString("\n")
+
+    val header =
+      if userImportsBlock.isEmpty then baseHeader + "\n"
+      else baseHeader + userImportsBlock + "\n\n"
 
     if specs.isEmpty then header + "# No strategies generated for this service.\n"
     else

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -11,6 +11,7 @@ object FilePaths:
   val TestsInitFile      = "tests/__init__.py"
   val ConftestFile       = "tests/conftest.py"
   val StrategiesFile     = "tests/strategies.py"
+  val StrategiesUserFile = "tests/strategies_user.py"
   val PredicatesFile     = "tests/predicates.py"
   val SkipsFile          = "tests/_testgen_skips.json"
   val AdminRouterFile    = "app/routers/test_admin.py"

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -1,6 +1,8 @@
 package specrest.testgen
 
 import munit.CatsEffectSuite
+import specrest.ir.ConventionRule
+import specrest.ir.ConventionsDecl
 import specrest.ir.EnumDecl
 import specrest.ir.Expr
 import specrest.ir.ServiceIR
@@ -157,6 +159,105 @@ class StrategiesTest extends CatsEffectSuite:
   test("safe_counter has no type aliases or enums; forIR returns empty"):
     loadFixture("fixtures/spec/safe_counter.spec").map: ir =>
       assertEquals(Strategies.forIR(ir), Nil)
+
+  test("convention override on alias replaces synthesized body and registers import"):
+    val ir = ServiceIR(
+      name = "X",
+      typeAliases = List(
+        TypeAliasDecl(name = "LongURL", typeExpr = TypeExpr.NamedType("String"))
+      ),
+      conventions = Some(
+        ConventionsDecl(
+          List(
+            ConventionRule(
+              target = "LongURL",
+              property = "strategy",
+              qualifier = None,
+              value = Expr.StringLit("tests.strategies_user:valid_url")
+            )
+          )
+        )
+      )
+    )
+    val spec = Strategies.forIR(ir).find(_.typeName == "LongURL").getOrElse(fail("no LongURL"))
+    assertEquals(spec.body, "valid_url()")
+    assertEquals(spec.skipped, Nil)
+    assertEquals(spec.imports, List(StrategyImport("tests.strategies_user", "valid_url")))
+
+  test("convention override on enum replaces st.sampled_from body"):
+    val ir = ServiceIR(
+      name = "X",
+      enums = List(EnumDecl(name = "Color", values = List("RED", "BLUE"))),
+      conventions = Some(
+        ConventionsDecl(
+          List(
+            ConventionRule(
+              target = "Color",
+              property = "strategy",
+              qualifier = None,
+              value = Expr.StringLit("tests.strategies_user:strong_color")
+            )
+          )
+        )
+      )
+    )
+    val spec = Strategies.forIR(ir).find(_.typeName == "Color").getOrElse(fail("no Color"))
+    assertEquals(spec.body, "strong_color()")
+    assertEquals(spec.skipped, Nil)
+    assertEquals(spec.imports, List(StrategyImport("tests.strategies_user", "strong_color")))
+
+  test("override only applies to the targeted type; other aliases keep synth"):
+    import specrest.ir.BinOp
+    val ir = ServiceIR(
+      name = "X",
+      typeAliases = List(
+        TypeAliasDecl(name = "Overridden", typeExpr = TypeExpr.NamedType("String")),
+        TypeAliasDecl(
+          name = "PosInt",
+          typeExpr = TypeExpr.NamedType("Int"),
+          constraint = Some(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("value"), Expr.IntLit(0)))
+        )
+      ),
+      conventions = Some(
+        ConventionsDecl(
+          List(
+            ConventionRule(
+              target = "Overridden",
+              property = "strategy",
+              qualifier = None,
+              value = Expr.StringLit("m:s")
+            )
+          )
+        )
+      )
+    )
+    val specs = Strategies.forIR(ir).map(s => s.typeName -> s).toMap
+    assertEquals(specs("Overridden").body, "s()")
+    assertEquals(specs("PosInt").body, "st.integers(min_value=1)")
+    assertEquals(specs("PosInt").imports, Nil)
+
+  test("malformed override (no colon) silently falls through to synth"):
+    val ir = ServiceIR(
+      name = "X",
+      typeAliases = List(
+        TypeAliasDecl(name = "Plain", typeExpr = TypeExpr.NamedType("String"))
+      ),
+      conventions = Some(
+        ConventionsDecl(
+          List(
+            ConventionRule(
+              target = "Plain",
+              property = "strategy",
+              qualifier = None,
+              value = Expr.StringLit("not_a_module_symbol")
+            )
+          )
+        )
+      )
+    )
+    val spec = Strategies.forIR(ir).head
+    assertEquals(spec.body, "st.text()")
+    assertEquals(spec.imports, Nil)
 
   test("multiple regex constraints in `And` chain are all applied"):
     import specrest.ir.BinOp

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -16,7 +16,7 @@ class TestEmitTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("emit produces 11 files at the M5.4-locked paths"):
+  test("emit produces 12 files at the locked paths"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val paths = files.map(_.path).toSet
@@ -28,6 +28,7 @@ class TestEmitTest extends CatsEffectSuite:
           "tests/conftest.py",
           "tests/predicates.py",
           "tests/strategies.py",
+          "tests/strategies_user.py",
           "tests/test_behavioral_url_shortener.py",
           "tests/test_stateful_url_shortener.py",
           "tests/test_structural_url_shortener.py",


### PR DESCRIPTION
## Summary

- Adds a `strategy` convention property targeting type aliases and enums:
  `LongURL.strategy = "tests.strategies_user:valid_url"` redirects testgen
  to a user-written Hypothesis strategy instead of the synthesised one.
- Emits `tests/strategies_user.py` stub, preserved across re-compile so
  user edits aren't overwritten.
- New `--strict-strategies` CLI flag fails compile (exit 1) when any type
  alias has unhandled \`where\` constraints AND no override is registered.

## What was built

| Layer | Change |
|---|---|
| `Validate.scala` | recognises alias/enum names as convention targets; enforces `module:symbol` shape on `strategy` values |
| `Strategies.scala` | new `StrategyImport`; `forIR` builds `Map[String, StrategyImport]` from `ir.conventions` and routes `specForAlias`/`specForEnum` through the override before falling through to synth |
| `TestEmit.scala` | `renderStrategiesFile` adds a deduped, alpha-sorted user-import block; emits `tests/strategies_user.py` |
| `Compile.scala` | adds `strictStrategies: Boolean` to `CompileOptions`; gates after the verify gate; preserves `tests/strategies_user.py` if it already exists on disk |
| `Main.scala` | wires `--strict-strategies` opt; warns if it's passed without `--with-tests` |

## Test plan

- [x] `sbt test` — 474 tests across all modules pass
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `cd docs && npm run build` clean
- [x] New tests:
  - `StrategyOverrideTest` (9) — Validate accepts/rejects \`strategy\` per target kind and value shape
  - `StrategiesTest` (+4) — alias override, enum override, mixed-with-synth, malformed override falls through
  - `CliSmokeTest` (+3) — \`--strict-strategies\` fail/pass, user-edit preservation across re-compile
  - `TestEmitTest` updated for 12-file emit set
- [x] Manual smoke:
  - \`compile --with-tests --strict-strategies --ignore-verify --out … strict_strategies_negative.spec\` → exit 1
  - \`compile --with-tests --strict-strategies --ignore-verify --out … strict_strategies_positive.spec\` → exit 0; \`strategies.py\` imports \`from tests.strategies_user import custom_code\`; recompile preserves user edits to \`strategies_user.py\`

## Notes for review

- The override only swaps the body of \`def strategy_<type>():\` — the
  function name stays \`strategy_<type>\`, so downstream callers
  (\`Stateful.scala\`, behavioral imports) are untouched.
- \`Strategies.strategyOverrides\` defensively re-validates the
  \`module:symbol\` shape. \`Validate\` already errors on malformed values
  before testgen runs, so this is belt-and-braces — keeps the runtime
  total in case someone bypasses Validate.
- New fixtures \`strict_strategies_{negative,positive}.spec\` are minimal
  and verify-clean by construction; tests pass them with \`--ignore-verify\`
  to keep CI fast and isolate the strategy gate from the SMT pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `conventions { ... }` configuration block to define custom strategy mappings for type aliases and enums
  * Added `--strict-strategies` CLI flag for compile-time validation of unhandled strategy constraints
  * Added user-editable strategies file for registering custom test strategies

* **Documentation**
  * Extended convention engine documentation with strategy override examples
  * Updated test generation pipeline documentation with custom strategy configuration details
  * Updated specification language documentation with new conventions syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `strategy` convention for type aliases and enums to plug in user-written Hypothesis strategies, and a `--strict-strategies` gate that fails builds when any synthesized strategy is incomplete without an override. Emits a `tests/strategies_user.py` stub and updates `tests/strategies.py` to import overrides; the stub is preserved on re-compile.

- **New Features**
  - Use `<Type>.strategy = "module:symbol"` to route `strategy_<type>()` to your function.
  - Emits `tests/strategies_user.py` once; preserved on re-compile. `tests/strategies.py` adds a deduped, grouped import block.
  - `--strict-strategies` (with `--with-tests`) fails compile if any alias/enum has an incomplete synthesized strategy — unhandled `where` constraints or unsupported base types — and no override. Warns if passed without `--with-tests`.
  - Convention validation now targets aliases/enums, rejects misuse on other targets, and enforces the `module:symbol` value shape.

- **Migration**
  - Add overrides for types with custom predicates or unsupported base types; enable `--strict-strategies` in CI.
  - Implement zero-arg functions in `tests/strategies_user.py` and check it into VCS.
  - No test caller changes: `strategy_<type>()` names stay the same.

<sup>Written for commit 14371978fdeebed51a274edf7e5d0ac64ae86209. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/146?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

