### PR TITLE
M_L.4.e — BinaryOp(NotIn) via composition (advances #130)

### DIFF
--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -982,13 +982,14 @@ implementation slice **`Z3-Core-1S`** (one-state).
 | `TypeAliasDecl`, `FactDecl`, `FunctionDecl`, `PredicateDecl`, `TransitionDecl`, `ConventionsDecl` | `defer` | — |
 | `TemporalDecl` | `exclude` | Always Alloy-routed; outside Z3 theorem. |
 
-### 14.4 Expression-Level Profile (post-M_L.4.a-d)
+### 14.4 Expression-Level Profile (post-M_L.4.a-e)
 
 | `Expr` case | Stage | Rule / reason |
 |---|---|---|
 | `BinaryOp(And \| Or \| Implies \| Iff)` | `bootstrap` | Core propositional layer. Soundness: M_L.2 closure. |
 | `BinaryOp(Eq \| Neq \| Lt \| Gt \| Le \| Ge)` | `bootstrap` | Core comparison layer. Soundness: M_L.2 closure. |
-| `BinaryOp(In \| NotIn)` | `bootstrap` | State-relation domain membership. Soundness: M_L.2 closure. |
+| `BinaryOp(In)` | `bootstrap` | State-relation domain membership. Soundness: M_L.2 closure. |
+| `BinaryOp(NotIn)` | `bootstrap` | **M_L.4.e closed via emitter-side composition:** `NotIn(e, r) ≡ ¬In(e, r)`. |
 | `BinaryOp(Add \| Sub \| Mul \| Div)` | `bootstrap` | **M_L.4.a closed.** `Div`-by-zero policy: `eval` returns `none`. |
 | `BinaryOp(Subset \| Union \| Intersect \| Diff)` | `defer` | Set algebra requires `List + Perm` carrier. |
 | `UnaryOp(Not \| Negate)` | `bootstrap` | M_L.2 closed. |

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -272,6 +272,12 @@ object Emit:
             // VerifiedSubset.classify rejects this shape; reaching here
             // implies a classifier-vs-renderer drift.
             case _ => unreachableShape("BinaryOp(In): non-identifier rhs")
+        case BinOp.NotIn =>
+          // NotIn(elem, rel)  ≡  Not(In(elem, rel)). Emitter-side composition
+          // mirrors Translator.scala:632-636 which renders the same shape.
+          r match
+            case Expr.Identifier(rel, _) => s"(.unNot (.member $lT ${quote(rel)}))"
+            case _                       => unreachableShape("BinaryOp(NotIn): non-identifier rhs")
         case _ => unreachableShape(s"BinaryOp.$op out of subset")
     case Expr.Let(v, value, body, _) =>
       s"(.letIn ${quote(v)} ${renderExpr(value)} ${renderExpr(body)})"

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -160,6 +160,8 @@ object EvalIR:
         v   <- eval(s, st, env, elem)
         dom <- relationDomain(st, relName)
       yield Value.VBool(dom.contains(v))
+    case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
+      eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
     case Expr.Let(name, value, body, _) =>
       eval(s, st, env, value).flatMap(v => eval(s, st, (name, v) :: env, body))
     case Expr.EnumAccess(Expr.Identifier(enName, _), member, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
@@ -38,15 +38,16 @@ object VerifiedSubset:
             BinOp.Lt | BinOp.Le | BinOp.Gt | BinOp.Ge |
             BinOp.Add | BinOp.Sub | BinOp.Mul | BinOp.Div =>
           chooseWorse(classify(l), classify(r))
-        case BinOp.In =>
-          // BinaryOp(In) is renderable only when the rhs is an `Identifier`
+        case BinOp.In | BinOp.NotIn =>
+          // BinaryOp(In/NotIn) is renderable only when the rhs is an `Identifier`
           // — M_L.1 ties `In` to state-relation domain membership and the
-          // emitter renders `.member elem relName` with a literal name.
+          // emitter renders `.member elem relName` with a literal name. NotIn is
+          // emitted as `(.unNot (.member elem relName))` (M_L.4.e composition).
           r match
             case _: Expr.Identifier => chooseWorse(classify(l), classify(r))
             case _ =>
               SubsetStatus.OutOfSubset(
-                "BinaryOp(In): rhs must be a state-relation identifier"
+                s"BinaryOp($op): rhs must be a state-relation identifier"
               )
         case other =>
           SubsetStatus.OutOfSubset(s"BinaryOp.$other not in M_L.1 verified subset")

--- a/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
@@ -33,6 +33,7 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.Gt",
     "BinaryOp.Ge",
     "BinaryOp.In",
+    "BinaryOp.NotIn",
     "BinaryOp.Add",
     "BinaryOp.Sub",
     "BinaryOp.Mul",
@@ -92,7 +93,8 @@ class ProofDriftAuditTest extends FunSuite:
     */
   private val needsStateRelations: Set[String] = Set(
     "UnaryOp.Cardinality",
-    "BinaryOp.In"
+    "BinaryOp.In",
+    "BinaryOp.NotIn"
   )
 
   test("A4: classifier-accepted probes never produce UNRENDERABLE in renderExpr"):
@@ -185,6 +187,7 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.Gt"         -> "BinOp.Gt",
     "BinaryOp.Ge"         -> "BinOp.Ge",
     "BinaryOp.In"         -> "BinOp.In",
+    "BinaryOp.NotIn"      -> "BinOp.NotIn",
     "BinaryOp.Add"        -> "BinOp.Add",
     "BinaryOp.Sub"        -> "BinOp.Sub",
     "BinaryOp.Mul"        -> "BinOp.Mul",

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -191,6 +191,11 @@ class EmitTest extends FunSuite:
         Expr.Identifier("u"),
         Expr.Identifier("active")
       ),
+      Expr.BinaryOp(
+        BinOp.NotIn,
+        Expr.Identifier("u"),
+        Expr.Identifier("active")
+      ),
       Expr.Let("x", Expr.IntLit(1), Expr.Identifier("x")),
       Expr.EnumAccess(Expr.Identifier("Color"), "Red"),
       Expr.Quantifier(
@@ -236,6 +241,8 @@ class EmitTest extends FunSuite:
       // Shape constraints — classifier rejects what renderExpr can't render:
       Expr.BinaryOp(BinOp.In, Expr.Identifier("u"), Expr.BoolLit(true))
         -> "BinaryOp(In): rhs must be a state-relation identifier",
+      Expr.BinaryOp(BinOp.NotIn, Expr.Identifier("u"), Expr.BoolLit(true))
+        -> "BinaryOp(NotIn): rhs must be a state-relation identifier",
       Expr.Quantifier(
         QuantKind.All,
         List(

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -32,7 +32,7 @@ The library implements the verified subset shipped through M_L.4.a-d:
 - integer comparisons (`=`, `!=`, `<`, `≤`, `>`, `≥`),
 - LIA arithmetic (`+`, `-`, `*`, `/` with `Div`-by-zero `none` policy),
 - `Not` / `Negate`,
-- state-relation membership (`In`),
+- state-relation membership (`In`, `NotIn` via emitter-side `¬In` composition),
 - state-relation cardinality (`#rel`),
 - `Let`, `EnumAccess`,
 - `Prime` / `Pre` (single-state collapse — true two-state semantics is M_L.4.b-ext),
@@ -82,27 +82,28 @@ The first six rows below are `sound` in this PR; the remainder are `translated` 
 as M_L.2 closure follow-up PRs land their per-case soundness proofs. See `STATUS.md` for the live
 per-case proof-state ledger.
 
-| Lean `Expr` constructor  | Scala `Expr` case                        | Lean `translate` output                      | Scala translator (line range, approx) |
-| ------------------------ | ---------------------------------------- | -------------------------------------------- | ------------------------------------- |
-| `Expr.boolLit b`         | `IExpr.BoolLit(v, _)`                    | `SmtTerm.bLit b`                             | `Translator.scala:588`                |
-| `Expr.intLit n`          | `IExpr.IntLit(v, _)`                     | `SmtTerm.iLit n`                             | `Translator.scala:587`                |
-| `Expr.ident x`           | `IExpr.Identifier(name, _)`              | `SmtTerm.var x`                              | `Translator.scala:590`                |
-| `Expr.unNot`             | `IExpr.UnaryOp(Not, _)`                  | `SmtTerm.not (translate ...)`                | unary-op section                      |
-| `Expr.unNeg`             | `IExpr.UnaryOp(Negate, _)`               | `SmtTerm.neg (translate ...)`                | unary-op section                      |
-| `Expr.boolBin .and`      | `IExpr.BinaryOp(And, _, _)`              | `SmtTerm.and l r`                            | bool-bin section                      |
-| `Expr.boolBin .or`       | `IExpr.BinaryOp(Or, _, _)`               | `SmtTerm.or l r`                             | bool-bin section                      |
-| `Expr.boolBin .implies`  | `IExpr.BinaryOp(Implies, _, _)`          | `SmtTerm.implies l r`                        | bool-bin section                      |
-| `Expr.boolBin .iff`      | `IExpr.BinaryOp(Iff, _, _)`              | `SmtTerm.and (.implies l r) (.implies r l)`  | bool-bin section                      |
-| `Expr.cmp .eq`           | `IExpr.BinaryOp(Eq, _, _)`               | `SmtTerm.eq l r`                             | `Translator.scala:1338`               |
-| `Expr.cmp .neq`          | `IExpr.BinaryOp(Neq, _, _)`              | `SmtTerm.not (.eq l r)`                      | cmp section                           |
-| `Expr.cmp .lt`           | `IExpr.BinaryOp(Lt, _, _)`               | `SmtTerm.lt l r`                             | cmp section                           |
-| `Expr.cmp .le`           | `IExpr.BinaryOp(Le, _, _)`               | `SmtTerm.or (.lt l r) (.eq l r)`             | cmp section                           |
-| `Expr.cmp .gt`           | `IExpr.BinaryOp(Gt, _, _)`               | `SmtTerm.lt r l`                             | cmp section                           |
-| `Expr.cmp .ge`           | `IExpr.BinaryOp(Ge, _, _)`               | `SmtTerm.or (.lt r l) (.eq l r)`             | cmp section                           |
-| `Expr.letIn`             | `IExpr.Let(_, _, _)`                     | `SmtTerm.letIn x v body`                     | let section                           |
-| `Expr.enumAccess en mem` | `IExpr.EnumAccess(name, member, _)`      | `SmtTerm.var (en ++ "." ++ mem)`             | enum-access section                   |
-| `Expr.member elem rel`   | `IExpr.BinaryOp(In, elem, ident-rel, _)` | `SmtTerm.inDom rel (translate elem)`         | `In`-membership section               |
-| `Expr.forallEnum`        | `IExpr.Quantifier(All, …)` over enums    | `SmtTerm.forallEnum var en (translate body)` | quantifier section                    |
+| Lean `Expr` constructor       | Scala `Expr` case                           | Lean `translate` output                      | Scala translator (line range, approx)    |
+| ----------------------------- | ------------------------------------------- | -------------------------------------------- | ---------------------------------------- |
+| `Expr.boolLit b`              | `IExpr.BoolLit(v, _)`                       | `SmtTerm.bLit b`                             | `Translator.scala:588`                   |
+| `Expr.intLit n`               | `IExpr.IntLit(v, _)`                        | `SmtTerm.iLit n`                             | `Translator.scala:587`                   |
+| `Expr.ident x`                | `IExpr.Identifier(name, _)`                 | `SmtTerm.var x`                              | `Translator.scala:590`                   |
+| `Expr.unNot`                  | `IExpr.UnaryOp(Not, _)`                     | `SmtTerm.not (translate ...)`                | unary-op section                         |
+| `Expr.unNeg`                  | `IExpr.UnaryOp(Negate, _)`                  | `SmtTerm.neg (translate ...)`                | unary-op section                         |
+| `Expr.boolBin .and`           | `IExpr.BinaryOp(And, _, _)`                 | `SmtTerm.and l r`                            | bool-bin section                         |
+| `Expr.boolBin .or`            | `IExpr.BinaryOp(Or, _, _)`                  | `SmtTerm.or l r`                             | bool-bin section                         |
+| `Expr.boolBin .implies`       | `IExpr.BinaryOp(Implies, _, _)`             | `SmtTerm.implies l r`                        | bool-bin section                         |
+| `Expr.boolBin .iff`           | `IExpr.BinaryOp(Iff, _, _)`                 | `SmtTerm.and (.implies l r) (.implies r l)`  | bool-bin section                         |
+| `Expr.cmp .eq`                | `IExpr.BinaryOp(Eq, _, _)`                  | `SmtTerm.eq l r`                             | `Translator.scala:1338`                  |
+| `Expr.cmp .neq`               | `IExpr.BinaryOp(Neq, _, _)`                 | `SmtTerm.not (.eq l r)`                      | cmp section                              |
+| `Expr.cmp .lt`                | `IExpr.BinaryOp(Lt, _, _)`                  | `SmtTerm.lt l r`                             | cmp section                              |
+| `Expr.cmp .le`                | `IExpr.BinaryOp(Le, _, _)`                  | `SmtTerm.or (.lt l r) (.eq l r)`             | cmp section                              |
+| `Expr.cmp .gt`                | `IExpr.BinaryOp(Gt, _, _)`                  | `SmtTerm.lt r l`                             | cmp section                              |
+| `Expr.cmp .ge`                | `IExpr.BinaryOp(Ge, _, _)`                  | `SmtTerm.or (.lt r l) (.eq l r)`             | cmp section                              |
+| `Expr.letIn`                  | `IExpr.Let(_, _, _)`                        | `SmtTerm.letIn x v body`                     | let section                              |
+| `Expr.enumAccess en mem`      | `IExpr.EnumAccess(name, member, _)`         | `SmtTerm.var (en ++ "." ++ mem)`             | enum-access section                      |
+| `Expr.member elem rel`        | `IExpr.BinaryOp(In, elem, ident-rel, _)`    | `SmtTerm.inDom rel (translate elem)`         | `In`-membership section                  |
+| `(.unNot (.member elem rel))` | `IExpr.BinaryOp(NotIn, elem, ident-rel, _)` | `SmtTerm.not (.inDom rel (translate elem))`  | `NotIn`-membership section (composition) |
+| `Expr.forallEnum`             | `IExpr.Quantifier(All, …)` over enums       | `SmtTerm.forallEnum var en (translate body)` | quantifier section                       |
 
 ## References
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -15,7 +15,7 @@ Status meanings, aligned with `docs/content/docs/research/10_translator_soundnes
 | `deferred`   | Not yet embedded; queued in `SpecRest/IR.lean.todo`.                      |
 | `excluded`   | Permanently outside the Z3 global-theorem track.                          |
 
-Last sync with the consolidated profile (now §14 of `10_translator_soundness.md`): M_L.4.a-d shipped
+Last sync with the consolidated profile (now §14 of `10_translator_soundness.md`): M_L.4.a-e shipped
 batch (post-2026-05-02).
 
 ## 1. M_L.1 verified subset (research doc §6.1)
@@ -31,6 +31,7 @@ batch (post-2026-05-02).
 | `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `sound` (M_L.2 closure) |
+| `BinaryOp(NotIn)` (composition `¬In`)             | `first ship`  | `sound` (M_L.4.e)       |
 | `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `Quantifier(All)` over enums                      | `bootstrap`   | `sound` (M_L.2 closure) |
@@ -95,6 +96,25 @@ ensures stubbed with `true` until `Prime`/`Pre` land in M_L.2), `InvariantDecl`,
 | `Index` (state-relation reference)             | `first ship`  | `deferred` |
 | `Quantifier(Some)` over enums                  | `first ship`  | `deferred` |
 | Two-state coupling via `OperationDecl.ensures` | `first ship`  | `deferred` |
+
+### M_L.4.e — BinaryOp(NotIn) via composition (closed in this PR)
+
+`BinaryOp(NotIn, elem, rel)` is now in the verified subset. Encoding is **purely emitter-side
+composition** — no new Lean constructors:
+
+- `NotIn(elem, rel)` → `(.unNot (.member elem rel))`
+
+This mirrors `Translator.scala:632-636` exactly: the production translator renders `In/NotIn`
+through the same `membership(...)` helper and only differs by an outer `Z3Expr.Not`. The Lean
+meta-theorem covers NotIn via the existing `member` and `unNot` arms; no new soundness theorem or
+mutual-induction lemma is needed. `EvalIR.eval` reduces the same way (`Not(In(...))`), so Scala and
+Lean compute identical values.
+
+Restrictions match `In`: rhs must be a state-relation identifier (literal name).
+
+Scala mirror: `cert/VerifiedSubset.scala` accepts `BinOp.NotIn` with the same identifier-rhs
+restriction; `cert/EvalIR.scala` desugars to `Not(In(...))`; `cert/Emit.scala` renders
+`(.unNot (.member $lT $rel))`.
 
 ### M_L.4.d — Quantifier(Some/No/Exists) over enums via composition (closed in this PR)
 


### PR DESCRIPTION
## Summary

- `BinaryOp(NotIn)` joins the verified subset via emitter-side composition: `NotIn(e, r) → (.unNot (.member e r))`.
- No new Lean constructors, no new soundness theorems, no mutual-induction lemmas — Lean covers it through the existing `member` + `unNot` arms of the universal `soundness` theorem.
- Mirrors `Translator.scala:632-636` exactly: the production translator routes `In/NotIn` through `membership(...)` and only differs by an outer `Z3Expr.Not`.
- Restrictions match `In`: rhs must be a state-relation identifier.

This is the smallest analogue to M_L.4.d (Some/No/Exists). Set-algebra (Subset/Union/Intersect/Diff) remains deferred — it requires Set-typed values in `Value` and `Set` SMT sorts, which is multi-PR territory.

## Files

| Layer | File | Change |
|---|---|---|
| Classifier | `cert/VerifiedSubset.scala` | Accept `BinOp.NotIn` under same identifier-rhs guard as `In`. |
| Reducer | `cert/EvalIR.scala` | Desugar `NotIn` → `Not(In(...))` so Scala and Lean compute identical values. |
| Emitter | `cert/Emit.scala` | Render `(.unNot (.member $lT $rel))`. |
| Tests | `cert/EmitTest.scala` | Positive + negative (non-identifier rhs) cases. |
| Drift audit | `audit/ProofDriftAuditTest.scala` | A1 `leanCoveredShapes`, A2 `translatorRequiredLiterals`, A4 `needsStateRelations` exemption. |
| Ledger | `proofs/lean/STATUS.md` | Row in §1 + new §M_L.4.e closure section. |
| Workspace doc | `proofs/lean/README.md` | Scope bullet + audit-appendix table row. |
| Profile | `docs/.../10_translator_soundness.md` §14.4 | Split `In/NotIn`; mark `NotIn` as M_L.4.e-closed. |

No Lean source changes. No lakefile version bump (A8 only fires on `proofs/lean/SpecRest/*.lean` changes).

## Test plan

- [x] `sbt verify/test` — 156 pass
- [x] `sbt scalafmtCheckAll && sbt "scalafixAll --check"` — clean
- [x] `cd docs && npm run build` — 26 html files, link check passed
- [x] `sbt "verify/testOnly *EmitTest *ProofDriftAuditTest"` — 19 pass (positive + negative NotIn)
- [ ] CI: build-and-test, lean-certs matrix, cubic, CodeRabbit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `BinaryOp(NotIn)` to the verified subset by composing it as `Not(In(...))`, matching the production translator and keeping the same rhs identifier restriction as `In`. Scala eval and Lean encoding stay aligned without adding new Lean constructors.

- **New Features**
  - Allow `BinaryOp.NotIn` in the subset (rhs must be an identifier).
  - Desugar to `Not(In(...))` in the evaluator.
  - Emit as `(.unNot (.member elem rel))`, mirroring the translator.
  - Update tests and docs; no Lean source changes.

<sup>Written for commit 10c43147384a982c4c2701c8bff1249eaab253e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `NotIn` (negated membership) operator support to verification and certificate generation workflows, implemented via an emitter-side composition mechanism.

* **Documentation**
  * Updated reference specifications and verification status records to document the new operator and its soundness properties.

* **Tests**
  * Extended test coverage to validate the new operator across verification phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->