### PR TITLE
M5.9 — TransitionDecl-aware property tests (closes #137)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -44,11 +44,11 @@ Production deployments must leave this unset; the router returns 403 by default.
 
 | File | Source | What it is |
 |---|---|---|
-| `app/routers/test_admin.py` | `AdminRouter.scala` | `/__test_admin__/reset` truncates entity tables; `/__test_admin__/state` returns spec state as JSON. Both 403 unless `ENABLE_TEST_ADMIN=1`. |
+| `app/routers/test_admin.py` | `AdminRouter.scala` | `/__test_admin__/reset` truncates entity tables; `/__test_admin__/state` returns spec state as JSON; `/__test_admin__/seed/<entity>` (per entity that participates in a `TransitionDecl`) inserts a row directly so transition tests can drive entities into a chosen status. All endpoints 403 unless `ENABLE_TEST_ADMIN=1`. |
 | `tests/__init__.py` | empty | makes `tests` a Python package |
 | `tests/conftest.py` | static template | `httpx` client + session-scoped fixture that **skips the whole suite** with a clear message if the service is unreachable or the admin router isn't enabled |
 | `tests/predicates.py` | static template | `is_valid_uri`, `is_valid_email` helpers used by strategies and assertions |
-| `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl` |
+| `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl`, plus one `def strategy_<entity>()` (returning `st.fixed_dictionaries`) per entity that participates in a `TransitionDecl` |
 | `tests/strategies_user.py` | static template | empty stub for user-supplied strategy functions referenced from `<Type>.strategy = "module:symbol"` convention rules. Preserved across re-compile. |
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
 | `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
@@ -81,14 +81,16 @@ def test_shorten_ensures_0(url):
         "ensures violated: ensures: (code not in pre(store))"
 ```
 
-**State-dependent preconditions are deferred.** If `requires` references a state field
-(e.g., `requires: code in store`), positive ensures tests are skipped — driving the system
-into the precondition-satisfying state requires either calls to other operations or direct
-seed-writes. `ExprToPython` translates every IR `Expr` shape, so the *coverage* gap is
-closed; the remaining gap is purely state-machine setup, tracked under
-[M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137). The clause appears in
-`_testgen_skips.json` with `reason: "state-dependent precondition; needs state-machine
-setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"`.
+**State-dependent preconditions are partially covered.** If `requires` references a state
+field (e.g., `requires: code in store`), positive ensures tests for the *generic* case are
+skipped — driving the system into the precondition-satisfying state requires either calls
+to other operations or direct seed-writes. For the *transition* case (operation referenced
+by a `via` clause in a `TransitionDecl`), M5.9 closes this gap with dedicated transition
+tests (see below). The clause still appears in `_testgen_skips.json`, but the reason text
+flips to `state-dependent precondition; covered by transition tests (M5.9)` for transition
+operations and stays as `... deferred to M5.9 ...` only for the residual non-transition
+operations (`GetTodo`, `UpdateTodo`, `DeleteTodo` in `todo_list`). `ExprToPython` translates
+every IR `Expr` shape, so the *translator coverage* gap is closed.
 
 ### 2. Negative `<input> in <state>` tests
 
@@ -126,6 +128,88 @@ def test_shorten_invariant_all_ur_ls_valid(url):
     assert all(is_valid_uri(post_state["store"][c]) for c in post_state["store"]), \
         "invariant violated: invariant allURLsValid: (all c in store | isValidURI(store[c]))"
 ```
+
+## Transition tests (M5.9)
+
+For specs that declare a state machine via `transition X { entity: E; field: f; FROM -> TO via Op ... }`,
+testgen synthesizes per-`via`-operation behavioral tests that drive the entity directly into
+each `from` status using a generated seed admin endpoint, then exercise the operation:
+
+- **Positive** test per legal `(from, to)` rule. Seed entity in `from`, call the via operation,
+  assert 2xx and the entity's `field` post-state equals `to`.
+- **Negative** test per illegal `from` (every value of the field's enum that is *not* a
+  `from`-state for `via X`). Seed entity in that state, call the via operation, assert 4xx.
+
+Setup uses `POST /__test_admin__/seed/<entity>` — emitted by `AdminRouter.scala` for every
+entity referenced by a `TransitionDecl`. The endpoint accepts a JSON dict, parses any
+`DateTime`-typed columns from ISO strings, inserts the row, and returns the new primary
+key. Like `/reset` and `/state`, it 403s unless `ENABLE_TEST_ADMIN=1`.
+
+Row strategies come from `Strategies.scala`'s new `strategy_<entity>()` function, emitted
+only for transition entities — non-transition specs (`safe_counter`, `url_shortener`)
+generate byte-identical strategies.py to before.
+
+```python
+@given(row=strategy_todo())
+@settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_start_work_transition_todo_to_in_progress(row):
+    """transition StartWork: TODO -> IN_PROGRESS (post-state status = IN_PROGRESS)"""
+    client.post("/__test_admin__/reset")
+    row = dict(row)
+    row["status"] = "TODO"
+    seed = client.post("/__test_admin__/seed/todo", json=row)
+    assume(seed.status_code == 201)
+    seeded_id = seed.json()["id"]
+    response = client.post(f"/todos/{seeded_id}/start")
+    assert response.status_code == 200, response.text
+    post_state = client.get("/__test_admin__/state").json()
+    bucket = post_state.get("todos", {})
+    entity_view = bucket.get(str(seeded_id)) or bucket.get(seeded_id)
+    actual = entity_view.get("status") if isinstance(entity_view, dict) else entity_view
+    assert actual == "IN_PROGRESS", f"expected status=IN_PROGRESS, got {actual!r}"
+```
+
+```python
+@given(row=strategy_todo())
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_archive_transition_illegal_from_in_progress(row):
+    """transition Archive: from=IN_PROGRESS is illegal (no rule); SUT must reject 4xx"""
+    client.post("/__test_admin__/reset")
+    row = dict(row)
+    row["status"] = "IN_PROGRESS"
+    seed = client.post("/__test_admin__/seed/todo", json=row)
+    assume(seed.status_code == 201)
+    seeded_id = seed.json()["id"]
+    response = client.post(f"/todos/{seeded_id}/archive")
+    assert 400 <= response.status_code < 500, f"expected 4xx, got {response.status_code}: {response.text}"
+```
+
+### What gets generated for `todo_list.spec`
+
+| `via` operation | Legal `(from, to)` | Positive tests | Illegal `from` (no rule) | Negative tests |
+|---|---|---|---|---|
+| `StartWork` | `TODO -> IN_PROGRESS` | 1 | `IN_PROGRESS, DONE, ARCHIVED` | 3 |
+| `Complete`  | `IN_PROGRESS -> DONE` | 1 | `TODO, DONE, ARCHIVED`        | 3 |
+| `Reopen`    | `DONE -> IN_PROGRESS` (guarded) | 0 (guard skip — see below) | `TODO, IN_PROGRESS, ARCHIVED` | 3 |
+| `Archive`   | `TODO -> ARCHIVED`, `DONE -> ARCHIVED` | 2 | `IN_PROGRESS, ARCHIVED` | 2 |
+
+15 transition tests total. `PauseWork` is referenced in the spec's transition graph but has
+no operation declaration in `todo_list.spec`, so it produces a `transition[PauseWork]` skip
+in `_testgen_skips.json` with reason `no operation named 'PauseWork' for via clause`.
+
+### Skipped categories
+
+- **Guarded positives.** Rules with a `when <guard>` clause cannot be reliably exercised by
+  a randomly-generated seed row (the guard is satisfied in only ~50% of cases; Hypothesis
+  `assume(...)` would discard most attempts). The positive test is skipped with reason
+  `guard '<expr>' not representable in seed dict (see #152)`. Negative tests for the same
+  rule's illegal-from cases still emit normally. Tracked under
+  [#152](https://github.com/HardMax71/spec_to_rest/issues/152).
+- **Non-enum transition field.** If `field: <name>` resolves to a type other than an enum
+  (or alias of an enum), the entire `TransitionDecl` is skipped — illegal-from enumeration
+  is undefined for non-enum status fields.
+- **Unknown via operation.** A `via X` whose `X` has no matching `operation` declaration is
+  skipped. Spec lint should catch this; the skip is a defensive backstop.
 
 ## Stateful tests (M5.2)
 
@@ -221,7 +305,8 @@ deadline trips on slow CI machines.
   simplicity and avoids re-translating every `ensures` clause as a model update.
 - It does **not** branch by `TransitionDecl` status (separate `pending_ids`, `shipped_ids`
   bundles). Status guards are exercised by loose rules instead. Per-status bundles are
-  tracked under [#137](https://github.com/HardMax71/spec_to_rest/issues/137) (M5.9).
+  tracked under [#153](https://github.com/HardMax71/spec_to_rest/issues/153) (M5.9
+  follow-up).
 - Per-rule ensures-asserts are handled by the behavioral tests, not duplicated here.
   Stateful surfaces multi-step bugs via the `@invariant()` checks that run after every step.
 
@@ -469,6 +554,8 @@ they regress.
   "strategies_skipped": [],
   "behavioral_skipped": [
     {"operation": "Resolve", "kind": "ensures", "reason": "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"},
+    {"operation": "StartWork", "kind": "ensures", "reason": "state-dependent precondition; covered by transition tests (M5.9)"},
+    {"operation": "Reopen", "kind": "transition[DONE_to_IN_PROGRESS]", "reason": "guard '(updated_at > completed_at)' not representable in seed dict (see #152)"},
     {"operation": "Shorten", "kind": "requires[0]", "reason": "M5.1: only `<input> in <state>` requires patterns get negative tests"}
   ]
 }
@@ -476,9 +563,12 @@ they regress.
 
 The `behavioral_skipped` array enumerates clauses that the test generator could not turn
 into a runnable test. Every entry signals one of: (a) state-machine setup is needed before
-the precondition is reachable (tracked under
-[M5.9 #137](https://github.com/HardMax71/spec_to_rest/issues/137)); (b) the requires shape
-is outside the recognized negative-test pattern; (c) a real user error in the spec.
+the precondition is reachable for a non-transition operation (no `via` rule covers it; the
+remaining gap on `GetTodo`-shaped operations); (b) the requires shape is outside the
+recognized negative-test pattern; (c) a guarded transition rule whose guard can't be
+satisfied by a randomly-generated seed dict (tracked under
+[#152](https://github.com/HardMax71/spec_to_rest/issues/152)); (d) a real user error in
+the spec.
 
 ## Runtime requirements
 
@@ -566,8 +656,8 @@ become compile errors under `--strict-strategies`.
 
 | Limit | Tracked under |
 |---|---|
-| State-dependent preconditions skip ensures tests | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) — TransitionDecl-aware state-machine setup |
-| Sensitive-field strategies (passwords/tokens) | [M5.8 (#136)](https://github.com/HardMax71/spec_to_rest/issues/136) |
-| Transition-aware property tests (per-status bundles) | [M5.9 (#137)](https://github.com/HardMax71/spec_to_rest/issues/137) |
+| State-dependent preconditions on **non-transition** ops still skip ensures tests | residual tail of M5.9; not currently scoped |
+| Guarded positive transition tests | [#152](https://github.com/HardMax71/spec_to_rest/issues/152) — extend the seed-row fix-up walker for guards like `updated_at > completed_at` |
+| Per-status bundles in stateful tests | [#153](https://github.com/HardMax71/spec_to_rest/issues/153) — split `<entity>_ids` into per-enum-value bundles in `Stateful.scala` |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |
 | Default `--with-tests` after M5.4 | [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140) |

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -2,6 +2,7 @@ package specrest.testgen
 
 import specrest.convention.Naming
 import specrest.ir.EntityDecl
+import specrest.ir.FieldDecl
 import specrest.ir.ServiceIR
 import specrest.ir.StateFieldDecl
 import specrest.ir.TypeExpr
@@ -45,10 +46,16 @@ object AdminRouter:
         val body  = pairs.mkString(",\n")
         s"$rowsLine    return {\n$body,\n    }"
 
+    val seedEntities = ir.transitions.map(_.entityName).toSet
+    val seedTargets  = entities.filter(e => seedEntities.contains(e.name))
+    val seedSection =
+      if seedTargets.isEmpty then ""
+      else seedTargets.map(e => seedHandler(e)).mkString("\n", "\n", "")
+
     s"""import os
        |from datetime import datetime, date
        |
-       |from fastapi import APIRouter, Depends, HTTPException
+       |from fastapi import APIRouter, Body, Depends, HTTPException
        |from fastapi.responses import Response
        |from sqlalchemy import delete, select
        |from sqlalchemy.ext.asyncio import AsyncSession
@@ -74,6 +81,12 @@ object AdminRouter:
        |    return out
        |
        |
+       |def _parse_iso(value):
+       |    if isinstance(value, str):
+       |        return datetime.fromisoformat(value)
+       |    return value
+       |
+       |
        |@router.post("/reset", status_code=204)
        |async def reset(session: AsyncSession = Depends(get_session)) -> Response:
        |    _check_enabled()
@@ -84,8 +97,39 @@ object AdminRouter:
        |@router.get("/state")
        |async def get_state(session: AsyncSession = Depends(get_session)) -> dict:
        |    _check_enabled()
-       |$stateProjections
+       |$stateProjections$seedSection
        |""".stripMargin
+
+  private def seedHandler(entity: EntityDecl): String =
+    val snake  = Naming.toSnakeCase(entity.name)
+    val pkName = primaryKeyField(entity).getOrElse("id")
+    val dtFields = entity.fields.collect:
+      case f if isDateTimeField(f) => f.name
+    val coercion =
+      if dtFields.isEmpty then ""
+      else
+        val lines = dtFields.map: n =>
+          val k = pyStringLit(n)
+          s"    if $k in payload and payload[$k] is not None:\n        payload[$k] = _parse_iso(payload[$k])"
+        lines.mkString("", "\n", "\n")
+    s"""|@router.post("/seed/$snake", status_code=201)
+        |async def seed_$snake(
+        |    payload: dict = Body(...),
+        |    session: AsyncSession = Depends(get_session),
+        |) -> dict:
+        |    _check_enabled()
+        |    payload = dict(payload)
+        |$coercion    obj = ${entity.name}(**payload)
+        |    session.add(obj)
+        |    await session.commit()
+        |    await session.refresh(obj)
+        |    return {"$pkName": obj.$pkName}
+        |""".stripMargin
+
+  private def isDateTimeField(f: FieldDecl): Boolean = f.typeExpr match
+    case TypeExpr.NamedType("DateTime", _)                         => true
+    case TypeExpr.OptionType(TypeExpr.NamedType("DateTime", _), _) => true
+    case _                                                         => false
 
   final private case class Projection(
       entityName: String,
@@ -141,7 +185,7 @@ object AdminRouter:
     case TypeExpr.NamedType(n, _) => Some(n)
     case _                        => None
 
-  private def primaryKeyField(e: EntityDecl): Option[String] =
+  private[testgen] def primaryKeyField(e: EntityDecl): Option[String] =
     e.fields.find(_.name == "id").map(_.name).orElse(e.fields.headOption.map(_.name))
 
   private def projectionLine(

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -2,7 +2,6 @@ package specrest.testgen
 
 import specrest.convention.Naming
 import specrest.ir.EntityDecl
-import specrest.ir.FieldDecl
 import specrest.ir.ServiceIR
 import specrest.ir.StateFieldDecl
 import specrest.ir.TypeExpr
@@ -50,7 +49,7 @@ object AdminRouter:
     val seedTargets  = entities.filter(e => seedEntities.contains(e.name))
     val seedSection =
       if seedTargets.isEmpty then ""
-      else seedTargets.map(e => seedHandler(e)).mkString("\n", "\n", "")
+      else seedTargets.map(e => seedHandler(e, ir)).mkString("\n", "\n", "")
 
     s"""import os
        |from datetime import datetime, date
@@ -100,11 +99,11 @@ object AdminRouter:
        |$stateProjections$seedSection
        |""".stripMargin
 
-  private def seedHandler(entity: EntityDecl): String =
+  private def seedHandler(entity: EntityDecl, ir: ServiceIR): String =
     val snake  = Naming.toSnakeCase(entity.name)
     val pkName = primaryKeyField(entity).getOrElse("id")
     val dtFields = entity.fields.collect:
-      case f if isDateTimeField(f) => f.name
+      case f if isDateTimeType(f.typeExpr, ir, Set.empty) => f.name
     val coercion =
       if dtFields.isEmpty then ""
       else
@@ -126,10 +125,15 @@ object AdminRouter:
         |    return {"$pkName": obj.$pkName}
         |""".stripMargin
 
-  private def isDateTimeField(f: FieldDecl): Boolean = f.typeExpr match
-    case TypeExpr.NamedType("DateTime", _)                         => true
-    case TypeExpr.OptionType(TypeExpr.NamedType("DateTime", _), _) => true
-    case _                                                         => false
+  private def isDateTimeType(t: TypeExpr, ir: ServiceIR, seen: Set[String]): Boolean =
+    t match
+      case TypeExpr.NamedType("DateTime", _) => true
+      case TypeExpr.OptionType(inner, _)     => isDateTimeType(inner, ir, seen)
+      case TypeExpr.NamedType(name, _) if !seen.contains(name) =>
+        ir.typeAliases
+          .find(_.name == name)
+          .exists(alias => isDateTimeType(alias.typeExpr, ir, seen + name))
+      case _ => false
 
   final private case class Projection(
       entityName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -32,40 +32,53 @@ final case class BehavioralOutput(
 object Behavioral:
 
   def emitFor(profiled: ProfiledService): BehavioralOutput =
-    val ir = profiled.ir
+    val ir               = profiled.ir
+    val transition       = transitionEmission(profiled, ir)
+    val coveredByTransit = transition.coveredOps
     val perOp = profiled.operations.flatMap: pop =>
       ir.operations.find(_.name == pop.operationName) match
-        case Some(opDecl) => testsForOperation(pop, opDecl, ir)
+        case Some(opDecl) => testsForOperation(pop, opDecl, ir, coveredByTransit)
         case None         => Nil
-    val transitionResults = transitionTests(profiled, ir)
-    val collected         = perOp ++ transitionResults
-    val tests             = collected.collect { case Right(t) => t }
-    val skips             = collected.collect { case Left(s) => s }
+    val collected = perOp ++ transition.results
+    val tests     = collected.collect { case Right(t) => t }
+    val skips     = collected.collect { case Left(s) => s }
     BehavioralOutput(tests = tests, skips = skips)
 
   private def testsForOperation(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
-      ir: ServiceIR
+      ir: ServiceIR,
+      coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
-    val ensures   = ensuresTests(pop, opDecl, ir)
+    val ensures   = ensuresTests(pop, opDecl, ir, coveredByTransit)
     val negatives = negativeTests(pop, opDecl, ir)
-    val invs      = invariantTests(pop, opDecl, ir)
+    val invs      = invariantTests(pop, opDecl, ir, coveredByTransit)
     ensures ++ negatives ++ invs
 
-  private def viaOperationNames(ir: ServiceIR): Set[String] =
-    ir.transitions.flatMap(_.rules.map(_.via)).toSet
-
-  private def stateDepSkipReason(opName: String, ir: ServiceIR): String =
-    if viaOperationNames(ir).contains(opName) then
+  private def stateDepSkipReason(opName: String, coveredByTransit: Set[String]): String =
+    if coveredByTransit.contains(opName) then
       "state-dependent precondition; covered by transition tests (M5.9)"
     else
       "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"
 
+  final private case class TransitionEmissionResult(
+      results: List[Either[TestSkip, GeneratedTest]],
+      coveredOps: Set[String]
+  )
+
+  private def transitionEmission(
+      profiled: ProfiledService,
+      ir: ServiceIR
+  ): TransitionEmissionResult =
+    ir.transitions.foldLeft(TransitionEmissionResult(Nil, Set.empty)): (acc, td) =>
+      val per = transitionTestsForTd(td, profiled, ir)
+      TransitionEmissionResult(acc.results ++ per.results, acc.coveredOps ++ per.coveredOps)
+
   private def ensuresTests(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
-      ir: ServiceIR
+      ir: ServiceIR,
+      coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
     val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
     val opSnake     = Naming.toSnakeCase(opDecl.name)
@@ -79,7 +92,7 @@ object Behavioral:
           TestSkip(
             operation = opDecl.name,
             kind = "ensures",
-            reason = stateDepSkipReason(opDecl.name, ir)
+            reason = stateDepSkipReason(opDecl.name, coveredByTransit)
           )
         )
       )
@@ -149,7 +162,8 @@ object Behavioral:
   private def invariantTests(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
-      ir: ServiceIR
+      ir: ServiceIR,
+      coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(opDecl.name)
     val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
@@ -160,7 +174,7 @@ object Behavioral:
           TestSkip(
             opDecl.name,
             s"invariant[${invName(inv, idx)}]",
-            stateDepSkipReason(opDecl.name, ir)
+            stateDepSkipReason(opDecl.name, coveredByTransit)
           )
         )
     else
@@ -190,71 +204,83 @@ object Behavioral:
                   )
                 )
 
-  private def transitionTests(
-      profiled: ProfiledService,
-      ir: ServiceIR
-  ): List[Either[TestSkip, GeneratedTest]] =
-    ir.transitions.flatMap(td => transitionTestsFor(td, profiled, ir))
-
-  private def transitionTestsFor(
+  private def transitionTestsForTd(
       td: TransitionDecl,
       profiled: ProfiledService,
       ir: ServiceIR
-  ): List[Either[TestSkip, GeneratedTest]] =
+  ): TransitionEmissionResult =
     val entityOpt = ir.entities.find(_.name == td.entityName)
     if entityOpt.isEmpty then
-      return List(Left(TestSkip(td.name, "transition", s"unknown entity '${td.entityName}'")))
+      return TransitionEmissionResult(
+        List(Left(TestSkip(td.name, "transition", s"unknown entity '${td.entityName}'"))),
+        Set.empty
+      )
     val entity   = entityOpt.get
     val fieldOpt = entity.fields.find(_.name == td.fieldName)
     if fieldOpt.isEmpty then
-      return List(
-        Left(
-          TestSkip(
-            td.name,
-            "transition",
-            s"entity '${entity.name}' has no field '${td.fieldName}'"
+      return TransitionEmissionResult(
+        List(
+          Left(
+            TestSkip(
+              td.name,
+              "transition",
+              s"entity '${entity.name}' has no field '${td.fieldName}'"
+            )
           )
-        )
+        ),
+        Set.empty
       )
     val enumValuesOpt = enumValuesForField(fieldOpt.get, ir)
     if enumValuesOpt.isEmpty then
-      return List(
-        Left(
-          TestSkip(
-            td.name,
-            "transition",
-            s"transition field '${td.fieldName}' is not an enum (or alias of enum); illegal-from enumeration undefined"
+      return TransitionEmissionResult(
+        List(
+          Left(
+            TestSkip(
+              td.name,
+              "transition",
+              s"transition field '${td.fieldName}' is not an enum (or alias of enum); illegal-from enumeration undefined"
+            )
           )
-        )
+        ),
+        Set.empty
       )
     val pkOpt = AdminRouter.primaryKeyField(entity)
     if pkOpt.isEmpty then
-      return List(
-        Left(
-          TestSkip(
-            td.name,
-            "transition",
-            s"entity '${entity.name}' has no field; cannot seed"
+      return TransitionEmissionResult(
+        List(
+          Left(
+            TestSkip(
+              td.name,
+              "transition",
+              s"entity '${entity.name}' has no field; cannot seed"
+            )
           )
-        )
+        ),
+        Set.empty
       )
     val statusValues = enumValuesOpt.get
     val pk           = pkOpt.get
     val byVia        = td.rules.groupBy(_.via)
-    byVia.toList.sortBy(_._1).flatMap: (viaName, rules) =>
-      val opDeclOpt = ir.operations.find(_.name == viaName)
-      val popOpt    = profiled.operations.find(_.operationName == viaName)
-      (opDeclOpt, popOpt) match
-        case (Some(opDecl), Some(pop))
-            if pop.endpoint.bodyParams.nonEmpty || pop.endpoint.queryParams.nonEmpty =>
-          List(
-            Left(
-              TestSkip(
-                viaName,
-                s"transition[$viaName]",
-                "transition tests for via ops with non-path inputs not yet supported (see #155)"
+    byVia.toList.sortBy(_._1).foldLeft(TransitionEmissionResult(Nil, Set.empty)): (acc, kv) =>
+      val (viaName, rules) = kv
+      val opDeclOpt        = ir.operations.find(_.name == viaName)
+      val popOpt           = profiled.operations.find(_.operationName == viaName)
+      val per: TransitionEmissionResult = (opDeclOpt, popOpt) match
+        case (Some(_), Some(pop))
+            if pop.endpoint.bodyParams.nonEmpty
+              || pop.endpoint.queryParams.nonEmpty
+              || pop.endpoint.pathParams.size != 1 =>
+          TransitionEmissionResult(
+            List(
+              Left(
+                TestSkip(
+                  viaName,
+                  s"transition[$viaName]",
+                  "transition tests require exactly one path input identifying the seeded entity; other input shapes are not yet supported (see #155)"
+                )
               )
-            )
+            ),
+            Set.empty
           )
         case (Some(opDecl), Some(pop)) =>
           val legalFroms   = rules.map(_.from).toSet
@@ -281,17 +307,26 @@ object Behavioral:
               opDecl = opDecl,
               pop = pop
             )
-          positives ++ negatives
-        case _ =>
-          List(
-            Left(
-              TestSkip(
-                viaName,
-                s"transition[$viaName]",
-                s"no operation named '$viaName' for via clause"
-              )
-            )
+          val emitted    = positives ++ negatives
+          val anyRuntime = emitted.exists(_.isRight)
+          TransitionEmissionResult(
+            emitted,
+            if anyRuntime then Set(viaName) else Set.empty
           )
+        case _ =>
+          TransitionEmissionResult(
+            List(
+              Left(
+                TestSkip(
+                  viaName,
+                  s"transition[$viaName]",
+                  s"no operation named '$viaName' for via clause"
+                )
+              )
+            ),
+            Set.empty
+          )
+      TransitionEmissionResult(acc.results ++ per.results, acc.coveredOps ++ per.coveredOps)
 
   private def enumValuesForField(field: FieldDecl, ir: ServiceIR): Option[List[String]] =
     field.typeExpr match

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -245,6 +245,17 @@ object Behavioral:
       val opDeclOpt = ir.operations.find(_.name == viaName)
       val popOpt    = profiled.operations.find(_.operationName == viaName)
       (opDeclOpt, popOpt) match
+        case (Some(opDecl), Some(pop))
+            if pop.endpoint.bodyParams.nonEmpty || pop.endpoint.queryParams.nonEmpty =>
+          List(
+            Left(
+              TestSkip(
+                viaName,
+                s"transition[$viaName]",
+                "transition tests for via ops with non-path inputs not yet supported (see #155)"
+              )
+            )
+          )
         case (Some(opDecl), Some(pop)) =>
           val legalFroms   = rules.map(_.from).toSet
           val illegalFroms = statusValues.filterNot(legalFroms.contains)
@@ -275,7 +286,7 @@ object Behavioral:
           List(
             Left(
               TestSkip(
-                td.name,
+                viaName,
                 s"transition[$viaName]",
                 s"no operation named '$viaName' for via clause"
               )
@@ -421,18 +432,7 @@ object Behavioral:
           "f" + ExprToPython.pyString(rendered)
         case None => ExprToPython.pyString(ep.path)
     val method = ep.method.toString.toLowerCase
-    val bodyExpr =
-      if ep.bodyParams.isEmpty then ""
-      else
-        val pairs = ep.bodyParams.map(p => s"${ExprToPython.pyString(p.name)}: None").mkString(", ")
-        s", json={$pairs}"
-    val queryExpr =
-      if ep.queryParams.isEmpty then ""
-      else
-        val pairs =
-          ep.queryParams.map(p => s"${ExprToPython.pyString(p.name)}: None").mkString(", ")
-        s", params={$pairs}"
-    s"    response = client.$method($pathExpr$bodyExpr$queryExpr)\n"
+    s"    response = client.$method($pathExpr)\n"
 
   private def stateFieldForEntity(entityName: String, ir: ServiceIR): Option[String] =
     ir.state.toList.flatMap(_.fields).collectFirst:

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -3,11 +3,16 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.BinOp
+import specrest.ir.EntityDecl
 import specrest.ir.Expr
+import specrest.ir.FieldDecl
 import specrest.ir.InvariantDecl
 import specrest.ir.OperationDecl
 import specrest.ir.PrettyPrint
 import specrest.ir.ServiceIR
+import specrest.ir.TransitionDecl
+import specrest.ir.TransitionRule
+import specrest.ir.TypeExpr
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -28,12 +33,14 @@ object Behavioral:
 
   def emitFor(profiled: ProfiledService): BehavioralOutput =
     val ir = profiled.ir
-    val collected = profiled.operations.flatMap: pop =>
+    val perOp = profiled.operations.flatMap: pop =>
       ir.operations.find(_.name == pop.operationName) match
         case Some(opDecl) => testsForOperation(pop, opDecl, ir)
         case None         => Nil
-    val tests = collected.collect { case Right(t) => t }
-    val skips = collected.collect { case Left(s) => s }
+    val transitionResults = transitionTests(profiled, ir)
+    val collected         = perOp ++ transitionResults
+    val tests             = collected.collect { case Right(t) => t }
+    val skips             = collected.collect { case Left(s) => s }
     BehavioralOutput(tests = tests, skips = skips)
 
   private def testsForOperation(
@@ -45,6 +52,15 @@ object Behavioral:
     val negatives = negativeTests(pop, opDecl, ir)
     val invs      = invariantTests(pop, opDecl, ir)
     ensures ++ negatives ++ invs
+
+  private def viaOperationNames(ir: ServiceIR): Set[String] =
+    ir.transitions.flatMap(_.rules.map(_.via)).toSet
+
+  private def stateDepSkipReason(opName: String, ir: ServiceIR): String =
+    if viaOperationNames(ir).contains(opName) then
+      "state-dependent precondition; covered by transition tests (M5.9)"
+    else
+      "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"
 
   private def ensuresTests(
       pop: ProfiledOperation,
@@ -63,8 +79,7 @@ object Behavioral:
           TestSkip(
             operation = opDecl.name,
             kind = "ensures",
-            reason =
-              "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"
+            reason = stateDepSkipReason(opDecl.name, ir)
           )
         )
       )
@@ -145,7 +160,7 @@ object Behavioral:
           TestSkip(
             opDecl.name,
             s"invariant[${invName(inv, idx)}]",
-            "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"
+            stateDepSkipReason(opDecl.name, ir)
           )
         )
     else
@@ -174,6 +189,259 @@ object Behavioral:
                     )
                   )
                 )
+
+  private def transitionTests(
+      profiled: ProfiledService,
+      ir: ServiceIR
+  ): List[Either[TestSkip, GeneratedTest]] =
+    ir.transitions.flatMap(td => transitionTestsFor(td, profiled, ir))
+
+  private def transitionTestsFor(
+      td: TransitionDecl,
+      profiled: ProfiledService,
+      ir: ServiceIR
+  ): List[Either[TestSkip, GeneratedTest]] =
+    val entityOpt = ir.entities.find(_.name == td.entityName)
+    if entityOpt.isEmpty then
+      return List(Left(TestSkip(td.name, "transition", s"unknown entity '${td.entityName}'")))
+    val entity   = entityOpt.get
+    val fieldOpt = entity.fields.find(_.name == td.fieldName)
+    if fieldOpt.isEmpty then
+      return List(
+        Left(
+          TestSkip(
+            td.name,
+            "transition",
+            s"entity '${entity.name}' has no field '${td.fieldName}'"
+          )
+        )
+      )
+    val enumValuesOpt = enumValuesForField(fieldOpt.get, ir)
+    if enumValuesOpt.isEmpty then
+      return List(
+        Left(
+          TestSkip(
+            td.name,
+            "transition",
+            s"transition field '${td.fieldName}' is not an enum (or alias of enum); illegal-from enumeration undefined"
+          )
+        )
+      )
+    val pkOpt = AdminRouter.primaryKeyField(entity)
+    if pkOpt.isEmpty then
+      return List(
+        Left(
+          TestSkip(
+            td.name,
+            "transition",
+            s"entity '${entity.name}' has no field; cannot seed"
+          )
+        )
+      )
+    val statusValues = enumValuesOpt.get
+    val pk           = pkOpt.get
+    val byVia        = td.rules.groupBy(_.via)
+    byVia.toList.sortBy(_._1).flatMap: (viaName, rules) =>
+      val opDeclOpt = ir.operations.find(_.name == viaName)
+      val popOpt    = profiled.operations.find(_.operationName == viaName)
+      (opDeclOpt, popOpt) match
+        case (Some(opDecl), Some(pop)) =>
+          val legalFroms   = rules.map(_.from).toSet
+          val illegalFroms = statusValues.filterNot(legalFroms.contains)
+          val stateField = stateFieldForEntity(td.entityName, ir)
+            .getOrElse(Naming.toSnakeCase(td.entityName) + "s")
+          val positives = rules.toList.map: rule =>
+            buildTransitionPositiveOrSkip(
+              td = td,
+              entity = entity,
+              fieldName = td.fieldName,
+              pkName = pk,
+              rule = rule,
+              opDecl = opDecl,
+              pop = pop,
+              stateField = stateField
+            )
+          val negatives = illegalFroms.toList.sorted.map: from =>
+            buildTransitionNegative(
+              entity = entity,
+              fieldName = td.fieldName,
+              pkName = pk,
+              from = from,
+              opDecl = opDecl,
+              pop = pop
+            )
+          positives ++ negatives
+        case _ =>
+          List(
+            Left(
+              TestSkip(
+                td.name,
+                s"transition[$viaName]",
+                s"no operation named '$viaName' for via clause"
+              )
+            )
+          )
+
+  private def enumValuesForField(field: FieldDecl, ir: ServiceIR): Option[List[String]] =
+    field.typeExpr match
+      case TypeExpr.NamedType(name, _) =>
+        ir.enums.find(_.name == name).map(_.values).orElse:
+          ir.typeAliases.find(_.name == name).flatMap: alias =>
+            enumValuesForField(field.copy(typeExpr = alias.typeExpr), ir)
+      case _ => None
+
+  private def buildTransitionPositiveOrSkip(
+      td: TransitionDecl,
+      entity: EntityDecl,
+      fieldName: String,
+      pkName: String,
+      rule: TransitionRule,
+      opDecl: OperationDecl,
+      pop: ProfiledOperation,
+      stateField: String
+  ): Either[TestSkip, GeneratedTest] =
+    rule.guard match
+      case Some(guard) =>
+        Left(
+          TestSkip(
+            opDecl.name,
+            s"transition[${rule.from}_to_${rule.to}]",
+            s"guard '${prettyOneLine(guard)}' not representable in seed dict (see #152)"
+          )
+        )
+      case None =>
+        Right(
+          buildTransitionPositive(
+            td = td,
+            entity = entity,
+            fieldName = fieldName,
+            pkName = pkName,
+            from = rule.from,
+            to = rule.to,
+            opDecl = opDecl,
+            pop = pop,
+            stateField = stateField
+          )
+        )
+
+  private def buildTransitionPositive(
+      td: TransitionDecl,
+      entity: EntityDecl,
+      fieldName: String,
+      pkName: String,
+      from: String,
+      to: String,
+      opDecl: OperationDecl,
+      pop: ProfiledOperation,
+      stateField: String
+  ): GeneratedTest =
+    val opSnake     = Naming.toSnakeCase(opDecl.name)
+    val entitySnake = Naming.toSnakeCase(entity.name)
+    val testName    = s"test_${opSnake}_transition_${from.toLowerCase}_to_${to.toLowerCase}"
+    val rowStrategy = Strategies.strategyFunctionName(entity.name)
+    val pkKey       = ExprToPython.pyString(pkName)
+    val fieldKey    = ExprToPython.pyString(fieldName)
+    val stateKey    = ExprToPython.pyString(stateField)
+    val sb          = new StringBuilder
+    sb.append(s"@given(row=$rowStrategy())\n")
+    sb.append(
+      "@settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])\n"
+    )
+    sb.append(s"def $testName(row):\n")
+    sb.append(
+      s"    \"\"\"transition ${opDecl.name}: $from -> $to (post-state ${td.fieldName} = $to)\"\"\"\n"
+    )
+    sb.append("    client.post(\"/__test_admin__/reset\")\n")
+    sb.append("    row = dict(row)\n")
+    sb.append(s"    row[$fieldKey] = ${ExprToPython.pyString(from)}\n")
+    sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
+    sb.append("    assume(seed.status_code == 201)\n")
+    sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
+    sb.append(transitionRequestCall(pop))
+    sb.append(s"    assert response.status_code == ${pop.endpoint.successStatus}, response.text\n")
+    sb.append("    post_state = client.get(\"/__test_admin__/state\").json()\n")
+    sb.append(
+      s"    bucket = post_state.get($stateKey, {})\n"
+    )
+    sb.append(
+      "    entity_view = bucket.get(str(seeded_id)) or bucket.get(seeded_id)\n"
+    )
+    sb.append(
+      s"    actual = entity_view.get($fieldKey) if isinstance(entity_view, dict) else entity_view\n"
+    )
+    sb.append(
+      s"    assert actual == ${ExprToPython.pyString(to)}, " +
+        s"f\"expected ${td.fieldName}=$to, got {actual!r}\"\n"
+    )
+    GeneratedTest(name = testName, body = sb.toString, skipReason = None)
+
+  private def buildTransitionNegative(
+      entity: EntityDecl,
+      fieldName: String,
+      pkName: String,
+      from: String,
+      opDecl: OperationDecl,
+      pop: ProfiledOperation
+  ): Either[TestSkip, GeneratedTest] =
+    val opSnake     = Naming.toSnakeCase(opDecl.name)
+    val entitySnake = Naming.toSnakeCase(entity.name)
+    val testName    = s"test_${opSnake}_transition_illegal_from_${from.toLowerCase}"
+    val rowStrategy = Strategies.strategyFunctionName(entity.name)
+    val pkKey       = ExprToPython.pyString(pkName)
+    val fieldKey    = ExprToPython.pyString(fieldName)
+    val sb          = new StringBuilder
+    sb.append(s"@given(row=$rowStrategy())\n")
+    sb.append(
+      "@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])\n"
+    )
+    sb.append(s"def $testName(row):\n")
+    sb.append(
+      s"    \"\"\"transition ${opDecl.name}: from=$from is illegal (no rule); SUT must reject 4xx\"\"\"\n"
+    )
+    sb.append("    client.post(\"/__test_admin__/reset\")\n")
+    sb.append("    row = dict(row)\n")
+    sb.append(s"    row[$fieldKey] = ${ExprToPython.pyString(from)}\n")
+    sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
+    sb.append("    assume(seed.status_code == 201)\n")
+    sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
+    sb.append(transitionRequestCall(pop))
+    sb.append(
+      s"    assert 400 <= response.status_code < 500, " +
+        s"f${'"'}expected 4xx, got {response.status_code}: {response.text}${'"'}\n"
+    )
+    Right(GeneratedTest(name = testName, body = sb.toString, skipReason = None))
+
+  private def transitionRequestCall(pop: ProfiledOperation): String =
+    val ep        = pop.endpoint
+    val pathParam = ep.pathParams.headOption.map(_.name)
+    val pathExpr =
+      pathParam match
+        case Some(p) =>
+          val rendered = ep.path.replace(s"{$p}", "{seeded_id}")
+          "f" + ExprToPython.pyString(rendered)
+        case None => ExprToPython.pyString(ep.path)
+    val method = ep.method.toString.toLowerCase
+    val bodyExpr =
+      if ep.bodyParams.isEmpty then ""
+      else
+        val pairs = ep.bodyParams.map(p => s"${ExprToPython.pyString(p.name)}: None").mkString(", ")
+        s", json={$pairs}"
+    val queryExpr =
+      if ep.queryParams.isEmpty then ""
+      else
+        val pairs =
+          ep.queryParams.map(p => s"${ExprToPython.pyString(p.name)}: None").mkString(", ")
+        s", params={$pairs}"
+    s"    response = client.$method($pathExpr$bodyExpr$queryExpr)\n"
+
+  private def stateFieldForEntity(entityName: String, ir: ServiceIR): Option[String] =
+    ir.state.toList.flatMap(_.fields).collectFirst:
+      case f if relationTargetsEntity(f.typeExpr, entityName) => f.name
+
+  private def relationTargetsEntity(t: TypeExpr, entity: String): Boolean = t match
+    case TypeExpr.RelationType(_, _, TypeExpr.NamedType(n, _), _) => n == entity
+    case TypeExpr.NamedType(n, _)                                 => n == entity
+    case _                                                        => false
 
   private def buildPositiveTest(
       name: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -215,13 +215,15 @@ object Strategies:
       (f.name, expr)
     val skipped = pairs.collect:
       case (n, StrategyExpr.Skip(r)) => s"entity '${entity.name}' field '$n': $r"
-    val entries = pairs.collect:
+    val codeEntries = pairs.collect:
       case (n, StrategyExpr.Code(t)) => s"        ${ExprToPython.pyString(n)}: $t"
-    .mkString(",\n")
+    val body =
+      if codeEntries.isEmpty then "st.fixed_dictionaries({})"
+      else s"st.fixed_dictionaries({\n${codeEntries.mkString(",\n")},\n    })"
     StrategySpec(
       typeName = entity.name,
       functionName = strategyFunctionName(entity.name),
-      body = s"st.fixed_dictionaries({\n$entries,\n    })",
+      body = body,
       skipped = skipped
     )
 
@@ -253,7 +255,10 @@ object Strategies:
       else
         ir.typeAliases.find(_.name == name) match
           case Some(alias) =>
-            jsonStrategyForType(alias.typeExpr, constraint.orElse(alias.constraint), ir)
+            val combined = (constraint, alias.constraint) match
+              case (Some(c), Some(a)) => Some(Expr.BinaryOp(BinOp.And, c, a))
+              case (c, a)             => c.orElse(a)
+            jsonStrategyForType(alias.typeExpr, combined, ir)
           case None =>
             if ir.entities.exists(_.name == name) then
               StrategyExpr.Skip(s"nested entity reference '$name' not seedable")

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -4,8 +4,10 @@ import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
 import specrest.ir.BinOp
 import specrest.ir.ConventionRule
+import specrest.ir.EntityDecl
 import specrest.ir.EnumDecl
 import specrest.ir.Expr
+import specrest.ir.FieldDecl
 import specrest.ir.ServiceIR
 import specrest.ir.TypeAliasDecl
 import specrest.ir.TypeExpr
@@ -95,10 +97,17 @@ final private case class IntConstraint(
 object Strategies:
 
   def forIR(ir: ServiceIR): List[StrategySpec] =
-    val overrides  = strategyOverrides(ir)
-    val aliasSpecs = ir.typeAliases.map(specForAlias(_, ir, overrides))
-    val enumSpecs  = ir.enums.map(specForEnum(_, overrides))
-    aliasSpecs ++ enumSpecs
+    val overrides     = strategyOverrides(ir)
+    val aliasSpecs    = ir.typeAliases.map(specForAlias(_, ir, overrides))
+    val enumSpecs     = ir.enums.map(specForEnum(_, overrides))
+    val transEntities = transitionEntityNames(ir)
+    val entitySpecs = ir.entities
+      .filter(e => transEntities.contains(e.name))
+      .map(e => specForEntity(e, ir))
+    aliasSpecs ++ enumSpecs ++ entitySpecs
+
+  def transitionEntityNames(ir: ServiceIR): Set[String] =
+    ir.transitions.map(_.entityName).toSet
 
   private def strategyOverrides(ir: ServiceIR): Map[String, StrategyImport] =
     ir.conventions.toList.flatMap(_.rules).flatMap:
@@ -196,6 +205,66 @@ object Strategies:
           body = body,
           skipped = skipped
         )
+
+  private def specForEntity(entity: EntityDecl, ir: ServiceIR): StrategySpec =
+    val pairs = entity.fields.map: f =>
+      val expr = jsonStrategyForField(f, ir)
+      (f.name, expr)
+    val skipped = pairs.collect:
+      case (n, StrategyExpr.Skip(r)) => s"entity '${entity.name}' field '$n': $r"
+    val entries = pairs.map:
+      case (n, StrategyExpr.Code(t)) => s"        ${ExprToPython.pyString(n)}: $t"
+      case (n, StrategyExpr.Skip(_)) => s"        ${ExprToPython.pyString(n)}: st.nothing()"
+    .mkString(",\n")
+    StrategySpec(
+      typeName = entity.name,
+      functionName = strategyFunctionName(entity.name),
+      body = s"st.fixed_dictionaries({\n$entries,\n    })",
+      skipped = skipped
+    )
+
+  private def jsonStrategyForField(f: FieldDecl, ir: ServiceIR): StrategyExpr =
+    jsonStrategyForType(f.typeExpr, f.constraint, ir)
+
+  private def jsonStrategyForType(
+      t: TypeExpr,
+      constraint: Option[Expr],
+      ir: ServiceIR
+  ): StrategyExpr = t match
+    case TypeExpr.NamedType("String", _) =>
+      val (cs, _) = collectStringConstraint(constraint)
+      StrategyExpr.Code(renderStringStrategy(cs))
+    case TypeExpr.NamedType("Int", _) =>
+      val (cs, _) = collectIntConstraint(constraint)
+      StrategyExpr.Code(renderIntStrategy(cs))
+    case TypeExpr.NamedType("Float", _) =>
+      StrategyExpr.Code("st.floats(allow_nan=False, allow_infinity=False)")
+    case TypeExpr.NamedType("Bool", _) => StrategyExpr.Code("st.booleans()")
+    case TypeExpr.NamedType("DateTime", _) =>
+      StrategyExpr.Code("st.datetimes().map(lambda d: d.isoformat())")
+    case TypeExpr.NamedType("Duration", _) =>
+      StrategyExpr.Code("st.timedeltas().map(lambda d: d.total_seconds())")
+    case TypeExpr.NamedType("Id", _) => StrategyExpr.Code("st.uuids().map(str)")
+    case TypeExpr.NamedType(name, _) =>
+      if ir.typeAliases.exists(_.name == name) || ir.enums.exists(_.name == name) then
+        StrategyExpr.Code(s"${strategyFunctionName(name)}()")
+      else if ir.entities.exists(_.name == name) then
+        StrategyExpr.Skip(s"nested entity reference '$name' not seedable")
+      else StrategyExpr.Skip(s"unknown named type '$name'")
+    case TypeExpr.OptionType(inner, _) =>
+      jsonStrategyForType(inner, None, ir) match
+        case StrategyExpr.Code(t) => StrategyExpr.Code(s"st.one_of(st.none(), $t)")
+        case s                    => s
+    case TypeExpr.SetType(inner, _) =>
+      jsonStrategyForType(inner, None, ir) match
+        case StrategyExpr.Code(t) => StrategyExpr.Code(s"st.lists($t, unique=True, max_size=5)")
+        case s                    => s
+    case TypeExpr.SeqType(inner, _) =>
+      jsonStrategyForType(inner, None, ir) match
+        case StrategyExpr.Code(t) => StrategyExpr.Code(s"st.lists($t, max_size=5)")
+        case s                    => s
+    case TypeExpr.MapType(_, _, _)         => StrategyExpr.Skip("MapType field not seedable")
+    case TypeExpr.RelationType(_, _, _, _) => StrategyExpr.Skip("RelationType field not seedable")
 
   private def specForEnum(
       decl: EnumDecl,

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -207,14 +207,16 @@ object Strategies:
         )
 
   private def specForEntity(entity: EntityDecl, ir: ServiceIR): StrategySpec =
+    val overrides = TestStrategyOverrides.from(ir)
     val pairs = entity.fields.map: f =>
-      val expr = jsonStrategyForField(f, ir)
+      val ctx     = StrategyCtx.EntityField(entity.name, f.name)
+      val rawExpr = jsonStrategyForField(f, ir)
+      val expr    = applyRedaction(rawExpr, ctx, overrides)
       (f.name, expr)
     val skipped = pairs.collect:
       case (n, StrategyExpr.Skip(r)) => s"entity '${entity.name}' field '$n': $r"
-    val entries = pairs.map:
+    val entries = pairs.collect:
       case (n, StrategyExpr.Code(t)) => s"        ${ExprToPython.pyString(n)}: $t"
-      case (n, StrategyExpr.Skip(_)) => s"        ${ExprToPython.pyString(n)}: st.nothing()"
     .mkString(",\n")
     StrategySpec(
       typeName = entity.name,
@@ -246,15 +248,20 @@ object Strategies:
       StrategyExpr.Code("st.timedeltas().map(lambda d: d.total_seconds())")
     case TypeExpr.NamedType("Id", _) => StrategyExpr.Code("st.uuids().map(str)")
     case TypeExpr.NamedType(name, _) =>
-      if ir.typeAliases.exists(_.name == name) || ir.enums.exists(_.name == name) then
+      if ir.enums.exists(_.name == name) then
         StrategyExpr.Code(s"${strategyFunctionName(name)}()")
-      else if ir.entities.exists(_.name == name) then
-        StrategyExpr.Skip(s"nested entity reference '$name' not seedable")
-      else StrategyExpr.Skip(s"unknown named type '$name'")
+      else
+        ir.typeAliases.find(_.name == name) match
+          case Some(alias) =>
+            jsonStrategyForType(alias.typeExpr, constraint.orElse(alias.constraint), ir)
+          case None =>
+            if ir.entities.exists(_.name == name) then
+              StrategyExpr.Skip(s"nested entity reference '$name' not seedable")
+            else StrategyExpr.Skip(s"unknown named type '$name'")
     case TypeExpr.OptionType(inner, _) =>
       jsonStrategyForType(inner, None, ir) match
         case StrategyExpr.Code(t) => StrategyExpr.Code(s"st.one_of(st.none(), $t)")
-        case s                    => s
+        case StrategyExpr.Skip(_) => StrategyExpr.Code("st.none()")
     case TypeExpr.SetType(inner, _) =>
       jsonStrategyForType(inner, None, ir) match
         case StrategyExpr.Code(t) => StrategyExpr.Code(s"st.lists($t, unique=True, max_size=5)")

--- a/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
@@ -74,3 +74,34 @@ class AdminRouterTest extends CatsEffectSuite:
     assert(cf.contains("if r.status_code >= 500"))
     assert(cf.contains("pytest.fail"))
     assert(cf.contains("atexit.register(client.close)"))
+
+  // ---------- M5.9: per-entity seed endpoint emission ----------
+
+  test("M5.9: todo_list emits POST /__test_admin__/seed/todo with DateTime coercion"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val src = AdminRouter.emit(profiled)
+      assert(src.contains("@router.post(\"/seed/todo\""), s"src=$src")
+      assert(src.contains("async def seed_todo("), s"src=$src")
+      assert(src.contains("Todo(**payload)"), s"src=$src")
+      assert(src.contains("def _parse_iso(value)"), s"src=$src")
+      assert(src.contains("payload[\"created_at\"] = _parse_iso"), s"src=$src")
+      assert(src.contains("payload[\"updated_at\"] = _parse_iso"), s"src=$src")
+      assert(src.contains("payload[\"completed_at\"] = _parse_iso"), s"src=$src")
+      assert(src.contains("return {\"id\": obj.id}"), s"src=$src")
+
+  test("M5.9: seed endpoint guarded by ENABLE_TEST_ADMIN like the rest of the router"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val src        = AdminRouter.emit(profiled)
+      val seedSlice  = src.indexOf("async def seed_todo")
+      val checkAfter = src.indexOf("_check_enabled()", seedSlice)
+      assert(seedSlice > 0 && checkAfter > seedSlice, s"_check_enabled() must follow seed def")
+
+  test("M5.9: url_shortener (no transitions) emits NO seed endpoint"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val src = AdminRouter.emit(profiled)
+      assert(!src.contains("/seed/"), s"unexpected seed endpoint; src=$src")
+
+  test("M5.9: safe_counter (no entities, no transitions) emits NO seed endpoint"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val src = AdminRouter.emit(profiled)
+      assert(!src.contains("/seed/"), s"unexpected seed endpoint; src=$src")

--- a/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
@@ -105,3 +105,52 @@ class AdminRouterTest extends CatsEffectSuite:
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val src = AdminRouter.emit(profiled)
       assert(!src.contains("/seed/"), s"unexpected seed endpoint; src=$src")
+
+  // ---------- M5.9 PR #154 review round 2 ----------
+
+  test("M5.9 fix G: aliased DateTime field gets _parse_iso() coercion"):
+    val spec =
+      """|service Demo {
+         |  type CreatedAt = DateTime
+         |  entity Foo {
+         |    id: Int
+         |    status: Status
+         |    at: CreatedAt
+         |    opt_at: Option[CreatedAt]
+         |  }
+         |  enum Status { ACTIVE, ARCHIVED }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  transition FooLifecycle {
+         |    entity: Foo
+         |    field: status
+         |    ACTIVE -> ARCHIVED via Archive
+         |  }
+         |  operation Archive {
+         |    input: id: Int
+         |    requires: id in foos
+         |    ensures: foos'[id].status = ARCHIVED
+         |  }
+         |  conventions {
+         |    Archive.http_method = "POST"
+         |    Archive.http_path = "/foos/{id}/archive"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val src      = AdminRouter.emit(profiled)
+            assert(
+              src.contains("payload[\"at\"] = _parse_iso(payload[\"at\"])"),
+              s"alias of DateTime needs _parse_iso coercion; src=$src"
+            )
+            assert(
+              src.contains("payload[\"opt_at\"] = _parse_iso(payload[\"opt_at\"])"),
+              s"Option[alias of DateTime] needs _parse_iso coercion; src=$src"
+            )
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -198,3 +198,111 @@ class BehavioralTest extends CatsEffectSuite:
         registerTests.exists(t => t.body.contains("opaque=st.just(\"***REDACTED***\")")),
         s"expected st.just placeholder under redacted override; tests=\n${registerTests.map(_.body).mkString("\n---\n")}"
       )
+
+  // ---------- M5.9: TransitionDecl-aware property tests ----------
+
+  test("M5.9: todo_list StartWork emits 1 positive (TODO->IN_PROGRESS) + 3 illegal-from tests"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out        = Behavioral.emitFor(profiled)
+      val startTests = out.tests.filter(_.name.startsWith("test_start_work_transition_"))
+      val names      = startTests.map(_.name).sorted
+      assertEquals(
+        names,
+        List(
+          "test_start_work_transition_illegal_from_archived",
+          "test_start_work_transition_illegal_from_done",
+          "test_start_work_transition_illegal_from_in_progress",
+          "test_start_work_transition_todo_to_in_progress"
+        )
+      )
+
+  test("M5.9: todo_list Archive emits 2 positive + 2 illegal-from tests"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out          = Behavioral.emitFor(profiled)
+      val archiveTests = out.tests.filter(_.name.startsWith("test_archive_transition_"))
+      val names        = archiveTests.map(_.name).sorted
+      assertEquals(
+        names,
+        List(
+          "test_archive_transition_done_to_archived",
+          "test_archive_transition_illegal_from_archived",
+          "test_archive_transition_illegal_from_in_progress",
+          "test_archive_transition_todo_to_archived"
+        )
+      )
+
+  test("M5.9: todo_list Reopen guard skips positive, still emits 3 illegal-from tests"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out         = Behavioral.emitFor(profiled)
+      val reopenTests = out.tests.filter(_.name.startsWith("test_reopen_transition_"))
+      val names       = reopenTests.map(_.name).sorted
+      assertEquals(
+        names,
+        List(
+          "test_reopen_transition_illegal_from_archived",
+          "test_reopen_transition_illegal_from_in_progress",
+          "test_reopen_transition_illegal_from_todo"
+        )
+      )
+      val guardSkips = out.skips.filter: s =>
+        s.operation == "Reopen" && s.kind.startsWith("transition[")
+      assert(
+        guardSkips.exists(s => s.reason.contains("guard") && s.reason.contains("#152")),
+        s"expected guard skip mentioning #152; got=$guardSkips"
+      )
+
+  test("M5.9: positive transition test seeds entity, asserts post-state field"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val test = out.tests
+        .find(_.name == "test_start_work_transition_todo_to_in_progress")
+        .getOrElse(fail("missing positive transition test"))
+      assert(test.body.contains("@given(row=strategy_todo())"), s"body=${test.body}")
+      assert(test.body.contains("client.post(\"/__test_admin__/reset\")"))
+      assert(test.body.contains("row[\"status\"] = \"TODO\""), s"body=${test.body}")
+      assert(
+        test.body.contains("client.post(\"/__test_admin__/seed/todo\""),
+        s"body=${test.body}"
+      )
+      assert(test.body.contains("seeded_id = seed.json()[\"id\"]"))
+      assert(
+        test.body.contains("client.post(f\"/todos/{seeded_id}/start\")"),
+        s"body=${test.body}"
+      )
+      assert(test.body.contains("post_state.get(\"todos\""), s"body=${test.body}")
+      assert(test.body.contains("\"IN_PROGRESS\""), s"body=${test.body}")
+
+  test("M5.9: negative transition test asserts 4xx on illegal from"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val test = out.tests
+        .find(_.name == "test_start_work_transition_illegal_from_done")
+        .getOrElse(fail("missing negative transition test"))
+      assert(test.body.contains("row[\"status\"] = \"DONE\""), s"body=${test.body}")
+      assert(test.body.contains("400 <= response.status_code < 500"), s"body=${test.body}")
+
+  test("M5.9: safe_counter (no transitions) emits no transition tests"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(out.tests.filter(_.name.contains("_transition_")), Nil)
+
+  test("M5.9: url_shortener (no transitions) emits no transition tests"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(out.tests.filter(_.name.contains("_transition_")), Nil)
+
+  test("M5.9: state-dep skip on a transition op now reads 'covered by transition tests'"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val startWorkSkips = out.skips.filter: s =>
+        s.operation == "StartWork" && s.kind == "ensures"
+      assert(
+        startWorkSkips.exists(_.reason.contains("covered by transition tests (M5.9)")),
+        s"expected updated skip text on StartWork.ensures; got=$startWorkSkips"
+      )
+      val getTodoSkips = out.skips.filter: s =>
+        s.operation == "GetTodo" && s.kind == "ensures"
+      assert(
+        getTodoSkips.exists(_.reason.contains("deferred to M5.9")),
+        s"non-transition op should retain deferred-to-M5.9 skip; got=$getTodoSkips"
+      )

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -306,3 +306,49 @@ class BehavioralTest extends CatsEffectSuite:
         getTodoSkips.exists(_.reason.contains("deferred to M5.9")),
         s"non-transition op should retain deferred-to-M5.9 skip; got=$getTodoSkips"
       )
+
+  // ---------- M5.9 PR #154 review fixes ----------
+
+  test("M5.9 fix D: unknown-via skip uses viaName (not TransitionDecl name) as operation"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out     = Behavioral.emitFor(profiled)
+      val pwSkips = out.skips.filter(s => s.kind == "transition[PauseWork]")
+      assert(pwSkips.nonEmpty, s"expected PauseWork transition skip; got skips=${out.skips}")
+      assertEquals(
+        pwSkips.map(_.operation).distinct,
+        List("PauseWork"),
+        "skip's operation field must be the via name, not the TransitionDecl name"
+      )
+
+  test("M5.9 fix E: ecommerce RecordPayment (body input) skips with #155 reference"):
+    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
+      val out     = Behavioral.emitFor(profiled)
+      val rpTests = out.tests.filter(_.name.startsWith("test_record_payment_transition_"))
+      assertEquals(
+        rpTests,
+        Nil,
+        s"RecordPayment has body input; transition tests must be skipped, got: ${rpTests.map(_.name)}"
+      )
+      val rpSkip = out.skips.find: s =>
+        s.operation == "RecordPayment" && s.kind == "transition[RecordPayment]"
+      assert(
+        rpSkip.nonEmpty,
+        s"expected RecordPayment transition skip; got=${out.skips.map(s => s.operation -> s.kind)}"
+      )
+      assert(
+        rpSkip.get.reason.contains("non-path inputs") && rpSkip.get.reason.contains("#155"),
+        s"skip reason must reference non-path inputs and #155; got=${rpSkip.get.reason}"
+      )
+
+  test("M5.9 fix E: todo_list (path-only via ops) is unaffected by the skip"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out        = Behavioral.emitFor(profiled)
+      val startTests = out.tests.filter(_.name.startsWith("test_start_work_transition_"))
+      assert(
+        startTests.nonEmpty,
+        "todo_list StartWork has only path input; should still emit tests"
+      )
+      assert(
+        out.skips.forall(s => !s.reason.contains("non-path inputs")),
+        s"todo_list shouldn't trigger non-path-input skip; got=${out.skips}"
+      )

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -336,8 +336,8 @@ class BehavioralTest extends CatsEffectSuite:
         s"expected RecordPayment transition skip; got=${out.skips.map(s => s.operation -> s.kind)}"
       )
       assert(
-        rpSkip.get.reason.contains("non-path inputs") && rpSkip.get.reason.contains("#155"),
-        s"skip reason must reference non-path inputs and #155; got=${rpSkip.get.reason}"
+        rpSkip.get.reason.contains("path input") && rpSkip.get.reason.contains("#155"),
+        s"skip reason must reference path-input shape and #155; got=${rpSkip.get.reason}"
       )
 
   test("M5.9 fix E: todo_list (path-only via ops) is unaffected by the skip"):
@@ -349,6 +349,32 @@ class BehavioralTest extends CatsEffectSuite:
         "todo_list StartWork has only path input; should still emit tests"
       )
       assert(
-        out.skips.forall(s => !s.reason.contains("non-path inputs")),
-        s"todo_list shouldn't trigger non-path-input skip; got=${out.skips}"
+        out.skips.forall(s => !s.reason.contains("require exactly one path input")),
+        s"todo_list shouldn't trigger path-input-shape skip; got=${out.skips}"
+      )
+
+  test("M5.9 fix H: filtered-out via op does NOT claim 'covered by transition tests'"):
+    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val rpEnsuresSkip = out.skips.find: s =>
+        s.operation == "RecordPayment" && s.kind == "ensures"
+      assert(rpEnsuresSkip.nonEmpty, s"expected RecordPayment ensures skip; got=${out.skips}")
+      assert(
+        !rpEnsuresSkip.get.reason.contains("covered by transition tests"),
+        s"RecordPayment was filtered out — must NOT claim coverage; got=${rpEnsuresSkip.get.reason}"
+      )
+      assert(
+        rpEnsuresSkip.get.reason.contains("deferred to M5.9"),
+        s"filtered-out via op should fall back to deferred reason; got=${rpEnsuresSkip.get.reason}"
+      )
+
+  test("M5.9 fix H: emitted transition op DOES claim 'covered by transition tests'"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val swEnsuresSkip = out.skips.find: s =>
+        s.operation == "StartWork" && s.kind == "ensures"
+      assert(swEnsuresSkip.nonEmpty, s"expected StartWork ensures skip; got=${out.skips}")
+      assert(
+        swEnsuresSkip.get.reason.contains("covered by transition tests (M5.9)"),
+        s"StartWork emits transition tests — should claim coverage; got=${swEnsuresSkip.get.reason}"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -395,3 +395,35 @@ class StrategiesTest extends CatsEffectSuite:
   test("anonymous ctx never wraps even for sensitive-named types"):
     val expr = Strategies.expressionFor(TypeExpr.NamedType("String"), emptyIR)
     assertEquals(expr, StrategyExpr.Code("st.text()"))
+
+  // ---------- M5.9: entity strategies for transition entities ----------
+
+  test("M5.9: todo_list emits strategy_todo with one entry per Todo field"):
+    loadFixture("fixtures/spec/todo_list.spec").map: ir =>
+      val specs = Strategies.forIR(ir)
+      val todo  = specs.find(_.typeName == "Todo").getOrElse(fail("no strategy_todo"))
+      assertEquals(todo.functionName, "strategy_todo")
+      assert(todo.body.startsWith("st.fixed_dictionaries"), s"body=${todo.body}")
+      assert(todo.body.contains("\"id\":"), s"body=${todo.body}")
+      assert(todo.body.contains("\"status\":"), s"body=${todo.body}")
+      assert(todo.body.contains("\"priority\":"), s"body=${todo.body}")
+      assert(todo.body.contains("\"title\":"), s"body=${todo.body}")
+      assert(todo.body.contains("strategy_status()"), s"body=${todo.body}")
+      assert(todo.body.contains("isoformat"), s"body=${todo.body}")
+
+  test("M5.9: url_shortener (no transitions) emits NO entity strategy"):
+    loadFixture("fixtures/spec/url_shortener.spec").map: ir =>
+      val specs = Strategies.forIR(ir)
+      assert(
+        !specs.exists(_.typeName == "UrlMapping"),
+        s"unexpected entity strategy; specs=${specs.map(_.typeName)}"
+      )
+
+  test("M5.9: safe_counter (no transitions, no entities) emits no entity strategies"):
+    loadFixture("fixtures/spec/safe_counter.spec").map: ir =>
+      val specs = Strategies.forIR(ir)
+      assertEquals(specs, Nil)
+
+  test("M5.9: transitionEntityNames returns the entities referenced by TransitionDecls"):
+    loadFixture("fixtures/spec/todo_list.spec").map: ir =>
+      assertEquals(Strategies.transitionEntityNames(ir), Set("Todo"))

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -427,3 +427,118 @@ class StrategiesTest extends CatsEffectSuite:
   test("M5.9: transitionEntityNames returns the entities referenced by TransitionDecls"):
     loadFixture("fixtures/spec/todo_list.spec").map: ir =>
       assertEquals(Strategies.transitionEntityNames(ir), Set("Todo"))
+
+  // ---------- M5.9 PR #154 review fixes ----------
+
+  test("M5.9 fix A: unseedable field is omitted from fixed_dictionaries (no st.nothing)"):
+    val ir = ServiceIR(
+      name = "X",
+      entities = List(specrest.ir.EntityDecl(
+        name = "Foo",
+        fields = List(
+          specrest.ir.FieldDecl("id", TypeExpr.NamedType("Int")),
+          specrest.ir.FieldDecl(
+            "stuff",
+            TypeExpr.MapType(TypeExpr.NamedType("String"), TypeExpr.NamedType("Int"))
+          )
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("FooLifecycle", "Foo", "id", Nil))
+    )
+    val foo = Strategies.forIR(ir).find(_.typeName == "Foo").getOrElse(fail("no strategy_foo"))
+    assert(
+      !foo.body.contains("st.nothing"),
+      s"unseedable must be omitted, not st.nothing: ${foo.body}"
+    )
+    assert(!foo.body.contains("\"stuff\""), s"unseedable key must be dropped: ${foo.body}")
+    assert(foo.body.contains("\"id\":"), s"seedable key must be present: ${foo.body}")
+    assert(
+      foo.skipped.exists(_.contains("'stuff'")),
+      s"unseedable field should be recorded in skipped: ${foo.skipped}"
+    )
+
+  test("M5.9 fix B: Option[Map[...]] field falls back to st.none() (not Skip)"):
+    val ir = ServiceIR(
+      name = "X",
+      entities = List(specrest.ir.EntityDecl(
+        name = "Foo",
+        fields = List(
+          specrest.ir.FieldDecl("id", TypeExpr.NamedType("Int")),
+          specrest.ir.FieldDecl(
+            "tags",
+            TypeExpr.OptionType(
+              TypeExpr.MapType(TypeExpr.NamedType("String"), TypeExpr.NamedType("Int"))
+            )
+          )
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("FooLifecycle", "Foo", "id", Nil))
+    )
+    val foo = Strategies.forIR(ir).find(_.typeName == "Foo").getOrElse(fail("no strategy_foo"))
+    assert(
+      foo.body.contains("\"tags\": st.none()"),
+      s"Option[Skip] should yield st.none(): ${foo.body}"
+    )
+    assert(!foo.skipped.exists(_.contains("'tags'")), s"tags should not skip: ${foo.skipped}")
+
+  test("M5.9 fix C: sensitive entity field is wrapped in redact() in entity strategy"):
+    val ir = ServiceIR(
+      name = "X",
+      entities = List(specrest.ir.EntityDecl(
+        name = "User",
+        fields = List(
+          specrest.ir.FieldDecl("id", TypeExpr.NamedType("Int")),
+          specrest.ir.FieldDecl("password_hash", TypeExpr.NamedType("String"))
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("UserLifecycle", "User", "id", Nil))
+    )
+    val user = Strategies.forIR(ir).find(_.typeName == "User").getOrElse(fail("no strategy_user"))
+    assert(
+      user.body.contains("\"password_hash\": redact("),
+      s"sensitive password_hash must be redact-wrapped: ${user.body}"
+    )
+
+  test("M5.9 fix C: test_strategy='live' override removes redact in entity strategy"):
+    val ir = ServiceIR(
+      name = "X",
+      entities = List(specrest.ir.EntityDecl(
+        name = "User",
+        fields = List(
+          specrest.ir.FieldDecl("id", TypeExpr.NamedType("Int")),
+          specrest.ir.FieldDecl("password", TypeExpr.NamedType("String"))
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("UserLifecycle", "User", "id", Nil)),
+      conventions = Some(ConventionsDecl(List(
+        ConventionRule("User", "test_strategy", Some("password"), Expr.StringLit("live"))
+      )))
+    )
+    val user = Strategies.forIR(ir).find(_.typeName == "User").getOrElse(fail("no strategy_user"))
+    assert(
+      !user.body.contains("\"password\": redact("),
+      s"live override must remove redact: ${user.body}"
+    )
+    assert(
+      user.body.contains("\"password\": st.text()"),
+      s"live override should emit bare strategy: ${user.body}"
+    )
+
+  test("M5.9 fix F: alias of DateTime in entity field produces isoformat-mapped strategy"):
+    val ir = ServiceIR(
+      name = "X",
+      typeAliases = List(TypeAliasDecl("CreatedAt", TypeExpr.NamedType("DateTime"))),
+      entities = List(specrest.ir.EntityDecl(
+        name = "Foo",
+        fields = List(
+          specrest.ir.FieldDecl("id", TypeExpr.NamedType("Int")),
+          specrest.ir.FieldDecl("at", TypeExpr.NamedType("CreatedAt"))
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("FooLifecycle", "Foo", "id", Nil))
+    )
+    val foo = Strategies.forIR(ir).find(_.typeName == "Foo").getOrElse(fail("no strategy_foo"))
+    assert(
+      foo.body.contains("\"at\": st.datetimes().map(lambda d: d.isoformat())"),
+      s"alias of DateTime should resolve to JSON-friendly isoformat: ${foo.body}"
+    )

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -542,3 +542,50 @@ class StrategiesTest extends CatsEffectSuite:
       foo.body.contains("\"at\": st.datetimes().map(lambda d: d.isoformat())"),
       s"alias of DateTime should resolve to JSON-friendly isoformat: ${foo.body}"
     )
+
+  test("M5.9 fix J: entity with no seedable fields emits valid st.fixed_dictionaries({})"):
+    val ir = ServiceIR(
+      name = "X",
+      entities = List(specrest.ir.EntityDecl(
+        name = "Foo",
+        fields = List(
+          specrest.ir.FieldDecl(
+            "stuff",
+            TypeExpr.MapType(TypeExpr.NamedType("String"), TypeExpr.NamedType("Int"))
+          )
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("FooLifecycle", "Foo", "stuff", Nil))
+    )
+    val foo = Strategies.forIR(ir).find(_.typeName == "Foo").getOrElse(fail("no strategy_foo"))
+    assertEquals(foo.body, "st.fixed_dictionaries({})")
+    assert(foo.skipped.exists(_.contains("'stuff'")), s"expected skip note: ${foo.skipped}")
+
+  test("M5.9 fix K: alias-of-Int with constraint AND field-level constraint are combined"):
+    import specrest.ir.BinOp
+    val ir = ServiceIR(
+      name = "X",
+      typeAliases = List(
+        TypeAliasDecl(
+          name = "PosInt",
+          typeExpr = TypeExpr.NamedType("Int"),
+          constraint = Some(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("value"), Expr.IntLit(0)))
+        )
+      ),
+      entities = List(specrest.ir.EntityDecl(
+        name = "Foo",
+        fields = List(
+          specrest.ir.FieldDecl(
+            "score",
+            TypeExpr.NamedType("PosInt"),
+            constraint = Some(Expr.BinaryOp(BinOp.Le, Expr.Identifier("value"), Expr.IntLit(100)))
+          )
+        )
+      )),
+      transitions = List(specrest.ir.TransitionDecl("FooLifecycle", "Foo", "score", Nil))
+    )
+    val foo = Strategies.forIR(ir).find(_.typeName == "Foo").getOrElse(fail("no strategy_foo"))
+    assert(
+      foo.body.contains("\"score\": st.integers(min_value=1, max_value=100)"),
+      s"both constraints must apply (alias 'value > 0' AND field 'value <= 100'): ${foo.body}"
+    )


### PR DESCRIPTION
## Summary

For specs that declare a state machine via `transition X { entity: E; field: f; FROM -> TO via Op ... }`, testgen now synthesizes per-`via` behavioral tests:

- **Positive** test per legal `(from, to)` rule: seed entity in `from`, call `Op`, assert 2xx and post-state `field == to`.
- **Negative** test per illegal `from` (every value of `field`'s enum that's *not* a `from`-state for `via Op`): seed in that state, call `Op`, assert 4xx.

Setup uses a new admin endpoint `POST /__test_admin__/seed/<entity>` emitted only for entities referenced by a `TransitionDecl`, with auto-generated DateTime ISO parsing. Gated by `ENABLE_TEST_ADMIN=1` like `/reset` and `/state`. Row strategies come from a new `strategy_<entity>()` (`st.fixed_dictionaries`) emitted by `Strategies.scala`.

State-dep skip messages on transition-via operations now read `"covered by transition tests (M5.9)"`. Non-transition residual ops keep the `"deferred to M5.9"` text.

## What `todo_list.spec` gets

| `via` op | Legal `(from, to)` | Positives | Illegal froms | Negatives |
|---|---|---:|---|---:|
| `StartWork` | `TODO -> IN_PROGRESS` | 1 | `IN_PROGRESS, DONE, ARCHIVED` | 3 |
| `Complete`  | `IN_PROGRESS -> DONE` | 1 | `TODO, DONE, ARCHIVED` | 3 |
| `Archive`   | `TODO -> ARCHIVED, DONE -> ARCHIVED` | 2 | `IN_PROGRESS, ARCHIVED` | 2 |
| `Reopen`    | `DONE -> IN_PROGRESS` (guarded) | 0 (skip → #152) | `TODO, IN_PROGRESS, ARCHIVED` | 3 |

15 transition tests total. `PauseWork` is in the transition graph but has no operation declaration in the spec — recorded in `_testgen_skips.json` as `transition[PauseWork] = no operation named 'PauseWork' for via clause`.

## Non-transition fixtures unchanged

`safe_counter` and `url_shortener` produce byte-identical output: no `_transition_` tests, no `/seed/` endpoints, no `strategy_<entity>()`.

## Skipped categories

- **Guarded positives** — rules with `when <guard>` skip with `guard '<expr>' not representable in seed dict (see #152)`. Negative tests for the same rule emit normally. Tracked: #152.
- **Non-enum transition field** — entire `TransitionDecl` skipped (illegal-from enumeration undefined).
- **Unknown via op** — defensive backstop for spec lint.

## Tests

170 testgen tests pass (was 154; +16):
- `BehavioralTest` — 8 new cases covering positive/negative shape, guard skip, non-transition specs unchanged, M5.1 skip-text rewrite.
- `StrategiesTest` — 4 new cases covering `strategy_<entity>()` emission and gating.
- `AdminRouterTest` — 4 new cases covering seed endpoint emission and gating.

Full `sbt test` green across 9 modules (520 tests). `scalafmtCheckAll` clean. `scalafixAll --check` clean. `cd docs && npm run build` clean (link-checker passes).

## Test plan

- [x] `sbt test` green
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt "scalafixAll --check"` clean
- [x] `cd docs && npm run build` clean
- [x] Smoke compile `todo_list.spec` — generated `tests/test_behavioral_todo_list.py` has 15 transition tests; `app/routers/test_admin.py` has `/seed/todo` with DateTime coercion; `tests/strategies.py` has `strategy_todo()`
- [x] Smoke compile `url_shortener.spec` — no transition tests, no seed endpoint, no entity strategy emitted
- [x] Smoke compile `safe_counter.spec` — no transition tests, no seed endpoint emitted
- [ ] (post-merge) End-to-end: boot generated todo_list service, `pytest tests/test_behavioral_todo_list.py -k transition` — collects all 15 tests; most fail on `NotImplementedError` from M4 stubs (documented M5.1 caveat)

## Follow-ups (already opened as separate issues)

- **#152** — Guarded positive transition tests (extend seed-row fix-up walker for `>`/`>=`/`=`/`!= none` patterns)
- **#153** — Per-status bundles in stateful tests (split `<entity>_ids` per enum value in `Stateful.scala`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TransitionDecl-aware property tests with per-operation positives/negatives and a per-entity seed endpoint to drive entities into specific statuses. Updates skip text and tightens via-op input shape checks; implements M5.9 and closes #137.

- **New Features**
  - Positive tests for each legal (from → to) per `via` op; assert 2xx and post-state field.
  - Negative tests for illegal from-states; assert 4xx.
  - Admin POST `/__test_admin__/seed/<entity>` for transition entities; parses ISO DateTime (aliases too); gated by `ENABLE_TEST_ADMIN`.
  - Emit `strategy_<entity>()` (`st.fixed_dictionaries`) for transition entities only.
  - Update state-dependent precondition skip text on `via` ops to “covered by transition tests (M5.9)”; non-transition ops unchanged.

- **Bug Fixes**
  - Skip transition tests unless the `via` op has exactly one path param and no body/query inputs; reason references #155.
  - Coverage claim now gated on actually emitted tests; filtered-out `via` ops keep the “deferred to M5.9” reason.
  - Omit unseedable fields from `strategy_<entity>()`; `Option[Skip]` becomes `st.none()`; sensitive fields are redacted unless `test_strategy = "live"`.
  - Resolve DateTime aliases to ISO strings in strategies, and coerce them in the seed handler.
  - If all fields are unseedable, emit `st.fixed_dictionaries({})`; combine alias and field constraints (e.g., min/max) correctly.
  - Unknown-`via` skips use the `via` op name in `operation`; matches docs.
  - Guarded positives skip with a #152 reason; per-status stateful bundles tracked in #153.

<sup>Written for commit 633f12928fc5f023cbb36da7ccac3c467f2d2dd0. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-entity seeding endpoints (`POST /seed/{entity}`) to the admin API for test data initialization
  * Introduced transition-aware behavioral tests that validate state changes across operations

* **Documentation**
  * Updated test generation documentation to reflect transition-aware testing behavior, skip reasons, and known limitations

* **Tests**
  * Expanded test coverage for seeding endpoints and transition-based test generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->