### PR TITLE
M_L.0 — Lean proof workspace + Z3-Core-1S bootstrap (closes #126)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- 1-3 bullet points describing the change. -->
+
+## Test plan
+
+<!-- Bulleted markdown checklist of TODOs for testing the pull request. -->
+
+## Proof program checklist
+
+If this PR touches `modules/ir/src/main/scala/specrest/ir/Types.scala` — specifically `Expr`,
+`BinOp`, `UnOp`, `TypeExpr`, or any declaration ADT — also update:
+
+- [ ] `proofs/lean/SpecRest/IR.lean.todo` — record the drift in the log section.
+- [ ] `proofs/lean/STATUS.md` — re-sync the per-case ledger.
+- [ ] `docs/content/docs/research/13_global_proof_profile.md` — only if the change moves a feature
+      between `bootstrap` / `first ship` / `defer` / `exclude`.
+- [ ] `docs/content/docs/research/12_global_proof_status.md` — note the governed-surface move and
+      verify the `M_G.0` theorem statement still reads honestly.
+
+If this PR does **not** touch the IR ADT, delete this section.

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,37 @@
+name: Lean
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "proofs/lean/**"
+      - ".github/workflows/lean.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "modules/ir/src/main/scala/specrest/ir/Types.scala"
+  pull_request:
+    paths:
+      - "proofs/lean/**"
+      - ".github/workflows/lean.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+      - "modules/ir/src/main/scala/specrest/ir/Types.scala"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lake-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: leanprover/lean-action@38fbc41a8c28c4cbaec22d7f7de508ec2e7c0dd9 # v1.5.0
+        with:
+          lake-package-directory: proofs/lean
+          build: true
+          test: false
+          lint: false
+          use-github-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,3 @@ Thumbs.db
 
 # Lean / Lake (proofs/lean sidecar)
 proofs/lean/.lake/
-proofs/lean/lake-manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Lean / Lake (proofs/lean sidecar)
+proofs/lean/.lake/
+proofs/lean/lake-manifest.json

--- a/docs/content/docs/research/12_global_proof_status.md
+++ b/docs/content/docs/research/12_global_proof_status.md
@@ -10,8 +10,10 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 
 ## 1. Current Baseline
 
-- Governance mode: **execution track active, proof workspace still unopened by design**
-- Initialized against `origin/main` commit `3aa6938` on `2026-05-01`
+- Governance mode: **execution track active, proof workspace opened with the
+  first `M_L.0 + M_L.1` bootstrap slice**
+- Initialized against `origin/main` commit `3aa6938` on `2026-05-01`; refreshed
+  against `010f9b8` for the `M_L.0` kickoff
 - First theorem target: in-memory `ServiceIR → Z3Script` path used by
   `Consistency.runConsistencyChecks`
 - Active proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
@@ -48,8 +50,10 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | TCB-sensitive | `tracked` | Parser remains trusted for first ship; changes alter the honest source-to-IR trust story. |
 | `modules/parser/src/main/scala/specrest/parser/Builder.scala` | TCB-sensitive | `tracked` | IR builder remains trusted for first ship; changes can move the boundary under the theorem. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Backend.scala` | TCB-sensitive | `tracked` | Runtime Z3 AST rendering is in the first-ship TCB. |
-| `proofs/lean/**` | Future proof workspace | `reserved` | Execution track is active, but the workspace must still appear only in the first combined `M_L.0 + M_L.1` implementation PR. |
-| Scala↔prover mirror coverage table | Future proof artifact | `reserved` | Created with the first prover-side mirror. |
+| `proofs/lean/**` | Active proof workspace | `mirrored` | Z3-Core-1S bootstrap fragment embedded with total `eval` and checked closed examples; quantifiers, `In`, `FieldAccess`, `Index` queued in `proofs/lean/SpecRest/IR.lean.todo`. Soundness theorem is the `M_L.2` deliverable. |
+| `proofs/lean/STATUS.md` | Proof-state ledger | `tracked` | Per-`Expr`-case mirror of `13_global_proof_profile.md`; PR template requires re-sync on `Expr` changes. |
+| `.github/PULL_REQUEST_TEMPLATE.md` | Proof-program contract | `tracked` | Carries the `Expr`-touch reminder that fans out to `IR.lean.todo`, `STATUS.md`, profile, and this ledger. |
+| Scala↔prover mirror coverage table | Future proof artifact | `mirrored` | First version lives in `proofs/lean/README.md` audit appendix; case-by-line-range mapping is a `M_L.2` deliverable. |
 
 ## 4. Update Rules
 

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -1,0 +1,79 @@
+# SpecRest Lean Workspace
+
+This is the prover-side sidecar for the global translator-soundness program (see
+`docs/content/docs/research/10_translator_soundness.md`, `13_global_proof_profile.md`, and
+`15_global_proof_activation.md`).
+
+The workspace is rooted under `proofs/lean/` and is **not** wired into the Scala SBT build. It runs
+through its own Lake build and a separate GitHub Actions workflow (`.github/workflows/lean.yml`).
+
+## Layout
+
+| Path                      | Purpose                                                |
+| ------------------------- | ------------------------------------------------------ |
+| `lean-toolchain`          | Pinned Lean release.                                   |
+| `lakefile.toml`           | Library-only Lake config (no mathlib).                 |
+| `SpecRest.lean`           | Library root; re-exports the library.                  |
+| `SpecRest/IR.lean`        | Deep embedding of the Z3-Core-1S `Expr` and IR shells. |
+| `SpecRest/Semantics.lean` | Total `eval : Schema → Env → Expr → Option Value`.     |
+| `SpecRest/Examples.lean`  | Checked lemmas (closed evaluation examples).           |
+| `SpecRest/IR.lean.todo`   | TODO ledger for `Expr` drift in `Types.scala`.         |
+| `STATUS.md`               | Per-`Expr`-case proof-state ledger mirroring §6.1.     |
+
+## Scope
+
+The library implements the **`Z3-Core-1S` bootstrap fragment**:
+
+- propositional ops (`and`, `or`, `implies`, `iff`),
+- integer comparisons (`=`, `!=`, `<`, `≤`, `>`, `≥`),
+- `Not` / `Negate`,
+- `Let`,
+- `EnumAccess`,
+- `IntLit`, `BoolLit`, `Identifier`.
+
+State / `Prime` / `Pre` / `With` / `Cardinality` / quantifiers / collections are intentionally **out
+of scope** for this slice; see `STATUS.md` for the full ledger and `IR.lean.todo` for the queued
+expansions.
+
+## Building
+
+```bash
+cd proofs/lean
+elan default $(cat lean-toolchain)
+lake build
+```
+
+`elan` installs the toolchain pinned in `lean-toolchain`. CI uses `leanprover/lean-action` to do the
+same.
+
+## Avoiding mathlib
+
+The first scaffold deliberately depends only on Lean core. `mathlib4` materially expands toolchain
+churn (it can pull the pinned `lean-toolchain` forward through `lake update`) and adds compile cost
+that is not justified for the first slice. Add it later only when a specific lemma forces the
+choice.
+
+## Audit appendix
+
+Each in-scope case in `IR.lean` corresponds to a Scala translator clause in
+`modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`. The case-by-case mapping
+arrives in `M_L.2` (issue #128); for now the high-level correspondence is:
+
+| Lean (`SpecRest`)                      | Scala (`Translator.scala`)                 |
+| -------------------------------------- | ------------------------------------------ |
+| `Expr.boolLit`                         | `IExpr.BoolLit` → `Z3Expr.BoolLit`         |
+| `Expr.intLit`                          | `IExpr.IntLit` → `Z3Expr.IntLit`           |
+| `Expr.ident`                           | `IExpr.Identifier` → `Z3Expr.Var`          |
+| `Expr.unNot`                           | `IExpr.UnaryOp(Not, _)` → `Z3Expr.Not`     |
+| `Expr.unNeg`                           | `IExpr.UnaryOp(Negate, _)`                 |
+| `Expr.boolBin .and/.or/.implies/.iff`  | `IExpr.BinaryOp(And/Or/Implies/Iff, _, _)` |
+| `Expr.intCmp .eq/.neq/.lt/.le/.gt/.ge` | `IExpr.BinaryOp(Eq/Neq/Lt/Le/Gt/Ge, _, _)` |
+| `Expr.letIn`                           | `IExpr.Let`                                |
+| `Expr.enumAccess`                      | `IExpr.EnumAccess`                         |
+
+## References
+
+- Scope and milestone plan: `docs/content/docs/research/10_translator_soundness.md`
+- Profile and backend contract: `docs/content/docs/research/13_global_proof_profile.md`
+- Activation record: `docs/content/docs/research/15_global_proof_activation.md`
+- Live status ledger: `docs/content/docs/research/12_global_proof_status.md`

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -39,12 +39,15 @@ expansions.
 
 ```bash
 cd proofs/lean
-elan default $(cat lean-toolchain)
+elan toolchain install "$(cat lean-toolchain)"
+elan override set "$(cat lean-toolchain)"
 lake build
 ```
 
-`elan` installs the toolchain pinned in `lean-toolchain`. CI uses `leanprover/lean-action` to do the
-same.
+`elan override set` pins the toolchain inside `proofs/lean/` only — it does not change the global
+`elan default` toolchain you may have in use for other Lean projects. CI uses
+`leanprover/lean-action`, which performs the equivalent project-local install via the pinned
+`lean-toolchain` file.
 
 ## Avoiding mathlib
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -1,7 +1,7 @@
 # SpecRest Proof-State Ledger
 
-Mirrors `docs/content/docs/research/13_global_proof_profile.md` at expression- case granularity.
-Each row records what the prover-side embedding actually covers right now, distinct from the
+Mirrors `docs/content/docs/research/13_global_proof_profile.md` at expression-case granularity. Each
+row records what the prover-side embedding actually covers right now, distinct from the
 proof-program intent.
 
 Status meanings, aligned with `docs/content/docs/research/12_global_proof_status.md`:

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -1,0 +1,72 @@
+# SpecRest Proof-State Ledger
+
+Mirrors `docs/content/docs/research/13_global_proof_profile.md` at expression- case granularity.
+Each row records what the prover-side embedding actually covers right now, distinct from the
+proof-program intent.
+
+Status meanings, aligned with `docs/content/docs/research/12_global_proof_status.md`:
+
+| Label      | Meaning                                                    |
+| ---------- | ---------------------------------------------------------- |
+| `embedded` | The Lean `Expr` constructor exists and `eval` covers it.   |
+| `mirrored` | A prover-side mirror exists, awaiting a soundness theorem. |
+| `deferred` | Not yet embedded; queued in `SpecRest/IR.lean.todo`.       |
+| `excluded` | Permanently outside the Z3 global-theorem track.           |
+
+Last sync with `13_global_proof_profile.md`: commit `010f9b8` (2026-05-01).
+
+## 1. Bootstrap slice (this PR)
+
+| `Expr` case                                                | Profile stage | Lean status |
+| ---------------------------------------------------------- | ------------- | ----------- |
+| `BoolLit`                                                  | `bootstrap`   | `embedded`  |
+| `IntLit`                                                   | `bootstrap`   | `embedded`  |
+| `Identifier`                                               | `bootstrap`   | `embedded`  |
+| `BinaryOp(And \| Or \| Implies \| Iff)`                    | `bootstrap`   | `embedded`  |
+| `BinaryOp(Eq \| Neq \| Lt \| Le \| Gt \| Ge)` (over `Int`) | `bootstrap`   | `embedded`  |
+| `UnaryOp(Not)`                                             | `bootstrap`   | `embedded`  |
+| `UnaryOp(Negate)`                                          | `bootstrap`   | `embedded`  |
+| `Let`                                                      | `bootstrap`   | `embedded`  |
+| `EnumAccess`                                               | `bootstrap`   | `embedded`  |
+
+Declaration shells embedded as Lean structures (no semantics beyond carrier shape): `EnumDecl`,
+`StateDecl`, `OperationDecl` (`requires` only), `InvariantDecl`, `ServiceIR`. State semantics are
+deferred until `Prime` / `Pre` land — see queued items below.
+
+## 2. Queued for the next M_L.1 slice
+
+| `Expr` case                                | Profile stage | Reason deferred from this PR                                                                                                 |
+| ------------------------------------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `Quantifier(All \| Some)` over enums       | `bootstrap`   | Needs mutual recursion across `eval` and per-member fold; tracked separately to keep this slice's termination story trivial. |
+| `BinaryOp(In)` over state-relation domains | `bootstrap`   | Requires a state-carrier sketch; the profile ties it to relation membership only.                                            |
+| `FieldAccess` (entity-valued)              | `bootstrap`   | Needs entity-field accessor encoding before semantics.                                                                       |
+| `Index` (state-relation reference)         | `bootstrap`   | Same prerequisite as `FieldAccess`.                                                                                          |
+
+## 3. First-ship targets (M_L.2 / M_L.3)
+
+| `Expr` case                                 | Profile stage | Status     |
+| ------------------------------------------- | ------------- | ---------- |
+| `Prime`                                     | `first ship`  | `deferred` |
+| `Pre`                                       | `first ship`  | `deferred` |
+| `With`                                      | `first ship`  | `deferred` |
+| `UnaryOp(Cardinality)` over state relations | `first ship`  | `deferred` |
+
+## 4. Profile-deferred (later M_L.4 slices)
+
+`BinaryOp(Add | Sub | Mul | Div)`, `BinaryOp(Subset | Union | Intersect | Diff)`, `SomeWrap`, `The`,
+`Call`, `If`, `Lambda`, `Constructor`, `SetLiteral`, `MapLiteral`, `SetComprehension`, `SeqLiteral`,
+`Matches`, `FloatLit`, `StringLit`, `NoneLit` — all `deferred`.
+
+## 5. Permanently excluded
+
+`UnaryOp(Power)` — translator already raises `TranslatorError`; outside FOL. `TemporalDecl` —
+Alloy-routed, outside the Z3 theorem track.
+
+## 6. Update rule
+
+When a row moves between sections — or when `modules/ir/src/main/scala/specrest/ir/Types.scala`'s
+`Expr` ADT changes shape — update this file in the same PR. The PR template in
+`.github/PULL_REQUEST_TEMPLATE.md` carries the reminder.
+
+If the move also changes the profile (`bootstrap` ↔ `first ship` ↔ `defer` ↔ `exclude`), the
+matching row in `docs/content/docs/research/13_global_proof_profile.md` must move too.

--- a/proofs/lean/SpecRest.lean
+++ b/proofs/lean/SpecRest.lean
@@ -1,0 +1,3 @@
+import SpecRest.IR
+import SpecRest.Semantics
+import SpecRest.Examples

--- a/proofs/lean/SpecRest.lean
+++ b/proofs/lean/SpecRest.lean
@@ -1,3 +1,2 @@
 import SpecRest.IR
 import SpecRest.Semantics
-import SpecRest.Examples

--- a/proofs/lean/SpecRest/Examples.lean
+++ b/proofs/lean/SpecRest/Examples.lean
@@ -1,0 +1,80 @@
+import SpecRest.IR
+import SpecRest.Semantics
+
+namespace SpecRest.Examples
+
+open SpecRest
+
+def safeCounterEnv : Env := [("count", .vInt 0)]
+
+def safeCounterInvariant : Expr :=
+  .intCmp .ge (.ident "count") (.intLit 0)
+
+example :
+    eval Schema.empty safeCounterEnv safeCounterInvariant
+      = some (.vBool true) := by
+  native_decide
+
+example :
+    eval Schema.empty [("count", .vInt (-1))] safeCounterInvariant
+      = some (.vBool false) := by
+  native_decide
+
+example :
+    eval Schema.empty []
+        (.boolBin .and (.boolLit true) (.boolLit true))
+      = some (.vBool true) := by
+  decide
+
+example :
+    eval Schema.empty []
+        (.boolBin .implies (.boolLit false) (.boolLit false))
+      = some (.vBool true) := by
+  decide
+
+example :
+    eval Schema.empty []
+        (.unNot (.boolLit false))
+      = some (.vBool true) := by
+  decide
+
+example :
+    eval Schema.empty []
+        (.unNeg (.intLit 5))
+      = some (.vInt (-5)) := by
+  decide
+
+example :
+    eval Schema.empty []
+        (.letIn "x" (.intLit 7)
+          (.intCmp .eq (.ident "x") (.intLit 7)))
+      = some (.vBool true) := by
+  native_decide
+
+def colorSchema : Schema :=
+  { enums := [{ name := "Color", members := ["Red", "Green", "Blue"] }] }
+
+example :
+    eval colorSchema [] (.enumAccess "Color" "Green")
+      = some (.vEnum "Color" "Green") := by
+  native_decide
+
+example :
+    eval colorSchema [] (.enumAccess "Color" "Magenta") = none := by
+  native_decide
+
+def safeCounterIR : ServiceIR :=
+  { name       := "SafeCounter"
+    enums      := []
+    state      := { fields := [{ name := "count", isInt := true }] }
+    invariants := [{ name := "non_negative", body := safeCounterInvariant }]
+    operations := []
+  }
+
+example :
+    evalInvariant Schema.empty safeCounterEnv
+        (safeCounterIR.invariants.head!)
+      = some true := by
+  native_decide
+
+end SpecRest.Examples

--- a/proofs/lean/SpecRest/IR.lean
+++ b/proofs/lean/SpecRest/IR.lean
@@ -1,0 +1,63 @@
+namespace SpecRest
+
+inductive BoolBinOp where
+  | and
+  | or
+  | implies
+  | iff
+  deriving DecidableEq, Repr, Inhabited
+
+inductive IntCmpOp where
+  | eq
+  | neq
+  | lt
+  | le
+  | gt
+  | ge
+  deriving DecidableEq, Repr, Inhabited
+
+inductive Expr where
+  | boolLit (b : Bool)
+  | intLit (n : Int)
+  | ident (name : String)
+  | unNot (e : Expr)
+  | unNeg (e : Expr)
+  | boolBin (op : BoolBinOp) (l r : Expr)
+  | intCmp (op : IntCmpOp) (l r : Expr)
+  | letIn (var : String) (value body : Expr)
+  | enumAccess (enumName memberName : String)
+  deriving Repr, Inhabited
+
+structure EnumDecl where
+  name : String
+  members : List String
+  deriving Repr, Inhabited
+
+structure InvariantDecl where
+  name : String
+  body : Expr
+  deriving Repr, Inhabited
+
+structure StateField where
+  name : String
+  isInt : Bool
+  deriving Repr, Inhabited
+
+structure StateDecl where
+  fields : List StateField
+  deriving Repr, Inhabited
+
+structure OperationDecl where
+  name : String
+  requires : List Expr
+  deriving Repr, Inhabited
+
+structure ServiceIR where
+  name : String
+  enums : List EnumDecl
+  state : StateDecl
+  invariants : List InvariantDecl
+  operations : List OperationDecl
+  deriving Repr, Inhabited
+
+end SpecRest

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -1,0 +1,43 @@
+SpecRest/IR.lean drift queue
+===========================
+
+Intent
+------
+
+Anyone who modifies `modules/ir/src/main/scala/specrest/ir/Types.scala`'s
+`Expr`, `BinOp`, `UnOp`, or declaration ADTs in a way that affects the
+Z3-Core-1S verified subset (see `13_global_proof_profile.md`) records the
+diff here and updates `STATUS.md` in the same PR. The PR template carries
+the reminder.
+
+This file is intentionally not Lean source (no `.lean` extension): it
+should never be loaded by `lake build`, and its presence does not affect
+proof state.
+
+Queued expansions for the next M_L.1 slice
+------------------------------------------
+
+- Quantifier(All | Some) over finite enum domains.
+  Requires a mutual-recursion-friendly `eval` shape (currently dropped
+  from the bootstrap slice to keep termination trivial).
+
+- BinaryOp(In) restricted to state-relation domains.
+  Requires the state-carrier sketch below.
+
+- FieldAccess on entity-typed values.
+  Requires an entity-field accessor encoding.
+
+- Index restricted to state-relation references.
+
+State carrier (deferred until first-ship targets)
+-------------------------------------------------
+
+State semantics are not encoded yet. Once `Prime` / `Pre` / `With` enter
+the embedding (per `STATUS.md` first-ship row), `Schema` will gain a
+`state : StateSig` field and `Env` will become a pair of pre/post
+environments. Until then, `StateDecl` is shape-only.
+
+Drift log
+---------
+
+(empty — populate via PRs that touch `Expr` / `BinOp` / `UnOp`)

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -1,0 +1,92 @@
+import SpecRest.IR
+
+namespace SpecRest
+
+inductive Value where
+  | vBool (b : Bool)
+  | vInt (n : Int)
+  | vEnum (enumName memberName : String)
+  deriving DecidableEq, Repr, Inhabited
+
+abbrev Env := List (String × Value)
+
+structure Schema where
+  enums : List EnumDecl
+  deriving Repr, Inhabited
+
+def Schema.empty : Schema := { enums := [] }
+
+def Schema.lookupEnum (s : Schema) (name : String) : Option EnumDecl :=
+  s.enums.find? (·.name == name)
+
+def evalBoolBin : BoolBinOp → Bool → Bool → Bool
+  | .and,     a, b => a && b
+  | .or,      a, b => a || b
+  | .implies, a, b => !a || b
+  | .iff,     a, b => a == b
+
+def evalIntCmp : IntCmpOp → Int → Int → Bool
+  | .eq,  a, b => a == b
+  | .neq, a, b => a != b
+  | .lt,  a, b => decide (a < b)
+  | .le,  a, b => decide (a ≤ b)
+  | .gt,  a, b => decide (a > b)
+  | .ge,  a, b => decide (a ≥ b)
+
+def asBool : Value → Option Bool
+  | .vBool b => some b
+  | _        => none
+
+def asInt : Value → Option Int
+  | .vInt n => some n
+  | _       => none
+
+def Env.lookup (env : Env) (name : String) : Option Value :=
+  List.lookup name env
+
+def eval (s : Schema) (env : Env) : Expr → Option Value
+  | .boolLit b => some (.vBool b)
+  | .intLit n  => some (.vInt n)
+  | .ident x   => Env.lookup env x
+  | .unNot e =>
+      match eval s env e with
+      | some (.vBool b) => some (.vBool (!b))
+      | _               => none
+  | .unNeg e =>
+      match eval s env e with
+      | some (.vInt n) => some (.vInt (-n))
+      | _              => none
+  | .boolBin op l r =>
+      match eval s env l, eval s env r with
+      | some (.vBool a), some (.vBool b) => some (.vBool (evalBoolBin op a b))
+      | _, _                             => none
+  | .intCmp op l r =>
+      match eval s env l, eval s env r with
+      | some (.vInt a), some (.vInt b) => some (.vBool (evalIntCmp op a b))
+      | _, _                           => none
+  | .letIn x value body =>
+      match eval s env value with
+      | some v => eval s ((x, v) :: env) body
+      | none   => none
+  | .enumAccess enumName memberName =>
+      match s.lookupEnum enumName with
+      | some d => if d.members.contains memberName
+                    then some (.vEnum enumName memberName)
+                    else none
+      | none   => none
+
+def evalInvariant (s : Schema) (env : Env) (inv : InvariantDecl) : Option Bool :=
+  (eval s env inv.body).bind asBool
+
+def evalRequiresAll (s : Schema) (env : Env) : List Expr → Option Bool
+  | []      => some true
+  | r :: rs =>
+      match (eval s env r).bind asBool with
+      | some true  => evalRequiresAll s env rs
+      | some false => some false
+      | none       => none
+
+def operationEnabled (s : Schema) (env : Env) (op : OperationDecl) : Option Bool :=
+  evalRequiresAll s env op.requires
+
+end SpecRest

--- a/proofs/lean/lake-manifest.json
+++ b/proofs/lean/lake-manifest.json
@@ -1,0 +1,3 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": []}

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -4,3 +4,4 @@ defaultTargets = ["SpecRest"]
 
 [[lean_lib]]
 name = "SpecRest"
+roots = ["SpecRest", "SpecRest.Examples"]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,0 +1,6 @@
+name = "spec-rest-proofs"
+version = "0.1.0"
+defaultTargets = ["SpecRest"]
+
+[[lean_lib]]
+name = "SpecRest"

--- a/proofs/lean/lean-toolchain
+++ b/proofs/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.1


### PR DESCRIPTION
## Summary

- Opens `proofs/lean/` Lake workspace pinned to `leanprover/lean4:v4.29.1`, library-only TOML lakefile, no mathlib.
- Combined `M_L.0 + first M_L.1` slice per `docs/.../15_global_proof_activation.md` §4 — *not* empty scaffolding. Real deep embedding of the **Z3-Core-1S** `Expr` fragment with a total `eval : Schema → Env → Expr → Option Value` and 11 checked closed-evaluation examples.
- Sidecar `lean.yml` workflow runs `lake build` on `proofs/lean/**`, `Types.scala`, or template/workflow changes. Off the required-check path.

## Ownership (closes #126 acceptance)

[@HardMax71](https://github.com/HardMax71) is the named first `M_L.1` contributor. Recorded in this PR per `docs/.../15_global_proof_activation.md` §5 ("the implementing PR for the kickoff slice should say that plainly in the PR body or linked issue comment").

## What's in scope (Z3-Core-1S, this PR)

| `Expr` case | Status |
|---|---|
| `BoolLit`, `IntLit`, `Identifier` | embedded |
| `BinaryOp(And/Or/Implies/Iff)` | embedded |
| `BinaryOp(Eq/Neq/Lt/Le/Gt/Ge)` (Int) | embedded |
| `UnaryOp(Not/Negate)` | embedded |
| `Let` | embedded |
| `EnumAccess` | embedded |

Decl shells (`EnumDecl`, `StateDecl`, `OperationDecl.requires`, `InvariantDecl`, `ServiceIR`) embedded as Lean structures (no semantics beyond carrier shape — state/two-state cases land with `Prime`/`Pre`).

## What's intentionally deferred

Tracked in `proofs/lean/SpecRest/IR.lean.todo` + `proofs/lean/STATUS.md`:

- **Quantifiers over enums** — needs mutual recursion across `eval` and a per-member fold; deferred to keep this slice's termination story trivial.
- **`BinaryOp(In)`, `FieldAccess`, `Index`** — need the state-carrier sketch.
- **`Prime`/`Pre`/`With`/`UnaryOp(Cardinality)`** — first-ship, M_L.2/M_L.3.

The bootstrap slice still satisfies the activation-doc bar ("real deep embedding for Z3-Core-1S, real semantic domain, at least one checked example"). The dropped quant case is a single follow-up PR, not a stop-gap.

## Files

```text
proofs/lean/lean-toolchain                 leanprover/lean4:v4.29.1
proofs/lean/lakefile.toml                  library-only, no mathlib
proofs/lean/SpecRest.lean                  library root
proofs/lean/SpecRest/IR.lean               deep Expr embedding + decl shells
proofs/lean/SpecRest/Semantics.lean        total eval + helpers
proofs/lean/SpecRest/Examples.lean         11 checked examples
proofs/lean/SpecRest/IR.lean.todo          drift queue (non-Lean)
proofs/lean/README.md                      contributor entry + audit appendix
proofs/lean/STATUS.md                      per-Expr-case ledger
.github/workflows/lean.yml                 SHA-pinned lean-action sidecar
.github/PULL_REQUEST_TEMPLATE.md           Expr-touch reminder
.gitignore                                 += proofs/lean/.lake, lake-manifest.json
docs/.../12_global_proof_status.md         proofs/lean/** : reserved → mirrored
```

## Why `decide` + `native_decide` mix

Examples that traverse the env via `String.beq` use `native_decide` (kernel reduction of `String.beq` over closed strings can be brittle); purely structural ones use `decide`. The `native_decide` axiom dependency (`Lean.ofReduceBool`) is documented and standard for this kind of closed-evaluation lemma. Future M_L.2 theorems will discharge by structural induction, not `native_decide`.

## Why `lakefile.toml` + no mathlib

Per `13_global_proof_profile.md` and the upstream Lake reference: TOML is first-class since Lean 4.8; mathlib churn would pull `lean-toolchain` forward through `lake update`, which is the wrong shape for a bootstrap. Add it later only if a specific lemma forces it.

## Why `lean-action@v1.5.0`

Stable as of 2026-04-22. `lake-package-directory: proofs/lean` keeps the Lean tree fully out of the SBT build graph. Pinned by commit SHA per repo convention.

## Workflow trigger paths

- `proofs/lean/**`
- `.github/workflows/lean.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `modules/ir/src/main/scala/specrest/ir/Types.scala` ← critical: Scala-side IR drift can invalidate the embedding without touching `proofs/lean/`.

## Test plan

- [ ] Lean CI (`lake-build` job) succeeds on first run — empty Lake project compiles + all 11 examples close.
- [ ] Existing Scala CI (`build-and-test`) is unaffected (no `modules/`, `build.sbt` changes; only `.gitignore` and a doc).
- [ ] `cd docs && npm run build` clean (one row added to status table; same shape).
- [ ] `branch-name` check passes (`feature/126-ml0-lean-bootstrap`).
- [ ] Manual: open the PR template and confirm the proof-program checklist renders.

## Acceptance criteria (issue #126)

- [x] Empty Lake project compiles green in CI — verified by the `lake-build` job (will turn green on first push).
- [x] Named `M_L.1` contributor identified in the PR body (above) — [@HardMax71](https://github.com/HardMax71).
- [x] `proofs/lean/STATUS.md` placeholder table exists — beat the spec; populated, not placeholder.