### PR TITLE
[codex] Define M_G.2 proof-safe profile

### DIFF
--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -8,7 +8,9 @@ description: "Scoping and milestone plan for proving the IR → Z3 verification 
 > assistant, defines the verified subset, and decomposes the work into shippable
 > milestones (M_L.0 → M_L.4). Global-proof activation and churn control now live in
 > [`11_global_proof_governance`](/research/11_global_proof_governance) and
-> [`12_global_proof_status`](/research/12_global_proof_status). Does **not** ship code —
+> [`12_global_proof_status`](/research/12_global_proof_status); the committed first
+> scope and backend contract now live in
+> [`13_global_proof_profile`](/research/13_global_proof_profile). Does **not** ship code —
 > that lands per milestone.
 
 ---

--- a/docs/content/docs/research/11_global_proof_governance.md
+++ b/docs/content/docs/research/11_global_proof_governance.md
@@ -41,6 +41,7 @@ The surfaces below are governed now. They are split by why they matter.
 | Proof-owned core | `modules/ir/src/main/scala/specrest/ir/Types.scala` | Defines `Expr`, `TypeExpr`, `ServiceIR`, and the AST shape the proof will mirror. |
 | Proof-owned core | `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` | Main translation function the prover-side mirror will track case-for-case. |
 | Proof-owned core | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Defines `Z3Script`, `Z3Expr`, and artifact structures in the first theorem target. |
+| Proof-scope artifact | `docs/content/docs/research/13_global_proof_profile.md` | Declares which fragment and backend contract the first ship claim actually covers. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Decides which checks are even in the Z3 proof scope versus routed to Alloy. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Defines the operational meaning of `global`, `requires`, `enabled`, and `preservation` checks. |
 | TCB-sensitive | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | Remains trusted in the first ship claim; parser changes can narrow or widen what that claim honestly covers. |
@@ -57,8 +58,7 @@ Two important non-members:
 Reserved future surfaces:
 
 - `proofs/lean/**` becomes proof-owned the moment `M_G.4` opens the workspace.
-- The proof-safe profile table and the Scala↔prover mirror table become proof-owned as soon as
-  they exist.
+- The Scala↔prover mirror table becomes proof-owned as soon as it exists.
 
 ## 4. Required Change Process
 
@@ -70,7 +70,9 @@ If a PR touches any proof-governed surface listed above, it must do all of the f
    - obligation/routing change,
    - or TCB-only change.
 3. State whether the current `M_G.0` theorem statement or TCB summary changed.
-4. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
+4. If the proof-safe profile membership changed, update
+   [`13_global_proof_profile`](/research/13_global_proof_profile) before merge.
+5. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
    governing issue before merge.
 
 This stays as a documented working rule, not a repo-level automation gate.
@@ -110,6 +112,7 @@ the written record brings them back into view.
 
 - Translator soundness scoping: [`10_translator_soundness`](/research/10_translator_soundness)
 - Live ledger: [`12_global_proof_status`](/research/12_global_proof_status)
+- Proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
 - Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
 - Theorem statement / TCB: [#171](https://github.com/HardMax71/spec_to_rest/issues/171)
 - This governance milestone: [#172](https://github.com/HardMax71/spec_to_rest/issues/172)

--- a/docs/content/docs/research/12_global_proof_status.md
+++ b/docs/content/docs/research/12_global_proof_status.md
@@ -12,6 +12,7 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 - Initialized against `origin/main` commit `3aa6938` on `2026-05-01`
 - First theorem target: in-memory `ServiceIR → Z3Script` path used by
   `Consistency.runConsistencyChecks`
+- Active proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
 - Still outside the first ship claim: `SmtLib.scala`, dump/export paths, Alloy-routed checks,
   proof replay, and full-source semantics refinement
 
@@ -32,13 +33,13 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 | `modules/ir/src/main/scala/specrest/ir/Types.scala` | Proof-owned core | `tracked` | Any AST change can invalidate semantics, mirror coverage, or the proof-safe profile. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` | Proof-owned core | `tracked` | Main proof target. New cases or changed encodings must be logged even before prover work starts. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Proof-owned core | `tracked` | `Z3Expr` / `Z3Script` shape is part of the first theorem target. |
+| `docs/content/docs/research/13_global_proof_profile.md` | Proof-scope artifact | `tracked` | This is the committed first-scope boundary for `M_G.2`; scope drift must be explicit. |
 | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Obligation contract | `tracked` | Routing changes can move checks in or out of the Z3 proof scope. |
 | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Obligation contract | `tracked` | Changes here can redefine the meaning of global, requires, enabled, or preservation checks. |
 | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | TCB-sensitive | `tracked` | Parser remains trusted for first ship; changes alter the honest source-to-IR trust story. |
 | `modules/parser/src/main/scala/specrest/parser/Builder.scala` | TCB-sensitive | `tracked` | IR builder remains trusted for first ship; changes can move the boundary under the theorem. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Backend.scala` | TCB-sensitive | `tracked` | Runtime Z3 AST rendering is in the first-ship TCB. |
 | `proofs/lean/**` | Future proof workspace | `reserved` | Becomes active only when `M_G.4` opens the execution track. |
-| Proof-safe profile table | Future proof artifact | `reserved` | Created by `M_G.2` or the first `M_L.1` implementation slice. |
 | Scala↔prover mirror coverage table | Future proof artifact | `reserved` | Created with the first prover-side mirror. |
 
 ## 4. Update Rules
@@ -51,3 +52,6 @@ When this file changes, the entry should say at least:
 
 If the answer to `3` is "no", the matching PR must also update
 [`11_global_proof_governance`](/research/11_global_proof_governance) or the governing issue.
+
+If the change moves a feature between `bootstrap`, `first ship`, `defer`, or `exclude`, it must
+also update [`13_global_proof_profile`](/research/13_global_proof_profile).

--- a/docs/content/docs/research/13_global_proof_profile.md
+++ b/docs/content/docs/research/13_global_proof_profile.md
@@ -1,0 +1,174 @@
+---
+title: "Global Proof Profile and Backend Contract"
+description: "Committed first-scope fragment and backend assumptions for the global translator-soundness program"
+---
+
+> Profile doc for issue [#173](https://github.com/HardMax71/spec_to_rest/issues/173).
+> Follows [`11_global_proof_governance`](/research/11_global_proof_governance) and
+> operationalizes the first stable scope that `M_L.1` and `M_L.2` should implement against.
+
+## 1. Decision Summary
+
+The global-proof program does **not** start from "all current language features."
+
+The committed first profile is a Z3-only fragment named **`Z3-Core`**:
+
+- the theorem target is the in-memory `ServiceIR → Z3Script` path described in
+  [`M_G.0`](https://github.com/HardMax71/spec_to_rest/issues/171),
+- Alloy-routed checks are outside the theorem boundary,
+- proof export / proof replay is outside the first ship,
+- and the profile is intentionally smaller than the full 25-case `Expr` ADT.
+
+Within `Z3-Core`, the first implementation slice is **`Z3-Core-1S`**:
+
+- one-state only,
+- `global` and `requires` checks only,
+- no `Prime`, `Pre`, frame synthesis, or post-state cardinality reasoning.
+
+`Z3-Core-1S` is where `M_L.1` should start. `Z3-Core` is the first honest ship claim for the
+global-proof program.
+
+## 2. Named Scope Stages
+
+| Stage | Meaning |
+| --- | --- |
+| `bootstrap` | In scope for `Z3-Core-1S`, the first end-to-end implementation slice. |
+| `first ship` | Not needed on day one, but required before the first public global-proof claim is honest. |
+| `defer` | Explicitly out of the first ship; can only enter later by profile expansion. |
+| `exclude` | Outside the Z3 global-theorem track entirely; would require a separate solver or semantics story. |
+
+## 3. Declaration-Level Profile
+
+| Construct | Stage | Rule |
+| --- | --- | --- |
+| `EnumDecl` | `bootstrap` | Finite domains are cheap to formalize and support the first bounded quantifier story. |
+| `EntityDecl` | `bootstrap` | Flat entities only: no inheritance, no per-field constraints, no constructor semantics. |
+| `StateDecl` | `bootstrap` | Scalar fields and simple relation/map fields over profile-safe types only. |
+| `InvariantDecl` | `bootstrap` | Must be expressible using only in-profile `Expr` cases. |
+| `OperationDecl` | `bootstrap` | Inputs and `requires` are in scope immediately. `ensures`, outputs, and post-state reasoning become `first ship` when they use only in-profile two-state forms. |
+| `TypeAliasDecl` | `defer` | Transparent aliases are cheap, but constrained aliases add a second semantic layer that is not needed for the first proof. |
+| `FactDecl` | `defer` | Not needed for the first Z3 theorem boundary; can be revisited later as additional assumptions. |
+| `FunctionDecl` | `defer` | User-defined function semantics would expand the proof target too early. |
+| `PredicateDecl` | `defer` | Same reason as functions; keep the first theorem on direct IR formulas. |
+| `TransitionDecl` | `defer` | Separate state-machine proof problem; not part of the current verification path theorem. |
+| `ConventionsDecl` | `defer` | Compiler-convention logic is not part of the verification obligation theorem. |
+| `TemporalDecl` | `exclude` | Always Alloy-routed and bounded today; incompatible with the first Z3 theorem. |
+
+## 4. Expression-Level Profile
+
+| `Expr` case | Stage | Rule / reason |
+| --- | --- | --- |
+| `BinaryOp(And \| Or \| Implies \| Iff)` | `bootstrap` | Core propositional layer. |
+| `BinaryOp(Eq \| Neq \| Lt \| Gt \| Le \| Ge)` | `bootstrap` | Core comparison layer over proof-safe scalar/entity values. |
+| `BinaryOp(In \| NotIn)` | `bootstrap` | Only for membership in state-relation domains or other profile-safe finite memberships; no powerset reasoning. |
+| `BinaryOp(Subset \| Union \| Intersect \| Diff)` | `defer` | Set algebra is supported in Scala but materially expands the semantic and lemma burden. |
+| `BinaryOp(Add \| Sub \| Mul \| Div)` | `defer` | Useful, but not required for the first proof slice; admit later as the first arithmetic expansion. |
+| `UnaryOp(Not \| Negate)` | `bootstrap` | Small, direct semantic cases. |
+| `UnaryOp(Cardinality)` | `first ship` | Restricted to state-relation identifiers and their `Prime`/`Pre` forms. Needed for realistic preservation proofs, not for the bootstrap slice. |
+| `UnaryOp(Power)` | `exclude` | Routed to Alloy / second-order style reasoning; not part of the Z3 theorem track. |
+| `Quantifier` | `bootstrap` | Only over finite enum domains in the first slice. Quantification over entity/state collections is deferred. |
+| `SomeWrap` | `defer` | Option semantics not needed in the first theorem. |
+| `The` | `defer` | Choice/operator semantics add proof complexity with little early payoff. |
+| `FieldAccess` | `bootstrap` | Needed for realistic entity-valued invariants and preconditions. |
+| `EnumAccess` | `bootstrap` | Cheap finite-constant semantics. |
+| `Index` | `bootstrap` | Restricted to state-relation references; no general map/sequence indexing in the first theorem. |
+| `Call` | `defer` | Builtins such as `len`, `isValidURI`, and `dom` need per-builtin semantics; higher-order calls are already unsupported. |
+| `Prime` | `first ship` | Two-state coupling is required for enabledness/preservation but not for the bootstrap slice. |
+| `Pre` | `first ship` | Same reason as `Prime`. |
+| `With` | `first ship` | Record-update semantics and frame interaction belong in the first full preservation claim, not the bootstrap slice. |
+| `If` | `defer` | Currently unsupported; can only enter after product and solver semantics exist. |
+| `Let` | `bootstrap` | Small environment-extension case; useful enough to keep. |
+| `Lambda` | `defer` | Outside first-order target shape and unsupported today. |
+| `Constructor` | `defer` | Requires explicit constructor semantics; not needed for the first claim. |
+| `SetLiteral` | `defer` | Current translator only partially supports it; keep the first theorem off collection literals. |
+| `MapLiteral` | `defer` | Unsupported today. |
+| `SetComprehension` | `defer` | Partially supported in narrow forms only; too brittle for the committed first profile. |
+| `SeqLiteral` | `defer` | Unsupported today. |
+| `Matches` | `defer` | Regex/string semantics are intentionally postponed. |
+| `IntLit` | `bootstrap` | Core scalar atom. |
+| `FloatLit` | `defer` | No committed solver semantics in the first proof profile. |
+| `StringLit` | `defer` | String literals are translated today, but the first theorem avoids uninterpreted-string and regex semantics. |
+| `BoolLit` | `bootstrap` | Core atom. |
+| `NoneLit` | `defer` | Option semantics deferred with `SomeWrap`. |
+| `Identifier` | `bootstrap` | Core atom. |
+
+## 5. Backend Contract
+
+| Question | Decision | Consequence |
+| --- | --- | --- |
+| Which solver remains trusted in the first ship? | **Z3** | The first theorem is Z3-trusting. It does not attempt solver-proof replay. |
+| Is the first theorem backend-agnostic? | **No** | The target is the current Z3 path, not a generic SMT theorem over all backends. |
+| Is Alloy in scope for the first ship? | **No** | Anything routed to Alloy is outside `Z3-Core` and outside the first global-proof claim. |
+| Is `SmtLib.scala` inside the first theorem? | **No** | The runtime path uses `Z3Script` plus `WasmBackend`; textual SMT export stays outside the first claim. |
+| Is proof export / replay in scope for the first ship? | **No** | That is a separate translation-validation / certificate track, not the initial global theorem. |
+| Is cvc5 cross-checking part of the proof claim? | **No** | Native cvc5 agreement in CI is defense in depth only. |
+
+The concrete runtime path covered by the program is:
+
+```mermaid
+flowchart LR
+  Parse["Parse.parseSpec"]
+  Build["Builder.buildIR"]
+  Checks["Consistency.runConsistencyChecks"]
+  Route["Classifier"]
+  ZTrans["z3.Translator"]
+  Backend["WasmBackend.check"]
+  Solver["Z3"]
+
+  Parse --> Build --> Checks --> Route --> ZTrans --> Backend --> Solver
+```
+
+The first theorem proves the prover-side mirror of the `z3.Translator` obligations for
+`Z3-Core`. The parser, builder, routing/orchestration code, backend renderer, and the Z3 API and
+solver remain in the trusted boundary defined by `M_G.0`.
+
+## 6. First End-to-End Slice
+
+The first slice the proof program should actually implement is:
+
+- `Z3-Core-1S`
+- `global` and `requires` checks only
+- no `Prime`, `Pre`, `With`, or `UnaryOp(Cardinality)`
+- no collection algebra, no strings, no regex/match builtins
+- quantifiers, if present, range only over enums
+
+This slice is deliberately small, but it is not fake work:
+
+- it still forces a real `Expr` semantics,
+- it still forces a real `ServiceIR → Z3Script` mirror,
+- and it avoids spending the first months on post-state/frame machinery.
+
+Only after `Z3-Core-1S` is stable should the program widen to the `first ship` cases needed for
+enabledness and preservation.
+
+## 7. Expansion Rule
+
+A feature may move from `defer` into `first ship` or a later profile only if all of the following
+are true:
+
+1. The source-level semantics are explicit enough to state the theorem honestly.
+2. The current Scala translator support is either full, or the restriction is narrow enough to
+   state precisely in this doc.
+3. The feature stays on the Z3 path; otherwise it starts a separate theorem track instead of
+   silently widening `Z3-Core`.
+4. The prover-side semantics and the Scala mirror both have at least one concrete fixture or
+   audit target.
+5. [`12_global_proof_status`](/research/12_global_proof_status) and this doc are updated in the
+   same change.
+
+Recommended expansion order after the bootstrap slice:
+
+1. `Prime` / `Pre` / `With` / restricted `Cardinality`
+2. integer arithmetic (`Add`, `Sub`, `Mul`, `Div`)
+3. restricted collection literals and set algebra
+4. string literals plus selected builtins
+5. user-defined functions / predicates, if they are still worth the proof cost
+
+## 8. References
+
+- Scoping and milestone plan: [`10_translator_soundness`](/research/10_translator_soundness)
+- Governance: [`11_global_proof_governance`](/research/11_global_proof_governance)
+- Status ledger: [`12_global_proof_status`](/research/12_global_proof_status)
+- Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
+- Theorem statement / TCB: [#171](https://github.com/HardMax71/spec_to_rest/issues/171)
+- This profile issue: [#173](https://github.com/HardMax71/spec_to_rest/issues/173)

--- a/docs/content/docs/research/13_global_proof_profile.md
+++ b/docs/content/docs/research/13_global_proof_profile.md
@@ -17,7 +17,7 @@ The committed first profile is a Z3-only fragment named **`Z3-Core`**:
   [`M_G.0`](https://github.com/HardMax71/spec_to_rest/issues/171),
 - Alloy-routed checks are outside the theorem boundary,
 - proof export / proof replay is outside the first ship,
-- and the profile is intentionally smaller than the full 25-case `Expr` ADT.
+- and the profile is intentionally smaller than the full `Expr` ADT.
 
 Within `Z3-Core`, the first implementation slice is **`Z3-Core-1S`**:
 

--- a/docs/content/docs/research/meta.json
+++ b/docs/content/docs/research/meta.json
@@ -15,6 +15,7 @@
     "10_translator_soundness",
     "11_global_proof_governance",
     "12_global_proof_status",
+    "13_global_proof_profile",
     "spec_to_test_tools_research"
   ]
 }


### PR DESCRIPTION
Closes #173.

## What changed

This PR operationalizes `M_G.2` as a committed research artifact instead of leaving the first proof scope spread across earlier exploratory docs.

- adds `docs/content/docs/research/13_global_proof_profile.md` as the source of truth for the proof-safe language profile and backend contract
- defines the staged first scope: `Z3-Core` as the first honest ship profile, with `Z3-Core-1S` as the first implementation slice for `M_L.1`
- classifies current IR constructs into `bootstrap`, `first ship`, `defer`, and `exclude`
- makes the backend contract explicit: first theorem is Z3-trusting, Alloy is out of scope, `SmtLib.scala` is out of the first claim, and proof replay/export is deferred
- updates `10_translator_soundness.md`, `11_global_proof_governance.md`, `12_global_proof_status.md`, and `meta.json` so the new profile doc is part of the active program rather than a future placeholder

## Why

`#88` and the long translator-soundness doc already contained a lot of the raw reasoning, but not a single committed first-scope decision that the implementation track could code against. This PR makes that decision explicit and stable.

## Validation

- `npm run build` in `docs/`

## Notes

`ml_issues_contents/` remains local and untracked; it is not part of this PR.
