### PR TITLE
codegen: typed __init__(body) on ORM, SecretStr at the schema boundary

### DIFF
--- a/fixtures/golden/ir/secret_create.json
+++ b/fixtures/golden/ir/secret_create.json
@@ -1,0 +1,1205 @@
+{
+  "kind" : "Service",
+  "name" : "AccountService",
+  "imports" : [
+  ],
+  "entities" : [
+    {
+      "kind" : "Entity",
+      "name" : "Account",
+      "extends_" : null,
+      "fields" : [
+        {
+          "kind" : "Field",
+          "name" : "id",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "AccountId",
+            "span" : {
+              "startLine" : 7,
+              "startCol" : 8,
+              "endLine" : 7,
+              "endCol" : 17
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 7,
+            "startCol" : 4,
+            "endLine" : 7,
+            "endCol" : 17
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "email",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Email",
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 11,
+              "endLine" : 8,
+              "endCol" : 16
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 8,
+            "startCol" : 4,
+            "endLine" : 8,
+            "endCol" : 16
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "password_hash",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 9,
+              "startCol" : 19,
+              "endLine" : 9,
+              "endCol" : 25
+            }
+          },
+          "constraint" : {
+            "kind" : "BinaryOp",
+            "op" : ">",
+            "left" : {
+              "kind" : "Call",
+              "callee" : {
+                "kind" : "Identifier",
+                "name" : "len",
+                "span" : {
+                  "startLine" : 9,
+                  "startCol" : 32,
+                  "endLine" : 9,
+                  "endCol" : 35
+                }
+              },
+              "args" : [
+                {
+                  "kind" : "Identifier",
+                  "name" : "value",
+                  "span" : {
+                    "startLine" : 9,
+                    "startCol" : 36,
+                    "endLine" : 9,
+                    "endCol" : 41
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 9,
+                "startCol" : 32,
+                "endLine" : 9,
+                "endCol" : 42
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 0,
+              "span" : {
+                "startLine" : 9,
+                "startCol" : 45,
+                "endLine" : 9,
+                "endCol" : 46
+              }
+            },
+            "span" : {
+              "startLine" : 9,
+              "startCol" : 32,
+              "endLine" : 9,
+              "endCol" : 46
+            }
+          },
+          "span" : {
+            "startLine" : 9,
+            "startCol" : 4,
+            "endLine" : 9,
+            "endCol" : 46
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "display_name",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 10,
+              "startCol" : 18,
+              "endLine" : 10,
+              "endCol" : 24
+            }
+          },
+          "constraint" : {
+            "kind" : "BinaryOp",
+            "op" : ">=",
+            "left" : {
+              "kind" : "Call",
+              "callee" : {
+                "kind" : "Identifier",
+                "name" : "len",
+                "span" : {
+                  "startLine" : 10,
+                  "startCol" : 31,
+                  "endLine" : 10,
+                  "endCol" : 34
+                }
+              },
+              "args" : [
+                {
+                  "kind" : "Identifier",
+                  "name" : "value",
+                  "span" : {
+                    "startLine" : 10,
+                    "startCol" : 35,
+                    "endLine" : 10,
+                    "endCol" : 40
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 10,
+                "startCol" : 31,
+                "endLine" : 10,
+                "endCol" : 41
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 10,
+                "startCol" : 45,
+                "endLine" : 10,
+                "endCol" : 46
+              }
+            },
+            "span" : {
+              "startLine" : 10,
+              "startCol" : 31,
+              "endLine" : 10,
+              "endCol" : 46
+            }
+          },
+          "span" : {
+            "startLine" : 10,
+            "startCol" : 4,
+            "endLine" : 10,
+            "endCol" : 46
+          }
+        }
+      ],
+      "invariants" : [
+      ],
+      "span" : {
+        "startLine" : 6,
+        "startCol" : 2,
+        "endLine" : 11,
+        "endCol" : 3
+      }
+    }
+  ],
+  "enums" : [
+  ],
+  "typeAliases" : [
+    {
+      "kind" : "TypeAlias",
+      "name" : "Email",
+      "typeExpr" : {
+        "kind" : "NamedType",
+        "name" : "String",
+        "span" : {
+          "startLine" : 3,
+          "startCol" : 15,
+          "endLine" : 3,
+          "endCol" : 21
+        }
+      },
+      "constraint" : {
+        "kind" : "BinaryOp",
+        "op" : "and",
+        "left" : {
+          "kind" : "BinaryOp",
+          "op" : ">=",
+          "left" : {
+            "kind" : "Call",
+            "callee" : {
+              "kind" : "Identifier",
+              "name" : "len",
+              "span" : {
+                "startLine" : 3,
+                "startCol" : 28,
+                "endLine" : 3,
+                "endCol" : 31
+              }
+            },
+            "args" : [
+              {
+                "kind" : "Identifier",
+                "name" : "value",
+                "span" : {
+                  "startLine" : 3,
+                  "startCol" : 32,
+                  "endLine" : 3,
+                  "endCol" : 37
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 28,
+              "endLine" : 3,
+              "endCol" : 38
+            }
+          },
+          "right" : {
+            "kind" : "IntLit",
+            "value" : 1,
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 42,
+              "endLine" : 3,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 3,
+            "startCol" : 28,
+            "endLine" : 3,
+            "endCol" : 43
+          }
+        },
+        "right" : {
+          "kind" : "BinaryOp",
+          "op" : "<=",
+          "left" : {
+            "kind" : "Call",
+            "callee" : {
+              "kind" : "Identifier",
+              "name" : "len",
+              "span" : {
+                "startLine" : 3,
+                "startCol" : 48,
+                "endLine" : 3,
+                "endCol" : 51
+              }
+            },
+            "args" : [
+              {
+                "kind" : "Identifier",
+                "name" : "value",
+                "span" : {
+                  "startLine" : 3,
+                  "startCol" : 52,
+                  "endLine" : 3,
+                  "endCol" : 57
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 48,
+              "endLine" : 3,
+              "endCol" : 58
+            }
+          },
+          "right" : {
+            "kind" : "IntLit",
+            "value" : 100,
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 62,
+              "endLine" : 3,
+              "endCol" : 65
+            }
+          },
+          "span" : {
+            "startLine" : 3,
+            "startCol" : 48,
+            "endLine" : 3,
+            "endCol" : 65
+          }
+        },
+        "span" : {
+          "startLine" : 3,
+          "startCol" : 28,
+          "endLine" : 3,
+          "endCol" : 65
+        }
+      },
+      "span" : {
+        "startLine" : 3,
+        "startCol" : 2,
+        "endLine" : 3,
+        "endCol" : 65
+      }
+    },
+    {
+      "kind" : "TypeAlias",
+      "name" : "AccountId",
+      "typeExpr" : {
+        "kind" : "NamedType",
+        "name" : "Int",
+        "span" : {
+          "startLine" : 4,
+          "startCol" : 19,
+          "endLine" : 4,
+          "endCol" : 22
+        }
+      },
+      "constraint" : {
+        "kind" : "BinaryOp",
+        "op" : ">",
+        "left" : {
+          "kind" : "Identifier",
+          "name" : "value",
+          "span" : {
+            "startLine" : 4,
+            "startCol" : 29,
+            "endLine" : 4,
+            "endCol" : 34
+          }
+        },
+        "right" : {
+          "kind" : "IntLit",
+          "value" : 0,
+          "span" : {
+            "startLine" : 4,
+            "startCol" : 37,
+            "endLine" : 4,
+            "endCol" : 38
+          }
+        },
+        "span" : {
+          "startLine" : 4,
+          "startCol" : 29,
+          "endLine" : 4,
+          "endCol" : 38
+        }
+      },
+      "span" : {
+        "startLine" : 4,
+        "startCol" : 2,
+        "endLine" : 4,
+        "endCol" : 38
+      }
+    }
+  ],
+  "state" : {
+    "kind" : "State",
+    "fields" : [
+      {
+        "kind" : "StateField",
+        "name" : "accounts",
+        "typeExpr" : {
+          "kind" : "RelationType",
+          "fromType" : {
+            "kind" : "NamedType",
+            "name" : "AccountId",
+            "span" : {
+              "startLine" : 14,
+              "startCol" : 14,
+              "endLine" : 14,
+              "endCol" : 23
+            }
+          },
+          "multiplicity" : "lone",
+          "toType" : {
+            "kind" : "NamedType",
+            "name" : "Account",
+            "span" : {
+              "startLine" : 14,
+              "startCol" : 32,
+              "endLine" : 14,
+              "endCol" : 39
+            }
+          },
+          "span" : {
+            "startLine" : 14,
+            "startCol" : 14,
+            "endLine" : 14,
+            "endCol" : 39
+          }
+        },
+        "span" : {
+          "startLine" : 14,
+          "startCol" : 4,
+          "endLine" : 14,
+          "endCol" : 39
+        }
+      },
+      {
+        "kind" : "StateField",
+        "name" : "next_id",
+        "typeExpr" : {
+          "kind" : "NamedType",
+          "name" : "AccountId",
+          "span" : {
+            "startLine" : 15,
+            "startCol" : 13,
+            "endLine" : 15,
+            "endCol" : 22
+          }
+        },
+        "span" : {
+          "startLine" : 15,
+          "startCol" : 4,
+          "endLine" : 15,
+          "endCol" : 22
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 13,
+      "startCol" : 2,
+      "endLine" : 16,
+      "endCol" : 3
+    }
+  },
+  "operations" : [
+    {
+      "kind" : "Operation",
+      "name" : "CreateAccount",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "email",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Email",
+            "span" : {
+              "startLine" : 19,
+              "startCol" : 19,
+              "endLine" : 19,
+              "endCol" : 24
+            }
+          },
+          "span" : {
+            "startLine" : 19,
+            "startCol" : 12,
+            "endLine" : 19,
+            "endCol" : 24
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "password_hash",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 20,
+              "startCol" : 27,
+              "endLine" : 20,
+              "endCol" : 33
+            }
+          },
+          "span" : {
+            "startLine" : 20,
+            "startCol" : 12,
+            "endLine" : 20,
+            "endCol" : 33
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "display_name",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 21,
+              "startCol" : 26,
+              "endLine" : 21,
+              "endCol" : 32
+            }
+          },
+          "span" : {
+            "startLine" : 21,
+            "startCol" : 12,
+            "endLine" : 21,
+            "endCol" : 32
+          }
+        }
+      ],
+      "outputs" : [
+        {
+          "kind" : "Param",
+          "name" : "account",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Account",
+            "span" : {
+              "startLine" : 22,
+              "startCol" : 21,
+              "endLine" : 22,
+              "endCol" : 28
+            }
+          },
+          "span" : {
+            "startLine" : 22,
+            "startCol" : 12,
+            "endLine" : 22,
+            "endCol" : 28
+          }
+        }
+      ],
+      "requires" : [
+        {
+          "kind" : "BoolLit",
+          "value" : true,
+          "span" : {
+            "startLine" : 25,
+            "startCol" : 6,
+            "endLine" : 25,
+            "endCol" : 10
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 28,
+                "startCol" : 6,
+                "endLine" : 28,
+                "endCol" : 13
+              }
+            },
+            "field" : "id",
+            "span" : {
+              "startLine" : 28,
+              "startCol" : 6,
+              "endLine" : 28,
+              "endCol" : 16
+            }
+          },
+          "right" : {
+            "kind" : "Pre",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_id",
+              "span" : {
+                "startLine" : 28,
+                "startCol" : 23,
+                "endLine" : 28,
+                "endCol" : 30
+              }
+            },
+            "span" : {
+              "startLine" : 28,
+              "startCol" : 19,
+              "endLine" : 28,
+              "endCol" : 31
+            }
+          },
+          "span" : {
+            "startLine" : 28,
+            "startCol" : 6,
+            "endLine" : 28,
+            "endCol" : 31
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 29,
+                "startCol" : 6,
+                "endLine" : 29,
+                "endCol" : 13
+              }
+            },
+            "field" : "email",
+            "span" : {
+              "startLine" : 29,
+              "startCol" : 6,
+              "endLine" : 29,
+              "endCol" : 19
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "email",
+            "span" : {
+              "startLine" : 29,
+              "startCol" : 22,
+              "endLine" : 29,
+              "endCol" : 27
+            }
+          },
+          "span" : {
+            "startLine" : 29,
+            "startCol" : 6,
+            "endLine" : 29,
+            "endCol" : 27
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 30,
+                "startCol" : 6,
+                "endLine" : 30,
+                "endCol" : 13
+              }
+            },
+            "field" : "password_hash",
+            "span" : {
+              "startLine" : 30,
+              "startCol" : 6,
+              "endLine" : 30,
+              "endCol" : 27
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "password_hash",
+            "span" : {
+              "startLine" : 30,
+              "startCol" : 30,
+              "endLine" : 30,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 30,
+            "startCol" : 6,
+            "endLine" : 30,
+            "endCol" : 43
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 31,
+                "startCol" : 6,
+                "endLine" : 31,
+                "endCol" : 13
+              }
+            },
+            "field" : "display_name",
+            "span" : {
+              "startLine" : 31,
+              "startCol" : 6,
+              "endLine" : 31,
+              "endCol" : 26
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "display_name",
+            "span" : {
+              "startLine" : 31,
+              "startCol" : 29,
+              "endLine" : 31,
+              "endCol" : 41
+            }
+          },
+          "span" : {
+            "startLine" : 31,
+            "startCol" : 6,
+            "endLine" : 31,
+            "endCol" : 41
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_id",
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 6,
+                "endLine" : 32,
+                "endCol" : 13
+              }
+            },
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 6,
+              "endLine" : 32,
+              "endCol" : 14
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "next_id",
+                "span" : {
+                  "startLine" : 32,
+                  "startCol" : 21,
+                  "endLine" : 32,
+                  "endCol" : 28
+                }
+              },
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 17,
+                "endLine" : 32,
+                "endCol" : 29
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 32,
+                "endLine" : 32,
+                "endCol" : 33
+              }
+            },
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 17,
+              "endLine" : 32,
+              "endCol" : 33
+            }
+          },
+          "span" : {
+            "startLine" : 32,
+            "startCol" : 6,
+            "endLine" : 32,
+            "endCol" : 33
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "accounts",
+              "span" : {
+                "startLine" : 33,
+                "startCol" : 6,
+                "endLine" : 33,
+                "endCol" : 14
+              }
+            },
+            "span" : {
+              "startLine" : 33,
+              "startCol" : 6,
+              "endLine" : 33,
+              "endCol" : 15
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "accounts",
+                "span" : {
+                  "startLine" : 33,
+                  "startCol" : 22,
+                  "endLine" : 33,
+                  "endCol" : 30
+                }
+              },
+              "span" : {
+                "startLine" : 33,
+                "startCol" : 18,
+                "endLine" : 33,
+                "endCol" : 31
+              }
+            },
+            "right" : {
+              "kind" : "MapLiteral",
+              "entries" : [
+                {
+                  "key" : {
+                    "kind" : "FieldAccess",
+                    "base" : {
+                      "kind" : "Identifier",
+                      "name" : "account",
+                      "span" : {
+                        "startLine" : 33,
+                        "startCol" : 35,
+                        "endLine" : 33,
+                        "endCol" : 42
+                      }
+                    },
+                    "field" : "id",
+                    "span" : {
+                      "startLine" : 33,
+                      "startCol" : 35,
+                      "endLine" : 33,
+                      "endCol" : 45
+                    }
+                  },
+                  "value" : {
+                    "kind" : "Identifier",
+                    "name" : "account",
+                    "span" : {
+                      "startLine" : 33,
+                      "startCol" : 49,
+                      "endLine" : 33,
+                      "endCol" : 56
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 33,
+                    "startCol" : 35,
+                    "endLine" : 33,
+                    "endCol" : 45
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 33,
+                "startCol" : 34,
+                "endLine" : 33,
+                "endCol" : 57
+              }
+            },
+            "span" : {
+              "startLine" : 33,
+              "startCol" : 18,
+              "endLine" : 33,
+              "endCol" : 57
+            }
+          },
+          "span" : {
+            "startLine" : 33,
+            "startCol" : 6,
+            "endLine" : 33,
+            "endCol" : 57
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "UnaryOp",
+            "op" : "cardinality",
+            "operand" : {
+              "kind" : "Prime",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "accounts",
+                "span" : {
+                  "startLine" : 34,
+                  "startCol" : 7,
+                  "endLine" : 34,
+                  "endCol" : 15
+                }
+              },
+              "span" : {
+                "startLine" : 34,
+                "startCol" : 7,
+                "endLine" : 34,
+                "endCol" : 16
+              }
+            },
+            "span" : {
+              "startLine" : 34,
+              "startCol" : 6,
+              "endLine" : 34,
+              "endCol" : 16
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "UnaryOp",
+              "op" : "cardinality",
+              "operand" : {
+                "kind" : "Pre",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "accounts",
+                  "span" : {
+                    "startLine" : 34,
+                    "startCol" : 24,
+                    "endLine" : 34,
+                    "endCol" : 32
+                  }
+                },
+                "span" : {
+                  "startLine" : 34,
+                  "startCol" : 20,
+                  "endLine" : 34,
+                  "endCol" : 33
+                }
+              },
+              "span" : {
+                "startLine" : 34,
+                "startCol" : 19,
+                "endLine" : 34,
+                "endCol" : 33
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 34,
+                "startCol" : 36,
+                "endLine" : 34,
+                "endCol" : 37
+              }
+            },
+            "span" : {
+              "startLine" : 34,
+              "startCol" : 19,
+              "endLine" : 34,
+              "endCol" : 37
+            }
+          },
+          "span" : {
+            "startLine" : 34,
+            "startCol" : 6,
+            "endLine" : 34,
+            "endCol" : 37
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 18,
+        "startCol" : 2,
+        "endLine" : 35,
+        "endCol" : 3
+      }
+    }
+  ],
+  "transitions" : [
+  ],
+  "invariants" : [
+  ],
+  "temporals" : [
+  ],
+  "facts" : [
+  ],
+  "functions" : [
+  ],
+  "predicates" : [
+    {
+      "kind" : "Predicate",
+      "name" : "isValidURI",
+      "params" : [
+        {
+          "kind" : "Param",
+          "name" : "s",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 3,
+              "startCol" : 26,
+              "endLine" : 3,
+              "endCol" : 32
+            }
+          },
+          "span" : {
+            "startLine" : 3,
+            "startCol" : 23,
+            "endLine" : 3,
+            "endCol" : 32
+          }
+        }
+      ],
+      "body" : {
+        "kind" : "Matches",
+        "expr" : {
+          "kind" : "Identifier",
+          "name" : "s",
+          "span" : {
+            "startLine" : 3,
+            "startCol" : 36,
+            "endLine" : 3,
+            "endCol" : 37
+          }
+        },
+        "pattern" : "^https?:..[^\\s]+",
+        "span" : {
+          "startLine" : 3,
+          "startCol" : 36,
+          "endLine" : 3,
+          "endCol" : 64
+        }
+      },
+      "span" : {
+        "startLine" : 3,
+        "startCol" : 2,
+        "endLine" : 3,
+        "endCol" : 64
+      }
+    },
+    {
+      "kind" : "Predicate",
+      "name" : "isValidEmail",
+      "params" : [
+        {
+          "kind" : "Param",
+          "name" : "s",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 5,
+              "startCol" : 28,
+              "endLine" : 5,
+              "endCol" : 34
+            }
+          },
+          "span" : {
+            "startLine" : 5,
+            "startCol" : 25,
+            "endLine" : 5,
+            "endCol" : 34
+          }
+        }
+      ],
+      "body" : {
+        "kind" : "Matches",
+        "expr" : {
+          "kind" : "Identifier",
+          "name" : "s",
+          "span" : {
+            "startLine" : 5,
+            "startCol" : 38,
+            "endLine" : 5,
+            "endCol" : 39
+          }
+        },
+        "pattern" : "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+        "span" : {
+          "startLine" : 5,
+          "startCol" : 38,
+          "endLine" : 5,
+          "endCol" : 76
+        }
+      },
+      "span" : {
+        "startLine" : 5,
+        "startCol" : 2,
+        "endLine" : 5,
+        "endCol" : 76
+      }
+    }
+  ],
+  "conventions" : {
+    "kind" : "Conventions",
+    "rules" : [
+      {
+        "kind" : "ConventionRule",
+        "target" : "CreateAccount",
+        "property" : "http_path",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "StringLit",
+          "value" : "/accounts",
+          "span" : {
+            "startLine" : 38,
+            "startCol" : 30,
+            "endLine" : 38,
+            "endCol" : 41
+          }
+        },
+        "span" : {
+          "startLine" : 38,
+          "startCol" : 4,
+          "endLine" : 38,
+          "endCol" : 41
+        }
+      },
+      {
+        "kind" : "ConventionRule",
+        "target" : "CreateAccount",
+        "property" : "http_method",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "StringLit",
+          "value" : "POST",
+          "span" : {
+            "startLine" : 39,
+            "startCol" : 32,
+            "endLine" : 39,
+            "endCol" : 38
+          }
+        },
+        "span" : {
+          "startLine" : 39,
+          "startCol" : 4,
+          "endLine" : 39,
+          "endCol" : 38
+        }
+      },
+      {
+        "kind" : "ConventionRule",
+        "target" : "CreateAccount",
+        "property" : "http_status_success",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "IntLit",
+          "value" : 201,
+          "span" : {
+            "startLine" : 40,
+            "startCol" : 40,
+            "endLine" : 40,
+            "endCol" : 43
+          }
+        },
+        "span" : {
+          "startLine" : 40,
+          "startCol" : 4,
+          "endLine" : 40,
+          "endCol" : 43
+        }
+      }
+    ],
+    "span" : {
+      "startLine" : 37,
+      "startCol" : 2,
+      "endLine" : 41,
+      "endCol" : 3
+    }
+  },
+  "span" : {
+    "startLine" : 1,
+    "startCol" : 0,
+    "endLine" : 42,
+    "endCol" : 1
+  }
+}

--- a/fixtures/golden/ir/secret_create.json
+++ b/fixtures/golden/ir/secret_create.json
@@ -192,6 +192,36 @@
             "endLine" : 10,
             "endCol" : 46
           }
+        },
+        {
+          "kind" : "Field",
+          "name" : "reset_token",
+          "typeExpr" : {
+            "kind" : "OptionType",
+            "innerType" : {
+              "kind" : "NamedType",
+              "name" : "String",
+              "span" : {
+                "startLine" : 11,
+                "startCol" : 24,
+                "endLine" : 11,
+                "endCol" : 30
+              }
+            },
+            "span" : {
+              "startLine" : 11,
+              "startCol" : 17,
+              "endLine" : 11,
+              "endCol" : 31
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 11,
+            "startCol" : 4,
+            "endLine" : 11,
+            "endCol" : 31
+          }
         }
       ],
       "invariants" : [
@@ -199,7 +229,7 @@
       "span" : {
         "startLine" : 6,
         "startCol" : 2,
-        "endLine" : 11,
+        "endLine" : 12,
         "endCol" : 3
       }
     }
@@ -402,9 +432,9 @@
             "kind" : "NamedType",
             "name" : "AccountId",
             "span" : {
-              "startLine" : 14,
+              "startLine" : 15,
               "startCol" : 14,
-              "endLine" : 14,
+              "endLine" : 15,
               "endCol" : 23
             }
           },
@@ -413,23 +443,23 @@
             "kind" : "NamedType",
             "name" : "Account",
             "span" : {
-              "startLine" : 14,
+              "startLine" : 15,
               "startCol" : 32,
-              "endLine" : 14,
+              "endLine" : 15,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 14,
+            "startLine" : 15,
             "startCol" : 14,
-            "endLine" : 14,
+            "endLine" : 15,
             "endCol" : 39
           }
         },
         "span" : {
-          "startLine" : 14,
+          "startLine" : 15,
           "startCol" : 4,
-          "endLine" : 14,
+          "endLine" : 15,
           "endCol" : 39
         }
       },
@@ -440,24 +470,24 @@
           "kind" : "NamedType",
           "name" : "AccountId",
           "span" : {
-            "startLine" : 15,
+            "startLine" : 16,
             "startCol" : 13,
-            "endLine" : 15,
+            "endLine" : 16,
             "endCol" : 22
           }
         },
         "span" : {
-          "startLine" : 15,
+          "startLine" : 16,
           "startCol" : 4,
-          "endLine" : 15,
+          "endLine" : 16,
           "endCol" : 22
         }
       }
     ],
     "span" : {
-      "startLine" : 13,
+      "startLine" : 14,
       "startCol" : 2,
-      "endLine" : 16,
+      "endLine" : 17,
       "endCol" : 3
     }
   },
@@ -473,16 +503,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 19,
+              "startLine" : 20,
               "startCol" : 19,
-              "endLine" : 19,
+              "endLine" : 20,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 19,
+            "startLine" : 20,
             "startCol" : 12,
-            "endLine" : 19,
+            "endLine" : 20,
             "endCol" : 24
           }
         },
@@ -493,16 +523,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 20,
+              "startLine" : 21,
               "startCol" : 27,
-              "endLine" : 20,
+              "endLine" : 21,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 20,
+            "startLine" : 21,
             "startCol" : 12,
-            "endLine" : 20,
+            "endLine" : 21,
             "endCol" : 33
           }
         },
@@ -513,17 +543,46 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 21,
+              "startLine" : 22,
               "startCol" : 26,
-              "endLine" : 21,
+              "endLine" : 22,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 21,
+            "startLine" : 22,
             "startCol" : 12,
-            "endLine" : 21,
+            "endLine" : 22,
             "endCol" : 32
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "reset_token",
+          "typeExpr" : {
+            "kind" : "OptionType",
+            "innerType" : {
+              "kind" : "NamedType",
+              "name" : "String",
+              "span" : {
+                "startLine" : 23,
+                "startCol" : 32,
+                "endLine" : 23,
+                "endCol" : 38
+              }
+            },
+            "span" : {
+              "startLine" : 23,
+              "startCol" : 25,
+              "endLine" : 23,
+              "endCol" : 39
+            }
+          },
+          "span" : {
+            "startLine" : 23,
+            "startCol" : 12,
+            "endLine" : 23,
+            "endCol" : 39
           }
         }
       ],
@@ -535,16 +594,16 @@
             "kind" : "NamedType",
             "name" : "Account",
             "span" : {
-              "startLine" : 22,
+              "startLine" : 24,
               "startCol" : 21,
-              "endLine" : 22,
+              "endLine" : 24,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 22,
+            "startLine" : 24,
             "startCol" : 12,
-            "endLine" : 22,
+            "endLine" : 24,
             "endCol" : 28
           }
         }
@@ -554,103 +613,14 @@
           "kind" : "BoolLit",
           "value" : true,
           "span" : {
-            "startLine" : 25,
+            "startLine" : 27,
             "startCol" : 6,
-            "endLine" : 25,
+            "endLine" : 27,
             "endCol" : 10
           }
         }
       ],
       "ensures" : [
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Identifier",
-              "name" : "account",
-              "span" : {
-                "startLine" : 28,
-                "startCol" : 6,
-                "endLine" : 28,
-                "endCol" : 13
-              }
-            },
-            "field" : "id",
-            "span" : {
-              "startLine" : 28,
-              "startCol" : 6,
-              "endLine" : 28,
-              "endCol" : 16
-            }
-          },
-          "right" : {
-            "kind" : "Pre",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "next_id",
-              "span" : {
-                "startLine" : 28,
-                "startCol" : 23,
-                "endLine" : 28,
-                "endCol" : 30
-              }
-            },
-            "span" : {
-              "startLine" : 28,
-              "startCol" : 19,
-              "endLine" : 28,
-              "endCol" : 31
-            }
-          },
-          "span" : {
-            "startLine" : 28,
-            "startCol" : 6,
-            "endLine" : 28,
-            "endCol" : 31
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Identifier",
-              "name" : "account",
-              "span" : {
-                "startLine" : 29,
-                "startCol" : 6,
-                "endLine" : 29,
-                "endCol" : 13
-              }
-            },
-            "field" : "email",
-            "span" : {
-              "startLine" : 29,
-              "startCol" : 6,
-              "endLine" : 29,
-              "endCol" : 19
-            }
-          },
-          "right" : {
-            "kind" : "Identifier",
-            "name" : "email",
-            "span" : {
-              "startLine" : 29,
-              "startCol" : 22,
-              "endLine" : 29,
-              "endCol" : 27
-            }
-          },
-          "span" : {
-            "startLine" : 29,
-            "startCol" : 6,
-            "endLine" : 29,
-            "endCol" : 27
-          }
-        },
         {
           "kind" : "BinaryOp",
           "op" : "=",
@@ -666,29 +636,38 @@
                 "endCol" : 13
               }
             },
-            "field" : "password_hash",
+            "field" : "id",
             "span" : {
               "startLine" : 30,
               "startCol" : 6,
               "endLine" : 30,
-              "endCol" : 27
+              "endCol" : 16
             }
           },
           "right" : {
-            "kind" : "Identifier",
-            "name" : "password_hash",
+            "kind" : "Pre",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_id",
+              "span" : {
+                "startLine" : 30,
+                "startCol" : 23,
+                "endLine" : 30,
+                "endCol" : 30
+              }
+            },
             "span" : {
               "startLine" : 30,
-              "startCol" : 30,
+              "startCol" : 19,
               "endLine" : 30,
-              "endCol" : 43
+              "endCol" : 31
             }
           },
           "span" : {
             "startLine" : 30,
             "startCol" : 6,
             "endLine" : 30,
-            "endCol" : 43
+            "endCol" : 31
           }
         },
         {
@@ -706,11 +685,91 @@
                 "endCol" : 13
               }
             },
-            "field" : "display_name",
+            "field" : "email",
             "span" : {
               "startLine" : 31,
               "startCol" : 6,
               "endLine" : 31,
+              "endCol" : 19
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "email",
+            "span" : {
+              "startLine" : 31,
+              "startCol" : 22,
+              "endLine" : 31,
+              "endCol" : 27
+            }
+          },
+          "span" : {
+            "startLine" : 31,
+            "startCol" : 6,
+            "endLine" : 31,
+            "endCol" : 27
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 32,
+                "startCol" : 6,
+                "endLine" : 32,
+                "endCol" : 13
+              }
+            },
+            "field" : "password_hash",
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 6,
+              "endLine" : 32,
+              "endCol" : 27
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "password_hash",
+            "span" : {
+              "startLine" : 32,
+              "startCol" : 30,
+              "endLine" : 32,
+              "endCol" : 43
+            }
+          },
+          "span" : {
+            "startLine" : 32,
+            "startCol" : 6,
+            "endLine" : 32,
+            "endCol" : 43
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 33,
+                "startCol" : 6,
+                "endLine" : 33,
+                "endCol" : 13
+              }
+            },
+            "field" : "display_name",
+            "span" : {
+              "startLine" : 33,
+              "startCol" : 6,
+              "endLine" : 33,
               "endCol" : 26
             }
           },
@@ -718,17 +777,57 @@
             "kind" : "Identifier",
             "name" : "display_name",
             "span" : {
-              "startLine" : 31,
+              "startLine" : 33,
               "startCol" : 29,
-              "endLine" : 31,
+              "endLine" : 33,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 31,
+            "startLine" : 33,
             "startCol" : 6,
-            "endLine" : 31,
+            "endLine" : 33,
             "endCol" : 41
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "account",
+              "span" : {
+                "startLine" : 34,
+                "startCol" : 6,
+                "endLine" : 34,
+                "endCol" : 13
+              }
+            },
+            "field" : "reset_token",
+            "span" : {
+              "startLine" : 34,
+              "startCol" : 6,
+              "endLine" : 34,
+              "endCol" : 25
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "reset_token",
+            "span" : {
+              "startLine" : 34,
+              "startCol" : 28,
+              "endLine" : 34,
+              "endCol" : 39
+            }
+          },
+          "span" : {
+            "startLine" : 34,
+            "startCol" : 6,
+            "endLine" : 34,
+            "endCol" : 39
           }
         },
         {
@@ -740,16 +839,16 @@
               "kind" : "Identifier",
               "name" : "next_id",
               "span" : {
-                "startLine" : 32,
+                "startLine" : 35,
                 "startCol" : 6,
-                "endLine" : 32,
+                "endLine" : 35,
                 "endCol" : 13
               }
             },
             "span" : {
-              "startLine" : 32,
+              "startLine" : 35,
               "startCol" : 6,
-              "endLine" : 32,
+              "endLine" : 35,
               "endCol" : 14
             }
           },
@@ -762,16 +861,16 @@
                 "kind" : "Identifier",
                 "name" : "next_id",
                 "span" : {
-                  "startLine" : 32,
+                  "startLine" : 35,
                   "startCol" : 21,
-                  "endLine" : 32,
+                  "endLine" : 35,
                   "endCol" : 28
                 }
               },
               "span" : {
-                "startLine" : 32,
+                "startLine" : 35,
                 "startCol" : 17,
-                "endLine" : 32,
+                "endLine" : 35,
                 "endCol" : 29
               }
             },
@@ -779,23 +878,23 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 32,
+                "startLine" : 35,
                 "startCol" : 32,
-                "endLine" : 32,
+                "endLine" : 35,
                 "endCol" : 33
               }
             },
             "span" : {
-              "startLine" : 32,
+              "startLine" : 35,
               "startCol" : 17,
-              "endLine" : 32,
+              "endLine" : 35,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 32,
+            "startLine" : 35,
             "startCol" : 6,
-            "endLine" : 32,
+            "endLine" : 35,
             "endCol" : 33
           }
         },
@@ -808,16 +907,16 @@
               "kind" : "Identifier",
               "name" : "accounts",
               "span" : {
-                "startLine" : 33,
+                "startLine" : 36,
                 "startCol" : 6,
-                "endLine" : 33,
+                "endLine" : 36,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 33,
+              "startLine" : 36,
               "startCol" : 6,
-              "endLine" : 33,
+              "endLine" : 36,
               "endCol" : 15
             }
           },
@@ -830,16 +929,16 @@
                 "kind" : "Identifier",
                 "name" : "accounts",
                 "span" : {
-                  "startLine" : 33,
+                  "startLine" : 36,
                   "startCol" : 22,
-                  "endLine" : 33,
+                  "endLine" : 36,
                   "endCol" : 30
                 }
               },
               "span" : {
-                "startLine" : 33,
+                "startLine" : 36,
                 "startCol" : 18,
-                "endLine" : 33,
+                "endLine" : 36,
                 "endCol" : 31
               }
             },
@@ -853,17 +952,17 @@
                       "kind" : "Identifier",
                       "name" : "account",
                       "span" : {
-                        "startLine" : 33,
+                        "startLine" : 36,
                         "startCol" : 35,
-                        "endLine" : 33,
+                        "endLine" : 36,
                         "endCol" : 42
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 33,
+                      "startLine" : 36,
                       "startCol" : 35,
-                      "endLine" : 33,
+                      "endLine" : 36,
                       "endCol" : 45
                     }
                   },
@@ -871,38 +970,38 @@
                     "kind" : "Identifier",
                     "name" : "account",
                     "span" : {
-                      "startLine" : 33,
+                      "startLine" : 36,
                       "startCol" : 49,
-                      "endLine" : 33,
+                      "endLine" : 36,
                       "endCol" : 56
                     }
                   },
                   "span" : {
-                    "startLine" : 33,
+                    "startLine" : 36,
                     "startCol" : 35,
-                    "endLine" : 33,
+                    "endLine" : 36,
                     "endCol" : 45
                   }
                 }
               ],
               "span" : {
-                "startLine" : 33,
+                "startLine" : 36,
                 "startCol" : 34,
-                "endLine" : 33,
+                "endLine" : 36,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 33,
+              "startLine" : 36,
               "startCol" : 18,
-              "endLine" : 33,
+              "endLine" : 36,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 33,
+            "startLine" : 36,
             "startCol" : 6,
-            "endLine" : 33,
+            "endLine" : 36,
             "endCol" : 57
           }
         },
@@ -918,23 +1017,23 @@
                 "kind" : "Identifier",
                 "name" : "accounts",
                 "span" : {
-                  "startLine" : 34,
+                  "startLine" : 37,
                   "startCol" : 7,
-                  "endLine" : 34,
+                  "endLine" : 37,
                   "endCol" : 15
                 }
               },
               "span" : {
-                "startLine" : 34,
+                "startLine" : 37,
                 "startCol" : 7,
-                "endLine" : 34,
+                "endLine" : 37,
                 "endCol" : 16
               }
             },
             "span" : {
-              "startLine" : 34,
+              "startLine" : 37,
               "startCol" : 6,
-              "endLine" : 34,
+              "endLine" : 37,
               "endCol" : 16
             }
           },
@@ -950,23 +1049,23 @@
                   "kind" : "Identifier",
                   "name" : "accounts",
                   "span" : {
-                    "startLine" : 34,
+                    "startLine" : 37,
                     "startCol" : 24,
-                    "endLine" : 34,
+                    "endLine" : 37,
                     "endCol" : 32
                   }
                 },
                 "span" : {
-                  "startLine" : 34,
+                  "startLine" : 37,
                   "startCol" : 20,
-                  "endLine" : 34,
+                  "endLine" : 37,
                   "endCol" : 33
                 }
               },
               "span" : {
-                "startLine" : 34,
+                "startLine" : 37,
                 "startCol" : 19,
-                "endLine" : 34,
+                "endLine" : 37,
                 "endCol" : 33
               }
             },
@@ -974,31 +1073,31 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 34,
+                "startLine" : 37,
                 "startCol" : 36,
-                "endLine" : 34,
+                "endLine" : 37,
                 "endCol" : 37
               }
             },
             "span" : {
-              "startLine" : 34,
+              "startLine" : 37,
               "startCol" : 19,
-              "endLine" : 34,
+              "endLine" : 37,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 34,
+            "startLine" : 37,
             "startCol" : 6,
-            "endLine" : 34,
+            "endLine" : 37,
             "endCol" : 37
           }
         }
       ],
       "span" : {
-        "startLine" : 18,
+        "startLine" : 19,
         "startCol" : 2,
-        "endLine" : 35,
+        "endLine" : 38,
         "endCol" : 3
       }
     }
@@ -1131,16 +1230,16 @@
           "kind" : "StringLit",
           "value" : "/accounts",
           "span" : {
-            "startLine" : 38,
+            "startLine" : 41,
             "startCol" : 30,
-            "endLine" : 38,
+            "endLine" : 41,
             "endCol" : 41
           }
         },
         "span" : {
-          "startLine" : 38,
+          "startLine" : 41,
           "startCol" : 4,
-          "endLine" : 38,
+          "endLine" : 41,
           "endCol" : 41
         }
       },
@@ -1153,16 +1252,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 39,
+            "startLine" : 42,
             "startCol" : 32,
-            "endLine" : 39,
+            "endLine" : 42,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 39,
+          "startLine" : 42,
           "startCol" : 4,
-          "endLine" : 39,
+          "endLine" : 42,
           "endCol" : 38
         }
       },
@@ -1175,31 +1274,31 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 40,
+            "startLine" : 43,
             "startCol" : 40,
-            "endLine" : 40,
+            "endLine" : 43,
             "endCol" : 43
           }
         },
         "span" : {
-          "startLine" : 40,
+          "startLine" : 43,
           "startCol" : 4,
-          "endLine" : 40,
+          "endLine" : 43,
           "endCol" : 43
         }
       }
     ],
     "span" : {
-      "startLine" : 37,
+      "startLine" : 40,
       "startCol" : 2,
-      "endLine" : 41,
+      "endLine" : 44,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 42,
+    "endLine" : 45,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/secret_create.spec
+++ b/fixtures/spec/secret_create.spec
@@ -1,0 +1,42 @@
+service AccountService {
+
+  type Email = String where len(value) >= 1 and len(value) <= 100
+  type AccountId = Int where value > 0
+
+  entity Account {
+    id: AccountId
+    email: Email
+    password_hash: String where len(value) > 0
+    display_name: String where len(value) >= 1
+  }
+
+  state {
+    accounts: AccountId -> lone Account
+    next_id: AccountId
+  }
+
+  operation CreateAccount {
+    input:  email: Email,
+            password_hash: String,
+            display_name: String
+    output: account: Account
+
+    requires:
+      true
+
+    ensures:
+      account.id = pre(next_id)
+      account.email = email
+      account.password_hash = password_hash
+      account.display_name = display_name
+      next_id' = pre(next_id) + 1
+      accounts' = pre(accounts) + {account.id -> account}
+      #accounts' = #pre(accounts) + 1
+  }
+
+  conventions {
+    CreateAccount.http_path = "/accounts"
+    CreateAccount.http_method = "POST"
+    CreateAccount.http_status_success = 201
+  }
+}

--- a/fixtures/spec/secret_create.spec
+++ b/fixtures/spec/secret_create.spec
@@ -8,6 +8,7 @@ service AccountService {
     email: Email
     password_hash: String where len(value) > 0
     display_name: String where len(value) >= 1
+    reset_token: Option[String]
   }
 
   state {
@@ -18,7 +19,8 @@ service AccountService {
   operation CreateAccount {
     input:  email: Email,
             password_hash: String,
-            display_name: String
+            display_name: String,
+            reset_token: Option[String]
     output: account: Account
 
     requires:
@@ -29,6 +31,7 @@ service AccountService {
       account.email = email
       account.password_hash = password_hash
       account.display_name = display_name
+      account.reset_token = reset_token
       next_id' = pre(next_id) + 1
       accounts' = pre(accounts) + {account.id -> account}
       #accounts' = #pre(accounts) + 1

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/models/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/models/entity.py.hbs
@@ -10,9 +10,7 @@ from sqlalchemy.dialects.postgresql import {{join postgresImports ", "}}
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-{{#if nonIdFields.length}}
 from app.schemas.{{snake_case entity.entityName}} import {{entity.createSchemaName}}
-{{/if}}
 
 
 class {{entity.modelClassName}}(Base):
@@ -22,7 +20,6 @@ class {{entity.modelClassName}}(Base):
 {{#each nonIdFields}}
     {{this.columnName}}: {{this.sqlalchemyType}} = mapped_column({{this.sqlalchemyColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
 {{/each}}
-{{#if nonIdFields.length}}
 
     def __init__(self, body: {{entity.createSchemaName}}) -> None:
         super().__init__(
@@ -30,4 +27,3 @@ class {{entity.modelClassName}}(Base):
             {{this.columnName}}={{this.bodyAccessor}},
 {{/each}}
         )
-{{/if}}

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/models/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/models/entity.py.hbs
@@ -10,6 +10,9 @@ from sqlalchemy.dialects.postgresql import {{join postgresImports ", "}}
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
+{{#if nonIdFields.length}}
+from app.schemas.{{snake_case entity.entityName}} import {{entity.createSchemaName}}
+{{/if}}
 
 
 class {{entity.modelClassName}}(Base):
@@ -19,3 +22,12 @@ class {{entity.modelClassName}}(Base):
 {{#each nonIdFields}}
     {{this.columnName}}: {{this.sqlalchemyType}} = mapped_column({{this.sqlalchemyColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
 {{/each}}
+{{#if nonIdFields.length}}
+
+    def __init__(self, body: {{entity.createSchemaName}}) -> None:
+        super().__init__(
+{{#each initFields}}
+            {{this.columnName}}={{this.bodyAccessor}},
+{{/each}}
+        )
+{{/if}}

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/schemas/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/schemas/entity.py.hbs
@@ -1,7 +1,7 @@
 {{#each stdlibImports}}
 from {{this.module}} import {{join this.names ", "}}
 {{/each}}
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict{{#if needsSecretStr}}, SecretStr{{/if}}
 
 
 class {{entity.createSchemaName}}(BaseModel):

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -25,7 +25,7 @@ class {{entity.entityName}}Service:
 {{/unless}}
 {{#if (eq this.routeKind "create")}}
     async def {{this.handlerName}}(self, body: {{../entity.createSchemaName}}) -> {{../entity.readSchemaName}}:
-        row = {{../entity.modelClassName}}(**body.model_dump())
+        row = {{../entity.modelClassName}}(body)
         self._session.add(row)
         await self._session.flush()
         return {{../entity.readSchemaName}}.model_validate(row)

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -335,7 +335,9 @@ object Emit:
   private def modelInitField(f: ProfiledField): ModelInitFieldView =
     val accessor =
       if SensitiveFields.isSensitive(f.columnName) then
-        s"body.${f.columnName}.get_secret_value()"
+        if f.nullable then
+          s"body.${f.columnName}.get_secret_value() if body.${f.columnName} is not None else None"
+        else s"body.${f.columnName}.get_secret_value()"
       else s"body.${f.columnName}"
     ModelInitFieldView(f.columnName, accessor)
 

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -26,7 +26,16 @@ final private case class StdlibImport(module: String, names: List[String])
 
 final private case class EnrichedPathParam(name: String, pythonType: String)
 
-final private case class CustomRequestSchema(schemaName: String, fields: List[ProfiledField])
+final private case class CustomRequestSchema(schemaName: String, fields: List[SchemaFieldView])
+
+final private case class SchemaFieldView(
+    columnName: String,
+    pydanticType: String,
+    pythonType: String,
+    nullable: Boolean
+)
+
+final private case class ModelInitFieldView(columnName: String, bodyAccessor: String)
 
 final private case class EnrichedOperation(
     operationName: String,
@@ -80,6 +89,7 @@ final private case class ModelCtx(
     table: Option[TableSpec],
     entityOperations: List[EnrichedOperation],
     nonIdFields: List[ProfiledField],
+    initFields: List[ModelInitFieldView],
     sqlalchemyImports: List[String],
     postgresImports: List[String],
     stdlibImports: List[StdlibImport]
@@ -95,9 +105,10 @@ final private case class SchemaCtx(
     entity: ProfiledEntity,
     table: Option[TableSpec],
     entityOperations: List[EnrichedOperation],
-    nonIdFields: List[ProfiledField],
-    readFields: List[ProfiledField],
+    nonIdFields: List[SchemaFieldView],
+    readFields: List[SchemaFieldView],
     customRequestSchemas: List[CustomRequestSchema],
+    needsSecretStr: Boolean,
     stdlibImports: List[StdlibImport]
 )
 
@@ -182,10 +193,17 @@ object Emit:
       val entitySnake = Naming.toSnakeCase(entity.entityName)
       val routerSnake = Naming.toSnakeCase(Naming.pluralize(entity.entityName))
 
-      val nonIdFields          = entity.fields.filterNot(_.fieldName == "id")
-      val readFields           = nonIdFields.filterNot(f => SensitiveFields.isSensitive(f.columnName))
+      val nonIdFields = entity.fields.filterNot(_.fieldName == "id")
+      val readFieldsRaw =
+        nonIdFields.filterNot(f => SensitiveFields.isSensitive(f.columnName))
+      val nonIdFieldViews      = nonIdFields.map(schemaInputField)
+      val readFieldViews       = readFieldsRaw.map(schemaReadField)
+      val initFieldViews       = nonIdFields.map(modelInitField)
       val customRequestSchemas = entityOps.flatMap(_.customRequestSchema)
       val schemaStdlib         = collectSchemaStdlibImports(entity, customRequestSchemas)
+      val needsSecretStr =
+        nonIdFields.exists(f => SensitiveFields.isSensitive(f.columnName)) ||
+          customRequestSchemas.exists(_.fields.exists(_.pydanticType == "SecretStr"))
 
       val modelCtx = ModelCtx(
         service = ctx.service,
@@ -198,6 +216,7 @@ object Emit:
         table = table,
         entityOperations = entityOps,
         nonIdFields = nonIdFields,
+        initFields = initFieldViews,
         sqlalchemyImports = imports.sqlalchemyImports,
         postgresImports = imports.postgresImports,
         stdlibImports = imports.stdlibImports
@@ -213,9 +232,10 @@ object Emit:
         entity = entity,
         table = table,
         entityOperations = entityOps,
-        nonIdFields = nonIdFields,
-        readFields = readFields,
+        nonIdFields = nonIdFieldViews,
+        readFields = readFieldViews,
         customRequestSchemas = customRequestSchemas,
+        needsSecretStr = needsSecretStr,
         stdlibImports = schemaStdlib
       )
 
@@ -304,6 +324,21 @@ object Emit:
 
     files.result()
 
+  private def schemaInputField(f: ProfiledField): SchemaFieldView =
+    val ptype =
+      if SensitiveFields.isSensitive(f.columnName) then "SecretStr" else f.pydanticType
+    SchemaFieldView(f.columnName, ptype, f.pythonType, f.nullable)
+
+  private def schemaReadField(f: ProfiledField): SchemaFieldView =
+    SchemaFieldView(f.columnName, f.pydanticType, f.pythonType, f.nullable)
+
+  private def modelInitField(f: ProfiledField): ModelInitFieldView =
+    val accessor =
+      if SensitiveFields.isSensitive(f.columnName) then
+        s"body.${f.columnName}.get_secret_value()"
+      else s"body.${f.columnName}"
+    ModelInitFieldView(f.columnName, accessor)
+
   private def buildTypeLookup(profiled: ProfiledService): Map[String, String] =
     val base = mutable.Map.empty[String, String]
     for (specType, mapping) <- profiled.profile.typeMap do base(specType) = mapping.python
@@ -376,7 +411,8 @@ object Emit:
         val pathParamNames    = endpoint.pathParams.map(_.name).toSet
         val fields = op.requestBodyFields.filter: f =>
           !pathParamNames.contains(f.fieldName) && requestBodyByName.contains(f.fieldName)
-        customRequestSchema = Some(CustomRequestSchema(requestBodyType, fields))
+        customRequestSchema =
+          Some(CustomRequestSchema(requestBodyType, fields.map(schemaInputField)))
 
     val routeKind =
       if initialRouteKind == RouteKind.Create && !matchesEntityCreateShape then
@@ -510,8 +546,8 @@ object Emit:
   ): List[StdlibImport] =
     val stdlibByModule = mutable.Map.empty[String, mutable.Set[String]]
     for field  <- entity.fields do mergeStdlibImport(stdlibByModule, field.pythonType)
-    for schema <- customRequestSchemas; field <- schema.fields do
-      mergeStdlibImport(stdlibByModule, field.pythonType)
+    for schema <- customRequestSchemas; view <- schema.fields do
+      mergeStdlibImport(stdlibByModule, view.pythonType)
     finalizeStdlibImports(stdlibByModule)
 
   private def collectRouterImports(

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -1,5 +1,6 @@
 package specrest.codegen
 
+import cats.effect.IO
 import munit.CatsEffectSuite
 import specrest.codegen.testutil.SpecFixtures
 
@@ -71,6 +72,110 @@ class EmitTest extends CatsEffectSuite:
       val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
       assertEquals(files("app/__init__.py"), "")
       assertEquals(files("app/db/__init__.py"), "")
+
+  test("schema with sensitive field imports SecretStr and types it as SecretStr"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val schema = files("app/schemas/user.py")
+      assert(
+        schema.contains("from pydantic import BaseModel, ConfigDict, SecretStr"),
+        s"user schema should import SecretStr; got:\n$schema"
+      )
+      assert(
+        schema.contains("password_hash: SecretStr"),
+        s"UserCreate should declare password_hash: SecretStr; got:\n$schema"
+      )
+      assert(
+        !schema.contains("password_hash: str"),
+        s"UserCreate should not have a plain-str password_hash; got:\n$schema"
+      )
+
+  test("read schema continues to exclude sensitive fields"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val schema = files("app/schemas/user.py")
+      val readBlock =
+        schema.linesIterator
+          .dropWhile(!_.contains("class UserRead"))
+          .takeWhile(!_.startsWith("class UserUpdate"))
+          .mkString("\n")
+      assert(
+        !readBlock.contains("password_hash"),
+        s"UserRead must not surface password_hash; got:\n$readBlock"
+      )
+
+  test("model emits typed __init__ taking the Create schema"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val model = files("app/models/user.py")
+      assert(
+        model.contains("from app.schemas.user import UserCreate"),
+        s"user model should import UserCreate; got:\n$model"
+      )
+      assert(
+        model.contains("def __init__(self, body: UserCreate) -> None:"),
+        s"User.__init__ should take a typed UserCreate; got:\n$model"
+      )
+      assert(
+        model.contains("password_hash=body.password_hash.get_secret_value()"),
+        s"User.__init__ should unwrap password_hash via get_secret_value(); got:\n$model"
+      )
+      assert(
+        model.contains("email=body.email"),
+        s"User.__init__ should pass email through; got:\n$model"
+      )
+
+  test("no service handler splats model_dump() into the ORM constructor"):
+    val cases = List("secret_create", "auth_service", "url_shortener", "todo_list", "ecommerce")
+    cases.foldLeft(IO.unit): (acc, name) =>
+      acc.flatMap: _ =>
+        SpecFixtures.loadProfiled(name).map: profiled =>
+          val offenders = Emit.emitProject(profiled).filter: f =>
+            f.path.startsWith("app/services/") && f.content.contains("model_dump()")
+          assert(
+            offenders.isEmpty,
+            s"$name: services still call model_dump(): ${offenders.map(_.path)}"
+          )
+
+  test("matching create-shape op renders typed row = Model(body) handler"):
+    SpecFixtures.loadProfiled("secret_create").map: profiled =>
+      val files   = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val service = files("app/services/account.py")
+      assert(
+        service.contains("row = Account(body)"),
+        s"create handler should call Account(body); got:\n$service"
+      )
+      assert(
+        !service.contains("NotImplementedError"),
+        s"create handler should not be a stub; got:\n$service"
+      )
+
+  test("secret_create — schema, model, service line up across the boundary"):
+    SpecFixtures.loadProfiled("secret_create").map: profiled =>
+      val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val schema = files("app/schemas/account.py")
+      val model  = files("app/models/account.py")
+      assert(
+        schema.contains("password_hash: SecretStr"),
+        s"AccountCreate should use SecretStr; got:\n$schema"
+      )
+      assert(
+        model.contains("password_hash=body.password_hash.get_secret_value()"),
+        s"Account.__init__ should unwrap SecretStr; got:\n$model"
+      )
+      assert(
+        model.contains("email=body.email") && model.contains("display_name=body.display_name"),
+        s"Account.__init__ should pass plain fields through; got:\n$model"
+      )
+
+  test("schema without sensitive fields does not import SecretStr"):
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val schema = files("app/schemas/url_mapping.py")
+      assert(
+        !schema.contains("SecretStr"),
+        s"url_mapping schema should not import SecretStr; got:\n$schema"
+      )
 
   test(
     "ci.yml renders GitHub Actions ${{ ... }} expressions literally (not Handlebars-substituted)"

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -168,6 +168,33 @@ class EmitTest extends CatsEffectSuite:
         s"Account.__init__ should pass plain fields through; got:\n$model"
       )
 
+  test("nullable sensitive field unwraps via guarded get_secret_value"):
+    SpecFixtures.loadProfiled("secret_create").map: profiled =>
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val model = files("app/models/account.py")
+      assert(
+        model.contains(
+          "reset_token=body.reset_token.get_secret_value() " +
+            "if body.reset_token is not None else None"
+        ),
+        s"nullable sensitive field should guard get_secret_value() against None; got:\n$model"
+      )
+
+  test("every entity model file emits a typed __init__ regardless of field count"):
+    val cases = List("secret_create", "auth_service", "url_shortener", "todo_list", "ecommerce")
+    cases.foldLeft(IO.unit): (acc, name) =>
+      acc.flatMap: _ =>
+        SpecFixtures.loadProfiled(name).map: profiled =>
+          val offenders = Emit.emitProject(profiled).filter: f =>
+            f.path.startsWith("app/models/") &&
+              f.path.endsWith(".py") &&
+              !f.path.endsWith("__init__.py") &&
+              !f.content.contains("def __init__(self, body:")
+          assert(
+            offenders.isEmpty,
+            s"$name: model files missing typed __init__: ${offenders.map(_.path)}"
+          )
+
   test("schema without sensitive fields does not import SecretStr"):
     SpecFixtures.loadProfiled("url_shortener").map: profiled =>
       val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap

--- a/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
@@ -19,7 +19,7 @@ class GoldenRoundtripTest extends munit.FunSuite:
 
   test("fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No golden fixtures found in $goldenDir")
-    assertEquals(fixtures.size, 20)
+    assertEquals(fixtures.size, 21)
 
   fixtures.foreach: path =>
     val name = path.getFileName.toString

--- a/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ParseBuildGoldenTest.scala
@@ -26,7 +26,7 @@ class ParseBuildGoldenTest extends CatsEffectSuite:
 
   test("spec fixtures directory is populated"):
     assert(fixtures.nonEmpty, s"No spec fixtures found in $specDir")
-    assertEquals(fixtures.size, 20)
+    assertEquals(fixtures.size, 21)
 
   fixtures.foreach: specPath =>
     val name       = specPath.getFileName.toString.stripSuffix(".spec")


### PR DESCRIPTION
Closes #150.

## Summary

- Replaces `row = Model(**body.model_dump())` with `row = Model(body)`. The ORM model now has a codegen-emitted typed `__init__(self, body: <CreateSchema>) -> None` whose body is N typed attribute reads — no reflection, no untyped dict, no `to_xx`/`from_xx` named converters.
- Sensitive fields (matched by `SensitiveFields.isSensitive`) become `SecretStr` in `*Create` / `*Update` / `*Request` schemas. Read schemas continue to exclude them.
- The codegen-emitted `__init__` calls `.get_secret_value()` at the single point where the type is statically known — the boundary between Pydantic and SQLAlchemy.

Why not the alternatives we considered:

- `**body.model_dump()` (today's shape): untyped dict; SecretStr isn't unwrapped by `model_dump(mode='python')`; Pydantic upstream closed `dump_secrets=True` as not-planned ([#7242](https://github.com/pydantic/pydantic/issues/7242)).
- `body.to_orm()` / `User.from_create(body)`: explicitly out-of-scope (named converter pattern).
- Custom `Base.__init__(source: BaseModel)` reflecting via `model_dump()`: hides untyped dict inside a base; same field-alignment gap.
- SQLModel: shared base would give static field-alignment but is an architectural change orthogonal to #150.
- `@overload` Pydantic-instance + kwargs: requires `**kwargs: Any` in the implementation, which is the very thing we wanted gone.

The single-signature typed `__init__` was the floor that meets the constraints. Trade-off: kwargs construction is no longer the public API for ORM models. Tests/fixtures construct via `Model(SchemaCreate(...))` instead. SQLAlchemy doesn't call `__init__` for loaded rows ([2.0 docs](https://docs.sqlalchemy.org/en/20/orm/constructors.html)), so `select`, `refresh`, `merge`, lazy loading are unaffected.

## What rendered for the new fixture

`fixtures/spec/secret_create.spec` exercises the path end-to-end:

```python
# app/services/account.py
async def create_account(self, body: AccountCreate) -> AccountRead:
    row = Account(body)
    self._session.add(row)
    await self._session.flush()
    return AccountRead.model_validate(row)

# app/schemas/account.py
class AccountCreate(BaseModel):
    email: str
    password_hash: SecretStr
    display_name: str

# app/models/account.py
class Account(Base):
    __tablename__ = "accounts"
    id: Mapped[int] = mapped_column(primary_key=True)
    email: Mapped[str] = mapped_column(String)
    password_hash: Mapped[str] = mapped_column(String)
    display_name: Mapped[str] = mapped_column(String)

    def __init__(self, body: AccountCreate) -> None:
        super().__init__(
            email=body.email,
            password_hash=body.password_hash.get_secret_value(),
            display_name=body.display_name,
        )
```

## Files changed

- `modules/codegen/src/main/scala/specrest/codegen/Emit.scala` — added `SchemaFieldView` (sensitivity-aware `pydanticType`), `ModelInitFieldView` (`bodyAccessor` is `body.x` or `body.x.get_secret_value()`), and a `needsSecretStr` flag for the conditional schema import.
- `modules/codegen/src/main/resources/templates/python-fastapi-postgres/models/entity.py.hbs` — emits the typed `__init__` and the `from app.schemas.<entity> import <CreateSchema>` line.
- `modules/codegen/src/main/resources/templates/python-fastapi-postgres/schemas/entity.py.hbs` — conditional `, SecretStr` import; sensitive fields use `SecretStr` in input schemas.
- `modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs` — `row = Model(body)`.
- `fixtures/spec/secret_create.spec` + `fixtures/golden/ir/secret_create.json` — new fixture exercising the matching create-shape path.
- Fixture-count assertions in `parser/ParseBuildGoldenTest.scala` and `ir/GoldenRoundtripTest.scala` bumped 20 → 21.
- `modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala` — 6 new assertions covering SecretStr emission, typed `__init__` shape, sensitive-field exclusion from read schemas, no-`model_dump()` invariant across services, and the end-to-end secret-create rendering.

## Test plan

- [x] `sbt codegen/test` — 34/34
- [x] `sbt parser/test` — 30/30 (golden roundtrip for new fixture)
- [x] `sbt ir/test` — 43/43
- [x] `sbt cli/test` — 29/29
- [x] `sbt verify/test` — 161/161
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] Hand-rendered `auth_service`, `url_shortener`, `secret_create` — schema, model, service files visually match the intended shape

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codegen now emits a typed ORM constructor that takes the matching Create schema and uses `SecretStr` for sensitive inputs. It removes untyped `model_dump()` splats and adds null-safe handling for secrets and entities with no non‑ID fields.

- **New Features**
  - Generated create handlers now use `row = Model(body)`.
  - ORM models always define `__init__(self, body: <CreateSchema>)` with direct, typed assignments (no reflection or dicts).
  - Sensitive inputs are `SecretStr` in `*Create`, `*Update`, and custom request schemas; secrets unwrap inside the model, guarded when nullable.
  - Read schemas continue to exclude sensitive fields.

- **Migration**
  - Update generated or custom create handlers to construct rows with `Model(body)`.
  - In tests/fixtures, construct models via `Model(CreateSchema(...))` instead of kwargs. Reads/loads are unaffected since `SQLAlchemy` doesn’t call `__init__` for loaded rows.

<sup>Written for commit 22b8970ca69a009d290953debeee1400cec90e82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for sensitive field handling in generated Python services
  * Added golden fixtures and specifications for account creation scenarios with secret field validation

* **Chores**
  * Updated test fixture counts to reflect new specification test cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->