### PR TITLE
Fix jackson-core GHSA-72hv-8253-57qq

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,10 @@ val declineVersion          = "2.6.2"
 val apispecVersion          = "0.11.3"
 val snakeYamlVersion        = "2.3"
 val catsEffectVersion       = "3.7.0"
+val jacksonCoreVersion      = "2.18.6"
+
+// Scala 3.6.3's scaladoc toolchain still resolves jackson-core 2.15.1.
+ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
 
 lazy val commonMainDeps = Seq(
   "org.typelevel" %% "cats-effect" % catsEffectVersion


### PR DESCRIPTION
## Summary
- add a build-wide dependency override for `com.fasterxml.jackson.core:jackson-core`
- pin the resolved version to `2.18.6`, the first patched release for `GHSA-72hv-8253-57qq`
- keep the change narrowly scoped to `jackson-core`, which is currently pulled transitively via Scala 3.6.3's `scaladoc_3`

## Why
GitHub Security and local sbt resolution both showed `jackson-core:2.15.1` in the build through `org.scala-lang:scaladoc_3:3.6.3`. This PR forces the build onto the patched line without changing the rest of the Scala or Jackson stack.

## Validation
- `sbt -Dsbt.log.noformat=true "show root / update" | grep -n "jackson-core\|scaladoc_3"`
  - before: `jackson-core:2.15.1`
  - after: `jackson-core:2.18.6`
- `sbt test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jackson Core dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->