### PR TITLE
[codex] Add verified set-valued algebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ The binary is ~30 MB with ~50 ms cold start, no JVM required at runtime.
 
 The `verify` command's correctness is **mechanically validated in Lean 4**. The universal soundness
 meta-theorem `SpecRest.soundness` in `proofs/lean/SpecRest/Soundness.lean` closes with **zero
-`sorry`** for the §6.1 verified subset (extended through M_L.4.i, 2026-05-02): atoms, identifiers,
-all logical/arithmetic/comparison operators, state-relation membership/cardinality/lookup/subset,
-FieldAccess on entity-typed state scalars, single-state `Prime`/`Pre` collapse, and quantifiers over
-enums and state-relations.
+`sorry`** for the §6.1 verified subset (extended through M_L.4.k plus issue #195 set algebra):
+atoms, identifiers, all logical/arithmetic/comparison operators, state-relation
+membership/cardinality/lookup/subset, set literals and set-valued `In`/`NotIn`/`Union`/`Intersect`/
+`Diff`, FieldAccess on entity-valued expressions, single-state `Prime`/`Pre` collapse, and
+quantifiers over enums and state-relations.
 
 What this means concretely: when `verify` returns UNSAT for an in-subset obligation, that verdict
 reflects a property of the spec — not just a coincidence between the translator and Z3. The Z3
@@ -79,8 +80,8 @@ cd /tmp/cert && lake build  # native-decide each in-subset cert; out-of-subset �
 CI checks all six fixture certs every build (`.github/workflows/lean-certs.yml`).
 
 The remaining out-of-scope shapes (true two-state `Prime`/`Pre` preservation, `With` record-update,
-set algebra over set values, `Call` builtins, nested `FieldAccess` on `Index`, strings) emit trivial
-stubs with `TODO[M_L.4]` markers. See
+`Call` builtins, strings, maps/sequences, and set comprehensions) emit trivial stubs with
+`TODO[M_L.4]` markers. See
 [10_translator_soundness.md §13.1](docs/content/docs/research/10_translator_soundness.md) for the
 formal claim, full trust closure, and roadmap.
 

--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -802,7 +802,7 @@ subset in §6.
 | `Prime` / `Pre` | full | state-mode switching for post/pre-state (589-592) |
 | `With` | full | record update via Skolem constant + equality constraints (1061-1098) |
 | `SetComprehension` | errored | only allowed inside membership; standalone fails (1100-1105) |
-| `SetLiteral` | partial | non-empty only; empty fails (1113-1116) |
+| `SetLiteral` | partial | non-empty literals; empty literals require type context and are covered in membership contexts |
 | `MapLiteral` | errored | catchall (597-601) |
 | `SeqLiteral` | errored | catchall (597-601) |
 | `Matches` | full | as uninterpreted predicate, mangled by pattern + arg sort (1037-1049) |
@@ -943,8 +943,9 @@ Any PR touching a proof-governed surface must:
   (`.github/workflows/lean-certs.yml` × 6 fixtures). Six fixture certs `lake build` clean;
   `safe_counter` 3/3 cert_decide, `set_ops` 5/11, `todo_list` 4/17, `edge_cases` 8/15,
   `url_shortener` 1/7, `auth_service` 0/21 (z3 backend errors unrelated to subset).
-  Stub reasons remaining: `Call` builtins (`len`), multi-binding quantifiers, set/string
-  literals, operation-input env binding, two-state preservation. None are soundness gaps —
+  Stub reasons remaining: `Call` builtins (`len`), multi-binding quantifiers,
+  strings and collection shapes outside finite set literals, operation-input env binding,
+  two-state preservation. None are soundness gaps —
   they are out-of-subset shapes that emit `theorem cert : True := trivial` with a
   `TODO[M_L.4]` marker and zero `sorry`. Nested FieldAccess (`users[uid].email`,
   `forall t in tasks, t.field`, chained `.f1.f2`) is no longer in this list — M_L.4.k
@@ -1085,7 +1086,8 @@ membership (`In`) + all four quantifier kinds (All/Some/No/Exists) over enum-nam
 identifiers + `Prime`/`Pre` (single-state collapse) + `cardRel`. Universal soundness theorem
 closes for this whole slice with zero `sorry`.
 
-Still deferred: collection algebra, set/map/seq literals, strings, `Call`, `Matches`,
+Still deferred: arbitrary collection algebra outside issue #195 set-valued
+Union/Intersect/Diff, map/sequence literals, set comprehensions, strings, `Call`, `Matches`,
 `If`, `Lambda`, `Constructor`, two-state `Prime`/`Pre`, `With`.
 
 This widened slice **does not include real ensures-clause preservation reasoning** — that

--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -407,11 +407,13 @@ Plus the IR top-level shells:
 | Excluded | Rationale |
 |---|---|
 | `BinaryOp(Add\|Sub\|Mul\|Div, ...)` | Defer to M_L.2; need carrier-set proof for Int |
-| `BinaryOp(Subset\|Union\|Intersect\|Diff, ...)` | Defer; finite-set Mathlib lemmas non-trivial |
+| `BinaryOp(Subset, ...)` | State-relation identifier subset is in subset; arbitrary set subset remains deferred |
+| `BinaryOp(Union\|Intersect\|Diff, ...)` | Closed for set-valued expressions in issue #195 |
 | `UnaryOp(Cardinality)` | Currently only on state relations; defer to state-mutation milestone |
 | `UnaryOp(Power)` | Translator already raises `TranslatorError` (undecidable in FOL) — permanent exclusion |
 | `Quantifier(_, _, _)` over entity collections | Defer to M_L.2 (needs frame axioms) |
-| `SetComprehension`, `SetLiteral`, `MapLiteral`, `SeqLiteral` | Out of scope until collections milestone |
+| `SetComprehension`, `MapLiteral`, `SeqLiteral` | Out of scope until collections milestone |
+| `SetLiteral` | Closed for finite literals in issue #195 |
 | `If`, `Lambda`, `Constructor`, `SomeWrap`, `The`, `NoneLit` | Translator already raises `TranslatorError` for most |
 | `Index`, `Call`, `EnumAccess` (dynamic), `With`, `Matches` | Defer; require advanced encoding |
 | `Prime`, `Pre` | M_L.2 adds two-state coupling |
@@ -953,9 +955,8 @@ Any PR touching a proof-governed surface must:
 - **Outside the first-ship claim (still genuinely deferred):** `SmtLib.scala`, dump/export
   paths, Alloy-routed checks, proof replay, full-source semantics refinement, **true
   two-state semantics for `Prime`/`Pre`** (single-state collapse only — M_L.4.b-ext gates
-  real preservation reasoning), `With` record-update (bundled with M_L.4.b-ext), set-valued
-  algebra (`Union`/`Intersect`/`Diff` — needs `Value.VSet` extension), collection literals,
-  strings, `Call`/`Matches`, multi-binding quantifiers.
+  real preservation reasoning), `With` record-update (bundled with M_L.4.b-ext),
+  map/sequence literals, set comprehensions, strings, `Call`/`Matches`, multi-binding quantifiers.
 
 ### 13.2 Status Labels
 
@@ -1024,7 +1025,7 @@ implementation slice **`Z3-Core-1S`** (one-state).
 | `BinaryOp(NotIn)` | `bootstrap` | **M_L.4.e closed via emitter-side composition:** `NotIn(e, r) ≡ ¬In(e, r)`. |
 | `BinaryOp(Add \| Sub \| Mul \| Div)` | `bootstrap` | **M_L.4.a closed.** `Div`-by-zero policy: `eval` returns `none`. |
 | `BinaryOp(Subset)` over state-relation identifiers | `bootstrap` | **M_L.4.i closed via emitter-side composition:** `Subset(r1, r2) ≡ ∀ x ∈ r1, x ∈ r2`. |
-| `BinaryOp(Union \| Intersect \| Diff)` | `defer` | Set-valued; needs `Value.VSet` extension. |
+| `BinaryOp(Union \| Intersect \| Diff)` | `bootstrap` | **Issue #195 closed.** Set-valued algebra over `Value.vSet` / `SmtVal.sSet`; non-set operands reduce to `none`. |
 | `UnaryOp(Not \| Negate)` | `bootstrap` | M_L.2 closed. |
 | `UnaryOp(Cardinality)` | `bootstrap` | **M_L.4.c closed.** Restricted to state-relation identifiers (mirrors `Translator.scala:876-881`). |
 | `UnaryOp(Power)` | `exclude` | Routed to Alloy. |
@@ -1042,7 +1043,8 @@ implementation slice **`Z3-Core-1S`** (one-state).
 | `Let` | `bootstrap` | M_L.2 closure. |
 | `Lambda` | `defer` | Outside FOL. |
 | `Constructor` | `defer` | Constructor semantics deferred. |
-| `SetLiteral`, `MapLiteral`, `SeqLiteral`, `SetComprehension` | `defer` | Collections deferred. |
+| `SetLiteral` | `bootstrap` | **Issue #195 closed.** Non-empty standalone literals and empty set-literal membership render as nested `.setInsert` over `.setEmpty`. |
+| `MapLiteral`, `SeqLiteral`, `SetComprehension` | `defer` | Collections deferred. |
 | `Matches` | `defer` | Regex/string semantics deferred. |
 | `IntLit`, `BoolLit`, `Identifier` | `bootstrap` | M_L.2 closed. |
 | `FloatLit`, `StringLit`, `NoneLit` | `defer` | No committed solver semantics. |
@@ -1194,11 +1196,12 @@ After M_G.4, the dependency chain is:
 - `#127` (M_L.1) — blocked on `#126` only. **Closed.**
 - `#128` (M_L.2) — blocked on `#127`. **Closed for §6.1 subset, zero sorry.**
 - `#129` (M_L.3) — blocked on `#127`. **Closed.**
-- `#130` (M_L.4) — blocked on `#128`. **Sub-slices a-k closed (LIA arithmetic, single-state
+- `#130` (M_L.4) — blocked on `#128`. **Sub-slices a-k plus issue #195 set algebra closed (LIA arithmetic, single-state
   Prime/Pre, Cardinality, enum quantifier composition, NotIn composition, state-relation
   quantifier, Index, FieldAccess on state scalars, Subset over rel-identifiers via composition,
-  nested FieldAccess via entity-id-keyed carrier). Remainder (`With`, true two-state,
-  set-valued algebra, `Call`, multi-binding quantifiers, strings) deferred to later slices
+  nested FieldAccess via entity-id-keyed carrier, set literals and set-valued
+  Union/Intersect/Diff/membership). Remainder (`With`, true two-state,
+  `Call`, multi-binding quantifiers, strings, maps/sequences, set comprehensions) deferred to later slices
   or M_L.4.b-ext.**
 
 ### 16.6 First-Ship Gate Met

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -256,6 +256,8 @@ object Emit:
     case EvalIR.Value.VInt(n)         => s".vInt ($n : Int)"
     case EvalIR.Value.VEnum(en, mem)  => s".vEnum ${quote(en)} ${quote(mem)}"
     case EvalIR.Value.VEntity(en, id) => s".vEntity ${quote(en)} ${quote(id)}"
+    case EvalIR.Value.VSet(members) =>
+      s".vSet [${members.map(renderValueLit).mkString(", ")}]"
 
   private def renderInvariantDecl(
       inv: InvariantDecl,
@@ -293,18 +295,20 @@ object Emit:
         case BinOp.Sub     => s"(.arith .sub $lT $rT)"
         case BinOp.Mul     => s"(.arith .mul $lT $rT)"
         case BinOp.Div     => s"(.arith .div $lT $rT)"
+        case BinOp.Union   => s"(.setBin .union $lT $rT)"
+        case BinOp.Intersect =>
+          s"(.setBin .intersect $lT $rT)"
+        case BinOp.Diff => s"(.setBin .diff $lT $rT)"
         case BinOp.In =>
           r match
             case Expr.Identifier(rel, _) => s"(.member $lT ${quote(rel)})"
-            // VerifiedSubset.classify rejects this shape; reaching here
-            // implies a classifier-vs-renderer drift.
-            case _ => unreachableShape("BinaryOp(In): non-identifier rhs")
+            case _                       => s"(.setMember $lT $rT)"
         case BinOp.NotIn =>
           // NotIn(elem, rel)  ≡  Not(In(elem, rel)). Emitter-side composition
           // mirrors Translator.scala:632-636 which renders the same shape.
           r match
             case Expr.Identifier(rel, _) => s"(.unNot (.member $lT ${quote(rel)}))"
-            case _                       => unreachableShape("BinaryOp(NotIn): non-identifier rhs")
+            case _                       => s"(.unNot (.setMember $lT $rT))"
         case BinOp.Subset =>
           // Subset(r1, r2)  ≡  ∀ x ∈ r1, x ∈ r2. Pure emit-time composition over
           // M_L.4.f forallRel + M_L.2 member. The bound variable name is unique to
@@ -314,7 +318,6 @@ object Emit:
               s"(.forallRel \"_subset_x\" ${quote(r1)} (.member (.ident \"_subset_x\") ${quote(r2)}))"
             case _ =>
               unreachableShape("BinaryOp(Subset): non-identifier operand(s)")
-        case _ => unreachableShape(s"BinaryOp.$op out of subset")
     case Expr.Let(v, value, body, _) =>
       s"(.letIn ${quote(v)} ${renderExpr(value, enumNames)} ${renderExpr(body, enumNames)})"
     case Expr.EnumAccess(Expr.Identifier(en, _), member, _) =>
@@ -332,6 +335,8 @@ object Emit:
       // arbitrary entity-valued expressions (Identifier, Index, chained
       // FieldAccess, quantifier-bound vars) through the id-keyed table.
       s"(.fieldAccess ${renderExpr(base, enumNames)} ${quote(field)})"
+    case Expr.SetLiteral(elements, _) =>
+      renderSetLiteral(elements, enumNames)
     case Expr.Quantifier(QuantKind.All, bindings, body, _) =>
       bindings match
         case List(QuantifierBinding(v, Expr.Identifier(name, _), _, _)) =>
@@ -372,6 +377,10 @@ object Emit:
     */
   private def unreachableShape(reason: String): String =
     s"(.boolLit false /- UNRENDERABLE: $reason -/)"
+
+  private def renderSetLiteral(elements: List[Expr], enumNames: Set[String]): String =
+    elements.foldRight(".setEmpty"): (elem, acc) =>
+      s"(.setInsert ${renderExpr(elem, enumNames)} $acc)"
 
   private def quote(s: String): String =
     val escaped = s.replace("\\", "\\\\").replace("\"", "\\\"")

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -9,6 +9,7 @@ object EvalIR:
     case VInt(n: BigInt)
     case VEnum(enumName: String, memberName: String)
     case VEntity(entityName: String, id: String)
+    case VSet(members: List[Value])
 
   type Env = List[(String, Value)]
 
@@ -37,10 +38,10 @@ object EvalIR:
     val empty: State = State(Nil, Nil, Nil, Nil)
 
     def demo(ir: ServiceIR): State =
-      val schema = Schema.of(ir)
-      val (scalarFields, relationFields) = ir.state match
-        case None       => (Nil, Nil)
-        case Some(decl) => decl.fields.partition(f => isScalarType(f.typeExpr))
+      val schema      = Schema.of(ir)
+      val stateFields = ir.state.fold(List.empty[StateFieldDecl])(_.fields)
+      val (scalarFields, relationFields) =
+        stateFields.partition(f => isScalarType(f.typeExpr))
       // M_L.4.k: entity-typed scalars are seeded as `vEntity name <fresh-id>`,
       // and the entityFields table is keyed by that fresh id. Seeding is
       // **recursive**: when an entity field is itself entity-typed (e.g.,
@@ -88,12 +89,17 @@ object EvalIR:
       // For chained FieldAccess on state scalars (`current_user.profile.email`
       // and the like), recursive entity seeding above handles the chain
       // without touching the relation tables.
-      val relations = relationFields.map(f => (f.name, List.empty[Value]))
-      val lookups   = relationFields.map(f => (f.name, List.empty[(Value, Value)]))
+      val setRelationFields = stateFields.filter:
+        case StateFieldDecl(_, TypeExpr.SetType(_, _), _) => true
+        case _                                            => false
+      val relationCarrierFields = (relationFields ++ setRelationFields).distinctBy(_.name)
+      val relations             = relationCarrierFields.map(f => (f.name, List.empty[Value]))
+      val lookups               = relationCarrierFields.map(f => (f.name, List.empty[(Value, Value)]))
       State(scalars, relations, lookups, entityFields)
 
     private def isScalarType(ty: TypeExpr): Boolean = ty match
       case _: TypeExpr.NamedType => true
+      case _: TypeExpr.SetType   => true
       case _                     => false
 
     /** Recursively materialise an entity instance and its nested entity-typed fields into the
@@ -142,7 +148,8 @@ object EvalIR:
         s.enums.collectFirst { case (n, members) if n == name => members } match
           case Some(member :: _) => Value.VEnum(name, member)
           case _                 => Value.VBool(false)
-    case _ => Value.VBool(false)
+    case _: TypeExpr.SetType => Value.VSet(Nil)
+    case _                   => Value.VBool(false)
 
   def envLookup(env: Env, name: String): Option[Value] =
     env.collectFirst { case (k, v) if k == name => v }
@@ -171,6 +178,23 @@ object EvalIR:
   def asInt(v: Value): Option[BigInt] = v match
     case Value.VInt(n) => Some(n)
     case _             => None
+
+  def asSet(v: Value): Option[List[Value]] = v match
+    case Value.VSet(members) => Some(members)
+    case _                   => None
+
+  private def dedupeValues(values: List[Value]): List[Value] =
+    values.foldRight(List.empty[Value]): (v, acc) =>
+      if acc.contains(v) then acc else v :: acc
+
+  private def setUnionValues(l: List[Value], r: List[Value]): List[Value] =
+    dedupeValues(l ++ r)
+
+  private def setIntersectValues(l: List[Value], r: List[Value]): List[Value] =
+    dedupeValues(l.filter(r.contains))
+
+  private def setDiffValues(l: List[Value], r: List[Value]): List[Value] =
+    dedupeValues(l.filterNot(r.contains))
 
   def evalBoolBin(op: BinOp, a: Boolean, b: Boolean): Option[Boolean] = op match
     case BinOp.And     => Some(a && b)
@@ -223,6 +247,16 @@ object EvalIR:
         case _                  => None
     case _ => None
 
+  def evalSetBin(op: BinOp, l: Value, r: Value): Option[Value] =
+    (asSet(l), asSet(r)) match
+      case (Some(a), Some(b)) =>
+        op match
+          case BinOp.Union     => Some(Value.VSet(setUnionValues(a, b)))
+          case BinOp.Intersect => Some(Value.VSet(setIntersectValues(a, b)))
+          case BinOp.Diff      => Some(Value.VSet(setDiffValues(a, b)))
+          case _               => None
+      case _ => None
+
   def eval(s: Schema, st: State, env: Env, expr: Expr): Option[Value] = expr match
     case Expr.BoolLit(v, _) => Some(Value.VBool(v))
     case Expr.IntLit(v, _)  => Some(Value.VInt(BigInt(v)))
@@ -254,13 +288,32 @@ object EvalIR:
         rv  <- eval(s, st, env, r)
         out <- evalCmp(op, lv, rv)
       yield Value.VBool(out)
-    case Expr.BinaryOp(BinOp.In, elem, Expr.Identifier(relName, _), _) =>
+    case Expr.BinaryOp(op, l, r, _) if isSetBinOp(op) =>
       for
-        v   <- eval(s, st, env, elem)
-        dom <- relationDomain(st, relName)
-      yield Value.VBool(dom.contains(v))
+        lv  <- eval(s, st, env, l)
+        rv  <- eval(s, st, env, r)
+        out <- evalSetBin(op, lv, rv)
+      yield out
+    case Expr.BinaryOp(BinOp.In, elem, Expr.Identifier(relName, _), _) =>
+      relationDomain(st, relName) match
+        case Some(dom) =>
+          eval(s, st, env, elem).map(v => Value.VBool(dom.contains(v)))
+        case None =>
+          for
+            v       <- eval(s, st, env, elem)
+            setVal  <- eval(s, st, env, Expr.Identifier(relName))
+            members <- asSet(setVal)
+          yield Value.VBool(members.contains(v))
+    case Expr.BinaryOp(BinOp.In, elem, setExpr, _) =>
+      for
+        v       <- eval(s, st, env, elem)
+        setVal  <- eval(s, st, env, setExpr)
+        members <- asSet(setVal)
+      yield Value.VBool(members.contains(v))
     case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
       eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
+    case Expr.BinaryOp(BinOp.NotIn, elem, setExpr, _) =>
+      eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, setExpr)))
     case Expr.BinaryOp(
           BinOp.Subset,
           Expr.Identifier(r1, _),
@@ -332,7 +385,11 @@ object EvalIR:
       )
     case Expr.Prime(inner, _) => eval(s, st, env, inner)
     case Expr.Pre(inner, _)   => eval(s, st, env, inner)
-    case _                    => None
+    case Expr.SetLiteral(elements, _) =>
+      val values = elements.map(eval(s, st, env, _))
+      if values.exists(_.isEmpty) then None
+      else Some(Value.VSet(dedupeValues(values.flatten)))
+    case _ => None
 
   private def isBoolBinOp(op: BinOp): Boolean = op match
     case BinOp.And | BinOp.Or | BinOp.Implies | BinOp.Iff => true
@@ -345,6 +402,10 @@ object EvalIR:
   private def isCmpOp(op: BinOp): Boolean = op match
     case BinOp.Eq | BinOp.Neq | BinOp.Lt | BinOp.Le | BinOp.Gt | BinOp.Ge => true
     case _                                                                => false
+
+  private def isSetBinOp(op: BinOp): Boolean = op match
+    case BinOp.Union | BinOp.Intersect | BinOp.Diff => true
+    case _                                          => false
 
   private def evalForallEnum(
       s: Schema,

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -163,9 +163,17 @@ object EvalIR:
   def relationPairs(st: State, name: String): Option[List[(Value, Value)]] =
     st.lookups.collectFirst { case (k, ps) if k == name => ps }
 
+  private def valueEq(l: Value, r: Value): Boolean = (l, r) match
+    case (Value.VSet(left), Value.VSet(right)) =>
+      left.forall(right.contains) && right.forall(left.contains)
+    case _ => l == r
+
+  private def containsValue(values: List[Value], needle: Value): Boolean =
+    values.exists(valueEq(_, needle))
+
   def lookupKey(st: State, relName: String, key: Value): Option[Value] =
     relationPairs(st, relName).flatMap: pairs =>
-      pairs.collectFirst { case (k, v) if k == key => v }
+      pairs.collectFirst { case (k, v) if valueEq(k, key) => v }
 
   def lookupField(st: State, entityId: String, fieldName: String): Option[Value] =
     st.entityFields.collectFirst { case (k, fs) if k == entityId => fs }
@@ -185,16 +193,16 @@ object EvalIR:
 
   private def dedupeValues(values: List[Value]): List[Value] =
     values.foldRight(List.empty[Value]): (v, acc) =>
-      if acc.contains(v) then acc else v :: acc
+      if containsValue(acc, v) then acc else v :: acc
 
   private def setUnionValues(l: List[Value], r: List[Value]): List[Value] =
     dedupeValues(l ++ r)
 
   private def setIntersectValues(l: List[Value], r: List[Value]): List[Value] =
-    dedupeValues(l.filter(r.contains))
+    dedupeValues(l.filter(v => containsValue(r, v)))
 
   private def setDiffValues(l: List[Value], r: List[Value]): List[Value] =
-    dedupeValues(l.filterNot(r.contains))
+    dedupeValues(l.filterNot(v => containsValue(r, v)))
 
   def evalBoolBin(op: BinOp, a: Boolean, b: Boolean): Option[Boolean] = op match
     case BinOp.And     => Some(a && b)
@@ -227,8 +235,8 @@ object EvalIR:
       case _ => None
 
   def evalCmp(op: BinOp, l: Value, r: Value): Option[Boolean] = op match
-    case BinOp.Eq  => Some(l == r)
-    case BinOp.Neq => Some(l != r)
+    case BinOp.Eq  => Some(valueEq(l, r))
+    case BinOp.Neq => Some(!valueEq(l, r))
     case BinOp.Lt =>
       (asInt(l), asInt(r)) match
         case (Some(a), Some(b)) => Some(a < b)
@@ -295,21 +303,18 @@ object EvalIR:
         out <- evalSetBin(op, lv, rv)
       yield out
     case Expr.BinaryOp(BinOp.In, elem, Expr.Identifier(relName, _), _) =>
-      relationDomain(st, relName) match
-        case Some(dom) =>
-          eval(s, st, env, elem).map(v => Value.VBool(dom.contains(v)))
+      eval(s, st, env, Expr.Identifier(relName)).flatMap(asSet) match
+        case Some(members) =>
+          eval(s, st, env, elem).map(v => Value.VBool(containsValue(members, v)))
         case None =>
-          for
-            v       <- eval(s, st, env, elem)
-            setVal  <- eval(s, st, env, Expr.Identifier(relName))
-            members <- asSet(setVal)
-          yield Value.VBool(members.contains(v))
+          relationDomain(st, relName)
+            .flatMap(dom => eval(s, st, env, elem).map(v => Value.VBool(containsValue(dom, v))))
     case Expr.BinaryOp(BinOp.In, elem, setExpr, _) =>
       for
         v       <- eval(s, st, env, elem)
         setVal  <- eval(s, st, env, setExpr)
         members <- asSet(setVal)
-      yield Value.VBool(members.contains(v))
+      yield Value.VBool(containsValue(members, v))
     case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
       eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
     case Expr.BinaryOp(BinOp.NotIn, elem, setExpr, _) =>
@@ -325,7 +330,7 @@ object EvalIR:
       for
         dom1 <- relationDomain(st, r1)
         dom2 <- relationDomain(st, r2)
-      yield Value.VBool(dom1.forall(dom2.contains))
+      yield Value.VBool(dom1.forall(v => containsValue(dom2, v)))
     case Expr.Index(Expr.Identifier(relName, _), keyExpr, _) =>
       eval(s, st, env, keyExpr).flatMap(kv => lookupKey(st, relName, kv))
     case Expr.FieldAccess(base, fieldName, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
@@ -39,16 +39,16 @@ object VerifiedSubset:
             BinOp.Add | BinOp.Sub | BinOp.Mul | BinOp.Div =>
           chooseWorse(classify(l), classify(r))
         case BinOp.In | BinOp.NotIn =>
-          // BinaryOp(In/NotIn) is renderable only when the rhs is an `Identifier`
-          // — M_L.1 ties `In` to state-relation domain membership and the
-          // emitter renders `.member elem relName` with a literal name. NotIn is
-          // emitted as `(.unNot (.member elem relName))` (M_L.4.e composition).
+          // Identifier RHS remains the legacy state-relation domain membership path.
+          // Any other RHS is rendered as set-valued membership (`.setMember`) and
+          // therefore must itself be in the verified subset.
           r match
             case _: Expr.Identifier => chooseWorse(classify(l), classify(r))
-            case _ =>
-              SubsetStatus.OutOfSubset(
-                s"BinaryOp($op): rhs must be a state-relation identifier"
-              )
+            case Expr.SetLiteral(elements, _) =>
+              chooseWorse(classify(l), classifySetLiteral(elements, allowEmpty = true))
+            case _ => chooseWorse(classify(l), classify(r))
+        case BinOp.Union | BinOp.Intersect | BinOp.Diff =>
+          chooseWorse(classify(l), classify(r))
         case BinOp.Subset =>
           // BinaryOp(Subset) over two state-relation identifiers desugars at emit
           // time to `forallRel x r1, member x r2` — pure composition over existing
@@ -60,8 +60,6 @@ object VerifiedSubset:
                 "BinaryOp(Subset): both operands must be state-relation identifiers " +
                   "(set-literal subset is collections-deferred)"
               )
-        case other =>
-          SubsetStatus.OutOfSubset(s"BinaryOp.$other not in M_L.1 verified subset")
     case Expr.Quantifier(kind, bindings, body, _) =>
       // ∃, No, Exists are encoded as compositions of `forallEnum/forallRel + unNot` at emit time:
       //   ∃ x, P  ≡  ¬ ∀ x, ¬ P
@@ -111,8 +109,9 @@ object VerifiedSubset:
     case _: Expr.If          => SubsetStatus.OutOfSubset("If: deferred")
     case _: Expr.Lambda      => SubsetStatus.OutOfSubset("Lambda: outside FOL")
     case _: Expr.Constructor => SubsetStatus.OutOfSubset("Constructor: deferred")
-    case _: Expr.SetLiteral  => SubsetStatus.OutOfSubset("SetLiteral: collections deferred")
-    case _: Expr.MapLiteral  => SubsetStatus.OutOfSubset("MapLiteral: collections deferred")
+    case Expr.SetLiteral(elements, _) =>
+      classifySetLiteral(elements, allowEmpty = false)
+    case _: Expr.MapLiteral => SubsetStatus.OutOfSubset("MapLiteral: collections deferred")
     case _: Expr.SetComprehension =>
       SubsetStatus.OutOfSubset("SetComprehension: collections deferred")
     case _: Expr.SeqLiteral => SubsetStatus.OutOfSubset("SeqLiteral: collections deferred")
@@ -128,6 +127,15 @@ object VerifiedSubset:
     case (SubsetStatus.InSubset, x)             => x
     case (x, SubsetStatus.InSubset)             => x
     case (out @ SubsetStatus.OutOfSubset(_), _) => out
+
+  private def classifySetLiteral(elements: List[Expr], allowEmpty: Boolean): SubsetStatus =
+    if elements.isEmpty && !allowEmpty then
+      SubsetStatus.OutOfSubset(
+        "SetLiteral: empty standalone literal needs type context"
+      )
+    else
+      elements.foldLeft[SubsetStatus](SubsetStatus.InSubset): (acc, elem) =>
+        chooseWorse(acc, classify(elem))
 
   def isInSubset(expr: Expr): Boolean = classify(expr) match
     case SubsetStatus.InSubset       => true

--- a/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
@@ -35,6 +35,9 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.In",
     "BinaryOp.NotIn",
     "BinaryOp.Subset",
+    "BinaryOp.Union",
+    "BinaryOp.Intersect",
+    "BinaryOp.Diff",
     "BinaryOp.Add",
     "BinaryOp.Sub",
     "BinaryOp.Mul",
@@ -49,7 +52,8 @@ class ProofDriftAuditTest extends FunSuite:
     "Pre",
     "UnaryOp.Cardinality",
     "Index",
-    "FieldAccess"
+    "FieldAccess",
+    "SetLiteral"
   )
 
   private val repoRoot: Path = locateRepoRoot()
@@ -99,8 +103,12 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.In",
     "BinaryOp.NotIn",
     "BinaryOp.Subset",
+    "BinaryOp.Union",
+    "BinaryOp.Intersect",
+    "BinaryOp.Diff",
     "Index",
-    "FieldAccess"
+    "FieldAccess",
+    "SetLiteral"
   )
 
   test("A4: classifier-accepted probes never produce UNRENDERABLE in renderExpr"):
@@ -122,8 +130,14 @@ class ProofDriftAuditTest extends FunSuite:
                 StateFieldDecl(name = "v", typeExpr = TypeExpr.NamedType("Int")),
                 StateFieldDecl(name = "n", typeExpr = TypeExpr.NamedType("Int")),
                 StateFieldDecl(name = "x", typeExpr = TypeExpr.NamedType("Int")),
-                StateFieldDecl(name = "a", typeExpr = TypeExpr.NamedType("Int")),
-                StateFieldDecl(name = "b", typeExpr = TypeExpr.NamedType("Int")),
+                StateFieldDecl(
+                  name = "a",
+                  typeExpr = TypeExpr.SetType(TypeExpr.NamedType("Int"))
+                ),
+                StateFieldDecl(
+                  name = "b",
+                  typeExpr = TypeExpr.SetType(TypeExpr.NamedType("Int"))
+                ),
                 StateFieldDecl(name = "rel", typeExpr = TypeExpr.NamedType("Int")),
                 StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int"))
               )
@@ -195,6 +209,9 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.In"         -> "BinOp.In",
     "BinaryOp.NotIn"      -> "BinOp.NotIn",
     "BinaryOp.Subset"     -> "BinOp.Subset",
+    "BinaryOp.Union"      -> "BinOp.Union",
+    "BinaryOp.Intersect"  -> "BinOp.Intersect",
+    "BinaryOp.Diff"       -> "BinOp.Diff",
     "BinaryOp.Add"        -> "BinOp.Add",
     "BinaryOp.Sub"        -> "BinOp.Sub",
     "BinaryOp.Mul"        -> "BinOp.Mul",
@@ -208,7 +225,8 @@ class ProofDriftAuditTest extends FunSuite:
     "Prime"               -> "Expr.Prime",
     "Pre"                 -> "Expr.Pre",
     "Index"               -> "Expr.Index",
-    "FieldAccess"         -> "Expr.FieldAccess"
+    "FieldAccess"         -> "Expr.FieldAccess",
+    "SetLiteral"          -> "Expr.SetLiteral"
   )
 
   test("A2: every leanCoveredShape's operator literal is present in z3.Translator.scala"):
@@ -258,6 +276,10 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp(Mul)"            -> "soundness_arith_mul_ints",
     "BinaryOp(Div nonzero)"    -> "soundness_arith_div_ints_nonZero",
     "BinaryOp(Div zero)"       -> "soundness_arith_div_ints_zero",
+    "BinaryOp(Union)"          -> "soundness_setBin_sets",
+    "BinaryOp(Intersect)"      -> "soundness_setBin_sets",
+    "BinaryOp(Diff)"           -> "soundness_setBin_sets",
+    "SetLiteral"               -> "soundness_setInsert_resolved",
     // M_L.4.b/c branches don't have dedicated soundness_<arm> theorems — they're inline
     // in the universal `soundness` theorem. We pin raw substrings (not theorem names)
     // for these so a rename or removal in Soundness.lean still red-fires A3.

--- a/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
@@ -103,12 +103,8 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.In",
     "BinaryOp.NotIn",
     "BinaryOp.Subset",
-    "BinaryOp.Union",
-    "BinaryOp.Intersect",
-    "BinaryOp.Diff",
     "Index",
-    "FieldAccess",
-    "SetLiteral"
+    "FieldAccess"
   )
 
   test("A4: classifier-accepted probes never produce UNRENDERABLE in renderExpr"):

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -519,6 +519,37 @@ class EmitTest extends FunSuite:
       Some(false)
     )
 
+  test("EvalIR treats finite set equality and membership extensionally"):
+    import EvalIR.*
+    val left  = Expr.SetLiteral(List(Expr.IntLit(1), Expr.IntLit(2)))
+    val right = Expr.SetLiteral(List(Expr.IntLit(2), Expr.IntLit(1), Expr.IntLit(1)))
+    assertEquals(
+      EvalIR.eval(Schema.empty, State.empty, Nil, Expr.BinaryOp(BinOp.Eq, left, right)),
+      Some(Value.VBool(true))
+    )
+    assertEquals(
+      EvalIR.eval(Schema.empty, State.empty, Nil, Expr.BinaryOp(BinOp.In, Expr.IntLit(1), right)),
+      Some(Value.VBool(true))
+    )
+
+  test("EvalIR prioritizes set-valued identifiers over relation carriers for membership"):
+    import EvalIR.*
+    val st = State(
+      scalars = List("items" -> Value.VSet(List(Value.VInt(BigInt(1))))),
+      relations = List("items" -> Nil),
+      lookups = Nil,
+      entityFields = Nil
+    )
+    assertEquals(
+      EvalIR.eval(
+        Schema.empty,
+        st,
+        Nil,
+        Expr.BinaryOp(BinOp.In, Expr.IntLit(1), Expr.Identifier("items"))
+      ),
+      Some(Value.VBool(true))
+    )
+
   test("M_L.4.k: bare FieldAccess on entity-typed scalar still reaches cert_decide"):
     val invariant = InvariantDecl(
       name = Some("emailNonEmpty"),

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -221,6 +221,37 @@ class EmitTest extends FunSuite:
         Expr.FieldAccess(Expr.Identifier("currentUser"), "profile"),
         "email"
       ),
+      Expr.SetLiteral(List(Expr.IntLit(1), Expr.IntLit(2))),
+      Expr.BinaryOp(
+        BinOp.In,
+        Expr.IntLit(1),
+        Expr.SetLiteral(List(Expr.IntLit(1), Expr.IntLit(2)))
+      ),
+      Expr.BinaryOp(
+        BinOp.NotIn,
+        Expr.IntLit(3),
+        Expr.SetLiteral(List(Expr.IntLit(1), Expr.IntLit(2)))
+      ),
+      Expr.BinaryOp(
+        BinOp.In,
+        Expr.IntLit(1),
+        Expr.SetLiteral(Nil)
+      ),
+      Expr.BinaryOp(
+        BinOp.Union,
+        Expr.SetLiteral(List(Expr.IntLit(1))),
+        Expr.SetLiteral(List(Expr.IntLit(2)))
+      ),
+      Expr.BinaryOp(
+        BinOp.Intersect,
+        Expr.SetLiteral(List(Expr.IntLit(1))),
+        Expr.SetLiteral(List(Expr.IntLit(1)))
+      ),
+      Expr.BinaryOp(
+        BinOp.Diff,
+        Expr.SetLiteral(List(Expr.IntLit(1))),
+        Expr.SetLiteral(List(Expr.IntLit(2)))
+      ),
       Expr.BinaryOp(BinOp.Subset, Expr.Identifier("active"), Expr.Identifier("members")),
       Expr.Quantifier(
         QuantKind.Some,
@@ -251,11 +282,8 @@ class EmitTest extends FunSuite:
         -> "BinaryOp(Subset): both operands must be state-relation identifiers",
       Expr.Index(Expr.IntLit(0), Expr.IntLit(1))
         -> "Index: only state-relation identifier base is supported",
-      // Shape constraints — classifier rejects what renderExpr can't render:
-      Expr.BinaryOp(BinOp.In, Expr.Identifier("u"), Expr.BoolLit(true))
-        -> "BinaryOp(In): rhs must be a state-relation identifier",
-      Expr.BinaryOp(BinOp.NotIn, Expr.Identifier("u"), Expr.BoolLit(true))
-        -> "BinaryOp(NotIn): rhs must be a state-relation identifier",
+      Expr.SetLiteral(Nil)
+        -> "SetLiteral: empty standalone literal needs type context",
       Expr.Quantifier(
         QuantKind.All,
         List(

--- a/proofs/lean/README.md
+++ b/proofs/lean/README.md
@@ -41,6 +41,8 @@ The library implements the verified subset shipped through M_L.4.a-k:
 - `Not` / `Negate`,
 - state-relation membership (`In`, `NotIn` via emitter-side `¬In` composition, `Subset` via
   emitter-side `forallRel + member` composition),
+- set literals and set-valued membership/algebra (`SetLiteral`, set-expression `In`/`NotIn`,
+  `Union`, `Intersect`, `Diff`) over list-backed `Value.vSet` / `SmtVal.sSet` carriers,
 - state-relation cardinality (`#rel`),
 - state-relation indexed lookup (`rel[key]`) over the strictly-additive `lookups` pair table,
 - entity-valued field access (`scalar.field`, `rel[k].field`, chained `.f1.f2`, quantifier-bound
@@ -54,9 +56,9 @@ The library implements the verified subset shipped through M_L.4.a-k:
 
 The universal `soundness` theorem closes for this slice with **zero `sorry`**.
 
-Still **out of scope**: `With`, `Call`, `Matches`, set-valued algebra (`Union`/`Intersect`/`Diff` —
-would need `Value.VSet` extension), collection literals, strings, true two-state preservation
-reasoning. See `STATUS.md` for the full ledger and `IR.lean.todo` for the queued expansions; see
+Still **out of scope**: `With`, `Call`, `Matches`, map/sequence literals, set comprehensions,
+strings, true two-state preservation reasoning. See `STATUS.md` for the full ledger and
+`IR.lean.todo` for the queued expansions; see
 `docs/content/docs/research/10_translator_soundness.md` §14 for the proof-safe profile and §16.3 for
 closure status.
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -1,10 +1,10 @@
 # SpecRest Proof-State Ledger
 
 > **First-ship gate met (2026-05-02).** The universal `soundness` meta-theorem is closed with **zero
-> `sorry`** for the §6.1 verified subset extended through M_L.4.a-k. The Z3 translator's output is
-> mechanically validated against the Lean `translate` function for every in-subset `Expr`. See
-> `docs/content/docs/research/10_translator_soundness.md` §13.1 for the formal claim and §16.6 for
-> the activation closure record.
+> `sorry`** for the §6.1 verified subset extended through M_L.4.a-k and issue #195 set algebra. The
+> Z3 translator's output is mechanically validated against the Lean `translate` function for every
+> in-subset `Expr`. See `docs/content/docs/research/10_translator_soundness.md` §13.1 for the formal
+> claim and §16.6 for the activation closure record.
 
 Mirrors `docs/content/docs/research/10_translator_soundness.md` §14 (proof-safe profile) at
 expression-case granularity. Each row records what the prover-side embedding actually covers right
@@ -37,8 +37,11 @@ batch (post-2026-05-02).
 | `BinaryOp(Eq \| Neq)` (polymorphic over `Value`)  | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(Lt \| Le \| Gt \| Ge)` (Int)            | `bootstrap`   | `sound` (M_L.2 closure) |
 | `BinaryOp(In)` (state-relation domain membership) | `bootstrap`   | `sound` (M_L.2 closure) |
+| `BinaryOp(In \| NotIn)` over set expressions      | `issue #195`  | `sound`                 |
 | `BinaryOp(NotIn)` (composition `¬In`)             | `first ship`  | `sound` (M_L.4.e)       |
 | `BinaryOp(Subset)` over rel-identifiers           | `first ship`  | `sound` (M_L.4.i)       |
+| `BinaryOp(Union \| Intersect \| Diff)`            | `issue #195`  | `sound`                 |
+| `SetLiteral`                                      | `issue #195`  | `sound`                 |
 | `UnaryOp(Not)`                                    | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `UnaryOp(Negate)` (Int)                           | `bootstrap`   | `sound` (M_L.2 closed)  |
 | `Quantifier(All)` over enums                      | `bootstrap`   | `sound` (M_L.2 closure) |
@@ -351,12 +354,26 @@ Scala mirror: `cert/VerifiedSubset.scala` accepts `Add/Sub/Mul/Div`; `cert/EvalI
 `count + 1` and `count - 1` move from `trivial` stub to `cert_decide`; `broken_decrement`,
 `auth_service.next_user_id + 1`, etc.
 
+### Issue #195 — Set-valued algebra (closed)
+
+Set-valued literals and algebra join the verified subset:
+
+- `Value.vSet` / `SmtVal.sSet` carriers with list-backed, duplicate-normalised operations.
+- `Expr.setEmpty`, `Expr.setInsert`, `Expr.setMember`, and `Expr.setBin` (`union`, `intersect`,
+  `diff`) mirror the Scala cert emitter.
+- `soundness_setInsert_resolved`, `soundness_setMember_resolved`, and `soundness_setBin_sets` close
+  the success paths; universal `soundness` propagates `none` for non-set operands.
+
+Scala mirror: `cert/VerifiedSubset.scala` accepts non-empty standalone `SetLiteral`, empty
+set-literal membership, `Union`, `Intersect`, `Diff`, and set-expression `In`/`NotIn`;
+`cert/EvalIR.scala` adds `Value.VSet`; `cert/Emit.scala` renders set literals as nested `.setInsert`
+over `.setEmpty` and set algebra as `.setBin`.
+
 ## 3. Profile-deferred (later M_L.4 slices)
 
-`BinaryOp(Union | Intersect | Diff)` (set-valued, need `Value.VSet` extension), `SomeWrap`, `The`,
-`Call`, `If`, `Lambda`, `Constructor`, `SetLiteral`, `MapLiteral`, `SetComprehension`, `SeqLiteral`,
-`Matches`, `FloatLit`, `StringLit`, `NoneLit` — all `deferred`. (`BinaryOp(Subset)` over rel
-identifiers closed in M_L.4.i.)
+`SomeWrap`, `The`, `Call`, `If`, `Lambda`, `Constructor`, `MapLiteral`, `SetComprehension`,
+`SeqLiteral`, `Matches`, `FloatLit`, `StringLit`, `NoneLit` — all `deferred`. (`BinaryOp(Subset)`
+over rel identifiers closed in M_L.4.i.)
 
 ## 4. Permanently excluded
 

--- a/proofs/lean/SpecRest/IR.lean
+++ b/proofs/lean/SpecRest/IR.lean
@@ -22,6 +22,12 @@ inductive ArithOp where
   | div
   deriving DecidableEq, Repr, Inhabited
 
+inductive SetOp where
+  | union
+  | intersect
+  | diff
+  deriving DecidableEq, Repr, Inhabited
+
 inductive CmpOp where
   | eq
   | neq
@@ -50,6 +56,10 @@ inductive Expr where
   | cardRel (relName : String)
   | indexRel (relName : String) (key : Expr)
   | fieldAccess (base : Expr) (fieldName : String)
+  | setEmpty
+  | setInsert (elem set : Expr)
+  | setMember (elem set : Expr)
+  | setBin (op : SetOp) (l r : Expr)
   deriving Repr, Inhabited
 
 structure FieldDecl where

--- a/proofs/lean/SpecRest/Lemmas.lean
+++ b/proofs/lean/SpecRest/Lemmas.lean
@@ -146,6 +146,106 @@ theorem eval_fieldAccess_nonEntity {base : Expr} {fieldName : String} {v : Value
   | vBool _ => rfl
   | vInt _ => rfl
   | vEnum _ _ => rfl
+  | vSet _ => rfl
+
+/-! ### Set literals, set membership, and set-valued binary operations. -/
+
+theorem eval_setEmpty :
+    eval s st env .setEmpty = some (.vSet []) := by
+  simp only [eval]
+
+theorem eval_setInsert_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some (.vSet members)) :
+    eval s st env (.setInsert elem set)
+      = some (.vSet (dedupeValues (v :: members))) := by
+  simp only [eval, hElem, hSet]
+
+theorem eval_setInsert_elem_none (elem set : Expr)
+    (hElem : eval s st env elem = none) :
+    eval s st env (.setInsert elem set) = none := by
+  simp only [eval, hElem]
+
+theorem eval_setInsert_set_none (elem set : Expr) (v : Value)
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = none) :
+    eval s st env (.setInsert elem set) = none := by
+  simp only [eval, hElem, hSet]
+
+theorem eval_setInsert_set_nonSet {elem set : Expr} {v setVal : Value}
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .vSet members) :
+    eval s st env (.setInsert elem set) = none := by
+  simp only [eval, hElem, hSet]
+  cases setVal with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem eval_setMember_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some (.vSet members)) :
+    eval s st env (.setMember elem set) = some (.vBool (containsValue members v)) := by
+  simp only [eval, hElem, hSet]
+
+theorem eval_setMember_elem_none (elem set : Expr)
+    (hElem : eval s st env elem = none) :
+    eval s st env (.setMember elem set) = none := by
+  simp only [eval, hElem]
+
+theorem eval_setMember_set_none (elem set : Expr) (v : Value)
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = none) :
+    eval s st env (.setMember elem set) = none := by
+  simp only [eval, hElem, hSet]
+
+theorem eval_setMember_set_nonSet {elem set : Expr} {v setVal : Value}
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .vSet members) :
+    eval s st env (.setMember elem set) = none := by
+  simp only [eval, hElem, hSet]
+  cases setVal with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem eval_setBin_sets (op : SetOp) (l r : Expr) (ls rs : List Value)
+    (hL : eval s st env l = some (.vSet ls))
+    (hR : eval s st env r = some (.vSet rs)) :
+    eval s st env (.setBin op l r) = evalSetBin op (some (.vSet ls)) (some (.vSet rs)) := by
+  simp only [eval, hL, hR]
+
+theorem eval_setBin_lhs_none (op : SetOp) (l r : Expr)
+    (hL : eval s st env l = none) :
+    eval s st env (.setBin op l r) = none := by
+  simp only [eval, hL]
+  cases op <;> rfl
+
+theorem eval_setBin_rhs_none (op : SetOp) (l r : Expr) (lv : Value)
+    (hL : eval s st env l = some lv)
+    (hR : eval s st env r = none) :
+    eval s st env (.setBin op l r) = none := by
+  simp only [eval, hL, hR]
+  cases op <;> cases lv <;> rfl
+
+theorem eval_setBin_lhs_nonSet (op : SetOp) (l r : Expr) (lv : Value)
+    (hNotSet : ∀ members, lv ≠ .vSet members)
+    (hL : eval s st env l = some lv) :
+    eval s st env (.setBin op l r) = none := by
+  simp only [eval, hL]
+  cases op <;> cases lv with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem eval_setBin_rhs_nonSet (op : SetOp) (l r : Expr) (ls : List Value) (rv : Value)
+    (hNotSet : ∀ members, rv ≠ .vSet members)
+    (hL : eval s st env l = some (.vSet ls))
+    (hR : eval s st env r = some rv) :
+    eval s st env (.setBin op l r) = none := by
+  simp only [eval, hL, hR]
+  cases op <;> cases rv with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
 
 /-! ### Prime and Pre — single-state collapse (identity). -/
 

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -66,12 +66,27 @@ end
 
 instance : DecidableEq Value := decEqValue
 
-instance : BEq Value where
-  beq a b := decide (a = b)
+def containsValueForBeq : List Value → Value → Bool
+  | [], _ => false
+  | x :: xs, v => decide (x = v) || containsValueForBeq xs v
 
-instance : LawfulBEq Value where
-  eq_of_beq {a b} h := of_decide_eq_true h
-  rfl {a} := by exact decide_eq_true rfl
+def subsetValueList : List Value → List Value → Bool
+  | [], _ => true
+  | x :: xs, ys => containsValueForBeq ys x && subsetValueList xs ys
+
+def setEqValueList (xs ys : List Value) : Bool :=
+  subsetValueList xs ys && subsetValueList ys xs
+
+def beqValue : Value → Value → Bool
+  | .vBool a, .vBool b => a == b
+  | .vInt a, .vInt b => a == b
+  | .vEnum en mem, .vEnum en' mem' => en == en' && mem == mem'
+  | .vEntity en id, .vEntity en' id' => en == en' && id == id'
+  | .vSet xs, .vSet ys => setEqValueList xs ys
+  | _, _ => false
+
+instance : BEq Value where
+  beq := beqValue
 
 abbrev Env := List (String × Value)
 

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -7,7 +7,71 @@ inductive Value where
   | vInt (n : Int)
   | vEnum (enumName memberName : String)
   | vEntity (entityName id : String)
-  deriving DecidableEq, Repr, Inhabited
+  | vSet (members : List Value)
+  deriving Repr, Inhabited
+
+mutual
+  def decEqValue : (a b : Value) → Decidable (a = b)
+    | .vBool a, .vBool b =>
+        if h : a = b then isTrue (by cases h; rfl)
+        else isFalse (by intro h'; cases h'; exact h rfl)
+    | .vInt a, .vInt b =>
+        if h : a = b then isTrue (by cases h; rfl)
+        else isFalse (by intro h'; cases h'; exact h rfl)
+    | .vEnum en mem, .vEnum en' mem' =>
+        if hEn : en = en' then
+          if hMem : mem = mem' then isTrue (by cases hEn; cases hMem; rfl)
+          else isFalse (by intro h'; cases h'; exact hMem rfl)
+        else isFalse (by intro h'; cases h'; exact hEn rfl)
+    | .vEntity en id, .vEntity en' id' =>
+        if hEn : en = en' then
+          if hId : id = id' then isTrue (by cases hEn; cases hId; rfl)
+          else isFalse (by intro h'; cases h'; exact hId rfl)
+        else isFalse (by intro h'; cases h'; exact hEn rfl)
+    | .vSet xs, .vSet ys =>
+        match decEqValueList xs ys with
+        | isTrue h  => isTrue (by cases h; rfl)
+        | isFalse h => isFalse (by intro h'; cases h'; exact h rfl)
+    | .vBool _, .vInt _ => isFalse (by intro h; cases h)
+    | .vBool _, .vEnum _ _ => isFalse (by intro h; cases h)
+    | .vBool _, .vEntity _ _ => isFalse (by intro h; cases h)
+    | .vBool _, .vSet _ => isFalse (by intro h; cases h)
+    | .vInt _, .vBool _ => isFalse (by intro h; cases h)
+    | .vInt _, .vEnum _ _ => isFalse (by intro h; cases h)
+    | .vInt _, .vEntity _ _ => isFalse (by intro h; cases h)
+    | .vInt _, .vSet _ => isFalse (by intro h; cases h)
+    | .vEnum _ _, .vBool _ => isFalse (by intro h; cases h)
+    | .vEnum _ _, .vInt _ => isFalse (by intro h; cases h)
+    | .vEnum _ _, .vEntity _ _ => isFalse (by intro h; cases h)
+    | .vEnum _ _, .vSet _ => isFalse (by intro h; cases h)
+    | .vEntity _ _, .vBool _ => isFalse (by intro h; cases h)
+    | .vEntity _ _, .vInt _ => isFalse (by intro h; cases h)
+    | .vEntity _ _, .vEnum _ _ => isFalse (by intro h; cases h)
+    | .vEntity _ _, .vSet _ => isFalse (by intro h; cases h)
+    | .vSet _, .vBool _ => isFalse (by intro h; cases h)
+    | .vSet _, .vInt _ => isFalse (by intro h; cases h)
+    | .vSet _, .vEnum _ _ => isFalse (by intro h; cases h)
+    | .vSet _, .vEntity _ _ => isFalse (by intro h; cases h)
+
+  def decEqValueList : (xs ys : List Value) → Decidable (xs = ys)
+    | [], [] => isTrue rfl
+    | [], _ :: _ => isFalse (by intro h; cases h)
+    | _ :: _, [] => isFalse (by intro h; cases h)
+    | x :: xs, y :: ys =>
+        match decEqValue x y, decEqValueList xs ys with
+        | isTrue hHead, isTrue hTail => isTrue (by cases hHead; cases hTail; rfl)
+        | isFalse hHead, _ => isFalse (by intro h; cases h; exact hHead rfl)
+        | _, isFalse hTail => isFalse (by intro h; cases h; exact hTail rfl)
+end
+
+instance : DecidableEq Value := decEqValue
+
+instance : BEq Value where
+  beq a b := decide (a = b)
+
+instance : LawfulBEq Value where
+  eq_of_beq {a b} h := of_decide_eq_true h
+  rfl {a} := by exact decide_eq_true rfl
 
 abbrev Env := List (String × Value)
 
@@ -113,6 +177,31 @@ def asInt : Value → Option Int
   | .vInt n => some n
   | _       => none
 
+def containsValue : List Value → Value → Bool
+  | [], _ => false
+  | x :: xs, v => (x == v) || containsValue xs v
+
+def dedupeValues : List Value → List Value
+  | [] => []
+  | x :: xs =>
+      let rest := dedupeValues xs
+      if containsValue rest x then rest else x :: rest
+
+def setUnionValues (l r : List Value) : List Value :=
+  dedupeValues (l ++ r)
+
+def setIntersectValues (l r : List Value) : List Value :=
+  dedupeValues (l.filter (fun v => containsValue r v))
+
+def setDiffValues (l r : List Value) : List Value :=
+  dedupeValues (l.filter (fun v => !containsValue r v))
+
+def evalSetBin : SetOp → Option Value → Option Value → Option Value
+  | .union,     some (.vSet l), some (.vSet r) => some (.vSet (setUnionValues l r))
+  | .intersect, some (.vSet l), some (.vSet r) => some (.vSet (setIntersectValues l r))
+  | .diff,      some (.vSet l), some (.vSet r) => some (.vSet (setDiffValues l r))
+  | _,          _,              _              => none
+
 mutual
 
   def eval (s : Schema) (st : State) (env : Env) : Expr → Option Value
@@ -176,6 +265,16 @@ mutual
         match eval s st env base with
         | some (.vEntity _ id) => st.lookupField id fieldName
         | _                    => none
+    | .setEmpty => some (.vSet [])
+    | .setInsert elem set =>
+        match eval s st env elem, eval s st env set with
+        | some v, some (.vSet members) => some (.vSet (dedupeValues (v :: members)))
+        | _,      _                    => none
+    | .setMember elem set =>
+        match eval s st env elem, eval s st env set with
+        | some v, some (.vSet members) => some (.vBool (containsValue members v))
+        | _,      _                    => none
+    | .setBin op l r => evalSetBin op (eval s st env l) (eval s st env r)
   termination_by e => (sizeOf e, 0)
 
   def evalForallEnum (s : Schema) (st : State) (env : Env)

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -21,7 +21,71 @@ inductive SmtVal where
   | sInt (n : Int)
   | sEnumElem (enumName memberName : String)
   | sEntityElem (entityName id : String)
-  deriving DecidableEq, Repr, Inhabited
+  | sSet (members : List SmtVal)
+  deriving Repr, Inhabited
+
+mutual
+  def decEqSmtVal : (a b : SmtVal) → Decidable (a = b)
+    | .sBool a, .sBool b =>
+        if h : a = b then isTrue (by cases h; rfl)
+        else isFalse (by intro h'; cases h'; exact h rfl)
+    | .sInt a, .sInt b =>
+        if h : a = b then isTrue (by cases h; rfl)
+        else isFalse (by intro h'; cases h'; exact h rfl)
+    | .sEnumElem en mem, .sEnumElem en' mem' =>
+        if hEn : en = en' then
+          if hMem : mem = mem' then isTrue (by cases hEn; cases hMem; rfl)
+          else isFalse (by intro h'; cases h'; exact hMem rfl)
+        else isFalse (by intro h'; cases h'; exact hEn rfl)
+    | .sEntityElem en id, .sEntityElem en' id' =>
+        if hEn : en = en' then
+          if hId : id = id' then isTrue (by cases hEn; cases hId; rfl)
+          else isFalse (by intro h'; cases h'; exact hId rfl)
+        else isFalse (by intro h'; cases h'; exact hEn rfl)
+    | .sSet xs, .sSet ys =>
+        match decEqSmtValList xs ys with
+        | isTrue h  => isTrue (by cases h; rfl)
+        | isFalse h => isFalse (by intro h'; cases h'; exact h rfl)
+    | .sBool _, .sInt _ => isFalse (by intro h; cases h)
+    | .sBool _, .sEnumElem _ _ => isFalse (by intro h; cases h)
+    | .sBool _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+    | .sBool _, .sSet _ => isFalse (by intro h; cases h)
+    | .sInt _, .sBool _ => isFalse (by intro h; cases h)
+    | .sInt _, .sEnumElem _ _ => isFalse (by intro h; cases h)
+    | .sInt _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+    | .sInt _, .sSet _ => isFalse (by intro h; cases h)
+    | .sEnumElem _ _, .sBool _ => isFalse (by intro h; cases h)
+    | .sEnumElem _ _, .sInt _ => isFalse (by intro h; cases h)
+    | .sEnumElem _ _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+    | .sEnumElem _ _, .sSet _ => isFalse (by intro h; cases h)
+    | .sEntityElem _ _, .sBool _ => isFalse (by intro h; cases h)
+    | .sEntityElem _ _, .sInt _ => isFalse (by intro h; cases h)
+    | .sEntityElem _ _, .sEnumElem _ _ => isFalse (by intro h; cases h)
+    | .sEntityElem _ _, .sSet _ => isFalse (by intro h; cases h)
+    | .sSet _, .sBool _ => isFalse (by intro h; cases h)
+    | .sSet _, .sInt _ => isFalse (by intro h; cases h)
+    | .sSet _, .sEnumElem _ _ => isFalse (by intro h; cases h)
+    | .sSet _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+
+  def decEqSmtValList : (xs ys : List SmtVal) → Decidable (xs = ys)
+    | [], [] => isTrue rfl
+    | [], _ :: _ => isFalse (by intro h; cases h)
+    | _ :: _, [] => isFalse (by intro h; cases h)
+    | x :: xs, y :: ys =>
+        match decEqSmtVal x y, decEqSmtValList xs ys with
+        | isTrue hHead, isTrue hTail => isTrue (by cases hHead; cases hTail; rfl)
+        | isFalse hHead, _ => isFalse (by intro h; cases h; exact hHead rfl)
+        | _, isFalse hTail => isFalse (by intro h; cases h; exact hTail rfl)
+end
+
+instance : DecidableEq SmtVal := decEqSmtVal
+
+instance : BEq SmtVal where
+  beq a b := decide (a = b)
+
+instance : LawfulBEq SmtVal where
+  eq_of_beq {a b} h := of_decide_eq_true h
+  rfl {a} := by exact decide_eq_true rfl
 
 inductive SmtTerm where
   | bLit (b : Bool)
@@ -46,6 +110,12 @@ inductive SmtTerm where
   | forallRel (var : String) (relName : String) (body : SmtTerm)
   | indexRel (relName : String) (key : SmtTerm)
   | fieldAccess (base : SmtTerm) (fieldName : String)
+  | setEmpty
+  | setInsert (elem set : SmtTerm)
+  | setMember (elem set : SmtTerm)
+  | setUnion (l r : SmtTerm)
+  | setIntersect (l r : SmtTerm)
+  | setDiff (l r : SmtTerm)
   deriving Repr, Inhabited
 
 /-- An SMT model resolves the free symbols left by the translator: the
@@ -98,6 +168,25 @@ def asSmtBool : SmtVal → Option Bool
 def asSmtInt : SmtVal → Option Int
   | .sInt n => some n
   | _       => none
+
+def containsSmtVal : List SmtVal → SmtVal → Bool
+  | [], _ => false
+  | x :: xs, v => (x == v) || containsSmtVal xs v
+
+def dedupeSmtVals : List SmtVal → List SmtVal
+  | [] => []
+  | x :: xs =>
+      let rest := dedupeSmtVals xs
+      if containsSmtVal rest x then rest else x :: rest
+
+def setUnionSmtVals (l r : List SmtVal) : List SmtVal :=
+  dedupeSmtVals (l ++ r)
+
+def setIntersectSmtVals (l r : List SmtVal) : List SmtVal :=
+  dedupeSmtVals (l.filter (fun v => containsSmtVal r v))
+
+def setDiffSmtVals (l r : List SmtVal) : List SmtVal :=
+  dedupeSmtVals (l.filter (fun v => !containsSmtVal r v))
 
 mutual
 
@@ -189,6 +278,27 @@ mutual
         match smtEval m env base with
         | some (.sEntityElem _ id) => m.lookupField id fieldName
         | _                        => none
+    | .setEmpty => some (.sSet [])
+    | .setInsert elem set =>
+        match smtEval m env elem, smtEval m env set with
+        | some v, some (.sSet members) => some (.sSet (dedupeSmtVals (v :: members)))
+        | _,      _                    => none
+    | .setMember elem set =>
+        match smtEval m env elem, smtEval m env set with
+        | some v, some (.sSet members) => some (.sBool (containsSmtVal members v))
+        | _,      _                    => none
+    | .setUnion l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setUnionSmtVals a b))
+        | _,              _              => none
+    | .setIntersect l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setIntersectSmtVals a b))
+        | _,              _              => none
+    | .setDiff l r =>
+        match smtEval m env l, smtEval m env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setDiffSmtVals a b))
+        | _,              _              => none
   termination_by t => (sizeOf t, 0)
 
   def smtEvalForallEnum (m : SmtModel) (env : SmtEnv)
@@ -468,6 +578,153 @@ theorem smtEval_fieldAccess_nonEntity {base : SmtTerm} {fieldName : String} {v :
   | sBool _ => rfl
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEval_setEmpty :
+    smtEval m env .setEmpty = some (.sSet []) := by
+  simp only [smtEval]
+
+theorem smtEval_setInsert_resolved (elem set : SmtTerm) (v : SmtVal)
+    (members : List SmtVal)
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = some (.sSet members)) :
+    smtEval m env (.setInsert elem set)
+      = some (.sSet (dedupeSmtVals (v :: members))) := by
+  simp only [smtEval, hElem, hSet]
+
+theorem smtEval_setInsert_elem_none (elem set : SmtTerm)
+    (hElem : smtEval m env elem = none) :
+    smtEval m env (.setInsert elem set) = none := by
+  simp only [smtEval, hElem]
+
+theorem smtEval_setInsert_set_none (elem set : SmtTerm) (v : SmtVal)
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = none) :
+    smtEval m env (.setInsert elem set) = none := by
+  simp only [smtEval, hElem, hSet]
+
+theorem smtEval_setInsert_set_nonSet {elem set : SmtTerm} {v setVal : SmtVal}
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .sSet members) :
+    smtEval m env (.setInsert elem set) = none := by
+  simp only [smtEval, hElem, hSet]
+  cases setVal with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEval_setMember_resolved (elem set : SmtTerm) (v : SmtVal)
+    (members : List SmtVal)
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = some (.sSet members)) :
+    smtEval m env (.setMember elem set) = some (.sBool (containsSmtVal members v)) := by
+  simp only [smtEval, hElem, hSet]
+
+theorem smtEval_setMember_elem_none (elem set : SmtTerm)
+    (hElem : smtEval m env elem = none) :
+    smtEval m env (.setMember elem set) = none := by
+  simp only [smtEval, hElem]
+
+theorem smtEval_setMember_set_none (elem set : SmtTerm) (v : SmtVal)
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = none) :
+    smtEval m env (.setMember elem set) = none := by
+  simp only [smtEval, hElem, hSet]
+
+theorem smtEval_setMember_set_nonSet {elem set : SmtTerm} {v setVal : SmtVal}
+    (hElem : smtEval m env elem = some v)
+    (hSet : smtEval m env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .sSet members) :
+    smtEval m env (.setMember elem set) = none := by
+  simp only [smtEval, hElem, hSet]
+  cases setVal with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEval_setUnion_sets (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some (.sSet rs)) :
+    smtEval m env (.setUnion l r) = some (.sSet (setUnionSmtVals ls rs)) := by
+  simp only [smtEval, hL, hR]
+
+theorem smtEval_setIntersect_sets (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some (.sSet rs)) :
+    smtEval m env (.setIntersect l r) = some (.sSet (setIntersectSmtVals ls rs)) := by
+  simp only [smtEval, hL, hR]
+
+theorem smtEval_setDiff_sets (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some (.sSet rs)) :
+    smtEval m env (.setDiff l r) = some (.sSet (setDiffSmtVals ls rs)) := by
+  simp only [smtEval, hL, hR]
+
+theorem smtEval_setUnion_lhs_none {l r : SmtTerm}
+    (hL : smtEval m env l = none) :
+    smtEval m env (.setUnion l r) = none := by simp only [smtEval, hL]
+theorem smtEval_setIntersect_lhs_none {l r : SmtTerm}
+    (hL : smtEval m env l = none) :
+    smtEval m env (.setIntersect l r) = none := by simp only [smtEval, hL]
+theorem smtEval_setDiff_lhs_none {l r : SmtTerm}
+    (hL : smtEval m env l = none) :
+    smtEval m env (.setDiff l r) = none := by simp only [smtEval, hL]
+
+theorem smtEval_setUnion_rhs_none {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEval m env l = some (.sSet ls)) (hR : smtEval m env r = none) :
+    smtEval m env (.setUnion l r) = none := by simp only [smtEval, hL, hR]
+theorem smtEval_setIntersect_rhs_none {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEval m env l = some (.sSet ls)) (hR : smtEval m env r = none) :
+    smtEval m env (.setIntersect l r) = none := by simp only [smtEval, hL, hR]
+theorem smtEval_setDiff_rhs_none {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEval m env l = some (.sSet ls)) (hR : smtEval m env r = none) :
+    smtEval m env (.setDiff l r) = none := by simp only [smtEval, hL, hR]
+
+theorem smtEval_setUnion_lhs_nonSet {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEval m env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setUnion l r) = none := by
+  simp only [smtEval, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEval_setIntersect_lhs_nonSet {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEval m env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setIntersect l r) = none := by
+  simp only [smtEval, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEval_setDiff_lhs_nonSet {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEval m env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setDiff l r) = none := by
+  simp only [smtEval, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEval_setUnion_rhs_nonSet {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setUnion l r) = none := by
+  simp only [smtEval, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEval_setIntersect_rhs_nonSet {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setIntersect l r) = none := by
+  simp only [smtEval, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEval_setDiff_rhs_nonSet {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEval m env l = some (.sSet ls))
+    (hR : smtEval m env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEval m env (.setDiff l r) = none := by
+  simp only [smtEval, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
 
 theorem smtEval_cardRel_unknown (relName : String)
     (h : m.lookupRel relName = none) :
@@ -509,6 +766,7 @@ theorem smtEval_not_nonBool {t : SmtTerm} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_neg_none (t : SmtTerm) (h : smtEval m env t = none) :
     smtEval m env (.neg t) = none := by
@@ -523,6 +781,7 @@ theorem smtEval_neg_nonInt {t : SmtTerm} {v : SmtVal}
   | sBool _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_and_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
     (h : smtEval m env l = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
@@ -533,6 +792,7 @@ theorem smtEval_and_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_and_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.and l r) = none := by
@@ -553,6 +813,7 @@ theorem smtEval_and_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_or_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.or l r) = none := by
@@ -567,6 +828,7 @@ theorem smtEval_or_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_or_rhs_none {l r : SmtTerm} {a : Bool}
     (hl : smtEval m env l = some (.sBool a)) (hr : smtEval m env r = none) :
@@ -583,6 +845,7 @@ theorem smtEval_or_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_implies_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.implies l r) = none := by
@@ -597,6 +860,7 @@ theorem smtEval_implies_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_implies_rhs_none {l r : SmtTerm} {a : Bool}
     (hl : smtEval m env l = some (.sBool a)) (hr : smtEval m env r = none) :
@@ -613,6 +877,7 @@ theorem smtEval_implies_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_eq_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.eq l r) = none := by
@@ -636,6 +901,7 @@ theorem smtEval_lt_lhs_nonInt {l r : SmtTerm} {v : SmtVal}
   | sBool _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_lt_rhs_none {l r : SmtTerm} {a : Int}
     (hl : smtEval m env l = some (.sInt a)) (hr : smtEval m env r = none) :
@@ -652,6 +918,7 @@ theorem smtEval_lt_rhs_nonInt {l r : SmtTerm} {a : Int} {v : SmtVal}
   | sBool _ => rfl
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
+  | sSet _ => rfl
 
 theorem smtEval_letIn_none {x : String} {value body : SmtTerm}
     (h : smtEval m env value = none) :

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -80,12 +80,27 @@ end
 
 instance : DecidableEq SmtVal := decEqSmtVal
 
-instance : BEq SmtVal where
-  beq a b := decide (a = b)
+def containsSmtValForBeq : List SmtVal → SmtVal → Bool
+  | [], _ => false
+  | x :: xs, v => decide (x = v) || containsSmtValForBeq xs v
 
-instance : LawfulBEq SmtVal where
-  eq_of_beq {a b} h := of_decide_eq_true h
-  rfl {a} := by exact decide_eq_true rfl
+def subsetSmtValList : List SmtVal → List SmtVal → Bool
+  | [], _ => true
+  | x :: xs, ys => containsSmtValForBeq ys x && subsetSmtValList xs ys
+
+def setEqSmtValList (xs ys : List SmtVal) : Bool :=
+  subsetSmtValList xs ys && subsetSmtValList ys xs
+
+def beqSmtVal : SmtVal → SmtVal → Bool
+  | .sBool a, .sBool b => a == b
+  | .sInt a, .sInt b => a == b
+  | .sEnumElem en mem, .sEnumElem en' mem' => en == en' && mem == mem'
+  | .sEntityElem en id, .sEntityElem en' id' => en == en' && id == id'
+  | .sSet xs, .sSet ys => setEqSmtValList xs ys
+  | _, _ => false
+
+instance : BEq SmtVal where
+  beq := beqSmtVal
 
 inductive SmtTerm where
   | bLit (b : Bool)

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -34,11 +34,28 @@ in `Smt.lean`. -/
 
 /-! ## Value ↔ SmtVal correlation -/
 
-def valueToSmt : Value → SmtVal
-  | .vBool b       => .sBool b
-  | .vInt n        => .sInt n
-  | .vEnum en mem  => .sEnumElem en mem
-  | .vEntity en id => .sEntityElem en id
+mutual
+  def valueToSmt : Value → SmtVal
+    | .vBool b       => .sBool b
+    | .vInt n        => .sInt n
+    | .vEnum en mem  => .sEnumElem en mem
+    | .vEntity en id => .sEntityElem en id
+    | .vSet members  => .sSet (valuesToSmt members)
+
+  def valuesToSmt : List Value → List SmtVal
+    | []        => []
+    | v :: rest => valueToSmt v :: valuesToSmt rest
+end
+
+@[simp] theorem valuesToSmt_eq_map (members : List Value) :
+    valuesToSmt members = members.map valueToSmt := by
+  induction members with
+  | nil => rfl
+  | cons _ rest ih => simp only [valuesToSmt, List.map, ih]
+
+@[simp] theorem valueToSmt_vSet (members : List Value) :
+    valueToSmt (.vSet members) = .sSet (members.map valueToSmt) := by
+  simp only [valueToSmt, valuesToSmt_eq_map]
 
 def valueToSmt? : Option Value → Option SmtVal
   | some v => some (valueToSmt v)
@@ -50,9 +67,51 @@ def valueToSmt? : Option Value → Option SmtVal
 @[simp] theorem valueToSmt?_none :
     valueToSmt? (none : Option Value) = none := rfl
 
-theorem valueToSmt_inj : ∀ {a b : Value}, valueToSmt a = valueToSmt b → a = b := by
-  intro a b h
-  cases a <;> cases b <;> (try cases h) <;> simp_all
+mutual
+  theorem valueToSmt_inj : ∀ {a b : Value}, valueToSmt a = valueToSmt b → a = b
+    | .vBool a, .vBool b, h => by cases h; rfl
+    | .vBool _, .vInt _, h => by cases h
+    | .vBool _, .vEnum _ _, h => by cases h
+    | .vBool _, .vEntity _ _, h => by cases h
+    | .vBool _, .vSet _, h => by cases h
+    | .vInt _, .vBool _, h => by cases h
+    | .vInt a, .vInt b, h => by cases h; rfl
+    | .vInt _, .vEnum _ _, h => by cases h
+    | .vInt _, .vEntity _ _, h => by cases h
+    | .vInt _, .vSet _, h => by cases h
+    | .vEnum _ _, .vBool _, h => by cases h
+    | .vEnum _ _, .vInt _, h => by cases h
+    | .vEnum en mem, .vEnum en' mem', h => by cases h; rfl
+    | .vEnum _ _, .vEntity _ _, h => by cases h
+    | .vEnum _ _, .vSet _, h => by cases h
+    | .vEntity _ _, .vBool _, h => by cases h
+    | .vEntity _ _, .vInt _, h => by cases h
+    | .vEntity _ _, .vEnum _ _, h => by cases h
+    | .vEntity en id, .vEntity en' id', h => by cases h; rfl
+    | .vEntity _ _, .vSet _, h => by cases h
+    | .vSet _, .vBool _, h => by cases h
+    | .vSet _, .vInt _, h => by cases h
+    | .vSet _, .vEnum _ _, h => by cases h
+    | .vSet _, .vEntity _ _, h => by cases h
+    | .vSet xs, .vSet ys, h => by
+        injection h with hList
+        have hValues : xs = ys := valuesToSmt_inj hList
+        cases hValues
+        rfl
+
+  theorem valuesToSmt_inj :
+      ∀ {xs ys : List Value}, valuesToSmt xs = valuesToSmt ys → xs = ys
+    | [], [], _ => rfl
+    | [], _ :: _, h => by cases h
+    | _ :: _, [], h => by cases h
+    | x :: xs, y :: ys, h => by
+        simp only [valuesToSmt, List.cons.injEq] at h
+        have hHead : x = y := valueToSmt_inj h.1
+        have hTail : xs = ys := valuesToSmt_inj h.2
+        cases hHead
+        cases hTail
+        rfl
+end
 
 /-- `SmtVal.sInt` boolean equality unfolds to `Int` boolean equality. -/
 theorem sInt_beq (a b : Int) : (SmtVal.sInt a == SmtVal.sInt b) = (a == b) := by
@@ -283,6 +342,60 @@ theorem contains_map_valueToSmt (dom : List Value) (v : Value) :
       rw [hbeq_false, hbeq_false']
       rw [List.elem_eq_contains, List.elem_eq_contains]
       exact ih
+
+theorem containsValue_map_valueToSmt (members : List Value) (v : Value) :
+    containsSmtVal (members.map valueToSmt) (valueToSmt v) = containsValue members v := by
+  induction members with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [List.map, containsSmtVal, containsValue]
+      rw [valueToSmt_beq hd v, ih]
+
+theorem dedupeValues_map_valueToSmt (members : List Value) :
+    (dedupeValues members).map valueToSmt = dedupeSmtVals (members.map valueToSmt) := by
+  induction members with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [dedupeValues, dedupeSmtVals, List.map]
+      rw [← ih, containsValue_map_valueToSmt]
+      cases containsValue (dedupeValues rest) hd <;> rfl
+
+theorem filter_containsValue_map_valueToSmt (l r : List Value) :
+    (l.filter (fun v => containsValue r v)).map valueToSmt =
+      (l.map valueToSmt).filter (fun v => containsSmtVal (r.map valueToSmt) v) := by
+  induction l with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [List.filter, List.map]
+      rw [containsValue_map_valueToSmt r hd]
+      cases containsValue r hd <;> simp only [List.map, ih]
+
+theorem filter_not_containsValue_map_valueToSmt (l r : List Value) :
+    (l.filter (fun v => !containsValue r v)).map valueToSmt =
+      (l.map valueToSmt).filter (fun v => !containsSmtVal (r.map valueToSmt) v) := by
+  induction l with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [List.filter, List.map]
+      rw [containsValue_map_valueToSmt r hd]
+      cases containsValue r hd <;> simp only [Bool.not_true, Bool.not_false, List.map, ih]
+
+theorem setUnionValues_map_valueToSmt (l r : List Value) :
+    (setUnionValues l r).map valueToSmt =
+      setUnionSmtVals (l.map valueToSmt) (r.map valueToSmt) := by
+  simp only [setUnionValues, setUnionSmtVals, ← List.map_append, dedupeValues_map_valueToSmt]
+
+theorem setIntersectValues_map_valueToSmt (l r : List Value) :
+    (setIntersectValues l r).map valueToSmt =
+      setIntersectSmtVals (l.map valueToSmt) (r.map valueToSmt) := by
+  simp only [setIntersectValues, setIntersectSmtVals]
+  rw [dedupeValues_map_valueToSmt, filter_containsValue_map_valueToSmt]
+
+theorem setDiffValues_map_valueToSmt (l r : List Value) :
+    (setDiffValues l r).map valueToSmt =
+      setDiffSmtVals (l.map valueToSmt) (r.map valueToSmt) := by
+  simp only [setDiffValues, setDiffSmtVals]
+  rw [dedupeValues_map_valueToSmt, filter_not_containsValue_map_valueToSmt]
 
 /-- `find?`-then-`map Prod.snd` commutes with `valueToSmt` mapping under `valueToSmt_beq`. -/
 theorem find_map_valueToSmt (pairs : List (Value × Value)) (key : Value) :
@@ -854,6 +967,9 @@ theorem evalForallEnum_correlated
           | vEntity en' i' =>
             rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ih
             rw [← ih]; simp only [valueToSmt?]
+          | vSet members =>
+            rw [valueToSmt_vSet members] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [show valueToSmt (Value.vInt n) = SmtVal.sInt n from rfl] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -862,6 +978,9 @@ theorem evalForallEnum_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vEntity en' i' =>
         rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vSet members =>
+        rw [valueToSmt_vSet members] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- `forallEnum` — universal quantifier over a known enum domain. -/
@@ -933,6 +1052,9 @@ theorem evalForallRel_correlated
           | vEntity en' i' =>
             rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ih
             rw [← ih]; simp only [valueToSmt?]
+          | vSet members =>
+            rw [valueToSmt_vSet members] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [show valueToSmt (Value.vInt n) = SmtVal.sInt n from rfl] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -941,6 +1063,9 @@ theorem evalForallRel_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vEntity en' i' =>
         rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vSet members =>
+        rw [valueToSmt_vSet members] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- `forallRel` — universal quantifier over a known state-relation domain. -/
@@ -993,6 +1118,7 @@ private theorem boolBin_lhs_nonBool (s : Schema) (st : State) (env : Env)
     | vInt _ => rfl
     | vEnum _ _ => rfl
     | vEntity _ _ => rfl
+    | vSet _ => rfl
   rw [hEvalNone]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
   simp only [valueToSmt?]
@@ -1005,6 +1131,7 @@ private theorem boolBin_lhs_nonBool (s : Schema) (st : State) (env : Env)
     | vInt _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   cases op with
   | and =>
     rw [show translate (.boolBin .and l r) = .and (translate l) (translate r) from rfl]
@@ -1040,6 +1167,7 @@ private theorem boolBin_rhs_nonBool_lhs_bool (s : Schema) (st : State) (env : En
     | vInt _ => rfl
     | vEnum _ _ => rfl
     | vEntity _ _ => rfl
+    | vSet _ => rfl
   rw [hEvalNone]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
   rw [show valueToSmt (Value.vBool a) = SmtVal.sBool a from rfl] at ihL
@@ -1054,6 +1182,7 @@ private theorem boolBin_rhs_nonBool_lhs_bool (s : Schema) (st : State) (env : En
     | vInt _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   cases op with
   | and =>
     rw [show translate (.boolBin .and l r) = .and (translate l) (translate r) from rfl]
@@ -1174,6 +1303,9 @@ private theorem cmp_rhs_eval_none (s : Schema) (st : State) (env : Env)
     | vEntity en' i' =>
       rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ihL
       exact (smtEval_lt_lhs_nonInt _ _ ihL.symm (fun _ => by intro h; cases h)).symm
+    | vSet members =>
+      rw [valueToSmt_vSet members] at ihL
+      exact (smtEval_lt_lhs_nonInt _ _ ihL.symm (fun _ => by intro h; cases h)).symm
   | le =>
     rw [show translate (.cmp .le l r)
           = .or (.lt (translate l) (translate r)) (.eq (translate l) (translate r)) from rfl]
@@ -1193,6 +1325,9 @@ private theorem cmp_rhs_eval_none (s : Schema) (st : State) (env : Env)
         exact smtEval_lt_lhs_nonInt _ _ ihL.symm (fun _ => by intro h; cases h)
       | vEntity en' i' =>
         rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ihL
+        exact smtEval_lt_lhs_nonInt _ _ ihL.symm (fun _ => by intro h; cases h)
+      | vSet members =>
+        rw [valueToSmt_vSet members] at ihL
         exact smtEval_lt_lhs_nonInt _ _ ihL.symm (fun _ => by intro h; cases h)
     rw [smtEval, hLt, hEq]
   | gt =>
@@ -1225,6 +1360,7 @@ private theorem cmp_lt_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => cases rv <;> rfl
     | vEnum _ _ => cases rv <;> rfl
     | vEntity _ _ => cases rv <;> rfl
+    | vSet _ => cases rv <;> rfl
   rw [hEvalNone]
   rw [show translate (.cmp .lt l r) = .lt (translate l) (translate r) from rfl]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
@@ -1238,6 +1374,7 @@ private theorem cmp_lt_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   exact (smtEval_lt_lhs_nonInt _ _ ihL.symm hSmtNotInt).symm
 
 /-- cmp lt: rhs is non-int (lhs is int). -/
@@ -1271,6 +1408,7 @@ private theorem cmp_lt_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
     | vBool _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   exact (smtEval_lt_rhs_nonInt _ _ ihL.symm ihR.symm hSmtNotInt).symm
 
 -- The le/gt/ge non-int variants below follow the same failure-shape pattern as lt and
@@ -1302,6 +1440,7 @@ private theorem arith_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   cases op with
   | add =>
     rw [show translate (.arith .add l r) = SmtTerm.add (translate l) (translate r) from rfl]
@@ -1345,6 +1484,7 @@ private theorem arith_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
     | vBool _ => simp [valueToSmt] at heq
     | vEnum _ _ => simp [valueToSmt] at heq
     | vEntity _ _ => simp [valueToSmt] at heq
+    | vSet _ => simp [valueToSmt] at heq
   cases op with
   | add =>
     rw [show translate (.arith .add l r) = SmtTerm.add (translate l) (translate r) from rfl]
@@ -1366,7 +1506,19 @@ private theorem hSmtLvNotInt (lv : Value) (hNotInt : ∀ n, lv ≠ .vInt n) :
   | vInt k =>
     have : k = n := by injection heq
     subst this; exact hNotInt k rfl
+    | vBool _ => simp [valueToSmt] at heq
+  | vEnum _ _ => simp [valueToSmt] at heq
+  | vEntity _ _ => simp [valueToSmt] at heq
+  | vSet _ => simp [valueToSmt] at heq
+
+private theorem hSmtValNotSet (v : Value) (hNotSet : ∀ members, v ≠ .vSet members) :
+    ∀ members, valueToSmt v ≠ .sSet members := by
+  intro members heq
+  cases v with
+  | vSet xs =>
+      exact hNotSet xs rfl
   | vBool _ => simp [valueToSmt] at heq
+  | vInt _ => simp [valueToSmt] at heq
   | vEnum _ _ => simp [valueToSmt] at heq
   | vEntity _ _ => simp [valueToSmt] at heq
 
@@ -1385,6 +1537,7 @@ private theorem cmp_le_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => cases rv <;> rfl
     | vEnum _ _ => cases rv <;> rfl
     | vEntity _ _ => cases rv <;> rfl
+    | vSet _ => cases rv <;> rfl
   rw [hEvalNone]
   rw [show translate (.cmp .le l r)
         = .or (.lt (translate l) (translate r)) (.eq (translate l) (translate r)) from rfl]
@@ -1436,6 +1589,7 @@ private theorem cmp_gt_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => cases rv <;> rfl
     | vEnum _ _ => cases rv <;> rfl
     | vEntity _ _ => cases rv <;> rfl
+    | vSet _ => cases rv <;> rfl
   rw [hEvalNone]
   rw [show translate (.cmp .gt l r) = .lt (translate r) (translate l) from rfl]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
@@ -1456,9 +1610,11 @@ private theorem cmp_gt_lhs_nonInt (s : Schema) (st : State) (env : Env)
       | sBool _ => rfl
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
+      | sSet _ => rfl
     | sBool _ => rfl
     | sEnumElem _ _ => rfl
     | sEntityElem _ _ => rfl
+    | sSet _ => rfl
 
 private theorem cmp_gt_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
     (l r : Expr) (a : Int) (rv : Value)
@@ -1495,6 +1651,7 @@ private theorem cmp_ge_lhs_nonInt (s : Schema) (st : State) (env : Env)
     | vBool _ => cases rv <;> rfl
     | vEnum _ _ => cases rv <;> rfl
     | vEntity _ _ => cases rv <;> rfl
+    | vSet _ => cases rv <;> rfl
   rw [hEvalNone]
   rw [show translate (.cmp .ge l r)
         = .or (.lt (translate r) (translate l)) (.eq (translate l) (translate r)) from rfl]
@@ -1515,9 +1672,11 @@ private theorem cmp_ge_lhs_nonInt (s : Schema) (st : State) (env : Env)
         | sBool _ => rfl
         | sEnumElem _ _ => rfl
         | sEntityElem _ _ => rfl
+        | sSet _ => rfl
       | sBool _ => rfl
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
+      | sSet _ => rfl
   exact (smtEval_or_lhs_none _ _ hLt).symm
 
 private theorem cmp_ge_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
@@ -1572,6 +1731,106 @@ theorem correlateModel_lookupSortMembers_none (s : Schema) (st : State) (en : St
   rw [lookup_map_pair_enumDecl]
   unfold Schema.lookupEnum at h
   rw [h]; rfl
+
+/-! ## Set-valued expression soundness helpers. -/
+
+theorem soundness_setEmpty :
+    valueToSmt? (eval s st env .setEmpty)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate .setEmpty) := by
+  rw [eval_setEmpty, valueToSmt?_some, valueToSmt_vSet]
+  rw [show translate Expr.setEmpty = SmtTerm.setEmpty from rfl]
+  rw [smtEval_setEmpty]
+  rfl
+
+theorem soundness_setInsert_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hSubElem : valueToSmt? (eval s st env elem)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate elem))
+    (hSubSet : valueToSmt? (eval s st env set)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate set))
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some (.vSet members)) :
+    valueToSmt? (eval s st env (.setInsert elem set))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.setInsert elem set)) := by
+  rw [eval_setInsert_resolved s st env elem set v members hElem hSet,
+      valueToSmt?_some, valueToSmt_vSet]
+  rw [show translate (.setInsert elem set) = .setInsert (translate elem) (translate set) from rfl]
+  have hElemSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate elem) = some (valueToSmt v) := by
+    rw [← hSubElem, hElem, valueToSmt?_some]
+  have hSetSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate set)
+        = some (.sSet (members.map valueToSmt)) := by
+    rw [← hSubSet, hSet, valueToSmt?_some, valueToSmt_vSet]
+  rw [smtEval_setInsert_resolved _ _ (translate elem) (translate set)
+        (valueToSmt v) (members.map valueToSmt) hElemSmt hSetSmt]
+  simp only [dedupeValues_map_valueToSmt, List.map]
+
+theorem soundness_setMember_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hSubElem : valueToSmt? (eval s st env elem)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate elem))
+    (hSubSet : valueToSmt? (eval s st env set)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate set))
+    (hElem : eval s st env elem = some v)
+    (hSet : eval s st env set = some (.vSet members)) :
+    valueToSmt? (eval s st env (.setMember elem set))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.setMember elem set)) := by
+  rw [eval_setMember_resolved s st env elem set v members hElem hSet,
+      valueToSmt?_some]
+  show some (SmtVal.sBool (containsValue members v)) = _
+  rw [show translate (.setMember elem set) = .setMember (translate elem) (translate set) from rfl]
+  have hElemSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate elem) = some (valueToSmt v) := by
+    rw [← hSubElem, hElem, valueToSmt?_some]
+  have hSetSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate set)
+        = some (.sSet (members.map valueToSmt)) := by
+    rw [← hSubSet, hSet, valueToSmt?_some, valueToSmt_vSet]
+  rw [smtEval_setMember_resolved _ _ (translate elem) (translate set)
+        (valueToSmt v) (members.map valueToSmt) hElemSmt hSetSmt]
+  rw [containsValue_map_valueToSmt]
+
+theorem soundness_setBin_sets (op : SetOp) (l r : Expr) (ls rs : List Value)
+    (hSubL : valueToSmt? (eval s st env l)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (eval s st env r)
+      = smtEval (correlateModel s st) (correlateEnv env) (translate r))
+    (hL : eval s st env l = some (.vSet ls))
+    (hR : eval s st env r = some (.vSet rs)) :
+    valueToSmt? (eval s st env (.setBin op l r))
+      = smtEval (correlateModel s st) (correlateEnv env) (translate (.setBin op l r)) := by
+  have hLSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate l)
+        = some (.sSet (ls.map valueToSmt)) := by
+    rw [← hSubL, hL, valueToSmt?_some, valueToSmt_vSet]
+  have hRSmt :
+      smtEval (correlateModel s st) (correlateEnv env) (translate r)
+        = some (.sSet (rs.map valueToSmt)) := by
+    rw [← hSubR, hR, valueToSmt?_some, valueToSmt_vSet]
+  cases op with
+  | union =>
+      rw [show eval s st env (.setBin .union l r)
+            = some (.vSet (setUnionValues ls rs)) from by simp only [eval, hL, hR, evalSetBin]]
+      rw [valueToSmt?_some, valueToSmt_vSet]
+      rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+      rw [smtEval_setUnion_sets _ _ (translate l) (translate r)
+            (ls.map valueToSmt) (rs.map valueToSmt) hLSmt hRSmt]
+      rw [setUnionValues_map_valueToSmt]
+  | intersect =>
+      rw [show eval s st env (.setBin .intersect l r)
+            = some (.vSet (setIntersectValues ls rs)) from by simp only [eval, hL, hR, evalSetBin]]
+      rw [valueToSmt?_some, valueToSmt_vSet]
+      rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+      rw [smtEval_setIntersect_sets _ _ (translate l) (translate r)
+            (ls.map valueToSmt) (rs.map valueToSmt) hLSmt hRSmt]
+      rw [setIntersectValues_map_valueToSmt]
+  | diff =>
+      rw [show eval s st env (.setBin .diff l r)
+            = some (.vSet (setDiffValues ls rs)) from by simp only [eval, hL, hR, evalSetBin]]
+      rw [valueToSmt?_some, valueToSmt_vSet]
+      rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+      rw [smtEval_setDiff_sets _ _ (translate l) (translate r)
+            (ls.map valueToSmt) (rs.map valueToSmt) hLSmt hRSmt]
+      rw [setDiffValues_map_valueToSmt]
 
 /-! ## Universal soundness theorem.
 
@@ -1637,6 +1896,12 @@ theorem soundness (e : Expr) :
         rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ih
         simp only [valueToSmt?]
         exact (smtEval_not_nonBool _ _ ih.symm (fun b => by intro h; cases h)).symm
+      | vSet members =>
+        rw [show eval s st env (.unNot e) = none from by simp only [eval, h]]
+        rw [h] at ih; rw [valueToSmt?_some] at ih
+        rw [valueToSmt_vSet members] at ih
+        simp only [valueToSmt?]
+        exact (smtEval_not_nonBool _ _ ih.symm (fun b => by intro h; cases h)).symm
   | unNeg e ih =>
     have ih := ih env
     rw [show translate (.unNeg e) = SmtTerm.neg (translate e) from rfl]
@@ -1665,6 +1930,12 @@ theorem soundness (e : Expr) :
         rw [show eval s st env (.unNeg e) = none from by simp only [eval, h]]
         rw [h] at ih; rw [valueToSmt?_some] at ih
         rw [show valueToSmt (Value.vEntity en' i') = SmtVal.sEntityElem en' i' from rfl] at ih
+        simp only [valueToSmt?]
+        exact (smtEval_neg_nonInt _ _ ih.symm (fun n => by intro h; cases h)).symm
+      | vSet members =>
+        rw [show eval s st env (.unNeg e) = none from by simp only [eval, h]]
+        rw [h] at ih; rw [valueToSmt?_some] at ih
+        rw [valueToSmt_vSet members] at ih
         simp only [valueToSmt?]
         exact (smtEval_neg_nonInt _ _ ih.symm (fun n => by intro h; cases h)).symm
   | boolBin op l r ihL ihR =>
@@ -1737,6 +2008,9 @@ theorem soundness (e : Expr) :
           | vEntity en' i' => exact boolBin_rhs_nonBool_lhs_bool s st env op l r a
                                       (.vEntity en' i') (fun b => by intro h; cases h)
                                       ihLE ihRE hL hR
+          | vSet members => exact boolBin_rhs_nonBool_lhs_bool s st env op l r a
+                                      (.vSet members) (fun b => by intro h; cases h)
+                                      ihLE ihRE hL hR
       | vInt n =>
         exact boolBin_lhs_nonBool s st env op l r (.vInt n)
                 (fun b => by intro h; cases h) ihLE ihRE hL
@@ -1745,6 +2019,9 @@ theorem soundness (e : Expr) :
                 (fun b => by intro h; cases h) ihLE ihRE hL
       | vEntity en' i' =>
         exact boolBin_lhs_nonBool s st env op l r (.vEntity en' i')
+                (fun b => by intro h; cases h) ihLE ihRE hL
+      | vSet members =>
+        exact boolBin_lhs_nonBool s st env op l r (.vSet members)
                 (fun b => by intro h; cases h) ihLE ihRE hL
   | arith op l r ihL ihR =>
     have ihLE := ihL env
@@ -1813,11 +2090,15 @@ theorem soundness (e : Expr) :
                             (fun n => by intro h; cases h) ihLE ihRE hL hR
           | vEntity en i => exact arith_rhs_nonInt_lhs_int s st env op l r a (.vEntity en i)
                               (fun n => by intro h; cases h) ihLE ihRE hL hR
+          | vSet members => exact arith_rhs_nonInt_lhs_int s st env op l r a (.vSet members)
+                              (fun n => by intro h; cases h) ihLE ihRE hL hR
       | vBool b => exact arith_lhs_nonInt s st env op l r (.vBool b)
                     (fun n => by intro h; cases h) ihLE ihRE hL
       | vEnum en m => exact arith_lhs_nonInt s st env op l r (.vEnum en m)
                        (fun n => by intro h; cases h) ihLE ihRE hL
       | vEntity en i => exact arith_lhs_nonInt s st env op l r (.vEntity en i)
+                          (fun n => by intro h; cases h) ihLE ihRE hL
+      | vSet members => exact arith_lhs_nonInt s st env op l r (.vSet members)
                           (fun n => by intro h; cases h) ihLE ihRE hL
   | cmp op l r ihL ihR =>
     have ihLE := ihL env
@@ -1843,11 +2124,15 @@ theorem soundness (e : Expr) :
                               (fun n => by intro h; cases h) ihLE ihRE hL hR
             | vEntity en i => exact cmp_lt_rhs_nonInt_lhs_int s st env l r a (.vEntity en i)
                                 (fun n => by intro h; cases h) ihLE ihRE hL hR
+            | vSet members => exact cmp_lt_rhs_nonInt_lhs_int s st env l r a (.vSet members)
+                                (fun n => by intro h; cases h) ihLE ihRE hL hR
           | vBool b => exact cmp_lt_lhs_nonInt s st env l r (.vBool b)
                         (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_lt_lhs_nonInt s st env l r (.vEnum en m)
                             (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEntity en i => exact cmp_lt_lhs_nonInt s st env l r (.vEntity en i)
+                              (fun n => by intro h; cases h) ihLE ihRE hL rv hR
+          | vSet members => exact cmp_lt_lhs_nonInt s st env l r (.vSet members)
                               (fun n => by intro h; cases h) ihLE ihRE hL rv hR
         | le =>
           cases lv with
@@ -1860,11 +2145,15 @@ theorem soundness (e : Expr) :
                               (fun n => by intro h; cases h) ihLE ihRE hL hR
             | vEntity en i => exact cmp_le_rhs_nonInt_lhs_int s st env l r a (.vEntity en i)
                                 (fun n => by intro h; cases h) ihLE ihRE hL hR
+            | vSet members => exact cmp_le_rhs_nonInt_lhs_int s st env l r a (.vSet members)
+                                (fun n => by intro h; cases h) ihLE ihRE hL hR
           | vBool b => exact cmp_le_lhs_nonInt s st env l r (.vBool b)
                         (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_le_lhs_nonInt s st env l r (.vEnum en m)
                             (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEntity en i => exact cmp_le_lhs_nonInt s st env l r (.vEntity en i)
+                              (fun n => by intro h; cases h) ihLE ihRE hL rv hR
+          | vSet members => exact cmp_le_lhs_nonInt s st env l r (.vSet members)
                               (fun n => by intro h; cases h) ihLE ihRE hL rv hR
         | gt =>
           cases lv with
@@ -1877,11 +2166,15 @@ theorem soundness (e : Expr) :
                               (fun n => by intro h; cases h) ihLE ihRE hL hR
             | vEntity en i => exact cmp_gt_rhs_nonInt_lhs_int s st env l r a (.vEntity en i)
                                 (fun n => by intro h; cases h) ihLE ihRE hL hR
+            | vSet members => exact cmp_gt_rhs_nonInt_lhs_int s st env l r a (.vSet members)
+                                (fun n => by intro h; cases h) ihLE ihRE hL hR
           | vBool b => exact cmp_gt_lhs_nonInt s st env l r (.vBool b)
                         (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_gt_lhs_nonInt s st env l r (.vEnum en m)
                             (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEntity en i => exact cmp_gt_lhs_nonInt s st env l r (.vEntity en i)
+                              (fun n => by intro h; cases h) ihLE ihRE hL rv hR
+          | vSet members => exact cmp_gt_lhs_nonInt s st env l r (.vSet members)
                               (fun n => by intro h; cases h) ihLE ihRE hL rv hR
         | ge =>
           cases lv with
@@ -1894,11 +2187,15 @@ theorem soundness (e : Expr) :
                               (fun n => by intro h; cases h) ihLE ihRE hL hR
             | vEntity en i => exact cmp_ge_rhs_nonInt_lhs_int s st env l r a (.vEntity en i)
                                 (fun n => by intro h; cases h) ihLE ihRE hL hR
+            | vSet members => exact cmp_ge_rhs_nonInt_lhs_int s st env l r a (.vSet members)
+                                (fun n => by intro h; cases h) ihLE ihRE hL hR
           | vBool b => exact cmp_ge_lhs_nonInt s st env l r (.vBool b)
                         (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_ge_lhs_nonInt s st env l r (.vEnum en m)
                             (fun n => by intro h; cases h) ihLE ihRE hL rv hR
           | vEntity en i => exact cmp_ge_lhs_nonInt s st env l r (.vEntity en i)
+                              (fun n => by intro h; cases h) ihLE ihRE hL rv hR
+          | vSet members => exact cmp_ge_lhs_nonInt s st env l r (.vSet members)
                               (fun n => by intro h; cases h) ihLE ihRE hL rv hR
   | letIn x value body ihV ihB =>
     have ihV := ihV env
@@ -2133,5 +2430,313 @@ theorem soundness (e : Expr) :
         simp only [valueToSmt?]
         exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
                 (fun en id => by intro h; cases h)).symm
+      | vSet members =>
+        have hEval : eval s st env (.fieldAccess base fieldName) = none :=
+          eval_fieldAccess_nonEntity s st env hBase
+            (fun en id => by intro h; cases h)
+        rw [hEval]
+        rw [show translate (.fieldAccess base fieldName)
+              = SmtTerm.fieldAccess (translate base) fieldName from rfl]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vSet members] at ihBase
+        simp only [valueToSmt?]
+        exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
+                (fun en id => by intro h; cases h)).symm
+  | setEmpty => exact soundness_setEmpty s st env
+  | setInsert elem set ihElem ihSet =>
+    have ihElem := ihElem env
+    have ihSet := ihSet env
+    rw [show translate (.setInsert elem set) = .setInsert (translate elem) (translate set) from rfl]
+    cases hElem : eval s st env elem with
+    | none =>
+      rw [eval_setInsert_elem_none s st env elem set hElem]
+      rw [hElem] at ihElem; simp only [valueToSmt?] at ihElem
+      simp only [valueToSmt?]
+      exact (smtEval_setInsert_elem_none _ _ (translate elem) (translate set) ihElem.symm).symm
+    | some v =>
+      cases hSet : eval s st env set with
+      | none =>
+        rw [eval_setInsert_set_none s st env elem set v hElem hSet]
+        rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+        rw [hSet] at ihSet; simp only [valueToSmt?] at ihSet
+        simp only [valueToSmt?]
+        exact (smtEval_setInsert_set_none _ _ (translate elem) (translate set)
+                  (valueToSmt v) ihElem.symm ihSet.symm).symm
+      | some setVal =>
+        cases setVal with
+        | vSet members =>
+          exact soundness_setInsert_resolved s st env elem set v members ihElem ihSet hElem hSet
+        | vBool b =>
+          have hNotSet : ∀ members, Value.vBool b ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setInsert_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vBool b) hNotSet)).symm
+        | vInt n =>
+          have hNotSet : ∀ members, Value.vInt n ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setInsert_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vInt n) hNotSet)).symm
+        | vEnum en mem =>
+          have hNotSet : ∀ members, Value.vEnum en mem ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setInsert_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+        | vEntity en id =>
+          have hNotSet : ∀ members, Value.vEntity en id ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setInsert_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+  | setMember elem set ihElem ihSet =>
+    have ihElem := ihElem env
+    have ihSet := ihSet env
+    rw [show translate (.setMember elem set) = .setMember (translate elem) (translate set) from rfl]
+    cases hElem : eval s st env elem with
+    | none =>
+      rw [eval_setMember_elem_none s st env elem set hElem]
+      rw [hElem] at ihElem; simp only [valueToSmt?] at ihElem
+      simp only [valueToSmt?]
+      exact (smtEval_setMember_elem_none _ _ (translate elem) (translate set) ihElem.symm).symm
+    | some v =>
+      cases hSet : eval s st env set with
+      | none =>
+        rw [eval_setMember_set_none s st env elem set v hElem hSet]
+        rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+        rw [hSet] at ihSet; simp only [valueToSmt?] at ihSet
+        simp only [valueToSmt?]
+        exact (smtEval_setMember_set_none _ _ (translate elem) (translate set)
+                  (valueToSmt v) ihElem.symm ihSet.symm).symm
+      | some setVal =>
+        cases setVal with
+        | vSet members =>
+          exact soundness_setMember_resolved s st env elem set v members ihElem ihSet hElem hSet
+        | vBool b =>
+          have hNotSet : ∀ members, Value.vBool b ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setMember_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vBool b) hNotSet)).symm
+        | vInt n =>
+          have hNotSet : ∀ members, Value.vInt n ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setMember_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vInt n) hNotSet)).symm
+        | vEnum en mem =>
+          have hNotSet : ∀ members, Value.vEnum en mem ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setMember_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+        | vEntity en id =>
+          have hNotSet : ∀ members, Value.vEntity en id ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setMember_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+  | setBin op l r ihL ihR =>
+    have ihL := ihL env
+    have ihR := ihR env
+    cases hL : eval s st env l with
+    | none =>
+      rw [eval_setBin_lhs_none s st env op l r hL]
+      rw [hL] at ihL; simp only [valueToSmt?] at ihL
+      simp only [valueToSmt?]
+      cases op with
+      | union =>
+        rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+        exact (smtEval_setUnion_lhs_none _ _ ihL.symm).symm
+      | intersect =>
+        rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+        exact (smtEval_setIntersect_lhs_none _ _ ihL.symm).symm
+      | diff =>
+        rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+        exact (smtEval_setDiff_lhs_none _ _ ihL.symm).symm
+    | some lv =>
+      cases lv with
+      | vSet ls =>
+        cases hR : eval s st env r with
+        | none =>
+          rw [eval_setBin_rhs_none s st env op l r (.vSet ls) hL hR]
+          rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+          rw [hR] at ihR; simp only [valueToSmt?] at ihR
+          simp only [valueToSmt?]
+          cases op with
+          | union =>
+            rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+            exact (smtEval_setUnion_rhs_none _ _ ihL.symm ihR.symm).symm
+          | intersect =>
+            rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+            exact (smtEval_setIntersect_rhs_none _ _ ihL.symm ihR.symm).symm
+          | diff =>
+            rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+            exact (smtEval_setDiff_rhs_none _ _ ihL.symm ihR.symm).symm
+        | some rv =>
+          cases rv with
+          | vSet rs =>
+            exact soundness_setBin_sets s st env op l r ls rs ihL ihR hL hR
+          | vBool b =>
+            have hNotSet : ∀ members, Value.vBool b ≠ .vSet members := by intro members h; cases h
+            rw [eval_setBin_rhs_nonSet s st env op l r ls (.vBool b) hNotSet hL hR]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+              exact (smtEval_setUnion_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) hNotSet)).symm
+            | intersect =>
+              rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+              exact (smtEval_setIntersect_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) hNotSet)).symm
+            | diff =>
+              rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+              exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) hNotSet)).symm
+          | vInt n =>
+            have hNotSet : ∀ members, Value.vInt n ≠ .vSet members := by intro members h; cases h
+            rw [eval_setBin_rhs_nonSet s st env op l r ls (.vInt n) hNotSet hL hR]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+              exact (smtEval_setUnion_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) hNotSet)).symm
+            | intersect =>
+              rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+              exact (smtEval_setIntersect_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) hNotSet)).symm
+            | diff =>
+              rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+              exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) hNotSet)).symm
+          | vEnum en mem =>
+            have hNotSet : ∀ members, Value.vEnum en mem ≠ .vSet members := by intro members h; cases h
+            rw [eval_setBin_rhs_nonSet s st env op l r ls (.vEnum en mem) hNotSet hL hR]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+              exact (smtEval_setUnion_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+            | intersect =>
+              rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+              exact (smtEval_setIntersect_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+            | diff =>
+              rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+              exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+          | vEntity en id =>
+            have hNotSet : ∀ members, Value.vEntity en id ≠ .vSet members := by intro members h; cases h
+            rw [eval_setBin_rhs_nonSet s st env op l r ls (.vEntity en id) hNotSet hL hR]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+              exact (smtEval_setUnion_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+            | intersect =>
+              rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+              exact (smtEval_setIntersect_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+            | diff =>
+              rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+              exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+      | vBool b =>
+        have hNotSet : ∀ members, Value.vBool b ≠ .vSet members := by intro members h; cases h
+        rw [eval_setBin_lhs_nonSet s st env op l r (.vBool b) hNotSet hL]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+          exact (smtEval_setUnion_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vBool b) hNotSet)).symm
+        | intersect =>
+          rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+          exact (smtEval_setIntersect_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vBool b) hNotSet)).symm
+        | diff =>
+          rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+          exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vBool b) hNotSet)).symm
+      | vInt n =>
+        have hNotSet : ∀ members, Value.vInt n ≠ .vSet members := by intro members h; cases h
+        rw [eval_setBin_lhs_nonSet s st env op l r (.vInt n) hNotSet hL]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+          exact (smtEval_setUnion_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vInt n) hNotSet)).symm
+        | intersect =>
+          rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+          exact (smtEval_setIntersect_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vInt n) hNotSet)).symm
+        | diff =>
+          rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+          exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vInt n) hNotSet)).symm
+      | vEnum en mem =>
+        have hNotSet : ∀ members, Value.vEnum en mem ≠ .vSet members := by intro members h; cases h
+        rw [eval_setBin_lhs_nonSet s st env op l r (.vEnum en mem) hNotSet hL]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+          exact (smtEval_setUnion_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+        | intersect =>
+          rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+          exact (smtEval_setIntersect_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+        | diff =>
+          rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+          exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEnum en mem) hNotSet)).symm
+      | vEntity en id =>
+        have hNotSet : ∀ members, Value.vEntity en id ≠ .vSet members := by intro members h; cases h
+        rw [eval_setBin_lhs_nonSet s st env op l r (.vEntity en id) hNotSet hL]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          rw [show translate (.setBin .union l r) = .setUnion (translate l) (translate r) from rfl]
+          exact (smtEval_setUnion_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+        | intersect =>
+          rw [show translate (.setBin .intersect l r) = .setIntersect (translate l) (translate r) from rfl]
+          exact (smtEval_setIntersect_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+        | diff =>
+          rw [show translate (.setBin .diff l r) = .setDiff (translate l) (translate r) from rfl]
+          exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -115,37 +115,47 @@ end
 
 /-- `SmtVal.sInt` boolean equality unfolds to `Int` boolean equality. -/
 theorem sInt_beq (a b : Int) : (SmtVal.sInt a == SmtVal.sInt b) = (a == b) := by
+  rfl
+
+theorem valueToSmt_decide_eq (a b : Value) :
+    (decide (valueToSmt a = valueToSmt b) : Bool) = decide (a = b) := by
   by_cases h : a = b
   · subst h
-    have ha : (a == a) = true := by rw [beq_iff_eq]
-    have hsa : (SmtVal.sInt a == SmtVal.sInt a) = true := by rw [beq_iff_eq]
-    rw [ha, hsa]
-  · have h1 : (a == b) = false := by
-      apply Bool.eq_false_iff.mpr
-      intro hb; exact h (eq_of_beq hb)
-    have h2 : (SmtVal.sInt a == SmtVal.sInt b) = false := by
-      apply Bool.eq_false_iff.mpr
+    simp
+  · have hMapped : valueToSmt a ≠ valueToSmt b := by
       intro hb
-      have : SmtVal.sInt a = SmtVal.sInt b := eq_of_beq hb
-      cases this; exact h rfl
-    rw [h1, h2]
+      exact h (valueToSmt_inj hb)
+    simp [h, hMapped]
+
+theorem containsValueForBeq_map_valueToSmt (members : List Value) (v : Value) :
+    containsSmtValForBeq (members.map valueToSmt) (valueToSmt v) =
+      containsValueForBeq members v := by
+  induction members with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [List.map, containsSmtValForBeq, containsValueForBeq]
+      rw [valueToSmt_decide_eq hd v, ih]
+
+theorem subsetValueList_map_valueToSmt (xs ys : List Value) :
+    subsetSmtValList (xs.map valueToSmt) (ys.map valueToSmt) =
+      subsetValueList xs ys := by
+  induction xs with
+  | nil => rfl
+  | cons hd rest ih =>
+      simp only [List.map, subsetSmtValList, subsetValueList]
+      rw [containsValueForBeq_map_valueToSmt ys hd, ih]
+
+theorem setEqValueList_map_valueToSmt (xs ys : List Value) :
+    setEqSmtValList (xs.map valueToSmt) (ys.map valueToSmt) =
+      setEqValueList xs ys := by
+  simp only [setEqSmtValList, setEqValueList]
+  rw [subsetValueList_map_valueToSmt xs ys, subsetValueList_map_valueToSmt ys xs]
 
 /-- Boolean equality on `Value` agrees with boolean equality on `SmtVal` after `valueToSmt`. -/
 theorem valueToSmt_beq (a b : Value) : (valueToSmt a == valueToSmt b) = (a == b) := by
-  by_cases h : a = b
-  · subst h
-    have ha : (a == a) = true := by rw [beq_iff_eq]
-    have hav : (valueToSmt a == valueToSmt a) = true := by rw [beq_iff_eq]
-    rw [ha, hav]
-  · have h1 : (a == b) = false := by
-      apply Bool.eq_false_iff.mpr
-      intro hb
-      exact h (eq_of_beq hb)
-    have h2 : (valueToSmt a == valueToSmt b) = false := by
-      apply Bool.eq_false_iff.mpr
-      intro hb
-      exact h (valueToSmt_inj (eq_of_beq hb))
-    rw [h1, h2]
+  cases a <;> cases b <;> try rfl
+  simp [valueToSmt, valuesToSmt_eq_map]
+  exact setEqValueList_map_valueToSmt _ _
 
 /-! ## Env / State / Schema ↔ SmtModel correlation -/
 

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -47,5 +47,11 @@ def translate : Expr → SmtTerm
   | .cardRel relName          => .cardRel relName
   | .indexRel relName key     => .indexRel relName (translate key)
   | .fieldAccess base fn      => .fieldAccess (translate base) fn
+  | .setEmpty                 => .setEmpty
+  | .setInsert elem set       => .setInsert (translate elem) (translate set)
+  | .setMember elem set       => .setMember (translate elem) (translate set)
+  | .setBin .union l r        => .setUnion (translate l) (translate r)
+  | .setBin .intersect l r    => .setIntersect (translate l) (translate r)
+  | .setBin .diff l r         => .setDiff (translate l) (translate r)
 
 end SpecRest


### PR DESCRIPTION
## Summary

Adds issue #195 set-valued algebra to the Lean proof mirror and Scala certificate path.

- Adds Lean Value.vSet / SmtVal.sSet, set literal constructors, set membership, and set binary operations for union, intersection, and difference.
- Extends Soundness.lean so the universal soundness theorem covers set literals, set membership, and set-valued algebra with non-set failure paths.
- Extends the Scala certificate mirror (EvalIR, Emit, VerifiedSubset) and drift/audit tests for the new in-subset shapes.
- Updates proof status and docs to mark set-valued algebra closed while keeping set comprehensions, maps, and sequences deferred.

## Validation

- lake build
- sbt test
- pre-commit hooks during commit: prettier, scalafmt, forbid placeholder check, lake build, merge-conflict / EOF / whitespace checks

## Notes

The cert classifier keeps empty standalone set literals out of subset because production Z3 still requires type context for that shape. Empty set literals are accepted in membership contexts, matching production behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Linear #195 by adding verified set-valued algebra to the Lean proof and Scala certificate paths. Supports set literals, set membership, and union/intersect/diff, and extends the universal soundness theorem to cover them.

- **New Features**
  - Lean: added `Value.vSet`/`SmtVal.sSet`, set IR (`setEmpty`, `setInsert`, `setMember`, `setBin`), decidable equality, lemmas, and soundness coverage for sets and failure paths.
  - Scala cert path: added `VSet` in `EvalIR`, emitter support for set literals and `.setMember`/`.setBin`, and updated `VerifiedSubset` to accept set-valued `In`/`NotIn` and algebra when the RHS is a set expression or an identifier; expanded drift/audit and emit tests.
  - Docs: updated status and research pages to mark set algebra closed; clarified FieldAccess applies to entity-valued expressions.
  - Note: empty set literals remain out of standalone subset classification (Z3 needs type context) but are allowed in membership contexts to match production behavior.

<sup>Written for commit f721117e8cbff3d841fb4a07b283ce2ea0678751. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for set operations (union, intersection, difference) to the verified subset.
  * Extended verification coverage to include set literals and set membership operations.
  * Closed Issue #195: set-valued algebra is now fully verified.

* **Documentation**
  * Updated verified subset scope documentation to reflect new set operation coverage.
  * Enhanced soundness status ledger with comprehensive set expression verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->