### PR TITLE
Transition tests for via ops with non-path inputs (closes #155)

### DIFF
--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -88,9 +88,10 @@ to other operations or direct seed-writes. For the *transition* case (operation 
 by a `via` clause in a `TransitionDecl`), M5.9 closes this gap with dedicated transition
 tests (see below). The clause still appears in `_testgen_skips.json`, but the reason text
 flips to `state-dependent precondition; covered by transition tests (M5.9)` for transition
-operations and stays as `... deferred to M5.9 ...` only for the residual non-transition
-operations (`GetTodo`, `UpdateTodo`, `DeleteTodo` in `todo_list`). `ExprToPython` translates
-every IR `Expr` shape, so the *translator coverage* gap is closed.
+operations and falls back to `... covered by stateful tests (M5.2) for ops bundled into
+the state machine ...` for the residual non-transition operations (`GetTodo`, `UpdateTodo`,
+`DeleteTodo` in `todo_list`). `ExprToPython` translates every IR `Expr` shape, so the
+*translator coverage* gap is closed.
 
 ### 2. Negative `<input> in <state>` tests
 
@@ -110,8 +111,36 @@ def test_resolve_negative_code_not_in_store(code):
         f"expected 4xx, got {response.status_code}: {response.text}"
 ```
 
-Other requires shapes (predicate violation, compound, ordering) are tracked as follow-ups
-and skipped with reason in `_testgen_skips.json`.
+A second negative pattern recognises status restrictions on existing entries:
+`<state>[<input>].<enum-field> = <required-value>` (the precondition that the entry,
+once it exists, must be in a particular status). When the underlying entity is in a
+`TransitionDecl` (so `/__test_admin__/seed/<entity>` exists), a negative test is
+emitted that seeds the entity in any *other* enum value of the field — picked by
+`st.sampled_from(<all-other-values>)` — and asserts a 4xx response:
+
+```python
+@given(row=strategy_order(), wrong_status=st.sampled_from(["DRAFT", "PAID", "SHIPPED", "DELIVERED", "CANCELLED", "RETURNED"]), amount=strategy_money())
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_record_payment_negative_orders_status_not_placed(row, wrong_status, amount):
+    """requires 'orders[order_id].status = PLACED' (negative): wrong status returns 4xx."""
+    client.post("/__test_admin__/reset")
+    row = dict(row)
+    row["status"] = wrong_status
+    seed = client.post("/__test_admin__/seed/order", json=row)
+    assume(seed.status_code == 201)
+    seeded_id = seed.json()["id"]
+    response = client.post(f"/orders/{seeded_id}/payments", json={"amount": amount})
+    assert 400 <= response.status_code < 500, f"expected 4xx, got {response.status_code}: {response.text}"
+```
+
+This covers business-logic illegal-from preconditions on **non-via** operations (e.g.,
+ecommerce `AddLineItem` requires `orders[order_id].status = DRAFT` but is not the via
+of any `TransitionDecl`). For via operations the same pattern emits an additional
+negative alongside the per-illegal-from transition negatives — they assert the same
+qualitative property from different angles.
+
+Other requires shapes (predicate violation, ordering, set-content checks) are tracked
+as follow-ups and skipped with reason in `_testgen_skips.json`.
 
 ### 3. Post-operation invariant checks
 

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -309,6 +309,13 @@ is reused. If any non-path input has no known strategy (e.g., `Map[K, V]`,
 `Relation[K, V]`, an unknown named type), the entire via is skipped with a reason
 naming the un-generable input.
 
+If a non-path input shares a name with a generated test local — `row`, `seed`,
+`seeded_id`, `response`, `client`, `pre_state`, `post_state`, `wrong_status` — the
+input is aliased to `_arg_<name>` (with a numeric suffix on collision) for the
+function parameter and the `@given` keyword, while the JSON / query dict key keeps
+the original parameter name. So a spec input named `seed` becomes
+`@given(..., _arg_seed=…)` / `def fn(row, _arg_seed)` / `json={"seed": _arg_seed}`.
+
 The positive transition still requires the via op's other `requires` clauses (besides
 the `from`-state pin) to be satisfied by the generated values; if the SUT enforces
 stricter preconditions (e.g., `requires: amount = orders[order_id].total`), the

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -251,6 +251,42 @@ Anything outside the table above keeps the skip with reason
 - **Top-level `or` / `implies`.** Pick-a-branch ambiguity; reduce to a
   conjunction and re-spec the rule if you want a deterministic test.
 
+### Body and query inputs on `via` operations (#155)
+
+When the via op takes parameters beyond the path id (e.g.,
+`RecordPayment(order_id: OrderId, amount: Money)` mounted at
+`POST /orders/{order_id}/payments`), the body/query inputs are generated through the
+same `Strategies.expressionFor(...)` used in non-transition tests, and wired into the
+`@given` decorator alongside `row=strategy_<entity>()`:
+
+```python
+@given(row=strategy_order(), amount=strategy_money())
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_record_payment_transition_illegal_from_draft(row, amount):
+    """transition RecordPayment: from=DRAFT is illegal (no rule); SUT must reject 4xx"""
+    client.post("/__test_admin__/reset")
+    row = dict(row)
+    row["status"] = "DRAFT"
+    seed = client.post("/__test_admin__/seed/order", json=row)
+    assume(seed.status_code == 201)
+    seeded_id = seed.json()["id"]
+    response = client.post(f"/orders/{seeded_id}/payments", json={"amount": amount})
+    assert 400 <= response.status_code < 500, f"expected 4xx, got {response.status_code}: {response.text}"
+```
+
+Body inputs go to `json={…}`, query inputs to `params={…}`. Sensitive-field redaction
+and per-operation `test_strategy` overrides apply, since the same `expressionFor` path
+is reused. If any non-path input has no known strategy (e.g., `Map[K, V]`,
+`Relation[K, V]`, an unknown named type), the entire via is skipped with a reason
+naming the un-generable input.
+
+The positive transition still requires the via op's other `requires` clauses (besides
+the `from`-state pin) to be satisfied by the generated values; if the SUT enforces
+stricter preconditions (e.g., `requires: amount = orders[order_id].total`), the
+positive test will fail by design — that's a real spec-vs-SUT divergence and surfaces
+where it should. (Recognising such relational preconditions on body inputs is a
+separate concern from #155.)
+
 ### Other skipped categories
 
 - **Non-enum transition field.** If `field: <name>` resolves to a type other than an enum
@@ -258,6 +294,13 @@ Anything outside the table above keeps the skip with reason
   is undefined for non-enum status fields.
 - **Unknown via operation.** A `via X` whose `X` has no matching `operation` declaration is
   skipped. Spec lint should catch this; the skip is a defensive backstop.
+- **Multi-path or zero-path via operation.** Transition tests need exactly one path
+  parameter to identify the seeded entity; nested-path shapes
+  (e.g., `/orders/{order_id}/items/{item_id}`) and zero-path shapes are skipped pending
+  multi-entity seed orchestration.
+- **Non-generable body or query input.** If `Strategies.expressionFor(...)` returns
+  `Skip` for any non-path input (most commonly `Map`/`Relation`-typed bodies), the via
+  is skipped with a reason naming the input and the un-generable type.
 
 ## Stateful tests (M5.2)
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -267,54 +267,68 @@ object Behavioral:
       val opDeclOpt        = ir.operations.find(_.name == viaName)
       val popOpt           = profiled.operations.find(_.operationName == viaName)
       val per: TransitionEmissionResult = (opDeclOpt, popOpt) match
-        case (Some(_), Some(pop))
-            if pop.endpoint.bodyParams.nonEmpty
-              || pop.endpoint.queryParams.nonEmpty
-              || pop.endpoint.pathParams.size != 1 =>
+        case (Some(_), Some(pop)) if pop.endpoint.pathParams.size != 1 =>
           TransitionEmissionResult(
             List(
               Left(
                 TestSkip(
                   viaName,
                   s"transition[$viaName]",
-                  "transition tests require exactly one path input identifying the seeded entity; other input shapes are not yet supported (see #155)"
+                  "transition tests require exactly one path input identifying the seeded entity; multi-path or zero-path shapes are not yet supported (see #155)"
                 )
               )
             ),
             Set.empty
           )
         case (Some(opDecl), Some(pop)) =>
-          val legalFroms   = rules.map(_.from).toSet
-          val illegalFroms = statusValues.filterNot(legalFroms.contains)
-          val stateField = stateFieldForEntity(td.entityName, ir)
-            .getOrElse(Naming.toSnakeCase(td.entityName) + "s")
-          val positives = rules.toList.map: rule =>
-            buildTransitionPositiveOrSkip(
-              td = td,
-              entity = entity,
-              fieldName = td.fieldName,
-              pkName = pk,
-              rule = rule,
-              opDecl = opDecl,
-              pop = pop,
-              stateField = stateField,
-              ir = ir
-            )
-          val negatives = illegalFroms.toList.sorted.map: from =>
-            buildTransitionNegative(
-              entity = entity,
-              fieldName = td.fieldName,
-              pkName = pk,
-              from = from,
-              opDecl = opDecl,
-              pop = pop
-            )
-          val emitted    = positives ++ negatives
-          val anyRuntime = emitted.exists(_.isRight)
-          TransitionEmissionResult(
-            emitted,
-            if anyRuntime then Set(viaName) else Set.empty
-          )
+          nonPathInputBindings(opDecl, pop, ir) match
+            case Left((paramName, reason)) =>
+              TransitionEmissionResult(
+                List(
+                  Left(
+                    TestSkip(
+                      viaName,
+                      s"transition[$viaName]",
+                      s"transition tests need a generable strategy for input '$paramName': $reason"
+                    )
+                  )
+                ),
+                Set.empty
+              )
+            case Right(nonPath) =>
+              val legalFroms   = rules.map(_.from).toSet
+              val illegalFroms = statusValues.filterNot(legalFroms.contains)
+              val stateField = stateFieldForEntity(td.entityName, ir)
+                .getOrElse(Naming.toSnakeCase(td.entityName) + "s")
+              val positives = rules.toList.map: rule =>
+                buildTransitionPositiveOrSkip(
+                  td = td,
+                  entity = entity,
+                  fieldName = td.fieldName,
+                  pkName = pk,
+                  rule = rule,
+                  opDecl = opDecl,
+                  pop = pop,
+                  stateField = stateField,
+                  ir = ir,
+                  nonPath = nonPath
+                )
+              val negatives = illegalFroms.toList.sorted.map: from =>
+                buildTransitionNegative(
+                  entity = entity,
+                  fieldName = td.fieldName,
+                  pkName = pk,
+                  from = from,
+                  opDecl = opDecl,
+                  pop = pop,
+                  nonPath = nonPath
+                )
+              val emitted    = positives ++ negatives
+              val anyRuntime = emitted.exists(_.isRight)
+              TransitionEmissionResult(
+                emitted,
+                if anyRuntime then Set(viaName) else Set.empty
+              )
         case _ =>
           TransitionEmissionResult(
             List(
@@ -338,6 +352,31 @@ object Behavioral:
             enumValuesForField(field.copy(typeExpr = alias.typeExpr), ir)
       case _ => None
 
+  final private case class NonPathInput(name: String, kind: NonPathKind, strategyExpr: String)
+  private enum NonPathKind:
+    case Body
+    case Query
+
+  private def nonPathInputBindings(
+      opDecl: OperationDecl,
+      pop: ProfiledOperation,
+      ir: ServiceIR
+  ): Either[(String, String), List[NonPathInput]] =
+    val overrides = TestStrategyOverrides.from(ir)
+    val tagged =
+      pop.endpoint.bodyParams.map(p => (p, NonPathKind.Body)) ++
+        pop.endpoint.queryParams.map(p => (p, NonPathKind.Query))
+    val resolved = tagged.map: (p, k) =>
+      val ctx  = StrategyCtx.OperationInput(opDecl.name, p.name)
+      val expr = Strategies.expressionFor(p.typeExpr, ir, ctx, overrides)
+      (p.name, k, expr)
+    resolved.collectFirst { case (n, _, StrategyExpr.Skip(r)) => (n, r) } match
+      case Some(skip) => Left(skip)
+      case None =>
+        Right(resolved.collect:
+          case (n, k, StrategyExpr.Code(t)) => NonPathInput(n, k, t)
+        )
+
   private def buildTransitionPositiveOrSkip(
       td: TransitionDecl,
       entity: EntityDecl,
@@ -347,7 +386,8 @@ object Behavioral:
       opDecl: OperationDecl,
       pop: ProfiledOperation,
       stateField: String,
-      ir: ServiceIR
+      ir: ServiceIR,
+      nonPath: List[NonPathInput]
   ): Either[TestSkip, GeneratedTest] =
     val fixLines = rule.guard match
       case None        => Some(Nil)
@@ -373,7 +413,8 @@ object Behavioral:
             opDecl = opDecl,
             pop = pop,
             stateField = stateField,
-            guardFixLines = lines
+            guardFixLines = lines,
+            nonPath = nonPath
           )
         )
 
@@ -387,7 +428,8 @@ object Behavioral:
       opDecl: OperationDecl,
       pop: ProfiledOperation,
       stateField: String,
-      guardFixLines: List[String]
+      guardFixLines: List[String],
+      nonPath: List[NonPathInput]
   ): GeneratedTest =
     val opSnake     = Naming.toSnakeCase(opDecl.name)
     val entitySnake = Naming.toSnakeCase(entity.name)
@@ -397,11 +439,11 @@ object Behavioral:
     val fieldKey    = ExprToPython.pyString(fieldName)
     val stateKey    = ExprToPython.pyString(stateField)
     val sb          = new StringBuilder
-    sb.append(s"@given(row=$rowStrategy())\n")
+    sb.append(givenLineFor(rowStrategy, nonPath))
     sb.append(
       "@settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])\n"
     )
-    sb.append(s"def $testName(row):\n")
+    sb.append(s"def $testName(${signatureFor(nonPath)}):\n")
     sb.append(
       s"    \"\"\"transition ${opDecl.name}: $from -> $to (post-state ${td.fieldName} = $to)\"\"\"\n"
     )
@@ -413,7 +455,7 @@ object Behavioral:
     sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
     sb.append("    assume(seed.status_code == 201)\n")
     sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
-    sb.append(transitionRequestCall(pop))
+    sb.append(transitionRequestCall(pop, nonPath))
     sb.append(s"    assert response.status_code == ${pop.endpoint.successStatus}, response.text\n")
     sb.append("    post_state = client.get(\"/__test_admin__/state\").json()\n")
     sb.append(
@@ -437,7 +479,8 @@ object Behavioral:
       pkName: String,
       from: String,
       opDecl: OperationDecl,
-      pop: ProfiledOperation
+      pop: ProfiledOperation,
+      nonPath: List[NonPathInput]
   ): Either[TestSkip, GeneratedTest] =
     val opSnake     = Naming.toSnakeCase(opDecl.name)
     val entitySnake = Naming.toSnakeCase(entity.name)
@@ -446,11 +489,11 @@ object Behavioral:
     val pkKey       = ExprToPython.pyString(pkName)
     val fieldKey    = ExprToPython.pyString(fieldName)
     val sb          = new StringBuilder
-    sb.append(s"@given(row=$rowStrategy())\n")
+    sb.append(givenLineFor(rowStrategy, nonPath))
     sb.append(
       "@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])\n"
     )
-    sb.append(s"def $testName(row):\n")
+    sb.append(s"def $testName(${signatureFor(nonPath)}):\n")
     sb.append(
       s"    \"\"\"transition ${opDecl.name}: from=$from is illegal (no rule); SUT must reject 4xx\"\"\"\n"
     )
@@ -460,14 +503,23 @@ object Behavioral:
     sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
     sb.append("    assume(seed.status_code == 201)\n")
     sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
-    sb.append(transitionRequestCall(pop))
+    sb.append(transitionRequestCall(pop, nonPath))
     sb.append(
       s"    assert 400 <= response.status_code < 500, " +
         s"f${'"'}expected 4xx, got {response.status_code}: {response.text}${'"'}\n"
     )
     Right(GeneratedTest(name = testName, body = sb.toString, skipReason = None))
 
-  private def transitionRequestCall(pop: ProfiledOperation): String =
+  private def givenLineFor(rowStrategy: String, nonPath: List[NonPathInput]): String =
+    val rowPair = s"row=$rowStrategy()"
+    val extra   = nonPath.map(i => s"${i.name}=${i.strategyExpr}")
+    val args    = (rowPair :: extra).mkString(", ")
+    s"@given($args)\n"
+
+  private def signatureFor(nonPath: List[NonPathInput]): String =
+    ("row" :: nonPath.map(_.name)).mkString(", ")
+
+  private def transitionRequestCall(pop: ProfiledOperation, nonPath: List[NonPathInput]): String =
     val ep        = pop.endpoint
     val pathParam = ep.pathParams.headOption.map(_.name)
     val pathExpr =
@@ -477,7 +529,15 @@ object Behavioral:
           "f" + ExprToPython.pyString(rendered)
         case None => ExprToPython.pyString(ep.path)
     val method = ep.method.toString.toLowerCase
-    s"    response = client.$method($pathExpr)\n"
+    val bodyEntries = nonPath.collect:
+      case NonPathInput(n, NonPathKind.Body, _) => s"${ExprToPython.pyString(n)}: $n"
+    val queryEntries = nonPath.collect:
+      case NonPathInput(n, NonPathKind.Query, _) => s"${ExprToPython.pyString(n)}: $n"
+    val bodyExpr =
+      if bodyEntries.isEmpty then "" else s", json={${bodyEntries.mkString(", ")}}"
+    val queryExpr =
+      if queryEntries.isEmpty then "" else s", params={${queryEntries.mkString(", ")}}"
+    s"    response = client.$method($pathExpr$bodyExpr$queryExpr)\n"
 
   private def stateFieldForEntity(entityName: String, ir: ServiceIR): Option[String] =
     ir.state.toList.flatMap(_.fields).collectFirst:

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -272,7 +272,7 @@ object Behavioral:
                 TestSkip(
                   viaName,
                   s"transition[$viaName]",
-                  "transition tests require exactly one path input identifying the seeded entity; multi-path or zero-path shapes are not yet supported (see #155)"
+                  "transition tests require exactly one path input identifying the seeded entity; multi-path or zero-path shapes need multi-entity seed orchestration"
                 )
               )
             ),
@@ -350,10 +350,30 @@ object Behavioral:
             enumValuesForField(field.copy(typeExpr = alias.typeExpr), ir)
       case _ => None
 
-  final private case class NonPathInput(name: String, kind: NonPathKind, strategyExpr: String)
+  final private case class NonPathInput(
+      name: String,
+      argName: String,
+      kind: NonPathKind,
+      strategyExpr: String
+  )
   private enum NonPathKind:
     case Body
     case Query
+
+  private val ReservedTestLocals: Set[String] =
+    Set("row", "seed", "seeded_id", "response", "client", "pre_state", "post_state", "wrong_status")
+
+  private def safeArgName(raw: String, taken: Set[String]): String =
+    if !ReservedTestLocals.contains(raw) && !taken.contains(raw) then raw
+    else
+      val base = s"_arg_$raw"
+      if !taken.contains(base) && !ReservedTestLocals.contains(base) then base
+      else
+        Iterator
+          .from(1)
+          .map(i => s"${base}_$i")
+          .find(n => !taken.contains(n) && !ReservedTestLocals.contains(n))
+          .get
 
   private def nonPathInputBindings(
       opDecl: OperationDecl,
@@ -371,9 +391,13 @@ object Behavioral:
     resolved.collectFirst { case (n, _, StrategyExpr.Skip(r)) => (n, r) } match
       case Some(skip) => Left(skip)
       case None =>
-        Right(resolved.collect:
-          case (n, k, StrategyExpr.Code(t)) => NonPathInput(n, k, t)
-        )
+        val withArgs = resolved
+          .collect { case (n, k, StrategyExpr.Code(t)) => (n, k, t) }
+          .foldLeft((List.empty[NonPathInput], Set.empty[String])):
+            case ((acc, taken), (n, k, t)) =>
+              val arg = safeArgName(n, taken)
+              (acc :+ NonPathInput(n, arg, k, t), taken + arg)
+        Right(withArgs._1)
 
   private def buildTransitionPositiveOrSkip(
       td: TransitionDecl,
@@ -510,12 +534,12 @@ object Behavioral:
 
   private def givenLineFor(rowStrategy: String, nonPath: List[NonPathInput]): String =
     val rowPair = s"row=$rowStrategy()"
-    val extra   = nonPath.map(i => s"${i.name}=${i.strategyExpr}")
+    val extra   = nonPath.map(i => s"${i.argName}=${i.strategyExpr}")
     val args    = (rowPair :: extra).mkString(", ")
     s"@given($args)\n"
 
   private def signatureFor(nonPath: List[NonPathInput]): String =
-    ("row" :: nonPath.map(_.name)).mkString(", ")
+    ("row" :: nonPath.map(_.argName)).mkString(", ")
 
   private def transitionRequestCall(pop: ProfiledOperation, nonPath: List[NonPathInput]): String =
     val ep        = pop.endpoint
@@ -528,9 +552,9 @@ object Behavioral:
         case None => ExprToPython.pyString(ep.path)
     val method = ep.method.toString.toLowerCase
     val bodyEntries = nonPath.collect:
-      case NonPathInput(n, NonPathKind.Body, _) => s"${ExprToPython.pyString(n)}: $n"
+      case NonPathInput(n, arg, NonPathKind.Body, _) => s"${ExprToPython.pyString(n)}: $arg"
     val queryEntries = nonPath.collect:
-      case NonPathInput(n, NonPathKind.Query, _) => s"${ExprToPython.pyString(n)}: $n"
+      case NonPathInput(n, arg, NonPathKind.Query, _) => s"${ExprToPython.pyString(n)}: $arg"
     val bodyExpr =
       if bodyEntries.isEmpty then "" else s", json={${bodyEntries.mkString(", ")}}"
     val queryExpr =
@@ -814,7 +838,16 @@ object Behavioral:
       restriction: StatusRestriction,
       idx: Int
   ): Option[Either[TestSkip, GeneratedTest]] =
-    if pop.endpoint.pathParams.size != 1 then None
+    if pop.endpoint.pathParams.size != 1 then
+      Some(
+        Left(
+          TestSkip(
+            opDecl.name,
+            s"requires[$idx]",
+            "status-restriction negative needs exactly one path input identifying the seeded entity; multi-path or zero-path shapes need multi-entity seed orchestration"
+          )
+        )
+      )
     else
       nonPathInputBindings(opDecl, pop, ir) match
         case Left((paramName, reason)) =>
@@ -847,9 +880,9 @@ object Behavioral:
     val sampledFrom = wrongValues.map(ExprToPython.pyString).mkString("[", ", ", "]")
     val extraGiven =
       List("row" -> s"$rowStrategy()", "wrong_status" -> s"st.sampled_from($sampledFrom)") ++
-        nonPath.map(i => i.name -> i.strategyExpr)
+        nonPath.map(i => i.argName -> i.strategyExpr)
     val givenArgs = extraGiven.map((n, e) => s"$n=$e").mkString(", ")
-    val sigParams = ("row" :: "wrong_status" :: nonPath.map(_.name)).mkString(", ")
+    val sigParams = ("row" :: "wrong_status" :: nonPath.map(_.argName)).mkString(", ")
     val sb        = new StringBuilder
     sb.append(s"@given($givenArgs)\n")
     sb.append(

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -60,7 +60,7 @@ object Behavioral:
     if coveredByTransit.contains(opName) then
       "state-dependent precondition; covered by transition tests (M5.9)"
     else
-      "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"
+      "state-dependent precondition; positive ensures/invariant tests are covered by stateful tests (M5.2) for ops bundled into the state machine; the single-shot behavioral test would need explicit pre-seeding"
 
   final private case class TransitionEmissionResult(
       results: List[Either[TestSkip, GeneratedTest]],
@@ -148,17 +148,21 @@ object Behavioral:
                 )
               )
         case None =>
-          if isTrivialTrue(req) then Nil
-          else
-            List(
-              Left(
-                TestSkip(
-                  opDecl.name,
-                  s"requires[$idx]",
-                  "M5.1: only `<input> in <state>` requires patterns get negative tests"
+          statusRestrictionPattern(req, inputs, stateFields, ir) match
+            case Some(restriction) =>
+              statusRestrictionNegativeOrSkip(opDecl, pop, ir, restriction, idx).toList
+            case None =>
+              if isTrivialTrue(req) then Nil
+              else
+                List(
+                  Left(
+                    TestSkip(
+                      opDecl.name,
+                      s"requires[$idx]",
+                      "M5.1: only `<input> in <state>` and `<state>[input].<enum-field> = <value>` requires patterns get negative tests"
+                    )
+                  )
                 )
-              )
-            )
 
   private def invariantTests(
       pop: ProfiledOperation,
@@ -180,28 +184,22 @@ object Behavioral:
         )
     else
       val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
-
-      ir.invariants.zipWithIndex.flatMap: (inv, idx) =>
-        ExprToPython.translate(inv.expr, ctx) match
-          case ExprPy.Skip(reason, _) =>
-            List(
-              Left(TestSkip(opDecl.name, s"invariant[${invName(inv, idx)}]", reason))
-            )
-          case ExprPy.Py(text) =>
-            inputArgList(pop, ir) match
-              case Left(reason) =>
-                List(Left(TestSkip(opDecl.name, s"invariant", reason)))
-              case Right(strategySig) =>
-                List(
-                  Right(
-                    buildInvariantTest(
-                      name = s"test_${opSnake}_invariant_${Naming.toSnakeCase(invName(inv, idx))}",
-                      docstring =
-                        s"invariant ${invName(inv, idx)}: ${prettyOneLine(inv.expr)}",
-                      inputArgs = strategySig,
-                      pop = pop,
-                      assertion = text
-                    )
+      inputArgList(pop, ir) match
+        case Left(reason) =>
+          List(Left(TestSkip(opDecl.name, "invariant_inputs", reason)))
+        case Right(strategySig) =>
+          ir.invariants.zipWithIndex.toList.map: (inv, idx) =>
+            ExprToPython.translate(inv.expr, ctx) match
+              case ExprPy.Skip(reason, _) =>
+                Left(TestSkip(opDecl.name, s"invariant[${invName(inv, idx)}]", reason))
+              case ExprPy.Py(text) =>
+                Right(
+                  buildInvariantTest(
+                    name = s"test_${opSnake}_invariant_${Naming.toSnakeCase(invName(inv, idx))}",
+                    docstring = s"invariant ${invName(inv, idx)}: ${prettyOneLine(inv.expr)}",
+                    inputArgs = strategySig,
+                    pop = pop,
+                    assertion = text
                   )
                 )
 
@@ -398,7 +396,7 @@ object Behavioral:
           TestSkip(
             opDecl.name,
             s"transition[${rule.from}_to_${rule.to}]",
-            s"guard '${prettyOneLine(rule.guard.get)}' not representable in seed dict (see #152)"
+            s"guard '${prettyOneLine(rule.guard.get)}' uses constructs the seed-dict recognizer does not cover; see docs 'Guarded positive transitions' for the supported shapes"
           )
         )
       case Some(lines) =>
@@ -751,6 +749,128 @@ object Behavioral:
           if inputs.contains(in) && state.contains(st) =>
         Some((in, st))
       case _ => None
+
+  final private case class StatusRestriction(
+      inputName: String,
+      stateName: String,
+      entityName: String,
+      fieldName: String,
+      requiredValue: String,
+      enumValues: List[String],
+      pkField: String
+  )
+
+  private def statusRestrictionPattern(
+      e: Expr,
+      inputs: Set[String],
+      state: Set[String],
+      ir: ServiceIR
+  ): Option[StatusRestriction] =
+    e match
+      case Expr.BinaryOp(
+            BinOp.Eq,
+            Expr.FieldAccess(
+              Expr.Index(Expr.Identifier(stName, _), Expr.Identifier(inName, _), _),
+              field,
+              _
+            ),
+            rhs,
+            _
+          ) if inputs.contains(inName) && state.contains(stName) =>
+        for
+          entityName <- entityForStateField(stName, ir)
+          entity     <- ir.entities.find(_.name == entityName)
+          if Strategies.transitionEntityNames(ir).contains(entityName)
+          fieldDecl <- entity.fields.find(_.name == field)
+          enumVals  <- enumValuesForField(fieldDecl, ir)
+          if enumVals.nonEmpty
+          rhsLit <- enumLiteralFor(rhs, enumVals)
+          pk     <- AdminRouter.primaryKeyField(entity)
+          if enumVals.size >= 2
+        yield StatusRestriction(inName, stName, entityName, field, rhsLit, enumVals, pk)
+      case _ => None
+
+  private def entityForStateField(stateFieldName: String, ir: ServiceIR): Option[String] =
+    ir.state.toList
+      .flatMap(_.fields)
+      .find(_.name == stateFieldName)
+      .flatMap(f => relationTargetEntityName(f.typeExpr))
+
+  private def relationTargetEntityName(t: TypeExpr): Option[String] = t match
+    case TypeExpr.RelationType(_, _, TypeExpr.NamedType(n, _), _) => Some(n)
+    case TypeExpr.NamedType(n, _)                                 => Some(n)
+    case _                                                        => None
+
+  private def enumLiteralFor(rhs: Expr, enumValues: List[String]): Option[String] =
+    rhs match
+      case Expr.EnumAccess(_, member, _) if enumValues.contains(member) => Some(member)
+      case Expr.Identifier(name, _) if enumValues.contains(name)        => Some(name)
+      case _                                                            => None
+
+  private def statusRestrictionNegativeOrSkip(
+      opDecl: OperationDecl,
+      pop: ProfiledOperation,
+      ir: ServiceIR,
+      restriction: StatusRestriction,
+      idx: Int
+  ): Option[Either[TestSkip, GeneratedTest]] =
+    if pop.endpoint.pathParams.size != 1 then None
+    else
+      nonPathInputBindings(opDecl, pop, ir) match
+        case Left((paramName, reason)) =>
+          Some(
+            Left(
+              TestSkip(
+                opDecl.name,
+                s"requires[$idx]",
+                s"status-restriction negative needs a generable strategy for input '$paramName': $reason"
+              )
+            )
+          )
+        case Right(nonPath) =>
+          Some(Right(buildStatusRestrictionNegative(opDecl, pop, restriction, nonPath)))
+
+  private def buildStatusRestrictionNegative(
+      opDecl: OperationDecl,
+      pop: ProfiledOperation,
+      r: StatusRestriction,
+      nonPath: List[NonPathInput]
+  ): GeneratedTest =
+    val opSnake     = Naming.toSnakeCase(opDecl.name)
+    val entitySnake = Naming.toSnakeCase(r.entityName)
+    val testName =
+      s"test_${opSnake}_negative_${r.stateName}_${r.fieldName}_not_${r.requiredValue.toLowerCase}"
+    val rowStrategy = Strategies.strategyFunctionName(r.entityName)
+    val pkKey       = ExprToPython.pyString(r.pkField)
+    val fieldKey    = ExprToPython.pyString(r.fieldName)
+    val wrongValues = r.enumValues.filterNot(_ == r.requiredValue)
+    val sampledFrom = wrongValues.map(ExprToPython.pyString).mkString("[", ", ", "]")
+    val extraGiven =
+      List("row" -> s"$rowStrategy()", "wrong_status" -> s"st.sampled_from($sampledFrom)") ++
+        nonPath.map(i => i.name -> i.strategyExpr)
+    val givenArgs = extraGiven.map((n, e) => s"$n=$e").mkString(", ")
+    val sigParams = ("row" :: "wrong_status" :: nonPath.map(_.name)).mkString(", ")
+    val sb        = new StringBuilder
+    sb.append(s"@given($givenArgs)\n")
+    sb.append(
+      "@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])\n"
+    )
+    sb.append(s"def $testName($sigParams):\n")
+    sb.append(
+      s"    \"\"\"requires '${r.stateName}[${r.inputName}].${r.fieldName} = ${r.requiredValue}' (negative): wrong status returns 4xx.\"\"\"\n"
+    )
+    sb.append("    client.post(\"/__test_admin__/reset\")\n")
+    sb.append("    row = dict(row)\n")
+    sb.append(s"    row[$fieldKey] = wrong_status\n")
+    sb.append(s"    seed = client.post(\"/__test_admin__/seed/$entitySnake\", json=row)\n")
+    sb.append("    assume(seed.status_code == 201)\n")
+    sb.append(s"    seeded_id = seed.json()[$pkKey]\n")
+    sb.append(transitionRequestCall(pop, nonPath))
+    sb.append(
+      s"    assert 400 <= response.status_code < 500, " +
+        s"f${'"'}expected 4xx, got {response.status_code}: {response.text}${'"'}\n"
+    )
+    GeneratedTest(name = testName, body = sb.toString, skipReason = None)
 
   private def isTrivialTrue(e: Expr): Boolean = e match
     case Expr.BoolLit(true, _) => true

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -248,7 +248,7 @@ object ExprToPython:
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx, span)
       case other =>
-        ExprPy.Skip(s"unknown function '$other/${args.size}'", span)
+        ExprPy.Skip(s"unknown function '$other/${args.size}' (see #138)", span)
 
   private def sumCall(
       coll: Expr,
@@ -279,7 +279,7 @@ object ExprToPython:
       .orElse(ctx.userPredicates.get(fname).map(_.params.size))
     expectedArity match
       case None =>
-        ExprPy.Skip(s"unknown function '$fname/${args.size}'", span)
+        ExprPy.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
       case Some(n) if n != args.size =>
         ExprPy.Skip(
           s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -1389,6 +1389,151 @@ class BehavioralTest extends CatsEffectSuite:
         s"old indistinguishable 'invariant' kind must be gone; got=${out.skips}"
       )
 
+  test(
+    "PR review R1: non-path input named 'row' is aliased to avoid collision with seed-row local"
+  ):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: id: Int, row: Int, seed: Int, seeded_id: Int
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("_arg_row=st.integers()") &&
+          pos.body.contains("_arg_seed=st.integers()") &&
+          pos.body.contains("_arg_seeded_id=st.integers()"),
+        s"reserved-name inputs must be aliased to _arg_<name>; body=${pos.body}"
+      )
+      assert(
+        !pos.body.contains("@given(row=strategy_item(), row="),
+        s"raw 'row' kwarg must not collide with the seed row strategy; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains(
+          "def test_promote_transition_low_to_high(row, _arg_row, _arg_seed, _arg_seeded_id):"
+        ),
+        s"signature must use aliased names; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains(
+          "json={\"row\": _arg_row, \"seed\": _arg_seed, \"seeded_id\": _arg_seeded_id}"
+        ),
+        s"JSON keys must use the original parameter names, values use the alias; body=${pos.body}"
+      )
+
+  test("PR review R2: multi-path/zero-path skip reason no longer cites #155"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Outer {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    outers: Int -> lone Outer
+         |  }
+         |  transition OuterLifecycle {
+         |    entity: Outer
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: outer_id: Int, inner_id: Int
+         |    requires: outer_id in outers
+         |    ensures: outers'[outer_id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/outers/{outer_id}/inner/{inner_id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out  = Behavioral.emitFor(profiled)
+      val skip = out.skips.find(_.kind == "transition[Promote]").getOrElse(fail("missing skip"))
+      assert(
+        skip.reason.contains("multi-path"),
+        s"skip should describe multi-path constraint; got=${skip.reason}"
+      )
+      assert(!skip.reason.contains("#155"), s"#155 must not be cited; got=${skip.reason}")
+
+  test(
+    "PR review R3: status-restriction recognized but multi-path emits explicit skip (not silent drop)"
+  ):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Outer {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    outers: Int -> lone Outer
+         |  }
+         |  transition OuterLifecycle {
+         |    entity: Outer
+         |    field: phase
+         |    LOW -> HIGH via Tick
+         |  }
+         |  operation Update {
+         |    input: outer_id: Int, inner_id: Int
+         |    requires:
+         |      outer_id in outers
+         |      outers[outer_id].phase = LOW
+         |    ensures: true
+         |  }
+         |  operation Tick {
+         |    input: id: Int
+         |    requires: id in outers
+         |    ensures: outers'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Update.http_method = "POST"
+         |    Update.http_path   = "/outers/{outer_id}/inner/{inner_id}"
+         |    Tick.http_method   = "POST"
+         |    Tick.http_path     = "/outers/{id}/tick"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(
+        out.tests.filter(_.name.contains("update_negative_outers_phase_not_low")),
+        Nil,
+        "multi-path Update cannot get a status-restriction negative"
+      )
+      val updSkips =
+        out.skips.filter(s => s.operation == "Update" && s.kind.startsWith("requires["))
+      assert(
+        updSkips.exists(_.reason.contains("multi-path")),
+        s"explicit skip with multi-path reason expected; got=$updSkips"
+      )
+
   test("audit A3: ExprToPython unknown function reference cites #138"):
     val spec =
       """|service Demo {

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -318,8 +318,8 @@ class BehavioralTest extends CatsEffectSuite:
       val getTodoSkips = out.skips.filter: s =>
         s.operation == "GetTodo" && s.kind == "ensures"
       assert(
-        getTodoSkips.exists(_.reason.contains("deferred to M5.9")),
-        s"non-transition op should retain deferred-to-M5.9 skip; got=$getTodoSkips"
+        getTodoSkips.exists(_.reason.contains("covered by stateful tests")),
+        s"non-transition op should reference stateful-tests coverage; got=$getTodoSkips"
       )
 
   // ---------- M5.9 PR #154 review fixes ----------
@@ -385,12 +385,13 @@ class BehavioralTest extends CatsEffectSuite:
       )
       assert(
         rpPositiveSkip.get.reason.contains("paymentCaptured") &&
-          rpPositiveSkip.get.reason.contains("#152"),
-        s"reason should cite paymentCaptured + #152; got=${rpPositiveSkip.get.reason}"
+          rpPositiveSkip.get.reason.contains("seed-dict recognizer"),
+        s"reason should cite paymentCaptured + recognizer doc pointer; got=${rpPositiveSkip.get.reason}"
       )
       assert(
-        !rpPositiveSkip.get.reason.contains("#155"),
-        s"#155 must not be cited any more; got=${rpPositiveSkip.get.reason}"
+        !rpPositiveSkip.get.reason.contains("#155") &&
+          !rpPositiveSkip.get.reason.contains("#152"),
+        s"closed-issue refs (#152, #155) must not be cited; got=${rpPositiveSkip.get.reason}"
       )
       assert(
         out.skips.forall(s => !s.reason.contains("#155")),
@@ -461,8 +462,8 @@ class BehavioralTest extends CatsEffectSuite:
         s"Promote was filtered out — must NOT claim coverage; got=${ensSkip.get.reason}"
       )
       assert(
-        ensSkip.get.reason.contains("deferred to M5.9"),
-        s"filtered-out via op should fall back to deferred reason; got=${ensSkip.get.reason}"
+        ensSkip.get.reason.contains("covered by stateful tests"),
+        s"filtered-out via op should fall back to stateful-tests reference; got=${ensSkip.get.reason}"
       )
 
   test("M5.9 fix H: emitted transition op DOES claim 'covered by transition tests'"):
@@ -597,7 +598,7 @@ class BehavioralTest extends CatsEffectSuite:
       assert(pos.body.contains("row[\"a\"] = row[\"b\"] + 1"), s"body=${pos.body}")
       assert(pos.body.contains("row[\"tier\"] = \"GOLD\""), s"body=${pos.body}")
 
-  test("#152: unrecognized guard shape still skips with #152 reason"):
+  test("#152: unrecognized guard shape still skips with recognizer-doc reason"):
     val spec =
       """|service Demo {
          |  enum Phase { LOW, HIGH }
@@ -630,7 +631,14 @@ class BehavioralTest extends CatsEffectSuite:
       val out  = Behavioral.emitFor(profiled)
       val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
       assert(skip.nonEmpty, s"expected guard skip; skips=${out.skips}")
-      assert(skip.get.reason.contains("#152"), s"reason=${skip.get.reason}")
+      assert(
+        skip.get.reason.contains("seed-dict recognizer"),
+        s"reason=${skip.get.reason}"
+      )
+      assert(
+        !skip.get.reason.contains("#152"),
+        s"closed-issue ref leaked; reason=${skip.get.reason}"
+      )
 
   test("#152: transition-field guard matching `from` is auto-satisfied (no extra fix)"):
     val spec =
@@ -990,7 +998,7 @@ class BehavioralTest extends CatsEffectSuite:
       val aIdx = body.indexOf("row[\"a\"] = row[\"b\"] + 1")
       assert(bIdx > 0 && aIdx > bIdx, s"b-write must precede a-write; b@$bIdx a@$aIdx; body=$body")
 
-  test("#156 R1: cyclic dependency in conjunction (a > b and b > a) skips with #152 reason"):
+  test("#156 R1: cyclic dependency in conjunction (a > b and b > a) skips with recognizer reason"):
     val spec =
       """|service Demo {
          |  enum Phase { LOW, HIGH }
@@ -1023,7 +1031,14 @@ class BehavioralTest extends CatsEffectSuite:
       val out  = Behavioral.emitFor(profiled)
       val skip = out.skips.find(s => s.operation == "Promote" && s.kind.startsWith("transition["))
       assert(skip.nonEmpty, s"expected skip on cyclic guard; got=${out.skips}")
-      assert(skip.get.reason.contains("#152"), s"reason=${skip.get.reason}")
+      assert(
+        skip.get.reason.contains("seed-dict recognizer"),
+        s"reason=${skip.get.reason}"
+      )
+      assert(
+        !skip.get.reason.contains("#152"),
+        s"closed-issue ref leaked; reason=${skip.get.reason}"
+      )
 
   test("#156 R5: literal in Option[Set[X]] adds None-anchor before list arithmetic"):
     val spec =
@@ -1247,4 +1262,154 @@ class BehavioralTest extends CatsEffectSuite:
       assert(
         !skip.reason.contains("#155"),
         s"#155 must not be cited; got=${skip.reason}"
+      )
+
+  // ---------- audit cleanup: status-restriction negative tests + closed-issue refs ----------
+
+  test("audit C1: ecommerce AddLineItem gets a status-restriction negative for status=DRAFT"):
+    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val t = out.tests
+        .find(_.name == "test_add_line_item_negative_orders_status_not_draft")
+        .getOrElse(
+          fail(s"missing status-restriction negative; tests=${out.tests.map(_.name)}")
+        )
+      assert(
+        t.body.contains(
+          "@given(row=strategy_order(), wrong_status=st.sampled_from(["
+        ),
+        s"missing wrong_status sampled_from; body=${t.body}"
+      )
+      assert(
+        !t.body.contains("\"DRAFT\""),
+        s"DRAFT (the required status) must NOT appear in sampled_from; body=${t.body}"
+      )
+      assert(
+        t.body.contains("seed = client.post(\"/__test_admin__/seed/order\""),
+        s"missing seed call; body=${t.body}"
+      )
+      assert(
+        t.body.contains("row[\"status\"] = wrong_status"),
+        s"missing wrong_status assignment; body=${t.body}"
+      )
+
+  test("audit C1: ecommerce RecordPayment gets status-restriction negative with amount strategy"):
+    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val t = out.tests
+        .find(_.name == "test_record_payment_negative_orders_status_not_placed")
+        .getOrElse(fail("missing"))
+      assert(
+        t.body.contains(", amount=strategy_money())"),
+        s"amount strategy must flow through; body=${t.body}"
+      )
+      assert(
+        t.body.contains(
+          "def test_record_payment_negative_orders_status_not_placed(row, wrong_status, amount):"
+        ),
+        s"signature must include amount; body=${t.body}"
+      )
+      assert(
+        t.body.contains(
+          "client.post(f\"/orders/{seeded_id}/payments\", json={\"amount\": amount})"
+        ),
+        s"missing body in request call; body=${t.body}"
+      )
+
+  test(
+    "audit C1: status-restriction negative is M5.1-skipped when entity is not in any TransitionDecl"
+  ):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  operation Read {
+         |    input: id: Int
+         |    requires:
+         |      id in items
+         |      items[id].phase = LOW
+         |    ensures: true
+         |  }
+         |  conventions {
+         |    Read.http_method = "GET"
+         |    Read.http_path   = "/items/{id}"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(
+        out.tests.filter(_.name.contains("_negative_items_phase_not_")),
+        Nil,
+        "no transition entity → no /seed/<entity> → status-restriction negative cannot be emitted"
+      )
+      val skip = out.skips.find(s => s.operation == "Read" && s.kind.startsWith("requires["))
+      assert(
+        skip.exists(_.reason.contains("M5.1: only")),
+        s"expected M5.1 fallback skip with updated wording; got=${skip.map(_.reason)}"
+      )
+
+  test("audit B1: invariant_inputs single skip when op input is non-generable"):
+    val spec =
+      """|service Demo {
+         |  state {
+         |    counts: Int -> lone Int
+         |  }
+         |  invariant invA: 0 = 0
+         |  invariant invB: 1 = 1
+         |  operation Foo {
+         |    input: payload: Map[String, Int]
+         |    requires: true
+         |    ensures: true
+         |  }
+         |  conventions {
+         |    Foo.http_method = "POST"
+         |    Foo.http_path   = "/foo"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val invInputSkips =
+        out.skips.filter(s => s.operation == "Foo" && s.kind == "invariant_inputs")
+      assertEquals(
+        invInputSkips.size,
+        1,
+        s"hoisted check must produce exactly one skip per op, not N (per invariant); got ${invInputSkips.size}: $invInputSkips"
+      )
+      assertEquals(
+        out.skips.count(s => s.operation == "Foo" && s.kind == "invariant"),
+        0,
+        s"old indistinguishable 'invariant' kind must be gone; got=${out.skips}"
+      )
+
+  test("audit A3: ExprToPython unknown function reference cites #138"):
+    val spec =
+      """|service Demo {
+         |  state {
+         |    n: Int
+         |  }
+         |  operation Foo {
+         |    input: x: Int
+         |    requires: true
+         |    ensures: someUnknownFn(x)
+         |  }
+         |  conventions {
+         |    Foo.http_method = "POST"
+         |    Foo.http_path   = "/foo"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out      = Behavioral.emitFor(profiled)
+      val ensSkips = out.skips.filter(s => s.operation == "Foo" && s.kind.startsWith("ensures"))
+      assert(
+        ensSkips.exists(_.reason.contains("#138")),
+        s"unknown function skip should cite #138; got=${ensSkips.map(_.reason)}"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -335,27 +335,69 @@ class BehavioralTest extends CatsEffectSuite:
         "skip's operation field must be the via name, not the TransitionDecl name"
       )
 
-  test("M5.9 fix E: ecommerce RecordPayment (body input) skips with #155 reference"):
+  test("#155: ecommerce RecordPayment illegal-from negatives now emit with @given(amount=…)"):
     loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
-      val out     = Behavioral.emitFor(profiled)
-      val rpTests = out.tests.filter(_.name.startsWith("test_record_payment_transition_"))
-      assertEquals(
-        rpTests,
-        Nil,
-        s"RecordPayment has body input; transition tests must be skipped, got: ${rpTests.map(_.name)}"
+      val out = Behavioral.emitFor(profiled)
+      val negNames = out.tests
+        .map(_.name)
+        .filter(_.startsWith("test_record_payment_transition_illegal_from_"))
+        .toSet
+      val expected = Set(
+        "test_record_payment_transition_illegal_from_draft",
+        "test_record_payment_transition_illegal_from_paid",
+        "test_record_payment_transition_illegal_from_shipped",
+        "test_record_payment_transition_illegal_from_delivered",
+        "test_record_payment_transition_illegal_from_cancelled",
+        "test_record_payment_transition_illegal_from_returned"
       )
-      val rpSkip = out.skips.find: s =>
-        s.operation == "RecordPayment" && s.kind == "transition[RecordPayment]"
+      assertEquals(negNames, expected, s"actual=$negNames")
+      val sample = out.tests
+        .find(_.name == "test_record_payment_transition_illegal_from_draft")
+        .getOrElse(fail("draft negative missing"))
       assert(
-        rpSkip.nonEmpty,
-        s"expected RecordPayment transition skip; got=${out.skips.map(s => s.operation -> s.kind)}"
+        sample.body.contains("@given(row=strategy_order(), amount=strategy_money())"),
+        s"missing strategy_money() in @given; body=${sample.body}"
       )
       assert(
-        rpSkip.get.reason.contains("path input") && rpSkip.get.reason.contains("#155"),
-        s"skip reason must reference path-input shape and #155; got=${rpSkip.get.reason}"
+        sample.body.contains("def test_record_payment_transition_illegal_from_draft(row, amount):"),
+        s"signature missing 'amount' param; body=${sample.body}"
+      )
+      assert(
+        sample.body.contains(
+          "client.post(f\"/orders/{seeded_id}/payments\", json={\"amount\": amount})"
+        ),
+        s"missing json={'amount': amount}; body=${sample.body}"
       )
 
-  test("M5.9 fix E: todo_list (path-only via ops) is unaffected by the skip"):
+  test("#155: RecordPayment positive PLACED→PAID skip references #152 (guard), not #155"):
+    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(
+        out.tests.filter(_.name == "test_record_payment_transition_placed_to_paid"),
+        Nil,
+        "guarded positive should still skip via #152"
+      )
+      val rpPositiveSkip = out.skips.find: s =>
+        s.operation == "RecordPayment" && s.kind == "transition[PLACED_to_PAID]"
+      assert(
+        rpPositiveSkip.nonEmpty,
+        s"expected RecordPayment positive skip; got=${out.skips.map(s => s.operation -> s.kind)}"
+      )
+      assert(
+        rpPositiveSkip.get.reason.contains("paymentCaptured") &&
+          rpPositiveSkip.get.reason.contains("#152"),
+        s"reason should cite paymentCaptured + #152; got=${rpPositiveSkip.get.reason}"
+      )
+      assert(
+        !rpPositiveSkip.get.reason.contains("#155"),
+        s"#155 must not be cited any more; got=${rpPositiveSkip.get.reason}"
+      )
+      assert(
+        out.skips.forall(s => !s.reason.contains("#155")),
+        s"no skip should cite #155 after this fix; got=${out.skips.map(_.reason)}"
+      )
+
+  test("#155: todo_list (path-only via ops) is unaffected by the change"):
     loadProfiled("fixtures/spec/todo_list.spec").map: profiled =>
       val out        = Behavioral.emitFor(profiled)
       val startTests = out.tests.filter(_.name.startsWith("test_start_work_transition_"))
@@ -367,20 +409,60 @@ class BehavioralTest extends CatsEffectSuite:
         out.skips.forall(s => !s.reason.contains("require exactly one path input")),
         s"todo_list shouldn't trigger path-input-shape skip; got=${out.skips}"
       )
-
-  test("M5.9 fix H: filtered-out via op does NOT claim 'covered by transition tests'"):
-    loadProfiled("fixtures/spec/ecommerce.spec").map: profiled =>
-      val out = Behavioral.emitFor(profiled)
-      val rpEnsuresSkip = out.skips.find: s =>
-        s.operation == "RecordPayment" && s.kind == "ensures"
-      assert(rpEnsuresSkip.nonEmpty, s"expected RecordPayment ensures skip; got=${out.skips}")
+      val pos = out.tests
+        .find(_.name == "test_start_work_transition_todo_to_in_progress")
+        .getOrElse(fail("missing positive"))
       assert(
-        !rpEnsuresSkip.get.reason.contains("covered by transition tests"),
-        s"RecordPayment was filtered out — must NOT claim coverage; got=${rpEnsuresSkip.get.reason}"
+        pos.body.contains("@given(row=strategy_todo())\n"),
+        s"path-only @given line drift; body=${pos.body}"
       )
       assert(
-        rpEnsuresSkip.get.reason.contains("deferred to M5.9"),
-        s"filtered-out via op should fall back to deferred reason; got=${rpEnsuresSkip.get.reason}"
+        pos.body.contains("def test_start_work_transition_todo_to_in_progress(row):\n"),
+        s"path-only signature drift; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains("response = client.post(f\"/todos/{seeded_id}/start\")\n"),
+        s"path-only request call drift; body=${pos.body}"
+      )
+
+  test("M5.9 fix H: filtered-out via op does NOT claim 'covered by transition tests'"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: id: Int, payload: Map[String, Int]
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out     = Behavioral.emitFor(profiled)
+      val ensSkip = out.skips.find(s => s.operation == "Promote" && s.kind == "ensures")
+      assert(ensSkip.nonEmpty, s"expected Promote ensures skip; got=${out.skips}")
+      assert(
+        !ensSkip.get.reason.contains("covered by transition tests"),
+        s"Promote was filtered out — must NOT claim coverage; got=${ensSkip.get.reason}"
+      )
+      assert(
+        ensSkip.get.reason.contains("deferred to M5.9"),
+        s"filtered-out via op should fall back to deferred reason; got=${ensSkip.get.reason}"
       )
 
   test("M5.9 fix H: emitted transition op DOES claim 'covered by transition tests'"):
@@ -1024,4 +1106,145 @@ class BehavioralTest extends CatsEffectSuite:
       assert(
         pos.body.contains("if row[\"tags\"] is None: row[\"tags\"] = []"),
         s"expected None-anchor for aliased Option[Set]; body=${pos.body}"
+      )
+
+  // ---------- #155: transition tests for via ops with body/query inputs ----------
+
+  test("#155: inline spec — guardless via with body input emits positive with @given(value=…)"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: id: Int, value: Int
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("@given(row=strategy_item(), value=st.integers())\n"),
+        s"missing value=st.integers() in @given; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains("def test_promote_transition_low_to_high(row, value):\n"),
+        s"signature missing 'value'; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains(
+          "response = client.post(f\"/items/{seeded_id}/promote\", json={\"value\": value})\n"
+        ),
+        s"missing json={'value': value}; body=${pos.body}"
+      )
+
+  test("#155: inline spec — query input routed to params={…}"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: id: Int, q: String
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "GET"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |    Promote.http_query  = "q"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val pos = out.tests
+        .find(_.name == "test_promote_transition_low_to_high")
+        .getOrElse(fail(s"missing positive; skips=${out.skips}"))
+      assert(
+        pos.body.contains("@given(row=strategy_item(), q="),
+        s"missing q strategy in @given; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains("def test_promote_transition_low_to_high(row, q):\n"),
+        s"signature missing 'q'; body=${pos.body}"
+      )
+      assert(
+        pos.body.contains(
+          "response = client.get(f\"/items/{seeded_id}/promote\", params={\"q\": q})\n"
+        ),
+        s"missing params={'q': q}; body=${pos.body}"
+      )
+
+  test("#155: inline spec — non-generable body input (Map) skips with refined reason"):
+    val spec =
+      """|service Demo {
+         |  enum Phase { LOW, HIGH }
+         |  entity Item {
+         |    id: Int
+         |    phase: Phase
+         |  }
+         |  state {
+         |    items: Int -> lone Item
+         |  }
+         |  transition ItemLifecycle {
+         |    entity: Item
+         |    field: phase
+         |    LOW -> HIGH via Promote
+         |  }
+         |  operation Promote {
+         |    input: id: Int, payload: Map[String, Int]
+         |    requires: id in items
+         |    ensures: items'[id].phase = HIGH
+         |  }
+         |  conventions {
+         |    Promote.http_method = "POST"
+         |    Promote.http_path   = "/items/{id}/promote"
+         |  }
+         |}
+         |""".stripMargin
+    loadProfiledFromSpec(spec).map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      assertEquals(
+        out.tests.filter(_.name.startsWith("test_promote_transition_")),
+        Nil,
+        "non-generable body input must skip via op"
+      )
+      val skip = out.skips.find(_.kind == "transition[Promote]").getOrElse(fail("missing skip"))
+      assert(
+        skip.reason.contains("payload") && skip.reason.contains("MapType"),
+        s"skip reason should name the input and the un-generable type; got=${skip.reason}"
+      )
+      assert(
+        !skip.reason.contains("#155"),
+        s"#155 must not be cited; got=${skip.reason}"
       )


### PR DESCRIPTION
## Summary

- Generates body/query inputs for transition tests via `Strategies.expressionFor(...,
  StrategyCtx.OperationInput(opName, paramName), overrides)` and wires them into
  `@given(...)` and the request call (`json={…}` / `params={…}`).
- Replaces the M5.9 catch-all veto on body/query inputs with a per-input strategy
  availability check; non-generable inputs (Map/Relation/unknown named type) keep a
  refined skip naming the offending input. Single-path-param requirement stays.
- Sensitive-field redaction and per-operation `test_strategy` overrides apply
  automatically — same `expressionFor` path as non-transition tests.

## Concrete impact on `ecommerce.spec`

| Op (transition rule) | Before #155 | After #155 |
|---|---|---|
| `RecordPayment` (body input `amount: Money`) | all 7 tests skipped with `(see #155)` | 6 illegal-from negatives emitted with `@given(row=strategy_order(), amount=strategy_money())` and `json={\"amount\": amount}`; positive `PLACED→PAID` still skipped (independently — via #152's `paymentCaptured(order_id)` recognizer, not #155) |
| Other via ops (path-only) | unchanged | unchanged byte-for-byte |

Verified `_testgen_skips.json` no longer cites `#155` anywhere; the only RecordPayment
transition skip is `transition[PLACED_to_PAID]: guard 'paymentCaptured(order_id)' not
representable in seed dict (see #152)`.

## #152 interaction (and why the literal AC moves)

Issue #155's literal AC names a positive `test_record_payment_transition_placed_to_paid`
test on the ecommerce fixture. Issue #155 was filed before #152 (which landed in #156)
shipped guard recognition; #152 independently skips this rule because
`when paymentCaptured(order_id)` calls an unknown user predicate. After #155, the
positive remains skipped for the #152 reason — not the #155 reason. Body-input
generation for unguarded transitions is exercised in tests via inline specs.

## Test plan

- [x] `sbt testgen/test` (218 tests, was 211; +7 covers RecordPayment negatives,
      RecordPayment positive-still-skips, todo_list path-only regression, inline
      body-input positive, inline query-input positive, inline non-generable Map skip,
      and an updated fix-H)
- [x] `sbt test` full suite green
- [x] `sbt scalafmtCheckAll`, `sbt scalafixAll --check` clean
- [x] `cd docs && npm run build` clean (link-check passes)
- [x] Manual smoke: `cli/run compile fixtures/spec/ecommerce.spec --out /tmp/ec_155
      --with-tests --ignore-verify` and inspected
      `tests/test_behavioral_order_service.py` + `_testgen_skips.json`.

## Out of scope (deferred)

- Solving body-input preconditions like `requires: amount = orders[order_id].total` —
  the positive transition for such ops will fail honestly (spec-vs-SUT divergence
  surfaces). Recognising relational preconditions on body inputs is its own concern.
- Multi-path or zero-path via op shapes — kept as a skip with a clearer reason. Multi-
  entity seed orchestration is a larger separate piece of work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coverage rules for transition tests handling body/query parameters alongside path parameters.

* **New Features**
  * Transition tests now support generating body/query parameters using strategy-based approaches alongside existing path parameter handling.

* **Tests**
  * Enhanced test validation to verify correct parameter generation and skip conditions for transition tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->