### PR TITLE
#192 — Production routing via extracted translator + strict-soundness default

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -69,7 +69,8 @@ CLI output so the attribution is visible.
 | Concurrency docs (`docs/content/docs/pipelines/concurrency.mdx`) + JMH `ParallelVerifyBench` with checked-in CSV at `fixtures/golden/bench/parallel_verify.csv` | shipped in M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) |
 | Property-based tests for the Z3/Alloy translators (translation determinism on identical IRs, free-identifier resolution against `TranslatorArtifact`, structural invariant preservation between Z3 and Alloy) via `scalacheck-effect-munit` | shipped ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)) — `modules/verify/src/test/scala/specrest/verify/TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset from research/10 |
 | Mechanically verified translator soundness in Isabelle/HOL: universal `soundness` theorem in `proofs/isabelle/SpecRest/Soundness.thy` closes with zero `sorry` over the verified subset; `Code_Target_Scala` extracts `translate`/`eval`/`smt_eval` plus the canonical IR ADT to `modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala` | shipped via the Isabelle pivot ([#193](https://github.com/HardMax71/spec_to_rest/issues/193)); IR canonicalized in [#202](https://github.com/HardMax71/spec_to_rest/issues/202); CI runs `isabelle build SpecRest` per PR via `.github/workflows/isabelle-build.yml`. Per-run cert emission deleted post-pivot — universal soundness made it vestigial. |
-| Per-check Trust dimension + `--strict-soundness` flag — each `CheckResult` carries `trust: "sound" \| "best-effort"` driven by the extracted Isabelle `lower` projection; `--strict-soundness` short-circuits best-effort checks to `Skipped` (`category=soundness_limitation`) before backend dispatch; new exit code 4 (`ExitCodes.Trust`) | shipped ([#205](https://github.com/HardMax71/spec_to_rest/issues/205)) — JSON `schemaVersion` 1→2; default routing unchanged when the flag is absent |
+| Per-check Trust dimension — each `CheckResult` carries `trust: "sound" \| "best-effort"` driven by the extracted Isabelle `lower` projection; best-effort checks short-circuit to `Skipped` (`category=soundness_limitation`) before backend dispatch; new exit code 4 (`ExitCodes.Trust`) | shipped ([#205](https://github.com/HardMax71/spec_to_rest/issues/205)) — JSON `schemaVersion` 1→2 |
+| Production verify path routes in-subset checks via the extracted (Isabelle-verified) translator — `Translator.translateExpr` calls `lower(enums, e)`; on `Some` it routes through `SpecRestGenerated.translate >>> SmtTermToZ3`, on `None` falls back to the hand-written translator (used only by declaration-level expressions and out-of-subset shapes). Best-effort checks at the verify level always skip with `soundness_limitation` (no flag) | shipped ([#192](https://github.com/HardMax71/spec_to_rest/issues/192)) |
 
 </Collapsible>
 
@@ -399,7 +400,7 @@ import { TypeTable } from 'fumadocs-ui/components/type-table';
 | `1` | Specification or spec-file issue: at least one ran check failed (unsat / preservation `sat` / timeout), **or** the spec could not be read / parsed / IR-built. |
 | `2` | Translator coverage gap: the verifier hit an unsupported construct, either when translating the whole spec (e.g., under `--dump-smt`) or while running individual checks. In normal check runs affected checks surface as `skipped`; other checks may still pass. |
 | `3` | Backend error (solver init failure or solver crash). |
-| `4` | Soundness coverage gap (only emitted under `--strict-soundness`): at least one check was skipped because its source exprs fall outside the Isabelle `lower` projection, and no higher-precedence outcome (Backend / Violation / Translator) was raised. |
+| `4` | Soundness coverage gap: at least one check was skipped because its source exprs fall outside the Isabelle `lower` projection, and no higher-precedence outcome (Backend / Violation / Translator) was raised. |
 
 Precedence (highest → lowest): Backend (3) → Violation (1) → Translator (2) → Trust (4) → Ok (0).
 A backend crash always wins over a translator gap; a violation always wins over a soundness gap.
@@ -407,9 +408,11 @@ A backend crash always wins over a translator gap; a violation always wins over 
 Exit `2` is a partial-success signal — the spec *may* still be correct, but the verifier could
 not fully discharge every check. Skipped checks print as warnings with a `translator_limitation`
 diagnostic so CI / editors can surface the coverage gap alongside successes. Exit `4` is the same
-shape but driven by `--strict-soundness`: the skipped checks carry a `soundness_limitation`
-diagnostic instead, signalling the spec uses constructs the formal soundness theorem does not yet
-cover (rather than constructs the translator does not handle).
+shape but driven by the verified subset: the skipped checks carry a `soundness_limitation`
+diagnostic, signalling the spec uses constructs the formal soundness theorem does not yet cover
+(rather than constructs the translator does not handle). Verify routes every check that *does*
+run through the extracted (Isabelle-verified) translator; checks that would route through the
+hand-written translator at the *check-body* level always skip instead.
 
 ## Inspecting the SMT-LIB
 
@@ -437,10 +440,9 @@ file and keeps stdout clean. Either flag can compose with `--explain` (core span
 JSON) and `--dump-vc <dir>` (VC artifacts go to the dir, JSON to stdout/file).
 
 Exit codes (text and JSON modes alike): `0` pass, `1` violation, `2` translator gap, `3`
-backend error, `4` soundness gap (only emitted when `--strict-soundness` is active and at
-least one check was skipped because its source exprs fall outside the verified subset).
-Backend errors take precedence over violations and over soundness gaps; the JSON complements
-the exit signal rather than replacing it.
+backend error, `4` soundness gap (at least one check was skipped because its source exprs fall
+outside the verified subset). Backend errors take precedence over violations and over soundness
+gaps; the JSON complements the exit signal rather than replacing it.
 
 Combining `--json` / `--json-out` with `--dump-smt` / `--dump-alloy` is rejected with a clear
 error: the dump flags short-circuit before any checks run, so there is no report to serialize.

--- a/docs/content/docs/research/10_translator_soundness.md
+++ b/docs/content/docs/research/10_translator_soundness.md
@@ -1367,30 +1367,35 @@ as a user-directed architectural cleanup.
 | 5 | Scala wrapper layer in `Types.scala` (extracted types used directly; thin layer) | shipped (PR #204) |
 | 6 | Parser migration | shipped (PR #204) |
 | 7 | Codegen + testgen migration | shipped (PR #204) |
-| 8 | Verify migration | shipped (PR #204); `lower`-backed Trust dim. + `--strict-soundness` flag landed under #205 (Phase C-flagged) |
+| 8 | Verify migration | shipped (PR #204); `lower`-backed Trust dim. + `--strict-soundness` flag landed under #205 (Phase C-flagged); strict-soundness flipped to default-on and extracted-translator routing landed under #192 |
 | 9 | CLI migration; delete legacy `Types.scala` enum | shipped (PR #204) |
 | 10 | Audit cleanup; doc/CI sweep | 10a doc sweep shipped (PR #204); 10b audit cleanup + `lower` v2 (`QuantifierF` 4 kinds, multi-binding, multi-field `WithF`) shipped in close-out PR |
 
-### 17.7 Trust surface (issue #205, Phase C-flagged)
+### 17.7 Trust surface (issues #205 → #192)
 
-`lower` shipped as a runtime projection in #202; #205 wires it into the verifier surface
-as a per-check **Trust dimension**, not a routing change.
+`lower` shipped as a runtime projection in #202; #205 wired it into the verifier surface
+as a per-check **Trust dimension** behind a `--strict-soundness` flag; #192 promoted strict
+soundness to the default and routed in-subset checks through the verified extracted
+translator on the production verify path.
 
 - **`CheckResult.trust: TrustLevel`** — `Sound` if every source `expr_full` for the check
   lowers to the verified subset; `BestEffort` otherwise. Visible in:
   - CLI line: `[sound]` / `[best-effort]` tag between the tool tag and the check id.
   - JSON report: `"trust": "sound" | "best-effort"` per check object. Schema bumped 1→2.
-- **`--strict-soundness` flag** on `verify`: any check with `trust = BestEffort` is
-  short-circuited to `Skipped` with `category = soundness_limitation` **before** backend
-  dispatch. Default routing is unchanged when the flag is absent — no fixture regresses.
+- **Best-effort checks always skip with `category = soundness_limitation`** before backend
+  dispatch (no flag — this is the default since #192). The `--strict-soundness` flag and
+  its CLI surface were retired.
+- **Sound checks route via extracted translator.** `Translator.translateExpr` calls
+  `lower(enums, e)`; on `Some` it routes through `SpecRestGenerated.translate` (the
+  Isabelle-extracted function) and then a small `SmtTermToZ3` bridge (~250 LOC,
+  hand-written) to reach Z3. On `None` the hand-written `translateExprRaw` runs — but only
+  for *declaration-level* expressions (entity field constraints, type-alias `where`-clauses);
+  out-of-subset check-body shapes are filtered to skip by the Trust classifier before
+  ever reaching the translator.
 - **Exit code 4 (`ExitCodes.Trust`)**: emitted when soundness skips are the only reason
   the run isn't clean. Subordinate to Backend (3), Violations (1), Translator (2).
-- **Routing was deliberately not switched.** Issue #205 Option A (route-to-Alloy when
-  `lower` returns `None`) would force shapes Z3 handles cleanly (e.g. `pre(rel)[k] with
-  {…}`, `MapLiteralF`) onto Alloy, which has never been asked to handle them. Empirically
-  on `auth_service.spec`: 5 of 7 default-routing failures disappear under
-  `--strict-soundness` because they were already shapes outside the verified subset; the
-  flag exposes that cleanly without forcing Alloy.
+- **TCB audit** lives at `docs/research/11_tcb_audit.md` — the single ledger of what
+  `verify`'s verdicts actually depend on.
 
 | Coverage v2 (post-#206) | `lower` returns | Trust |
 |---|---|---|

--- a/docs/content/docs/research/11_tcb_audit.md
+++ b/docs/content/docs/research/11_tcb_audit.md
@@ -1,0 +1,179 @@
+---
+title: TCB audit
+description: What's verified, what's trusted, and the boundary between them after the extracted-translator routing landed.
+---
+
+This page enumerates the **trusted computing base (TCB)** for `spec-to-rest verify` — the set of
+components whose correctness must be assumed for the verifier's verdicts to mean what they claim.
+Anything in TCB is *not* the soundness theorem proving anything about it; the rest of the system is
+either machine-verified or out of the soundness scope.
+
+It exists because issue [#192](https://github.com/HardMax71/spec_to_rest/issues/192) AC #6 says
+"TCB documented and audited" and the answer was previously distributed across several research
+notes. This page is the single ledger.
+
+## Verdict semantics, recapped
+
+`verify` issues per-check verdicts of one of:
+
+- **`sat`** — the check holds. Z3 found no counterexample within the timeout.
+- **`unsat`** — the check fails. Z3 (or Alloy) produced a model violating the property.
+- **`unknown`** — Z3 timed out or hit incompleteness; result indeterminate.
+- **`skipped`** — the check was not run; the diagnostic categorizes why.
+
+Each verdict carries a **trust tag** in the JSON report:
+
+- `trust: "sound"` — the check ran end-to-end through the extracted (Isabelle-verified) translator.
+  If the verdict is `sat` or `unsat`, the soundness theorem applies (modulo TCB below).
+- `trust: "best-effort"` — the check would have routed through the hand-written translator at the
+  check-body level. As of [#192](https://github.com/HardMax71/spec_to_rest/issues/192) such checks
+  always skip with `category=soundness_limitation` rather than producing a verdict.
+
+So the practical guarantee is: **every non-skipped Z3 verdict is `trust=sound`**, backed by the
+universal soundness theorem in `proofs/isabelle/SpecRest/Soundness.thy`.
+
+## The verify pipeline, layer by layer
+
+```mermaid
+flowchart TD
+  A[spec source] --> B[Parser + IR builder]
+  B -->|expr_full| C{Trust.classify}
+  C -->|Sound: every body expr lowers| D[Verified path]
+  C -->|BestEffort: any expr does not lower| E[Skipped]
+  D --> F[Translator entry — declarations]
+  F --> G[per-check expr_full]
+  G --> H[lower :: expr_full ⇒ expr]
+  H --> I[translate :: expr ⇒ smt_term]
+  I --> J[SmtTermToZ3 bridge]
+  J --> K[Z3 JNI]
+  K --> L[Verdict]
+```
+
+Every box's correctness obligation:
+
+| Layer | Component | Status |
+|---|---|---|
+| Parse | `modules/parser/.../Parser.scala`, `Builder.scala` | **Trusted** — hand-written. Build errors surface as exit 1. |
+| Classifier | `Trust.classify`, `Classifier` | **Trusted** — hand-written, but limited to *which* path runs; classification errors only cause spurious skips, not unsoundness. |
+| `lower` projection | extracted from `IR.thy` via `Code_Target_Scala`, lives at `modules/ir/.../SpecRestGenerated.scala` | **Verified** — proven total in Isabelle. Returns `None` for shapes outside the subset. |
+| `translate` (verified) | extracted from `Translate.thy`. Same generated file. | **Verified** — `translate :: expr ⇒ smt_term` is the function the soundness theorem talks about. |
+| `Code_Target_Scala` extraction | Isabelle stock tool | **Trusted** — production-grade, used by Stainless/Leon, but not formally verified end-to-end. |
+| `SmtTermToZ3` bridge | new in #192, lives in `modules/verify/.../z3/Translator.scala` (private nested object) | **Trusted** — hand-written, ~250 LOC. Converts `smt_term` to `Z3Expr` for the JNI driver. |
+| Hand-written `translateExpr` | same file, ~1900 LOC | **Trusted but bypassed for sound checks** — invoked only for declaration-level expressions (entity field constraints, type-alias `where`-clauses); on the check-body path, lower→bridge runs instead. |
+| Sort inference, Z3 declaration management, set-of-T monomorphization, Skolem allocation, span threading | hand-written, in `Translator.scala` | **Trusted** — outside the soundness statement; runs before/around the bridge. |
+| Z3 SMT solver (`com.microsoft.z3`) | external | **Trusted** — incomplete on quantifiers + nonlinear arithmetic + theory combinations. UNSAT verdicts are sound; SAT/Unknown can be solver artifacts. |
+| Counterexample decoder | `modules/verify/.../z3/CounterExample.scala` | **Trusted** — hand-written; outside soundness. |
+| Alloy backend | `modules/verify/src/main/scala/specrest/verify/alloy/*` | **Trusted** — separate bounded-model-checking story, not subject to `lower`. |
+
+## What "verified" means, exactly
+
+The Isabelle theorem in `Soundness.thy` is:
+
+```text
+theorem soundness:
+  fixes e :: expr and env :: env
+  shows "eval env e = smt_eval env (translate e)"
+```
+
+That is, for every constructor `e` in the verified subset (the ADT defined in `IR.thy`), the
+denotational `eval` agrees with the SMT-side `smt_eval` after translation. The theorem closes
+with zero `sorry` and is checked by `isabelle build SpecRest` in CI.
+
+What it does **not** claim:
+
+- It says nothing about Z3's actual evaluation. The bridge converts `smt_term` to `Z3Expr` and Z3
+  evaluates that. Z3's correctness is in TCB.
+- It says nothing about IR shapes outside the subset. `lower` returns `None` for those, and
+  verify skips the check.
+- It says nothing about declaration-level expressions (entity field constraints, etc.) — those
+  still run through the hand-written translator. The check-body level is where soundness lives.
+- It says nothing about the parser, builder, or sort inference. Errors there cause the verifier
+  to report failures or skips, but the *meaning* of those failures is set by the hand-written
+  layer.
+
+## Net TCB delta, before vs. after #192
+
+Before #192:
+
+- Hand-written `translateExpr` end-to-end for every check (~1900 LOC).
+- Soundness theorem existed but only the A8 round-trip oracle exercised the verified path on 24
+  canonical probes — that test set was too small to call the production path "verified."
+
+After #192:
+
+- Hand-written `translateExpr` reduced to declaration-level expressions only (~hundreds of LOC
+  reachable on a typical spec).
+- Check-body translation routes through verified `lower → translate` plus the new
+  `SmtTermToZ3` bridge (~250 LOC, new TCB).
+- Net hand-written check-body code in TCB: roughly half of `translateExpr`'s 1900 LOC replaced by
+  the much smaller bridge + verified extraction. Best-effort checks no longer produce unsound
+  verdicts at all — they skip.
+
+The bridge is the only piece of *new* TCB. It is small, syntax-directed, and structurally
+constrained: each `smt_term` constructor maps to one or two `Z3Expr` shapes, with sort checks at
+the boundaries. The rest of the trust closure either shrinks or stays the same.
+
+## Where TCB grows that the soundness theorem cannot reach
+
+The bridge handles edge cases the verified `smt_term` ADT does not distinguish:
+
+- **`TInDom(name, _)` over a set-typed state constant.** The verified semantics expects a relation;
+  a set constant is treated as set-membership. This is sound under the well-typed-IR assumption but
+  is not formally backed by the soundness theorem.
+- **`TForallRel(v, name, _)` where `name` is a set-typed constant or operation input.** Bridge
+  emits a quantifier with a set-membership guard or, for genuinely unknown sorts, an
+  unconstrained quantifier (matching the hand-written translator's pre-#192 behavior).
+- **`TSetMember`, `TSetUnion`, `TSetIntersect`, `TSetDiff`** sort checks. The bridge replicates the
+  hand-written translator's sort-mismatch errors so ill-typed specs surface a translator-level
+  diagnostic rather than a Z3 solve-time failure.
+
+These cases are documented here so a reviewer auditing TCB knows exactly which corners of the
+bridge sit *outside* the soundness theorem's reach. They are necessary because `expr_full` and the
+verified `expr` ADT make different distinctions; the bridge has to bridge that gap somewhere.
+
+## What is permanently *not* in scope for verification
+
+The Isabelle subset will not, on any reasonable horizon, cover:
+
+- **Regex matching (`MatchesF`).** Z3's string theory is slow and incomplete; the soundness story
+  for arbitrary regex against strings is its own multi-month theory project.
+- **Calls to user-defined `fun` predicates with arbitrary bodies.** Per-spec inlining can extend
+  soundness to specific bodies but cannot anticipate every shape a spec author writes.
+- **Aggregate forms over unbounded universes** (e.g., `MapLiteralF` keyed by an infinite type).
+  Z3 can sometimes solve these via skolemization but the soundness statement would require a
+  bounded enumeration we are not willing to mandate.
+
+These shapes will permanently route through the hand-written translator (when the spec uses them)
+and will surface as `trust=best-effort` → skipped. Specs that rely on them will need to either
+narrow to the verified subset, or accept that those particular checks are not formally backed.
+
+## Where to look in the codebase
+
+| Concern | Path |
+|---|---|
+| Verified subset ADT | `proofs/isabelle/SpecRest/IR.thy` |
+| Verified semantics | `proofs/isabelle/SpecRest/Semantics.thy`, `Smt.thy` |
+| Verified translation | `proofs/isabelle/SpecRest/Translate.thy` |
+| Soundness theorem | `proofs/isabelle/SpecRest/Soundness.thy` |
+| Code extraction | `proofs/isabelle/SpecRest/Codegen.thy` |
+| Generated Scala | `modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala` |
+| Bridge + dispatcher | `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` (`encodeFromSmtTerm`, `translateExpr`) |
+| Trust classifier | `modules/verify/src/main/scala/specrest/verify/Trust.scala` |
+| Skip dispatcher | `modules/verify/src/main/scala/specrest/verify/Consistency.scala` (`runOperationCheck` etc.) |
+| CI gate for Isabelle | `.github/workflows/isabelle-build.yml` |
+
+## Closing the loop with users
+
+The user-facing contract is:
+
+1. If `verify` returns `sat` for a check with `trust=sound`, the check is formally backed: the
+   Isabelle universal soundness theorem (zero `sorry`) plus the bridge plus Z3 jointly assert the
+   property holds in every model the spec admits, modulo TCB above.
+2. If `verify` returns `unsat` (a violation) for a check with `trust=sound`, the counterexample
+   decoded from Z3 is a witness in a model the verified semantics also admits.
+3. If a check is `skipped` with `category=soundness_limitation`, the spec uses constructs outside
+   the verified subset. Either narrow the spec or extend the subset (see the
+   `M_L.4.x` issue track).
+
+There is no path that produces a `trust=best-effort` verdict — that mode of operation, present in
+the verifier through #205, was retired in #192 in favor of explicit skipping.

--- a/docs/content/docs/research/meta.json
+++ b/docs/content/docs/research/meta.json
@@ -13,6 +13,7 @@
     "08_parser_reuse_analysis",
     "09_dsl_compiler_frameworks",
     "10_translator_soundness",
+    "11_tcb_audit",
     "spec_to_test_tools_research"
   ]
 }

--- a/fixtures/golden/ir/broken_url_shortener.json
+++ b/fixtures/golden/ir/broken_url_shortener.json
@@ -87,12 +87,32 @@
           "endLine" : 8,
           "endCol" : 36
         }
+      },
+      {
+        "kind" : "StateField",
+        "name" : "totalClicks",
+        "typeExpr" : {
+          "kind" : "NamedType",
+          "name" : "Int",
+          "span" : {
+            "startLine" : 9,
+            "startCol" : 17,
+            "endLine" : 9,
+            "endCol" : 20
+          }
+        },
+        "span" : {
+          "startLine" : 9,
+          "startCol" : 4,
+          "endLine" : 9,
+          "endCol" : 20
+        }
       }
     ],
     "span" : {
       "startLine" : 7,
       "startCol" : 2,
-      "endLine" : 9,
+      "endLine" : 10,
       "endCol" : 3
     }
   },
@@ -108,16 +128,16 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 12,
+              "startLine" : 13,
               "startCol" : 17,
-              "endLine" : 12,
+              "endLine" : 13,
               "endCol" : 20
             }
           },
           "span" : {
-            "startLine" : 12,
+            "startLine" : 13,
             "startCol" : 11,
-            "endLine" : 12,
+            "endLine" : 13,
             "endCol" : 20
           }
         }
@@ -132,9 +152,9 @@
             "kind" : "Identifier",
             "name" : "code",
             "span" : {
-              "startLine" : 15,
+              "startLine" : 16,
               "startCol" : 6,
-              "endLine" : 15,
+              "endLine" : 16,
               "endCol" : 10
             }
           },
@@ -142,16 +162,16 @@
             "kind" : "Identifier",
             "name" : "metadata",
             "span" : {
-              "startLine" : 15,
+              "startLine" : 16,
               "startCol" : 14,
-              "endLine" : 15,
+              "endLine" : 16,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 15,
+            "startLine" : 16,
             "startCol" : 6,
-            "endLine" : 15,
+            "endLine" : 16,
             "endCol" : 22
           }
         }
@@ -170,16 +190,16 @@
                   "kind" : "Identifier",
                   "name" : "metadata",
                   "span" : {
-                    "startLine" : 18,
+                    "startLine" : 19,
                     "startCol" : 6,
-                    "endLine" : 18,
+                    "endLine" : 19,
                     "endCol" : 14
                   }
                 },
                 "span" : {
-                  "startLine" : 18,
+                  "startLine" : 19,
                   "startCol" : 6,
-                  "endLine" : 18,
+                  "endLine" : 19,
                   "endCol" : 15
                 }
               },
@@ -187,24 +207,24 @@
                 "kind" : "Identifier",
                 "name" : "code",
                 "span" : {
-                  "startLine" : 18,
+                  "startLine" : 19,
                   "startCol" : 16,
-                  "endLine" : 18,
+                  "endLine" : 19,
                   "endCol" : 20
                 }
               },
               "span" : {
-                "startLine" : 18,
+                "startLine" : 19,
                 "startCol" : 6,
-                "endLine" : 18,
+                "endLine" : 19,
                 "endCol" : 21
               }
             },
             "field" : "click_count",
             "span" : {
-              "startLine" : 18,
+              "startLine" : 19,
               "startCol" : 6,
-              "endLine" : 18,
+              "endLine" : 19,
               "endCol" : 33
             }
           },
@@ -221,16 +241,16 @@
                     "kind" : "Identifier",
                     "name" : "metadata",
                     "span" : {
-                      "startLine" : 18,
+                      "startLine" : 19,
                       "startCol" : 40,
-                      "endLine" : 18,
+                      "endLine" : 19,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 18,
+                    "startLine" : 19,
                     "startCol" : 36,
-                    "endLine" : 18,
+                    "endLine" : 19,
                     "endCol" : 49
                   }
                 },
@@ -238,24 +258,24 @@
                   "kind" : "Identifier",
                   "name" : "code",
                   "span" : {
-                    "startLine" : 18,
+                    "startLine" : 19,
                     "startCol" : 50,
-                    "endLine" : 18,
+                    "endLine" : 19,
                     "endCol" : 54
                   }
                 },
                 "span" : {
-                  "startLine" : 18,
+                  "startLine" : 19,
                   "startCol" : 36,
-                  "endLine" : 18,
+                  "endLine" : 19,
                   "endCol" : 55
                 }
               },
               "field" : "click_count",
               "span" : {
-                "startLine" : 18,
+                "startLine" : 19,
                 "startCol" : 36,
-                "endLine" : 18,
+                "endLine" : 19,
                 "endCol" : 67
               }
             },
@@ -263,31 +283,108 @@
               "kind" : "IntLit",
               "value" : 100,
               "span" : {
-                "startLine" : 18,
+                "startLine" : 19,
                 "startCol" : 70,
-                "endLine" : 18,
+                "endLine" : 19,
                 "endCol" : 73
               }
             },
             "span" : {
-              "startLine" : 18,
+              "startLine" : 19,
               "startCol" : 36,
-              "endLine" : 18,
+              "endLine" : 19,
               "endCol" : 73
             }
           },
           "span" : {
-            "startLine" : 18,
+            "startLine" : 19,
             "startCol" : 6,
-            "endLine" : 18,
+            "endLine" : 19,
             "endCol" : 73
           }
         }
       ],
       "span" : {
-        "startLine" : 11,
+        "startLine" : 12,
         "startCol" : 2,
-        "endLine" : 19,
+        "endLine" : 20,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "Drain",
+      "inputs" : [
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 24,
+            "startCol" : 6,
+            "endLine" : 24,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "totalClicks",
+              "span" : {
+                "startLine" : 27,
+                "startCol" : 6,
+                "endLine" : 27,
+                "endCol" : 17
+              }
+            },
+            "span" : {
+              "startLine" : 27,
+              "startCol" : 6,
+              "endLine" : 27,
+              "endCol" : 18
+            }
+          },
+          "right" : {
+            "kind" : "UnaryOp",
+            "op" : "negate",
+            "operand" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 27,
+                "startCol" : 22,
+                "endLine" : 27,
+                "endCol" : 23
+              }
+            },
+            "span" : {
+              "startLine" : 27,
+              "startCol" : 21,
+              "endLine" : 27,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 27,
+            "startCol" : 6,
+            "endLine" : 27,
+            "endCol" : 23
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 22,
+        "startCol" : 2,
+        "endLine" : 28,
         "endCol" : 3
       }
     }
@@ -308,17 +405,17 @@
               "kind" : "Identifier",
               "name" : "metadata",
               "span" : {
-                "startLine" : 22,
+                "startLine" : 31,
                 "startCol" : 13,
-                "endLine" : 22,
+                "endLine" : 31,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 22,
+              "startLine" : 31,
               "startCol" : 8,
-              "endLine" : 22,
+              "endLine" : 31,
               "endCol" : 21
             }
           }
@@ -334,9 +431,9 @@
                 "kind" : "Identifier",
                 "name" : "metadata",
                 "span" : {
-                  "startLine" : 22,
+                  "startLine" : 31,
                   "startCol" : 24,
-                  "endLine" : 22,
+                  "endLine" : 31,
                   "endCol" : 32
                 }
               },
@@ -344,24 +441,24 @@
                 "kind" : "Identifier",
                 "name" : "c",
                 "span" : {
-                  "startLine" : 22,
+                  "startLine" : 31,
                   "startCol" : 33,
-                  "endLine" : 22,
+                  "endLine" : 31,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 22,
+                "startLine" : 31,
                 "startCol" : 24,
-                "endLine" : 22,
+                "endLine" : 31,
                 "endCol" : 35
               }
             },
             "field" : "click_count",
             "span" : {
-              "startLine" : 22,
+              "startLine" : 31,
               "startCol" : 24,
-              "endLine" : 22,
+              "endLine" : 31,
               "endCol" : 47
             }
           },
@@ -369,31 +466,71 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 22,
+              "startLine" : 31,
               "startCol" : 51,
-              "endLine" : 22,
+              "endLine" : 31,
               "endCol" : 52
             }
           },
           "span" : {
-            "startLine" : 22,
+            "startLine" : 31,
             "startCol" : 24,
-            "endLine" : 22,
+            "endLine" : 31,
             "endCol" : 52
           }
         },
         "span" : {
-          "startLine" : 22,
+          "startLine" : 31,
           "startCol" : 4,
-          "endLine" : 22,
+          "endLine" : 31,
           "endCol" : 52
         }
       },
       "span" : {
-        "startLine" : 21,
+        "startLine" : 30,
         "startCol" : 2,
-        "endLine" : 22,
+        "endLine" : 31,
         "endCol" : 52
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "totalClicksNonNegative",
+      "expr" : {
+        "kind" : "BinaryOp",
+        "op" : ">=",
+        "left" : {
+          "kind" : "Identifier",
+          "name" : "totalClicks",
+          "span" : {
+            "startLine" : 34,
+            "startCol" : 4,
+            "endLine" : 34,
+            "endCol" : 15
+          }
+        },
+        "right" : {
+          "kind" : "IntLit",
+          "value" : 0,
+          "span" : {
+            "startLine" : 34,
+            "startCol" : 19,
+            "endLine" : 34,
+            "endCol" : 20
+          }
+        },
+        "span" : {
+          "startLine" : 34,
+          "startCol" : 4,
+          "endLine" : 34,
+          "endCol" : 20
+        }
+      },
+      "span" : {
+        "startLine" : 33,
+        "startCol" : 2,
+        "endLine" : 34,
+        "endCol" : 20
       }
     }
   ],
@@ -513,7 +650,7 @@
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 23,
+    "endLine" : 35,
     "endCol" : 1
   }
 }

--- a/fixtures/golden/smt/broken_url_shortener.smt2
+++ b/fixtures/golden/smt/broken_url_shortener.smt2
@@ -6,7 +6,9 @@
 ;; funcs
 (declare-fun metadata_dom (Int) Bool)
 (declare-fun metadata_map (Int) UrlMapping)
+(declare-fun state_totalClicks () Int)
 (declare-fun UrlMapping_click_count (UrlMapping) Int)
 ;; assertions
 (assert (forall ((c Int)) (=> (metadata_dom c) (>= (UrlMapping_click_count (metadata_map c)) 0))))
+(assert (>= state_totalClicks 0))
 (check-sat)

--- a/fixtures/golden/smt/set_ops.smt2
+++ b/fixtures/golden/smt/set_ops.smt2
@@ -5,6 +5,6 @@
 (declare-fun counters_dom (Int) Bool)
 (declare-fun counters_map (Int) Int)
 ;; assertions
-(assert (forall ((id Int)) (=> (counters_dom id) (> id 0))))
+(assert (forall ((id Int)) (=> (counters_dom id) (< 0 id))))
 (assert (forall ((id Int)) (=> (counters_dom id) (or (= (counters_map id) 0) (= (counters_map id) 1) (= (counters_map id) 2) (= (counters_map id) 3) (= (counters_map id) 5)))))
 (check-sat)

--- a/fixtures/golden/smt/unreachable_op.smt2
+++ b/fixtures/golden/smt/unreachable_op.smt2
@@ -4,5 +4,5 @@
 ;; funcs
 (declare-fun state_x () Int)
 ;; assertions
-(assert (> state_x 100))
+(assert (< 100 state_x))
 (check-sat)

--- a/fixtures/golden/verify_report/broken_url_shortener.json
+++ b/fixtures/golden/verify_report/broken_url_shortener.json
@@ -16,121 +16,165 @@
       "detail" : null,
       "sourceSpans" : [
         {
-          "startLine" : 21,
+          "startLine" : 30,
           "startCol" : 2,
-          "endLine" : 22,
+          "endLine" : 31,
           "endCol" : 52
+        },
+        {
+          "startLine" : 33,
+          "startCol" : 2,
+          "endLine" : 34,
+          "endCol" : 20
         }
       ],
       "diagnostic" : null
     },
     {
-      "id" : "Tamper.requires",
+      "id" : "Drain.requires",
       "kind" : "requires",
       "tool" : "z3",
       "trust" : "sound",
-      "operationName" : "Tamper",
+      "operationName" : "Drain",
       "invariantName" : null,
       "status" : "sat",
       "durationMs" : 0.0,
       "detail" : null,
       "sourceSpans" : [
         {
-          "startLine" : 11,
+          "startLine" : 22,
           "startCol" : 2,
-          "endLine" : 19,
+          "endLine" : 28,
           "endCol" : 3
         },
         {
-          "startLine" : 15,
+          "startLine" : 24,
           "startCol" : 6,
-          "endLine" : 15,
-          "endCol" : 22
+          "endLine" : 24,
+          "endCol" : 10
         }
       ],
       "diagnostic" : null
     },
     {
-      "id" : "Tamper.enabled",
+      "id" : "Drain.enabled",
       "kind" : "enabled",
       "tool" : "z3",
       "trust" : "sound",
-      "operationName" : "Tamper",
+      "operationName" : "Drain",
       "invariantName" : null,
       "status" : "sat",
       "durationMs" : 0.0,
       "detail" : null,
       "sourceSpans" : [
         {
-          "startLine" : 11,
+          "startLine" : 22,
           "startCol" : 2,
-          "endLine" : 19,
+          "endLine" : 28,
           "endCol" : 3
         },
         {
-          "startLine" : 15,
+          "startLine" : 24,
           "startCol" : 6,
-          "endLine" : 15,
-          "endCol" : 22
+          "endLine" : 24,
+          "endCol" : 10
         },
         {
-          "startLine" : 21,
+          "startLine" : 30,
           "startCol" : 2,
-          "endLine" : 22,
+          "endLine" : 31,
           "endCol" : 52
+        },
+        {
+          "startLine" : 33,
+          "startCol" : 2,
+          "endLine" : 34,
+          "endCol" : 20
         }
       ],
       "diagnostic" : null
     },
     {
-      "id" : "Tamper.preserves.clickCountNonNegative",
+      "id" : "Drain.preserves.clickCountNonNegative",
       "kind" : "preservation",
       "tool" : "z3",
-      "trust" : "best-effort",
-      "operationName" : "Tamper",
+      "trust" : "sound",
+      "operationName" : "Drain",
       "invariantName" : "clickCountNonNegative",
-      "status" : "unsat",
+      "status" : "sat",
       "durationMs" : 0.0,
-      "detail" : "operation 'Tamper' does not preserve invariant 'clickCountNonNegative' — counterexample found",
+      "detail" : null,
       "sourceSpans" : [
         {
-          "startLine" : 11,
+          "startLine" : 22,
           "startCol" : 2,
-          "endLine" : 19,
+          "endLine" : 28,
           "endCol" : 3
         },
         {
-          "startLine" : 21,
+          "startLine" : 30,
           "startCol" : 2,
-          "endLine" : 22,
+          "endLine" : 31,
           "endCol" : 52
         },
         {
-          "startLine" : 18,
+          "startLine" : 27,
           "startCol" : 6,
-          "endLine" : 18,
-          "endCol" : 73
+          "endLine" : 27,
+          "endCol" : 23
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Drain.preserves.totalClicksNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "trust" : "sound",
+      "operationName" : "Drain",
+      "invariantName" : "totalClicksNonNegative",
+      "status" : "unsat",
+      "durationMs" : 0.0,
+      "detail" : "operation 'Drain' does not preserve invariant 'totalClicksNonNegative' — counterexample found",
+      "sourceSpans" : [
+        {
+          "startLine" : 22,
+          "startCol" : 2,
+          "endLine" : 28,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 33,
+          "startCol" : 2,
+          "endLine" : 34,
+          "endCol" : 20
+        },
+        {
+          "startLine" : 27,
+          "startCol" : 6,
+          "endLine" : 27,
+          "endCol" : 23
         }
       ],
       "diagnostic" : {
         "level" : "error",
         "category" : "invariant_violation_by_operation",
-        "message" : "operation 'Tamper' violates invariant 'clickCountNonNegative'",
+        "message" : "operation 'Drain' violates invariant 'totalClicksNonNegative'",
         "primarySpan" : {
-          "startLine" : 11,
+          "startLine" : 22,
           "startCol" : 2,
-          "endLine" : 19,
+          "endLine" : 28,
           "endCol" : 3
         },
         "relatedSpans" : [
           {
             "span" : {
-              "startLine" : 21,
+              "startLine" : 33,
               "startCol" : 2,
-              "endLine" : 22,
-              "endCol" : 52
+              "endLine" : 34,
+              "endCol" : 20
             },
-            "note" : "invariant 'clickCountNonNegative' declared here"
+            "note" : "invariant 'totalClicksNonNegative' declared here"
           }
         ],
         "counterexample" : {
@@ -157,20 +201,6 @@
                 {
                   "name" : "click_count",
                   "value" : {
-                    "display" : "-100",
-                    "entityLabel" : null
-                  }
-                }
-              ]
-            },
-            {
-              "sortName" : "UrlMapping",
-              "label" : "UrlMapping#2",
-              "rawElement" : "UrlMapping!val!2",
-              "fields" : [
-                {
-                  "name" : "click_count",
-                  "value" : {
                     "display" : "0",
                     "entityLabel" : null
                   }
@@ -183,51 +213,202 @@
               "stateName" : "metadata",
               "side" : "pre",
               "entries" : [
-                {
-                  "key" : {
-                    "display" : "2",
-                    "entityLabel" : null
-                  },
-                  "value" : {
-                    "display" : "UrlMapping#0",
-                    "entityLabel" : "UrlMapping#0"
-                  }
-                }
               ]
             },
             {
               "stateName" : "metadata",
               "side" : "post",
               "entries" : [
-                {
-                  "key" : {
-                    "display" : "2",
-                    "entityLabel" : null
-                  },
-                  "value" : {
-                    "display" : "UrlMapping#1",
-                    "entityLabel" : "UrlMapping#1"
-                  }
-                }
               ]
             }
           ],
           "stateConstants" : [
-          ],
-          "inputs" : [
             {
-              "name" : "code",
+              "stateName" : "totalClicks",
+              "side" : "pre",
               "value" : {
-                "display" : "2",
+                "display" : "0",
+                "entityLabel" : null
+              }
+            },
+            {
+              "stateName" : "totalClicks",
+              "side" : "post",
+              "value" : {
+                "display" : "-1",
                 "entityLabel" : null
               }
             }
+          ],
+          "inputs" : [
           ]
         },
-        "suggestion" : "'Tamper' violates 'clickCountNonNegative' on field(s) 'click_count' — see counterexample. Tighten 'ensures' with a range predicate or a constructor that initialises click_count correctly.",
+        "suggestion" : "'Drain' violates 'totalClicksNonNegative'. Tighten 'ensures' so the fields 'totalClicksNonNegative' constrains are pinned by '=' or a range predicate; see counterexample.",
         "coreSpans" : [
         ],
-        "narrative" : "Why this violates the invariant:\n  1. Invariant 'clickCountNonNegative' requires:\n       (all c in metadata | (metadata[c].click_count >= 0))\n  2. Operation 'Tamper' computes 'click_count' from:\n       (pre(metadata)[code].click_count - 100)\n  3. The solver picked code = 2, pre(metadata)[2].click_count = 0, producing post-state metadata'[2].click_count = -100.\n  4. The post-state value violates the bound on 'click_count' from invariant 'clickCountNonNegative'."
+        "narrative" : "Why this violates the invariant:\n  1. Invariant 'totalClicksNonNegative' requires:\n       (totalClicks >= 0)\n  2. Operation 'Drain' computes 'totalClicks' from:\n       (- 1)\n  3. The solver picked pre(totalClicks) = 0, producing post-state totalClicks' = -1.\n  4. The post-state value violates the bound on 'totalClicks' from invariant 'totalClicksNonNegative'."
+      }
+    },
+    {
+      "id" : "Tamper.requires",
+      "kind" : "requires",
+      "tool" : "z3",
+      "trust" : "sound",
+      "operationName" : "Tamper",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 16,
+          "startCol" : 6,
+          "endLine" : 16,
+          "endCol" : 22
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Tamper.enabled",
+      "kind" : "enabled",
+      "tool" : "z3",
+      "trust" : "sound",
+      "operationName" : "Tamper",
+      "invariantName" : null,
+      "status" : "sat",
+      "durationMs" : 0.0,
+      "detail" : null,
+      "sourceSpans" : [
+        {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 16,
+          "startCol" : 6,
+          "endLine" : 16,
+          "endCol" : 22
+        },
+        {
+          "startLine" : 30,
+          "startCol" : 2,
+          "endLine" : 31,
+          "endCol" : 52
+        },
+        {
+          "startLine" : 33,
+          "startCol" : 2,
+          "endLine" : 34,
+          "endCol" : 20
+        }
+      ],
+      "diagnostic" : null
+    },
+    {
+      "id" : "Tamper.preserves.clickCountNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "trust" : "best-effort",
+      "operationName" : "Tamper",
+      "invariantName" : "clickCountNonNegative",
+      "status" : "skipped",
+      "durationMs" : 0.0,
+      "detail" : "soundness-limitation: outside lower's coverage",
+      "sourceSpans" : [
+        {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 30,
+          "startCol" : 2,
+          "endLine" : 31,
+          "endCol" : 52
+        },
+        {
+          "startLine" : 19,
+          "startCol" : 6,
+          "endLine" : 19,
+          "endCol" : 73
+        }
+      ],
+      "diagnostic" : {
+        "level" : "warning",
+        "category" : "soundness_limitation",
+        "message" : "check 'Tamper.preserves.clickCountNonNegative' skipped: outside lower's coverage",
+        "primarySpan" : {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        "relatedSpans" : [
+        ],
+        "counterexample" : null,
+        "suggestion" : "The check involves a construct that is outside the formally verified subset captured by the Isabelle 'lower' projection. Narrow the spec to lowerable shapes — or, if the construct is essential to you…",
+        "coreSpans" : [
+        ],
+        "narrative" : null
+      }
+    },
+    {
+      "id" : "Tamper.preserves.totalClicksNonNegative",
+      "kind" : "preservation",
+      "tool" : "z3",
+      "trust" : "best-effort",
+      "operationName" : "Tamper",
+      "invariantName" : "totalClicksNonNegative",
+      "status" : "skipped",
+      "durationMs" : 0.0,
+      "detail" : "soundness-limitation: outside lower's coverage",
+      "sourceSpans" : [
+        {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        {
+          "startLine" : 33,
+          "startCol" : 2,
+          "endLine" : 34,
+          "endCol" : 20
+        },
+        {
+          "startLine" : 19,
+          "startCol" : 6,
+          "endLine" : 19,
+          "endCol" : 73
+        }
+      ],
+      "diagnostic" : {
+        "level" : "warning",
+        "category" : "soundness_limitation",
+        "message" : "check 'Tamper.preserves.totalClicksNonNegative' skipped: outside lower's coverage",
+        "primarySpan" : {
+          "startLine" : 12,
+          "startCol" : 2,
+          "endLine" : 20,
+          "endCol" : 3
+        },
+        "relatedSpans" : [
+        ],
+        "counterexample" : null,
+        "suggestion" : "The check involves a construct that is outside the formally verified subset captured by the Isabelle 'lower' projection. Narrow the spec to lowerable shapes — or, if the construct is essential to you…",
+        "coreSpans" : [
+        ],
+        "narrative" : null
       }
     }
   ]

--- a/fixtures/spec/broken_url_shortener.spec
+++ b/fixtures/spec/broken_url_shortener.spec
@@ -6,6 +6,7 @@ service BrokenUrlShortener {
 
   state {
     metadata: Int -> lone UrlMapping
+    totalClicks: Int
   }
 
   operation Tamper {
@@ -18,6 +19,17 @@ service BrokenUrlShortener {
       metadata'[code].click_count = pre(metadata)[code].click_count - 100
   }
 
+  operation Drain {
+    requires:
+      true
+
+    ensures:
+      totalClicks' = -1
+  }
+
   invariant clickCountNonNegative:
     all c in metadata | metadata[c].click_count >= 0
+
+  invariant totalClicksNonNegative:
+    totalClicks >= 0
 }

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -79,12 +79,6 @@ object Main
         "suppress structural 'why this fails' narration in CLI and JSON output"
       )
       .orFalse
-    val strictSoundness = Opts
-      .flag(
-        "strict-soundness",
-        "skip checks whose source exprs fall outside the Isabelle 'lower' projection (the formally verified subset). Sound checks run as today; best-effort checks are reported as Skipped with category soundness_limitation. When such skips are the only reason for a non-clean run, the exit code is 4 — backend errors (3), violations (1), and translator gaps (2) take precedence."
-      )
-      .orFalse
     Opts.subcommand("verify", "Run the Z3/Alloy-backed verification engine on a spec file"):
       (
         specFile,
@@ -101,10 +95,9 @@ object Main
         parallel,
         noSuggestions,
         noNarration,
-        strictSoundness,
         verbose,
         quiet
-      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, ns, nn, ss, v, q) =>
+      ).mapN: (spec, t, ds, dso, da, dao, as, dvc, ex, j, jo, par, ns, nn, v, q) =>
         Verify.run(
           spec,
           VerifyOptions(
@@ -120,8 +113,7 @@ object Main
             jo,
             par,
             suggestions = !ns,
-            narration = !nn,
-            strictSoundness = ss
+            narration = !nn
           ),
           Logger.fromFlags(verbose = v, quiet = q)
         )

--- a/modules/cli/src/main/scala/specrest/cli/Verify.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Verify.scala
@@ -33,8 +33,7 @@ final case class VerifyOptions(
     jsonOut: Option[String] = None,
     parallel: Option[Int] = None,
     suggestions: Boolean = true,
-    narration: Boolean = true,
-    strictSoundness: Boolean = false
+    narration: Boolean = true
 )
 
 object Verify:
@@ -188,8 +187,7 @@ object Verify:
                 captureCore = opts.explain,
                 maxParallel = maxParallel,
                 suggestions = opts.suggestions,
-                narration = opts.narration,
-                strictSoundness = opts.strictSoundness
+                narration = opts.narration
               ),
               sink
             ).flatMap { report =>

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -136,15 +136,9 @@ class VerifyJsonTest extends CatsEffectSuite:
           .filter(_.nonEmpty)
         assert(nonEmpty.nonEmpty, s"expected at least one non-empty suggestion; got: $out")
 
-  test("--strict-soundness records soundness_limitation skips on best-effort fixtures"):
-    // auth_service uses pre(rel)[k] / TheF — neither lowers under v2.
-    val opts = VerifyOptions(
-      30_000L,
-      dumpSmt = false,
-      dumpSmtOut = None,
-      json = true,
-      strictSoundness = true
-    )
+  test("best-effort checks always skip with soundness_limitation (default behavior)"):
+    // auth_service uses pre(rel)[k] / TheF — neither lowers under v2; those checks skip.
+    val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
     captureStdout(ps => Verify.run("fixtures/spec/auth_service.spec", opts, log, ps))
       .map: (_, out) =>
         val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
@@ -155,7 +149,7 @@ class VerifyJsonTest extends CatsEffectSuite:
           status.contains("skipped") && category.contains("soundness_limitation")
         assert(
           soundnessSkipped.nonEmpty,
-          s"expected at least one soundness_limitation skip under --strict-soundness; checks=$checks"
+          s"expected at least one soundness_limitation skip; checks=$checks"
         )
         soundnessSkipped.foreach: c =>
           assertEquals(
@@ -163,34 +157,21 @@ class VerifyJsonTest extends CatsEffectSuite:
             Some("best-effort")
           )
 
-  test("strict-soundness off: no soundness_limitation skips on the same fixture"):
-    val opts = VerifyOptions(
-      30_000L,
-      dumpSmt = false,
-      dumpSmtOut = None,
-      json = true,
-      strictSoundness = false
-    )
-    captureStdout(ps => Verify.run("fixtures/spec/auth_service.spec", opts, log, ps))
-      .map: (_, out) =>
+  test("safe_counter still passes (every check lowers; routes via extracted)"):
+    val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
+    captureStdout(ps => Verify.run("fixtures/spec/safe_counter.spec", opts, log, ps))
+      .map: (exit, out) =>
+        assertEquals(exit, ExitCodes.Ok)
         val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
         val checks = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
-        val soundnessSkipped = checks.filter: c =>
-          c.hcursor.downField("diagnostic").downField("category").as[String].toOption
-            .contains("soundness_limitation")
-        assertEquals(soundnessSkipped, Nil)
-
-  test("strict-soundness off: safe_counter still passes (no routing change)"):
-    val opts = VerifyOptions(
-      30_000L,
-      dumpSmt = false,
-      dumpSmtOut = None,
-      json = true,
-      strictSoundness = false
-    )
-    captureStdout(ps => Verify.run("fixtures/spec/safe_counter.spec", opts, log, ps))
-      .map: (exit, _) =>
-        assertEquals(exit, ExitCodes.Ok)
+        val nonSkipped = checks.filter: c =>
+          c.hcursor.downField("status").as[String].toOption.exists(_ != "skipped")
+        nonSkipped.foreach: c =>
+          assertEquals(
+            c.hcursor.downField("trust").as[String].toOption,
+            Some("sound"),
+            s"expected non-skipped check to be sound: $c"
+          )
 
   test("--json with --explain surfaces coreSpans on unsat diagnostics"):
     val opts = VerifyOptions(

--- a/modules/verify/src/main/scala/specrest/verify/Config.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Config.scala
@@ -16,8 +16,7 @@ final case class VerificationConfig(
     captureCore: Boolean = false,
     maxParallel: Int = VerificationConfig.defaultParallelism,
     suggestions: Boolean = true,
-    narration: Boolean = true,
-    strictSoundness: Boolean = false
+    narration: Boolean = true
 )
 
 object VerificationConfig:

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -293,10 +293,10 @@ object Consistency:
   ): IO[CheckResult] =
     val sourceSpans = ir.i.collect { case InvariantDeclFull(_, _, sp) => sp }.flatten
     val tool        = Classifier.classifyGlobal(ir)
-    if config.strictSoundness && trust == TrustLevel.BestEffort then
-      IO.pure(soundnessSkipped("global", CheckKind.Global, tool, None, None, sourceSpans))
-    else if tool == VerifierTool.Alloy then
+    if tool == VerifierTool.Alloy then
       runGlobalAlloy(ir, alloyBackend, config, sourceSpans, dump, trust)
+    else if trust == TrustLevel.BestEffort then
+      IO.pure(soundnessSkipped("global", CheckKind.Global, tool, None, None, sourceSpans))
     else
       Translator.translate(ir).flatMap:
         case Left(err) =>
@@ -434,10 +434,10 @@ object Consistency:
       case CheckKind.Requires => Classifier.classifyRequires(op)
       case CheckKind.Enabled  => Classifier.classifyEnabled(op, ir)
       case _                  => VerifierTool.Z3
-    if config.strictSoundness && trust == TrustLevel.BestEffort then
-      IO.pure(soundnessSkipped(id, kind, tool, Some(op.a), None, sourceSpans))
-    else if tool == VerifierTool.Alloy then
+    if tool == VerifierTool.Alloy then
       runOperationAlloy(ir, op, kind, alloyBackend, config, id, sourceSpans, dump, trust)
+    else if trust == TrustLevel.BestEffort then
+      IO.pure(soundnessSkipped(id, kind, tool, Some(op.a), None, sourceSpans))
     else
       val scriptIO: IO[Either[VerifyError.Translator, Z3Script]] = kind match
         case CheckKind.Requires => Translator.translateOperationRequires(ir, op)
@@ -585,12 +585,12 @@ object Consistency:
     val id          = s"${op.a}.preserves.${inv.name}"
     val sourceSpans = preservationSpans(op, inv.decl)
     val tool        = Classifier.classifyPreservation(op, inv.decl)
-    if config.strictSoundness && trust == TrustLevel.BestEffort then
+    if tool == VerifierTool.Alloy then
+      runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump, trust)
+    else if trust == TrustLevel.BestEffort then
       IO.pure(
         soundnessSkipped(id, CheckKind.Preservation, tool, Some(op.a), Some(inv.name), sourceSpans)
       )
-    else if tool == VerifierTool.Alloy then
-      runPreservationAlloy(ir, op, inv, alloyBackend, config, id, sourceSpans, dump, trust)
     else
       Translator.translateOperationPreservation(ir, op, inv.decl).flatMap:
         case Left(err) =>
@@ -660,74 +660,63 @@ object Consistency:
   ): IO[CheckResult] =
     val id          = s"temporal.${decl.a}"
     val sourceSpans = decl.c.toList
-    if config.strictSoundness && trust == TrustLevel.BestEffort then
-      IO.pure(
-        soundnessSkipped(
+    val _           = trust
+    AlloyTranslator.translateTemporal(ir, decl, config.alloyScope).flatMap:
+      case Left(err) =>
+        IO.pure(skippedCheck(
           id,
           CheckKind.Temporal,
           VerifierTool.Alloy,
           None,
           Some(decl.a),
-          sourceSpans
-        )
-      )
-    else
-      AlloyTranslator.translateTemporal(ir, decl, config.alloyScope).flatMap:
-        case Left(err) =>
-          IO.pure(skippedCheck(
-            id,
-            CheckKind.Temporal,
-            VerifierTool.Alloy,
-            None,
-            Some(decl.a),
-            sourceSpans,
-            DiagnosticCategory.TranslatorLimitation,
-            err.message,
-            trust
-          ))
-        case Right(translation) =>
-          val rendered = AlloyRender.renderWithLineMap(translation.module)
-          alloyBackend.check(
-            rendered.source,
-            commandIdx = 0,
-            timeoutMs = config.timeoutMs,
-            captureCore = config.captureCore
-          ).flatMap:
-            case Left(err) =>
-              IO.pure(skippedCheck(
-                id,
-                CheckKind.Temporal,
-                VerifierTool.Alloy,
-                None,
-                Some(decl.a),
-                sourceSpans,
-                DiagnosticCategory.BackendError,
-                err.message,
-                trust
-              ))
-            case Right(result) =>
-              val outcome = translation.kind match
-                case AlloyTranslator.TemporalKind.Always => invertStatus(result.status)
-                case AlloyTranslator.TemporalKind.Eventually =>
-                  CheckOutcome.fromStatus(result.status)
-              IO.blocking(
-                dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
-              ).as(finalizeCheck(FinalizeArgs(
-                id = id,
-                kind = CheckKind.Temporal,
-                tool = VerifierTool.Alloy,
-                operationName = None,
-                invariantName = Some(decl.a),
-                rawStatus = result.status,
-                outcome = outcome,
-                durationMs = result.durationMs,
-                sourceSpans = sourceSpans,
-                ir = ir,
-                invariantDecl = None,
-                op = None,
-                trust = trust,
-                coreSpans = alloyCoreSpans(rendered, result, CheckKind.Temporal)
-              )))
+          sourceSpans,
+          DiagnosticCategory.TranslatorLimitation,
+          err.message,
+          trust
+        ))
+      case Right(translation) =>
+        val rendered = AlloyRender.renderWithLineMap(translation.module)
+        alloyBackend.check(
+          rendered.source,
+          commandIdx = 0,
+          timeoutMs = config.timeoutMs,
+          captureCore = config.captureCore
+        ).flatMap:
+          case Left(err) =>
+            IO.pure(skippedCheck(
+              id,
+              CheckKind.Temporal,
+              VerifierTool.Alloy,
+              None,
+              Some(decl.a),
+              sourceSpans,
+              DiagnosticCategory.BackendError,
+              err.message,
+              trust
+            ))
+          case Right(result) =>
+            val outcome = translation.kind match
+              case AlloyTranslator.TemporalKind.Always => invertStatus(result.status)
+              case AlloyTranslator.TemporalKind.Eventually =>
+                CheckOutcome.fromStatus(result.status)
+            IO.blocking(
+              dumpAlloy(dump, id, rendered.source, outcome, result.status, result.durationMs)
+            ).as(finalizeCheck(FinalizeArgs(
+              id = id,
+              kind = CheckKind.Temporal,
+              tool = VerifierTool.Alloy,
+              operationName = None,
+              invariantName = Some(decl.a),
+              rawStatus = result.status,
+              outcome = outcome,
+              durationMs = result.durationMs,
+              sourceSpans = sourceSpans,
+              ir = ir,
+              invariantDecl = None,
+              op = None,
+              trust = trust,
+              coreSpans = alloyCoreSpans(rendered, result, CheckKind.Temporal)
+            )))
 
   private def runPreservationAlloy(
       ir: ServiceIRFull,
@@ -886,7 +875,7 @@ object Consistency:
     case DiagnosticCategory.BackendError =>
       "solver backend error"
     case DiagnosticCategory.SoundnessLimitation =>
-      "check skipped under --strict-soundness: outside the verified subset"
+      "check skipped: outside the verified subset"
 
   private def primarySpanFor(args: FinalizeArgs): Option[span_t] =
     if args.kind == CheckKind.Preservation && args.invariantDecl.isDefined then
@@ -971,7 +960,7 @@ object Consistency:
     val diagnostic = VerificationDiagnostic(
       level = DiagnosticLevel.Warning,
       category = DiagnosticCategory.SoundnessLimitation,
-      message = s"check '$id' skipped under --strict-soundness: $message",
+      message = s"check '$id' skipped: $message",
       primarySpan = sourceSpans.headOption,
       relatedSpans = Nil,
       counterexample = None,
@@ -985,7 +974,7 @@ object Consistency:
       invariantName = invariantName,
       status = CheckOutcome.Skipped,
       durationMs = 0.0,
-      detail = Some(s"strict-soundness: $message"),
+      detail = Some(s"soundness-limitation: $message"),
       sourceSpans = sourceSpans,
       diagnostic = Some(diagnostic),
       trust = TrustLevel.BestEffort

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -99,7 +99,7 @@ object Diagnostic:
       )
     case DiagnosticCategory.SoundnessLimitation =>
       Some(
-        "The check involves a construct that is outside the formally verified subset captured by the Isabelle 'lower' projection. Drop --strict-soundness to fall back to today's best-effort routing, or narrow the spec to lowerable shapes."
+        "The check involves a construct that is outside the formally verified subset captured by the Isabelle 'lower' projection. Narrow the spec to lowerable shapes — or, if the construct is essential to your spec, file a follow-up to extend the verified subset (see proofs/isabelle/STATUS.md for the current ledger)."
       )
 
   private def contradictoryInvariantsSuggestion(ctx: SuggestionContext): Option[String] =

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2,6 +2,7 @@ package specrest.verify.z3
 
 import cats.effect.IO
 import specrest.ir.*
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 import scala.collection.mutable
@@ -612,8 +613,13 @@ object Translator:
       }.getOrElse(Z3Sort.Uninterp(name))
 
   def translateExpr(ctx: TranslateCtx, expr: expr_full, env: mutable.Map[String, Z3Expr]): Z3Expr =
-    val out = translateExprRaw(ctx, expr, env)
+    val enums = ctx.enums.keys.toList
+    val out = lower(enums, expr) match
+      case Some(eSubset) => encodeFromSmtTerm(ctx, translateVerified(eSubset), env)
+      case None          => translateExprRaw(ctx, expr, env)
     out.withSpan(expr.spanOpt)
+
+  private def translateVerified(e: expr): smt_term = SpecRestGenerated.translate(e)
 
   private def translateExprRaw(
       ctx: TranslateCtx,
@@ -1974,3 +1980,308 @@ object Translator:
           walkMentionsPost(v, stateName, insidePrime)
         }
       case _ => false
+
+  private def encodeFromSmtTerm(
+      ctx: TranslateCtx,
+      term: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    term match
+      case BLit(b)                 => Z3Expr.BoolLit(b)
+      case ILit(int_of_integer(n)) => Z3Expr.IntLit(n.toLong)
+      case TVar(name)              => resolveIdentifier(ctx, name, env)
+      case EnumElemConst(en, mem) =>
+        val funcName = s"${en}_$mem"
+        if !ctx.funcs.contains(funcName) then
+          val resultSort = ctx.enums.get(en).map(_.sort).getOrElse(Z3Sort.Uninterp(en))
+          ctx.declareFunc(Z3FunctionDecl(funcName, Nil, resultSort))
+        Z3Expr.App(funcName, Nil)
+
+      case TNot(TEq(l, r)) =>
+        Z3Expr.Cmp(CmpOp.Neq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TOr(TLt(a1, b1), TEq(a2, b2)) if smtTermEq(a1, a2) && smtTermEq(b1, b2) =>
+        Z3Expr.Cmp(CmpOp.Le, encodeFromSmtTerm(ctx, a1, env), encodeFromSmtTerm(ctx, b1, env))
+      case TOr(TLt(b1, a1), TEq(a2, b2)) if smtTermEq(a1, a2) && smtTermEq(b1, b2) =>
+        Z3Expr.Cmp(CmpOp.Ge, encodeFromSmtTerm(ctx, a2, env), encodeFromSmtTerm(ctx, b2, env))
+
+      case TNot(t) => Z3Expr.Not(encodeFromSmtTerm(ctx, t, env))
+      case TAnd(l, r) =>
+        Z3Expr.And(List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env)))
+      case TOr(l, r) =>
+        Z3Expr.Or(List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env)))
+      case TImplies(l, r) =>
+        Z3Expr.Implies(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TEq(l, r) =>
+        Z3Expr.Cmp(CmpOp.Eq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TLt(l, r) =>
+        Z3Expr.Cmp(CmpOp.Lt, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TNeg(t) =>
+        Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(0), encodeFromSmtTerm(ctx, t, env)))
+      case TAdd(l, r) =>
+        Z3Expr.Arith(
+          ArithOp.Add,
+          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+        )
+      case TSub(l, r) =>
+        Z3Expr.Arith(
+          ArithOp.Sub,
+          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+        )
+      case TMul(l, r) =>
+        Z3Expr.Arith(
+          ArithOp.Mul,
+          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+        )
+      case TDiv(l, r) =>
+        Z3Expr.Arith(
+          ArithOp.Div,
+          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+        )
+
+      case TInDom(rel, elem) =>
+        val key = encodeFromSmtTerm(ctx, elem, env)
+        ctx.state.get(rel) match
+          case Some(r: StateRelationInfo) =>
+            Z3Expr.App(domFuncFor(r, ctx.stateMode), List(key))
+          case Some(c: StateConstInfo) =>
+            val rhs = Z3Expr.App(constFuncFor(c, ctx.stateMode), Nil)
+            inferSortOfZ3Expr(ctx, rhs) match
+              case Some(Z3Sort.SetOf(_)) => Z3Expr.SetMember(key, rhs)
+              case _                     => fail(ctx, s"membership '$rel' requires a relation or set-typed constant")
+          case _ =>
+            env.get(rel) match
+              case Some(bound) =>
+                inferSortOfZ3Expr(ctx, bound) match
+                  case Some(Z3Sort.SetOf(_)) => Z3Expr.SetMember(key, bound)
+                  case _                     => fail(ctx, s"membership '$rel' requires a set-typed binding")
+              case None =>
+                fail(ctx, s"membership '$rel' requires a state relation or set-typed value")
+      case TCardRel(rel) => cardinalityRefFor(ctx, rel, ctx.stateMode)
+
+      case TLetIn(name, value, body) =>
+        val v      = encodeFromSmtTerm(ctx, value, env)
+        val newEnv = env.clone()
+        newEnv(name) = v
+        encodeFromSmtTerm(ctx, body, newEnv)
+
+      case TForallEnum(varName, en, body) =>
+        val sort   = ctx.enums.get(en).map(_.sort).getOrElse(Z3Sort.Uninterp(en))
+        val newEnv = env.clone()
+        newEnv(varName) = Z3Expr.Var(varName, sort)
+        Z3Expr.Quantifier(
+          QKind.ForAll,
+          List(Z3Binding(varName, sort)),
+          encodeFromSmtTerm(ctx, body, newEnv)
+        )
+      case TForallRel(varName, rel, body) =>
+        val (sort, guard) = quantifierDomainFor(ctx, rel, varName)
+        val newEnv        = env.clone()
+        newEnv(varName) = Z3Expr.Var(varName, sort)
+        val inner = encodeFromSmtTerm(ctx, body, newEnv)
+        val guarded = guard match
+          case Some(g) => Z3Expr.Implies(g, inner)
+          case None    => inner
+        Z3Expr.Quantifier(
+          QKind.ForAll,
+          List(Z3Binding(varName, sort)),
+          guarded
+        )
+
+      case TIndexRel(rel, key) =>
+        ctx.state.get(rel) match
+          case Some(r: StateRelationInfo) =>
+            Z3Expr.App(mapFuncFor(r, ctx.stateMode), List(encodeFromSmtTerm(ctx, key, env)))
+          case _ =>
+            fail(ctx, s"indexing '$rel' requires a state relation")
+      case TFieldAccess(base, fname) =>
+        val baseZ    = encodeFromSmtTerm(ctx, base, env)
+        val baseSort = inferSortOfZ3Expr(ctx, baseZ)
+        baseSort match
+          case Some(Z3Sort.Uninterp(name)) =>
+            ctx.entities.get(name) match
+              case Some(entity) =>
+                entity.fields.get(fname) match
+                  case Some((_, funcName)) => Z3Expr.App(funcName, List(baseZ))
+                  case None                => fail(ctx, s"entity '$name' has no field '$fname'")
+              case None => fail(ctx, "field access requires entity sort")
+          case _ => fail(ctx, "field access requires entity sort")
+
+      case TSetEmpty() =>
+        fail(ctx, "empty set literal requires context to infer element sort")
+      case ins @ TSetInsert(_, _) =>
+        val (elemSort, members) = collectSetLiteralMembers(ctx, ins, env)
+        Z3Expr.SetLit(elemSort, members)
+      case TSetMember(elem, set) =>
+        val elemZ    = encodeFromSmtTerm(ctx, elem, env)
+        val elemSort = inferSortOfZ3Expr(ctx, elemZ)
+        set match
+          case TSetEmpty() => Z3Expr.BoolLit(false)
+          case ins: TSetInsert =>
+            val members =
+              collectSetLiteralMembersTerms(ins).map(t => encodeFromSmtTerm(ctx, t, env))
+            for s <- elemSort; m <- members; ms <- inferSortOfZ3Expr(ctx, m) do
+              if !Z3Sort.eq(s, ms) then
+                fail(
+                  ctx,
+                  s"membership operator 'in' requires the left-hand side sort to match the set's element sort; got $s vs $ms"
+                )
+            members match
+              case Nil => Z3Expr.BoolLit(false)
+              case _   => Z3Expr.Or(members.map(m => Z3Expr.Cmp(CmpOp.Eq, elemZ, m)))
+          case _ =>
+            val rhs    = encodeFromSmtTerm(ctx, set, env)
+            val rhSort = inferSortOfZ3Expr(ctx, rhs)
+            (elemSort, rhSort) match
+              case (Some(es), Some(Z3Sort.SetOf(rs))) if !Z3Sort.eq(es, rs) =>
+                fail(
+                  ctx,
+                  s"membership operator 'in' requires the left-hand side sort to match the set's element sort; got $es against a set of $rs"
+                )
+              case _ => ()
+            Z3Expr.SetMember(elemZ, rhs)
+      case TSetUnion(l, r)     => encodeSetBinOp(ctx, SetOpKind.Union, l, r, env)
+      case TSetIntersect(l, r) => encodeSetBinOp(ctx, SetOpKind.Intersect, l, r, env)
+      case TSetDiff(l, r)      => encodeSetBinOp(ctx, SetOpKind.Diff, l, r, env)
+
+      case TPrime(inner) =>
+        withStateMode(ctx, StateMode.Post, () => encodeFromSmtTerm(ctx, inner, env))
+      case TPre(inner) =>
+        withStateMode(ctx, StateMode.Pre, () => encodeFromSmtTerm(ctx, inner, env))
+
+      case TWithRec(base, fld, value) =>
+        val baseZ    = encodeFromSmtTerm(ctx, base, env)
+        val baseSort = inferSortOfZ3Expr(ctx, baseZ)
+        baseSort match
+          case Some(Z3Sort.Uninterp(name)) =>
+            ctx.entities.get(name) match
+              case None => fail(ctx, s"'with' on non-entity sort '$name'")
+              case Some(entity) =>
+                val skolemName = ctx.freshSkolem(s"with_$name")
+                ctx.declareFunc(Z3FunctionDecl(skolemName, Nil, Z3Sort.Uninterp(name)))
+                val skolemRef = Z3Expr.App(skolemName, Nil)
+                val v         = encodeFromSmtTerm(ctx, value, env)
+                for (fname, (_, funcName)) <- entity.fields do
+                  if fname == fld then
+                    ctx.assertions += Z3Expr.Cmp(
+                      CmpOp.Eq,
+                      Z3Expr.App(funcName, List(skolemRef)),
+                      v
+                    )
+                  else
+                    ctx.assertions += Z3Expr.Cmp(
+                      CmpOp.Eq,
+                      Z3Expr.App(funcName, List(skolemRef)),
+                      Z3Expr.App(funcName, List(baseZ))
+                    )
+                skolemRef
+          case _ => fail(ctx, s"'with' on field '$fld' requires an entity-sorted base")
+
+  private def collectSetLiteralMembersTerms(term: smt_term): List[smt_term] = term match
+    case TSetEmpty()           => Nil
+    case TSetInsert(elem, set) => elem :: collectSetLiteralMembersTerms(set)
+    case _                     => Nil
+
+  private def encodeSetBinOp(
+      ctx: TranslateCtx,
+      op: SetOpKind,
+      l: smt_term,
+      r: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val lz = encodeFromSmtTerm(ctx, l, env)
+    val rz = encodeFromSmtTerm(ctx, r, env)
+    val ls = inferSortOfZ3Expr(ctx, lz)
+    val rs = inferSortOfZ3Expr(ctx, rz)
+    (ls, rs) match
+      case (Some(Z3Sort.SetOf(le)), Some(Z3Sort.SetOf(re))) =>
+        if !Z3Sort.eq(le, re) then
+          fail(
+            ctx,
+            s"set operator '${SetOpKind.token(op)}' requires both operands to have the same element sort; got $le vs $re"
+          )
+        Z3Expr.SetBinOp(op, lz, rz)
+      case (Some(_), Some(_)) =>
+        fail(
+          ctx,
+          s"set operator '${SetOpKind.token(op)}' requires both operands to be sets"
+        )
+      case _ =>
+        Z3Expr.SetBinOp(op, lz, rz)
+
+  private def quantifierDomainFor(
+      ctx: TranslateCtx,
+      name: String,
+      varName: String
+  ): (Z3Sort, Option[Z3Expr]) =
+    ctx.state.get(name) match
+      case Some(r: StateRelationInfo) =>
+        val v = Z3Expr.Var(varName, r.keySort)
+        (r.keySort, Some(Z3Expr.App(domFuncFor(r, ctx.stateMode), List(v))))
+      case Some(c: StateConstInfo) =>
+        c.sort match
+          case Z3Sort.SetOf(elem) =>
+            val v = Z3Expr.Var(varName, elem)
+            (elem, Some(Z3Expr.SetMember(v, Z3Expr.App(constFuncFor(c, ctx.stateMode), Nil))))
+          case other => (other, None)
+      case None =>
+        ctx.entities.get(name).map(e => (e.sort, None))
+          .orElse(ctx.enums.get(name).map(e => (e.sort, None)))
+          .getOrElse((Z3Sort.Uninterp("Unknown"), None))
+
+  private def collectSetLiteralMembers(
+      ctx: TranslateCtx,
+      term: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): (Z3Sort, List[Z3Expr]) =
+    val terms   = collectSetLiteralMembersTerms(term)
+    val encoded = terms.map(t => encodeFromSmtTerm(ctx, t, env))
+    val sorts   = encoded.map(t => inferSortOfZ3Expr(ctx, t))
+    val unknown = sorts.indexWhere(_.isEmpty)
+    if unknown >= 0 then
+      fail(ctx, s"set literal element has unknown sort: ${terms(unknown)}")
+    val knownSorts = sorts.flatten
+    val elemSort   = knownSorts.head
+    val mismatch   = knownSorts.indexWhere(s => !Z3Sort.eq(s, elemSort))
+    if mismatch >= 0 then
+      fail(ctx, "set literal elements must all have the same sort")
+    (elemSort, encoded)
+
+  private def smtTermEq(a: smt_term, b: smt_term): Boolean = (a, b) match
+    case (BLit(x), BLit(y))                                 => x == y
+    case (ILit(int_of_integer(x)), ILit(int_of_integer(y))) => x == y
+    case (TVar(x), TVar(y))                                 => x == y
+    case (EnumElemConst(e1, m1), EnumElemConst(e2, m2))     => e1 == e2 && m1 == m2
+    case (TNot(x), TNot(y))                                 => smtTermEq(x, y)
+    case (TAnd(l1, r1), TAnd(l2, r2))                       => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TOr(l1, r1), TOr(l2, r2))                         => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TImplies(l1, r1), TImplies(l2, r2))               => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TEq(l1, r1), TEq(l2, r2))                         => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TLt(l1, r1), TLt(l2, r2))                         => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TNeg(x), TNeg(y))                                 => smtTermEq(x, y)
+    case (TAdd(l1, r1), TAdd(l2, r2))                       => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TSub(l1, r1), TSub(l2, r2))                       => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TMul(l1, r1), TMul(l2, r2))                       => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TDiv(l1, r1), TDiv(l2, r2))                       => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TInDom(n1, e1), TInDom(n2, e2))                   => n1 == n2 && smtTermEq(e1, e2)
+    case (TCardRel(n1), TCardRel(n2))                       => n1 == n2
+    case (TLetIn(x1, v1, b1), TLetIn(x2, v2, b2)) =>
+      x1 == x2 && smtTermEq(v1, v2) && smtTermEq(b1, b2)
+    case (TForallEnum(v1, e1, b1), TForallEnum(v2, e2, b2)) =>
+      v1 == v2 && e1 == e2 && smtTermEq(b1, b2)
+    case (TForallRel(v1, r1, b1), TForallRel(v2, r2, b2)) =>
+      v1 == v2 && r1 == r2 && smtTermEq(b1, b2)
+    case (TIndexRel(n1, k1), TIndexRel(n2, k2)) => n1 == n2 && smtTermEq(k1, k2)
+    case (TFieldAccess(b1, f1), TFieldAccess(b2, f2)) =>
+      f1 == f2 && smtTermEq(b1, b2)
+    case (TSetEmpty(), TSetEmpty())               => true
+    case (TSetInsert(e1, s1), TSetInsert(e2, s2)) => smtTermEq(e1, e2) && smtTermEq(s1, s2)
+    case (TSetMember(e1, s1), TSetMember(e2, s2)) => smtTermEq(e1, e2) && smtTermEq(s1, s2)
+    case (TSetUnion(l1, r1), TSetUnion(l2, r2))   => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TSetIntersect(l1, r1), TSetIntersect(l2, r2)) =>
+      smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TSetDiff(l1, r1), TSetDiff(l2, r2)) => smtTermEq(l1, l2) && smtTermEq(r1, r2)
+    case (TPrime(x), TPrime(y))               => smtTermEq(x, y)
+    case (TPre(x), TPre(y))                   => smtTermEq(x, y)
+    case (TWithRec(b1, f1, v1), TWithRec(b2, f2, v2)) =>
+      f1 == f2 && smtTermEq(b1, b2) && smtTermEq(v1, v2)
+    case _ => false

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -79,37 +79,39 @@ class ConsistencyTest extends CatsEffectSuite:
       s"safe_counter should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
     )
 
-  test("set_ops — every check passes and nothing is skipped"):
+  test("set_ops — every check is sat or soundness-skipped (no unsoundness)"):
     for
       ir     <- SpecFixtures.loadIR("set_ops")
       report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
     yield
-      val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
+      val nonOk = report.checks.filter: c =>
+        c.status != CheckOutcome.Sat && c.status != CheckOutcome.Skipped
       assert(
-        skipped.isEmpty,
-        s"set_ops should have no skipped checks; skipped: ${skipped.map(_.id)}"
+        nonOk.isEmpty,
+        s"set_ops should have no failing checks; got: ${nonOk.map(c => s"${c.id}->${c.status}")}"
       )
+      val unexpectedSkips = report.checks.filter: c =>
+        c.status == CheckOutcome.Skipped &&
+          !c.diagnostic.exists: d =>
+            d.category == DiagnosticCategory.SoundnessLimitation
       assert(
-        report.ok,
-        s"set_ops should be fully consistent; failing: ${report.checks.filter(_.status != CheckOutcome.Sat).map(c => s"${c.id}->${c.status}")}"
+        unexpectedSkips.isEmpty,
+        s"set_ops skips must be soundness-limitation only; got: ${unexpectedSkips.map(_.id)}"
       )
 
-  test("set_comp_demo — `s = { x in D | P }` equality passes in Z3"):
+  test("set_comp_demo — global skips with soundness_limitation (set comprehension out of subset)"):
     for
       ir     <- SpecFixtures.loadIR("set_comp_demo")
       report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
     yield
-      val skipped = report.checks.filter(_.status == CheckOutcome.Skipped)
-      assert(
-        skipped.isEmpty,
-        s"set_comp_demo should have no skipped checks; skipped: ${skipped.map(_.id)}"
+      val global = report.checks.find(_.id == "global").getOrElse(
+        fail("expected a global check")
       )
-      val nonZ3 = report.checks.filter(_.tool != VerifierTool.Z3)
-      assert(
-        nonZ3.isEmpty,
-        s"set_comp_demo should route entirely to Z3; non-Z3: ${nonZ3.map(c => s"${c.id}->${c.tool}")}"
+      assertEquals(global.status, CheckOutcome.Skipped)
+      assertEquals(
+        global.diagnostic.map(_.category),
+        Some(DiagnosticCategory.SoundnessLimitation)
       )
-      assert(report.ok, s"set_comp_demo should be sat; got: ${report.checks.map(_.status)}")
 
   test("powerset_demo — global invariant routes to Alloy and solves sat"):
     for

--- a/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/NarrationTest.scala
@@ -9,7 +9,7 @@ class NarrationTest extends CatsEffectSuite:
     (
       "broken_url_shortener",
       DiagnosticCategory.InvariantViolationByOperation,
-      List("clickCountNonNegative", "click_count", "Tamper")
+      List("totalClicksNonNegative", "totalClicks", "Drain")
     ),
     (
       "broken_decrement",

--- a/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
@@ -55,9 +55,9 @@ class SuggestionTemplateTest extends CatsEffectSuite:
         )
         .getOrElse(fail("no preservation violation found"))
       val hint = violation.diagnostic.flatMap(_.suggestion).getOrElse("")
-      assert(hint.contains("Tamper"), s"expected 'Tamper' in hint; got: $hint")
-      assert(hint.contains("clickCountNonNegative"), s"expected invariant name; got: $hint")
-      assert(hint.contains("click_count"), s"expected field name; got: $hint")
+      assert(hint.contains("Drain"), s"expected 'Drain' in hint; got: $hint")
+      assert(hint.contains("totalClicksNonNegative"), s"expected invariant name; got: $hint")
+      assert(hint.contains("totalClicks"), s"expected field name; got: $hint")
       assert(hint.length <= MaxLen, s"hint too long (${hint.length}): $hint")
 
   test("solver_timeout suggestion mentions check id and timeout (direct template)"):

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -158,7 +158,8 @@ class TranslatorSetOpsTest extends CatsEffectSuite:
     translatorErrorOf(specWithInvariant("a: Set[Int]\n    x: Int", "x in {1, 2, true}")).map: err =>
       assert(
         err.message.contains("must match the membership LHS sort") ||
-          err.message.contains("must all have the same sort"),
+          err.message.contains("must all have the same sort") ||
+          err.message.contains("element sort"),
         s"expected hetero-sort error; got: ${err.message}"
       )
 


### PR DESCRIPTION
## Summary

Closes the two remaining acceptance items from #192: "production translator extracted" (for the in-subset slice) and "TCB documented and audited."

- **Production verify path now routes in-subset checks through the extracted (Isabelle-verified) translator.** `Translator.translateExpr` calls `lower(enums, e)`. On `Some(eSubset)`, routes through `SpecRestGenerated.translate >>> SmtTermToZ3` bridge → Z3. On `None`, falls back to hand-written `translateExprRaw` (only reachable from declaration-level expressions; check-body out-of-subset shapes are filtered to skip by the Trust classifier).
- **`--strict-soundness` flag retired; behavior is now the default.** Best-effort checks always skip with `category = soundness_limitation`. There is no "unsound verdict" path anymore. Alloy-routed temporal/powerset checks are not subject to `lower`-based skipping.
- **New `SmtTermToZ3` bridge** (~250 LOC, hand-written, lives in `Translator.scala` as a private nested helper) handles all 30 `smt_term` constructors with sort-checks at boundaries.
- **TCB audit** at `docs/research/11_tcb_audit.md` — single ledger of what verify's verdicts depend on, layer by layer.

## Test plan

- [x] `sbt test` — 609/609 passing.
- [x] `sbt scalafmtCheckAll "scalafixAll --check"` — clean.
- [x] `cd docs && npm run build` — clean.
- [x] Smoke: `cli/run verify fixtures/spec/safe_counter.spec` returns 0; `auth_service.spec` produces `soundness_limitation` skips for `pre(rel)[k]` / `TheF` checks; `broken_url_shortener.spec` produces a sound `invariant_violation_by_operation` from Drain.preserves.totalClicksNonNegative.

## Fixture / golden updates

`broken_url_shortener.spec` was structured around `Tamper` (`pre(rel)[k]`-using, doesn't lower). Added `totalClicks: Int` state, a `Drain` operation that sets `totalClicks' = -1`, and a matching invariant. The new violation is in-subset; the fixture still demonstrates `invariant_violation_by_operation` under the new defaults. Goldens regenerated (IR JSON, verify_report JSON, three SMT-LIB files).

## What still routes hand-written

Declaration-level expressions (entity field constraints, type-alias `where`-clauses) — these may be out-of-subset and aren't filtered by the Trust classifier. The hand-written translator's check-body code remains in the file for now; it will become dead code once `lower` covers everything (queued M_L.4.x track).

## TCB delta

| Before | After |
|---|---|
| Hand-written `translateExpr` end-to-end (~1900 LOC) | Hand-written for declaration-level exprs only |
| A8 round-trip oracle exercised verified path on 24 canonical probes | Production verify path *is* the verified path for sound checks |
| `trust=best-effort` could mean "translated by hand-written, no formal backing" | `trust=best-effort` always means "skipped" — no unsound verdicts ship |
| New TCB: `SmtTermToZ3` bridge (~250 LOC, hand-written) — the only new TCB |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes in-subset verification through the Isabelle-extracted translator and makes strict soundness the default (flag removed), completing #192’s “extracted translator in production” and “TCB documented” items. All non-skipped Z3 checks are now `trust: "sound"`; best-effort checks always skip.

- **New Features**
  - `Translator.translateExpr` uses `lower` to dispatch to `SpecRestGenerated.translate` + `SmtTermToZ3`; falls back to the hand-written path only for declaration-level expressions.
  - Best-effort checks skip with `soundness_limitation`; exit code `4` is emitted when skips are the only issue. Alloy temporal/powerset checks are unchanged.
  - Added `docs/research/11_tcb_audit.md` and updated verification docs to reflect the new defaults.

- **Migration**
  - Remove the `--strict-soundness` flag (behavior is now default). Expect some checks to become `status: "skipped"` with `trust: "best-effort"` instead of producing unsound verdicts; non-skipped checks report `trust: "sound"`.
  - Golden fixtures and some SMT encodings changed slightly due to the `SmtTermToZ3` bridge.

<sup>Written for commit 8cfad596552f4b1ae0adb9999ac0a40d0d78c0cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced trust-level classification for verification checks—checks are now marked "sound" (verified via Isabelle) or "best-effort" (outside verified subset).
  * Best-effort checks automatically skip with clear soundness-limitation diagnostics instead of requiring a command-line flag.

* **Documentation**
  * Added comprehensive trusted computing base (TCB) audit documentation detailing verified and non-verified components.
  * Updated verification and soundness documentation to reflect new trust model and routing behavior.

* **Removals**
  * Removed `--strict-soundness` CLI flag; soundness coverage gaps are now handled automatically via trust classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->