### PR TITLE
ci: wire scala-steward for sbt deps (#211)

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,31 @@
+name: Scala Steward
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: scala-steward-org/scala-steward-action@b186ab858ce163f9af7b016fac32cfb3f2c2f503 # v2.88.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-config: .scala-steward.conf
+          author-email: 'scala-steward@spec-to-rest'
+          author-name: 'scala-steward'

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,16 @@
+pullRequests.frequency = "@weekly"
+
+commits.message = "deps: bump ${artifactName} from ${currentVersion} to ${nextVersion}"
+
+pullRequests.grouping = [
+  { name = "circe", title = "deps(circe): grouped bump", filter = [{ group = "io.circe" }] },
+  { name = "alloy", title = "deps(alloy): grouped bump", filter = [{ group = "org.alloytools" }] },
+  { name = "munit", title = "deps(munit): grouped bump", filter = [{ artifact = "munit*" }] }
+]
+
+updates.ignore = [
+  { version = { contains = "-RC" } },
+  { version = { contains = "-M" } },
+  { version = { contains = "-alpha" } },
+  { version = { contains = "-beta" } }
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+## Dependency updates
+
+Two bots own the update PR stream, split by ecosystem:
+
+- **Dependabot** (`.github/dependabot.yml`) — GitHub Actions and the `/docs` npm workspace. Weekly
+  cadence, grouped per ecosystem.
+- **scala-steward** (`.scala-steward.conf`, `.github/workflows/scala-steward.yml`) — sbt:
+  `build.sbt` library deps, `project/plugins.sbt`, and `project/build.properties`. Weekly cron
+  (Mondays, 08:00 UTC) plus `workflow_dispatch` for ad-hoc runs.
+
+The domains don't overlap (Dependabot never sees sbt; scala-steward never sees GHA), so the two-bot
+setup doesn't produce duplicate PRs. The decision and trade-off vs Renovate is recorded on issue
+#163.
+
+### Grouping rationale
+
+Three sbt families are grouped so a single PR bumps all sibling artifacts together:
+
+- **circe** (`io.circe:*`) — `circe-core`, `circe-generic`, `circe-parser` share a version pin
+  (`circeVersion` in `build.sbt`); split bumps wedge compilation.
+- **alloy** (`org.alloytools:*`) — `alloy.application`, `alloy.core`, `pardinus.core`,
+  `pardinus.native` likewise share `alloyVersion` and ship as one upstream release.
+- **munit** (artifact `munit*`) — `munit` and `munit-cats-effect` are separate group IDs but version
+  in lockstep with Cats Effect / munit releases; grouping by artifact glob covers both.
+
+Pre-releases (`-RC`, `-M`, `-alpha`, `-beta`) are filtered out — we only track stable.
+
+### Token
+
+scala-steward runs with the workflow's default `GITHUB_TOKEN`. Trade-off: PRs created by
+`GITHUB_TOKEN` do **not** trigger downstream workflows (GitHub's loop-protection rule). Concretely,
+when a steward PR lands, the `CI`, `native`, and `quality` workflows will not run automatically on
+it.
+
+To run CI on a steward PR, the reviewer pushes an empty commit (or closes and reopens the PR):
+
+```bash
+gh pr checkout <PR-number>
+git commit --allow-empty -m "ci: trigger"
+git push
+```
+
+The trade-off is intentional: this avoids provisioning a fine-grained PAT or GitHub App for a
+low-volume bot. If the manual step becomes annoying, swap `secrets.GITHUB_TOKEN` for a fine-grained
+PAT (`contents:write` + `pull-requests:write`, scoped to this repo).


### PR DESCRIPTION
## Summary

- Adds `.scala-steward.conf` + weekly GHA cron (`.github/workflows/scala-steward.yml`) so sbt library and plugin pins in `build.sbt` / `project/plugins.sbt` / `project/build.properties` stop drifting manually. Dependabot continues to own GHA + `/docs` npm.
- Groups three sbt families per shared version pin: **circe** (`io.circe:*`), **alloy** (`org.alloytools:*`), **munit** (artifact `munit*`). Sibling artifacts that share a `xxxVersion` val in `build.sbt` bump together — split bumps wedge compilation.
- Filters `-RC` / `-M` / `-alpha` / `-beta` pre-releases.
- Custom commit-message format: `"deps: bump <artifact> from <a> to <b>"`.
- Documents the rationale and the token trade-off in `CONTRIBUTING.md` (new file at repo root).

Closes #211. Follow-up to #163.

## Token decision: `GITHUB_TOKEN`

Workflow uses `secrets.GITHUB_TOKEN`, not a fine-grained PAT. Trade-off: PRs created by `GITHUB_TOKEN` do **not** trigger downstream workflows (GitHub's documented loop-protection rule). Concretely, the `CI` / `native` / `quality` jobs will not run automatically on a steward-filed PR. Reviewer kicks CI by pushing an empty commit:

\`\`\`bash
gh pr checkout <PR-number>
git commit --allow-empty -m "ci: trigger"
git push
\`\`\`

This is intentional — avoids provisioning a PAT or GitHub App for a low-volume bot. Documented in `CONTRIBUTING.md`. If the empty-commit step gets annoying, swap to a PAT (one-line change in the workflow).

## Action pin

`scala-steward-org/scala-steward-action@b186ab858ce163f9af7b016fac32cfb3f2c2f503` (v2.88.0, latest stable). SHA-pinned, matching the repo's zizmor convention.

## Test plan

- [x] Pre-commit hooks pass: prettier, actionlint, yaml-check.
- [ ] After merge, run `gh workflow run scala-steward.yml` to smoke the cron path manually before the first scheduled Monday run.
- [ ] First non-trivial bump lands cleanly through CI (scalafmt + scalafix + tests + native-image). Reviewer triggers CI per the empty-commit step above.
- [ ] After the first cats-effect / circe major bump, confirm `scalafix-migrations` were applied by steward; document if not.

## Out of scope

- Renovate evaluation — closed via #163's decision.
- Auto-merge on patch bumps — not requested; manual review remains the default.
- Z3 SMT golden re-snapshot on `z3-turnkey` bumps — caught by existing `z3-cross-check` CI job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates sbt dependency and plugin updates with Scala Steward via a weekly GitHub Actions workflow, keeping `build.sbt`, `project/plugins.sbt`, and `project/build.properties` current. Dependabot continues to handle GitHub Actions and `/docs` npm updates; closes #211.

- **New Features**
  - Adds `.scala-steward.conf` and a weekly workflow with schedule and manual dispatch.
  - Groups version bumps for `io.circe`, `org.alloytools`, and `munit*` so shared pins update together.
  - Ignores pre-releases and standardizes commit messages: "deps: bump <artifact> from <a> to <b>".
  - Documents scope and token trade-offs in `CONTRIBUTING.md`.

- **Migration**
  - Steward PRs created with `GITHUB_TOKEN` do not auto-run CI; push an empty commit or reopen the PR to trigger, or switch the workflow to a PAT.

<sup>Written for commit 6aa6e78f2486e7e0e7224dacff521cbd483aadc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates for Scala/sbt dependencies with configurable grouping and pre-release filtering.

* **Documentation**
  * Added contribution guidelines documenting the automated dependency update process and procedures for triggering CI on update pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->