### PR TITLE
Misc fixes: native-image M5.8 templates, docs link health, railroad SVGs, Collapsible component

### DIFF
--- a/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/app/(docs)/[[...slug]]/page.tsx
@@ -23,7 +23,7 @@ export default async function Page(props: {
   if (!page) notFound();
 
   const MDX = page.data.body;
-  const repoRel = `docs/content/${page.path}`;
+  const repoRel = `docs/content/docs/${page.path}`;
   const lastModified = getGitLastModified(repoRel);
 
   const editUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}/edit/${REPO_BRANCH}/${repoRel}`;

--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,5 +1,6 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { Collapsible } from "@/components/mdx/collapsible";
 import { Mermaid } from "@/components/mdx/mermaid";
 import { RailroadDiagram } from "@/components/mdx/railroad-diagram";
 import {
@@ -12,6 +13,7 @@ import {
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    Collapsible,
     Mermaid,
     RailroadDiagram,
     FileTree,

--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -1,6 +1,7 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
 import { Mermaid } from "@/components/mdx/mermaid";
+import { RailroadDiagram } from "@/components/mdx/railroad-diagram";
 import {
   FileTree,
   FileTreeFolder,
@@ -12,6 +13,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     Mermaid,
+    RailroadDiagram,
     FileTree,
     FileTreeFolder,
     FileTreeRow,

--- a/docs/components/mdx/collapsible.tsx
+++ b/docs/components/mdx/collapsible.tsx
@@ -1,0 +1,28 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface Props {
+  title: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export function Collapsible({ title, defaultOpen = false, children }: Props) {
+  return (
+    <details
+      className="fd-collapsible my-4 rounded-lg border bg-fd-card overflow-hidden [&[open]>summary>.fd-collapsible-chevron]:rotate-90"
+      {...(defaultOpen ? { open: true } : {})}
+    >
+      <summary className="flex cursor-pointer select-none list-none items-center gap-2 px-4 py-3 text-sm font-medium hover:bg-fd-accent [&::-webkit-details-marker]:hidden">
+        <ChevronRight
+          aria-hidden="true"
+          className="fd-collapsible-chevron h-4 w-4 shrink-0 transition-transform duration-150"
+        />
+        <span>{title}</span>
+      </summary>
+      <div className="border-t bg-fd-background/40 px-4 py-3 [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/docs/components/mdx/railroad-diagram.tsx
+++ b/docs/components/mdx/railroad-diagram.tsx
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const RESPONSIVE_TWEAKS = `
+.fd-railroad svg {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  height: auto;
+}
+`;
+
+const cache = new Map<string, string>();
+
+function readSvg(name: string): string {
+  const cached = cache.get(name);
+  if (cached !== undefined) return cached;
+  const file = path.join(process.cwd(), "public", "grammar", `${name}.svg`);
+  const svg = fs.readFileSync(file, "utf8");
+  cache.set(name, svg);
+  return svg;
+}
+
+interface Props {
+  name: string;
+  alt: string;
+}
+
+export function RailroadDiagram({ name, alt }: Props) {
+  const svg = readSvg(name);
+  return (
+    <div
+      className="fd-railroad not-prose my-4 w-full overflow-x-auto"
+      role="img"
+      aria-label={alt}
+    >
+      <style>{RESPONSIVE_TWEAKS}</style>
+      <div dangerouslySetInnerHTML={{ __html: svg }} />
+    </div>
+  );
+}

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -9,7 +9,7 @@ description: Compiler internals, IR design, and implementation plan
 - **Parser:** ANTLR4 (Java runtime) via `sbt-antlr4`
 - **Effect runtime:** [Cats Effect 3.7](https://typelevel.org/cats-effect/) — every pipeline
   stage returns `IO`; the CLI runs as `CommandIOApp`. See
-  [Concurrency and Cancellation](../pipelines/concurrency).
+  [Concurrency and Cancellation](/pipelines/concurrency).
 - **Verification IL:** Dafny (auto-active verification, compiles to C#/Java/Go/JS/Python)
 - **Constraint solver:** Z3 Java bindings via `tools.aqua:z3-turnkey` (bundles libz3 natively — no system install)
 - **LLM synthesis:** Claude / GPT-4 with CEGIS (Counter-Example Guided Inductive Synthesis) loop
@@ -28,7 +28,7 @@ flowchart LR
 ```
 
 1. **Parse** — ANTLR4 grammar → CST → typed AST (Scala 3 enums + case classes).
-   See [Parser Implementation Notes](../pipelines/parser-implementation) for deviations from the EBNF spec.
+   See [Parser Implementation Notes](/pipelines/parser-implementation) for deviations from the EBNF spec.
 2. **Verify** — Static analysis: type checking, invariant satisfiability, deadlock detection
 3. **Map** — Convention Engine applies M1–M10 rules, resolving HTTP methods, DB types, endpoints
 4. **Synthesize** — CEGIS loop: LLM generates Dafny code → verifier checks → counterexamples feed
@@ -88,7 +88,7 @@ fiber tree rooted at `CommandIOApp.main`. Backends are acquired as `Resource[IO,
 finalizers run on success, failure, and cancellation alike. The `--parallel` flag maps to
 `parTraverseN(n)`; `--timeout` is enforced natively inside each backend (Z3's `timeout`
 solver param; Alloy's `Future.get(timeout, …)`). See
-[Concurrency and Cancellation](../pipelines/concurrency) for the full model, JMH numbers,
+[Concurrency and Cancellation](/pipelines/concurrency) for the full model, JMH numbers,
 and the cancellation contract.
 
 ## Build plan

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -3,6 +3,7 @@ title: Introduction
 description: A compiler that proves your REST service satisfies its specification before emitting a single line of code.
 ---
 
+import Link from 'next/link';
 import { Callout } from 'fumadocs-ui/components/callout';
 import {
   ShieldCheck,
@@ -31,20 +32,20 @@ import {
     on failed verification &mdash; so what ships is what was checked.
   </div>
   <div className="mt-1 flex flex-wrap gap-3">
-    <a
+    <Link
       href="/spec-language"
       className="inline-flex items-center gap-2 rounded-lg bg-fd-primary px-4 py-2 text-sm font-medium text-fd-primary-foreground shadow transition hover:bg-fd-primary/90"
     >
       <BookOpen className="h-4 w-4" />
       Spec language reference
-    </a>
-    <a
+    </Link>
+    <Link
       href="/pipelines/verification"
       className="inline-flex items-center gap-2 rounded-lg border bg-fd-card px-4 py-2 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent"
     >
       <ShieldCheck className="h-4 w-4" />
       How verification works
-    </a>
+    </Link>
     <a
       href="https://github.com/HardMax71/spec_to_rest"
       target="_blank"

--- a/docs/content/docs/pipelines/concurrency.mdx
+++ b/docs/content/docs/pipelines/concurrency.mdx
@@ -207,8 +207,8 @@ immediately on the first Ctrl+C.
 
 ## See also
 
-- [Verification Engine](./verification) — Z3/Alloy routing, timeout semantics, exit codes.
-- [Architecture](../design/architecture) — where the effect layer sits in the overall
+- [Verification Engine](/pipelines/verification) — Z3/Alloy routing, timeout semantics, exit codes.
+- [Architecture](/design/architecture) — where the effect layer sits in the overall
   compiler.
 - [M_CE migration meta #95](https://github.com/HardMax71/spec_to_rest/issues/95) — the
   complete Cats Effect 3 migration log.

--- a/docs/content/docs/pipelines/parser-implementation.mdx
+++ b/docs/content/docs/pipelines/parser-implementation.mdx
@@ -173,7 +173,7 @@ precedence chain.
 assigns implicit precedence by alternative order — **first alternative = highest precedence
 (tightest binding)**, last = lowest. The alternatives are ordered accordingly:
 
-<img src="/spec_to_rest/grammar/expr-precedence.svg" alt="expr precedence chain (tightest → loosest)" className="my-4 mx-auto block max-w-full h-auto" />
+<RailroadDiagram name="expr-precedence" alt="expr precedence chain (tightest → loosest)" />
 
 ```text
 Alternative order in grammar (first = tightest):
@@ -193,9 +193,9 @@ Alternative order in grammar (first = tightest):
 
 The two top-level structural rules render as:
 
-<img src="/spec_to_rest/grammar/service-toplevel.svg" alt="service / entity / operation top-level structure" className="my-4 mx-auto block max-w-full h-auto" />
+<RailroadDiagram name="service-toplevel" alt="service / entity / operation top-level structure" />
 
-<img src="/spec_to_rest/grammar/operation-decl.svg" alt="operation declaration" className="my-4 mx-auto block max-w-full h-auto" />
+<RailroadDiagram name="operation-decl" alt="operation declaration" />
 
 Regenerate the SVGs with `node docs/scripts/build-railroad.mjs` whenever the grammar changes.
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -13,7 +13,7 @@ layers, conformance runner, mutation testing)? See
 [Test Generation Pipeline (research)](/research/05_test_generation). This page documents what
 `--with-tests` actually delivers today; the nightly mutation-testing CI gate that
 keeps the suite honest is documented separately on the
-[Mutation Testing](/docs/pipelines/mutation-testing) page.
+[Mutation Testing](/pipelines/mutation-testing) page.
 
 ## Quick start
 
@@ -485,7 +485,7 @@ is outside the recognized negative-test pattern; (c) a real user error in the sp
 - Setting `SPEC_TEST_INPROC=1` flips `conftest.py` to use FastAPI's `TestClient` against
   an in-process import of `app.main:app` instead of going over HTTP to `SPEC_TEST_BASE_URL`.
   Each `pytest` invocation re-imports the app fresh — required for mutation testing
-  (see [Mutation Testing](/docs/pipelines/mutation-testing)) where the runner has to
+  (see [Mutation Testing](/pipelines/mutation-testing)) where the runner has to
   observe edits to `app/`. The admin router is auto-enabled in this mode (the conftest
   unconditionally sets `ENABLE_TEST_ADMIN=1` before importing `app.main`). Postgres (or
   whatever `DATABASE_URL` points at) is still required because the in-process app makes

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -40,6 +40,8 @@ Production deployments must leave this unset; the router returns 403 by default.
 
 ## What gets generated
 
+<Collapsible title="Generated files — full table">
+
 | File | Source | What it is |
 |---|---|---|
 | `app/routers/test_admin.py` | `AdminRouter.scala` | `/__test_admin__/reset` truncates entity tables; `/__test_admin__/state` returns spec state as JSON. Both 403 unless `ENABLE_TEST_ADMIN=1`. |
@@ -54,6 +56,8 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/run_conformance.py` | static template | three-phase orchestrator (structural → behavioral → stateful) with JUnit XML output and a unified exit code |
 | `tests/_testgen_skips.json` | testgen | machine-readable list of clauses that were not turned into tests, with reasons |
 | `pytest.ini` | static template | disables `pytest-xdist` parallelism (admin-router state is global) |
+
+</Collapsible>
 
 ## Three test kinds emitted per operation
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -21,6 +21,8 @@ Every verification check is routed to **exactly one** backend based on structura
 the expression — there is no overlap, and each check line is tagged `[z3]` or `[alloy]` in the
 CLI output so the attribution is visible.
 
+<Collapsible title="Capability status — full table">
+
 | Capability                                                          | Status |
 | ------------------------------------------------------------------- | ------ |
 | IR-to-SMT translator (entities, enums, state relations, invariants) | shipped |
@@ -65,6 +67,8 @@ CLI output so the attribution is visible.
 | `spec-to-rest` as `CommandIOApp` — structured `IO[ExitCode]` subcommands, SIGINT wired to fiber cancellation | shipped in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)) |
 | Single-API pipeline — every `Parse`, `Builder`, `Translator`, `WasmBackend`, `AlloyBackend`, and `Consistency` entry point returns `IO`; synchronous wrappers removed; test suites migrated to `CatsEffectSuite` with per-module `SpecFixtures.loadIR` helpers | shipped in M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) |
 | Concurrency docs (`docs/content/docs/pipelines/concurrency.mdx`) + JMH `ParallelVerifyBench` with checked-in CSV at `fixtures/golden/bench/parallel_verify.csv` | shipped in M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) |
+
+</Collapsible>
 
 ## Preservation VC shape
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -568,7 +568,7 @@ the effect layer: per-check fibers via `parTraverseN`, `Resource[IO, WasmBackend
 `onCancel`, and a `CommandIOApp` shutdown hook for signal handling. The full mechanics &mdash;
 JMH numbers, native-memory caveats, the cancellation contract, and the `Context.interrupt()`
 mid-call abort details &mdash; are documented in
-[Concurrency &amp; Cancellation](./concurrency).
+[Concurrency &amp; Cancellation](/pipelines/concurrency).
 
 ## Set theory
 
@@ -670,7 +670,7 @@ A spec that exits `2` blocks codegen because the gate cannot prove the spec corr
 
 ## See also
 
-- [Convention Engine](../design/convention-engine) — the other half of the M1–M10 pipeline.
-- [Architecture](../design/architecture) — where verification sits in the overall compiler.
-- Research: [Spec Verification](../research/06_spec_verification) — the full verification design
+- [Convention Engine](/design/convention-engine) — the other half of the M1–M10 pipeline.
+- [Architecture](/design/architecture) — where verification sits in the overall compiler.
+- Research: [Spec Verification](/research/06_spec_verification) — the full verification design
   (pipeline, Alloy/Quint backends, counterexample shape).

--- a/docs/content/docs/research/06_spec_verification.md
+++ b/docs/content/docs/research/06_spec_verification.md
@@ -2551,7 +2551,7 @@ Quint/TLC for temporal checking.
 
 ## 9. Implementation Strategy
 
-> **Forward pointer**: see [10. Mechanically Verified Translator Soundness](10_translator_soundness.md)
+> **Forward pointer**: see [10. Mechanically Verified Translator Soundness](/research/10_translator_soundness)
 > for the long-term plan to mechanically prove the IR → SMT-LIB translation step
 > sound (issue [#88](https://github.com/HardMax71/spec_to_rest/issues/88)). That
 > doc covers the trust-chain framing, 2024-2026 prior art, why Z3 proof

--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -751,8 +751,8 @@ Inherits #88's non-goals, plus:
 
 ### 11.7 spec_to_rest cross-references
 
-- [`docs/content/docs/research/06_spec_verification.md`](06_spec_verification.md) — verification pipeline design
-- [`docs/content/docs/spec-language.mdx`](../spec-language.mdx) — current English-prose semantics
+- [`docs/content/docs/research/06_spec_verification.md`](/research/06_spec_verification) — verification pipeline design
+- [`docs/content/docs/spec-language.mdx`](/spec-language) — current English-prose semantics
 - [Issue #88 — Mechanically verified translator soundness](https://github.com/HardMax71/spec_to_rest/issues/88)
 - [Issue #77 — Proof-certificate / unsat-core export (closed)](https://github.com/HardMax71/spec_to_rest/issues/77)
 - [Issue #20 — M4.4 error reporting + spans](https://github.com/HardMax71/spec_to_rest/issues/20)

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -3,6 +3,7 @@ title: Python + FastAPI + PostgreSQL
 description: Reference for the python-fastapi-postgres deployment target
 ---
 
+import Link from 'next/link';
 import { APIPage } from '@/lib/openapi';
 
 This page documents exactly what the compiler emits when a spec is compiled against the
@@ -20,7 +21,7 @@ an issue or PR to correct the doc.
 
 `compile` runs the verification engine as a pre-codegen gate: a spec with any failing or skipped
 check causes `compile` to exit non-zero and write no files. Pass `--ignore-verify` to opt out
-(with a warning). See [Verify-as-gate in `compile`](../pipelines/verification#verify-as-gate-in-compile)
+(with a warning). See [Verify-as-gate in `compile`](/pipelines/verification#verify-as-gate-in-compile)
 for the full contract.
 
 ## At a glance
@@ -191,13 +192,13 @@ milestone.
       </div>
     </div>
     <div className="flex shrink-0 flex-wrap gap-2">
-      <a
+      <Link
         href="/openapi/url_shortener.yaml"
         className="inline-flex items-center gap-1.5 rounded-md border bg-fd-background px-3 py-1.5 text-xs font-medium hover:bg-fd-accent"
         download
       >
         Download YAML
-      </a>
+      </Link>
       <a
         href="https://github.com/HardMax71/spec_to_rest/blob/main/fixtures/spec/url_shortener.spec"
         target="_blank"

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "dev": "next dev",
     "dev:static": "rm -rf .next .source out .preview && next build && mkdir -p .preview/spec_to_rest && cp -al out/. .preview/spec_to_rest/ && npx --yes serve@latest .preview -p 3000",
+    "prebuild": "node scripts/build-railroad.mjs",
     "build": "next build",
     "postbuild": "node scripts/check-links.mjs",
     "check-links": "node scripts/check-links.mjs",
+    "build-railroad": "node scripts/build-railroad.mjs",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,8 @@
     "dev": "next dev",
     "dev:static": "rm -rf .next .source out .preview && next build && mkdir -p .preview/spec_to_rest && cp -al out/. .preview/spec_to_rest/ && npx --yes serve@latest .preview -p 3000",
     "build": "next build",
+    "postbuild": "node scripts/check-links.mjs",
+    "check-links": "node scripts/check-links.mjs",
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {

--- a/docs/scripts/check-links.mjs
+++ b/docs/scripts/check-links.mjs
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT_DIR = path.resolve(__dirname, "..", "out");
+const BASE_PATH = "/spec_to_rest";
+const ORIGIN = "http://docs.local";
+
+if (!fs.existsSync(OUT_DIR)) {
+  console.error(`✘ ${OUT_DIR} does not exist; run \`next build\` first`);
+  process.exit(1);
+}
+
+function walk(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(full));
+    else if (entry.isFile() && entry.name.endsWith(".html")) out.push(full);
+  }
+  return out;
+}
+
+const HREF_RE = /<a\b[^>]*?\shref=("([^"]*)"|'([^']*)')/gi;
+const ID_RE = /\sid=("([^"]+)"|'([^']+)')/gi;
+
+function extractHrefs(html) {
+  const hrefs = [];
+  let m;
+  HREF_RE.lastIndex = 0;
+  while ((m = HREF_RE.exec(html)) !== null) hrefs.push(m[2] ?? m[3]);
+  return hrefs;
+}
+
+function extractIds(html) {
+  const ids = new Set();
+  let m;
+  ID_RE.lastIndex = 0;
+  while ((m = ID_RE.exec(html)) !== null) ids.add(m[2] ?? m[3]);
+  return ids;
+}
+
+function pageUrlForHtml(htmlAbs) {
+  const rel = path.relative(OUT_DIR, htmlAbs).split(path.sep).join("/");
+  if (rel === "index.html") return `${BASE_PATH}/`;
+  if (rel.endsWith("/index.html")) return `${BASE_PATH}/${rel.slice(0, -"index.html".length)}`;
+  return `${BASE_PATH}/${rel}`;
+}
+
+function isExternal(href) {
+  return /^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith("//");
+}
+
+function shouldCheck(href) {
+  if (!href) return false;
+  if (isExternal(href)) return false;
+  if (href.startsWith("#")) return false;
+  return true;
+}
+
+function resolveAbs(href, fromHtml) {
+  const pageUrl = pageUrlForHtml(fromHtml);
+  return new URL(href, `${ORIGIN}${pageUrl}`);
+}
+
+const ASSET_PREFIXES = ["/_next/", "/api/"];
+function isAssetPath(pathname) {
+  for (const p of ASSET_PREFIXES) if (pathname.startsWith(BASE_PATH + p)) return true;
+  return false;
+}
+
+function resolveTargetFile(pathname) {
+  if (!pathname.startsWith(BASE_PATH)) return { error: "outside-basepath" };
+  let rel = pathname.slice(BASE_PATH.length);
+  if (rel === "" || rel === "/") return { file: path.join(OUT_DIR, "index.html") };
+  if (rel.endsWith("/")) {
+    const f = path.join(OUT_DIR, rel, "index.html");
+    return fs.existsSync(f) ? { file: f } : { error: "missing" };
+  }
+  const candidates = [
+    path.join(OUT_DIR, rel),
+    path.join(OUT_DIR, rel + ".html"),
+    path.join(OUT_DIR, rel, "index.html"),
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c) && fs.statSync(c).isFile()) return { file: c };
+  }
+  return { error: "missing" };
+}
+
+const idCache = new Map();
+function getIds(file) {
+  if (idCache.has(file)) return idCache.get(file);
+  const html = fs.readFileSync(file, "utf8");
+  const ids = extractIds(html);
+  idCache.set(file, ids);
+  return ids;
+}
+
+const issues = [];
+const htmlFiles = walk(OUT_DIR);
+
+for (const htmlFile of htmlFiles) {
+  const html = fs.readFileSync(htmlFile, "utf8");
+  const hrefs = extractHrefs(html);
+  const fromRel = path.relative(OUT_DIR, htmlFile);
+  for (const href of hrefs) {
+    if (!shouldCheck(href)) continue;
+    let abs;
+    try {
+      abs = resolveAbs(href, htmlFile);
+    } catch (e) {
+      issues.push({ from: fromRel, href, msg: `unparseable URL (${e.message})` });
+      continue;
+    }
+    if (abs.origin !== ORIGIN) continue;
+    if (isAssetPath(abs.pathname)) continue;
+    const resolved = resolveTargetFile(abs.pathname);
+    if (resolved.error) {
+      issues.push({ from: fromRel, href, msg: `404 (${abs.pathname})` });
+      continue;
+    }
+    if (abs.hash) {
+      const anchor = decodeURIComponent(abs.hash.slice(1));
+      const ids = getIds(resolved.file);
+      if (!ids.has(anchor)) {
+        issues.push({
+          from: fromRel,
+          href,
+          msg: `missing anchor #${anchor} in ${path.relative(OUT_DIR, resolved.file)}`,
+        });
+      }
+    }
+  }
+}
+
+if (issues.length) {
+  console.error(`✘ Found ${issues.length} broken internal link(s):`);
+  const seen = new Set();
+  for (const i of issues) {
+    const key = `${i.from} -> ${i.href}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    console.error(`  ${i.from}`);
+    console.error(`    -> ${i.href}`);
+    console.error(`    ${i.msg}`);
+  }
+  process.exit(1);
+}
+
+console.log(`✓ Link check passed (${htmlFiles.length} html files scanned)`);

--- a/modules/cli/src/main/resources/META-INF/native-image/resource-config.json
+++ b/modules/cli/src/main/resources/META-INF/native-image/resource-config.json
@@ -27,6 +27,8 @@
   }, {
     "pattern":"\\Qtemplates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs\\E"
   }, {
+    "pattern":"\\Qtemplates/python-fastapi-postgres/app/redaction.py.hbs\\E"
+  }, {
     "pattern":"\\Qtemplates/python-fastapi-postgres/config.py.hbs\\E"
   }, {
     "pattern":"\\Qtemplates/python-fastapi-postgres/database.py.hbs\\E"
@@ -65,11 +67,15 @@
   }, {
     "pattern":"\\Qtemplates/python-fastapi-postgres/tests/test_health.py.hbs\\E"
   }, {
+    "pattern":"\\Qtemplates/python-fastapi-postgres/tests/test_log_redaction.py.hbs\\E"
+  }, {
     "pattern":"\\Qtestgen-templates/python-fastapi-postgres/tests/conftest.py\\E"
   }, {
     "pattern":"\\Qtestgen-templates/python-fastapi-postgres/tests/predicates.py\\E"
   }, {
     "pattern":"\\Qtestgen-templates/python-fastapi-postgres/tests/pytest.ini\\E"
+  }, {
+    "pattern":"\\Qtestgen-templates/python-fastapi-postgres/tests/redaction.py\\E"
   }]},
   "bundles":[]
 }


### PR DESCRIPTION
Grab-bag of small fixes uncovered while clicking around the deployed site.

## Summary

- **Native-image build was broken on `main`.** The M5.8 PR (#148) added three Handlebars templates and one static testgen file, but did not register them in `modules/cli/src/main/resources/META-INF/native-image/resource-config.json`. The native binary failed at codegen with `template resource not found on classpath`. This commit registers the missing entries.
- **Homepage CTA buttons 404.** `<a href="/spec-language">` / `<a href="/pipelines/verification">` are not basePath-aware (Next.js only rewrites `next/link` `Link` components). Switched both to `Link` so they resolve under `/spec_to_rest/...`.
- **"Edit on GitHub" 404.** `editUrl` was built as ``docs/content/${page.path}``, but fumadocs' `page.path` is relative to the docs *source* root (`docs/content/docs/`). Adding the missing `/docs` segment also fixes the silently-broken last-modified mtime lookup that read from the same wrong path.
- **Internal markdown link sweep.** `[text](../foo/bar)` from a page at `/section/page/` resolves URL-relatively (browsers strip the trailing slash one segment), so the link landed at `/section/foo/bar` instead of `/foo/bar`. Converted every `../*` and `./*` internal markdown link to absolute `/<section>/<page>` form. Also fixed three standalone bugs caught in the sweep:
  - `pipelines/test-generation.mdx` linked to `/docs/pipelines/mutation-testing` (extra `/docs/` segment).
  - `research/06_spec_verification.md` linked to `10_translator_soundness.md` (literal `.md` filename).
  - `targets/python-fastapi-postgres.mdx` used a plain `<a href="/openapi/...">` for the YAML download (basePath stripping); switched to `next/link`.
- **Build-gate against future link rot.** New `docs/scripts/check-links.mjs` runs as the npm `postbuild` script. It walks every emitted HTML file, extracts all `<a href>`s, resolves each via the browser-equivalent `URL` constructor, verifies the target page exists, and (if the href has a `#fragment`) verifies the destination contains an element with that `id`. CI's docs workflow already runs `npm run build`, so any future broken internal link blocks the deploy.
- **Railroad diagrams were invisible / missing.** Two compounding issues: (1) `node scripts/build-railroad.mjs` was a manual step easy to forget after a grammar change, and (2) embedding the SVGs via `<img src>` puts them in an isolated SVG document where `stroke: currentColor` defaults to black — invisible on the dark theme. Fixed by adding a `<RailroadDiagram>` server component that reads each SVG at SSG time and inlines it via `dangerouslySetInnerHTML` (same pattern as the existing `Mermaid` component); inlining lets `currentColor` inherit from `<DocsBody>` and track the active theme. The script is now wired as `prebuild`, so any `npm run build` regenerates the SVGs from the live grammar.
- **`<Collapsible>` MDX component.** Generic native-`<details>` wrapper with theme-aware chrome and a chevron that rotates 90° on open via a Tailwind arbitrary variant — zero JS. Used to hide the 44-row capability-status table on the verification page and the 12-row "What gets generated" table on the test-generation page; both pages now lead with prose instead of a wall of cells.

## Commits

1. `2241e9a` — Register M5.8 templates in native-image `resource-config.json`.
2. `676afbd` — Switch homepage CTA buttons to `next/link` (basePath fix).
3. `4f10a54` — Add missing `/docs` segment to `editUrl`.
4. `e9610aa` — Convert relative markdown links to absolute; add `check-links.mjs` and wire as `postbuild`.
5. `6de1ad0` — Inline railroad SVGs via a server component; auto-generate on `prebuild`.
6. `5f3a8d8` — Add `<Collapsible>` MDX component; hide capability-status table.
7. `d3ed6cb` — Hide "What gets generated" table on the test-generation page.

## Test plan

- [ ] `sbt nativeImage` builds, and `./modules/cli/target/native-image/spec-to-rest compile fixtures/spec/url_shortener.spec --out /tmp/smoke` finishes without `template resource not found`.
- [ ] `(cd docs && npm run build)` succeeds, including `prebuild` (railroad regen) and `postbuild` (link checker).
- [ ] Click each CTA on the deployed homepage — both navigate to a real page (no `https://hardmax71.github.io/pipelines/...` 404).
- [ ] "Edit on GitHub" button on any page opens an existing file under `docs/content/docs/...`.
- [ ] Verification page → "Concurrency and Cancellation" link in the intro callout reaches `/spec_to_rest/pipelines/concurrency`.
- [ ] Parser implementation page renders three theme-aware railroad diagrams (visible in both light and dark mode).
- [ ] Verification page's capability-status table starts collapsed, expands cleanly when clicked. Same for test-generation's "What gets generated" table.
- [ ] No regression in any existing docs page (sidebar, search, code highlighting).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native-image resource packaging and multiple docs link issues, and improves docs UX with inlined railroad diagrams and a new Collapsible component. Adds a link checker that fails the build on broken internal links.

- **Bug Fixes**
  - Register missing M5.8 templates and testgen files in native-image `resource-config.json` to stop "template resource not found".
  - Switch homepage CTAs and the OpenAPI YAML download to `next/link` so `basePath` is honored.
  - Fix "Edit on GitHub" path and last-modified lookup by adding the missing `/docs` segment.
  - Convert relative docs links to absolute site paths and fix a few bad targets.

- **New Features**
  - Inline grammar diagrams with `<RailroadDiagram>` server component; inherits theme colors; regenerate SVGs on `prebuild`.
  - Add `<Collapsible>` MDX component (no JS) and collapse long reference tables on verification and test-generation pages.
  - Build-gate: run `docs/scripts/check-links.mjs` on `postbuild` to validate internal links and `#anchor`s; fails the build on errors.

<sup>Written for commit d3ed6cb5ffe838b27b9bfac7cd33244efa962197. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/151?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collapsible sections in documentation for improved content organization
  * Enhanced railroad diagram rendering with improved display and accessibility

* **Documentation**
  * Updated navigation links throughout documentation for consistent routing
  * Improved internal linking with optimized navigation components

* **Chores**
  * Added build-time link validation for documentation
  * Updated build process and resource configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->