### PR TITLE
M_L.2 — Translator soundness foundations + first proven cases (partial #128)

### DIFF
--- a/docs/content/docs/research/12_global_proof_status.md
+++ b/docs/content/docs/research/12_global_proof_status.md
@@ -11,11 +11,12 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 ## 1. Current Baseline
 
 - Governance mode: **execution track active, proof workspace covers the full
-  `M_L.1` verified subset (research doc §6.1)**
+  `M_L.1` verified subset (research doc §6.1) plus `M_L.2` foundations
+  (research doc §8.3)**
 - Initialized against `origin/main` commit `3aa6938` on `2026-05-01`; refreshed
-  against `010f9b8` for the `M_L.0` kickoff. The `M_L.1` semantics slice builds
-  on the `M_L.0` merge commit `a430ddc`; this baseline line is re-pinned in the
-  next maintenance pass after `M_L.1` lands on `main`.
+  against `010f9b8` for the `M_L.0` kickoff and against `2f8d659` for the
+  `M_L.1` merge. The `M_L.2` foundations slice builds on top of `2f8d659`; the
+  baseline is re-pinned post-merge after `M_L.2` lands.
 - First theorem target: in-memory `ServiceIR → Z3Script` path used by
   `Consistency.runConsistencyChecks`
 - Active proof-safe profile: [`13_global_proof_profile`](/research/13_global_proof_profile)
@@ -52,11 +53,14 @@ description: "Live ledger for proof-governed surfaces, proof-state labels, and d
 | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | TCB-sensitive | `tracked` | Parser remains trusted for first ship; changes alter the honest source-to-IR trust story. |
 | `modules/parser/src/main/scala/specrest/parser/Builder.scala` | TCB-sensitive | `tracked` | IR builder remains trusted for first ship; changes can move the boundary under the theorem. |
 | `modules/verify/src/main/scala/specrest/verify/z3/Backend.scala` | TCB-sensitive | `tracked` | Runtime Z3 AST rendering is in the first-ship TCB. |
-| `proofs/lean/**` | Active proof workspace | `mirrored` | Full M_L.1 verified subset embedded: `BinaryOp(In)`, `Quantifier(All)` over enums, polymorphic `Eq`/`Neq` over `Value`, entity-typed values, and explicit `State` carrier. Per-operator denotation lemmas in `SpecRest/Lemmas.lean`. `safe_counter` invariant proved as a named theorem. `Prime`/`Pre`/`With`/`FieldAccess`/`Index` queued in `proofs/lean/SpecRest/IR.lean.todo` for `M_L.2`. |
+| `proofs/lean/**` | Active proof workspace | `mirrored` | Full M_L.1 verified subset embedded: `BinaryOp(In)`, `Quantifier(All)` over enums, polymorphic `Eq`/`Neq` over `Value`, entity-typed values, and explicit `State` carrier. Per-operator denotation lemmas in `SpecRest/Lemmas.lean`. `safe_counter` invariant proved as a named theorem. M_L.2 foundations (Smt embedding + translator + per-case soundness for atoms/Not/Negate/And) ship in `SpecRest/{Smt,Translate,Soundness}.lean`. The universal `soundness` theorem is `sorry`-gated; closure follow-ups land the remaining cases (Or/Implies/Iff, full cmp, letIn, enumAccess, member, forallEnum). |
 | `proofs/lean/STATUS.md` | Proof-state ledger | `tracked` | Per-`Expr`-case mirror of `13_global_proof_profile.md`; PR template requires re-sync on `Expr` changes. |
 | `.github/PULL_REQUEST_TEMPLATE.md` | Proof-program contract | `tracked` | Carries the `Expr`-touch reminder that fans out to `IR.lean.todo`, `STATUS.md`, profile, and this ledger. |
 | `proofs/lean/SpecRest/Lemmas.lean` | Proof-owned core | `tracked` | Per-operator denotation lemmas (the `M_L.2` building blocks). New `Expr` cases must add a corresponding lemma here. |
-| Scala↔prover mirror coverage table | Future proof artifact | `mirrored` | First version lives in `proofs/lean/README.md` audit appendix; case-by-line-range mapping is a `M_L.2` deliverable. |
+| `proofs/lean/SpecRest/Smt.lean` | Proof-owned core | `tracked` | Shallow SMT-LIB embedding with `smtEval` + per-constructor characterization lemmas. New `Expr` cases that translate to new `SmtTerm` shapes must extend the ADT here. |
+| `proofs/lean/SpecRest/Translate.lean` | Proof-owned core | `tracked` | `translate : Expr → SmtTerm` mirror of `z3.Translator.scala`. Must stay aligned case-for-case with the Scala translator on the verified subset. |
+| `proofs/lean/SpecRest/Soundness.lean` | Proof-owned core | `tracked` | Per-case soundness theorems + universal `soundness` meta-theorem. New translation cases must add a per-case soundness theorem before being declared `sound` in `STATUS.md`. |
+| Scala↔prover mirror coverage table | Live proof artifact | `tracked` | Audit appendix in `proofs/lean/README.md` lists Lean ↔ Scala translator mappings; M_L.2 closure PRs may add line-range pins to specific Scala translator clauses. |
 
 ## 4. Update Rules
 

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -9,16 +9,20 @@ through its own Lake build and a separate GitHub Actions workflow (`.github/work
 
 ## Layout
 
-| Path                      | Purpose                                                |
-| ------------------------- | ------------------------------------------------------ |
-| `lean-toolchain`          | Pinned Lean release.                                   |
-| `lakefile.toml`           | Library-only Lake config (no mathlib).                 |
-| `SpecRest.lean`           | Library root; re-exports the library.                  |
-| `SpecRest/IR.lean`        | Deep embedding of the Z3-Core-1S `Expr` and IR shells. |
-| `SpecRest/Semantics.lean` | Total `eval : Schema → Env → Expr → Option Value`.     |
-| `SpecRest/Examples.lean`  | Checked lemmas (closed evaluation examples).           |
-| `SpecRest/IR.lean.todo`   | TODO ledger for `Expr` drift in `Types.scala`.         |
-| `STATUS.md`               | Per-`Expr`-case proof-state ledger mirroring §6.1.     |
+| Path                      | Purpose                                                        |
+| ------------------------- | -------------------------------------------------------------- |
+| `lean-toolchain`          | Pinned Lean release.                                           |
+| `lakefile.toml`           | Library-only Lake config (no mathlib).                         |
+| `SpecRest.lean`           | Library root; re-exports the library.                          |
+| `SpecRest/IR.lean`        | Deep embedding of the verified-subset `Expr` and IR shells.    |
+| `SpecRest/Semantics.lean` | Total `eval : Schema → State → Env → Expr → Option Value`.     |
+| `SpecRest/Lemmas.lean`    | Per-operator denotation lemmas (M_L.2 building blocks).        |
+| `SpecRest/Smt.lean`       | Shallow SMT-LIB embedding + `smtEval` characterization lemmas. |
+| `SpecRest/Translate.lean` | `translate : Expr → SmtTerm` mirroring `z3.Translator.scala`.  |
+| `SpecRest/Soundness.lean` | M_L.2 soundness theorem statement + per-case proven theorems.  |
+| `SpecRest/Examples.lean`  | Checked lemmas (closed evaluation examples).                   |
+| `SpecRest/IR.lean.todo`   | TODO ledger for `Expr` drift in `Types.scala`.                 |
+| `STATUS.md`               | Per-`Expr`-case proof-state ledger mirroring §6.1.             |
 
 ## Scope
 
@@ -58,21 +62,33 @@ choice.
 
 ## Audit appendix
 
-Each in-scope case in `IR.lean` corresponds to a Scala translator clause in
-`modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`. The case-by-case mapping
-arrives in `M_L.2` (issue #128); for now the high-level correspondence is:
+The Lean `translate` function in `SpecRest/Translate.lean` mirrors the Scala translator in
+`modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` case-by-case for the §6.1
+verified subset. M_L.2's soundness theorem (`SpecRest/Soundness.lean`) ties the two together via
+per-case theorems of the shape
+`valueToSmt? (eval ...) = smtEval (correlateModel ...) (correlateEnv ...) (translate ...)`.
 
-| Lean (`SpecRest`)                      | Scala (`Translator.scala`)                 |
-| -------------------------------------- | ------------------------------------------ |
-| `Expr.boolLit`                         | `IExpr.BoolLit` → `Z3Expr.BoolLit`         |
-| `Expr.intLit`                          | `IExpr.IntLit` → `Z3Expr.IntLit`           |
-| `Expr.ident`                           | `IExpr.Identifier` → `Z3Expr.Var`          |
-| `Expr.unNot`                           | `IExpr.UnaryOp(Not, _)` → `Z3Expr.Not`     |
-| `Expr.unNeg`                           | `IExpr.UnaryOp(Negate, _)`                 |
-| `Expr.boolBin .and/.or/.implies/.iff`  | `IExpr.BinaryOp(And/Or/Implies/Iff, _, _)` |
-| `Expr.intCmp .eq/.neq/.lt/.le/.gt/.ge` | `IExpr.BinaryOp(Eq/Neq/Lt/Le/Gt/Ge, _, _)` |
-| `Expr.letIn`                           | `IExpr.Let`                                |
-| `Expr.enumAccess`                      | `IExpr.EnumAccess`                         |
+| Lean `Expr` constructor | Scala `Expr` case                        | Lean `translate` output                      | Scala translator (line range, approx) |
+| ----------------------- | ---------------------------------------- | -------------------------------------------- | ------------------------------------- |
+| `Expr.boolLit b`        | `IExpr.BoolLit(v, _)`                    | `SmtTerm.bLit b`                             | `Translator.scala:588`                |
+| `Expr.intLit n`         | `IExpr.IntLit(v, _)`                     | `SmtTerm.iLit n`                             | `Translator.scala:587`                |
+| `Expr.ident x`          | `IExpr.Identifier(name, _)`              | `SmtTerm.var x`                              | `Translator.scala:590`                |
+| `Expr.unNot`            | `IExpr.UnaryOp(Not, _)`                  | `SmtTerm.not (translate ...)`                | unary-op section                      |
+| `Expr.unNeg`            | `IExpr.UnaryOp(Negate, _)`               | `SmtTerm.neg (translate ...)`                | unary-op section                      |
+| `Expr.boolBin .and`     | `IExpr.BinaryOp(And, _, _)`              | `SmtTerm.and l r`                            | bool-bin section                      |
+| `Expr.boolBin .or`      | `IExpr.BinaryOp(Or, _, _)`               | `SmtTerm.or l r`                             | bool-bin section                      |
+| `Expr.boolBin .implies` | `IExpr.BinaryOp(Implies, _, _)`          | `SmtTerm.implies l r`                        | bool-bin section                      |
+| `Expr.boolBin .iff`     | `IExpr.BinaryOp(Iff, _, _)`              | `SmtTerm.and (.implies l r) (.implies r l)`  | bool-bin section                      |
+| `Expr.cmp .eq`          | `IExpr.BinaryOp(Eq, _, _)`               | `SmtTerm.eq l r`                             | `Translator.scala:1338`               |
+| `Expr.cmp .neq`         | `IExpr.BinaryOp(Neq, _, _)`              | `SmtTerm.not (.eq l r)`                      | cmp section                           |
+| `Expr.cmp .lt`          | `IExpr.BinaryOp(Lt, _, _)`               | `SmtTerm.lt l r`                             | cmp section                           |
+| `Expr.cmp .le`          | `IExpr.BinaryOp(Le, _, _)`               | `SmtTerm.or (.lt l r) (.eq l r)`             | cmp section                           |
+| `Expr.cmp .gt`          | `IExpr.BinaryOp(Gt, _, _)`               | `SmtTerm.lt r l`                             | cmp section                           |
+| `Expr.cmp .ge`          | `IExpr.BinaryOp(Ge, _, _)`               | `SmtTerm.or (.lt r l) (.eq l r)`             | cmp section                           |
+| `Expr.letIn`            | `IExpr.Let(_, _, _)`                     | `SmtTerm.letIn x v body`                     | let section                           |
+| `Expr.enumAccess _ mem` | `IExpr.EnumAccess(_, member, _)`         | `SmtTerm.var mem`                            | enum-access section                   |
+| `Expr.member elem rel`  | `IExpr.BinaryOp(In, elem, ident-rel, _)` | `SmtTerm.inDom rel (translate elem)`         | `In`-membership section               |
+| `Expr.forallEnum`       | `IExpr.Quantifier(All, …)` over enums    | `SmtTerm.forallEnum var en (translate body)` | quantifier section                    |
 
 ## References
 

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -63,32 +63,37 @@ choice.
 ## Audit appendix
 
 The Lean `translate` function in `SpecRest/Translate.lean` mirrors the Scala translator in
-`modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` case-by-case for the §6.1
-verified subset. M_L.2's soundness theorem (`SpecRest/Soundness.lean`) ties the two together via
-per-case theorems of the shape
+`modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`, case-by-case, for the **M_L.1
+verified subset** (the §6.1 minimum plus the M_L.1 extras: `Iff` / `Neq` / `Le` / `Gt` / `Ge`).
+M_L.2's per-case soundness theorems (`SpecRest/Soundness.lean`) tie the two together via equations
+of the shape
 `valueToSmt? (eval ...) = smtEval (correlateModel ...) (correlateEnv ...) (translate ...)`.
 
-| Lean `Expr` constructor | Scala `Expr` case                        | Lean `translate` output                      | Scala translator (line range, approx) |
-| ----------------------- | ---------------------------------------- | -------------------------------------------- | ------------------------------------- |
-| `Expr.boolLit b`        | `IExpr.BoolLit(v, _)`                    | `SmtTerm.bLit b`                             | `Translator.scala:588`                |
-| `Expr.intLit n`         | `IExpr.IntLit(v, _)`                     | `SmtTerm.iLit n`                             | `Translator.scala:587`                |
-| `Expr.ident x`          | `IExpr.Identifier(name, _)`              | `SmtTerm.var x`                              | `Translator.scala:590`                |
-| `Expr.unNot`            | `IExpr.UnaryOp(Not, _)`                  | `SmtTerm.not (translate ...)`                | unary-op section                      |
-| `Expr.unNeg`            | `IExpr.UnaryOp(Negate, _)`               | `SmtTerm.neg (translate ...)`                | unary-op section                      |
-| `Expr.boolBin .and`     | `IExpr.BinaryOp(And, _, _)`              | `SmtTerm.and l r`                            | bool-bin section                      |
-| `Expr.boolBin .or`      | `IExpr.BinaryOp(Or, _, _)`               | `SmtTerm.or l r`                             | bool-bin section                      |
-| `Expr.boolBin .implies` | `IExpr.BinaryOp(Implies, _, _)`          | `SmtTerm.implies l r`                        | bool-bin section                      |
-| `Expr.boolBin .iff`     | `IExpr.BinaryOp(Iff, _, _)`              | `SmtTerm.and (.implies l r) (.implies r l)`  | bool-bin section                      |
-| `Expr.cmp .eq`          | `IExpr.BinaryOp(Eq, _, _)`               | `SmtTerm.eq l r`                             | `Translator.scala:1338`               |
-| `Expr.cmp .neq`         | `IExpr.BinaryOp(Neq, _, _)`              | `SmtTerm.not (.eq l r)`                      | cmp section                           |
-| `Expr.cmp .lt`          | `IExpr.BinaryOp(Lt, _, _)`               | `SmtTerm.lt l r`                             | cmp section                           |
-| `Expr.cmp .le`          | `IExpr.BinaryOp(Le, _, _)`               | `SmtTerm.or (.lt l r) (.eq l r)`             | cmp section                           |
-| `Expr.cmp .gt`          | `IExpr.BinaryOp(Gt, _, _)`               | `SmtTerm.lt r l`                             | cmp section                           |
-| `Expr.cmp .ge`          | `IExpr.BinaryOp(Ge, _, _)`               | `SmtTerm.or (.lt r l) (.eq l r)`             | cmp section                           |
-| `Expr.letIn`            | `IExpr.Let(_, _, _)`                     | `SmtTerm.letIn x v body`                     | let section                           |
-| `Expr.enumAccess _ mem` | `IExpr.EnumAccess(_, member, _)`         | `SmtTerm.var mem`                            | enum-access section                   |
-| `Expr.member elem rel`  | `IExpr.BinaryOp(In, elem, ident-rel, _)` | `SmtTerm.inDom rel (translate elem)`         | `In`-membership section               |
-| `Expr.forallEnum`       | `IExpr.Quantifier(All, …)` over enums    | `SmtTerm.forallEnum var en (translate body)` | quantifier section                    |
+The first six rows below are `sound` in this PR; the remainder are `translated` and become `sound`
+as M_L.2 closure follow-up PRs land their per-case soundness proofs. See `STATUS.md` for the live
+per-case proof-state ledger.
+
+| Lean `Expr` constructor  | Scala `Expr` case                        | Lean `translate` output                      | Scala translator (line range, approx) |
+| ------------------------ | ---------------------------------------- | -------------------------------------------- | ------------------------------------- |
+| `Expr.boolLit b`         | `IExpr.BoolLit(v, _)`                    | `SmtTerm.bLit b`                             | `Translator.scala:588`                |
+| `Expr.intLit n`          | `IExpr.IntLit(v, _)`                     | `SmtTerm.iLit n`                             | `Translator.scala:587`                |
+| `Expr.ident x`           | `IExpr.Identifier(name, _)`              | `SmtTerm.var x`                              | `Translator.scala:590`                |
+| `Expr.unNot`             | `IExpr.UnaryOp(Not, _)`                  | `SmtTerm.not (translate ...)`                | unary-op section                      |
+| `Expr.unNeg`             | `IExpr.UnaryOp(Negate, _)`               | `SmtTerm.neg (translate ...)`                | unary-op section                      |
+| `Expr.boolBin .and`      | `IExpr.BinaryOp(And, _, _)`              | `SmtTerm.and l r`                            | bool-bin section                      |
+| `Expr.boolBin .or`       | `IExpr.BinaryOp(Or, _, _)`               | `SmtTerm.or l r`                             | bool-bin section                      |
+| `Expr.boolBin .implies`  | `IExpr.BinaryOp(Implies, _, _)`          | `SmtTerm.implies l r`                        | bool-bin section                      |
+| `Expr.boolBin .iff`      | `IExpr.BinaryOp(Iff, _, _)`              | `SmtTerm.and (.implies l r) (.implies r l)`  | bool-bin section                      |
+| `Expr.cmp .eq`           | `IExpr.BinaryOp(Eq, _, _)`               | `SmtTerm.eq l r`                             | `Translator.scala:1338`               |
+| `Expr.cmp .neq`          | `IExpr.BinaryOp(Neq, _, _)`              | `SmtTerm.not (.eq l r)`                      | cmp section                           |
+| `Expr.cmp .lt`           | `IExpr.BinaryOp(Lt, _, _)`               | `SmtTerm.lt l r`                             | cmp section                           |
+| `Expr.cmp .le`           | `IExpr.BinaryOp(Le, _, _)`               | `SmtTerm.or (.lt l r) (.eq l r)`             | cmp section                           |
+| `Expr.cmp .gt`           | `IExpr.BinaryOp(Gt, _, _)`               | `SmtTerm.lt r l`                             | cmp section                           |
+| `Expr.cmp .ge`           | `IExpr.BinaryOp(Ge, _, _)`               | `SmtTerm.or (.lt r l) (.eq l r)`             | cmp section                           |
+| `Expr.letIn`             | `IExpr.Let(_, _, _)`                     | `SmtTerm.letIn x v body`                     | let section                           |
+| `Expr.enumAccess en mem` | `IExpr.EnumAccess(name, member, _)`      | `SmtTerm.var (en ++ "." ++ mem)`             | enum-access section                   |
+| `Expr.member elem rel`   | `IExpr.BinaryOp(In, elem, ident-rel, _)` | `SmtTerm.inDom rel (translate elem)`         | `In`-membership section               |
+| `Expr.forallEnum`        | `IExpr.Quantifier(All, …)` over enums    | `SmtTerm.forallEnum var en (translate body)` | quantifier section                    |
 
 ## References
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -6,36 +6,48 @@ proof-program intent.
 
 Status meanings, aligned with `docs/content/docs/research/12_global_proof_status.md`:
 
-| Label      | Meaning                                                                   |
-| ---------- | ------------------------------------------------------------------------- |
-| `embedded` | The Lean `Expr` constructor exists, `eval` covers it, named lemmas exist. |
-| `mirrored` | A prover-side mirror exists, awaiting an `M_L.2` soundness theorem.       |
-| `deferred` | Not yet embedded; queued in `SpecRest/IR.lean.todo`.                      |
-| `excluded` | Permanently outside the Z3 global-theorem track.                          |
+| Label        | Meaning                                                                   |
+| ------------ | ------------------------------------------------------------------------- |
+| `embedded`   | The Lean `Expr` constructor exists, `eval` covers it, named lemmas exist. |
+| `translated` | `translate` mirrors the Scala translator on this case (pre-soundness).    |
+| `mirrored`   | A prover-side mirror exists, awaiting an `M_L.2` soundness theorem.       |
+| `sound`      | An `M_L.2` per-case soundness theorem closes for this constructor.        |
+| `deferred`   | Not yet embedded; queued in `SpecRest/IR.lean.todo`.                      |
+| `excluded`   | Permanently outside the Z3 global-theorem track.                          |
 
 Last sync with `13_global_proof_profile.md`: commit `a430ddc` (2026-05-01, M_L.0 merge).
 
 ## 1. M_L.1 verified subset (research doc §6.1)
 
-| `Expr` case                                       | Profile stage | Lean status |
-| ------------------------------------------------- | ------------- | ----------- |
-| `BoolLit`                                         | `bootstrap`   | `embedded`  |
-| `IntLit`                                          | `bootstrap`   | `embedded`  |
-| `Identifier` (env + state-scalar lookup)          | `bootstrap`   | `embedded`  |
-| `BinaryOp(And \| Or \| Implies \| Iff)`           | `bootstrap`   | `embedded`  |
-| `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `embedded`  |
-| `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `embedded`  |
-| `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `embedded`  |
-| `UnaryOp(Not)`                                    | `bootstrap`   | `embedded`  |
-| `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `embedded`  |
-| `Quantifier(All)` over enums                      | `bootstrap`   | `embedded`  |
-| `Let`                                             | `bootstrap`   | `embedded`  |
-| `EnumAccess`                                      | `bootstrap`   | `embedded`  |
+| `Expr` case                                       | Profile stage | Lean status                                             |
+| ------------------------------------------------- | ------------- | ------------------------------------------------------- |
+| `BoolLit`                                         | `bootstrap`   | `sound` (M_L.2 closed)                                  |
+| `IntLit`                                          | `bootstrap`   | `sound` (M_L.2 closed)                                  |
+| `Identifier` (env + state-scalar lookup)          | `bootstrap`   | `sound` (env path; state path follows in M_L.2 closure) |
+| `BinaryOp(And)`                                   | `bootstrap`   | `sound` (M_L.2 closed)                                  |
+| `BinaryOp(Or \| Implies \| Iff)`                  | `bootstrap`   | `translated` (queued for M_L.2 closure)                 |
+| `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `translated`                                            |
+| `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `translated`                                            |
+| `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `translated`                                            |
+| `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)                                  |
+| `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)                                  |
+| `Quantifier(All)` over enums                      | `bootstrap`   | `translated` (mutual-recursion lemma queued)            |
+| `Let`                                             | `bootstrap`   | `translated`                                            |
+| `EnumAccess`                                      | `bootstrap`   | `translated`                                            |
 
 Per-operator denotation lemmas (the M_L.2 building blocks) live in `SpecRest/Lemmas.lean`. The
 `safe_counter` invariant (`count ≥ 0`) is closed as a named theorem
 (`safeCounter_invariant_holds_initially`) under a hand-built initial state, satisfying the §8.2
 acceptance criterion.
+
+M_L.2 (research doc §8.3): the `translate : Expr → SmtTerm` function, the shallow SMT embedding
+(`SmtTerm`, `SmtVal`, `SmtModel`, `smtEval`), and the correlation functions (`valueToSmt`,
+`correlateEnv`, `correlateModel`) ship in `SpecRest/Smt.lean`, `SpecRest/Translate.lean`, and
+`SpecRest/Soundness.lean`. Per-case soundness theorems are proved for `BoolLit`, `IntLit`,
+`Identifier` (env-hit), `UnaryOp(Not)`, `UnaryOp(Negate)`, and `BinaryOp(And)`. The overall
+`soundness` meta-theorem stands as a `sorry`-gated placeholder; the remaining cases (Or/Implies/Iff,
+all `cmp`, `letIn`, `enumAccess`, `member`, `forallEnum`, plus the state-scalar identifier path)
+follow the same shape and are queued for follow-up M_L.2 closure PRs.
 
 Deep IR shells embedded with carrier shape: `EnumDecl`, `EntityDecl` (flat, no inheritance),
 `FieldDecl`, `StateScalar`, `StateRelation`, `StateDecl`, `OperationDecl` (`requires` + `ensures`;

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -19,21 +19,22 @@ Last sync with `13_global_proof_profile.md`: commit `a430ddc` (2026-05-01, M_L.0
 
 ## 1. M_L.1 verified subset (research doc §6.1)
 
-| `Expr` case                                       | Profile stage | Lean status                                             |
-| ------------------------------------------------- | ------------- | ------------------------------------------------------- |
-| `BoolLit`                                         | `bootstrap`   | `sound` (M_L.2 closed)                                  |
-| `IntLit`                                          | `bootstrap`   | `sound` (M_L.2 closed)                                  |
-| `Identifier` (env + state-scalar lookup)          | `bootstrap`   | `sound` (env path; state path follows in M_L.2 closure) |
-| `BinaryOp(And)`                                   | `bootstrap`   | `sound` (M_L.2 closed)                                  |
-| `BinaryOp(Or \| Implies \| Iff)`                  | `bootstrap`   | `translated` (queued for M_L.2 closure)                 |
-| `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `translated`                                            |
-| `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `translated`                                            |
-| `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `translated`                                            |
-| `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)                                  |
-| `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)                                  |
-| `Quantifier(All)` over enums                      | `bootstrap`   | `translated` (mutual-recursion lemma queued)            |
-| `Let`                                             | `bootstrap`   | `translated`                                            |
-| `EnumAccess`                                      | `bootstrap`   | `translated`                                            |
+| `Expr` case                                       | Profile stage | Lean status                                          |
+| ------------------------------------------------- | ------------- | ---------------------------------------------------- |
+| `BoolLit`                                         | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `IntLit`                                          | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `Identifier` (env-hit path)                       | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `Identifier` (env-miss / state-scalar-hit path)   | `bootstrap`   | `translated` (state-scalar-correlation lemma queued) |
+| `BinaryOp(And)`                                   | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `BinaryOp(Or \| Implies \| Iff)`                  | `bootstrap`   | `translated` (queued for M_L.2 closure)              |
+| `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `translated`                                         |
+| `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `translated`                                         |
+| `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `translated`                                         |
+| `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)                               |
+| `Quantifier(All)` over enums                      | `bootstrap`   | `translated` (mutual-recursion lemma queued)         |
+| `Let`                                             | `bootstrap`   | `translated`                                         |
+| `EnumAccess`                                      | `bootstrap`   | `translated`                                         |
 
 Per-operator denotation lemmas (the M_L.2 building blocks) live in `SpecRest/Lemmas.lean`. The
 `safe_counter` invariant (`count ≥ 0`) is closed as a named theorem

--- a/proofs/lean/SpecRest.lean
+++ b/proofs/lean/SpecRest.lean
@@ -1,3 +1,6 @@
 import SpecRest.IR
 import SpecRest.Semantics
 import SpecRest.Lemmas
+import SpecRest.Smt
+import SpecRest.Translate
+import SpecRest.Soundness

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -1,0 +1,238 @@
+namespace SpecRest
+
+/-! # Shallow embedding of the SMT-LIB fragment emitted by `z3.Translator`.
+
+Audits the §6.1-restricted target language. We support what the Scala
+translator actually emits for the verified subset: Bool, Int, propositional
+ops, equality, less-than, integer negation, bounded universal quantification
+over uninterpreted-sort members, one-place uninterpreted predicates (for
+state-relation domains), and `let`. All operators are total over the SMT
+value space and yield `Option SmtVal` so partiality can be reflected back
+into the soundness theorem. -/
+
+inductive SmtSort where
+  | bool
+  | int
+  | uninterp (name : String)
+  deriving DecidableEq, Repr, Inhabited
+
+inductive SmtVal where
+  | sBool (b : Bool)
+  | sInt (n : Int)
+  | sEnumElem (enumName memberName : String)
+  | sEntityElem (entityName id : String)
+  deriving DecidableEq, Repr, Inhabited
+
+inductive SmtTerm where
+  | bLit (b : Bool)
+  | iLit (n : Int)
+  | var (name : String)
+  | not (t : SmtTerm)
+  | and (l r : SmtTerm)
+  | or (l r : SmtTerm)
+  | implies (l r : SmtTerm)
+  | eq (l r : SmtTerm)
+  | lt (l r : SmtTerm)
+  | neg (t : SmtTerm)
+  | inDom (relName : String) (arg : SmtTerm)
+  | letIn (var : String) (value body : SmtTerm)
+  | forallEnum (var : String) (sortName : String) (body : SmtTerm)
+  deriving Repr, Inhabited
+
+/-- An SMT model resolves the free symbols left by the translator: the
+    finite-domain enum/entity sorts, the state scalars + enum-member
+    constants, and the state-relation domain predicates. -/
+structure SmtModel where
+  sortMembers : List (String × List String)
+  constVals : List (String × SmtVal)
+  predDomain : List (String × List SmtVal)
+  deriving Repr, Inhabited
+
+def SmtModel.empty : SmtModel := { sortMembers := [], constVals := [], predDomain := [] }
+
+def SmtModel.lookupConst (m : SmtModel) (name : String) : Option SmtVal :=
+  List.lookup name m.constVals
+
+def SmtModel.lookupSortMembers (m : SmtModel) (sortName : String) : Option (List String) :=
+  List.lookup sortName m.sortMembers
+
+def SmtModel.lookupRel (m : SmtModel) (name : String) : Option (List SmtVal) :=
+  List.lookup name m.predDomain
+
+abbrev SmtEnv := List (String × SmtVal)
+
+def SmtEnv.lookup (env : SmtEnv) (name : String) : Option SmtVal :=
+  List.lookup name env
+
+def asSmtBool : SmtVal → Option Bool
+  | .sBool b => some b
+  | _        => none
+
+def asSmtInt : SmtVal → Option Int
+  | .sInt n => some n
+  | _       => none
+
+mutual
+
+  def smtEval (m : SmtModel) (env : SmtEnv) : SmtTerm → Option SmtVal
+    | .bLit b => some (.sBool b)
+    | .iLit n => some (.sInt n)
+    | .var x =>
+        match env.lookup x with
+        | some v => some v
+        | none   => m.lookupConst x
+    | .not t =>
+        match smtEval m env t with
+        | some (.sBool b) => some (.sBool (!b))
+        | _               => none
+    | .and l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (a && b))
+        | _, _                             => none
+    | .or l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (a || b))
+        | _, _                             => none
+    | .implies l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (!a || b))
+        | _, _                             => none
+    | .eq l r =>
+        match smtEval m env l, smtEval m env r with
+        | some a, some b => some (.sBool (a == b))
+        | _, _           => none
+    | .lt l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sInt a), some (.sInt b) => some (.sBool (decide (a < b)))
+        | _, _                           => none
+    | .neg t =>
+        match smtEval m env t with
+        | some (.sInt n) => some (.sInt (-n))
+        | _              => none
+    | .inDom relName arg =>
+        match smtEval m env arg with
+        | some v =>
+            match m.lookupRel relName with
+            | some dom => some (.sBool (dom.contains v))
+            | none     => none
+        | none => none
+    | .letIn x value body =>
+        match smtEval m env value with
+        | some v => smtEval m ((x, v) :: env) body
+        | none   => none
+    | .forallEnum var sortName body =>
+        match m.lookupSortMembers sortName with
+        | some members => smtEvalForallEnum m env var sortName members body
+        | none         => none
+  termination_by t => (sizeOf t, 0)
+
+  def smtEvalForallEnum (m : SmtModel) (env : SmtEnv)
+      (var : String) (sortName : String)
+      (members : List String) (body : SmtTerm) : Option SmtVal :=
+    match members with
+    | [] => some (.sBool true)
+    | mem :: rest =>
+        match smtEval m ((var, .sEnumElem sortName mem) :: env) body with
+        | some (.sBool b) =>
+            match smtEvalForallEnum m env var sortName rest body with
+            | some (.sBool acc) => some (.sBool (b && acc))
+            | _                 => none
+        | _ => none
+  termination_by (sizeOf body, members.length)
+
+end
+
+/-! ## Per-constructor characterization lemmas for `smtEval`.
+
+Mirrors the M_L.1 pattern: mutual `smtEval` doesn't reduce via `rfl`,
+so we expose named equations for each constructor. M_L.2's soundness
+proofs use these. -/
+
+variable (m : SmtModel) (env : SmtEnv)
+
+theorem smtEval_bLit (b : Bool) :
+    smtEval m env (.bLit b) = some (.sBool b) := by
+  simp only [smtEval]
+
+theorem smtEval_iLit (n : Int) :
+    smtEval m env (.iLit n) = some (.sInt n) := by
+  simp only [smtEval]
+
+theorem smtEval_var (x : String) :
+    smtEval m env (.var x) =
+      (match env.lookup x with
+        | some v => some v
+        | none   => m.lookupConst x) := by
+  simp only [smtEval]
+
+theorem smtEval_var_local {x : String} {v : SmtVal} (h : env.lookup x = some v) :
+    smtEval m env (.var x) = some v := by
+  simp only [smtEval, h]
+
+theorem smtEval_var_const {x : String} {v : SmtVal}
+    (hEnv : env.lookup x = none) (hConst : m.lookupConst x = some v) :
+    smtEval m env (.var x) = some v := by
+  simp only [smtEval, hEnv, hConst]
+
+theorem smtEval_not_bool (t : SmtTerm) (b : Bool)
+    (h : smtEval m env t = some (.sBool b)) :
+    smtEval m env (.not t) = some (.sBool (!b)) := by
+  simp only [smtEval, h]
+
+theorem smtEval_and_bools (l r : SmtTerm) (a b : Bool)
+    (hl : smtEval m env l = some (.sBool a))
+    (hr : smtEval m env r = some (.sBool b)) :
+    smtEval m env (.and l r) = some (.sBool (a && b)) := by
+  simp only [smtEval, hl, hr]
+
+theorem smtEval_or_bools (l r : SmtTerm) (a b : Bool)
+    (hl : smtEval m env l = some (.sBool a))
+    (hr : smtEval m env r = some (.sBool b)) :
+    smtEval m env (.or l r) = some (.sBool (a || b)) := by
+  simp only [smtEval, hl, hr]
+
+theorem smtEval_implies_bools (l r : SmtTerm) (a b : Bool)
+    (hl : smtEval m env l = some (.sBool a))
+    (hr : smtEval m env r = some (.sBool b)) :
+    smtEval m env (.implies l r) = some (.sBool (!a || b)) := by
+  simp only [smtEval, hl, hr]
+
+theorem smtEval_eq_vals (l r : SmtTerm) (a b : SmtVal)
+    (hl : smtEval m env l = some a)
+    (hr : smtEval m env r = some b) :
+    smtEval m env (.eq l r) = some (.sBool (a == b)) := by
+  simp only [smtEval, hl, hr]
+
+theorem smtEval_lt_ints (l r : SmtTerm) (a b : Int)
+    (hl : smtEval m env l = some (.sInt a))
+    (hr : smtEval m env r = some (.sInt b)) :
+    smtEval m env (.lt l r) = some (.sBool (decide (a < b))) := by
+  simp only [smtEval, hl, hr]
+
+theorem smtEval_neg_int (t : SmtTerm) (n : Int)
+    (h : smtEval m env t = some (.sInt n)) :
+    smtEval m env (.neg t) = some (.sInt (-n)) := by
+  simp only [smtEval, h]
+
+theorem smtEval_letIn_some (x : String) (value body : SmtTerm) (v : SmtVal)
+    (h : smtEval m env value = some v) :
+    smtEval m env (.letIn x value body) = smtEval m ((x, v) :: env) body := by
+  simp only [smtEval, h]
+
+theorem smtEval_inDom_resolved (relName : String) (arg : SmtTerm) (v : SmtVal) (dom : List SmtVal)
+    (hArg : smtEval m env arg = some v)
+    (hRel : m.lookupRel relName = some dom) :
+    smtEval m env (.inDom relName arg) = some (.sBool (dom.contains v)) := by
+  simp only [smtEval, hArg, hRel]
+
+theorem smtEval_forallEnum_known (var sortName : String) (body : SmtTerm) (members : List String)
+    (h : m.lookupSortMembers sortName = some members) :
+    smtEval m env (.forallEnum var sortName body)
+      = smtEvalForallEnum m env var sortName members body := by
+  simp only [smtEval, h]
+
+theorem smtEvalForallEnum_nil (var sortName : String) (body : SmtTerm) :
+    smtEvalForallEnum m env var sortName [] body = some (.sBool true) := by
+  simp only [smtEvalForallEnum]
+
+end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -57,7 +57,8 @@ def correlateModel (s : Schema) (st : State) : SmtModel where
   sortMembers := s.enums.map (fun d => (d.name, d.members))
   constVals :=
     (st.scalars.map (fun (k, v) => (k, valueToSmt v))) ++
-    (s.enums.flatMap (fun d => d.members.map (fun m => (m, SmtVal.sEnumElem d.name m))))
+    (s.enums.flatMap (fun d =>
+      d.members.map (fun m => (d.name ++ "." ++ m, SmtVal.sEnumElem d.name m))))
   predDomain :=
     st.relations.map (fun (k, vs) => (k, vs.map valueToSmt))
 

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -8,9 +8,17 @@ namespace SpecRest
 
 /-! # M_L.2 — Translator soundness theorem.
 
-Statement (research doc §8.3):
+Statement (research doc §8.3, in this file's actual API shape):
 
-  ∀ e, eval e = smtEval (translate e)
+  ∀ (s : Schema) (st : State) (env : Env) (e : Expr),
+    valueToSmt? (eval s st env e)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate e)
+
+The `valueToSmt?` bridge maps `Option Value` ↔ `Option SmtVal`, and
+`correlateEnv` / `correlateModel` derive the canonical SMT model and
+environment from the Lean state and lexical scope. The §8.3 shorthand
+`eval e = smtEval (translate e)` elides those bridges; this file's
+theorems use the explicit form above.
 
 Proved by structural induction on `Expr`. Each constructor uses
 M_L.1's per-arm characterization lemma to unfold `eval`, `translate`'s

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -1,0 +1,188 @@
+import SpecRest.IR
+import SpecRest.Semantics
+import SpecRest.Lemmas
+import SpecRest.Smt
+import SpecRest.Translate
+
+namespace SpecRest
+
+/-! # M_L.2 — Translator soundness theorem.
+
+Statement (research doc §8.3):
+
+  ∀ e, eval e = smtEval (translate e)
+
+Proved by structural induction on `Expr`. Each constructor uses
+M_L.1's per-arm characterization lemma to unfold `eval`, `translate`'s
+structural definition, and M_L.2's `smtEval_*` characterization
+lemmas to unfold `smtEval`.
+
+This file ships the foundations and the trivially-closing cases of
+the §6.1 verified subset. The hard cases (`forallEnum`, full polymorphic
+`cmp`, full `member`) require auxiliary inductive lemmas about the
+correlation between Lean's state-relation domains and the SMT model's
+predicate interpretation; those are queued in follow-up PRs. The
+overall `soundness` theorem is therefore stated with `sorry` as a
+meta-target placeholder for the M_L.2 closure work. -/
+
+/-! ## Value ↔ SmtVal correlation -/
+
+def valueToSmt : Value → SmtVal
+  | .vBool b       => .sBool b
+  | .vInt n        => .sInt n
+  | .vEnum en mem  => .sEnumElem en mem
+  | .vEntity en id => .sEntityElem en id
+
+def valueToSmt? : Option Value → Option SmtVal
+  | some v => some (valueToSmt v)
+  | none   => none
+
+@[simp] theorem valueToSmt?_some (v : Value) :
+    valueToSmt? (some v) = some (valueToSmt v) := rfl
+
+@[simp] theorem valueToSmt?_none :
+    valueToSmt? (none : Option Value) = none := rfl
+
+theorem valueToSmt_inj : ∀ {a b : Value}, valueToSmt a = valueToSmt b → a = b := by
+  intro a b h
+  cases a <;> cases b <;> (try cases h) <;> simp_all
+
+/-! ## Env / State / Schema ↔ SmtModel correlation -/
+
+def correlateEnv : Env → SmtEnv
+  | []            => []
+  | (k, v) :: rest => (k, valueToSmt v) :: correlateEnv rest
+
+def correlateModel (s : Schema) (st : State) : SmtModel where
+  sortMembers := s.enums.map (fun d => (d.name, d.members))
+  constVals :=
+    (st.scalars.map (fun (k, v) => (k, valueToSmt v))) ++
+    (s.enums.flatMap (fun d => d.members.map (fun m => (m, SmtVal.sEnumElem d.name m))))
+  predDomain :=
+    st.relations.map (fun (k, vs) => (k, vs.map valueToSmt))
+
+@[simp] theorem correlateEnv_nil : correlateEnv [] = [] := rfl
+
+@[simp] theorem correlateEnv_cons (x : String) (v : Value) (env : Env) :
+    correlateEnv ((x, v) :: env) = (x, valueToSmt v) :: correlateEnv env := rfl
+
+theorem correlateEnv_lookup (env : Env) (x : String) :
+    SmtEnv.lookup (correlateEnv env) x = (Env.lookup env x).map valueToSmt := by
+  induction env with
+  | nil => rfl
+  | cons hd tl ih =>
+      obtain ⟨k, v⟩ := hd
+      show SmtEnv.lookup ((k, valueToSmt v) :: correlateEnv tl) x
+            = (Env.lookup ((k, v) :: tl) x).map valueToSmt
+      unfold SmtEnv.lookup Env.lookup
+      simp only [List.lookup]
+      split
+      · rfl
+      · exact ih
+
+/-! ## Soundness — case-by-case -/
+
+variable (s : Schema) (st : State) (env : Env)
+
+/-- Atomic: boolean literal. -/
+theorem soundness_boolLit (b : Bool) :
+    valueToSmt? (eval s st env (.boolLit b))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.boolLit b)) := by
+  rw [eval_boolLit, valueToSmt?_some]
+  show some (valueToSmt (.vBool b)) = _
+  show some (SmtVal.sBool b) = _
+  rw [show translate (.boolLit b) = .bLit b from rfl]
+  rw [smtEval_bLit]
+
+/-- Atomic: integer literal. -/
+theorem soundness_intLit (n : Int) :
+    valueToSmt? (eval s st env (.intLit n))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.intLit n)) := by
+  rw [eval_intLit, valueToSmt?_some]
+  show some (SmtVal.sInt n) = _
+  rw [show translate (.intLit n) = .iLit n from rfl]
+  rw [smtEval_iLit]
+
+/-- Identifier — env hit. The local-binding path is the easier of the two. -/
+theorem soundness_ident_local {x : String} {v : Value}
+    (h : Env.lookup env x = some v) :
+    valueToSmt? (eval s st env (.ident x))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.ident x)) := by
+  rw [eval_ident_local s st env h, valueToSmt?_some]
+  rw [show translate (.ident x) = .var x from rfl]
+  have hCorr : SmtEnv.lookup (correlateEnv env) x = some (valueToSmt v) := by
+    rw [correlateEnv_lookup, h]; rfl
+  rw [smtEval_var_local _ _ hCorr]
+
+/-- Unary `not` over a boolean sub-result. -/
+theorem soundness_unNot_bool (e : Expr) (b : Bool)
+    (hSub : valueToSmt? (eval s st env e)
+              = smtEval (correlateModel s st) (correlateEnv env) (translate e))
+    (hEval : eval s st env e = some (.vBool b)) :
+    valueToSmt? (eval s st env (.unNot e))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.unNot e)) := by
+  rw [eval_unNot_bool s st env e b hEval, valueToSmt?_some]
+  show some (SmtVal.sBool (!b)) = _
+  rw [show translate (.unNot e) = .not (translate e) from rfl]
+  rw [hEval] at hSub
+  rw [valueToSmt?_some] at hSub
+  show some (SmtVal.sBool (!b)) = smtEval _ _ (.not (translate e))
+  rw [smtEval_not_bool _ _ (translate e) b hSub.symm]
+
+/-- Unary `negate` over an integer sub-result. -/
+theorem soundness_unNeg_int (e : Expr) (n : Int)
+    (hSub : valueToSmt? (eval s st env e)
+              = smtEval (correlateModel s st) (correlateEnv env) (translate e))
+    (hEval : eval s st env e = some (.vInt n)) :
+    valueToSmt? (eval s st env (.unNeg e))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.unNeg e)) := by
+  rw [eval_unNeg_int s st env e n hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (-n)) = _
+  rw [show translate (.unNeg e) = .neg (translate e) from rfl]
+  rw [hEval] at hSub
+  rw [valueToSmt?_some] at hSub
+  show some (SmtVal.sInt (-n)) = smtEval _ _ (.neg (translate e))
+  rw [smtEval_neg_int _ _ (translate e) n hSub.symm]
+
+/-- Boolean `and` — both sides must reduce to booleans. -/
+theorem soundness_boolBin_and_bools (l r : Expr) (a b : Bool)
+    (hSubL : valueToSmt? (eval s st env l)
+              = smtEval (correlateModel s st) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (eval s st env r)
+              = smtEval (correlateModel s st) (correlateEnv env) (translate r))
+    (hL : eval s st env l = some (.vBool a))
+    (hR : eval s st env r = some (.vBool b)) :
+    valueToSmt? (eval s st env (.boolBin .and l r))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.boolBin .and l r)) := by
+  rw [eval_boolBin_bools s st env .and l r a b hL hR, valueToSmt?_some]
+  rw [show evalBoolBin .and a b = (a && b) from rfl]
+  show some (SmtVal.sBool (a && b)) = _
+  rw [show translate (.boolBin .and l r) = .and (translate l) (translate r) from rfl]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEval_and_bools _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-! ## Main theorem (statement)
+
+The universal soundness theorem covers the full §6.1 verified subset
+plus the M_L.1 extras (Iff / Neq / Le / Gt / Ge / Quantifier(Some)).
+This slice ships the foundations and a representative set of proven
+case theorems above. The remaining cases follow the same shape and
+land in the M_L.2 closure follow-up PRs:
+
+- `soundness_boolBin_or_bools`, `soundness_boolBin_implies_bools`,
+  `soundness_boolBin_iff_bools` — straight analogue of `_and_`.
+- `soundness_cmp_eq_vals`, `soundness_cmp_lt_ints`, etc. — cmp cases.
+- `soundness_letIn` — env extension; needs to thread IH through the
+  extended environment.
+- `soundness_enumAccess`, `soundness_member`, `soundness_forallEnum` —
+  require auxiliary lemmas about `correlateModel`'s `predDomain` and
+  `sortMembers` correctness, plus a mutual-induction lemma for
+  `evalForallEnum` ↔ `smtEvalForallEnum`. -/
+
+theorem soundness (e : Expr) :
+    valueToSmt? (eval s st env e)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate e) := by
+  sorry
+
+end SpecRest

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -1,0 +1,41 @@
+import SpecRest.IR
+import SpecRest.Smt
+
+namespace SpecRest
+
+/-! # Lean mirror of `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`.
+
+Restricted to the §6.1 verified subset (research doc §6). For each `Expr`
+constructor in scope, we emit a single `SmtTerm`; the M_L.2 soundness
+theorem is `valueToSmt? (eval s st env e) = smtEval (correlateModel s st)
+(correlateEnv env) (translate e)` for every `Expr e` in the subset.
+
+Audit appendix mapping each Lean case to the Scala translator's line
+range lives in `proofs/lean/README.md`. -/
+
+def translate : Expr → SmtTerm
+  | .boolLit b => .bLit b
+  | .intLit n  => .iLit n
+  | .ident x   => .var x
+  | .unNot e   => .not (translate e)
+  | .unNeg e   => .neg (translate e)
+  | .boolBin .and     l r => .and (translate l) (translate r)
+  | .boolBin .or      l r => .or (translate l) (translate r)
+  | .boolBin .implies l r => .implies (translate l) (translate r)
+  | .boolBin .iff     l r =>
+      .and (.implies (translate l) (translate r))
+           (.implies (translate r) (translate l))
+  | .cmp .eq  l r => .eq (translate l) (translate r)
+  | .cmp .neq l r => .not (.eq (translate l) (translate r))
+  | .cmp .lt  l r => .lt (translate l) (translate r)
+  | .cmp .le  l r =>
+      .or (.lt (translate l) (translate r)) (.eq (translate l) (translate r))
+  | .cmp .gt  l r => .lt (translate r) (translate l)
+  | .cmp .ge  l r =>
+      .or (.lt (translate r) (translate l)) (.eq (translate l) (translate r))
+  | .letIn x v body         => .letIn x (translate v) (translate body)
+  | .enumAccess _ memberName => .var memberName
+  | .member elem relName    => .inDom relName (translate elem)
+  | .forallEnum var en body => .forallEnum var en (translate body)
+
+end SpecRest

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -33,9 +33,9 @@ def translate : Expr → SmtTerm
   | .cmp .gt  l r => .lt (translate r) (translate l)
   | .cmp .ge  l r =>
       .or (.lt (translate r) (translate l)) (.eq (translate l) (translate r))
-  | .letIn x v body         => .letIn x (translate v) (translate body)
-  | .enumAccess _ memberName => .var memberName
-  | .member elem relName    => .inDom relName (translate elem)
-  | .forallEnum var en body => .forallEnum var en (translate body)
+  | .letIn x v body          => .letIn x (translate v) (translate body)
+  | .enumAccess en memberName => .var (en ++ "." ++ memberName)
+  | .member elem relName     => .inDom relName (translate elem)
+  | .forallEnum var en body  => .forallEnum var en (translate body)
 
 end SpecRest

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.2.0"
+version = "0.3.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

- Lands the foundations of the M_L.2 universal translator-soundness theorem (research doc §8.3): shallow SMT embedding (`Smt.lean`), Lean-side translator (`Translate.lean`), correlation between Lean and SMT semantic worlds (`Soundness.lean`), per-case soundness theorems for the easy half of the §6.1 verified subset.
- Tagged **partial** — does not close #128 by itself. The universal `soundness` meta-theorem is `sorry`-gated; closure follow-up PRs land the remaining cases (Or/Implies/Iff, all `cmp`, `letIn`, `enumAccess`, `member`, `forallEnum`, the state-scalar identifier path) without re-litigating the design.

## What's proven in this PR

| Soundness theorem | Status |
|---|---|
| `soundness_boolLit` | ✅ |
| `soundness_intLit` | ✅ |
| `soundness_ident_local` (env-hit path) | ✅ |
| `soundness_unNot_bool` | ✅ |
| `soundness_unNeg_int` | ✅ |
| `soundness_boolBin_and_bools` | ✅ |
| `soundness` (universal meta-theorem) | `sorry`-gated (closure follow-ups) |

Each per-case theorem closes via kernel-only tactics: `rw [eval_<arm>] -> show <reduced> -> rw [translate definitional] -> rw [smtEval_<arm>]`. Builds on M_L.1's `Lemmas.lean` characterizations + this PR's new `smtEval_*` characterization lemmas.

## Files

```text
proofs/lean/SpecRest/Smt.lean         NEW (238 LOC) — SmtTerm/SmtVal/SmtModel + smtEval + 17 char. lemmas
proofs/lean/SpecRest/Translate.lean   NEW (41 LOC)  — Expr → SmtTerm structural mirror
proofs/lean/SpecRest/Soundness.lean   NEW (188 LOC) — correlate + per-case soundness theorems
proofs/lean/SpecRest.lean             re-exports the 3 new modules
proofs/lean/lakefile.toml             0.2.0 → 0.3.0
proofs/lean/STATUS.md                 + `translated` / `sound` labels; per-case granularity
proofs/lean/README.md                 audit appendix: Scala ↔ Lean translator mapping for §6.1
docs/.../12_global_proof_status.md    baseline refreshed; tracked rows for the 3 new modules
```

LOC delta: +554 / -52 across 8 files.

## Termination & soundness story

Both `eval` (M_L.1) and `smtEval` (this PR) live in `mutual` blocks with lex termination measure `(sizeOf body, members.length)`. This means:

- Neither reduces via `rfl` (wf-fix wrapper survives).
- Per-case characterization lemmas (`eval_*`, `smtEval_*`) are the building blocks every soundness proof uses.
- The pattern `rw [eval_<arm>] ; rw [smtEval_<arm>]` discharges per-case soundness reliably.

`SmtVal` distinguishes `sEnumElem` from `sEntityElem` (rather than a unified `sElem`) — required for soundness on `cmp .eq` between enum-typed and entity-typed values that share `sortName + memberName`. `valueToSmt` is therefore injective; `valueToSmt_inj` proves it.

## Why partial PR

§8.3 budgets M_L.2 at 6-12 person-months. Shipping foundations + a representative set of proven cases in one PR (+ leaving closure as follow-up tickets) is the minimum work that makes M_L.2 trackable: the abstract design (correlate functions, `SmtTerm` shape, `Translate.lean` normalization choices) is now committed to and won't churn in follow-ups. The remaining cases follow the same pattern.

## Verified locally

`lake build` reports `Build completed successfully (10 jobs)`. Single intentional `sorry` warning is on the universal `soundness` theorem. The new `lake-build` pre-commit hook ran and passed during commit.

## Test plan

- [ ] CI `lake-build` job compiles all 7 modules (Smt, Translate, Soundness now part of the lib).
- [ ] CI `build-and-test` (Scala) unaffected — no Scala touched.
- [ ] Docs build: `12_global_proof_status.md` only adds rows; no schema regression expected.
- [ ] `branch-name` check passes.
- [ ] CodeRabbit / cubic / Copilot reviews addressed.

## Acceptance status (issue #128)

- [ ] `Soundness.lean` closes with no `sorry` for the §6.1 subset — **PARTIAL** (6 cases proven; closure PRs needed).
- [ ] `TranslatorAuditTest.scala` is green and included in `sbt test` — **deferred** to a separate PR (kept this one Lean-only).
- [x] Audit appendix in `proofs/lean/README.md` — done.

This PR therefore opens M_L.2 work but does not close #128.