### PR TITLE
M_G.4: activate proof execution track

### DIFF
--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -11,8 +11,10 @@ description: "Scoping and milestone plan for proving the IR → Z3 verification 
 > [`12_global_proof_status`](/research/12_global_proof_status); the committed first
 > scope and backend contract now live in
 > [`13_global_proof_profile`](/research/13_global_proof_profile); owner, runway, and fallback
-> policy now live in [`14_global_proof_runway`](/research/14_global_proof_runway). Does **not**
-> ship code — that lands per milestone.
+> policy now live in [`14_global_proof_runway`](/research/14_global_proof_runway); execution-track
+> activation and first-proof kickoff shape now live in
+> [`15_global_proof_activation`](/research/15_global_proof_activation). Does **not** ship code —
+> that lands per milestone.
 
 ---
 
@@ -64,11 +66,10 @@ As of `M_G.0`, the first honest theorem target is the in-memory
 optional `SmtLib.scala` exporter. The exporter stays outside the first ship claim
 until a later milestone.
 
-**Status: active program with bounded runway.** `M_G.3` moves the global-soundness
-effort out of opportunistic-research mode and into an explicit proof-priority track
-with recorded trade-offs. The execution work still starts only when `M_G.4` opens
-`M_L.*`, but once active, proof work is not assumed to coexist with full-speed
-feature expansion elsewhere in the roadmap.
+**Status: execution track activated.** `M_G.3` committed the runway and trade-offs;
+`M_G.4` now activates `M_L.*` and defines the first implementation shape as a
+combined scaffolding-plus-semantics kickoff. The proof effort is no longer
+opportunistic research, and it is no longer waiting on another planning-layer gate.
 
 ---
 

--- a/docs/content/docs/research/11_global_proof_governance.md
+++ b/docs/content/docs/research/11_global_proof_governance.md
@@ -6,7 +6,8 @@ description: "Proof-governed surfaces, change rules, and churn policy for the tr
 > Governance doc for issues [#170](https://github.com/HardMax71/spec_to_rest/issues/170),
 > [#171](https://github.com/HardMax71/spec_to_rest/issues/171),
 > [#172](https://github.com/HardMax71/spec_to_rest/issues/172), and
-> [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
+> [#174](https://github.com/HardMax71/spec_to_rest/issues/174), and
+> [#175](https://github.com/HardMax71/spec_to_rest/issues/175).
 > Defines which repo surfaces are proof-governed before the `M_L.*` execution track starts.
 
 ## 1. Why this exists
@@ -44,6 +45,7 @@ The surfaces below are governed now. They are split by why they matter.
 | Proof-owned core | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Defines `Z3Script`, `Z3Expr`, and artifact structures in the first theorem target. |
 | Proof-scope artifact | `docs/content/docs/research/13_global_proof_profile.md` | Declares which fragment and backend contract the first ship claim actually covers. |
 | Program-commitment artifact | `docs/content/docs/research/14_global_proof_runway.md` | Records owner, priority runway, paused work, and the stall rule that gate activation of `M_L.*`. |
+| Program-commitment artifact | `docs/content/docs/research/15_global_proof_activation.md` | Records that the activation gate is satisfied and defines the first combined `M_L.0 + M_L.1` kickoff shape. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Decides which checks are even in the Z3 proof scope versus routed to Alloy. |
 | Obligation contract | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Defines the operational meaning of `global`, `requires`, `enabled`, and `preservation` checks. |
 | TCB-sensitive | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | Remains trusted in the first ship claim; parser changes can narrow or widen what that claim honestly covers. |
@@ -77,7 +79,9 @@ If a PR touches any proof-governed surface listed above, it must do all of the f
    [`13_global_proof_profile`](/research/13_global_proof_profile) before merge.
 5. If the owner, priority statement, paused-work set, or stall rule changed, update
    [`14_global_proof_runway`](/research/14_global_proof_runway) before merge.
-6. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
+6. If the activation state or first kickoff shape changed, update
+   [`15_global_proof_activation`](/research/15_global_proof_activation) before merge.
+7. If the theorem boundary, TCB, or governed-surface set changed, update this doc or the
    governing issue before merge.
 
 This stays as a documented working rule, not a repo-level automation gate.
@@ -97,9 +101,10 @@ The expected transition is:
 
 1. `M_G.1` lands with governed surfaces and a live ledger.
 2. `M_G.2` defines the proof-safe profile.
-3. `M_G.4` opens `proofs/lean/` and moves the proof-owned core plus the new prover files into a
-   semi-frozen state.
-4. A short hard-freeze window is allowed later for the `M_L.2` universal-soundness push.
+3. `M_G.4` activates the execution track and defines the first combined kickoff shape.
+4. The first `M_L` PR opens `proofs/lean/` and moves the proof-owned core plus the new prover
+   files into a semi-frozen state.
+5. A short hard-freeze window is allowed later for the `M_L.2` universal-soundness push.
 
 ## 6. Solo-Contributor Rule
 
@@ -119,6 +124,7 @@ the written record brings them back into view.
 - Live ledger: [`12_global_proof_status`](/research/12_global_proof_status)
 - Proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
 - Runway and priority: [`14_global_proof_runway`](/research/14_global_proof_runway)
+- Activation and kickoff: [`15_global_proof_activation`](/research/15_global_proof_activation)
 - Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
 - Theorem statement / TCB: [#171](https://github.com/HardMax71/spec_to_rest/issues/171)
 - This governance milestone: [#172](https://github.com/HardMax71/spec_to_rest/issues/172)

--- a/docs/content/docs/research/12_global_proof_status.md
+++ b/docs/content/docs/research/12_global_proof_status.md
@@ -3,13 +3,14 @@ title: "Global Proof Status"
 description: "Live ledger for proof-governed surfaces, proof-state labels, and drift-control checkpoints"
 ---
 
-> Live ledger for issues [#172](https://github.com/HardMax71/spec_to_rest/issues/172) and
-> [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
+> Live ledger for issues [#172](https://github.com/HardMax71/spec_to_rest/issues/172),
+> [#174](https://github.com/HardMax71/spec_to_rest/issues/174), and
+> [#175](https://github.com/HardMax71/spec_to_rest/issues/175).
 > Update this file whenever a proof-governed surface moves.
 
 ## 1. Current Baseline
 
-- Governance mode: **controlled churn**
+- Governance mode: **execution track active, proof workspace still unopened by design**
 - Initialized against `origin/main` commit `3aa6938` on `2026-05-01`
 - First theorem target: in-memory `ServiceIR → Z3Script` path used by
   `Consistency.runConsistencyChecks`
@@ -17,6 +18,8 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 - Proof owner: [HardMax71](https://github.com/HardMax71)
 - Runway mode: one six-week proof-priority cycle with fixed time / variable scope, per
   [`14_global_proof_runway`](/research/14_global_proof_runway)
+- Execution-track activation: `M_L.*` activated by
+  [`15_global_proof_activation`](/research/15_global_proof_activation)
 - Still outside the first ship claim: `SmtLib.scala`, dump/export paths, Alloy-routed checks,
   proof replay, and full-source semantics refinement
 
@@ -39,12 +42,13 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 | `modules/verify/src/main/scala/specrest/verify/z3/Types.scala` | Proof-owned core | `tracked` | `Z3Expr` / `Z3Script` shape is part of the first theorem target. |
 | `docs/content/docs/research/13_global_proof_profile.md` | Proof-scope artifact | `tracked` | This is the committed first-scope boundary for `M_G.2`; scope drift must be explicit. |
 | `docs/content/docs/research/14_global_proof_runway.md` | Program-commitment artifact | `tracked` | Owner, priority runway, paused work, and stall policy must stay explicit while the proof program is active. |
+| `docs/content/docs/research/15_global_proof_activation.md` | Program-commitment artifact | `tracked` | Activation state and first kickoff shape must stay aligned with the actual `M_L.*` chain. |
 | `modules/verify/src/main/scala/specrest/verify/Classifier.scala` | Obligation contract | `tracked` | Routing changes can move checks in or out of the Z3 proof scope. |
 | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` | Obligation contract | `tracked` | Changes here can redefine the meaning of global, requires, enabled, or preservation checks. |
 | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | TCB-sensitive | `tracked` | Parser remains trusted for first ship; changes alter the honest source-to-IR trust story. |
 | `modules/parser/src/main/scala/specrest/parser/Builder.scala` | TCB-sensitive | `tracked` | IR builder remains trusted for first ship; changes can move the boundary under the theorem. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Backend.scala` | TCB-sensitive | `tracked` | Runtime Z3 AST rendering is in the first-ship TCB. |
-| `proofs/lean/**` | Future proof workspace | `reserved` | Becomes active only when `M_G.4` opens the execution track. |
+| `proofs/lean/**` | Future proof workspace | `reserved` | Execution track is active, but the workspace must still appear only in the first combined `M_L.0 + M_L.1` implementation PR. |
 | Scala↔prover mirror coverage table | Future proof artifact | `reserved` | Created with the first prover-side mirror. |
 
 ## 4. Update Rules
@@ -63,3 +67,6 @@ also update [`13_global_proof_profile`](/research/13_global_proof_profile).
 
 If the change alters owner, runway, paused roadmap lanes, or the stall rule, it must also update
 [`14_global_proof_runway`](/research/14_global_proof_runway).
+
+If the change alters activation state or the first kickoff shape, it must also update
+[`15_global_proof_activation`](/research/15_global_proof_activation).

--- a/docs/content/docs/research/13_global_proof_profile.md
+++ b/docs/content/docs/research/13_global_proof_profile.md
@@ -7,7 +7,8 @@ description: "Committed first-scope fragment and backend assumptions for the glo
 > Follows [`11_global_proof_governance`](/research/11_global_proof_governance) and
 > operationalizes the first stable scope that `M_L.1` and `M_L.2` should implement against.
 > Scheduling priority and stall policy live in
-> [`14_global_proof_runway`](/research/14_global_proof_runway).
+> [`14_global_proof_runway`](/research/14_global_proof_runway). Activation and the first kickoff
+> shape live in [`15_global_proof_activation`](/research/15_global_proof_activation).
 
 ## 1. Decision Summary
 

--- a/docs/content/docs/research/14_global_proof_runway.md
+++ b/docs/content/docs/research/14_global_proof_runway.md
@@ -6,7 +6,8 @@ description: "Named owner, bounded runway, paused work, and stall policy for the
 > Runway doc for issues [#170](https://github.com/HardMax71/spec_to_rest/issues/170) and
 > [#174](https://github.com/HardMax71/spec_to_rest/issues/174).
 > Commits ownership, time budget, roadmap trade-offs, and the stall rule that must hold before
-> the `M_L.*` execution track starts.
+> the `M_L.*` execution track starts. Activation and kickoff are recorded in
+> [`15_global_proof_activation`](/research/15_global_proof_activation).
 
 ## 1. Decision Summary
 
@@ -154,6 +155,9 @@ have:
 
 That is the missing readiness layer between "interesting research direction" and "open the prover
 workspace now."
+
+That readiness layer is now consumed by `M_G.4`; the next work is execution, not another planning
+round.
 
 ## 8. References
 

--- a/docs/content/docs/research/15_global_proof_activation.md
+++ b/docs/content/docs/research/15_global_proof_activation.md
@@ -1,0 +1,130 @@
+---
+title: "Global Proof Activation and M_L Kickoff"
+description: "Gate review, execution-track activation, and first proof-implementation shape for the global soundness program"
+---
+
+> Activation doc for issue [#175](https://github.com/HardMax71/spec_to_rest/issues/175).
+> Closes the gap between readiness planning (`M_G.*`) and active theorem work (`M_L.*`).
+
+## 1. Activation Decision
+
+`M_G.4` activates the `M_L.*` execution track.
+
+As of `2026-05-01`, the repo no longer treats `#126`-`#130` as blocked on program activation.
+The activation gate itself is now satisfied. What remains is the execution order inside the
+`M_L.*` chain.
+
+The decision is:
+
+- `M_G.0` through `M_G.3` are satisfied,
+- [HardMax71](https://github.com/HardMax71) is the active owner of the proof program and the first
+  `M_L.1` contributor,
+- `#126` is unblocked as the first implementation issue,
+- `#127`-`#130` remain gated only by their predecessor milestones, not by activation uncertainty,
+- and the first proof PR must combine theorem-prover scaffolding with real semantics work.
+
+This does **not** claim that theorem work is easy or short. It claims the repo has done enough
+planning discipline that active proof work can begin without lying about scope, trust, or
+priority.
+
+## 2. Gate Review
+
+The activation gate is satisfied because each prerequisite now has a concrete artifact:
+
+| Gate | Artifact | Why it is sufficient |
+| --- | --- | --- |
+| `M_G.0` theorem statement and TCB | [`10_translator_soundness`](/research/10_translator_soundness), issue [#171](https://github.com/HardMax71/spec_to_rest/issues/171) | The first honest theorem target is written down, and the first-ship TCB is explicit. |
+| `M_G.1` governed proof surfaces | [`11_global_proof_governance`](/research/11_global_proof_governance), [`12_global_proof_status`](/research/12_global_proof_status) | Target movement is visible instead of implicit. |
+| `M_G.2` proof-safe profile | [`13_global_proof_profile`](/research/13_global_proof_profile) | The first theorem scope is smaller than the full language and bound to the Z3 path. |
+| `M_G.3` owner, runway, and fallback | [`14_global_proof_runway`](/research/14_global_proof_runway) | The work now has a named owner, a bounded runway, paused competing lanes, and a circuit breaker. |
+
+No additional planning-layer blocker remains that would justify keeping `M_L.*` in suspended
+state.
+
+## 3. What Is Unblocked
+
+Activation does **not** flatten the `M_L.*` dependency chain. It changes what the chain is blocked
+on.
+
+After `M_G.4`:
+
+- `#126` is active implementation work.
+- `#127` is still blocked on `#126`, but no longer blocked on "is the proof program real?"
+- `#128` and `#129` stay blocked on `#127` in the normal milestone sense.
+- `#130` stays blocked on `#128`.
+
+This keeps the work serialized where it needs to be serialized, without preserving the old
+"planning is not done yet" ambiguity.
+
+## 4. First M_L PR Shape
+
+The first `M_L` implementation PR must be a **combined `M_L.0 + first M_L.1 slice`** change.
+
+It should not be a standalone scaffolding PR.
+
+The minimum honest kickoff shape is:
+
+- `proofs/lean/lean-toolchain` pinned to `leanprover/lean4:v4.29.1`
+- `proofs/lean/lakefile.toml`
+- `proofs/lean/README.md`
+- `proofs/lean/STATUS.md`
+- `proofs/lean/SpecRest/IR.lean`
+- `proofs/lean/SpecRest/Semantics.lean`
+- `proofs/lean/SpecRest/Examples.lean`
+- `proofs/lean/SpecRest/IR.lean.todo`
+- `.github/workflows/lean.yml` as a non-blocking proof-workflow job
+
+The required substance in that PR is:
+
+- a real deep embedding for the `Z3-Core-1S` bootstrap fragment,
+- a real semantic domain for the first values / environments / states it needs,
+- at least one checked example or lemma that demonstrates the workspace is already doing proof
+  work,
+- and a status table that makes future partial completion legible.
+
+What is explicitly **not** acceptable as the first PR:
+
+- namespace-only scaffolding,
+- a toolchain pin plus empty files,
+- or a CI-only Lean setup with no semantics artifact.
+
+This is the concrete anti-decay rule for the execution track.
+
+## 5. Owner and Kickoff Rule
+
+[HardMax71](https://github.com/HardMax71) is the named first `M_L.1` contributor.
+
+The implementing PR for the kickoff slice should say that plainly in the PR body or linked issue
+comment so `#126`'s ownership requirement is satisfied in the work artifact itself, not only in a
+planning doc.
+
+The intended work order is:
+
+1. Open the proof workspace together with the first semantics files.
+2. Land the bootstrap `Z3-Core-1S` semantic kernel.
+3. Expand that kernel until `#127` has a real machine-checked subset semantics.
+4. Only then branch into the `#128` universal theorem and `#129` translation-validation paths.
+
+## 6. Activation Invariants
+
+The following rules remain in force after activation:
+
+- `proofs/lean/` must still not appear in `main` until it lands with active proof content.
+- Changes to proof-governed Scala surfaces still require status updates in the matching proof
+  docs.
+- If the first six-week runway fails to produce meaningful theorem artifacts, follow the circuit
+  breaker in [`14_global_proof_runway`](/research/14_global_proof_runway) instead of quietly
+  extending scope.
+
+Activation is therefore a commitment to start, not permission to drift.
+
+## 7. References
+
+- Scoping and milestone plan: [`10_translator_soundness`](/research/10_translator_soundness)
+- Governance: [`11_global_proof_governance`](/research/11_global_proof_governance)
+- Status ledger: [`12_global_proof_status`](/research/12_global_proof_status)
+- Proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
+- Runway and fallback: [`14_global_proof_runway`](/research/14_global_proof_runway)
+- Umbrella: [#170](https://github.com/HardMax71/spec_to_rest/issues/170)
+- This activation issue: [#175](https://github.com/HardMax71/spec_to_rest/issues/175)
+- First execution milestone: [#126](https://github.com/HardMax71/spec_to_rest/issues/126)

--- a/docs/content/docs/research/meta.json
+++ b/docs/content/docs/research/meta.json
@@ -17,6 +17,7 @@
     "12_global_proof_status",
     "13_global_proof_profile",
     "14_global_proof_runway",
+    "15_global_proof_activation",
     "spec_to_test_tools_research"
   ]
 }


### PR DESCRIPTION
## Summary
- add `15_global_proof_activation` as the explicit `M_G.4` activation record
- update the proof-program docs and status ledger so `M_L.*` is now treated as active execution work rather than pre-activation planning
- define the first honest `M_L` kickoff as a combined `M_L.0 + M_L.1` PR and align `#126`-`#130` with that gate

## Why
`M_G.4` is the transition point between planning and real theorem work. This PR closes the activation gap without violating the anti-decay rule by putting idle Lean scaffolding in the repo.

## Validation
- `npm run build` in `docs/`
