### PR TITLE
docs: refresh against shipped code (top-level + pipelines + research)

### DIFF
--- a/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/app/(docs)/[[...slug]]/page.tsx
@@ -28,17 +28,27 @@ export default async function Page(props: {
 
   const editUrl = `https://github.com/${REPO_OWNER}/${REPO_NAME}/edit/${REPO_BRANCH}/${repoRel}`;
 
+  const lastUpdatedLabel = lastModified
+    ? lastModified.toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : null;
+
   return (
-    <DocsPage
-      toc={page.data.toc}
-      full={page.data.full}
-      lastUpdate={lastModified ?? undefined}
-    >
+    <DocsPage toc={page.data.toc} full={page.data.full}>
       <div className="flex items-start justify-between gap-4">
         <DocsTitle>{page.data.title}</DocsTitle>
         <EditOnGitHub href={editUrl} className="shrink-0 mt-1" />
       </div>
       <DocsDescription>{page.data.description}</DocsDescription>
+      {lastUpdatedLabel && (
+        <p className="-mt-2 text-xs text-fd-muted-foreground">
+          Last updated:{" "}
+          <time dateTime={lastModified?.toISOString()}>{lastUpdatedLabel}</time>
+        </p>
+      )}
       <DocsBody>
         <MDX components={getMDXComponents()} />
       </DocsBody>

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -1,39 +1,70 @@
 ---
 title: Architecture
-description: Compiler internals, IR design, and implementation plan
+description: Compiler internals, IR design, module layout, and shipped vs. planned scope
 ---
 
 ## Technology stack
 
-- **Language:** Scala 3
+- **Language:** Scala 3.6.3
 - **Parser:** ANTLR4 (Java runtime) via `sbt-antlr4`
 - **Effect runtime:** [Cats Effect 3.7](https://typelevel.org/cats-effect/) — every pipeline
-  stage returns `IO`; the CLI runs as `CommandIOApp`. See
+  stage returns `IO`; the CLI runs as a `decline-effect` `CommandIOApp`. See
   [Concurrency and Cancellation](/pipelines/concurrency).
-- **Verification IL:** Dafny (auto-active verification, compiles to C#/Java/Go/JS/Python)
-- **Constraint solver:** Z3 Java bindings via `tools.aqua:z3-turnkey` (bundles libz3 natively — no system install)
-- **LLM synthesis:** Claude / GPT-4 with CEGIS (Counter-Example Guided Inductive Synthesis) loop
-- **Code generation:** Handlebars templates (`handlebars.java`) for Python/FastAPI, Go/chi, TS/Express targets
-- **Test generation:** Schemathesis (property-based API testing) + Hypothesis
-- **Distribution:** GraalVM native-image — single static binary, ~50 ms cold start, no JVM runtime required for end users
+- **Constraint solver:** Z3 Java bindings via `tools.aqua:z3-turnkey` 4.13 (bundles `libz3`
+  natively — no system install). A second Z3-vs-cvc5 cross-check job runs in CI
+  ([#131](https://github.com/HardMax71/spec_to_rest/issues/131)).
+- **Bounded model checker:** Alloy 6.2 (powerset + temporal `always`/`eventually`).
+- **Translation-validation certs:** Lean 4 toolchain (Lake project under `proofs/lean/`),
+  closed by `cert_decide` (= `native_decide`). Per-run certs land via
+  `verify --emit-cert <dir>` ([#129](https://github.com/HardMax71/spec_to_rest/issues/129),
+  [#88](https://github.com/HardMax71/spec_to_rest/issues/88)).
+- **Code generation:** Handlebars templates (`handlebars.java`) for the
+  `python-fastapi-postgres` target. Go/chi ([#33](https://github.com/HardMax71/spec_to_rest/issues/33))
+  and TypeScript/Express ([#35](https://github.com/HardMax71/spec_to_rest/issues/35)) are
+  open Phase 7 work, **not yet shipped**.
+- **Test generation:** Hypothesis property tests + Schemathesis OpenAPI conformance,
+  emitted alongside the FastAPI project under `tests/` when `compile --with-tests` is
+  passed.
+- **Distribution:** GraalVM native-image (`sbt-native-image`); built by the `native.yml`
+  workflow. JVM `sbt cli/run …` is the day-to-day entry point.
 
 ## Compiler pipeline
 
+The shipped pipeline is parse → IR build → verify → convention map → emit. The optional
+`--with-tests` flag adds a sixth stage that walks the same IR and emits Python property
+tests. There is no LLM stage; LLM-driven body synthesis (Phase 6, Dafny + CEGIS, issues
+[#27](https://github.com/HardMax71/spec_to_rest/issues/27)–[#32](https://github.com/HardMax71/spec_to_rest/issues/32))
+is open future work.
+
 ```mermaid
 flowchart LR
-  Parse["Parse\n(ANTLR4)"] --> Verify["Verify\n(Z3)"]
-  Verify --> Map["Map\n(Conventions)"]
-  Map --> Synthesize["Synthesize\n(LLM+Dafny)"]
-  Synthesize --> Emit["Emit\n(Code)"]
+  Parse["Parse<br/>(ANTLR4)"] --> Build["IR build<br/>(Scala 3 ADT)"]
+  Build --> Verify["Verify<br/>(Z3 + Alloy)"]
+  Verify --> Map["Convention map<br/>(M1–M10)"]
+  Map --> Emit["Emit<br/>(Handlebars)"]
+  Verify -.->|--emit-cert| Cert["Lean cert<br/>(cert_decide)"]
+  Map -.->|--with-tests| Tests["Testgen<br/>(Hypothesis + Schemathesis)"]
 ```
 
-1. **Parse** — ANTLR4 grammar → CST → typed AST (Scala 3 enums + case classes).
-   See [Parser Implementation Notes](/pipelines/parser-implementation) for deviations from the EBNF spec.
-2. **Verify** — Static analysis: type checking, invariant satisfiability, deadlock detection
-3. **Map** — Convention Engine applies M1–M10 rules, resolving HTTP methods, DB types, endpoints
-4. **Synthesize** — CEGIS loop: LLM generates Dafny code → verifier checks → counterexamples feed
-   back
-5. **Emit** — Templates produce target-language code, DB migrations, OpenAPI spec, and test suites
+1. **Parse** — ANTLR4 grammar (`Spec.g4`) → CST → typed IR. The parser auto-injects a
+   short preamble (`isValidURI`, `isValidEmail`). See
+   [Parser Implementation Notes](/pipelines/parser-implementation).
+2. **IR build** — CST → `ServiceIR` (Scala 3 enum/case-class ADT) with span tracking.
+3. **Verify** — `verify` runs structural lints (L01–L06, see
+   [Spec Language — Structural lints](/spec-language#structural-lints)), then translates
+   each obligation to either Z3 SMT-LIB or Alloy (non-overlapping routing) and checks it.
+   With `--emit-cert <dir>`, it also emits a Lake project of Lean theorems closed by
+   `cert_decide`. The `compile` command treats `verify` as a hard gate
+   (`--ignore-verify` to bypass).
+4. **Convention map** — The convention engine applies M1–M10 operation-classification
+   rules; user-supplied `conventions { ... }` overrides win where present. See
+   [Convention Engine](/design/convention-engine).
+5. **Emit** — Handlebars templates produce the FastAPI project: `app/`, `db/`, `alembic/`,
+   `tests/`, `Dockerfile`, `docker-compose.yml`, `openapi.yaml`, `.github/workflows/ci.yml`,
+   `Makefile`, `pyproject.toml`.
+6. **Testgen (optional)** — `--with-tests` adds property tests under `tests/` derived
+   from the same `requires`/`ensures`/`invariant` clauses; coverage and skip rates are
+   asserted by `SkipRateProbeTest`.
 
 ## Internal representation
 
@@ -41,44 +72,65 @@ The IR uses Scala 3 enums (true ADTs) with exhaustive pattern matching:
 
 ```scala
 enum Expr derives CanEqual:
-  case BinaryOp(op: BinOp, left: Expr, right: Expr, span: Option[Span])
-  case Identifier(name: String, span: Option[Span])
-  case IntLit(value: Long, span: Option[Span])
-  // ... 25 total variants
+  case BinaryOp(op: BinOp, left: Expr, right: Expr, span: Option[Span] = None)
+  case UnaryOp(op: UnOp, operand: Expr, span: Option[Span] = None)
+  case Quantifier(quantifier: QuantKind, bindings: List[QuantifierBinding],
+                  body: Expr, span: Option[Span] = None)
+  case Identifier(name: String, span: Option[Span] = None)
+  case IntLit(value: Long, span: Option[Span] = None)
+  // ... 27 variants total
 
-enum TypeExpr:
-  case NamedType(name: String, span: Option[Span])
-  case SetType(elementType: TypeExpr, span: Option[Span])
-  case RelationType(fromType: TypeExpr, multiplicity: Multiplicity, toType: TypeExpr, span: Option[Span])
-  // ...
+enum TypeExpr derives CanEqual:
+  case NamedType(name: String, span: Option[Span] = None)
+  case SetType(elementType: TypeExpr, span: Option[Span] = None)
+  case MapType(keyType: TypeExpr, valueType: TypeExpr, span: Option[Span] = None)
+  case SeqType(elementType: TypeExpr, span: Option[Span] = None)
+  case OptionType(innerType: TypeExpr, span: Option[Span] = None)
+  case RelationType(fromType: TypeExpr, multiplicity: Multiplicity,
+                    toType: TypeExpr, span: Option[Span] = None)
 
 final case class ServiceIR(
     name: String,
     entities: List[EntityDecl],
     enums: List[EnumDecl],
+    typeAliases: List[TypeAliasDecl],
+    state: Option[StateDecl],
     operations: List[OperationDecl],
     invariants: List[InvariantDecl],
-    state: Option[StateDecl],
-    // ... other top-level decls
+    temporals: List[TemporalDecl],
+    facts: List[FactDecl],
+    functions: List[FunctionDecl],
+    predicates: List[PredicateDecl],
+    transitions: List[TransitionDecl],
+    conventions: Option[ConventionsDecl]
 )
 ```
+
+The same IR feeds the verifier (Z3 + Alloy translators), the cert emitter (Lean
+embedding), the convention engine, the codegen, and the testgen.
 
 ## Project layout
 
 ```tree
 modules/
-├── ir/         # IR types · JSON serializer (circe)
-├── parser/     # ANTLR grammar · Parse · Builder (IO)
-├── convention/ # M1-M10 classifier · naming · path · schema · validate
+├── ir/         # IR types · JSON serializer (circe) · VerifyError ADT
+├── parser/     # ANTLR4 grammar · Parse · Builder · Preamble injection
+├── lint/       # Structural lints L01–L06
+├── convention/ # M1–M10 classifier · naming · path · schema · validate
 ├── profile/    # Deployment profiles · type mapping · annotation
-├── verify/     # Z3 + Alloy translator · backend · Consistency · CounterExample · Diagnostic
+├── verify/     # Z3 + Alloy translators · backends · Consistency · Diagnostic
+│               # · Narration · Cert emit (Lean)
 ├── codegen/    # Engine (handlebars.java) · Emit · OpenAPI · Alembic
+├── testgen/    # ExprToPython · Strategies · Stateful/Structural/Behavioral
 ├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile
 └── bench/      # JMH benchmarks (ParallelVerifyBench, parallel verify CSV golden)
+
+proofs/
+└── lean/       # Lake workspace: Semantics, Soundness, Cert, Examples · M_L track
 ```
 
-Each module is a separate sbt subproject with test isolation; `sbt <module>/test` runs one module's tests.
-Every public entry point in `verify/` returns `IO[Either[VerifyError, _]]`.
+Each module is a separate sbt subproject with test isolation; `sbt <module>/test` runs one
+module's tests. Every public entry point in `verify/` returns `IO[Either[VerifyError, _]]`.
 
 ## Effect system layer
 
@@ -91,13 +143,37 @@ solver param; Alloy's `Future.get(timeout, …)`). See
 [Concurrency and Cancellation](/pipelines/concurrency) for the full model, JMH numbers,
 and the cancellation contract.
 
-## Build plan
+## CI surface
 
-The implementation is divided into 6 phases over ~20 weeks:
+Eleven workflows live under `.github/workflows/`:
 
-1. **Core parser** (weeks 1–3) — ANTLR4 grammar, AST builder, basic CLI
-2. **Type system** (weeks 4–6) — Type checker, scope analysis, error reporting
-3. **Convention engine** (weeks 7–9) — Mapping rules, override system, deployment profiles
-4. **Verification** (weeks 10–13) — Z3 integration, invariant checking, state machine analysis
-5. **LLM synthesis** (weeks 14–17) — CEGIS loop, Dafny integration, prompt engineering
-6. **Code generation** (weeks 18–20) — Templates, multi-target output, test generation
+| Workflow              | What it gates                                                                  |
+|-----------------------|--------------------------------------------------------------------------------|
+| `ci.yml`              | full `sbt test` matrix + cvc5 cross-check on a curated subset                  |
+| `lean.yml`            | `lake build` on the in-repo `proofs/lean/` workspace                           |
+| `lean-certs.yml`      | per-fixture `--emit-cert` bundles compile + per-fixture `cert_decide` counts   |
+| `mutation-testing.yml`| `mutmut` against the generated Python services for selected fixtures           |
+| `bench.yml`           | JMH parallel-verify regression vs. golden CSV                                  |
+| `native.yml`          | GraalVM native-image build smoke                                               |
+| `docs.yml`            | Fumadocs production build + link check                                         |
+| `quality.yml`         | scalafmt, scalafix, wartremover, coverage floor                                |
+| `dependency-submission.yml` / `branch-name.yml` / `lint-workflows.yml` | repo hygiene |
+
+## Roadmap status
+
+The project is past the verifier-and-codegen stage. Roadmap labels live as `phase-N`
+on issues; the table below shows where each phase stands today.
+
+| Phase | Theme                                                  | Status                                                                                 |
+|-------|--------------------------------------------------------|----------------------------------------------------------------------------------------|
+| 1     | Core parser / IR build                                 | Shipped                                                                                |
+| 2     | Convention engine (M1–M10)                             | Shipped                                                                                |
+| 3     | `python-fastapi-postgres` codegen + Alembic + OpenAPI  | Shipped                                                                                |
+| 4     | Verification (Z3 + Alloy + Lean translation-validation) | Shipped — open follow-ups in [#192](https://github.com/HardMax71/spec_to_rest/issues/192) / [#193](https://github.com/HardMax71/spec_to_rest/issues/193) (Lean → Scala extraction) |
+| 5     | Test generation (Hypothesis + Schemathesis)            | Largely shipped — [#86](https://github.com/HardMax71/spec_to_rest/issues/86) (runtime invariant enforcement) open |
+| 6     | LLM / Dafny synthesis (CEGIS)                          | **Not started.** Tracked in [#27](https://github.com/HardMax71/spec_to_rest/issues/27)–[#32](https://github.com/HardMax71/spec_to_rest/issues/32). |
+| 7     | Multi-target codegen — Go/chi, TS/Express              | **Not started.** [#33](https://github.com/HardMax71/spec_to_rest/issues/33), [#35](https://github.com/HardMax71/spec_to_rest/issues/35), [#34](https://github.com/HardMax71/spec_to_rest/issues/34) (distribution), [#36](https://github.com/HardMax71/spec_to_rest/issues/36) (CLI polish). |
+| 8     | Authentication DSL                                     | **Not started.** [#53](https://github.com/HardMax71/spec_to_rest/issues/53)–[#55](https://github.com/HardMax71/spec_to_rest/issues/55). |
+
+The "shipped" entries are continuously hardened by the CI workflows above; the
+"not started" entries have issue threads but no merged code on `main`.

--- a/docs/content/docs/design/convention-engine.mdx
+++ b/docs/content/docs/design/convention-engine.mdx
@@ -1,67 +1,151 @@
 ---
 title: Convention Engine Reference
-description: How the live compiler maps spec concepts to REST, HTTP, and DB conventions
+description: How the live compiler maps spec operations and entities to REST, HTTP, and DB conventions
 ---
 
 ## Overview
 
 The Convention Engine is the bridge between the abstract world of formal specifications and the
-concrete world of REST APIs, HTTP methods, database schemas, and validation rules.
+concrete world of REST APIs, HTTP methods, database schemas, and validation rules. It reads the
+parsed `ServiceIR`, classifies each operation against the **M1–M10** rules, derives endpoints
+(method + path + status code), derives a relational schema for the entities, and validates
+user-supplied convention overrides.
 
-Looking for the **design rationale** — every M1–M10 rule, edge case, and override mechanism
-end-to-end? See [Convention Engine (research)](/research/02_convention_engine).
+Looking for the **design rationale** — every rule, edge case, and override mechanism end-to-end?
+See [Convention Engine (research)](/research/02_convention_engine).
 
-It applies a set of deterministic mapping rules (M1–M10) to transform spec constructs into
-implementation decisions.
+The engine is **deterministic**: identical IR → identical endpoint and schema decisions, every
+run. Authoritative source: `modules/convention/src/main/scala/specrest/convention/`.
 
-## Core mapping rules
+## Operation classification (M1–M10)
 
-| Rule | Spec concept             | REST/DB mapping                    |
-| ---- | ------------------------ | ---------------------------------- |
-| M1   | `entity`                 | DB table + REST resource           |
-| M2   | Entity field             | DB column + JSON property          |
-| M3   | State-mutating operation | `POST` endpoint                    |
-| M4   | Read-only operation      | `GET` endpoint                     |
-| M5   | `requires` clause        | Input validation (HTTP 422)        |
-| M6   | `ensures` clause         | Property-based test assertion      |
-| M7   | `invariant`              | DB constraint + runtime check      |
-| M8   | Collection types         | Join table / JSON array            |
-| M9   | `Id` type                | UUID primary key, auto-generated   |
-| M10  | Default values           | DB defaults + application defaults |
+The M-rules classify **operations**, not entities or fields. Each operation in a spec gets
+exactly one rule, and that rule decides the HTTP method. Field- and entity-level mappings (DB
+column types, table names, etc.) are handled separately by `Schema` and `Naming` (covered below).
+
+| Rule | When it fires (from `Classify.scala`)                                                            | HTTP method | Default path                     | Default status |
+|------|--------------------------------------------------------------------------------------------------|-------------|----------------------------------|----------------|
+| M1   | Op mutates a state relation **and** introduces a new key                                         | `POST`      | `/<plural>`                      | 201            |
+| M2   | Op does not mutate state, ≤ 3 filter inputs                                                      | `GET`       | `/<plural>` or `/<plural>/{id}`  | 200            |
+| M3   | Op mutates an existing entity and the `with`/ensures touches **every** field of that entity      | `PUT`       | `/<plural>/{id}`                 | 200            |
+| M4   | Op mutates an existing entity and only a subset of fields appear in ensures                      | `PATCH`     | `/<plural>/{id}`                 | 200            |
+| M5   | Op deletes a key from a state relation                                                           | `DELETE`    | `/<plural>/{id}`                 | 204            |
+| M6   | *Reserved* (`OperationKind.CreateChild`); not currently emitted by the classifier                | —           | —                                | —              |
+| M7   | Op does not mutate state, **> 3** filter inputs                                                  | `GET`       | `/<plural>`                      | 200            |
+| M8   | Op mutates state but doesn't fit any other pattern (catch-all side-effect)                       | `POST`      | `/<kebab-op-name>`               | 200            |
+| M9   | Op has a collection input **and** mutates state                                                  | `POST`      | `/<plural>/batch`                | 200            |
+| M10  | Op is named in a `transition` block                                                              | `POST`      | `/<plural>/{id}/<verb>`          | 200            |
+
+`OperationKind` lives in
+[`Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Types.scala);
+the dispatch logic lives in
+[`Classify.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Classify.scala).
+M6 is reserved in the enum (`CreateChild`) but no current dispatch arm produces it — nested
+`POST /parent/{id}/child` is on the roadmap. See
+[Convention Engine (research) §M6](/research/02_convention_engine) for the planned semantics.
+
+### Path / status derivation
+
+Once an operation is classified, `Path.deriveEndpoints` builds the `EndpointSpec`:
+
+- **Method**: `http_method` override → falls back to the rule's default.
+- **Path**: `http_path` override → falls back to a kind-specific shape (table above).
+  Paths are computed from the target entity's pluralized name (`Naming.toPathSegment`),
+  with `{id}` interpolated from the input parameter whose type matches the relation's
+  domain key.
+- **Status code**: `http_status_success` override → otherwise `201` for `Create`/`CreateChild`,
+  `204` for `Delete` (and any DELETE method), `200` everywhere else.
+- **Body vs. query**: GET methods send non-path params as query parameters; everything else
+  sends them in the body.
+
+## Entity → DB schema
+
+`Schema.deriveSchema` lifts the IR's entities and state relations into a `DatabaseSchema` of
+`TableSpec` records. The engine maps spec types directly to PostgreSQL column types
+(`PrimitiveTypeMap`):
+
+| Spec type   | PostgreSQL type     |
+|-------------|---------------------|
+| `String`    | `TEXT`              |
+| `Int`       | `INTEGER`           |
+| `Float`     | `DOUBLE PRECISION`  |
+| `Bool`      | `BOOLEAN`           |
+| `DateTime`  | `TIMESTAMPTZ`       |
+| `Date`      | `DATE`              |
+| `UUID`      | `UUID`              |
+| `Decimal`   | `NUMERIC(19, 4)`    |
+| `Bytes`     | `BYTEA`             |
+| `Money`     | `INTEGER` (cents)   |
+
+State relations with `set` or `some` multiplicity (`A -> set B`, `A -> some B`) emit
+**junction tables** for the many-to-many relationship. Enum values become `TEXT` columns
+with a `CHECK (col IN (...))` constraint. User type aliases are resolved to their underlying
+primitive plus any `where` predicate (translated to a SQL `CHECK`).
+
+Derivation lives in
+[`Schema.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Schema.scala);
+naming (pluralization, kebab-case, snake_case, table names) lives in
+[`Naming.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Naming.scala),
+which carries explicit **uncountable** and **irregular** plural tables (`person → people`,
+`data` → `data`, etc.).
+
+Trigger and partial-index derivation are tracked in
+[#57](https://github.com/HardMax71/spec_to_rest/issues/57) (M7.6) and not yet emitted.
 
 ## Override system
 
-Any convention can be overridden using flat `with` syntax:
+All convention overrides live in a service-wide `conventions { ... }` block. There is
+**no** per-operation `with` clause — the only place to override is the conventions block.
+Each rule has the shape `Target.property [qualifier] = value`.
 
-```
-operation Resolve(code: String) -> Url
-  with { http_method = "GET", http_path = "/{code}" }
-{
-  requires store.exists(u => u.code == code)
-  ensures result == store.find(u => u.code == code)
-}
-```
-
-A service-wide `conventions { ... }` block also targets entities, type aliases,
-and enums:
-
-```
+```spec
 conventions {
-  Url.db_table = "url_mappings"
-  LongURL.strategy = "tests.strategies_user:valid_url"
-  Status.strategy = "tests.strategies_user:realistic_status"
+  Shorten.http_method         = "POST"
+  Shorten.http_path           = "/shorten"
+  Shorten.http_status_success = 201
+
+  Resolve.http_method            = "GET"
+  Resolve.http_path              = "/{code}"
+  Resolve.http_status_success    = 302
+  Resolve.http_header "Location" = output.url
+
+  UrlMapping.db_table       = "url_mappings"
+  UrlMapping.db_timestamps  = true
+  UrlMapping.plural         = "url_mappings"
+
+  ShortCode.strategy = "tests.strategies_user:short_code"
+  Status.strategy    = "tests.strategies_user:realistic_status"
+
+  User.test_strategy.password = "tests.strategies_user:strong_password"
 }
 ```
 
-The `strategy` property is wired by the test-generation pipeline; see
-[Test Generation — Custom strategies](/pipelines/test-generation) for the
-end-to-end flow including the `--strict-strategies` CI gate.
+The full property × target matrix lives in
+[Spec Language — Convention overrides](/spec-language#convention-overrides). Validation runs
+in
+[`Validate.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Validate.scala);
+unknown properties, mismatched targets, missing qualifiers, and duplicate rules surface as
+structured `ConventionDiagnostic`s. The convention override system was hardened under
+[#10 (M2.3)](https://github.com/HardMax71/spec_to_rest/issues/10) and the per-field
+`test_strategy` work under
+[#134 (M5.6)](https://github.com/HardMax71/spec_to_rest/issues/134).
 
 ## Deployment profiles
 
-The engine supports 4 built-in profiles that adjust conventions for different environments:
+Profiles bundle target-language and runtime conventions (Python types, SQLAlchemy column
+mapping, FastAPI imports, etc.). The shipped registry contains exactly **one** profile:
 
-- **development** — SQLite, debug logging, relaxed CORS
-- **staging** — PostgreSQL, structured logging, restricted CORS
-- **production** — PostgreSQL, minimal logging, strict CORS, rate limiting
-- **testing** — In-memory SQLite, no auth, deterministic IDs
+- **`python-fastapi-postgres`** (default) — FastAPI + SQLAlchemy 2 (async) + Alembic +
+  PostgreSQL 16. The only profile `compile` accepts on `main`.
+
+Multiple-environment overrides (development / staging / production / testing) and additional
+target profiles (Go/chi, TS/Express) are roadmap work:
+
+- [#33 (M7.1) — Go/chi Target](https://github.com/HardMax71/spec_to_rest/issues/33)
+- [#35 (M7.2) — TypeScript/Express Target](https://github.com/HardMax71/spec_to_rest/issues/35)
+- [#63 (M7.9) — Multi-environment compose overrides (staging/prod)](https://github.com/HardMax71/spec_to_rest/issues/63)
+- [#58 (M7.7) — Alternative database dialects (SQLite, MySQL)](https://github.com/HardMax71/spec_to_rest/issues/58)
+
+The registry is a tiny `Map[String, DeploymentProfile]` in
+[`Registry.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Registry.scala);
+adding a new profile is a registry insertion plus a Handlebars template tree.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -60,8 +60,8 @@ import {
 
 ## Spec → Verify → Emit
 
-The same 25-line URL-shortener spec, the verifier's verdict, and a fragment of the FastAPI route
-the emitter writes &mdash; all from one `compile` invocation:
+A trimmed view of `fixtures/spec/url_shortener.spec`, the verifier's check list, and an excerpt
+of the FastAPI router the emitter writes &mdash; all from one `compile` invocation:
 
 <div className="not-prose my-6 grid gap-4 lg:grid-cols-[1.1fr_0.9fr_1fr]">
   <div className="rounded-xl border bg-fd-card overflow-hidden">
@@ -69,29 +69,32 @@ the emitter writes &mdash; all from one `compile` invocation:
       url_shortener.spec
     </div>
     <pre className="m-0 overflow-x-auto p-4 text-xs leading-relaxed"><code>{`service UrlShortener {
-  entity Url {
-    code: String
-    target: String
-    clicks: Int = 0
+  type ShortCode = String where
+    len(value) >= 6 and len(value) <= 10
+
+  entity UrlMapping {
+    code: ShortCode
+    url: String where isValidURI(value)
+    click_count: Int where value >= 0
   }
 
-  operation Shorten(target: String) -> Url {
-    requires valid_url(target)
-    ensures store'.contains(result)
-    ensures result.clicks == 0
+  state {
+    store: ShortCode -> lone String
+    metadata: ShortCode -> lone UrlMapping
   }
 
-  operation Resolve(code: String) -> Url {
-    requires store.exists(u =>
-      u.code == code)
-    ensures result.clicks ==
-      pre(result.clicks) + 1
+  operation Shorten {
+    input:  url: String
+    output: code: ShortCode
+
+    requires: isValidURI(url)
+    ensures:
+      code not in pre(store)
+      store' = pre(store) + {code -> url}
   }
 
-  invariant unique_codes {
-    forall a, b in store:
-      a.code == b.code => a == b
-  }
+  invariant metadataConsistent:
+    dom(store) = dom(metadata)
 }`}</code></pre>
   </div>
   <div className="rounded-xl border bg-fd-card overflow-hidden">
@@ -101,69 +104,73 @@ the emitter writes &mdash; all from one `compile` invocation:
     <div className="space-y-2 p-4 font-mono text-xs leading-relaxed">
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>global &mdash; <span className="text-fd-muted-foreground">invariants jointly satisfiable</span></span>
+        <span>[z3] global <span className="text-fd-muted-foreground">&mdash; invariants jointly sat</span></span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Shorten.requires</span>
+        <span>[z3] Shorten.requires</span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Shorten.enabled</span>
+        <span>[z3] Shorten.enabled</span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Shorten × unique_codes <span className="text-fd-muted-foreground">preservation</span></span>
+        <span>[z3] Shorten.preserves.<wbr/>metadataConsistent</span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Resolve.requires</span>
+        <span>[z3] Resolve.requires</span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Resolve.enabled</span>
+        <span>[z3] Resolve.preserves.<wbr/>metadataConsistent</span>
       </div>
       <div className="flex items-start gap-2">
         <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>Resolve × unique_codes <span className="text-fd-muted-foreground">preservation</span></span>
+        <span>[z3] Delete.preserves.<wbr/>metadataConsistent</span>
       </div>
       <div className="border-t pt-2 text-fd-muted-foreground">
-        7 / 7 sat &middot; 0 unknown &middot; <span className="text-emerald-500">exit 0</span>
+        consistency checks passed &middot; <span className="text-emerald-500">exit 0</span>
       </div>
     </div>
   </div>
   <div className="rounded-xl border bg-fd-card overflow-hidden">
     <div className="border-b bg-fd-muted/40 px-4 py-2 text-xs font-medium uppercase tracking-wider text-fd-muted-foreground">
-      app/routers/urls.py <span className="lowercase">(emitted)</span>
+      app/routers/url_mapping.py <span className="lowercase">(emitted)</span>
     </div>
-    <pre className="m-0 overflow-x-auto p-4 text-xs leading-relaxed"><code>{`@router.post(
-  "/shorten",
-  status_code=201,
-  response_model=UrlRead,
-)
-async def shorten(
-    body: UrlCreate,
-    db: AsyncSession = Depends(get_db),
-) -> UrlRead:
-    if not is_valid_url(body.target):
-        raise HTTPException(422)
-    row = Url(
-        code=generate_code(),
-        target=body.target,
-        clicks=0,
-    )
-    db.add(row)
-    await db.commit()
-    await db.refresh(row)
-    return row
+    <pre className="m-0 overflow-x-auto p-4 text-xs leading-relaxed"><code>{`from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
 
-@router.get(
-  "/{code}",
-  status_code=302,
-  response_class=RedirectResponse,
+from app.database import get_session
+from app.schemas.url_mapping import (
+    ShortenRequest,
+    UrlMappingRead,
 )
-async def resolve(...):
-    ...`}</code></pre>
+from app.services.url_mapping import UrlMappingService
+
+router = APIRouter(tags=["url_mapping"])
+
+
+@router.post("/shorten", status_code=201)
+async def shorten(
+    body: ShortenRequest,
+    session: AsyncSession = Depends(get_session),
+) -> UrlMappingRead:
+    svc = UrlMappingService(session)
+    return await svc.shorten(body)
+
+
+@router.get("/{code}", status_code=200)
+async def resolve(
+    code: str,
+    session: AsyncSession = Depends(get_session),
+) -> UrlMappingRead:
+    svc = UrlMappingService(session)
+    result = await svc.resolve(code)
+    if result is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return result`}</code></pre>
   </div>
 </div>
 
@@ -236,9 +243,16 @@ generated handlers, on every input the specification admits, leave the invariant
         <td className="p-3"><Check className="inline h-4 w-4 text-emerald-500" /></td>
         <td className="p-3"><Check className="inline h-4 w-4 text-emerald-500" /></td>
       </tr>
+      <tr className="border-b">
+        <td className="p-3 font-sans">Lean translation-validation cert</td>
+        <td className="p-3"><Check className="inline h-4 w-4 text-emerald-500" /> <code className="text-xs">--emit-cert</code></td>
+        <td className="p-3"><CircleX className="inline h-4 w-4 text-fd-muted-foreground" /></td>
+        <td className="p-3"><CircleX className="inline h-4 w-4 text-fd-muted-foreground" /></td>
+        <td className="p-3"><CircleX className="inline h-4 w-4 text-fd-muted-foreground" /></td>
+      </tr>
       <tr>
         <td className="p-3 font-sans">Backend portability</td>
-        <td className="p-3 text-fd-muted-foreground">Python · Go &amp; TS planned</td>
+        <td className="p-3 text-fd-muted-foreground">Python (FastAPI · SQLAlchemy · Postgres)</td>
         <td className="p-3"><Check className="inline h-4 w-4 text-emerald-500" /></td>
         <td className="p-3"><Check className="inline h-4 w-4 text-emerald-500" /></td>
         <td className="p-3 text-fd-muted-foreground">Postgres-locked</td>
@@ -309,9 +323,11 @@ generated handlers, on every input the specification admits, leave the invariant
     </div>
     <div className="mb-1 font-medium">Reproducible artifacts</div>
     <div className="text-sm text-fd-muted-foreground">
-      <code className="text-xs">--dump-vc</code> writes per-check SMT-LIB and Alloy <code className="text-xs">.als</code>
-      side-by-side. <code className="text-xs">--explain</code> extracts the unsat core and surfaces the
-      contributing spec spans.
+      <code className="text-xs">--dump-vc &lt;dir&gt;</code> writes per-check <code className="text-xs">.smt2</code> /
+      <code className="text-xs">.als</code> alongside a <code className="text-xs">verdicts.json</code>.
+      <code className="text-xs">--explain</code> extracts the Z3 unsat core and surfaces the contributing
+      spec spans. <code className="text-xs">--emit-cert &lt;dir&gt;</code> writes a Lake project of
+      Lean theorems closed by <code className="text-xs">cert_decide</code>.
     </div>
   </div>
 </div>

--- a/docs/content/docs/pipelines/concurrency.mdx
+++ b/docs/content/docs/pipelines/concurrency.mdx
@@ -17,7 +17,9 @@ We chose [**Cats Effect 3**](https://typelevel.org/cats-effect/) (CE3) for three
 1. **Structured concurrency.** `parTraverseN` gives deterministic bounded parallelism and
    cancels losers when any sibling errors. `Resource` gives finalizer guarantees — when an
    enclosing effect completes (success, error, or cancellation of the parent fiber) the Z3
-   `Context` closes and the Alloy backend pool shuts down.
+   `Context` closes via `WasmBackend.close()`. Alloy's per-call executor is created and
+   torn down inside the `check()` body's `try/finally`, not via the Resource finalizer
+   (`AlloyBackend.close()` is a no-op kept for symmetry).
 2. **Explicit blocking boundary.** The Z3 and Alloy solver calls live inside `IO.blocking`,
    which is uncancelable until natural completion: parent-fiber cancellation waits for the
    in-flight solver call to return (bounded by the solver's own inner timeout) before
@@ -39,10 +41,12 @@ that landed between M_CE.1 and M_CE.8 and the numbers from M_CE.9.
 
 ## Resource lifecycle
 
-Each parallel fiber allocates a fresh Z3 + Alloy backend pair via `Resource.make`, runs the
-check, and releases on either success, failure, or cancellation. Z3's Java bindings are not
-thread-safe across a single `Context`, so one `Context` per fiber is mandatory — which also
-means the `use { … }` scope and the fiber lifetime coincide.
+In parallel mode each fiber allocates a fresh `(WasmBackend, AlloyBackend)` pair via
+`Resource.make`, runs the check, and releases on either success, failure, or cancellation.
+Z3's Java bindings are not thread-safe across a single `Context`, so one `Context` per
+fiber is mandatory — which also means the `use { … }` scope and the fiber lifetime
+coincide. In serial mode (`--parallel 0` or `1`) one outer `backendsResource.use` wraps
+the whole `plans.traverse(...)`, so all checks share a single backend pair.
 
 ```mermaid
 sequenceDiagram
@@ -51,7 +55,7 @@ sequenceDiagram
   participant Par as parTraverseN(n)
   participant Fiber as Fiber (one per check)
   participant Wasm as WasmBackend (Z3 Context)
-  participant Alloy as AlloyBackend (pool + Kodkod)
+  participant Alloy as AlloyBackend (per-call executor)
 
   Main->>Plan: IO[ConsistencyReport]
   Plan->>Par: plans.parTraverseN(cfg.maxParallel)
@@ -60,16 +64,21 @@ sequenceDiagram
     Fiber->>Wasm: Resource.make
     Fiber->>Alloy: Resource.make
     Fiber->>Fiber: translate + solve (IO.blocking)
+    Note over Fiber,Alloy: pool = newSingleThreadExecutor()<br/>future.get(timeoutMs, MILLIS)<br/>pool.shutdownNow() in finally
     Fiber-->>Wasm: Context.close (finalizer)
-    Fiber-->>Alloy: pool.shutdownNow (finalizer)
+    Fiber-->>Alloy: close() = no-op (finalizer)
     Fiber-->>Par: CheckResult
   end
   Par-->>Plan: List[CheckResult]
   Plan-->>Main: ConsistencyReport
 ```
 
-The finalizers run on every exit path — success, error, cancellation, or timeout fallback —
-because they're wired with `Resource.make(acquire)(release)` rather than `try/finally`.
+The Z3 `Context.close()` runs on every exit path — success, error, cancellation, or
+timeout fallback — because it's wired with `Resource.make(acquire)(release)` rather than
+`try/finally`. Alloy's executor lifecycle is not Resource-managed: it's created on the
+hot path inside `check()` and shut down in the same call's `finally`, so it always
+terminates when the `IO.blocking` body returns (naturally, on inner timeout, or after
+`onCancel` interrupts the future).
 
 ## `--parallel` semantics
 
@@ -156,10 +165,15 @@ is discarded by the cancelled fiber), the blocking body completes, and the
 single-digit ms; `TimeoutTest` keeps a looser ~2 s regression bound to absorb JIT / GC / CI
 noise on slower runners.
 
-Alloy's backend uses an internal `Future.get(timeout)` pool for its inner deadline, and the
-`Resource` finalizer shuts the pool down on cancel; its equivalent of `Context.interrupt()`
-is `future.cancel(true)`, which is in the timeout path but not yet in the `onCancel` path. A
-symmetric fix is filed as a follow-up if demand materializes.
+Alloy's backend creates a single-thread `Executor` per call to drive its `solveTask` with
+a `Future.get(timeoutMs, MILLISECONDS)` deadline. The executor is shut down via
+`pool.shutdownNow()` in the same call's `finally`, so it always terminates regardless of
+whether the deadline expired or the call returned naturally — no Resource-managed pool is
+involved (`AlloyBackend.close()` is a no-op). Alloy's equivalent of `Context.interrupt()`
+is `future.cancel(true)`, which is in the timeout path but not yet wired into the
+`onCancel` finalizer the way Z3's interrupt is. A symmetric `onCancel(future.cancel(true))`
+is filed as a follow-up if mid-call cancel of a long Alloy run becomes a problem in
+practice.
 
 ### SIGINT handling
 
@@ -167,8 +181,11 @@ symmetric fix is filed as a follow-up if demand materializes.
 installs the `io-cancel-hook` shutdown hook. SIGINT (Ctrl+C) and SIGTERM both feed into
 top-level fiber cancellation, which propagates through the path above &mdash; in-flight Z3
 calls abort via `Context.interrupt()`, `parTraverseN` cancels sibling fibers,
-`Resource[IO, WasmBackend]` and `Resource[IO, AlloyBackend]` finalizers fire in reverse, and
-the JVM exits cleanly. The shutdown hook honours a 30 s grace deadline before forcing exit.
+`Resource[IO, WasmBackend]` and `Resource[IO, AlloyBackend]` finalizers fire in reverse
+acquisition order (Alloy first, then Wasm), and the JVM exits cleanly. The Wasm finalizer
+calls `ctx.close()`; the Alloy finalizer is a no-op (its per-call executor pool is shut
+down inside the `check()` body, not via Resource). The shutdown hook honours a 30 s grace
+deadline before forcing exit.
 
 ## Troubleshooting
 

--- a/docs/content/docs/pipelines/mutation-testing.mdx
+++ b/docs/content/docs/pipelines/mutation-testing.mdx
@@ -23,27 +23,39 @@ runs on `schedule: '0 3 * * *'` (3 AM UTC) and on `workflow_dispatch`. It is
 deliberately **not** part of the per-PR CI: a single mutmut run on
 `url_shortener` is hundreds of pytest invocations and easily exceeds the
 per-PR budget. The matrix covers `safe_counter`, `todo_list`, and
-`url_shortener`. Each fixture gets its own runner with a Postgres service
-container; the runners are independent (`fail-fast: false`).
+`url_shortener` (each fixture has its own job with `timeout-minutes: 90`).
+Each fixture gets a Postgres 17 service container with
+`POSTGRES_USER`/`PASSWORD`/`DB` all set to the fixture name; the jobs are
+independent (`fail-fast: false`).
+[`auth_service`](https://github.com/HardMax71/spec_to_rest/issues/149) is
+tracked for inclusion once its 15% testgen-translator skip rate closes.
 
 ## How a single matrix entry works
 
 ```text
-1. sbt cli/run compile --with-tests --ignore-verify --out generated/<fixture> ...
-2. uv sync --all-extras                       # installs mutmut as a dev dep
-3. uv run alembic upgrade head                # creates the schema
-4. uv run pytest tests/test_behavioral_*.py   # sanity: must pass before mutating
-5. echo '[tool.mutmut] ...' >> pyproject.toml # paths_to_mutate, runner
-6. uv run mutmut run                          # populates .mutmut-cache
-7. scripts/mutation_check.sh generated/<fixture> 90  # gate
+1. sbt cli/run compile --with-tests --ignore-verify --out generated/<fixture> \
+     --target python-fastapi-postgres ...
+2. uv sync --all-extras                       # pulls mutmut>=3.3,<4 from generated pyproject
+3. uv run alembic upgrade head                # creates the schema in the postgres service
+4. uv run pytest tests/test_behavioral_*.py -x --tb=short -q  # sanity: must pass before mutating
+5. cat >> pyproject.toml <<'TOML'             # paths_to_mutate / paths_to_exclude / runner
+   [tool.mutmut]
+   paths_to_mutate = ["app/"]
+   paths_to_exclude = ["app/db/", "app/routers/test_admin.py"]
+   runner = "uv run pytest tests/test_behavioral_*.py -x --tb=no -q"
+   TOML
+6. uv run mutmut run || true                  # populates .mutmut-cache
+7. scripts/mutation_check.sh generated/<fixture> "$MUTATION_THRESHOLD"  # gate (90 today)
 ```
 
 Step 4 is the safety net: if behavioral tests don't pass against the
 unmutated app, mutmut runs are noise. Step 5 writes the mutmut config inline
-because mutmut auto-discovers `[tool.mutmut]` in `pyproject.toml`. Step 6
-runs without `set -e` short-circuiting (`|| true`) — mutmut exits non-zero on
-any survived mutation, but the gate decision belongs to the threshold
-script, not mutmut.
+because mutmut auto-discovers `[tool.mutmut]` in `pyproject.toml`; the runner
+uses `--tb=no` (less noise — mutmut just needs the exit code) while step 4's
+sanity check uses `--tb=short` (so a real failure is debuggable). Step 6
+runs with `|| true` so mutmut's nonzero exit on any survived mutation
+doesn't short-circuit the workflow — the gate decision belongs to the
+threshold script.
 
 ## The TestClient mode (`SPEC_TEST_INPROC=1`)
 
@@ -109,7 +121,9 @@ bash ~/Desktop/spec_to_rest/scripts/mutation_check.sh . 90
 
 ## Reading a failing report
 
-A typical failure block in the workflow log:
+A typical failure block in the workflow log (`mutmut_check.sh` writes the
+score line to stdout, the failure breakdown and per-mutation diffs to
+stderr; CI logs concatenate both):
 
 ```text
 mutmut score: 86.45% (killed=45 evaluated=52; survived=5 suspicious=2 timeout=0; skipped=0 no_tests=3)
@@ -117,16 +131,26 @@ mutmut score: 86.45% (killed=45 evaluated=52; survived=5 suspicious=2 timeout=0;
 MUTATION SCORE 86.45% < threshold 90%
 survived/suspicious/timeout mutations:
 
---- app.services.url_shortener.x_resolve__mutmut_3 ---
-# app.services.url_shortener.x_resolve__mutmut_3: survived
---- app/services/url_shortener.py
-+++ app/services/url_shortener.py
-@@ -23,4 +23,4 @@
- async def resolve(code: str, session: AsyncSession) -> Url | None:
--    result = await session.execute(select(Url).where(Url.code == code))
-+    result = await session.execute(select(Url).where(Url.code != code))
-     return result.scalar_one_or_none()
+--- app.services.url_mapping.x_list_all__mutmut_2 ---
+# app.services.url_mapping.x_list_all__mutmut_2: survived
+--- app/services/url_mapping.py
++++ app/services/url_mapping.py
+@@ -34,5 +34,5 @@
+ async def list_all(self) -> list[UrlMappingRead]:
+-    result = await self._session.execute(select(UrlMapping))
++    result = await self._session.execute(select(None))
+     rows = result.scalars().all()
+     return [UrlMappingRead.model_validate(row) for row in rows]
 ```
+
+The example uses `app/services/url_mapping.py` because that's the entity-named
+service file the codegen actually emits for `url_shortener.spec` (entity
+`UrlMapping` snake-cased). Today's M4-stage codegen emits service stubs that
+`raise NotImplementedError` for most operations — the live mutation surface
+is currently dominated by framework code (`app/main.py`, `app/database.py`,
+read-only CRUD shells like `list_all` above). Mutation surface will widen as
+[#86](https://github.com/HardMax71/spec_to_rest/issues/86) (runtime invariant
+enforcement) lands and operations grow real bodies.
 
 For each survived mutation, decide:
 
@@ -149,7 +173,7 @@ disk to reproduce locally:
 
 ```bash
 cd generated/url_shortener
-uv run mutmut apply app.services.url_shortener.x_resolve__mutmut_3
+uv run mutmut apply app.services.url_mapping.x_list_all__mutmut_2
 git diff app/  # see the mutation
 uv run pytest tests/test_behavioral_url_shortener.py -x   # observe what (didn't) catch it
 git checkout app/  # revert
@@ -175,15 +199,19 @@ a global lower bar.
 - `app/routers/test_admin.py` — the admin router only exists to support
   tests. Mutating it would change the test harness, not the code under test.
 
-Routers (`app/routers/<entity>.py`), services (`app/services/<service>.py`),
-schemas (`app/schemas/`), and models (`app/models/`) are all in scope.
+Routers (`app/routers/<entity-plural>.py`), services
+(`app/services/<entity>.py`), schemas (`app/schemas/<entity>.py`), and
+models (`app/models/<entity>.py`) are all in scope, plus the framework
+glue (`app/main.py`, `app/config.py`, `app/database.py`, `app/redaction.py`).
 
 ## Non-goals
 
 - **Per-PR mutation testing.** Too slow; the PR-time gate is the structural
   + behavioral + stateful conformance suite.
 - **Mutating the testgen Scala code.** That's a separate concern (would
-  exercise our IR/codegen, not the generated services). Out of scope for M5.7.
+  exercise our IR/codegen, not the generated services). Tracked under
+  [#161 (stryker4s)](https://github.com/HardMax71/spec_to_rest/issues/161);
+  out of scope for M5.7.
 - **Alternative engines** (cosmic-ray, MutPy). mutmut is the canonical
   choice today; switching engines is a much larger lift than tuning the
   current setup.

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -50,6 +50,7 @@ Production deployments must leave this unset; the router returns 403 by default.
 | `tests/predicates.py` | rendered from `ir.predicates` | `_powerset` plus one Python helper per spec/preamble predicate (auto-derived from the body) |
 | `tests/strategies.py` | `Strategies.scala` | one `def strategy_<type>(): return …` per `TypeAliasDecl` and `EnumDecl`, plus one `def strategy_<entity>()` (returning `st.fixed_dictionaries`) per entity that participates in a `TransitionDecl` |
 | `tests/strategies_user.py` | static template | empty stub for user-supplied strategy functions referenced from `<Type>.strategy = "module:symbol"` convention rules. Preserved across re-compile. |
+| `tests/redaction.py` | static template | `redact(strategy)` wrapper + `_RedactedStr` mask class for sensitive Hypothesis values (M5.8) |
 | `tests/test_behavioral_<service>.py` | `Behavioral.scala` | the property tests themselves |
 | `tests/test_stateful_<service>.py` | `Stateful.scala` | a Hypothesis `RuleBasedStateMachine` exercising multi-step operation sequences |
 | `tests/test_structural_<service>.py` | `Structural.scala` | Schemathesis-driven structural tests: schema fuzzing + spec-derived custom checks + OpenAPI-Links state machine |
@@ -74,11 +75,11 @@ def test_shorten_ensures_0(url):
     client.post("/__test_admin__/reset")
     pre_state = client.get("/__test_admin__/state").json()
     response = client.post("/shorten", json={"url": url})
+    assume(response.status_code == 201)
     assert response.status_code == 201, response.text
     response_data = response.json() if response.content else {}
     post_state = client.get("/__test_admin__/state").json()
-    assert ((response_data["code"]) not in (pre_state["store"])), \
-        "ensures violated: ensures: (code not in pre(store))"
+    assert ((response_data["code"]) not in (pre_state["store"])), "ensures violated: ensures: (code not in pre(store))"
 ```
 
 **State-dependent preconditions are partially covered.** If `requires` references a state
@@ -101,14 +102,14 @@ calls the operation, and asserts a 4xx response:
 
 ```python
 @given(code=strategy_short_code())
+@settings(max_examples=10, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_resolve_negative_code_not_in_store(code):
     """requires 'code in store' (negative): missing key returns 4xx."""
     client.post("/__test_admin__/reset")
     pre_state = client.get("/__test_admin__/state").json()
     assume(code not in pre_state.get("store", {}))
     response = client.get(f"/{code}")
-    assert response.status_code in (404, 409, 422), \
-        f"expected 4xx, got {response.status_code}: {response.text}"
+    assert 400 <= response.status_code < 500, f"expected 4xx, got {response.status_code}: {response.text}"
 ```
 
 A second negative pattern recognises status restrictions on existing entries:
@@ -148,14 +149,16 @@ For each global invariant, one test per operation that has a non-state-dep requi
 
 ```python
 @given(url=strategy_long_url())
+@settings(max_examples=20, suppress_health_check=[HealthCheck.function_scoped_fixture])
 def test_shorten_invariant_all_ur_ls_valid(url):
     """invariant allURLsValid: (all c in store | isValidURI(store[c]))"""
     client.post("/__test_admin__/reset")
+    pre_state = client.get("/__test_admin__/state").json()
     response = client.post("/shorten", json={"url": url})
     assume(response.status_code == 201)
+    response_data = response.json() if response.content else {}
     post_state = client.get("/__test_admin__/state").json()
-    assert all(is_valid_uri(post_state["store"][c]) for c in post_state["store"]), \
-        "invariant violated: invariant allURLsValid: (all c in store | isValidURI(store[c]))"
+    assert all(is_valid_uri(post_state["store"][c]) for c in (post_state["store"])), "invariant violated: invariant allURLsValid: (all c in store | isValidURI(store[c]))"
 ```
 
 ## Transition tests (M5.9)
@@ -736,9 +739,13 @@ they regress.
   "service": "UrlShortener",
   "strategies_skipped": [],
   "behavioral_skipped": [
-    {"operation": "Resolve", "kind": "ensures", "reason": "state-dependent precondition; needs state-machine setup before assume() can succeed (deferred to M5.9: TransitionDecl-aware tests, #137)"},
-    {"operation": "StartWork", "kind": "ensures", "reason": "state-dependent precondition; covered by transition tests (M5.9)"},
-    {"operation": "Shorten", "kind": "requires[0]", "reason": "M5.1: only `<input> in <state>` requires patterns get negative tests"}
+    {"operation": "Shorten", "kind": "requires[0]", "reason": "M5.1: only `<input> in <state>` and `<state>[input].<enum-field> = <value>` requires patterns get negative tests"},
+    {"operation": "Resolve", "kind": "ensures", "reason": "state-dependent precondition; positive ensures/invariant tests are covered by stateful tests (M5.2) for ops bundled into the state machine; the single-shot behavioral test would need explicit pre-seeding"},
+    {"operation": "Resolve", "kind": "invariant[allURLsValid]", "reason": "state-dependent precondition; positive ensures/invariant tests are covered by stateful tests (M5.2) for ops bundled into the state machine; the single-shot behavioral test would need explicit pre-seeding"}
+  ],
+  "structural_skipped": [
+    {"operation": "Shorten", "kind": "structural_ensures[0]", "reason": "ensures references pre()/prime() — covered by behavioral/stateful layers"},
+    {"operation": "Shorten", "kind": "structural_ensures[2]", "reason": "ensures references state field — covered by stateful invariants"}
   ]
 }
 ```

--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -68,6 +68,7 @@ CLI output so the attribution is visible.
 | Single-API pipeline — every `Parse`, `Builder`, `Translator`, `WasmBackend`, `AlloyBackend`, and `Consistency` entry point returns `IO`; synchronous wrappers removed; test suites migrated to `CatsEffectSuite` with per-module `SpecFixtures.loadIR` helpers | shipped in M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) |
 | Concurrency docs (`docs/content/docs/pipelines/concurrency.mdx`) + JMH `ParallelVerifyBench` with checked-in CSV at `fixtures/golden/bench/parallel_verify.csv` | shipped in M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) |
 | Property-based tests for the Z3/Alloy translators (translation determinism on identical IRs, free-identifier resolution against `TranslatorArtifact`, structural invariant preservation between Z3 and Alloy) via `scalacheck-effect-munit` | shipped ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)) — `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset from research/10 |
+| Lean translation-validation certificate (`--emit-cert <dir>`) — Lake project of theorems closed by `cert_decide` (= `native_decide`), one per invariant + per `requires` clause + per (operation × invariant) preservation | shipped under the M_L track ([#88](https://github.com/HardMax71/spec_to_rest/issues/88), [#129](https://github.com/HardMax71/spec_to_rest/issues/129), [#170](https://github.com/HardMax71/spec_to_rest/issues/170)); CI compiles every fixture's bundle in `lean-certs.yml` and asserts per-fixture `cert_decide` counts |
 
 </Collapsible>
 
@@ -206,33 +207,32 @@ opt-in suggestion.
 
 ```text
 $ spec-to-rest verify fixtures/spec/broken_url_shortener.spec
-✘ fixtures/spec/broken_url_shortener.spec:11:3: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
-  related: fixtures/spec/broken_url_shortener.spec:21:3 (invariant 'clickCountNonNegative' declared here)
+✘ fixtures/spec/broken_url_shortener.spec: 1 failure(s), 0 skipped in 4 consistency checks (396ms)
+✘
+✘ fixtures/spec/broken_url_shortener.spec:11:2: error: operation 'Tamper' violates invariant 'clickCountNonNegative'
+  related: fixtures/spec/broken_url_shortener.spec:21:2 (invariant 'clickCountNonNegative' declared here)
 
   Counterexample:
   inputs:
-    code = 2
+    code = 1
   entities:
-    UrlMapping#0 { click_count = -100 }
-    UrlMapping#1 { click_count = 0 }
+    UrlMapping#0 { click_count = -1 }
+    UrlMapping#1 { click_count = 99 }
+    UrlMapping#2 { click_count = -1 }
   pre-state:
-    metadata = { 2 → UrlMapping#1 }
+    metadata = { 1 → UrlMapping#1 }
   post-state:
-    metadata' = { 2 → UrlMapping#0 }
+    metadata' = { 1 → UrlMapping#0 }
 
   Why this violates the invariant:
     1. Invariant 'clickCountNonNegative' requires:
          (all c in metadata | (metadata[c].click_count >= 0))
     2. Operation 'Tamper' computes 'click_count' from:
          (pre(metadata)[code].click_count - 100)
-    3. The solver picked code = 2, pre(metadata)[2].click_count = 0,
-       producing post-state metadata'[2].click_count = -100.
-    4. The post-state value violates the bound on 'click_count' from
-       invariant 'clickCountNonNegative'.
+    3. The solver picked code = 1, pre(metadata)[1].click_count = 99, producing post-state metadata'[1].click_count = -1.
+    4. The post-state value violates the bound on 'click_count' from invariant 'clickCountNonNegative'.
 
-  hint: 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see
-  counterexample. Tighten 'ensures' with a range predicate or a constructor that
-  initialises click_count correctly.
+  hint: 'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises click_count correctly.
 ```
 
 The hint names the violating operation, the violated invariant, and the field(s) the
@@ -260,40 +260,55 @@ rewritten to the readable `UrlMapping#N` labels.
 
 ```text
 $ spec-to-rest verify fixtures/spec/unsat_invariants.spec
-✘ fixtures/spec/unsat_invariants.spec:4:3: error: invariants are jointly unsatisfiable — no valid state exists
-  related: fixtures/spec/unsat_invariants.spec:5:3 (invariant 'tooHigh')
+✘ fixtures/spec/unsat_invariants.spec: 1 failure(s), 0 skipped in 1 consistency checks (336ms)
+✘
+✘ fixtures/spec/unsat_invariants.spec:2:2: error: invariants are jointly unsatisfiable — no valid state exists
+  related: fixtures/spec/unsat_invariants.spec:3:2 (invariant 'inv_1')
+  related: fixtures/spec/unsat_invariants.spec:4:2 (invariant 'inv_2')
 
-  hint: The invariant set is jointly unsatisfiable; for example, review 'inv_0',
-  'inv_1', 'inv_2' for a pair whose range constraints cannot overlap (e.g.,
-  'x >= 10' alongside 'x <= 5'); narrow or drop one.
+  Why these invariants conflict:
+    1. The verifier could not satisfy all invariants jointly.
+    2. Invariants involved: inv_0, inv_1, inv_2.
+       (Run with --explain to see the contributing pair.)
+
+  hint: The invariant set is jointly unsatisfiable; for example, review 'inv_0', 'inv_1', 'inv_2' for a pair whose range constraints cannot overlap (e.g., 'x >= 10' alongside 'x <= 5'); narrow or drop one.
 ```
 
 No counterexample is emitted here — the engine concluded `unsat` on the invariant conjunction
-alone, so there's no model to decode. Unsat-core extraction (tracked in #77) will sharpen the
-`related:` list to the minimal contradictory subset.
+alone, so there's no model to decode. Pass `--explain` to extract the unsat core and sharpen
+the `related:` list to the minimal contradictory subset; with `--explain` off, the related
+spans cover the full invariant set.
 
 ## Using the CLI
 
 ```bash
 $ spec-to-rest verify fixtures/spec/url_shortener.spec
-✔ fixtures/spec/url_shortener.spec: 22/25 consistency checks passed (3 skipped) (842ms)
+⚠ fixtures/spec/url_shortener.spec: 15/21 checks passed; 6 skipped (translator coverage gap) (523ms)
 ```
 
-Add `-v` for stage timing, per-check timing, and the full check table:
+Add `-v` for stage timing, per-check timing, and the full check table. Each per-check line
+carries its routed backend tag (`[z3]` or `[alloy]`):
 
 ```text
-$ spec-to-rest verify -v fixtures/spec/url_shortener.spec
-verbose Parsed in 4ms
-verbose Built IR in 1ms
-verbose Timeout: 30000ms
-✔ … 22/25 consistency checks passed (3 skipped) (842ms)
-verbose   ✔ global                       sat         236ms
-verbose   ✔ Delete.requires              sat          11ms
-verbose   ✔ Delete.enabled               sat          12ms
-verbose   ✔ Delete.preserves.allURLsValid       sat     54ms
-verbose   ∙ Shorten.preserves.allURLsValid  skipped — arithmetic operator '+'
-verbose   …
+$ spec-to-rest verify -v fixtures/spec/safe_counter.spec
+  Parsed in 77ms
+  Built IR in 47ms
+  Timeout: 30000ms
+  Alloy scope: 5
+  Max parallel: 16
+✔ fixtures/spec/safe_counter.spec: 7/7 consistency checks passed (350ms)
+    ✔ [z3]    global                       sat          11ms
+    ✔ [z3]    Decrement.requires           sat          13ms
+    ✔ [z3]    Decrement.enabled            sat          12ms
+    ✔ [z3]    Decrement.preserves.countNonNegative sat          12ms
+    ✔ [z3]    Increment.requires           sat          10ms
+    ✔ [z3]    Increment.enabled            sat          12ms
+    ✔ [z3]    Increment.preserves.countNonNegative sat          13ms
 ```
+
+Skipped checks (translator coverage gap) print as a separate `⚠ translator limitation on
+check '<id>': <reason>` warning block before the surviving entries in the per-check table —
+they don't appear inline as a `skipped` row.
 
 ### Options
 
@@ -306,14 +321,46 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       type: 'number',
       default: '30000',
     },
+    '--alloy-scope <n>': {
+      description: 'Scope (atoms-per-signature upper bound) for Alloy-routed checks.',
+      type: 'number',
+      default: '5',
+    },
+    '--parallel <n>': {
+      description: 'Max concurrent checks. Default: host `availableProcessors`. `0` = serial (regression parity).',
+      type: 'number',
+      default: 'auto',
+    },
     '--dump-smt': {
-      description: 'Emit SMT-LIB to stdout and exit without running the solver.',
+      description: 'Emit Z3 SMT-LIB to stdout and exit without running the solver.',
       type: 'flag',
       default: 'false',
     },
     '--dump-smt-out <file>': {
-      description: 'Write SMT-LIB to `<file>` and exit without running the solver.',
+      description: 'Write Z3 SMT-LIB to `<file>` and exit without running the solver.',
       type: 'path',
+    },
+    '--dump-alloy': {
+      description: 'Emit Alloy source to stdout and exit without running Alloy.',
+      type: 'flag',
+      default: 'false',
+    },
+    '--dump-alloy-out <file>': {
+      description: 'Write Alloy source to `<file>` and exit without running Alloy.',
+      type: 'path',
+    },
+    '--dump-vc <dir>': {
+      description: 'Write per-check VC artifacts (`.smt2` / `.als`) and `verdicts.json` into `<dir>`. Runs the full check pipeline.',
+      type: 'path',
+    },
+    '--emit-cert <dir>': {
+      description: 'After verify, write a Lean translation-validation certificate Lake project into `<dir>`. Run `cd <dir> && lake build` to discharge the certs.',
+      type: 'path',
+    },
+    '--explain': {
+      description: 'Extract unsat cores; surface contributing spec spans on `unsat` diagnostics. Modest overhead — Z3 switches to assert-and-track, Alloy to a core-capable SAT backend.',
+      type: 'flag',
+      default: 'false',
     },
     '--json': {
       description: 'Emit machine-readable JSON report to stdout (suppresses text).',
@@ -321,13 +368,8 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
       default: 'false',
     },
     '--json-out <file>': {
-      description: 'Write machine-readable JSON report to `<file>` (suppresses text).',
+      description: 'Write machine-readable JSON report to `<file>` (implies JSON mode; suppresses text).',
       type: 'path',
-    },
-    '--parallel <n>': {
-      description: 'Max concurrent checks. Default: host `availableProcessors`. `0` = serial (regression parity).',
-      type: 'number',
-      default: 'auto',
     },
     '--no-suggestions': {
       description: 'Suppress per-diagnostic `hint:` text in CLI and `suggestion` in JSON output.',
@@ -341,6 +383,11 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
     },
     '-v, --verbose': {
       description: 'Print stage timing and per-check timing / status.',
+      type: 'flag',
+      default: 'false',
+    },
+    '-q, --quiet': {
+      description: 'Suppress non-error output.',
       type: 'flag',
       default: 'false',
     },
@@ -433,6 +480,7 @@ Each entry in `checks` mirrors the internal `CheckResult` 1:1:
       "inputs": [{ "name": "code", "value": { "display": "2", "entityLabel": null } }]
     },
     "suggestion": "Tighten the 'ensures' clause so…",
+    "narrative": "Why this violates the invariant:\n  1. Invariant 'clickCountNonNegative' requires:\n       (all c in metadata | (metadata[c].click_count >= 0))\n  …",
     "coreSpans": []
   }
 }
@@ -440,7 +488,9 @@ Each entry in `checks` mirrors the internal `CheckResult` 1:1:
 
 Passing checks have `diagnostic: null`. Checks without a counterexample (e.g. global
 `unsat`) have `counterexample: null`. `coreSpans` is an empty array when `--explain` is off
-or the backend can't provide a core.
+or the backend can't provide a core. `narrative` is `null` outside the three categories that
+support narration (see [Reading diagnostics](#reading-diagnostics)) or when `--no-narration`
+is set.
 
 ### Stable enum tokens
 
@@ -551,6 +601,33 @@ arithmetic encoding (e.g. cardinality constraints `#s = N`). Those still produce
 `unsat` verdict; only the per-fact attribution is unavailable. Relational / quantifier-driven
 contradictions return populated cores.
 
+### Lean translation-validation cert (`--emit-cert`)
+
+`spec-to-rest verify --emit-cert <dir> <spec>` runs the full check pipeline and, on top of
+that, emits a self-contained Lake project to `<dir>` containing one Lean theorem per
+invariant, per `requires` clause, and per (operation × invariant) preservation pair.
+Each theorem is closed by the `cert_decide` macro (alias for `native_decide`) — closed
+evaluation against the in-repo `proofs/lean/` semantics — so `lake build` is `sorry`-free
+when the theorems hold.
+
+```text
+out/
+├── lakefile.toml          # path-based [[require]] against proofs/lean/
+├── lean-toolchain         # copied from proofs/lean/lean-toolchain
+└── <ServiceName>Cert.lean # one namespace, one theorem per obligation
+```
+
+Out-of-subset clauses (constructs the verified subset doesn't yet cover) emit a
+trivially-discharged `True` theorem with a `TODO[M_L.4]` marker in the docstring naming
+the offending operator, so the bundle stays `sorry`-free even when subset coverage is
+incomplete. `lean-certs.yml` runs `lake build` on every fixture's bundle in CI, plus
+asserts per-fixture `cert_decide`-vs-trivial counts as regression checks.
+
+Trust closure: the M_L.1 semantics + the `Lean.ofReduceBool` axiom that `native_decide`
+introduces. Tracked under [#88](https://github.com/HardMax71/spec_to_rest/issues/88) /
+[#129](https://github.com/HardMax71/spec_to_rest/issues/129) /
+[#170](https://github.com/HardMax71/spec_to_rest/issues/170).
+
 ### What's intentionally not exported
 
 Full Z3 proof terms (Alethe-format, machine-checkable by `carcara` / `veriT`) are not
@@ -645,7 +722,7 @@ debugging, a known translator-coverage gap, a demo on a counterexample spec — 
 ```bash
 $ spec-to-rest compile --ignore-verify --out /tmp/out fixtures/spec/unsat_invariants.spec
 ⚠ proceeding without verification (--ignore-verify)
-✔ wrote 24 files to /tmp/out
+✔ wrote 26 files to /tmp/out
 ```
 
 The warning prints on every `--ignore-verify` run — the flag is conspicuous by design, not a

--- a/docs/content/docs/research/02_convention_engine.md
+++ b/docs/content/docs/research/02_convention_engine.md
@@ -2425,49 +2425,55 @@ The entity analyzer classifies each entity in the spec:
 | **Value type**      | Single field, no own state relations, used inline | `ShortCode`, `LongURL`             |
 | **Junction entity** | Only exists to link two other entities (M:N)      | Auto-detected from `set` relations |
 
-It also builds a relationship graph:
+It also builds a relationship graph (the live shape lives in
+[`modules/ir/src/main/scala/specrest/ir/Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/ir/src/main/scala/specrest/ir/Types.scala);
+sketch shown here):
 
-```python
-@dataclass
-class EntityInfo:
-    name: str
-    classification: Literal["root", "child", "value", "junction"]
-    fields: list[FieldInfo]
-    invariants: list[InvariantExpr]
-    parent: Optional[str]          # for child entities
-    children: list[str]            # for root entities
-    relations: list[RelationInfo]  # all relations involving this entity
+```scala
+enum EntityClassification derives CanEqual:
+  case Root, Child, Value, Junction
+
+final case class EntityInfo(
+    name: String,
+    classification: EntityClassification,
+    fields: List[FieldDecl],
+    invariants: List[Expr],
+    parent: Option[String],            // for child entities
+    children: List[String],            // for root entities
+    relations: List[RelationInfo]      // all relations involving this entity
+)
 ```
 
 ### 8.3 Phase 2: Operation Analysis
 
-The operation analyzer classifies each operation:
+The operation analyzer classifies each operation. The shipped types live in
+[`modules/convention/src/main/scala/specrest/convention/Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Types.scala):
 
-```python
-@dataclass
-class OperationClassification:
-    op_name: str
-    kind: Literal[
-        "create",          # new entity added to state
-        "read_one",        # single entity retrieved by ID
-        "read_many",       # collection retrieved with optional filters
-        "update_full",     # all fields of existing entity modified
-        "update_partial",  # subset of fields modified
-        "delete",          # entity removed from state
-        "transition",      # status/state field changed
-        "action",          # side effect, possibly cross-entity
-        "search",          # complex read with structured input
-    ]
-    target_entity: Optional[str]      # primary entity affected
-    parent_entity: Optional[str]      # if operating on a child
-    mutated_relations: list[str]      # state relations that change
-    read_relations: list[str]         # state relations that are read
-    path_params: list[ParamInfo]      # inputs that become path params
-    query_params: list[ParamInfo]     # inputs that become query params
-    body_params: list[ParamInfo]      # inputs that become body fields
-    transition_field: Optional[str]   # for state machine transitions
-    transition_from: Optional[set[str]]  # valid source states
-    transition_to: Optional[str]      # target state
+```scala
+enum OperationKind derives CanEqual:
+  case Create, Read, Replace, PartialUpdate, Delete, CreateChild,
+       FilteredRead, SideEffect, BatchMutation, Transition
+
+final case class AnalysisSignals(
+    mutatedRelations: List[String],
+    preservedRelations: List[String],
+    createsNewKey: Boolean,
+    deletesKey: Boolean,
+    targetEntityFieldCount: Option[Int],
+    withFieldCount: Option[Int],
+    filterParamCount: Int,
+    isTransition: Boolean,
+    hasCollectionInput: Boolean
+)
+
+final case class OperationClassification(
+    operationName: String,
+    kind: OperationKind,
+    method: HttpMethod,
+    matchedRule: String,        // "M1".."M10"
+    targetEntity: Option[String],
+    signals: AnalysisSignals
+)
 ```
 
 The classification algorithm:
@@ -2493,32 +2499,40 @@ The classification algorithm:
 
 ### 8.4 Phase 3: Rule Application
 
-Rules are applied in a deterministic order. Each rule is a function:
+The shipped classifier ([`Classify.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Classify.scala))
+collapses the rule-table form below into a single deterministic top-down match
+(first match wins, no priorities) — the shape this design doc imagines is:
 
-```python
-class ConventionRule:
-    name: str
-    priority: int                    # lower = higher priority
-    applies_to: Callable[[OpClassification], bool]
-    apply: Callable[[OpClassification, EntityInfo], ConventionDecision]
+```scala
+final case class ConventionRule(
+    name: String,
+    priority: Int,                                 // lower = higher priority
+    appliesTo: OperationClassification => Boolean,
+    apply: (OperationClassification, EntityInfo) => ConventionDecision
+)
 ```
 
 Rules are organized into groups:
 
-```python
-HTTP_METHOD_RULES = [
-    Rule("M1_create",     priority=10, applies_to=is_create,     apply=lambda _: POST),
-    Rule("M2_read",       priority=10, applies_to=is_read,       apply=lambda _: GET),
-    Rule("M3_update_full", priority=10, applies_to=is_full_update, apply=lambda _: PUT),
-    Rule("M4_update_partial", priority=10, applies_to=is_partial_update, apply=lambda _: PATCH),
-    Rule("M5_delete",     priority=10, applies_to=is_delete,     apply=lambda _: DELETE),
-    Rule("M6_child_create", priority=5, applies_to=is_child_create, apply=lambda _: POST),
-    Rule("M7_search",     priority=20, applies_to=is_complex_search, apply=decide_search_method),
-    Rule("M8_action",     priority=30, applies_to=is_action,     apply=lambda _: POST),
-    Rule("M9_batch",      priority=15, applies_to=is_batch,      apply=lambda _: POST),
-    Rule("M10_transition", priority=5, applies_to=is_transition,  apply=lambda _: POST),
-]
+```scala
+val HttpMethodRules: List[ConventionRule] = List(
+  ConventionRule("M1_create",          priority = 10, appliesTo = isCreate,         apply = (_, _) => POST),
+  ConventionRule("M2_read",            priority = 10, appliesTo = isRead,           apply = (_, _) => GET),
+  ConventionRule("M3_update_full",     priority = 10, appliesTo = isFullUpdate,     apply = (_, _) => PUT),
+  ConventionRule("M4_update_partial",  priority = 10, appliesTo = isPartialUpdate,  apply = (_, _) => PATCH),
+  ConventionRule("M5_delete",          priority = 10, appliesTo = isDelete,         apply = (_, _) => DELETE),
+  ConventionRule("M6_child_create",    priority =  5, appliesTo = isChildCreate,    apply = (_, _) => POST),
+  ConventionRule("M7_search",          priority = 20, appliesTo = isComplexSearch,  apply = decideSearchMethod),
+  ConventionRule("M8_action",          priority = 30, appliesTo = isAction,         apply = (_, _) => POST),
+  ConventionRule("M9_batch",           priority = 15, appliesTo = isBatch,          apply = (_, _) => POST),
+  ConventionRule("M10_transition",     priority =  5, appliesTo = isTransition,     apply = (_, _) => POST)
+)
 ```
+
+`Classify.scala` realises this as a top-down `if/else` over `AnalysisSignals`,
+emitting the matched rule's name (`"M1"`–`"M10"`) into
+`OperationClassification.matchedRule`. M6 (`CreateChild`) is reserved in the
+enum but no current dispatch arm produces it.
 
 **Priority resolution:** When multiple rules match (e.g., an operation both creates an entity AND is
 a child creation), the rule with the lower priority number wins. If two rules have equal priority
@@ -2533,71 +2547,79 @@ each priority level).
 
 ### 8.5 Phase 4: Override Merge
 
-Overrides are merged in the resolution order specified in Section 3.3:
+Overrides are merged in the resolution order specified in Section 3.3
+([`Path.getConvention`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Path.scala) is the live entry point):
 
-```python
-def resolve(path: str, op: OpClassification) -> Any:
-    # 1. Operation-level override
-    if f"{op.name}.{path}" in overrides:
-        return overrides[f"{op.name}.{path}"]
-    # 2. Entity-level override
-    if op.target_entity and f"{op.target_entity}.{path}" in overrides:
-        return overrides[f"{op.target_entity}.{path}"]
-    # 3. Global override
-    if f"global.{path}" in overrides:
-        return overrides[f"global.{path}"]
-    # 4. Profile default
-    if path in profile.defaults:
-        return profile.defaults[path]
-    # 5. Engine default
-    return engine_default(path)
+```scala
+def resolve(
+    property: String,
+    op: OperationClassification,
+    overrides: Map[String, Expr],
+    profile: DeploymentProfile
+): Option[String] =
+  // 1. Operation-level override
+  overrides.get(s"${op.operationName}.$property").flatMap(exprToString)
+    // 2. Entity-level override
+    .orElse(op.targetEntity.flatMap(t => overrides.get(s"$t.$property")).flatMap(exprToString))
+    // 3. Global override
+    .orElse(overrides.get(s"global.$property").flatMap(exprToString))
+    // 4. Profile default
+    .orElse(profile.defaults.get(property))
+    // 5. Engine default
+    .orElse(engineDefault(property, op))
 ```
 
 ### 8.6 Output Data Structure
 
-The convention engine produces a structured output that downstream code emitters consume:
+The convention engine produces a structured output that downstream code emitters consume.
+The shipped types ([`Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/Types.scala))
+are leaner than the design sketch — `EndpointSpec` is per-operation, `DatabaseSchema`
+is just `tables: List[TableSpec]`, and OpenAPI / triggers / partial indexes are emitted
+elsewhere or tracked as future work:
 
-```python
-@dataclass
-class ConventionOutput:
-    endpoints: list[EndpointSpec]
-    db_schema: DatabaseSchema
-    validation_rules: list[ValidationRule]
-    error_mappings: list[ErrorMapping]
-    openapi: OpenAPISpec
+```scala
+final case class EndpointSpec(
+    operationName: String,
+    method: HttpMethod,            // GET, POST, PUT, PATCH, DELETE
+    path: String,                  // /orders/{order_id}/line-items
+    pathParams: List[ParamSpec],
+    queryParams: List[ParamSpec],
+    bodyParams: List[ParamSpec],
+    successStatus: Int             // 200, 201, 204, 302
+)
 
-@dataclass
-class EndpointSpec:
-    method: str                        # GET, POST, PUT, PATCH, DELETE
-    path: str                          # /orders/{order_id}/line-items
-    operation_id: str                  # addLineItem
-    summary: str                       # Add a line item to an order
-    path_params: list[ParamSpec]
-    query_params: list[ParamSpec]
-    request_body: Optional[SchemaSpec]
-    response_body: Optional[SchemaSpec]
-    success_status: int                # 200, 201, 204, 302
-    error_responses: list[ErrorSpec]
-    headers: dict[str, str]            # custom response headers
-    auth: Optional[str]                # bearer, api_key, etc.
+final case class ColumnSpec(
+    name: String,
+    sqlType: String,
+    nullable: Boolean,
+    defaultValue: Option[String]
+)
 
-@dataclass
-class DatabaseSchema:
-    tables: list[TableSpec]
-    indexes: list[IndexSpec]
-    constraints: list[ConstraintSpec]
-    triggers: list[TriggerSpec]
-    migrations: list[MigrationSpec]
+final case class ForeignKeySpec(
+    column: String,
+    refTable: String,
+    refColumn: String,
+    onDelete: String
+)
 
-@dataclass
-class TableSpec:
-    name: str
-    columns: list[ColumnSpec]
-    primary_key: str
-    foreign_keys: list[ForeignKeySpec]
-    checks: list[str]                  # CHECK constraint SQL expressions
-    unique_constraints: list[list[str]]  # groups of columns
+final case class IndexSpec(name: String, columns: List[String], unique: Boolean)
+
+final case class TableSpec(
+    name: String,
+    entityName: String,
+    columns: List[ColumnSpec],
+    primaryKey: String,
+    foreignKeys: List[ForeignKeySpec],
+    checks: List[String],          // CHECK constraint SQL expressions
+    indexes: List[IndexSpec]
+)
+
+final case class DatabaseSchema(tables: List[TableSpec])
 ```
+
+OpenAPI 3.1 emission is handled separately by `modules/codegen/.../openapi/`;
+trigger and partial-index derivation are tracked as future work in
+[#57](https://github.com/HardMax71/spec_to_rest/issues/57).
 
 ### 8.7 Extensibility: Custom Rules and Plugins
 
@@ -2626,39 +2648,43 @@ rules (use explicit overrides for that).
 - Profile-specific schema transformations (e.g., using Prisma's schema language instead of raw SQL)
 - Profile-specific validation implementations
 
-Plugin interface:
+Plugin interface (shipped shape:
+[`DeploymentProfile`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Types.scala) +
+[`Annotate.buildProfiledService`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Annotate.scala)
+together fill this role; today only `python-fastapi-postgres` is registered):
 
-```python
-class ProfilePlugin:
-    def transform_schema(self, schema: DatabaseSchema) -> Any:
-        """Convert generic schema to profile-specific format"""
-        ...
+```scala
+trait ProfilePlugin:
+  /** Convert generic schema to profile-specific format. */
+  def transformSchema(schema: DatabaseSchema): ProfileSchema
 
-    def transform_endpoint(self, endpoint: EndpointSpec) -> Any:
-        """Convert generic endpoint to profile-specific route definition"""
-        ...
+  /** Convert generic endpoint to profile-specific route definition. */
+  def transformEndpoint(endpoint: EndpointSpec): ProfileEndpoint
 
-    def additional_artifacts(self, output: ConventionOutput) -> dict[str, str]:
-        """Generate additional files (Dockerfile, config, etc.)"""
-        ...
+  /** Generate additional files (Dockerfile, config, etc.) keyed by output path. */
+  def additionalArtifacts(output: ConventionOutput): Map[String, String]
 ```
 
 ### 8.8 Testing and Debugging
 
 The convention engine is designed to be testable:
 
-**Unit testing:** Each rule is a pure function that can be tested in isolation:
+**Unit testing:** Each rule is a pure function that can be tested in isolation
+(the project uses munit + munit-cats-effect; see
+[`modules/convention/src/test/scala/`](https://github.com/HardMax71/spec_to_rest/tree/main/modules/convention/src/test/scala)):
 
-```python
-def test_create_operation_maps_to_post():
-    op = make_op(kind="create", target="Order")
-    result = HTTP_METHOD_RULES.apply(op)
-    assert result.method == "POST"
+```scala
+test("create operation maps to POST"):
+  val op     = makeOp(kind = OperationKind.Create, target = "Order")
+  val result = Classify.classifyOperation(op, ir)
+  assertEquals(result.method, HttpMethod.POST)
 
-def test_read_operation_maps_to_get():
+test("read operation maps to GET"):
     op = make_op(kind="read_one", target="Order")
     result = HTTP_METHOD_RULES.apply(op)
-    assert result.method == "GET"
+  val op2     = makeOp(kind = OperationKind.Read, target = "Order")
+  val result2 = Classify.classifyOperation(op2, ir)
+  assertEquals(result2.method, HttpMethod.GET)
 ```
 
 **Decision tracing:** The engine can produce a trace of every decision it made, which is invaluable

--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -7,6 +7,20 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > for the spec-to-REST compiler. Covers architecture, Dafny integration, prompt engineering,
 > Clover-style triangulation, failure handling, security, and cost analysis. Written 2026-04-05.
 
+> **Status — not yet implemented.** This document is the **Phase 6** design proposal. It
+> has **not** been built: there is no Dafny in the codebase, no LLM SDK wired up, no CEGIS
+> loop on `main`. Open trackers under the `phase-6` label cover the breakdown:
+> [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) — operation classification (direct emit vs. LLM),
+> [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) — Dafny signature generation,
+> [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering,
+> [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop,
+> [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation,
+> [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy.
+> The Python code samples below sketch the data shapes and flow; once Phase 6 lands, the
+> implementation will live in Scala alongside the rest of the compiler (matching the
+> `Scala 3 + Cats Effect 3 + IO`-typed pipeline documented in
+> [Architecture](/design/architecture)).
+
 ---
 
 ## Table of Contents

--- a/docs/content/docs/research/04_code_generation_pipeline.md
+++ b/docs/content/docs/research/04_code_generation_pipeline.md
@@ -8,6 +8,19 @@ description: "Multi-target code emission from verified intermediate representati
 > integration, infrastructure code, quality assurance, incremental regeneration, extensibility, and
 > comparison with existing generators.
 
+> **Status.** The shipped codegen lives in
+> [`modules/codegen/`](https://github.com/HardMax71/spec_to_rest/tree/main/modules/codegen)
+> and emits the `python-fastapi-postgres` target via Handlebars templates — see the
+> live [Python + FastAPI + PostgreSQL target reference](/targets/python-fastapi-postgres).
+> The Dafny integration (Phase 6, [#27–32](https://github.com/HardMax71/spec_to_rest/issues/27))
+> is **not yet implemented**; the generated services raise `NotImplementedError` for
+> non-trivial operation bodies until that work lands. Multi-target emission (Go/chi
+> [#33](https://github.com/HardMax71/spec_to_rest/issues/33), TS/Express
+> [#35](https://github.com/HardMax71/spec_to_rest/issues/35)) is **Phase 7**, also
+> not yet on `main`. Python-shaped code samples below are design sketches; the
+> implementation language is Scala 3 (see
+> [Architecture](/design/architecture)).
+
 ---
 
 ## Table of Contents
@@ -2143,31 +2156,49 @@ Expressiveness and developer familiarity dominate the choice.
 
 ### 2.2 IR-to-Template Variable Mapping
 
-The IR produced by the spec parser is a structured Python dataclass tree. The template engine
-receives it as a context dictionary:
+The IR produced by the spec parser is a Scala 3 ADT (sealed enums + case classes).
+The Handlebars engine receives a `ProfiledService` view that wraps the IR with the
+convention-engine annotations. The shipped types live in
+[`modules/ir/src/main/scala/specrest/ir/Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/ir/src/main/scala/specrest/ir/Types.scala)
+and `modules/profile/.../Types.scala`:
 
-```python
-@dataclass
-class ServiceIR:
-    name: str                          # "UrlShortener"
-    entities: list[EntityIR]           # ShortCode, LongURL
-    state: StateIR                     # store, created_at
-    operations: list[OperationIR]      # Shorten, Resolve, Delete
-    invariants: list[InvariantIR]      # global invariants
-    conventions: ConventionOverrides   # user-specified overrides
+```scala
+final case class ServiceIR(
+    name: String,                      // "UrlShortener"
+    entities: List[EntityDecl],        // UrlMapping
+    enums: List[EnumDecl],
+    typeAliases: List[TypeAliasDecl],  // ShortCode, LongURL, BaseURL
+    state: Option[StateDecl],          // store, metadata, base_url
+    operations: List[OperationDecl],   // Shorten, Resolve, Delete, ListAll
+    invariants: List[InvariantDecl],   // global invariants
+    temporals: List[TemporalDecl],
+    facts: List[FactDecl],
+    functions: List[FunctionDecl],
+    predicates: List[PredicateDecl],
+    transitions: List[TransitionDecl],
+    conventions: Option[ConventionsDecl]   // user-specified overrides
+)
 
-@dataclass
-class OperationIR:
-    name: str                          # "Shorten"
-    inputs: list[FieldIR]             # url: LongURL
-    outputs: list[FieldIR]            # code: ShortCode, short_url: String
-    requires: list[ExprIR]            # isValidURI(url.value)
-    ensures: list[ExprIR]             # code not in pre(store), ...
-    mutates_state: bool               # True (inferred from ensures referencing store')
-    http_method: str                   # "POST" (from convention engine)
-    http_path: str                     # "/shorten" (from convention engine)
-    http_success_status: int           # 201 (from convention engine)
-    http_error_responses: list[ErrorMapping]  # 422 -> "Validation error"
+final case class OperationDecl(
+    name: String,                      // "Shorten"
+    inputs: List[ParamDecl] = Nil,     // url: LongURL
+    outputs: List[ParamDecl] = Nil,    // code: ShortCode, short_url: String
+    requires: List[Expr] = Nil,        // isValidURI(url)
+    ensures: List[Expr] = Nil,         // code not in pre(store), ...
+    span: Option[Span] = None
+)
+
+// HTTP-shape annotation produced by the convention engine and added by
+// modules/profile/.../Annotate.buildProfiledService before templates render.
+final case class EndpointSpec(
+    operationName: String,             // "Shorten"
+    method: HttpMethod,                // POST
+    path: String,                      // "/shorten"
+    pathParams: List[ParamSpec],
+    queryParams: List[ParamSpec],
+    bodyParams: List[ParamSpec],
+    successStatus: Int                 // 201
+)
 ```
 
 The convention engine annotates each `OperationIR` with HTTP mapping decisions before templates are
@@ -3432,34 +3463,37 @@ async def notify_analytics(result):
 
 ### 9.2 Plugin System for Custom Code Generators
 
-Users can register custom code generator plugins:
+Users can register custom code generator plugins. The shipped plugin shape is the
+`DeploymentProfile` registry in
+[`modules/profile/src/main/scala/specrest/profile/Registry.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Registry.scala);
+new targets like Go/chi (#33) and TS/Express (#35) plug in as additional registry
+entries plus a Handlebars template tree:
 
-```python
-# plugins/custom_target.py
+```scala
+// modules/profile/src/main/scala/specrest/profile/KotlinSpring.scala (sketch)
+package specrest.profile
 
-from spec_to_rest.codegen import CodegenPlugin, GeneratedFile
+object KotlinSpring:
+  val profile: DeploymentProfile = DeploymentProfile(
+    name = "kotlin-spring-postgres",
+    displayName = "Kotlin + Spring Boot + PostgreSQL",
+    language = "kotlin",
+    framework = "spring",
+    // ... typeMap, dependencies, etc.
+  )
 
-class KotlinSpringPlugin(CodegenPlugin):
-    target_name = "kotlin-spring-postgres"
-
-    def generate(self, ir, conventions):
-        yield GeneratedFile(
-            path="build.gradle.kts",
-            content=self.render_template("build.gradle.kts.j2", ir=ir),
-        )
-        yield GeneratedFile(
-            path="src/main/kotlin/Application.kt",
-            content=self.render_template("application.kt.j2", ir=ir),
-        )
-        # ... more files
+// Then register in Registry.scala:
+object Registry:
+  private val Profiles: Map[String, DeploymentProfile] = Map(
+    "python-fastapi-postgres" -> PythonFastapi.profile,
+    "kotlin-spring-postgres"  -> KotlinSpring.profile
+  )
 ```
 
-Plugins provide their own templates and are registered via entry points:
-
-```toml
-[project.entry-points."spec_to_rest.targets"]
-kotlin-spring = "plugins.custom_target:KotlinSpringPlugin"
-```
+Templates live under `modules/codegen/src/main/resources/templates/<target-name>/`
+and `modules/codegen/src/main/scala/specrest/codegen/Emit.scala` dispatches on the
+profile's `name` field. There is no separate plugin-discovery mechanism today —
+adding a target is a registry entry plus a template tree.
 
 ### 9.3 Custom Endpoints
 

--- a/docs/content/docs/research/05_test_generation.md
+++ b/docs/content/docs/research/05_test_generation.md
@@ -6,15 +6,23 @@ description: "Structural, behavioral, and stateful test generation from formal s
 > Design document for the spec-to-REST compiler's test generation subsystem. Covers structural,
 > behavioral, and stateful test layers with complete worked examples for three service domains.
 
-> **Implementation status (2026-04):** §3 (Hypothesis property tests, behavioral layer) is
-> partially landed via M5.1 — see [pipelines/test-generation.mdx](/pipelines/test-generation)
-> for what `--with-tests` actually emits today. §2 (Schemathesis), §4 (stateful), §6 (TLA+),
-> §7 (conformance runner), §9 (mutation testing) are tracked under sister tickets:
-> [#26](https://github.com/HardMax71/spec_to_rest/issues/26),
-> [#25](https://github.com/HardMax71/spec_to_rest/issues/25),
-> [#23](https://github.com/HardMax71/spec_to_rest/issues/23),
-> [#135](https://github.com/HardMax71/spec_to_rest/issues/135). This page is the design
-> vision; the pipelines page is the shipped surface.
+> **Implementation status.** Phase 5 is **largely shipped.** Closed milestones cover §2
+> Schemathesis ([#26](https://github.com/HardMax71/spec_to_rest/issues/26)), §3 Hypothesis
+> behavioral tests ([#24](https://github.com/HardMax71/spec_to_rest/issues/24)), §4 stateful
+> tests ([#25](https://github.com/HardMax71/spec_to_rest/issues/25)), §5 custom strategies
+> ([#134](https://github.com/HardMax71/spec_to_rest/issues/134)), §7 conformance runner
+> ([#23](https://github.com/HardMax71/spec_to_rest/issues/23)), §9 mutation testing gate
+> ([#135](https://github.com/HardMax71/spec_to_rest/issues/135)), plus M5.5–M5.10
+> follow-ups. §6 TLA+ trace validation remains a non-goal in v1. The shipped surface lives
+> in [`modules/testgen/`](https://github.com/HardMax71/spec_to_rest/tree/main/modules/testgen)
+> (Scala 3); the live `--with-tests` reference is
+> [pipelines/test-generation.mdx](/pipelines/test-generation). Open follow-ups:
+> [#86](https://github.com/HardMax71/spec_to_rest/issues/86) (runtime invariant enforcement)
+> and [#139](https://github.com/HardMax71/spec_to_rest/issues/139) /
+> [#140](https://github.com/HardMax71/spec_to_rest/issues/140) (multi-target test gen,
+> default-on `--with-tests`). Python code samples below are the spec-vision shapes;
+> emitted Python in `tests/*.py` is what the live shipped pipeline produces and is
+> documented in detail on the pipelines page.
 
 ---
 

--- a/docs/content/docs/research/06_spec_verification.md
+++ b/docs/content/docs/research/06_spec_verification.md
@@ -7,6 +7,17 @@ description: "Model-checking specifications before code generation"
 > Catches design errors at the specification level rather than discovering them in the generated
 > implementation.
 
+> **Status.** Verification is **shipped** in
+> [`modules/verify/`](https://github.com/HardMax71/spec_to_rest/tree/main/modules/verify) (Scala 3 + Cats Effect 3),
+> backed by Z3 (via `tools.aqua:z3-turnkey`) for first-order checks and Alloy 6 for
+> powerset / temporal checks. Lean 4 translation-validation certs (M_L track,
+> [#88](https://github.com/HardMax71/spec_to_rest/issues/88)) emit a sibling Lake project
+> per run via `--emit-cert`. The live reference is the
+> [Verification Engine pipeline page](/pipelines/verification). The Quint subprocess
+> path explored in §2 was **not** adopted — Z3 + Alloy cover the shipped surface, and
+> Quint is referenced here only as a comparison point. Python and TypeScript code
+> samples below are design illustrations; the production compiler is Scala 3.
+
 ---
 
 ## Table of Contents
@@ -2938,395 +2949,78 @@ class QuintSpecVerifier:
 
 ### 9.4 API Design for the Verification Engine
 
-```python
-from dataclasses import dataclass, field
-from enum import Enum
-from typing import Optional
+The shipped verification engine entry point is
+[`Consistency.runConsistencyChecks`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/verify/src/main/scala/specrest/verify/Consistency.scala).
+Result categories live in
+[`Diagnostic.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala);
+the per-check `CheckResult` and `CheckOutcome` ADTs are in `Consistency.scala`.
+Sketch (Scala 3 + Cats Effect 3):
 
-class Severity(Enum):
-    ERROR = "error"
-    WARNING = "warning"
-    INFO = "info"
+```scala
+import cats.effect.IO
+import specrest.ir.{ServiceIR, Span}
 
-class CheckCategory(Enum):
-    TYPE = "type"
-    SATISFIABILITY = "satisfiability"
-    PRESERVATION = "preservation"
-    REACHABILITY = "reachability"
-    TEMPORAL = "temporal"
-    SEMANTIC = "semantic"
+enum DiagnosticLevel derives CanEqual: case Error, Warning
 
-@dataclass
-class VerificationResult:
-    status: str                            # "PASS", "FAIL", "UNKNOWN"
-    severity: Severity = Severity.ERROR
-    category: CheckCategory = CheckCategory.TYPE
-    message: str = ""
-    location: Optional['SourceLocation'] = None
-    counterexample: Optional[dict] = None
-    suggestion: Optional[str] = None
-    check_name: str = ""
-    duration_ms: int = 0
+enum DiagnosticCategory derives CanEqual:
+  case ContradictoryInvariants, UnsatisfiablePrecondition, UnreachableOperation,
+       InvariantViolationByOperation, SolverTimeout, TranslatorLimitation, BackendError
 
-@dataclass
-class SourceLocation:
-    file: str
-    line: int
-    column: int
-    end_line: Optional[int] = None
-    end_column: Optional[int] = None
+enum CheckKind derives CanEqual: case Global, Requires, Enabled, Preservation, Temporal
+enum CheckOutcome derives CanEqual: case Sat, Unsat, Unknown, Skipped
+enum VerifierTool derives CanEqual: case Z3, Alloy
 
-@dataclass
-class VerificationReport:
-    results: list[VerificationResult] = field(default_factory=list)
-    total_checks: int = 0
-    passed: int = 0
-    failed: int = 0
-    unknown: int = 0
-    total_duration_ms: int = 0
+final case class Diagnostic(
+    level: DiagnosticLevel,
+    category: DiagnosticCategory,
+    message: String,
+    primarySpan: Option[Span],
+    relatedSpans: List[(Span, String)],
+    counterexample: Option[Counterexample],
+    suggestion: Option[String],
+    narrative: Option[String],
+    coreSpans: List[Span]
+)
 
-    @property
-    def has_errors(self):
-        return any(
-            r.status == "FAIL" and r.severity == Severity.ERROR
-            for r in self.results
-        )
+final case class CheckResult(
+    id: String,
+    kind: CheckKind,
+    tool: VerifierTool,
+    operationName: Option[String],
+    invariantName: Option[String],
+    status: CheckOutcome,
+    durationMs: Double,
+    detail: Option[String],
+    sourceSpans: List[Span],
+    diagnostic: Option[Diagnostic]
+)
 
-    @property
-    def errors(self):
-        return [r for r in self.results
-                if r.status == "FAIL" and r.severity == Severity.ERROR]
+final case class ConsistencyReport(checks: List[CheckResult], totalMs: Double, ok: Boolean)
 
-    @property
-    def warnings(self):
-        return [r for r in self.results
-                if r.status == "FAIL" and r.severity == Severity.WARNING]
-
-
-class SpecVerifier:
-    """
-    Main entry point for spec verification.
-
-    Usage:
-        ir = parse_spec("service.spec")
-        verifier = SpecVerifier(ir)
-        report = verifier.verify()
-        if report.has_errors:
-            for error in report.errors:
-                print(format_error(error))
-            sys.exit(1)
-        else:
-            # Proceed to code generation
-            compile(ir)
-    """
-
-    def __init__(self, ir, config=None):
-        self.ir = ir
-        self.config = config or VerificationConfig()
-        self._z3 = Z3SpecVerifier(ir)
-        self._alloy = AlloySpecVerifier(ir) if config.use_alloy else None
-        self._quint = QuintSpecVerifier(ir) if config.use_quint else None
-
-    def verify(self, categories=None) -> VerificationReport:
-        """
-        Run all verification checks and return a consolidated report.
-
-        Args:
-            categories: Optional list of CheckCategory to run. If None, run all.
-
-        Returns:
-            VerificationReport with all results.
-        """
-        report = VerificationReport()
-
-        checks = [
-            (CheckCategory.TYPE, self._check_types),
-            (CheckCategory.SEMANTIC, self._check_dead_definitions),
-            (CheckCategory.SATISFIABILITY, self._check_satisfiability),
-            (CheckCategory.PRESERVATION, self._check_invariant_preservation),
-            (CheckCategory.REACHABILITY, self._check_reachability),
-            (CheckCategory.TEMPORAL, self._check_temporal),
-            (CheckCategory.SEMANTIC, self._check_semantic_warnings),
-        ]
-
-        for category, check_fn in checks:
-            if categories and category not in categories:
-                continue
-
-            results = check_fn()
-            report.results.extend(results)
-            report.total_checks += len(results)
-            report.passed += sum(1 for r in results if r.status == "PASS")
-            report.failed += sum(1 for r in results if r.status == "FAIL")
-            report.unknown += sum(1 for r in results if r.status == "UNKNOWN")
-
-            # Early termination: if type errors found, skip deeper checks
-            if category == CheckCategory.TYPE and any(
-                r.status == "FAIL" for r in results
-            ):
-                report.results.append(VerificationResult(
-                    status="UNKNOWN",
-                    severity=Severity.INFO,
-                    message="Skipping deeper checks due to type errors."
-                ))
-                break
-
-            # Early termination: if invariants unsatisfiable, skip preservation
-            if category == CheckCategory.SATISFIABILITY and any(
-                r.status == "FAIL" and "unsatisfiable" in r.message.lower()
-                for r in results
-            ):
-                report.results.append(VerificationResult(
-                    status="UNKNOWN",
-                    severity=Severity.INFO,
-                    message="Skipping preservation checks: invariants are unsatisfiable."
-                ))
-                break
-
-        return report
-
-    def verify_incremental(self, changed_operations=None,
-                           changed_invariants=None) -> VerificationReport:
-        """
-        Re-verify only the parts affected by changes.
-
-        Args:
-            changed_operations: Names of operations that were modified.
-            changed_invariants: Indices of invariants that were modified.
-        """
-        report = VerificationReport()
-
-        # Always re-run type checking (fast)
-        report.results.extend(self._check_types())
-
-        if changed_operations:
-            for op_name in changed_operations:
-                op = self.ir.get_operation(op_name)
-                for inv in self.ir.invariants:
-                    result = self._z3.check_invariant_preservation(op, inv)
-                    report.results.append(result)
-
-        if changed_invariants:
-            for inv_idx in changed_invariants:
-                inv = self.ir.invariants[inv_idx]
-                # Check satisfiability of the changed invariant with all others
-                result = self._z3.check_invariant_satisfiability(
-                    [inv] + [i for j, i in enumerate(self.ir.invariants)
-                             if j != inv_idx]
-                )
-                report.results.append(result)
-                # Check preservation against all operations
-                for op in self.ir.operations:
-                    result = self._z3.check_invariant_preservation(op, inv)
-                    report.results.append(result)
-
-        return report
-
-    def _check_types(self):
-        """Run type checking on the IR."""
-        results = []
-        for entity in self.ir.entities:
-            for field in entity.fields:
-                if not self._is_valid_type(field.type):
-                    results.append(VerificationResult(
-                        status="FAIL",
-                        severity=Severity.ERROR,
-                        category=CheckCategory.TYPE,
-                        message=f"Unknown type '{field.type}' for field "
-                                f"'{entity.name}.{field.name}'",
-                        location=field.location,
-                    ))
-
-        for op in self.ir.operations:
-            # Check all referenced fields exist
-            for ref in op.field_references:
-                if not self._resolve_field(ref):
-                    results.append(VerificationResult(
-                        status="FAIL",
-                        severity=Severity.ERROR,
-                        category=CheckCategory.TYPE,
-                        message=f"Unknown field '{ref}' in operation "
-                                f"'{op.name}'",
-                        location=ref.location,
-                    ))
-
-            # Check expression types
-            for expr in op.all_expressions:
-                type_result = self._check_expression_types(expr)
-                if type_result:
-                    results.append(type_result)
-
-        if not results:
-            results.append(VerificationResult(
-                status="PASS",
-                category=CheckCategory.TYPE,
-                check_name="type_check"
-            ))
-
-        return results
-
-    def _check_dead_definitions(self):
-        """Detect unused entities, fields, and relations."""
-        results = []
-        referenced_entities = self._collect_referenced_entities()
-        for entity in self.ir.entities:
-            if entity.name not in referenced_entities:
-                results.append(VerificationResult(
-                    status="FAIL",
-                    severity=Severity.WARNING,
-                    category=CheckCategory.SEMANTIC,
-                    message=f"Entity '{entity.name}' is defined but never "
-                            f"referenced in any operation or state declaration",
-                    location=entity.location,
-                    suggestion=f"Remove entity '{entity.name}' or add "
-                               f"operations that use it."
-                ))
-
-        # Check for state relations that are read but never written
-        for rel in self.ir.state.relations:
-            writers = [op for op in self.ir.operations
-                       if rel.name in op.written_relations]
-            readers = [op for op in self.ir.operations
-                       if rel.name in op.read_relations]
-            if readers and not writers:
-                results.append(VerificationResult(
-                    status="FAIL",
-                    severity=Severity.WARNING,
-                    category=CheckCategory.SEMANTIC,
-                    message=f"State relation '{rel.name}' is read by "
-                            f"{[op.name for op in readers]} but never written. "
-                            f"It will always be empty.",
-                    location=rel.location,
-                ))
-
-        return results
-
-    def _check_satisfiability(self):
-        """Check invariant satisfiability and operation enabledness."""
-        results = []
-
-        # Check combined invariant satisfiability
-        sat_result = self._z3.check_invariant_satisfiability(self.ir.invariants)
-        results.append(sat_result)
-
-        # Check each operation's requires clause
-        for op in self.ir.operations:
-            req_result = self._z3.check_requires_satisfiable(op)
-            results.append(req_result)
-
-        return results
-
-    def _check_invariant_preservation(self):
-        """Check invariant preservation for each (operation, invariant) pair."""
-        results = []
-        for op in self.ir.operations:
-            for inv in self.ir.invariants:
-                result = self._z3.check_invariant_preservation(op, inv)
-                result.check_name = f"{op.name}_preserves_inv_{inv.id}"
-                results.append(result)
-        return results
-
-    def _check_reachability(self):
-        """Check state machine reachability and operation reachability."""
-        results = []
-
-        # Extract state machine if present
-        sm = self._extract_state_machine()
-        if sm:
-            reachable = sm.compute_reachable_states()
-            all_states = sm.all_states
-
-            for state in all_states - reachable:
-                results.append(VerificationResult(
-                    status="FAIL",
-                    severity=Severity.WARNING,
-                    category=CheckCategory.REACHABILITY,
-                    message=f"State '{state}' is unreachable from the "
-                            f"initial state '{sm.initial_state}'",
-                    suggestion=f"Add a transition to '{state}' or remove it."
-                ))
-
-            # Check for deadlocks
-            for state in reachable - sm.terminal_states:
-                outgoing = sm.transitions_from(state)
-                if not outgoing:
-                    results.append(VerificationResult(
-                        status="FAIL",
-                        severity=Severity.ERROR,
-                        category=CheckCategory.REACHABILITY,
-                        message=f"Deadlock: state '{state}' has no outgoing "
-                                f"transitions and is not terminal",
-                        counterexample=sm.path_to(state),
-                    ))
-
-        return results
-
-    def _check_temporal(self):
-        """Check temporal properties via Quint."""
-        if not self._quint:
-            return []
-
-        results = []
-        # Deadlock freedom
-        result = self._quint.check_temporal("deadlockFree")
-        result.check_name = "deadlock_freedom"
-        results.append(result)
-
-        # Custom temporal properties from the spec
-        for prop in self.ir.temporal_properties:
-            result = self._quint.check_temporal(prop.name)
-            result.check_name = prop.name
-            results.append(result)
-
-        return results
-
-    def _check_semantic_warnings(self):
-        """Check for semantic issues (likely bugs, not definite errors)."""
-        results = []
-
-        for op in self.ir.operations:
-            # Empty postcondition
-            if op.ensures_is_trivially_true():
-                results.append(VerificationResult(
-                    status="FAIL",
-                    severity=Severity.WARNING,
-                    category=CheckCategory.SEMANTIC,
-                    message=f"Operation '{op.name}' has a trivially true "
-                            f"postcondition (ensures: true). It specifies "
-                            f"no observable behavior.",
-                    location=op.ensures_location,
-                    suggestion="Add postconditions describing what the "
-                               "operation accomplishes."
-                ))
-
-            # Trivially true precondition
-            if op.requires_is_trivially_true():
-                results.append(VerificationResult(
-                    status="FAIL",
-                    severity=Severity.WARNING,
-                    category=CheckCategory.SEMANTIC,
-                    message=f"Operation '{op.name}' has a trivially true "
-                            f"precondition (requires: true). It accepts "
-                            f"every input unconditionally.",
-                    location=op.requires_location,
-                ))
-
-        # Check for duplicate operations
-        for i, op1 in enumerate(self.ir.operations):
-            for op2 in self.ir.operations[i+1:]:
-                if self._operations_equivalent(op1, op2):
-                    results.append(VerificationResult(
-                        status="FAIL",
-                        severity=Severity.WARNING,
-                        category=CheckCategory.SEMANTIC,
-                        message=f"Operations '{op1.name}' and '{op2.name}' "
-                                f"appear to be functionally identical.",
-                        suggestion=f"Remove one of them or differentiate "
-                                   f"their behavior."
-                    ))
-
-        return results
+object Consistency:
+  def runConsistencyChecks(
+      ir: ServiceIR,
+      config: VerificationConfig,
+      dump: Option[DumpSink] = None
+  ): IO[ConsistencyReport] = ???  // see Consistency.scala
 ```
+
+Behavioural notes that diverge from the original Python sketch:
+
+- **No staged early-termination on type errors.** Z3/Alloy translation reports
+  `TranslatorLimitation` per affected check (skipped, not fatal); the rest of the run
+  continues. The CLI exit-code mapping in
+  [`ExitCodes.forCheckResults`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala)
+  surfaces translator gaps as exit `2` after the run.
+- **Per-check failures are data, not exceptions.** `runConsistencyChecks` returns
+  `IO[ConsistencyReport]` — failures stay inside `CheckResult.diagnostic`, so a
+  partial-pass run still yields a populated report. `IO[Either[VerifyError, _]]` is
+  reserved for parse / build / translator-level errors that abort the run.
+- **No `verify_incremental`.** Incremental verification is not on the current
+  roadmap; the gate runs all checks in parallel via `parTraverseN(maxParallel)`.
+- **Exit-code mapping** lives separately in `ExitCodes` (0 / 1 / 2 / 3) — see
+  [Verification Engine — Exit codes](/pipelines/verification#exit-codes).
+
 
 ### 9.5 How Verification Results Feed into the Compilation Pipeline
 

--- a/docs/content/docs/research/07_implementation_architecture.md
+++ b/docs/content/docs/research/07_implementation_architecture.md
@@ -7,6 +7,20 @@ description: "Compiler toolchain, parser technology, IR design, and build plan"
 > dependency choices, and build plan. This covers HOW we build the compiler itself -- not what it
 > compiles to.
 
+> **Status — actual decisions vs. this research doc.** This doc evaluated five compiler-host
+> languages and originally recommended TypeScript (§1.7). The shipped compiler runs on
+> **Scala 3.6.3** (see [Architecture](/design/architecture) for the live overview). The
+> language-comparison sketches in §1 are kept as historical context — they're "if we used
+> Python / Rust / TS / Go / Kotlin, here's what code would look like", not project source.
+> The Scala source of truth for each component is linked from the live docs:
+> [IR types](https://github.com/HardMax71/spec_to_rest/blob/main/modules/ir/src/main/scala/specrest/ir/Types.scala),
+> [parser](https://github.com/HardMax71/spec_to_rest/tree/main/modules/parser),
+> [verifier](https://github.com/HardMax71/spec_to_rest/tree/main/modules/verify),
+> [convention engine](https://github.com/HardMax71/spec_to_rest/tree/main/modules/convention),
+> [codegen](https://github.com/HardMax71/spec_to_rest/tree/main/modules/codegen),
+> [testgen](https://github.com/HardMax71/spec_to_rest/tree/main/modules/testgen),
+> [CLI](https://github.com/HardMax71/spec_to_rest/tree/main/modules/cli).
+
 ---
 
 ## Table of Contents
@@ -466,27 +480,34 @@ Weights: Parser, Z3, Alloy, Dafny integration weighted 1.5x (core compiler conce
 
 ### 1.7 Recommendation
 
-**Decision: TypeScript** for the compiler implementation (all phases).
+**Original research recommendation: TypeScript.** **Actual decision: Scala 3** (the
+shipped compiler lives in Scala 3.6.3 under `modules/`). The TypeScript recommendation
+was overruled during M0 in favour of the Kotlin-leaning `38` row of the comparative matrix
+above, generalised to the JVM. Drivers:
 
-Rationale:
+- Alloy 6 is a Java library (`org.alloytools:org.alloytools.alloy.core`) and Kodkod is
+  Java — JVM-native invocation without subprocess fragility was decisive.
+- Z3 via `tools.aqua:z3-turnkey` ships `libz3` natively for every supported OS/arch
+  (no system install, no WASM step) and exposes the full Z3 Java API.
+- Scala 3's `enum` ADTs with `derives CanEqual` give the IR exhaustive pattern-match
+  guarantees, with `Mirror`-based JSON via circe.
+- ANTLR4 has first-class Scala support via `sbt-antlr4`.
+- Cats Effect 3 + decline-effect + munit-cats-effect give the `IO`-typed pipeline,
+  per-check `Resource` lifecycle, and `parTraverseN` parallelism — see
+  [Concurrency and Cancellation](/pipelines/concurrency).
+- Lean 4 translation-validation certs (M_L track, [#88](https://github.com/HardMax71/spec_to_rest/issues/88))
+  emit a sibling Lake project that closes per-run theorems via `cert_decide`; the same
+  Scala-side translator drives both verification and cert emission.
 
-- ANTLR4 is available via the `antlr-ng` TypeScript target, providing a mature parser generator with
-  the TypeScript ecosystem's development velocity.
-- The `@anthropic-ai/sdk` is an official, production-grade Anthropic package for LLM integration.
-  OpenAI's Node SDK is equally mature.
-- TypeScript's discriminated union types and interfaces provide good IR modeling.
-- Distribution via `npm install -g spec-to-rest` or single-binary via `esbuild`/`bun` is adequate
-  for the target audience (developers).
-- The `z3-solver` npm package provides WASM-compiled Z3. For heavier workloads, the compiler can
-  shell out to the native Z3 binary.
-- A single language across the compiler, CLI, and potential IDE extension (LSP server) reduces
-  context switching and maximizes code reuse.
+The generated code targets are unchanged from the original recommendation
+(Python/FastAPI shipped today; Go/chi [#33](https://github.com/HardMax71/spec_to_rest/issues/33)
+and TS/Express [#35](https://github.com/HardMax71/spec_to_rest/issues/35) tracked as Phase 7
+work) — those are output targets, not the compiler's own implementation language.
 
-Note: The generated code targets (Python/FastAPI, Go/chi, TypeScript/Express) remain unchanged --
-those are output targets, not the compiler's own implementation language.
-
-The remainder of this document presents design examples in Python and TypeScript for illustrative
-purposes. The production compiler will be TypeScript throughout.
+The remainder of this document presents design examples in Python and TypeScript for
+illustrative comparison; the production compiler is Scala 3, and the live source of
+truth for the IR ADT is
+[`modules/ir/src/main/scala/specrest/ir/Types.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/ir/src/main/scala/specrest/ir/Types.scala).
 
 ---
 

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -18,62 +18,118 @@ long-term direction tracked under issue
 [#88](https://github.com/HardMax71/spec_to_rest/issues/88) and scoped in
 [Mechanically Verified Translator Soundness (research)](/research/10_translator_soundness).
 
+The authoritative grammar lives at
+[`modules/parser/src/main/antlr4/Spec.g4`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/parser/src/main/antlr4/Spec.g4);
+when in doubt, that file wins over this prose.
+
 ## Core concepts
 
 ### Services
 
 A `service` is the top-level unit. Each service maps to one REST API.
 
-```
+```spec
 service MyService {
-  // entities, operations, invariants
+  // entities, enums, type aliases, state, operations, invariants, conventions
 }
 ```
 
 ### Entities
 
-Entities define the data model. Each entity maps to a database table and a REST resource.
+Entities define the data model. Each entity maps to a database table and a REST resource. Field
+constraints attach via a `where` clause, not a default-value `=`. Per-entity `invariant:` clauses
+constrain the entity's own fields.
 
-```
-entity User {
-  id: Id
-  email: String
-  name: String
-  role: Role = Role.Member
-  created: DateTime = now()
+```spec
+entity Url {
+  code: ShortCode
+  target: String where isValidURI(value)
+  click_count: Int where value >= 0
+
+  invariant: click_count >= 0
 }
 ```
 
-Supported types: `String`, `Int`, `Float`, `Bool`, `DateTime`, `Duration`, `Id`, user-defined enums,
-and collection types (`Set<T>`, `Seq<T>`, `Map<K,V>`).
+Primitive types: `String`, `Int`, `Bool`, `Float`, `DateTime`, `Duration`, `UUID`. Collection
+constructors use `[ ]` (not `< >`): `Set[T]`, `Map[K, V]`, `Seq[T]`, `Option[T]`. User-defined
+`enum` and `entity` names are also valid types. Type aliases (`type ShortCode = String where ...`)
+let you name a constrained primitive once and reuse it.
+
+### State
+
+The `state { ... }` block declares the named, mutable fields the operations read and write. State
+fields can be scalars, sets, sequences, or relations (`A -> [one|lone|some|set] B`).
+
+```spec
+state {
+  store:    ShortCode -> lone String
+  metadata: ShortCode -> lone UrlMapping
+  base_url: String
+}
+```
+
+Inside `requires` / `ensures`, a bare state name (e.g. `store`) refers to the **pre-state**; a
+**primed** name (e.g. `store'`) refers to the **post-state**, following the TLA+ convention. `pre(e)`
+is an explicit pre-state cast for sub-expressions inside an `ensures` clause.
 
 ### Operations
 
-Operations define state transitions with pre/post conditions.
+Operations declare state transitions with pre/post conditions. There is **no** function-style
+signature — inputs and outputs go in their own clauses, and contract clauses use `requires:` /
+`ensures:` (with the colon).
 
-```
-operation CreateUser(email: String, name: String) -> User {
-  requires valid_email(email)
-  requires not store.exists(u => u.email == email)
-  ensures store'.contains(result)
-  ensures result.email == email
+```spec
+operation Shorten {
+  input:  url: String
+  output: code: ShortCode
+
+  requires:
+    isValidURI(url)
+
+  ensures:
+    code not in pre(store)
+    store' = pre(store) + {code -> url}
+    metadata'[code].url = url
+    metadata'[code].click_count = 0
 }
 ```
 
-- **`requires`** — preconditions (must hold before execution)
-- **`ensures`** — postconditions (must hold after execution)
-- **`store`** — the pre-state (before the operation)
-- **`store'`** — the post-state (after the operation), using TLA+ primed-variable convention
+- **`input:` / `output:`** — comma-separated `name: type` lists; both clauses are optional.
+- **`requires:`** — preconditions; one or more expressions, all conjoined.
+- **`ensures:`** — postconditions; one or more expressions, all conjoined.
 
 ### Invariants
 
-Invariants are properties that must hold across all states.
+Invariants are properties that must hold across all states. The body comes after a colon — there
+is no brace-block form. Invariants may be named or anonymous.
 
+```spec
+invariant unique_codes:
+  all c1, c2 in dom(store) |
+    store[c1] = store[c2] implies c1 = c2
 ```
-invariant unique_emails {
-  forall a, b in store: a.email == b.email => a == b
-}
+
+Quantifiers use the keywords `all`, `some`, `no`, `exists`. Bindings can be membership
+(`x in expr`) or type-named (`x: TypeName`). The body is separated from the bindings by a pipe
+(`|`), not a colon. Logical operators are word-form: `and`, `or`, `not`, `implies`, `iff`.
+Comparison is single `=` (not `==`); inequality is `!=`.
+
+### Functions and predicates
+
+User-defined helpers reduce duplication and feed both the verifier (inlined into VCs) and testgen
+(rendered as Python functions).
+
+```spec
+function days_until(deadline: DateTime, now: DateTime): Duration =
+  deadline - now
+
+predicate is_active(u: User) =
+  u.status = Status.Active and u.deleted_at = none
 ```
+
+The standard preamble auto-injects two predicates so every spec can use them without declaring
+them: `isValidURI(s: String)` and `isValidEmail(s: String)`. Recognized built-ins translate
+directly into Python and SMT-LIB: `len`, `dom`, `ran`, `max`, `min`, `now`, `days`, `sum`.
 
 ## Structural lints
 
@@ -122,45 +178,57 @@ the generated tests rather than emitted as `pytest.skip` notes.
 | `If`, `Let`, `SetLiteral`, `SeqLiteral`, `MapLiteral`, `Constructor`, `With` | `Quantifier` with `Colon` typing |
 | `Quantifier` (`All`/`Some`/`Exists`/`No` over `in`-bindings) | `Call` to an undeclared function (neither built-in nor in `ir.functions`/`ir.predicates`) |
 | `SetComprehension`, `Lambda`, `Matches`, `The`, `SomeWrap` | — |
-| recognized built-ins: `len`, `dom`, `ran`, `isValidURI`, `valid_email`, `max`, `min`, `now`, `days`, `sum`, user-declared `function`/`predicate` calls, indirect call (lambda applied) | — |
+| recognized built-ins: `len`, `dom`, `ran`, `max`, `min`, `now`, `days`, `sum`, plus preamble `isValidURI` / `isValidEmail` and user-declared `function` / `predicate` calls | — |
 | bare enum-member identifiers resolve to string literals | — |
 
-Empirical skip rates on the canonical fixtures (locked in CI): `safe_counter`,
-`url_shortener`, `todo_list`, `edge_cases` all 0.0%; `ecommerce` 2.6% (parser scope leak in
-multi-clause `let ... in` body); `auth_service` 15.0% (undeclared `hash`/
-`recentFailedAttempts` calls). See [Test Generation pipeline](/pipelines/test-generation)
-for the full surface.
+Empirical skip rates on the canonical fixtures (locked in
+[`SkipRateProbeTest`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala)):
+`safe_counter`, `url_shortener`, `todo_list`, `edge_cases` all 0.0%; `ecommerce` 2.6%
+(2 / 76 — parser scope leak in multi-clause `let ... in` body); `auth_service` 15.0%
+(6 / 40 — undeclared `hash` / `recentFailedAttempts` calls). See
+[Test Generation pipeline](/pipelines/test-generation) for the full surface.
 
 ## Convention overrides
 
-Default REST/DB mappings can be overridden per-operation:
+Default REST/DB mappings are overridden in a service-wide `conventions { ... }` block (per-operation
+`with` clauses are not part of the grammar). Each rule has the shape
+`Target.property [qualifier] = value`, where `qualifier` is a string literal used by
+`http_header` and `test_strategy`.
 
-```
-operation Resolve(code: String) -> Url
-  with { http_method = "GET", http_path = "/{code}" }
-{
-  // ...
+```spec
+conventions {
+  Shorten.http_method         = "POST"
+  Shorten.http_path           = "/shorten"
+  Shorten.http_status_success = 201
+
+  Resolve.http_method         = "GET"
+  Resolve.http_path           = "/{code}"
+  Resolve.http_status_success = 302
+  Resolve.http_header "Location" = output.url
+
+  UrlMapping.db_table = "url_mappings"
+  UrlMapping.plural   = "url_mappings"
+  ShortCode.strategy  = "tests.strategies_user:short_code"
 }
 ```
 
-A service-wide `conventions { ... }` block targets operations, entities, type
-aliases, and enums by name. Each property is valid against a specific target
-kind:
+Each property is valid against a specific target kind:
 
-| Property              | Valid targets        |
-|-----------------------|----------------------|
-| `http_method`         | operation            |
-| `http_path`           | operation            |
-| `http_status_success` | operation            |
-| `http_header`         | operation            |
-| `db_table`            | entity               |
-| `db_timestamps`       | entity               |
-| `plural`              | entity               |
-| `strategy`            | type alias, enum     |
+| Property              | Valid targets        | Notes |
+|-----------------------|----------------------|-------|
+| `http_method`         | operation            | `"GET" "POST" "PUT" "PATCH" "DELETE"` |
+| `http_path`           | operation            | string literal, `{param}` placeholders allowed |
+| `http_status_success` | operation            | integer status code |
+| `http_header`         | operation            | requires a string-literal qualifier (header name) |
+| `db_table`            | entity               | string literal |
+| `db_timestamps`       | entity               | bool |
+| `plural`              | entity               | string literal — pluralized URL segment |
+| `strategy`            | type alias, enum     | `"module:symbol"` Hypothesis strategy |
+| `test_strategy`       | entity               | requires a field-name qualifier; `EntityName.test_strategy.field = "module:fn"` |
 
-The `strategy` property points testgen at a user-supplied Hypothesis strategy:
-`<TypeAliasOrEnum>.strategy = "module:symbol"`. See
-[Test Generation pipeline — Custom strategies](/pipelines/test-generation) for
-the integration with `--with-tests` and the `--strict-strategies` CI gate.
+The `strategy` and `test_strategy` properties point testgen at user-supplied Hypothesis
+strategies. See
+[Test Generation pipeline — Custom strategies](/pipelines/test-generation) for the
+integration with `--with-tests` and the `--strict-strategies` CI gate.
 
 See [Convention Engine](/design/convention-engine) for the full mapping rules.

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -34,6 +34,7 @@ for the full contract.
 | Migration tool  | Alembic ≥1.14                             |
 | Database        | PostgreSQL 17 (via `asyncpg`)             |
 | Validation      | Pydantic v2 + `pydantic-settings`         |
+| Logging         | `structlog` 24+ with sensitive-key redactor |
 | HTTP server     | Uvicorn (`uvicorn[standard]`)             |
 | Package manager | `uv` (Astral)                             |
 | Async mode      | `async def` end-to-end                    |
@@ -56,8 +57,8 @@ url_shortener/                                 # emitted project root
 ├── .github/workflows/                         # CI
 │   └── ci.yml                                 # install · lint · typecheck · test
 ├── .gitignore
-├── Dockerfile                                 # python:3.12-slim · uvicorn entry
-├── Makefile                                   # install / run / test / migrate / docker-up
+├── Dockerfile                                 # python:3.13-slim-bookworm · uvicorn entry
+├── Makefile                                   # install / run / test / lint / typecheck / migrate / docker-up / test-conformance(-docker) / clean
 ├── README.md                                  # warns: regeneration overwrites
 ├── alembic.ini
 ├── alembic/                                   # migrations
@@ -69,6 +70,7 @@ url_shortener/                                 # emitted project root
 │   ├── config.py                              # pydantic-settings, reads .env
 │   ├── database.py                            # async engine + session factory
 │   ├── main.py                                # FastAPI() + router registration
+│   ├── redaction.py                           # structlog processor that masks SensitiveFields keys
 │   ├── db/                                    # SQLAlchemy declarative base
 │   │   ├── __init__.py
 │   │   └── base.py
@@ -84,12 +86,19 @@ url_shortener/                                 # emitted project root
 │   └── services/                              # business logic invoked by routers
 │       ├── __init__.py
 │       └── url_mapping.py
-├── docker-compose.yml                         # api + postgres stack
+├── docker-compose.yml                         # api + postgres + migrations stack
 ├── openapi.yaml                               # OpenAPI 3.1 — see live viewer below
 ├── pyproject.toml                             # uv-managed deps · ruff · mypy
 └── tests/
-    └── test_health.py                         # liveness probe smoke
+    ├── test_health.py                         # liveness probe smoke
+    └── test_log_redaction.py                  # asserts app/redaction.py masks sensitive keys
 ```
+
+`tests/test_admin.py` (admin router), `tests/test_behavioral_*.py`,
+`tests/test_stateful_*.py`, `tests/test_structural_*.py`, plus `tests/conftest.py`,
+`tests/predicates.py`, `tests/strategies.py`, `tests/strategies_user.py`,
+`tests/redaction.py`, `tests/run_conformance.py`, and `tests/_testgen_skips.json`
+appear only with `--with-tests`. See [Test Generation](/pipelines/test-generation).
 
 Multi-entity specs (e.g. `fixtures/spec/ecommerce.spec`) produce one parallel
 `app/models/<entity>.py`, `app/schemas/<entity>.py`, `app/routers/<entities>.py`, and
@@ -268,13 +277,25 @@ Template: `modules/codegen/src/main/resources/templates/python-fastapi-postgres/
 
 ### CI workflow
 
-GitHub Actions workflow with two jobs:
+GitHub Actions workflow triggered on push/PR to `main` plus a nightly
+`schedule: '0 2 * * *'`. Two jobs (the second `needs: test`):
 
-- **test** — installs `uv`, runs ruff + mypy + alembic migrations + pytest, starts the app as a
-  background process, waits for `/health`, then runs
-  `schemathesis run openapi.yaml --stateful=links`. Postgres is provided by the `services:`
-  block.
-- **docker** — smoke test of `docker compose up -d --build` followed by a `/health` curl.
+- **test** — installs `uv`, sets up Python 3.13, syncs deps, runs `ruff check app/`,
+  `mypy app/`, `alembic upgrade head`, then `pytest tests/test_health.py`. After unit
+  tests pass it boots the app in the background with `ENABLE_TEST_ADMIN=1` (required by
+  the admin router the conformance suite uses), waits up to 30 s for `/health`, and runs
+  `make test-conformance PROFILE=$SPEC_TEST_PROFILE`. The profile is `exhaustive` on
+  scheduled runs and `thorough` otherwise — selected via
+  `${{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}`. JUnit XML
+  results from the conformance phases are uploaded as an artifact on every run
+  (`if: always()`). Postgres is provided by the workflow's `services:` block
+  (`postgres:17-alpine`).
+- **docker** — `cp .env.example .env`, `docker compose up -d --build`, smoke `/health`
+  with a 60 s timeout, then `docker compose down -v` (in `if: always()`).
+
+Schemathesis is invoked **inside** the conformance suite (the `tests/test_structural_*.py`
+files emitted by `--with-tests`), not directly from the workflow — see
+[Test Generation — Structural tests](/pipelines/test-generation#structural-tests-m53).
 
 Template: `modules/codegen/src/main/resources/templates/python-fastapi-postgres/github/workflows/ci.yml.hbs`
 (the leading dot is removed from the resource path since sbt's default `HiddenFileFilter` excludes

--- a/docs/lib/git-timestamp.ts
+++ b/docs/lib/git-timestamp.ts
@@ -1,12 +1,13 @@
 import { execSync } from "node:child_process";
+import { statSync } from "node:fs";
 import path from "node:path";
 
 const REPO_ROOT = path.resolve(process.cwd(), "..");
 
-export function getGitLastModified(repoRelPath: string): Date | null {
+function gitCommittedDate(repoRelPath: string): Date | null {
   try {
     const out = execSync(
-      `git log -1 --pretty=format:%cI -- ${JSON.stringify(repoRelPath)}`,
+      `git log -1 --follow --pretty=format:%cI -- ${JSON.stringify(repoRelPath)}`,
       { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "ignore"] },
     )
       .toString()
@@ -16,4 +17,19 @@ export function getGitLastModified(repoRelPath: string): Date | null {
   } catch {
     return null;
   }
+}
+
+function fileMtime(repoRelPath: string): Date | null {
+  try {
+    return statSync(path.resolve(REPO_ROOT, repoRelPath)).mtime;
+  } catch {
+    return null;
+  }
+}
+
+export function getGitLastModified(repoRelPath: string): Date | null {
+  const committed = gitCommittedDate(repoRelPath);
+  const mtime = fileMtime(repoRelPath);
+  if (committed && mtime) return mtime > committed ? mtime : committed;
+  return committed ?? mtime;
 }


### PR DESCRIPTION
## Summary

Cross-checked every page in \`docs/content/docs/\` against the actual source under \`modules/\`, fixed factual drift, removed fabricated examples, and converted \"in our project we do X\" Python sketches in \`research/\` to Scala matching the live ADTs.

The \"Last updated\" timestamp also now renders at the page header (under the description) instead of at the bottom, and accounts for working-tree mtime so uncommitted edits don't leave it stale.

### Top-level

- **\`index.mdx\`** — real spec syntax (no fake \`operation Foo(x): ->\`), real verdict format (\`Op.preserves.invariant\`), real FastAPI router output (no fake \`response_model=\`/\`response_class=\`); accurate comparison table; \`--emit-cert\` callout for Lean cert capability.
- **\`spec-language.mdx\`** — corrected operation/entity/invariant grammar; \`UUID\` (not \`Id\`) primitive; \`Set[T]\`/\`Map[K, V]\` (not \`<>\`); \`all\`/\`some\`/\`exists\` (not \`forall\`); conventions block (no per-op \`with\`); added \`test_strategy\` property; pointer to \`Spec.g4\`.
- **\`design/architecture.mdx\`** — removed Dafny/CEGIS/Go/TS-as-current claims; replaced fictional 20-week build plan with real roadmap status table; added Lean cert + cvc5 cross-check + lint/ + testgen/ + CI workflow surface.
- **\`design/convention-engine.mdx\`** — rewrote the M1–M10 table from \`Classify.scala\` (the page had fictional mappings); dropped fake per-op \`with { ... }\` and fake 4 deployment profiles; added Path / Schema / Naming subsections.

### Pipelines

- **\`verification.mdx\`** — live-verified summary-line format and verbose output (no \`verbose\` literal prefix; \`[z3]\`/\`[alloy]\` tag); fixed worked-example spans/values for \`broken_url_shortener.spec\` and \`unsat_invariants.spec\`; added missing CLI flags (\`--alloy-scope\`, \`--dump-vc\`, \`--emit-cert\`, \`--explain\`, \`--dump-alloy\`, \`-q\`); added \`narrative\` field to JSON example; added Lean cert subsection.
- **\`test-generation.mdx\`** — added \`tests/redaction.py\` to file table; fixed positive ensures (missing \`assume\`), negative test (real \`400 <= ... < 500\` range, missing \`@settings\`), invariant test (missing \`pre_state\` / \`response_data\`); \`_testgen_skips.json\` reasons match current emitter including \`structural_skipped\` array.
- **\`mutation-testing.mdx\`** — real workflow details (Postgres 17, \`timeout-minutes: 90\`); pseudocode mirrors real step bodies; replaced fabricated \`url_shortener.py\` mutation diff with real \`url_mapping.py\` \`list_all\` (M4-stub services dominate today); fixed \`<service>.py\` → \`<entity>.py\`; linked #149 / #161.
- **\`concurrency.mdx\`** — fixed Alloy resource-finalizer claims: \`AlloyBackend.close()\` is a no-op, the executor pool is per-call inside \`check()\`'s \`try/finally\`, not Resource-managed; updated mermaid + SIGINT prose accordingly.

### Targets

- **\`python-fastapi-postgres.mdx\`** — Dockerfile annotation now reads \`3.13-slim-bookworm\` (not \`3.12\`); added \`app/redaction.py\` and \`tests/test_log_redaction.py\` to file tree; rewrote CI section to match the real workflow (\`make test-conformance\` not direct \`schemathesis run\`; cron-based \`exhaustive\`/\`thorough\` profile selection); added \`structlog\` row to at-a-glance.

### Research

- **\`02_convention_engine.md\`** — converted \`EntityInfo\`, \`OperationClassification\`, \`ConventionRule\`, \`HTTP_METHOD_RULES\`, \`resolve(...)\`, \`ConventionOutput\` family, \`ProfilePlugin\`, and unit-test sketches from Python to Scala matching shipped ADTs in \`modules/convention/Types.scala\`. Kept generated FastAPI/pydantic blocks (output, not project source).
- **\`03_llm_verifier_synthesis.md\`** — added status banner: Phase 6 (Dafny + LLM + CEGIS) is unstarted, links to #27–#32.
- **\`04_code_generation_pipeline.md\`** — status banner; converted \`ServiceIR\`/\`OperationIR\` Python dataclasses to Scala matching \`ir/Types.scala\`; rewrote Kotlin-Spring plugin example to match shipped \`Registry.scala\` pattern.
- **\`05_test_generation.md\`** — refreshed status banner; pointed at the live pipelines page.
- **\`06_spec_verification.md\`** — replaced 388-line Python \`SpecVerifier\` API design with a concise Scala sketch matching shipped \`Consistency.runConsistencyChecks\` + the real \`Diagnostic\` / \`CheckResult\` / \`CheckKind\` / \`CheckOutcome\` / \`VerifierTool\` / \`DiagnosticCategory\` ADTs.
- **\`07_implementation_architecture.md\`** — top-of-doc banner: original recommendation was TypeScript, actual decision is Scala 3; updated §1.7 with the six concrete drivers.

### Header timestamp wiring

- **\`docs/lib/git-timestamp.ts\`** — \`max(git committed date, working-tree mtime)\` + \`--follow\` so renames keep history; uncommitted edits no longer leave the displayed date stale.
- **\`docs/app/(docs)/[[...slug]]/page.tsx\`** — renders \`Last updated: <Month Day, Year>\` under the page description (was previously at the page bottom via the \`DocsPage lastUpdate\` prop). Per-page date is computed from each page's own MDX path.

## Test plan

- [x] \`cd docs && npm run build\` — passes locally, link check clean (26 HTML files scanned).
- [x] Per-page dates verified to differ across pages by grepping the build output (8 distinct dates across pages).
- [ ] Visual review on Vercel preview deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes docs across top-level, pipelines, targets, and research to match the shipped Scala implementation, removing fabricated examples and fixing outdated claims. Adds an accurate per‑page “Last updated” header.

- **New Features**
  - Shows “Last updated: <Month Day, Year>” under the page description. Date is the max of git committed time (with `--follow`) and file mtime, so renames and uncommitted edits are reflected.

- **Refactors**
  - Top-level and language: real spec grammar and verdicts; corrected primitives/quantifiers; linked to `Spec.g4`.
  - Pipelines: updated verification flags/output incl. Lean certs; fixed test-gen examples and added `tests/redaction.py`; documented mutation-testing workflow (Postgres 17, 90‑min job timeouts); corrected Alloy concurrency details.
  - Target (`python-fastapi-postgres`): Python `3.13-slim-bookworm`, added `structlog`, updated CI flow to `make test-conformance`.
  - Research: converted Python sketches to Scala matching shipped ADTs; added status banners clarifying shipped vs. planned scope; aligned examples with `ir/Types.scala` and `convention/Types.scala`.

<sup>Written for commit 5877fca877400b4e4256e645ff575d99de867b0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all documentation to reflect the current shipped implementation (Scala 3 compiler, Python-FastAPI-PostgreSQL target).
  * Clarified verification pipeline capabilities, including Lean translation-validation certificates (`--emit-cert`).
  * Expanded test generation and CI/CD documentation with concrete examples.
  * Made language reference grammar-driven via ANTLR grammar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->