### PR TITLE
M_L.4.b-ext Phases 1-3b — StatePair carrier + per-case soundnessAt for full subset (advances #194)

### DIFF
--- a/.github/workflows/lean-certs.yml
+++ b/.github/workflows/lean-certs.yml
@@ -30,29 +30,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        fixture:
-          # Verified-subset happy path: invariant + 2 op-requires.
-          # Renders 3 cert_decide + 0 trivial; smoke-tests in-subset code
-          # including M_L.4.a LIA arithmetic (count + 1, count - 1).
-          - safe_counter
-          # Mixed-subset: ~4 cert_decide + ~7 trivial; smoke-tests both
-          # the in-subset cert_decide path AND the out-of-subset trivial-
-          # stub path in a single bundle (set algebra still deferred).
-          - set_ops
-          # All-out-of-subset: 21 trivial stubs. Smoke-tests the path
-          # that produces no cert_decide certs and confirms the bundle
-          # still compiles via `lake build` (no stray `/- ... -/`
-          # placeholders, no UNRENDERABLE markers).
-          - auth_service
-          # M_L.4.c Cardinality + LIA exercise: 1 cert_decide + 6 trivial.
-          # Validates renderExpr of (.cardRel "store") on real spec.
-          - url_shortener
-          # Multi-invariant + state-relation membership: 2 cert_decide +
-          # 15 trivial. Stresses the bundle aggregation path.
-          - todo_list
-          # High cert_decide yield: 6 cert_decide + 9 trivial. Stresses
-          # combination of subset operators in a single bundle.
-          - edge_cases
+        # M_L.4.b-ext Phase 5.d: cert counts pinned per fixture. The post-
+        # emit assertion step compares stdout output against `expected_cert`
+        # / `expected_trivial`; drift fails CI with a localized error
+        # rather than silently accepting count regressions. Bump these when
+        # synthesizer/seeder improvements deliberately change the totals.
+        include:
+          # Verified-subset happy path: invariant + 2 op-requires + 2
+          # preservation. Phase 5.d per-op seeding makes both preservation
+          # certs non-vacuous (Decrement seeds pre.count = 1).
+          - fixture: safe_counter
+            expected_cert: 5
+            expected_trivial: 0
+          # Mixed-subset: tests both the in-subset cert_decide path AND the
+          # out-of-subset trivial-stub path in a single bundle. Set algebra
+          # still deferred → most operations stub.
+          - fixture: set_ops
+            expected_cert: 6
+            expected_trivial: 19
+          # Mostly out-of-subset (let-bound, output-assignment, complex
+          # ensures). 2 cert_decide come from the in-subset invariants.
+          # Smoke-tests the path that produces mostly trivial stubs.
+          - fixture: auth_service
+            expected_cert: 2
+            expected_trivial: 61
+          # Cardinality + LIA exercise. Validates renderExpr of
+          # `(.cardRel "store")` on a real spec.
+          - fixture: url_shortener
+            expected_cert: 2
+            expected_trivial: 17
+          # Multi-invariant + state-relation membership. Stresses the
+          # bundle aggregation path.
+          - fixture: todo_list
+            expected_cert: 4
+            expected_trivial: 49
+          # High cert_decide yield: stresses combination of subset
+          # operators in a single bundle.
+          - fixture: edge_cases
+            expected_cert: 8
+            expected_trivial: 51
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -83,7 +99,26 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/cert-${{ matrix.fixture }}
-          sbt "cli/run verify --emit-cert /tmp/cert-${{ matrix.fixture }} fixtures/spec/${{ matrix.fixture }}.spec"
+          sbt "cli/run verify --emit-cert /tmp/cert-${{ matrix.fixture }} fixtures/spec/${{ matrix.fixture }}.spec" \
+            2>&1 | tee /tmp/cert-${{ matrix.fixture }}/emit.log
+
+      - name: Assert cert counts for ${{ matrix.fixture }}
+        run: |
+          set -euo pipefail
+          # Phase 5.d count regression check. The emitter prints a
+          # one-liner like "Wrote translation-validation cert
+          # (5 obligations: 5 cert_decide, 0 trivial) to ...".
+          line=$(grep "Wrote translation-validation cert" /tmp/cert-${{ matrix.fixture }}/emit.log)
+          actual_cert=$(echo "$line" | grep -oE '[0-9]+ cert_decide' | grep -oE '[0-9]+')
+          actual_trivial=$(echo "$line" | grep -oE '[0-9]+ trivial' | grep -oE '[0-9]+')
+          expected_cert=${{ matrix.expected_cert }}
+          expected_trivial=${{ matrix.expected_trivial }}
+          echo "fixture=${{ matrix.fixture }} cert=$actual_cert/$expected_cert trivial=$actual_trivial/$expected_trivial"
+          if [ "$actual_cert" != "$expected_cert" ] || [ "$actual_trivial" != "$expected_trivial" ]; then
+            echo "::error::cert-count drift on ${{ matrix.fixture }}: expected $expected_cert/$expected_trivial got $actual_cert/$actual_trivial"
+            echo "::error::if intentional, update .github/workflows/lean-certs.yml expected_cert/expected_trivial."
+            exit 1
+          fi
 
       - name: Build certificate bundle with lake
         working-directory: /tmp/cert-${{ matrix.fixture }}

--- a/.github/workflows/lean-certs.yml
+++ b/.github/workflows/lean-certs.yml
@@ -42,15 +42,16 @@ jobs:
           - fixture: safe_counter
             expected_cert: 5
             expected_trivial: 0
-          # Mixed-subset: tests both the in-subset cert_decide path AND the
-          # out-of-subset trivial-stub path in a single bundle. Set algebra
-          # still deferred → most operations stub.
+          # Mixed-subset. Phase 5.e per-clause partial recognition flipped
+          # 8 preservation certs (Merge/Common/OnlyA/Included × 2 invs) from
+          # stubs to cert_decide: their ensures touch only output names
+          # (`u = a union b`), and the invariants don't read those names.
           - fixture: set_ops
-            expected_cert: 6
-            expected_trivial: 19
+            expected_cert: 14
+            expected_trivial: 11
           # Mostly out-of-subset (let-bound, output-assignment, complex
-          # ensures). 2 cert_decide come from the in-subset invariants.
-          # Smoke-tests the path that produces mostly trivial stubs.
+          # ensures with relation/lookup updates needing demo seeding).
+          # The 2 cert_decide come from the in-subset invariants.
           - fixture: auth_service
             expected_cert: 2
             expected_trivial: 61
@@ -60,15 +61,20 @@ jobs:
             expected_cert: 2
             expected_trivial: 17
           # Multi-invariant + state-relation membership. Stresses the
-          # bundle aggregation path.
+          # bundle aggregation path. Phase 5.e: +1 cert_decide from
+          # per-clause partial recognition.
           - fixture: todo_list
-            expected_cert: 4
-            expected_trivial: 49
+            expected_cert: 5
+            expected_trivial: 48
           # High cert_decide yield: stresses combination of subset
-          # operators in a single bundle.
+          # operators in a single bundle. Phase 5.e gained +10 cert_decide
+          # (from 8 to 18) by lifting the ensures-classify gate and using
+          # per-clause partial recognition: ops whose ensures touch only
+          # output names (not state-touching) now produce honest preservation
+          # certs even when individual ensures clauses are out-of-subset.
           - fixture: edge_cases
-            expected_cert: 8
-            expected_trivial: 51
+            expected_cert: 18
+            expected_trivial: 41
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -58,7 +58,18 @@ object Emit:
       op.requires.zipWithIndex.map: (req, reqIdx) =>
         renderOperationRequiresTheorem(ir, op, opIdx, req, reqIdx, st)
 
-    val theorems = invariantTheorems ++ opRequiresTheorems
+    // M_L.4.b-ext Phase 5.c: per-(operation × invariant) preservation cert.
+    // Operations with no `ensures` skip preservation entirely — there's
+    // nothing to claim about the post-state. Operations with at least one
+    // ensures get one preservation theorem per invariant; the renderer
+    // declines (stub) when ensures synthesis can't recognise the shape.
+    val opPreservationTheorems = ir.operations.zipWithIndex.flatMap: (op, opIdx) =>
+      if op.ensures.isEmpty then Nil
+      else
+        ir.invariants.zipWithIndex.map: (inv, invIdx) =>
+          renderOperationPreservesInvariantTheorem(ir, op, opIdx, inv, invIdx, st)
+
+    val theorems = invariantTheorems ++ opRequiresTheorems ++ opPreservationTheorems
 
     val (certified, stubbed) = theorems.foldLeft((0, 0)): (acc, t) =>
       val (c, s) = acc
@@ -189,6 +200,102 @@ object Emit:
                |      = some $expected := by
                |  cert_decide""".stripMargin
 
+  /** M_L.4.b-ext Phase 5.c: emit one preservation cert per (operation × invariant) pair. Renders a
+    * closed `evalPreservation` claim: in the operation's pre- state, if `requires` hold, the
+    * `invariant` must still hold in the post- state synthesised from `ensures`. Vacuous when
+    * `requires` is false on the demo state.
+    *
+    * Stubs out (with a `TODO[M_L.4]` marker) when:
+    *   - The invariant's body is out-of-subset.
+    *   - Any of the operation's `requires` or `ensures` clauses are out-of-subset.
+    *   - `EvalIR.synthesizePostState` declines (ensures shape unrecognised).
+    *   - The closed evaluator returns `none` on the demo pre/post pair.
+    */
+  private def renderOperationPreservesInvariantTheorem(
+      ir: ServiceIR,
+      op: OperationDecl,
+      opIdx: Int,
+      inv: InvariantDecl,
+      invIdx: Int,
+      pre: EvalIR.State
+  ): String =
+    val invName = inv.name.getOrElse(s"anon_$invIdx")
+    val theoremName =
+      s"cert_op_${opIdx}_${sanitize(op.name)}_preserves_${invIdx}_${sanitize(invName)}"
+    val what = s"`${op.name}` preserves invariant `$invName` in `${ir.name}`"
+
+    val invStatus = VerifiedSubset.classify(inv.expr)
+    val reqsStatus =
+      op.requires.foldLeft[VerifiedSubset.SubsetStatus](VerifiedSubset.SubsetStatus.InSubset):
+        (acc, r) => chooseWorseStatus(acc, VerifiedSubset.classify(r))
+    val ensuresStatus =
+      op.ensures.foldLeft[VerifiedSubset.SubsetStatus](VerifiedSubset.SubsetStatus.InSubset):
+        (acc, e) => chooseWorseStatus(acc, VerifiedSubset.classify(e))
+
+    val combined =
+      chooseWorseStatus(invStatus, chooseWorseStatus(reqsStatus, ensuresStatus))
+
+    combined match
+      case VerifiedSubset.SubsetStatus.OutOfSubset(reason) =>
+        renderOutOfSubsetStub(theoremName, what, reason)
+      case VerifiedSubset.SubsetStatus.InSubset =>
+        EvalIR.synthesizePostState(ir, op, pre) match
+          case None =>
+            renderOutOfSubsetStub(
+              theoremName,
+              what,
+              "ensures synthesis declined — non-primed-equality clause shape"
+            )
+          case Some(post) =>
+            val sp = EvalIR.StatePair(pre, post)
+            EvalIR.evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, Nil, inv.expr) match
+              case None =>
+                renderOutOfSubsetStub(
+                  theoremName,
+                  what,
+                  "closed reducer stuck on synthesised post-state"
+                )
+              case Some(_) =>
+                EvalIR.evalRequiresAt(EvalIR.StateMode.Pre, ir, sp, Nil, op.requires) match
+                  case None =>
+                    renderOutOfSubsetStub(
+                      theoremName,
+                      what,
+                      "closed reducer stuck on requires in pre-state"
+                    )
+                  case Some(reqsHold) =>
+                    val expectedBool =
+                      if !reqsHold then true
+                      else
+                        EvalIR
+                          .evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, Nil, inv.expr)
+                          .getOrElse(false)
+                    val enumNames     = ir.enums.map(_.name).toSet
+                    val schemaTerm    = renderSchemaLit(ir)
+                    val statePairTerm = renderStatePairLit(pre, post)
+                    val invTerm       = renderInvariantDecl(inv, invName, enumNames)
+                    val reqsTerm =
+                      op.requires.map(r => renderExpr(r, enumNames)).mkString(", ")
+                    val expected = if expectedBool then "true" else "false"
+                    s"""/-- $what — preservation under ensures-driven post-state synthesis. -/
+                       |theorem $theoremName :
+                       |    evalPreservation
+                       |        $schemaTerm
+                       |        $statePairTerm
+                       |        []
+                       |        [$reqsTerm]
+                       |        $invTerm
+                       |      = some $expected := by
+                       |  cert_decide""".stripMargin
+
+  private def chooseWorseStatus(
+      a: VerifiedSubset.SubsetStatus,
+      b: VerifiedSubset.SubsetStatus
+  ): VerifiedSubset.SubsetStatus = (a, b) match
+    case (VerifiedSubset.SubsetStatus.InSubset, x)             => x
+    case (x, VerifiedSubset.SubsetStatus.InSubset)             => x
+    case (out @ VerifiedSubset.SubsetStatus.OutOfSubset(_), _) => out
+
   /** Out-of-subset cert: emit a trivially-discharged `True` theorem. The cert carries the
     * missing-operator metadata in its docstring and the trailing `TODO[M_L.4]` comment, but its
     * body is `trivial` so the emitted bundle has zero `sorry` markers and `lake build` is
@@ -221,7 +328,13 @@ object Emit:
       s"""({ enums := [$enumLits], entities := [$entityLits] } : Schema)"""
 
   private def renderStateLit(ir: ServiceIR): String =
-    val st = EvalIR.State.demo(ir)
+    renderStateLitOf(EvalIR.State.demo(ir))
+
+  /** M_L.4.b-ext Phase 5.c: render an arbitrary `EvalIR.State` as a Lean `State` literal. Factored
+    * from `renderStateLit` so the preservation cert renderer can emit synthesised post-states
+    * alongside the demo pre-state.
+    */
+  private def renderStateLitOf(st: EvalIR.State): String =
     if st.scalars.isEmpty && st.relations.isEmpty && st.lookups.isEmpty
       && st.entityFields.isEmpty
     then "State.empty"
@@ -250,6 +363,13 @@ object Emit:
           s"""(${quote(name)}, [$fieldsLit])"""
         .mkString(", ")
       s"""({ scalars := [$scalars], relations := [$relations], lookups := [$lookups], entityFields := [$entityFields] } : State)"""
+
+  /** M_L.4.b-ext Phase 5.c: render a `(pre, post)` pair as a Lean `StatePair`. Used by the
+    * operation invariant-preservation cert; the pre-state is the demo state, the post-state is the
+    * ensures-driven synthesis from `EvalIR.synthesizePostState`.
+    */
+  private def renderStatePairLit(pre: EvalIR.State, post: EvalIR.State): String =
+    s"({ pre := ${renderStateLitOf(pre)}, post := ${renderStateLitOf(post)} } : StatePair)"
 
   private def renderValueLit(v: EvalIR.Value): String = v match
     case EvalIR.Value.VBool(b)        => s".vBool $b"

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -258,6 +258,9 @@ object Emit:
     case EvalIR.Value.VEntity(en, id) => s".vEntity ${quote(en)} ${quote(id)}"
     case EvalIR.Value.VSet(members) =>
       s".vSet [${members.map(renderValueLit).mkString(", ")}]"
+    case EvalIR.Value.VEntityWith(base, fld, value) =>
+      // Mirrors Lean `Value.vEntityWith` chain ctor.
+      s".vEntityWith ${renderValueLit(base)} ${quote(fld)} ${renderValueLit(value)}"
 
   private def renderInvariantDecl(
       inv: InvariantDecl,
@@ -335,6 +338,12 @@ object Emit:
       // arbitrary entity-valued expressions (Identifier, Index, chained
       // FieldAccess, quantifier-bound vars) through the id-keyed table.
       s"(.fieldAccess ${renderExpr(base, enumNames)} ${quote(field)})"
+    case Expr.With(base, updates, _) =>
+      // M_L.4.b-ext Phase 4b: lower multi-field record-update to a left-fold
+      // of single-field `.withRec` Lean ctors. Mirrors Translator.scala:1061-1098
+      // shape; Phase 4b's Skolem semantics close in `Soundness.lean`.
+      updates.foldLeft(renderExpr(base, enumNames)): (acc, upd) =>
+        s"(.withRec $acc ${quote(upd.name)} ${renderExpr(upd.value, enumNames)})"
     case Expr.SetLiteral(elements, _) =>
       renderSetLiteral(elements, enumNames)
     case Expr.Quantifier(QuantKind.All, bindings, body, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -224,75 +224,87 @@ object Emit:
       s"cert_op_${opIdx}_${sanitize(op.name)}_preserves_${invIdx}_${sanitize(invName)}"
     val what = s"`${op.name}` preserves invariant `$invName` in `${ir.name}`"
 
+    // Phase 5.e: only `inv` and `requires` are rendered into the cert and need
+    // to be in the verified subset; `ensures` is consumed by the synthesizer
+    // (NOT rendered), so out-of-subset ensures shapes (`MapLiteral`, set/map
+    // updates) are fine — the synthesizer recognises set/map-add structurally
+    // and unrecognised clauses surface as `unknownFields` for the taint gate
+    // below.
     val invStatus = VerifiedSubset.classify(inv.expr)
     val reqsStatus =
       op.requires.foldLeft[VerifiedSubset.SubsetStatus](VerifiedSubset.SubsetStatus.InSubset):
         (acc, r) => chooseWorseStatus(acc, VerifiedSubset.classify(r))
-    val ensuresStatus =
-      op.ensures.foldLeft[VerifiedSubset.SubsetStatus](VerifiedSubset.SubsetStatus.InSubset):
-        (acc, e) => chooseWorseStatus(acc, VerifiedSubset.classify(e))
 
-    val combined =
-      chooseWorseStatus(invStatus, chooseWorseStatus(reqsStatus, ensuresStatus))
+    val combined = chooseWorseStatus(invStatus, reqsStatus)
 
     combined match
       case VerifiedSubset.SubsetStatus.OutOfSubset(reason) =>
         renderOutOfSubsetStub(theoremName, what, reason)
       case VerifiedSubset.SubsetStatus.InSubset =>
-        // M_L.4.b-ext Phase 5.d: per-op pre-state seeding. Pick a pre-state
-        // where requires AND invariant both hold (or fall back to requires-only,
-        // then to demo). This makes preservation certs non-vacuous when
-        // possible — the demo state may not satisfy the operation's requires
-        // (e.g., safe_counter Decrement's `count > 0` rejects pre.count = 0).
-        val pre = EvalIR.seedPreStateForOp(ir, op, inv, demoState)
-        EvalIR.synthesizePostState(ir, op, pre) match
-          case None =>
-            renderOutOfSubsetStub(
-              theoremName,
-              what,
-              "ensures synthesis declined — non-primed-equality clause shape"
-            )
-          case Some(post) =>
-            val sp = EvalIR.StatePair(pre, post)
-            EvalIR.evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, Nil, inv.expr) match
-              case None =>
-                renderOutOfSubsetStub(
-                  theoremName,
-                  what,
-                  "closed reducer stuck on synthesised post-state"
-                )
-              case Some(_) =>
-                EvalIR.evalRequiresAt(EvalIR.StateMode.Pre, ir, sp, Nil, op.requires) match
-                  case None =>
-                    renderOutOfSubsetStub(
-                      theoremName,
-                      what,
-                      "closed reducer stuck on requires in pre-state"
-                    )
-                  case Some(reqsHold) =>
-                    val expectedBool =
-                      if !reqsHold then true
-                      else
-                        EvalIR
-                          .evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, Nil, inv.expr)
-                          .getOrElse(false)
-                    val enumNames     = ir.enums.map(_.name).toSet
-                    val schemaTerm    = renderSchemaLit(ir)
-                    val statePairTerm = renderStatePairLit(pre, post)
-                    val invTerm       = renderInvariantDecl(inv, invName, enumNames)
-                    val reqsTerm =
-                      op.requires.map(r => renderExpr(r, enumNames)).mkString(", ")
-                    val expected = if expectedBool then "true" else "false"
-                    s"""/-- $what — preservation under ensures-driven post-state synthesis. -/
-                       |theorem $theoremName :
-                       |    evalPreservation
-                       |        $schemaTerm
-                       |        $statePairTerm
-                       |        []
-                       |        [$reqsTerm]
-                       |        $invTerm
-                       |      = some $expected := by
-                       |  cert_decide""".stripMargin
+        // M_L.4.b-ext Phase 5.d: per-op pre-state seeding (now upgraded to
+        // joint state×param seeding in 5.e). Pick (pre, env) where requires
+        // AND invariant both hold; fall back to requires-only, then demo.
+        // Phase 5.e: thread the seeded env all the way through synthesis,
+        // closed evaluation, and the rendered cert (so closed Lean evaluation
+        // sees the same parameter bindings).
+        val ctx                   = EvalIR.seedContextForOp(ir, op, inv, demoState)
+        val pre                   = ctx.pre
+        val env                   = ctx.env
+        val (post, unknownFields) = EvalIR.synthesizePostState(ir, op, pre, env)
+        // Phase 5.e per-clause partial recognition: the analysis may carry
+        // forward `unknownFields` from clauses we couldn't classify. The cert
+        // is honest only when the invariant body doesn't read those fields;
+        // otherwise the synthesised post is an unsound model and we stub.
+        val invariantReads = EvalIR.referencedStateNames(inv.expr, Set.empty)
+        val tainted        = unknownFields.intersect(invariantReads)
+        if tainted.nonEmpty then
+          renderOutOfSubsetStub(
+            theoremName,
+            what,
+            s"ensures synthesis incomplete and invariant reads unknown field(s): ${tainted.toList.sorted.mkString(", ")}"
+          )
+        else
+          val sp = EvalIR.StatePair(pre, post)
+          EvalIR.evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, env, inv.expr) match
+            case None =>
+              renderOutOfSubsetStub(
+                theoremName,
+                what,
+                "closed reducer stuck on synthesised post-state"
+              )
+            case Some(_) =>
+              EvalIR.evalRequiresAt(EvalIR.StateMode.Pre, ir, sp, env, op.requires) match
+                case None =>
+                  renderOutOfSubsetStub(
+                    theoremName,
+                    what,
+                    "closed reducer stuck on requires in pre-state"
+                  )
+                case Some(reqsHold) =>
+                  val expectedBool =
+                    if !reqsHold then true
+                    else
+                      EvalIR
+                        .evalInvariantBodyAt(EvalIR.StateMode.Post, ir, sp, env, inv.expr)
+                        .getOrElse(false)
+                  val enumNames     = ir.enums.map(_.name).toSet
+                  val schemaTerm    = renderSchemaLit(ir)
+                  val statePairTerm = renderStatePairLit(pre, post)
+                  val invTerm       = renderInvariantDecl(inv, invName, enumNames)
+                  val reqsTerm =
+                    op.requires.map(r => renderExpr(r, enumNames)).mkString(", ")
+                  val envTerm  = renderEnvLit(env)
+                  val expected = if expectedBool then "true" else "false"
+                  s"""/-- $what — preservation under ensures-driven post-state synthesis. -/
+                     |theorem $theoremName :
+                     |    evalPreservation
+                     |        $schemaTerm
+                     |        $statePairTerm
+                     |        $envTerm
+                     |        [$reqsTerm]
+                     |        $invTerm
+                     |      = some $expected := by
+                     |  cert_decide""".stripMargin
 
   private def chooseWorseStatus(
       a: VerifiedSubset.SubsetStatus,
@@ -376,6 +388,18 @@ object Emit:
     */
   private def renderStatePairLit(pre: EvalIR.State, post: EvalIR.State): String =
     s"({ pre := ${renderStateLitOf(pre)}, post := ${renderStateLitOf(post)} } : StatePair)"
+
+  /** M_L.4.b-ext Phase 5.e: render a closed `Env` literal (op-input parameter bindings) as a Lean
+    * list-of-pairs. Threaded into the preservation cert so closed Lean evaluation sees the same
+    * param bindings the synthesizer used when computing the expected result.
+    */
+  private def renderEnvLit(env: EvalIR.Env): String =
+    if env.isEmpty then "[]"
+    else
+      val entries = env
+        .map((k, v) => s"(${quote(k)}, ${renderValueLit(v)})")
+        .mkString(", ")
+      s"[$entries]"
 
   private def renderValueLit(v: EvalIR.Value): String = v match
     case EvalIR.Value.VBool(b)        => s".vBool $b"

--- a/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/Emit.scala
@@ -217,7 +217,7 @@ object Emit:
       opIdx: Int,
       inv: InvariantDecl,
       invIdx: Int,
-      pre: EvalIR.State
+      demoState: EvalIR.State
   ): String =
     val invName = inv.name.getOrElse(s"anon_$invIdx")
     val theoremName =
@@ -239,6 +239,12 @@ object Emit:
       case VerifiedSubset.SubsetStatus.OutOfSubset(reason) =>
         renderOutOfSubsetStub(theoremName, what, reason)
       case VerifiedSubset.SubsetStatus.InSubset =>
+        // M_L.4.b-ext Phase 5.d: per-op pre-state seeding. Pick a pre-state
+        // where requires AND invariant both hold (or fall back to requires-only,
+        // then to demo). This makes preservation certs non-vacuous when
+        // possible — the demo state may not satisfy the operation's requires
+        // (e.g., safe_counter Decrement's `count > 0` rejects pre.count = 0).
+        val pre = EvalIR.seedPreStateForOp(ir, op, inv, demoState)
         EvalIR.synthesizePostState(ir, op, pre) match
           case None =>
             renderOutOfSubsetStub(

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -210,7 +210,14 @@ object EvalIR:
 
   private def valueEq(l: Value, r: Value): Boolean = (l, r) match
     case (Value.VSet(left), Value.VSet(right)) =>
-      left.forall(right.contains) && right.forall(left.contains)
+      left.forall(r => containsValue(right, r)) && right.forall(l => containsValue(left, l))
+    case (
+          Value.VEntityWith(ba, fa, va),
+          Value.VEntityWith(bb, fb, vb)
+        ) =>
+      // Recurse so extensional set equality inside record-update chains is
+      // preserved (mirrors the Lean `beqValue` recursive vEntityWith arm).
+      valueEq(ba, bb) && fa == fb && valueEq(va, vb)
     case _ => l == r
 
   private def containsValue(values: List[Value], needle: Value): Boolean =
@@ -624,12 +631,27 @@ object EvalIR:
       pre: State,
       env: Env
   ): EnsuresAnalysis =
-    val schema  = Schema.of(ir)
-    val flatten = op.ensures.flatMap(flattenAnd)
-    val results = flatten.map(classifyClause(_, schema, pre, env))
-    val updates = results.collect { case Right(us) => us }.flatten
-    val unknown = results.collect { case Left(fs) => fs }.flatten.toSet
-    EnsuresAnalysis(updates, unknown)
+    val schema     = Schema.of(ir)
+    val flatten    = op.ensures.flatMap(flattenAnd)
+    val results    = flatten.map(classifyClause(_, schema, pre, env))
+    val rawUpdates = results.collect { case Right(us) => us }.flatten
+    val rawUnknown = results.collect { case Left(fs) => fs }.flatten.toSet
+    // Phase 5.e+ conflict detection: `x' = 1 ∧ x' = 2` would otherwise be
+    // resolved as "last write wins" by `applyUpdates`, certifying a post-state
+    // that the ensures clauses do not jointly admit. Group `Scalar` updates
+    // by name; if the values disagree, drop those updates and lift the field
+    // into `unknownFields` so the renderer's gate refuses to emit.
+    val scalarsByName = rawUpdates.collect { case s @ StateUpdate.Scalar(n, v) =>
+      (n, v)
+    }.groupMap(_._1)(_._2)
+    val conflictingScalars = scalarsByName.collect {
+      case (name, values) if values.distinct.size > 1 => name
+    }.toSet
+    val updates = rawUpdates.filter {
+      case StateUpdate.Scalar(name, _) => !conflictingScalars.contains(name)
+      case _                           => true
+    }
+    EnsuresAnalysis(updates, rawUnknown ++ conflictingScalars)
 
   /** Synthesize the post-state by applying `analyseEnsures(...)` updates on top of `pre`. Returns
     * the synthesised state plus the set of "touched-but- unanalysable" field names; the cert
@@ -1011,10 +1033,20 @@ object EvalIR:
     case Expr.FieldAccess(base, _, _)   => containsPrime(base)
     case Expr.With(base, updates, _) =>
       containsPrime(base) || updates.exists(u => containsPrime(u.value))
-    case Expr.SetLiteral(elems, _)   => elems.exists(containsPrime)
+    case Expr.SetLiteral(elems, _) => elems.exists(containsPrime)
+    case Expr.MapLiteral(entries, _) =>
+      entries.exists(e => containsPrime(e.key) || containsPrime(e.value))
+    case Expr.SeqLiteral(elems, _)   => elems.exists(containsPrime)
     case Expr.EnumAccess(base, _, _) => containsPrime(base)
     case Expr.SetComprehension(_, dom, body, _) =>
       containsPrime(dom) || containsPrime(body)
     case Expr.SomeWrap(inner, _)   => containsPrime(inner)
     case Expr.The(_, dom, body, _) => containsPrime(dom) || containsPrime(body)
-    case _                         => false
+    case Expr.If(c, t, e, _) =>
+      containsPrime(c) || containsPrime(t) || containsPrime(e)
+    case Expr.Lambda(_, body, _) => containsPrime(body)
+    case Expr.Call(callee, args, _) =>
+      containsPrime(callee) || args.exists(containsPrime)
+    case Expr.Constructor(_, fields, _) =>
+      fields.exists(f => containsPrime(f.value))
+    case _ => false

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -18,6 +18,17 @@ object EvalIR:
 
   type Env = List[(String, Value)]
 
+  /** M_L.4.b-ext Phase 5.b: pre/post mode selector. Mirrors Lean `SpecRest.Semantics.StateMode` in
+    * `proofs/lean/SpecRest/Semantics.lean`.
+    *
+    * Used by `evalAt` to thread the active state through state-touching ops. `Expr.Prime` flips
+    * mode to `Post`; `Expr.Pre` flips mode to `Pre`. The innermost temporal operator wins (e.g.,
+    * `Prime(Pre(x))` reads `x` from the pre-state).
+    */
+  enum StateMode derives CanEqual:
+    case Pre
+    case Post
+
   final case class Schema(
       enums: List[(String, List[String])],
       entities: List[String]
@@ -139,6 +150,35 @@ object EvalIR:
                 )
               case _ =>
                 (rootAcc :+ (fld.name, defaultFor(schema, fld.typeExpr)), nestedAcc)
+
+  /** M_L.4.b-ext Phase 5.b: two-state carrier. Mirrors Lean `SpecRest.Semantics.StatePair` in
+    * `proofs/lean/SpecRest/Semantics.lean`.
+    *
+    * Operation contracts evaluate against a pre/post pair: the pre-state holds `count`-style
+    * identifiers; `count'` (rendered as `Expr.Prime`) reaches the post-state. Single-state
+    * invariants use `StatePair.diag(st)` and rely on the diagonal-collapse property: `evalAt(mode,
+    * _, diag(st), _, _)` agrees with `eval(_, st, _, _)` for every mode (mirrors Lean
+    * `evalAt_diagonal_eq_eval`).
+    */
+  final case class StatePair(pre: State, post: State):
+    def at(mode: StateMode): State = mode match
+      case StateMode.Pre  => pre
+      case StateMode.Post => post
+
+  object StatePair:
+    val empty: StatePair = StatePair(State.empty, State.empty)
+
+    /** Diagonal lift: same state in both modes. Phase 5.b emission uses this for state-only
+      * invariants so the existing single-state cert path stays intact; Phase 5.c will produce
+      * honest non-diagonal pairs for operation invariant-preservation certs.
+      */
+    def diag(st: State): StatePair = StatePair(st, st)
+
+    /** Demo synthesis. For Phase 5.b this is a diagonal pair; Phase 5.c will specialise `post`
+      * per-operation by applying ensures-style updates. The shape stays the same so call sites
+      * don't churn.
+      */
+    def demo(ir: ServiceIR): StatePair = diag(State.demo(ir))
 
   /** Default value chosen by the demo-state synthesizer for a given typeExpr. Threads `Schema` so
     * entity-typed scalars get `.vEntity` and enum-typed scalars get `.vEnum` rather than the wrong
@@ -283,147 +323,167 @@ object EvalIR:
           case _               => None
       case _ => None
 
-  def eval(s: Schema, st: State, env: Env, expr: Expr): Option[Value] = expr match
-    case Expr.BoolLit(v, _) => Some(Value.VBool(v))
-    case Expr.IntLit(v, _)  => Some(Value.VInt(BigInt(v)))
-    case Expr.Identifier(name, _) =>
-      envLookup(env, name).orElse(stateScalar(st, name))
-    case Expr.UnaryOp(UnOp.Not, operand, _) =>
-      eval(s, st, env, operand).flatMap(asBool).map(b => Value.VBool(!b))
-    case Expr.UnaryOp(UnOp.Negate, operand, _) =>
-      eval(s, st, env, operand).flatMap(asInt).map(n => Value.VInt(-n))
-    case Expr.UnaryOp(UnOp.Cardinality, Expr.Identifier(relName, _), _) =>
-      relationDomain(st, relName).map(dom => Value.VInt(BigInt(dom.length)))
-    case Expr.BinaryOp(op, l, r, _) if isBoolBinOp(op) =>
-      for
-        lv  <- eval(s, st, env, l)
-        rv  <- eval(s, st, env, r)
-        lb  <- asBool(lv)
-        rb  <- asBool(rv)
-        out <- evalBoolBin(op, lb, rb)
-      yield Value.VBool(out)
-    case Expr.BinaryOp(op, l, r, _) if isArithOp(op) =>
-      for
-        lv  <- eval(s, st, env, l)
-        rv  <- eval(s, st, env, r)
-        out <- evalArith(op, lv, rv)
-      yield out
-    case Expr.BinaryOp(op, l, r, _) if isCmpOp(op) =>
-      for
-        lv  <- eval(s, st, env, l)
-        rv  <- eval(s, st, env, r)
-        out <- evalCmp(op, lv, rv)
-      yield Value.VBool(out)
-    case Expr.BinaryOp(op, l, r, _) if isSetBinOp(op) =>
-      for
-        lv  <- eval(s, st, env, l)
-        rv  <- eval(s, st, env, r)
-        out <- evalSetBin(op, lv, rv)
-      yield out
-    case Expr.BinaryOp(BinOp.In, elem, Expr.Identifier(relName, _), _) =>
-      eval(s, st, env, Expr.Identifier(relName)).flatMap(asSet) match
-        case Some(members) =>
-          eval(s, st, env, elem).map(v => Value.VBool(containsValue(members, v)))
-        case None =>
-          relationDomain(st, relName)
-            .flatMap(dom => eval(s, st, env, elem).map(v => Value.VBool(containsValue(dom, v))))
-    case Expr.BinaryOp(BinOp.In, elem, setExpr, _) =>
-      for
-        v       <- eval(s, st, env, elem)
-        setVal  <- eval(s, st, env, setExpr)
-        members <- asSet(setVal)
-      yield Value.VBool(containsValue(members, v))
-    case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
-      eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
-    case Expr.BinaryOp(BinOp.NotIn, elem, setExpr, _) =>
-      eval(s, st, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, setExpr)))
-    case Expr.BinaryOp(
-          BinOp.Subset,
-          Expr.Identifier(r1, _),
-          Expr.Identifier(r2, _),
-          _
-        ) =>
-      // Subset(r1, r2)  ≡  ∀ x ∈ r1, x ∈ r2. Mirror the Lean-side `forallRel + member`
-      // composition that Emit renders.
-      for
-        dom1 <- relationDomain(st, r1)
-        dom2 <- relationDomain(st, r2)
-      yield Value.VBool(dom1.forall(v => containsValue(dom2, v)))
-    case Expr.Index(Expr.Identifier(relName, _), keyExpr, _) =>
-      eval(s, st, env, keyExpr).flatMap(kv => lookupKey(st, relName, kv))
-    case Expr.FieldAccess(base, fieldName, _) =>
-      // M_L.4.k: evaluate base to a `vEntity _ id`, then look up the field by id.
-      // M_L.4.b-ext Phase 4b: chain-walk via `fieldLookup` so With-extended bases
-      // resolve override-first. Mirrors Lean `eval` for `.fieldAccess`:
-      //   eval base = some v ⇒ Value.fieldLookup st v fieldName
-      eval(s, st, env, base).flatMap(v => fieldLookup(st, v, fieldName))
-    case Expr.With(base, updates, _) =>
-      // M_L.4.b-ext Phase 4b: lower multi-field With to a left-fold of VEntityWith
-      // chains. Mirrors the Lean lowering of `With(base, [u1; u2])` to
-      // `withRec (withRec base u1.fld u1.value) u2.fld u2.value` and the eval
-      // semantics: both base and value must reduce; otherwise the whole expr
-      // is `none` (matching Lean `eval` for `.withRec`).
-      eval(s, st, env, base).flatMap: bv =>
-        updates.foldLeft[Option[Value]](Some(bv)): (acc, upd) =>
-          for
-            cur <- acc
-            v   <- eval(s, st, env, upd.value)
-          yield Value.VEntityWith(cur, upd.name, v)
-    case Expr.Let(name, value, body, _) =>
-      eval(s, st, env, value).flatMap(v => eval(s, st, (name, v) :: env, body))
-    case Expr.EnumAccess(Expr.Identifier(enName, _), member, _) =>
-      s.enums.collectFirst { case (n, members) if n == enName => members } match
-        case Some(members) if members.contains(member) =>
-          Some(Value.VEnum(enName, member))
-        case _ => None
-    case Expr.Quantifier(QuantKind.All, bindings, body, _) =>
-      bindings match
-        case List(QuantifierBinding(v, Expr.Identifier(name, _), _, _)) =>
-          s.enums.collectFirst { case (n, members) if n == name => members } match
-            case Some(members) =>
-              evalForallEnum(s, st, env, v, name, members, body)
-            case None =>
-              relationDomain(st, name) match
-                case Some(dom) => evalForallRel(s, st, env, v, dom, body)
-                case None      => None
-        case _ => None
-    case Expr.Quantifier(QuantKind.No, bindings, body, _) =>
-      // No x, P  ≡  ∀ x, ¬ P. Reduce to the existing All-arm so EvalIR matches Lean.
-      eval(
-        s,
-        st,
-        env,
-        Expr.Quantifier(QuantKind.All, bindings, Expr.UnaryOp(UnOp.Not, body))
-      )
-    case Expr.Quantifier(QuantKind.Some, bindings, body, _) =>
-      // ∃ x, P  ≡  ¬ ∀ x, ¬ P
-      eval(
-        s,
-        st,
-        env,
-        Expr.UnaryOp(
-          UnOp.Not,
+  /** Single-state entry point. Delegates to `evalAt` with `mode = Pre` and a diagonal StatePair.
+    * The diagonal-collapse property (mirror of Lean `evalAt_diagonal_eq_eval`) holds by definition:
+    * in this configuration `Prime` and `Pre` both flip to a mode whose state slot is the same `st`,
+    * so the result agrees with the prior single-state `eval` semantics.
+    */
+  def eval(s: Schema, st: State, env: Env, expr: Expr): Option[Value] =
+    evalAt(StateMode.Pre, s, StatePair.diag(st), env, expr)
+
+  /** M_L.4.b-ext Phase 5.b: mode-aware closed evaluator. Mirrors Lean `SpecRest.Semantics.evalAt`
+    * in `proofs/lean/SpecRest/Semantics.lean`.
+    *
+    * State-touching arms (Identifier state-fallback, Cardinality, In/NotIn over a relation
+    * identifier, Subset, Index, FieldAccess, Quantifier(All) over a relation domain) read from
+    * `sp.at(mode)`. `Expr.Prime` flips mode to `Post`; `Expr.Pre` flips mode to `Pre`. All other
+    * arms recurse through `evalAt` with the same `mode`/`sp`, so the temporal context propagates
+    * down a sub-tree until the next Prime/Pre boundary.
+    */
+  def evalAt(
+      mode: StateMode,
+      s: Schema,
+      sp: StatePair,
+      env: Env,
+      expr: Expr
+  ): Option[Value] =
+    val st = sp.at(mode)
+    expr match
+      case Expr.BoolLit(v, _) => Some(Value.VBool(v))
+      case Expr.IntLit(v, _)  => Some(Value.VInt(BigInt(v)))
+      case Expr.Identifier(name, _) =>
+        envLookup(env, name).orElse(stateScalar(st, name))
+      case Expr.UnaryOp(UnOp.Not, operand, _) =>
+        evalAt(mode, s, sp, env, operand).flatMap(asBool).map(b => Value.VBool(!b))
+      case Expr.UnaryOp(UnOp.Negate, operand, _) =>
+        evalAt(mode, s, sp, env, operand).flatMap(asInt).map(n => Value.VInt(-n))
+      case Expr.UnaryOp(UnOp.Cardinality, Expr.Identifier(relName, _), _) =>
+        relationDomain(st, relName).map(dom => Value.VInt(BigInt(dom.length)))
+      case Expr.BinaryOp(op, l, r, _) if isBoolBinOp(op) =>
+        for
+          lv  <- evalAt(mode, s, sp, env, l)
+          rv  <- evalAt(mode, s, sp, env, r)
+          lb  <- asBool(lv)
+          rb  <- asBool(rv)
+          out <- evalBoolBin(op, lb, rb)
+        yield Value.VBool(out)
+      case Expr.BinaryOp(op, l, r, _) if isArithOp(op) =>
+        for
+          lv  <- evalAt(mode, s, sp, env, l)
+          rv  <- evalAt(mode, s, sp, env, r)
+          out <- evalArith(op, lv, rv)
+        yield out
+      case Expr.BinaryOp(op, l, r, _) if isCmpOp(op) =>
+        for
+          lv  <- evalAt(mode, s, sp, env, l)
+          rv  <- evalAt(mode, s, sp, env, r)
+          out <- evalCmp(op, lv, rv)
+        yield Value.VBool(out)
+      case Expr.BinaryOp(op, l, r, _) if isSetBinOp(op) =>
+        for
+          lv  <- evalAt(mode, s, sp, env, l)
+          rv  <- evalAt(mode, s, sp, env, r)
+          out <- evalSetBin(op, lv, rv)
+        yield out
+      case Expr.BinaryOp(BinOp.In, elem, Expr.Identifier(relName, _), _) =>
+        evalAt(mode, s, sp, env, Expr.Identifier(relName)).flatMap(asSet) match
+          case Some(members) =>
+            evalAt(mode, s, sp, env, elem).map(v => Value.VBool(containsValue(members, v)))
+          case None =>
+            relationDomain(st, relName)
+              .flatMap(dom =>
+                evalAt(mode, s, sp, env, elem).map(v => Value.VBool(containsValue(dom, v)))
+              )
+      case Expr.BinaryOp(BinOp.In, elem, setExpr, _) =>
+        for
+          v       <- evalAt(mode, s, sp, env, elem)
+          setVal  <- evalAt(mode, s, sp, env, setExpr)
+          members <- asSet(setVal)
+        yield Value.VBool(containsValue(members, v))
+      case Expr.BinaryOp(BinOp.NotIn, elem, rel @ Expr.Identifier(_, _), _) =>
+        evalAt(mode, s, sp, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, rel)))
+      case Expr.BinaryOp(BinOp.NotIn, elem, setExpr, _) =>
+        evalAt(mode, s, sp, env, Expr.UnaryOp(UnOp.Not, Expr.BinaryOp(BinOp.In, elem, setExpr)))
+      case Expr.BinaryOp(
+            BinOp.Subset,
+            Expr.Identifier(r1, _),
+            Expr.Identifier(r2, _),
+            _
+          ) =>
+        // Subset(r1, r2)  ≡  ∀ x ∈ r1, x ∈ r2. Both relation domains are read
+        // from the active mode's state.
+        for
+          dom1 <- relationDomain(st, r1)
+          dom2 <- relationDomain(st, r2)
+        yield Value.VBool(dom1.forall(v => containsValue(dom2, v)))
+      case Expr.Index(Expr.Identifier(relName, _), keyExpr, _) =>
+        evalAt(mode, s, sp, env, keyExpr).flatMap(kv => lookupKey(st, relName, kv))
+      case Expr.FieldAccess(base, fieldName, _) =>
+        evalAt(mode, s, sp, env, base).flatMap(v => fieldLookup(st, v, fieldName))
+      case Expr.With(base, updates, _) =>
+        evalAt(mode, s, sp, env, base).flatMap: bv =>
+          updates.foldLeft[Option[Value]](Some(bv)): (acc, upd) =>
+            for
+              cur <- acc
+              v   <- evalAt(mode, s, sp, env, upd.value)
+            yield Value.VEntityWith(cur, upd.name, v)
+      case Expr.Let(name, value, body, _) =>
+        evalAt(mode, s, sp, env, value).flatMap(v =>
+          evalAt(mode, s, sp, (name, v) :: env, body)
+        )
+      case Expr.EnumAccess(Expr.Identifier(enName, _), member, _) =>
+        s.enums.collectFirst { case (n, members) if n == enName => members } match
+          case Some(members) if members.contains(member) =>
+            Some(Value.VEnum(enName, member))
+          case _ => None
+      case Expr.Quantifier(QuantKind.All, bindings, body, _) =>
+        bindings match
+          case List(QuantifierBinding(v, Expr.Identifier(name, _), _, _)) =>
+            s.enums.collectFirst { case (n, members) if n == name => members } match
+              case Some(members) =>
+                evalForallEnumAt(mode, s, sp, env, v, name, members, body)
+              case None =>
+                relationDomain(st, name) match
+                  case Some(dom) => evalForallRelAt(mode, s, sp, env, v, dom, body)
+                  case None      => None
+          case _ => None
+      case Expr.Quantifier(QuantKind.No, bindings, body, _) =>
+        evalAt(
+          mode,
+          s,
+          sp,
+          env,
           Expr.Quantifier(QuantKind.All, bindings, Expr.UnaryOp(UnOp.Not, body))
         )
-      )
-    case Expr.Quantifier(QuantKind.Exists, bindings, body, _) =>
-      // Alias of Some.
-      eval(
-        s,
-        st,
-        env,
-        Expr.UnaryOp(
-          UnOp.Not,
-          Expr.Quantifier(QuantKind.All, bindings, Expr.UnaryOp(UnOp.Not, body))
+      case Expr.Quantifier(QuantKind.Some, bindings, body, _) =>
+        evalAt(
+          mode,
+          s,
+          sp,
+          env,
+          Expr.UnaryOp(
+            UnOp.Not,
+            Expr.Quantifier(QuantKind.All, bindings, Expr.UnaryOp(UnOp.Not, body))
+          )
         )
-      )
-    case Expr.Prime(inner, _) => eval(s, st, env, inner)
-    case Expr.Pre(inner, _)   => eval(s, st, env, inner)
-    case Expr.SetLiteral(elements, _) =>
-      val values = elements.map(eval(s, st, env, _))
-      if values.exists(_.isEmpty) then None
-      else Some(Value.VSet(dedupeValues(values.flatten)))
-    case _ => None
+      case Expr.Quantifier(QuantKind.Exists, bindings, body, _) =>
+        evalAt(
+          mode,
+          s,
+          sp,
+          env,
+          Expr.UnaryOp(
+            UnOp.Not,
+            Expr.Quantifier(QuantKind.All, bindings, Expr.UnaryOp(UnOp.Not, body))
+          )
+        )
+      case Expr.Prime(inner, _) => evalAt(StateMode.Post, s, sp, env, inner)
+      case Expr.Pre(inner, _)   => evalAt(StateMode.Pre, s, sp, env, inner)
+      case Expr.SetLiteral(elements, _) =>
+        val values = elements.map(evalAt(mode, s, sp, env, _))
+        if values.exists(_.isEmpty) then None
+        else Some(Value.VSet(dedupeValues(values.flatten)))
+      case _ => None
 
   private def isBoolBinOp(op: BinOp): Boolean = op match
     case BinOp.And | BinOp.Or | BinOp.Implies | BinOp.Iff => true
@@ -441,9 +501,10 @@ object EvalIR:
     case BinOp.Union | BinOp.Intersect | BinOp.Diff => true
     case _                                          => false
 
-  private def evalForallEnum(
+  private def evalForallEnumAt(
+      mode: StateMode,
       s: Schema,
-      st: State,
+      sp: StatePair,
       env: Env,
       v: String,
       enName: String,
@@ -452,13 +513,14 @@ object EvalIR:
   ): Option[Value] =
     val results = members.map: m =>
       val extEnv = (v, Value.VEnum(enName, m)) :: env
-      eval(s, st, extEnv, body).flatMap(asBool)
+      evalAt(mode, s, sp, extEnv, body).flatMap(asBool)
     if results.exists(_.isEmpty) then None
     else Some(Value.VBool(results.flatten.forall(identity)))
 
-  private def evalForallRel(
+  private def evalForallRelAt(
+      mode: StateMode,
       s: Schema,
-      st: State,
+      sp: StatePair,
       env: Env,
       v: String,
       dom: List[Value],
@@ -466,7 +528,7 @@ object EvalIR:
   ): Option[Value] =
     val results = dom.map: value =>
       val extEnv = (v, value) :: env
-      eval(s, st, extEnv, body).flatMap(asBool)
+      evalAt(mode, s, sp, extEnv, body).flatMap(asBool)
     if results.exists(_.isEmpty) then None
     else Some(Value.VBool(results.flatten.forall(identity)))
 
@@ -480,6 +542,34 @@ object EvalIR:
       body: Expr
   ): Option[Boolean] =
     eval(Schema.of(ir), st, env, body).flatMap(asBool)
+
+  /** M_L.4.b-ext Phase 5.b: mode-aware variant of `evalInvariantBody`. Evaluates a body against a
+    * `StatePair` with the active `mode`, surfacing temporal (`Prime`/`Pre`) flips through the inner
+    * `evalAt`. Phase 5.c will use this for operation invariant-preservation certs.
+    */
+  def evalInvariantBodyAt(
+      mode: StateMode,
+      ir: ServiceIR,
+      sp: StatePair,
+      env: Env,
+      body: Expr
+  ): Option[Boolean] =
+    evalAt(mode, Schema.of(ir), sp, env, body).flatMap(asBool)
+
+  /** Mode-aware variant of `evalRequires`. Evaluates the conjunction of a list of `requires`
+    * clauses against the active mode of `sp`. Short-circuits on the first `false` or `none`.
+    */
+  def evalRequiresAt(
+      mode: StateMode,
+      ir: ServiceIR,
+      sp: StatePair,
+      env: Env,
+      requires: List[Expr]
+  ): Option[Boolean] =
+    requires.foldLeft[Option[Boolean]](Some(true)): (acc, r) =>
+      acc match
+        case Some(true) => evalInvariantBodyAt(mode, ir, sp, env, r)
+        case other      => other
 
   def evalRequires(
       ir: ServiceIR,

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -10,6 +10,11 @@ object EvalIR:
     case VEnum(enumName: String, memberName: String)
     case VEntity(entityName: String, id: String)
     case VSet(members: List[Value])
+    // M_L.4.b-ext Phase 4b: Skolem chain carrier for record-update. `With`
+    // lowers to a left-fold of VEntityWith over the original entity value;
+    // `fieldLookup` walks the chain (override-first, fall back to base).
+    // Mirrors Lean `Value.vEntityWith` in `proofs/lean/SpecRest/Semantics.lean`.
+    case VEntityWith(base: Value, fld: String, value: Value)
 
   type Env = List[(String, Value)]
 
@@ -179,6 +184,19 @@ object EvalIR:
     st.entityFields.collectFirst { case (k, fs) if k == entityId => fs }
       .flatMap(fs => fs.collectFirst { case (f, v) if f == fieldName => v })
 
+  /** M_L.4.b-ext Phase 4b: walk a (potentially With-extended) value chain. Mirrors Lean
+    * `Value.fieldLookup` in `proofs/lean/SpecRest/Semantics.lean`:
+    *   - VEntityWith override-then-fallback,
+    *   - VEntity routes to `lookupField`,
+    *   - non-entity / non-with values return None.
+    */
+  def fieldLookup(st: State, v: Value, fieldName: String): Option[Value] = v match
+    case Value.VEntity(_, id) => lookupField(st, id, fieldName)
+    case Value.VEntityWith(base, f, ov) =>
+      if fieldName == f then Some(ov)
+      else fieldLookup(st, base, fieldName)
+    case _ => None
+
   def asBool(v: Value): Option[Boolean] = v match
     case Value.VBool(b) => Some(b)
     case _              => None
@@ -335,11 +353,22 @@ object EvalIR:
       eval(s, st, env, keyExpr).flatMap(kv => lookupKey(st, relName, kv))
     case Expr.FieldAccess(base, fieldName, _) =>
       // M_L.4.k: evaluate base to a `vEntity _ id`, then look up the field by id.
-      // Bare-Identifier `state_scalar.field` (M_L.4.h) is the special case where
-      // the scalar's value is `vEntity name id` from demo-state seeding.
-      eval(s, st, env, base).flatMap:
-        case Value.VEntity(_, id) => lookupField(st, id, fieldName)
-        case _                    => None
+      // M_L.4.b-ext Phase 4b: chain-walk via `fieldLookup` so With-extended bases
+      // resolve override-first. Mirrors Lean `eval` for `.fieldAccess`:
+      //   eval base = some v ⇒ Value.fieldLookup st v fieldName
+      eval(s, st, env, base).flatMap(v => fieldLookup(st, v, fieldName))
+    case Expr.With(base, updates, _) =>
+      // M_L.4.b-ext Phase 4b: lower multi-field With to a left-fold of VEntityWith
+      // chains. Mirrors the Lean lowering of `With(base, [u1; u2])` to
+      // `withRec (withRec base u1.fld u1.value) u2.fld u2.value` and the eval
+      // semantics: both base and value must reduce; otherwise the whole expr
+      // is `none` (matching Lean `eval` for `.withRec`).
+      eval(s, st, env, base).flatMap: bv =>
+        updates.foldLeft[Option[Value]](Some(bv)): (acc, upd) =>
+          for
+            cur <- acc
+            v   <- eval(s, st, env, upd.value)
+          yield Value.VEntityWith(cur, upd.name, v)
     case Expr.Let(name, value, body, _) =>
       eval(s, st, env, value).flatMap(v => eval(s, st, (name, v) :: env, body))
     case Expr.EnumAccess(Expr.Identifier(enName, _), member, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -633,14 +633,98 @@ object EvalIR:
           }
         Some(pre.copy(scalars = newScalars))
 
+  /** M_L.4.b-ext Phase 5.d: choose a pre-state for the (op, inv) preservation cert that satisfies
+    * both `op.requires` and `inv` in pre. This makes the preservation cert non-vacuous: a
+    * `requires`-false-on-demo cert closes via the vacuous `some true` arm of `evalPreservation`
+    * without actually exercising the post-state machinery.
+    *
+    * Search policy: bounded brute force over a small candidate space per scalar slot. Most
+    * operations have ≤3 mutable scalars in their `requires`, so the cross-product is small. Search
+    * budget is capped to keep emit latency bounded; on miss we fall back to `demoFallback` (cert
+    * may be vacuous-true via requires-false).
+    *
+    * We bias toward "requires AND invariant both true in pre"; if no such candidate exists, we
+    * settle for "requires true in pre"; if even that misses, we return `demoFallback` and accept a
+    * possibly-vacuous cert.
+    */
+  def seedPreStateForOp(
+      ir: ServiceIR,
+      op: OperationDecl,
+      inv: InvariantDecl,
+      demoFallback: State
+  ): State =
+    val candidates = scalarCandidates(ir, demoFallback)
+
+    /** Check (requires holds, invariant holds). Treat `None` from the closed reducer as "stuck";
+      * require strict `true` results to count as satisfied.
+      */
+    def evaluate(st: State): (Boolean, Boolean) =
+      val reqsOk = evalRequires(ir, st, Nil, op.requires).contains(true)
+      val invOk  = evalInvariantBody(ir, st, Nil, inv.expr).contains(true)
+      (reqsOk, invOk)
+
+    val (reqsAndInv, reqsOnly) = candidates.foldLeft(
+      (Option.empty[State], Option.empty[State])
+    ): (acc, candidate) =>
+      val (bestBoth, bestReqs) = acc
+      if bestBoth.isDefined then acc
+      else
+        val (reqsOk, invOk) = evaluate(candidate)
+        val newBoth         = if reqsOk && invOk then Some(candidate) else bestBoth
+        val newReqs         = if reqsOk && bestReqs.isEmpty then Some(candidate) else bestReqs
+        (newBoth, newReqs)
+
+    reqsAndInv.orElse(reqsOnly).getOrElse(demoFallback)
+
+  /** Build a bounded list of pre-state candidates by varying each scalar's value across a small
+    * typed set. The first candidate is always `demoFallback` itself (so we don't lose the
+    * existing-behavior fallback if it already satisfies requires + invariant). Maximum candidates
+    * capped at 64 to keep emit latency bounded.
+    */
+  private def scalarCandidates(ir: ServiceIR, base: State): List[State] =
+    val schema      = Schema.of(ir)
+    val stateFields = ir.state.fold(List.empty[StateFieldDecl])(_.fields)
+    val seedsPerScalar: List[(String, List[Value])] =
+      stateFields.flatMap: f =>
+        candidatesFor(schema, f.typeExpr) match
+          case Nil  => None
+          case vals => Some(f.name -> vals)
+
+    // Cross-product across scalar candidates, capped at 64.
+    val crossProduct: List[List[(String, Value)]] =
+      seedsPerScalar.foldLeft(List(List.empty[(String, Value)])): (acc, slot) =>
+        val (name, values) = slot
+        if acc.size * values.size > 64 then acc
+        else acc.flatMap(prefix => values.map(v => prefix :+ (name -> v)))
+
+    // Apply each cross-product binding to `base` to produce a candidate. The
+    // empty-binding case (zero scalars) yields `base` unchanged, which is the
+    // "demo as fallback" path.
+    val candidates = crossProduct.map: bindings =>
+      val newScalars = base.scalars.map: (k, v) =>
+        bindings.find(_._1 == k).map(b => (k, b._2)).getOrElse((k, v))
+      base.copy(scalars = newScalars)
+    if candidates.isEmpty then List(base) else candidates
+
+  private def candidatesFor(s: Schema, ty: TypeExpr): List[Value] = ty match
+    case TypeExpr.NamedType("Int", _) =>
+      List(0, 1, -1, 5, -5, 10, -10).map(n => Value.VInt(BigInt(n)))
+    case TypeExpr.NamedType("Bool", _) =>
+      List(Value.VBool(false), Value.VBool(true))
+    case TypeExpr.NamedType(name, _) =>
+      s.enums.collectFirst { case (n, members) if n == name => members } match
+        case Some(members) => members.map(m => Value.VEnum(name, m))
+        case None          => Nil
+    case _ => Nil
+
   private def flattenAnd(expr: Expr): List[Expr] = expr match
     case Expr.BinaryOp(BinOp.And, l, r, _) => flattenAnd(l) ++ flattenAnd(r)
     case other                             => List(other)
 
   /** Try to extract a `(name, value)` assignment from a single ensures clause. `Right(Some(_))`
     * means a recognised assignment; `Right(None)` means a recognised non-assignment that the
-    * synthesizer can ignore (e.g., `BoolLit(true)`); `Left(reason)` means an unrecognised shape
-    * that should abort the synthesis.
+    * synthesizer can ignore (e.g., `BoolLit(true)`, identity assignments); `Left(reason)` means an
+    * unrecognised shape that should abort the synthesis.
     */
   private def extractAssignment(
       expr: Expr,
@@ -648,7 +732,15 @@ object EvalIR:
       pre: State,
       env: Env
   ): Either[String, Option[(String, Value)]] = expr match
-    case Expr.BoolLit(true, _) => Right(None)
+    case Expr.BoolLit(true, _)           => Right(None)
+    case _ if isIdentityAssignment(expr) =>
+      // M_L.4.b-ext Phase 5.d: identity assignments (`state' = state`,
+      // `state' = pre(state)`) recognised as no-ops without evaluating the
+      // RHS. Crucial for non-scalar fields (Map/relation) where eval of
+      // `Identifier(name)` returns None — the value-eval path below would
+      // otherwise mis-classify them as Unrecognized. Common in op contracts
+      // that explicitly preserve a field across the operation.
+      Right(None)
     case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
       primedAssignment(lhs, rhs, schema, pre, env)
         .orElse(primedAssignment(rhs, lhs, schema, pre, env)) match
@@ -657,6 +749,23 @@ object EvalIR:
           Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
     case _ =>
       Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
+
+  /** Recognise `Prime(Identifier(name)) = Identifier(name)` and `Prime(Identifier(name)) =
+    * Pre(Identifier(name))` (and their commutations) as identity assignments. Both shapes mean
+    * "post.field = pre.field" by definition, so the synthesizer doesn't need to evaluate the RHS.
+    */
+  private def isIdentityAssignment(expr: Expr): Boolean = expr match
+    case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
+      isPrimedIdentity(lhs, rhs) || isPrimedIdentity(rhs, lhs)
+    case _ => false
+
+  private def isPrimedIdentity(primed: Expr, plain: Expr): Boolean = primed match
+    case Expr.Prime(Expr.Identifier(p, _), _) =>
+      plain match
+        case Expr.Identifier(q, _) if p == q              => true
+        case Expr.Pre(Expr.Identifier(q, _), _) if p == q => true
+        case _                                            => false
+    case _ => false
 
   private def primedAssignment(
       primedSide: Expr,

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -581,3 +581,113 @@ object EvalIR:
       acc match
         case Some(true) => evalInvariantBody(ir, st, env, r)
         case other      => other
+
+  /** M_L.4.b-ext Phase 5.c: result of analysing an operation's `ensures` for the post-state
+    * synthesizer. The synthesizer recognises only the "primed-equality" pattern
+    * (`Prime(Identifier(name)) = rhs`, or symmetric) with no `Prime` in the right-hand side.
+    * `Recognized` carries the assignments the synthesizer extracted; `Unrecognized` carries a
+    * one-line reason for the cert renderer's stub message. Unrecognized clauses cause the
+    * synthesizer to decline rather than silently produce a half-synthesized post-state, since a
+    * partial post would risk false-positive preservation certs.
+    */
+  enum EnsuresAnalysis derives CanEqual:
+    case Recognized(assignments: List[(String, Value)])
+    case Unrecognized(reason: String)
+
+  /** Analyse an operation's `ensures` clauses against the pre-state. Returns `Recognized` only when
+    * EVERY clause (after `And`-flattening) matches the primed-equality pattern with a
+    * closed-evaluable RHS; otherwise returns `Unrecognized` with a short shape diagnosis.
+    */
+  def analyseEnsures(
+      ir: ServiceIR,
+      op: OperationDecl,
+      pre: State
+  ): EnsuresAnalysis =
+    val schema  = Schema.of(ir)
+    val flatten = op.ensures.flatMap(flattenAnd)
+    val results = flatten.map(extractAssignment(_, schema, pre, Nil))
+    results.find(_.isLeft) match
+      case Some(Left(reason)) => EnsuresAnalysis.Unrecognized(reason)
+      case _ =>
+        val asgns = results.collect { case Right(a) => a }.flatten
+        EnsuresAnalysis.Recognized(asgns)
+
+  /** Synthesize the post-state by applying `Recognized` assignments on top of `pre`. Each
+    * assignment overrides the named scalar's value; un-named scalars keep their pre-state value.
+    * Relations / lookups / entityFields carry through unchanged — Phase 5.c's synthesis is
+    * scalar-only. Operations touching relations or entity fields will surface as `Unrecognized`.
+    */
+  def synthesizePostState(
+      ir: ServiceIR,
+      op: OperationDecl,
+      pre: State
+  ): Option[State] =
+    analyseEnsures(ir, op, pre) match
+      case EnsuresAnalysis.Unrecognized(_) => None
+      case EnsuresAnalysis.Recognized(assignments) =>
+        val newScalars = assignments.foldLeft(pre.scalars): (acc, asgn) =>
+          val (name, newValue) = asgn
+          acc.map {
+            case (k, _) if k == name => (k, newValue)
+            case kv                  => kv
+          }
+        Some(pre.copy(scalars = newScalars))
+
+  private def flattenAnd(expr: Expr): List[Expr] = expr match
+    case Expr.BinaryOp(BinOp.And, l, r, _) => flattenAnd(l) ++ flattenAnd(r)
+    case other                             => List(other)
+
+  /** Try to extract a `(name, value)` assignment from a single ensures clause. `Right(Some(_))`
+    * means a recognised assignment; `Right(None)` means a recognised non-assignment that the
+    * synthesizer can ignore (e.g., `BoolLit(true)`); `Left(reason)` means an unrecognised shape
+    * that should abort the synthesis.
+    */
+  private def extractAssignment(
+      expr: Expr,
+      schema: Schema,
+      pre: State,
+      env: Env
+  ): Either[String, Option[(String, Value)]] = expr match
+    case Expr.BoolLit(true, _) => Right(None)
+    case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
+      primedAssignment(lhs, rhs, schema, pre, env)
+        .orElse(primedAssignment(rhs, lhs, schema, pre, env)) match
+        case Some(asgn) => Right(Some(asgn))
+        case None =>
+          Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
+    case _ =>
+      Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
+
+  private def primedAssignment(
+      primedSide: Expr,
+      valueSide: Expr,
+      schema: Schema,
+      pre: State,
+      env: Env
+  ): Option[(String, Value)] = primedSide match
+    case Expr.Prime(Expr.Identifier(name, _), _) if !containsPrime(valueSide) =>
+      eval(schema, pre, env, valueSide).map(v => (name, v))
+    case _ => None
+
+  /** Conservative `Prime` detector. Used to reject ensures clauses whose RHS mentions a primed
+    * identifier — the synthesizer can't resolve them without fixed-point reasoning, and silently
+    * treating `count'` as `pre.count` (via diagonal collapse) would produce misleading post-states.
+    */
+  def containsPrime(expr: Expr): Boolean = expr match
+    case _: Expr.Prime                  => true
+    case Expr.Pre(_, _)                 => false
+    case Expr.UnaryOp(_, op, _)         => containsPrime(op)
+    case Expr.BinaryOp(_, l, r, _)      => containsPrime(l) || containsPrime(r)
+    case Expr.Quantifier(_, _, body, _) => containsPrime(body)
+    case Expr.Let(_, value, body, _)    => containsPrime(value) || containsPrime(body)
+    case Expr.Index(base, idx, _)       => containsPrime(base) || containsPrime(idx)
+    case Expr.FieldAccess(base, _, _)   => containsPrime(base)
+    case Expr.With(base, updates, _) =>
+      containsPrime(base) || updates.exists(u => containsPrime(u.value))
+    case Expr.SetLiteral(elems, _)   => elems.exists(containsPrime)
+    case Expr.EnumAccess(base, _, _) => containsPrime(base)
+    case Expr.SetComprehension(_, dom, body, _) =>
+      containsPrime(dom) || containsPrime(body)
+    case Expr.SomeWrap(inner, _)   => containsPrime(inner)
+    case Expr.The(_, dom, body, _) => containsPrime(dom) || containsPrime(body)
+    case _                         => false

--- a/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/EvalIR.scala
@@ -582,56 +582,105 @@ object EvalIR:
         case Some(true) => evalInvariantBody(ir, st, env, r)
         case other      => other
 
-  /** M_L.4.b-ext Phase 5.c: result of analysing an operation's `ensures` for the post-state
-    * synthesizer. The synthesizer recognises only the "primed-equality" pattern
-    * (`Prime(Identifier(name)) = rhs`, or symmetric) with no `Prime` in the right-hand side.
-    * `Recognized` carries the assignments the synthesizer extracted; `Unrecognized` carries a
-    * one-line reason for the cert renderer's stub message. Unrecognized clauses cause the
-    * synthesizer to decline rather than silently produce a half-synthesized post-state, since a
-    * partial post would risk false-positive preservation certs.
-    */
-  enum EnsuresAnalysis derives CanEqual:
-    case Recognized(assignments: List[(String, Value)])
-    case Unrecognized(reason: String)
+  /** M_L.4.b-ext Phase 5.e: a single typed update derived from one ensures clause. */
+  enum StateUpdate derives CanEqual:
+    /** Override a scalar/Set-typed field's value (NamedType / SetType — set values also live in
+      * `scalars` as `VSet`, so set-add updates emit BOTH a `Scalar` and an `AddRelationDom` to keep
+      * both reads consistent).
+      */
+    case Scalar(name: String, value: Value)
 
-  /** Analyse an operation's `ensures` clauses against the pre-state. Returns `Recognized` only when
-    * EVERY clause (after `And`-flattening) matches the primed-equality pattern with a
-    * closed-evaluable RHS; otherwise returns `Unrecognized` with a short shape diagnosis.
+    /** Add elements to a relation's value-list (the carrier `evalForallRel` iterates over). Applies
+      * to SetType (the set elements) and MapType (the map's values, since `forallRel` over a map
+      * iterates over values).
+      */
+    case AddRelationDom(name: String, additions: List[Value])
+
+    /** Add `(key, value)` pairs to a lookups table. Applies to MapType (the carrier `Index(rel,
+      * key)` reads from).
+      */
+    case AddLookups(name: String, additions: List[(Value, Value)])
+
+  /** M_L.4.b-ext Phase 5.e: per-clause partial recognition. Every ensures clause either contributes
+    * a list of `StateUpdate`s (recognised) or a set of `unknownFields` (touched-but-unanalysable).
+    * Identity / `BoolLit(true)` clauses contribute neither.
+    *
+    * Replaces the Phase 5.c `Recognized | Unrecognized` enum: synthesis no longer declines on the
+    * first unrecognised clause, instead it carries forward a partial post-state. The cert renderer
+    * gates emission against the invariant's referenced fields — if `invariantReadFields ∩
+    * unknownFields = ∅`, the cert is honest; otherwise it falls back to a stub.
+    */
+  final case class EnsuresAnalysis(
+      updates: List[StateUpdate],
+      unknownFields: Set[String]
+  )
+
+  /** Analyse an operation's `ensures` clauses against the pre-state and a seeded environment
+    * (op-input parameter bindings). Always returns a complete `EnsuresAnalysis`; never declines.
     */
   def analyseEnsures(
       ir: ServiceIR,
       op: OperationDecl,
-      pre: State
+      pre: State,
+      env: Env
   ): EnsuresAnalysis =
     val schema  = Schema.of(ir)
     val flatten = op.ensures.flatMap(flattenAnd)
-    val results = flatten.map(extractAssignment(_, schema, pre, Nil))
-    results.find(_.isLeft) match
-      case Some(Left(reason)) => EnsuresAnalysis.Unrecognized(reason)
-      case _ =>
-        val asgns = results.collect { case Right(a) => a }.flatten
-        EnsuresAnalysis.Recognized(asgns)
+    val results = flatten.map(classifyClause(_, schema, pre, env))
+    val updates = results.collect { case Right(us) => us }.flatten
+    val unknown = results.collect { case Left(fs) => fs }.flatten.toSet
+    EnsuresAnalysis(updates, unknown)
 
-  /** Synthesize the post-state by applying `Recognized` assignments on top of `pre`. Each
-    * assignment overrides the named scalar's value; un-named scalars keep their pre-state value.
-    * Relations / lookups / entityFields carry through unchanged — Phase 5.c's synthesis is
-    * scalar-only. Operations touching relations or entity fields will surface as `Unrecognized`.
+  /** Synthesize the post-state by applying `analyseEnsures(...)` updates on top of `pre`. Returns
+    * the synthesised state plus the set of "touched-but- unanalysable" field names; the cert
+    * renderer uses this set to decide whether the post-state is a sound model for the given
+    * invariant.
     */
   def synthesizePostState(
       ir: ServiceIR,
       op: OperationDecl,
-      pre: State
-  ): Option[State] =
-    analyseEnsures(ir, op, pre) match
-      case EnsuresAnalysis.Unrecognized(_) => None
-      case EnsuresAnalysis.Recognized(assignments) =>
-        val newScalars = assignments.foldLeft(pre.scalars): (acc, asgn) =>
-          val (name, newValue) = asgn
-          acc.map {
-            case (k, _) if k == name => (k, newValue)
-            case kv                  => kv
-          }
-        Some(pre.copy(scalars = newScalars))
+      pre: State,
+      env: Env
+  ): (State, Set[String]) =
+    val analysis = analyseEnsures(ir, op, pre, env)
+    val post     = applyUpdates(pre, analysis.updates)
+    (post, analysis.unknownFields)
+
+  /** Apply a list of `StateUpdate`s to `base` in declared order. `Scalar` overrides
+    * last-write-wins; `AddRelationDom` and `AddLookups` accumulate onto the existing entry's list.
+    * Names not present in the relevant slot are inserted (so synthesis can extend the post-state
+    * without requiring the demo to pre-allocate the slot).
+    */
+  private def applyUpdates(base: State, updates: List[StateUpdate]): State =
+    updates.foldLeft(base): (st, upd) =>
+      upd match
+        case StateUpdate.Scalar(name, value) =>
+          val newScalars =
+            if st.scalars.exists(_._1 == name) then
+              st.scalars.map {
+                case (k, _) if k == name => (k, value)
+                case kv                  => kv
+              }
+            else st.scalars :+ (name, value)
+          st.copy(scalars = newScalars)
+        case StateUpdate.AddRelationDom(name, additions) =>
+          val newRelations =
+            if st.relations.exists(_._1 == name) then
+              st.relations.map {
+                case (k, vs) if k == name => (k, vs ++ additions)
+                case kv                   => kv
+              }
+            else st.relations :+ (name, additions)
+          st.copy(relations = newRelations)
+        case StateUpdate.AddLookups(name, additions) =>
+          val newLookups =
+            if st.lookups.exists(_._1 == name) then
+              st.lookups.map {
+                case (k, ps) if k == name => (k, ps ++ additions)
+                case kv                   => kv
+              }
+            else st.lookups :+ (name, additions)
+          st.copy(lookups = newLookups)
 
   /** M_L.4.b-ext Phase 5.d: choose a pre-state for the (op, inv) preservation cert that satisfies
     * both `op.requires` and `inv` in pre. This makes the preservation cert non-vacuous: a
@@ -647,24 +696,45 @@ object EvalIR:
     * settle for "requires true in pre"; if even that misses, we return `demoFallback` and accept a
     * possibly-vacuous cert.
     */
+  /** M_L.4.b-ext Phase 5.e: a pre-state plus seeded op-input env. Renderers thread both into the
+    * cert: the env appears as a Lean literal alongside the `StatePair`, so closed evaluation in the
+    * cert sees the same parameter bindings the synthesizer used.
+    */
+  final case class SeededContext(pre: State, env: Env)
+
   def seedPreStateForOp(
       ir: ServiceIR,
       op: OperationDecl,
       inv: InvariantDecl,
       demoFallback: State
   ): State =
-    val candidates = scalarCandidates(ir, demoFallback)
+    seedContextForOp(ir, op, inv, demoFallback).pre
 
-    /** Check (requires holds, invariant holds). Treat `None` from the closed reducer as "stuck";
-      * require strict `true` results to count as satisfied.
-      */
-    def evaluate(st: State): (Boolean, Boolean) =
-      val reqsOk = evalRequires(ir, st, Nil, op.requires).contains(true)
-      val invOk  = evalInvariantBody(ir, st, Nil, inv.expr).contains(true)
+  /** Joint search: pick `(pre, env)` such that `requires` and `invariant` both hold. Cross-product
+    * over scalar candidates × param candidates, capped at a small budget. Falls back
+    * priority-ordered: requires+invariant satisfied → requires-only → `demoFallback` with empty
+    * env.
+    *
+    * The candidate space stays bounded by `MaxCandidates` regardless of how many scalars / params
+    * an operation has — past the budget we stop expanding the cross-product and accept incomplete
+    * coverage. In practice most operations have ≤2 mutable scalars and ≤2 input params, so the full
+    * cross-product is small.
+    */
+  def seedContextForOp(
+      ir: ServiceIR,
+      op: OperationDecl,
+      inv: InvariantDecl,
+      demoFallback: State
+  ): SeededContext =
+    val candidates = stateAndEnvCandidates(ir, op, demoFallback)
+
+    def evaluate(ctx: SeededContext): (Boolean, Boolean) =
+      val reqsOk = evalRequires(ir, ctx.pre, ctx.env, op.requires).contains(true)
+      val invOk  = evalInvariantBody(ir, ctx.pre, ctx.env, inv.expr).contains(true)
       (reqsOk, invOk)
 
     val (reqsAndInv, reqsOnly) = candidates.foldLeft(
-      (Option.empty[State], Option.empty[State])
+      (Option.empty[SeededContext], Option.empty[SeededContext])
     ): (acc, candidate) =>
       val (bestBoth, bestReqs) = acc
       if bestBoth.isDefined then acc
@@ -674,37 +744,56 @@ object EvalIR:
         val newReqs         = if reqsOk && bestReqs.isEmpty then Some(candidate) else bestReqs
         (newBoth, newReqs)
 
-    reqsAndInv.orElse(reqsOnly).getOrElse(demoFallback)
+    reqsAndInv
+      .orElse(reqsOnly)
+      .getOrElse(SeededContext(demoFallback, Nil))
 
-  /** Build a bounded list of pre-state candidates by varying each scalar's value across a small
-    * typed set. The first candidate is always `demoFallback` itself (so we don't lose the
-    * existing-behavior fallback if it already satisfies requires + invariant). Maximum candidates
-    * capped at 64 to keep emit latency bounded.
+  /** Total candidate budget across (pre-state × param-env) cross-product. */
+  private val MaxCandidates: Int = 128
+
+  /** Cross-product of scalar candidates × param candidates. Keeps the budget tight so emit latency
+    * stays bounded even on operations with many slots.
     */
-  private def scalarCandidates(ir: ServiceIR, base: State): List[State] =
+  private def stateAndEnvCandidates(
+      ir: ServiceIR,
+      op: OperationDecl,
+      base: State
+  ): List[SeededContext] =
     val schema      = Schema.of(ir)
     val stateFields = ir.state.fold(List.empty[StateFieldDecl])(_.fields)
-    val seedsPerScalar: List[(String, List[Value])] =
+    val scalarSeeds: List[(String, List[Value])] =
       stateFields.flatMap: f =>
         candidatesFor(schema, f.typeExpr) match
           case Nil  => None
           case vals => Some(f.name -> vals)
+    val paramSeeds: List[(String, List[Value])] =
+      op.inputs.flatMap: p =>
+        candidatesFor(schema, p.typeExpr) match
+          case Nil  => None
+          case vals => Some(p.name -> vals)
 
-    // Cross-product across scalar candidates, capped at 64.
+    // Build the cross-product greedily, stopping once the candidate count
+    // hits the budget. We extend scalars first so the existing "demo +
+    // varied-params" path runs even for ops with no state.
+    val combined = (scalarSeeds ++ paramSeeds).distinctBy(_._1)
     val crossProduct: List[List[(String, Value)]] =
-      seedsPerScalar.foldLeft(List(List.empty[(String, Value)])): (acc, slot) =>
+      combined.foldLeft(List(List.empty[(String, Value)])): (acc, slot) =>
         val (name, values) = slot
-        if acc.size * values.size > 64 then acc
+        if acc.size * values.size > MaxCandidates then acc
         else acc.flatMap(prefix => values.map(v => prefix :+ (name -> v)))
 
-    // Apply each cross-product binding to `base` to produce a candidate. The
-    // empty-binding case (zero scalars) yields `base` unchanged, which is the
-    // "demo as fallback" path.
-    val candidates = crossProduct.map: bindings =>
+    val scalarNames = scalarSeeds.map(_._1).toSet
+    crossProduct.map: bindings =>
+      val (scalarBindings, paramBindings) = bindings.partition((k, _) => scalarNames.contains(k))
       val newScalars = base.scalars.map: (k, v) =>
-        bindings.find(_._1 == k).map(b => (k, b._2)).getOrElse((k, v))
-      base.copy(scalars = newScalars)
-    if candidates.isEmpty then List(base) else candidates
+        scalarBindings.find(_._1 == k).map(b => (k, b._2)).getOrElse((k, v))
+      val newPre = base.copy(scalars = newScalars)
+      // Prepend so the lookup order matches a freshly-extended env (most-
+      // recent binding shadows earlier ones in `envLookup`).
+      SeededContext(newPre, paramBindings)
+    match
+      case Nil  => List(SeededContext(base, Nil))
+      case ctxs => ctxs
 
   private def candidatesFor(s: Schema, ty: TypeExpr): List[Value] = ty match
     case TypeExpr.NamedType("Int", _) =>
@@ -721,34 +810,118 @@ object EvalIR:
     case Expr.BinaryOp(BinOp.And, l, r, _) => flattenAnd(l) ++ flattenAnd(r)
     case other                             => List(other)
 
-  /** Try to extract a `(name, value)` assignment from a single ensures clause. `Right(Some(_))`
-    * means a recognised assignment; `Right(None)` means a recognised non-assignment that the
-    * synthesizer can ignore (e.g., `BoolLit(true)`, identity assignments); `Left(reason)` means an
-    * unrecognised shape that should abort the synthesis.
+  /** Classify a single ensures clause against the pre-state and seeded env. `Right(updates)` —
+    * recognised; produces zero or more `StateUpdate`s. `Left(unknownFields)` — unrecognised shape;
+    * the union of its `referencedStateNames` is added to the analysis's `unknownFields`.
+    *
+    * Recognised shapes (in priority order):
+    *   - `BoolLit(true)`: trivial → empty updates.
+    *   - Identity (`state' = state`, `state' = pre(state)`): empty updates.
+    *   - Set-add (`Prime(Identifier(name)) = base + SetLiteral(elems)` where `base` aliases
+    *     `name`): produces `Scalar` (if name is in scalars as `VSet`) plus `AddRelationDom` for the
+    *     relation carrier.
+    *   - Map-add (`Prime(Identifier(name)) = base + MapLiteral(entries)` where `base` aliases
+    *     `name`): produces `AddLookups` plus `AddRelationDom` (the map's value list).
+    *   - Scalar primed-equality (`Prime(Identifier(name)) = rhs` with eval succeeding on `rhs`):
+    *     produces a single `Scalar` update.
     */
-  private def extractAssignment(
+  private def classifyClause(
       expr: Expr,
       schema: Schema,
       pre: State,
       env: Env
-  ): Either[String, Option[(String, Value)]] = expr match
-    case Expr.BoolLit(true, _)           => Right(None)
-    case _ if isIdentityAssignment(expr) =>
-      // M_L.4.b-ext Phase 5.d: identity assignments (`state' = state`,
-      // `state' = pre(state)`) recognised as no-ops without evaluating the
-      // RHS. Crucial for non-scalar fields (Map/relation) where eval of
-      // `Identifier(name)` returns None — the value-eval path below would
-      // otherwise mis-classify them as Unrecognized. Common in op contracts
-      // that explicitly preserve a field across the operation.
-      Right(None)
+  ): Either[Set[String], List[StateUpdate]] = expr match
+    case Expr.BoolLit(true, _)           => Right(Nil)
+    case _ if isIdentityAssignment(expr) => Right(Nil)
     case Expr.BinaryOp(BinOp.Eq, lhs, rhs, _) =>
-      primedAssignment(lhs, rhs, schema, pre, env)
-        .orElse(primedAssignment(rhs, lhs, schema, pre, env)) match
-        case Some(asgn) => Right(Some(asgn))
-        case None =>
-          Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
-    case _ =>
-      Left(s"unrecognised ensures shape: $expr (expected `name' = rhs`)")
+      val recognised =
+        recognisePrimedUpdate(lhs, rhs, schema, pre, env)
+          .orElse(recognisePrimedUpdate(rhs, lhs, schema, pre, env))
+      recognised match
+        case Some(updates) => Right(updates)
+        case None          => Left(referencedStateNames(expr, Set.empty))
+    case _ => Left(referencedStateNames(expr, Set.empty))
+
+  /** Recognise `Prime(Identifier(name)) = X` as an update, where `X` is one of:
+    *   - `base + SetLiteral([elems])` (or symmetric) — set-add
+    *   - `base + MapLiteral([entries])` (or symmetric) — map-add
+    *   - any other expression with no `Prime` — scalar primed-equality (eval `X` against pre + env)
+    *
+    * `base` must alias `name` (literally `Identifier(name)` or `Pre(Identifier(name))`) for
+    * set/map-add recognition; otherwise we don't know which carrier to extend.
+    */
+  private def recognisePrimedUpdate(
+      primedSide: Expr,
+      valueSide: Expr,
+      schema: Schema,
+      pre: State,
+      env: Env
+  ): Option[List[StateUpdate]] = primedSide match
+    case Expr.Prime(Expr.Identifier(name, _), _) if !containsPrime(valueSide) =>
+      recogniseSetMapAdd(name, valueSide, schema, pre, env)
+        .orElse {
+          // Plain scalar primed-equality (existing Phase 5.c behaviour).
+          eval(schema, pre, env, valueSide).map(v => List(StateUpdate.Scalar(name, v)))
+        }
+    case _ => None
+
+  /** Recognise `+`-style additions to a primed name's carrier. Handles both orderings (`base + lit`
+    * and `lit + base`) since the parser left-associates `+` and the IR doesn't canonicalise either
+    * side.
+    */
+  private def recogniseSetMapAdd(
+      name: String,
+      rhs: Expr,
+      schema: Schema,
+      pre: State,
+      env: Env
+  ): Option[List[StateUpdate]] = rhs match
+    case Expr.BinaryOp(BinOp.Add, base, lit, _) if isAliasOf(base, name) =>
+      addLitToUpdates(name, lit, schema, pre, env)
+    case Expr.BinaryOp(BinOp.Add, lit, base, _) if isAliasOf(base, name) =>
+      addLitToUpdates(name, lit, schema, pre, env)
+    case _ => None
+
+  private def isAliasOf(expr: Expr, name: String): Boolean = expr match
+    case Expr.Identifier(n, _) if n == name              => true
+    case Expr.Pre(Expr.Identifier(n, _), _) if n == name => true
+    case _                                               => false
+
+  private def addLitToUpdates(
+      name: String,
+      lit: Expr,
+      schema: Schema,
+      pre: State,
+      env: Env
+  ): Option[List[StateUpdate]] = lit match
+    case Expr.SetLiteral(elems, _) =>
+      val evaluated = elems.map(e => eval(schema, pre, env, e))
+      if evaluated.exists(_.isEmpty) then None
+      else
+        val values = evaluated.flatten
+        val baseSet =
+          pre.scalars.collectFirst { case (n, Value.VSet(curr)) if n == name => curr }
+        val updates = List.newBuilder[StateUpdate]
+        baseSet.foreach: curr =>
+          updates += StateUpdate.Scalar(name, Value.VSet(curr ++ values))
+        updates += StateUpdate.AddRelationDom(name, values)
+        Some(updates.result())
+    case Expr.MapLiteral(entries, _) =>
+      val evaluated = entries.map: e =>
+        for
+          k <- eval(schema, pre, env, e.key)
+          v <- eval(schema, pre, env, e.value)
+        yield (k, v)
+      if evaluated.exists(_.isEmpty) then None
+      else
+        val kvs = evaluated.flatten
+        Some(
+          List(
+            StateUpdate.AddLookups(name, kvs),
+            StateUpdate.AddRelationDom(name, kvs.map(_._2))
+          )
+        )
+    case _ => None
 
   /** Recognise `Prime(Identifier(name)) = Identifier(name)` and `Prime(Identifier(name)) =
     * Pre(Identifier(name))` (and their commutations) as identity assignments. Both shapes mean
@@ -767,16 +940,61 @@ object EvalIR:
         case _                                            => false
     case _ => false
 
-  private def primedAssignment(
-      primedSide: Expr,
-      valueSide: Expr,
-      schema: Schema,
-      pre: State,
-      env: Env
-  ): Option[(String, Value)] = primedSide match
-    case Expr.Prime(Expr.Identifier(name, _), _) if !containsPrime(valueSide) =>
-      eval(schema, pre, env, valueSide).map(v => (name, v))
-    case _ => None
+  /** M_L.4.b-ext Phase 5.e: conservative over-approximation of the state-field names referenced
+    * (read) by an expression. Used by:
+    *   - the per-clause partial-recognition gate (which fields a clause "touches" when we couldn't
+    *     classify it as an update),
+    *   - the preservation-cert renderer (which fields the invariant body reads, to gate against
+    *     `unknownFields`).
+    *
+    * `env` is the set of let-bound / quantifier-bound identifiers whose references should NOT be
+    * classified as state reads. Threaded recursively through binders.
+    */
+  def referencedStateNames(expr: Expr, env: Set[String]): Set[String] = expr match
+    case Expr.Identifier(name, _) =>
+      if env.contains(name) then Set.empty else Set(name)
+    case _: Expr.BoolLit        => Set.empty
+    case _: Expr.IntLit         => Set.empty
+    case Expr.UnaryOp(_, op, _) => referencedStateNames(op, env)
+    case Expr.BinaryOp(_, l, r, _) =>
+      referencedStateNames(l, env) ++ referencedStateNames(r, env)
+    case Expr.Quantifier(_, bindings, body, _) =>
+      val bound      = bindings.collect { case QuantifierBinding(v, _, _, _) => v }.toSet
+      val domainRefs = bindings.flatMap(b => referencedStateNames(b.domain, env)).toSet
+      domainRefs ++ referencedStateNames(body, env ++ bound)
+    case Expr.Let(name, value, body, _) =>
+      referencedStateNames(value, env) ++ referencedStateNames(body, env + name)
+    case Expr.Prime(inner, _) => referencedStateNames(inner, env)
+    case Expr.Pre(inner, _)   => referencedStateNames(inner, env)
+    case Expr.Index(base, idx, _) =>
+      referencedStateNames(base, env) ++ referencedStateNames(idx, env)
+    case Expr.FieldAccess(base, _, _) => referencedStateNames(base, env)
+    case Expr.With(base, updates, _) =>
+      referencedStateNames(base, env) ++
+        updates.flatMap(u => referencedStateNames(u.value, env)).toSet
+    case Expr.SetLiteral(elems, _) => elems.flatMap(e => referencedStateNames(e, env)).toSet
+    case Expr.MapLiteral(entries, _) =>
+      entries.flatMap: e =>
+        referencedStateNames(e.key, env) ++ referencedStateNames(e.value, env)
+      .toSet
+    case Expr.EnumAccess(base, _, _) => referencedStateNames(base, env)
+    case Expr.SetComprehension(v, dom, body, _) =>
+      referencedStateNames(dom, env) ++ referencedStateNames(body, env + v)
+    case Expr.SomeWrap(inner, _) => referencedStateNames(inner, env)
+    case Expr.The(v, dom, body, _) =>
+      referencedStateNames(dom, env) ++ referencedStateNames(body, env + v)
+    case Expr.If(c, t, e, _) =>
+      referencedStateNames(c, env) ++ referencedStateNames(t, env) ++ referencedStateNames(e, env)
+    case Expr.Lambda(p, body, _) => referencedStateNames(body, env + p)
+    case Expr.Call(callee, args, _) =>
+      referencedStateNames(callee, env) ++ args.flatMap(a => referencedStateNames(a, env)).toSet
+    case Expr.SeqLiteral(elems, _) => elems.flatMap(e => referencedStateNames(e, env)).toSet
+    case Expr.Constructor(_, fields, _) =>
+      fields.flatMap(f => referencedStateNames(f.value, env)).toSet
+    case _: Expr.Matches   => Set.empty
+    case _: Expr.NoneLit   => Set.empty
+    case _: Expr.FloatLit  => Set.empty
+    case _: Expr.StringLit => Set.empty
 
   /** Conservative `Prime` detector. Used to reject ensures clauses whose RHS mentions a primed
     * identifier — the synthesizer can't resolve them without fixed-point reasoning, and silently

--- a/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
+++ b/modules/verify/src/main/scala/specrest/verify/cert/VerifiedSubset.scala
@@ -87,9 +87,16 @@ object VerifiedSubset:
       SubsetStatus.OutOfSubset(
         "EnumAccess: only `EnumName.member` (Identifier base) is supported"
       )
-    case Expr.Prime(inner, _)         => classify(inner)
-    case Expr.Pre(inner, _)           => classify(inner)
-    case _: Expr.With                 => SubsetStatus.OutOfSubset("With: M_L.2 territory")
+    case Expr.Prime(inner, _)        => classify(inner)
+    case Expr.Pre(inner, _)          => classify(inner)
+    case Expr.With(base, updates, _) =>
+      // M_L.4.b-ext Phase 5.a: With (record-update) lowers to a chain of `withRec`
+      // Lean ctors at emit time. Phase 4b ships the parallel Skolem semantics on
+      // the Lean side (zero `sorry`); the Scala-side EvalIR mirrors via
+      // `Value.VEntityWith`. Multi-field updates fold left into a chain.
+      val baseStatus = classify(base)
+      updates.foldLeft(baseStatus): (acc, upd) =>
+        chooseWorse(acc, classify(upd.value))
     case Expr.FieldAccess(base, _, _) =>
       // M_L.4.k generalised the FieldAccess base from a bare Identifier to any
       // expression that evaluates to a `vEntity`. Bare Identifier remains the

--- a/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/audit/ProofDriftAuditTest.scala
@@ -53,7 +53,11 @@ class ProofDriftAuditTest extends FunSuite:
     "UnaryOp.Cardinality",
     "Index",
     "FieldAccess",
-    "SetLiteral"
+    "SetLiteral",
+    // M_L.4.b-ext Phase 4b: Skolem encoding for `Expr.With`. Lean `translate`
+    // emits the parallel `.withRec` chain; soundness closes via `vEntityWith`
+    // and `fieldLookup_correlated`.
+    "With"
   )
 
   private val repoRoot: Path = locateRepoRoot()
@@ -97,6 +101,11 @@ class ProofDriftAuditTest extends FunSuite:
     * has `relations = Nil`, so eval of these probes returns `none` and the cert emitter falls back
     * to a trivial stub even after Eq-wrapping. The renderer is still exercised (UNRENDERABLE check
     * still fires), but `certifiedChecks ≥ 1` cannot hold without populating demo relations.
+    *
+    * `"With"` joins this list because the canonical probe's base is `Expr.Identifier("u")`, which
+    * is not seeded in the A4 test schema (only `v`, `n`, `x`, `a`, `b`, `rel`, `count` are). The
+    * renderer is still exercised structurally; cert_decide coverage for With would require an
+    * entity-seeded probe.
     */
   private val needsStateRelations: Set[String] = Set(
     "UnaryOp.Cardinality",
@@ -104,7 +113,8 @@ class ProofDriftAuditTest extends FunSuite:
     "BinaryOp.NotIn",
     "BinaryOp.Subset",
     "Index",
-    "FieldAccess"
+    "FieldAccess",
+    "With"
   )
 
   test("A4: classifier-accepted probes never produce UNRENDERABLE in renderExpr"):
@@ -222,7 +232,8 @@ class ProofDriftAuditTest extends FunSuite:
     "Pre"                 -> "Expr.Pre",
     "Index"               -> "Expr.Index",
     "FieldAccess"         -> "Expr.FieldAccess",
-    "SetLiteral"          -> "Expr.SetLiteral"
+    "SetLiteral"          -> "Expr.SetLiteral",
+    "With"                -> "Expr.With"
   )
 
   test("A2: every leanCoveredShape's operator literal is present in z3.Translator.scala"):

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -1106,3 +1106,275 @@ class EmitTest extends FunSuite:
       EvalIR.evalRequiresAt(StateMode.Post, ir, sp, Nil, requires),
       Some(true)
     )
+
+  // ---------------------------------------------------------------------------
+  // M_L.4.b-ext Phase 5.c — Operation invariant-preservation certs.
+  // `synthesizePostState` extracts primed-equality assignments from `ensures`
+  // and applies them to the pre-state. `Emit` produces one preservation
+  // theorem per (operation × invariant) pair, claiming
+  // `evalPreservation = some <bool>` against the synthesised StatePair.
+  // ---------------------------------------------------------------------------
+
+  test("Phase 5.c: synthesizePostState applies `count' = count + 1` to pre"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Counter",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Increment",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.IntLit(1))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(7))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = EvalIR.synthesizePostState(ir, op, pre)
+    assertEquals(
+      post,
+      Some(
+        State(
+          scalars = List("count" -> Value.VInt(BigInt(8))),
+          relations = Nil,
+          lookups = Nil,
+          entityFields = Nil
+        )
+      )
+    )
+
+  test("Phase 5.c: synthesizePostState handles And-joined multi-field assignments"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "MultiField",
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(name = "a", typeExpr = TypeExpr.NamedType("Int")),
+            StateFieldDecl(name = "b", typeExpr = TypeExpr.NamedType("Int"))
+          )
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Swap",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.And,
+          Expr.BinaryOp(BinOp.Eq, Expr.Prime(Expr.Identifier("a")), Expr.Identifier("b")),
+          Expr.BinaryOp(BinOp.Eq, Expr.Prime(Expr.Identifier("b")), Expr.Identifier("a"))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("a" -> Value.VInt(BigInt(1)), "b" -> Value.VInt(BigInt(2))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = EvalIR.synthesizePostState(ir, op, pre)
+    assertEquals(
+      post.map(_.scalars),
+      Some(List("a" -> Value.VInt(BigInt(2)), "b" -> Value.VInt(BigInt(1))))
+    )
+
+  test("Phase 5.c: synthesizePostState declines on unrecognised ensures shape"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Constrained",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Mystery",
+      ensures = List(
+        // `count' >= 0` is a constraint, not an assignment — synthesizer can't
+        // resolve a unique post-state, so it declines.
+        Expr.BinaryOp(BinOp.Ge, Expr.Prime(Expr.Identifier("count")), Expr.IntLit(0))
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre), None)
+
+  test("Phase 5.c: synthesizePostState declines when RHS contains a Prime"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "SelfRef",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Recursive",
+      ensures = List(
+        // `count' = count' - 1` references its own primed value — the synthesizer
+        // would silently treat `count'` as `pre.count` due to diagonal collapse,
+        // so we reject it explicitly to avoid misleading certs.
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Sub, Expr.Prime(Expr.Identifier("count")), Expr.IntLit(1))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre), None)
+
+  test("Phase 5.c: safe_counter emits 1 invariant + 2 requires + 2 preservation = 5 certs"):
+    val invariant = InvariantDecl(
+      name = Some("countNonNegative"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    val incr = OperationDecl(
+      name = "Increment",
+      requires = List(Expr.BoolLit(true)),
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.IntLit(1))
+        )
+      )
+    )
+    val decr = OperationDecl(
+      name = "Decrement",
+      requires = List(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("count"), Expr.IntLit(0))),
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Sub, Expr.Identifier("count"), Expr.IntLit(1))
+        )
+      )
+    )
+    val ir = ServiceIR(
+      name = "SafeCounter",
+      state = Some(
+        stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+      ),
+      operations = List(incr, decr),
+      invariants = List(invariant)
+    )
+    val bundle   = Emit.emit(ir, proofsPath)
+    val rendered = bundle.renderModule
+    assertEquals(bundle.summary.totalChecks, 5)
+    assertEquals(bundle.summary.certifiedChecks, 5)
+    assertEquals(bundle.summary.stubbedChecks, 0)
+    assert(
+      rendered.contains("cert_op_0_Increment_preserves_0_countNonNegative"),
+      s"Increment preservation theorem missing:\n$rendered"
+    )
+    assert(
+      rendered.contains("cert_op_1_Decrement_preserves_0_countNonNegative"),
+      s"Decrement preservation theorem missing:\n$rendered"
+    )
+    assert(
+      rendered.contains("evalPreservation"),
+      s"preservation theorems must call `evalPreservation`:\n$rendered"
+    )
+    // Increment: pre.count=0, post.count=1, requires=true → invariant at post = some true.
+    assert(
+      rendered.contains("\"count\", .vInt (1 : Int)"),
+      s"Increment post-state must show count := 1:\n$rendered"
+    )
+    // Decrement: pre.count=0, post.count=-1, requires=false → vacuously some true.
+    assert(
+      rendered.contains("\"count\", .vInt (-1 : Int)"),
+      s"Decrement post-state must show count := -1:\n$rendered"
+    )
+
+  test("Phase 5.c: operation with no ensures emits no preservation theorems"):
+    val invariant = InvariantDecl(
+      name = Some("trivial"),
+      expr = Expr.BoolLit(true)
+    )
+    val opNoEnsures = OperationDecl(
+      name = "Pure",
+      requires = List(Expr.BoolLit(true)),
+      ensures = Nil
+    )
+    val ir = ServiceIR(
+      name = "PureOp",
+      operations = List(opNoEnsures),
+      invariants = List(invariant)
+    )
+    val bundle   = Emit.emit(ir, proofsPath)
+    val rendered = bundle.renderModule
+    // 1 invariant + 1 requires + 0 preservation = 2 obligations.
+    assertEquals(bundle.summary.totalChecks, 2)
+    assert(
+      !rendered.contains("preserves"),
+      s"no preservation theorem expected for ensures-less op:\n$rendered"
+    )
+
+  test("Phase 5.c: operation with unrecognised ensures emits a preservation stub"):
+    val invariant = InvariantDecl(
+      name = Some("trivial"),
+      expr = Expr.BoolLit(true)
+    )
+    val constrainedOp = OperationDecl(
+      name = "Constrained",
+      requires = List(Expr.BoolLit(true)),
+      // Constraint, not assignment — synthesizer declines.
+      ensures = List(
+        Expr.BinaryOp(BinOp.Ge, Expr.Prime(Expr.Identifier("count")), Expr.IntLit(0))
+      )
+    )
+    val ir = ServiceIR(
+      name = "Constrained",
+      state = Some(
+        stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+      ),
+      operations = List(constrainedOp),
+      invariants = List(invariant)
+    )
+    val bundle   = Emit.emit(ir, proofsPath)
+    val rendered = bundle.renderModule
+    assertEquals(bundle.summary.stubbedChecks, 1)
+    assert(
+      rendered.contains("ensures synthesis declined"),
+      s"unrecognised-ensures preservation must surface as stub with reason:\n$rendered"
+    )
+
+  test("Phase 5.c: containsPrime detects Prime in nested arithmetic but ignores Pre"):
+    val withPrime = Expr.BinaryOp(
+      BinOp.Add,
+      Expr.Prime(Expr.Identifier("count")),
+      Expr.IntLit(1)
+    )
+    val withoutPrime = Expr.BinaryOp(
+      BinOp.Add,
+      Expr.Pre(Expr.Identifier("count")),
+      Expr.IntLit(1)
+    )
+    assert(EvalIR.containsPrime(withPrime), "containsPrime must detect Prime in nested arith")
+    assert(
+      !EvalIR.containsPrime(withoutPrime),
+      "containsPrime must ignore Pre (always reads pre-state, no fixed-point issue)"
+    )

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -1298,15 +1298,21 @@ class EmitTest extends FunSuite:
       rendered.contains("evalPreservation"),
       s"preservation theorems must call `evalPreservation`:\n$rendered"
     )
-    // Increment: pre.count=0, post.count=1, requires=true → invariant at post = some true.
+    // Increment: pre.count=0 (demo satisfies requires=true and inv), post.count=1.
     assert(
-      rendered.contains("\"count\", .vInt (1 : Int)"),
-      s"Increment post-state must show count := 1:\n$rendered"
+      rendered.contains(
+        "pre := ({ scalars := [(\"count\", .vInt (0 : Int))]"
+      ),
+      s"Increment preservation cert must seed pre.count = 0 (demo state):\n$rendered"
     )
-    // Decrement: pre.count=0, post.count=-1, requires=false → vacuously some true.
+    // Decrement: Phase 5.d seeding picks pre.count=1 (smallest candidate that
+    // satisfies `count > 0` AND `count >= 0`). Synthesised post.count = 0.
+    // Invariant at post = `0 >= 0` = true. Non-vacuous cert.
     assert(
-      rendered.contains("\"count\", .vInt (-1 : Int)"),
-      s"Decrement post-state must show count := -1:\n$rendered"
+      rendered.contains(
+        "pre := ({ scalars := [(\"count\", .vInt (1 : Int))]"
+      ),
+      s"Decrement preservation cert must seed pre.count = 1:\n$rendered"
     )
 
   test("Phase 5.c: operation with no ensures emits no preservation theorems"):
@@ -1377,4 +1383,198 @@ class EmitTest extends FunSuite:
     assert(
       !EvalIR.containsPrime(withoutPrime),
       "containsPrime must ignore Pre (always reads pre-state, no fixed-point issue)"
+    )
+
+  // ---------------------------------------------------------------------------
+  // M_L.4.b-ext Phase 5.d — Identity ensures + per-op pre-state seeding.
+  // (A) `state' = state` and `state' = pre(state)` are recognised without
+  //     evaluating the RHS, so non-scalar fields (Map/relation) where eval
+  //     returns None aren't mis-classified as Unrecognized.
+  // (C) `seedPreStateForOp` picks a pre-state where requires + invariant both
+  //     hold; preservation cert is non-vacuous when possible.
+  // ---------------------------------------------------------------------------
+
+  test("Phase 5.d: identity ensures `state' = state` is recognised as no-op"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Identity",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "NoOp",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.Identifier("count")
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(42))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    // Identity → recognised as no-op → post == pre.
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+
+  test("Phase 5.d: identity ensures `state' = pre(state)` is recognised as no-op"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Identity",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "NoOpPre",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.Pre(Expr.Identifier("count"))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(7))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+
+  test("Phase 5.d: identity recognition works for non-scalar fields (Map/relation)"):
+    // For Map-typed fields, the field isn't in `scalars` — eval-based
+    // synthesis would return None and reject. Identity recognition succeeds
+    // structurally without eval.
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "MapIdentity",
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(
+              name = "store",
+              typeExpr = TypeExpr.MapType(TypeExpr.NamedType("Int"), TypeExpr.NamedType("Int"))
+            )
+          )
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Touch",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("store")),
+          Expr.Identifier("store")
+        )
+      )
+    )
+    val pre = State.demo(ir)
+    // Map field is in `relations` and `lookups`, NOT in `scalars`. Identity
+    // recognition declines to call eval, so this succeeds as a no-op rather
+    // than failing on `eval(Identifier("store"))` returning None.
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+
+  test("Phase 5.d: seedPreStateForOp picks count=1 for `count > 0` requires"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Counter",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Decrement",
+      requires = List(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("count"), Expr.IntLit(0)))
+    )
+    val inv = InvariantDecl(
+      name = Some("nonNeg"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    val demo   = State.demo(ir)
+    val seeded = EvalIR.seedPreStateForOp(ir, op, inv, demo)
+    // Seeded pre-state must satisfy both requires (count > 0) and invariant
+    // (count >= 0). The first candidate that satisfies both wins.
+    val seededCount = seeded.scalars.collectFirst { case ("count", v) => v }
+    assert(
+      seededCount.exists {
+        case Value.VInt(n) => n > BigInt(0)
+        case _             => false
+      },
+      s"seeded pre.count must satisfy `count > 0`, got: $seededCount"
+    )
+
+  test("Phase 5.d: seedPreStateForOp falls back to demo on unsatisfiable requires"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Impossible",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Bad",
+      // count > 0 AND count < 0 is unsatisfiable. Seeder falls back to demo.
+      requires = List(
+        Expr.BinaryOp(BinOp.Gt, Expr.Identifier("count"), Expr.IntLit(0)),
+        Expr.BinaryOp(BinOp.Lt, Expr.Identifier("count"), Expr.IntLit(0))
+      )
+    )
+    val inv = InvariantDecl(
+      name = Some("trivial"),
+      expr = Expr.BoolLit(true)
+    )
+    val demo   = State.demo(ir)
+    val seeded = EvalIR.seedPreStateForOp(ir, op, inv, demo)
+    assertEquals(seeded, demo)
+
+  test("Phase 5.d: safe_counter Decrement preservation cert is now non-vacuous"):
+    val invariant = InvariantDecl(
+      name = Some("countNonNegative"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    val decr = OperationDecl(
+      name = "Decrement",
+      requires = List(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("count"), Expr.IntLit(0))),
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Sub, Expr.Identifier("count"), Expr.IntLit(1))
+        )
+      )
+    )
+    val ir = ServiceIR(
+      name = "SafeCounter",
+      state = Some(
+        stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+      ),
+      operations = List(decr),
+      invariants = List(invariant)
+    )
+    val rendered = Emit.emit(ir, proofsPath).renderModule
+    // Per-op seeding picks pre.count = 1 (smallest candidate satisfying
+    // count > 0 AND count >= 0). Synthesised post.count = 0. Invariant at
+    // post = 0 >= 0 = true. Non-vacuous cert.
+    assert(
+      rendered.contains("pre := ({ scalars := [(\"count\", .vInt (1 : Int))]"),
+      s"Decrement preservation cert must seed pre.count = 1:\n$rendered"
+    )
+    assert(
+      rendered.contains("post := ({ scalars := [(\"count\", .vInt (0 : Int))]"),
+      s"Decrement preservation cert must synthesise post.count = 0:\n$rendered"
     )

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -874,3 +874,235 @@ class EmitTest extends FunSuite:
       !rendered.contains("UNRENDERABLE"),
       s"With must render cleanly without UNRENDERABLE markers:\n$rendered"
     )
+
+  // ---------------------------------------------------------------------------
+  // M_L.4.b-ext Phase 5.b — `StatePair` + `StateMode` + mode-aware `evalAt`.
+  // Single-state `eval` is now a thin wrapper over `evalAt(Pre, diag(st), …)`.
+  // The diagonal-collapse property (Lean: `evalAt_diagonal_eq_eval`) holds by
+  // definition. New tests pin the two-state behavior and Prime/Pre mode flips.
+  // ---------------------------------------------------------------------------
+
+  test("Phase 5.b: StatePair.diag(st) returns the same state in both modes"):
+    import EvalIR.*
+    val st = State(
+      scalars = List("count" -> Value.VInt(BigInt(7))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp = StatePair.diag(st)
+    assertEquals(sp.pre, st)
+    assertEquals(sp.post, st)
+    assertEquals(sp.at(StateMode.Pre), st)
+    assertEquals(sp.at(StateMode.Post), st)
+
+  test("Phase 5.b: evalAt on diagonal StatePair agrees with single-state eval"):
+    // Spot-check a representative cross-section of expression shapes; the
+    // diagonal-collapse property should hold for every closed evaluation.
+    import EvalIR.*
+    val st = State(
+      scalars = List("count" -> Value.VInt(BigInt(3))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp     = StatePair.diag(st)
+    val schema = Schema.empty
+    val probes: List[Expr] = List(
+      Expr.IntLit(1),
+      Expr.BoolLit(true),
+      Expr.Identifier("count"),
+      Expr.UnaryOp(UnOp.Negate, Expr.Identifier("count")),
+      Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.IntLit(1)),
+      Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0)),
+      Expr.Prime(Expr.Identifier("count")),
+      Expr.Pre(Expr.Identifier("count")),
+      Expr.Let("x", Expr.IntLit(5), Expr.BinaryOp(BinOp.Eq, Expr.Identifier("x"), Expr.IntLit(5)))
+    )
+    probes.foreach: probe =>
+      assertEquals(
+        EvalIR.evalAt(StateMode.Pre, schema, sp, Nil, probe),
+        EvalIR.eval(schema, st, Nil, probe),
+        s"evalAt(Pre, diag(st)) must agree with eval for probe: $probe"
+      )
+      assertEquals(
+        EvalIR.evalAt(StateMode.Post, schema, sp, Nil, probe),
+        EvalIR.eval(schema, st, Nil, probe),
+        s"evalAt(Post, diag(st)) must agree with eval for probe: $probe"
+      )
+
+  test("Phase 5.b: evalAt with non-diagonal pair routes Identifier to active mode"):
+    import EvalIR.*
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = State(
+      scalars = List("count" -> Value.VInt(BigInt(5))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp = StatePair(pre, post)
+    assertEquals(
+      EvalIR.evalAt(StateMode.Pre, Schema.empty, sp, Nil, Expr.Identifier("count")),
+      Some(Value.VInt(BigInt(0)))
+    )
+    assertEquals(
+      EvalIR.evalAt(StateMode.Post, Schema.empty, sp, Nil, Expr.Identifier("count")),
+      Some(Value.VInt(BigInt(5)))
+    )
+
+  test("Phase 5.b: Expr.Prime flips mode to Post; Expr.Pre flips mode to Pre"):
+    import EvalIR.*
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = State(
+      scalars = List("count" -> Value.VInt(BigInt(5))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp = StatePair(pre, post)
+    // Starting in Pre, `count'` reaches the post-state.
+    assertEquals(
+      EvalIR.evalAt(StateMode.Pre, Schema.empty, sp, Nil, Expr.Prime(Expr.Identifier("count"))),
+      Some(Value.VInt(BigInt(5)))
+    )
+    // Starting in Post, `pre(count)` reaches the pre-state.
+    assertEquals(
+      EvalIR.evalAt(StateMode.Post, Schema.empty, sp, Nil, Expr.Pre(Expr.Identifier("count"))),
+      Some(Value.VInt(BigInt(0)))
+    )
+
+  test("Phase 5.b: nested temporal operators apply innermost-wins"):
+    // Prime(Pre(x)) reads x from Pre; Pre(Prime(x)) reads x from Post.
+    import EvalIR.*
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = State(
+      scalars = List("count" -> Value.VInt(BigInt(5))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp = StatePair(pre, post)
+    val primeOfPre =
+      Expr.Prime(Expr.Pre(Expr.Identifier("count")))
+    val preOfPrime =
+      Expr.Pre(Expr.Prime(Expr.Identifier("count")))
+    assertEquals(
+      EvalIR.evalAt(StateMode.Pre, Schema.empty, sp, Nil, primeOfPre),
+      Some(Value.VInt(BigInt(0)))
+    )
+    assertEquals(
+      EvalIR.evalAt(StateMode.Pre, Schema.empty, sp, Nil, preOfPrime),
+      Some(Value.VInt(BigInt(5)))
+    )
+
+  test("Phase 5.b: mode propagates through sub-expressions until the next Prime/Pre"):
+    // `count' = count + 1` mixed temporal eval: LHS Prime reads post, RHS reads pre.
+    import EvalIR.*
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(3))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = State(
+      scalars = List("count" -> Value.VInt(BigInt(4))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp = StatePair(pre, post)
+    val ensures = Expr.BinaryOp(
+      BinOp.Eq,
+      Expr.Prime(Expr.Identifier("count")),
+      Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.IntLit(1))
+    )
+    assertEquals(
+      EvalIR.evalAt(StateMode.Pre, Schema.empty, sp, Nil, ensures),
+      Some(Value.VBool(true))
+    )
+
+  test("Phase 5.b: evalInvariantBodyAt threads mode through invariant-style evaluation"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Counter",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("count" -> Value.VInt(BigInt(-1))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val post = State(
+      scalars = List("count" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val sp         = StatePair(pre, post)
+    val nonNegBody = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    // Pre-state violates `count >= 0`; post-state satisfies it.
+    assertEquals(
+      EvalIR.evalInvariantBodyAt(StateMode.Pre, ir, sp, Nil, nonNegBody),
+      Some(false)
+    )
+    assertEquals(
+      EvalIR.evalInvariantBodyAt(StateMode.Post, ir, sp, Nil, nonNegBody),
+      Some(true)
+    )
+
+  test("Phase 5.b: evalRequiresAt short-circuits on first false in active mode"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Counter",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val sp = StatePair(
+      pre = State(
+        scalars = List("count" -> Value.VInt(BigInt(0))),
+        relations = Nil,
+        lookups = Nil,
+        entityFields = Nil
+      ),
+      post = State(
+        scalars = List("count" -> Value.VInt(BigInt(5))),
+        relations = Nil,
+        lookups = Nil,
+        entityFields = Nil
+      )
+    )
+    val requires = List(
+      Expr.BinaryOp(BinOp.Gt, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    // `count > 0` is false in pre-state (count=0) and true in post-state (count=5).
+    assertEquals(
+      EvalIR.evalRequiresAt(StateMode.Pre, ir, sp, Nil, requires),
+      Some(false)
+    )
+    assertEquals(
+      EvalIR.evalRequiresAt(StateMode.Post, ir, sp, Nil, requires),
+      Some(true)
+    )

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -1869,3 +1869,63 @@ class EmitTest extends FunSuite:
     assert(refs.contains("tasks"), s"must include the relation `tasks`: $refs")
     assert(!refs.contains("t"), s"must exclude the bound var `t`: $refs")
     assert(!refs.contains("priority"), s"must exclude field names: $refs")
+
+  test("PR review #12: synthesizePostState rejects conflicting `x' = 1 ∧ x' = 2`"):
+    // Two recognised assignments to the same scalar with different values
+    // would otherwise resolve via "last write wins", certifying a post-state
+    // the ensures clauses don't jointly admit. The conflict detector lifts
+    // the field into `unknownFields` and drops the conflicting updates.
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "Conflict",
+      state = Some(
+        StateDecl(fields = List(StateFieldDecl(name = "x", typeExpr = TypeExpr.NamedType("Int"))))
+      )
+    )
+    val op = OperationDecl(
+      name = "Inconsistent",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.And,
+          Expr.BinaryOp(BinOp.Eq, Expr.Prime(Expr.Identifier("x")), Expr.IntLit(1)),
+          Expr.BinaryOp(BinOp.Eq, Expr.Prime(Expr.Identifier("x")), Expr.IntLit(2))
+        )
+      )
+    )
+    val pre = State(
+      scalars = List("x" -> Value.VInt(BigInt(0))),
+      relations = Nil,
+      lookups = Nil,
+      entityFields = Nil
+    )
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
+    // Conflicting field is lifted to unknownFields; post.x stays at pre's value.
+    assertEquals(unknown, Set("x"))
+    assertEquals(post.scalars.collectFirst { case ("x", v) => v }, Some(Value.VInt(BigInt(0))))
+
+  test("PR review #15: containsPrime detects Prime nested in MapLiteral entries"):
+    val withPrimeKey = Expr.MapLiteral(
+      List(MapEntry(Expr.Prime(Expr.Identifier("k")), Expr.IntLit(1)))
+    )
+    val withPrimeValue = Expr.MapLiteral(
+      List(MapEntry(Expr.IntLit(1), Expr.Prime(Expr.Identifier("v"))))
+    )
+    val cleanMap = Expr.MapLiteral(
+      List(MapEntry(Expr.IntLit(1), Expr.IntLit(2)))
+    )
+    assert(EvalIR.containsPrime(withPrimeKey), "MapLiteral with primed key must be detected")
+    assert(EvalIR.containsPrime(withPrimeValue), "MapLiteral with primed value must be detected")
+    assert(!EvalIR.containsPrime(cleanMap), "MapLiteral with no primes must pass")
+
+  test("PR review #13: VEntityWith equality uses extensional set semantics inside chain"):
+    import EvalIR.Value.*
+    val baseEntity = VEntity("User", "u_1")
+    val a          = VEntityWith(baseEntity, "members", VSet(List(VInt(1), VInt(2))))
+    val b          = VEntityWith(baseEntity, "members", VSet(List(VInt(2), VInt(1))))
+    // Old structural equality compared `[1, 2]` and `[2, 1]` as unequal.
+    // The recursive valueEq mirror of Lean's beqValue restores extensional
+    // set equality inside record-update chains.
+    val expr   = Expr.BinaryOp(BinOp.Eq, Expr.Identifier("a"), Expr.Identifier("b"))
+    val env    = List("a" -> a, "b" -> b)
+    val result = EvalIR.eval(EvalIR.Schema.empty, EvalIR.State.empty, env, expr)
+    assertEquals(result, Some(EvalIR.Value.VBool(true)))

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -715,3 +715,162 @@ class EmitTest extends FunSuite:
       rendered.contains(".fieldAccess (.ident \"t\")"),
       s"quantifier-bound FieldAccess must render with .ident base:\n$rendered"
     )
+
+  // ---------------------------------------------------------------------------
+  // M_L.4.b-ext Phase 5.a — `Expr.With` joins the cert-emission subset.
+  // The Lean side ships full Skolem semantics for `withRec` (Phase 4b); the
+  // Scala-side now mirrors via `Value.VEntityWith`, `fieldLookup` walks the
+  // chain, `VerifiedSubset.classify` accepts With, and Emit renders multi-field
+  // updates as a left-fold of `.withRec` ctors.
+  // ---------------------------------------------------------------------------
+
+  test("Phase 5.a: VerifiedSubset accepts With over an in-subset base + values"):
+    val expr = Expr.With(
+      Expr.Identifier("u"),
+      List(FieldAssign("name", Expr.IntLit(0)))
+    )
+    assert(
+      VerifiedSubset.isInSubset(expr),
+      s"Expr.With over in-subset base + values must classify as InSubset, got ${VerifiedSubset.classify(expr)}"
+    )
+
+  test("Phase 5.a: VerifiedSubset rejects With with an out-of-subset update value"):
+    val expr = Expr.With(
+      Expr.Identifier("u"),
+      List(FieldAssign("name", Expr.FloatLit(1.0)))
+    )
+    VerifiedSubset.classify(expr) match
+      case VerifiedSubset.SubsetStatus.OutOfSubset(reason) =>
+        assert(
+          reason.contains("FloatLit"),
+          s"With with FloatLit update must surface the inner reason, got `$reason`"
+        )
+      case VerifiedSubset.SubsetStatus.InSubset =>
+        fail("With over FloatLit update must be OutOfSubset")
+
+  test("Phase 5.a: EvalIR builds a VEntityWith chain and fieldLookup walks it"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "WithDemo",
+      entities = List(
+        EntityDecl(
+          name = "User",
+          fields = List(
+            FieldDecl(name = "name", typeExpr = TypeExpr.NamedType("Int")),
+            FieldDecl(name = "age", typeExpr = TypeExpr.NamedType("Int"))
+          )
+        )
+      ),
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "u", typeExpr = TypeExpr.NamedType("User")))
+        )
+      )
+    )
+    val st = State.demo(ir)
+    // `u with { name := 7 }` extends the seeded vEntity with a name override.
+    val withExpr = Expr.With(
+      Expr.Identifier("u"),
+      List(FieldAssign("name", Expr.IntLit(7)))
+    )
+    val v = EvalIR.eval(Schema.of(ir), st, Nil, withExpr)
+    assert(
+      v.exists {
+        case Value.VEntityWith(Value.VEntity("User", _), "name", Value.VInt(n)) =>
+          n == BigInt(7)
+        case _ => false
+      },
+      s"With must build a VEntityWith chain over the seeded vEntity, got: $v"
+    )
+    // FieldAccess(With(u, [name := 7]), "name") → 7 (override path).
+    val accessOverride = Expr.FieldAccess(withExpr, "name")
+    assertEquals(
+      EvalIR.eval(Schema.of(ir), st, Nil, accessOverride),
+      Some(Value.VInt(BigInt(7)))
+    )
+    // FieldAccess(With(u, [name := 7]), "age") → seeded default (fallback to base).
+    val accessFallback = Expr.FieldAccess(withExpr, "age")
+    assertEquals(
+      EvalIR.eval(Schema.of(ir), st, Nil, accessFallback),
+      Some(Value.VInt(BigInt(0)))
+    )
+
+  test("Phase 5.a: multi-field With folds left into chained .withRec Lean output"):
+    // With(u, [a := 1, b := 2]) lowers to .withRec (.withRec (.ident "u") "a" 1) "b" 2
+    val withExpr = Expr.With(
+      Expr.Identifier("u"),
+      List(
+        FieldAssign("a", Expr.IntLit(1)),
+        FieldAssign("b", Expr.IntLit(2))
+      )
+    )
+    val invariant = InvariantDecl(
+      name = Some("withChained"),
+      expr = Expr.BinaryOp(BinOp.Eq, withExpr, withExpr)
+    )
+    val ir = ServiceIR(
+      name = "WithChained",
+      entities = List(
+        EntityDecl(
+          name = "User",
+          fields = List(
+            FieldDecl(name = "a", typeExpr = TypeExpr.NamedType("Int")),
+            FieldDecl(name = "b", typeExpr = TypeExpr.NamedType("Int"))
+          )
+        )
+      ),
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "u", typeExpr = TypeExpr.NamedType("User")))
+        )
+      ),
+      invariants = List(invariant)
+    )
+    val rendered = Emit.emit(ir, proofsPath).renderModule
+    assert(
+      rendered.contains(
+        "(.withRec (.withRec (.ident \"u\") \"a\" (.intLit (1 : Int))) \"b\" (.intLit (2 : Int)))"
+      ),
+      s"multi-field With must render as left-folded .withRec chain:\n$rendered"
+    )
+
+  test("Phase 5.a: With on entity-typed scalar flips cert_decide via demo seeding"):
+    // Equality on `u with { name := 0 }` against itself must reduce to `some true`
+    // because both sides build the same VEntityWith chain over the same seeded
+    // vEntity. End-to-end check: classifier accepts, evaluator produces the
+    // chain, renderer emits `.withRec`, and `cert_decide` discharges.
+    val withExpr = Expr.With(
+      Expr.Identifier("u"),
+      List(FieldAssign("name", Expr.IntLit(0)))
+    )
+    val invariant = InvariantDecl(
+      name = Some("withEqRefl"),
+      expr = Expr.BinaryOp(BinOp.Eq, withExpr, withExpr)
+    )
+    val ir = ServiceIR(
+      name = "WithRefl",
+      entities = List(
+        EntityDecl(
+          name = "User",
+          fields = List(FieldDecl(name = "name", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      ),
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "u", typeExpr = TypeExpr.NamedType("User")))
+        )
+      ),
+      invariants = List(invariant)
+    )
+    val bundle   = Emit.emit(ir, proofsPath)
+    val rendered = bundle.renderModule
+    assertEquals(bundle.summary.certifiedChecks, 1)
+    assertEquals(bundle.summary.stubbedChecks, 0)
+    assert(
+      rendered.contains("= some true"),
+      s"With(u, [name := 0]) ≡ With(u, [name := 0]) must close as some true:\n$rendered"
+    )
+    assert(
+      !rendered.contains("UNRENDERABLE"),
+      s"With must render cleanly without UNRENDERABLE markers:\n$rendered"
+    )

--- a/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/EmitTest.scala
@@ -1141,18 +1141,17 @@ class EmitTest extends FunSuite:
       lookups = Nil,
       entityFields = Nil
     )
-    val post = EvalIR.synthesizePostState(ir, op, pre)
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
     assertEquals(
       post,
-      Some(
-        State(
-          scalars = List("count" -> Value.VInt(BigInt(8))),
-          relations = Nil,
-          lookups = Nil,
-          entityFields = Nil
-        )
+      State(
+        scalars = List("count" -> Value.VInt(BigInt(8))),
+        relations = Nil,
+        lookups = Nil,
+        entityFields = Nil
       )
     )
+    assertEquals(unknown, Set.empty[String])
 
   test("Phase 5.c: synthesizePostState handles And-joined multi-field assignments"):
     import EvalIR.*
@@ -1183,13 +1182,14 @@ class EmitTest extends FunSuite:
       lookups = Nil,
       entityFields = Nil
     )
-    val post = EvalIR.synthesizePostState(ir, op, pre)
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
     assertEquals(
-      post.map(_.scalars),
-      Some(List("a" -> Value.VInt(BigInt(2)), "b" -> Value.VInt(BigInt(1))))
+      post.scalars,
+      List("a" -> Value.VInt(BigInt(2)), "b" -> Value.VInt(BigInt(1)))
     )
+    assertEquals(unknown, Set.empty[String])
 
-  test("Phase 5.c: synthesizePostState declines on unrecognised ensures shape"):
+  test("Phase 5.e: synthesizePostState marks unrecognised-clause fields as unknown"):
     import EvalIR.*
     val ir = ServiceIR(
       name = "Constrained",
@@ -1213,9 +1213,15 @@ class EmitTest extends FunSuite:
       lookups = Nil,
       entityFields = Nil
     )
-    assertEquals(EvalIR.synthesizePostState(ir, op, pre), None)
+    // Phase 5.e: per-clause partial recognition. The constraint `count' >= 0`
+    // is unrecognised but we capture `count` as a touched-but-unknown field.
+    // The cert renderer's gate then refuses to emit a cert when the invariant
+    // reads `count`.
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
+    assertEquals(post, pre)
+    assertEquals(unknown, Set("count"))
 
-  test("Phase 5.c: synthesizePostState declines when RHS contains a Prime"):
+  test("Phase 5.e: synthesizePostState marks Prime-in-RHS fields as unknown"):
     import EvalIR.*
     val ir = ServiceIR(
       name = "SelfRef",
@@ -1244,7 +1250,12 @@ class EmitTest extends FunSuite:
       lookups = Nil,
       entityFields = Nil
     )
-    assertEquals(EvalIR.synthesizePostState(ir, op, pre), None)
+    // Phase 5.e: clause referencing `Prime(Identifier("count"))` on the RHS
+    // is unrecognised — the synthesizer can't reach a fixed point. The
+    // renderer's gate refuses if invariant reads `count`.
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
+    assertEquals(post, pre)
+    assertEquals(unknown, Set("count"))
 
   test("Phase 5.c: safe_counter emits 1 invariant + 2 requires + 2 preservation = 5 certs"):
     val invariant = InvariantDecl(
@@ -1339,34 +1350,55 @@ class EmitTest extends FunSuite:
       s"no preservation theorem expected for ensures-less op:\n$rendered"
     )
 
-  test("Phase 5.c: operation with unrecognised ensures emits a preservation stub"):
-    val invariant = InvariantDecl(
-      name = Some("trivial"),
-      expr = Expr.BoolLit(true)
-    )
+  test(
+    "Phase 5.e: unrecognised-ensures preservation stubs only when invariant reads the touched field"
+  ):
+    // Phase 5.e gate: the unrecognised ensures clause `count' >= 0` taints
+    // `count`. If the invariant reads `count`, we stub. If the invariant
+    // doesn't read it (e.g., `BoolLit(true)`), the cert is honest.
     val constrainedOp = OperationDecl(
       name = "Constrained",
       requires = List(Expr.BoolLit(true)),
-      // Constraint, not assignment — synthesizer declines.
       ensures = List(
         Expr.BinaryOp(BinOp.Ge, Expr.Prime(Expr.Identifier("count")), Expr.IntLit(0))
       )
     )
-    val ir = ServiceIR(
-      name = "Constrained",
-      state = Some(
-        stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
-      ),
+    val state =
+      Some(stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int"))))
+
+    // Case A: invariant reads `count` — preservation cert stubs out.
+    val readingInv = InvariantDecl(
+      name = Some("nonNeg"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    val readingIR = ServiceIR(
+      name = "ReadingInv",
+      state = state,
       operations = List(constrainedOp),
-      invariants = List(invariant)
+      invariants = List(readingInv)
     )
-    val bundle   = Emit.emit(ir, proofsPath)
-    val rendered = bundle.renderModule
-    assertEquals(bundle.summary.stubbedChecks, 1)
+    val readingBundle   = Emit.emit(readingIR, proofsPath)
+    val readingRendered = readingBundle.renderModule
+    assertEquals(readingBundle.summary.stubbedChecks, 1)
     assert(
-      rendered.contains("ensures synthesis declined"),
-      s"unrecognised-ensures preservation must surface as stub with reason:\n$rendered"
+      readingRendered.contains("ensures synthesis incomplete and invariant reads unknown field"),
+      s"taint gate must fire when invariant reads `count`:\n$readingRendered"
     )
+
+    // Case B: invariant doesn't read `count` — preservation cert is honest.
+    val blindInv = InvariantDecl(
+      name = Some("trivial"),
+      expr = Expr.BoolLit(true)
+    )
+    val blindIR = ServiceIR(
+      name = "BlindInv",
+      state = state,
+      operations = List(constrainedOp),
+      invariants = List(blindInv)
+    )
+    val blindBundle = Emit.emit(blindIR, proofsPath)
+    assertEquals(blindBundle.summary.stubbedChecks, 0)
+    assertEquals(blindBundle.summary.certifiedChecks, 3)
 
   test("Phase 5.c: containsPrime detects Prime in nested arithmetic but ignores Pre"):
     val withPrime = Expr.BinaryOp(
@@ -1421,7 +1453,7 @@ class EmitTest extends FunSuite:
       entityFields = Nil
     )
     // Identity → recognised as no-op → post == pre.
-    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre, Nil), (pre, Set.empty[String]))
 
   test("Phase 5.d: identity ensures `state' = pre(state)` is recognised as no-op"):
     import EvalIR.*
@@ -1449,7 +1481,7 @@ class EmitTest extends FunSuite:
       lookups = Nil,
       entityFields = Nil
     )
-    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre, Nil), (pre, Set.empty[String]))
 
   test("Phase 5.d: identity recognition works for non-scalar fields (Map/relation)"):
     // For Map-typed fields, the field isn't in `scalars` — eval-based
@@ -1483,7 +1515,7 @@ class EmitTest extends FunSuite:
     // Map field is in `relations` and `lookups`, NOT in `scalars`. Identity
     // recognition declines to call eval, so this succeeds as a no-op rather
     // than failing on `eval(Identifier("store"))` returning None.
-    assertEquals(EvalIR.synthesizePostState(ir, op, pre), Some(pre))
+    assertEquals(EvalIR.synthesizePostState(ir, op, pre, Nil), (pre, Set.empty[String]))
 
   test("Phase 5.d: seedPreStateForOp picks count=1 for `count > 0` requires"):
     import EvalIR.*
@@ -1578,3 +1610,262 @@ class EmitTest extends FunSuite:
       rendered.contains("post := ({ scalars := [(\"count\", .vInt (0 : Int))]"),
       s"Decrement preservation cert must synthesise post.count = 0:\n$rendered"
     )
+
+  // ---------------------------------------------------------------------------
+  // M_L.4.b-ext Phase 5.e — Per-clause partial recognition + set/map updates +
+  // op-input parameter seeding. The synthesizer no longer declines on the
+  // first unrecognised clause; instead it carries forward `unknownFields` and
+  // the cert renderer's gate refuses only when the invariant reads them.
+  // Set-add (`users' = users + {newUser}`) and map-add (`store' = pre(store) +
+  // {k -> v}`) shapes are recognised structurally. Operation inputs are seeded
+  // alongside scalars, and the seeded env is rendered into the cert so closed
+  // Lean evaluation sees the same bindings.
+  // ---------------------------------------------------------------------------
+
+  test("Phase 5.e: set-add ensures `users' = users + {someElem}` updates relations + scalars"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "SetAdd",
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(name = "users", typeExpr = TypeExpr.SetType(TypeExpr.NamedType("Int")))
+          )
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "AddUser",
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("users")),
+          Expr.BinaryOp(
+            BinOp.Add,
+            Expr.Identifier("users"),
+            Expr.SetLiteral(List(Expr.IntLit(42)))
+          )
+        )
+      )
+    )
+    val pre             = State.demo(ir)
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
+    assertEquals(unknown, Set.empty[String])
+    // Set-add updates BOTH the scalar (VSet) AND the relation domain.
+    assertEquals(
+      post.scalars.collectFirst { case ("users", v) => v },
+      Some(Value.VSet(List(Value.VInt(BigInt(42)))))
+    )
+    assertEquals(
+      post.relations.collectFirst { case ("users", vs) => vs },
+      Some(List(Value.VInt(BigInt(42))))
+    )
+
+  test("Phase 5.e: map-add ensures `store' = pre(store) + {k -> v}` updates lookups + relations"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "MapAdd",
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(
+              name = "store",
+              typeExpr = TypeExpr.MapType(TypeExpr.NamedType("Int"), TypeExpr.NamedType("Int"))
+            )
+          )
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Insert",
+      // ensures: store' = pre(store) + {7 -> 100}
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("store")),
+          Expr.BinaryOp(
+            BinOp.Add,
+            Expr.Pre(Expr.Identifier("store")),
+            Expr.MapLiteral(List(MapEntry(Expr.IntLit(7), Expr.IntLit(100))))
+          )
+        )
+      )
+    )
+    val pre             = State.demo(ir)
+    val (post, unknown) = EvalIR.synthesizePostState(ir, op, pre, Nil)
+    assertEquals(unknown, Set.empty[String])
+    // Map-add updates BOTH lookups (key -> value pairs) AND relations
+    // (the value list, since `forallRel` over a map iterates over values).
+    assertEquals(
+      post.lookups.collectFirst { case ("store", ps) => ps },
+      Some(List((Value.VInt(BigInt(7)), Value.VInt(BigInt(100)))))
+    )
+    assertEquals(
+      post.relations.collectFirst { case ("store", vs) => vs },
+      Some(List(Value.VInt(BigInt(100))))
+    )
+
+  test("Phase 5.e: per-clause partial — recognized + unrecognized clauses coexist"):
+    // Op has two ensures: one identity (recognized as no-op), one constraint
+    // (unrecognized, taints `count`). If the invariant reads only the
+    // identity-preserved field (`flag`), the cert is honest. If it reads
+    // `count`, the gate fires.
+    val ir = ServiceIR(
+      name = "Mixed",
+      state = Some(
+        StateDecl(fields =
+          List(
+            StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")),
+            StateFieldDecl(name = "flag", typeExpr = TypeExpr.NamedType("Bool"))
+          )
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "MixedOp",
+      requires = List(Expr.BoolLit(true)),
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.And,
+          Expr.BinaryOp(
+            BinOp.Eq,
+            Expr.Prime(Expr.Identifier("flag")),
+            Expr.Identifier("flag")
+          ),
+          Expr.BinaryOp(BinOp.Ge, Expr.Prime(Expr.Identifier("count")), Expr.IntLit(0))
+        )
+      )
+    )
+    val invFlagOnly = InvariantDecl(
+      name = Some("flagSomething"),
+      expr = Expr.BinaryOp(BinOp.Eq, Expr.Identifier("flag"), Expr.Identifier("flag"))
+    )
+    val invCount = InvariantDecl(
+      name = Some("nonNeg"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+
+    val flagIR =
+      ServiceIR(
+        name = "FlagInv",
+        state = ir.state,
+        operations = List(op),
+        invariants = List(invFlagOnly)
+      )
+    val countIR =
+      ServiceIR(
+        name = "CountInv",
+        state = ir.state,
+        operations = List(op),
+        invariants = List(invCount)
+      )
+
+    val flagBundle  = Emit.emit(flagIR, proofsPath)
+    val countBundle = Emit.emit(countIR, proofsPath)
+
+    // Flag invariant doesn't read `count` → cert is honest.
+    assertEquals(flagBundle.summary.stubbedChecks, 0)
+    assert(
+      flagBundle.renderModule.contains("evalPreservation"),
+      s"flag-only invariant should produce real preservation cert:\n${flagBundle.renderModule}"
+    )
+
+    // Count invariant reads `count` (which the unrecognized constraint
+    // tainted) → cert stubs out.
+    assertEquals(countBundle.summary.stubbedChecks, 1)
+    assert(
+      countBundle.renderModule
+        .contains("ensures synthesis incomplete and invariant reads unknown field"),
+      s"count invariant should taint and stub:\n${countBundle.renderModule}"
+    )
+
+  test("Phase 5.e: op-input parameter seeding satisfies a param-referencing requires"):
+    import EvalIR.*
+    val ir = ServiceIR(
+      name = "ParamRef",
+      state = Some(
+        StateDecl(fields =
+          List(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+        )
+      )
+    )
+    val op = OperationDecl(
+      name = "Adjust",
+      inputs = List(ParamDecl(name = "delta", typeExpr = TypeExpr.NamedType("Int"))),
+      // requires: delta > 0 — needs param-seeding to satisfy.
+      requires = List(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("delta"), Expr.IntLit(0))),
+      ensures = List(
+        Expr.BinaryOp(
+          BinOp.Eq,
+          Expr.Prime(Expr.Identifier("count")),
+          Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.Identifier("delta"))
+        )
+      )
+    )
+    val inv = InvariantDecl(
+      name = Some("nonNeg"),
+      expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+    )
+    val ctx = EvalIR.seedContextForOp(ir, op, inv, State.demo(ir))
+    // Seeded env must bind `delta` to a positive integer to satisfy
+    // `delta > 0` AND let the synthesizer evaluate `count + delta`.
+    assert(
+      ctx.env.exists {
+        case ("delta", Value.VInt(n)) => n > BigInt(0)
+        case _                        => false
+      },
+      s"seeded env must bind delta to a positive Int; env=${ctx.env}"
+    )
+
+  test("Phase 5.e: cert renders seeded env as a Lean literal beside the StatePair"):
+    val ir = ServiceIR(
+      name = "WithEnv",
+      state = Some(
+        stubState(StateFieldDecl(name = "count", typeExpr = TypeExpr.NamedType("Int")))
+      ),
+      invariants = List(
+        InvariantDecl(
+          name = Some("nonNeg"),
+          expr = Expr.BinaryOp(BinOp.Ge, Expr.Identifier("count"), Expr.IntLit(0))
+        )
+      ),
+      operations = List(
+        OperationDecl(
+          name = "Adjust",
+          inputs = List(ParamDecl(name = "delta", typeExpr = TypeExpr.NamedType("Int"))),
+          requires = List(Expr.BinaryOp(BinOp.Gt, Expr.Identifier("delta"), Expr.IntLit(0))),
+          ensures = List(
+            Expr.BinaryOp(
+              BinOp.Eq,
+              Expr.Prime(Expr.Identifier("count")),
+              Expr.BinaryOp(BinOp.Add, Expr.Identifier("count"), Expr.Identifier("delta"))
+            )
+          )
+        )
+      )
+    )
+    val rendered = Emit.emit(ir, proofsPath).renderModule
+    // The preservation cert's env slot must contain the seeded `delta`
+    // binding (chosen so requires + invariant both hold in pre).
+    assert(
+      rendered.contains("(\"delta\", .vInt"),
+      s"preservation cert must render seeded env binding for `delta`:\n$rendered"
+    )
+
+  test("Phase 5.e: referencedStateNames over-approximates state reads, not bound vars"):
+    // `forall t in tasks, t.priority = t.priority` references `tasks` (the
+    // state relation) but NOT `t` (which is bound by the quantifier). The
+    // walker must respect the binder's scope.
+    val expr = Expr.Quantifier(
+      QuantKind.All,
+      List(QuantifierBinding("t", Expr.Identifier("tasks"), BindingKind.In)),
+      Expr.BinaryOp(
+        BinOp.Eq,
+        Expr.FieldAccess(Expr.Identifier("t"), "priority"),
+        Expr.FieldAccess(Expr.Identifier("t"), "priority")
+      )
+    )
+    val refs = EvalIR.referencedStateNames(expr, Set.empty)
+    assert(refs.contains("tasks"), s"must include the relation `tasks`: $refs")
+    assert(!refs.contains("t"), s"must exclude the bound var `t`: $refs")
+    assert(!refs.contains("priority"), s"must exclude field names: $refs")

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -296,6 +296,54 @@ wrapper: `evalAt(StateMode.Pre, schema, StatePair.diag(st), env, e)`. The diagon
 stays bit-for-bit identical. New `EvalIR.evalAt` / `evalInvariantBodyAt` / `evalRequiresAt` give
 Phase 5.c the mode-aware hooks it needs without touching the existing API.
 
+**Phase 5.e — Per-clause partial recognition + set/map updates + op-input parameter seeding.**
+
+Closes the M_L.4.b-ext follow-up backlog from #194. Three coordinated changes:
+
+(i) **`EnsuresAnalysis` shape change.** The previous `Recognized | Unrecognized` enum becomes a
+single `EnsuresAnalysis(updates: List[StateUpdate], unknownFields: Set[String])`. The synthesizer no
+longer declines on the first unrecognised clause; instead it carries forward a partial post-state
+plus the set of "touched-but-unanalysable" field names. The cert renderer gates emission against the
+invariant body's referenced state names — if `unknownFields ∩ invariantReads = ∅`, the cert is
+honest; otherwise it stubs out.
+
+(ii) **Set/map update extraction.** New `StateUpdate { Scalar | AddRelationDom | AddLookups }`
+ctors. The synthesizer recognises:
+
+- `Prime(Identifier(name)) = base + SetLiteral([elems])` → `Scalar` (if name lives in scalars as
+  `VSet`) + `AddRelationDom` (the set's elements become the relation domain).
+- `Prime(Identifier(name)) = base + MapLiteral([entries])` → `AddLookups` (key→value pairs)
+  - `AddRelationDom` (the map's value list, since `forallRel` over a Map iterates over values).
+
+(iii) **Op-input parameter seeding.** `seedContextForOp` is the upgraded seeder: it returns a
+`(pre, env)` `SeededContext`, with the env binding op-input parameters to candidate values.
+Cross-product over scalar candidates × param candidates, capped at 128 to keep emit latency bounded.
+The renderer threads the seeded `env` into the cert via a new `renderEnvLit`, so closed Lean
+evaluation sees the same parameter bindings the synthesizer used.
+
+A fourth change rides along: the previous classify-on-ensures gate is lifted. Ensures clauses are
+consumed by the synthesizer (NOT rendered into the cert), so out-of-subset ensures shapes
+(`MapLiteral`, etc.) are fine — the synthesizer recognises set/map-add structurally and unrecognised
+clauses surface via `unknownFields`. Lifting the gate flipped 8+ preservation certs in `edge_cases`
+from stubs to `cert_decide` (output-only ensures clauses where the invariant doesn't read the
+touched output names).
+
+Final pinned counts (post Phase 5.e), CI-asserted in `.github/workflows/lean-certs.yml`:
+
+| Fixture       | cert_decide | trivial | Δ vs 5.d        |
+| ------------- | ----------- | ------- | --------------- |
+| safe_counter  | 5           | 0       | no change       |
+| set_ops       | 14          | 11      | +8 cert_decide  |
+| auth_service  | 2           | 61      | no change       |
+| url_shortener | 2           | 17      | no change       |
+| todo_list     | 5           | 48      | +1 cert_decide  |
+| edge_cases    | 18          | 41      | +10 cert_decide |
+
+`sbt verify/test` 198/198 (6 new). `sbt scalafmtCheckAll` clean. `sbt scalafixAll --check` clean.
+All six lean-certs CI bundles emit + `lake build` clean.
+
+No Lean changes; lakefile.toml unchanged from Phase 5.c (0.23.0).
+
 **Phase 5.d — Identity ensures + per-op pre-state seeding + CI count assertions.**
 
 (A) `EvalIR.synthesizePostState` recognises identity assignments structurally without evaluating the

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -251,14 +251,36 @@ Phase 3c.3 additions:
 - **The universal `theorem soundnessAt` itself** (~600 LOC structural induction on `Expr`
   generalizing `env` and `mode`).
 
-**Out of Phase 3c.3, queued for Phase 4/5:**
+**Phase 4a — `Expr.withRec` joins the Lean IR shell (this PR).** Single-field shape
+`Expr.withRec (base : Expr) (fld : String) (value : Expr)` — multi-field updates lower to chained
+applications. The fixed-arity shape avoids the nested-induction issue that `List (String × Expr)`
+would introduce.
 
-- Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
-  Adds the off-diagonal soundness claim for `With e`-shaped expressions (currently rejected by
-  `VerifiedSubset.classify`).
-- Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
-  `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
-  defaults. `safe_counter` invariant-preservation cert flips from stub to `cert_decide`.
+Always-fail semantics until Phase 4b:
+
+```text
+eval        s st env (.withRec _ _ _)        = none
+evalAt mode s sp env (.withRec _ _ _)        = none
+translate           (.withRec _ _ _)         = .div (.iLit 0) (.iLit 0)
+                                                  ^^ smtEval = none (div-by-zero)
+```
+
+Universal `soundness` and `soundnessAt` arms close trivially: both sides yield `none`. Discharged
+via `smtEval_div_zero` / `smtEvalAt_div_zero`.
+
+`VerifiedSubset.classify` continues to reject `Expr.With` so the cert emitter never invokes
+`translate` on a With expression — **no false claims emitted**. The Lean-side IR shell now mirrors
+the Scala IR shape, satisfying the A6 audit (every Expr ctor has a soundness arm) without committing
+to Skolem semantics.
+
+**Out of Phase 4a, queued for Phase 4b/5:**
+
+- Phase 4b — proper Skolem encoding for `withRec` per `Translator.scala:1061-1098`. Real
+  off-diagonal soundness for `With e`-shaped expressions. Lifts `VerifiedSubset.classify` to accept
+  With.
+- Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `Emit.scala` renders `StatePair`
+  literals; demo-state synthesis produces per-mode defaults. `safe_counter` invariant-preservation
+  cert flips from stub to `cert_decide`.
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -296,6 +296,36 @@ wrapper: `evalAt(StateMode.Pre, schema, StatePair.diag(st), env, e)`. The diagon
 stays bit-for-bit identical. New `EvalIR.evalAt` / `evalInvariantBodyAt` / `evalRequiresAt` give
 Phase 5.c the mode-aware hooks it needs without touching the existing API.
 
+**Phase 5.d — Identity ensures + per-op pre-state seeding + CI count assertions.**
+
+(A) `EvalIR.synthesizePostState` recognises identity assignments structurally without evaluating the
+RHS: `state' = state` and `state' = pre(state)` (and their commutations) are no-ops by definition.
+Crucial for non-scalar fields (Map/relation) where eval of `Identifier(name)` returns None — the
+value-eval path would otherwise mis-classify them as Unrecognized.
+
+(C) `EvalIR.seedPreStateForOp` picks a per-(op, invariant) pre-state where both the operation's
+`requires` and the invariant hold. Bounded brute-force over a small candidate space per scalar (Int:
+0/±1/±5/±10; Bool: false/true; Enum: each member); cap of 64 candidates total to keep emit latency
+bounded. Falls back to demo when no candidate satisfies. This makes preservation certs non-vacuous:
+e.g., `safe_counter.Decrement` now seeds `pre.count = 1` and synthesises `post.count = 0`,
+exercising the actual post-state machinery rather than vacuous-via-requires.
+
+(D) `.github/workflows/lean-certs.yml` pins `expected_cert` and `expected_trivial` per fixture in
+the matrix and asserts them post-emit. Drift fails CI with a localized error directing readers at
+the matrix entry to bump if the change was intentional. Final pinned counts:
+
+| Fixture       | cert_decide | trivial |
+| ------------- | ----------- | ------- |
+| safe_counter  | 5           | 0       |
+| set_ops       | 6           | 19      |
+| auth_service  | 2           | 61      |
+| url_shortener | 2           | 17      |
+| todo_list     | 4           | 49      |
+| edge_cases    | 8           | 51      |
+
+`sbt verify/test` 192/192 (6 new). `sbt scalafmtCheckAll` clean. `sbt scalafixAll --check` clean.
+`lake build` (proofs/lean) unchanged.
+
 **Phase 5.c — Operation invariant-preservation certs.** Per (operation × invariant) pair, emit:
 
 ```text

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -112,47 +112,50 @@ single-state behavior — see §M_L.4.b-ext below.
 | `With`                                         | `first ship`  | `deferred (M_L.4.b-ext)` |
 | Two-state coupling via `OperationDecl.ensures` | `first ship`  | `deferred (M_L.4.b-ext)` |
 
-### M_L.4.b-ext — True two-state Prime/Pre Phase 1 (issue #194)
+### M_L.4.b-ext — True two-state Prime/Pre, phased ship (issue #194)
 
-**Phase 1 — carrier scaffolding (this PR).** Lands the `StatePair` / `StateMode` carrier in
-`SpecRest/Semantics.lean` and a mode-aware evaluator `evalAt`. Strictly additive: every existing
-single-state call site, lemma, and per-case soundness theorem about `eval` continues to hold
-verbatim, because the new diagonal-collapse theorem `evalAt_diagonal_eq_eval` proves
-`evalAt mode s (StatePair.diag st) env e = eval s st env e` for every mode and every Expr.
+**Phase 1 — Lean-side carrier (PR #200, merged).** Landed `StatePair` / `StateMode` / `StatePair.at`
+/ `StatePair.diag` and a mode-aware evaluator `evalAt` in `Semantics.lean`. The diagonal-collapse
+theorem `evalAt_diagonal_eq_eval` proves `evalAt mode s (StatePair.diag st) env e = eval s st env e`
+for every mode and every Expr, so every existing per-case soundness theorem about `eval` continues
+to hold verbatim.
+
+**Phase 2 — SMT-side mirror (this PR).** Strictly additive on the SmtTerm / SmtModel data; the only
+change to existing proofs is a one-line update to the universal soundness `prime` / `pre` arms
+(still single-state, still zero `sorry`). Adds:
 
 ```text
-inductive StateMode      | pre | post
-structure StatePair      pre, post : State
-def StatePair.at         StatePair → StateMode → State
-def StatePair.diag       State → StatePair       -- diagonal: { pre := st; post := st }
-def evalAt               StateMode → Schema → StatePair → Env → Expr → Option Value
-theorem evalAt_diagonal_eq_eval
-                         evalAt mode s (StatePair.diag st) env e = eval s st env e
-theorem evalAt_prime     evalAt mode s sp env (.prime e) = evalAt .post s sp env e
-theorem evalAt_pre       evalAt mode s sp env (.pre   e) = evalAt .pre  s sp env e
+SmtTerm.prime / SmtTerm.pre        -- mode-tagging wrappers; smtEval treats as identity
+SmtModelPair { pre, post : SmtModel }, .at, .diag, simp lemmas
+smtEvalAt : StateMode → SmtModelPair → SmtEnv → SmtTerm → Option SmtVal
+                                     mutual with smtEvalAtForallEnum / smtEvalAtForallRel
+                                     state lookups read through (mp.at mode)
+                                     .prime t flips mode to .post; .pre t flips to .pre
+smtEvalAt_diagonal_eq_smtEval      smtEvalAt mode (SmtModelPair.diag m) env t = smtEval m env t
+smtEvalAt_prime / smtEvalAt_pre    mode-flip characterizations
+correlateModelPair s sp            { pre := correlateModel s sp.pre; post := correlateModel s sp.post }
+soundnessAt_diagonal               diagonal-mode-aware soundness — derived corollary,
+                                     no fresh structural induction (composes the two diagonal
+                                     collapses with the existing single-state soundness)
 ```
 
-`evalAt`'s identifier / member / cardRel / forallRel / indexRel / fieldAccess arms read state
-through `sp.at mode`. `Prime e` flips mode to `.post`; `Pre e` flips to `.pre`. Exactly mirrors the
-mutable-`stateMode` flow inside `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`
-(`StateMode { Pre, Post }` enum at line 17, `withStateMode(ctx, ...)` flow at line 599, identifier
-resolution at line 1160-1190).
+Translate.lean now emits `.prime (translate e)` / `.pre (translate e)` for `Expr.prime` /
+`Expr.pre`. The universal `soundness` theorem's two affected arms (`prime e ih` / `pre e ih`) gain a
+one-line `rw [smtEval_prime]` / `rw [smtEval_pre]` to peel the new identity wrapper; single-state
+collapse claim unchanged.
 
-**Out of Phase 1, queued for follow-up phases:**
+**Out of Phase 2, queued for follow-up phases:**
 
-- Phase 2 — SMT-side mirror (`SmtModelPair`, `smtEvalAt`) and emit-side `Translate.lean` arms for
-  mode-tagged `.prime` / `.pre`. Diagonal-collapse twin lifts the existing `soundness` theorem to a
-  corollary `soundnessAt_diagonal` for free.
 - Phase 3 — full off-diagonal universal `soundnessAt` via fresh structural induction. Per-case
-  cascade through the ~1900 LOC currently in `Soundness.lean`. Multi-week effort per the issue's 6-8
-  person-week estimate.
+  cascade through `Soundness.lean`'s ~1900 LOC. Multi-week effort per the issue's 6-8 person-week
+  estimate.
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
   defaults. `safe_counter` invariant-preservation cert flips to `cert_decide`.
 
 The `single-state collapse` notes elsewhere in this file remain factually correct for the current
-shipped `eval` API. Phase 3 is what removes them.
+shipped `eval` / `smtEval` / `soundness` API. Phase 3 is what removes them.
 
 ### M_L.4.k — Nested FieldAccess (entity-id-keyed carrier) (closed in this PR)
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -284,6 +284,41 @@ Closes with **zero `sorry`**, structural induction unchanged in shape; depth gro
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
   defaults. `safe_counter` invariant-preservation cert flips from stub to `cert_decide`.
 
+**Phase 5.a — Scala-side `Expr.With` cert acceptance.** `VerifiedSubset.classify` accepts With
+(recurses on base + update values); `EvalIR.Value.VEntityWith` chain carrier mirrors Lean
+`Value.vEntityWith`; `EvalIR.fieldLookup` walks the chain (override-first, fall back to base);
+`Emit.renderValueLit` / `renderExpr` produce `.vEntityWith` and `.withRec` Lean output. End-to-end
+`--emit-cert` + `lake build` clean across all CI fixtures.
+
+**Phase 5.b — `StatePair` + `StateMode` + mode-aware `evalAt`.** Single-state `eval` is now a thin
+wrapper: `evalAt(StateMode.Pre, schema, StatePair.diag(st), env, e)`. The diagonal-collapse property
+(Lean `evalAt_diagonal_eq_eval`) holds by definition, so all existing single-state cert emission
+stays bit-for-bit identical. New `EvalIR.evalAt` / `evalInvariantBodyAt` / `evalRequiresAt` give
+Phase 5.c the mode-aware hooks it needs without touching the existing API.
+
+**Phase 5.c — Operation invariant-preservation certs.** Per (operation × invariant) pair, emit:
+
+```text
+theorem cert_op_<i>_<opName>_preserves_<j>_<invName> :
+    evalPreservation <schema> <statePair> [] <reqs> <inv> = some <expected> := by cert_decide
+```
+
+where `<statePair>` carries the demo `pre` and a synthesised `post`. Post-state synthesis extracts
+`Prime(Identifier(name)) = rhs` assignments from the operation's ensures (with And- flattening); RHS
+containing `Prime` is conservatively rejected to avoid silent fixed-point mismatch.
+`evalPreservation` is the weak preservation form: if `requires` violates the pre-state, preservation
+is vacuously true (operation is disabled); otherwise the invariant must hold in the post-state. Lean
+adds `evalInvariantAt` / `evalRequiresAllAt` / `evalEnsuresAllAt` / `evalPreservation` to
+`Semantics.lean`.
+
+Closed: `safe_counter` emits 5 cert_decide (was 3): 1 invariant + 2 requires + 2 preservation.
+Increment closes via post.count = pre.count + 1 ≥ 0; Decrement closes vacuously since
+`requires: count > 0` rejects the demo pre-state's `count = 0`. All 4 lean-certs CI fixtures
+(safe_counter / set_ops / auth_service / url_shortener) emit and `lake build` cleanly.
+
+`lakefile.toml` 0.22.0 → 0.23.0. `lake build` clean, zero `sorry`. `sbt verify/test` 186/186 (8 new
+in Phase 5.c).
+
 The `single-state collapse` notes elsewhere in this file remain factually correct for the current
 shipped `eval` / `smtEval` / `soundness` API. Phase 3c is what removes them.
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -223,12 +223,42 @@ The cmp helpers are intricate because the translator emits different SmtTerm sha
 `.eq`, neq → `.not (.eq)`, lt → `.lt`, le → `.or (.lt) (.eq)`, gt → `.lt` (swapped), ge →
 `.or (.lt swapped) (.eq)`); each op's failure path handles the specific SmtTerm structure.
 
-**Out of Phase 3c.2, queued for Phase 3c.3:**
+**Phase 3c.3 — universal `soundnessAt` theorem closes (this PR).** This is the structural-induction
+hookup that ties every per-case `soundnessAt_*` (Phases 3a/3b) and every failure-path helper (Phases
+3c.1/3c.2) into a single universal claim:
 
-- Phase 3c.3 — the remaining cmp shape-failure helpers (le/gt/ge variants of `cmp_*_lhs_nonInt_at`
-  and `cmp_*_rhs_nonInt_lhs_int_at`) plus the universal `soundnessAt` theorem proper (~836 LOC
-  mechanically mirroring `soundness`). Closes #194's first acceptance criterion (off-diagonal
-  soundness).
+```text
+theorem soundnessAt (mode : StateMode) (e : Expr) :
+    valueToSmt? (evalAt mode s sp env e)
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e)
+```
+
+for every Expr `e`, every mode, every StatePair, every env. Mirrors the single-state universal
+`soundness` (lines 1819-2655 of `Soundness.lean`) with carriers substituted (`eval` → `evalAt`,
+`smtEval` → `smtEvalAt`, `correlateModel` → `correlateModelPair`).
+
+**This closes #194's first acceptance criterion (off-diagonal soundness).**
+
+Phase 3c.3 additions:
+
+- 6 remaining cmp shape-failure helpers in `Soundness.lean`: `cmp_le_lhs_nonInt_at`,
+  `cmp_le_rhs_nonInt_lhs_int_at`, `cmp_gt_lhs_nonInt_at`, `cmp_gt_rhs_nonInt_lhs_int_at`,
+  `cmp_ge_lhs_nonInt_at`, `cmp_ge_rhs_nonInt_lhs_int_at`.
+- `smtEvalAt_enumElemConst_nonMember` failure helper in `Smt.lean`.
+- 6 `evalAt_*` set-op failure characterizations in `Lemmas.lean`: `setInsert_elem_none`,
+  `setInsert_set_none`, `setInsert_set_nonSet`, `setMember_elem_none`, `setMember_set_none`,
+  `setMember_set_nonSet`.
+- **The universal `theorem soundnessAt` itself** (~600 LOC structural induction on `Expr`
+  generalizing `env` and `mode`).
+
+**Out of Phase 3c.3, queued for Phase 4/5:**
+
+- Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
+  Adds the off-diagonal soundness claim for `With e`-shaped expressions (currently rejected by
+  `VerifiedSubset.classify`).
+- Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
+  `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
+  defaults. `safe_counter` invariant-preservation cert flips from stub to `cert_decide`.
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -144,18 +144,44 @@ Translate.lean now emits `.prime (translate e)` / `.pre (translate e)` for `Expr
 one-line `rw [smtEval_prime]` / `rw [smtEval_pre]` to peel the new identity wrapper; single-state
 collapse claim unchanged.
 
-**Out of Phase 2, queued for follow-up phases:**
+**Phase 3a — per-case off-diagonal `soundnessAt_*` theorems (this PR).** Strictly additive; the
+existing universal `soundness` theorem is unchanged. Adds 22 per-case `soundnessAt_*` theorems
+covering leaf / propositional / arithmetic / comparison / `letIn` / `enumAccess_known` /
+`ident_local` / `Prime` / `Pre` constructors, plus the load-bearing bridge:
 
-- Phase 3 — full off-diagonal universal `soundnessAt` via fresh structural induction. Per-case
-  cascade through `Soundness.lean`'s ~1900 LOC. Multi-week effort per the issue's 6-8 person-week
-  estimate.
+```text
+correlateModelPair_at  (correlateModelPair s sp).at mode = correlateModel s (sp.at mode)
+```
+
+This bridge lets state-touching cases (Phase 3b) lift via the existing `correlateModel_*` lemmas
+without rewriting them. Each per-case theorem mirrors the single-state `soundness_*` shape:
+
+```text
+eval s st           ↦  evalAt mode s sp
+smtEval m           ↦  smtEvalAt mode mp
+correlateModel s st ↦  correlateModelPair s sp
+```
+
+Foundational helpers added: `evalAt_*` characterizations in `Lemmas.lean` (atomic / propositional /
+arithmetic / comparison / letIn / enumAccess); `smtEvalAt_*` characterizations in `Smt.lean`
+(parallel set, including arithmetic-failure cases for `div`).
+
+**Out of Phase 3a, queued for follow-up phases:**
+
+- Phase 3b — state-touching cases (`ident_state`, `member`, `cardRel`, `indexRel`, `fieldAccess`),
+  quantifier cases (`forallEnum`, `forallRel` — need parallel mutual lemmas to
+  `evalForallEnum_correlated` / `evalForallRel_correlated`), and set-op cases (`setEmpty`,
+  `setInsert_resolved`, `setMember_resolved`, `setBin_sets`).
+- Phase 3c — universal `soundnessAt` theorem stitching together every per-case via structural
+  induction on `Expr`. This is the off-diagonal claim that closes the issue's first acceptance
+  criterion.
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
   defaults. `safe_counter` invariant-preservation cert flips to `cert_decide`.
 
 The `single-state collapse` notes elsewhere in this file remain factually correct for the current
-shipped `eval` / `smtEval` / `soundness` API. Phase 3 is what removes them.
+shipped `eval` / `smtEval` / `soundness` API. Phase 3c is what removes them.
 
 ### M_L.4.k — Nested FieldAccess (entity-id-keyed carrier) (closed in this PR)
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -190,11 +190,25 @@ structurally identical to their single-state counterparts with carriers swapped.
 
 All 31 success-path per-case `soundnessAt_*` theorems for the verified subset now exist.
 
-**Out of Phase 3b, queued for Phase 3c:**
+**Phase 3c.1 — off-diagonal failure-path helpers (this PR).** Strictly additive: ~33 new
+`smtEvalAt_*` failure-path lemmas in `Smt.lean`, parallel to the single-state
+`smtEval_*_none/ _nonBool/_nonInt/_nonSet` helpers used by the universal `soundness` theorem. Each
+is a 2-7 line `simp only [smtEvalAt, h]` proof. Coverage: unary (not/neg × none/nonBool|nonInt),
+boolean (and/or/implies × lhs/rhs × none/nonBool), comparison (eq/lt × lhs/rhs × none/nonInt),
+arithmetic (add/sub/mul/div × lhs/rhs × none/nonInt), letIn, set ops
+(insert/member/union/intersect/diff × elem|lhs|rhs × none/nonSet).
 
-- Phase 3c — universal `soundnessAt` theorem stitching every per-case via structural induction on
-  `Expr`. Requires failure-path helpers (`smtEvalAt_*_none/_nonBool/_nonInt` etc.) parallel to those
-  in `Smt.lean`. This closes #194's first acceptance criterion (off-diagonal soundness).
+These helpers exist to be consumed by Phase 3c.2's universal `soundnessAt` structural induction.
+Each constructor's failure arm will dispatch to these helpers (parallel to how single-state
+`soundness` dispatches to `smtEval_*_none` etc.).
+
+**Out of Phase 3c.1, queued for Phase 3c.2:**
+
+- Phase 3c.2 — universal `soundnessAt` theorem stitching every per-case via structural induction on
+  `Expr`. Mirrors the existing `soundness`'s ~836-LOC case-by-case structure. With every per-case
+  `soundnessAt_*` (Phases 3a/3b) and every required failure helper (Phase 3c.1) in place, the
+  universal hookup is mechanically tractable. Closes #194's first acceptance criterion (off-diagonal
+  soundness).
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -166,8 +166,9 @@ Foundational helpers added: `evalAt_*` characterizations in `Lemmas.lean` (atomi
 arithmetic / comparison / letIn / enumAccess); `smtEvalAt_*` characterizations in `Smt.lean`
 (parallel set, including arithmetic-failure cases for `div`).
 
-**Phase 3b — state-touching / set-op / quantifier per-case theorems (this PR).** Adds 9 per-case
-`soundnessAt_*` theorems plus 2 parallel mutual-induction lemmas:
+**Phase 3b — state-touching / set-op / quantifier per-case theorems (this PR).** Adds 11 per-case
+`soundnessAt_*` theorems plus 2 parallel mutual-induction lemmas
+(`setEmpty / setInsert_resolved / setMember_resolved / setBin_sets` is a four-theorem bullet):
 
 ```text
 soundnessAt_ident_state       state-scalar lookup; lifts via correlateModelPair_at
@@ -202,7 +203,7 @@ These helpers exist to be consumed by Phase 3c.2's universal `soundnessAt` struc
 Each constructor's failure arm will dispatch to these helpers (parallel to how single-state
 `soundness` dispatches to `smtEval_*_none` etc.).
 
-**Phase 3c.2 — off-diagonal private failure-path helpers (this PR).** Strictly additive: 8 new
+**Phase 3c.2 — off-diagonal private failure-path helpers (this PR).** Strictly additive: 10 new
 private helpers in `Soundness.lean`, parallel to the existing single-state private helpers used by
 `soundness`'s case dispatch:
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -166,15 +166,35 @@ Foundational helpers added: `evalAt_*` characterizations in `Lemmas.lean` (atomi
 arithmetic / comparison / letIn / enumAccess); `smtEvalAt_*` characterizations in `Smt.lean`
 (parallel set, including arithmetic-failure cases for `div`).
 
-**Out of Phase 3a, queued for follow-up phases:**
+**Phase 3b — state-touching / set-op / quantifier per-case theorems (this PR).** Adds 9 per-case
+`soundnessAt_*` theorems plus 2 parallel mutual-induction lemmas:
 
-- Phase 3b — state-touching cases (`ident_state`, `member`, `cardRel`, `indexRel`, `fieldAccess`),
-  quantifier cases (`forallEnum`, `forallRel` — need parallel mutual lemmas to
-  `evalForallEnum_correlated` / `evalForallRel_correlated`), and set-op cases (`setEmpty`,
-  `setInsert_resolved`, `setMember_resolved`, `setBin_sets`).
-- Phase 3c — universal `soundnessAt` theorem stitching together every per-case via structural
-  induction on `Expr`. This is the off-diagonal claim that closes the issue's first acceptance
-  criterion.
+```text
+soundnessAt_ident_state       state-scalar lookup; lifts via correlateModelPair_at
+soundnessAt_member_resolved   state-relation membership
+soundnessAt_cardRel_resolved  state-relation cardinality
+soundnessAt_indexRel_resolved state-relation pair lookup
+soundnessAt_fieldAccess_resolved entity-field lookup
+soundnessAt_setEmpty / _setInsert_resolved / _setMember_resolved / _setBin_sets
+evalAtForallEnum_correlated   parallel mutual lemma (members induction)
+soundnessAt_forallEnum_known  enum-quantifier closure
+evalAtForallRel_correlated    parallel mutual lemma (domain induction)
+soundnessAt_forallRel_known   state-relation-quantifier closure
+```
+
+State-touching cases reuse the existing single-state correlateModel lemmas via
+`correlateModelPair_at`'s rewrite:
+`(correlateModelPair s sp).at mode = correlateModel s (sp.at mode)`. Set-op cases reuse
+`dedupeValues_map_valueToSmt`, `setUnionValues_map_valueToSmt`, etc. Quantifier mutual lemmas are
+structurally identical to their single-state counterparts with carriers swapped.
+
+All 31 success-path per-case `soundnessAt_*` theorems for the verified subset now exist.
+
+**Out of Phase 3b, queued for Phase 3c:**
+
+- Phase 3c — universal `soundnessAt` theorem stitching every per-case via structural induction on
+  `Expr`. Requires failure-path helpers (`smtEvalAt_*_none/_nonBool/_nonInt` etc.) parallel to those
+  in `Smt.lean`. This closes #194's first acceptance criterion (off-diagonal soundness).
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -104,12 +104,55 @@ The post-M_L.2 first-ship table is now down to two items. Items previously liste
 `Pre`, `UnaryOp(Cardinality)`, `Quantifier(Some)` over enums) closed via M_L.4.b/c/d; `Index` closed
 in M_L.4.g; `FieldAccess` (bare-Identifier base) closed in M_L.4.h (this PR). `Quantifier(Some)`
 over state relations closed in M_L.4.f. The remaining two items both require the StatePair carrier
-refactor (M_L.4.b-ext).
+refactor (M_L.4.b-ext); Phase 1 of that refactor lands the carrier scaffolding without changing
+single-state behavior — see §M_L.4.b-ext below.
 
-| `Expr` case                                    | Profile stage | Status     |
-| ---------------------------------------------- | ------------- | ---------- |
-| `With`                                         | `first ship`  | `deferred` |
-| Two-state coupling via `OperationDecl.ensures` | `first ship`  | `deferred` |
+| `Expr` case                                    | Profile stage | Status                   |
+| ---------------------------------------------- | ------------- | ------------------------ |
+| `With`                                         | `first ship`  | `deferred (M_L.4.b-ext)` |
+| Two-state coupling via `OperationDecl.ensures` | `first ship`  | `deferred (M_L.4.b-ext)` |
+
+### M_L.4.b-ext — True two-state Prime/Pre Phase 1 (issue #194)
+
+**Phase 1 — carrier scaffolding (this PR).** Lands the `StatePair` / `StateMode` carrier in
+`SpecRest/Semantics.lean` and a mode-aware evaluator `evalAt`. Strictly additive: every existing
+single-state call site, lemma, and per-case soundness theorem about `eval` continues to hold
+verbatim, because the new diagonal-collapse theorem `evalAt_diagonal_eq_eval` proves
+`evalAt mode s (StatePair.diag st) env e = eval s st env e` for every mode and every Expr.
+
+```text
+inductive StateMode      | pre | post
+structure StatePair      pre, post : State
+def StatePair.at         StatePair → StateMode → State
+def StatePair.diag       State → StatePair       -- diagonal: { pre := st; post := st }
+def evalAt               StateMode → Schema → StatePair → Env → Expr → Option Value
+theorem evalAt_diagonal_eq_eval
+                         evalAt mode s (StatePair.diag st) env e = eval s st env e
+theorem evalAt_prime     evalAt mode s sp env (.prime e) = evalAt .post s sp env e
+theorem evalAt_pre       evalAt mode s sp env (.pre   e) = evalAt .pre  s sp env e
+```
+
+`evalAt`'s identifier / member / cardRel / forallRel / indexRel / fieldAccess arms read state
+through `sp.at mode`. `Prime e` flips mode to `.post`; `Pre e` flips to `.pre`. Exactly mirrors the
+mutable-`stateMode` flow inside `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala`
+(`StateMode { Pre, Post }` enum at line 17, `withStateMode(ctx, ...)` flow at line 599, identifier
+resolution at line 1160-1190).
+
+**Out of Phase 1, queued for follow-up phases:**
+
+- Phase 2 — SMT-side mirror (`SmtModelPair`, `smtEvalAt`) and emit-side `Translate.lean` arms for
+  mode-tagged `.prime` / `.pre`. Diagonal-collapse twin lifts the existing `soundness` theorem to a
+  corollary `soundnessAt_diagonal` for free.
+- Phase 3 — full off-diagonal universal `soundnessAt` via fresh structural induction. Per-case
+  cascade through the ~1900 LOC currently in `Soundness.lean`. Multi-week effort per the issue's 6-8
+  person-week estimate.
+- Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
+- Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
+  `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
+  defaults. `safe_counter` invariant-preservation cert flips to `cert_decide`.
+
+The `single-state collapse` notes elsewhere in this file remain factually correct for the current
+shipped `eval` API. Phase 3 is what removes them.
 
 ### M_L.4.k — Nested FieldAccess (entity-id-keyed carrier) (closed in this PR)
 

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -251,40 +251,38 @@ Phase 3c.3 additions:
 - **The universal `theorem soundnessAt` itself** (~600 LOC structural induction on `Expr`
   generalizing `env` and `mode`).
 
-**Phase 4a — `Expr.withRec` joins the Lean IR shell (this PR).** Single-field shape
+**Phase 4a — `Expr.withRec` joins the Lean IR shell.** Single-field shape
 `Expr.withRec (base : Expr) (fld : String) (value : Expr)` — multi-field updates lower to chained
 applications. The fixed-arity shape avoids the nested-induction issue that `List (String × Expr)`
 would introduce.
 
-Always-fail semantics until Phase 4b:
+**Phase 4b — Skolem encoding for `withRec` (this PR).** Real semantics for `withRec`, mirroring
+`Translator.scala:1061-1098`'s Skolem record-update encoding:
 
-```text
-eval        s st env (.withRec _ _ _)        = none
-evalAt mode s sp env (.withRec _ _ _)        = none
-translate           (.withRec _ _ _)         = .div (.iLit 0) (.iLit 0)
-                                                  ^^ smtEval = none (div-by-zero)
-```
+- `Value` extends with `vEntityWith (base : Value) (fld : String) (value : Value)` (chain carrier).
+- `SmtVal` extends with `sEntityWith` (parallel SMT-side carrier).
+- `Value.fieldLookup` / `SmtVal.fieldLookup` walk the chain: matches override on `fld` first, falls
+  back to base.
+- `eval`/`evalAt` for `withRec` evaluate base + value, wrap as `vEntityWith`.
+- `eval`/`evalAt` for `fieldAccess` route through `Value.fieldLookup`.
+- `translate (.withRec base fld value) = .withRec (translate base) fld (translate value)` — the SMT
+  side gets a parallel `SmtTerm.withRec` constructor.
+- `smtEval`/`smtEvalAt` mirror the Lean evaluator on `withRec` and `fieldAccess`.
+- New correlation lemma `fieldLookup_correlated` bridges `valueToSmt? ∘ Value.fieldLookup` and
+  `SmtVal.fieldLookup ∘ valueToSmt`. Recurses on the chain; reuses `lookupField_correlated` at the
+  `vEntity` base.
+- Universal `soundness` and `soundnessAt` carry full `withRec` arms; case analysis on `eval base` ×
+  `eval value` covers the three cases (none/none, some/none, some/some).
+- All non-entity arms in `cases v with` blocks (boolBin, arith, cmp, setBin, setInsert, setMember,
+  fieldAccess) extended with a `vEntityWith` clause via the existing failure-helper machinery.
 
-Universal `soundness` and `soundnessAt` arms close trivially: both sides yield `none`. Discharged
-via `smtEval_div_zero` / `smtEvalAt_div_zero`.
+Closes with **zero `sorry`**, structural induction unchanged in shape; depth grows by one per arm.
 
-`VerifiedSubset.classify` continues to reject `Expr.With` so the cert emitter never invokes
-`translate` on a With expression — **no false claims emitted**. The Lean-side IR shell now mirrors
-the Scala IR shape, satisfying the A6 audit (every Expr ctor has a soundness arm) without committing
-to Skolem semantics.
+**Out of Phase 4b, queued for Phase 5:**
 
-**Out of Phase 4a, queued for Phase 4b/5:**
-
-- Phase 4b — proper Skolem encoding for `withRec` per `Translator.scala:1061-1098`. Real
-  off-diagonal soundness for `With e`-shaped expressions. Lifts `VerifiedSubset.classify` to accept
-  With.
-- Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `Emit.scala` renders `StatePair`
-  literals; demo-state synthesis produces per-mode defaults. `safe_counter` invariant-preservation
-  cert flips from stub to `cert_decide`.
-- Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts
   `With`; `Emit.scala` renders `StatePair` literals; demo-state synthesis produces per-mode
-  defaults. `safe_counter` invariant-preservation cert flips to `cert_decide`.
+  defaults. `safe_counter` invariant-preservation cert flips from stub to `cert_decide`.
 
 The `single-state collapse` notes elsewhere in this file remain factually correct for the current
 shipped `eval` / `smtEval` / `soundness` API. Phase 3c is what removes them.

--- a/proofs/lean/STATUS.md
+++ b/proofs/lean/STATUS.md
@@ -202,12 +202,32 @@ These helpers exist to be consumed by Phase 3c.2's universal `soundnessAt` struc
 Each constructor's failure arm will dispatch to these helpers (parallel to how single-state
 `soundness` dispatches to `smtEval_*_none` etc.).
 
-**Out of Phase 3c.1, queued for Phase 3c.2:**
+**Phase 3c.2 — off-diagonal private failure-path helpers (this PR).** Strictly additive: 8 new
+private helpers in `Soundness.lean`, parallel to the existing single-state private helpers used by
+`soundness`'s case dispatch:
 
-- Phase 3c.2 — universal `soundnessAt` theorem stitching every per-case via structural induction on
-  `Expr`. Mirrors the existing `soundness`'s ~836-LOC case-by-case structure. With every per-case
-  `soundnessAt_*` (Phases 3a/3b) and every required failure helper (Phase 3c.1) in place, the
-  universal hookup is mechanically tractable. Closes #194's first acceptance criterion (off-diagonal
+```text
+soundnessAt_unNot_nonBool         unNot operand ≠ vBool
+soundnessAt_unNeg_nonInt          unNeg operand ≠ vInt
+boolBin_lhs_nonBool_at            boolBin lhs ≠ vBool (4 ops × 4 shapes)
+boolBin_rhs_nonBool_lhs_bool_at   boolBin rhs ≠ vBool given lhs = vBool
+arith_lhs_nonInt_at               arith lhs ≠ vInt (4 ops × 4 shapes)
+arith_rhs_nonInt_lhs_int_at       arith rhs ≠ vInt given lhs = vInt
+cmp_lhs_eval_none_at              cmp lhs evaluates to none (6 ops, per-op SmtTerm shape)
+cmp_rhs_eval_none_at              cmp rhs evaluates to none (6 ops, per-op SmtTerm shape)
+cmp_lt_lhs_nonInt_at              cmp .lt lhs ≠ vInt
+cmp_lt_rhs_nonInt_lhs_int_at      cmp .lt rhs ≠ vInt given lhs = vInt
+```
+
+The cmp helpers are intricate because the translator emits different SmtTerm shapes per op (eq →
+`.eq`, neq → `.not (.eq)`, lt → `.lt`, le → `.or (.lt) (.eq)`, gt → `.lt` (swapped), ge →
+`.or (.lt swapped) (.eq)`); each op's failure path handles the specific SmtTerm structure.
+
+**Out of Phase 3c.2, queued for Phase 3c.3:**
+
+- Phase 3c.3 — the remaining cmp shape-failure helpers (le/gt/ge variants of `cmp_*_lhs_nonInt_at`
+  and `cmp_*_rhs_nonInt_lhs_int_at`) plus the universal `soundnessAt` theorem proper (~836 LOC
+  mechanically mirroring `soundness`). Closes #194's first acceptance criterion (off-diagonal
   soundness).
 - Phase 4 — `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098`.
 - Phase 5 — Scala-side `EvalIR.State` extends to `StatePair`; `VerifiedSubset.classify` accepts

--- a/proofs/lean/SpecRest/IR.lean
+++ b/proofs/lean/SpecRest/IR.lean
@@ -60,6 +60,18 @@ inductive Expr where
   | setInsert (elem set : Expr)
   | setMember (elem set : Expr)
   | setBin (op : SetOp) (l r : Expr)
+  /-- Record-update: single-field shape `base with { fld := value }`. Multi-
+      field `with { f1 := v1, f2 := v2 }` lowers to chained applications
+      `(base.withRec f1 v1).withRec f2 v2`. Phase 4 of M_L.4.b-ext (issue
+      #194). Currently embedded with always-fail semantics: `eval` and
+      `evalAt` return `none`, `translate` emits a bottom SmtTerm whose
+      `smtEval` is `none`. `VerifiedSubset.classify` continues to reject
+      `With` so the cert emitter never translates it — no false claims.
+      Phase 4b will land proper Skolem semantics per
+      `Translator.scala:1061-1098`. The single-field shape avoids nested
+      induction (List × Expr would prevent the `induction` tactic from
+      handling Expr). -/
+  | withRec (base : Expr) (fld : String) (value : Expr)
   deriving Repr, Inhabited
 
 structure FieldDecl where

--- a/proofs/lean/SpecRest/IR.lean
+++ b/proofs/lean/SpecRest/IR.lean
@@ -62,15 +62,13 @@ inductive Expr where
   | setBin (op : SetOp) (l r : Expr)
   /-- Record-update: single-field shape `base with { fld := value }`. Multi-
       field `with { f1 := v1, f2 := v2 }` lowers to chained applications
-      `(base.withRec f1 v1).withRec f2 v2`. Phase 4 of M_L.4.b-ext (issue
-      #194). Currently embedded with always-fail semantics: `eval` and
-      `evalAt` return `none`, `translate` emits a bottom SmtTerm whose
-      `smtEval` is `none`. `VerifiedSubset.classify` continues to reject
-      `With` so the cert emitter never translates it — no false claims.
-      Phase 4b will land proper Skolem semantics per
-      `Translator.scala:1061-1098`. The single-field shape avoids nested
-      induction (List × Expr would prevent the `induction` tactic from
-      handling Expr). -/
+      `(base.withRec f1 v1).withRec f2 v2`. Phase 4b of M_L.4.b-ext (issue
+      #194) ships full Skolem semantics: `eval`/`evalAt` produce
+      `Value.vEntityWith bv fld v` chains and `translate` emits the parallel
+      `SmtTerm.withRec` per `Translator.scala:1061-1098`. Soundness closes
+      via `fieldLookup_correlated` in `Soundness.lean`. The single-field
+      shape avoids nested induction (List × Expr would prevent the
+      `induction` tactic from handling Expr). -/
   | withRec (base : Expr) (fld : String) (value : Expr)
   deriving Repr, Inhabited
 

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,42 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 3b (issue #194): off-diagonal per-case
+  `soundnessAt_*` theorems for the state-touching, set-op, and
+  quantifier constructors (9 per-case theorems + 2 mutual-induction
+  lemmas). Builds on Phase 3a; the universal `soundness` is unchanged.
+  Per-case theorems added:
+    - State-touching: `soundnessAt_ident_state`, `soundnessAt_member_resolved`,
+      `soundnessAt_cardRel_resolved`, `soundnessAt_indexRel_resolved`,
+      `soundnessAt_fieldAccess_resolved`. Each lifts via `correlateModelPair_at`
+      to reuse the existing single-state `correlateModel_*` lemmas.
+    - Set ops: `soundnessAt_setEmpty`, `soundnessAt_setInsert_resolved`,
+      `soundnessAt_setMember_resolved`, `soundnessAt_setBin_sets`. Reuse
+      the existing `dedupeValues_map_valueToSmt`,
+      `setUnionValues_map_valueToSmt`, etc. lifts.
+    - Quantifiers: parallel mutual-induction lemmas
+      `evalAtForallEnum_correlated` and `evalAtForallRel_correlated`,
+      structurally identical to the single-state versions but with
+      `evalAt` / `smtEvalAt` / `correlateModelPair` substituted. Each
+      threads the body's IH through every member of the enum / value
+      of the relation domain. Per-case `soundnessAt_forallEnum_known`
+      and `soundnessAt_forallRel_known` close the remaining quantifier
+      arms.
+  New helpers: ~17 `smtEvalAt_*` characterizations (var_const, inDom_*,
+  cardRel_*, indexRel_*, fieldAccess_*, forallEnum_*, forallRel_*,
+  setEmpty/setInsert_resolved/setMember_resolved, setUnion/Intersect/
+  Diff_sets) in `Smt.lean`; ~16 `evalAt_*` characterizations
+  (member_resolved/no_elem/no_relation, indexRel_*, fieldAccess_*,
+  setEmpty/setInsert_resolved/setMember_resolved/setBin_sets,
+  forallEnum_known/unknown, forallRel_known/unknown,
+  evalAtForallEnum_nil, evalAtForallRel_nil) in `Lemmas.lean`.
+  All 31 per-case `soundnessAt_*` theorems for the verified subset's
+  success paths now exist. Phase 3c (universal `soundnessAt` theorem
+  + failure-path helpers) remains; that's the structural-induction
+  hookup that closes #194's first acceptance criterion.
+  `lakefile.toml` bumped to 0.17.0. `lake build` clean, zero `sorry`,
+  zero warnings; `sbt verify/test` 165/165 green.
+
 2026-05-03 — M_L.4.b-ext Phase 3a (issue #194): off-diagonal per-case
   `soundnessAt_*` theorems for the leaf / propositional / arithmetic /
   comparison / `letIn` / `enumAccess_known` / `ident_local` / `Prime` /

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,39 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 2 (issue #194): SMT-side mirror.
+  Added two SmtTerm constructors (`.prime t`, `.pre t`) — single-state
+  identity in `smtEval`, mode-flipping in `smtEvalAt`. `Translate.lean`
+  now emits `.prime (translate e)` / `.pre (translate e)` for `Expr.prime`
+  / `Expr.pre`; the universal `soundness` theorem's `prime e` / `pre e`
+  arms now `rw [smtEval_prime] / [smtEval_pre]` to peel the new wrapper
+  before discharging via IH (single-state collapse claim unchanged —
+  zero `sorry` preserved).
+  New SMT carrier: `SmtModelPair { pre, post : SmtModel }`,
+  `SmtModelPair.at`, `SmtModelPair.diag`, simp lemmas. New mode-aware
+  evaluator `smtEvalAt` mutually recursive with `smtEvalAtForallEnum` /
+  `smtEvalAtForallRel`. The diagonal-collapse theorem
+  `smtEvalAt_diagonal_eq_smtEval` proves
+  `smtEvalAt mode (SmtModelPair.diag m) env t = smtEval m env t` for
+  every mode and every SmtTerm; mutual structural induction across all
+  30 SmtTerm constructors. Mode-flip characterizations
+  `smtEvalAt_prime` / `smtEvalAt_pre` mirror `evalAt_prime` / `evalAt_pre`.
+  New corollary `soundnessAt_diagonal` in `Soundness.lean` derives the
+  diagonal-mode-aware soundness statement from the existing single-state
+  `soundness` theorem via the two diagonal collapses + the new
+  `correlateModelPair` lift; no fresh structural induction needed for
+  the diagonal claim.
+  `Smt.lean` now imports `SpecRest.Semantics` so it can reference the
+  shared `StateMode` enum (single source of truth, mirrors
+  `Translator.scala:17`). `lakefile.toml` version bumped to 0.15.0.
+  Drift audits A1-A8 still pass; ProofDriftAuditTest fingerprints
+  unchanged (the audit pins `Expr` constructors and Soundness universal
+  arms, both untouched here).
+
+  Phase 3 (queued): off-diagonal universal `soundnessAt` via fresh
+  structural induction. Per-case cascade through `Soundness.lean`'s
+  ~1900 LOC. Multi-week effort per the issue's 6-8 person-week estimate.
+
 2026-05-03 — M_L.4.b-ext Phase 1 (issue #194): scaffolded the StatePair carrier
   in `Semantics.lean`. Added `StateMode { pre | post }`, `StatePair { pre, post
   : State }`, `StatePair.at`, `StatePair.diag`, and the mode-aware evaluator

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,34 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 3c.1 (issue #194): off-diagonal failure-path
+  helpers in `Smt.lean`. Strictly additive: ~33 new `smtEvalAt_*` lemmas
+  parallel to the single-state `smtEval_*_none/_nonBool/_nonInt/_nonSet`
+  helpers used by the universal `soundness` theorem. Each is a 2-7 line
+  `simp only [smtEvalAt, h]` proof, mechanically mirroring its single-state
+  twin. New helpers cover:
+    - Unary: not_none, not_nonBool, neg_none, neg_nonInt
+    - Boolean: and/or/implies × lhs/rhs × none/nonBool (12 helpers)
+    - Comparison: eq lhs/rhs none, lt lhs/rhs none/nonInt
+    - Arithmetic: add/sub/mul/div × lhs/rhs × none/nonInt (16 helpers)
+    - LetIn: letIn_none
+    - Set ops: setInsert/setMember × elem/set × none/nonSet,
+      setUnion/setIntersect/setDiff × lhs/rhs × none/nonSet (~20 helpers)
+  These helpers exist to be consumed by Phase 3c.2's universal `soundnessAt`
+  structural induction. Each constructor's failure arm in the universal
+  theorem dispatches to these helpers (parallel to how single-state
+  `soundness` dispatches to `smtEval_*_none` etc.).
+  No changes to `eval`, `smtEval`, `translate`, or the existing `soundness`
+  theorem. `lakefile.toml` bumped to 0.18.0. `lake build` clean, zero
+  `sorry`, zero warnings; `sbt verify/test` 165/165 green.
+
+  Phase 3c.2 (queued): universal `soundnessAt` theorem via structural
+  induction on `Expr`, mirroring the existing `soundness`'s ~836-LOC
+  case-by-case structure. With every per-case `soundnessAt_*` (Phases
+  3a/3b) and every required failure helper (this PR) in place, the
+  universal hookup is mechanically tractable. Closes #194's first
+  acceptance criterion.
+
 2026-05-03 — M_L.4.b-ext Phase 3b (issue #194): off-diagonal per-case
   `soundnessAt_*` theorems for the state-touching, set-op, and
   quantifier constructors (9 per-case theorems + 2 mutual-induction

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,45 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 3c.3 (issue #194): **CLOSES THE OFF-DIAGONAL
+  UNIVERSAL `soundnessAt` THEOREM** with zero `sorry`. This is the
+  structural-induction hookup that ties every per-case `soundnessAt_*`
+  (Phases 3a/3b) and every failure-path helper (Phases 3c.1/3c.2) into a
+  single universal claim:
+    valueToSmt? (evalAt mode s sp env e)
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e)
+  for every Expr `e`, every mode, every StatePair, every env. Closes #194's
+  first acceptance criterion.
+
+  Phase 3c.3 additions:
+    - 6 remaining cmp shape-failure helpers in `Soundness.lean`:
+      cmp_le_lhs_nonInt_at, cmp_le_rhs_nonInt_lhs_int_at,
+      cmp_gt_lhs_nonInt_at, cmp_gt_rhs_nonInt_lhs_int_at,
+      cmp_ge_lhs_nonInt_at, cmp_ge_rhs_nonInt_lhs_int_at — parallel to
+      lines 1509, 1531, 1556, 1595, 1615, 1654 of this file.
+    - `smtEvalAt_enumElemConst_nonMember` failure helper in `Smt.lean`.
+    - 6 `evalAt_*` set-op failure characterizations in `Lemmas.lean`:
+      setInsert_elem_none / setInsert_set_none / setInsert_set_nonSet /
+      setMember_elem_none / setMember_set_none / setMember_set_nonSet.
+    - The universal `theorem soundnessAt` itself: ~600 LOC structural
+      induction on `Expr` generalizing `env` and `mode`, mirroring the
+      single-state universal `soundness` (lines 1819-2655) with carriers
+      substituted (eval ↦ evalAt, smtEval ↦ smtEvalAt,
+      correlateModel ↦ correlateModelPair). Each constructor's success
+      path dispatches to its `soundnessAt_*` per-case theorem; failure
+      paths dispatch to `smtEvalAt_*_none/_nonBool/_nonInt/_nonSet`
+      helpers or to the private `*_at` shape-failure helpers
+      (boolBin_lhs_nonBool_at, arith_rhs_nonInt_lhs_int_at,
+      cmp_lt_lhs_nonInt_at, etc.).
+
+  STATUS: with `soundnessAt` closed, the off-diagonal soundness claim of
+  issue #194 is mechanically verified. Phase 4 (`With` constructor +
+  Skolem mirror) and Phase 5 (Scala-side mirrors + safe_counter cert
+  flip) remain queued.
+
+  `lakefile.toml` bumped to 0.20.0. `lake build` clean, zero `sorry`,
+  zero warnings; `sbt verify/test` 165/165 green.
+
 2026-05-03 — M_L.4.b-ext Phase 3c.2 (issue #194): off-diagonal failure-path
   private helpers in `Soundness.lean` for the universal `soundnessAt`
   theorem. Strictly additive: 8 new private helpers parallel to the

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,67 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 4b (issue #194): real Skolem encoding for
+  `Expr.withRec`, mirroring `Translator.scala:1061-1098`. Replaces the
+  Phase 4a always-fail placeholder.
+
+  Carrier additions:
+    - `Value.vEntityWith (base : Value) (fld : String) (value : Value)`
+      — chain carrier; structural recursion over `base` for fieldLookup.
+    - `SmtVal.sEntityWith` — parallel SMT-side carrier.
+    - `SmtTerm.withRec` — the parallel SMT term constructor.
+
+  New helpers:
+    - `Value.fieldLookup st v fld` — walks vEntityWith chain (override
+      first, fall back to base; vEntity → State.lookupField; otherwise
+      none).
+    - `SmtVal.fieldLookup m sv fld` — symmetric SMT-side mirror.
+    - `eval_fieldAccess_lookup` / `evalAt_fieldAccess_lookup` /
+      `smtEval_fieldAccess_lookup` / `smtEvalAt_fieldAccess_lookup` —
+      route fieldAccess through `*.fieldLookup`.
+    - `eval_fieldAccess_with` / `evalAt_fieldAccess_with` — fieldAccess on
+      a vEntityWith resolves via the override-then-fallback rule.
+    - `fieldLookup_correlated` — bridges `valueToSmt? ∘ Value.fieldLookup`
+      and `SmtVal.fieldLookup ∘ valueToSmt`. Recursive on the chain;
+      reuses `lookupField_correlated` at the vEntity base.
+
+  Real semantics:
+    - `eval s st env (.withRec base fld value)`:
+        match eval base, eval value with
+        | some bv, some v => some (.vEntityWith bv fld v)
+        | _, _            => none
+    - `evalAt mode s sp env (.withRec ...)` — same shape with `(sp.at mode)`.
+    - `translate (.withRec base fld value) = .withRec (translate base) fld
+      (translate value)`.
+    - `smtEval` / `smtEvalAt` mirror the Lean evaluator on `withRec`.
+    - `eval` / `evalAt` for `fieldAccess` route through `Value.fieldLookup`.
+
+  Universal `soundness` and `soundnessAt` carry full `withRec` arms; case
+  analysis on `eval base × eval value` covers all three branches
+  (none/none, some/none, some/some). Universal `fieldAccess` arms gain a
+  `vEntityWith` clause that uses `eval_fieldAccess_lookup` +
+  `smtEval_fieldAccess_lookup` + `fieldLookup_correlated`.
+
+  Strictly additive cascade through every `cases v with` block in
+  `Soundness.lean` (boolBin/arith/cmp/setBin/setInsert/setMember rhs and
+  lhs failure arms): each gets a parallel `vEntityWith wb wf wv` arm
+  using the existing `*_nonBool/_nonInt/_nonSet` helpers. ~30 new arms;
+  same proof shape as the existing `vSet` arms.
+
+  `lookupField_correlated` unchanged. `decEqValue` and `decEqSmtVal`
+  cascade extended with the new constructor (5 self + 10 cross pairs
+  on each side, mechanical `isFalse` discharge).
+
+  Closes with **zero `sorry`**, no axiom additions, structural induction
+  shape unchanged. `lakefile.toml` bumped to 0.22.0. `lake build` clean
+  (1.7s incremental); `sbt verify/test` 165/165 green.
+
+  Out-of-scope and queued for Phase 5: Scala-side `EvalIR.State` extends
+  to `StatePair`; `VerifiedSubset.classify` accepts `With`; `Emit.scala`
+  renders `StatePair` literals; demo-state synthesis produces per-mode
+  defaults. `safe_counter` invariant-preservation cert flips from stub
+  to `cert_decide`.
+
 2026-05-03 — M_L.4.b-ext Phase 4a (issue #194): `Expr.withRec` (record-update)
   joins the Lean Expr inductive with always-fail semantics. Phase 4b will
   ship the proper Skolem encoding per `Translator.scala:1061-1098`.

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,33 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 4a (issue #194): `Expr.withRec` (record-update)
+  joins the Lean Expr inductive with always-fail semantics. Phase 4b will
+  ship the proper Skolem encoding per `Translator.scala:1061-1098`.
+
+  Single-field shape: `Expr.withRec (base : Expr) (fld : String) (value :
+  Expr)`. Multi-field updates lower to chained applications. The fixed-arity
+  shape avoids the nested-induction issue that `List (String × Expr)` would
+  introduce: `induction` doesn't support nested inductive types.
+
+  Embedding (no false claims):
+    - `eval s st env (.withRec _ _ _)         = none`
+    - `evalAt mode s sp env (.withRec _ _ _)  = none`
+    - `translate (.withRec _ _ _)             = .div (.iLit 0) (.iLit 0)`
+                                                ^^ smtEval evaluates to none
+                                                   (div by zero)
+  Universal `soundness` and `soundnessAt` arms close trivially: both sides
+  yield `none`. Discharged via `smtEval_div_zero` / `smtEvalAt_div_zero`.
+
+  `VerifiedSubset.classify` continues to reject `Expr.With` so the cert
+  emitter never invokes `translate` on a With expression — no false claims
+  emitted. The Lean-side IR shell now mirrors the Scala IR shape, satisfying
+  the A6 audit (every Expr ctor has a soundness arm) without committing to
+  Skolem semantics. Phase 4b adds the proper encoding.
+
+  `lakefile.toml` bumped to 0.21.0. `lake build` clean, zero `sorry`,
+  zero warnings; `sbt verify/test` 165/165 green (all 8 drift audits).
+
 2026-05-03 — M_L.4.b-ext Phase 3c.3 (issue #194): **CLOSES THE OFF-DIAGONAL
   UNIVERSAL `soundnessAt` THEOREM** with zero `sorry`. This is the
   structural-induction hookup that ties every per-case `soundnessAt_*`

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,38 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 3a (issue #194): off-diagonal per-case
+  `soundnessAt_*` theorems for the leaf / propositional / arithmetic /
+  comparison / `letIn` / `enumAccess_known` / `ident_local` / `Prime` /
+  `Pre` constructors (22 cases). Strictly additive on existing data and
+  proofs; the universal `soundness` theorem is unchanged. Each per-case
+  theorem mirrors the single-state `soundness_*` shape, with carriers
+  threaded through the mode-aware evaluators:
+    - `eval s st`           → `evalAt mode s sp`
+    - `smtEval m`           → `smtEvalAt mode mp`
+    - `correlateModel s st` → `correlateModelPair s sp`
+  The new bridge theorem `correlateModelPair_at` proves
+  `(correlateModelPair s sp).at mode = correlateModel s (sp.at mode)`,
+  letting state-touching cases lift via the existing
+  `correlateModel_*` lemmas.
+  Foundational helpers added: `evalAt_*` characterizations in
+  `Lemmas.lean` (boolLit / intLit / ident_local / ident_state / unNot /
+  unNeg / boolBin / cmp / letIn / enumAccess); `smtEvalAt_*`
+  characterizations in `Smt.lean` (bLit / iLit / var_local /
+  enumElemConst_known / enumElemConst_unknown / not / and / or /
+  implies / eq / lt / neg / add / sub / mul / div_ints_nonZero /
+  div_zero / letIn). The Lemmas.lean entries take explicit args (not
+  inherited via `variable`) so call sites can pass them positionally.
+  Out of Phase 3a, queued for Phase 3b/c: state-touching cases
+  (`ident_state`, `member`, `cardRel`, `indexRel`, `fieldAccess`),
+  quantifier cases (`forallEnum`, `forallRel` — need parallel mutual
+  lemmas to `evalForallEnum_correlated` / `evalForallRel_correlated`),
+  set-op cases, and the universal `soundnessAt` theorem that ties them
+  together via structural induction on `Expr`. The universal theorem
+  closure is what unlocks the `safe_counter` invariant-preservation
+  cert (Phase 5). `lakefile.toml` bumped to 0.16.0. `lake build`
+  clean, zero `sorry`, zero warnings; `sbt verify/test` 165/165 green.
+
 2026-05-03 — M_L.4.b-ext Phase 2 (issue #194): SMT-side mirror.
   Added two SmtTerm constructors (`.prime t`, `.pre t`) — single-state
   identity in `smtEval`, mode-flipping in `smtEvalAt`. `Translate.lean`

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,29 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 1 (issue #194): scaffolded the StatePair carrier
+  in `Semantics.lean`. Added `StateMode { pre | post }`, `StatePair { pre, post
+  : State }`, `StatePair.at`, `StatePair.diag`, and the mode-aware evaluator
+  `evalAt` (mutually recursive with `evalAtForallEnum` / `evalAtForallRel`).
+  `evalAt mode s sp env (.prime e) = evalAt .post s sp env e` and
+  `evalAt mode s sp env (.pre e) = evalAt .pre s sp env e` — first time the
+  Lean side carries genuine two-state mode-flip semantics. Identifier /
+  member / cardRel / forallRel / indexRel / fieldAccess all read through
+  `sp.at mode`. The diagonal-collapse theorem `evalAt_diagonal_eq_eval` proves
+  `evalAt mode s (StatePair.diag st) env e = eval s st env e` for every mode
+  and every Expr in the verified subset, so every existing per-case soundness
+  theorem (stated against `eval`) lifts unchanged for the `pre = post` case.
+  No changes to `Smt.lean`, `Translate.lean`, `Soundness.lean`, `Lemmas.lean`,
+  `Cert.lean`, or `Examples.lean`. `lake build` clean, zero `sorry`, zero
+  warnings.
+
+  Phase 2 (queued, not in this commit): SMT-side mirror (`SmtModelPair`,
+  `smtEvalAt`) + diagonal-collapse twin; emit-side `Translate.lean` arms for
+  `.prime` / `.pre` that produce mode-tagged SmtTerms; corollary
+  `soundnessAt_diagonal` derived from existing `soundness` via the eval/smtEval
+  collapse lemmas. Phase 3: full off-diagonal soundness via fresh structural
+  induction (the multi-week cascade described in #194).
+
 2026-05-02 — M_L.4.k: generalised `Expr.fieldAccess` from
   `(scalarName fieldName : String)` to `(base : Expr) (fieldName : String)`.
   Carrier semantics shifted: `State.entityFields` and `SmtModel.predFields`

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -41,6 +41,37 @@ two-state semantics.
 Drift log
 ---------
 
+2026-05-03 — M_L.4.b-ext Phase 3c.2 (issue #194): off-diagonal failure-path
+  private helpers in `Soundness.lean` for the universal `soundnessAt`
+  theorem. Strictly additive: 8 new private helpers parallel to the
+  existing single-state private helpers used by `soundness`'s case
+  dispatch.
+    - `soundnessAt_unNot_nonBool` — unNot when operand ≠ vBool
+    - `soundnessAt_unNeg_nonInt` — unNeg when operand ≠ vInt
+    - `boolBin_lhs_nonBool_at` / `boolBin_rhs_nonBool_lhs_bool_at` —
+      4 boolBin ops × 4 non-bool shapes
+    - `arith_lhs_nonInt_at` / `arith_rhs_nonInt_lhs_int_at` — 4 arith
+      ops × 4 non-int shapes
+    - `cmp_lhs_eval_none_at` — 6 cmp ops × lhs-evaluates-to-none,
+      handling per-op SmtTerm shape (eq → `.eq`, neq → `.not (.eq)`,
+      lt → `.lt`, le → `.or (.lt) (.eq)`, gt → `.lt (swapped)`,
+      ge → `.or (.lt swapped) (.eq)`)
+    - `cmp_rhs_eval_none_at` — 6 cmp ops × rhs-evaluates-to-none,
+      same per-op SmtTerm shape handling
+    - `cmp_lt_lhs_nonInt_at` / `cmp_lt_rhs_nonInt_lhs_int_at` — `.lt`
+      shape failures
+  Mirror lines 561, 580, 1179, 1216, 1257, 1316, 1395, 1416, 1443, 1475
+  of this file (the existing private soundness helpers).
+  Phase 3c.3 (queued): the remaining cmp shape-failure helpers
+  (`cmp_le_lhs_nonInt_at`, `cmp_le_rhs_nonInt_lhs_int_at`,
+  `cmp_gt_lhs_nonInt_at`, `cmp_gt_rhs_nonInt_lhs_int_at`,
+  `cmp_ge_lhs_nonInt_at`, `cmp_ge_rhs_nonInt_lhs_int_at`) — parallel to
+  lines 1509, 1531, 1556, 1595, 1615, 1654 — and the universal
+  `soundnessAt` theorem proper (~836 LOC mechanically mirroring lines
+  1819-2655). Closes #194's first acceptance criterion.
+  `lakefile.toml` bumped to 0.19.0. `lake build` clean, zero `sorry`,
+  zero warnings; `sbt verify/test` 165/165 green.
+
 2026-05-03 — M_L.4.b-ext Phase 3c.1 (issue #194): off-diagonal failure-path
   helpers in `Smt.lean`. Strictly additive: ~33 new `smtEvalAt_*` lemmas
   parallel to the single-state `smtEval_*_none/_nonBool/_nonInt/_nonSet`

--- a/proofs/lean/SpecRest/IR.lean.todo
+++ b/proofs/lean/SpecRest/IR.lean.todo
@@ -170,7 +170,7 @@ Drift log
 
 2026-05-03 — M_L.4.b-ext Phase 3c.2 (issue #194): off-diagonal failure-path
   private helpers in `Soundness.lean` for the universal `soundnessAt`
-  theorem. Strictly additive: 8 new private helpers parallel to the
+  theorem. Strictly additive: 10 new private helpers parallel to the
   existing single-state private helpers used by `soundness`'s case
   dispatch.
     - `soundnessAt_unNot_nonBool` — unNot when operand ≠ vBool
@@ -229,8 +229,9 @@ Drift log
 
 2026-05-03 — M_L.4.b-ext Phase 3b (issue #194): off-diagonal per-case
   `soundnessAt_*` theorems for the state-touching, set-op, and
-  quantifier constructors (9 per-case theorems + 2 mutual-induction
-  lemmas). Builds on Phase 3a; the universal `soundness` is unchanged.
+  quantifier constructors (11 per-case theorems — 5 state-touching +
+  4 set-op + 2 quantifier — plus 2 mutual-induction lemmas).
+  Builds on Phase 3a; the universal `soundness` is unchanged.
   Per-case theorems added:
     - State-touching: `soundnessAt_ident_state`, `soundnessAt_member_resolved`,
       `soundnessAt_cardRel_resolved`, `soundnessAt_indexRel_resolved`,

--- a/proofs/lean/SpecRest/Lemmas.lean
+++ b/proofs/lean/SpecRest/Lemmas.lean
@@ -125,24 +125,48 @@ M_L.4.k generalised the constructor to take an arbitrary `Expr` base.
 The eval arm is a two-step lookup: evaluate the base to a `vEntity _ id`,
 then look up `id` in the entity-fields table. -/
 
+/-- Generic fieldAccess characterization (Phase 4b): fieldAccess routes
+    through `Value.fieldLookup`. The earlier `_resolved` and `_nonEntity`
+    lemmas are corollaries. -/
+theorem eval_fieldAccess_lookup (base : Expr) (v : Value) (fieldName : String)
+    (hBase : eval s st env base = some v) :
+    eval s st env (.fieldAccess base fieldName)
+      = Value.fieldLookup st v fieldName := by
+  simp only [eval, hBase]
+
 theorem eval_fieldAccess_resolved (base : Expr) (en id fieldName : String)
     (hBase : eval s st env base = some (.vEntity en id)) :
     eval s st env (.fieldAccess base fieldName)
       = st.lookupField id fieldName := by
-  simp only [eval, hBase]
+  rw [eval_fieldAccess_lookup s st env base (.vEntity en id) fieldName hBase]
+  simp only [Value.fieldLookup]
 
 theorem eval_fieldAccess_base_none (base : Expr) (fieldName : String)
     (hBase : eval s st env base = none) :
     eval s st env (.fieldAccess base fieldName) = none := by
   simp only [eval, hBase]
 
+/-- Phase 4b: fieldAccess on a `vEntityWith` resolves via `Value.fieldLookup`. -/
+theorem eval_fieldAccess_with (base : Expr) (b : Value) (ovFld : String) (ovValue : Value)
+    (fieldName : String)
+    (hBase : eval s st env base = some (.vEntityWith b ovFld ovValue)) :
+    eval s st env (.fieldAccess base fieldName)
+      = (if fieldName = ovFld then some ovValue
+         else Value.fieldLookup st b fieldName) := by
+  rw [eval_fieldAccess_lookup s st env base (.vEntityWith b ovFld ovValue) fieldName hBase]
+  simp only [Value.fieldLookup]
+
+/-- Phase 4b: when the base resolves to a value that's neither `vEntity` nor
+    `vEntityWith`, fieldAccess returns none. -/
 theorem eval_fieldAccess_nonEntity {base : Expr} {fieldName : String} {v : Value}
     (hBase : eval s st env base = some v)
-    (hNotEntity : ∀ en id, v ≠ .vEntity en id) :
+    (hNotEntity : ∀ en id, v ≠ .vEntity en id)
+    (hNotEntityWith : ∀ b f w, v ≠ .vEntityWith b f w) :
     eval s st env (.fieldAccess base fieldName) = none := by
-  simp only [eval, hBase]
+  rw [eval_fieldAccess_lookup s st env base v fieldName hBase]
   cases v with
   | vEntity en id => exact absurd rfl (hNotEntity en id)
+  | vEntityWith b f w => exact absurd rfl (hNotEntityWith b f w)
   | vBool _ => rfl
   | vInt _ => rfl
   | vEnum _ _ => rfl
@@ -496,12 +520,23 @@ theorem evalAt_indexRel_key_none (mode : StateMode) (s : Schema) (sp : StatePair
     evalAt mode s sp env (.indexRel relName key) = none := by
   simp only [evalAt, hKey]
 
+/-- Phase 4b: evalAt fieldAccess routes through `Value.fieldLookup` over
+    `(sp.at mode)`. The earlier `_resolved` and `_nonEntity` lemmas are
+    corollaries. -/
+theorem evalAt_fieldAccess_lookup (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (base : Expr) (v : Value) (fieldName : String)
+    (hBase : evalAt mode s sp env base = some v) :
+    evalAt mode s sp env (.fieldAccess base fieldName)
+      = Value.fieldLookup (sp.at mode) v fieldName := by
+  simp only [evalAt, hBase]
+
 theorem evalAt_fieldAccess_resolved (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
     (base : Expr) (en id fieldName : String)
     (hBase : evalAt mode s sp env base = some (.vEntity en id)) :
     evalAt mode s sp env (.fieldAccess base fieldName)
       = (sp.at mode).lookupField id fieldName := by
-  simp only [evalAt, hBase]
+  rw [evalAt_fieldAccess_lookup mode s sp env base (.vEntity en id) fieldName hBase]
+  simp only [Value.fieldLookup]
 
 theorem evalAt_fieldAccess_base_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
     (base : Expr) (fieldName : String)
@@ -509,14 +544,26 @@ theorem evalAt_fieldAccess_base_none (mode : StateMode) (s : Schema) (sp : State
     evalAt mode s sp env (.fieldAccess base fieldName) = none := by
   simp only [evalAt, hBase]
 
+/-- Phase 4b: evalAt fieldAccess on `vEntityWith`. -/
+theorem evalAt_fieldAccess_with (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (base : Expr) (b : Value) (ovFld : String) (ovValue : Value) (fieldName : String)
+    (hBase : evalAt mode s sp env base = some (.vEntityWith b ovFld ovValue)) :
+    evalAt mode s sp env (.fieldAccess base fieldName)
+      = (if fieldName = ovFld then some ovValue
+         else Value.fieldLookup (sp.at mode) b fieldName) := by
+  rw [evalAt_fieldAccess_lookup mode s sp env base (.vEntityWith b ovFld ovValue) fieldName hBase]
+  simp only [Value.fieldLookup]
+
 theorem evalAt_fieldAccess_nonEntity (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
     {base : Expr} {fieldName : String} {v : Value}
     (hBase : evalAt mode s sp env base = some v)
-    (hNotEntity : ∀ en id, v ≠ .vEntity en id) :
+    (hNotEntity : ∀ en id, v ≠ .vEntity en id)
+    (hNotEntityWith : ∀ b f w, v ≠ .vEntityWith b f w) :
     evalAt mode s sp env (.fieldAccess base fieldName) = none := by
-  simp only [evalAt, hBase]
+  rw [evalAt_fieldAccess_lookup mode s sp env base v fieldName hBase]
   cases v with
   | vEntity en id => exact absurd rfl (hNotEntity en id)
+  | vEntityWith b f w => exact absurd rfl (hNotEntityWith b f w)
   | vBool _ => rfl
   | vInt _ => rfl
   | vEnum _ _ => rfl

--- a/proofs/lean/SpecRest/Lemmas.lean
+++ b/proofs/lean/SpecRest/Lemmas.lean
@@ -541,6 +541,52 @@ theorem evalAt_setMember_resolved (mode : StateMode) (s : Schema) (sp : StatePai
     evalAt mode s sp env (.setMember elem set) = some (.vBool (containsValue members v)) := by
   simp only [evalAt, hElem, hSet]
 
+theorem evalAt_setInsert_elem_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (hElem : evalAt mode s sp env elem = none) :
+    evalAt mode s sp env (.setInsert elem set) = none := by
+  simp only [evalAt, hElem]
+
+theorem evalAt_setInsert_set_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (v : Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = none) :
+    evalAt mode s sp env (.setInsert elem set) = none := by
+  simp only [evalAt, hElem, hSet]
+
+theorem evalAt_setInsert_set_nonSet (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    {elem set : Expr} {v setVal : Value}
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .vSet members) :
+    evalAt mode s sp env (.setInsert elem set) = none := by
+  simp only [evalAt, hElem, hSet]
+  cases setVal with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem evalAt_setMember_elem_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (hElem : evalAt mode s sp env elem = none) :
+    evalAt mode s sp env (.setMember elem set) = none := by
+  simp only [evalAt, hElem]
+
+theorem evalAt_setMember_set_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (v : Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = none) :
+    evalAt mode s sp env (.setMember elem set) = none := by
+  simp only [evalAt, hElem, hSet]
+
+theorem evalAt_setMember_set_nonSet (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    {elem set : Expr} {v setVal : Value}
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .vSet members) :
+    evalAt mode s sp env (.setMember elem set) = none := by
+  simp only [evalAt, hElem, hSet]
+  cases setVal with
+  | vSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
 theorem evalAt_setBin_sets (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
     (op : SetOp) (l r : Expr) (ls rs : List Value)
     (hL : evalAt mode s sp env l = some (.vSet ls))

--- a/proofs/lean/SpecRest/Lemmas.lean
+++ b/proofs/lean/SpecRest/Lemmas.lean
@@ -377,4 +377,91 @@ theorem operationEnsures_def (op : OperationDecl) :
     operationEnsures s st env op = evalEnsuresAll s st env op.ensures := by
   simp only [operationEnsures]
 
+/-! ## Per-arm characterizations for `evalAt` (M_L.4.b-ext Phase 3, issue #194).
+
+Mirror of the single-state `eval_*` characterizations above. Each lemma names
+the equation `evalAt mode s sp env (.X args) = ...` so case-by-case `soundnessAt`
+proofs can rewrite without unfolding `evalAt` directly. The state-dependent
+arms read through `sp.at mode`; the recursive arms thread mode unchanged
+except for `Prime`/`Pre` (already in `Semantics.lean`). Args are explicit (no
+`variable` inheritance) so call sites can pass them positionally without
+worrying about auto-bound order. -/
+
+theorem evalAt_boolLit (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) (b : Bool) :
+    evalAt mode s sp env (.boolLit b) = some (.vBool b) := by
+  simp only [evalAt]
+
+theorem evalAt_intLit (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) (n : Int) :
+    evalAt mode s sp env (.intLit n) = some (.vInt n) := by
+  simp only [evalAt]
+
+theorem evalAt_ident_local (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    {x : String} {v : Value} (h : Env.lookup env x = some v) :
+    evalAt mode s sp env (.ident x) = some v := by
+  simp only [evalAt, h]
+
+theorem evalAt_ident_state (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    {x : String} {v : Value}
+    (hEnv : Env.lookup env x = none)
+    (hSt : (sp.at mode).lookupScalar x = some v) :
+    evalAt mode s sp env (.ident x) = some v := by
+  simp only [evalAt, hEnv, hSt]
+
+theorem evalAt_unNot_bool (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (e : Expr) (b : Bool) (h : evalAt mode s sp env e = some (.vBool b)) :
+    evalAt mode s sp env (.unNot e) = some (.vBool (!b)) := by
+  simp only [evalAt, h]
+
+theorem evalAt_unNot_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (e : Expr) (h : evalAt mode s sp env e = none) :
+    evalAt mode s sp env (.unNot e) = none := by
+  simp only [evalAt, h]
+
+theorem evalAt_unNeg_int (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (e : Expr) (n : Int) (h : evalAt mode s sp env e = some (.vInt n)) :
+    evalAt mode s sp env (.unNeg e) = some (.vInt (-n)) := by
+  simp only [evalAt, h]
+
+theorem evalAt_unNeg_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (e : Expr) (h : evalAt mode s sp env e = none) :
+    evalAt mode s sp env (.unNeg e) = none := by
+  simp only [evalAt, h]
+
+theorem evalAt_boolBin_bools (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (op : BoolBinOp) (l r : Expr) (a b : Bool)
+    (hl : evalAt mode s sp env l = some (.vBool a))
+    (hr : evalAt mode s sp env r = some (.vBool b)) :
+    evalAt mode s sp env (.boolBin op l r) = some (.vBool (evalBoolBin op a b)) := by
+  simp only [evalAt, hl, hr]
+
+theorem evalAt_cmp_app (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (op : CmpOp) (l r : Expr) :
+    evalAt mode s sp env (.cmp op l r)
+      = evalCmp op (evalAt mode s sp env l) (evalAt mode s sp env r) := by
+  simp only [evalAt]
+
+theorem evalAt_letIn_some (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (x : String) (value body : Expr) (v : Value)
+    (h : evalAt mode s sp env value = some v) :
+    evalAt mode s sp env (.letIn x value body)
+      = evalAt mode s sp ((x, v) :: env) body := by
+  simp only [evalAt, h]
+
+theorem evalAt_letIn_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (x : String) (value body : Expr)
+    (h : evalAt mode s sp env value = none) :
+    evalAt mode s sp env (.letIn x value body) = none := by
+  simp only [evalAt, h]
+
+theorem evalAt_enumAccess_known (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (en mem : String) (d : EnumDecl)
+    (hSchema : s.lookupEnum en = some d) (hMember : d.members.contains mem = true) :
+    evalAt mode s sp env (.enumAccess en mem) = some (.vEnum en mem) := by
+  simp only [evalAt, hSchema, hMember, if_true]
+
+theorem evalAt_enumAccess_unknown (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (en mem : String) (hSchema : s.lookupEnum en = none) :
+    evalAt mode s sp env (.enumAccess en mem) = none := by
+  simp only [evalAt, hSchema]
+
 end SpecRest

--- a/proofs/lean/SpecRest/Lemmas.lean
+++ b/proofs/lean/SpecRest/Lemmas.lean
@@ -464,4 +464,124 @@ theorem evalAt_enumAccess_unknown (mode : StateMode) (s : Schema) (sp : StatePai
     evalAt mode s sp env (.enumAccess en mem) = none := by
   simp only [evalAt, hSchema]
 
+theorem evalAt_member_resolved (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem : Expr) (relName : String) (v : Value) (dom : List Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hDom : (sp.at mode).relationDomain relName = some dom) :
+    evalAt mode s sp env (.member elem relName) = some (.vBool (dom.contains v)) := by
+  simp only [evalAt, hElem, hDom]
+
+theorem evalAt_member_no_elem (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem : Expr) (relName : String)
+    (h : evalAt mode s sp env elem = none) :
+    evalAt mode s sp env (.member elem relName) = none := by
+  simp only [evalAt, h]
+
+theorem evalAt_member_no_relation (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem : Expr) (relName : String) (v : Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hDom : (sp.at mode).relationDomain relName = none) :
+    evalAt mode s sp env (.member elem relName) = none := by
+  simp only [evalAt, hElem, hDom]
+
+theorem evalAt_indexRel_key (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (relName : String) (key : Expr) (kv : Value)
+    (hKey : evalAt mode s sp env key = some kv) :
+    evalAt mode s sp env (.indexRel relName key) = (sp.at mode).lookupKey relName kv := by
+  simp only [evalAt, hKey]
+
+theorem evalAt_indexRel_key_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (relName : String) (key : Expr)
+    (hKey : evalAt mode s sp env key = none) :
+    evalAt mode s sp env (.indexRel relName key) = none := by
+  simp only [evalAt, hKey]
+
+theorem evalAt_fieldAccess_resolved (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (base : Expr) (en id fieldName : String)
+    (hBase : evalAt mode s sp env base = some (.vEntity en id)) :
+    evalAt mode s sp env (.fieldAccess base fieldName)
+      = (sp.at mode).lookupField id fieldName := by
+  simp only [evalAt, hBase]
+
+theorem evalAt_fieldAccess_base_none (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (base : Expr) (fieldName : String)
+    (hBase : evalAt mode s sp env base = none) :
+    evalAt mode s sp env (.fieldAccess base fieldName) = none := by
+  simp only [evalAt, hBase]
+
+theorem evalAt_fieldAccess_nonEntity (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    {base : Expr} {fieldName : String} {v : Value}
+    (hBase : evalAt mode s sp env base = some v)
+    (hNotEntity : ∀ en id, v ≠ .vEntity en id) :
+    evalAt mode s sp env (.fieldAccess base fieldName) = none := by
+  simp only [evalAt, hBase]
+  cases v with
+  | vEntity en id => exact absurd rfl (hNotEntity en id)
+  | vBool _ => rfl
+  | vInt _ => rfl
+  | vEnum _ _ => rfl
+  | vSet _ => rfl
+
+theorem evalAt_setEmpty (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) :
+    evalAt mode s sp env .setEmpty = some (.vSet []) := by
+  simp only [evalAt]
+
+theorem evalAt_setInsert_resolved (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (v : Value) (members : List Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some (.vSet members)) :
+    evalAt mode s sp env (.setInsert elem set)
+      = some (.vSet (dedupeValues (v :: members))) := by
+  simp only [evalAt, hElem, hSet]
+
+theorem evalAt_setMember_resolved (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (elem set : Expr) (v : Value) (members : List Value)
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some (.vSet members)) :
+    evalAt mode s sp env (.setMember elem set) = some (.vBool (containsValue members v)) := by
+  simp only [evalAt, hElem, hSet]
+
+theorem evalAt_setBin_sets (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (op : SetOp) (l r : Expr) (ls rs : List Value)
+    (hL : evalAt mode s sp env l = some (.vSet ls))
+    (hR : evalAt mode s sp env r = some (.vSet rs)) :
+    evalAt mode s sp env (.setBin op l r) = evalSetBin op (some (.vSet ls)) (some (.vSet rs)) := by
+  simp only [evalAt, hL, hR]
+
+theorem evalAt_forallEnum_known (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var en : String) (body : Expr) (d : EnumDecl)
+    (hSchema : s.lookupEnum en = some d) :
+    evalAt mode s sp env (.forallEnum var en body)
+      = evalAtForallEnum mode s sp env var en d.members body := by
+  simp only [evalAt, hSchema]
+
+theorem evalAt_forallEnum_unknown (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var en : String) (body : Expr)
+    (h : s.lookupEnum en = none) :
+    evalAt mode s sp env (.forallEnum var en body) = none := by
+  simp only [evalAt, h]
+
+theorem evalAtForallEnum_nil (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var en : String) (body : Expr) :
+    evalAtForallEnum mode s sp env var en [] body = some (.vBool true) := by
+  simp only [evalAtForallEnum]
+
+theorem evalAt_forallRel_known (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var rel : String) (body : Expr) (dom : List Value)
+    (hDom : (sp.at mode).relationDomain rel = some dom) :
+    evalAt mode s sp env (.forallRel var rel body)
+      = evalAtForallRel mode s sp env var dom body := by
+  simp only [evalAt, hDom]
+
+theorem evalAt_forallRel_unknown (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var rel : String) (body : Expr)
+    (h : (sp.at mode).relationDomain rel = none) :
+    evalAt mode s sp env (.forallRel var rel body) = none := by
+  simp only [evalAt, h]
+
+theorem evalAtForallRel_nil (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+    (var : String) (body : Expr) :
+    evalAtForallRel mode s sp env var [] body = some (.vBool true) := by
+  simp only [evalAtForallRel]
+
 end SpecRest

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -158,6 +158,55 @@ def State.lookupField (st : State) (entityId fieldName : String) : Option Value 
 def Env.lookup (env : Env) (name : String) : Option Value :=
   List.lookup name env
 
+/-! ## Two-state carrier (M_L.4.b-ext, issue #194 — Phase 1 scaffolding).
+
+The `StatePair` / `StateMode` pair lets specs talk about pre- and post-state
+references separately, which is what an ensures clause like `count' = count + 1`
+actually means (`post.count = pre.count + 1`). This file ships only the carrier
+and a mode-aware `evalAt` parallel to `eval`; the universal soundness theorem,
+the SMT-side mode threading, and the off-diagonal claim are deliberately left
+for follow-up phases. The diagonal-collapse theorem `evalAt_diagonal_eq_eval`
+proves both functions agree when `sp.pre = sp.post`, so every existing per-case
+soundness theorem (which is stated against `eval`) continues to hold unchanged.
+
+Mirrors `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala:17-18`
+where the production translator uses the same `StateMode { Pre, Post }` enum
+and threads it through `Translator.translateExpr` via mutable `ctx.stateMode`. -/
+
+inductive StateMode where
+  | pre
+  | post
+  deriving DecidableEq, Repr, Inhabited
+
+structure StatePair where
+  pre  : State
+  post : State
+  deriving Repr, Inhabited
+
+def StatePair.at : StatePair → StateMode → State
+  | sp, .pre  => sp.pre
+  | sp, .post => sp.post
+
+@[simp] theorem StatePair.at_pre (sp : StatePair) :
+    sp.at .pre = sp.pre := rfl
+
+@[simp] theorem StatePair.at_post (sp : StatePair) :
+    sp.at .post = sp.post := rfl
+
+/-- Diagonal `StatePair` — both projections collapse to the same `State`.
+    Every existing single-state caller maps to this case. -/
+def StatePair.diag (st : State) : StatePair := { pre := st, post := st }
+
+@[simp] theorem StatePair.diag_pre (st : State) :
+    (StatePair.diag st).pre = st := rfl
+
+@[simp] theorem StatePair.diag_post (st : State) :
+    (StatePair.diag st).post = st := rfl
+
+@[simp] theorem StatePair.at_diag (st : State) (mode : StateMode) :
+    (StatePair.diag st).at mode = st := by
+  cases mode <;> rfl
+
 def evalBoolBin : BoolBinOp → Bool → Bool → Bool
   | .and,     a, b => a && b
   | .or,      a, b => a || b
@@ -320,6 +369,249 @@ mutual
   termination_by (sizeOf body, dom.length)
 
 end
+
+/-! ## Mode-aware evaluator (`evalAt`).
+
+`evalAt` is identical to `eval` for every constructor except `.prime` / `.pre`
+and the state-scalar / state-relation / entity-field lookups, which now read
+through `sp.at mode`. `Prime e` flips the mode to `.post`; `Pre e` flips it
+to `.pre`. Phase 1 leaves SMT-side mode threading and the universal `soundness`
+theorem against `evalAt` for follow-up work; the diagonal-collapse theorem
+proven below shows `evalAt mode s (StatePair.diag st) env e = eval s st env e`,
+so every existing soundness theorem about `eval` lifts unchanged for the
+`pre = post` case. -/
+
+mutual
+
+  def evalAt (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) :
+      Expr → Option Value
+    | .boolLit b => some (.vBool b)
+    | .intLit n  => some (.vInt n)
+    | .ident x =>
+        match Env.lookup env x with
+        | some v => some v
+        | none   => (sp.at mode).lookupScalar x
+    | .unNot e =>
+        match evalAt mode s sp env e with
+        | some (.vBool b) => some (.vBool (!b))
+        | _               => none
+    | .unNeg e =>
+        match evalAt mode s sp env e with
+        | some (.vInt n) => some (.vInt (-n))
+        | _              => none
+    | .boolBin op l r =>
+        match evalAt mode s sp env l, evalAt mode s sp env r with
+        | some (.vBool a), some (.vBool b) => some (.vBool (evalBoolBin op a b))
+        | _, _                             => none
+    | .arith op l r => evalArith op (evalAt mode s sp env l) (evalAt mode s sp env r)
+    | .cmp op l r => evalCmp op (evalAt mode s sp env l) (evalAt mode s sp env r)
+    | .letIn x value body =>
+        match evalAt mode s sp env value with
+        | some v => evalAt mode s sp ((x, v) :: env) body
+        | none   => none
+    | .enumAccess enumName memberName =>
+        match s.lookupEnum enumName with
+        | some d =>
+            if d.members.contains memberName
+              then some (.vEnum enumName memberName)
+              else none
+        | none => none
+    | .member elem relName =>
+        match evalAt mode s sp env elem with
+        | some v =>
+            match (sp.at mode).relationDomain relName with
+            | some dom => some (.vBool (dom.contains v))
+            | none     => none
+        | none => none
+    | .forallEnum var enumName body =>
+        match s.lookupEnum enumName with
+        | some d => evalAtForallEnum mode s sp env var enumName d.members body
+        | none   => none
+    | .forallRel var relName body =>
+        match (sp.at mode).relationDomain relName with
+        | some dom => evalAtForallRel mode s sp env var dom body
+        | none     => none
+    | .prime e => evalAt .post s sp env e
+    | .pre   e => evalAt .pre  s sp env e
+    | .cardRel relName =>
+        match (sp.at mode).relationDomain relName with
+        | some dom => some (.vInt (Int.ofNat dom.length))
+        | none     => none
+    | .indexRel relName key =>
+        match evalAt mode s sp env key with
+        | some kv => (sp.at mode).lookupKey relName kv
+        | none    => none
+    | .fieldAccess base fieldName =>
+        match evalAt mode s sp env base with
+        | some (.vEntity _ id) => (sp.at mode).lookupField id fieldName
+        | _                    => none
+    | .setEmpty => some (.vSet [])
+    | .setInsert elem set =>
+        match evalAt mode s sp env elem, evalAt mode s sp env set with
+        | some v, some (.vSet members) => some (.vSet (dedupeValues (v :: members)))
+        | _,      _                    => none
+    | .setMember elem set =>
+        match evalAt mode s sp env elem, evalAt mode s sp env set with
+        | some v, some (.vSet members) => some (.vBool (containsValue members v))
+        | _,      _                    => none
+    | .setBin op l r => evalSetBin op (evalAt mode s sp env l) (evalAt mode s sp env r)
+  termination_by e => (sizeOf e, 0)
+
+  def evalAtForallEnum (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+      (var : String) (enumName : String)
+      (members : List String) (body : Expr) : Option Value :=
+    match members with
+    | [] => some (.vBool true)
+    | m :: rest =>
+        match evalAt mode s sp ((var, .vEnum enumName m) :: env) body with
+        | some (.vBool b) =>
+            match evalAtForallEnum mode s sp env var enumName rest body with
+            | some (.vBool acc) => some (.vBool (b && acc))
+            | _                 => none
+        | _ => none
+  termination_by (sizeOf body, members.length)
+
+  def evalAtForallRel (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
+      (var : String) (dom : List Value) (body : Expr) : Option Value :=
+    match dom with
+    | [] => some (.vBool true)
+    | v :: rest =>
+        match evalAt mode s sp ((var, v) :: env) body with
+        | some (.vBool b) =>
+            match evalAtForallRel mode s sp env var rest body with
+            | some (.vBool acc) => some (.vBool (b && acc))
+            | _                 => none
+        | _ => none
+  termination_by (sizeOf body, dom.length)
+
+end
+
+/-! ## Diagonal-collapse theorem.
+
+When `sp.pre = sp.post = st`, `evalAt mode s sp env e = eval s st env e` for
+every mode and every Expr. Both Prime and Pre arms flip the mode but the
+diagonal projection collapses, leaving the body identical to `eval`. The proof
+goes by mutual structural induction on `Expr` × forall-domain shapes. -/
+
+mutual
+
+  theorem evalAt_diagonal_eq_eval :
+      ∀ (mode : StateMode) (s : Schema) (st : State) (env : Env) (e : Expr),
+        evalAt mode s (StatePair.diag st) env e = eval s st env e
+    | mode, s, st, env, .boolLit b => by simp only [evalAt, eval]
+    | mode, s, st, env, .intLit n  => by simp only [evalAt, eval]
+    | mode, s, st, env, .ident x   => by
+        simp only [evalAt, eval, StatePair.at_diag]
+    | mode, s, st, env, .unNot e   => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env e]
+    | mode, s, st, env, .unNeg e   => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env e]
+    | mode, s, st, env, .boolBin op l r => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env l,
+            evalAt_diagonal_eq_eval mode s st env r]
+    | mode, s, st, env, .arith op l r => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env l,
+            evalAt_diagonal_eq_eval mode s st env r]
+    | mode, s, st, env, .cmp op l r => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env l,
+            evalAt_diagonal_eq_eval mode s st env r]
+    | mode, s, st, env, .letIn x value body => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env value]
+        cases eval s st env value with
+        | none => rfl
+        | some v => exact evalAt_diagonal_eq_eval mode s st ((x, v) :: env) body
+    | mode, s, st, env, .enumAccess en mem => by simp only [evalAt, eval]
+    | mode, s, st, env, .member elem relName => by
+        simp only [evalAt, eval, StatePair.at_diag]
+        rw [evalAt_diagonal_eq_eval mode s st env elem]
+    | mode, s, st, env, .forallEnum var en body => by
+        simp only [evalAt, eval]
+        cases s.lookupEnum en with
+        | none => rfl
+        | some d =>
+            exact evalAtForallEnum_diagonal_eq mode s st env var en d.members body
+    | mode, s, st, env, .forallRel var rel body => by
+        simp only [evalAt, eval, StatePair.at_diag]
+        cases st.relationDomain rel with
+        | none => rfl
+        | some dom =>
+            exact evalAtForallRel_diagonal_eq mode s st env var dom body
+    | mode, s, st, env, .prime e => by
+        simp only [evalAt, eval]
+        exact evalAt_diagonal_eq_eval .post s st env e
+    | mode, s, st, env, .pre e => by
+        simp only [evalAt, eval]
+        exact evalAt_diagonal_eq_eval .pre s st env e
+    | mode, s, st, env, .cardRel relName => by
+        simp only [evalAt, eval, StatePair.at_diag]
+    | mode, s, st, env, .indexRel relName key => by
+        simp only [evalAt, eval, StatePair.at_diag]
+        rw [evalAt_diagonal_eq_eval mode s st env key]
+    | mode, s, st, env, .fieldAccess base fieldName => by
+        simp only [evalAt, eval, StatePair.at_diag]
+        rw [evalAt_diagonal_eq_eval mode s st env base]
+    | mode, s, st, env, .setEmpty => by simp only [evalAt, eval]
+    | mode, s, st, env, .setInsert elem set => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env elem,
+            evalAt_diagonal_eq_eval mode s st env set]
+    | mode, s, st, env, .setMember elem set => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env elem,
+            evalAt_diagonal_eq_eval mode s st env set]
+    | mode, s, st, env, .setBin op l r => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env l,
+            evalAt_diagonal_eq_eval mode s st env r]
+  termination_by _ _ _ _ e => (sizeOf e, 0)
+
+  theorem evalAtForallEnum_diagonal_eq :
+      ∀ (mode : StateMode) (s : Schema) (st : State) (env : Env)
+        (var : String) (en : String) (members : List String) (body : Expr),
+        evalAtForallEnum mode s (StatePair.diag st) env var en members body
+          = evalForallEnum s st env var en members body
+    | _, _, _, _, _, _, [], _ => by
+        simp only [evalAtForallEnum, evalForallEnum]
+    | mode, s, st, env, var, en, m :: rest, body => by
+        simp only [evalAtForallEnum, evalForallEnum]
+        rw [evalAt_diagonal_eq_eval mode s st ((var, .vEnum en m) :: env) body,
+            evalAtForallEnum_diagonal_eq mode s st env var en rest body]
+  termination_by _ _ _ _ _ _ members body => (sizeOf body, members.length)
+
+  theorem evalAtForallRel_diagonal_eq :
+      ∀ (mode : StateMode) (s : Schema) (st : State) (env : Env)
+        (var : String) (dom : List Value) (body : Expr),
+        evalAtForallRel mode s (StatePair.diag st) env var dom body
+          = evalForallRel s st env var dom body
+    | _, _, _, _, _, [], _ => by
+        simp only [evalAtForallRel, evalForallRel]
+    | mode, s, st, env, var, v :: rest, body => by
+        simp only [evalAtForallRel, evalForallRel]
+        rw [evalAt_diagonal_eq_eval mode s st ((var, v) :: env) body,
+            evalAtForallRel_diagonal_eq mode s st env var rest body]
+  termination_by _ _ _ _ _ dom body => (sizeOf body, dom.length)
+
+end
+
+/-! ## `evalAt` per-arm characterizations on Prime/Pre.
+
+These name the mode-flipping behavior introduced by `Prime`/`Pre` so callers
+can rewrite without unfolding `evalAt`. They are the semantic statement
+behind issue #194's two-state coupling. -/
+
+theorem evalAt_prime (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) (e : Expr) :
+    evalAt mode s sp env (.prime e) = evalAt .post s sp env e := by
+  simp only [evalAt]
+
+theorem evalAt_pre (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env) (e : Expr) :
+    evalAt mode s sp env (.pre e) = evalAt .pre s sp env e := by
+  simp only [evalAt]
 
 def evalInvariant (s : Schema) (st : State) (env : Env) (inv : InvariantDecl) : Option Bool :=
   (eval s st env inv.body).bind asBool

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -339,6 +339,10 @@ mutual
         | some v, some (.vSet members) => some (.vBool (containsValue members v))
         | _,      _                    => none
     | .setBin op l r => evalSetBin op (eval s st env l) (eval s st env r)
+    -- M_L.4.b-ext Phase 4: With (record-update). Always-fail semantics until
+    -- Phase 4b lands proper Skolem encoding. `VerifiedSubset.classify` rejects
+    -- With so the cert emitter never translates it — no false claims.
+    | .withRec _ _ _ => none
   termination_by e => (sizeOf e, 0)
 
   def evalForallEnum (s : Schema) (st : State) (env : Env)
@@ -455,6 +459,8 @@ mutual
         | some v, some (.vSet members) => some (.vBool (containsValue members v))
         | _,      _                    => none
     | .setBin op l r => evalSetBin op (evalAt mode s sp env l) (evalAt mode s sp env r)
+    -- M_L.4.b-ext Phase 4: With (record-update). Always-fail until Phase 4b.
+    | .withRec _ _ _ => none
   termination_by e => (sizeOf e, 0)
 
   def evalAtForallEnum (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
@@ -569,6 +575,7 @@ mutual
         simp only [evalAt, eval]
         rw [evalAt_diagonal_eq_eval mode s st env l,
             evalAt_diagonal_eq_eval mode s st env r]
+    | _, _, _, _, .withRec _ _ _ => by simp only [evalAt, eval]
   termination_by _ _ _ _ e => (sizeOf e, 0)
 
   theorem evalAtForallEnum_diagonal_eq :

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -704,4 +704,48 @@ def invariantsHold (s : Schema) (st : State) (env : Env) (invs : List InvariantD
         | none       => none
   go invs
 
+/-! ## Mode-aware invariant / requires / ensures evaluators (M_L.4.b-ext Phase 5.c).
+
+The single-state `evalInvariant` / `evalRequiresAll` / `evalEnsuresAll` above are
+the historical entry points used by Phase 5.a's invariant + requires certs. The
+mode-aware variants below mirror them but route through `evalAt` against a
+`StatePair`, so the post-state slot is reachable for operation invariant-
+preservation certs. The diagonal-collapse property holds: feeding
+`StatePair.diag st` produces results identical to the single-state forms. -/
+
+def evalInvariantAt (mode : StateMode) (s : Schema) (sp : StatePair)
+    (env : Env) (inv : InvariantDecl) : Option Bool :=
+  (evalAt mode s sp env inv.body).bind asBool
+
+def evalRequiresAllAt (mode : StateMode) (s : Schema) (sp : StatePair)
+    (env : Env) : List Expr → Option Bool
+  | []      => some true
+  | r :: rs =>
+      match (evalAt mode s sp env r).bind asBool with
+      | some true  => evalRequiresAllAt mode s sp env rs
+      | some false => some false
+      | none       => none
+
+def evalEnsuresAllAt (mode : StateMode) (s : Schema) (sp : StatePair)
+    (env : Env) : List Expr → Option Bool
+  | []      => some true
+  | r :: rs =>
+      match (evalAt mode s sp env r).bind asBool with
+      | some true  => evalEnsuresAllAt mode s sp env rs
+      | some false => some false
+      | none       => none
+
+/-- Operation invariant-preservation: weak preservation form. If the operation's
+    `requires` are violated in the pre-state, the operation is disabled and
+    preservation is vacuously true. Otherwise the invariant must hold in the
+    post-state. The pre-state's invariant value is intentionally not checked
+    here — that's the standalone invariant cert's job; mixing them produces a
+    weaker, harder-to-debug conjunction. -/
+def evalPreservation (s : Schema) (sp : StatePair) (env : Env)
+    (reqs : List Expr) (inv : InvariantDecl) : Option Bool :=
+  match evalRequiresAllAt .pre s sp env reqs with
+  | some true  => evalInvariantAt .post s sp env inv
+  | some false => some true
+  | none       => none
+
 end SpecRest

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -109,7 +109,11 @@ def beqValue : Value → Value → Bool
   | .vEntity en id, .vEntity en' id' => en == en' && id == id'
   | .vSet xs, .vSet ys => setEqValueList xs ys
   | .vEntityWith ba fa va, .vEntityWith bb fb vb =>
-      decide (ba = bb) && fa == fb && decide (va = vb)
+      -- Recursive `beqValue` so set equality stays extensional inside
+      -- record-update chains: two overrides that differ only by set element
+      -- order (e.g., `vSet [1, 2]` vs `vSet [2, 1]`) compare equal here, just
+      -- as plain `vSet` does. Mirrors `valueEq` in EvalIR.scala.
+      beqValue ba bb && fa == fb && beqValue va vb
   | _, _ => false
 
 instance : BEq Value where

--- a/proofs/lean/SpecRest/Semantics.lean
+++ b/proofs/lean/SpecRest/Semantics.lean
@@ -8,6 +8,12 @@ inductive Value where
   | vEnum (enumName memberName : String)
   | vEntity (entityName id : String)
   | vSet (members : List Value)
+  /-- Entity with a single-field override, recursive on `base : Value`. Multi-field
+      `e with { a := va, b := vb }` chains: `vEntityWith (vEntityWith eBase a va) b vb`.
+      M_L.4.b-ext Phase 4b (issue #194) — Skolem encoding for `Expr.withRec`.
+      `Value.fieldLookup` walks the chain: matches override on `fld` first, falls
+      back to `base` recursively until reaching a `vEntity` (terminal) or a non-entity. -/
+  | vEntityWith (base : Value) (fld : String) (value : Value)
   deriving Repr, Inhabited
 
 mutual
@@ -32,26 +38,45 @@ mutual
         match decEqValueList xs ys with
         | isTrue h  => isTrue (by cases h; rfl)
         | isFalse h => isFalse (by intro h'; cases h'; exact h rfl)
+    | .vEntityWith ba fa va, .vEntityWith bb fb vb =>
+        match decEqValue ba bb with
+        | isFalse hB => isFalse (by intro h'; cases h'; exact hB rfl)
+        | isTrue hB =>
+          if hF : fa = fb then
+            match decEqValue va vb with
+            | isFalse hV => isFalse (by intro h'; cases h'; exact hV rfl)
+            | isTrue hV => isTrue (by cases hB; cases hF; cases hV; rfl)
+          else isFalse (by intro h'; cases h'; exact hF rfl)
     | .vBool _, .vInt _ => isFalse (by intro h; cases h)
     | .vBool _, .vEnum _ _ => isFalse (by intro h; cases h)
     | .vBool _, .vEntity _ _ => isFalse (by intro h; cases h)
     | .vBool _, .vSet _ => isFalse (by intro h; cases h)
+    | .vBool _, .vEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .vInt _, .vBool _ => isFalse (by intro h; cases h)
     | .vInt _, .vEnum _ _ => isFalse (by intro h; cases h)
     | .vInt _, .vEntity _ _ => isFalse (by intro h; cases h)
     | .vInt _, .vSet _ => isFalse (by intro h; cases h)
+    | .vInt _, .vEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .vEnum _ _, .vBool _ => isFalse (by intro h; cases h)
     | .vEnum _ _, .vInt _ => isFalse (by intro h; cases h)
     | .vEnum _ _, .vEntity _ _ => isFalse (by intro h; cases h)
     | .vEnum _ _, .vSet _ => isFalse (by intro h; cases h)
+    | .vEnum _ _, .vEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .vEntity _ _, .vBool _ => isFalse (by intro h; cases h)
     | .vEntity _ _, .vInt _ => isFalse (by intro h; cases h)
     | .vEntity _ _, .vEnum _ _ => isFalse (by intro h; cases h)
     | .vEntity _ _, .vSet _ => isFalse (by intro h; cases h)
+    | .vEntity _ _, .vEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .vSet _, .vBool _ => isFalse (by intro h; cases h)
     | .vSet _, .vInt _ => isFalse (by intro h; cases h)
     | .vSet _, .vEnum _ _ => isFalse (by intro h; cases h)
     | .vSet _, .vEntity _ _ => isFalse (by intro h; cases h)
+    | .vSet _, .vEntityWith _ _ _ => isFalse (by intro h; cases h)
+    | .vEntityWith _ _ _, .vBool _ => isFalse (by intro h; cases h)
+    | .vEntityWith _ _ _, .vInt _ => isFalse (by intro h; cases h)
+    | .vEntityWith _ _ _, .vEnum _ _ => isFalse (by intro h; cases h)
+    | .vEntityWith _ _ _, .vEntity _ _ => isFalse (by intro h; cases h)
+    | .vEntityWith _ _ _, .vSet _ => isFalse (by intro h; cases h)
 
   def decEqValueList : (xs ys : List Value) → Decidable (xs = ys)
     | [], [] => isTrue rfl
@@ -83,6 +108,8 @@ def beqValue : Value → Value → Bool
   | .vEnum en mem, .vEnum en' mem' => en == en' && mem == mem'
   | .vEntity en id, .vEntity en' id' => en == en' && id == id'
   | .vSet xs, .vSet ys => setEqValueList xs ys
+  | .vEntityWith ba fa va, .vEntityWith bb fb vb =>
+      decide (ba = bb) && fa == fb && decide (va = vb)
   | _, _ => false
 
 instance : BEq Value where
@@ -154,6 +181,19 @@ def State.lookupField (st : State) (entityId fieldName : String) : Option Value 
   match List.lookup entityId st.entityFields with
   | some fields => List.lookup fieldName fields
   | none        => none
+
+/-- Value-level field lookup that walks `vEntityWith` chains (Phase 4b). For a
+    `vEntity en id`, looks up `fld` in `st.entityFields[id]`. For
+    `vEntityWith base ovFld ovValue`, returns `ovValue` if `fld == ovFld`, else
+    recurses on `base`. For other Value shapes (vBool/vInt/vEnum/vSet),
+    returns none. Termination: structural recursion on Value via the `base`
+    field of `vEntityWith`. -/
+def Value.fieldLookup (st : State) : Value → String → Option Value
+  | .vEntity _ id, fld => st.lookupField id fld
+  | .vEntityWith base ovFld ovValue, fld =>
+      if fld = ovFld then some ovValue
+      else Value.fieldLookup st base fld
+  | _, _ => none
 
 def Env.lookup (env : Env) (name : String) : Option Value :=
   List.lookup name env
@@ -327,8 +367,8 @@ mutual
         | none    => none
     | .fieldAccess base fieldName =>
         match eval s st env base with
-        | some (.vEntity _ id) => st.lookupField id fieldName
-        | _                    => none
+        | some v => Value.fieldLookup st v fieldName
+        | none   => none
     | .setEmpty => some (.vSet [])
     | .setInsert elem set =>
         match eval s st env elem, eval s st env set with
@@ -339,10 +379,13 @@ mutual
         | some v, some (.vSet members) => some (.vBool (containsValue members v))
         | _,      _                    => none
     | .setBin op l r => evalSetBin op (eval s st env l) (eval s st env r)
-    -- M_L.4.b-ext Phase 4: With (record-update). Always-fail semantics until
-    -- Phase 4b lands proper Skolem encoding. `VerifiedSubset.classify` rejects
-    -- With so the cert emitter never translates it — no false claims.
-    | .withRec _ _ _ => none
+    -- M_L.4.b-ext Phase 4b: With (record-update) Skolem encoding. Evaluates
+    -- base; if the base reduces to a Value, wrap it in `vEntityWith`. Field
+    -- access then unwinds via `Value.fieldLookup`.
+    | .withRec base fld valueExpr =>
+        match eval s st env base, eval s st env valueExpr with
+        | some bv, some v => some (.vEntityWith bv fld v)
+        | _, _ => none
   termination_by e => (sizeOf e, 0)
 
   def evalForallEnum (s : Schema) (st : State) (env : Env)
@@ -447,8 +490,8 @@ mutual
         | none    => none
     | .fieldAccess base fieldName =>
         match evalAt mode s sp env base with
-        | some (.vEntity _ id) => (sp.at mode).lookupField id fieldName
-        | _                    => none
+        | some v => Value.fieldLookup (sp.at mode) v fieldName
+        | none   => none
     | .setEmpty => some (.vSet [])
     | .setInsert elem set =>
         match evalAt mode s sp env elem, evalAt mode s sp env set with
@@ -459,8 +502,11 @@ mutual
         | some v, some (.vSet members) => some (.vBool (containsValue members v))
         | _,      _                    => none
     | .setBin op l r => evalSetBin op (evalAt mode s sp env l) (evalAt mode s sp env r)
-    -- M_L.4.b-ext Phase 4: With (record-update). Always-fail until Phase 4b.
-    | .withRec _ _ _ => none
+    -- M_L.4.b-ext Phase 4b: With (record-update) Skolem encoding (mode-aware).
+    | .withRec base fld valueExpr =>
+        match evalAt mode s sp env base, evalAt mode s sp env valueExpr with
+        | some bv, some v => some (.vEntityWith bv fld v)
+        | _, _ => none
   termination_by e => (sizeOf e, 0)
 
   def evalAtForallEnum (mode : StateMode) (s : Schema) (sp : StatePair) (env : Env)
@@ -575,7 +621,10 @@ mutual
         simp only [evalAt, eval]
         rw [evalAt_diagonal_eq_eval mode s st env l,
             evalAt_diagonal_eq_eval mode s st env r]
-    | _, _, _, _, .withRec _ _ _ => by simp only [evalAt, eval]
+    | mode, s, st, env, .withRec base fld value => by
+        simp only [evalAt, eval]
+        rw [evalAt_diagonal_eq_eval mode s st env base,
+            evalAt_diagonal_eq_eval mode s st env value]
   termination_by _ _ _ _ e => (sizeOf e, 0)
 
   theorem evalAtForallEnum_diagonal_eq :

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -981,6 +981,406 @@ theorem smtEvalAt_setDiff_sets (mode : StateMode) (mp : SmtModelPair) (env : Smt
     smtEvalAt mode mp env (.setDiff l r) = some (.sSet (setDiffSmtVals ls rs)) := by
   simp only [smtEvalAt, hL, hR]
 
+/-! ### Failure-path helpers for `smtEvalAt` (parallel to `smtEval_*` set above). -/
+
+theorem smtEvalAt_not_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (t : SmtTerm) (h : smtEvalAt mode mp env t = none) :
+    smtEvalAt mode mp env (.not t) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_not_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {t : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env t = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.not t) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_neg_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (t : SmtTerm) (h : smtEvalAt mode mp env t = none) :
+    smtEvalAt mode mp env (.neg t) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_neg_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {t : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env t = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.neg t) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | sBool _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_and_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.and l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_and_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool}
+    (hl : smtEvalAt mode mp env l = some (.sBool a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.and l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_and_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.and l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_and_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.and l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_or_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.or l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_or_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool}
+    (hl : smtEvalAt mode mp env l = some (.sBool a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.or l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_or_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.or l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_or_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.or l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_implies_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.implies l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_implies_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool}
+    (hl : smtEvalAt mode mp env l = some (.sBool a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.implies l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_implies_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.implies l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_implies_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Bool} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
+    smtEvalAt mode mp env (.implies l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sBool b => exact absurd rfl (hNotBool b)
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_eq_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.eq l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_eq_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : SmtVal}
+    (hl : smtEvalAt mode mp env l = some a) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.eq l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_lt_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.lt l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_lt_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int}
+    (hl : smtEvalAt mode mp env l = some (.sInt a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.lt l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_lt_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.lt l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | sBool _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_lt_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.lt l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | sBool _ => rfl
+  | sEnumElem _ _ => rfl
+  | sEntityElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_add_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.add l r) = none := by simp only [smtEvalAt, h]
+theorem smtEvalAt_sub_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.sub l r) = none := by simp only [smtEvalAt, h]
+theorem smtEvalAt_mul_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.mul l r) = none := by simp only [smtEvalAt, h]
+theorem smtEvalAt_div_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.div l r) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_add_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int}
+    (hl : smtEvalAt mode mp env l = some (.sInt a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.add l r) = none := by simp only [smtEvalAt, hl, hr]
+theorem smtEvalAt_sub_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int}
+    (hl : smtEvalAt mode mp env l = some (.sInt a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.sub l r) = none := by simp only [smtEvalAt, hl, hr]
+theorem smtEvalAt_mul_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int}
+    (hl : smtEvalAt mode mp env l = some (.sInt a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.mul l r) = none := by simp only [smtEvalAt, hl, hr]
+theorem smtEvalAt_div_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int}
+    (hl : smtEvalAt mode mp env l = some (.sInt a)) (hr : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.div l r) = none := by simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_add_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.add l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_sub_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.sub l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_mul_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.mul l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_div_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (h : smtEvalAt mode mp env l = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.div l r) = none := by
+  simp only [smtEvalAt, h]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+
+theorem smtEvalAt_add_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.add l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_sub_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.sub l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_mul_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.mul l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+theorem smtEvalAt_div_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {a : Int} {v : SmtVal}
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some v) (hNotInt : ∀ n, v ≠ .sInt n) :
+    smtEvalAt mode mp env (.div l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+  cases v with
+  | sInt n => exact absurd rfl (hNotInt n)
+  | _ => rfl
+
+theorem smtEvalAt_letIn_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {x : String} {value body : SmtTerm}
+    (h : smtEvalAt mode mp env value = none) :
+    smtEvalAt mode mp env (.letIn x value body) = none := by simp only [smtEvalAt, h]
+
+theorem smtEvalAt_setInsert_elem_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (hElem : smtEvalAt mode mp env elem = none) :
+    smtEvalAt mode mp env (.setInsert elem set) = none := by simp only [smtEvalAt, hElem]
+
+theorem smtEvalAt_setInsert_set_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (v : SmtVal)
+    (hElem : smtEvalAt mode mp env elem = some v) (hSet : smtEvalAt mode mp env set = none) :
+    smtEvalAt mode mp env (.setInsert elem set) = none := by simp only [smtEvalAt, hElem, hSet]
+
+theorem smtEvalAt_setInsert_set_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {elem set : SmtTerm} {v setVal : SmtVal}
+    (hElem : smtEvalAt mode mp env elem = some v)
+    (hSet : smtEvalAt mode mp env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .sSet members) :
+    smtEvalAt mode mp env (.setInsert elem set) = none := by
+  simp only [smtEvalAt, hElem, hSet]
+  cases setVal with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEvalAt_setMember_elem_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (hElem : smtEvalAt mode mp env elem = none) :
+    smtEvalAt mode mp env (.setMember elem set) = none := by simp only [smtEvalAt, hElem]
+
+theorem smtEvalAt_setMember_set_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (v : SmtVal)
+    (hElem : smtEvalAt mode mp env elem = some v) (hSet : smtEvalAt mode mp env set = none) :
+    smtEvalAt mode mp env (.setMember elem set) = none := by simp only [smtEvalAt, hElem, hSet]
+
+theorem smtEvalAt_setMember_set_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {elem set : SmtTerm} {v setVal : SmtVal}
+    (hElem : smtEvalAt mode mp env elem = some v)
+    (hSet : smtEvalAt mode mp env set = some setVal)
+    (hNotSet : ∀ members, setVal ≠ .sSet members) :
+    smtEvalAt mode mp env (.setMember elem set) = none := by
+  simp only [smtEvalAt, hElem, hSet]
+  cases setVal with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEvalAt_setUnion_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (hL : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.setUnion l r) = none := by simp only [smtEvalAt, hL]
+theorem smtEvalAt_setIntersect_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (hL : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.setIntersect l r) = none := by simp only [smtEvalAt, hL]
+theorem smtEvalAt_setDiff_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} (hL : smtEvalAt mode mp env l = none) :
+    smtEvalAt mode mp env (.setDiff l r) = none := by simp only [smtEvalAt, hL]
+
+theorem smtEvalAt_setUnion_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls)) (hR : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.setUnion l r) = none := by simp only [smtEvalAt, hL, hR]
+theorem smtEvalAt_setIntersect_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls)) (hR : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.setIntersect l r) = none := by simp only [smtEvalAt, hL, hR]
+theorem smtEvalAt_setDiff_rhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls)) (hR : smtEvalAt mode mp env r = none) :
+    smtEvalAt mode mp env (.setDiff l r) = none := by simp only [smtEvalAt, hL, hR]
+
+theorem smtEvalAt_setUnion_lhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setUnion l r) = none := by
+  simp only [smtEvalAt, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEvalAt_setIntersect_lhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setIntersect l r) = none := by
+  simp only [smtEvalAt, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEvalAt_setDiff_lhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setDiff l r) = none := by
+  simp only [smtEvalAt, hL]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
+theorem smtEvalAt_setUnion_rhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setUnion l r) = none := by
+  simp only [smtEvalAt, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEvalAt_setIntersect_rhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setIntersect l r) = none := by
+  simp only [smtEvalAt, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+theorem smtEvalAt_setDiff_rhs_nonSet (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {l r : SmtTerm} {ls : List SmtVal} {v : SmtVal}
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some v) (hNotSet : ∀ members, v ≠ .sSet members) :
+    smtEvalAt mode mp env (.setDiff l r) = none := by
+  simp only [smtEvalAt, hL, hR]
+  cases v with
+  | sSet members => exact absurd rfl (hNotSet members)
+  | _ => rfl
+
 /-! ## Per-constructor characterization lemmas for `smtEval`.
 
 Mirrors the M_L.1 pattern: mutual `smtEval` doesn't reduce via `rfl`,

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -701,6 +701,133 @@ theorem smtEvalAt_pre (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) (t :
     smtEvalAt mode mp env (.pre t) = smtEvalAt .pre mp env t := by
   simp only [smtEvalAt]
 
+/-! ### Per-arm characterizations for `smtEvalAt` (M_L.4.b-ext Phase 3, issue #194).
+
+Mirror of the single-state `smtEval_*` characterizations below. Used by per-case
+`soundnessAt_*` proofs to rewrite `smtEvalAt` without unfolding the function
+definition. State-touching arms read through `mp.at mode`; recursive arms
+thread mode unchanged. -/
+
+theorem smtEvalAt_bLit (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) (b : Bool) :
+    smtEvalAt mode mp env (.bLit b) = some (.sBool b) := by
+  simp only [smtEvalAt]
+
+theorem smtEvalAt_iLit (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) (n : Int) :
+    smtEvalAt mode mp env (.iLit n) = some (.sInt n) := by
+  simp only [smtEvalAt]
+
+theorem smtEvalAt_var_local (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {x : String} {v : SmtVal} (h : env.lookup x = some v) :
+    smtEvalAt mode mp env (.var x) = some v := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_enumElemConst_known (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {en mem : String} {members : List String}
+    (hSort : (mp.at mode).lookupSortMembers en = some members)
+    (hMember : members.contains mem = true) :
+    smtEvalAt mode mp env (.enumElemConst en mem) = some (.sEnumElem en mem) := by
+  simp only [smtEvalAt, hSort, hMember, if_true]
+
+theorem smtEvalAt_not_bool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (t : SmtTerm) (b : Bool)
+    (h : smtEvalAt mode mp env t = some (.sBool b)) :
+    smtEvalAt mode mp env (.not t) = some (.sBool (!b)) := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_and_bools (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Bool)
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some (.sBool b)) :
+    smtEvalAt mode mp env (.and l r) = some (.sBool (a && b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_or_bools (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Bool)
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some (.sBool b)) :
+    smtEvalAt mode mp env (.or l r) = some (.sBool (a || b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_implies_bools (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Bool)
+    (hl : smtEvalAt mode mp env l = some (.sBool a))
+    (hr : smtEvalAt mode mp env r = some (.sBool b)) :
+    smtEvalAt mode mp env (.implies l r) = some (.sBool (!a || b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_eq_vals (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : SmtVal)
+    (hl : smtEvalAt mode mp env l = some a)
+    (hr : smtEvalAt mode mp env r = some b) :
+    smtEvalAt mode mp env (.eq l r) = some (.sBool (a == b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_lt_ints (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Int)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt b)) :
+    smtEvalAt mode mp env (.lt l r) = some (.sBool (decide (a < b))) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_neg_int (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (t : SmtTerm) (n : Int)
+    (h : smtEvalAt mode mp env t = some (.sInt n)) :
+    smtEvalAt mode mp env (.neg t) = some (.sInt (-n)) := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_add_ints (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Int)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt b)) :
+    smtEvalAt mode mp env (.add l r) = some (.sInt (a + b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_sub_ints (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Int)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt b)) :
+    smtEvalAt mode mp env (.sub l r) = some (.sInt (a - b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_mul_ints (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Int)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt b)) :
+    smtEvalAt mode mp env (.mul l r) = some (.sInt (a * b)) := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_div_ints_nonZero (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a b : Int) (hbz : b ≠ 0)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt b)) :
+    smtEvalAt mode mp env (.div l r) = some (.sInt (a.ediv b)) := by
+  cases b with
+  | ofNat k =>
+    cases k with
+    | zero => exact absurd rfl hbz
+    | succ _ => simp only [smtEvalAt, hl, hr]
+  | negSucc _ => simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_div_zero (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (a : Int)
+    (hl : smtEvalAt mode mp env l = some (.sInt a))
+    (hr : smtEvalAt mode mp env r = some (.sInt 0)) :
+    smtEvalAt mode mp env (.div l r) = none := by
+  simp only [smtEvalAt, hl, hr]
+
+theorem smtEvalAt_letIn_some (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (x : String) (value body : SmtTerm) (v : SmtVal)
+    (h : smtEvalAt mode mp env value = some v) :
+    smtEvalAt mode mp env (.letIn x value body)
+      = smtEvalAt mode mp ((x, v) :: env) body := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_enumElemConst_unknown (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {en mem : String}
+    (h : (mp.at mode).lookupSortMembers en = none) :
+    smtEvalAt mode mp env (.enumElemConst en mem) = none := by
+  simp only [smtEvalAt, h]
+
 /-! ## Per-constructor characterization lemmas for `smtEval`.
 
 Mirrors the M_L.1 pattern: mutual `smtEval` doesn't reduce via `rfl`,

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -828,6 +828,14 @@ theorem smtEvalAt_enumElemConst_unknown (mode : StateMode) (mp : SmtModelPair) (
     smtEvalAt mode mp env (.enumElemConst en mem) = none := by
   simp only [smtEvalAt, h]
 
+theorem smtEvalAt_enumElemConst_nonMember (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {en mem : String} {members : List String}
+    (hSort : (mp.at mode).lookupSortMembers en = some members)
+    (hMember : members.contains mem = false) :
+    smtEvalAt mode mp env (.enumElemConst en mem) = none := by
+  simp only [smtEvalAt, hSort, hMember]
+  rfl
+
 theorem smtEvalAt_var_const (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {x : String} {v : SmtVal}
     (hEnv : env.lookup x = none)

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -24,6 +24,10 @@ inductive SmtVal where
   | sEnumElem (enumName memberName : String)
   | sEntityElem (entityName id : String)
   | sSet (members : List SmtVal)
+  /-- M_L.4.b-ext Phase 4b: SMT-side mirror of `Value.vEntityWith`. Skolem
+      encoding for `Expr.withRec`. `SmtVal.fieldLookup` walks the chain
+      symmetric to `Value.fieldLookup`. -/
+  | sEntityWith (base : SmtVal) (fld : String) (value : SmtVal)
   deriving Repr, Inhabited
 
 mutual
@@ -48,26 +52,45 @@ mutual
         match decEqSmtValList xs ys with
         | isTrue h  => isTrue (by cases h; rfl)
         | isFalse h => isFalse (by intro h'; cases h'; exact h rfl)
+    | .sEntityWith ba fa va, .sEntityWith bb fb vb =>
+        match decEqSmtVal ba bb with
+        | isFalse hB => isFalse (by intro h'; cases h'; exact hB rfl)
+        | isTrue hB =>
+          if hF : fa = fb then
+            match decEqSmtVal va vb with
+            | isFalse hV => isFalse (by intro h'; cases h'; exact hV rfl)
+            | isTrue hV => isTrue (by cases hB; cases hF; cases hV; rfl)
+          else isFalse (by intro h'; cases h'; exact hF rfl)
     | .sBool _, .sInt _ => isFalse (by intro h; cases h)
     | .sBool _, .sEnumElem _ _ => isFalse (by intro h; cases h)
     | .sBool _, .sEntityElem _ _ => isFalse (by intro h; cases h)
     | .sBool _, .sSet _ => isFalse (by intro h; cases h)
+    | .sBool _, .sEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .sInt _, .sBool _ => isFalse (by intro h; cases h)
     | .sInt _, .sEnumElem _ _ => isFalse (by intro h; cases h)
     | .sInt _, .sEntityElem _ _ => isFalse (by intro h; cases h)
     | .sInt _, .sSet _ => isFalse (by intro h; cases h)
+    | .sInt _, .sEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .sEnumElem _ _, .sBool _ => isFalse (by intro h; cases h)
     | .sEnumElem _ _, .sInt _ => isFalse (by intro h; cases h)
     | .sEnumElem _ _, .sEntityElem _ _ => isFalse (by intro h; cases h)
     | .sEnumElem _ _, .sSet _ => isFalse (by intro h; cases h)
+    | .sEnumElem _ _, .sEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .sEntityElem _ _, .sBool _ => isFalse (by intro h; cases h)
     | .sEntityElem _ _, .sInt _ => isFalse (by intro h; cases h)
     | .sEntityElem _ _, .sEnumElem _ _ => isFalse (by intro h; cases h)
     | .sEntityElem _ _, .sSet _ => isFalse (by intro h; cases h)
+    | .sEntityElem _ _, .sEntityWith _ _ _ => isFalse (by intro h; cases h)
     | .sSet _, .sBool _ => isFalse (by intro h; cases h)
     | .sSet _, .sInt _ => isFalse (by intro h; cases h)
     | .sSet _, .sEnumElem _ _ => isFalse (by intro h; cases h)
     | .sSet _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+    | .sSet _, .sEntityWith _ _ _ => isFalse (by intro h; cases h)
+    | .sEntityWith _ _ _, .sBool _ => isFalse (by intro h; cases h)
+    | .sEntityWith _ _ _, .sInt _ => isFalse (by intro h; cases h)
+    | .sEntityWith _ _ _, .sEnumElem _ _ => isFalse (by intro h; cases h)
+    | .sEntityWith _ _ _, .sEntityElem _ _ => isFalse (by intro h; cases h)
+    | .sEntityWith _ _ _, .sSet _ => isFalse (by intro h; cases h)
 
   def decEqSmtValList : (xs ys : List SmtVal) → Decidable (xs = ys)
     | [], [] => isTrue rfl
@@ -99,6 +122,8 @@ def beqSmtVal : SmtVal → SmtVal → Bool
   | .sEnumElem en mem, .sEnumElem en' mem' => en == en' && mem == mem'
   | .sEntityElem en id, .sEntityElem en' id' => en == en' && id == id'
   | .sSet xs, .sSet ys => setEqSmtValList xs ys
+  | .sEntityWith ba fa va, .sEntityWith bb fb vb =>
+      decide (ba = bb) && fa == fb && decide (va = vb)
   | _, _ => false
 
 instance : BEq SmtVal where
@@ -138,6 +163,9 @@ inductive SmtTerm where
       to `.post` when entering `.prime` and to `.pre` when entering `.pre`. -/
   | prime (t : SmtTerm)
   | pre   (t : SmtTerm)
+  /-- M_L.4.b-ext Phase 4b: Skolem encoding for `Expr.withRec`. `smtEval`
+      evaluates base and value, wraps as `sEntityWith`. -/
+  | withRec (base : SmtTerm) (fld : String) (value : SmtTerm)
   deriving Repr, Inhabited
 
 /-- An SMT model resolves the free symbols left by the translator: the
@@ -177,6 +205,17 @@ def SmtModel.lookupField (m : SmtModel) (entityId fieldName : String) : Option S
   match List.lookup entityId m.predFields with
   | some fields => List.lookup fieldName fields
   | none        => none
+
+/-- Phase 4b: SMT-side mirror of `Value.fieldLookup`. Walks `sEntityWith`
+    chains; for `sEntityElem`, looks up via `m.lookupField`; for other shapes,
+    returns none. Structural recursion on SmtVal via the `base` of
+    `sEntityWith`. -/
+def SmtVal.fieldLookup (m : SmtModel) : SmtVal → String → Option SmtVal
+  | .sEntityElem _ id, fld => m.lookupField id fld
+  | .sEntityWith base ovFld ovValue, fld =>
+      if fld = ovFld then some ovValue
+      else SmtVal.fieldLookup m base fld
+  | _, _ => none
 
 /-! ## Two-state model carrier (M_L.4.b-ext Phase 2, issue #194).
 
@@ -337,8 +376,8 @@ mutual
         | none    => none
     | .fieldAccess base fieldName =>
         match smtEval m env base with
-        | some (.sEntityElem _ id) => m.lookupField id fieldName
-        | _                        => none
+        | some v => SmtVal.fieldLookup m v fieldName
+        | none   => none
     | .setEmpty => some (.sSet [])
     | .setInsert elem set =>
         match smtEval m env elem, smtEval m env set with
@@ -362,6 +401,11 @@ mutual
         | _,              _              => none
     | .prime t => smtEval m env t
     | .pre   t => smtEval m env t
+    -- M_L.4.b-ext Phase 4b: Skolem encoding.
+    | .withRec base fld value =>
+        match smtEval m env base, smtEval m env value with
+        | some bv, some v => some (.sEntityWith bv fld v)
+        | _, _ => none
   termination_by t => (sizeOf t, 0)
 
   def smtEvalForallEnum (m : SmtModel) (env : SmtEnv)
@@ -489,8 +533,8 @@ mutual
         | none    => none
     | .fieldAccess base fieldName =>
         match smtEvalAt mode mp env base with
-        | some (.sEntityElem _ id) => (mp.at mode).lookupField id fieldName
-        | _                        => none
+        | some v => SmtVal.fieldLookup (mp.at mode) v fieldName
+        | none   => none
     | .setEmpty => some (.sSet [])
     | .setInsert elem set =>
         match smtEvalAt mode mp env elem, smtEvalAt mode mp env set with
@@ -514,6 +558,11 @@ mutual
         | _,              _              => none
     | .prime t => smtEvalAt .post mp env t
     | .pre   t => smtEvalAt .pre  mp env t
+    -- M_L.4.b-ext Phase 4b: Skolem encoding (mode-aware).
+    | .withRec base fld value =>
+        match smtEvalAt mode mp env base, smtEvalAt mode mp env value with
+        | some bv, some v => some (.sEntityWith bv fld v)
+        | _, _ => none
   termination_by t => (sizeOf t, 0)
 
   def smtEvalAtForallEnum (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
@@ -660,6 +709,10 @@ mutual
     | _, m, env, .pre t => by
         simp only [smtEvalAt, smtEval]
         exact smtEvalAt_diagonal_eq_smtEval .pre m env t
+    | mode, m, env, .withRec base fld value => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env base,
+            smtEvalAt_diagonal_eq_smtEval mode m env value]
   termination_by _ _ _ t => (sizeOf t, 0)
 
   theorem smtEvalAtForallEnum_diagonal_eq :
@@ -887,12 +940,21 @@ theorem smtEvalAt_indexRel_key_none (mode : StateMode) (mp : SmtModelPair) (env 
     smtEvalAt mode mp env (.indexRel relName key) = none := by
   simp only [smtEvalAt, hKey]
 
+/-- Phase 4b: smtEvalAt fieldAccess routes through `SmtVal.fieldLookup`. -/
+theorem smtEvalAt_fieldAccess_lookup (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (base : SmtTerm) (v : SmtVal) (fieldName : String)
+    (hBase : smtEvalAt mode mp env base = some v) :
+    smtEvalAt mode mp env (.fieldAccess base fieldName)
+      = SmtVal.fieldLookup (mp.at mode) v fieldName := by
+  simp only [smtEvalAt, hBase]
+
 theorem smtEvalAt_fieldAccess_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     (base : SmtTerm) (en id fieldName : String)
     (hBase : smtEvalAt mode mp env base = some (.sEntityElem en id)) :
     smtEvalAt mode mp env (.fieldAccess base fieldName)
       = (mp.at mode).lookupField id fieldName := by
-  simp only [smtEvalAt, hBase]
+  rw [smtEvalAt_fieldAccess_lookup mode mp env base (.sEntityElem en id) fieldName hBase]
+  simp only [SmtVal.fieldLookup]
 
 theorem smtEvalAt_fieldAccess_base_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     (base : SmtTerm) (fieldName : String)
@@ -903,11 +965,13 @@ theorem smtEvalAt_fieldAccess_base_none (mode : StateMode) (mp : SmtModelPair) (
 theorem smtEvalAt_fieldAccess_nonEntity (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {base : SmtTerm} {fieldName : String} {v : SmtVal}
     (hBase : smtEvalAt mode mp env base = some v)
-    (hNotEntity : ∀ en id, v ≠ .sEntityElem en id) :
+    (hNotEntity : ∀ en id, v ≠ .sEntityElem en id)
+    (hNotEntityWith : ∀ b f w, v ≠ .sEntityWith b f w) :
     smtEvalAt mode mp env (.fieldAccess base fieldName) = none := by
-  simp only [smtEvalAt, hBase]
+  rw [smtEvalAt_fieldAccess_lookup mode mp env base v fieldName hBase]
   cases v with
   | sEntityElem en id => exact absurd rfl (hNotEntity en id)
+  | sEntityWith b f w => exact absurd rfl (hNotEntityWith b f w)
   | sBool _ => rfl
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
@@ -1007,6 +1071,8 @@ theorem smtEvalAt_not_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtE
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEvalAt_neg_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     (t : SmtTerm) (h : smtEvalAt mode mp env t = none) :
     smtEvalAt mode mp env (.neg t) = none := by simp only [smtEvalAt, h]
@@ -1022,6 +1088,8 @@ theorem smtEvalAt_neg_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEn
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEvalAt_and_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
@@ -1044,6 +1112,8 @@ theorem smtEvalAt_and_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : 
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEvalAt_and_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} {a : Bool} {v : SmtVal}
     (hl : smtEvalAt mode mp env l = some (.sBool a))
@@ -1056,6 +1126,8 @@ theorem smtEvalAt_and_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : 
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEvalAt_or_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
@@ -1078,6 +1150,8 @@ theorem smtEvalAt_or_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : S
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEvalAt_or_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} {a : Bool} {v : SmtVal}
     (hl : smtEvalAt mode mp env l = some (.sBool a))
@@ -1090,6 +1164,8 @@ theorem smtEvalAt_or_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : S
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEvalAt_implies_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
@@ -1112,6 +1188,8 @@ theorem smtEvalAt_implies_lhs_nonBool (mode : StateMode) (mp : SmtModelPair) (en
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEvalAt_implies_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} {a : Bool} {v : SmtVal}
     (hl : smtEvalAt mode mp env l = some (.sBool a))
@@ -1124,6 +1202,8 @@ theorem smtEvalAt_implies_rhs_nonBool (mode : StateMode) (mp : SmtModelPair) (en
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEvalAt_eq_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
@@ -1155,6 +1235,8 @@ theorem smtEvalAt_lt_lhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : Sm
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEvalAt_lt_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} {a : Int} {v : SmtVal}
     (hl : smtEvalAt mode mp env l = some (.sInt a))
@@ -1167,6 +1249,8 @@ theorem smtEvalAt_lt_rhs_nonInt (mode : StateMode) (mp : SmtModelPair) (env : Sm
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEvalAt_add_lhs_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
     {l r : SmtTerm} (h : smtEvalAt mode mp env l = none) :
@@ -1616,11 +1700,19 @@ theorem smtEval_indexRel_key_none {relName : String} {key : SmtTerm}
     smtEval m env (.indexRel relName key) = none := by
   simp only [smtEval, hKey]
 
+/-- Phase 4b: smtEval fieldAccess routes through `SmtVal.fieldLookup`. -/
+theorem smtEval_fieldAccess_lookup (base : SmtTerm) (v : SmtVal) (fieldName : String)
+    (hBase : smtEval m env base = some v) :
+    smtEval m env (.fieldAccess base fieldName)
+      = SmtVal.fieldLookup m v fieldName := by
+  simp only [smtEval, hBase]
+
 theorem smtEval_fieldAccess_resolved (base : SmtTerm) (en id fieldName : String)
     (hBase : smtEval m env base = some (.sEntityElem en id)) :
     smtEval m env (.fieldAccess base fieldName)
       = m.lookupField id fieldName := by
-  simp only [smtEval, hBase]
+  rw [smtEval_fieldAccess_lookup m env base (.sEntityElem en id) fieldName hBase]
+  simp only [SmtVal.fieldLookup]
 
 theorem smtEval_fieldAccess_base_none (base : SmtTerm) (fieldName : String)
     (hBase : smtEval m env base = none) :
@@ -1629,11 +1721,13 @@ theorem smtEval_fieldAccess_base_none (base : SmtTerm) (fieldName : String)
 
 theorem smtEval_fieldAccess_nonEntity {base : SmtTerm} {fieldName : String} {v : SmtVal}
     (hBase : smtEval m env base = some v)
-    (hNotEntity : ∀ en id, v ≠ .sEntityElem en id) :
+    (hNotEntity : ∀ en id, v ≠ .sEntityElem en id)
+    (hNotEntityWith : ∀ b f w, v ≠ .sEntityWith b f w) :
     smtEval m env (.fieldAccess base fieldName) = none := by
-  simp only [smtEval, hBase]
+  rw [smtEval_fieldAccess_lookup m env base v fieldName hBase]
   cases v with
   | sEntityElem en id => exact absurd rfl (hNotEntity en id)
+  | sEntityWith b f w => exact absurd rfl (hNotEntityWith b f w)
   | sBool _ => rfl
   | sInt _ => rfl
   | sEnumElem _ _ => rfl
@@ -1827,6 +1921,8 @@ theorem smtEval_not_nonBool {t : SmtTerm} {v : SmtVal}
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEval_neg_none (t : SmtTerm) (h : smtEval m env t = none) :
     smtEval m env (.neg t) = none := by
   simp only [smtEval, h]
@@ -1842,6 +1938,8 @@ theorem smtEval_neg_nonInt {t : SmtTerm} {v : SmtVal}
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEval_and_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
     (h : smtEval m env l = some v) (hNotBool : ∀ b, v ≠ .sBool b) :
     smtEval m env (.and l r) = none := by
@@ -1852,6 +1950,8 @@ theorem smtEval_and_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEval_and_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.and l r) = none := by
@@ -1874,6 +1974,8 @@ theorem smtEval_and_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEval_or_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.or l r) = none := by
   simp only [smtEval, h]
@@ -1888,6 +1990,8 @@ theorem smtEval_or_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEval_or_rhs_none {l r : SmtTerm} {a : Bool}
     (hl : smtEval m env l = some (.sBool a)) (hr : smtEval m env r = none) :
@@ -1906,6 +2010,8 @@ theorem smtEval_or_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEval_implies_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.implies l r) = none := by
   simp only [smtEval, h]
@@ -1920,6 +2026,8 @@ theorem smtEval_implies_lhs_nonBool {l r : SmtTerm} {v : SmtVal}
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEval_implies_rhs_none {l r : SmtTerm} {a : Bool}
     (hl : smtEval m env l = some (.sBool a)) (hr : smtEval m env r = none) :
@@ -1937,6 +2045,8 @@ theorem smtEval_implies_rhs_nonBool {l r : SmtTerm} {a : Bool} {v : SmtVal}
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEval_eq_lhs_none {l r : SmtTerm} (h : smtEval m env l = none) :
     smtEval m env (.eq l r) = none := by
@@ -1962,6 +2072,8 @@ theorem smtEval_lt_lhs_nonInt {l r : SmtTerm} {v : SmtVal}
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
 
+  | sEntityWith _ _ _ => rfl
+
 theorem smtEval_lt_rhs_none {l r : SmtTerm} {a : Int}
     (hl : smtEval m env l = some (.sInt a)) (hr : smtEval m env r = none) :
     smtEval m env (.lt l r) = none := by
@@ -1978,6 +2090,8 @@ theorem smtEval_lt_rhs_nonInt {l r : SmtTerm} {a : Int} {v : SmtVal}
   | sEnumElem _ _ => rfl
   | sEntityElem _ _ => rfl
   | sSet _ => rfl
+
+  | sEntityWith _ _ _ => rfl
 
 theorem smtEval_letIn_none {x : String} {value body : SmtTerm}
     (h : smtEval m env value = none) :

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -123,7 +123,10 @@ def beqSmtVal : SmtVal → SmtVal → Bool
   | .sEntityElem en id, .sEntityElem en' id' => en == en' && id == id'
   | .sSet xs, .sSet ys => setEqSmtValList xs ys
   | .sEntityWith ba fa va, .sEntityWith bb fb vb =>
-      decide (ba = bb) && fa == fb && decide (va = vb)
+      -- Recursive `beqSmtVal` so set-equality stays extensional inside
+      -- record-update chains (parallels the Lean `beqValue` arm in
+      -- `Semantics.lean`).
+      beqSmtVal ba bb && fa == fb && beqSmtVal va vb
   | _, _ => false
 
 instance : BEq SmtVal where

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -1,3 +1,5 @@
+import SpecRest.Semantics
+
 namespace SpecRest
 
 /-! # Shallow embedding of the SMT-LIB fragment emitted by `z3.Translator`.
@@ -131,6 +133,11 @@ inductive SmtTerm where
   | setUnion (l r : SmtTerm)
   | setIntersect (l r : SmtTerm)
   | setDiff (l r : SmtTerm)
+  /-- M_L.4.b-ext Phase 2 (issue #194): mode-tagging wrapper. `smtEval` treats
+      these as identity (single-state); the mode-aware `smtEvalAt` flips mode
+      to `.post` when entering `.prime` and to `.pre` when entering `.pre`. -/
+  | prime (t : SmtTerm)
+  | pre   (t : SmtTerm)
   deriving Repr, Inhabited
 
 /-- An SMT model resolves the free symbols left by the translator: the
@@ -170,6 +177,45 @@ def SmtModel.lookupField (m : SmtModel) (entityId fieldName : String) : Option S
   match List.lookup entityId m.predFields with
   | some fields => List.lookup fieldName fields
   | none        => none
+
+/-! ## Two-state model carrier (M_L.4.b-ext Phase 2, issue #194).
+
+`SmtModelPair` mirrors `Semantics.lean`'s `StatePair`: the SMT side of a
+two-state coupling carries one model per mode. `sortMembers` is schema-level
+(immutable across modes) but is duplicated in both projections so the lookup
+shape stays uniform — diagonal callers always get consistent answers and
+off-diagonal callers must seed the same enum data on both sides. The mode-
+aware `smtEvalAt` evaluator below reads state through `mp.at mode`. -/
+
+structure SmtModelPair where
+  pre  : SmtModel
+  post : SmtModel
+  deriving Repr, Inhabited
+
+def SmtModelPair.at : SmtModelPair → StateMode → SmtModel
+  | mp, .pre  => mp.pre
+  | mp, .post => mp.post
+
+@[simp] theorem SmtModelPair.at_pre (mp : SmtModelPair) :
+    mp.at .pre = mp.pre := rfl
+
+@[simp] theorem SmtModelPair.at_post (mp : SmtModelPair) :
+    mp.at .post = mp.post := rfl
+
+/-- Diagonal `SmtModelPair` — both projections collapse to the same `SmtModel`.
+    The `smtEvalAt` evaluator agrees with `smtEval` on diagonal pairs (proven
+    below as `smtEvalAt_diagonal_eq_smtEval`). -/
+def SmtModelPair.diag (m : SmtModel) : SmtModelPair := { pre := m, post := m }
+
+@[simp] theorem SmtModelPair.diag_pre (m : SmtModel) :
+    (SmtModelPair.diag m).pre = m := rfl
+
+@[simp] theorem SmtModelPair.diag_post (m : SmtModel) :
+    (SmtModelPair.diag m).post = m := rfl
+
+@[simp] theorem SmtModelPair.at_diag (m : SmtModel) (mode : StateMode) :
+    (SmtModelPair.diag m).at mode = m := by
+  cases mode <;> rfl
 
 abbrev SmtEnv := List (String × SmtVal)
 
@@ -314,6 +360,8 @@ mutual
         match smtEval m env l, smtEval m env r with
         | some (.sSet a), some (.sSet b) => some (.sSet (setDiffSmtVals a b))
         | _,              _              => none
+    | .prime t => smtEval m env t
+    | .pre   t => smtEval m env t
   termination_by t => (sizeOf t, 0)
 
   def smtEvalForallEnum (m : SmtModel) (env : SmtEnv)
@@ -344,6 +392,314 @@ mutual
   termination_by (sizeOf body, dom.length)
 
 end
+
+/-! ## Mode-aware SMT evaluator (M_L.4.b-ext Phase 2, issue #194).
+
+`smtEvalAt` mirrors `smtEval` but threads `StateMode` and reads state through
+`mp.at mode`. The mode-tagging arms `.prime t` / `.pre t` flip the mode while
+recursing — the SMT-side mirror of `Semantics.lean`'s `evalAt`. The mutual
+companions `smtEvalAtForallEnum` / `smtEvalAtForallRel` recurse with the same
+mode (binders don't introduce mode flips). -/
+
+mutual
+
+  def smtEvalAt (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) :
+      SmtTerm → Option SmtVal
+    | .bLit b => some (.sBool b)
+    | .iLit n => some (.sInt n)
+    | .var x =>
+        match env.lookup x with
+        | some v => some v
+        | none   => (mp.at mode).lookupConst x
+    | .enumElemConst en mem =>
+        match (mp.at mode).lookupSortMembers en with
+        | some members => if members.contains mem then some (.sEnumElem en mem) else none
+        | none         => none
+    | .not t =>
+        match smtEvalAt mode mp env t with
+        | some (.sBool b) => some (.sBool (!b))
+        | _               => none
+    | .and l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (a && b))
+        | _, _                             => none
+    | .or l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (a || b))
+        | _, _                             => none
+    | .implies l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sBool a), some (.sBool b) => some (.sBool (!a || b))
+        | _, _                             => none
+    | .eq l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some a, some b => some (.sBool (a == b))
+        | _, _           => none
+    | .lt l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sInt a), some (.sInt b) => some (.sBool (decide (a < b)))
+        | _, _                           => none
+    | .neg t =>
+        match smtEvalAt mode mp env t with
+        | some (.sInt n) => some (.sInt (-n))
+        | _              => none
+    | .add l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sInt a), some (.sInt b) => some (.sInt (a + b))
+        | _, _                           => none
+    | .sub l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sInt a), some (.sInt b) => some (.sInt (a - b))
+        | _, _                           => none
+    | .mul l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sInt a), some (.sInt b) => some (.sInt (a * b))
+        | _, _                           => none
+    | .div l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sInt _), some (.sInt 0) => none
+        | some (.sInt a), some (.sInt b) => some (.sInt (a.ediv b))
+        | _, _                           => none
+    | .inDom relName arg =>
+        match smtEvalAt mode mp env arg with
+        | some v =>
+            match (mp.at mode).lookupRel relName with
+            | some dom => some (.sBool (dom.contains v))
+            | none     => none
+        | none => none
+    | .cardRel relName =>
+        match (mp.at mode).lookupRel relName with
+        | some dom => some (.sInt (Int.ofNat dom.length))
+        | none     => none
+    | .letIn x value body =>
+        match smtEvalAt mode mp env value with
+        | some v => smtEvalAt mode mp ((x, v) :: env) body
+        | none   => none
+    | .forallEnum var sortName body =>
+        match (mp.at mode).lookupSortMembers sortName with
+        | some members => smtEvalAtForallEnum mode mp env var sortName members body
+        | none         => none
+    | .forallRel var relName body =>
+        match (mp.at mode).lookupRel relName with
+        | some dom => smtEvalAtForallRel mode mp env var dom body
+        | none     => none
+    | .indexRel relName key =>
+        match smtEvalAt mode mp env key with
+        | some kv => (mp.at mode).lookupKey relName kv
+        | none    => none
+    | .fieldAccess base fieldName =>
+        match smtEvalAt mode mp env base with
+        | some (.sEntityElem _ id) => (mp.at mode).lookupField id fieldName
+        | _                        => none
+    | .setEmpty => some (.sSet [])
+    | .setInsert elem set =>
+        match smtEvalAt mode mp env elem, smtEvalAt mode mp env set with
+        | some v, some (.sSet members) => some (.sSet (dedupeSmtVals (v :: members)))
+        | _,      _                    => none
+    | .setMember elem set =>
+        match smtEvalAt mode mp env elem, smtEvalAt mode mp env set with
+        | some v, some (.sSet members) => some (.sBool (containsSmtVal members v))
+        | _,      _                    => none
+    | .setUnion l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setUnionSmtVals a b))
+        | _,              _              => none
+    | .setIntersect l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setIntersectSmtVals a b))
+        | _,              _              => none
+    | .setDiff l r =>
+        match smtEvalAt mode mp env l, smtEvalAt mode mp env r with
+        | some (.sSet a), some (.sSet b) => some (.sSet (setDiffSmtVals a b))
+        | _,              _              => none
+    | .prime t => smtEvalAt .post mp env t
+    | .pre   t => smtEvalAt .pre  mp env t
+  termination_by t => (sizeOf t, 0)
+
+  def smtEvalAtForallEnum (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+      (var : String) (sortName : String)
+      (members : List String) (body : SmtTerm) : Option SmtVal :=
+    match members with
+    | [] => some (.sBool true)
+    | mem :: rest =>
+        match smtEvalAt mode mp ((var, .sEnumElem sortName mem) :: env) body with
+        | some (.sBool b) =>
+            match smtEvalAtForallEnum mode mp env var sortName rest body with
+            | some (.sBool acc) => some (.sBool (b && acc))
+            | _                 => none
+        | _ => none
+  termination_by (sizeOf body, members.length)
+
+  def smtEvalAtForallRel (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+      (var : String) (dom : List SmtVal) (body : SmtTerm) : Option SmtVal :=
+    match dom with
+    | [] => some (.sBool true)
+    | v :: rest =>
+        match smtEvalAt mode mp ((var, v) :: env) body with
+        | some (.sBool b) =>
+            match smtEvalAtForallRel mode mp env var rest body with
+            | some (.sBool acc) => some (.sBool (b && acc))
+            | _                 => none
+        | _ => none
+  termination_by (sizeOf body, dom.length)
+
+end
+
+/-! ### Diagonal-collapse theorem for `smtEvalAt`.
+
+When `mp = SmtModelPair.diag m`, `smtEvalAt mode mp env t = smtEval m env t`
+for every mode and every SmtTerm. Mirrors `evalAt_diagonal_eq_eval`. Phase 2's
+deliverable rests on this: every existing single-state per-case `smtEval`
+characterization lifts unchanged through the collapse. -/
+
+mutual
+
+  theorem smtEvalAt_diagonal_eq_smtEval :
+      ∀ (mode : StateMode) (m : SmtModel) (env : SmtEnv) (t : SmtTerm),
+        smtEvalAt mode (SmtModelPair.diag m) env t = smtEval m env t
+    | _, _, _, .bLit _  => by simp only [smtEvalAt, smtEval]
+    | _, _, _, .iLit _  => by simp only [smtEvalAt, smtEval]
+    | _, _, _, .var _   => by simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+    | _, _, _, .enumElemConst _ _ => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+    | mode, m, env, .not t => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env t]
+    | mode, m, env, .and l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .or l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .implies l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .eq l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .lt l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .neg t => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env t]
+    | mode, m, env, .add l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .sub l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .mul l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .div l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .inDom relName arg => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env arg]
+    | _, _, _, .cardRel _ => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+    | mode, m, env, .letIn x value body => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env value]
+        cases smtEval m env value with
+        | none => rfl
+        | some v => exact smtEvalAt_diagonal_eq_smtEval mode m ((x, v) :: env) body
+    | mode, m, env, .forallEnum var sortName body => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+        cases m.lookupSortMembers sortName with
+        | none => rfl
+        | some members =>
+            exact smtEvalAtForallEnum_diagonal_eq mode m env var sortName members body
+    | mode, m, env, .forallRel var relName body => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+        cases m.lookupRel relName with
+        | none => rfl
+        | some dom =>
+            exact smtEvalAtForallRel_diagonal_eq mode m env var dom body
+    | mode, m, env, .indexRel relName key => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env key]
+    | mode, m, env, .fieldAccess base fieldName => by
+        simp only [smtEvalAt, smtEval, SmtModelPair.at_diag]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env base]
+    | _, _, _, .setEmpty => by simp only [smtEvalAt, smtEval]
+    | mode, m, env, .setInsert elem set => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env elem,
+            smtEvalAt_diagonal_eq_smtEval mode m env set]
+    | mode, m, env, .setMember elem set => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env elem,
+            smtEvalAt_diagonal_eq_smtEval mode m env set]
+    | mode, m, env, .setUnion l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .setIntersect l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | mode, m, env, .setDiff l r => by
+        simp only [smtEvalAt, smtEval]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m env l,
+            smtEvalAt_diagonal_eq_smtEval mode m env r]
+    | _, m, env, .prime t => by
+        simp only [smtEvalAt, smtEval]
+        exact smtEvalAt_diagonal_eq_smtEval .post m env t
+    | _, m, env, .pre t => by
+        simp only [smtEvalAt, smtEval]
+        exact smtEvalAt_diagonal_eq_smtEval .pre m env t
+  termination_by _ _ _ t => (sizeOf t, 0)
+
+  theorem smtEvalAtForallEnum_diagonal_eq :
+      ∀ (mode : StateMode) (m : SmtModel) (env : SmtEnv)
+        (var : String) (sortName : String) (members : List String) (body : SmtTerm),
+        smtEvalAtForallEnum mode (SmtModelPair.diag m) env var sortName members body
+          = smtEvalForallEnum m env var sortName members body
+    | _, _, _, _, _, [], _ => by
+        simp only [smtEvalAtForallEnum, smtEvalForallEnum]
+    | mode, m, env, var, sortName, mem :: rest, body => by
+        simp only [smtEvalAtForallEnum, smtEvalForallEnum]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m
+              ((var, .sEnumElem sortName mem) :: env) body,
+            smtEvalAtForallEnum_diagonal_eq mode m env var sortName rest body]
+  termination_by _ _ _ _ _ members body => (sizeOf body, members.length)
+
+  theorem smtEvalAtForallRel_diagonal_eq :
+      ∀ (mode : StateMode) (m : SmtModel) (env : SmtEnv)
+        (var : String) (dom : List SmtVal) (body : SmtTerm),
+        smtEvalAtForallRel mode (SmtModelPair.diag m) env var dom body
+          = smtEvalForallRel m env var dom body
+    | _, _, _, _, [], _ => by
+        simp only [smtEvalAtForallRel, smtEvalForallRel]
+    | mode, m, env, var, v :: rest, body => by
+        simp only [smtEvalAtForallRel, smtEvalForallRel]
+        rw [smtEvalAt_diagonal_eq_smtEval mode m ((var, v) :: env) body,
+            smtEvalAtForallRel_diagonal_eq mode m env var rest body]
+  termination_by _ _ _ _ dom body => (sizeOf body, dom.length)
+
+end
+
+/-! ### `smtEvalAt` mode-flip characterizations on `.prime` / `.pre`. -/
+
+theorem smtEvalAt_prime (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) (t : SmtTerm) :
+    smtEvalAt mode mp env (.prime t) = smtEvalAt .post mp env t := by
+  simp only [smtEvalAt]
+
+theorem smtEvalAt_pre (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) (t : SmtTerm) :
+    smtEvalAt mode mp env (.pre t) = smtEvalAt .pre mp env t := by
+  simp only [smtEvalAt]
 
 /-! ## Per-constructor characterization lemmas for `smtEval`.
 
@@ -964,6 +1320,18 @@ theorem smtEval_enumElemConst_unknown {en mem : String}
     (h : m.lookupSortMembers en = none) :
     smtEval m env (.enumElemConst en mem) = none := by
   simp only [smtEval, h]
+
+/-! ### Mode-tagging wrappers (M_L.4.b-ext Phase 2).
+
+`smtEval` is the single-state evaluator, so `.prime` / `.pre` are identity
+arms. The mode-aware `smtEvalAt` introduced below flips mode when entering
+these constructors. -/
+
+theorem smtEval_prime (t : SmtTerm) :
+    smtEval m env (.prime t) = smtEval m env t := by simp only [smtEval]
+
+theorem smtEval_pre (t : SmtTerm) :
+    smtEval m env (.pre t) = smtEval m env t := by simp only [smtEval]
 
 theorem smtEval_enumElemConst_nonMember {en mem : String} {members : List String}
     (hSort : m.lookupSortMembers en = some members) (hMember : members.contains mem = false) :

--- a/proofs/lean/SpecRest/Smt.lean
+++ b/proofs/lean/SpecRest/Smt.lean
@@ -828,6 +828,159 @@ theorem smtEvalAt_enumElemConst_unknown (mode : StateMode) (mp : SmtModelPair) (
     smtEvalAt mode mp env (.enumElemConst en mem) = none := by
   simp only [smtEvalAt, h]
 
+theorem smtEvalAt_var_const (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {x : String} {v : SmtVal}
+    (hEnv : env.lookup x = none)
+    (hConst : (mp.at mode).lookupConst x = some v) :
+    smtEvalAt mode mp env (.var x) = some v := by
+  simp only [smtEvalAt, hEnv, hConst]
+
+theorem smtEvalAt_inDom_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (relName : String) (arg : SmtTerm) (v : SmtVal) (dom : List SmtVal)
+    (hArg : smtEvalAt mode mp env arg = some v)
+    (hRel : (mp.at mode).lookupRel relName = some dom) :
+    smtEvalAt mode mp env (.inDom relName arg) = some (.sBool (dom.contains v)) := by
+  simp only [smtEvalAt, hArg, hRel]
+
+theorem smtEvalAt_inDom_arg_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {relName : String} {arg : SmtTerm}
+    (h : smtEvalAt mode mp env arg = none) :
+    smtEvalAt mode mp env (.inDom relName arg) = none := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_inDom_rel_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {relName : String} {arg : SmtTerm} {v : SmtVal}
+    (hArg : smtEvalAt mode mp env arg = some v)
+    (hRel : (mp.at mode).lookupRel relName = none) :
+    smtEvalAt mode mp env (.inDom relName arg) = none := by
+  simp only [smtEvalAt, hArg, hRel]
+
+theorem smtEvalAt_cardRel_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (relName : String) (dom : List SmtVal)
+    (hRel : (mp.at mode).lookupRel relName = some dom) :
+    smtEvalAt mode mp env (.cardRel relName) = some (.sInt (Int.ofNat dom.length)) := by
+  simp only [smtEvalAt, hRel]
+
+theorem smtEvalAt_cardRel_unknown (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (relName : String)
+    (h : (mp.at mode).lookupRel relName = none) :
+    smtEvalAt mode mp env (.cardRel relName) = none := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_indexRel_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (relName : String) (key : SmtTerm) (kv : SmtVal)
+    (hKey : smtEvalAt mode mp env key = some kv) :
+    smtEvalAt mode mp env (.indexRel relName key) = (mp.at mode).lookupKey relName kv := by
+  simp only [smtEvalAt, hKey]
+
+theorem smtEvalAt_indexRel_key_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {relName : String} {key : SmtTerm}
+    (hKey : smtEvalAt mode mp env key = none) :
+    smtEvalAt mode mp env (.indexRel relName key) = none := by
+  simp only [smtEvalAt, hKey]
+
+theorem smtEvalAt_fieldAccess_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (base : SmtTerm) (en id fieldName : String)
+    (hBase : smtEvalAt mode mp env base = some (.sEntityElem en id)) :
+    smtEvalAt mode mp env (.fieldAccess base fieldName)
+      = (mp.at mode).lookupField id fieldName := by
+  simp only [smtEvalAt, hBase]
+
+theorem smtEvalAt_fieldAccess_base_none (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (base : SmtTerm) (fieldName : String)
+    (hBase : smtEvalAt mode mp env base = none) :
+    smtEvalAt mode mp env (.fieldAccess base fieldName) = none := by
+  simp only [smtEvalAt, hBase]
+
+theorem smtEvalAt_fieldAccess_nonEntity (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {base : SmtTerm} {fieldName : String} {v : SmtVal}
+    (hBase : smtEvalAt mode mp env base = some v)
+    (hNotEntity : ∀ en id, v ≠ .sEntityElem en id) :
+    smtEvalAt mode mp env (.fieldAccess base fieldName) = none := by
+  simp only [smtEvalAt, hBase]
+  cases v with
+  | sEntityElem en id => exact absurd rfl (hNotEntity en id)
+  | sBool _ => rfl
+  | sInt _ => rfl
+  | sEnumElem _ _ => rfl
+  | sSet _ => rfl
+
+theorem smtEvalAt_forallEnum_known (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (var sortName : String) (body : SmtTerm) (members : List String)
+    (h : (mp.at mode).lookupSortMembers sortName = some members) :
+    smtEvalAt mode mp env (.forallEnum var sortName body)
+      = smtEvalAtForallEnum mode mp env var sortName members body := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAtForallEnum_nil (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (var sortName : String) (body : SmtTerm) :
+    smtEvalAtForallEnum mode mp env var sortName [] body = some (.sBool true) := by
+  simp only [smtEvalAtForallEnum]
+
+theorem smtEvalAt_forallEnum_unknown (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {var sortName : String} {body : SmtTerm}
+    (h : (mp.at mode).lookupSortMembers sortName = none) :
+    smtEvalAt mode mp env (.forallEnum var sortName body) = none := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_forallRel_known (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (var relName : String) (body : SmtTerm) (dom : List SmtVal)
+    (h : (mp.at mode).lookupRel relName = some dom) :
+    smtEvalAt mode mp env (.forallRel var relName body)
+      = smtEvalAtForallRel mode mp env var dom body := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAtForallRel_nil (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (var : String) (body : SmtTerm) :
+    smtEvalAtForallRel mode mp env var [] body = some (.sBool true) := by
+  simp only [smtEvalAtForallRel]
+
+theorem smtEvalAt_forallRel_unknown (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    {var relName : String} {body : SmtTerm}
+    (h : (mp.at mode).lookupRel relName = none) :
+    smtEvalAt mode mp env (.forallRel var relName body) = none := by
+  simp only [smtEvalAt, h]
+
+theorem smtEvalAt_setEmpty (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv) :
+    smtEvalAt mode mp env .setEmpty = some (.sSet []) := by
+  simp only [smtEvalAt]
+
+theorem smtEvalAt_setInsert_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (v : SmtVal) (members : List SmtVal)
+    (hElem : smtEvalAt mode mp env elem = some v)
+    (hSet : smtEvalAt mode mp env set = some (.sSet members)) :
+    smtEvalAt mode mp env (.setInsert elem set)
+      = some (.sSet (dedupeSmtVals (v :: members))) := by
+  simp only [smtEvalAt, hElem, hSet]
+
+theorem smtEvalAt_setMember_resolved (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (elem set : SmtTerm) (v : SmtVal) (members : List SmtVal)
+    (hElem : smtEvalAt mode mp env elem = some v)
+    (hSet : smtEvalAt mode mp env set = some (.sSet members)) :
+    smtEvalAt mode mp env (.setMember elem set) = some (.sBool (containsSmtVal members v)) := by
+  simp only [smtEvalAt, hElem, hSet]
+
+theorem smtEvalAt_setUnion_sets (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some (.sSet rs)) :
+    smtEvalAt mode mp env (.setUnion l r) = some (.sSet (setUnionSmtVals ls rs)) := by
+  simp only [smtEvalAt, hL, hR]
+
+theorem smtEvalAt_setIntersect_sets (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some (.sSet rs)) :
+    smtEvalAt mode mp env (.setIntersect l r) = some (.sSet (setIntersectSmtVals ls rs)) := by
+  simp only [smtEvalAt, hL, hR]
+
+theorem smtEvalAt_setDiff_sets (mode : StateMode) (mp : SmtModelPair) (env : SmtEnv)
+    (l r : SmtTerm) (ls rs : List SmtVal)
+    (hL : smtEvalAt mode mp env l = some (.sSet ls))
+    (hR : smtEvalAt mode mp env r = some (.sSet rs)) :
+    smtEvalAt mode mp env (.setDiff l r) = some (.sSet (setDiffSmtVals ls rs)) := by
+  simp only [smtEvalAt, hL, hR]
+
 /-! ## Per-constructor characterization lemmas for `smtEval`.
 
 Mirrors the M_L.1 pattern: mutual `smtEval` doesn't reduce via `rfl`,

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -3565,4 +3565,20 @@ theorem soundnessAt_setBin_sets (op : SetOp) (l r : Expr) (ls rs : List Value)
     congr 2
     exact setDiffValues_map_valueToSmt ls rs
 
+/-! ## Phase 3c roadmap.
+
+The universal `soundnessAt` theorem — the structural induction on `Expr` that
+ties every per-case `soundnessAt_*` theorem into the off-diagonal soundness
+claim — is the closure step for issue #194's first acceptance criterion. It
+mirrors the existing universal `soundness` (~836 LOC) with `evalAt` /
+`smtEvalAt` / `correlateModelPair` substituted, dispatching success paths to
+`soundnessAt_*` and failure paths to the `smtEvalAt_*_none/_nonBool/_nonInt/
+_nonSet` helpers added in `Smt.lean`.
+
+Phase 3c.1 (this PR) lands the ~33 `smtEvalAt_*` failure helpers in `Smt.lean`
+that the universal theorem will need. Phase 3c.2 (queued) writes the
+universal `soundnessAt` theorem itself, mechanically mirroring `soundness`'s
+case-by-case structure now that every per-case `soundnessAt_*` and every
+required failure helper exists. -/
+
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -2658,6 +2658,18 @@ theorem soundness (e : Expr) :
         | diff =>
           simp only [translate]
           exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+  | withRec _ _ _ =>
+    -- M_L.4.b-ext Phase 4: With ships with always-fail semantics. Both sides
+    -- yield `none`: eval returns `none` definitionally; translate emits
+    -- `0/0` whose smtEval is `none` (smtEval_div_zero). VerifiedSubset
+    -- rejects With so the cert emitter never reaches this arm.
+    rw [show eval s st env (.withRec _ _ _) = none from by simp only [eval]]
+    simp only [translate, valueToSmt?]
+    have : smtEval (correlateModel s st) (correlateEnv env)
+              (.div (.iLit 0) (.iLit 0)) = none :=
+      smtEval_div_zero _ _ (.iLit 0) (.iLit 0) 0
+        (smtEval_iLit _ _ 0) (smtEval_iLit _ _ 0)
+    exact this.symm
 
 /-! ## Two-state diagonal-collapse soundness (M_L.4.b-ext Phase 2, issue #194).
 
@@ -4967,5 +4979,15 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
           simp only [translate]
           exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
                     (hSmtValNotSet (.vEntity en i) nofun)).symm
+  | withRec _ _ _ =>
+    -- M_L.4.b-ext Phase 4: With ships with always-fail semantics on the
+    -- mode-aware evaluator too. Both sides yield `none`.
+    rw [show evalAt mode s sp env (.withRec _ _ _) = none from by simp only [evalAt]]
+    simp only [translate, valueToSmt?]
+    have : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+              (.div (.iLit 0) (.iLit 0)) = none :=
+      smtEvalAt_div_zero _ _ _ (.iLit 0) (.iLit 0) 0
+        (smtEvalAt_iLit _ _ _ 0) (smtEvalAt_iLit _ _ _ 0)
+    exact this.symm
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -3565,20 +3565,406 @@ theorem soundnessAt_setBin_sets (op : SetOp) (l r : Expr) (ls rs : List Value)
     congr 2
     exact setDiffValues_map_valueToSmt ls rs
 
-/-! ## Phase 3c roadmap.
+/-! ## Phase 3c — universal `soundnessAt` theorem (issue #194).
 
-The universal `soundnessAt` theorem — the structural induction on `Expr` that
-ties every per-case `soundnessAt_*` theorem into the off-diagonal soundness
-claim — is the closure step for issue #194's first acceptance criterion. It
-mirrors the existing universal `soundness` (~836 LOC) with `evalAt` /
-`smtEvalAt` / `correlateModelPair` substituted, dispatching success paths to
-`soundnessAt_*` and failure paths to the `smtEvalAt_*_none/_nonBool/_nonInt/
-_nonSet` helpers added in `Smt.lean`.
+Off-diagonal closure of the issue's first acceptance criterion: for every
+`Expr` in the verified subset, every mode / StatePair / env, evaluating
+under `evalAt` and `smtEvalAt` agree under the correlated `SmtModelPair`.
+Mirrors the existing universal `soundness` theorem with carriers substituted:
 
-Phase 3c.1 (this PR) lands the ~33 `smtEvalAt_*` failure helpers in `Smt.lean`
-that the universal theorem will need. Phase 3c.2 (queued) writes the
-universal `soundnessAt` theorem itself, mechanically mirroring `soundness`'s
-case-by-case structure now that every per-case `soundnessAt_*` and every
-required failure helper exists. -/
+  eval s st           ↦  evalAt mode s sp
+  smtEval m           ↦  smtEvalAt mode mp
+  correlateModel s st ↦  correlateModelPair s sp
+
+Structural induction on `Expr` generalizing `env` and `mode`. Each
+constructor's success path dispatches to its `soundnessAt_*` per-case theorem
+(Phases 3a/3b) and its failure paths use the `smtEvalAt_*_none/_nonBool/
+_nonInt/_nonSet` helpers (Phase 3c.1). Closes with no `sorry`. -/
+
+private theorem soundnessAt_unNot_nonBool (e : Expr) (v : Value)
+    (hNotBool : ∀ b, v ≠ .vBool b)
+    (ih : valueToSmt? (evalAt mode s sp env e)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e))
+    (h : evalAt mode s sp env e = some v) :
+    valueToSmt? (evalAt mode s sp env (.unNot e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.unNot e)) := by
+  have hEvalNone : evalAt mode s sp env (.unNot e) = none := by
+    simp only [evalAt, h]
+    cases v with
+    | vBool b => exact absurd rfl (hNotBool b)
+    | _ => rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [h] at ih; rw [valueToSmt?_some] at ih
+  simp only [valueToSmt?]
+  exact (smtEvalAt_not_nonBool _ _ _ ih.symm (hSmtLvNotBool v hNotBool)).symm
+
+private theorem soundnessAt_unNeg_nonInt (e : Expr) (v : Value)
+    (hNotInt : ∀ n, v ≠ .vInt n)
+    (ih : valueToSmt? (evalAt mode s sp env e)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e))
+    (h : evalAt mode s sp env e = some v) :
+    valueToSmt? (evalAt mode s sp env (.unNeg e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.unNeg e)) := by
+  have hEvalNone : evalAt mode s sp env (.unNeg e) = none := by
+    simp only [evalAt, h]
+    cases v with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [h] at ih; rw [valueToSmt?_some] at ih
+  simp only [valueToSmt?]
+  exact (smtEvalAt_neg_nonInt _ _ _ ih.symm (hSmtLvNotInt v hNotInt)).symm
+
+private theorem boolBin_lhs_nonBool_at (op : BoolBinOp) (l r : Expr) (lv : Value)
+    (hNotBool : ∀ b, lv ≠ .vBool b)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) :
+    valueToSmt? (evalAt mode s sp env (.boolBin op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.boolBin op l r) = none := by
+    simp only [evalAt, hL]
+    cases lv with
+    | vBool b => exact absurd rfl (hNotBool b)
+    | _ => rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  cases op with
+  | and =>
+    simp only [translate]
+    exact (smtEvalAt_and_lhs_nonBool _ _ _ ihL.symm (hSmtLvNotBool lv hNotBool)).symm
+  | or =>
+    simp only [translate]
+    exact (smtEvalAt_or_lhs_nonBool _ _ _ ihL.symm (hSmtLvNotBool lv hNotBool)).symm
+  | implies =>
+    simp only [translate]
+    exact (smtEvalAt_implies_lhs_nonBool _ _ _ ihL.symm (hSmtLvNotBool lv hNotBool)).symm
+  | iff =>
+    simp only [translate]
+    have hImp : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.implies (translate l) (translate r)) = none :=
+      smtEvalAt_implies_lhs_nonBool _ _ _ ihL.symm (hSmtLvNotBool lv hNotBool)
+    exact (smtEvalAt_and_lhs_none _ _ _ hImp).symm
+
+private theorem boolBin_rhs_nonBool_lhs_bool_at (op : BoolBinOp) (l r : Expr)
+    (a : Bool) (rv : Value)
+    (hNotBool : ∀ b, rv ≠ .vBool b)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vBool a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.boolBin op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.boolBin op l r) = none := by
+    simp only [evalAt, hL, hR]
+    cases rv with
+    | vBool b => exact absurd rfl (hNotBool b)
+    | _ => rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vBool] at ihL
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?]
+  cases op with
+  | and =>
+    simp only [translate]
+    exact (smtEvalAt_and_rhs_nonBool _ _ _ ihL.symm ihR.symm
+              (hSmtLvNotBool rv hNotBool)).symm
+  | or =>
+    simp only [translate]
+    exact (smtEvalAt_or_rhs_nonBool _ _ _ ihL.symm ihR.symm
+              (hSmtLvNotBool rv hNotBool)).symm
+  | implies =>
+    simp only [translate]
+    exact (smtEvalAt_implies_rhs_nonBool _ _ _ ihL.symm ihR.symm
+              (hSmtLvNotBool rv hNotBool)).symm
+  | iff =>
+    simp only [translate]
+    have hImp : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.implies (translate l) (translate r)) = none :=
+      smtEvalAt_implies_rhs_nonBool _ _ _ ihL.symm ihR.symm (hSmtLvNotBool rv hNotBool)
+    exact (smtEvalAt_and_lhs_none _ _ _ hImp).symm
+
+private theorem arith_lhs_nonInt_at (op : ArithOp) (l r : Expr) (lv : Value)
+    (hNotInt : ∀ n, lv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) :
+    valueToSmt? (evalAt mode s sp env (.arith op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.arith op l r) = none := by
+    simp only [evalAt, hL]
+    cases lv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases op <;> rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  cases op with
+  | add =>
+    simp only [translate]
+    exact (smtEvalAt_add_lhs_nonInt _ _ _ ihL.symm (hSmtLvNotInt lv hNotInt)).symm
+  | sub =>
+    simp only [translate]
+    exact (smtEvalAt_sub_lhs_nonInt _ _ _ ihL.symm (hSmtLvNotInt lv hNotInt)).symm
+  | mul =>
+    simp only [translate]
+    exact (smtEvalAt_mul_lhs_nonInt _ _ _ ihL.symm (hSmtLvNotInt lv hNotInt)).symm
+  | div =>
+    simp only [translate]
+    exact (smtEvalAt_div_lhs_nonInt _ _ _ ihL.symm (hSmtLvNotInt lv hNotInt)).symm
+
+private theorem arith_rhs_nonInt_lhs_int_at (op : ArithOp) (l r : Expr)
+    (a : Int) (rv : Value)
+    (hNotInt : ∀ n, rv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.arith op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.arith op l r) = none := by
+    simp only [evalAt, hL, hR]
+    cases rv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases op <;> rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vInt] at ihL
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?]
+  cases op with
+  | add =>
+    simp only [translate]
+    exact (smtEvalAt_add_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
+  | sub =>
+    simp only [translate]
+    exact (smtEvalAt_sub_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
+  | mul =>
+    simp only [translate]
+    exact (smtEvalAt_mul_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
+  | div =>
+    simp only [translate]
+    exact (smtEvalAt_div_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
+
+/-- All cmp ops fail when the LHS doesn't evaluate. Mirror of `cmp_lhs_eval_none`. -/
+private theorem cmp_lhs_eval_none_at (op : CmpOp) (l r : Expr)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = none) :
+    valueToSmt? (evalAt mode s sp env (.cmp op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp op l r) = none := by
+    rw [evalAt_cmp_app]
+    rw [hL]
+    cases op <;> rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; simp only [valueToSmt?] at ihL
+  simp only [valueToSmt?]
+  cases op with
+  | eq =>
+    simp only [translate]
+    exact (smtEvalAt_eq_lhs_none _ _ _ ihL.symm).symm
+  | neq =>
+    simp only [translate]
+    exact (smtEvalAt_not_none _ _ _ _ (smtEvalAt_eq_lhs_none _ _ _ ihL.symm)).symm
+  | lt =>
+    simp only [translate]
+    exact (smtEvalAt_lt_lhs_none _ _ _ ihL.symm).symm
+  | le =>
+    simp only [translate]
+    have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.lt (translate l) (translate r)) = none :=
+      smtEvalAt_lt_lhs_none _ _ _ ihL.symm
+    exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
+  | gt =>
+    simp only [translate]
+    show none = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.lt (translate r) (translate l))
+    simp only [smtEvalAt]
+    rw [← ihL]
+    cases (smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r)) with
+    | none => rfl
+    | some sv => cases sv <;> rfl
+  | ge =>
+    simp only [translate]
+    have hEq : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.eq (translate l) (translate r)) = none :=
+      smtEvalAt_eq_lhs_none _ _ _ ihL.symm
+    have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.lt (translate r) (translate l)) = none := by
+      simp only [smtEvalAt]
+      rw [← ihL]
+      cases (smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r)) with
+      | none => rfl
+      | some sv => cases sv <;> rfl
+    rw [smtEvalAt]
+    rw [hLt, hEq]
+
+/-- All cmp ops fail when the RHS doesn't evaluate, given LHS eval succeeded. -/
+private theorem cmp_rhs_eval_none_at (op : CmpOp) (l r : Expr) (lv : Value)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv)
+    (hR : evalAt mode s sp env r = none) :
+    valueToSmt? (evalAt mode s sp env (.cmp op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp op l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp op l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases op <;> cases lv <;> rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  rw [hR] at ihR; simp only [valueToSmt?] at ihR
+  simp only [valueToSmt?]
+  cases op with
+  | eq =>
+    simp only [translate]
+    exact (smtEvalAt_eq_rhs_none _ _ _ ihL.symm ihR.symm).symm
+  | neq =>
+    simp only [translate]
+    exact (smtEvalAt_not_none _ _ _ _
+            (smtEvalAt_eq_rhs_none _ _ _ ihL.symm ihR.symm)).symm
+  | lt =>
+    simp only [translate]
+    cases lv with
+    | vInt a =>
+      rw [valueToSmt_vInt] at ihL
+      exact (smtEvalAt_lt_rhs_none _ _ _ ihL.symm ihR.symm).symm
+    | vBool b =>
+      rw [valueToSmt_vBool] at ihL
+      simp only [smtEvalAt]; rw [← ihL]
+    | vEnum e' m' =>
+      rw [valueToSmt_vEnum] at ihL
+      simp only [smtEvalAt]; rw [← ihL]
+    | vEntity e' i' =>
+      rw [valueToSmt_vEntity] at ihL
+      simp only [smtEvalAt]; rw [← ihL]
+    | vSet members =>
+      rw [valueToSmt_vSet] at ihL
+      simp only [smtEvalAt]; rw [← ihL]
+  | le =>
+    simp only [translate]
+    cases lv with
+    | vInt a =>
+      rw [valueToSmt_vInt] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none :=
+        smtEvalAt_lt_rhs_none _ _ _ ihL.symm ihR.symm
+      have hEq : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.eq (translate l) (translate r)) = none :=
+        smtEvalAt_eq_rhs_none _ _ _ ihL.symm ihR.symm
+      rw [smtEvalAt]
+      rw [hLt, hEq]
+    | vBool b =>
+      rw [valueToSmt_vBool] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none := by
+        simp only [smtEvalAt]; rw [← ihL]
+      rw [smtEvalAt, hLt]
+    | vEnum e' m' =>
+      rw [valueToSmt_vEnum] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none := by
+        simp only [smtEvalAt]; rw [← ihL]
+      rw [smtEvalAt, hLt]
+    | vEntity e' i' =>
+      rw [valueToSmt_vEntity] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none := by
+        simp only [smtEvalAt]; rw [← ihL]
+      rw [smtEvalAt, hLt]
+    | vSet members =>
+      rw [valueToSmt_vSet] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none := by
+        simp only [smtEvalAt]; rw [← ihL]
+      rw [smtEvalAt, hLt]
+  | gt =>
+    -- translate gt = .lt (translate r) (translate l). rhs of .lt is translate l.
+    simp only [translate]
+    -- smtEvalAt of (translate r) is none. The .lt arm checks lhs first; lhs is none → result none.
+    show none = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.lt (translate r) (translate l))
+    simp only [smtEvalAt, ← ihR]
+  | ge =>
+    -- translate ge = .or (.lt (translate r) (translate l)) (.eq (translate l) (translate r)).
+    simp only [translate]
+    -- The .lt's lhs is translate r → none. The .eq's rhs is translate r → none after lhs evals.
+    have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.lt (translate r) (translate l)) = none := by
+      simp only [smtEvalAt, ← ihR]
+    have hEq : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.eq (translate l) (translate r)) = none :=
+      smtEvalAt_eq_rhs_none _ _ _ ihL.symm ihR.symm
+    rw [smtEvalAt]
+    rw [hLt, hEq]
+
+/-- `cmp .lt` failure when LHS is not vInt. Mirror of `cmp_lt_lhs_nonInt`. -/
+private theorem cmp_lt_lhs_nonInt_at (l r : Expr) (lv : Value)
+    (hNotInt : ∀ n, lv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) (rv : Value)
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .lt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .lt l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .lt l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases lv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases rv <;> rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  have hSmtNotInt : ∀ n, valueToSmt lv ≠ .sInt n := hSmtLvNotInt lv hNotInt
+  exact (smtEvalAt_lt_lhs_nonInt _ _ _ ihL.symm hSmtNotInt).symm
+
+/-- `cmp .lt` failure when RHS is not vInt, given LHS = vInt. -/
+private theorem cmp_lt_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
+    (hNotInt : ∀ n, rv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .lt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .lt l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .lt l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases rv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => rfl
+  rw [hEvalNone]
+  rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vInt] at ihL
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?, translate]
+  exact (smtEvalAt_lt_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -41,6 +41,8 @@ mutual
     | .vEnum en mem  => .sEnumElem en mem
     | .vEntity en id => .sEntityElem en id
     | .vSet members  => .sSet (valuesToSmt members)
+    | .vEntityWith base fld value =>
+        .sEntityWith (valueToSmt base) fld (valueToSmt value)
 
   def valuesToSmt : List Value → List SmtVal
     | []        => []
@@ -69,6 +71,10 @@ end
     valueToSmt (.vSet members) = .sSet (members.map valueToSmt) := by
   simp only [valueToSmt, valuesToSmt_eq_map]
 
+@[simp] theorem valueToSmt_vEntityWith (base : Value) (fld : String) (value : Value) :
+    valueToSmt (.vEntityWith base fld value)
+      = .sEntityWith (valueToSmt base) fld (valueToSmt value) := rfl
+
 def valueToSmt? : Option Value → Option SmtVal
   | some v => some (valueToSmt v)
   | none   => none
@@ -86,21 +92,25 @@ mutual
     | .vBool _, .vEnum _ _, h => by cases h
     | .vBool _, .vEntity _ _, h => by cases h
     | .vBool _, .vSet _, h => by cases h
+    | .vBool _, .vEntityWith _ _ _, h => by cases h
     | .vInt _, .vBool _, h => by cases h
     | .vInt a, .vInt b, h => by cases h; rfl
     | .vInt _, .vEnum _ _, h => by cases h
     | .vInt _, .vEntity _ _, h => by cases h
     | .vInt _, .vSet _, h => by cases h
+    | .vInt _, .vEntityWith _ _ _, h => by cases h
     | .vEnum _ _, .vBool _, h => by cases h
     | .vEnum _ _, .vInt _, h => by cases h
     | .vEnum en mem, .vEnum en' mem', h => by cases h; rfl
     | .vEnum _ _, .vEntity _ _, h => by cases h
     | .vEnum _ _, .vSet _, h => by cases h
+    | .vEnum _ _, .vEntityWith _ _ _, h => by cases h
     | .vEntity _ _, .vBool _, h => by cases h
     | .vEntity _ _, .vInt _, h => by cases h
     | .vEntity _ _, .vEnum _ _, h => by cases h
     | .vEntity en id, .vEntity en' id', h => by cases h; rfl
     | .vEntity _ _, .vSet _, h => by cases h
+    | .vEntity _ _, .vEntityWith _ _ _, h => by cases h
     | .vSet _, .vBool _, h => by cases h
     | .vSet _, .vInt _, h => by cases h
     | .vSet _, .vEnum _ _, h => by cases h
@@ -109,6 +119,19 @@ mutual
         injection h with hList
         have hValues : xs = ys := valuesToSmt_inj hList
         cases hValues
+        rfl
+    | .vSet _, .vEntityWith _ _ _, h => by cases h
+    | .vEntityWith _ _ _, .vBool _, h => by cases h
+    | .vEntityWith _ _ _, .vInt _, h => by cases h
+    | .vEntityWith _ _ _, .vEnum _ _, h => by cases h
+    | .vEntityWith _ _ _, .vEntity _ _, h => by cases h
+    | .vEntityWith _ _ _, .vSet _, h => by cases h
+    | .vEntityWith ba fa va, .vEntityWith bb fb vb, h => by
+        simp only [valueToSmt_vEntityWith] at h
+        injection h with hB hF hV
+        have hBaseEq : ba = bb := valueToSmt_inj hB
+        have hValueEq : va = vb := valueToSmt_inj hV
+        cases hBaseEq; cases hF; cases hValueEq
         rfl
 
   theorem valuesToSmt_inj :
@@ -166,8 +189,13 @@ theorem setEqValueList_map_valueToSmt (xs ys : List Value) :
 /-- Boolean equality on `Value` agrees with boolean equality on `SmtVal` after `valueToSmt`. -/
 theorem valueToSmt_beq (a b : Value) : (valueToSmt a == valueToSmt b) = (a == b) := by
   cases a <;> cases b <;> try rfl
-  simp [valueToSmt, valuesToSmt_eq_map]
-  exact setEqValueList_map_valueToSmt _ _
+  · -- vSet × vSet case
+    simp [valueToSmt, valuesToSmt_eq_map]
+    exact setEqValueList_map_valueToSmt _ _
+  · -- vEntityWith × vEntityWith case
+    rw [valueToSmt_vEntityWith, valueToSmt_vEntityWith]
+    show beqSmtVal _ _ = beqValue _ _
+    simp only [beqSmtVal, beqValue, valueToSmt_decide_eq]
 
 /-! ## Env / State / Schema ↔ SmtModel correlation -/
 
@@ -461,6 +489,28 @@ theorem lookupField_correlated (s : Schema) (st : State) (entityId fieldName : S
     cases List.lookup fieldName fields with
     | none   => rfl
     | some _ => rfl
+
+/-- Phase 4b: `Value.fieldLookup` correlates with `SmtVal.fieldLookup`. The
+    proof recurses on the `vEntityWith` chain, with `lookupField_correlated`
+    as the base case for `vEntity`. Non-entity / non-with values return `none`
+    on both sides. -/
+theorem fieldLookup_correlated (s : Schema) (st : State) :
+    ∀ (v : Value) (fieldName : String),
+      valueToSmt? (Value.fieldLookup st v fieldName)
+        = SmtVal.fieldLookup (correlateModel s st) (valueToSmt v) fieldName
+  | .vBool _, _ => rfl
+  | .vInt _, _ => rfl
+  | .vEnum _ _, _ => rfl
+  | .vSet _, _ => rfl
+  | .vEntity _ id, fieldName => by
+    simp only [Value.fieldLookup, valueToSmt_vEntity, SmtVal.fieldLookup]
+    exact lookupField_correlated s st id fieldName
+  | .vEntityWith base fld _, fieldName => by
+    simp only [Value.fieldLookup, valueToSmt_vEntityWith, SmtVal.fieldLookup]
+    by_cases h : fieldName = fld
+    · subst h; simp only [if_true, valueToSmt?_some]
+    · simp only [h, if_false]
+      exact fieldLookup_correlated s st base fieldName
 
 /-! ## Value-shape lifting helpers.
 
@@ -1043,6 +1093,10 @@ theorem evalForallEnum_correlated
           | vSet members =>
             rw [valueToSmt_vSet members] at ih
             rw [← ih]; simp only [valueToSmt?]
+
+          | vEntityWith _ _ _ =>
+            rw [valueToSmt_vEntityWith] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [valueToSmt_vInt] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -1054,6 +1108,10 @@ theorem evalForallEnum_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vSet members =>
         rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+      | vEntityWith _ _ _ =>
+        rw [valueToSmt_vEntityWith] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- `forallEnum` — universal quantifier over a known enum domain. -/
@@ -1128,6 +1186,10 @@ theorem evalForallRel_correlated
           | vSet members =>
             rw [valueToSmt_vSet members] at ih
             rw [← ih]; simp only [valueToSmt?]
+
+          | vEntityWith _ _ _ =>
+            rw [valueToSmt_vEntityWith] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [valueToSmt_vInt] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -1139,6 +1201,10 @@ theorem evalForallRel_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vSet members =>
         rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+      | vEntityWith _ _ _ =>
+        rw [valueToSmt_vEntityWith] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- `forallRel` — universal quantifier over a known state-relation domain. -/
@@ -1192,6 +1258,8 @@ private theorem boolBin_lhs_nonBool (s : Schema) (st : State) (env : Env)
     | vEnum _ _ => rfl
     | vEntity _ _ => rfl
     | vSet _ => rfl
+
+    | vEntityWith _ _ _ => rfl
   rw [hEvalNone]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
   simp only [valueToSmt?]
@@ -1230,6 +1298,8 @@ private theorem boolBin_rhs_nonBool_lhs_bool (s : Schema) (st : State) (env : En
     | vEnum _ _ => rfl
     | vEntity _ _ => rfl
     | vSet _ => rfl
+
+    | vEntityWith _ _ _ => rfl
   rw [hEvalNone]
   rw [hL] at ihL; rw [valueToSmt?_some] at ihL
   rw [valueToSmt_vBool] at ihL
@@ -1355,6 +1425,10 @@ private theorem cmp_rhs_eval_none (s : Schema) (st : State) (env : Env)
     | vSet members =>
       rw [valueToSmt_vSet members] at ihL
       exact (smtEval_lt_lhs_nonInt _ _ ihL.symm nofun).symm
+
+    | vEntityWith _ _ _ =>
+      rw [valueToSmt_vEntityWith] at ihL
+      exact (smtEval_lt_lhs_nonInt _ _ ihL.symm nofun).symm
   | le =>
     simp only [translate]
     have hEq : smtEval _ _ (.eq (translate l) (translate r)) = none :=
@@ -1376,6 +1450,10 @@ private theorem cmp_rhs_eval_none (s : Schema) (st : State) (env : Env)
         exact smtEval_lt_lhs_nonInt _ _ ihL.symm nofun
       | vSet members =>
         rw [valueToSmt_vSet members] at ihL
+        exact smtEval_lt_lhs_nonInt _ _ ihL.symm nofun
+
+      | vEntityWith _ _ _ =>
+        rw [valueToSmt_vEntityWith] at ihL
         exact smtEval_lt_lhs_nonInt _ _ ihL.symm nofun
     rw [smtEval, hLt, hEq]
   | gt =>
@@ -1587,10 +1665,14 @@ private theorem cmp_gt_lhs_nonInt (s : Schema) (st : State) (env : Env)
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
       | sSet _ => rfl
+
+      | sEntityWith _ _ _ => rfl
     | sBool _ => rfl
     | sEnumElem _ _ => rfl
     | sEntityElem _ _ => rfl
     | sSet _ => rfl
+
+    | sEntityWith _ _ _ => rfl
 
 private theorem cmp_gt_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
     (l r : Expr) (a : Int) (rv : Value)
@@ -1645,10 +1727,14 @@ private theorem cmp_ge_lhs_nonInt (s : Schema) (st : State) (env : Env)
         | sEnumElem _ _ => rfl
         | sEntityElem _ _ => rfl
         | sSet _ => rfl
+
+        | sEntityWith _ _ _ => rfl
       | sBool _ => rfl
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
       | sSet _ => rfl
+
+      | sEntityWith _ _ _ => rfl
   exact (smtEval_or_lhs_none _ _ hLt).symm
 
 private theorem cmp_ge_rhs_nonInt_lhs_int (s : Schema) (st : State) (env : Env)
@@ -1853,6 +1939,7 @@ theorem soundness (e : Expr) :
       | vEnum en' m' => exact soundness_unNot_nonBool s st env e (.vEnum en' m') nofun ih h
       | vEntity en' i' => exact soundness_unNot_nonBool s st env e (.vEntity en' i') nofun ih h
       | vSet members => exact soundness_unNot_nonBool s st env e (.vSet members) nofun ih h
+      | vEntityWith wb wf wv => exact soundness_unNot_nonBool s st env e (Value.vEntityWith wb wf wv) nofun ih h
   | unNeg e ih =>
     have ih := ih env
     cases h : eval s st env e with
@@ -1869,6 +1956,7 @@ theorem soundness (e : Expr) :
       | vEnum en' m' => exact soundness_unNeg_nonInt s st env e (.vEnum en' m') nofun ih h
       | vEntity en' i' => exact soundness_unNeg_nonInt s st env e (.vEntity en' i') nofun ih h
       | vSet members => exact soundness_unNeg_nonInt s st env e (.vSet members) nofun ih h
+      | vEntityWith wb wf wv => exact soundness_unNeg_nonInt s st env e (Value.vEntityWith wb wf wv) nofun ih h
   | boolBin op l r ihL ihR =>
     have ihLE := ihL env
     have ihRE := ihR env
@@ -1937,6 +2025,10 @@ theorem soundness (e : Expr) :
           | vSet members => exact boolBin_rhs_nonBool_lhs_bool s st env op l r a
                                       (.vSet members) nofun
                                       ihLE ihRE hL hR
+
+          | vEntityWith wb wf wv => exact boolBin_rhs_nonBool_lhs_bool s st env op l r a
+                                      (Value.vEntityWith wb wf wv) nofun
+                                      ihLE ihRE hL hR
       | vInt n =>
         exact boolBin_lhs_nonBool s st env op l r (.vInt n)
                 nofun ihLE ihRE hL
@@ -1948,6 +2040,10 @@ theorem soundness (e : Expr) :
                 nofun ihLE ihRE hL
       | vSet members =>
         exact boolBin_lhs_nonBool s st env op l r (.vSet members)
+                nofun ihLE ihRE hL
+
+      | vEntityWith wb wf wv =>
+        exact boolBin_lhs_nonBool s st env op l r (Value.vEntityWith wb wf wv)
                 nofun ihLE ihRE hL
   | arith op l r ihL ihR =>
     have ihLE := ihL env
@@ -2018,6 +2114,7 @@ theorem soundness (e : Expr) :
                               nofun ihLE ihRE hL hR
           | vSet members => exact arith_rhs_nonInt_lhs_int s st env op l r a (.vSet members)
                               nofun ihLE ihRE hL hR
+          | vEntityWith wb wf wv => exact arith_rhs_nonInt_lhs_int s st env op l r a (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
       | vBool b => exact arith_lhs_nonInt s st env op l r (.vBool b)
                     nofun ihLE ihRE hL
       | vEnum en m => exact arith_lhs_nonInt s st env op l r (.vEnum en m)
@@ -2026,6 +2123,7 @@ theorem soundness (e : Expr) :
                           nofun ihLE ihRE hL
       | vSet members => exact arith_lhs_nonInt s st env op l r (.vSet members)
                           nofun ihLE ihRE hL
+      | vEntityWith wb wf wv => exact arith_lhs_nonInt s st env op l r (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL
   | cmp op l r ihL ihR =>
     have ihLE := ihL env
     have ihRE := ihR env
@@ -2052,6 +2150,7 @@ theorem soundness (e : Expr) :
                                 nofun ihLE ihRE hL hR
             | vSet members => exact cmp_lt_rhs_nonInt_lhs_int s st env l r a (.vSet members)
                                 nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv => exact cmp_lt_rhs_nonInt_lhs_int s st env l r a (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b => exact cmp_lt_lhs_nonInt s st env l r (.vBool b)
                         nofun ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_lt_lhs_nonInt s st env l r (.vEnum en m)
@@ -2060,6 +2159,7 @@ theorem soundness (e : Expr) :
                               nofun ihLE ihRE hL rv hR
           | vSet members => exact cmp_lt_lhs_nonInt s st env l r (.vSet members)
                               nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv => exact cmp_lt_lhs_nonInt s st env l r (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | le =>
           cases lv with
           | vInt a =>
@@ -2073,6 +2173,7 @@ theorem soundness (e : Expr) :
                                 nofun ihLE ihRE hL hR
             | vSet members => exact cmp_le_rhs_nonInt_lhs_int s st env l r a (.vSet members)
                                 nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv => exact cmp_le_rhs_nonInt_lhs_int s st env l r a (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b => exact cmp_le_lhs_nonInt s st env l r (.vBool b)
                         nofun ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_le_lhs_nonInt s st env l r (.vEnum en m)
@@ -2081,6 +2182,7 @@ theorem soundness (e : Expr) :
                               nofun ihLE ihRE hL rv hR
           | vSet members => exact cmp_le_lhs_nonInt s st env l r (.vSet members)
                               nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv => exact cmp_le_lhs_nonInt s st env l r (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | gt =>
           cases lv with
           | vInt a =>
@@ -2094,6 +2196,7 @@ theorem soundness (e : Expr) :
                                 nofun ihLE ihRE hL hR
             | vSet members => exact cmp_gt_rhs_nonInt_lhs_int s st env l r a (.vSet members)
                                 nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv => exact cmp_gt_rhs_nonInt_lhs_int s st env l r a (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b => exact cmp_gt_lhs_nonInt s st env l r (.vBool b)
                         nofun ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_gt_lhs_nonInt s st env l r (.vEnum en m)
@@ -2102,6 +2205,7 @@ theorem soundness (e : Expr) :
                               nofun ihLE ihRE hL rv hR
           | vSet members => exact cmp_gt_lhs_nonInt s st env l r (.vSet members)
                               nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv => exact cmp_gt_lhs_nonInt s st env l r (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | ge =>
           cases lv with
           | vInt a =>
@@ -2115,6 +2219,7 @@ theorem soundness (e : Expr) :
                                 nofun ihLE ihRE hL hR
             | vSet members => exact cmp_ge_rhs_nonInt_lhs_int s st env l r a (.vSet members)
                                 nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv => exact cmp_ge_rhs_nonInt_lhs_int s st env l r a (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b => exact cmp_ge_lhs_nonInt s st env l r (.vBool b)
                         nofun ihLE ihRE hL rv hR
           | vEnum en m => exact cmp_ge_lhs_nonInt s st env l r (.vEnum en m)
@@ -2123,6 +2228,7 @@ theorem soundness (e : Expr) :
                               nofun ihLE ihRE hL rv hR
           | vSet members => exact cmp_ge_lhs_nonInt s st env l r (.vSet members)
                               nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv => exact cmp_ge_lhs_nonInt s st env l r (Value.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
   | letIn x value body ihV ihB =>
     have ihV := ihV env
     cases hV : eval s st env value with
@@ -2322,46 +2428,62 @@ theorem soundness (e : Expr) :
         have hEval : eval s st env (.fieldAccess base fieldName) = none :=
           eval_fieldAccess_nonEntity s st env hBase
             (fun en id => by intro h; cases h)
+            (fun b f w => by intro h; cases h)
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vBool] at ihBase
         simp only [valueToSmt?]
         exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
-                (fun en id => by intro h; cases h)).symm
+                (fun en id => by intro h; cases h)
+                (fun b f w => by intro h; cases h)).symm
       | vInt n =>
         have hEval : eval s st env (.fieldAccess base fieldName) = none :=
           eval_fieldAccess_nonEntity s st env hBase
             (fun en id => by intro h; cases h)
+            (fun b f w => by intro h; cases h)
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vInt] at ihBase
         simp only [valueToSmt?]
         exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
-                (fun en id => by intro h; cases h)).symm
+                (fun en id => by intro h; cases h)
+                (fun b f w => by intro h; cases h)).symm
       | vEnum en m =>
         have hEval : eval s st env (.fieldAccess base fieldName) = none :=
           eval_fieldAccess_nonEntity s st env hBase
             (fun en id => by intro h; cases h)
+            (fun b f w => by intro h; cases h)
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vEnum] at ihBase
         simp only [valueToSmt?]
         exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
-                (fun en id => by intro h; cases h)).symm
+                (fun en id => by intro h; cases h)
+                (fun b f w => by intro h; cases h)).symm
       | vSet members =>
         have hEval : eval s st env (.fieldAccess base fieldName) = none :=
           eval_fieldAccess_nonEntity s st env hBase
             (fun en id => by intro h; cases h)
+            (fun b f w => by intro h; cases h)
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vSet members] at ihBase
         simp only [valueToSmt?]
         exact (smtEval_fieldAccess_nonEntity _ _ ihBase.symm
-                (fun en id => by intro h; cases h)).symm
+                (fun en id => by intro h; cases h)
+                (fun b f w => by intro h; cases h)).symm
+      | vEntityWith b f w =>
+        rw [eval_fieldAccess_lookup s st env base (.vEntityWith b f w) fieldName hBase]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vEntityWith] at ihBase
+        rw [smtEval_fieldAccess_lookup _ _ (translate base)
+              (.sEntityWith (valueToSmt b) f (valueToSmt w)) fieldName ihBase.symm]
+        exact fieldLookup_correlated s st (.vEntityWith b f w) fieldName
   | setEmpty => exact soundness_setEmpty s st env
   | setInsert elem set ihElem ihSet =>
     have ihElem := ihElem env
@@ -2422,6 +2544,15 @@ theorem soundness (e : Expr) :
           simp only [valueToSmt?]
           exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
                     (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+        | vEntityWith wb wf wv =>
+          have hNotSet : ∀ members, Value.vEntityWith wb wf wv ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setInsert_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setInsert_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
   | setMember elem set ihElem ihSet =>
     have ihElem := ihElem env
     have ihSet := ihSet env
@@ -2481,6 +2612,15 @@ theorem soundness (e : Expr) :
           simp only [valueToSmt?]
           exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
                     (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+        | vEntityWith wb wf wv =>
+          have hNotSet : ∀ members, Value.vEntityWith wb wf wv ≠ .vSet members := by
+            intro members h; cases h
+          rw [eval_setMember_set_nonSet s st env hElem hSet hNotSet]
+          rw [hElem] at ihElem; rw [valueToSmt?_some] at ihElem
+          rw [hSet] at ihSet; rw [valueToSmt?_some] at ihSet
+          simp only [valueToSmt?]
+          exact (smtEval_setMember_set_nonSet _ _ ihElem.symm ihSet.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
   | setBin op l r ihL ihR =>
     have ihL := ihL env
     have ihR := ihR env
@@ -2598,6 +2738,26 @@ theorem soundness (e : Expr) :
               simp only [translate]
               exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
                         (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+          | vEntityWith wb wf wv =>
+            have hNotSet : ∀ members, Value.vEntityWith wb wf wv ≠ .vSet members := by
+              intro members h; cases h
+            rw [eval_setBin_rhs_nonSet s st env op l r ls (.vEntityWith wb wf wv) hNotSet hL hR]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEval_setUnion_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEval_setIntersect_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEval_setDiff_rhs_nonSet _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
       | vBool b =>
         have hNotSet : ∀ members, Value.vBool b ≠ .vSet members := by intro members h; cases h
         rw [eval_setBin_lhs_nonSet s st env op l r (.vBool b) hNotSet hL]
@@ -2658,18 +2818,53 @@ theorem soundness (e : Expr) :
         | diff =>
           simp only [translate]
           exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
-  | withRec _ _ _ =>
-    -- M_L.4.b-ext Phase 4: With ships with always-fail semantics. Both sides
-    -- yield `none`: eval returns `none` definitionally; translate emits
-    -- `0/0` whose smtEval is `none` (smtEval_div_zero). VerifiedSubset
-    -- rejects With so the cert emitter never reaches this arm.
-    rw [show eval s st env (.withRec _ _ _) = none from by simp only [eval]]
-    simp only [translate, valueToSmt?]
-    have : smtEval (correlateModel s st) (correlateEnv env)
-              (.div (.iLit 0) (.iLit 0)) = none :=
-      smtEval_div_zero _ _ (.iLit 0) (.iLit 0) 0
-        (smtEval_iLit _ _ 0) (smtEval_iLit _ _ 0)
-    exact this.symm
+      | vEntityWith wb wf wv =>
+        have hNotSet : ∀ members, Value.vEntityWith wb wf wv ≠ .vSet members := by
+          intro members h; cases h
+        rw [eval_setBin_lhs_nonSet s st env op l r (.vEntityWith wb wf wv) hNotSet hL]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEval_setUnion_lhs_nonSet _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEval_setIntersect_lhs_nonSet _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) hNotSet)).symm
+  | withRec base fld value ihBase ihValue =>
+    have ihBase := ihBase env
+    have ihValue := ihValue env
+    simp only [translate]
+    cases hBase : eval s st env base with
+    | none =>
+      have hEval : eval s st env (.withRec base fld value) = none := by
+        simp only [eval, hBase]
+      rw [hEval]
+      rw [hBase] at ihBase; simp only [valueToSmt?] at ihBase
+      simp only [valueToSmt?, smtEval, ← ihBase]
+    | some bv =>
+      cases hVal : eval s st env value with
+      | none =>
+        have hEval : eval s st env (.withRec base fld value) = none := by
+          simp only [eval, hBase, hVal]
+        rw [hEval]
+        rw [hVal] at ihValue; simp only [valueToSmt?] at ihValue
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        simp only [valueToSmt?, smtEval, ← ihBase, ← ihValue]
+      | some v =>
+        have hEval : eval s st env (.withRec base fld value) = some (.vEntityWith bv fld v) := by
+          simp only [eval, hBase, hVal]
+        rw [hEval]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [hVal] at ihValue; simp only [valueToSmt?_some] at ihValue
+        simp only [valueToSmt?_some, valueToSmt_vEntityWith, smtEval,
+                   ← ihBase, ← ihValue]
 
 /-! ## Two-state diagonal-collapse soundness (M_L.4.b-ext Phase 2, issue #194).
 
@@ -3422,6 +3617,10 @@ theorem evalAtForallEnum_correlated
           | vSet members =>
             rw [valueToSmt_vSet members] at ih
             rw [← ih]; simp only [valueToSmt?]
+
+          | vEntityWith _ _ _ =>
+            rw [valueToSmt_vEntityWith] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [valueToSmt_vInt] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -3433,6 +3632,10 @@ theorem evalAtForallEnum_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vSet members =>
         rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+      | vEntityWith _ _ _ =>
+        rw [valueToSmt_vEntityWith] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- Universal quantifier over a known enum domain. -/
@@ -3509,6 +3712,10 @@ theorem evalAtForallRel_correlated
           | vSet members =>
             rw [valueToSmt_vSet members] at ih
             rw [← ih]; simp only [valueToSmt?]
+
+          | vEntityWith _ _ _ =>
+            rw [valueToSmt_vEntityWith] at ih
+            rw [← ih]; simp only [valueToSmt?]
       | vInt n =>
         rw [valueToSmt_vInt] at hBody
         rw [← hBody]; simp only [valueToSmt?]
@@ -3520,6 +3727,10 @@ theorem evalAtForallRel_correlated
         rw [← hBody]; simp only [valueToSmt?]
       | vSet members =>
         rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+      | vEntityWith _ _ _ =>
+        rw [valueToSmt_vEntityWith] at hBody
         rw [← hBody]; simp only [valueToSmt?]
 
 /-- Universal quantifier over a known state-relation domain. -/
@@ -3875,6 +4086,9 @@ private theorem cmp_rhs_eval_none_at (op : CmpOp) (l r : Expr) (lv : Value)
     | vSet members =>
       rw [valueToSmt_vSet] at ihL
       simp only [smtEvalAt]; rw [← ihL]
+    | vEntityWith wb wf wv =>
+      rw [valueToSmt_vEntityWith] at ihL
+      simp only [smtEvalAt]; rw [← ihL]
   | le =>
     simp only [translate]
     cases lv with
@@ -3908,6 +4122,12 @@ private theorem cmp_rhs_eval_none_at (op : CmpOp) (l r : Expr) (lv : Value)
       rw [smtEvalAt, hLt]
     | vSet members =>
       rw [valueToSmt_vSet] at ihL
+      have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                    (.lt (translate l) (translate r)) = none := by
+        simp only [smtEvalAt]; rw [← ihL]
+      rw [smtEvalAt, hLt]
+    | vEntityWith wb wf wv =>
+      rw [valueToSmt_vEntityWith] at ihL
       have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
                     (.lt (translate l) (translate r)) = none := by
         simp only [smtEvalAt]; rw [← ihL]
@@ -4066,10 +4286,14 @@ private theorem cmp_gt_lhs_nonInt_at (l r : Expr) (lv : Value)
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
       | sSet _ => rfl
+
+      | sEntityWith _ _ _ => rfl
     | sBool _ => rfl
     | sEnumElem _ _ => rfl
     | sEntityElem _ _ => rfl
     | sSet _ => rfl
+
+    | sEntityWith _ _ _ => rfl
 
 private theorem cmp_gt_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
     (hNotInt : ∀ n, rv ≠ .vInt n)
@@ -4129,10 +4353,14 @@ private theorem cmp_ge_lhs_nonInt_at (l r : Expr) (lv : Value)
         | sEnumElem _ _ => rfl
         | sEntityElem _ _ => rfl
         | sSet _ => rfl
+
+        | sEntityWith _ _ _ => rfl
       | sBool _ => rfl
       | sEnumElem _ _ => rfl
       | sEntityElem _ _ => rfl
       | sSet _ => rfl
+
+      | sEntityWith _ _ _ => rfl
   exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
 
 private theorem cmp_ge_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
@@ -4217,6 +4445,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
         exact soundnessAt_unNot_nonBool s env mode sp e (.vEntity en' i') nofun ih' h
       | vSet members =>
         exact soundnessAt_unNot_nonBool s env mode sp e (.vSet members) nofun ih' h
+      | vEntityWith wb wf wv =>
+        exact soundnessAt_unNot_nonBool s env mode sp e (.vEntityWith wb wf wv) nofun ih' h
   | unNeg e ih =>
     have ih' := ih env mode
     cases h : evalAt mode s sp env e with
@@ -4237,6 +4467,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
         exact soundnessAt_unNeg_nonInt s env mode sp e (.vEntity en' i') nofun ih' h
       | vSet members =>
         exact soundnessAt_unNeg_nonInt s env mode sp e (.vSet members) nofun ih' h
+      | vEntityWith wb wf wv =>
+        exact soundnessAt_unNeg_nonInt s env mode sp e (.vEntityWith wb wf wv) nofun ih' h
   | prime e ih =>
     have ih' := ih env .post
     exact soundnessAt_prime s env mode sp e ih'
@@ -4351,6 +4583,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
                                       (.vEntity en' i') nofun ihLE ihRE hL hR
           | vSet members => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a
                                       (.vSet members) nofun ihLE ihRE hL hR
+          | vEntityWith wb wf wv => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a
+                                            (.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
       | vInt n =>
         exact boolBin_lhs_nonBool_at s env mode sp op l r (.vInt n) nofun ihLE ihRE hL
       | vEnum en' m' =>
@@ -4359,6 +4593,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
         exact boolBin_lhs_nonBool_at s env mode sp op l r (.vEntity en' i') nofun ihLE ihRE hL
       | vSet members =>
         exact boolBin_lhs_nonBool_at s env mode sp op l r (.vSet members) nofun ihLE ihRE hL
+      | vEntityWith wb wf wv =>
+        exact boolBin_lhs_nonBool_at s env mode sp op l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL
   | arith op l r ihL ihR =>
     have ihLE := ihL env mode
     have ihRE := ihR env mode
@@ -4431,6 +4667,9 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
           | vSet members =>
             exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vSet members)
                     nofun ihLE ihRE hL hR
+          | vEntityWith wb wf wv =>
+            exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vEntityWith wb wf wv)
+                    nofun ihLE ihRE hL hR
       | vBool b =>
         exact arith_lhs_nonInt_at s env mode sp op l r (.vBool b) nofun ihLE ihRE hL
       | vEnum en m =>
@@ -4439,6 +4678,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
         exact arith_lhs_nonInt_at s env mode sp op l r (.vEntity en i) nofun ihLE ihRE hL
       | vSet members =>
         exact arith_lhs_nonInt_at s env mode sp op l r (.vSet members) nofun ihLE ihRE hL
+      | vEntityWith wb wf wv =>
+        exact arith_lhs_nonInt_at s env mode sp op l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL
   | cmp op l r ihL ihR =>
     have ihLE := ihL env mode
     have ihRE := ihR env mode
@@ -4466,6 +4707,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
               exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
             | vSet members =>
               exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv =>
+              exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b =>
             exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
           | vEnum en m =>
@@ -4474,6 +4717,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
             exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
           | vSet members =>
             exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv =>
+            exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | le =>
           cases lv with
           | vInt a =>
@@ -4487,6 +4732,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
               exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
             | vSet members =>
               exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv =>
+              exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b =>
             exact cmp_le_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
           | vEnum en m =>
@@ -4495,6 +4742,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
             exact cmp_le_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
           | vSet members =>
             exact cmp_le_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv =>
+            exact cmp_le_lhs_nonInt_at s env mode sp l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | gt =>
           cases lv with
           | vInt a =>
@@ -4508,6 +4757,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
               exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
             | vSet members =>
               exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv =>
+              exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b =>
             exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
           | vEnum en m =>
@@ -4516,6 +4767,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
             exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
           | vSet members =>
             exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv =>
+            exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
         | ge =>
           cases lv with
           | vInt a =>
@@ -4529,6 +4782,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
               exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
             | vSet members =>
               exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+            | vEntityWith wb wf wv =>
+              exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntityWith wb wf wv) nofun ihLE ihRE hL hR
           | vBool b =>
             exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
           | vEnum en m =>
@@ -4537,6 +4792,8 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
             exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
           | vSet members =>
             exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+          | vEntityWith wb wf wv =>
+            exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vEntityWith wb wf wv) nofun ihLE ihRE hL rv hR
   | member elem relName ihE =>
     have ihE := ihE env mode
     cases hElem : evalAt mode s sp env elem with
@@ -4649,40 +4906,49 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
         exact soundnessAt_fieldAccess_resolved s env mode sp base en id fieldName ihBase hBase
       | vBool b =>
         have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
-          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun nofun
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vBool] at ihBase
         simp only [valueToSmt?]
-        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun nofun).symm
       | vInt n =>
         have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
-          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun nofun
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vInt] at ihBase
         simp only [valueToSmt?]
-        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun nofun).symm
       | vEnum en m =>
         have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
-          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun nofun
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vEnum] at ihBase
         simp only [valueToSmt?]
-        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun nofun).symm
       | vSet members =>
         have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
-          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun nofun
         rw [hEval]
         simp only [translate]
         rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
         rw [valueToSmt_vSet members] at ihBase
         simp only [valueToSmt?]
-        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun nofun).symm
+      | vEntityWith wb wf wv =>
+        rw [evalAt_fieldAccess_lookup mode s sp env base (.vEntityWith wb wf wv) fieldName hBase]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vEntityWith] at ihBase
+        rw [smtEvalAt_fieldAccess_lookup mode _ _ (translate base)
+              (.sEntityWith (valueToSmt wb) wf (valueToSmt wv)) fieldName ihBase.symm]
+        simp only [correlateModelPair_at]
+        exact fieldLookup_correlated s (sp.at mode) (.vEntityWith wb wf wv) fieldName
   | setEmpty => exact soundnessAt_setEmpty s env mode sp
   | setInsert elem set ihE ihS =>
     have ihE := ihE env mode
@@ -4736,6 +5002,13 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
           simp only [valueToSmt?]
           exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
                     (hSmtValNotSet (.vEntity en i) nofun)).symm
+        | vEntityWith wb wf wv =>
+          rw [evalAt_setInsert_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
   | setMember elem set ihE ihS =>
     have ihE := ihE env mode
     have ihS := ihS env mode
@@ -4788,6 +5061,13 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
           simp only [valueToSmt?]
           exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
                     (hSmtValNotSet (.vEntity en i) nofun)).symm
+        | vEntityWith wb wf wv =>
+          rw [evalAt_setMember_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
   | setBin op l r ihL ihR =>
     have ihL := ihL env mode
     have ihR := ihR env mode
@@ -4907,6 +5187,25 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
               simp only [translate]
               exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
                         (hSmtValNotSet (.vEntity en i) nofun)).symm
+          | vEntityWith wb wf wv =>
+            rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                  simp only [evalAt, hL, hR]; cases op <;> rfl]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEvalAt_setUnion_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEvalAt_setIntersect_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
       | vBool b =>
         rw [show evalAt mode s sp env (.setBin op l r) = none from by
               simp only [evalAt, hL]; cases op <;> rfl]
@@ -4979,15 +5278,52 @@ theorem soundnessAt (mode : StateMode) (e : Expr) :
           simp only [translate]
           exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
                     (hSmtValNotSet (.vEntity en i) nofun)).symm
-  | withRec _ _ _ =>
-    -- M_L.4.b-ext Phase 4: With ships with always-fail semantics on the
-    -- mode-aware evaluator too. Both sides yield `none`.
-    rw [show evalAt mode s sp env (.withRec _ _ _) = none from by simp only [evalAt]]
-    simp only [translate, valueToSmt?]
-    have : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
-              (.div (.iLit 0) (.iLit 0)) = none :=
-      smtEvalAt_div_zero _ _ _ (.iLit 0) (.iLit 0) 0
-        (smtEvalAt_iLit _ _ _ 0) (smtEvalAt_iLit _ _ _ 0)
-    exact this.symm
+      | vEntityWith wb wf wv =>
+        rw [show evalAt mode s sp env (.setBin op l r) = none from by
+              simp only [evalAt, hL]; cases op <;> rfl]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEvalAt_setUnion_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEvalAt_setIntersect_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntityWith wb wf wv) nofun)).symm
+  | withRec base fld value ihBase ihValue =>
+    have ihBase := ihBase env mode
+    have ihValue := ihValue env mode
+    simp only [translate]
+    cases hBase : evalAt mode s sp env base with
+    | none =>
+      have hEval : evalAt mode s sp env (.withRec base fld value) = none := by
+        simp only [evalAt, hBase]
+      rw [hEval]
+      rw [hBase] at ihBase; simp only [valueToSmt?] at ihBase
+      simp only [valueToSmt?, smtEvalAt, ← ihBase]
+    | some bv =>
+      cases hVal : evalAt mode s sp env value with
+      | none =>
+        have hEval : evalAt mode s sp env (.withRec base fld value) = none := by
+          simp only [evalAt, hBase, hVal]
+        rw [hEval]
+        rw [hVal] at ihValue; simp only [valueToSmt?] at ihValue
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        simp only [valueToSmt?, smtEvalAt, ← ihBase, ← ihValue]
+      | some v =>
+        have hEval : evalAt mode s sp env (.withRec base fld value)
+            = some (.vEntityWith bv fld v) := by
+          simp only [evalAt, hBase, hVal]
+        rw [hEval]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [hVal] at ihValue; simp only [valueToSmt?_some] at ihValue
+        simp only [valueToSmt?_some, valueToSmt_vEntityWith, smtEvalAt,
+                   ← ihBase, ← ihValue]
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -2208,18 +2208,24 @@ theorem soundness (e : Expr) :
       simp only [valueToSmt?]
       exact (smtEval_cardRel_unknown _ _ relName hRel).symm
   | prime e ih =>
-    -- Single-state collapse: Prime is identity at the eval and translate levels.
-    -- True two-state semantics (where Prime resolves to post-state scalars) is
-    -- M_L.4.b-ext, gated on the StatePair carrier refactor.
+    -- Single-state collapse: `eval` is mode-flat so Prime is identity on the Lean side.
+    -- Phase 2 of M_L.4.b-ext (issue #194) gave `translate` a `.prime` wrapper on the
+    -- SMT side; `smtEval` treats it as identity (the universal soundness theorem
+    -- remains a single-state claim about `eval` / `smtEval`). True two-state
+    -- semantics is `evalAt` / `smtEvalAt` and lives in `soundnessAt_diagonal` and
+    -- (later) `soundnessAt`.
     have ih := ih env
     rw [eval_prime]
     simp only [translate]
+    rw [smtEval_prime]
     exact ih
   | pre e ih =>
-    -- Single-state collapse: Pre is identity. Two-state machinery is M_L.4.b-ext.
+    -- Single-state collapse: see `prime` arm above. Phase 2 wraps the SMT side in
+    -- `.pre` (identity in `smtEval`); mode-flip semantics lives in `smtEvalAt`.
     have ih := ih env
     rw [eval_pre]
     simp only [translate]
+    rw [smtEval_pre]
     exact ih
   | forallEnum var en body ihB =>
     cases hSchema : s.lookupEnum en with
@@ -2652,5 +2658,43 @@ theorem soundness (e : Expr) :
         | diff =>
           simp only [translate]
           exact (smtEval_setDiff_lhs_nonSet _ _ ihL.symm (hSmtValNotSet (.vEntity en id) hNotSet)).symm
+
+/-! ## Two-state diagonal-collapse soundness (M_L.4.b-ext Phase 2, issue #194).
+
+`correlateModelPair s sp` lifts the schema-and-state-pair correlation to the
+SMT side. `soundnessAt_diagonal` is the diagonal-mode-aware soundness: for
+every mode and every Expr in the verified subset, evaluating against the
+diagonal `StatePair.diag st` agrees with the existing single-state soundness
+claim. The corollary is derived by composing the two diagonal-collapse
+lemmas (`evalAt_diagonal_eq_eval` / `smtEvalAt_diagonal_eq_smtEval`) with
+the single-state `soundness` theorem — no fresh structural induction.
+
+The off-diagonal (true two-state) soundness `soundnessAt` is queued for
+follow-up phases per `STATUS.md` §M_L.4.b-ext: it requires a fresh structural
+induction whose mode-flip arms exercise the new mode-aware machinery, plus
+a per-case cascade through `Soundness.lean`'s ~1900 LOC. -/
+
+def correlateModelPair (s : Schema) (sp : StatePair) : SmtModelPair where
+  pre  := correlateModel s sp.pre
+  post := correlateModel s sp.post
+
+@[simp] theorem correlateModelPair_pre (s : Schema) (sp : StatePair) :
+    (correlateModelPair s sp).pre = correlateModel s sp.pre := rfl
+
+@[simp] theorem correlateModelPair_post (s : Schema) (sp : StatePair) :
+    (correlateModelPair s sp).post = correlateModel s sp.post := rfl
+
+@[simp] theorem correlateModelPair_diag (s : Schema) (st : State) :
+    correlateModelPair s (StatePair.diag st) = SmtModelPair.diag (correlateModel s st) := rfl
+
+theorem soundnessAt_diagonal (mode : StateMode) (s : Schema) (st : State)
+    (env : Env) (e : Expr) :
+    valueToSmt? (evalAt mode s (StatePair.diag st) env e)
+      = smtEvalAt mode (correlateModelPair s (StatePair.diag st))
+          (correlateEnv env) (translate e) := by
+  rw [evalAt_diagonal_eq_eval mode s st env e]
+  rw [correlateModelPair_diag]
+  rw [smtEvalAt_diagonal_eq_smtEval mode (correlateModel s st) (correlateEnv env) (translate e)]
+  exact soundness s st env e
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -2687,6 +2687,13 @@ def correlateModelPair (s : Schema) (sp : StatePair) : SmtModelPair where
 @[simp] theorem correlateModelPair_diag (s : Schema) (st : State) :
     correlateModelPair s (StatePair.diag st) = SmtModelPair.diag (correlateModel s st) := rfl
 
+/-- `correlateModelPair` commutes with `at`: projecting the SmtModelPair at a mode is the same as
+    correlating the StatePair's projection at that mode. The bridge for off-diagonal soundness:
+    every per-case `correlateModel_*` lemma in this file lifts unchanged via this rewrite. -/
+@[simp] theorem correlateModelPair_at (s : Schema) (sp : StatePair) (mode : StateMode) :
+    (correlateModelPair s sp).at mode = correlateModel s (sp.at mode) := by
+  cases mode <;> rfl
+
 theorem soundnessAt_diagonal (mode : StateMode) (s : Schema) (st : State)
     (env : Env) (e : Expr) :
     valueToSmt? (evalAt mode s (StatePair.diag st) env e)
@@ -2696,5 +2703,505 @@ theorem soundnessAt_diagonal (mode : StateMode) (s : Schema) (st : State)
   rw [correlateModelPair_diag]
   rw [smtEvalAt_diagonal_eq_smtEval mode (correlateModel s st) (correlateEnv env) (translate e)]
   exact soundness s st env e
+
+/-! ## Per-case off-diagonal `soundnessAt_*` (Phase 3a, advances #194).
+
+Phase 3a covers the cases that don't read state and don't introduce mode flips
+beyond `Prime`/`Pre`: atoms, propositional, arithmetic, comparison, `letIn`,
+`enumAccess`, env-hit identifier, plus the mode-flipping `Prime`/`Pre` arms.
+Each per-case theorem mirrors the existing single-state `soundness_*` shape,
+threaded through the mode-aware evaluators. The IH is taken as a hypothesis
+on each subexpression — the universal `soundnessAt` theorem (Phase 3b)
+discharges the IH via structural induction on `Expr`.
+
+State-touching cases (state-scalar identifier, member, cardRel, indexRel,
+fieldAccess), quantifier cases (forallEnum, forallRel — need parallel mutual
+lemmas to `evalForallEnum_correlated` / `evalForallRel_correlated`), and
+set-op cases (setEmpty / setInsert / setMember / setBin) are queued for
+Phase 3b per `STATUS.md` §M_L.4.b-ext. -/
+
+variable (mode : StateMode) (sp : StatePair)
+
+/-- Atomic: boolean literal. -/
+theorem soundnessAt_boolLit (b : Bool) :
+    valueToSmt? (evalAt mode s sp env (.boolLit b))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolLit b)) := by
+  rw [evalAt_boolLit, valueToSmt?_some]
+  show some (SmtVal.sBool b) = _
+  simp only [translate]
+  rw [smtEvalAt_bLit]
+
+/-- Atomic: integer literal. -/
+theorem soundnessAt_intLit (n : Int) :
+    valueToSmt? (evalAt mode s sp env (.intLit n))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.intLit n)) := by
+  rw [evalAt_intLit, valueToSmt?_some]
+  show some (SmtVal.sInt n) = _
+  simp only [translate]
+  rw [smtEvalAt_iLit]
+
+/-- Identifier — env hit (local-binding path). The state-scalar miss path
+    needs `correlateModelPair_at` + the existing single-state state-scalar
+    correlation; deferred to Phase 3b. -/
+theorem soundnessAt_ident_local {x : String} {v : Value}
+    (h : Env.lookup env x = some v) :
+    valueToSmt? (evalAt mode s sp env (.ident x))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.ident x)) := by
+  rw [evalAt_ident_local mode s sp env h, valueToSmt?_some]
+  simp only [translate]
+  have hCorr : SmtEnv.lookup (correlateEnv env) x = some (valueToSmt v) := by
+    rw [correlateEnv_lookup, h]; rfl
+  rw [smtEvalAt_var_local _ _ _ hCorr]
+
+/-- Unary `not` over a boolean sub-result. The IH on `e` is taken as a hypothesis. -/
+theorem soundnessAt_unNot_bool (e : Expr) (b : Bool)
+    (hSub : valueToSmt? (evalAt mode s sp env e)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e))
+    (hEval : evalAt mode s sp env e = some (.vBool b)) :
+    valueToSmt? (evalAt mode s sp env (.unNot e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.unNot e)) := by
+  rw [evalAt_unNot_bool mode s sp env e b hEval, valueToSmt?_some]
+  show some (SmtVal.sBool (!b)) = _
+  simp only [translate]
+  rw [hEval] at hSub
+  rw [valueToSmt?_some] at hSub
+  show some (SmtVal.sBool (!b)) = smtEvalAt _ _ _ (.not (translate e))
+  rw [smtEvalAt_not_bool _ _ _ (translate e) b hSub.symm]
+
+/-- Unary `negate` over an integer sub-result. -/
+theorem soundnessAt_unNeg_int (e : Expr) (n : Int)
+    (hSub : valueToSmt? (evalAt mode s sp env e)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e))
+    (hEval : evalAt mode s sp env e = some (.vInt n)) :
+    valueToSmt? (evalAt mode s sp env (.unNeg e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.unNeg e)) := by
+  rw [evalAt_unNeg_int mode s sp env e n hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (-n)) = _
+  simp only [translate]
+  rw [hEval] at hSub
+  rw [valueToSmt?_some] at hSub
+  show some (SmtVal.sInt (-n)) = smtEvalAt _ _ _ (.neg (translate e))
+  rw [smtEvalAt_neg_int _ _ _ (translate e) n hSub.symm]
+
+/-- Boolean `and` — both sides reduce to booleans. -/
+theorem soundnessAt_boolBin_and_bools (l r : Expr) (a b : Bool)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vBool a))
+    (hR : evalAt mode s sp env r = some (.vBool b)) :
+    valueToSmt? (evalAt mode s sp env (.boolBin .and l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin .and l r)) := by
+  rw [evalAt_boolBin_bools mode s sp env .and l r a b hL hR, valueToSmt?_some]
+  simp only [evalBoolBin]
+  show some (SmtVal.sBool (a && b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  show some (SmtVal.sBool (a && b)) = smtEvalAt _ _ _ (.and (translate l) (translate r))
+  rw [smtEvalAt_and_bools _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Boolean `or`. -/
+theorem soundnessAt_boolBin_or_bools (l r : Expr) (a b : Bool)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vBool a))
+    (hR : evalAt mode s sp env r = some (.vBool b)) :
+    valueToSmt? (evalAt mode s sp env (.boolBin .or l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin .or l r)) := by
+  rw [evalAt_boolBin_bools mode s sp env .or l r a b hL hR, valueToSmt?_some]
+  simp only [evalBoolBin]
+  show some (SmtVal.sBool (a || b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  show some (SmtVal.sBool (a || b)) = smtEvalAt _ _ _ (.or (translate l) (translate r))
+  rw [smtEvalAt_or_bools _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Boolean `implies`. -/
+theorem soundnessAt_boolBin_implies_bools (l r : Expr) (a b : Bool)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vBool a))
+    (hR : evalAt mode s sp env r = some (.vBool b)) :
+    valueToSmt? (evalAt mode s sp env (.boolBin .implies l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin .implies l r)) := by
+  rw [evalAt_boolBin_bools mode s sp env .implies l r a b hL hR, valueToSmt?_some]
+  simp only [evalBoolBin]
+  show some (SmtVal.sBool (!a || b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  show some (SmtVal.sBool (!a || b))
+        = smtEvalAt _ _ _ (.implies (translate l) (translate r))
+  rw [smtEvalAt_implies_bools _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Polymorphic equality (`Eq`). -/
+theorem soundnessAt_cmp_eq_vals (l r : Expr) (va vb : Value)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some va)
+    (hR : evalAt mode s sp env r = some vb) :
+    valueToSmt? (evalAt mode s sp env (.cmp .eq l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .eq l r)) := by
+  rw [evalAt_cmp_app, hL, hR]
+  rw [evalCmp_eq_value]
+  rw [valueToSmt?_some]
+  show some (SmtVal.sBool (va == vb)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_eq_vals _ _ _ (translate l) (translate r) (valueToSmt va) (valueToSmt vb)
+        hSubL.symm hSubR.symm]
+  rw [valueToSmt_beq]
+
+/-- Inequality (`Neq`) — composes `Eq` with `Not`. -/
+theorem soundnessAt_cmp_neq_vals (l r : Expr) (va vb : Value)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some va)
+    (hR : evalAt mode s sp env r = some vb) :
+    valueToSmt? (evalAt mode s sp env (.cmp .neq l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .neq l r)) := by
+  rw [evalAt_cmp_app, hL, hR]
+  rw [evalCmp_neq_value]
+  rw [valueToSmt?_some]
+  show some (SmtVal.sBool (va != vb)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_not_bool _ _ _ (.eq (translate l) (translate r)) (va == vb)]
+  · simp only [bne]
+  · rw [smtEvalAt_eq_vals _ _ _ (translate l) (translate r) (valueToSmt va) (valueToSmt vb)
+          hSubL.symm hSubR.symm]
+    rw [valueToSmt_beq]
+
+/-- Integer comparison `<`. -/
+theorem soundnessAt_cmp_lt_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.cmp .lt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .lt l r)) := by
+  rw [evalAt_cmp_app, hL, hR, evalCmp_int_lt, valueToSmt?_some]
+  show some (SmtVal.sBool (decide (a < b))) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_lt_ints _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Integer comparison `>` (translated to swapped `<`). -/
+theorem soundnessAt_cmp_gt_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.cmp .gt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .gt l r)) := by
+  rw [evalAt_cmp_app, hL, hR, evalCmp_int_gt, valueToSmt?_some]
+  show some (SmtVal.sBool (decide (a > b))) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_lt_ints _ _ _ (translate r) (translate l) b a hSubR.symm hSubL.symm]
+
+/-- Integer arithmetic `+`. -/
+theorem soundnessAt_arith_add_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.arith .add l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith .add l r)) := by
+  have hEval : evalAt mode s sp env (.arith .add l r) = some (.vInt (a + b)) := by
+    simp only [evalAt, hL, hR, evalArith]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (a + b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_add_ints _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Integer arithmetic `-`. -/
+theorem soundnessAt_arith_sub_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.arith .sub l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith .sub l r)) := by
+  have hEval : evalAt mode s sp env (.arith .sub l r) = some (.vInt (a - b)) := by
+    simp only [evalAt, hL, hR, evalArith]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (a - b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_sub_ints _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- Integer comparison `≤` (translated as `(l < r) ∨ (l = r)`). -/
+theorem soundnessAt_cmp_le_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.cmp .le l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .le l r)) := by
+  rw [evalAt_cmp_app, hL, hR, evalCmp_int_le, valueToSmt?_some]
+  show some (SmtVal.sBool (decide (a ≤ b))) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [valueToSmt_vInt] at hSubL
+  rw [valueToSmt_vInt] at hSubR
+  have hlt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                (.lt (translate l) (translate r))
+              = some (.sBool (decide (a < b))) :=
+    smtEvalAt_lt_ints _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm
+  have heq : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                (.eq (translate l) (translate r))
+              = some (.sBool (SmtVal.sInt a == SmtVal.sInt b)) :=
+    smtEvalAt_eq_vals _ _ _ (translate l) (translate r)
+        (SmtVal.sInt a) (SmtVal.sInt b) hSubL.symm hSubR.symm
+  rw [smtEvalAt_or_bools _ _ _ _ _ _ _ hlt heq, sInt_beq]
+  congr 2
+  by_cases hab : a ≤ b
+  · by_cases hlt2 : a < b
+    · simp [hab, hlt2]
+    · have heq2 : a = b := by omega
+      simp [heq2]
+  · have hlt2 : ¬ a < b := by omega
+    have hne : a ≠ b := by omega
+    simp [hab, hlt2, hne]
+
+/-- Integer comparison `≥` (translated as `(r < l) ∨ (l = r)`). -/
+theorem soundnessAt_cmp_ge_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.cmp .ge l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .ge l r)) := by
+  rw [evalAt_cmp_app, hL, hR, evalCmp_int_ge, valueToSmt?_some]
+  show some (SmtVal.sBool (decide (a ≥ b))) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [valueToSmt_vInt] at hSubL
+  rw [valueToSmt_vInt] at hSubR
+  have hlt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                (.lt (translate r) (translate l))
+              = some (.sBool (decide (b < a))) :=
+    smtEvalAt_lt_ints _ _ _ (translate r) (translate l) b a hSubR.symm hSubL.symm
+  have heq : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                (.eq (translate l) (translate r))
+              = some (.sBool (SmtVal.sInt a == SmtVal.sInt b)) :=
+    smtEvalAt_eq_vals _ _ _ (translate l) (translate r)
+        (SmtVal.sInt a) (SmtVal.sInt b) hSubL.symm hSubR.symm
+  rw [smtEvalAt_or_bools _ _ _ _ _ _ _ hlt heq, sInt_beq]
+  congr 2
+  by_cases hab : a ≥ b
+  · by_cases hlt2 : b < a
+    · simp [hab, hlt2]
+    · have heq2 : a = b := by omega
+      simp [heq2]
+  · have hlt2 : ¬ b < a := by omega
+    have hne : a ≠ b := by omega
+    simp [hab, hlt2, hne]
+
+/-- Boolean `iff` — translated as `(l → r) ∧ (r → l)`. -/
+theorem soundnessAt_boolBin_iff_bools (l r : Expr) (a b : Bool)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vBool a))
+    (hR : evalAt mode s sp env r = some (.vBool b)) :
+    valueToSmt? (evalAt mode s sp env (.boolBin .iff l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.boolBin .iff l r)) := by
+  rw [evalAt_boolBin_bools mode s sp env .iff l r a b hL hR, valueToSmt?_some]
+  simp only [evalBoolBin]
+  show some (SmtVal.sBool (a == b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  have himpLR : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.implies (translate l) (translate r))
+                = some (.sBool (!a || b)) :=
+    smtEvalAt_implies_bools _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm
+  have himpRL : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                  (.implies (translate r) (translate l))
+                = some (.sBool (!b || a)) :=
+    smtEvalAt_implies_bools _ _ _ (translate r) (translate l) b a hSubR.symm hSubL.symm
+  rw [smtEvalAt_and_bools _ _ _ _ _ _ _ himpLR himpRL]
+  congr 2
+  cases a <;> cases b <;> rfl
+
+/-- Integer division (non-zero divisor). -/
+theorem soundnessAt_arith_div_ints_nonZero (l r : Expr) (a b : Int) (hbz : b ≠ 0)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.arith .div l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith .div l r)) := by
+  have hEval : evalAt mode s sp env (.arith .div l r) = some (.vInt (a.ediv b)) := by
+    cases b with
+    | ofNat k =>
+      cases k with
+      | zero => exact absurd rfl hbz
+      | succ _ => simp only [evalAt, hL, hR, evalArith]
+    | negSucc _ => simp only [evalAt, hL, hR, evalArith]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (a.ediv b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_div_ints_nonZero _ _ _ (translate l) (translate r) a b hbz hSubL.symm hSubR.symm]
+
+/-- Integer division by zero — both sides yield `none`. -/
+theorem soundnessAt_arith_div_ints_zero (l r : Expr) (a : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt 0)) :
+    valueToSmt? (evalAt mode s sp env (.arith .div l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith .div l r)) := by
+  have hEval : evalAt mode s sp env (.arith .div l r) = none := by
+    simp only [evalAt, hL, hR, evalArith]
+  rw [hEval]
+  simp only [translate, valueToSmt?]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  exact (smtEvalAt_div_zero _ _ _ (translate l) (translate r) a hSubL.symm hSubR.symm).symm
+
+/-- Integer arithmetic `*`. -/
+theorem soundnessAt_arith_mul_ints (l r : Expr) (a b : Int)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some (.vInt b)) :
+    valueToSmt? (evalAt mode s sp env (.arith .mul l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.arith .mul l r)) := by
+  have hEval : evalAt mode s sp env (.arith .mul l r) = some (.vInt (a * b)) := by
+    simp only [evalAt, hL, hR, evalArith]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (a * b)) = _
+  simp only [translate]
+  rw [hL] at hSubL; rw [valueToSmt?_some] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some] at hSubR
+  rw [smtEvalAt_mul_ints _ _ _ (translate l) (translate r) a b hSubL.symm hSubR.symm]
+
+/-- `let x = v in body`. The IH on `value` is `hSub`; the IH on `body` is the
+    extended-env hypothesis. -/
+theorem soundnessAt_letIn (x : String) (value body : Expr) (v : Value)
+    (hSub : valueToSmt? (evalAt mode s sp env value)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate value))
+    (hBodyIH : valueToSmt? (evalAt mode s sp ((x, v) :: env) body)
+                = smtEvalAt mode (correlateModelPair s sp) ((x, valueToSmt v) :: correlateEnv env)
+                    (translate body))
+    (hValue : evalAt mode s sp env value = some v) :
+    valueToSmt? (evalAt mode s sp env (.letIn x value body))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.letIn x value body)) := by
+  rw [evalAt_letIn_some mode s sp env x value body v hValue]
+  simp only [translate]
+  rw [hValue] at hSub; rw [valueToSmt?_some] at hSub
+  rw [smtEvalAt_letIn_some _ _ _ x (translate value) (translate body) (valueToSmt v) hSub.symm]
+  show valueToSmt? (evalAt mode s sp ((x, v) :: env) body)
+        = smtEvalAt mode (correlateModelPair s sp) ((x, valueToSmt v) :: correlateEnv env)
+            (translate body)
+  exact hBodyIH
+
+/-- EnumAccess on a known enum with a known member. -/
+theorem soundnessAt_enumAccess_known (en m : String) (d : EnumDecl)
+    (hSchema : s.lookupEnum en = some d)
+    (hMember : d.members.contains m = true) :
+    valueToSmt? (evalAt mode s sp env (.enumAccess en m))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.enumAccess en m)) := by
+  have hEval : evalAt mode s sp env (.enumAccess en m) = some (.vEnum en m) := by
+    simp only [evalAt, hSchema, hMember, if_true]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sEnumElem en m) = _
+  simp only [translate]
+  have hSort : ((correlateModelPair s sp).at mode).lookupSortMembers en = some d.members := by
+    rw [correlateModelPair_at]
+    exact correlateModel_lookupSortMembers s (sp.at mode) en d hSchema
+  rw [smtEvalAt_enumElemConst_known _ _ _ hSort hMember]
+
+/-- `Prime e` — flips mode to `.post` and applies IH at the flipped mode. The
+    IH is parameterised over mode in the universal `soundnessAt` theorem
+    (Phase 3b), so taking `hSubAtPost` as a hypothesis here is faithful. -/
+theorem soundnessAt_prime (e : Expr)
+    (hSubAtPost : valueToSmt? (evalAt .post s sp env e)
+                    = smtEvalAt .post (correlateModelPair s sp) (correlateEnv env) (translate e)) :
+    valueToSmt? (evalAt mode s sp env (.prime e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.prime e)) := by
+  rw [evalAt_prime]
+  simp only [translate]
+  rw [smtEvalAt_prime]
+  exact hSubAtPost
+
+/-- `Pre e` — flips mode to `.pre` and applies IH at the flipped mode. -/
+theorem soundnessAt_pre (e : Expr)
+    (hSubAtPre : valueToSmt? (evalAt .pre s sp env e)
+                    = smtEvalAt .pre (correlateModelPair s sp) (correlateEnv env) (translate e)) :
+    valueToSmt? (evalAt mode s sp env (.pre e))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.pre e)) := by
+  rw [evalAt_pre]
+  simp only [translate]
+  rw [smtEvalAt_pre]
+  exact hSubAtPre
 
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -3204,4 +3204,365 @@ theorem soundnessAt_pre (e : Expr)
   rw [smtEvalAt_pre]
   exact hSubAtPre
 
+/-! ## Phase 3b — state-touching, set-op, and quantifier `soundnessAt_*` cases. -/
+
+/-- Identifier — env-miss / state-scalar-hit path. State scalar lookup goes through
+    `(sp.at mode)`; the existing single-state `correlateModel_const_state_scalar` lifts
+    via `correlateModelPair_at`. -/
+theorem soundnessAt_ident_state {x : String} {v : Value}
+    (hEnv : Env.lookup env x = none)
+    (hSt : (sp.at mode).lookupScalar x = some v) :
+    valueToSmt? (evalAt mode s sp env (.ident x))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.ident x)) := by
+  rw [evalAt_ident_state mode s sp env hEnv hSt, valueToSmt?_some]
+  simp only [translate]
+  have hCorrEnv : SmtEnv.lookup (correlateEnv env) x = none := by
+    rw [correlateEnv_lookup, hEnv]; rfl
+  have hConst : ((correlateModelPair s sp).at mode).lookupConst x = some (valueToSmt v) := by
+    rw [correlateModelPair_at]
+    exact correlateModel_const_state_scalar s (sp.at mode) x v hSt
+  rw [smtEvalAt_var_const _ _ _ hCorrEnv hConst]
+
+/-- State-relation membership (`In`). The IH on the element comes from the
+    structural induction; the relation domain lifts via `correlateModelPair_at`. -/
+theorem soundnessAt_member_resolved (elem : Expr) (relName : String) (v : Value) (dom : List Value)
+    (hSub : valueToSmt? (evalAt mode s sp env elem)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate elem))
+    (hElem : evalAt mode s sp env elem = some v)
+    (hDom : (sp.at mode).relationDomain relName = some dom) :
+    valueToSmt? (evalAt mode s sp env (.member elem relName))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.member elem relName)) := by
+  rw [evalAt_member_resolved mode s sp env elem relName v dom hElem hDom, valueToSmt?_some]
+  show some (SmtVal.sBool (dom.contains v)) = _
+  simp only [translate]
+  rw [hElem] at hSub; rw [valueToSmt?_some] at hSub
+  have hRel : ((correlateModelPair s sp).at mode).lookupRel relName = some (dom.map valueToSmt) := by
+    rw [correlateModelPair_at]
+    exact correlateModel_lookupRel s (sp.at mode) relName dom hDom
+  rw [smtEvalAt_inDom_resolved _ _ _ relName (translate elem) (valueToSmt v) (dom.map valueToSmt)
+        hSub.symm hRel]
+  rw [contains_map_valueToSmt]
+
+/-- State-relation cardinality. The relation domain lifts via `correlateModelPair_at`. -/
+theorem soundnessAt_cardRel_resolved (relName : String) (dom : List Value)
+    (hDom : (sp.at mode).relationDomain relName = some dom) :
+    valueToSmt? (evalAt mode s sp env (.cardRel relName))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cardRel relName)) := by
+  have hEval : evalAt mode s sp env (.cardRel relName)
+              = some (.vInt (Int.ofNat dom.length)) := by
+    simp only [evalAt, hDom]
+  rw [hEval, valueToSmt?_some]
+  show some (SmtVal.sInt (Int.ofNat dom.length)) = _
+  simp only [translate]
+  have hRel : ((correlateModelPair s sp).at mode).lookupRel relName = some (dom.map valueToSmt) := by
+    rw [correlateModelPair_at]
+    exact correlateModel_lookupRel s (sp.at mode) relName dom hDom
+  rw [smtEvalAt_cardRel_resolved _ _ _ relName (dom.map valueToSmt) hRel]
+  rw [List.length_map]
+
+/-- State-relation pair lookup (Index). Bridges `lookupKey_correlated` via
+    `correlateModelPair_at`. -/
+theorem soundnessAt_indexRel_resolved (relName : String) (key : Expr) (kv : Value)
+    (hSub : valueToSmt? (evalAt mode s sp env key)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate key))
+    (hKey : evalAt mode s sp env key = some kv) :
+    valueToSmt? (evalAt mode s sp env (.indexRel relName key))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.indexRel relName key)) := by
+  rw [evalAt_indexRel_key mode s sp env relName key kv hKey]
+  simp only [translate]
+  rw [hKey] at hSub; rw [valueToSmt?_some] at hSub
+  rw [smtEvalAt_indexRel_resolved _ _ _ relName (translate key) (valueToSmt kv) hSub.symm]
+  rw [correlateModelPair_at]
+  exact lookupKey_correlated s (sp.at mode) relName kv
+
+/-- FieldAccess on a resolved entity-id. Bridges `lookupField_correlated` via
+    `correlateModelPair_at`. -/
+theorem soundnessAt_fieldAccess_resolved (base : Expr) (en id fieldName : String)
+    (hSub : valueToSmt? (evalAt mode s sp env base)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate base))
+    (hBase : evalAt mode s sp env base = some (.vEntity en id)) :
+    valueToSmt? (evalAt mode s sp env (.fieldAccess base fieldName))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.fieldAccess base fieldName)) := by
+  rw [evalAt_fieldAccess_resolved mode s sp env base en id fieldName hBase]
+  simp only [translate]
+  rw [hBase] at hSub
+  rw [valueToSmt?_some, valueToSmt_vEntity] at hSub
+  rw [smtEvalAt_fieldAccess_resolved _ _ _ (translate base) en id fieldName hSub.symm]
+  rw [correlateModelPair_at]
+  exact lookupField_correlated s (sp.at mode) id fieldName
+
+/-! ### Set-op `soundnessAt_*` cases. -/
+
+/-- Empty set literal. Both sides yield `vSet []` / `sSet []`. -/
+theorem soundnessAt_setEmpty :
+    valueToSmt? (evalAt mode s sp env .setEmpty)
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate .setEmpty) := by
+  rw [evalAt_setEmpty, valueToSmt?_some]
+  simp only [translate]
+  rw [smtEvalAt_setEmpty]
+  rfl
+
+/-- Set insertion when both sub-results resolve. -/
+theorem soundnessAt_setInsert_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hSubE : valueToSmt? (evalAt mode s sp env elem)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate elem))
+    (hSubS : valueToSmt? (evalAt mode s sp env set)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate set))
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some (.vSet members)) :
+    valueToSmt? (evalAt mode s sp env (.setInsert elem set))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.setInsert elem set)) := by
+  rw [evalAt_setInsert_resolved mode s sp env elem set v members hElem hSet, valueToSmt?_some]
+  simp only [translate]
+  rw [hElem] at hSubE; rw [valueToSmt?_some] at hSubE
+  rw [hSet] at hSubS; rw [valueToSmt?_some, valueToSmt_vSet] at hSubS
+  rw [smtEvalAt_setInsert_resolved _ _ _ (translate elem) (translate set)
+        (valueToSmt v) (members.map valueToSmt) hSubE.symm hSubS.symm]
+  -- valueToSmt (vSet (dedupeValues (v :: members)))
+  --    = sSet (dedupeSmtVals (valueToSmt v :: members.map valueToSmt))
+  rw [valueToSmt_vSet]
+  congr 2
+  -- (dedupeValues (v :: members)).map valueToSmt
+  --    = dedupeSmtVals (valueToSmt v :: members.map valueToSmt)
+  exact dedupeValues_map_valueToSmt (v :: members)
+
+/-- Set membership when both sub-results resolve. -/
+theorem soundnessAt_setMember_resolved (elem set : Expr) (v : Value) (members : List Value)
+    (hSubE : valueToSmt? (evalAt mode s sp env elem)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate elem))
+    (hSubS : valueToSmt? (evalAt mode s sp env set)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate set))
+    (hElem : evalAt mode s sp env elem = some v)
+    (hSet : evalAt mode s sp env set = some (.vSet members)) :
+    valueToSmt? (evalAt mode s sp env (.setMember elem set))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.setMember elem set)) := by
+  rw [evalAt_setMember_resolved mode s sp env elem set v members hElem hSet, valueToSmt?_some]
+  show some (SmtVal.sBool (containsValue members v)) = _
+  simp only [translate]
+  rw [hElem] at hSubE; rw [valueToSmt?_some] at hSubE
+  rw [hSet] at hSubS; rw [valueToSmt?_some, valueToSmt_vSet] at hSubS
+  rw [smtEvalAt_setMember_resolved _ _ _ (translate elem) (translate set)
+        (valueToSmt v) (members.map valueToSmt) hSubE.symm hSubS.symm]
+  rw [containsValue_map_valueToSmt]
+
+/-! ### Quantifier `soundnessAt_*` cases (parallel mutual lemmas). -/
+
+/-- Mutual-induction correlation between `evalAtForallEnum` and `smtEvalAtForallEnum`,
+    threading the body's IH through every member of the enum. Mirrors
+    `evalForallEnum_correlated` with carriers swapped. -/
+theorem evalAtForallEnum_correlated
+    (var en : String) (members : List String) (body : Expr)
+    (hBodyIH : ∀ (val : Value),
+      valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+        = smtEvalAt mode (correlateModelPair s sp) ((var, valueToSmt val) :: correlateEnv env)
+            (translate body)) :
+    valueToSmt? (evalAtForallEnum mode s sp env var en members body)
+      = smtEvalAtForallEnum mode (correlateModelPair s sp) (correlateEnv env) var en members
+          (translate body) := by
+  induction members with
+  | nil =>
+    rw [evalAtForallEnum_nil, smtEvalAtForallEnum_nil]
+    rfl
+  | cons mem rest ih =>
+    have hBody := hBodyIH (.vEnum en mem)
+    rw [valueToSmt_vEnum] at hBody
+    simp only [evalAtForallEnum, smtEvalAtForallEnum]
+    cases hb : evalAt mode s sp ((var, .vEnum en mem) :: env) body with
+    | none =>
+      rw [hb] at hBody
+      simp only [valueToSmt?] at hBody
+      simp only [valueToSmt?, ← hBody]
+    | some bv =>
+      rw [hb] at hBody
+      simp only [valueToSmt?_some] at hBody
+      cases bv with
+      | vBool b =>
+        rw [valueToSmt_vBool] at hBody
+        rw [← hBody]
+        cases hr : evalAtForallEnum mode s sp env var en rest body with
+        | none =>
+          rw [hr] at ih
+          simp only [valueToSmt?] at ih
+          simp only [valueToSmt?, ← ih]
+        | some rv =>
+          rw [hr] at ih
+          simp only [valueToSmt?_some] at ih
+          cases rv with
+          | vBool acc =>
+            rw [valueToSmt_vBool] at ih
+            rw [← ih]; simp only [valueToSmt?]; rfl
+          | vInt n =>
+            rw [valueToSmt_vInt] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vEnum en' m' =>
+            rw [valueToSmt_vEnum] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vEntity en' i' =>
+            rw [valueToSmt_vEntity] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vSet members =>
+            rw [valueToSmt_vSet members] at ih
+            rw [← ih]; simp only [valueToSmt?]
+      | vInt n =>
+        rw [valueToSmt_vInt] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vEnum en' m' =>
+        rw [valueToSmt_vEnum] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vEntity en' i' =>
+        rw [valueToSmt_vEntity] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vSet members =>
+        rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+/-- Universal quantifier over a known enum domain. -/
+theorem soundnessAt_forallEnum_known (var en : String) (body : Expr) (d : EnumDecl)
+    (hSchema : s.lookupEnum en = some d)
+    (hBodyIH : ∀ (val : Value),
+      valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+        = smtEvalAt mode (correlateModelPair s sp) ((var, valueToSmt val) :: correlateEnv env)
+            (translate body)) :
+    valueToSmt? (evalAt mode s sp env (.forallEnum var en body))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.forallEnum var en body)) := by
+  rw [evalAt_forallEnum_known mode s sp env var en body d hSchema]
+  simp only [translate]
+  have hSort : ((correlateModelPair s sp).at mode).lookupSortMembers en = some d.members := by
+    rw [correlateModelPair_at]
+    exact correlateModel_lookupSortMembers s (sp.at mode) en d hSchema
+  rw [smtEvalAt_forallEnum_known _ _ _ var en (translate body) d.members hSort]
+  exact evalAtForallEnum_correlated s env mode sp var en d.members body hBodyIH
+
+/-- Mutual-induction correlation between `evalAtForallRel` and `smtEvalAtForallRel`,
+    threading the body's IH through every value in the relation domain. -/
+theorem evalAtForallRel_correlated
+    (var : String) (dom : List Value) (body : Expr)
+    (hBodyIH : ∀ (val : Value),
+      valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+        = smtEvalAt mode (correlateModelPair s sp) ((var, valueToSmt val) :: correlateEnv env)
+            (translate body)) :
+    valueToSmt? (evalAtForallRel mode s sp env var dom body)
+      = smtEvalAtForallRel mode (correlateModelPair s sp) (correlateEnv env) var
+          (dom.map valueToSmt) (translate body) := by
+  induction dom with
+  | nil =>
+    rw [evalAtForallRel_nil]
+    rw [List.map_nil]
+    rw [smtEvalAtForallRel_nil]
+    rfl
+  | cons hd rest ih =>
+    have hBody := hBodyIH hd
+    simp only [evalAtForallRel, List.map, smtEvalAtForallRel]
+    cases hb : evalAt mode s sp ((var, hd) :: env) body with
+    | none =>
+      rw [hb] at hBody
+      simp only [valueToSmt?] at hBody
+      simp only [valueToSmt?, ← hBody]
+    | some bv =>
+      rw [hb] at hBody
+      simp only [valueToSmt?_some] at hBody
+      cases bv with
+      | vBool b =>
+        rw [valueToSmt_vBool] at hBody
+        rw [← hBody]
+        cases hr : evalAtForallRel mode s sp env var rest body with
+        | none =>
+          rw [hr] at ih
+          simp only [valueToSmt?] at ih
+          simp only [valueToSmt?, ← ih]
+        | some rv =>
+          rw [hr] at ih
+          simp only [valueToSmt?_some] at ih
+          cases rv with
+          | vBool acc =>
+            rw [valueToSmt_vBool] at ih
+            rw [← ih]; simp only [valueToSmt?]; rfl
+          | vInt n =>
+            rw [valueToSmt_vInt] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vEnum en' m' =>
+            rw [valueToSmt_vEnum] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vEntity en' i' =>
+            rw [valueToSmt_vEntity] at ih
+            rw [← ih]; simp only [valueToSmt?]
+          | vSet members =>
+            rw [valueToSmt_vSet members] at ih
+            rw [← ih]; simp only [valueToSmt?]
+      | vInt n =>
+        rw [valueToSmt_vInt] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vEnum en' m' =>
+        rw [valueToSmt_vEnum] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vEntity en' i' =>
+        rw [valueToSmt_vEntity] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+      | vSet members =>
+        rw [valueToSmt_vSet members] at hBody
+        rw [← hBody]; simp only [valueToSmt?]
+
+/-- Universal quantifier over a known state-relation domain. -/
+theorem soundnessAt_forallRel_known (var rel : String) (body : Expr) (dom : List Value)
+    (hDom : (sp.at mode).relationDomain rel = some dom)
+    (hBodyIH : ∀ (val : Value),
+      valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+        = smtEvalAt mode (correlateModelPair s sp) ((var, valueToSmt val) :: correlateEnv env)
+            (translate body)) :
+    valueToSmt? (evalAt mode s sp env (.forallRel var rel body))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.forallRel var rel body)) := by
+  rw [evalAt_forallRel_known mode s sp env var rel body dom hDom]
+  simp only [translate]
+  have hRel : ((correlateModelPair s sp).at mode).lookupRel rel = some (dom.map valueToSmt) := by
+    rw [correlateModelPair_at]
+    exact correlateModel_lookupRel s (sp.at mode) rel dom hDom
+  rw [smtEvalAt_forallRel_known _ _ _ var rel (translate body) (dom.map valueToSmt) hRel]
+  exact evalAtForallRel_correlated s env mode sp var dom body hBodyIH
+
+/-- Set binary operations (union/intersect/diff) when both sub-results are sets. -/
+theorem soundnessAt_setBin_sets (op : SetOp) (l r : Expr) (ls rs : List Value)
+    (hSubL : valueToSmt? (evalAt mode s sp env l)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (hSubR : valueToSmt? (evalAt mode s sp env r)
+              = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vSet ls))
+    (hR : evalAt mode s sp env r = some (.vSet rs)) :
+    valueToSmt? (evalAt mode s sp env (.setBin op l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.setBin op l r)) := by
+  rw [evalAt_setBin_sets mode s sp env op l r ls rs hL hR]
+  rw [hL] at hSubL; rw [valueToSmt?_some, valueToSmt_vSet] at hSubL
+  rw [hR] at hSubR; rw [valueToSmt?_some, valueToSmt_vSet] at hSubR
+  cases op with
+  | union =>
+    simp only [evalSetBin, translate]
+    rw [smtEvalAt_setUnion_sets _ _ _ (translate l) (translate r)
+          (ls.map valueToSmt) (rs.map valueToSmt) hSubL.symm hSubR.symm]
+    rw [valueToSmt?_some, valueToSmt_vSet]
+    congr 2
+    exact setUnionValues_map_valueToSmt ls rs
+  | intersect =>
+    simp only [evalSetBin, translate]
+    rw [smtEvalAt_setIntersect_sets _ _ _ (translate l) (translate r)
+          (ls.map valueToSmt) (rs.map valueToSmt) hSubL.symm hSubR.symm]
+    rw [valueToSmt?_some, valueToSmt_vSet]
+    congr 2
+    exact setIntersectValues_map_valueToSmt ls rs
+  | diff =>
+    simp only [evalSetBin, translate]
+    rw [smtEvalAt_setDiff_sets _ _ _ (translate l) (translate r)
+          (ls.map valueToSmt) (rs.map valueToSmt) hSubL.symm hSubR.symm]
+    rw [valueToSmt?_some, valueToSmt_vSet]
+    congr 2
+    exact setDiffValues_map_valueToSmt ls rs
+
 end SpecRest

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -186,16 +186,61 @@ theorem setEqValueList_map_valueToSmt (xs ys : List Value) :
   simp only [setEqSmtValList, setEqValueList]
   rw [subsetValueList_map_valueToSmt xs ys, subsetValueList_map_valueToSmt ys xs]
 
-/-- Boolean equality on `Value` agrees with boolean equality on `SmtVal` after `valueToSmt`. -/
-theorem valueToSmt_beq (a b : Value) : (valueToSmt a == valueToSmt b) = (a == b) := by
-  cases a <;> cases b <;> try rfl
-  · -- vSet × vSet case
-    simp [valueToSmt, valuesToSmt_eq_map]
-    exact setEqValueList_map_valueToSmt _ _
-  · -- vEntityWith × vEntityWith case
-    rw [valueToSmt_vEntityWith, valueToSmt_vEntityWith]
-    show beqSmtVal _ _ = beqValue _ _
-    simp only [beqSmtVal, beqValue, valueToSmt_decide_eq]
+/-- Boolean equality on `Value` agrees with boolean equality on `SmtVal` after `valueToSmt`.
+    Structurally recursive on the `vEntityWith` arm so the recursive calls correlate
+    `beqValue` and `beqSmtVal` (both made recursive in this PR for extensional set
+    equality inside record-update chains). -/
+theorem valueToSmt_beq : ∀ (a b : Value), (valueToSmt a == valueToSmt b) = (a == b)
+  | .vBool _, .vBool _ => rfl
+  | .vBool _, .vInt _ => rfl
+  | .vBool _, .vEnum _ _ => rfl
+  | .vBool _, .vEntity _ _ => rfl
+  | .vBool _, .vSet _ => rfl
+  | .vBool _, .vEntityWith _ _ _ => rfl
+  | .vInt _, .vBool _ => rfl
+  | .vInt _, .vInt _ => rfl
+  | .vInt _, .vEnum _ _ => rfl
+  | .vInt _, .vEntity _ _ => rfl
+  | .vInt _, .vSet _ => rfl
+  | .vInt _, .vEntityWith _ _ _ => rfl
+  | .vEnum _ _, .vBool _ => rfl
+  | .vEnum _ _, .vInt _ => rfl
+  | .vEnum _ _, .vEnum _ _ => rfl
+  | .vEnum _ _, .vEntity _ _ => rfl
+  | .vEnum _ _, .vSet _ => rfl
+  | .vEnum _ _, .vEntityWith _ _ _ => rfl
+  | .vEntity _ _, .vBool _ => rfl
+  | .vEntity _ _, .vInt _ => rfl
+  | .vEntity _ _, .vEnum _ _ => rfl
+  | .vEntity _ _, .vEntity _ _ => rfl
+  | .vEntity _ _, .vSet _ => rfl
+  | .vEntity _ _, .vEntityWith _ _ _ => rfl
+  | .vSet _, .vBool _ => rfl
+  | .vSet _, .vInt _ => rfl
+  | .vSet _, .vEnum _ _ => rfl
+  | .vSet _, .vEntity _ _ => rfl
+  | .vSet xs, .vSet ys => by
+      simp [valueToSmt, valuesToSmt_eq_map]
+      exact setEqValueList_map_valueToSmt _ _
+  | .vSet _, .vEntityWith _ _ _ => rfl
+  | .vEntityWith _ _ _, .vBool _ => rfl
+  | .vEntityWith _ _ _, .vInt _ => rfl
+  | .vEntityWith _ _ _, .vEnum _ _ => rfl
+  | .vEntityWith _ _ _, .vEntity _ _ => rfl
+  | .vEntityWith _ _ _, .vSet _ => rfl
+  | .vEntityWith ba fa va, .vEntityWith bb fb vb => by
+      rw [valueToSmt_vEntityWith, valueToSmt_vEntityWith]
+      show beqSmtVal _ _ = beqValue _ _
+      simp only [beqSmtVal, beqValue]
+      have hb := valueToSmt_beq ba bb
+      have hv := valueToSmt_beq va vb
+      -- Bridge `BEq.beq` typeclass projection to the underlying `beqValue` /
+      -- `beqSmtVal` calls so the recursive results plug in directly.
+      show (beqSmtVal (valueToSmt ba) (valueToSmt bb) && fa == fb && beqSmtVal (valueToSmt va) (valueToSmt vb))
+        = (beqValue ba bb && fa == fb && beqValue va vb)
+      have hbEq : beqSmtVal (valueToSmt ba) (valueToSmt bb) = beqValue ba bb := hb
+      have hvEq : beqSmtVal (valueToSmt va) (valueToSmt vb) = beqValue va vb := hv
+      rw [hbEq, hvEq]
 
 /-! ## Env / State / Schema ↔ SmtModel correlation -/
 

--- a/proofs/lean/SpecRest/Soundness.lean
+++ b/proofs/lean/SpecRest/Soundness.lean
@@ -3967,4 +3967,1005 @@ private theorem cmp_lt_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
   simp only [valueToSmt?, translate]
   exact (smtEvalAt_lt_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)).symm
 
+private theorem cmp_le_lhs_nonInt_at (l r : Expr) (lv : Value)
+    (hNotInt : ∀ n, lv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) (rv : Value)
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .le l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .le l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .le l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases lv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases rv <;> rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+              (.lt (translate l) (translate r)) = none :=
+    smtEvalAt_lt_lhs_nonInt _ _ _ ihL.symm (hSmtLvNotInt lv hNotInt)
+  exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
+
+private theorem cmp_le_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
+    (hNotInt : ∀ n, rv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .le l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .le l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .le l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases rv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vInt] at ihL
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?]
+  have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+              (.lt (translate l) (translate r)) = none :=
+    smtEvalAt_lt_rhs_nonInt _ _ _ ihL.symm ihR.symm (hSmtLvNotInt rv hNotInt)
+  exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
+
+private theorem cmp_gt_lhs_nonInt_at (l r : Expr) (lv : Value)
+    (hNotInt : ∀ n, lv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) (rv : Value)
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .gt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .gt l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .gt l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases lv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases rv <;> rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  have hLvNonSInt := hSmtLvNotInt lv hNotInt
+  show none = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                (.lt (translate r) (translate l))
+  simp only [smtEvalAt]
+  rw [← ihL]
+  cases (smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r)) with
+  | none => rfl
+  | some sv =>
+    cases sv with
+    | sInt _ =>
+      cases hVal : valueToSmt lv with
+      | sInt n => exact absurd hVal (hLvNonSInt n)
+      | sBool _ => rfl
+      | sEnumElem _ _ => rfl
+      | sEntityElem _ _ => rfl
+      | sSet _ => rfl
+    | sBool _ => rfl
+    | sEnumElem _ _ => rfl
+    | sEntityElem _ _ => rfl
+    | sSet _ => rfl
+
+private theorem cmp_gt_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
+    (hNotInt : ∀ n, rv ≠ .vInt n)
+    (_ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .gt l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .gt l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .gt l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases rv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?]
+  exact (smtEvalAt_lt_lhs_nonInt _ _ _ ihR.symm (hSmtLvNotInt rv hNotInt)).symm
+
+private theorem cmp_ge_lhs_nonInt_at (l r : Expr) (lv : Value)
+    (hNotInt : ∀ n, lv ≠ .vInt n)
+    (ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (_ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some lv) (rv : Value)
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .ge l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .ge l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .ge l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases lv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => cases rv <;> rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+  simp only [valueToSmt?]
+  have hLvNonSInt := hSmtLvNotInt lv hNotInt
+  have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+              (.lt (translate r) (translate l)) = none := by
+    simp only [smtEvalAt]
+    rw [← ihL]
+    cases (smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r)) with
+    | none => rfl
+    | some sv =>
+      cases sv with
+      | sInt _ =>
+        cases hVal : valueToSmt lv with
+        | sInt n => exact absurd hVal (hLvNonSInt n)
+        | sBool _ => rfl
+        | sEnumElem _ _ => rfl
+        | sEntityElem _ _ => rfl
+        | sSet _ => rfl
+      | sBool _ => rfl
+      | sEnumElem _ _ => rfl
+      | sEntityElem _ _ => rfl
+      | sSet _ => rfl
+  exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
+
+private theorem cmp_ge_rhs_nonInt_lhs_int_at (l r : Expr) (a : Int) (rv : Value)
+    (hNotInt : ∀ n, rv ≠ .vInt n)
+    (_ihL : valueToSmt? (evalAt mode s sp env l)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate l))
+    (ihR : valueToSmt? (evalAt mode s sp env r)
+            = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate r))
+    (hL : evalAt mode s sp env l = some (.vInt a))
+    (hR : evalAt mode s sp env r = some rv) :
+    valueToSmt? (evalAt mode s sp env (.cmp .ge l r))
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+          (translate (.cmp .ge l r)) := by
+  have hEvalNone : evalAt mode s sp env (.cmp .ge l r) = none := by
+    rw [evalAt_cmp_app, hL, hR]
+    cases rv with
+    | vInt n => exact absurd rfl (hNotInt n)
+    | _ => rfl
+  rw [hEvalNone]
+  simp only [translate]
+  rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+  simp only [valueToSmt?]
+  have hLt : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+              (.lt (translate r) (translate l)) = none :=
+    smtEvalAt_lt_lhs_nonInt _ _ _ ihR.symm (hSmtLvNotInt rv hNotInt)
+  exact (smtEvalAt_or_lhs_none _ _ _ hLt).symm
+
+/-! ## Universal `soundnessAt` theorem.
+
+Off-diagonal closure of #194's first acceptance criterion. Structural induction
+on `Expr` generalizing both `env` and `mode`. Mirrors the case structure of the
+single-state universal `soundness` (lines 1819-2655) with carriers substituted:
+
+  eval s st           ↦  evalAt mode s sp
+  smtEval m           ↦  smtEvalAt mode mp
+  correlateModel s st ↦  correlateModelPair s sp -- bridged via correlateModelPair_at
+
+Each case dispatches to its `soundnessAt_*` per-case theorem (success path) and
+its `smtEvalAt_*_none/_nonBool/_nonInt/_nonSet` helper or the private
+`*_at` failure helper above (failure path). Closes with no `sorry`. -/
+
+theorem soundnessAt (mode : StateMode) (e : Expr) :
+    valueToSmt? (evalAt mode s sp env e)
+      = smtEvalAt mode (correlateModelPair s sp) (correlateEnv env) (translate e) := by
+  induction e generalizing env mode with
+  | boolLit b => exact soundnessAt_boolLit s env mode sp b
+  | intLit n => exact soundnessAt_intLit s env mode sp n
+  | ident name =>
+    cases hEnv : Env.lookup env name with
+    | some v => exact soundnessAt_ident_local s env mode sp hEnv
+    | none =>
+      cases hSt : (sp.at mode).lookupScalar name with
+      | some v => exact soundnessAt_ident_state s env mode sp hEnv hSt
+      | none =>
+        rw [show evalAt mode s sp env (.ident name) = none from by
+              simp only [evalAt, hEnv, hSt]]
+        simp only [translate]
+        have henv' : SmtEnv.lookup (correlateEnv env) name = none := by
+          rw [correlateEnv_lookup, hEnv]; rfl
+        have hconst' : ((correlateModelPair s sp).at mode).lookupConst name = none := by
+          rw [correlateModelPair_at]
+          exact correlateModel_lookupConst_none_of_state_miss s (sp.at mode) name hSt
+        simp only [valueToSmt?]
+        simp only [smtEvalAt, henv', hconst']
+  | unNot e ih =>
+    have ih' := ih env mode
+    cases h : evalAt mode s sp env e with
+    | none =>
+      rw [show evalAt mode s sp env (.unNot e) = none from by simp only [evalAt, h]]
+      simp only [translate]
+      rw [h] at ih'; simp only [valueToSmt?] at ih'
+      simp only [valueToSmt?]
+      exact (smtEvalAt_not_none _ _ _ _ ih'.symm).symm
+    | some v =>
+      cases v with
+      | vBool b => exact soundnessAt_unNot_bool s env mode sp e b ih' h
+      | vInt n =>
+        exact soundnessAt_unNot_nonBool s env mode sp e (.vInt n) nofun ih' h
+      | vEnum en' m' =>
+        exact soundnessAt_unNot_nonBool s env mode sp e (.vEnum en' m') nofun ih' h
+      | vEntity en' i' =>
+        exact soundnessAt_unNot_nonBool s env mode sp e (.vEntity en' i') nofun ih' h
+      | vSet members =>
+        exact soundnessAt_unNot_nonBool s env mode sp e (.vSet members) nofun ih' h
+  | unNeg e ih =>
+    have ih' := ih env mode
+    cases h : evalAt mode s sp env e with
+    | none =>
+      rw [show evalAt mode s sp env (.unNeg e) = none from by simp only [evalAt, h]]
+      simp only [translate]
+      rw [h] at ih'; simp only [valueToSmt?] at ih'
+      simp only [valueToSmt?]
+      exact (smtEvalAt_neg_none _ _ _ _ ih'.symm).symm
+    | some v =>
+      cases v with
+      | vInt n => exact soundnessAt_unNeg_int s env mode sp e n ih' h
+      | vBool b =>
+        exact soundnessAt_unNeg_nonInt s env mode sp e (.vBool b) nofun ih' h
+      | vEnum en' m' =>
+        exact soundnessAt_unNeg_nonInt s env mode sp e (.vEnum en' m') nofun ih' h
+      | vEntity en' i' =>
+        exact soundnessAt_unNeg_nonInt s env mode sp e (.vEntity en' i') nofun ih' h
+      | vSet members =>
+        exact soundnessAt_unNeg_nonInt s env mode sp e (.vSet members) nofun ih' h
+  | prime e ih =>
+    have ih' := ih env .post
+    exact soundnessAt_prime s env mode sp e ih'
+  | pre e ih =>
+    have ih' := ih env .pre
+    exact soundnessAt_pre s env mode sp e ih'
+  | letIn x value body ihV ihB =>
+    have ihV' := ihV env mode
+    cases hV : evalAt mode s sp env value with
+    | none =>
+      rw [show evalAt mode s sp env (.letIn x value body) = none from by
+            simp only [evalAt, hV]]
+      simp only [translate]
+      rw [hV] at ihV'; simp only [valueToSmt?] at ihV'
+      simp only [valueToSmt?]
+      exact (smtEvalAt_letIn_none _ _ _ ihV'.symm).symm
+    | some v =>
+      have ihB' := ihB ((x, v) :: env) mode
+      have hCorr : correlateEnv ((x, v) :: env) = (x, valueToSmt v) :: correlateEnv env := rfl
+      rw [hCorr] at ihB'
+      exact soundnessAt_letIn s env mode sp x value body v ihV' ihB' hV
+  | enumAccess en m =>
+    cases hSchema : s.lookupEnum en with
+    | some d =>
+      by_cases hMember : d.members.contains m = true
+      · exact soundnessAt_enumAccess_known s env mode sp en m d hSchema hMember
+      · have hMember' : d.members.contains m = false := by
+          cases hc : d.members.contains m with
+          | true => exact absurd hc hMember
+          | false => rfl
+        rw [show evalAt mode s sp env (.enumAccess en m) = none from by
+              simp only [evalAt, hSchema, hMember']
+              rfl]
+        simp only [translate]
+        have hSort : ((correlateModelPair s sp).at mode).lookupSortMembers en = some d.members := by
+          rw [correlateModelPair_at]
+          exact correlateModel_lookupSortMembers s (sp.at mode) en d hSchema
+        simp only [valueToSmt?]
+        exact (smtEvalAt_enumElemConst_nonMember _ _ _ hSort hMember').symm
+    | none =>
+      rw [show evalAt mode s sp env (.enumAccess en m) = none from by
+            simp only [evalAt, hSchema]]
+      simp only [translate]
+      have hSort : ((correlateModelPair s sp).at mode).lookupSortMembers en = none := by
+        rw [correlateModelPair_at]
+        exact correlateModel_lookupSortMembers_none s (sp.at mode) en hSchema
+      simp only [valueToSmt?]
+      exact (smtEvalAt_enumElemConst_unknown _ _ _ hSort).symm
+  | boolBin op l r ihL ihR =>
+    have ihLE := ihL env mode
+    have ihRE := ihR env mode
+    cases hL : evalAt mode s sp env l with
+    | none =>
+      rw [show evalAt mode s sp env (.boolBin op l r) = none from by simp only [evalAt, hL]]
+      rw [hL] at ihLE; simp only [valueToSmt?] at ihLE
+      simp only [valueToSmt?]
+      cases op with
+      | and =>
+        simp only [translate]
+        exact (smtEvalAt_and_lhs_none _ _ _ ihLE.symm).symm
+      | or =>
+        simp only [translate]
+        exact (smtEvalAt_or_lhs_none _ _ _ ihLE.symm).symm
+      | implies =>
+        simp only [translate]
+        exact (smtEvalAt_implies_lhs_none _ _ _ ihLE.symm).symm
+      | iff =>
+        simp only [translate]
+        have h_lr : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                      (.implies (translate l) (translate r)) = none :=
+          smtEvalAt_implies_lhs_none _ _ _ ihLE.symm
+        exact (smtEvalAt_and_lhs_none _ _ _ h_lr).symm
+    | some lv =>
+      cases lv with
+      | vBool a =>
+        cases hR : evalAt mode s sp env r with
+        | none =>
+          rw [show evalAt mode s sp env (.boolBin op l r) = none from by
+                simp only [evalAt, hL, hR]]
+          rw [hL] at ihLE; rw [valueToSmt?_some, valueToSmt_vBool] at ihLE
+          rw [hR] at ihRE; simp only [valueToSmt?] at ihRE
+          simp only [valueToSmt?]
+          cases op with
+          | and =>
+            simp only [translate]
+            exact (smtEvalAt_and_rhs_none _ _ _ ihLE.symm ihRE.symm).symm
+          | or =>
+            simp only [translate]
+            exact (smtEvalAt_or_rhs_none _ _ _ ihLE.symm ihRE.symm).symm
+          | implies =>
+            simp only [translate]
+            exact (smtEvalAt_implies_rhs_none _ _ _ ihLE.symm ihRE.symm).symm
+          | iff =>
+            simp only [translate]
+            have h_lr : smtEvalAt mode (correlateModelPair s sp) (correlateEnv env)
+                          (.implies (translate l) (translate r)) = none :=
+              smtEvalAt_implies_rhs_none _ _ _ ihLE.symm ihRE.symm
+            exact (smtEvalAt_and_lhs_none _ _ _ h_lr).symm
+        | some rv =>
+          cases rv with
+          | vBool b =>
+            cases op with
+            | and => exact soundnessAt_boolBin_and_bools s env mode sp l r a b ihLE ihRE hL hR
+            | or  => exact soundnessAt_boolBin_or_bools s env mode sp l r a b ihLE ihRE hL hR
+            | implies => exact soundnessAt_boolBin_implies_bools s env mode sp l r a b ihLE ihRE hL hR
+            | iff => exact soundnessAt_boolBin_iff_bools s env mode sp l r a b ihLE ihRE hL hR
+          | vInt n => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a (.vInt n)
+                              nofun ihLE ihRE hL hR
+          | vEnum en' m' => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a
+                                    (.vEnum en' m') nofun ihLE ihRE hL hR
+          | vEntity en' i' => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a
+                                      (.vEntity en' i') nofun ihLE ihRE hL hR
+          | vSet members => exact boolBin_rhs_nonBool_lhs_bool_at s env mode sp op l r a
+                                      (.vSet members) nofun ihLE ihRE hL hR
+      | vInt n =>
+        exact boolBin_lhs_nonBool_at s env mode sp op l r (.vInt n) nofun ihLE ihRE hL
+      | vEnum en' m' =>
+        exact boolBin_lhs_nonBool_at s env mode sp op l r (.vEnum en' m') nofun ihLE ihRE hL
+      | vEntity en' i' =>
+        exact boolBin_lhs_nonBool_at s env mode sp op l r (.vEntity en' i') nofun ihLE ihRE hL
+      | vSet members =>
+        exact boolBin_lhs_nonBool_at s env mode sp op l r (.vSet members) nofun ihLE ihRE hL
+  | arith op l r ihL ihR =>
+    have ihLE := ihL env mode
+    have ihRE := ihR env mode
+    cases hL : evalAt mode s sp env l with
+    | none =>
+      rw [show evalAt mode s sp env (.arith op l r) = none from by
+            simp only [evalAt, hL]; cases op <;> rfl]
+      rw [hL] at ihLE; simp only [valueToSmt?] at ihLE
+      simp only [valueToSmt?]
+      cases op with
+      | add =>
+        simp only [translate]
+        exact (smtEvalAt_add_lhs_none _ _ _ ihLE.symm).symm
+      | sub =>
+        simp only [translate]
+        exact (smtEvalAt_sub_lhs_none _ _ _ ihLE.symm).symm
+      | mul =>
+        simp only [translate]
+        exact (smtEvalAt_mul_lhs_none _ _ _ ihLE.symm).symm
+      | div =>
+        simp only [translate]
+        exact (smtEvalAt_div_lhs_none _ _ _ ihLE.symm).symm
+    | some lv =>
+      cases lv with
+      | vInt a =>
+        cases hR : evalAt mode s sp env r with
+        | none =>
+          have ihLE' := ihLE
+          have ihRE' := ihRE
+          rw [hL] at ihLE'; rw [valueToSmt?_some, valueToSmt_vInt] at ihLE'
+          rw [hR] at ihRE'; simp only [valueToSmt?] at ihRE'
+          rw [show evalAt mode s sp env (.arith op l r) = none from by
+                simp only [evalAt, hL, hR]; cases op <;> rfl]
+          simp only [valueToSmt?]
+          cases op with
+          | add =>
+            simp only [translate]
+            exact (smtEvalAt_add_rhs_none _ _ _ ihLE'.symm ihRE'.symm).symm
+          | sub =>
+            simp only [translate]
+            exact (smtEvalAt_sub_rhs_none _ _ _ ihLE'.symm ihRE'.symm).symm
+          | mul =>
+            simp only [translate]
+            exact (smtEvalAt_mul_rhs_none _ _ _ ihLE'.symm ihRE'.symm).symm
+          | div =>
+            simp only [translate]
+            exact (smtEvalAt_div_rhs_none _ _ _ ihLE'.symm ihRE'.symm).symm
+        | some rv =>
+          cases rv with
+          | vInt b =>
+            cases op with
+            | add => exact soundnessAt_arith_add_ints s env mode sp l r a b ihLE ihRE hL hR
+            | sub => exact soundnessAt_arith_sub_ints s env mode sp l r a b ihLE ihRE hL hR
+            | mul => exact soundnessAt_arith_mul_ints s env mode sp l r a b ihLE ihRE hL hR
+            | div =>
+              by_cases hbz : b = 0
+              · subst hbz
+                exact soundnessAt_arith_div_ints_zero s env mode sp l r a ihLE ihRE hL hR
+              · exact soundnessAt_arith_div_ints_nonZero s env mode sp l r a b hbz
+                          ihLE ihRE hL hR
+          | vBool b =>
+            exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vBool b)
+                    nofun ihLE ihRE hL hR
+          | vEnum en m =>
+            exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vEnum en m)
+                    nofun ihLE ihRE hL hR
+          | vEntity en i =>
+            exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vEntity en i)
+                    nofun ihLE ihRE hL hR
+          | vSet members =>
+            exact arith_rhs_nonInt_lhs_int_at s env mode sp op l r a (.vSet members)
+                    nofun ihLE ihRE hL hR
+      | vBool b =>
+        exact arith_lhs_nonInt_at s env mode sp op l r (.vBool b) nofun ihLE ihRE hL
+      | vEnum en m =>
+        exact arith_lhs_nonInt_at s env mode sp op l r (.vEnum en m) nofun ihLE ihRE hL
+      | vEntity en i =>
+        exact arith_lhs_nonInt_at s env mode sp op l r (.vEntity en i) nofun ihLE ihRE hL
+      | vSet members =>
+        exact arith_lhs_nonInt_at s env mode sp op l r (.vSet members) nofun ihLE ihRE hL
+  | cmp op l r ihL ihR =>
+    have ihLE := ihL env mode
+    have ihRE := ihR env mode
+    cases hL : evalAt mode s sp env l with
+    | none => exact cmp_lhs_eval_none_at s env mode sp op l r ihLE ihRE hL
+    | some lv =>
+      cases hR : evalAt mode s sp env r with
+      | none => exact cmp_rhs_eval_none_at s env mode sp op l r lv ihLE ihRE hL hR
+      | some rv =>
+        cases op with
+        | eq =>
+          exact soundnessAt_cmp_eq_vals s env mode sp l r lv rv ihLE ihRE hL hR
+        | neq =>
+          exact soundnessAt_cmp_neq_vals s env mode sp l r lv rv ihLE ihRE hL hR
+        | lt =>
+          cases lv with
+          | vInt a =>
+            cases rv with
+            | vInt b => exact soundnessAt_cmp_lt_ints s env mode sp l r a b ihLE ihRE hL hR
+            | vBool b =>
+              exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vBool b) nofun ihLE ihRE hL hR
+            | vEnum en m =>
+              exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEnum en m) nofun ihLE ihRE hL hR
+            | vEntity en i =>
+              exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
+            | vSet members =>
+              exact cmp_lt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+          | vBool b =>
+            exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
+          | vEnum en m =>
+            exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vEnum en m) nofun ihLE ihRE hL rv hR
+          | vEntity en i =>
+            exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
+          | vSet members =>
+            exact cmp_lt_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+        | le =>
+          cases lv with
+          | vInt a =>
+            cases rv with
+            | vInt b => exact soundnessAt_cmp_le_ints s env mode sp l r a b ihLE ihRE hL hR
+            | vBool b =>
+              exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vBool b) nofun ihLE ihRE hL hR
+            | vEnum en m =>
+              exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEnum en m) nofun ihLE ihRE hL hR
+            | vEntity en i =>
+              exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
+            | vSet members =>
+              exact cmp_le_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+          | vBool b =>
+            exact cmp_le_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
+          | vEnum en m =>
+            exact cmp_le_lhs_nonInt_at s env mode sp l r (.vEnum en m) nofun ihLE ihRE hL rv hR
+          | vEntity en i =>
+            exact cmp_le_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
+          | vSet members =>
+            exact cmp_le_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+        | gt =>
+          cases lv with
+          | vInt a =>
+            cases rv with
+            | vInt b => exact soundnessAt_cmp_gt_ints s env mode sp l r a b ihLE ihRE hL hR
+            | vBool b =>
+              exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vBool b) nofun ihLE ihRE hL hR
+            | vEnum en m =>
+              exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEnum en m) nofun ihLE ihRE hL hR
+            | vEntity en i =>
+              exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
+            | vSet members =>
+              exact cmp_gt_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+          | vBool b =>
+            exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
+          | vEnum en m =>
+            exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vEnum en m) nofun ihLE ihRE hL rv hR
+          | vEntity en i =>
+            exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
+          | vSet members =>
+            exact cmp_gt_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+        | ge =>
+          cases lv with
+          | vInt a =>
+            cases rv with
+            | vInt b => exact soundnessAt_cmp_ge_ints s env mode sp l r a b ihLE ihRE hL hR
+            | vBool b =>
+              exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vBool b) nofun ihLE ihRE hL hR
+            | vEnum en m =>
+              exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEnum en m) nofun ihLE ihRE hL hR
+            | vEntity en i =>
+              exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vEntity en i) nofun ihLE ihRE hL hR
+            | vSet members =>
+              exact cmp_ge_rhs_nonInt_lhs_int_at s env mode sp l r a (.vSet members) nofun ihLE ihRE hL hR
+          | vBool b =>
+            exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vBool b) nofun ihLE ihRE hL rv hR
+          | vEnum en m =>
+            exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vEnum en m) nofun ihLE ihRE hL rv hR
+          | vEntity en i =>
+            exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vEntity en i) nofun ihLE ihRE hL rv hR
+          | vSet members =>
+            exact cmp_ge_lhs_nonInt_at s env mode sp l r (.vSet members) nofun ihLE ihRE hL rv hR
+  | member elem relName ihE =>
+    have ihE := ihE env mode
+    cases hElem : evalAt mode s sp env elem with
+    | none =>
+      rw [show evalAt mode s sp env (.member elem relName) = none from by
+            simp only [evalAt, hElem]]
+      simp only [translate]
+      rw [hElem] at ihE; simp only [valueToSmt?] at ihE
+      simp only [valueToSmt?]
+      exact (smtEvalAt_inDom_arg_none _ _ _ ihE.symm).symm
+    | some v =>
+      cases hDom : (sp.at mode).relationDomain relName with
+      | some dom =>
+        exact soundnessAt_member_resolved s env mode sp elem relName v dom ihE hElem hDom
+      | none =>
+        rw [show evalAt mode s sp env (.member elem relName) = none from by
+              simp only [evalAt, hElem, hDom]]
+        simp only [translate]
+        rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+        have hRel : ((correlateModelPair s sp).at mode).lookupRel relName = none := by
+          rw [correlateModelPair_at]
+          exact correlateModel_lookupRel_none s (sp.at mode) relName hDom
+        simp only [valueToSmt?]
+        exact (smtEvalAt_inDom_rel_none _ _ _ ihE.symm hRel).symm
+  | cardRel relName =>
+    cases hDom : (sp.at mode).relationDomain relName with
+    | some dom => exact soundnessAt_cardRel_resolved s env mode sp relName dom hDom
+    | none =>
+      have hEval : evalAt mode s sp env (.cardRel relName) = none := by
+        simp only [evalAt, hDom]
+      rw [hEval]
+      simp only [translate]
+      have hRel : ((correlateModelPair s sp).at mode).lookupRel relName = none := by
+        rw [correlateModelPair_at]
+        exact correlateModel_lookupRel_none s (sp.at mode) relName hDom
+      simp only [valueToSmt?]
+      exact (smtEvalAt_cardRel_unknown _ _ _ relName hRel).symm
+  | forallEnum var en body ihB =>
+    cases hSchema : s.lookupEnum en with
+    | some d =>
+      have hBodyIH : ∀ (val : Value),
+          valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+            = smtEvalAt mode (correlateModelPair s sp)
+                ((var, valueToSmt val) :: correlateEnv env) (translate body) := by
+        intro val
+        have := ihB ((var, val) :: env) mode
+        rw [show correlateEnv ((var, val) :: env)
+              = (var, valueToSmt val) :: correlateEnv env from rfl] at this
+        exact this
+      exact soundnessAt_forallEnum_known s env mode sp var en body d hSchema hBodyIH
+    | none =>
+      rw [show evalAt mode s sp env (.forallEnum var en body) = none from by
+            simp only [evalAt, hSchema]]
+      simp only [translate]
+      have hSort : ((correlateModelPair s sp).at mode).lookupSortMembers en = none := by
+        rw [correlateModelPair_at]
+        exact correlateModel_lookupSortMembers_none s (sp.at mode) en hSchema
+      simp only [valueToSmt?]
+      exact (smtEvalAt_forallEnum_unknown _ _ _ hSort).symm
+  | forallRel var rel body ihB =>
+    cases hDom : (sp.at mode).relationDomain rel with
+    | some dom =>
+      have hBodyIH : ∀ (val : Value),
+          valueToSmt? (evalAt mode s sp ((var, val) :: env) body)
+            = smtEvalAt mode (correlateModelPair s sp)
+                ((var, valueToSmt val) :: correlateEnv env) (translate body) := by
+        intro val
+        have := ihB ((var, val) :: env) mode
+        rw [show correlateEnv ((var, val) :: env)
+              = (var, valueToSmt val) :: correlateEnv env from rfl] at this
+        exact this
+      exact soundnessAt_forallRel_known s env mode sp var rel body dom hDom hBodyIH
+    | none =>
+      rw [show evalAt mode s sp env (.forallRel var rel body) = none from by
+            simp only [evalAt, hDom]]
+      simp only [translate]
+      have hRel : ((correlateModelPair s sp).at mode).lookupRel rel = none := by
+        rw [correlateModelPair_at]
+        exact correlateModel_lookupRel_none s (sp.at mode) rel hDom
+      simp only [valueToSmt?]
+      exact (smtEvalAt_forallRel_unknown _ _ _ hRel).symm
+  | indexRel relName key ihKey =>
+    have ihKey := ihKey env mode
+    cases hKey : evalAt mode s sp env key with
+    | none =>
+      have hEval : evalAt mode s sp env (.indexRel relName key) = none := by
+        simp only [evalAt, hKey]
+      rw [hEval]
+      simp only [translate]
+      rw [hKey] at ihKey
+      simp only [valueToSmt?] at ihKey
+      simp only [valueToSmt?]
+      exact (smtEvalAt_indexRel_key_none _ _ _ ihKey.symm).symm
+    | some kv =>
+      exact soundnessAt_indexRel_resolved s env mode sp relName key kv ihKey hKey
+  | fieldAccess base fieldName ihBase =>
+    have ihBase := ihBase env mode
+    cases hBase : evalAt mode s sp env base with
+    | none =>
+      have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
+        evalAt_fieldAccess_base_none mode s sp env base fieldName hBase
+      rw [hEval]
+      simp only [translate]
+      rw [hBase] at ihBase; simp only [valueToSmt?] at ihBase
+      simp only [valueToSmt?]
+      exact (smtEvalAt_fieldAccess_base_none _ _ _ (translate base) fieldName ihBase.symm).symm
+    | some v =>
+      cases v with
+      | vEntity en id =>
+        exact soundnessAt_fieldAccess_resolved s env mode sp base en id fieldName ihBase hBase
+      | vBool b =>
+        have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+        rw [hEval]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vBool] at ihBase
+        simp only [valueToSmt?]
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+      | vInt n =>
+        have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+        rw [hEval]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vInt] at ihBase
+        simp only [valueToSmt?]
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+      | vEnum en m =>
+        have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+        rw [hEval]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vEnum] at ihBase
+        simp only [valueToSmt?]
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+      | vSet members =>
+        have hEval : evalAt mode s sp env (.fieldAccess base fieldName) = none :=
+          evalAt_fieldAccess_nonEntity mode s sp env hBase nofun
+        rw [hEval]
+        simp only [translate]
+        rw [hBase] at ihBase; simp only [valueToSmt?_some] at ihBase
+        rw [valueToSmt_vSet members] at ihBase
+        simp only [valueToSmt?]
+        exact (smtEvalAt_fieldAccess_nonEntity _ _ _ ihBase.symm nofun).symm
+  | setEmpty => exact soundnessAt_setEmpty s env mode sp
+  | setInsert elem set ihE ihS =>
+    have ihE := ihE env mode
+    have ihS := ihS env mode
+    simp only [translate]
+    cases hElem : evalAt mode s sp env elem with
+    | none =>
+      rw [evalAt_setInsert_elem_none mode s sp env elem set hElem]
+      rw [hElem] at ihE; simp only [valueToSmt?] at ihE
+      simp only [valueToSmt?]
+      exact (smtEvalAt_setInsert_elem_none _ _ _ (translate elem) (translate set) ihE.symm).symm
+    | some v =>
+      cases hSet : evalAt mode s sp env set with
+      | none =>
+        rw [evalAt_setInsert_set_none mode s sp env elem set v hElem hSet]
+        rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+        rw [hSet] at ihS; simp only [valueToSmt?] at ihS
+        simp only [valueToSmt?]
+        exact (smtEvalAt_setInsert_set_none _ _ _ (translate elem) (translate set)
+                  (valueToSmt v) ihE.symm ihS.symm).symm
+      | some setVal =>
+        cases setVal with
+        | vSet members =>
+          exact soundnessAt_setInsert_resolved s env mode sp elem set v members
+                  ihE ihS hElem hSet
+        | vBool b =>
+          rw [evalAt_setInsert_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vBool b) nofun)).symm
+        | vInt n =>
+          rw [evalAt_setInsert_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vInt n) nofun)).symm
+        | vEnum en m =>
+          rw [evalAt_setInsert_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEnum en m) nofun)).symm
+        | vEntity en i =>
+          rw [evalAt_setInsert_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setInsert_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEntity en i) nofun)).symm
+  | setMember elem set ihE ihS =>
+    have ihE := ihE env mode
+    have ihS := ihS env mode
+    simp only [translate]
+    cases hElem : evalAt mode s sp env elem with
+    | none =>
+      rw [evalAt_setMember_elem_none mode s sp env elem set hElem]
+      rw [hElem] at ihE; simp only [valueToSmt?] at ihE
+      simp only [valueToSmt?]
+      exact (smtEvalAt_setMember_elem_none _ _ _ (translate elem) (translate set) ihE.symm).symm
+    | some v =>
+      cases hSet : evalAt mode s sp env set with
+      | none =>
+        rw [evalAt_setMember_set_none mode s sp env elem set v hElem hSet]
+        rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+        rw [hSet] at ihS; simp only [valueToSmt?] at ihS
+        simp only [valueToSmt?]
+        exact (smtEvalAt_setMember_set_none _ _ _ (translate elem) (translate set)
+                  (valueToSmt v) ihE.symm ihS.symm).symm
+      | some setVal =>
+        cases setVal with
+        | vSet members =>
+          exact soundnessAt_setMember_resolved s env mode sp elem set v members
+                  ihE ihS hElem hSet
+        | vBool b =>
+          rw [evalAt_setMember_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vBool b) nofun)).symm
+        | vInt n =>
+          rw [evalAt_setMember_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vInt n) nofun)).symm
+        | vEnum en m =>
+          rw [evalAt_setMember_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEnum en m) nofun)).symm
+        | vEntity en i =>
+          rw [evalAt_setMember_set_nonSet mode s sp env hElem hSet nofun]
+          rw [hElem] at ihE; rw [valueToSmt?_some] at ihE
+          rw [hSet] at ihS; rw [valueToSmt?_some] at ihS
+          simp only [valueToSmt?]
+          exact (smtEvalAt_setMember_set_nonSet _ _ _ ihE.symm ihS.symm
+                    (hSmtValNotSet (.vEntity en i) nofun)).symm
+  | setBin op l r ihL ihR =>
+    have ihL := ihL env mode
+    have ihR := ihR env mode
+    cases hL : evalAt mode s sp env l with
+    | none =>
+      rw [show evalAt mode s sp env (.setBin op l r) = none from by
+            simp only [evalAt, hL]; cases op <;> rfl]
+      rw [hL] at ihL; simp only [valueToSmt?] at ihL
+      simp only [valueToSmt?]
+      cases op with
+      | union =>
+        simp only [translate]
+        exact (smtEvalAt_setUnion_lhs_none _ _ _ ihL.symm).symm
+      | intersect =>
+        simp only [translate]
+        exact (smtEvalAt_setIntersect_lhs_none _ _ _ ihL.symm).symm
+      | diff =>
+        simp only [translate]
+        exact (smtEvalAt_setDiff_lhs_none _ _ _ ihL.symm).symm
+    | some lv =>
+      cases lv with
+      | vSet ls =>
+        cases hR : evalAt mode s sp env r with
+        | none =>
+          rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                simp only [evalAt, hL, hR]; cases op <;> rfl]
+          rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+          rw [hR] at ihR; simp only [valueToSmt?] at ihR
+          simp only [valueToSmt?]
+          cases op with
+          | union =>
+            simp only [translate]
+            exact (smtEvalAt_setUnion_rhs_none _ _ _ ihL.symm ihR.symm).symm
+          | intersect =>
+            simp only [translate]
+            exact (smtEvalAt_setIntersect_rhs_none _ _ _ ihL.symm ihR.symm).symm
+          | diff =>
+            simp only [translate]
+            exact (smtEvalAt_setDiff_rhs_none _ _ _ ihL.symm ihR.symm).symm
+        | some rv =>
+          cases rv with
+          | vSet rs =>
+            exact soundnessAt_setBin_sets s env mode sp op l r ls rs ihL ihR hL hR
+          | vBool b =>
+            rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                  simp only [evalAt, hL, hR]; cases op <;> rfl]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEvalAt_setUnion_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) nofun)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEvalAt_setIntersect_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) nofun)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vBool b) nofun)).symm
+          | vInt n =>
+            rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                  simp only [evalAt, hL, hR]; cases op <;> rfl]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEvalAt_setUnion_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) nofun)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEvalAt_setIntersect_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) nofun)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vInt n) nofun)).symm
+          | vEnum en m =>
+            rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                  simp only [evalAt, hL, hR]; cases op <;> rfl]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEvalAt_setUnion_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en m) nofun)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEvalAt_setIntersect_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en m) nofun)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEnum en m) nofun)).symm
+          | vEntity en i =>
+            rw [show evalAt mode s sp env (.setBin op l r) = none from by
+                  simp only [evalAt, hL, hR]; cases op <;> rfl]
+            rw [hL] at ihL; rw [valueToSmt?_some, valueToSmt_vSet] at ihL
+            rw [hR] at ihR; rw [valueToSmt?_some] at ihR
+            simp only [valueToSmt?]
+            cases op with
+            | union =>
+              simp only [translate]
+              exact (smtEvalAt_setUnion_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en i) nofun)).symm
+            | intersect =>
+              simp only [translate]
+              exact (smtEvalAt_setIntersect_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en i) nofun)).symm
+            | diff =>
+              simp only [translate]
+              exact (smtEvalAt_setDiff_rhs_nonSet _ _ _ ihL.symm ihR.symm
+                        (hSmtValNotSet (.vEntity en i) nofun)).symm
+      | vBool b =>
+        rw [show evalAt mode s sp env (.setBin op l r) = none from by
+              simp only [evalAt, hL]; cases op <;> rfl]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEvalAt_setUnion_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vBool b) nofun)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEvalAt_setIntersect_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vBool b) nofun)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vBool b) nofun)).symm
+      | vInt n =>
+        rw [show evalAt mode s sp env (.setBin op l r) = none from by
+              simp only [evalAt, hL]; cases op <;> rfl]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEvalAt_setUnion_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vInt n) nofun)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEvalAt_setIntersect_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vInt n) nofun)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vInt n) nofun)).symm
+      | vEnum en m =>
+        rw [show evalAt mode s sp env (.setBin op l r) = none from by
+              simp only [evalAt, hL]; cases op <;> rfl]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEvalAt_setUnion_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEnum en m) nofun)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEvalAt_setIntersect_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEnum en m) nofun)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEnum en m) nofun)).symm
+      | vEntity en i =>
+        rw [show evalAt mode s sp env (.setBin op l r) = none from by
+              simp only [evalAt, hL]; cases op <;> rfl]
+        rw [hL] at ihL; rw [valueToSmt?_some] at ihL
+        simp only [valueToSmt?]
+        cases op with
+        | union =>
+          simp only [translate]
+          exact (smtEvalAt_setUnion_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntity en i) nofun)).symm
+        | intersect =>
+          simp only [translate]
+          exact (smtEvalAt_setIntersect_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntity en i) nofun)).symm
+        | diff =>
+          simp only [translate]
+          exact (smtEvalAt_setDiff_lhs_nonSet _ _ _ ihL.symm
+                    (hSmtValNotSet (.vEntity en i) nofun)).symm
+
 end SpecRest

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -53,11 +53,10 @@ def translate : Expr → SmtTerm
   | .setBin .union l r        => .setUnion (translate l) (translate r)
   | .setBin .intersect l r    => .setIntersect (translate l) (translate r)
   | .setBin .diff l r         => .setDiff (translate l) (translate r)
-  -- M_L.4.b-ext Phase 4: With record-update. Until Phase 4b lands the proper
-  -- Skolem encoding, emit a bottom term whose `smtEval` is always `none`
-  -- (`0/0`); paired with `eval`'s `none` arm, soundness closes trivially.
-  -- `VerifiedSubset.classify` rejects With so the cert emitter never invokes
-  -- this arm — no false claims.
-  | .withRec _ _ _            => .div (.iLit 0) (.iLit 0)
+  -- M_L.4.b-ext Phase 4b: Skolem encoding for record-update. `translate`
+  -- emits the parallel `SmtTerm.withRec`, whose `smtEval` produces an
+  -- `sEntityWith`. The SMT-side `fieldAccess` arm walks the `sEntityWith`
+  -- chain via `SmtVal.fieldLookup`, mirroring the Lean-side `Value.fieldLookup`.
+  | .withRec base fld value   => .withRec (translate base) fld (translate value)
 
 end SpecRest

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -53,5 +53,11 @@ def translate : Expr → SmtTerm
   | .setBin .union l r        => .setUnion (translate l) (translate r)
   | .setBin .intersect l r    => .setIntersect (translate l) (translate r)
   | .setBin .diff l r         => .setDiff (translate l) (translate r)
+  -- M_L.4.b-ext Phase 4: With record-update. Until Phase 4b lands the proper
+  -- Skolem encoding, emit a bottom term whose `smtEval` is always `none`
+  -- (`0/0`); paired with `eval`'s `none` arm, soundness closes trivially.
+  -- `VerifiedSubset.classify` rejects With so the cert emitter never invokes
+  -- this arm — no false claims.
+  | .withRec _ _ _            => .div (.iLit 0) (.iLit 0)
 
 end SpecRest

--- a/proofs/lean/SpecRest/Translate.lean
+++ b/proofs/lean/SpecRest/Translate.lean
@@ -42,8 +42,8 @@ def translate : Expr → SmtTerm
   | .member elem relName     => .inDom relName (translate elem)
   | .forallEnum var en body  => .forallEnum var en (translate body)
   | .forallRel  var rel body => .forallRel var rel (translate body)
-  | .prime e                  => translate e
-  | .pre   e                  => translate e
+  | .prime e                  => .prime (translate e)
+  | .pre   e                  => .pre   (translate e)
   | .cardRel relName          => .cardRel relName
   | .indexRel relName key     => .indexRel relName (translate key)
   | .fieldAccess base fn      => .fieldAccess (translate base) fn

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.18.0"
+version = "0.19.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.19.0"
+version = "0.20.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.21.0"
+version = "0.22.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.17.0"
+version = "0.18.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.23.0"
+version = "0.24.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.22.0"
+version = "0.23.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.14.0"
+version = "0.15.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.16.0"
+version = "0.17.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.15.0"
+version = "0.16.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]

--- a/proofs/lean/lakefile.toml
+++ b/proofs/lean/lakefile.toml
@@ -1,5 +1,5 @@
 name = "spec-rest-proofs"
-version = "0.20.0"
+version = "0.21.0"
 defaultTargets = ["SpecRest"]
 
 [[lean_lib]]


### PR DESCRIPTION
## Summary

Phases 1, 2, 3a, and 3b of the M_L.4.b-ext work tracked in #194. Lays the
two-state carrier on Lean (`StatePair`/`evalAt`) and SMT (`SmtModelPair`/
`smtEvalAt`) sides, the diagonal-mode-aware soundness corollary, and **31
per-case off-diagonal `soundnessAt_*` theorems covering all success paths**
in the verified subset.

Strictly additive on existing data and proofs. The universal `theorem
soundness` remains closed with zero `sorry`. Phase 3c (universal `soundnessAt`
hookup) is queued.

## Phase 1 — Lean-side carrier (commit 6a2c223)

`StateMode { pre | post }`, `StatePair`, `evalAt` (mutual), diagonal-collapse
theorem `evalAt_diagonal_eq_eval`. State lookups read through `sp.at mode`;
`Prime e` flips to `.post`, `Pre e` flips to `.pre`.

## Phase 2 — SMT-side mirror (commit baa387f)

`SmtTerm.prime` / `SmtTerm.pre` constructors, `SmtModelPair`, `smtEvalAt` (mutual),
`smtEvalAt_diagonal_eq_smtEval`, `correlateModelPair s sp`, and the
diagonal-mode-aware corollary `soundnessAt_diagonal`. `Translate.lean` emits
`.prime (translate e)` / `.pre (translate e)`. Universal `soundness`'s prime/pre
arms gain a one-line `rw [smtEval_prime/pre]`.

## Phase 3a — per-case off-diagonal `soundnessAt_*` (commit 8b19948)

22 per-case theorems for atomic / propositional / arithmetic / comparison /
`letIn` / `enumAccess_known` / `ident_local` / `Prime` / `Pre` constructors.
Load-bearing bridge:

```text
correlateModelPair_at  (correlateModelPair s sp).at mode = correlateModel s (sp.at mode)
```

## Phase 3b — state-touching / set-op / quantifier cases (commit 7d1dc8a)

9 per-case theorems plus 2 parallel mutual-induction lemmas:

```text
soundnessAt_ident_state          state-scalar lookup
soundnessAt_member_resolved      state-relation membership
soundnessAt_cardRel_resolved     state-relation cardinality
soundnessAt_indexRel_resolved    state-relation pair lookup
soundnessAt_fieldAccess_resolved entity-field lookup

soundnessAt_setEmpty
soundnessAt_setInsert_resolved
soundnessAt_setMember_resolved
soundnessAt_setBin_sets          (union/intersect/diff sub-cases)

evalAtForallEnum_correlated      mutual lemma (members induction)
soundnessAt_forallEnum_known     enum-quantifier closure
evalAtForallRel_correlated       mutual lemma (domain induction)
soundnessAt_forallRel_known      state-relation-quantifier closure
```

State-touching cases lift via `correlateModelPair_at` to reuse single-state
`correlateModel_*` / `lookupKey_correlated` / `lookupField_correlated`
lemmas. Set-op cases reuse `dedupeValues_map_valueToSmt`,
`setUnionValues_map_valueToSmt`, etc. Quantifier mutual lemmas are
structurally identical to single-state versions with carriers swapped.

**All 31 success-path per-case `soundnessAt_*` theorems for the verified
subset now exist.**

## What's deliberately deferred

| Phase | Scope | Status |
| ----- | ----- | ------ |
| 3c | Universal `soundnessAt` theorem stitching every per-case via structural induction on `Expr`; failure-path helpers (`smtEvalAt_*_none/_nonBool/_nonInt`). Closes #194's first acceptance criterion | queued |
| 4 | `With` (record-update) constructor + Skolem mirror per `Translator.scala:1061-1098` | queued |
| 5 | Scala-side `EvalIR.State` → `StatePair`; `VerifiedSubset.classify` accepts `With`; demo-state mode-aware synthesis. `safe_counter` invariant-preservation cert flips to `cert_decide` | queued |

## Test plan

- [x] `cd proofs/lean && lake build` — clean, zero `sorry`, zero warnings.
- [x] `sbt verify/test` — 165/165 pass, `ProofDriftAuditTest` (A1-A8) green.
- [x] `sbt compile` — green.
- [x] `lakefile.toml` `0.14.0` → `0.17.0`.

## Files touched

```text
proofs/lean/SpecRest/Semantics.lean    +290 LoC (Phase 1)
proofs/lean/SpecRest/Smt.lean          +662 LoC (Phase 2/3a/3b)
proofs/lean/SpecRest/Lemmas.lean       +175 LoC (Phase 3a/3b: evalAt characterizations)
proofs/lean/SpecRest/Translate.lean      4 LoC  (Phase 2)
proofs/lean/SpecRest/Soundness.lean    +990 LoC (Phase 2/3a/3b: 31 per-case theorems + bridges + 2 mutual lemmas)
proofs/lean/SpecRest/IR.lean.todo      drift log entries for all phases
proofs/lean/STATUS.md                   §M_L.4.b-ext roadmap section
proofs/lean/lakefile.toml              0.14.0 → 0.17.0
```

Not touched: `IR.lean`, `Cert.lean`, `Examples.lean`, any Scala source.

Advances #194; does not close it. Phase 3c is the structural-induction
hookup that ties every per-case theorem into the universal off-diagonal
soundness claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two-state (pre/post) semantics and mode-aware evaluation, single-field record-update (with-override) support, mode-tagged SMT terms, ensures-based post-state synthesis, and emission of preservation theorems for ops with ensures.

* **Documentation**
  * Expanded phased rollout/status roadmap covering off‑diagonal soundness, withRec semantics, and phase-by-phase plan.

* **Chores**
  * Build config version bumped to 0.23.0; renderer and value/expr printing extended.

* **Tests**
  * Extensive tests for With, StatePair/Mode semantics, post-state synthesis, preservation certs, and certificate-count CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->