### PR TITLE
M_L.4 tail + hygiene: Subset, demo-state seeding, A6 audit (closes #130, advances #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The binary is ~30 MB with ~50 ms cold start, no JVM required at runtime.
 
 The `verify` command's correctness is **mechanically validated in Lean 4**. The universal soundness
 meta-theorem `SpecRest.soundness` in `proofs/lean/SpecRest/Soundness.lean` closes with **zero
-`sorry`** for the §6.1 verified subset (extended through M_L.4.h, 2026-05-02): atoms, identifiers,
-all logical/arithmetic/comparison operators, state-relation membership/cardinality/lookup,
+`sorry`** for the §6.1 verified subset (extended through M_L.4.i, 2026-05-02): atoms, identifiers,
+all logical/arithmetic/comparison operators, state-relation membership/cardinality/lookup/subset,
 FieldAccess on entity-typed state scalars, single-state `Prime`/`Pre` collapse, and quantifiers over
 enums and state-relations.
 

--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -873,7 +873,7 @@ proof impact in the same PR.
 | TCB-sensitive | `modules/parser/src/main/scala/specrest/parser/Parse.scala` | Parser remains trusted; changes can narrow/widen the honest claim. |
 | TCB-sensitive | `modules/parser/src/main/scala/specrest/parser/Builder.scala` | IR construction remains trusted. |
 | TCB-sensitive | `modules/verify/src/main/scala/specrest/verify/z3/Backend.scala` | Runtime renderer from `Z3Script` to Z3 ASTs. |
-| Proof-owned CI | `.github/workflows/lean-certs.yml` | Sidecar matrix: per fixture, `verify --emit-cert` + `lake build`. Six fixtures as of M_L.4.a-h. |
+| Proof-owned CI | `.github/workflows/lean-certs.yml` | Sidecar matrix: per fixture, `verify --emit-cert` + `lake build`. Six fixtures as of M_L.4.a-i. |
 | Proof-state ledger | `proofs/lean/STATUS.md` | Per-`Expr`-case mirror; PR template enforces re-sync on `Expr` changes. |
 | PR contract | `.github/PULL_REQUEST_TEMPLATE.md` | Carries the `Expr`-touch reminder fanning out to all of the above. |
 
@@ -911,7 +911,7 @@ Any PR touching a proof-governed surface must:
 > [#174](https://github.com/HardMax71/spec_to_rest/issues/174),
 > [#175](https://github.com/HardMax71/spec_to_rest/issues/175).
 
-### 13.1 Current Baseline (post-M_L.4.a-h) — first-ship gate met
+### 13.1 Current Baseline (post-M_L.4.a-i) — first-ship gate met
 
 - **Governance mode:** execution track active; M_L.2 universal soundness closed for the
   §6.1 verified subset (zero `sorry`). M_L.4.a/b/c/d/e/f/g/h all merged.
@@ -919,7 +919,8 @@ Any PR touching a proof-governed surface must:
   language (atoms, identifiers, scalar reads, all logical/arithmetic/comparison operators,
   state-relation membership / cardinality / Index / forall, FieldAccess on entity-typed state
   scalars, single-state `Prime`/`Pre` collapse, enum quantifiers and their `Some`/`No`/`Exists`
-  composition aliases, NotIn composition) is mechanically validated against the Z3 translator.
+  composition aliases, NotIn composition, Subset over rel-identifiers via composition) is
+  mechanically validated against the Z3 translator.
   The deployable claim:
 
   > **For every `ServiceIR` whose invariants and operation `requires` clauses fall in the
@@ -949,8 +950,8 @@ Any PR touching a proof-governed surface must:
 - **Outside the first-ship claim (still genuinely deferred):** `SmtLib.scala`, dump/export
   paths, Alloy-routed checks, proof replay, full-source semantics refinement, **true
   two-state semantics for `Prime`/`Pre`** (single-state collapse only — M_L.4.b-ext gates
-  real preservation reasoning), `With` record-update (bundled with M_L.4.b-ext), set
-  algebra (`Subset`/`Union`/`Intersect`/`Diff` over set values), collection literals,
+  real preservation reasoning), `With` record-update (bundled with M_L.4.b-ext), set-valued
+  algebra (`Union`/`Intersect`/`Diff` — needs `Value.VSet` extension), collection literals,
   strings, `Call`/`Matches`, nested `FieldAccess` on `Index` results.
 
 ### 13.2 Status Labels
@@ -981,7 +982,7 @@ When the ledger changes, the entry should say at least:
 
 > Originally `13_global_proof_profile.md`. Issue
 > [#173](https://github.com/HardMax71/spec_to_rest/issues/173). The committed first scope
-> the global-proof program ships against. Updated post-M_L.4.a-h.
+> the global-proof program ships against. Updated post-M_L.4.a-i.
 
 ### 14.1 Decision Summary
 
@@ -1010,7 +1011,7 @@ implementation slice **`Z3-Core-1S`** (one-state).
 | `TypeAliasDecl`, `FactDecl`, `FunctionDecl`, `PredicateDecl`, `TransitionDecl`, `ConventionsDecl` | `defer` | — |
 | `TemporalDecl` | `exclude` | Always Alloy-routed; outside Z3 theorem. |
 
-### 14.4 Expression-Level Profile (post-M_L.4.a-h)
+### 14.4 Expression-Level Profile (post-M_L.4.a-i)
 
 | `Expr` case | Stage | Rule / reason |
 |---|---|---|
@@ -1019,7 +1020,8 @@ implementation slice **`Z3-Core-1S`** (one-state).
 | `BinaryOp(In)` | `bootstrap` | State-relation domain membership. Soundness: M_L.2 closure. |
 | `BinaryOp(NotIn)` | `bootstrap` | **M_L.4.e closed via emitter-side composition:** `NotIn(e, r) ≡ ¬In(e, r)`. |
 | `BinaryOp(Add \| Sub \| Mul \| Div)` | `bootstrap` | **M_L.4.a closed.** `Div`-by-zero policy: `eval` returns `none`. |
-| `BinaryOp(Subset \| Union \| Intersect \| Diff)` | `defer` | Set algebra requires `List + Perm` carrier. |
+| `BinaryOp(Subset)` over state-relation identifiers | `bootstrap` | **M_L.4.i closed via emitter-side composition:** `Subset(r1, r2) ≡ ∀ x ∈ r1, x ∈ r2`. |
+| `BinaryOp(Union \| Intersect \| Diff)` | `defer` | Set-valued; needs `Value.VSet` extension. |
 | `UnaryOp(Not \| Negate)` | `bootstrap` | M_L.2 closed. |
 | `UnaryOp(Cardinality)` | `bootstrap` | **M_L.4.c closed.** Restricted to state-relation identifiers (mirrors `Translator.scala:876-881`). |
 | `UnaryOp(Power)` | `exclude` | Routed to Alloy. |
@@ -1066,7 +1068,7 @@ flowchart LR
   Parse --> Build --> Checks --> Route --> ZTrans --> Backend --> Solver
 ```
 
-### 14.6 Actual Coverage After M_L.4.a-h
+### 14.6 Actual Coverage After M_L.4.a-i
 
 The originally-targeted `Z3-Core-1S` slice was: `global` and `requires` checks only; no
 `Prime`/`Pre`/`With`/`Cardinality`; no collections, strings, regex; quantifiers over
@@ -1189,11 +1191,11 @@ After M_G.4, the dependency chain is:
 - `#127` (M_L.1) — blocked on `#126` only. **Closed.**
 - `#128` (M_L.2) — blocked on `#127`. **Closed for §6.1 subset, zero sorry.**
 - `#129` (M_L.3) — blocked on `#127`. **Closed.**
-- `#130` (M_L.4) — blocked on `#128`. **Sub-slices a-h closed (LIA arithmetic, single-state
+- `#130` (M_L.4) — blocked on `#128`. **Sub-slices a-i closed (LIA arithmetic, single-state
   Prime/Pre, Cardinality, enum quantifier composition, NotIn composition, state-relation
-  quantifier, Index, FieldAccess on state scalars). Remainder
-  (`With`, true two-state, set algebra, `Call`, nested FieldAccess, strings) deferred to
-  later slices or M_L.4.b-ext.**
+  quantifier, Index, FieldAccess on state scalars, Subset over rel-identifiers via composition).
+  Remainder (`With`, true two-state, set-valued algebra, `Call`, nested FieldAccess, strings)
+  deferred to later slices or M_L.4.b-ext.**
 
 ### 16.6 First-Ship Gate Met
 
@@ -1204,7 +1206,7 @@ As of **2026-05-02**, the activation umbrella's success conditions are satisfied
 | Stable theorem target | `SpecRest.soundness` in `proofs/lean/SpecRest/Soundness.lean` (zero `sorry`). |
 | Explicit TCB | M_L.1 axioms (IR / Semantics) + `Lean.ofReduceBool` for `native_decide` (M_L.3 certs). |
 | Frozen / governed IR surface | `proofs/lean/SpecRest/IR.lean.todo` drift queue; `ProofDriftAuditTest` (A1-A8) enforced in CI. |
-| Proof-safe first scope | §14.4 verified-subset profile (post-M_L.4.a-h). |
+| Proof-safe first scope | §14.4 verified-subset profile (post-M_L.4.a-i). |
 | Active contributor commitment | M_L.0 → M_L.4.h shipped between PR #180 (2026-04-30) and PR #189 (2026-05-02). |
 | Linked kickoff | M_L.0 PR #180 (combined M_L.0 + M_L.1 first slice). |
 

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -305,6 +305,15 @@ object Emit:
           r match
             case Expr.Identifier(rel, _) => s"(.unNot (.member $lT ${quote(rel)}))"
             case _                       => unreachableShape("BinaryOp(NotIn): non-identifier rhs")
+        case BinOp.Subset =>
+          // Subset(r1, r2)  ≡  ∀ x ∈ r1, x ∈ r2. Pure emit-time composition over
+          // M_L.4.f forallRel + M_L.2 member. The bound variable name is unique to
+          // this lowering and shadows safely (List.lookup finds the head binding).
+          (l, r) match
+            case (Expr.Identifier(r1, _), Expr.Identifier(r2, _)) =>
+              s"(.forallRel \"_subset_x\" ${quote(r1)} (.member (.ident \"_subset_x\") ${quote(r2)}))"
+            case _ =>
+              unreachableShape("BinaryOp(Subset): non-identifier operand(s)")
         case _ => unreachableShape(s"BinaryOp.$op out of subset")
     case Expr.Let(v, value, body, _) =>
       s"(.letIn ${quote(v)} ${renderExpr(value, enumNames)} ${renderExpr(body, enumNames)})"

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -44,19 +44,29 @@ object EvalIR:
       val scalars   = scalarFields.map(f => (f.name, defaultFor(schema, f.typeExpr)))
       val relations = relationFields.map(f => (f.name, List.empty[Value]))
       val lookups   = relationFields.map(f => (f.name, List.empty[(Value, Value)]))
-      // Entity-typed scalars get an empty field-table entry so FieldAccess on demo
-      // state returns None deterministically (instead of stubbing on a missing entry).
-      val entityScalars = scalarFields.filter(f => isEntityType(schema, f.typeExpr))
-      val entityFields  = entityScalars.map(f => (f.name, List.empty[(String, Value)]))
+      // Entity-typed scalars: seed the entity's fields with `defaultFor`-synthesized
+      // values, mirroring the production scalar synthesis. Without this, FieldAccess
+      // on a state scalar of entity type returns `none` and the cert emitter stubs
+      // (the M_L.4.h "reducer stuck on placeholder demo state" case). Populating
+      // matches the per-run translation-validation contract: cert_decide checks that
+      // EvalIR (Scala) and `eval` (Lean) compute the same value on this concrete
+      // state — the value's "realism" doesn't affect soundness.
+      val entityFields = scalarFields.flatMap: f =>
+        f.typeExpr match
+          case TypeExpr.NamedType(entityName, _) if schema.entities.contains(entityName) =>
+            ir.entities.find(_.name == entityName) match
+              case Some(entityDecl) =>
+                val seeded = entityDecl.fields.map: fld =>
+                  (fld.name, defaultFor(schema, fld.typeExpr))
+                Some((f.name, seeded))
+              case None =>
+                Some((f.name, List.empty[(String, Value)]))
+          case _ => None
       State(scalars, relations, lookups, entityFields)
 
     private def isScalarType(ty: TypeExpr): Boolean = ty match
       case _: TypeExpr.NamedType => true
       case _                     => false
-
-    private def isEntityType(s: Schema, ty: TypeExpr): Boolean = ty match
-      case TypeExpr.NamedType(name, _) => s.entities.contains(name)
-      case _                           => false
 
   /** Default value chosen by the demo-state synthesizer for a given typeExpr. Threads `Schema` so
     * entity-typed scalars get `.vEntity` and enum-typed scalars get `.vEnum` rather than the wrong
@@ -190,6 +200,18 @@ object EvalIR:
       yield Value.VBool(dom.contains(v))
     case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
       eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
+    case Expr.BinaryOp(
+          BinOp.Subset,
+          Expr.Identifier(r1, _),
+          Expr.Identifier(r2, _),
+          _
+        ) =>
+      // Subset(r1, r2)  ≡  ∀ x ∈ r1, x ∈ r2. Mirror the Lean-side `forallRel + member`
+      // composition that Emit renders.
+      for
+        dom1 <- relationDomain(st, r1)
+        dom2 <- relationDomain(st, r2)
+      yield Value.VBool(dom1.forall(dom2.contains))
     case Expr.Index(Expr.Identifier(relName, _), keyExpr, _) =>
       eval(s, st, env, keyExpr).flatMap(kv => lookupKey(st, relName, kv))
     case Expr.FieldAccess(Expr.Identifier(scalarName, _), fieldName, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
@@ -49,6 +49,17 @@ object VerifiedSubset:
               SubsetStatus.OutOfSubset(
                 s"BinaryOp($op): rhs must be a state-relation identifier"
               )
+        case BinOp.Subset =>
+          // BinaryOp(Subset) over two state-relation identifiers desugars at emit
+          // time to `forallRel x r1, member x r2` — pure composition over existing
+          // M_L.4.f forallRel + M_L.2 member arms. No new Lean constructor.
+          (l, r) match
+            case (_: Expr.Identifier, _: Expr.Identifier) => SubsetStatus.InSubset
+            case _ =>
+              SubsetStatus.OutOfSubset(
+                "BinaryOp(Subset): both operands must be state-relation identifiers " +
+                  "(set-literal subset is collections-deferred)"
+              )
         case other =>
           SubsetStatus.OutOfSubset(s"BinaryOp.$other not in M_L.1 verified subset")
     case Expr.Quantifier(kind, bindings, body, _) =>

--- a/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
@@ -34,6 +34,7 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.Ge",
     "BinaryOp.In",
     "BinaryOp.NotIn",
+    "BinaryOp.Subset",
     "BinaryOp.Add",
     "BinaryOp.Sub",
     "BinaryOp.Mul",
@@ -97,6 +98,7 @@ class ProofDriftAuditTest extends FunSuite:
     "UnaryOp.Cardinality",
     "BinaryOp.In",
     "BinaryOp.NotIn",
+    "BinaryOp.Subset",
     "Index",
     "FieldAccess"
   )
@@ -192,6 +194,7 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.Ge"         -> "BinOp.Ge",
     "BinaryOp.In"         -> "BinOp.In",
     "BinaryOp.NotIn"      -> "BinOp.NotIn",
+    "BinaryOp.Subset"     -> "BinOp.Subset",
     "BinaryOp.Add"        -> "BinOp.Add",
     "BinaryOp.Sub"        -> "BinOp.Sub",
     "BinaryOp.Mul"        -> "BinOp.Mul",
@@ -287,6 +290,42 @@ class ProofDriftAuditTest extends FunSuite:
           |
           |Either the theorem/match-arm was renamed/removed (update soundRowToTheorem here),
           |or STATUS.md falsely claims this row is sound (downgrade STATUS row).
+          |""".stripMargin
+      )
+
+  /** A6 closes the previously-empty A6 numbering slot. Catches the drift class "I added a new Expr
+    * constructor in IR.lean but forgot to extend the universal soundness theorem". Lake's
+    * exhaustiveness checker would catch it eventually, but A6 surfaces it as a unit-test failure
+    * with a localized message instead of burying it in the lake build log.
+    */
+  test(
+    "A6: every Expr constructor in IR.lean has an arm in Soundness.lean's universal soundness theorem"
+  ):
+    val irPath = repoRoot.resolve("proofs/lean/SpecRest/IR.lean")
+    val ctors  = SourceParsers.parseLeanInductiveCases(irPath, "Expr")
+    assert(ctors.nonEmpty, "A6: failed to parse Expr constructors from IR.lean")
+    val soundnessSrc = Files.readString(
+      repoRoot.resolve("proofs/lean/SpecRest/Soundness.lean")
+    )
+    val soundnessIdx = soundnessSrc.indexOf("theorem soundness")
+    assert(
+      soundnessIdx > 0,
+      "A6: could not locate `theorem soundness` block in Soundness.lean"
+    )
+    val soundnessBody = soundnessSrc.substring(soundnessIdx)
+    ctors.foreach: ctor =>
+      val pattern = s"| $ctor"
+      assert(
+        soundnessBody.contains(pattern),
+        clue = s"""
+          |A6 drift: Soundness.lean's universal `theorem soundness` has no `$pattern`
+          |arm for the Expr constructor `.$ctor` declared in IR.lean.
+          |
+          |Fix:
+          |  - If a new Expr constructor was added, dispatch it in the universal
+          |    soundness theorem (success path → per-case theorem; failure path →
+          |    `smtEval_..._none/_unknown` lemma).
+          |  - If the constructor was renamed/removed, update IR.lean accordingly.
           |""".stripMargin
       )
 

--- a/modules/verify/src/test/scala/specrest/verify/audit/SourceParsers.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/SourceParsers.scala
@@ -6,9 +6,10 @@ import java.nio.file.Path
 object SourceParsers:
 
   /** Parse `inductive <name> where | foo (...) | bar (...)` from a Lean source file. Returns
-    * lowercase constructor names. Robust to comments and whitespace. On parse failure (file
-    * missing, inductive not found), returns the empty set so the containing test fails with a clear
-    * "no Lean cases found" rather than throwing.
+    * constructor names verbatim (case-sensitive — Lean identifiers are case-sensitive, and A6
+    * matches against `| ctorName` arms in Soundness.lean which preserve case). Robust to comments
+    * and whitespace. On parse failure (file missing, inductive not found), returns the empty set so
+    * the containing test fails with a clear "no Lean cases found" rather than throwing.
     */
   def parseLeanInductiveCases(path: Path, name: String): Set[String] =
     if !Files.exists(path) then return Set.empty
@@ -27,7 +28,7 @@ object SourceParsers:
       if trimmed.startsWith("|") then
         val afterBar = trimmed.drop(1).trim
         // Strip any leading namespace dot pattern, take the first identifier
-        val tok = afterBar.takeWhile(c => c.isLetterOrDigit || c == '_').toLowerCase
+        val tok = afterBar.takeWhile(c => c.isLetterOrDigit || c == '_')
         if tok.nonEmpty then Some(tok) else None
       else None
     cases.toSet

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -212,6 +212,7 @@ class EmitTest extends FunSuite:
       Expr.UnaryOp(UnOp.Cardinality, Expr.Identifier("rel")),
       Expr.Index(Expr.Identifier("users"), Expr.Identifier("uid")),
       Expr.FieldAccess(Expr.Identifier("currentUser"), "email"),
+      Expr.BinaryOp(BinOp.Subset, Expr.Identifier("active"), Expr.Identifier("members")),
       Expr.Quantifier(
         QuantKind.Some,
         List(QuantifierBinding("c", Expr.Identifier("Color"), BindingKind.In)),
@@ -237,8 +238,8 @@ class EmitTest extends FunSuite:
   test("VerifiedSubset.classify rejects out-of-subset cases with a reason"):
     val rejected = List(
       Expr.UnaryOp(UnOp.Power, Expr.Identifier("x")) -> "UnaryOp.Power",
-      Expr.BinaryOp(BinOp.Subset, Expr.Identifier("a"), Expr.Identifier("b"))
-        -> "BinaryOp.Subset",
+      Expr.BinaryOp(BinOp.Subset, Expr.IntLit(0), Expr.Identifier("b"))
+        -> "BinaryOp(Subset): both operands must be state-relation identifiers",
       Expr.FieldAccess(Expr.IntLit(0), "id")
         -> "FieldAccess: only `state_scalar.field` (Identifier base) is supported",
       Expr.Index(Expr.IntLit(0), Expr.IntLit(1))
@@ -368,6 +369,51 @@ class EmitTest extends FunSuite:
     assert(
       rendered.contains("(\"users\", [])"),
       s"renderStateLit must emit relation entries with their (possibly empty) domains:\n$rendered"
+    )
+
+  test("renderExpr emits `.forallRel + .member` composition for Subset over relations"):
+    // M_L.4.i: BinaryOp(Subset, r1, r2) over two state-relation identifiers desugars
+    // at emit time to `forallRel _subset_x r1 (member (.ident _subset_x) r2)`.
+    // No new Lean constructor; pure composition.
+    val subsetInv = InvariantDecl(
+      name = Some("activeSubset"),
+      expr = Expr.BinaryOp(
+        BinOp.Subset,
+        Expr.Identifier("active"),
+        Expr.Identifier("members")
+      )
+    )
+    val ir = ServiceIR(
+      name = "SubsetProbe",
+      enums = Nil,
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(
+              name = "active",
+              typeExpr = TypeExpr.SetType(TypeExpr.NamedType("Int"))
+            ),
+            StateFieldDecl(
+              name = "members",
+              typeExpr = TypeExpr.SetType(TypeExpr.NamedType("Int"))
+            )
+          )
+        )
+      ),
+      invariants = List(subsetInv)
+    )
+    val rendered = Emit.emit(ir, proofsPath).renderModule
+    assert(
+      rendered.contains(".forallRel") &&
+        rendered.contains("\"active\"") &&
+        rendered.contains(".member") &&
+        rendered.contains("\"_subset_x\"") &&
+        rendered.contains("\"members\""),
+      s"Subset composition must render forallRel+member with both relation names:\n$rendered"
+    )
+    assert(
+      !rendered.contains("UNRENDERABLE"),
+      s"Subset arm must not produce UNRENDERABLE:\n$rendered"
     )
 
   test("EvalIR demo state synthesizes vEntity for entity-typed scalars"):

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -1,8 +1,8 @@
 # SpecRest Lean Workspace
 
-> **Status (post-M_L.4.h, 2026-05-02): first-ship gate met.** The universal `soundness` meta-theorem
-> in `SpecRest/Soundness.lean` closes with zero `sorry` for the §6.1 verified subset, and per-run
-> translation-validation certificates (M_L.3) build cleanly for all six fixtures in
+> **Status (post-M_L.4.a-i, 2026-05-02): first-ship gate met.** The universal `soundness`
+> meta-theorem in `SpecRest/Soundness.lean` closes with zero `sorry` for the §6.1 verified subset,
+> and per-run translation-validation certificates (M_L.3) build cleanly for all six fixtures in
 > `.github/workflows/lean-certs.yml`. The deployable claim, full trust closure, and remaining
 > out-of-scope items are documented in §13.1 of
 > `docs/content/docs/research/10_translator_soundness.md`.
@@ -31,15 +31,16 @@ through its own Lake build and a separate GitHub Actions workflow (`.github/work
 | `SpecRest/IR.lean.todo`   | TODO ledger for `Expr` drift in `Types.scala`.                 |
 | `STATUS.md`               | Per-`Expr`-case proof-state ledger mirroring §6.1.             |
 
-## Scope (post-M_L.4.a-h)
+## Scope (post-M_L.4.a-i)
 
-The library implements the verified subset shipped through M_L.4.a-h:
+The library implements the verified subset shipped through M_L.4.a-i:
 
 - propositional ops (`and`, `or`, `implies`, `iff`),
 - integer comparisons (`=`, `!=`, `<`, `≤`, `>`, `≥`),
 - LIA arithmetic (`+`, `-`, `*`, `/` with `Div`-by-zero `none` policy),
 - `Not` / `Negate`,
-- state-relation membership (`In`, `NotIn` via emitter-side `¬In` composition),
+- state-relation membership (`In`, `NotIn` via emitter-side `¬In` composition, `Subset` via
+  emitter-side `forallRel + member` composition),
 - state-relation cardinality (`#rel`),
 - state-relation indexed lookup (`rel[key]`) over the strictly-additive `lookups` pair table,
 - entity-typed state-scalar field access (`scalar.field`) over the strictly-additive `entityFields`
@@ -53,8 +54,8 @@ The library implements the verified subset shipped through M_L.4.a-h:
 
 The universal `soundness` theorem closes for this slice with **zero `sorry`**.
 
-Still **out of scope**: `With`, `Call`, `Matches`, set algebra
-(`Subset`/`Union`/`Intersect`/`Diff`), collection literals, strings, true two-state preservation
+Still **out of scope**: `With`, `Call`, `Matches`, set-valued algebra (`Union`/`Intersect`/`Diff` —
+would need `Value.VSet` extension), collection literals, strings, true two-state preservation
 reasoning. See `STATUS.md` for the full ledger and `IR.lean.todo` for the queued expansions; see
 `docs/content/docs/research/10_translator_soundness.md` §14 for the proof-safe profile and §16.3 for
 closure status.

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -1,7 +1,7 @@
 # SpecRest Proof-State Ledger
 
 > **First-ship gate met (2026-05-02).** The universal `soundness` meta-theorem is closed with **zero
-> `sorry`** for the §6.1 verified subset extended through M_L.4.h. The Z3 translator's output is
+> `sorry`** for the §6.1 verified subset extended through M_L.4.a-i. The Z3 translator's output is
 > mechanically validated against the Lean `translate` function for every in-subset `Expr`. See
 > `docs/content/docs/research/10_translator_soundness.md` §13.1 for the formal claim and §16.6 for
 > the activation closure record.
@@ -21,7 +21,7 @@ Status meanings, aligned with `docs/content/docs/research/10_translator_soundnes
 | `deferred`   | Not yet embedded; queued in `SpecRest/IR.lean.todo`.                      |
 | `excluded`   | Permanently outside the Z3 global-theorem track.                          |
 
-Last sync with the consolidated profile (now §14 of `10_translator_soundness.md`): M_L.4.a-h shipped
+Last sync with the consolidated profile (now §14 of `10_translator_soundness.md`): M_L.4.a-i shipped
 batch (post-2026-05-02).
 
 ## 1. M_L.1 verified subset (research doc §6.1)
@@ -38,6 +38,7 @@ batch (post-2026-05-02).
 | `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(NotIn)` (composition `¬In`)             | `first ship`  | `sound` (M_L.4.e)       |
+| `BinaryOp(Subset)` over rel-identifiers           | `first ship`  | `sound` (M_L.4.i)       |
 | `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `Quantifier(All)` over enums                      | `bootstrap`   | `sound` (M_L.2 closure) |
@@ -105,6 +106,23 @@ refactor (M_L.4.b-ext).
 | ---------------------------------------------- | ------------- | ---------- |
 | `With`                                         | `first ship`  | `deferred` |
 | Two-state coupling via `OperationDecl.ensures` | `first ship`  | `deferred` |
+
+### M_L.4.i — BinaryOp(Subset) via composition (closed in this PR)
+
+`BinaryOp(Subset, r1, r2)` over two state-relation identifiers joins the verified subset. Encoding
+is **purely emitter-side composition** — no new Lean constructors:
+
+- `Subset(r1, r2)` → `(.forallRel "_subset_x" r1 (.member (.ident "_subset_x") r2))`
+
+This composes M_L.4.f `forallRel` with M_L.2 `member` arms; the universal `soundness` meta-theorem
+covers the composition without a new dispatch arm. `EvalIR.eval` mirrors the value
+(`dom1.forall(dom2.contains)`).
+
+Restricted to two state-relation identifiers (`Subset(r1, r2)` where both are bare identifiers).
+Subset over set-literals is collections-deferred.
+
+Scala mirror: `cert/VerifiedSubset.scala` accepts `BinaryOp(Subset, Identifier, Identifier)`;
+`cert/EvalIR.scala` adds a direct eval arm; `cert/Emit.scala` renders the composition.
 
 ### M_L.4.h — FieldAccess on entity-typed state scalars (closed in this PR)
 
@@ -289,9 +307,10 @@ Scala mirror: `cert/VerifiedSubset.scala` accepts `Add/Sub/Mul/Div`; `cert/EvalI
 
 ## 3. Profile-deferred (later M_L.4 slices)
 
-`BinaryOp(Subset | Union | Intersect | Diff)`, `SomeWrap`, `The`, `Call`, `If`, `Lambda`,
-`Constructor`, `SetLiteral`, `MapLiteral`, `SetComprehension`, `SeqLiteral`, `Matches`, `FloatLit`,
-`StringLit`, `NoneLit` — all `deferred`.
+`BinaryOp(Union | Intersect | Diff)` (set-valued, need `Value.VSet` extension), `SomeWrap`, `The`,
+`Call`, `If`, `Lambda`, `Constructor`, `SetLiteral`, `MapLiteral`, `SetComprehension`, `SeqLiteral`,
+`Matches`, `FloatLit`, `StringLit`, `NoneLit` — all `deferred`. (`BinaryOp(Subset)` over rel
+identifiers closed in M_L.4.i.)
 
 ## 4. Permanently excluded
 

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,16 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-02 — M_L.4.i + EvalIR seeding + A6 audit: BinaryOp(Subset) over
+  state-relation identifiers joins the verified subset via emitter-side
+  composition (forallRel + member) — no new Lean constructor. EvalIR.State.demo
+  now seeds entity-typed state scalars with `defaultFor`-synthesized field
+  values via `entityFields`, allowing FieldAccess on state scalars to resolve
+  to concrete defaults instead of stubbing on a missing entry. ProofDriftAuditTest
+  gains A6: every Expr constructor in IR.lean must have a `| ctorName` arm in
+  Soundness.lean's universal soundness theorem; SourceParsers.parseLeanInductiveCases
+  preserves case (was lowercased — no other consumer relied on it).
+
 2026-05-02 — M_L.4.h: added `Expr.fieldAccess` (entity-typed state-scalar
   field read). Strictly-additive carrier extension: `State.entityFields :
   List (String × List (String × Value))` and `SmtModel.predFields : List


### PR DESCRIPTION
## Summary

Three pieces in one PR — the loose ends from the post-M_L.5 punch list.

### (1) M_L.4.i — `BinaryOp(Subset)` over state-relation identifiers

Pure emit-time composition over existing arms — no new Lean constructor:

  `Subset(r1, r2)`  →  `(.forallRel "_subset_x" r1 (.member (.ident "_subset_x") r2))`

Universal `soundness` covers the composition without a new dispatch arm. EvalIR mirrors as `dom1.forall(dom2.contains)`. Restricted to two bare-Identifier operands; subset over set-literals stays collections-deferred.

### (2) Demo-state seeding for entity-typed state scalars

`EvalIR.State.demo` now populates `entityFields` for each entity-typed state scalar with `defaultFor`-synthesized field values, parallel to scalar seeding. Without this, FieldAccess on a state scalar of entity type returned `None` and the cert emitter stubbed (the M_L.4.h "reducer stuck on placeholder demo state" case for state-scalar-rooted FieldAccess paths). Per-run translation-validation soundness only requires Scala/Lean agreement on the concrete state — the value's "realism" doesn't affect the cert claim.

**Honest scope**: this seeds STATE SCALARS only, not quantifier-bound entity instances (those need an entity-ID-keyed carrier; M_L.4.k territory). Real-fixture coverage uplift is therefore narrower than projected — the seeding helps any future spec with `current_user`-style entity-typed state scalars but doesn't move the needle on the existing 5 fixtures (which all use `forall t in tasks, t.field` patterns).

### (3) A6 audit-test gap closed

`ProofDriftAuditTest` had A1-A5, A7, A8; A6 was a numbering hole. Filled with: every `Expr` constructor in `IR.lean` has a `| ctorName` arm in `Soundness.lean`'s universal soundness theorem. Catches the drift class "new ctor added but soundness dispatch not extended" as a unit-test failure with a localized message instead of burying it in the lake build log.

`SourceParsers.parseLeanInductiveCases` now preserves case (was lowercased — no other consumer relied on the lowercasing).

## Issue closures (post-merge actions, not in this diff)

- **#170** (activation umbrella) — success conditions met in PR #190; safe to close after this PR merges.
- **#130** (M_L.4 sub-issue) — original acceptance criterion (a-h closure) met; this PR adds Subset (i). Remaining single-PR slices (multi-binding quantifier, `Call` builtins) and multi-week M_L.4.b-ext can each get their own focused issues. Closing #130 now is appropriate.

## Files

| Layer | File | Change |
|---|---|---|
| Classifier | `cert/VerifiedSubset.scala` | Accept `BinOp.Subset(Identifier, Identifier)`. |
| Reducer | `cert/EvalIR.scala` | Subset eval arm + entityFields demo-state seeding. |
| Emitter | `cert/Emit.scala` | Subset rendering as forallRel + member composition. |
| Tests | `cert/EmitTest.scala` | Subset positive + dedicated render test + adjusted negative case. |
| Audit | `audit/ProofDriftAuditTest.scala` | A1/A2/A4 entries + new A6. |
| Audit helper | `audit/SourceParsers.scala` | Preserve case in Lean ctor parser. |
| Drift log | `IR.lean.todo` | Entry. |
| Ledger | `STATUS.md` | Subset row + closure section + §3 deferred update + banner. |
| Workspace doc | `proofs/lean/README.md` | Scope bullet + banner. |
| Profile | `10_translator_soundness.md` | §13.1/§14.4/§16.3 — Subset added; "post-M_L.4.a-h" → "post-M_L.4.a-i". |
| User-facing | `README.md` | Verified-subset list extended with subset. |

No Lean source changed (Subset is composition-only). No lakefile bump (A8 only fires on Lean changes).

## Test plan

- [x] `lake build` — 11 jobs, zero `sorry` (unchanged from M_L.5)
- [x] `sbt verify/test` — 159 pass (was 157; +1 Subset render test, +1 A6 audit)
- [x] `sbt scalafmtCheckAll && sbt "scalafixAll --check"` — clean
- [x] All 5 fixtures emit + `lake build` clean
- [x] `cd docs && npm run build` — clean (26 html)
- [ ] CI: build-and-test, lean-certs matrix, cubic, CodeRabbit

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `BinaryOp(Subset)` over relation identifiers via emit-time composition, seeds demo state for entity-typed scalars, and adds an A6 audit to catch missing soundness dispatch. This extends the verified subset to M_L.4.i without changing Lean sources.

- **New Features**
  - `Subset(r1, r2)` over two relation identifiers lowers to `.forallRel + .member`; `EvalIR` mirrors (`dom1.forall(dom2.contains)`); `VerifiedSubset` accepts it.
  - `EvalIR.State.demo` now seeds `entityFields` for entity-typed state scalars using `defaultFor`, so `stateScalar.field` resolves to concrete defaults.

- **Bug Fixes**
  - A6 audit: checks every `Expr` ctor in `IR.lean` has a `| ctorName` arm in `Soundness.lean`; localized failure instead of surfacing in lake logs.
  - `SourceParsers.parseLeanInductiveCases` preserves constructor case to match Lean.

<sup>Written for commit 26057c05b6a12e3fde5f7ba321d285654f6b19ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

