### PR TITLE
M5.7 — Mutation testing CI gate (closes #135)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,120 @@
+name: Mutation Testing
+
+# Mutates the generated app/ source on canonical fixtures and runs the
+# generated behavioral tests; gates the kill rate per fixture. Nightly only —
+# mutmut over a real FastAPI service runs hundreds of pytest invocations and
+# is too slow to put on the per-PR critical path. Manual `workflow_dispatch`
+# is supported so a contributor can re-run on a feature branch.
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  mutate:
+    strategy:
+      fail-fast: false
+      matrix:
+        fixture: [safe_counter, todo_list, url_shortener]
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: ${{ matrix.fixture }}
+          POSTGRES_PASSWORD: ${{ matrix.fixture }}
+          POSTGRES_DB: ${{ matrix.fixture }}
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd "pg_isready -U ${{ matrix.fixture }}"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://${{ matrix.fixture }}:${{ matrix.fixture }}@localhost:5432/${{ matrix.fixture }}
+      SPEC_TEST_INPROC: "1"
+      ENABLE_TEST_ADMIN: "1"
+      MUTATION_THRESHOLD: "90"
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+
+      - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - uses: astral-sh/setup-uv@bd01e18f51369d5a26f1651c3cb451d3417e3bba # v7.2.1
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.13"
+
+      - name: Compile fixture --with-tests
+        run: |
+          sbt "cli/run compile \
+            --target python-fastapi-postgres \
+            --with-tests \
+            --ignore-verify \
+            --out generated/${{ matrix.fixture }} \
+            fixtures/spec/${{ matrix.fixture }}.spec"
+
+      - name: Install generated project deps
+        working-directory: generated/${{ matrix.fixture }}
+        run: uv sync --all-extras
+
+      - name: Run alembic migrations
+        working-directory: generated/${{ matrix.fixture }}
+        run: uv run alembic upgrade head
+
+      - name: Sanity-check behavioral tests pass before mutation
+        working-directory: generated/${{ matrix.fixture }}
+        run: uv run pytest tests/test_behavioral_*.py -x --tb=short -q
+
+      - name: Configure mutmut for this run
+        working-directory: generated/${{ matrix.fixture }}
+        run: |
+          cat >> pyproject.toml <<'TOML'
+
+          [tool.mutmut]
+          paths_to_mutate = ["app/"]
+          paths_to_exclude = ["app/db/", "app/routers/test_admin.py"]
+          runner = "uv run pytest tests/test_behavioral_*.py -x --tb=no -q"
+          TOML
+
+      - name: Run mutmut
+        working-directory: generated/${{ matrix.fixture }}
+        run: uv run mutmut run || true
+
+      - name: Gate mutation score
+        run: scripts/mutation_check.sh generated/${{ matrix.fixture }} "$MUTATION_THRESHOLD"
+
+      - name: Dump survived mutations
+        if: failure()
+        working-directory: generated/${{ matrix.fixture }}
+        run: |
+          uv run mutmut results --all True > mutmut-results.txt 2>&1 || true
+          echo "::group::All mutations"
+          cat mutmut-results.txt
+          echo "::endgroup::"
+
+      - name: Upload mutmut artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mutmut-${{ matrix.fixture }}
+          path: |
+            generated/${{ matrix.fixture }}/mutants/
+            generated/${{ matrix.fixture }}/mutmut-results.txt
+          if-no-files-found: warn

--- a/docs/content/docs/pipelines/meta.json
+++ b/docs/content/docs/pipelines/meta.json
@@ -4,6 +4,7 @@
     "parser-implementation",
     "verification",
     "test-generation",
+    "mutation-testing",
     "concurrency"
   ]
 }

--- a/docs/content/docs/pipelines/mutation-testing.mdx
+++ b/docs/content/docs/pipelines/mutation-testing.mdx
@@ -103,7 +103,8 @@ SPEC_TEST_INPROC=1 ENABLE_TEST_ADMIN=1 \
 DATABASE_URL=postgresql+asyncpg://safe_counter:safe_counter@localhost:5432/safe_counter \
   uv run mutmut run
 
-bash $REPO/scripts/mutation_check.sh . 90
+# From the spec_to_rest checkout (adjust the path to your clone):
+bash ~/Desktop/spec_to_rest/scripts/mutation_check.sh . 90
 ```
 
 ## Reading a failing report

--- a/docs/content/docs/pipelines/mutation-testing.mdx
+++ b/docs/content/docs/pipelines/mutation-testing.mdx
@@ -1,0 +1,188 @@
+---
+title: Mutation Testing
+description: Nightly mutmut gate that mutates the generated app/ source and asserts the generated behavioral suite kills >=90% of mutants
+---
+
+The behavioral test suite is only as good as the bugs it catches. A test that
+exercises every line of `app/` but never fails when that code is wrong is a
+liability. To keep the generated suite honest we run [mutmut](https://mutmut.readthedocs.io)
+nightly: it rewrites the generated `app/` source one mutation at a time
+(`==` to `!=`, `<` to `<=`, `True` to `False`, drop `return` value, etc.) and
+re-runs `pytest tests/test_behavioral_*.py` against each mutated copy. A
+mutation that survives means the suite did not detect the change — either the
+clause it should have caught is not actually being asserted, or the mutation
+is genuinely equivalent (rare, but real).
+
+The CI gate fails if the kill rate drops below 90% on any of the canonical
+fixtures.
+
+## Where it runs
+
+[`.github/workflows/mutation-testing.yml`](https://github.com/HardMax71/spec_to_rest/blob/main/.github/workflows/mutation-testing.yml)
+runs on `schedule: '0 3 * * *'` (3 AM UTC) and on `workflow_dispatch`. It is
+deliberately **not** part of the per-PR CI: a single mutmut run on
+`url_shortener` is hundreds of pytest invocations and easily exceeds the
+per-PR budget. The matrix covers `safe_counter`, `todo_list`, and
+`url_shortener`. Each fixture gets its own runner with a Postgres service
+container; the runners are independent (`fail-fast: false`).
+
+## How a single matrix entry works
+
+```text
+1. sbt cli/run compile --with-tests --ignore-verify --out generated/<fixture> ...
+2. uv sync --all-extras                       # installs mutmut as a dev dep
+3. uv run alembic upgrade head                # creates the schema
+4. uv run pytest tests/test_behavioral_*.py   # sanity: must pass before mutating
+5. echo '[tool.mutmut] ...' >> pyproject.toml # paths_to_mutate, runner
+6. uv run mutmut run                          # populates .mutmut-cache
+7. scripts/mutation_check.sh generated/<fixture> 90  # gate
+```
+
+Step 4 is the safety net: if behavioral tests don't pass against the
+unmutated app, mutmut runs are noise. Step 5 writes the mutmut config inline
+because mutmut auto-discovers `[tool.mutmut]` in `pyproject.toml`. Step 6
+runs without `set -e` short-circuiting (`|| true`) — mutmut exits non-zero on
+any survived mutation, but the gate decision belongs to the threshold
+script, not mutmut.
+
+## The TestClient mode (`SPEC_TEST_INPROC=1`)
+
+`mutmut` mutates files on disk. For the runner to **see** those mutations
+the test has to import `app/` fresh per invocation. The default conftest
+sends HTTP to an external `uvicorn`, which gets loaded once and pins the
+original bytecode — every mutation would survive trivially. Setting
+`SPEC_TEST_INPROC=1` makes `tests/conftest.py` instantiate
+`fastapi.testclient.TestClient(app)` against `from app.main import app`, so
+each `pytest` process imports the (mutated) app fresh. Postgres is still in
+the loop; the FastAPI request handler runs in-process, but its DB calls go
+to the real database.
+
+The workflow sets this env var globally; local users can opt in the same way.
+
+## The threshold script
+
+[`scripts/mutation_check.sh`](https://github.com/HardMax71/spec_to_rest/blob/main/scripts/mutation_check.sh)
+parses `mutmut results --all True` and computes:
+
+```text
+score = killed / (killed + survived + suspicious + timeout)
+```
+
+`skipped` and `no_tests` mutations are excluded from the denominator —
+they're not a quality signal (mutmut couldn't run the test for some
+infrastructure reason; a survived mutation by contrast is a real gap). On
+failure the script lists each survived/suspicious/timeout mutation with its
+diff (`mutmut show <id>`), so the workflow log alone is enough to start
+investigating.
+
+Threshold defaults to 90. To run the gate locally:
+
+```bash
+sbt "cli/run compile --target python-fastapi-postgres --with-tests --ignore-verify --out /tmp/svc fixtures/spec/safe_counter.spec"
+cd /tmp/svc && uv sync --all-extras
+
+# Postgres on :5432 with user/pass/db = "safe_counter"
+docker run -d --rm -p 5432:5432 \
+  -e POSTGRES_USER=safe_counter \
+  -e POSTGRES_PASSWORD=safe_counter \
+  -e POSTGRES_DB=safe_counter \
+  postgres:17-alpine
+
+DATABASE_URL=postgresql+asyncpg://safe_counter:safe_counter@localhost:5432/safe_counter \
+  uv run alembic upgrade head
+
+cat >> pyproject.toml <<'TOML'
+
+[tool.mutmut]
+paths_to_mutate = ["app/"]
+paths_to_exclude = ["app/db/", "app/routers/test_admin.py"]
+runner = "uv run pytest tests/test_behavioral_*.py -x --tb=no -q"
+TOML
+
+SPEC_TEST_INPROC=1 ENABLE_TEST_ADMIN=1 \
+DATABASE_URL=postgresql+asyncpg://safe_counter:safe_counter@localhost:5432/safe_counter \
+  uv run mutmut run
+
+bash $REPO/scripts/mutation_check.sh . 90
+```
+
+## Reading a failing report
+
+A typical failure block in the workflow log:
+
+```text
+mutmut score: 86.45% (killed=45 evaluated=52; survived=5 suspicious=2 timeout=0; skipped=0 no_tests=3)
+
+MUTATION SCORE 86.45% < threshold 90%
+survived/suspicious/timeout mutations:
+
+--- app.services.url_shortener.x_resolve__mutmut_3 ---
+# app.services.url_shortener.x_resolve__mutmut_3: survived
+--- app/services/url_shortener.py
++++ app/services/url_shortener.py
+@@ -23,4 +23,4 @@
+ async def resolve(code: str, session: AsyncSession) -> Url | None:
+-    result = await session.execute(select(Url).where(Url.code == code))
++    result = await session.execute(select(Url).where(Url.code != code))
+     return result.scalar_one_or_none()
+```
+
+For each survived mutation, decide:
+
+- **Genuine gap** — the spec ensures clause that should have caught this
+  mutation is not being translated to a property test, or the property test
+  is too lax. Fix is in [`Behavioral.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala)
+  or its callers.
+- **Equivalent mutation** — the mutation produces semantically identical
+  code (e.g., `await session.commit()` ↔ `await session.flush()` in some
+  paths, or a guard whose condition is implied by an earlier guard).
+  Equivalents are inevitable; the 10% slack in the 90% threshold absorbs them.
+- **Test infrastructure gap** — the property test runs but its assertions
+  don't cover this code path (e.g., a status-code assertion that's lax
+  enough to accept the mutated 200 alongside the original 201). Tighten the
+  ensures expression in the spec or the assertion in `Behavioral.scala`.
+
+The mutation IDs are stable across runs as long as `app/` source positions
+don't shift, so an investigation can pin a specific ID and apply it on
+disk to reproduce locally:
+
+```bash
+cd generated/url_shortener
+uv run mutmut apply app.services.url_shortener.x_resolve__mutmut_3
+git diff app/  # see the mutation
+uv run pytest tests/test_behavioral_url_shortener.py -x   # observe what (didn't) catch it
+git checkout app/  # revert
+```
+
+## Threshold rationale
+
+Per-fixture threshold is a single number passed to
+`scripts/mutation_check.sh` as the second argument. Today every matrix
+entry uses 90. If a fixture proves to have an unusually high equivalent-
+mutation rate (e.g., heavy SQLAlchemy session boilerplate that mutmut keeps
+mutating between morally-equivalent shapes), the per-fixture threshold can
+be lowered in the workflow without changing the script. We prefer that to
+a global lower bar.
+
+## Excluded paths
+
+`paths_to_exclude` skips:
+
+- `app/db/` — Alembic migrations and base SQLAlchemy metadata. Mutating
+  schema definitions yields runtime errors that aren't a test-quality
+  signal.
+- `app/routers/test_admin.py` — the admin router only exists to support
+  tests. Mutating it would change the test harness, not the code under test.
+
+Routers (`app/routers/<entity>.py`), services (`app/services/<service>.py`),
+schemas (`app/schemas/`), and models (`app/models/`) are all in scope.
+
+## Non-goals
+
+- **Per-PR mutation testing.** Too slow; the PR-time gate is the structural
+  + behavioral + stateful conformance suite.
+- **Mutating the testgen Scala code.** That's a separate concern (would
+  exercise our IR/codegen, not the generated services). Out of scope for M5.7.
+- **Alternative engines** (cosmic-ray, MutPy). mutmut is the canonical
+  choice today; switching engines is a much larger lift than tuning the
+  current setup.

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -431,9 +431,11 @@ is outside the recognized negative-test pattern; (c) a real user error in the sp
 - Setting `SPEC_TEST_INPROC=1` flips `conftest.py` to use FastAPI's `TestClient` against
   an in-process import of `app.main:app` instead of going over HTTP to `SPEC_TEST_BASE_URL`.
   Each `pytest` invocation re-imports the app fresh — required for mutation testing
-  ([M5.7](#mutation-testing-m57)) where the runner has to observe edits to `app/`.
-  The admin router is auto-enabled in this mode. Postgres (or whatever DATABASE_URL points
-  at) is still required because the in-process app makes real DB calls.
+  (see [Mutation Testing](/docs/pipelines/mutation-testing)) where the runner has to
+  observe edits to `app/`. The admin router is auto-enabled in this mode (the conftest
+  unconditionally sets `ENABLE_TEST_ADMIN=1` before importing `app.main`). Postgres (or
+  whatever `DATABASE_URL` points at) is still required because the in-process app makes
+  real DB calls.
 - Today's M4-stage codegen emits service stubs that raise `NotImplementedError` for most
   operations. M5.1 ships the test-generation machinery; making the assertions pass at
   runtime requires [#86](https://github.com/HardMax71/spec_to_rest/issues/86)

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -11,7 +11,9 @@ invariant becomes a post-operation check.
 Looking for the **design rationale and the full vision** (structural + behavioral + stateful
 layers, conformance runner, mutation testing)? See
 [Test Generation Pipeline (research)](/research/05_test_generation). This page documents what
-`--with-tests` actually delivers today (M5.1).
+`--with-tests` actually delivers today; the nightly mutation-testing CI gate that
+keeps the suite honest is documented separately on the
+[Mutation Testing](/docs/pipelines/mutation-testing) page.
 
 ## Quick start
 
@@ -426,6 +428,12 @@ is outside the recognized negative-test pattern; (c) a real user error in the sp
   (default `http://localhost:8000`).
 - The service must have started with `ENABLE_TEST_ADMIN=1`. Without it, the conftest
   fixture skips the whole suite with a clear message rather than failing weirdly.
+- Setting `SPEC_TEST_INPROC=1` flips `conftest.py` to use FastAPI's `TestClient` against
+  an in-process import of `app.main:app` instead of going over HTTP to `SPEC_TEST_BASE_URL`.
+  Each `pytest` invocation re-imports the app fresh — required for mutation testing
+  ([M5.7](#mutation-testing-m57)) where the runner has to observe edits to `app/`.
+  The admin router is auto-enabled in this mode. Postgres (or whatever DATABASE_URL points
+  at) is still required because the in-process app makes real DB calls.
 - Today's M4-stage codegen emits service stubs that raise `NotImplementedError` for most
   operations. M5.1 ships the test-generation machinery; making the assertions pass at
   runtime requires [#86](https://github.com/HardMax71/spec_to_rest/issues/86)
@@ -499,7 +507,6 @@ become compile errors under `--strict-strategies`.
 | Limit | Tracked under |
 |---|---|
 | State-dependent preconditions skip ensures tests | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) — TransitionDecl-aware state-machine setup |
-| Mutation-testing CI gate | [M5.7 (#135)](https://github.com/HardMax71/spec_to_rest/issues/135) |
 | Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
 | Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/pyproject.toml.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/pyproject.toml.hbs
@@ -19,6 +19,7 @@ dev = [
     "{{this.name}}{{this.version}}",
 {{/each}}
     "schemathesis>=4.16,<5",
+    "mutmut>=3.3,<4",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/conftest.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/conftest.py
@@ -9,19 +9,18 @@ BASE_URL = os.environ.get("SPEC_TEST_BASE_URL", "http://localhost:8000")
 INPROC = os.environ.get("SPEC_TEST_INPROC") == "1"
 
 
-def _build_client() -> httpx.Client:
-    if INPROC:
-        os.environ.setdefault("ENABLE_TEST_ADMIN", "1")
-        from fastapi.testclient import TestClient
+if INPROC:
+    os.environ["ENABLE_TEST_ADMIN"] = "1"
+    from fastapi.testclient import TestClient
 
-        from app.main import app
+    from app.main import app
 
-        return TestClient(app, base_url=BASE_URL)
-    return httpx.Client(base_url=BASE_URL, timeout=10.0)
-
-
-client = _build_client()
-atexit.register(client.close)
+    client = TestClient(app, base_url=BASE_URL)
+    client.__enter__()
+    atexit.register(client.__exit__, None, None, None)
+else:
+    client = httpx.Client(base_url=BASE_URL, timeout=10.0)
+    atexit.register(client.close)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/conftest.py
+++ b/modules/testgen/src/main/resources/testgen-templates/python-fastapi-postgres/tests/conftest.py
@@ -6,20 +6,36 @@ import httpx
 import pytest
 
 BASE_URL = os.environ.get("SPEC_TEST_BASE_URL", "http://localhost:8000")
+INPROC = os.environ.get("SPEC_TEST_INPROC") == "1"
 
-client = httpx.Client(base_url=BASE_URL, timeout=10.0)
+
+def _build_client() -> httpx.Client:
+    if INPROC:
+        os.environ.setdefault("ENABLE_TEST_ADMIN", "1")
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        return TestClient(app, base_url=BASE_URL)
+    return httpx.Client(base_url=BASE_URL, timeout=10.0)
+
+
+client = _build_client()
 atexit.register(client.close)
 
 
 @pytest.fixture(scope="session", autouse=True)
 def _admin_endpoint_available():
     """Fail-fast guard: tests need the test_admin router enabled on the service."""
-    with httpx.Client(base_url=BASE_URL, timeout=5.0) as probe:
-        try:
-            r = probe.post("/__test_admin__/reset")
-        except httpx.HTTPError as e:
-            pytest.skip(f"service unreachable at {BASE_URL}: {e}")
-            return
+    if INPROC:
+        r = client.post("/__test_admin__/reset")
+    else:
+        with httpx.Client(base_url=BASE_URL, timeout=5.0) as probe:
+            try:
+                r = probe.post("/__test_admin__/reset")
+            except httpx.HTTPError as e:
+                pytest.skip(f"service unreachable at {BASE_URL}: {e}")
+                return
     if r.status_code == 403:
         pytest.skip(
             "ENABLE_TEST_ADMIN=1 is not set on the service; "

--- a/scripts/mutation_check.sh
+++ b/scripts/mutation_check.sh
@@ -47,6 +47,8 @@ total=$((evaluated + skipped + no_tests))
 
 if [ "$evaluated" -eq 0 ]; then
   echo "no mutations evaluated (total=$total skipped=$skipped no_tests=$no_tests)" >&2
+  echo "raw mutmut output:" >&2
+  printf '%s\n' "$results" >&2
   exit 2
 fi
 
@@ -63,7 +65,7 @@ if awk -v s="$score" -v th="$threshold" 'BEGIN{exit !(s+0 < th+0)}'; then
     | while read -r id; do
         [ -n "$id" ] || continue
         printf '\n--- %s ---\n' "$id" >&2
-        uv run --no-sync mutmut show "$id" 2>&1 >&2 || true
+        uv run --no-sync mutmut show "$id" >&2 2>&1 || true
       done
   exit 1
 fi

--- a/scripts/mutation_check.sh
+++ b/scripts/mutation_check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Gate the mutation score from a `mutmut run` against a per-fixture threshold.
+#
+# Usage: scripts/mutation_check.sh <project-dir> [threshold-percent]
+#
+# Expects mutmut 3.x to be installed in <project-dir>'s venv (uv sync) and a
+# `.mutmut-cache` populated by a prior `mutmut run` in <project-dir>.
+#
+# Score = killed / (killed + survived + suspicious + timeout)
+# `skipped` and `no_tests` mutations are excluded from the denominator.
+#
+# On failure, prints each survived/suspicious/timeout mutation with its diff.
+set -euo pipefail
+export LC_ALL=C
+
+project="${1:?usage: $0 <project-dir> [threshold-percent]}"
+threshold="${2:-90}"
+
+if [ ! -d "$project" ]; then
+  echo "project dir not found: $project" >&2
+  exit 2
+fi
+
+cd "$project"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not on PATH; mutation_check.sh expects to invoke uv-managed mutmut" >&2
+  exit 2
+fi
+
+results=$(uv run --no-sync mutmut results --all True 2>&1 || true)
+
+if [ -z "$results" ]; then
+  echo "mutmut produced no results; did mutmut run complete?" >&2
+  exit 2
+fi
+
+killed=$(printf '%s\n' "$results" | awk '/: killed$/ {n++} END{print n+0}')
+survived=$(printf '%s\n' "$results" | awk '/: survived$/ {n++} END{print n+0}')
+suspicious=$(printf '%s\n' "$results" | awk '/: suspicious$/ {n++} END{print n+0}')
+timeout=$(printf '%s\n' "$results" | awk '/: timeout$/ {n++} END{print n+0}')
+skipped=$(printf '%s\n' "$results" | awk '/: skipped$/ {n++} END{print n+0}')
+no_tests=$(printf '%s\n' "$results" | awk '/: no_tests$/ {n++} END{print n+0}')
+
+evaluated=$((killed + survived + suspicious + timeout))
+total=$((evaluated + skipped + no_tests))
+
+if [ "$evaluated" -eq 0 ]; then
+  echo "no mutations evaluated (total=$total skipped=$skipped no_tests=$no_tests)" >&2
+  exit 2
+fi
+
+score=$(awk -v k="$killed" -v t="$evaluated" 'BEGIN{printf "%.2f", 100*k/t}')
+
+printf 'mutmut score: %s%% (killed=%d evaluated=%d; survived=%d suspicious=%d timeout=%d; skipped=%d no_tests=%d)\n' \
+  "$score" "$killed" "$evaluated" "$survived" "$suspicious" "$timeout" "$skipped" "$no_tests"
+
+if awk -v s="$score" -v th="$threshold" 'BEGIN{exit !(s+0 < th+0)}'; then
+  printf '\nMUTATION SCORE %s%% < threshold %s%%\n' "$score" "$threshold" >&2
+  printf 'survived/suspicious/timeout mutations:\n' >&2
+  printf '%s\n' "$results" \
+    | awk '/: (survived|suspicious|timeout)$/ {sub(/^[[:space:]]+/, ""); sub(/:.*/, ""); print}' \
+    | while read -r id; do
+        [ -n "$id" ] || continue
+        printf '\n--- %s ---\n' "$id" >&2
+        uv run --no-sync mutmut show "$id" 2>&1 >&2 || true
+      done
+  exit 1
+fi
+
+printf '\nmutation score %s%% >= threshold %s%%\n' "$score" "$threshold"


### PR DESCRIPTION
## Summary

- Nightly mutation-testing workflow (`.github/workflows/mutation-testing.yml`) runs `mutmut` over generated `app/` for `safe_counter`, `todo_list`, `url_shortener`; gates kill rate >=90% per fixture; uploads `mutants/` + survived diffs as artifact.
- New `SPEC_TEST_INPROC=1` mode in `tests/conftest.py` template swaps the external `httpx.Client` for `fastapi.testclient.TestClient(app)` so each `pytest` invocation re-imports `app/` and observes mutmut's disk mutations. Default (env var unset) is unchanged.
- `scripts/mutation_check.sh` parses `mutmut results --all True` and emits each survived/suspicious/timeout mutation's `mutmut show <id>` diff on failure.
- `mutmut>=3.3,<4` added to generated pyproject dev deps.

## Why TestClient mode

`mutmut run --paths-to-mutate=app/` mutates files on disk. The default conftest's `httpx.Client(base_url=...)` points at an external `uvicorn` whose bytecode is pinned at startup; that uvicorn does not pick up disk mutations, so every mutation would survive trivially. TestClient is in-process and re-imports `app.main:app` per pytest invocation. Postgres remains in the loop — TestClient just wraps the request handler in-process; DB calls hit the real database.

## Threshold

Single per-fixture argument to `scripts/mutation_check.sh`; defaulted to 90 across the matrix today. If a fixture has an unusually high equivalent-mutation rate (e.g., async session boilerplate), per-fixture thresholds can be tuned in the workflow without script changes.

## Excluded paths

- `app/db/` — Alembic migrations / SQLAlchemy metadata; mutating them yields runtime errors that aren't a test-quality signal.
- `app/routers/test_admin.py` — admin router exists for tests; mutating it changes the harness, not the code under test.

Routers, services, schemas, and models are all in scope.

## Local smoke deferred

A real local smoke needs Postgres, which I couldn't bring up under the current sandbox. The first `workflow_dispatch` after this merges is the load-bearing verification — if 90% turns out unreasonable for a specific fixture we tune in a follow-up.

## Test plan

- [ ] sbt test green (verified locally)
- [ ] sbt scalafmtCheckAll clean (verified locally)
- [ ] sbt scalafixAll --check clean (verified locally)
- [ ] docs `npm run build` clean (verified locally)
- [ ] After merge: trigger `Mutation Testing` via workflow_dispatch on main; confirm at least one fixture passes; tune per-fixture thresholds if any fail with score >85% (likely equivalent-mutation noise; investigate before lowering further).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a nightly mutation-testing CI gate that runs `mutmut` on generated FastAPI apps and fails if the kill rate drops below 90% per fixture. Adds an in-process test mode so mutations are picked up by `pytest`, and documents the setup (implements M5.7, issue #135).

- **New Features**
  - GitHub Actions workflow runs `mutmut` for `safe_counter`, `todo_list`, `url_shortener` with a Postgres service, then gates score via `scripts/mutation_check.sh` (prints diffs on failure and uploads artifacts).
  - `SPEC_TEST_INPROC=1` switches to `fastapi.testclient.TestClient(app)` (entered as a context manager so lifespan events run) and forces `ENABLE_TEST_ADMIN=1`; default `httpx.Client` path is unchanged when unset.
  - `scripts/mutation_check.sh` computes the score, now dumps raw `mutmut` output when parsing fails and fixes stderr redirection so `mutmut show` diffs are visible; prints survived/suspicious/timeout diffs on failure.
  - Excludes `app/db/` and `app/routers/test_admin.py` from mutation scope; threshold defaults to 90% and can be tuned per fixture in the workflow.
  - Docs: new Mutation Testing page, cross-links from the test-generation page, and minor fixes (broken anchor, local example path).

- **Dependencies**
  - Adds `mutmut>=3.3,<4` to generated `pyproject.toml` dev dependencies.

<sup>Written for commit f2a05749a07e1bb7add8793ca611e9d8225a0833. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/147?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

