### PR TITLE
#152: Recognize guarded transitions for positive tests

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -215,11 +215,32 @@ the rewrite is an arithmetic shift off the strategy-generated RHS — e.g.
 This composes with `where` constraints already enforced by the strategy. For numeric the
 shift is `row[a] = row[b] + 1` (or `+ 0` for `>=` / `<=`, `- 1` for `<`).
 
-Anything outside the recognized shapes (function calls, set operations, nested field
-access, comparisons against non-field expressions, conjunctions where any branch fails
-recognition, or guards that touch the transition field itself) keeps the existing skip
-with reason `guard '<expr>' not representable in seed dict (see #152)`. Conflicting
-fixes within a conjunction (e.g. `a > b and a < b`) also fall back to skip.
+Anything outside the recognized shapes keeps the existing skip with reason
+`guard '<expr>' not representable in seed dict (see #152)`. Concretely, the
+recognizer falls back to skip on:
+
+- **Function calls** in the guard (e.g. `len(tags) > 0`, `is_valid_email(addr)`).
+- **Set / map / sequence operations** (e.g. `tag in tags`, `#tags >= 1`,
+  `tags - banned = {}`).
+- **Nested field access** on either side (e.g. `parent.status = ARCHIVED`,
+  `priority.level > 3`) — the recognizer only accepts bare `Identifier` operands
+  resolving to entity fields of the seeded entity.
+- **`Pre(...)` / `Prime(...)`** — guards reference state, not the row being seeded.
+- **Comparisons against non-field expressions** other than the four literal kinds
+  listed above (e.g. `a > b + 1`, `a > some_function()`).
+- **Mismatched operand kinds** in ordered comparison — one DateTime-ish, one
+  numeric; the recognizer requires the same kind on both sides.
+- **Guards that touch the transition field itself** — the row's transition field
+  is owned by the `row[<field>] = <from>` line and must not be overridden.
+- **Conjunctions where any branch fails recognition.** Recognition is all-or-
+  nothing across an `and` tree; partial application would silently miss the
+  unrecognized branch.
+- **Conflicting fixes within a conjunction** (e.g. `a > b and a < b` produces
+  two writes to `row[a]` with different RHS) — recognition fails fast rather
+  than emitting an unsatisfiable test.
+- **Disjunctions and negations** at the top level of a guard. `or` / `not` /
+  `implies` aren't supported; reduce them to a conjunction and re-spec the
+  rule if you want a deterministic test.
 
 ### Other skipped categories
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -197,14 +197,32 @@ def test_archive_transition_illegal_from_in_progress(row):
 no operation declaration in `todo_list.spec`, so it produces a `transition[PauseWork]` skip
 in `_testgen_skips.json` with reason `no operation named 'PauseWork' for via clause`.
 
-### Skipped categories
+### Guarded positive transitions (#152)
 
-- **Guarded positives.** Rules with a `when <guard>` clause cannot be reliably exercised by
-  a randomly-generated seed row (the guard is satisfied in only ~50% of cases; Hypothesis
-  `assume(...)` would discard most attempts). The positive test is skipped with reason
-  `guard '<expr>' not representable in seed dict (see #152)`. Negative tests for the same
-  rule's illegal-from cases still emit normally. Tracked under
-  [#152](https://github.com/HardMax71/spec_to_rest/issues/152).
+Rules with a `when <guard>` clause are recognized when the guard reduces to one of these
+shapes (or a conjunction of them):
+
+- ordered comparison on entity fields, both DateTime-ish or both numeric:
+  `a > b`, `a >= b`, `a < b`, `a <= b`
+- equality on enum / literal: `a = ENUM_MEMBER`, `a = 42`, `a = "x"`, `a = true`
+- existence on optional: `a != none`
+
+For each recognized shape testgen inserts a deterministic row mutation between the
+strategy and the seed POST so the guard holds by construction. For ordered comparison
+the rewrite is an arithmetic shift off the strategy-generated RHS — e.g.
+`updated_at > completed_at` becomes
+`row["updated_at"] = (datetime.datetime.fromisoformat(row["completed_at"]) + datetime.timedelta(seconds=1)).isoformat()`.
+This composes with `where` constraints already enforced by the strategy. For numeric the
+shift is `row[a] = row[b] + 1` (or `+ 0` for `>=` / `<=`, `- 1` for `<`).
+
+Anything outside the recognized shapes (function calls, set operations, nested field
+access, comparisons against non-field expressions, conjunctions where any branch fails
+recognition, or guards that touch the transition field itself) keeps the existing skip
+with reason `guard '<expr>' not representable in seed dict (see #152)`. Conflicting
+fixes within a conjunction (e.g. `a > b and a < b`) also fall back to skip.
+
+### Other skipped categories
+
 - **Non-enum transition field.** If `field: <name>` resolves to a type other than an enum
   (or alias of an enum), the entire `TransitionDecl` is skipped — illegal-from enumeration
   is undefined for non-enum status fields.
@@ -555,7 +573,6 @@ they regress.
   "behavioral_skipped": [
     {"operation": "Resolve", "kind": "ensures", "reason": "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"},
     {"operation": "StartWork", "kind": "ensures", "reason": "state-dependent precondition; covered by transition tests (M5.9)"},
-    {"operation": "Reopen", "kind": "transition[DONE_to_IN_PROGRESS]", "reason": "guard '(updated_at > completed_at)' not representable in seed dict (see #152)"},
     {"operation": "Shorten", "kind": "requires[0]", "reason": "M5.1: only `<input> in <state>` requires patterns get negative tests"}
   ]
 }
@@ -565,10 +582,9 @@ The `behavioral_skipped` array enumerates clauses that the test generator could 
 into a runnable test. Every entry signals one of: (a) state-machine setup is needed before
 the precondition is reachable for a non-transition operation (no `via` rule covers it; the
 remaining gap on `GetTodo`-shaped operations); (b) the requires shape is outside the
-recognized negative-test pattern; (c) a guarded transition rule whose guard can't be
-satisfied by a randomly-generated seed dict (tracked under
-[#152](https://github.com/HardMax71/spec_to_rest/issues/152)); (d) a real user error in
-the spec.
+recognized negative-test pattern; (c) a guarded transition rule whose guard sits outside
+the recognizer's recognized shapes (ordered comparison / enum or literal equality /
+not-none / conjunction of those); (d) a real user error in the spec.
 
 ## Runtime requirements
 
@@ -657,7 +673,7 @@ become compile errors under `--strict-strategies`.
 | Limit | Tracked under |
 |---|---|
 | State-dependent preconditions on **non-transition** ops still skip ensures tests | residual tail of M5.9; not currently scoped |
-| Guarded positive transition tests | [#152](https://github.com/HardMax71/spec_to_rest/issues/152) — extend the seed-row fix-up walker for guards like `updated_at > completed_at` |
+| Guards outside `>`/`>=`/`<`/`<=` / `=` literal / `!= none` / their conjunctions | extend `GuardSatisfier` in `Behavioral.scala` to cover further patterns case-by-case |
 | Per-status bundles in stateful tests | [#153](https://github.com/HardMax71/spec_to_rest/issues/153) — split `<entity>_ids` into per-enum-value bundles in `Stateful.scala` |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |
 | Default `--with-tests` after M5.4 | [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140) |

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -199,48 +199,53 @@ in `_testgen_skips.json` with reason `no operation named 'PauseWork' for via cla
 
 ### Guarded positive transitions (#152)
 
-Rules with a `when <guard>` clause are recognized when the guard reduces to one of these
-shapes (or a conjunction of them):
+Rules with a `when <guard>` clause are recognized when the guard reduces to a
+conjunction (`and`) — or single instance — of these shapes:
 
-- ordered comparison on entity fields, both DateTime-ish or both numeric:
-  `a > b`, `a >= b`, `a < b`, `a <= b`
-- equality on enum / literal: `a = ENUM_MEMBER`, `a = 42`, `a = "x"`, `a = true`
-- existence on optional: `a != none`
+| Shape | Example | Emitted fix-up |
+|---|---|---|
+| ordered comparison on two entity fields, both DateTime-ish | `updated_at > completed_at` | `row["updated_at"] = (datetime.datetime.fromisoformat(row["completed_at"]) + datetime.timedelta(seconds=1)).isoformat()` (with optional `if row[..] is None` anchor when the RHS is `Option[DateTime]`) |
+| ordered comparison on two entity fields, both numeric | `score > threshold` | `row["score"] = row["threshold"] + 1` (or `+ 0`/`- 1` for `>=`/`<=`/`<`) |
+| ordered comparison vs. numeric literal | `score > 10` | `row["score"] = 10 + 1` |
+| equality with enum or literal RHS | `tier = GOLD`, `count = 7`, `name = "x"` | `row["tier"] = "GOLD"` |
+| equality with `none` on Option field | `closed_at = none` | `row["closed_at"] = None` |
+| existence (`!= none`) on Option field | `closed_at != none` | `if row["closed_at"] is None: row["closed_at"] = <inner-default>` |
+| cardinality on Set/Seq field | `#tags > 2`, `len(tags) >= 1`, `#tags = 0` | `row["tags"] = ["x0", "x1", "x2"]` (size and fillers depend on inner type) |
+| literal membership in Set/Seq field | `"URGENT" in tags` | `row["tags"] = list(row["tags"]) + ["URGENT"]` |
+| transition-field self-equality matching `from` | rule `LOW -> HIGH ... when phase = LOW` | no extra fix line — already satisfied by the `row[<field>] = LOW` step |
+| top-level `not (...)` (De Morgan inversion) | `not (a > b)` | recurses on `a <= b` |
 
-For each recognized shape testgen inserts a deterministic row mutation between the
-strategy and the seed POST so the guard holds by construction. For ordered comparison
-the rewrite is an arithmetic shift off the strategy-generated RHS — e.g.
-`updated_at > completed_at` becomes
-`row["updated_at"] = (datetime.datetime.fromisoformat(row["completed_at"]) + datetime.timedelta(seconds=1)).isoformat()`.
-This composes with `where` constraints already enforced by the strategy. For numeric the
-shift is `row[a] = row[b] + 1` (or `+ 0` for `>=` / `<=`, `- 1` for `<`).
+Recognized clauses can be combined freely with `and`. The arithmetic-shift form
+on ordered comparisons composes with field-level `where` constraints already
+enforced by the strategy because we keep the strategy-generated RHS value and
+shift LHS off it.
 
-Anything outside the recognized shapes keeps the existing skip with reason
-`guard '<expr>' not representable in seed dict (see #152)`. Concretely, the
-recognizer falls back to skip on:
+Anything outside the table above keeps the skip with reason
+`guard '<expr>' not representable in seed dict (see #152)`. Cases that fall back:
 
-- **Function calls** in the guard (e.g. `len(tags) > 0`, `is_valid_email(addr)`).
-- **Set / map / sequence operations** (e.g. `tag in tags`, `#tags >= 1`,
-  `tags - banned = {}`).
+- **User function calls** other than `len(...)` (e.g. `is_valid_email(addr)`,
+  `paymentCaptured(order_id)`) — would need runtime predicate evaluation.
+- **Set/map/seq arithmetic** beyond cardinality and membership (e.g.
+  `tags - banned = {}`, `tags = other_tags`).
 - **Nested field access** on either side (e.g. `parent.status = ARCHIVED`,
-  `priority.level > 3`) — the recognizer only accepts bare `Identifier` operands
-  resolving to entity fields of the seeded entity.
-- **`Pre(...)` / `Prime(...)`** — guards reference state, not the row being seeded.
-- **Comparisons against non-field expressions** other than the four literal kinds
-  listed above (e.g. `a > b + 1`, `a > some_function()`).
+  `priority.level > 3`) — would need multi-entity seed orchestration; the
+  recognizer only accepts bare `Identifier` operands of the seeded entity.
+- **`Pre(...)` / `Prime(...)`** — references system pre-/post-state, not the
+  row being seeded; structurally not row-local.
+- **Compound RHS expressions** other than the literal forms in the table
+  (e.g. `a > b + 1`, `a > some_function()`).
 - **Mismatched operand kinds** in ordered comparison — one DateTime-ish, one
   numeric; the recognizer requires the same kind on both sides.
-- **Guards that touch the transition field itself** — the row's transition field
-  is owned by the `row[<field>] = <from>` line and must not be overridden.
-- **Conjunctions where any branch fails recognition.** Recognition is all-or-
-  nothing across an `and` tree; partial application would silently miss the
-  unrecognized branch.
+- **Transition-field self-equality contradicting the rule's `from`** (e.g.
+  rule `LOW -> HIGH ... when phase = HIGH` — the guard can never hold for any
+  row of phase=LOW).
+- **Conjunctions where any branch fails recognition.** All-or-nothing across
+  an `and` tree; a partial pass would silently miss the unrecognized branch.
 - **Conflicting fixes within a conjunction** (e.g. `a > b and a < b` produces
   two writes to `row[a]` with different RHS) — recognition fails fast rather
   than emitting an unsatisfiable test.
-- **Disjunctions and negations** at the top level of a guard. `or` / `not` /
-  `implies` aren't supported; reduce them to a conjunction and re-spec the
-  rule if you want a deterministic test.
+- **Top-level `or` / `implies`.** Pick-a-branch ambiguity; reduce to a
+  conjunction and re-spec the rule if you want a deterministic test.
 
 ### Other skipped categories
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -190,12 +190,16 @@ def test_archive_transition_illegal_from_in_progress(row):
 |---|---|---|---|---|
 | `StartWork` | `TODO -> IN_PROGRESS` | 1 | `IN_PROGRESS, DONE, ARCHIVED` | 3 |
 | `Complete`  | `IN_PROGRESS -> DONE` | 1 | `TODO, DONE, ARCHIVED`        | 3 |
-| `Reopen`    | `DONE -> IN_PROGRESS` (guarded) | 0 (guard skip — see below) | `TODO, IN_PROGRESS, ARCHIVED` | 3 |
+| `Reopen`    | `DONE -> IN_PROGRESS` (guarded by `updated_at > completed_at`) | 1 | `TODO, IN_PROGRESS, ARCHIVED` | 3 |
 | `Archive`   | `TODO -> ARCHIVED`, `DONE -> ARCHIVED` | 2 | `IN_PROGRESS, ARCHIVED` | 2 |
 
-15 transition tests total. `PauseWork` is referenced in the spec's transition graph but has
-no operation declaration in `todo_list.spec`, so it produces a `transition[PauseWork]` skip
-in `_testgen_skips.json` with reason `no operation named 'PauseWork' for via clause`.
+16 transition tests total — including the `Reopen` positive whose guard
+`updated_at > completed_at` is satisfied deterministically by the recognizer in
+[#152](https://github.com/HardMax71/spec_to_rest/issues/152) (see "Guarded
+positive transitions" below). `PauseWork` is referenced in the spec's transition
+graph but has no operation declaration in `todo_list.spec`, so it produces a
+`transition[PauseWork]` skip in `_testgen_skips.json` with reason
+`no operation named 'PauseWork' for via clause`.
 
 ### Guarded positive transitions (#152)
 

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -125,7 +125,7 @@ object AdminRouter:
         |    return {"$pkName": obj.$pkName}
         |""".stripMargin
 
-  private def isDateTimeType(t: TypeExpr, ir: ServiceIR, seen: Set[String]): Boolean =
+  private[testgen] def isDateTimeType(t: TypeExpr, ir: ServiceIR, seen: Set[String]): Boolean =
     t match
       case TypeExpr.NamedType("DateTime", _) => true
       case TypeExpr.OptionType(inner, _)     => isDateTimeType(inner, ir, seen)
@@ -134,6 +134,20 @@ object AdminRouter:
           .find(_.name == name)
           .exists(alias => isDateTimeType(alias.typeExpr, ir, seen + name))
       case _ => false
+
+  private[testgen] def isNumericType(t: TypeExpr, ir: ServiceIR, seen: Set[String]): Boolean =
+    t match
+      case TypeExpr.NamedType(n, _) if Set("Int", "Long", "Float", "Double").contains(n) => true
+      case TypeExpr.OptionType(inner, _)                                                 => isNumericType(inner, ir, seen)
+      case TypeExpr.NamedType(name, _) if !seen.contains(name) =>
+        ir.typeAliases
+          .find(_.name == name)
+          .exists(alias => isNumericType(alias.typeExpr, ir, seen + name))
+      case _ => false
+
+  private[testgen] def isOptionalType(t: TypeExpr): Boolean = t match
+    case TypeExpr.OptionType(_, _) => true
+    case _                         => false
 
   final private case class Projection(
       entityName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -145,9 +145,14 @@ object AdminRouter:
           .exists(alias => isNumericType(alias.typeExpr, ir, seen + name))
       case _ => false
 
-  private[testgen] def isOptionalType(t: TypeExpr): Boolean = t match
-    case TypeExpr.OptionType(_, _) => true
-    case _                         => false
+  private[testgen] def isOptionalType(t: TypeExpr, ir: ServiceIR, seen: Set[String]): Boolean =
+    t match
+      case TypeExpr.OptionType(_, _) => true
+      case TypeExpr.NamedType(name, _) if !seen.contains(name) =>
+        ir.typeAliases
+          .find(_.name == name)
+          .exists(alias => isOptionalType(alias.typeExpr, ir, seen + name))
+      case _ => false
 
   final private case class Projection(
       entityName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -13,6 +13,7 @@ import specrest.ir.ServiceIR
 import specrest.ir.TransitionDecl
 import specrest.ir.TransitionRule
 import specrest.ir.TypeExpr
+import specrest.ir.UnOp
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -350,7 +351,7 @@ object Behavioral:
   ): Either[TestSkip, GeneratedTest] =
     val fixLines = rule.guard match
       case None        => Some(Nil)
-      case Some(guard) => GuardSatisfier.recognize(guard, entity, fieldName, ir)
+      case Some(guard) => GuardSatisfier.recognize(guard, entity, fieldName, rule.from, ir)
     fixLines match
       case None =>
         Left(
@@ -714,7 +715,7 @@ object Behavioral:
       def writeKey: String
       def lines: List[String]
 
-    private case class OrderedShift(
+    private case class OrderedShiftField(
         leftKey: String,
         rightKey: String,
         kind: FieldKind,
@@ -733,9 +734,7 @@ object Behavioral:
             val anchorIfNone =
               if rightOptional then List(s"if row[$rk] is None: row[$rk] = $anchor.isoformat()")
               else Nil
-            anchorIfNone ++ List(
-              s"row[$lk] = ($parseR + $deltaPy).isoformat()"
-            )
+            anchorIfNone ++ List(s"row[$lk] = ($parseR + $deltaPy).isoformat()")
           case NumericField =>
             val anchorIfNone =
               if rightOptional then List(s"if row[$rk] is None: row[$rk] = 0")
@@ -745,6 +744,29 @@ object Behavioral:
               else if deltaSeconds > 0 then s"row[$rk] + $deltaSeconds"
               else s"row[$rk] - ${-deltaSeconds}"
             anchorIfNone ++ List(s"row[$lk] = $rhs")
+
+    private case class OrderedShiftConst(
+        field: String,
+        kind: FieldKind,
+        constPy: String,
+        deltaSeconds: Int
+    ) extends Fix:
+      def writeKey: String = field
+      def lines: List[String] =
+        val k = ExprToPython.pyString(field)
+        kind match
+          case NumericField =>
+            val rhs = deltaSeconds match
+              case 0          => constPy
+              case d if d > 0 => s"$constPy + $d"
+              case d          => s"$constPy - ${-d}"
+            List(s"row[$k] = $rhs")
+          case DateTimeField =>
+            // not currently reachable — spec syntax has no DateTime literal — but
+            // keep the branch coherent by treating the const as an ISO string.
+            val parsed = s"datetime.datetime.fromisoformat($constPy)"
+            val delta  = s"datetime.timedelta(seconds=$deltaSeconds)"
+            List(s"row[$k] = ($parsed + $delta).isoformat()")
 
     private case class Assign(field: String, pyValue: String) extends Fix:
       def writeKey: String = field
@@ -757,14 +779,34 @@ object Behavioral:
         val k = ExprToPython.pyString(field)
         List(s"if row[$k] is None: row[$k] = $anchor")
 
+    private case class ListOfSize(field: String, items: List[String]) extends Fix:
+      def writeKey: String = field
+      def lines: List[String] =
+        val k = ExprToPython.pyString(field)
+        List(s"row[$k] = [${items.mkString(", ")}]")
+
+    private case class ListAppend(field: String, pyElem: String) extends Fix:
+      def writeKey: String = field
+      def lines: List[String] =
+        val k = ExprToPython.pyString(field)
+        List(s"row[$k] = list(row[$k]) + [$pyElem]")
+
+    private case class NoOp(label: String) extends Fix:
+      def writeKey: String    = s"__noop:$label"
+      def lines: List[String] = Nil
+
     def recognize(
         guard: Expr,
         entity: EntityDecl,
         transitionField: String,
+        from: String,
         ir: ServiceIR
     ): Option[List[String]] =
-      collect(guard, entity, transitionField, ir).flatMap: fixes =>
-        val byKey = fixes.groupBy(_.writeKey)
+      collect(guard, entity, transitionField, from, ir).flatMap: fixes =>
+        val realFixes = fixes.filter:
+          case _: NoOp => false
+          case _       => true
+        val byKey = realFixes.groupBy(_.writeKey)
         val conflict = byKey.exists: (_, group) =>
           group.map(_.lines).distinct.size > 1
         if conflict then None
@@ -776,13 +818,23 @@ object Behavioral:
         guard: Expr,
         entity: EntityDecl,
         transitionField: String,
+        from: String,
         ir: ServiceIR
     ): Option[List[Fix]] = guard match
+
+      case Expr.UnaryOp(UnOp.Not, inner, _) =>
+        negate(inner).flatMap(collect(_, entity, transitionField, from, ir))
+
       case Expr.BinaryOp(BinOp.And, l, r, _) =>
         for
-          a <- collect(l, entity, transitionField, ir)
-          b <- collect(r, entity, transitionField, ir)
+          a <- collect(l, entity, transitionField, from, ir)
+          b <- collect(r, entity, transitionField, from, ir)
         yield a ++ b
+
+      case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), rhs, _) if a == transitionField =>
+        literalValueFor(rhs, ir).flatMap: py =>
+          if py == ExprToPython.pyString(from) then Some(List(NoOp(s"$a=$from")))
+          else None
 
       case Expr.BinaryOp(op, Expr.Identifier(a, _), Expr.Identifier(b, _), _)
           if Set[BinOp](BinOp.Gt, BinOp.Ge, BinOp.Lt, BinOp.Le).contains(op) =>
@@ -799,22 +851,37 @@ object Behavioral:
                 AdminRouter.isNumericType(fb.typeExpr, ir, Set.empty)
               then Some(NumericField)
               else None
-          yield
-            val delta = op match
-              case BinOp.Gt => 1
-              case BinOp.Ge => 0
-              case BinOp.Lt => -1
-              case BinOp.Le => 0
-              case _        => 0
-            List(
-              OrderedShift(
-                leftKey = a,
-                rightKey = b,
-                kind = kind,
-                rightOptional = AdminRouter.isOptionalType(fb.typeExpr),
-                deltaSeconds = delta
-              )
+          yield List(
+            OrderedShiftField(
+              leftKey = a,
+              rightKey = b,
+              kind = kind,
+              rightOptional = AdminRouter.isOptionalType(fb.typeExpr),
+              deltaSeconds = orderedDelta(op)
             )
+          )
+
+      case Expr.BinaryOp(op, Expr.Identifier(a, _), rhs, _)
+          if Set[BinOp](BinOp.Gt, BinOp.Ge, BinOp.Lt, BinOp.Le).contains(op)
+            && a != transitionField =>
+        for
+          fa <- entity.fields.find(_.name == a)
+          if AdminRouter.isNumericType(fa.typeExpr, ir, Set.empty)
+          constPy <- numericLiteralPy(rhs)
+        yield List(
+          OrderedShiftConst(
+            field = a,
+            kind = NumericField,
+            constPy = constPy,
+            deltaSeconds = orderedDelta(op)
+          )
+        )
+
+      case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), Expr.NoneLit(_), _)
+          if a != transitionField =>
+        entity.fields.find(_.name == a).flatMap: f =>
+          if AdminRouter.isOptionalType(f.typeExpr) then Some(List(Assign(a, "None")))
+          else None
 
       case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), rhs, _)
           if a != transitionField =>
@@ -826,13 +893,108 @@ object Behavioral:
         entity.fields.find(_.name == a).flatMap: f =>
           notNoneAnchorFor(f, ir).map(anchor => List(NotNoneAnchor(a, anchor)))
 
+      case Expr.BinaryOp(BinOp.In, lit, Expr.Identifier(field, _), _)
+          if field != transitionField =>
+        for
+          f     <- entity.fields.find(_.name == field)
+          inner <- collectionElementType(f.typeExpr)
+          py    <- literalForElementType(lit, inner, ir)
+        yield List(ListAppend(field, py))
+
+      case Expr.BinaryOp(op, lenOrCard, Expr.IntLit(n, _), _)
+          if Set[BinOp](BinOp.Gt, BinOp.Ge, BinOp.Lt, BinOp.Le, BinOp.Eq).contains(op) =>
+        for
+          field <- isLenOrCardOf(lenOrCard)
+          if field != transitionField
+          f       <- entity.fields.find(_.name == field)
+          inner   <- collectionElementType(f.typeExpr)
+          size    <- desiredSize(op, n.toInt)
+          fillers <- buildFillers(size, inner, ir)
+        yield List(ListOfSize(field, fillers))
+
       case _ => None
+
+    private def orderedDelta(op: BinOp): Int = op match
+      case BinOp.Gt => 1
+      case BinOp.Ge => 0
+      case BinOp.Lt => -1
+      case BinOp.Le => 0
+      case _        => 0
+
+    private def negate(e: Expr): Option[Expr] = e match
+      case Expr.UnaryOp(UnOp.Not, inner, _)   => Some(inner)
+      case Expr.BinaryOp(BinOp.Gt, l, r, sp)  => Some(Expr.BinaryOp(BinOp.Le, l, r, sp))
+      case Expr.BinaryOp(BinOp.Ge, l, r, sp)  => Some(Expr.BinaryOp(BinOp.Lt, l, r, sp))
+      case Expr.BinaryOp(BinOp.Lt, l, r, sp)  => Some(Expr.BinaryOp(BinOp.Ge, l, r, sp))
+      case Expr.BinaryOp(BinOp.Le, l, r, sp)  => Some(Expr.BinaryOp(BinOp.Gt, l, r, sp))
+      case Expr.BinaryOp(BinOp.Eq, l, r, sp)  => Some(Expr.BinaryOp(BinOp.Neq, l, r, sp))
+      case Expr.BinaryOp(BinOp.Neq, l, r, sp) => Some(Expr.BinaryOp(BinOp.Eq, l, r, sp))
+      case _                                  => None
+
+    private def isLenOrCardOf(e: Expr): Option[String] = e match
+      case Expr.UnaryOp(UnOp.Cardinality, Expr.Identifier(name, _), _)             => Some(name)
+      case Expr.Call(Expr.Identifier("len", _), List(Expr.Identifier(name, _)), _) => Some(name)
+      case _                                                                       => None
+
+    private def desiredSize(op: BinOp, n: Int): Option[Int] = op match
+      case BinOp.Gt => Some(n + 1)
+      case BinOp.Ge => Some(n)
+      case BinOp.Eq => Some(n).filter(_ >= 0)
+      case BinOp.Lt => Some(0).filter(_ < n)
+      case BinOp.Le => Some(0).filter(_ <= n)
+      case _        => None
+
+    private def collectionElementType(t: TypeExpr): Option[TypeExpr] = t match
+      case TypeExpr.SetType(inner, _)    => Some(inner)
+      case TypeExpr.SeqType(inner, _)    => Some(inner)
+      case TypeExpr.OptionType(inner, _) => collectionElementType(inner)
+      case _                             => None
+
+    private def buildFillers(size: Int, inner: TypeExpr, ir: ServiceIR): Option[List[String]] =
+      if size == 0 then Some(Nil)
+      else if AdminRouter.isNumericType(inner, ir, Set.empty) then
+        Some((0 until size).map(_.toString).toList)
+      else
+        inner match
+          case TypeExpr.NamedType("String", _) =>
+            Some((0 until size).map(i => ExprToPython.pyString(s"x$i")).toList)
+          case TypeExpr.NamedType("Bool", _) if size <= 2 =>
+            Some(List("True", "False").take(size))
+          case TypeExpr.NamedType(name, _) =>
+            ir.enums.find(_.name == name) match
+              case Some(e) if size <= e.values.size =>
+                Some(e.values.take(size).map(ExprToPython.pyString))
+              case _ => None
+          case _ => None
+
+    private def numericLiteralPy(e: Expr): Option[String] = e match
+      case Expr.IntLit(v, _)   => Some(v.toString)
+      case Expr.FloatLit(v, _) => Some(v.toString)
+      case _                   => None
+
+    private def literalForElementType(
+        lit: Expr,
+        inner: TypeExpr,
+        ir: ServiceIR
+    ): Option[String] =
+      val _ = inner
+      lit match
+        case Expr.StringLit(s, _)          => Some(ExprToPython.pyString(s))
+        case Expr.IntLit(v, _)             => Some(v.toString)
+        case Expr.FloatLit(v, _)           => Some(v.toString)
+        case Expr.BoolLit(v, _)            => Some(if v then "True" else "False")
+        case Expr.EnumAccess(_, member, _) => Some(ExprToPython.pyString(member))
+        case Expr.Identifier(name, _) =>
+          val enumNames = ir.enums.flatMap(_.values).toSet
+          if enumNames.contains(name) then Some(ExprToPython.pyString(name))
+          else None
+        case _ => None
 
     private def literalValueFor(rhs: Expr, ir: ServiceIR): Option[String] =
       rhs match
         case Expr.EnumAccess(_, member, _) => Some(ExprToPython.pyString(member))
         case Expr.Identifier(name, _) =>
-          val enumNames = ir.enums.flatMap(e => e.values.map(v => v -> ())).map(_._1).toSet
+          val enumNames = ir.enums.flatMap(_.values).toSet
           if enumNames.contains(name) then Some(ExprToPython.pyString(name))
           else None
         case Expr.StringLit(s, _) => Some(ExprToPython.pyString(s))

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -296,7 +296,8 @@ object Behavioral:
               rule = rule,
               opDecl = opDecl,
               pop = pop,
-              stateField = stateField
+              stateField = stateField,
+              ir = ir
             )
           val negatives = illegalFroms.toList.sorted.map: from =>
             buildTransitionNegative(
@@ -344,18 +345,22 @@ object Behavioral:
       rule: TransitionRule,
       opDecl: OperationDecl,
       pop: ProfiledOperation,
-      stateField: String
+      stateField: String,
+      ir: ServiceIR
   ): Either[TestSkip, GeneratedTest] =
-    rule.guard match
-      case Some(guard) =>
+    val fixLines = rule.guard match
+      case None        => Some(Nil)
+      case Some(guard) => GuardSatisfier.recognize(guard, entity, fieldName, ir)
+    fixLines match
+      case None =>
         Left(
           TestSkip(
             opDecl.name,
             s"transition[${rule.from}_to_${rule.to}]",
-            s"guard '${prettyOneLine(guard)}' not representable in seed dict (see #152)"
+            s"guard '${prettyOneLine(rule.guard.get)}' not representable in seed dict (see #152)"
           )
         )
-      case None =>
+      case Some(lines) =>
         Right(
           buildTransitionPositive(
             td = td,
@@ -366,7 +371,8 @@ object Behavioral:
             to = rule.to,
             opDecl = opDecl,
             pop = pop,
-            stateField = stateField
+            stateField = stateField,
+            guardFixLines = lines
           )
         )
 
@@ -379,7 +385,8 @@ object Behavioral:
       to: String,
       opDecl: OperationDecl,
       pop: ProfiledOperation,
-      stateField: String
+      stateField: String,
+      guardFixLines: List[String]
   ): GeneratedTest =
     val opSnake     = Naming.toSnakeCase(opDecl.name)
     val entitySnake = Naming.toSnakeCase(entity.name)
@@ -400,6 +407,8 @@ object Behavioral:
     sb.append("    client.post(\"/__test_admin__/reset\")\n")
     sb.append("    row = dict(row)\n")
     sb.append(s"    row[$fieldKey] = ${ExprToPython.pyString(from)}\n")
+    guardFixLines.foreach: line =>
+      sb.append(s"    $line\n")
     sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
     sb.append("    assume(seed.status_code == 201)\n")
     sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
@@ -694,3 +703,155 @@ object Behavioral:
 
   private def escapeDocstring(s: String): String =
     s.replace("\\", "\\\\").replace("\"\"\"", "\\\"\\\"\\\"")
+
+  private[testgen] object GuardSatisfier:
+
+    sealed trait FieldKind
+    case object DateTimeField extends FieldKind
+    case object NumericField  extends FieldKind
+
+    sealed trait Fix:
+      def writeKey: String
+      def lines: List[String]
+
+    private case class OrderedShift(
+        leftKey: String,
+        rightKey: String,
+        kind: FieldKind,
+        rightOptional: Boolean,
+        deltaSeconds: Int
+    ) extends Fix:
+      def writeKey: String = leftKey
+      def lines: List[String] =
+        val lk      = ExprToPython.pyString(leftKey)
+        val rk      = ExprToPython.pyString(rightKey)
+        val anchor  = "datetime.datetime(2024, 1, 1)"
+        val parseR  = s"datetime.datetime.fromisoformat(row[$rk])"
+        val deltaPy = s"datetime.timedelta(seconds=$deltaSeconds)"
+        kind match
+          case DateTimeField =>
+            val anchorIfNone =
+              if rightOptional then List(s"if row[$rk] is None: row[$rk] = $anchor.isoformat()")
+              else Nil
+            anchorIfNone ++ List(
+              s"row[$lk] = ($parseR + $deltaPy).isoformat()"
+            )
+          case NumericField =>
+            val anchorIfNone =
+              if rightOptional then List(s"if row[$rk] is None: row[$rk] = 0")
+              else Nil
+            val rhs =
+              if deltaSeconds == 0 then s"row[$rk]"
+              else if deltaSeconds > 0 then s"row[$rk] + $deltaSeconds"
+              else s"row[$rk] - ${-deltaSeconds}"
+            anchorIfNone ++ List(s"row[$lk] = $rhs")
+
+    private case class Assign(field: String, pyValue: String) extends Fix:
+      def writeKey: String = field
+      def lines: List[String] =
+        List(s"row[${ExprToPython.pyString(field)}] = $pyValue")
+
+    private case class NotNoneAnchor(field: String, anchor: String) extends Fix:
+      def writeKey: String = field
+      def lines: List[String] =
+        val k = ExprToPython.pyString(field)
+        List(s"if row[$k] is None: row[$k] = $anchor")
+
+    def recognize(
+        guard: Expr,
+        entity: EntityDecl,
+        transitionField: String,
+        ir: ServiceIR
+    ): Option[List[String]] =
+      collect(guard, entity, transitionField, ir).flatMap: fixes =>
+        val byKey = fixes.groupBy(_.writeKey)
+        val conflict = byKey.exists: (_, group) =>
+          group.map(_.lines).distinct.size > 1
+        if conflict then None
+        else
+          val deduped = byKey.toList.sortBy(_._1).map(_._2.head)
+          Some(deduped.flatMap(_.lines))
+
+    private def collect(
+        guard: Expr,
+        entity: EntityDecl,
+        transitionField: String,
+        ir: ServiceIR
+    ): Option[List[Fix]] = guard match
+      case Expr.BinaryOp(BinOp.And, l, r, _) =>
+        for
+          a <- collect(l, entity, transitionField, ir)
+          b <- collect(r, entity, transitionField, ir)
+        yield a ++ b
+
+      case Expr.BinaryOp(op, Expr.Identifier(a, _), Expr.Identifier(b, _), _)
+          if Set[BinOp](BinOp.Gt, BinOp.Ge, BinOp.Lt, BinOp.Le).contains(op) =>
+        if a == transitionField || b == transitionField then None
+        else
+          for
+            fa <- entity.fields.find(_.name == a)
+            fb <- entity.fields.find(_.name == b)
+            kind <-
+              if AdminRouter.isDateTimeType(fa.typeExpr, ir, Set.empty) &&
+                AdminRouter.isDateTimeType(fb.typeExpr, ir, Set.empty)
+              then Some(DateTimeField)
+              else if AdminRouter.isNumericType(fa.typeExpr, ir, Set.empty) &&
+                AdminRouter.isNumericType(fb.typeExpr, ir, Set.empty)
+              then Some(NumericField)
+              else None
+          yield
+            val delta = op match
+              case BinOp.Gt => 1
+              case BinOp.Ge => 0
+              case BinOp.Lt => -1
+              case BinOp.Le => 0
+              case _        => 0
+            List(
+              OrderedShift(
+                leftKey = a,
+                rightKey = b,
+                kind = kind,
+                rightOptional = AdminRouter.isOptionalType(fb.typeExpr),
+                deltaSeconds = delta
+              )
+            )
+
+      case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), rhs, _)
+          if a != transitionField =>
+        entity.fields.find(_.name == a).flatMap: _ =>
+          literalValueFor(rhs, ir).map(py => List(Assign(a, py)))
+
+      case Expr.BinaryOp(BinOp.Neq, Expr.Identifier(a, _), Expr.NoneLit(_), _)
+          if a != transitionField =>
+        entity.fields.find(_.name == a).flatMap: f =>
+          notNoneAnchorFor(f, ir).map(anchor => List(NotNoneAnchor(a, anchor)))
+
+      case _ => None
+
+    private def literalValueFor(rhs: Expr, ir: ServiceIR): Option[String] =
+      rhs match
+        case Expr.EnumAccess(_, member, _) => Some(ExprToPython.pyString(member))
+        case Expr.Identifier(name, _) =>
+          val enumNames = ir.enums.flatMap(e => e.values.map(v => v -> ())).map(_._1).toSet
+          if enumNames.contains(name) then Some(ExprToPython.pyString(name))
+          else None
+        case Expr.StringLit(s, _) => Some(ExprToPython.pyString(s))
+        case Expr.IntLit(v, _)    => Some(v.toString)
+        case Expr.BoolLit(v, _)   => Some(if v then "True" else "False")
+        case Expr.FloatLit(v, _)  => Some(v.toString)
+        case _                    => None
+
+    private def notNoneAnchorFor(f: FieldDecl, ir: ServiceIR): Option[String] =
+      val inner = f.typeExpr match
+        case TypeExpr.OptionType(t, _) => t
+        case t                         => t
+      if AdminRouter.isDateTimeType(inner, ir, Set.empty) then
+        Some("datetime.datetime(2024, 1, 1).isoformat()")
+      else if AdminRouter.isNumericType(inner, ir, Set.empty) then Some("0")
+      else
+        inner match
+          case TypeExpr.NamedType("String", _) => Some(ExprToPython.pyString("x"))
+          case TypeExpr.NamedType("Bool", _)   => Some("True")
+          case TypeExpr.NamedType(name, _) =>
+            ir.enums.find(_.name == name).flatMap(_.values.headOption).map(ExprToPython.pyString)
+          case _ => None

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -713,6 +713,7 @@ object Behavioral:
 
     sealed trait Fix:
       def writeKey: String
+      def reads: Set[String] = Set.empty
       def lines: List[String]
 
     private case class OrderedShiftField(
@@ -722,7 +723,8 @@ object Behavioral:
         rightOptional: Boolean,
         deltaSeconds: Int
     ) extends Fix:
-      def writeKey: String = leftKey
+      def writeKey: String            = leftKey
+      override def reads: Set[String] = Set(rightKey)
       def lines: List[String] =
         val lk      = ExprToPython.pyString(leftKey)
         val rk      = ExprToPython.pyString(rightKey)
@@ -785,11 +787,13 @@ object Behavioral:
         val k = ExprToPython.pyString(field)
         List(s"row[$k] = [${items.mkString(", ")}]")
 
-    private case class ListAppend(field: String, pyElem: String) extends Fix:
-      def writeKey: String = field
+    private case class ListAppend(field: String, pyElem: String, optional: Boolean) extends Fix:
+      def writeKey: String            = field
+      override def reads: Set[String] = Set(field)
       def lines: List[String] =
-        val k = ExprToPython.pyString(field)
-        List(s"row[$k] = list(row[$k]) + [$pyElem]")
+        val k      = ExprToPython.pyString(field)
+        val anchor = if optional then List(s"if row[$k] is None: row[$k] = []") else Nil
+        anchor ++ List(s"row[$k] = list(row[$k]) + [$pyElem]")
 
     private case class NoOp(label: String) extends Fix:
       def writeKey: String    = s"__noop:$label"
@@ -812,7 +816,23 @@ object Behavioral:
         if conflict then None
         else
           val deduped = byKey.toList.sortBy(_._1).map(_._2.head)
-          Some(deduped.flatMap(_.lines))
+          topoOrder(deduped).map(_.flatMap(_.lines))
+
+    @scala.annotation.tailrec
+    private def topoStep(remaining: List[Fix], placed: List[Fix]): Option[List[Fix]] =
+      if remaining.isEmpty then Some(placed.reverse)
+      else
+        val pendingWrites = remaining.map(_.writeKey).toSet
+        val idx = remaining.indexWhere: f =>
+          f.reads.filterNot(_ == f.writeKey).forall(r => !pendingWrites.contains(r))
+        if idx < 0 then None
+        else
+          val (pre, mid) = remaining.splitAt(idx)
+          val picked     = mid.head
+          val rest       = pre ++ mid.tail
+          topoStep(rest, picked :: placed)
+
+    private def topoOrder(fixes: List[Fix]): Option[List[Fix]] = topoStep(fixes, Nil)
 
     private def collect(
         guard: Expr,
@@ -856,7 +876,7 @@ object Behavioral:
               leftKey = a,
               rightKey = b,
               kind = kind,
-              rightOptional = AdminRouter.isOptionalType(fb.typeExpr),
+              rightOptional = AdminRouter.isOptionalType(fb.typeExpr, ir, Set.empty),
               deltaSeconds = orderedDelta(op)
             )
           )
@@ -880,7 +900,8 @@ object Behavioral:
       case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), Expr.NoneLit(_), _)
           if a != transitionField =>
         entity.fields.find(_.name == a).flatMap: f =>
-          if AdminRouter.isOptionalType(f.typeExpr) then Some(List(Assign(a, "None")))
+          if AdminRouter.isOptionalType(f.typeExpr, ir, Set.empty) then
+            Some(List(Assign(a, "None")))
           else None
 
       case Expr.BinaryOp(BinOp.Eq, Expr.Identifier(a, _), rhs, _)
@@ -897,9 +918,9 @@ object Behavioral:
           if field != transitionField =>
         for
           f     <- entity.fields.find(_.name == field)
-          inner <- collectionElementType(f.typeExpr)
+          inner <- collectionElementType(f.typeExpr, ir)
           py    <- literalForElementType(lit, inner, ir)
-        yield List(ListAppend(field, py))
+        yield List(ListAppend(field, py, AdminRouter.isOptionalType(f.typeExpr, ir, Set.empty)))
 
       case Expr.BinaryOp(op, lenOrCard, Expr.IntLit(n, _), _)
           if Set[BinOp](BinOp.Gt, BinOp.Ge, BinOp.Lt, BinOp.Le, BinOp.Eq).contains(op) =>
@@ -907,7 +928,7 @@ object Behavioral:
           field <- isLenOrCardOf(lenOrCard)
           if field != transitionField
           f       <- entity.fields.find(_.name == field)
-          inner   <- collectionElementType(f.typeExpr)
+          inner   <- collectionElementType(f.typeExpr, ir)
           size    <- desiredSize(op, n.toInt)
           fillers <- buildFillers(size, inner, ir)
         yield List(ListOfSize(field, fillers))
@@ -944,11 +965,22 @@ object Behavioral:
       case BinOp.Le => Some(0).filter(_ <= n)
       case _        => None
 
-    private def collectionElementType(t: TypeExpr): Option[TypeExpr] = t match
+    private def collectionElementType(t: TypeExpr, ir: ServiceIR): Option[TypeExpr] =
+      collectionElementTypeIn(t, ir, Set.empty)
+
+    private def collectionElementTypeIn(
+        t: TypeExpr,
+        ir: ServiceIR,
+        seen: Set[String]
+    ): Option[TypeExpr] = t match
       case TypeExpr.SetType(inner, _)    => Some(inner)
       case TypeExpr.SeqType(inner, _)    => Some(inner)
-      case TypeExpr.OptionType(inner, _) => collectionElementType(inner)
-      case _                             => None
+      case TypeExpr.OptionType(inner, _) => collectionElementTypeIn(inner, ir, seen)
+      case TypeExpr.NamedType(name, _) if !seen.contains(name) =>
+        ir.typeAliases
+          .find(_.name == name)
+          .flatMap(alias => collectionElementTypeIn(alias.typeExpr, ir, seen + name))
+      case _ => None
 
     private def buildFillers(size: Int, inner: TypeExpr, ir: ServiceIR): Option[List[String]] =
       if size == 0 then Some(Nil)

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -231,7 +231,7 @@ class BehavioralTest extends CatsEffectSuite:
         )
       )
 
-  test("M5.9: todo_list Reopen guard skips positive, still emits 3 illegal-from tests"):
+  test("#152: todo_list Reopen guard recognized: positive test emitted with shift fix-up"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
       val out         = Behavioral.emitFor(profiled)
       val reopenTests = out.tests.filter(_.name.startsWith("test_reopen_transition_"))
@@ -239,17 +239,32 @@ class BehavioralTest extends CatsEffectSuite:
       assertEquals(
         names,
         List(
+          "test_reopen_transition_done_to_in_progress",
           "test_reopen_transition_illegal_from_archived",
           "test_reopen_transition_illegal_from_in_progress",
           "test_reopen_transition_illegal_from_todo"
         )
       )
+      val positive = reopenTests
+        .find(_.name == "test_reopen_transition_done_to_in_progress")
+        .getOrElse(fail("missing positive Reopen test"))
+      assert(
+        positive.body.contains("if row[\"completed_at\"] is None: row[\"completed_at\"] ="),
+        s"expected Option-anchor for completed_at; body=${positive.body}"
+      )
+      assert(
+        positive.body.contains(
+          "row[\"updated_at\"] = (datetime.datetime.fromisoformat(row[\"completed_at\"])"
+        ),
+        s"expected datetime arithmetic shift; body=${positive.body}"
+      )
+      assert(
+        positive.body.contains("+ datetime.timedelta(seconds=1)).isoformat()"),
+        s"expected +1s shift; body=${positive.body}"
+      )
       val guardSkips = out.skips.filter: s =>
         s.operation == "Reopen" && s.kind.startsWith("transition[")
-      assert(
-        guardSkips.exists(s => s.reason.contains("guard") && s.reason.contains("#152")),
-        s"expected guard skip mentioning #152; got=$guardSkips"
-      )
+      assertEquals(guardSkips, Nil, s"expected no guard skip after #152; got=$guardSkips")
 
   test("M5.9: positive transition test seeds entity, asserts post-state field"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
@@ -377,4 +392,231 @@ class BehavioralTest extends CatsEffectSuite:
       assert(
         swEnsuresSkip.get.reason.contains("covered by transition tests (M5.9)"),
         s"StartWork emits transition tests — should claim coverage; got=${swEnsuresSkip.get.reason}"
+      )
+
+  // ---------- #152: guarded positive transition tests ----------
+
+  private def loadProfiledFromSpec(spec: String) =
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("#152: numeric > guard yields row[a] = row[b] + 1 fix-up"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    a: Int
+         |    b: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when a > b
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"a\"] = row[\"b\"] + 1"), s"body=${pos.body}")
+
+  test("#152: enum equality guard yields row[a] = \"VALUE\" fix-up"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  enum Tier  { GOLD, SILVER }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    tier: Tier
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when tier = GOLD
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"tier\"] = \"GOLD\""), s"body=${pos.body}")
+
+  test("#152: conjunction recognized when both sides are recognized shapes"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  enum Tier  { GOLD, SILVER }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    tier: Tier
+         |    a: Int
+         |    b: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when a > b and tier = GOLD
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"a\"] = row[\"b\"] + 1"), s"body=${pos.body}")
+      assert(pos.body.contains("row[\"tier\"] = \"GOLD\""), s"body=${pos.body}")
+
+  test("#152: unrecognized guard shape still skips with #152 reason"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    a: Int
+         |    b: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when a + 1 > b
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out  = Behavioral.emitFor(profiled)
+      val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
+      assert(skip.nonEmpty, s"expected guard skip; skips=${out.skips}")
+      assert(skip.get.reason.contains("#152"), s"reason=${skip.get.reason}")
+
+  test("#152: guard touching the transition field itself is rejected (skipped)"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    other: Phase
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when phase = LOW
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out  = Behavioral.emitFor(profiled)
+      val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
+      assert(skip.nonEmpty, s"expected skip when guard touches transition field; got=${out.skips}")
+
+  test("#152: not-none guard yields if-None anchor for Option[DateTime]"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { OPEN, CLOSED }
+         |  entity Ticket {
+         |    id: Int
+         |    phase: Phase
+         |    closed_at: Option[DateTime]
+         |  }
+         |  state {
+         |    tickets: Int -> lone Ticket
+         |  }
+         |  transition TicketLifecycle {
+         |    entity: Ticket
+         |    field: phase
+         |    OPEN -> CLOSED via Close when closed_at != none
+         |  }
+         |  operation Close {
+         |    input: id: Int
+         |    requires: id in tickets
+         |    ensures: tickets'[id].phase = CLOSED
+         |  }
+         |  conventions {
+         |    Close.http_method = "POST"
+         |    Close.http_path   = "/tickets/{id}/close"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_close_transition_open_to_closed")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(
+        pos.body.contains("if row[\"closed_at\"] is None: row[\"closed_at\"] ="),
+        s"body=${pos.body}"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -550,14 +550,13 @@ class BehavioralTest extends CatsEffectSuite:
       assert(skip.nonEmpty, s"expected guard skip; skips=${out.skips}")
       assert(skip.get.reason.contains("#152"), s"reason=${skip.get.reason}")
 
-  test("#152: guard touching the transition field itself is rejected (skipped)"):
+  test("#152: transition-field guard matching `from` is auto-satisfied (no extra fix)"):
     val spec =
       """|service Demo {
          |  enum Phase { LOW, HIGH }
          |  entity Counter {
          |    id: Int
          |    phase: Phase
-         |    other: Phase
          |  }
          |  state {
          |    counters: Int -> lone Counter
@@ -579,9 +578,54 @@ class BehavioralTest extends CatsEffectSuite:
          |}
          |""".stripMargin
     loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      val mutationLineCount = pos.body.linesIterator
+        .count(l =>
+          l.trim.startsWith("row[") && !l.trim.startsWith("row = dict")
+        )
+      assertEquals(
+        mutationLineCount,
+        1,
+        s"only the `row[\"phase\"] = \"LOW\"` step-3 line; body=${pos.body}"
+      )
+
+  test("#152: transition-field guard contradicting `from` is rejected (skipped)"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when phase = HIGH
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
       val out  = Behavioral.emitFor(profiled)
       val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
-      assert(skip.nonEmpty, s"expected skip when guard touches transition field; got=${out.skips}")
+      assert(
+        skip.nonEmpty,
+        s"expected skip when guard contradicts rule's from; got=${out.skips}"
+      )
 
   test("#152: not-none guard yields if-None anchor for Option[DateTime]"):
     val spec =
@@ -620,3 +664,204 @@ class BehavioralTest extends CatsEffectSuite:
         pos.body.contains("if row[\"closed_at\"] is None: row[\"closed_at\"] ="),
         s"body=${pos.body}"
       )
+
+  // ---------- #152 round 2: extended recognizer ----------
+
+  private def cardinalitySpec =
+    """|service Demo {
+       |  enum Phase { LOW, HIGH }
+       |  entity Item {
+       |    id: Int
+       |    phase: Phase
+       |    tags: Set[String]
+       |  }
+       |  state {
+       |    items: Int -> lone Item
+       |  }
+       |  transition ItemLifecycle {
+       |    entity: Item
+       |    field: phase
+       |    LOW -> HIGH via Promote when GUARD
+       |  }
+       |  operation Promote {
+       |    input: id: Int
+       |    requires: id in items
+       |    ensures: items'[id].phase = HIGH
+       |  }
+       |  conventions {
+       |    Promote.http_method = "POST"
+       |    Promote.http_path   = "/items/{id}/promote"
+       |  }
+       |}
+       |""".stripMargin
+
+  test("#152 ext: #tags > 2 yields a 3-element list literal"):
+    loadProfiledFromSpec(cardinalitySpec.replace("GUARD", "#tags > 2")).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(
+        pos.body.contains("row[\"tags\"] = [\"x0\", \"x1\", \"x2\"]"),
+        s"body=${pos.body}"
+      )
+
+  test("#152 ext: #tags >= 1 yields a 1-element list literal"):
+    loadProfiledFromSpec(cardinalitySpec.replace("GUARD", "#tags >= 1")).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"tags\"] = [\"x0\"]"), s"body=${pos.body}")
+
+  test("#152 ext: #tags = 0 yields the empty list"):
+    loadProfiledFromSpec(cardinalitySpec.replace("GUARD", "#tags = 0")).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"tags\"] = []"), s"body=${pos.body}")
+
+  test("#152 ext: literal in <field> yields list-append fix-up"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |    tags: Set[String]
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote when "URGENT" in tags
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("row[\"tags\"] = list(row[\"tags\"]) + [\"URGENT\"]"),
+        s"body=${pos.body}"
+      )
+
+  test("#152 ext: a > <int_literal> yields row[a] = literal + 1"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    score: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when score > 10
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"score\"] = 10 + 1"), s"body=${pos.body}")
+
+  test("#152 ext: not (a > b) reduces via De Morgan to a <= b"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    a: Int
+         |    b: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when not (a > b)
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"a\"] = row[\"b\"]"), s"body=${pos.body}")
+
+  test("#152 ext: a = none on Option field yields row[a] = None"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { OPEN, ARCHIVED }
+         |  entity Ticket {
+         |    id: Int
+         |    phase: Phase
+         |    closed_at: Option[DateTime]
+         |  }
+         |  state {
+         |    tickets: Int -> lone Ticket
+         |  }
+         |  transition TicketLifecycle {
+         |    entity: Ticket
+         |    field: phase
+         |    OPEN -> ARCHIVED via Archive when closed_at = none
+         |  }
+         |  operation Archive {
+         |    input: id: Int
+         |    requires: id in tickets
+         |    ensures: tickets'[id].phase = ARCHIVED
+         |  }
+         |  conventions {
+         |    Archive.http_method = "POST"
+         |    Archive.http_path   = "/tickets/{id}/archive"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_archive_transition_open_to_archived")
+        .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
+      assert(pos.body.contains("row[\"closed_at\"] = None"), s"body=${pos.body}")

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -865,3 +865,163 @@ class BehavioralTest extends CatsEffectSuite:
         .find(_.name == "test_archive_transition_open_to_archived")
         .getOrElse(fail(s"missing positive; tests=${out.tests.map(_.name)}; skips=${out.skips}"))
       assert(pos.body.contains("row[\"closed_at\"] = None"), s"body=${pos.body}")
+
+  // ---------- #152 PR #156 review round ----------
+
+  test("#156 R1: a > b and b > c emits writes in dependency order (b before a)"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    a: Int
+         |    b: Int
+         |    c: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when a > b and b > c
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      val body = pos.body
+      val bIdx = body.indexOf("row[\"b\"] = row[\"c\"] + 1")
+      val aIdx = body.indexOf("row[\"a\"] = row[\"b\"] + 1")
+      assert(bIdx > 0 && aIdx > bIdx, s"b-write must precede a-write; b@$bIdx a@$aIdx; body=$body")
+
+  test("#156 R1: cyclic dependency in conjunction (a > b and b > a) skips with #152 reason"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Counter {
+         |    id: Int
+         |    phase: Phase
+         |    a: Int
+         |    b: Int
+         |  }
+         |  state {
+         |    counters: Int -> lone Counter
+         |  }
+         |  transition CounterLifecycle {
+         |    entity: Counter
+         |    field: phase
+         |    LOW -> HIGH via Promote when a > b and b > a
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in counters
+         |    ensures: counters'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/counters/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out  = Behavioral.emitFor(profiled)
+      val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
+      assert(skip.nonEmpty, s"expected skip on cyclic guard; got=${out.skips}")
+      assert(skip.get.reason.contains("#152"), s"reason=${skip.get.reason}")
+
+  test("#156 R5: literal in Option[Set[X]] adds None-anchor before list arithmetic"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |    tags: Option[Set[String]]
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote when "URGENT" in tags
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("if row[\"tags\"] is None: row[\"tags\"] = []"),
+        s"expected None-anchor for Option[Set]; body=${pos.body}"
+      )
+      val anchorIdx = pos.body.indexOf("if row[\"tags\"] is None")
+      val appendIdx = pos.body.indexOf("row[\"tags\"] = list(row[\"tags\"])")
+      assert(
+        anchorIdx > 0 && appendIdx > anchorIdx,
+        s"None-anchor must precede list arithmetic; body=${pos.body}"
+      )
+
+  test("#156 R2: aliased Option type detected by isOptionalType — no list crash"):
+    val spec =
+      """|service Demo {
+         |  type Maybe = Option[Set[String]]
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |    tags: Maybe
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote when "URGENT" in tags
+         |  }
+         |  operation Promote {
+         |    input: id: Int
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("if row[\"tags\"] is None: row[\"tags\"] = []"),
+        s"expected None-anchor for aliased Option[Set]; body=${pos.body}"
+      )


### PR DESCRIPTION
## Summary

Closes #152 (M5.9 follow-up). Extends `Behavioral.scala`'s transition walker with a small `GuardSatisfier` recognizer that turns a guarded `TransitionRule` into a deterministic seed-row mutation, emitted between the Hypothesis-generated row and the `seed` POST. `todo_list.spec`'s `Reopen` (the canonical guarded transition) now emits a positive test instead of a `(see #152)` skip.

### Recognized guard shapes

- ordered comparison on entity fields, both DateTime-ish or both numeric: `a > b`, `a >= b`, `a < b`, `a <= b`
- equality on enum / literal: `a = ENUM_MEMBER`, `a = 42`, `a = "x"`, `a = true`
- existence on optional: `a != none`
- conjunctions of any of the above

### Emission

**Ordered, DateTime fields** (the `Reopen` example):
```python
if row["completed_at"] is None: row["completed_at"] = datetime.datetime(2024, 1, 1).isoformat()
row["updated_at"] = (datetime.datetime.fromisoformat(row["completed_at"]) + datetime.timedelta(seconds=1)).isoformat()
```

**Ordered, numeric fields**: `row["a"] = row["b"] + 1` (or `+ 0` for `>=`/`<=`, `- 1` for `<`).

**Enum/literal equality**: `row["a"] = "ENUM_MEMBER"`.

**Not-none on Option[X]**: `if row["a"] is None: row["a"] = <inner-default>` — DateTime → ISO anchor, numeric → 0, String → `"x"`, Bool → True, enum → first member.

### Why arithmetic shift instead of fixed anchors

Per discussion in the analysis, anchoring both operands to a fixed sentinel (`datetime(2024, 1, 1)`) would override strategy-generated values that may carry their own `where`-bounds. Shifting the LHS off the strategy-generated RHS preserves any `where` constraints on the RHS field (DateTime `value < now`, numeric range bounds). The Option-RHS path falls back to anchoring only when the strategy returned `None`, since `fromisoformat(None)` would crash.

### Fall-back skips

Anything outside the recognized shapes keeps the existing skip text:
- nested expressions (`FieldAccess`, `Pre`, `Prime`, function calls, set ops)
- both operands not entity fields, or fields of mismatched type tag (one DateTime, one numeric)
- guard touching the transition field itself
- conjunction where any branch fails recognition
- conflicting fixes within a conjunction (`a > b and a < b`)

## Files changed

- `modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala` — `GuardSatisfier` recognizer + `Fix` ADT (~140 LoC); `buildTransitionPositiveOrSkip` calls the recognizer; `buildTransitionPositive` accepts and inserts `guardFixLines`.
- `modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala` — promote `isDateTimeType` to `private[testgen]`; add sibling `isNumericType` and `isOptionalType` helpers.
- `modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala` — update the existing `Reopen guard skips` test to assert the positive test is now emitted; add 5 new tests covering numeric-`>`, enum-`=`, conjunction, unrecognized-shape skip, transition-field-guard skip, and `Option[DateTime]` anchor for `!= none`.
- `docs/content/docs/pipelines/test-generation.mdx` — replace the "Skipped categories → Guarded positives" section with a "Guarded positive transitions (#152)" section documenting the recognized shapes; update the `_testgen_skips.json` example to drop the obsolete `Reopen guard` entry; flip the `#152` row in the limitations table.

## Test plan

- [x] `sbt test` — full suite green (539 tests)
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `cd docs && npm run build` clean (link checker passed)
- [x] Smoke compile `fixtures/spec/todo_list.spec` — `test_behavioral_todo_list.py` contains `test_reopen_transition_done_to_in_progress` with the expected fix-up lines; `_testgen_skips.json` no longer carries the `Reopen` guard skip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables positive tests for guarded transitions by translating guards into deterministic seed fix-ups, now ordered correctly and with better Option handling. Closes #152; `Reopen` in `todo_list.spec` now emits a positive test.

- **New Features**
  - Added `GuardSatisfier` in `Behavioral.scala` to satisfy guards via seed mutations. Supports: ordered comparisons on fields (DateTime/numeric) and numeric literals; enum/literal equality (incl. `= none`); `!= none`; cardinality via `#field`/`len(field)`; literal membership in Set/Seq; transition-field self-equality that matches `from` (no-op); top-level `not (...)`; and their conjunctions.
  - Emits arithmetic shifts for DateTime/numeric; anchors Option RHS where needed; builds list literals for cardinality; appends for membership (with None-anchors for `Option[Set/Seq]`). Falls back to skip when the transition field is touched incorrectly, any branch is unrecognized, fixes conflict, or a topological order can’t be found.

- **Bug Fixes**
  - Fix-up lines are now topologically ordered by dependencies (e.g., `b > c` before `a > b`); cyclic guards (e.g., `a > b and b > a`) skip with the existing #152 reason.
  - `isOptionalType` in `AdminRouter.scala` now resolves type aliases; collection element-type detection does too, enabling correct handling of aliased `Option[Set[X]]`.
  - For membership guards on `Option[Set/Seq]`, emit a `None` anchor (`[]`) before list arithmetic to avoid runtime crashes.
  - Docs updated to show `Reopen` counted as a positive (16 total transitions); tests expanded for ordering, cycles, Option-aliased detection, and list anchoring.

<sup>Written for commit 7a827fada290f23c398743066a88a67e077757a7. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced test generation for guarded transitions, enabling more transition scenarios to be tested with automatic guard satisfaction logic.

* **Documentation**
  * Updated test generation documentation to reflect improved handling of specific guard patterns (comparisons, equality checks, optional field existence).

* **Tests**
  * Expanded test coverage for guarded transition test generation, including numeric and enum field guards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->