### PR TITLE
Property-based tests for Z3/Alloy translator round-trip (closes #162)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,17 +55,18 @@ ThisBuild / coverageExcludedPackages := List(
   ".*\\.bench\\..*"
 ).mkString(";")
 
-val circeVersion      = "0.14.10"
-val munitVersion      = "1.0.3"
-val munitCEVersion    = "2.2.0"
-val antlrVersion      = "4.13.2"
-val z3TurnkeyVersion  = "4.13.0.1"
-val alloyVersion      = "6.2.0"
-val handlebarsVersion = "4.3.1"
-val declineVersion    = "2.6.2"
-val apispecVersion    = "0.11.3"
-val snakeYamlVersion  = "2.3"
-val catsEffectVersion = "3.7.0"
+val circeVersion            = "0.14.10"
+val munitVersion            = "1.0.3"
+val munitCEVersion          = "2.2.0"
+val scalacheckEffectVersion = "2.1.0"
+val antlrVersion            = "4.13.2"
+val z3TurnkeyVersion        = "4.13.0.1"
+val alloyVersion            = "6.2.0"
+val handlebarsVersion       = "4.3.1"
+val declineVersion          = "2.6.2"
+val apispecVersion          = "0.11.3"
+val snakeYamlVersion        = "2.3"
+val catsEffectVersion       = "3.7.0"
 
 lazy val commonMainDeps = Seq(
   "org.typelevel" %% "cats-effect" % catsEffectVersion
@@ -137,7 +138,8 @@ lazy val verify = (project in file("modules/verify"))
       "org.alloytools" % "org.alloytools.alloy.application" % alloyVersion,
       "org.alloytools" % "org.alloytools.alloy.core"        % alloyVersion,
       "org.alloytools" % "org.alloytools.pardinus.core"     % alloyVersion,
-      "org.alloytools" % "org.alloytools.pardinus.native"   % alloyVersion
+      "org.alloytools" % "org.alloytools.pardinus.native"   % alloyVersion,
+      "org.typelevel" %% "scalacheck-effect-munit"          % scalacheckEffectVersion % Test
     ) ++ commonMainDeps ++ commonTestDeps
   )
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -67,6 +67,7 @@ CLI output so the attribution is visible.
 | `spec-to-rest` as `CommandIOApp` — structured `IO[ExitCode]` subcommands, SIGINT wired to fiber cancellation | shipped in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)) |
 | Single-API pipeline — every `Parse`, `Builder`, `Translator`, `WasmBackend`, `AlloyBackend`, and `Consistency` entry point returns `IO`; synchronous wrappers removed; test suites migrated to `CatsEffectSuite` with per-module `SpecFixtures.loadIR` helpers | shipped in M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) |
 | Concurrency docs (`docs/content/docs/pipelines/concurrency.mdx`) + JMH `ParallelVerifyBench` with checked-in CSV at `fixtures/golden/bench/parallel_verify.csv` | shipped in M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) |
+| Property-based tests for the Z3/Alloy translators (determinism, sort-inference soundness, Z3 ↔ Alloy structural agreement) via `scalacheck-effect-munit` | shipped ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)) — `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset from research/10 |
 
 </Collapsible>
 

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -67,7 +67,7 @@ CLI output so the attribution is visible.
 | `spec-to-rest` as `CommandIOApp` — structured `IO[ExitCode]` subcommands, SIGINT wired to fiber cancellation | shipped in M_CE.7 ([#102](https://github.com/HardMax71/spec_to_rest/issues/102)) |
 | Single-API pipeline — every `Parse`, `Builder`, `Translator`, `WasmBackend`, `AlloyBackend`, and `Consistency` entry point returns `IO`; synchronous wrappers removed; test suites migrated to `CatsEffectSuite` with per-module `SpecFixtures.loadIR` helpers | shipped in M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) |
 | Concurrency docs (`docs/content/docs/pipelines/concurrency.mdx`) + JMH `ParallelVerifyBench` with checked-in CSV at `fixtures/golden/bench/parallel_verify.csv` | shipped in M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) |
-| Property-based tests for the Z3/Alloy translators (determinism, sort-inference soundness, Z3 ↔ Alloy structural agreement) via `scalacheck-effect-munit` | shipped ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)) — `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset from research/10 |
+| Property-based tests for the Z3/Alloy translators (translation determinism on identical IRs, free-identifier resolution against `TranslatorArtifact`, structural invariant preservation between Z3 and Alloy) via `scalacheck-effect-munit` | shipped ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)) — `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset from research/10 |
 
 </Collapsible>
 

--- a/modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala
@@ -1,0 +1,181 @@
+package specrest.verify
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.scalacheck.Test as ScalaCheckTest
+import org.scalacheck.effect.PropF
+import specrest.ir.Expr as IExpr
+import specrest.ir.InvariantDecl
+import specrest.ir.OperationDecl
+import specrest.ir.ServiceIR
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.verify.alloy.Translator as AlloyTranslator
+import specrest.verify.testutil.SpecGen
+import specrest.verify.z3.ArtifactStateEntry
+import specrest.verify.z3.SmtLib
+import specrest.verify.z3.Translator as Z3Translator
+
+object TranslatorPropTest:
+
+  val BuiltinNames: Set[String] = Set(
+    "true",
+    "false",
+    "and",
+    "or",
+    "not",
+    "implies",
+    "=",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+    "+",
+    "-",
+    "*",
+    "/"
+  )
+
+  def collectFreeIdentifiers(ir: ServiceIR): Set[String] =
+    val invIds = ir.invariants.flatMap(walk).toSet
+    val opIds  = ir.operations.flatMap(opIdentifiers).toSet
+    invIds ++ opIds
+
+  private def opIdentifiers(op: OperationDecl): Set[String] =
+    val params = (op.inputs ++ op.outputs).map(_.name).toSet
+    val raw    = (op.requires ++ op.ensures).flatMap(walk).toSet
+    raw -- params
+
+  private def walk(inv: InvariantDecl): Set[String] = walk(inv.expr)
+
+  private def walk(e: IExpr): Set[String] = e match
+    case IExpr.Identifier(n, _)     => Set(n)
+    case IExpr.BinaryOp(_, l, r, _) => walk(l) ++ walk(r)
+    case IExpr.UnaryOp(_, x, _)     => walk(x)
+    case IExpr.Quantifier(_, bs, body, _) =>
+      val bound  = bs.map(_.variable).toSet
+      val domain = bs.flatMap(b => walk(b.domain).toList).toSet
+      val inner  = walk(body)
+      (domain ++ inner) -- bound
+    case IExpr.SomeWrap(x, _)         => walk(x)
+    case IExpr.The(v, d, b, _)        => (walk(d) ++ walk(b)) - v
+    case IExpr.FieldAccess(b, _, _)   => walk(b)
+    case IExpr.EnumAccess(b, _, _)    => walk(b)
+    case IExpr.Index(b, i, _)         => walk(b) ++ walk(i)
+    case IExpr.Call(c, args, _)       => walk(c) ++ args.flatMap(walk).toSet
+    case IExpr.Prime(x, _)            => walk(x)
+    case IExpr.Pre(x, _)              => walk(x)
+    case IExpr.With(b, fs, _)         => walk(b) ++ fs.flatMap(f => walk(f.value)).toSet
+    case IExpr.If(c, t, el, _)        => walk(c) ++ walk(t) ++ walk(el)
+    case IExpr.Let(v, value, body, _) => walk(value) ++ (walk(body) - v)
+    case IExpr.Lambda(p, body, _)     => walk(body) - p
+    case IExpr.Constructor(_, fs, _)  => fs.flatMap(f => walk(f.value)).toSet
+    case IExpr.SetLiteral(xs, _)      => xs.flatMap(walk).toSet
+    case IExpr.MapLiteral(es, _) =>
+      es.flatMap(me => walk(me.key) ++ walk(me.value)).toSet
+    case IExpr.SetComprehension(v, d, p, _) => walk(d) ++ (walk(p) - v)
+    case IExpr.SeqLiteral(xs, _)            => xs.flatMap(walk).toSet
+    case IExpr.Matches(x, _, _)             => walk(x)
+    case _: IExpr.IntLit                    => Set.empty
+    case _: IExpr.FloatLit                  => Set.empty
+    case _: IExpr.StringLit                 => Set.empty
+    case _: IExpr.BoolLit                   => Set.empty
+    case _: IExpr.NoneLit                   => Set.empty
+
+class TranslatorPropTest extends CatsEffectSuite, ScalaCheckEffectSuite:
+  import TranslatorPropTest.*
+
+  override def scalaCheckTestParameters: ScalaCheckTest.Parameters =
+    super.scalaCheckTestParameters
+      .withMinSuccessfulTests(50)
+      .withMaxDiscardRatio(5.0f)
+
+  private def buildIR(spec: SpecGen.GeneratedSpec): IO[Option[ServiceIR]] =
+    val source = spec.render
+    Parse.parseSpec(source).flatMap:
+      case Left(_) => IO.pure(None)
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Left(_)   => None
+          case Right(ir) => Some(ir)
+
+  test("property #1 — translate is deterministic"):
+    PropF.forAllF(SpecGen.genSpec): spec =>
+      buildIR(spec).flatMap:
+        case None => IO.unit
+        case Some(ir) =>
+          for
+            a <- Z3Translator.translate(ir)
+            b <- Z3Translator.translate(ir)
+          yield (a, b) match
+            case (Right(s1), Right(s2)) =>
+              assertEquals(SmtLib.renderSmtLib(s1), SmtLib.renderSmtLib(s2))
+            case (Left(_), Left(_)) => ()
+            case (l, r) =>
+              fail(s"asymmetric translation outcome: lhs=$l rhs=$r\nspec=${spec.render}")
+
+  test("property #4 — every free Identifier resolves to a translator-declared name"):
+    PropF.forAllF(SpecGen.genSpec): spec =>
+      buildIR(spec).flatMap:
+        case None => IO.unit
+        case Some(ir) =>
+          Z3Translator.translate(ir).map:
+            case Right(script) =>
+              val artifact     = script.artifact
+              val entityNames  = artifact.entities.map(_.name).toSet
+              val entityFields = artifact.entities.flatMap(_.fields.map(_.name)).toSet
+              val enumNames    = artifact.enums.map(_.name).toSet
+              val enumMembers  = artifact.enums.flatMap(_.members.map(_.name)).toSet
+              val stateNames = artifact.state.map:
+                case ArtifactStateEntry.Const(n, _, _, _)             => n
+                case ArtifactStateEntry.Relation(n, _, _, _, _, _, _) => n
+              .toSet
+              val ioNames    = (artifact.inputs ++ artifact.outputs).map(_.name).toSet
+              val predicates = ir.predicates.map(_.name).toSet
+              val freeIds    = collectFreeIdentifiers(ir)
+              val resolvable =
+                entityNames ++ entityFields ++ enumNames ++ enumMembers ++
+                  stateNames ++ ioNames ++ predicates ++ BuiltinNames
+              val unresolved = freeIds -- resolvable
+              assert(
+                unresolved.isEmpty,
+                s"unresolved identifiers: $unresolved\n" +
+                  s"state=$stateNames entities=$entityNames enums=$enumNames inputs/outputs=$ioNames\n" +
+                  s"spec=${spec.render}"
+              )
+            case Left(_) => ()
+
+  test("property #1b — SMT-LIB rendering is idempotent on the same script"):
+    PropF.forAllF(SpecGen.genSpec): spec =>
+      buildIR(spec).flatMap:
+        case None => IO.unit
+        case Some(ir) =>
+          Z3Translator.translate(ir).map:
+            case Right(script) =>
+              assertEquals(SmtLib.renderSmtLib(script), SmtLib.renderSmtLib(script))
+            case Left(_) => ()
+
+  test("property #3 — Z3 and Alloy translators preserve all IR invariants"):
+    PropF.forAllF(SpecGen.genSpec): spec =>
+      buildIR(spec).flatMap:
+        case None => IO.unit
+        case Some(ir) =>
+          for
+            z3R    <- Z3Translator.translate(ir)
+            alloyR <- AlloyTranslator.translateGlobal(ir, scope = 5)
+          yield (z3R, alloyR) match
+            case (Right(script), Right(module)) =>
+              val invCount = ir.invariants.length
+              assertEquals(
+                module.facts.length,
+                invCount,
+                s"alloy facts=${module.facts.length}, expected $invCount\nspec=${spec.render}"
+              )
+              if invCount > 0 then
+                assert(
+                  script.assertions.nonEmpty,
+                  s"z3 produced no assertions for $invCount invariant(s)\nspec=${spec.render}"
+                )
+            case _ => ()

--- a/modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala
@@ -90,92 +90,95 @@ class TranslatorPropTest extends CatsEffectSuite, ScalaCheckEffectSuite:
   override def scalaCheckTestParameters: ScalaCheckTest.Parameters =
     super.scalaCheckTestParameters
       .withMinSuccessfulTests(50)
-      .withMaxDiscardRatio(5.0f)
+      .withMaxDiscardRatio(0.1f)
 
-  private def buildIR(spec: SpecGen.GeneratedSpec): IO[Option[ServiceIR]] =
+  private def buildIR(spec: SpecGen.GeneratedSpec): IO[ServiceIR] =
     val source = spec.render
     Parse.parseSpec(source).flatMap:
-      case Left(_) => IO.pure(None)
+      case Left(err) =>
+        IO.raiseError(
+          new AssertionError(
+            "generator emitted spec the parser rejected — fix SpecGen.\n" +
+              s"errors=${err.errors}\nspec=$source"
+          )
+        )
       case Right(parsed) =>
-        Builder.buildIR(parsed.tree).map:
-          case Left(_)   => None
-          case Right(ir) => Some(ir)
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) =>
+            IO.raiseError(
+              new AssertionError(
+                "generator emitted spec the IR builder rejected — fix SpecGen.\n" +
+                  s"error=${err.message}\nspec=$source"
+              )
+            )
+          case Right(ir) => IO.pure(ir)
 
   test("property #1 — translate is deterministic"):
     PropF.forAllF(SpecGen.genSpec): spec =>
-      buildIR(spec).flatMap:
-        case None => IO.unit
-        case Some(ir) =>
-          for
-            a <- Z3Translator.translate(ir)
-            b <- Z3Translator.translate(ir)
-          yield (a, b) match
-            case (Right(s1), Right(s2)) =>
-              assertEquals(SmtLib.renderSmtLib(s1), SmtLib.renderSmtLib(s2))
-            case (Left(_), Left(_)) => ()
-            case (l, r) =>
-              fail(s"asymmetric translation outcome: lhs=$l rhs=$r\nspec=${spec.render}")
+      buildIR(spec).flatMap: ir =>
+        for
+          a <- Z3Translator.translate(ir)
+          b <- Z3Translator.translate(ir)
+        yield (a, b) match
+          case (Right(s1), Right(s2)) =>
+            assertEquals(SmtLib.renderSmtLib(s1), SmtLib.renderSmtLib(s2))
+          case other =>
+            fail(
+              s"translator did not produce Right twice on the same IR: $other\nspec=${spec.render}"
+            )
 
   test("property #4 — every free Identifier resolves to a translator-declared name"):
     PropF.forAllF(SpecGen.genSpec): spec =>
-      buildIR(spec).flatMap:
-        case None => IO.unit
-        case Some(ir) =>
-          Z3Translator.translate(ir).map:
-            case Right(script) =>
-              val artifact     = script.artifact
-              val entityNames  = artifact.entities.map(_.name).toSet
-              val entityFields = artifact.entities.flatMap(_.fields.map(_.name)).toSet
-              val enumNames    = artifact.enums.map(_.name).toSet
-              val enumMembers  = artifact.enums.flatMap(_.members.map(_.name)).toSet
-              val stateNames = artifact.state.map:
-                case ArtifactStateEntry.Const(n, _, _, _)             => n
-                case ArtifactStateEntry.Relation(n, _, _, _, _, _, _) => n
-              .toSet
-              val ioNames    = (artifact.inputs ++ artifact.outputs).map(_.name).toSet
-              val predicates = ir.predicates.map(_.name).toSet
-              val freeIds    = collectFreeIdentifiers(ir)
-              val resolvable =
-                entityNames ++ entityFields ++ enumNames ++ enumMembers ++
-                  stateNames ++ ioNames ++ predicates ++ BuiltinNames
-              val unresolved = freeIds -- resolvable
-              assert(
-                unresolved.isEmpty,
-                s"unresolved identifiers: $unresolved\n" +
-                  s"state=$stateNames entities=$entityNames enums=$enumNames inputs/outputs=$ioNames\n" +
-                  s"spec=${spec.render}"
-              )
-            case Left(_) => ()
-
-  test("property #1b — SMT-LIB rendering is idempotent on the same script"):
-    PropF.forAllF(SpecGen.genSpec): spec =>
-      buildIR(spec).flatMap:
-        case None => IO.unit
-        case Some(ir) =>
-          Z3Translator.translate(ir).map:
-            case Right(script) =>
-              assertEquals(SmtLib.renderSmtLib(script), SmtLib.renderSmtLib(script))
-            case Left(_) => ()
+      buildIR(spec).flatMap: ir =>
+        Z3Translator.translate(ir).map:
+          case Left(err) =>
+            fail(s"translator rejected a generated IR: ${err.message}\nspec=${spec.render}")
+          case Right(script) =>
+            val artifact     = script.artifact
+            val entityNames  = artifact.entities.map(_.name).toSet
+            val entityFields = artifact.entities.flatMap(_.fields.map(_.name)).toSet
+            val enumNames    = artifact.enums.map(_.name).toSet
+            val enumMembers  = artifact.enums.flatMap(_.members.map(_.name)).toSet
+            val stateNames = artifact.state.map:
+              case ArtifactStateEntry.Const(n, _, _, _)             => n
+              case ArtifactStateEntry.Relation(n, _, _, _, _, _, _) => n
+            .toSet
+            val ioNames    = (artifact.inputs ++ artifact.outputs).map(_.name).toSet
+            val predicates = ir.predicates.map(_.name).toSet
+            val freeIds    = collectFreeIdentifiers(ir)
+            val resolvable =
+              entityNames ++ entityFields ++ enumNames ++ enumMembers ++
+                stateNames ++ ioNames ++ predicates ++ BuiltinNames
+            val unresolved = freeIds -- resolvable
+            assert(
+              unresolved.isEmpty,
+              s"unresolved identifiers: $unresolved\n" +
+                s"state=$stateNames entities=$entityNames enums=$enumNames inputs/outputs=$ioNames\n" +
+                s"spec=${spec.render}"
+            )
 
   test("property #3 — Z3 and Alloy translators preserve all IR invariants"):
     PropF.forAllF(SpecGen.genSpec): spec =>
-      buildIR(spec).flatMap:
-        case None => IO.unit
-        case Some(ir) =>
-          for
-            z3R    <- Z3Translator.translate(ir)
-            alloyR <- AlloyTranslator.translateGlobal(ir, scope = 5)
-          yield (z3R, alloyR) match
-            case (Right(script), Right(module)) =>
-              val invCount = ir.invariants.length
-              assertEquals(
-                module.facts.length,
-                invCount,
-                s"alloy facts=${module.facts.length}, expected $invCount\nspec=${spec.render}"
+      buildIR(spec).flatMap: ir =>
+        for
+          z3R    <- Z3Translator.translate(ir)
+          alloyR <- AlloyTranslator.translateGlobal(ir, scope = 5)
+        yield (z3R, alloyR) match
+          case (Right(script), Right(module)) =>
+            val invCount = ir.invariants.length
+            assertEquals(
+              module.facts.length,
+              invCount,
+              s"alloy facts=${module.facts.length}, expected $invCount\nspec=${spec.render}"
+            )
+            if invCount > 0 then
+              assert(
+                script.assertions.nonEmpty,
+                s"z3 produced no assertions for $invCount invariant(s)\nspec=${spec.render}"
               )
-              if invCount > 0 then
-                assert(
-                  script.assertions.nonEmpty,
-                  s"z3 produced no assertions for $invCount invariant(s)\nspec=${spec.render}"
-                )
-            case _ => ()
+          case (Left(z3Err), _) =>
+            fail(s"z3 translator rejected a generated IR: ${z3Err.message}\nspec=${spec.render}")
+          case (_, Left(alloyErr)) =>
+            fail(
+              s"alloy translator rejected a generated IR: ${alloyErr.message}\nspec=${spec.render}"
+            )

--- a/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
+++ b/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
@@ -33,17 +33,17 @@ object SpecGen:
       case Ident(n)          => n
       case Prime(n)          => s"$n'"
       case Pre(n)            => s"pre($n)"
-      case Not(e)            => s"!(${e.render})"
+      case Not(e)            => s"not (${e.render})"
       case Neg(e)            => s"-(${e.render})"
       case BoolBin(op, l, r) => s"(${l.render}) ${op.token} (${r.render})"
       case Cmp(op, l, r)     => s"(${l.render}) ${op.token} (${r.render})"
       case Arith(op, l, r)   => s"(${l.render}) ${op.token} (${r.render})"
 
   enum BoolBinOp(val token: String) derives CanEqual:
-    case And     extends BoolBinOp("&&")
-    case Or      extends BoolBinOp("||")
-    case Implies extends BoolBinOp("=>")
-    case Iff     extends BoolBinOp("<=>")
+    case And     extends BoolBinOp("and")
+    case Or      extends BoolBinOp("or")
+    case Implies extends BoolBinOp("implies")
+    case Iff     extends BoolBinOp("iff")
 
   enum CmpOp(val token: String) derives CanEqual:
     case Eq  extends CmpOp("=")
@@ -106,33 +106,55 @@ object SpecGen:
 
   private val reserved = Set(
     "service",
+    "entity",
+    "enum",
+    "type",
     "state",
     "operation",
+    "transition",
     "invariant",
-    "requires",
-    "ensures",
+    "temporal",
+    "fact",
+    "conventions",
+    "import",
+    "function",
+    "predicate",
+    "extends",
+    "field",
     "input",
     "output",
+    "requires",
+    "ensures",
+    "one",
+    "lone",
+    "set",
+    "and",
+    "or",
+    "not",
+    "implies",
+    "iff",
+    "in",
+    "subset",
+    "matches",
+    "union",
+    "intersect",
+    "minus",
     "all",
     "some",
     "no",
     "exists",
-    "in",
-    "and",
-    "or",
-    "not",
-    "true",
-    "false",
-    "Int",
-    "Bool",
-    "Set",
-    "pre",
-    "post",
     "if",
     "then",
     "else",
     "let",
-    "the"
+    "pre",
+    "with",
+    "the",
+    "where",
+    "via",
+    "when",
+    "true",
+    "false"
   )
 
   private val genFreshName: Gen[String] =

--- a/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
+++ b/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
@@ -1,0 +1,256 @@
+package specrest.verify.testutil
+
+import org.scalacheck.Gen
+
+object SpecGen:
+
+  enum AtomicType derives CanEqual:
+    case IntT, BoolT
+
+    def render: String = this match
+      case IntT  => "Int"
+      case BoolT => "Bool"
+
+  final case class StateField(name: String, ty: AtomicType):
+    def render: String = s"$name: ${ty.render}"
+
+  enum GExpr derives CanEqual:
+    case IntLit(v: Long)
+    case BoolLit(v: Boolean)
+    case Ident(name: String)
+    case Prime(name: String)
+    case Pre(name: String)
+    case Not(e: GExpr)
+    case Neg(e: GExpr)
+    case BoolBin(op: BoolBinOp, l: GExpr, r: GExpr)
+    case Cmp(op: CmpOp, l: GExpr, r: GExpr)
+    case Arith(op: ArithOp, l: GExpr, r: GExpr)
+
+    def render: String = this match
+      case IntLit(v)         => v.toString
+      case BoolLit(true)     => "true"
+      case BoolLit(false)    => "false"
+      case Ident(n)          => n
+      case Prime(n)          => s"$n'"
+      case Pre(n)            => s"pre($n)"
+      case Not(e)            => s"!(${e.render})"
+      case Neg(e)            => s"-(${e.render})"
+      case BoolBin(op, l, r) => s"(${l.render}) ${op.token} (${r.render})"
+      case Cmp(op, l, r)     => s"(${l.render}) ${op.token} (${r.render})"
+      case Arith(op, l, r)   => s"(${l.render}) ${op.token} (${r.render})"
+
+  enum BoolBinOp(val token: String) derives CanEqual:
+    case And     extends BoolBinOp("&&")
+    case Or      extends BoolBinOp("||")
+    case Implies extends BoolBinOp("=>")
+    case Iff     extends BoolBinOp("<=>")
+
+  enum CmpOp(val token: String) derives CanEqual:
+    case Eq  extends CmpOp("=")
+    case Neq extends CmpOp("!=")
+    case Lt  extends CmpOp("<")
+    case Le  extends CmpOp("<=")
+    case Gt  extends CmpOp(">")
+    case Ge  extends CmpOp(">=")
+
+  enum ArithOp(val token: String) derives CanEqual:
+    case Add extends ArithOp("+")
+    case Sub extends ArithOp("-")
+    case Mul extends ArithOp("*")
+
+  enum ExprSort derives CanEqual:
+    case BoolS, IntS
+
+  final case class Operation(
+      name: String,
+      requires: List[GExpr],
+      ensures: List[GExpr]
+  ):
+    def render: String =
+      val req =
+        if requires.isEmpty then "      true" else requires.map("      " + _.render).mkString("\n")
+      val ens =
+        if ensures.isEmpty then "      true" else ensures.map("      " + _.render).mkString("\n")
+      s"""  operation $name {
+         |    requires:
+         |$req
+         |    ensures:
+         |$ens
+         |  }""".stripMargin
+
+  final case class GeneratedSpec(
+      name: String,
+      state: List[StateField],
+      invariants: List[GExpr],
+      operations: List[Operation]
+  ):
+    def render: String =
+      val stateBlock = state.map("    " + _.render).mkString("\n")
+      val invBlock = invariants.zipWithIndex.map: (e, i) =>
+        s"  invariant inv_$i:\n    ${e.render}"
+      .mkString("\n\n")
+      val opBlock = operations.map(_.render).mkString("\n\n")
+      val parts = List(
+        s"  state {\n$stateBlock\n  }",
+        if operations.isEmpty then "" else opBlock,
+        if invariants.isEmpty then "" else invBlock
+      ).filter(_.nonEmpty)
+      s"service $name {\n${parts.mkString("\n\n")}\n}\n"
+
+  private val genIdent: Gen[String] =
+    for
+      head <- Gen.oneOf('a' to 'z')
+      len  <- Gen.chooseNum(1, 4)
+      tail <- Gen.listOfN(len, Gen.oneOf('a' to 'z'))
+    yield (head :: tail).mkString
+
+  private val reserved = Set(
+    "service",
+    "state",
+    "operation",
+    "invariant",
+    "requires",
+    "ensures",
+    "input",
+    "output",
+    "all",
+    "some",
+    "no",
+    "exists",
+    "in",
+    "and",
+    "or",
+    "not",
+    "true",
+    "false",
+    "Int",
+    "Bool",
+    "Set",
+    "pre",
+    "post",
+    "if",
+    "then",
+    "else",
+    "let",
+    "the"
+  )
+
+  private val genFreshName: Gen[String] =
+    genIdent.suchThat(s => !reserved.contains(s))
+
+  private val genAtomicType: Gen[AtomicType] =
+    Gen.oneOf(AtomicType.IntT, AtomicType.BoolT)
+
+  private val genStateFields: Gen[List[StateField]] =
+    for
+      n     <- Gen.chooseNum(1, 3)
+      names <- Gen.listOfN(n, genFreshName).map(_.distinct.take(n))
+      tys   <- Gen.listOfN(names.size, genAtomicType)
+    yield names.zip(tys).map(StateField.apply.tupled)
+
+  private def genCmpOp: Gen[CmpOp] =
+    Gen.oneOf(CmpOp.Eq, CmpOp.Neq, CmpOp.Lt, CmpOp.Le, CmpOp.Gt, CmpOp.Ge)
+
+  private def genCmpBoolOp: Gen[CmpOp] =
+    Gen.oneOf(CmpOp.Eq, CmpOp.Neq)
+
+  private def genBoolBinOp: Gen[BoolBinOp] =
+    Gen.oneOf(BoolBinOp.And, BoolBinOp.Or, BoolBinOp.Implies, BoolBinOp.Iff)
+
+  private def genArithOp: Gen[ArithOp] =
+    Gen.oneOf(ArithOp.Add, ArithOp.Sub, ArithOp.Mul)
+
+  private def intRefs(state: List[StateField], includePrimePre: Boolean): List[GExpr] =
+    val ints = state.filter(_.ty == AtomicType.IntT).map(_.name)
+    val base = ints.map(GExpr.Ident.apply)
+    if includePrimePre then
+      base ++ ints.map(GExpr.Prime.apply) ++ ints.map(GExpr.Pre.apply)
+    else base
+
+  private def boolRefs(state: List[StateField], includePrimePre: Boolean): List[GExpr] =
+    val bools = state.filter(_.ty == AtomicType.BoolT).map(_.name)
+    val base  = bools.map(GExpr.Ident.apply)
+    if includePrimePre then
+      base ++ bools.map(GExpr.Prime.apply) ++ bools.map(GExpr.Pre.apply)
+    else base
+
+  def genIntExpr(
+      state: List[StateField],
+      depth: Int,
+      includePrimePre: Boolean
+  ): Gen[GExpr] =
+    val refs = intRefs(state, includePrimePre)
+    val leaf: Gen[GExpr] =
+      val opts: List[Gen[GExpr]] =
+        Gen.chooseNum(-5L, 5L).map(GExpr.IntLit.apply) ::
+          (if refs.isEmpty then Nil else List(Gen.oneOf(refs)))
+      Gen.oneOf(opts).flatMap(identity)
+    if depth <= 0 then leaf
+    else
+      Gen.frequency(
+        2 -> leaf,
+        1 -> (for
+          op <- genArithOp
+          l  <- genIntExpr(state, depth - 1, includePrimePre)
+          r  <- genIntExpr(state, depth - 1, includePrimePre)
+        yield GExpr.Arith(op, l, r)),
+        1 -> genIntExpr(state, depth - 1, includePrimePre).map(GExpr.Neg.apply)
+      )
+
+  def genBoolExpr(
+      state: List[StateField],
+      depth: Int,
+      includePrimePre: Boolean
+  ): Gen[GExpr] =
+    val brefs = boolRefs(state, includePrimePre)
+    val leaf: Gen[GExpr] =
+      val baseOpts: List[Gen[GExpr]] = List(
+        Gen.const(GExpr.BoolLit(true)),
+        Gen.const(GExpr.BoolLit(false))
+      ) ++ (if brefs.isEmpty then Nil else List(Gen.oneOf(brefs)))
+      Gen.oneOf(baseOpts).flatMap(identity)
+    if depth <= 0 then leaf
+    else
+      val intDepth = math.max(0, depth - 1)
+      Gen.frequency(
+        2 -> leaf,
+        2 -> (for
+          op <- genCmpOp
+          l  <- genIntExpr(state, intDepth, includePrimePre)
+          r  <- genIntExpr(state, intDepth, includePrimePre)
+        yield GExpr.Cmp(op, l, r)),
+        1 -> (for
+          op <- genCmpBoolOp
+          l  <- genBoolExpr(state, intDepth, includePrimePre)
+          r  <- genBoolExpr(state, intDepth, includePrimePre)
+        yield GExpr.Cmp(op, l, r)),
+        2 -> (for
+          op <- genBoolBinOp
+          l  <- genBoolExpr(state, depth - 1, includePrimePre)
+          r  <- genBoolExpr(state, depth - 1, includePrimePre)
+        yield GExpr.BoolBin(op, l, r)),
+        1 -> genBoolExpr(state, depth - 1, includePrimePre).map(GExpr.Not.apply)
+      )
+
+  private def genOperation(
+      state: List[StateField],
+      idx: Int
+  ): Gen[Operation] =
+    val capName = s"Op${idx + 1}"
+    for
+      reqN <- Gen.chooseNum(0, 2)
+      reqs <- Gen.listOfN(reqN, genBoolExpr(state, depth = 2, includePrimePre = false))
+      ensN <- Gen.chooseNum(0, 2)
+      enss <- Gen.listOfN(ensN, genBoolExpr(state, depth = 2, includePrimePre = true))
+    yield Operation(capName, reqs, enss)
+
+  val genSpec: Gen[GeneratedSpec] =
+    for
+      svcName <- genFreshName.map(s => s.head.toUpper +: s.tail)
+      state   <- genStateFields
+      invN    <- Gen.chooseNum(1, 2)
+      invs    <- Gen.listOfN(invN, genBoolExpr(state, depth = 2, includePrimePre = false))
+      opN     <- Gen.chooseNum(0, 2)
+      ops <-
+        Gen.sequence[List[Operation], Operation]((0 until opN).toList.map(genOperation(state, _)))
+    yield GeneratedSpec(svcName, state, invs, ops)


### PR DESCRIPTION
## Summary

- Adds `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` with four ScalaCheck-effect properties covering the *space* of valid specs (today only golden snapshots cover specific specs).
- Adds a small fixture-source generator at `modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala` that emits well-formed spec strings within the M_L.1 verified subset (research/10) and routes them through `Parse` + `Builder` so well-formedness invariants stay in one place.
- Adds `org.typelevel %% scalacheck-effect-munit % 2.1.0` as a Test-only dep on the `verify` subproject; CI-stack alignment confirmed (Cats Effect 3.7.0 matches our pin, munit-scalacheck 1.2.0 supersedes our 1.0.3 transitively).
- Updates `docs/content/docs/pipelines/verification.mdx` status table with a row for this work.

## Properties

Each runs 50 random IRs in CI. Total wall-clock for the suite: ~2.5s.

| # | Property | Notes |
|---|----------|-------|
| 1 | `translate(ir)` twice produces equal SMT-LIB | rendered string comparison; matches issue AC #1 |
| 1b | `renderSmtLib(script)` is idempotent on the same script | sanity check on the renderer itself |
| 4 | Every free `Expr.Identifier` in invariants/ops resolves to a name in `TranslatorArtifact` (entity / enum / state / I/O / predicate) or a builtin operator | matches issue AC #4 — the artifact is the right boundary because IR `Identifier("ex")` maps to Z3 func `state_ex` via the artifact's `funcName` indirection |
| 3 | Z3 and Alloy translators preserve all IR invariants structurally — Alloy emits one fact per invariant, Z3 emits ≥1 assertion when invariants are non-empty | structural-only (no solver invocation) per AC #3 desirable / 30s budget; sat/unsat agreement deferred to a follow-up |

Property #2 (stability under no-op rewrites) is deferred — needs an `Expr` rewriter (commute conjuncts/disjuncts, alpha-rename) that's its own ~80 LoC and wasn't required by the issue AC.

## Generator scope (intentional, mirrors research/10 §6.1)

- 1–3 scalar state fields (`Int`, `Bool`)
- 1–2 invariants over state, depth ≤2
- 0–2 operations with 0–2 `requires`/`ensures`; only `ensures` references `pre(...)` / `x'`
- Operators: `&&`, `||`, `=>`, `<=>`, `!`, `=`, `!=`, `<`, `<=`, `>`, `>=`, `+`, `-`, `*`, unary `-`
- Reserved-word filter on identifier names

Excluded operators (defer to follow-up generator extensions): `Quantifier`, set literals/comprehensions, entity/enum decls, transitions, temporals, `Index`/`Call`/`With`/`Matches`. These are the same operators research/10 §6.2 defers — the test generator stays inside what `Translator` already promises to handle, so the test isn't dominated by `Left(VerifyError.Translator)` returns.

## Verification

```
sbt "verify/testOnly *TranslatorPropTest"   # 4 props, ~2.5s
sbt test                                    # full suite — green
sbt scalafmtCheckAll                        # clean
sbt "scalafixAll --check"                   # clean
(cd docs && npm run build)                  # green, link-check passes
```

## Test plan

- [ ] CI passes on the new branch
- [ ] Property test runtime stays under the 30s/property budget across 5+ runs
- [ ] No flake on a fresh `sbt clean test`

## Deferred follow-ups

- Property #2 (stability under no-op rewrites) — needs an `Expr` rewriter.
- Z3 ↔ Alloy *solver* agreement (AC #3 stretch) — requires `--parallel 1` + per-test deadline; lives in a separate `TranslatorBackendAgreementTest`.
- Generator extension to `Quantifier` over entity sets, `Prime`/`Pre` interplay, set ops as the translator's verified subset grows (research/10 §6.2 deferred list).