### PR TITLE
M_G.3: add global proof runway

### DIFF
--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -10,8 +10,9 @@ description: "Scoping and milestone plan for proving the IR → Z3 verification 
 > [`11_global_proof_governance`](/research/11_global_proof_governance) and
 > [`12_global_proof_status`](/research/12_global_proof_status); the committed first
 > scope and backend contract now live in
-> [`13_global_proof_profile`](/research/13_global_proof_profile). Does **not** ship code —
-> that lands per milestone.
+> [`13_global_proof_profile`](/research/13_global_proof_profile); owner, runway, and fallback
+> policy now live in [`14_global_proof_runway`](/research/14_global_proof_runway). Does **not**
+> ship code — that lands per milestone.
 
 ---
 
@@ -63,9 +64,11 @@ As of `M_G.0`, the first honest theorem target is the in-memory
 optional `SmtLib.scala` exporter. The exporter stays outside the first ship claim
 until a later milestone.
 
-**Status: research-flavored, opportunistic.** No deliverable in this doc is currently
-blocking any user. Land partial work as opportunities arise (intern projects, guest
-contributors); update this doc as milestones complete.
+**Status: active program with bounded runway.** `M_G.3` moves the global-soundness
+effort out of opportunistic-research mode and into an explicit proof-priority track
+with recorded trade-offs. The execution work still starts only when `M_G.4` opens
+`M_L.*`, but once active, proof work is not assumed to coexist with full-speed
+feature expansion elsewhere in the roadmap.
 
 ---
 

--- a/docs/content/docs/research/11_global_proof_governance.md
+++ b/docs/content/docs/research/11_global_proof_governance.md
@@ -4,8 +4,9 @@ description: "Proof-governed surfaces, change rules, and churn policy for the tr
 ---
 
 > Governance doc for issues [#170](https://github.com/HardMax71/spec_to_rest/issues/170),
-> [#171](https://github.com/HardMax71/spec_to_rest/issues/171), and
-> [#172](https://github.com/HardMax71/spec_to_rest/issues/172).
+> [#171](https://github.com/HardMax71/spec_to_rest/issues/171),
+> [#172](https://github.com/HardMax71/spec_to_rest/issues/172), and
+> [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
 > Defines which repo surfaces are proof-governed before the `M_L.*` execution track starts.
 
 ## 1. Why this exists
@@ -42,6 +43,7 @@ The surfaces below are governed now. They are split by why they matter.
 | Proof-owned core | `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` | Main translation function the prover-side mirror will track case-for-case. |
 | Proof-owned core | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Defines `Z3Script`, `Z3Expr`, and artifact structures in the first theorem target. |
 | Proof-scope artifact | `docs/content/docs/research/13_global_proof_profile.md` | Declares which fragment and backend contract the first ship claim actually covers. |
+| Program-commitment artifact | `docs/content/docs/research/14_global_proof_runway.md` | Records owner, priority runway, paused work, and the stall rule that gate activation of `M_L.*`. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Decides which checks are even in the Z3 proof scope versus routed to Alloy. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Defines the operational meaning of `global`, `requires`, `enabled`, and `preservation` checks. |
 | TCB-sensitive | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | Remains trusted in the first ship claim; parser changes can narrow or widen what that claim honestly covers. |
@@ -68,11 +70,14 @@ If a PR touches any proof-governed surface listed above, it must do all of the f
 2. State whether the change is one of:
    - proof-target shape change,
    - obligation/routing change,
-   - or TCB-only change.
+   - TCB-only change,
+   - or program-commitment change.
 3. State whether the current `M_G.0` theorem statement or TCB summary changed.
 4. If the proof-safe profile membership changed, update
    [`13_global_proof_profile`](/research/13_global_proof_profile) before merge.
-5. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
+5. If the owner, priority statement, paused-work set, or stall rule changed, update
+   [`14_global_proof_runway`](/research/14_global_proof_runway) before merge.
+6. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
    governing issue before merge.
 
 This stays as a documented working rule, not a repo-level automation gate.
@@ -113,6 +118,7 @@ the written record brings them back into view.
 - Translator soundness scoping: [`10_translator_soundness`](/research/10_translator_soundness)
 - Live ledger: [`12_global_proof_status`](/research/12_global_proof_status)
 - Proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
+- Runway and priority: [`14_global_proof_runway`](/research/14_global_proof_runway)
 - Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
 - Theorem statement / TCB: [#171](https://github.com/HardMax71/spec_to_rest/issues/171)
 - This governance milestone: [#172](https://github.com/HardMax71/spec_to_rest/issues/172)

--- a/docs/content/docs/research/12_global_proof_status.md
+++ b/docs/content/docs/research/12_global_proof_status.md
@@ -3,7 +3,8 @@ title: "Global Proof Status"
 description: "Live ledger for proof-governed surfaces, proof-state labels, and drift-control checkpoints"
 ---
 
-> Live ledger for issue [#172](https://github.com/HardMax71/spec_to_rest/issues/172).
+> Live ledger for issues [#172](https://github.com/HardMax71/spec_to_rest/issues/172) and
+> [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
 > Update this file whenever a proof-governed surface moves.
 
 ## 1. Current Baseline
@@ -13,6 +14,9 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 - First theorem target: in-memory `ServiceIR → Z3Script` path used by
   `Consistency.runConsistencyChecks`
 - Active proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
+- Proof owner: [HardMax71](https://github.com/HardMax71)
+- Runway mode: one six-week proof-priority cycle with fixed time / variable scope, per
+  [`14_global_proof_runway`](/research/14_global_proof_runway)
 - Still outside the first ship claim: `SmtLib.scala`, dump/export paths, Alloy-routed checks,
   proof replay, and full-source semantics refinement
 
@@ -34,6 +38,7 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 | `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` | Proof-owned core | `tracked` | Main proof target. New cases or changed encodings must be logged even before prover work starts. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Proof-owned core | `tracked` | `Z3Expr` / `Z3Script` shape is part of the first theorem target. |
 | `docs/content/docs/research/13_global_proof_profile.md` | Proof-scope artifact | `tracked` | This is the committed first-scope boundary for `M_G.2`; scope drift must be explicit. |
+| `docs/content/docs/research/14_global_proof_runway.md` | Program-commitment artifact | `tracked` | Owner, priority runway, paused work, and stall policy must stay explicit while the proof program is active. |
 | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Obligation contract | `tracked` | Routing changes can move checks in or out of the Z3 proof scope. |
 | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Obligation contract | `tracked` | Changes here can redefine the meaning of global, requires, enabled, or preservation checks. |
 | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | TCB-sensitive | `tracked` | Parser remains trusted for first ship; changes alter the honest source-to-IR trust story. |
@@ -55,3 +60,6 @@ If the answer to `3` is "no", the matching PR must also update
 
 If the change moves a feature between `bootstrap`, `first ship`, `defer`, or `exclude`, it must
 also update [`13_global_proof_profile`](/research/13_global_proof_profile).
+
+If the change alters owner, runway, paused roadmap lanes, or the stall rule, it must also update
+[`14_global_proof_runway`](/research/14_global_proof_runway).

--- a/docs/content/docs/research/13_global_proof_profile.md
+++ b/docs/content/docs/research/13_global_proof_profile.md
@@ -6,6 +6,8 @@ description: "Committed first-scope fragment and backend assumptions for the glo
 > Profile doc for issue [#173](https://github.com/HardMax71/spec_to_rest/issues/173).
 > Follows [`11_global_proof_governance`](/research/11_global_proof_governance) and
 > operationalizes the first stable scope that `M_L.1` and `M_L.2` should implement against.
+> Scheduling priority and stall policy live in
+> [`14_global_proof_runway`](/research/14_global_proof_runway).
 
 ## 1. Decision Summary
 

--- a/docs/content/docs/research/14_global_proof_runway.md
+++ b/docs/content/docs/research/14_global_proof_runway.md
@@ -1,0 +1,172 @@
+---
+title: "Global Proof Runway and Roadmap Priority"
+description: "Named owner, bounded runway, paused work, and stall policy for the global translator-soundness program"
+---
+
+> Runway doc for issues [#170](https://github.com/HardMax71/spec_to_rest/issues/170) and
+> [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
+> Commits ownership, time budget, roadmap trade-offs, and the stall rule that must hold before
+> the `M_L.*` execution track starts.
+
+## 1. Decision Summary
+
+The global-proof program is now an **active, bounded priority**, not background research.
+
+This repo currently has one active contributor. That makes the main risk scheduling, not only
+theorem difficulty. A credible proof program therefore needs an explicit owner, an explicit time
+budget, and an explicit list of work that will not continue at full speed while proof work is
+active.
+
+The committed `M_G.3` decision is:
+
+- **Owner:** [HardMax71](https://github.com/HardMax71)
+- **Runway:** one uninterrupted six-week proof-priority cycle, starting when `M_G.4` activates
+  `M_L.*`
+- **Scoping rule:** fixed time, variable scope
+- **Competing work:** explicitly paused or demoted while the cycle is active
+- **Fallback:** if the global-proof push stalls, shrink to `Z3-Core-1S`; if that still fails,
+  revert the primary trust-improvement path to `M_L.3`-style translation validation instead of
+  pretending the universal theorem is still the active track
+
+This is a commitment to a real program, not a promise that the full global theorem ships inside
+one cycle.
+
+## 2. Named Owner and Priority Statement
+
+[HardMax71](https://github.com/HardMax71) is the named owner of the global-proof program.
+
+While the proof runway is active:
+
+- proof work is the default priority for discretionary project time,
+- work that directly supports `M_G.4`, `M_L.0`, `M_L.1`, and the early `M_L.2` theorem path takes
+  precedence over new feature lanes,
+- and the repo should not describe global soundness as "background research" or "opportunistic"
+  work anymore.
+
+This does **not** mean every non-proof change stops. It means non-proof work must justify itself
+as either:
+
+- critical maintenance,
+- proof-enabling support work,
+- or explicitly secondary work accepted as slower.
+
+## 3. Runway Model
+
+The proof program adopts a bounded runway modeled on appetite-first planning: protect a fixed
+amount of uninterrupted time, then shrink scope rather than quietly extending the schedule.
+
+The first committed runway is:
+
+- **length:** six weeks,
+- **start condition:** `M_G.4` closes and unblocks `#126`-`#130`,
+- **mode:** one active primary lane, not parallel proof work plus full-speed roadmap work,
+- **review point:** end of cycle; no automatic renewal.
+
+The first cycle is expected to produce active theorem work, not repo decoration. At minimum, the
+cycle should land all of the following:
+
+- `proofs/lean/` opened together with active proof files,
+- a live prover-side semantics kernel for the `Z3-Core-1S` fragment,
+- and a concrete Scala↔prover mirror artifact or checked theorem fragment that covers real current
+  translator cases.
+
+If those artifacts are not materializing, the correct response is to cut scope or switch tracks,
+not to silently turn the runway into an open-ended research queue.
+
+## 4. Reprioritized Roadmap While the Runway Is Active
+
+The following lanes are **paused** while the proof runway is active:
+
+| Lane | Issues | Runway status | Reason |
+| --- | --- | --- | --- |
+| LLM synthesis track | `#31`, `#32`, `#28`, `#29`, `#27`, `#30` | `paused` | Valuable, but orthogonal to the proof objective and too large to run in parallel in a solo-contributor repo. |
+| New target expansion and distribution | `#33`, `#35`, `#34`, `#36`, `#56` | `paused` | New targets, packaging, and CLI expansion widen the surface area without helping the proof program ship. |
+
+The following lanes are **secondary-only** while the proof runway is active:
+
+| Lane | Issues | Runway status | Rule |
+| --- | --- | --- | --- |
+| Auth/security feature lane | `#53`, `#54`, `#55` | `secondary` | May move only if work is urgent, tightly scoped, or blocks another near-term external need. |
+| Maintenance and experiments | `#149`, `#150`, `#161`, `#163` | `secondary` | Nice to have, but not allowed to displace proof time. |
+
+The following work is still allowed normally:
+
+- build-break and CI-fix work needed to keep `main` usable,
+- correctness or security regressions in already-shipped behavior,
+- narrowly scoped doc fixes,
+- and parser/IR/translator/verification changes that directly support the proof track and update
+  the governed proof docs honestly.
+
+## 5. Interrupt Policy
+
+The proof runway is supposed to provide uninterrupted time, but not at the cost of leaving the
+repo broken.
+
+Interrupts are allowed for:
+
+- red CI or release-blocking build failures,
+- correctness bugs in the current verification path,
+- security issues in shipped code,
+- or narrowly bounded maintenance tasks that can be completed without reopening multiple feature
+  lanes.
+
+Interrupts are **not** a license to resume paused roadmap themes "for a day" and then let them
+sprawl. If an interrupt turns into a second active lane, the runway is no longer honest.
+
+## 6. Stall Rule and Circuit Breaker
+
+The proof program must have a visible stall rule before `M_L.*` starts.
+
+The circuit breaker is:
+
+1. At the end of the first six-week cycle, do **not** auto-renew by default.
+2. If the cycle produced active proof artifacts but the scope was too broad, shrink explicitly to
+   `Z3-Core-1S` and continue only with the narrower target.
+3. If the program is already at `Z3-Core-1S` and still fails to produce meaningful theorem
+   progress, pause the universal-theorem push (`M_L.2`-style expansion) and switch the primary
+   trust-improvement goal to `M_L.3`-style per-run translation validation / certificate work.
+4. Keep any reusable semantics kernel or mirror artifacts already produced; do not discard useful
+   formalization work just because the full theorem stalls.
+
+For this repo, "meaningful theorem progress" means at least one of:
+
+- a merged prover-side semantics artifact that is clearly connected to live Scala structures,
+- a merged mirror artifact that covers real translator cases,
+- or a checked proof fragment stronger than setup-only scaffolding.
+
+What does **not** count:
+
+- empty prover scaffolding,
+- pinned toolchains without live proof code,
+- or long-lived "proof soon" status notes with no checked artifact.
+
+## 7. Exit Condition into `M_G.4`
+
+`M_G.3` exists to make `M_G.4` honest.
+
+After this decision lands, `M_G.4` can activate the execution track because the repo will already
+have:
+
+- a named owner,
+- an explicit priority statement,
+- an explicit trade-off against competing roadmap work,
+- and a written fallback if the proof effort stalls.
+
+That is the missing readiness layer between "interesting research direction" and "open the prover
+workspace now."
+
+## 8. References
+
+- Scoping and milestone plan: [`10_translator_soundness`](/research/10_translator_soundness)
+- Governance: [`11_global_proof_governance`](/research/11_global_proof_governance)
+- Status ledger: [`12_global_proof_status`](/research/12_global_proof_status)
+- Proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
+- Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
+- This runway issue: [#174](https://github.com/HardMax71/spec_to_rest/issues/174)
+- Basecamp, *Shape Up*: [Set Boundaries](https://basecamp.com/shapeup/1.2-chapter-03),
+  [The Betting Table](https://basecamp.com/shapeup/2.2-chapter-08), and
+  [Place Your Bets](https://basecamp.com/shapeup/2.3-chapter-09)
+- Gaurav Parthasarathy, Thibault Dardinier, Benjamin Bonneau, Peter Müller, and Alexander J.
+  Summers, [*Towards Trustworthy Automated Program Verifiers*](https://arxiv.org/abs/2404.03614)
+- Thibault Dardinier, Michael J. Sammler, Gaurav Parthasarathy, Alexander J. Summers, and Peter
+  Müller, [*Formal Foundations for Translational Separation Logic Verifiers*](https://doi.org/10.1145/3704856)

--- a/docs/content/docs/research/meta.json
+++ b/docs/content/docs/research/meta.json
@@ -16,6 +16,7 @@
     "11_global_proof_governance",
     "12_global_proof_status",
     "13_global_proof_profile",
+    "14_global_proof_runway",
     "spec_to_test_tools_research"
   ]
 }


### PR DESCRIPTION
## Summary
- add `14_global_proof_runway` to commit the named owner, six-week runway, paused lanes, and stall rule for `M_G.3`
- update the soundness/governance/status/profile docs so the repo no longer describes the proof program as opportunistic research
- add the new runway doc to the research nav and governance/status ledgers

## Why
`M_G.3` exists to make the global proof program a real roadmap decision in a solo-contributor repo. The doc set now states who owns the work, what gets deprioritized while it is active, and what happens if the theorem push stalls.

## Validation
- `npm run build` in `docs/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Formalized the global proof program as a bounded initiative with explicit owner, six-week runtime, and variable scope.
  * Documented scheduling priorities, interrupt policies, and work constraints in dedicated governance documents separate from the main profile.
  * Defined which roadmap activities pause during the proof cycle and established scope reduction rules as a circuit breaker.
  * Updated cross-references and status tracking across proof-related governance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->