### PR TITLE
Per-status bundles in stateful tests (closes #153)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -333,11 +333,13 @@ Rules then route ids through bundles by status:
 - **Create**: `@rule(target=<initial-status-bundle>, …)` — pushes the new id into the
   bundle for the status the ensures sets.
 - **Unguarded transition** (no `when` clause): one Python rule per `TransitionRule`,
-  named `<via>_from_<from-status>`. Decorator is
+  named `<via>_from_<from>_to_<to>`. Decorator is
   `@rule(target=<to>_bundle, <id>=consumes(<from>_bundle))`. The body asserts strict
   success and `return`s the id — Hypothesis transfers it from `<from>` into `<to>`.
-  An operation that fires from multiple `from`-states (e.g., `Archive` from both `TODO`
-  and `DONE`) emits one rule per source bundle (`archive_from_todo`, `archive_from_done`).
+  Including `_to_<to>` in the function name keeps each rule unique even when several
+  rules share the same via and `from` but differ in `to`. An operation that fires from
+  multiple `from`-states (e.g., `Archive` from both `TODO` and `DONE`) emits one rule
+  per source bundle (`archive_from_todo_to_archived`, `archive_from_done_to_archived`).
 - **Guarded transition** (has a `when` clause that bundle membership cannot guarantee):
   same `consumes`+`target` shape, but the body branches:
   ```python
@@ -351,14 +353,21 @@ Rules then route ids through bundles by status:
   `multiple()` with no arguments tells Hypothesis "no result" — the id leaves the source
   bundle without being added to the target, keeping bundle/SUT bookkeeping consistent.
 - **Read / Update / Replace / SideEffect** with an id parameter:
-  - If `requires` includes `<id> in <state> and <state>[id].status (= X | in {X, Y, …})`,
-    the rule draws from `st.one_of(<bundle X>, <bundle Y>, …)`.
-  - If `requires` is just `<id> in <state>` (no status restriction) or includes any
-    unrecognized non-key shape, the rule draws from `st.one_of(<all-status-bundles>)`
-    non-consuming and falls back to **loose** assertion.
-- **Delete with single-bundle status restriction**: `consumes(<bundle>)`, strict.
-- **Delete with multi-bundle (or no) status restriction**: non-consuming
-  `st.one_of(…)` + loose. (`consumes(st.one_of(…))` is not supported by Hypothesis.)
+  - If `requires` is just `<id> in <state>` (membership only), the rule draws from
+    `st.one_of(<all-status-bundles>)` and asserts strict success — bundle membership
+    fully covers the precondition by construction.
+  - If `requires` includes `<id> in <state> and <state>[id].<transition-field> (= X | in {X, Y, …})`,
+    the rule draws from `st.one_of(<bundle X>, <bundle Y>, …)` and is strict.
+    Repeated conjunctive restrictions on the same field are intersected (AND semantics).
+  - If `requires` includes any unrecognized non-key conjunct (or a `state[id].field` access
+    on a field that isn't the entity's transition field), the rule draws from
+    `st.one_of(<all-status-bundles>)` non-consuming and falls back to **loose** assertion.
+- **Delete**:
+  - With a recognized status restriction that narrows to a single bundle, or just
+    `<id> in <state>` membership — `consumes(<bundle>)`, strict.
+  - With a multi-bundle restriction or any unrecognized requires conjunct — non-consuming
+    `st.one_of(…)` + loose. (`consumes(st.one_of(…))` is not supported by Hypothesis,
+    and consuming an id that the SUT may reject would leak bundle/SUT state.)
 
 Entities without a `TransitionDecl` over an enum field, or whose Create operation
 doesn't deterministically set an initial status, fall back to the legacy single-bundle

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -363,11 +363,11 @@ Rules then route ids through bundles by status:
     on a field that isn't the entity's transition field), the rule draws from
     `st.one_of(<all-status-bundles>)` non-consuming and falls back to **loose** assertion.
 - **Delete**:
-  - With a recognized status restriction that narrows to a single bundle, or just
-    `<id> in <state>` membership — `consumes(<bundle>)`, strict.
-  - With a multi-bundle restriction or any unrecognized requires conjunct — non-consuming
-    `st.one_of(…)` + loose. (`consumes(st.one_of(…))` is not supported by Hypothesis,
-    and consuming an id that the SUT may reject would leak bundle/SUT state.)
+  - With a recognized status restriction that narrows to a single bundle — `consumes(<bundle>)`, strict.
+  - With just `<id> in <state>` membership, a multi-bundle restriction, or any unrecognized
+    requires conjunct — non-consuming `st.one_of(…)` + loose. (`consumes(st.one_of(…))` is
+    not supported by Hypothesis, and consuming an id that the SUT may reject would leak
+    bundle/SUT state.)
 
 Entities without a `TransitionDecl` over an enum field, or whose Create operation
 doesn't deterministically set an initial status, fall back to the legacy single-bundle

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -315,18 +315,69 @@ The `<entity>_ids` bundle name follows the entity's snake-cased name (e.g., `url
 `todo_ids`). The id projection from the response uses the entity's primary-key field
 (`id` if present, otherwise the first declared field — for `url_shortener` this is `code`).
 
+### Per-status bundles for `transition`-driven entities (#153)
+
+When an entity has a `TransitionDecl` over an enum field AND every `Create` operation
+deterministically sets the initial status (e.g., `todo.status = TODO` in the ensures),
+testgen splits the single `<entity>_ids` bundle into one bundle per enum value:
+
+| Entity | Status enum value | Bundle name |
+|---|---|---|
+| `Todo` | `TODO` | `todo_todo_ids` |
+| `Todo` | `IN_PROGRESS` | `todo_in_progress_ids` |
+| `Todo` | `DONE` | `todo_done_ids` |
+| `Todo` | `ARCHIVED` | `todo_archived_ids` |
+
+Rules then route ids through bundles by status:
+
+- **Create**: `@rule(target=<initial-status-bundle>, …)` — pushes the new id into the
+  bundle for the status the ensures sets.
+- **Unguarded transition** (no `when` clause): one Python rule per `TransitionRule`,
+  named `<via>_from_<from-status>`. Decorator is
+  `@rule(target=<to>_bundle, <id>=consumes(<from>_bundle))`. The body asserts strict
+  success and `return`s the id — Hypothesis transfers it from `<from>` into `<to>`.
+  An operation that fires from multiple `from`-states (e.g., `Archive` from both `TODO`
+  and `DONE`) emits one rule per source bundle (`archive_from_todo`, `archive_from_done`).
+- **Guarded transition** (has a `when` clause that bundle membership cannot guarantee):
+  same `consumes`+`target` shape, but the body branches:
+  ```python
+  if response.status_code == <success>:
+      return id              # SUT accepted → id moves from → to
+  elif 400 <= response.status_code < 500:
+      return multiple()      # guard failed → id is consumed and dropped (no move)
+  else:
+      assert False, ...
+  ```
+  `multiple()` with no arguments tells Hypothesis "no result" — the id leaves the source
+  bundle without being added to the target, keeping bundle/SUT bookkeeping consistent.
+- **Read / Update / Replace / SideEffect** with an id parameter:
+  - If `requires` includes `<id> in <state> and <state>[id].status (= X | in {X, Y, …})`,
+    the rule draws from `st.one_of(<bundle X>, <bundle Y>, …)`.
+  - If `requires` is just `<id> in <state>` (no status restriction) or includes any
+    unrecognized non-key shape, the rule draws from `st.one_of(<all-status-bundles>)`
+    non-consuming and falls back to **loose** assertion.
+- **Delete with single-bundle status restriction**: `consumes(<bundle>)`, strict.
+- **Delete with multi-bundle (or no) status restriction**: non-consuming
+  `st.one_of(…)` + loose. (`consumes(st.one_of(…))` is not supported by Hypothesis.)
+
+Entities without a `TransitionDecl` over an enum field, or whose Create operation
+doesn't deterministically set an initial status, fall back to the legacy single-bundle
+shape. `url_shortener` and `safe_counter` outputs stay byte-identical.
+
 ### Strict vs loose status assertions
 
 For each rule, testgen decides whether to assert the success status strictly or to also
 accept any 4xx (the SUT rejecting because its own preconditions failed):
 
-- **Strict** (`assert response.status_code == <success>`): used for `Create` rules and for
-  rules whose every `requires` clause is either trivially `true` or a `<input> in <state>`
-  pattern that is satisfied by construction via bundle membership.
+- **Strict** (`assert response.status_code == <success>`): used for `Create` rules,
+  unguarded transition rules (bundle membership guarantees the precondition by
+  construction), and rules whose every `requires` clause is either trivially `true` or
+  a `<input> in <state>` pattern that is satisfied by construction via bundle membership.
 - **Loose** (`if-elif`-`else`, accepting `<success>` or `400..499`): used for rules with
   any other state-dependent precondition (e.g., transition guards like
-  `todos[id].status = TODO`). A 4xx response there is the SUT correctly rejecting an
-  unsatisfied precondition, not a bug.
+  `todos[id].status = TODO` that aren't recognised by the per-status splitter, or
+  `when`-clause time guards like `updated_at > completed_at`). A 4xx response there is
+  the SUT correctly rejecting an unsatisfied precondition, not a bug.
 
 ### Settings
 
@@ -351,10 +402,6 @@ deadline trips on slow CI machines.
 - It does **not** maintain a Python-side ghost model of state. The SUT, accessed via
   `/__test_admin__/state`, is the model. This trades shrink-output detail for emitter
   simplicity and avoids re-translating every `ensures` clause as a model update.
-- It does **not** branch by `TransitionDecl` status (separate `pending_ids`, `shipped_ids`
-  bundles). Status guards are exercised by loose rules instead. Per-status bundles are
-  tracked under [#153](https://github.com/HardMax71/spec_to_rest/issues/153) (M5.9
-  follow-up).
 - Per-rule ensures-asserts are handled by the behavioral tests, not duplicated here.
   Stateful surfaces multi-step bugs via the `@invariant()` checks that run after every step.
 
@@ -704,6 +751,5 @@ become compile errors under `--strict-strategies`.
 |---|---|
 | State-dependent preconditions on **non-transition** ops still skip ensures tests | residual tail of M5.9; not currently scoped |
 | Guards outside `>`/`>=`/`<`/`<=` / `=` literal / `!= none` / their conjunctions | extend `GuardSatisfier` in `Behavioral.scala` to cover further patterns case-by-case |
-| Per-status bundles in stateful tests | [#153](https://github.com/HardMax71/spec_to_rest/issues/153) — split `<entity>_ids` into per-enum-value bundles in `Stateful.scala` |
 | Multi-target test gen (TS/Jest, Go) | [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) |
 | Default `--with-tests` after M5.4 | [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140) |

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -11,6 +11,8 @@ import specrest.ir.InvariantDecl
 import specrest.ir.OperationDecl
 import specrest.ir.PrettyPrint
 import specrest.ir.ServiceIR
+import specrest.ir.TransitionDecl
+import specrest.ir.TransitionRule
 import specrest.ir.TypeExpr
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -24,15 +26,27 @@ object Stateful:
 
   final private case class BundleSpec(
       entityName: String,
+      statusValue: Option[String],
       bundleName: String,
       pyVarName: String,
       pkFieldName: String,
       pkTypeExpr: TypeExpr
   )
 
+  final private case class EntityBundles(
+      entityName: String,
+      pkFieldName: String,
+      pkTypeExpr: TypeExpr,
+      transition: Option[TransitionDecl],
+      enumValues: List[String],
+      bundles: List[BundleSpec],
+      initialStatusByCreateOp: Map[String, String]
+  )
+
   private enum InputBinding:
     case BundleDraw(bundle: BundleSpec)
     case BundleConsume(bundle: BundleSpec)
+    case BundleUnion(bundles: List[BundleSpec], consume: Boolean)
     case Generated(strategy: String)
     case Skip(reason: String)
 
@@ -43,15 +57,16 @@ object Stateful:
   private val TQ = "\"\"\""
 
   def emitFor(profiled: ProfiledService): StatefulOutput =
-    val ir       = profiled.ir
-    val bundles  = inferBundles(profiled)
-    val machName = s"${ir.name}StateMachine"
-    val testName = s"TestStateful${ir.name}"
+    val ir            = profiled.ir
+    val entityBundles = inferEntityBundles(profiled)
+    val bundles       = entityBundles.flatMap(_.bundles)
+    val machName      = s"${ir.name}StateMachine"
+    val testName      = s"TestStateful${ir.name}"
 
-    val rulesAndSkips = profiled.operations.map: pop =>
+    val rulesAndSkips = profiled.operations.flatMap: pop =>
       ir.operations.find(_.name == pop.operationName) match
-        case Some(opDecl) => emitRule(pop, opDecl, ir, bundles)
-        case None         => Right(Nil) -> Nil
+        case Some(opDecl) => emitRules(pop, opDecl, ir, entityBundles)
+        case None         => Nil
     val ruleBlocks = rulesAndSkips.flatMap(_._1.toOption.toList.flatten)
     val ruleSkips  = rulesAndSkips.flatMap(_._2)
 
@@ -71,7 +86,7 @@ object Stateful:
 
     StatefulOutput(file = py, skips = ruleSkips ++ invariantSkips)
 
-  private def inferBundles(profiled: ProfiledService): List[BundleSpec] =
+  private def inferEntityBundles(profiled: ProfiledService): List[EntityBundles] =
     val ir = profiled.ir
     val createOps = profiled.operations.filter: pop =>
       pop.kind == OperationKind.Create || pop.kind == OperationKind.CreateChild
@@ -79,32 +94,210 @@ object Stateful:
     byEntity.keys.toList.sorted.flatMap: entityName =>
       ir.entities.find(_.name == entityName).flatMap: entity =>
         primaryKey(entity).map: pk =>
-          BundleSpec(
-            entityName = entityName,
-            bundleName = s"${Naming.toSnakeCase(entityName)}_ids",
-            pyVarName = s"${Naming.toSnakeCase(entityName)}_ids",
-            pkFieldName = pk.name,
-            pkTypeExpr = pk.typeExpr
-          )
+          val perStatus = perStatusBundlesFor(entity, ir)
+          perStatus match
+            case Some((td, enumValues, initialByOp)) =>
+              val perStatusBundles = enumValues.map: status =>
+                BundleSpec(
+                  entityName = entity.name,
+                  statusValue = Some(status),
+                  bundleName = s"${Naming.toSnakeCase(entity.name)}_${status.toLowerCase}_ids",
+                  pyVarName = s"${Naming.toSnakeCase(entity.name)}_${status.toLowerCase}_ids",
+                  pkFieldName = pk.name,
+                  pkTypeExpr = pk.typeExpr
+                )
+              EntityBundles(
+                entityName = entity.name,
+                pkFieldName = pk.name,
+                pkTypeExpr = pk.typeExpr,
+                transition = Some(td),
+                enumValues = enumValues,
+                bundles = perStatusBundles,
+                initialStatusByCreateOp = initialByOp
+              )
+            case None =>
+              val legacy = BundleSpec(
+                entityName = entity.name,
+                statusValue = None,
+                bundleName = s"${Naming.toSnakeCase(entity.name)}_ids",
+                pyVarName = s"${Naming.toSnakeCase(entity.name)}_ids",
+                pkFieldName = pk.name,
+                pkTypeExpr = pk.typeExpr
+              )
+              EntityBundles(
+                entityName = entity.name,
+                pkFieldName = pk.name,
+                pkTypeExpr = pk.typeExpr,
+                transition = None,
+                enumValues = Nil,
+                bundles = List(legacy),
+                initialStatusByCreateOp = Map.empty
+              )
+
+  private def perStatusBundlesFor(
+      entity: EntityDecl,
+      ir: ServiceIR
+  ): Option[(TransitionDecl, List[String], Map[String, String])] =
+    val td = ir.transitions.find(_.entityName == entity.name) match
+      case Some(t) => t
+      case None    => return None
+    val field = entity.fields.find(_.name == td.fieldName) match
+      case Some(f) => f
+      case None    => return None
+    val enumValues = enumValuesForField(field, ir) match
+      case Some(vs) if vs.nonEmpty => vs
+      case _                       => return None
+
+    val initialByOp = ir.operations.flatMap: op =>
+      op.outputs.find(p => isEntityType(p.typeExpr, entity.name)).flatMap: p =>
+        op.ensures.iterator
+          .collectFirst:
+            case Expr.BinaryOp(
+                  BinOp.Eq,
+                  Expr.FieldAccess(Expr.Identifier(b, _), f, _),
+                  rhs,
+                  _
+                )
+                if b == p.name && f == td.fieldName =>
+              enumLiteralName(rhs, enumValues)
+          .flatten
+          .map(op.name -> _)
+    if initialByOp.isEmpty then None
+    else Some((td, enumValues, initialByOp.toMap))
+
+  private def enumLiteralName(rhs: Expr, enumValues: List[String]): Option[String] =
+    rhs match
+      case Expr.EnumAccess(_, member, _) if enumValues.contains(member) => Some(member)
+      case Expr.Identifier(name, _) if enumValues.contains(name)        => Some(name)
+      case _                                                            => None
 
   private def primaryKey(entity: EntityDecl): Option[FieldDecl] =
     entity.fields.find(_.name == "id").orElse(entity.fields.headOption)
+
+  private def emitRules(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      ir: ServiceIR,
+      entityBundles: List[EntityBundles]
+  ): List[(Either[Unit, List[String]], List[TestSkip])] =
+    if pop.kind == OperationKind.Transition then
+      pop.targetEntity.flatMap(en => entityBundles.find(_.entityName == en)) match
+        case Some(eb) if eb.bundles.exists(_.statusValue.isDefined) =>
+          emitTransitionRules(pop, opDecl, ir, eb, entityBundles)
+        case _ =>
+          List(emitRule(pop, opDecl, ir, entityBundles))
+    else
+      List(emitRule(pop, opDecl, ir, entityBundles))
+
+  private def emitTransitionRules(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      ir: ServiceIR,
+      eb: EntityBundles,
+      entityBundles: List[EntityBundles]
+  ): List[(Either[Unit, List[String]], List[TestSkip])] =
+    val td            = eb.transition.get
+    val matchingRules = td.rules.filter(_.via == pop.operationName)
+    if matchingRules.isEmpty then List(emitRule(pop, opDecl, ir, entityBundles))
+    else
+      val pathParamNames = pop.endpoint.pathParams.map(_.name)
+      if pathParamNames.size != 1 || pop.endpoint.bodyParams.nonEmpty || pop.endpoint.queryParams.nonEmpty
+      then List(emitRule(pop, opDecl, ir, entityBundles))
+      else
+        val pathParam = pathParamNames.head
+        matchingRules.toList.map: tr =>
+          buildTransitionMoveRule(pop, opDecl, eb, tr, pathParam)
+
+  private def buildTransitionMoveRule(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      eb: EntityBundles,
+      tr: TransitionRule,
+      pathParam: String
+  ): (Either[Unit, List[String]], List[TestSkip]) =
+    val fromBundle = eb.bundles.find(_.statusValue.contains(tr.from))
+    val toBundle   = eb.bundles.find(_.statusValue.contains(tr.to))
+    (fromBundle, toBundle) match
+      case (Some(fb), Some(tb)) =>
+        val funcName = s"${Naming.toSnakeCase(opDecl.name)}_from_${tr.from.toLowerCase}"
+        val body = buildTransitionMoveBlock(
+          pop = pop,
+          opDecl = opDecl,
+          from = tr.from,
+          to = tr.to,
+          fromBundle = fb,
+          toBundle = tb,
+          pathParam = pathParam,
+          guarded = tr.guard.isDefined,
+          funcName = funcName
+        )
+        (Right(List(body)), Nil)
+      case _ =>
+        val skip = TestSkip(
+          opDecl.name,
+          s"stateful_transition[${tr.from}_to_${tr.to}]",
+          s"unknown enum value for transition '${tr.from} -> ${tr.to}'"
+        )
+        (Right(Nil), List(skip))
+
+  private def buildTransitionMoveBlock(
+      pop: ProfiledOperation,
+      opDecl: OperationDecl,
+      from: String,
+      to: String,
+      fromBundle: BundleSpec,
+      toBundle: BundleSpec,
+      pathParam: String,
+      guarded: Boolean,
+      funcName: String
+  ): String =
+    val ruleArgs  = s"target=${toBundle.pyVarName}, $pathParam=consumes(${fromBundle.pyVarName})"
+    val sigParams = s"self, $pathParam"
+    val sb        = new StringBuilder
+    sb.append(s"    @rule($ruleArgs)\n")
+    sb.append(s"    def $funcName($sigParams):\n")
+    sb.append(
+      s"        $TQ${escapeDocstring(operationSummary(opDecl))} (transition $from -> $to)$TQ\n"
+    )
+    sb.append(s"        response = ${requestCallExpr(pop)}\n")
+    val successCode = pop.endpoint.successStatus
+    if guarded then
+      sb.append(s"        if response.status_code == $successCode:\n")
+      sb.append(s"            return $pathParam\n")
+      sb.append("        elif 400 <= response.status_code < 500:\n")
+      sb.append("            return multiple()\n")
+      sb.append(
+        "        else:\n            assert False, f\"unexpected status {response.status_code}: {response.text}\"\n"
+      )
+    else
+      sb.append(s"        assert response.status_code == $successCode, response.text\n")
+      sb.append(s"        return $pathParam\n")
+    sb.toString
 
   private def emitRule(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
       ir: ServiceIR,
-      bundles: List[BundleSpec]
+      entityBundles: List[EntityBundles]
   ): (Either[Unit, List[String]], List[TestSkip]) =
-    val (role, roleSkips) = inferCreateRole(pop, opDecl, bundles)
+    val (role, roleSkips) = inferCreateRole(pop, opDecl, entityBundles)
     val pathParamNames    = pop.endpoint.pathParams.map(_.name).toSet
     val bodyParamNames    = pop.endpoint.bodyParams.map(_.name).toSet
     val queryParamNames   = pop.endpoint.queryParams.map(_.name).toSet
     val allParams         = pathParamNames ++ bodyParamNames ++ queryParamNames
 
+    val statusRestriction = recognizeStatusRestriction(opDecl, ir)
+
     val bindings = opDecl.inputs.collect:
       case p if allParams.contains(p.name) =>
-        p.name -> bindForInput(p.name, p.typeExpr, pop, ir, bundles)
+        p.name -> bindForInput(
+          p.name,
+          p.typeExpr,
+          pop,
+          ir,
+          entityBundles,
+          statusRestriction
+        )
     val skipped = bindings.collect:
       case (n, InputBinding.Skip(r)) =>
         TestSkip(opDecl.name, "stateful_rule", s"input '$n': $r")
@@ -123,25 +316,33 @@ object Stateful:
   private def inferCreateRole(
       pop: ProfiledOperation,
       opDecl: OperationDecl,
-      bundles: List[BundleSpec]
+      entityBundles: List[EntityBundles]
   ): (RuleRole, List[TestSkip]) =
     if pop.kind != OperationKind.Create && pop.kind != OperationKind.CreateChild then
       (RuleRole.Plain, Nil)
     else
-      pop.targetEntity.flatMap(en => bundles.find(_.entityName == en)) match
+      pop.targetEntity.flatMap(en => entityBundles.find(_.entityName == en)) match
         case None => (RuleRole.Plain, Nil)
-        case Some(bundle) =>
-          projectionForCreateOutput(opDecl, bundle) match
-            case Some(proj) => (RuleRole.CreateTarget(bundle, proj), Nil)
-            case None =>
-              val skip = TestSkip(
-                opDecl.name,
-                "stateful_create_target",
-                s"Create operation has no output of entity type '${bundle.entityName}' " +
-                  s"or PK type '${typeName(bundle.pkTypeExpr).getOrElse("?")}'; " +
-                  "emitting parameter-less rule without target= bundle"
-              )
-              (RuleRole.Plain, List(skip))
+        case Some(eb) =>
+          val targetBundle =
+            if eb.bundles.exists(_.statusValue.isDefined) then
+              eb.initialStatusByCreateOp.get(opDecl.name).flatMap: status =>
+                eb.bundles.find(_.statusValue.contains(status))
+            else eb.bundles.headOption
+          targetBundle match
+            case None => (RuleRole.Plain, Nil)
+            case Some(bundle) =>
+              projectionForCreateOutput(opDecl, bundle) match
+                case Some(proj) => (RuleRole.CreateTarget(bundle, proj), Nil)
+                case None =>
+                  val skip = TestSkip(
+                    opDecl.name,
+                    "stateful_create_target",
+                    s"Create operation has no output of entity type '${bundle.entityName}' " +
+                      s"or PK type '${typeName(bundle.pkTypeExpr).getOrElse("?")}'; " +
+                      "emitting parameter-less rule without target= bundle"
+                  )
+                  (RuleRole.Plain, List(skip))
 
   private def projectionForCreateOutput(
       opDecl: OperationDecl,
@@ -173,30 +374,147 @@ object Stateful:
     case TypeExpr.NamedType(n, _) => Some(n)
     case _                        => None
 
+  private def enumValuesForField(field: FieldDecl, ir: ServiceIR): Option[List[String]] =
+    enumValuesForType(field.typeExpr, ir, Set.empty)
+
+  private def enumValuesForType(
+      t: TypeExpr,
+      ir: ServiceIR,
+      seen: Set[String]
+  ): Option[List[String]] =
+    t match
+      case TypeExpr.NamedType(name, _) =>
+        ir.enums.find(_.name == name).map(_.values).orElse:
+          if seen.contains(name) then None
+          else
+            ir.typeAliases
+              .find(_.name == name)
+              .flatMap(alias => enumValuesForType(alias.typeExpr, ir, seen + name))
+      case _ => None
+
+  final private case class StatusRestriction(
+      stateFieldName: String,
+      inputName: String,
+      allowedStatuses: Option[Set[String]]
+  )
+
+  private def recognizeStatusRestriction(
+      opDecl: OperationDecl,
+      ir: ServiceIR
+  ): Option[StatusRestriction] =
+    val stateFields = ir.state.toList.flatMap(_.fields.map(_.name)).toSet
+    val inputs      = opDecl.inputs.map(_.name).toSet
+    val conjuncts   = flattenAnd(opDecl.requires)
+    val keyExists = conjuncts.collectFirst:
+      case Expr.BinaryOp(BinOp.In, Expr.Identifier(in, _), Expr.Identifier(state, _), _)
+          if inputs.contains(in) && stateFields.contains(state) =>
+        (in, state)
+    keyExists.map: (inputName, stateName) =>
+      val statusRestricted = conjuncts.iterator
+        .map(c => statusConjunct(c, inputName, stateName))
+        .collectFirst { case Some(set) => set }
+      val anyUnrecognized = conjuncts.exists: c =>
+        !isKeyExistsConj(c, inputName, stateName) &&
+          !isStatusRestrictionConj(c, inputName, stateName) &&
+          !isTrivialTrue(c)
+      if anyUnrecognized then StatusRestriction(stateName, inputName, None)
+      else StatusRestriction(stateName, inputName, statusRestricted)
+
+  private def isKeyExistsConj(c: Expr, inputName: String, stateName: String): Boolean =
+    c match
+      case Expr.BinaryOp(
+            BinOp.In,
+            Expr.Identifier(in, _),
+            Expr.Identifier(state, _),
+            _
+          ) =>
+        in == inputName && state == stateName
+      case _ => false
+
+  private def isStatusRestrictionConj(
+      c: Expr,
+      inputName: String,
+      stateName: String
+  ): Boolean = statusConjunct(c, inputName, stateName).isDefined
+
+  private def statusConjunct(
+      c: Expr,
+      inputName: String,
+      stateName: String
+  ): Option[Set[String]] =
+    c match
+      case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
+        if isStatusFieldOf(lhs, inputName, stateName) then
+          enumLitFromExpr(rhs).map(Set(_))
+        else None
+      case Expr.BinaryOp(BinOp.In, lhs, Expr.SetLiteral(elems, _), _) =>
+        if isStatusFieldOf(lhs, inputName, stateName) then
+          val maybeSet = elems.map(enumLitFromExpr)
+          if maybeSet.forall(_.isDefined) then Some(maybeSet.flatten.toSet)
+          else None
+        else None
+      case _ => None
+
+  private def isStatusFieldOf(e: Expr, inputName: String, stateName: String): Boolean =
+    e match
+      case Expr.FieldAccess(Expr.Index(Expr.Identifier(s, _), Expr.Identifier(i, _), _), _, _) =>
+        s == stateName && i == inputName
+      case _ => false
+
+  private def enumLitFromExpr(e: Expr): Option[String] = e match
+    case Expr.EnumAccess(_, member, _) => Some(member)
+    case Expr.Identifier(name, _)      => Some(name)
+    case _                             => None
+
+  private def flattenAnd(exprs: List[Expr]): List[Expr] =
+    exprs.flatMap(flattenAndOne)
+
+  private def flattenAndOne(e: Expr): List[Expr] = e match
+    case Expr.BinaryOp(BinOp.And, l, r, _) => flattenAndOne(l) ++ flattenAndOne(r)
+    case other                             => List(other)
+
   private def bindForInput(
       paramName: String,
       paramType: TypeExpr,
       pop: ProfiledOperation,
       ir: ServiceIR,
-      bundles: List[BundleSpec]
+      entityBundles: List[EntityBundles],
+      statusRestriction: Option[StatusRestriction]
   ): InputBinding =
-    val targetEntityBundle = pop.targetEntity.flatMap: en =>
-      bundles.find(b => b.entityName == en && sameNamedType(paramType, b.pkTypeExpr))
-    val pkFieldNameMatch = bundles.find: b =>
-      sameNamedType(paramType, b.pkTypeExpr) &&
-        (paramName == b.pkFieldName || paramName == s"${Naming.toSnakeCase(b.entityName)}_id")
-    val typeMatches = bundles.filter(b => sameNamedType(paramType, b.pkTypeExpr))
+    val targetEbBundles = pop.targetEntity.flatMap: en =>
+      entityBundles
+        .find(eb => eb.entityName == en && sameNamedType(paramType, eb.pkTypeExpr))
+    val pkFieldNameMatch = entityBundles.find: eb =>
+      sameNamedType(paramType, eb.pkTypeExpr) &&
+        (paramName == eb.pkFieldName || paramName == s"${Naming.toSnakeCase(eb.entityName)}_id")
+    val typeMatches = entityBundles.filter(eb => sameNamedType(paramType, eb.pkTypeExpr))
     val uniqueTypeMatch = typeMatches match
       case head :: Nil => Some(head)
       case _           => None
 
-    val matchingBundle =
-      targetEntityBundle.orElse(pkFieldNameMatch).orElse(uniqueTypeMatch)
+    val matchingEb = targetEbBundles.orElse(pkFieldNameMatch).orElse(uniqueTypeMatch)
 
-    matchingBundle match
-      case Some(bundle) =>
-        if pop.kind == OperationKind.Delete then InputBinding.BundleConsume(bundle)
-        else InputBinding.BundleDraw(bundle)
+    matchingEb match
+      case Some(eb) =>
+        val perStatus = eb.bundles.exists(_.statusValue.isDefined)
+        val activeBundles =
+          if !perStatus then eb.bundles
+          else
+            statusRestriction match
+              case Some(StatusRestriction(_, _, Some(allowed))) =>
+                eb.bundles.filter(_.statusValue.exists(allowed.contains))
+              case _ => eb.bundles
+        val isDelete = pop.kind == OperationKind.Delete
+        activeBundles match
+          case Nil =>
+            InputBinding.Skip(
+              s"no bundle matches restriction for entity '${eb.entityName}'"
+            )
+          case head :: Nil =>
+            if isDelete then InputBinding.BundleConsume(head)
+            else InputBinding.BundleDraw(head)
+          case multi =>
+            InputBinding.BundleUnion(multi, consume = false)
       case None =>
         val ctx       = StrategyCtx.OperationInput(pop.operationName, paramName)
         val overrides = TestStrategyOverrides.from(ir)
@@ -263,8 +581,11 @@ object Stateful:
       val rhs = b match
         case InputBinding.BundleDraw(bundle)    => bundle.pyVarName
         case InputBinding.BundleConsume(bundle) => s"consumes(${bundle.pyVarName})"
-        case InputBinding.Generated(text)       => text
-        case InputBinding.Skip(_)               => "st.nothing()"
+        case InputBinding.BundleUnion(bs, _) =>
+          val joined = bs.map(_.pyVarName).mkString(", ")
+          s"st.one_of($joined)"
+        case InputBinding.Generated(text) => text
+        case InputBinding.Skip(_)         => "st.nothing()"
       s"$name=$rhs"
     (targetArg ++ paramArgs).mkString(", ")
 
@@ -315,13 +636,15 @@ object Stateful:
       invariantBlocks: List[String]
   ): String =
     val needsConsumes = ruleBlocks.exists(_.contains("consumes("))
+    val needsMultiple = ruleBlocks.exists(_.contains("multiple()"))
     val statefulImports = List(
       "RuleBasedStateMachine",
       "Bundle",
       "rule",
       "initialize",
       "invariant"
-    ) ++ (if needsConsumes then List("consumes") else Nil)
+    ) ++ (if needsConsumes then List("consumes") else Nil) ++
+      (if needsMultiple then List("multiple") else Nil)
     val statefulImportLine =
       statefulImports.map("    " + _ + ",").mkString("\n")
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -44,9 +44,9 @@ object Stateful:
   )
 
   private enum InputBinding:
-    case BundleDraw(bundle: BundleSpec)
-    case BundleConsume(bundle: BundleSpec)
-    case BundleUnion(bundles: List[BundleSpec], consume: Boolean)
+    case BundleDraw(bundle: BundleSpec, strictByConstruction: Boolean)
+    case BundleConsume(bundle: BundleSpec, strictByConstruction: Boolean)
+    case BundleUnion(bundles: List[BundleSpec], strictByConstruction: Boolean)
     case Generated(strategy: String)
     case Skip(reason: String)
 
@@ -92,9 +92,11 @@ object Stateful:
       pop.kind == OperationKind.Create || pop.kind == OperationKind.CreateChild
     val byEntity = createOps.flatMap(pop => pop.targetEntity.map(_ -> pop)).groupBy(_._1)
     byEntity.keys.toList.sorted.flatMap: entityName =>
+      val createOpsForEntity = byEntity(entityName).map(_._2)
+      val createOpNames      = createOpsForEntity.map(_.operationName).toSet
       ir.entities.find(_.name == entityName).flatMap: entity =>
         primaryKey(entity).map: pk =>
-          val perStatus = perStatusBundlesFor(entity, ir)
+          val perStatus = perStatusBundlesFor(entity, ir, createOpNames)
           perStatus match
             case Some((td, enumValues, initialByOp)) =>
               val perStatusBundles = enumValues.map: status =>
@@ -136,7 +138,8 @@ object Stateful:
 
   private def perStatusBundlesFor(
       entity: EntityDecl,
-      ir: ServiceIR
+      ir: ServiceIR,
+      createOpNames: Set[String]
   ): Option[(TransitionDecl, List[String], Map[String, String])] =
     val td = ir.transitions.find(_.entityName == entity.name) match
       case Some(t) => t
@@ -148,7 +151,9 @@ object Stateful:
       case Some(vs) if vs.nonEmpty => vs
       case _                       => return None
 
-    val initialByOp = ir.operations.flatMap: op =>
+    val createDecls = ir.operations.filter(op => createOpNames.contains(op.name))
+    if createDecls.isEmpty then return None
+    val initialByOp = createDecls.flatMap: op =>
       op.outputs.find(p => isEntityType(p.typeExpr, entity.name)).flatMap: p =>
         op.ensures.iterator
           .collectFirst:
@@ -162,7 +167,7 @@ object Stateful:
               enumLiteralName(rhs, enumValues)
           .flatten
           .map(op.name -> _)
-    if initialByOp.isEmpty then None
+    if initialByOp.size != createDecls.size then None
     else Some((td, enumValues, initialByOp.toMap))
 
   private def enumLiteralName(rhs: Expr, enumValues: List[String]): Option[String] =
@@ -219,7 +224,8 @@ object Stateful:
     val toBundle   = eb.bundles.find(_.statusValue.contains(tr.to))
     (fromBundle, toBundle) match
       case (Some(fb), Some(tb)) =>
-        val funcName = s"${Naming.toSnakeCase(opDecl.name)}_from_${tr.from.toLowerCase}"
+        val funcName =
+          s"${Naming.toSnakeCase(opDecl.name)}_from_${tr.from.toLowerCase}_to_${tr.to.toLowerCase}"
         val body = buildTransitionMoveBlock(
           pop = pop,
           opDecl = opDecl,
@@ -395,7 +401,7 @@ object Stateful:
   final private case class StatusRestriction(
       stateFieldName: String,
       inputName: String,
-      allowedStatuses: Option[Set[String]]
+      perFieldRestrictions: Map[String, Set[String]]
   )
 
   private def recognizeStatusRestriction(
@@ -409,16 +415,21 @@ object Stateful:
       case Expr.BinaryOp(BinOp.In, Expr.Identifier(in, _), Expr.Identifier(state, _), _)
           if inputs.contains(in) && stateFields.contains(state) =>
         (in, state)
-    keyExists.map: (inputName, stateName) =>
-      val statusRestricted = conjuncts.iterator
-        .map(c => statusConjunct(c, inputName, stateName))
-        .collectFirst { case Some(set) => set }
-      val anyUnrecognized = conjuncts.exists: c =>
-        !isKeyExistsConj(c, inputName, stateName) &&
-          !isStatusRestrictionConj(c, inputName, stateName) &&
-          !isTrivialTrue(c)
-      if anyUnrecognized then StatusRestriction(stateName, inputName, None)
-      else StatusRestriction(stateName, inputName, statusRestricted)
+    keyExists.flatMap: (inputName, stateName) =>
+      var perField     = Map.empty[String, Set[String]]
+      var unrecognized = false
+      conjuncts.foreach: c =>
+        if isKeyExistsConj(c, inputName, stateName) || isTrivialTrue(c) then ()
+        else
+          fieldRestrictionConjunct(c, inputName, stateName) match
+            case Some((fieldName, allowed)) =>
+              perField = perField.updated(
+                fieldName,
+                perField.getOrElse(fieldName, Set.empty) ++ allowed
+              )
+            case None => unrecognized = true
+      if unrecognized then None
+      else Some(StatusRestriction(stateName, inputName, perField))
 
   private def isKeyExistsConj(c: Expr, inputName: String, stateName: String): Boolean =
     c match
@@ -431,35 +442,35 @@ object Stateful:
         in == inputName && state == stateName
       case _ => false
 
-  private def isStatusRestrictionConj(
+  private def fieldRestrictionConjunct(
       c: Expr,
       inputName: String,
       stateName: String
-  ): Boolean = statusConjunct(c, inputName, stateName).isDefined
-
-  private def statusConjunct(
-      c: Expr,
-      inputName: String,
-      stateName: String
-  ): Option[Set[String]] =
+  ): Option[(String, Set[String])] =
     c match
       case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
-        if isStatusFieldOf(lhs, inputName, stateName) then
-          enumLitFromExpr(rhs).map(Set(_))
-        else None
+        fieldNameIfStateIndex(lhs, inputName, stateName).flatMap: fname =>
+          enumLitFromExpr(rhs).map(lit => (fname, Set(lit)))
       case Expr.BinaryOp(BinOp.In, lhs, Expr.SetLiteral(elems, _), _) =>
-        if isStatusFieldOf(lhs, inputName, stateName) then
+        fieldNameIfStateIndex(lhs, inputName, stateName).flatMap: fname =>
           val maybeSet = elems.map(enumLitFromExpr)
-          if maybeSet.forall(_.isDefined) then Some(maybeSet.flatten.toSet)
+          if maybeSet.forall(_.isDefined) then Some((fname, maybeSet.flatten.toSet))
           else None
-        else None
       case _ => None
 
-  private def isStatusFieldOf(e: Expr, inputName: String, stateName: String): Boolean =
+  private def fieldNameIfStateIndex(
+      e: Expr,
+      inputName: String,
+      stateName: String
+  ): Option[String] =
     e match
-      case Expr.FieldAccess(Expr.Index(Expr.Identifier(s, _), Expr.Identifier(i, _), _), _, _) =>
-        s == stateName && i == inputName
-      case _ => false
+      case Expr.FieldAccess(
+            Expr.Index(Expr.Identifier(s, _), Expr.Identifier(i, _), _),
+            fname,
+            _
+          ) if s == stateName && i == inputName =>
+        Some(fname)
+      case _ => None
 
   private def enumLitFromExpr(e: Expr): Option[String] = e match
     case Expr.EnumAccess(_, member, _) => Some(member)
@@ -496,25 +507,35 @@ object Stateful:
 
     matchingEb match
       case Some(eb) =>
-        val perStatus = eb.bundles.exists(_.statusValue.isDefined)
+        val perStatus       = eb.bundles.exists(_.statusValue.isDefined)
+        val applicableSr    = statusRestriction.filter(_.inputName == paramName)
+        val transitionField = eb.transition.map(_.fieldName)
+        val statusFilter: Option[Set[String]] = (applicableSr, transitionField) match
+          case (Some(sr), Some(tf)) => sr.perFieldRestrictions.get(tf)
+          case _                    => None
         val activeBundles =
           if !perStatus then eb.bundles
           else
-            statusRestriction match
-              case Some(StatusRestriction(_, _, Some(allowed))) =>
-                eb.bundles.filter(_.statusValue.exists(allowed.contains))
-              case _ => eb.bundles
+            statusFilter match
+              case Some(allowed) => eb.bundles.filter(_.statusValue.exists(allowed.contains))
+              case None          => eb.bundles
         val isDelete = pop.kind == OperationKind.Delete
+        val strictByConstruction = applicableSr.exists: sr =>
+          transitionField match
+            case Some(tf) => sr.perFieldRestrictions.keys.forall(_ == tf)
+            case None     => sr.perFieldRestrictions.isEmpty
         activeBundles match
           case Nil =>
-            InputBinding.Skip(
-              s"no bundle matches restriction for entity '${eb.entityName}'"
-            )
+            InputBinding.Skip(s"no bundle matches restriction for entity '${eb.entityName}'")
           case head :: Nil =>
-            if isDelete then InputBinding.BundleConsume(head)
-            else InputBinding.BundleDraw(head)
+            if isDelete then InputBinding.BundleConsume(head, strictByConstruction)
+            else InputBinding.BundleDraw(head, strictByConstruction)
           case multi =>
-            InputBinding.BundleUnion(multi, consume = false)
+            // Multi-bundle non-consuming union; for Delete this leaks ids past the
+            // SUT's view → subsequent draws may hit deleted ids and 4xx, so we mark
+            // it not strict-by-construction even when the recognizer fully understood.
+            val unionStrict = strictByConstruction && !isDelete
+            InputBinding.BundleUnion(multi, unionStrict)
       case None =>
         val ctx       = StrategyCtx.OperationInput(pop.operationName, paramName)
         val overrides = TestStrategyOverrides.from(ir)
@@ -539,15 +560,28 @@ object Stateful:
     sb.append(s"        $TQ${escapeDocstring(operationSummary(opDecl))}$TQ\n")
     sb.append(s"        response = ${requestCallExpr(pop)}\n")
 
-    val bundleInputNames = bindings.collect:
-      case (n, InputBinding.BundleDraw(_) | InputBinding.BundleConsume(_)) => n
-    val allRequiresSatisfiableByBundles =
+    val classicBundleInputNames = bindings.collect:
+      case (n, InputBinding.BundleDraw(_, _) | InputBinding.BundleConsume(_, _)) => n
+    val classicSatisfied =
       opDecl.requires.forall: r =>
-        requiresIsSatisfiedByBundles(r, bundleInputNames.toSet, stateFields)
+        requiresIsSatisfiedByBundles(r, classicBundleInputNames.toSet, stateFields)
+    val anyBundleBinding = bindings.exists:
+      case (
+            _,
+            _: (InputBinding.BundleDraw | InputBinding.BundleConsume | InputBinding.BundleUnion)
+          ) =>
+        true
+      case _ => false
+    val allBundleBindingsStrict = bindings.forall:
+      case (_, InputBinding.BundleDraw(_, s))    => s
+      case (_, InputBinding.BundleConsume(_, s)) => s
+      case (_, InputBinding.BundleUnion(_, s))   => s
+      case _                                     => true
+    val recognizedStrict = anyBundleBinding && allBundleBindingsStrict
     val expectsStrictSuccess =
       role match
         case RuleRole.CreateTarget(_, _) => true
-        case RuleRole.Plain              => allRequiresSatisfiableByBundles
+        case RuleRole.Plain              => classicSatisfied || recognizedStrict
 
     val successCode = pop.endpoint.successStatus
     if expectsStrictSuccess then
@@ -579,8 +613,8 @@ object Stateful:
       case RuleRole.Plain              => Nil
     val paramArgs = bindings.map: (name, b) =>
       val rhs = b match
-        case InputBinding.BundleDraw(bundle)    => bundle.pyVarName
-        case InputBinding.BundleConsume(bundle) => s"consumes(${bundle.pyVarName})"
+        case InputBinding.BundleDraw(bundle, _)    => bundle.pyVarName
+        case InputBinding.BundleConsume(bundle, _) => s"consumes(${bundle.pyVarName})"
         case InputBinding.BundleUnion(bs, _) =>
           val joined = bs.map(_.pyVarName).mkString(", ")
           s"st.one_of($joined)"

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -423,10 +423,10 @@ object Stateful:
         else
           fieldRestrictionConjunct(c, inputName, stateName) match
             case Some((fieldName, allowed)) =>
-              perField = perField.updated(
-                fieldName,
-                perField.getOrElse(fieldName, Set.empty) ++ allowed
-              )
+              val merged = perField.get(fieldName) match
+                case Some(existing) => existing.intersect(allowed)
+                case None           => allowed
+              perField = perField.updated(fieldName, merged)
             case None => unrecognized = true
       if unrecognized then None
       else Some(StatusRestriction(stateName, inputName, perField))
@@ -528,7 +528,10 @@ object Stateful:
           case Nil =>
             InputBinding.Skip(s"no bundle matches restriction for entity '${eb.entityName}'")
           case head :: Nil =>
-            if isDelete then InputBinding.BundleConsume(head, strictByConstruction)
+            // Only consume when success is guaranteed by construction; otherwise a 4xx
+            // would leave the row in the SUT while the bundle has dropped its id.
+            if isDelete && strictByConstruction then
+              InputBinding.BundleConsume(head, strictByConstruction = true)
             else InputBinding.BundleDraw(head, strictByConstruction)
           case multi =>
             // Multi-bundle non-consuming union; for Delete this leaks ids past the

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -131,7 +131,7 @@ class StatefulTest extends CatsEffectSuite:
         out.file.contains("@rule(target=todo_in_progress_ids, id=consumes(todo_todo_ids))"),
         out.file
       )
-      assert(out.file.contains("def start_work_from_todo(self, id):"), out.file)
+      assert(out.file.contains("def start_work_from_todo_to_in_progress(self, id):"), out.file)
       assert(
         out.file.contains("assert response.status_code == 200, response.text"),
         out.file
@@ -144,12 +144,12 @@ class StatefulTest extends CatsEffectSuite:
         out.file.contains("@rule(target=todo_archived_ids, id=consumes(todo_todo_ids))"),
         out.file
       )
-      assert(out.file.contains("def archive_from_todo(self, id):"), out.file)
+      assert(out.file.contains("def archive_from_todo_to_archived(self, id):"), out.file)
       assert(
         out.file.contains("@rule(target=todo_archived_ids, id=consumes(todo_done_ids))"),
         out.file
       )
-      assert(out.file.contains("def archive_from_done(self, id):"), out.file)
+      assert(out.file.contains("def archive_from_done_to_archived(self, id):"), out.file)
 
   test("#153: guarded Reopen returns id on 2xx, multiple() on 4xx"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
@@ -158,17 +158,19 @@ class StatefulTest extends CatsEffectSuite:
         out.file.contains("@rule(target=todo_in_progress_ids, id=consumes(todo_done_ids))"),
         out.file
       )
-      assert(out.file.contains("def reopen_from_done(self, id):"), out.file)
+      assert(out.file.contains("def reopen_from_done_to_in_progress(self, id):"), out.file)
       val reopenBlock = out.file
         .linesIterator
-        .dropWhile(!_.contains("def reopen_from_done"))
+        .dropWhile(!_.contains("def reopen_from_done_to_in_progress"))
         .takeWhile(!_.startsWith("    @"))
         .mkString("\n")
       assert(reopenBlock.contains("if response.status_code == 200:"), reopenBlock)
       assert(reopenBlock.contains("return id"), reopenBlock)
       assert(reopenBlock.contains("return multiple()"), reopenBlock)
 
-  test("#153: GetTodo (no status restriction) draws from st.one_of of all 4 bundles"):
+  test(
+    "#153: GetTodo (recognized `id in todos`) draws from union of all 4 bundles, strict"
+  ):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
       val out = Stateful.emitFor(profiled)
       assert(
@@ -183,8 +185,12 @@ class StatefulTest extends CatsEffectSuite:
         .takeWhile(!_.startsWith("    @"))
         .mkString("\n")
       assert(
-        getBlock.contains("400 <= response.status_code < 500"),
-        s"unrecognized non-key requires → loose;\nblock=$getBlock"
+        getBlock.contains("assert response.status_code == 200, response.text"),
+        s"GetTodo's `id in todos` is fully satisfied by union membership → strict;\nblock=$getBlock"
+      )
+      assert(
+        !getBlock.contains("400 <= response.status_code < 500"),
+        s"strict path — no loose 4xx fallback;\nblock=$getBlock"
       )
 
   test("#153: DeleteTodo draws from union, non-consuming, loose"):
@@ -226,6 +232,184 @@ class StatefulTest extends CatsEffectSuite:
       val out = Stateful.emitFor(profiled)
       assert(!out.file.contains("Bundle("), s"no entities → no bundles:\n${out.file}")
       assert(!out.file.contains("multiple()"), s"no transitions → no multiple():\n${out.file}")
+
+  // ---------- PR #157 review round 1 fixes ----------
+
+  test("#157 fix A: Create without deterministic status falls back to legacy single bundle"):
+    val spec =
+      """|service Demo {
+         |  enum Status { ACTIVE, ARCHIVED }
+         |  entity Foo {
+         |    id: Int
+         |    status: Status
+         |  }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  transition FooLifecycle {
+         |    entity: Foo
+         |    field: status
+         |    ACTIVE -> ARCHIVED via Archive
+         |  }
+         |  operation CreateFoo {
+         |    input: status: Status
+         |    output: foo: Foo
+         |    ensures:
+         |      foo.id = 1
+         |      foo.status = status
+         |      foos' = pre(foos) + {foo.id -> foo}
+         |  }
+         |  operation Archive {
+         |    input: id: Int
+         |    requires: id in foos
+         |    ensures: foos'[id].status = ARCHIVED
+         |  }
+         |  conventions {
+         |    CreateFoo.http_path = "/foos"
+         |    CreateFoo.http_status_success = 201
+         |    Archive.http_method = "POST"
+         |    Archive.http_path = "/foos/{id}/archive"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out      = Stateful.emitFor(profiled)
+            assert(out.file.contains("foo_ids = Bundle(\"foo_ids\")"), out.file)
+            assert(
+              !out.file.contains("foo_active_ids = Bundle"),
+              s"non-deterministic Create should disable per-status:\n${out.file}"
+            )
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("#157 fix B: status conjunct on non-transition field doesn't shrink bundles to empty"):
+    val spec =
+      """|service Demo {
+         |  enum Status { ACTIVE, ARCHIVED }
+         |  enum Priority { LOW, HIGH }
+         |  entity Foo {
+         |    id: Int
+         |    status: Status
+         |    priority: Priority
+         |  }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  transition FooLifecycle {
+         |    entity: Foo
+         |    field: status
+         |    ACTIVE -> ARCHIVED via Archive
+         |  }
+         |  operation CreateFoo {
+         |    input: priority: Priority
+         |    output: foo: Foo
+         |    ensures:
+         |      foo.id = 1
+         |      foo.status = ACTIVE
+         |      foo.priority = priority
+         |      foos' = pre(foos) + {foo.id -> foo}
+         |  }
+         |  operation HighPriorityOnly {
+         |    input: id: Int
+         |    requires:
+         |      id in foos
+         |      foos[id].priority = HIGH
+         |    ensures: foos' = pre(foos)
+         |  }
+         |  operation Archive {
+         |    input: id: Int
+         |    requires: id in foos
+         |    ensures: foos'[id].status = ARCHIVED
+         |  }
+         |  conventions {
+         |    CreateFoo.http_path = "/foos"
+         |    CreateFoo.http_status_success = 201
+         |    HighPriorityOnly.http_method = "POST"
+         |    HighPriorityOnly.http_path = "/foos/{id}/high"
+         |    Archive.http_method = "POST"
+         |    Archive.http_path = "/foos/{id}/archive"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out      = Stateful.emitFor(profiled)
+            // bundles for both status enum values exist
+            assert(out.file.contains("foo_active_ids = Bundle(\"foo_active_ids\")"), out.file)
+            assert(out.file.contains("foo_archived_ids = Bundle(\"foo_archived_ids\")"), out.file)
+            // priority restriction (non-transition field) does NOT zero the bundle list
+            // → HighPriorityOnly draws from union (not Skipped), and is loose
+            val highBlock = out.file
+              .linesIterator
+              .dropWhile(!_.contains("def high_priority_only"))
+              .takeWhile(!_.startsWith("    @"))
+              .mkString("\n")
+            assert(
+              highBlock.contains("400 <= response.status_code < 500"),
+              s"priority restriction unsatisfied by status bundles → loose:\n$highBlock"
+            )
+            assert(
+              !out.file.contains("st.nothing()"),
+              s"priority restriction must not skip the rule:\n${out.file}"
+            )
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("#157 fix D: distinct from→to pairs get distinct function names"):
+    val spec =
+      """|service Demo {
+         |  enum Status { A, B, C }
+         |  entity Foo {
+         |    id: Int
+         |    status: Status
+         |  }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  transition FooLifecycle {
+         |    entity: Foo
+         |    field: status
+         |    A -> B via Move
+         |    A -> C via Move
+         |  }
+         |  operation CreateFoo {
+         |    input: x: Int
+         |    output: foo: Foo
+         |    ensures:
+         |      foo.id = x
+         |      foo.status = A
+         |      foos' = pre(foos) + {foo.id -> foo}
+         |  }
+         |  operation Move {
+         |    input: id: Int
+         |    requires: id in foos
+         |    ensures: foos'[id].status = B
+         |  }
+         |  conventions {
+         |    CreateFoo.http_path = "/foos"
+         |    CreateFoo.http_status_success = 201
+         |    Move.http_method = "POST"
+         |    Move.http_path = "/foos/{id}/move"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out      = Stateful.emitFor(profiled)
+            assert(out.file.contains("def move_from_a_to_b(self, id):"), out.file)
+            assert(out.file.contains("def move_from_a_to_c(self, id):"), out.file)
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
 
   test("rule whose only requires is `<input> in <state>` uses strict assertion"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -98,23 +98,134 @@ class StatefulTest extends CatsEffectSuite:
       assert(out.file.contains("def decrement(self):"))
       assert(!out.file.contains("consumes("), "no bundles → no consumes import or use")
 
-  test("todo_list: CreateTodo emits target=todo_ids, all sub-strategies"):
+  test("todo_list: CreateTodo emits target=todo_todo_ids (initial status from ensures)"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
       val out = Stateful.emitFor(profiled)
-      assert(out.file.contains("todo_ids = Bundle(\"todo_ids\")"))
-      assert(out.file.contains("@rule(target=todo_ids"))
+      assert(out.file.contains("todo_todo_ids = Bundle(\"todo_todo_ids\")"), out.file)
+      assert(out.file.contains("@rule(target=todo_todo_ids"), out.file)
       assert(out.file.contains("def create_todo(self,"))
       assert(out.file.contains("strategy_priority()"))
       assert(out.file.contains("return response_data[\"id\"]"))
 
-  test("todo_list: state-dep transition rules use loose 4xx-tolerant assertion"):
+  // ---------- #153: per-status bundles ----------
+
+  test("#153: todo_list declares one Bundle per Status enum value"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
       val out = Stateful.emitFor(profiled)
-      assert(out.file.contains("def start_work(self, id):"))
+      assert(out.file.contains("todo_todo_ids = Bundle(\"todo_todo_ids\")"), out.file)
       assert(
-        out.file.contains("400 <= response.status_code < 500"),
-        s"transition rules should accept 4xx for unsatisfied non-key requires:\n${out.file}"
+        out.file.contains("todo_in_progress_ids = Bundle(\"todo_in_progress_ids\")"),
+        out.file
       )
+      assert(out.file.contains("todo_done_ids = Bundle(\"todo_done_ids\")"), out.file)
+      assert(out.file.contains("todo_archived_ids = Bundle(\"todo_archived_ids\")"), out.file)
+      assert(
+        !out.file.contains("    todo_ids = Bundle"),
+        s"legacy single bundle should be gone:\n${out.file}"
+      )
+
+  test("#153: unguarded transition consumes from + targets to + strict success"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(
+        out.file.contains("@rule(target=todo_in_progress_ids, id=consumes(todo_todo_ids))"),
+        out.file
+      )
+      assert(out.file.contains("def start_work_from_todo(self, id):"), out.file)
+      assert(
+        out.file.contains("assert response.status_code == 200, response.text"),
+        out.file
+      )
+
+  test("#153: Archive emits archive_from_todo + archive_from_done (one per from)"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(
+        out.file.contains("@rule(target=todo_archived_ids, id=consumes(todo_todo_ids))"),
+        out.file
+      )
+      assert(out.file.contains("def archive_from_todo(self, id):"), out.file)
+      assert(
+        out.file.contains("@rule(target=todo_archived_ids, id=consumes(todo_done_ids))"),
+        out.file
+      )
+      assert(out.file.contains("def archive_from_done(self, id):"), out.file)
+
+  test("#153: guarded Reopen returns id on 2xx, multiple() on 4xx"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(
+        out.file.contains("@rule(target=todo_in_progress_ids, id=consumes(todo_done_ids))"),
+        out.file
+      )
+      assert(out.file.contains("def reopen_from_done(self, id):"), out.file)
+      val reopenBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def reopen_from_done"))
+        .takeWhile(!_.startsWith("    @"))
+        .mkString("\n")
+      assert(reopenBlock.contains("if response.status_code == 200:"), reopenBlock)
+      assert(reopenBlock.contains("return id"), reopenBlock)
+      assert(reopenBlock.contains("return multiple()"), reopenBlock)
+
+  test("#153: GetTodo (no status restriction) draws from st.one_of of all 4 bundles"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(
+        out.file.contains(
+          "@rule(id=st.one_of(todo_todo_ids, todo_in_progress_ids, todo_done_ids, todo_archived_ids))"
+        ),
+        out.file
+      )
+      val getBlock = out.file
+        .linesIterator
+        .dropWhile(!_.contains("def get_todo"))
+        .takeWhile(!_.startsWith("    @"))
+        .mkString("\n")
+      assert(
+        getBlock.contains("400 <= response.status_code < 500"),
+        s"unrecognized non-key requires → loose;\nblock=$getBlock"
+      )
+
+  test("#153: DeleteTodo draws from union, non-consuming, loose"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out    = Stateful.emitFor(profiled)
+      val lines  = out.file.linesIterator.toList
+      val defIdx = lines.indexWhere(_.contains("def delete_todo"))
+      assert(defIdx > 0, s"missing delete_todo def:\n${out.file}")
+      val ruleLine = lines(defIdx - 1)
+      assertEquals(
+        ruleLine.trim,
+        "@rule(id=st.one_of(todo_todo_ids, todo_in_progress_ids, todo_done_ids, todo_archived_ids))",
+        s"DeleteTodo across multi-bundle union should be non-consuming;\nrule=$ruleLine"
+      )
+      assert(!ruleLine.contains("consumes("), s"DeleteTodo over union must NOT consume:\n$ruleLine")
+
+  test("#153: imports include consumes and multiple when used"):
+    loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("    consumes,"), out.file)
+      assert(out.file.contains("    multiple,"), out.file)
+
+  test("#153: url_shortener (no enum transition) keeps single legacy bundle"):
+    loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(out.file.contains("url_mapping_ids = Bundle(\"url_mapping_ids\")"), out.file)
+      assert(
+        !out.file.contains("multiple()"),
+        s"no guarded transitions → no multiple():\n${out.file}"
+      )
+      assert(!out.file.contains("    multiple,"), s"no multiple() use → no import:\n${out.file}")
+      assert(
+        !out.file.contains("st.one_of(url_mapping_ids"),
+        s"single bundle → no union:\n${out.file}"
+      )
+
+  test("#153: safe_counter (no entities) unchanged"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Stateful.emitFor(profiled)
+      assert(!out.file.contains("Bundle("), s"no entities → no bundles:\n${out.file}")
+      assert(!out.file.contains("multiple()"), s"no transitions → no multiple():\n${out.file}")
 
   test("rule whose only requires is `<input> in <state>` uses strict assertion"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -411,6 +411,136 @@ class StatefulTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
+  test(
+    "#157 fix I: conjunctive status restrictions intersect (AND semantics, not union)"
+  ):
+    val spec =
+      """|service Demo {
+         |  enum Status { ACTIVE, PAUSED, ARCHIVED }
+         |  entity Foo {
+         |    id: Int
+         |    status: Status
+         |  }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  transition FooLifecycle {
+         |    entity: Foo
+         |    field: status
+         |    ACTIVE -> ARCHIVED via Archive
+         |  }
+         |  operation CreateFoo {
+         |    input: x: Int
+         |    output: foo: Foo
+         |    ensures:
+         |      foo.id = x
+         |      foo.status = ACTIVE
+         |      foos' = pre(foos) + {foo.id -> foo}
+         |  }
+         |  operation Narrow {
+         |    input: id: Int
+         |    requires:
+         |      id in foos
+         |      foos[id].status in {ACTIVE, ARCHIVED}
+         |      foos[id].status = ACTIVE
+         |    ensures: foos' = pre(foos)
+         |  }
+         |  operation Archive {
+         |    input: id: Int
+         |    requires: id in foos
+         |    ensures: foos'[id].status = ARCHIVED
+         |  }
+         |  conventions {
+         |    CreateFoo.http_path = "/foos"
+         |    CreateFoo.http_status_success = 201
+         |    Narrow.http_method = "POST"
+         |    Narrow.http_path = "/foos/{id}/narrow"
+         |    Archive.http_method = "POST"
+         |    Archive.http_path = "/foos/{id}/archive"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out      = Stateful.emitFor(profiled)
+            // intersection of {ACTIVE, ARCHIVED} ∩ {ACTIVE} = {ACTIVE} → single bundle
+            assert(
+              out.file.contains("@rule(id=foo_active_ids)"),
+              s"intersection of {ACTIVE,ARCHIVED} and {ACTIVE} should be just ACTIVE;\n${out.file}"
+            )
+            assert(out.file.contains("def narrow(self, id):"), out.file)
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test(
+    "#157 fix J: single-bundle Delete with unrecognized requires uses non-consuming + loose"
+  ):
+    val spec =
+      """|service Demo {
+         |  entity Foo {
+         |    id: Int
+         |    locked: Bool
+         |  }
+         |  state {
+         |    foos: Int -> lone Foo
+         |  }
+         |  operation CreateFoo {
+         |    input: x: Int
+         |    output: foo: Foo
+         |    ensures:
+         |      foo.id = x
+         |      foo.locked = false
+         |      foos' = pre(foos) + {foo.id -> foo}
+         |  }
+         |  operation DeleteFoo {
+         |    input: id: Int
+         |    requires:
+         |      id in foos
+         |      foos[id].locked = false
+         |    ensures: foos' = pre(foos) - {id}
+         |  }
+         |  conventions {
+         |    CreateFoo.http_path = "/foos"
+         |    CreateFoo.http_status_success = 201
+         |    DeleteFoo.http_method = "DELETE"
+         |    DeleteFoo.http_path = "/foos/{id}"
+         |  }
+         |}
+         |""".stripMargin
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out      = Stateful.emitFor(profiled)
+            // No transition → legacy single bundle. requires `foos[id].locked = false`
+            // uses bool literal — not enum, so recognizer marks it unrecognized.
+            // strictByConstruction = false → must NOT consume.
+            assert(out.file.contains("foo_ids = Bundle"), out.file)
+            assert(
+              out.file.contains("@rule(id=foo_ids)"),
+              s"non-strict Delete must draw non-consuming;\n${out.file}"
+            )
+            assert(
+              !out.file.contains("@rule(id=consumes(foo_ids))"),
+              s"non-strict Delete must NOT consume:\n${out.file}"
+            )
+            // body must be loose
+            val delBlock = out.file
+              .linesIterator
+              .dropWhile(!_.contains("def delete_foo"))
+              .takeWhile(!_.startsWith("    @"))
+              .mkString("\n")
+            assert(
+              delBlock.contains("400 <= response.status_code < 500"),
+              s"non-strict Delete must be loose;\nblock=$delBlock"
+            )
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
   test("rule whose only requires is `<input> in <state>` uses strict assertion"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val out = Stateful.emitFor(profiled)


### PR DESCRIPTION
## Summary

Splits `<entity>_ids` into one Hypothesis `Bundle` per enum value when the entity has a `TransitionDecl` over an enum field AND every `Create` op deterministically sets the initial status. Otherwise falls back to the legacy single bundle, so `url_shortener` / `safe_counter` outputs stay byte-identical.

For `todo_list.spec`:

- 4 bundles: `todo_todo_ids`, `todo_in_progress_ids`, `todo_done_ids`, `todo_archived_ids`.
- `CreateTodo` → `@rule(target=todo_todo_ids, …)` (initial status from `todo.status = TODO`).
- Each `via` rule emits one Python rule per `TransitionRule` (`start_work_from_todo`, `complete_from_in_progress`, `archive_from_todo`, `archive_from_done`, `reopen_from_done`) using `@rule(target=<to>, id=consumes(<from>))` so Hypothesis transfers the id between bundles.
- Guarded `Reopen` returns `id` on 200 and `multiple()` on 4xx, keeping bundle/SUT bookkeeping consistent.
- `GetTodo`/`UpdateTodo`/`DeleteTodo` (no recognized status restriction) draw from `st.one_of(<all 4 bundles>)` non-consuming + loose status.

## Hypothesis API verification

Confirmed via Context7 (`HypothesisWorks/hypothesis`) and the `hypothesis/stateful.py` source:

- `@rule(target=B, id=consumes(A))` is supported and idiomatic.
- `return multiple()` (no args) tells Hypothesis "no result" — id leaves the source bundle without being pushed to target.
- `consumes(st.one_of(...))` is **not** part of the API — Delete with multi-bundle restriction stays non-consuming.
- Empty bundles silently disable rules; no deadlock unless every rule is invalid.

## Test plan

- [x] 9 new `StatefulTest` cases for the per-status pattern (todo_list)
- [x] `url_shortener` byte-identical (no enum transition) — asserted via single-bundle/no-`multiple()`/no-`st.one_of(url_mapping_ids` substrings
- [x] `safe_counter` unchanged (no entities)
- [x] `sbt test` — 559 tests green
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `npm run build` (docs) clean
- [x] Docs: new "Per-status bundles for `transition`-driven entities (#153)" section under Stateful tests; #153 row removed from limitations table

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-status bundles in stateful tests by splitting `<entity>_ids` into one bundle per enum value when a `TransitionDecl` exists and all `Create` ops deterministically set the initial status; otherwise falls back to the single bundle. Tightens rule targeting, transition flow, and assertion strictness while keeping `url_shortener` and `safe_counter` unchanged. Closes #153.

- **New Features**
  - Generate one bundle per status (e.g., `todo_todo_ids`, `todo_in_progress_ids`, …); otherwise keep the legacy single bundle.
  - `Create` rules target the initial-status bundle; unguarded transitions move ids with `@rule(target=<to>, id=consumes(<from>))` and strict success; guarded transitions return `id` on success or `multiple()` on 4xx.
  - Inputs with status filters draw from `st.one_of(<matching bundles>)` with strict success; membership-only `<id> in <state>` across unions is strict; unknown/no filter draws from `st.one_of(<all bundles>)`.
  - Delete: per-status membership-only delete draws from a union non-consuming + loose; only when a recognized status filter narrows to a single bundle do we use `consumes(<bundle>)` + strict. Legacy single-bundle delete still consumes when strict-by-construction.

- **Bug Fixes**
  - Enable per-status bundles only if all `Create`/`CreateChild` ops set the initial status deterministically; otherwise fall back to a single bundle.
  - Apply status restrictions only to the bound id and only on the transition field; intersect repeated same-field restrictions (AND), avoiding cross-pollution in multi-id ops.
  - Strictness: treat recognized union draws as strict; keep delete-over-union loose; for single-bundle delete, consume only when strict-by-construction, else draw non-consuming and assert loosely.
  - Name transition rules `<via>_from_<from>_to_<to>` to avoid collisions.

<sup>Written for commit c61e3475688b4a29595f5c21df738af08861b1e8. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/157?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test generation documentation to specify improved handling of entities with status-based transitions, including bundle splitting behavior and refined routing for create and transition operations.

* **Tests**
  * Expanded test suite to validate per-status bundle schemes and transition rule generation with proper assertion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->