### PR TITLE
#28 — M6.3 LLM Integration + Prompt Engineering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,8 @@ val apispecVersion          = "0.11.3"
 val snakeYamlVersion        = "2.3"
 val catsEffectVersion       = "3.7.0"
 val jacksonCoreVersion      = "2.18.6"
+val anthropicJavaVersion    = "2.30.0"
+val openaiJavaVersion       = "4.35.0"
 
 // Scala 3.6.3's scaladoc toolchain still resolves jackson-core 2.15.1.
 ThisBuild / dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % jacksonCoreVersion
@@ -159,6 +161,20 @@ lazy val codegen = (project in file("modules/codegen"))
     ) ++ commonMainDeps ++ commonTestDeps
   )
 
+lazy val synth = (project in file("modules/synth"))
+  .settings(noTestWarts *)
+  .dependsOn(ir, convention, parser % Test)
+  .settings(
+    name := "spec-synth",
+    libraryDependencies ++= Seq(
+      "com.anthropic" % "anthropic-java" % anthropicJavaVersion,
+      "com.openai"    % "openai-java"    % openaiJavaVersion,
+      "io.circe"     %% "circe-core"     % circeVersion,
+      "io.circe"     %% "circe-generic"  % circeVersion,
+      "io.circe"     %% "circe-parser"   % circeVersion
+    ) ++ commonMainDeps ++ commonTestDeps
+  )
+
 lazy val testgen = (project in file("modules/testgen"))
   .settings(noTestWarts *)
   .dependsOn(ir, convention, profile, codegen, parser % Test)
@@ -184,7 +200,7 @@ lazy val bench = (project in file("modules/bench"))
 
 lazy val cli = (project in file("modules/cli"))
   .settings(noTestWarts *)
-  .dependsOn(ir, parser, convention, profile, verify, codegen, testgen, lint)
+  .dependsOn(ir, parser, convention, profile, verify, codegen, testgen, lint, synth)
   .enablePlugins(NativeImagePlugin)
   .settings(
     name                := "spec-to-rest",
@@ -217,7 +233,7 @@ lazy val cli = (project in file("modules/cli"))
   )
 
 lazy val root = (project in file("."))
-  .aggregate(ir, parser, convention, profile, verify, codegen, testgen, lint, cli, bench)
+  .aggregate(ir, parser, convention, profile, verify, codegen, testgen, lint, synth, cli, bench)
   .settings(
     name           := "spec-to-rest-root",
     publish / skip := true

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -112,7 +112,8 @@ modules/
 ├── verify/     # Z3 + Alloy translators · backends · Consistency · Diagnostic · Narration
 ├── codegen/    # Engine (handlebars.java) · Emit · OpenAPI · Alembic
 ├── testgen/    # ExprToPython · Strategies · Stateful/Structural/Behavioral
-├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile
+├── synth/      # LLM integration · PromptBuilder · DiffChecker · Cache · Tracker
+├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile / synth
 └── bench/      # JMH benchmarks (ParallelVerifyBench, parallel verify CSV golden)
 
 proofs/
@@ -160,7 +161,7 @@ on issues; the table below shows where each phase stands today.
 | 3     | `python-fastapi-postgres` codegen + Alembic + OpenAPI  | Shipped                                                                                |
 | 4     | Verification (Z3 + Alloy + Isabelle/HOL universal soundness) | Shipped — pivoted from Lean 4 to Isabelle/HOL via [#193](https://github.com/HardMax71/spec_to_rest/issues/193); IR-canonicalization follow-up in [#202](https://github.com/HardMax71/spec_to_rest/issues/202) |
 | 5     | Test generation (Hypothesis + Schemathesis)            | Largely shipped — [#86](https://github.com/HardMax71/spec_to_rest/issues/86) (runtime invariant enforcement) open |
-| 6     | LLM / Dafny synthesis (CEGIS)                          | **Partially implemented.** [#31](https://github.com/HardMax71/spec_to_rest/issues/31) (operation classification) and [#32](https://github.com/HardMax71/spec_to_rest/issues/32) (Dafny signature generation) shipped — `inspect --format dafny` emits the LLM-prompt skeleton. CEGIS loop, prompts, and Dafny→target compilation still tracked in [#27](https://github.com/HardMax71/spec_to_rest/issues/27), [#28](https://github.com/HardMax71/spec_to_rest/issues/28), [#29](https://github.com/HardMax71/spec_to_rest/issues/29), [#30](https://github.com/HardMax71/spec_to_rest/issues/30). |
+| 6     | LLM / Dafny synthesis (CEGIS)                          | **Partially implemented.** [#31](https://github.com/HardMax71/spec_to_rest/issues/31) (operation classification), [#32](https://github.com/HardMax71/spec_to_rest/issues/32) (Dafny signature generation), and [#28](https://github.com/HardMax71/spec_to_rest/issues/28) (LLM integration + prompt engineering) shipped — `inspect --format dafny-prompt` renders the LLM prompt; `synth try` invokes Anthropic / OpenAI for one candidate body, with diff-checker + filesystem cache. CEGIS loop and Dafny→target compilation still tracked in [#27](https://github.com/HardMax71/spec_to_rest/issues/27), [#29](https://github.com/HardMax71/spec_to_rest/issues/29), [#30](https://github.com/HardMax71/spec_to_rest/issues/30). |
 | 7     | Multi-target codegen — Go/chi, TS/Express              | **Not started.** [#33](https://github.com/HardMax71/spec_to_rest/issues/33), [#35](https://github.com/HardMax71/spec_to_rest/issues/35), [#34](https://github.com/HardMax71/spec_to_rest/issues/34) (distribution), [#36](https://github.com/HardMax71/spec_to_rest/issues/36) (CLI polish). |
 | 8     | Authentication DSL                                     | **Not started.** [#53](https://github.com/HardMax71/spec_to_rest/issues/53)–[#55](https://github.com/HardMax71/spec_to_rest/issues/55). |
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -6,6 +6,7 @@
     "---Core---",
     "...design",
     "...pipelines",
+    "...synth",
     "---Deployment Targets---",
     "...targets",
     "---Research---",

--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -8,20 +8,21 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > Clover-style triangulation, failure handling, security, and cost analysis. Written 2026-04-05.
 
 > **Status — partially implemented.** This document is the **Phase 6** design proposal.
-> Two foundational wedges have shipped (#31 operation classification and #32 Dafny
-> signature generation — `inspect --format dafny`); the LLM SDK, CEGIS loop, and
+> Three foundational wedges have shipped: #31 operation classification, #32 Dafny
+> signature generation (`inspect --format dafny`), and #28 LLM integration + prompt
+> engineering (`inspect --format dafny-prompt`, `synth try`); the CEGIS loop and
 > Dafny→target compilation remain unbuilt on `main`. Open trackers under the `phase-6`
 > label cover the breakdown:
 > [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) — operation classification (direct emit vs. LLM) — **shipped**,
 > [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) — Dafny signature generation — **shipped**,
-> [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering,
+> [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering — **shipped**,
 > [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop,
 > [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation,
 > [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy.
-> The Python code samples below sketch the data shapes and flow; once Phase 6 lands, the
-> implementation will live in Scala alongside the rest of the compiler (matching the
-> `Scala 3 + Cats Effect 3 + IO`-typed pipeline documented in
-> [Architecture](/design/architecture)).
+> The Scala implementation lives in `modules/synth/` (`PromptBuilder`,
+> `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, plus
+> Anthropic / OpenAI providers wrapping the official Java SDKs). The Python code
+> samples below remain useful as data-shape sketches.
 
 ---
 

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -88,7 +88,7 @@ Flags:
 |---|---|---|
 | `--operation NAME` | _required_ | Must match a `LLM_SYNTHESIS`-classified op |
 | `--model M` | `claude-sonnet-4-6` | `gpt-*` routes to OpenAI; otherwise Anthropic |
-| `--temperature T` | `1.0` | Ignored on Anthropic models released after Opus 4.6 |
+| `--temperature T` | `1.0` | Honoured by OpenAI; **ignored on Anthropic** (the current `AnthropicProvider` omits the SDK's `.temperature(...)` builder call) |
 | `--max-tokens N` | `2048` | Per-response output cap |
 | `--no-cache` | off | Skip on-disk cache for this call |
 | `--cache-dir PATH` | `.spec-to-rest/synth-cache/` | Override cache root |
@@ -117,11 +117,12 @@ same way it does for Z3 / Alloy backends.
 ## Anthropic temperature note
 
 The Anthropic Messages API rejects `temperature != 1.0` on models released after
-Claude Opus 4.6 (4xx error from the API). The `AnthropicProvider` therefore omits
-`.temperature(...)` from the SDK builder entirely — newer models default to 1.0
-and older models are unaffected. The `--temperature` flag is honoured by
-`OpenAIProvider`. For deterministic synthesis on Anthropic, rely on prompt
-structure and `--max-tokens` instead.
+Claude Opus 4.6 (4xx error from the API). To stay forward-compatible across the
+whole Anthropic lineup, `AnthropicProvider` does **not** call the SDK's
+`.temperature(...)` builder for any model — Anthropic's server-side default
+(currently 1.0) applies in all cases, regardless of `--temperature`. The flag
+is honoured by `OpenAIProvider`. For deterministic synthesis on Anthropic, rely
+on prompt structure and `--max-tokens` instead.
 
 ## Caching
 

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -1,0 +1,161 @@
+---
+title: LLM Integration (M6.3)
+description: Anthropic + OpenAI clients, prompt construction, diff-checker, cost ledger, on-disk cache
+---
+
+`modules/synth/` ships the LLM-facing layer of Phase 6. It builds prompts from the
+Dafny skeleton emitted by [`inspect --format dafny`](/design/convention-engine) (#32),
+calls a provider, parses the response, runs a diff-checker against the immutable
+contract clauses, and tracks token cost. The CEGIS loop, `dafny verify`, and
+target-language compilation are deferred to [#29](https://github.com/HardMax71/spec_to_rest/issues/29)
+and [#27](https://github.com/HardMax71/spec_to_rest/issues/27).
+
+## Modules and entry points
+
+```mermaid
+flowchart LR
+  Inspect["inspect --format dafny-prompt<br/>(no network)"] --> PromptBuilder
+  SynthCmd["synth try<br/>(real LLM call)"] --> Synthesizer
+  PromptBuilder["PromptBuilder.initial<br/>system + user sections"] --> SynthCmd
+  Synthesizer --> Cache["Cache lookup<br/>SHA-256 over contract"]
+  Cache -->|hit| Result
+  Cache -->|miss| Provider
+  Provider["LlmProvider<br/>Anthropic | OpenAI | Mock"] --> Parser["ResponseParser<br/>extract dafny block + body"]
+  Parser --> Diff["DiffChecker<br/>contracts unchanged?"]
+  Diff --> Tracker["Tracker<br/>token + cost ledger"]
+  Tracker --> Result["SynthResult<br/>(body, usage, cost)"]
+```
+
+- `LlmProvider` — sealed surface (`AnthropicProvider`, `OpenAIProvider`,
+  `MockProvider`). Each call returns `IO[Either[ProviderError, LlmResponse]]`.
+  Real providers wrap the official `com.anthropic:anthropic-java` (2.30.x) and
+  `com.openai:openai-java` (4.35.x) SDKs in `IO.blocking` with `Resource`-managed
+  client lifecycles.
+- `PromptBuilder` — produces a `Prompt(system, user)` pair from the
+  `(OperationClassification, DafnyMethodHeader, skeleton)` triple. System prompts
+  live as resources under `modules/synth/src/main/resources/specrest/synth/prompts/`.
+  Few-shot examples live alongside under `few-shot/`; selection is keyed on
+  `OperationKind`. Both `initial` and `repair` prompts are implemented; the repair
+  variant is wired but only invoked once the CEGIS loop in #29 lands.
+- `ResponseParser` — extracts the first ` ```dafny ` (or ` ```csharp `, fallback
+  ` ``` `) fenced block from the LLM's response, then locates the named method's
+  body. The brace-matching scanner is string-aware and skips Dafny line and block
+  comments.
+- `DiffChecker` — given the canonical `DafnyMethodHeader` and the LLM's full
+  candidate, normalizes the `requires` / `ensures` / `modifies` clauses and rejects
+  any change. Also rejects any newly-introduced `{:extern}` declaration.
+- `Cache` — filesystem-backed key/value store. Keys are SHA-256 hashes over
+  `(signature, requires, ensures, modifies, model, temperature, SynthPromptVersion)`.
+  Writes are atomic (`tmp → ATOMIC_MOVE`). Default root: `.spec-to-rest/synth-cache/`
+  in the working directory; override with `--cache-dir`.
+- `Tracker` — `Ref`-backed call ledger. Each call records
+  `(operation, model, usage, costUsd, cached)`. `summary: IO[CostSummary]` aggregates
+  across the run.
+- `Pricing` — static table of input/output rates per million tokens. Verified
+  2026-05-08 against vendor pricing pages. `forModel` matches both bare and
+  date-suffixed model IDs (`claude-haiku-4-5-20251001` resolves to the
+  `claude-haiku-4-5` row).
+
+## CLI
+
+### `inspect --format dafny-prompt`
+
+Pure render — no network call, no API key required.
+
+```bash
+sbt "cli/run inspect fixtures/spec/url_shortener.spec --format dafny-prompt"
+sbt "cli/run inspect fixtures/spec/url_shortener.spec --format dafny-prompt --operation Shorten"
+```
+
+With `--operation NAME`, only that operation's prompt is rendered. Without it, every
+operation classified `LLM_SYNTHESIS` is emitted, separated by a markdown horizontal
+rule. Operations classified `DIRECT_EMIT` are skipped (the convention engine handles
+them; no LLM is ever consulted).
+
+### `synth try`
+
+Sends the constructed prompt to the LLM provider and prints the parsed body to
+stdout. Cost is reported on stderr.
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... \
+  sbt "cli/run synth try fixtures/spec/url_shortener.spec --operation Shorten"
+```
+
+Flags:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--operation NAME` | _required_ | Must match a `LLM_SYNTHESIS`-classified op |
+| `--model M` | `claude-sonnet-4-6` | `gpt-*` routes to OpenAI; otherwise Anthropic |
+| `--temperature T` | `1.0` | Ignored on Anthropic models released after Opus 4.6 |
+| `--max-tokens N` | `2048` | Per-response output cap |
+| `--no-cache` | off | Skip on-disk cache for this call |
+| `--cache-dir PATH` | `.spec-to-rest/synth-cache/` | Override cache root |
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | Body produced, diff-check passed |
+| 1 | Spec missing / parse / build / classification error / op classified DIRECT_EMIT |
+| 2 | LLM response unparseable, or diff-check rejected (contract changed, or new `{:extern}` introduced) |
+| 3 | Provider HTTP / API error, or cache write failed |
+
+## Provider routing
+
+`synth try` selects a provider based on the model name prefix:
+
+- Model starts with `gpt` (case-insensitive) → `OpenAIProvider.fromEnv`. Reads
+  `OPENAI_API_KEY` (and optionally `OPENAI_BASE_URL` for Azure deployments).
+- Otherwise → `AnthropicProvider.fromEnv`. Reads `ANTHROPIC_API_KEY`.
+
+Both providers use `Resource[IO, _]` so the underlying OkHttp client is closed on
+success, failure, and cancellation alike. Cancellation propagates through CE3 the
+same way it does for Z3 / Alloy backends.
+
+## Anthropic temperature note
+
+The Anthropic Messages API rejects `temperature != 1.0` on models released after
+Claude Opus 4.6 (4xx error from the API). The `AnthropicProvider` therefore omits
+`.temperature(...)` from the SDK builder entirely — newer models default to 1.0
+and older models are unaffected. The `--temperature` flag is honoured by
+`OpenAIProvider`. For deterministic synthesis on Anthropic, rely on prompt
+structure and `--max-tokens` instead.
+
+## Caching
+
+Cache keys are content-addressed and intentionally do not include the spec source
+or skeleton text — only the contract surface that matters for verification. This
+means trivial spec edits (renames, comment changes) do not invalidate the cache,
+but any change to the operation's signature, requires, ensures, modifies, or to
+the `SynthPromptVersion` constant immediately misses.
+
+`SynthPromptVersion` is a manual bump knob (`v1` at time of writing). Bump it when
+the system prompts or few-shot library changes substantively.
+
+Cache misses cause one provider call; the response is parsed, diff-checked, and
+written atomically (`<file>.tmp` → `Files.move(..., ATOMIC_MOVE, REPLACE_EXISTING)`).
+Concurrent writers writing the same key are idempotent.
+
+## Cost tracking
+
+Every call emits one stderr line:
+
+```text
+[synth] op=Shorten model=claude-sonnet-4-6 in=1234tok out=456tok cost=$0.0114
+```
+
+`Tracker.summary` returns an aggregate `CostSummary(operations, inputTokens,
+outputTokens, totalUsd, cachedHits)` that #29 will surface in its end-of-run report.
+
+## What's deferred
+
+| Concern | Tracked in |
+|---|---|
+| `dafny verify` invocation, sandboxing, error parsing | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
+| CEGIS iteration loop, repair-prompt invocation | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
+| Dafny → Python / Go splice + post-process | [#27](https://github.com/HardMax71/spec_to_rest/issues/27) |
+| Decomposition, model-escalation, skeleton fallback | [#30](https://github.com/HardMax71/spec_to_rest/issues/30) |
+| `compile` integrating synth output | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
+| Few-shot examples machine-verified by `dafny verify` in CI | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |

--- a/docs/content/docs/synth/meta.json
+++ b/docs/content/docs/synth/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Synthesis",
+  "pages": ["llm-integration"]
+}

--- a/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
+++ b/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
@@ -2,6 +2,11 @@ package specrest.cli
 
 import cats.effect.ExitCode
 import specrest.ir.VerifyError
+import specrest.synth.CacheFailure
+import specrest.synth.DiffCheckFailure
+import specrest.synth.ProviderFailure
+import specrest.synth.ResponseParseFailure
+import specrest.synth.SynthError
 import specrest.verify.CheckOutcome
 import specrest.verify.CheckResult
 import specrest.verify.DiagnosticCategory
@@ -14,6 +19,12 @@ object ExitCodes:
   val Translator: ExitCode = ExitCode(2)
   val Backend: ExitCode    = ExitCode(3)
   val Trust: ExitCode      = ExitCode(4)
+
+  def forSynthError(e: SynthError): ExitCode = e match
+    case _: ProviderFailure      => Backend
+    case _: ResponseParseFailure => Translator
+    case _: DiffCheckFailure     => Translator
+    case _: CacheFailure         => Backend
 
   def forVerifyError(e: VerifyError): ExitCode = e match
     case _: VerifyError.Parse           => Violations

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -8,25 +8,29 @@ import io.circe.syntax.EncoderOps
 import specrest.convention.Classify
 import specrest.convention.OperationClassification
 import specrest.convention.SynthesisStrategy
+import specrest.convention.dafny.DafnyMethodHeader
 import specrest.convention.dafny.Generator as DafnyGenerator
 import specrest.ir.Serialize.given
 import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.parser.Builder
 import specrest.parser.Parse
+import specrest.synth.PromptBuilder
 
 import java.io.PrintStream
 
 enum InspectFormat derives CanEqual:
-  case Summary, Json, Ir, Dafny
+  case Summary, Json, Ir, Dafny, DafnyPrompt
 
 object InspectFormat:
   def parse(s: String): Either[String, InspectFormat] = s match
-    case "summary" => Right(Summary)
-    case "json"    => Right(Json)
-    case "ir"      => Right(Ir)
-    case "dafny"   => Right(Dafny)
-    case other     => Left(s"unknown format '$other'; choices: summary, json, ir, dafny")
+    case "summary"      => Right(Summary)
+    case "json"         => Right(Json)
+    case "ir"           => Right(Ir)
+    case "dafny"        => Right(Dafny)
+    case "dafny-prompt" => Right(DafnyPrompt)
+    case other =>
+      Left(s"unknown format '$other'; choices: summary, json, ir, dafny, dafny-prompt")
 
 object Inspect:
 
@@ -34,7 +38,8 @@ object Inspect:
       specFile: String,
       format: InspectFormat,
       log: Logger,
-      out: PrintStream = System.out
+      out: PrintStream = System.out,
+      operation: Option[String] = None
   ): IO[ExitCode] =
     Check.readSource(specFile, log).flatMap:
       case Left(code) => IO.pure(code)
@@ -50,12 +55,16 @@ object Inspect:
               case Left(err) =>
                 IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitCodes.Violations)
               case Right(ir) =>
-                renderIR(ir, format) match
+                renderIR(ir, format, operation) match
                   case Right(text) => IO.blocking(out.println(text)).as(ExitCodes.Ok)
                   case Left(msg) =>
                     IO.delay(log.error(s"$specFile: $msg")).as(ExitCodes.Translator)
 
-  private def renderIR(ir: ServiceIRFull, format: InspectFormat): Either[String, String] =
+  private def renderIR(
+      ir: ServiceIRFull,
+      format: InspectFormat,
+      operation: Option[String]
+  ): Either[String, String] =
     val classifications = Classify.classifyOperations(ir)
     format match
       case InspectFormat.Json =>
@@ -90,8 +99,55 @@ object Inspect:
             }
             s"Dafny generation failed$loc: ${err.message}"
           }
+      case InspectFormat.DafnyPrompt =>
+        renderDafnyPrompt(ir, classifications, operation)
 
   private def strategyTally(classifications: List[OperationClassification]): (Int, Int) =
     val d = classifications.count(_.strategy == SynthesisStrategy.DirectEmit)
     val l = classifications.count(_.strategy == SynthesisStrategy.LlmSynthesis)
     (d, l)
+
+  private def renderDafnyPrompt(
+      ir: ServiceIRFull,
+      classifications: List[OperationClassification],
+      operation: Option[String]
+  ): Either[String, String] =
+    DafnyGenerator.generate(ir).left.map { err =>
+      val loc = err.span.fold("") {
+        case SpanT(int_of_integer(line), int_of_integer(col), _, _) =>
+          s" at ${line.toLong}:${col.toLong}"
+      }
+      s"Dafny generation failed$loc: ${err.message}"
+    }.flatMap { dafny =>
+      val byName: Map[String, DafnyMethodHeader] = dafny.methods.map(h => h.name -> h).toMap
+      val targets = operation match
+        case Some(name) =>
+          classifications
+            .filter(_.operationName == name)
+            .map(c => (c, byName.get(c.operationName)))
+        case None =>
+          classifications
+            .filter(_.strategy == SynthesisStrategy.LlmSynthesis)
+            .map(c => (c, byName.get(c.operationName)))
+      val rendered = targets.flatMap:
+        case (c, Some(header)) =>
+          val prompt = PromptBuilder.initial(c, header, dafny.text)
+          List(formatPrompt(c.operationName, prompt))
+        case _ => Nil
+      if targets.isEmpty then
+        operation match
+          case Some(name) => Left(s"operation '$name' not found")
+          case None       => Right("(no operations classified as LLM_SYNTHESIS)")
+      else if rendered.isEmpty then
+        Left("no Dafny method headers were generated for the requested operations")
+      else Right(rendered.mkString("\n\n---\n\n"))
+    }
+
+  private def formatPrompt(name: String, p: specrest.synth.Prompt): String =
+    s"""# Operation: $name
+       |
+       |## System
+       |${p.system}
+       |
+       |## User
+       |${p.user}""".stripMargin

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -19,15 +19,22 @@ object Main
 
   private val inspectCmd: Opts[IO[ExitCode]] =
     val format = Opts
-      .option[String]("format", "output format (summary, json, ir, dafny)", short = "f")
+      .option[String](
+        "format",
+        "output format (summary, json, ir, dafny, dafny-prompt)",
+        short = "f"
+      )
       .withDefault("summary")
       .mapValidated: raw =>
         InspectFormat.parse(raw) match
           case Right(f)  => cats.data.Validated.valid(f)
           case Left(err) => cats.data.Validated.invalidNel(err)
+    val operation = Opts
+      .option[String]("operation", "filter to a single operation (used by dafny-prompt)")
+      .orNone
     Opts.subcommand("inspect", "Print the IR for a spec file"):
-      (specFile, format, verbose, quiet).mapN: (spec, fmt, v, q) =>
-        Inspect.run(spec, fmt, Logger.fromFlags(verbose = v, quiet = q))
+      (specFile, format, operation, verbose, quiet).mapN: (spec, fmt, op, v, q) =>
+        Inspect.run(spec, fmt, Logger.fromFlags(verbose = v, quiet = q), operation = op)
 
   private val checkCmd: Opts[IO[ExitCode]] =
     Opts.subcommand("check", "Parse and validate a spec file"):
@@ -147,5 +154,26 @@ object Main
             Logger.fromFlags(verbose = v, quiet = q)
           )
 
+  private val synthCmd: Opts[IO[ExitCode]] =
+    val operation = Opts.option[String]("operation", "operation to synthesize", short = "o")
+    val model = Opts
+      .option[String]("model", "LLM model (gpt-* routes to OpenAI; otherwise Anthropic)")
+      .withDefault("claude-sonnet-4-6")
+    val temperature = Opts
+      .option[Double]("temperature", "sampling temperature (ignored on newer Anthropic models)")
+      .withDefault(1.0)
+    val maxTokens = Opts.option[Int]("max-tokens", "max output tokens").withDefault(2048)
+    val noCache   = Opts.flag("no-cache", "bypass on-disk synthesis cache").orFalse
+    val cacheDir  = Opts.option[String]("cache-dir", "override synth cache directory").orNone
+    Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
+      Opts.subcommand("try", "Generate one Dafny body candidate via LLM"):
+        (specFile, operation, model, temperature, maxTokens, noCache, cacheDir, verbose, quiet)
+          .mapN: (spec, op, m, t, mt, nc, cd, v, q) =>
+            Synth.run(
+              spec,
+              SynthOptions(op, m, t, mt, nc, cd),
+              Logger.fromFlags(verbose = v, quiet = q)
+            )
+
   override def main: Opts[IO[ExitCode]] =
-    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd
+    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -1,0 +1,143 @@
+package specrest.cli
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import specrest.cli.ExitCodes.given
+import specrest.convention.Classify
+import specrest.convention.OperationClassification
+import specrest.convention.SynthesisStrategy
+import specrest.convention.dafny.DafnyMethodHeader
+import specrest.convention.dafny.Generator as DafnyGenerator
+import specrest.ir.VerifyError
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.synth.Cache
+import specrest.synth.LlmProvider
+import specrest.synth.SynthRequest
+import specrest.synth.SynthResult
+import specrest.synth.Synthesizer
+import specrest.synth.Tracker
+import specrest.synth.providers.AnthropicProvider
+import specrest.synth.providers.OpenAIProvider
+
+import java.io.PrintStream
+import java.nio.file.Paths
+
+final case class SynthOptions(
+    operation: String,
+    model: String,
+    temperature: Double,
+    maxTokens: Int,
+    noCache: Boolean,
+    cacheDir: Option[String]
+)
+
+object Synth:
+
+  def run(
+      specFile: String,
+      opts: SynthOptions,
+      log: Logger,
+      out: PrintStream = System.out,
+      err: PrintStream = System.err
+  ): IO[ExitCode] =
+    Check.readSource(specFile, log).flatMap:
+      case Left(code) => IO.pure(code)
+      case Right(source) =>
+        Parse.parseSpec(source).flatMap:
+          case Left(VerifyError.Parse(errors)) =>
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitCodes.Violations)
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).flatMap:
+              case Left(buildErr) =>
+                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
+                  .as(ExitCodes.Violations)
+              case Right(ir) =>
+                runWithIR(specFile, ir, opts, log, out, err)
+
+  private def runWithIR(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: SynthOptions,
+      log: Logger,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[ExitCode] =
+    val classifications = Classify.classifyOperations(ir)
+    classifications.find(_.operationName == opts.operation) match
+      case None =>
+        IO.delay(log.error(s"$specFile: operation '${opts.operation}' not found"))
+          .as(ExitCodes.Violations)
+      case Some(c) if c.strategy == SynthesisStrategy.DirectEmit =>
+        IO.delay(
+          log.error(
+            s"$specFile: operation '${opts.operation}' is classified DIRECT_EMIT; " +
+              "no LLM synthesis required"
+          )
+        ).as(ExitCodes.Violations)
+      case Some(c) =>
+        DafnyGenerator.generate(ir) match
+          case Left(dErr) =>
+            IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
+              .as(ExitCodes.Translator)
+          case Right(dafny) =>
+            dafny.methods.find(_.name == c.operationName) match
+              case None =>
+                IO.delay(log.error(s"$specFile: no Dafny header for '${c.operationName}'"))
+                  .as(ExitCodes.Translator)
+              case Some(header) =>
+                executeSynth(specFile, c, header, dafny.text, opts, log, out, err)
+
+  private def executeSynth(
+      specFile: String,
+      c: OperationClassification,
+      header: DafnyMethodHeader,
+      skeleton: String,
+      opts: SynthOptions,
+      log: Logger,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[ExitCode] =
+    val req = SynthRequest(c, header, skeleton, opts.model, opts.temperature, opts.maxTokens)
+    providerResource(opts.model).use: provider =>
+      cacheResource(opts).flatMap: cache =>
+        Tracker.empty.flatMap: tracker =>
+          val synth = new Synthesizer(provider, cache, tracker)
+          synth.synthesize(req).flatMap:
+            case Left(synthErr) =>
+              IO.delay(log.error(s"$specFile: synth ${c.operationName}: ${synthErr.message}"))
+                .as(ExitCodes.forSynthError(synthErr))
+            case Right(result) => emitResult(result, c.operationName, out, err).as(ExitCodes.Ok)
+
+  private def cacheResource(opts: SynthOptions): IO[Option[Cache]] =
+    if opts.noCache then IO.pure(None)
+    else
+      val root = opts.cacheDir match
+        case Some(p) => Paths.get(p)
+        case None    => Cache.defaultRoot(Paths.get(""))
+      Cache.make(root).map(Some(_))
+
+  private def providerResource(model: String): Resource[IO, LlmProvider] =
+    if model.toLowerCase.startsWith("gpt") then
+      OpenAIProvider.fromEnv.map(p => p: LlmProvider)
+    else AnthropicProvider.fromEnv.map(p => p: LlmProvider)
+
+  private def emitResult(
+      r: SynthResult,
+      opName: String,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[Unit] =
+    IO.blocking {
+      out.println(r.body)
+      val cacheTag = if r.cached then "(cached)" else ""
+      err.println(
+        f"[synth] op=$opName model=${r.model} in=${r.usage.inputTokens}tok " +
+          f"out=${r.usage.outputTokens}tok cost=$$${r.costUsd}%.4f $cacheTag".trim
+      )
+    }

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -29,10 +29,14 @@ class CliSmokeTest extends CatsEffectSuite:
     Inspect.run("fixtures/spec/safe_counter.spec", InspectFormat.Json, log)
       .assertEquals(ExitCodes.Ok)
 
-  private def captureInspect(spec: String, format: InspectFormat): IO[(ExitCode, String)] =
+  private def captureInspect(
+      spec: String,
+      format: InspectFormat,
+      op: Option[String] = None
+  ): IO[(ExitCode, String)] =
     val buf = new java.io.ByteArrayOutputStream()
     val ps  = new java.io.PrintStream(buf, true, "UTF-8")
-    Inspect.run(spec, format, log, ps).map: exit =>
+    Inspect.run(spec, format, log, ps, op).map: exit =>
       ps.flush()
       (exit, buf.toString("UTF-8"))
 
@@ -89,22 +93,11 @@ class CliSmokeTest extends CatsEffectSuite:
       Some(InspectFormat.DafnyPrompt)
     )
 
-  private def captureInspectWithOperation(
-      spec: String,
-      format: InspectFormat,
-      op: Option[String]
-  ): IO[(ExitCode, String)] =
-    val buf = new java.io.ByteArrayOutputStream()
-    val ps  = new java.io.PrintStream(buf, true, "UTF-8")
-    Inspect.run(spec, format, log, ps, op).map: exit =>
-      ps.flush()
-      (exit, buf.toString("UTF-8"))
-
   test("inspect --format dafny-prompt renders LLM-bound sections for url_shortener (#28)"):
-    captureInspectWithOperation(
+    captureInspect(
       "fixtures/spec/url_shortener.spec",
       InspectFormat.DafnyPrompt,
-      Some("Shorten")
+      op = Some("Shorten")
     ).map: (exit, out) =>
       assertEquals(exit, ExitCodes.Ok)
       assert(out.contains("# Operation: Shorten"), s"missing operation header:\n$out")
@@ -112,10 +105,9 @@ class CliSmokeTest extends CatsEffectSuite:
       assert(out.contains("## Similar Verified Examples"), s"missing few-shot section:\n$out")
 
   test("inspect --format dafny-prompt without --operation lists all LLM_SYNTHESIS ops"):
-    captureInspectWithOperation(
+    captureInspect(
       "fixtures/spec/url_shortener.spec",
-      InspectFormat.DafnyPrompt,
-      None
+      InspectFormat.DafnyPrompt
     ).map: (exit, out) =>
       assertEquals(exit, ExitCodes.Ok)
       assert(out.contains("# Operation: Shorten"), s"missing Shorten:\n$out")

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -83,6 +83,53 @@ class CliSmokeTest extends CatsEffectSuite:
       .run("fixtures/spec/edge_cases.spec", InspectFormat.Dafny, log)
       .assertEquals(ExitCodes.Translator)
 
+  test("InspectFormat.parse accepts dafny-prompt (#28)"):
+    assertEquals(
+      InspectFormat.parse("dafny-prompt").toOption,
+      Some(InspectFormat.DafnyPrompt)
+    )
+
+  private def captureInspectWithOperation(
+      spec: String,
+      format: InspectFormat,
+      op: Option[String]
+  ): IO[(ExitCode, String)] =
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps  = new java.io.PrintStream(buf, true, "UTF-8")
+    Inspect.run(spec, format, log, ps, op).map: exit =>
+      ps.flush()
+      (exit, buf.toString("UTF-8"))
+
+  test("inspect --format dafny-prompt renders LLM-bound sections for url_shortener (#28)"):
+    captureInspectWithOperation(
+      "fixtures/spec/url_shortener.spec",
+      InspectFormat.DafnyPrompt,
+      Some("Shorten")
+    ).map: (exit, out) =>
+      assertEquals(exit, ExitCodes.Ok)
+      assert(out.contains("# Operation: Shorten"), s"missing operation header:\n$out")
+      assert(out.contains("## Method Signature"), s"missing signature section:\n$out")
+      assert(out.contains("## Similar Verified Examples"), s"missing few-shot section:\n$out")
+
+  test("inspect --format dafny-prompt without --operation lists all LLM_SYNTHESIS ops"):
+    captureInspectWithOperation(
+      "fixtures/spec/url_shortener.spec",
+      InspectFormat.DafnyPrompt,
+      None
+    ).map: (exit, out) =>
+      assertEquals(exit, ExitCodes.Ok)
+      assert(out.contains("# Operation: Shorten"), s"missing Shorten:\n$out")
+
+  test("inspect --format dafny-prompt --operation unknown exits Translator"):
+    Inspect
+      .run(
+        "fixtures/spec/safe_counter.spec",
+        InspectFormat.DafnyPrompt,
+        log,
+        operation = Some("DoesNotExist")
+      )
+      .assertEquals(ExitCodes.Translator)
+
   test("verify safe_counter returns exit 0"):
     Verify.run(
       "fixtures/spec/safe_counter.spec",

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/map_delete.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/map_delete.dfy
@@ -1,0 +1,9 @@
+// Deleting a key from a map
+method Remove<K(==),V>(m: map<K,V>, k: K) returns (m': map<K,V>)
+  requires k in m
+  ensures k !in m'
+  ensures |m'| == |m| - 1
+  ensures forall j :: j in m && j != k ==> j in m' && m'[j] == m[j]
+{
+  m' := map j | j in m && j != k :: m[j];
+}

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/map_insert_fresh.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/map_insert_fresh.dfy
@@ -1,0 +1,8 @@
+// Inserting a fresh key into a map
+method Insert<K(==),V>(m: map<K,V>, k: K, v: V) returns (m': map<K,V>)
+  requires k !in m
+  ensures m' == m[k := v]
+  ensures |m'| == |m| + 1
+{
+  m' := m[k := v];
+}

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/map_update_existing.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/map_update_existing.dfy
@@ -1,0 +1,8 @@
+// Updating the value at an existing key — cardinality is preserved
+method Update<K(==),V>(m: map<K,V>, k: K, v: V) returns (m': map<K,V>)
+  requires k in m
+  ensures m' == m[k := v]
+  ensures |m'| == |m|
+{
+  m' := m[k := v];
+}

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/seq_sum.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/seq_sum.dfy
@@ -1,0 +1,22 @@
+// Summing a sequence with a loop invariant
+ghost function SumSpec(s: seq<int>): int
+  decreases |s|
+{
+  if |s| == 0 then 0
+  else s[0] + SumSpec(s[1..])
+}
+
+method Sum(s: seq<int>) returns (total: int)
+  ensures total == SumSpec(s)
+{
+  total := 0;
+  var i := |s|;
+  while i > 0
+    invariant 0 <= i <= |s|
+    invariant total == SumSpec(s[i..])
+    decreases i
+  {
+    i := i - 1;
+    total := s[i] + total;
+  }
+}

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/state_modify.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/state_modify.dfy
@@ -1,0 +1,12 @@
+// Updating a counter field on a class while leaving other state untouched
+class Counter {
+  var count: int
+}
+
+method Increment(c: Counter)
+  modifies c
+  requires c.count >= 0
+  ensures c.count == old(c.count) + 1
+{
+  c.count := c.count + 1;
+}

--- a/modules/synth/src/main/resources/specrest/synth/prompts/initial.system.txt
+++ b/modules/synth/src/main/resources/specrest/synth/prompts/initial.system.txt
@@ -1,0 +1,16 @@
+You are an expert Dafny programmer specializing in verified implementations.
+Your task is to produce a method body that the Dafny verifier will accept.
+
+Rules:
+1. You MUST NOT modify the method signature, requires, ensures, or modifies clauses.
+2. You MUST produce code that satisfies ALL postconditions.
+3. You MAY add local variables, assertions, loop invariants, and ghost code.
+4. You MAY define helper lemmas inline before the method.
+5. You SHOULD add intermediate assertions to help the verifier.
+6. You SHOULD use `calc` blocks for complex multi-step reasoning.
+7. You MUST NOT introduce new {:extern} declarations.
+8. Prefer simple, straightforward implementations over clever ones.
+
+Return your code inside a single ```dafny fenced block. Include any helper
+lemmas you need before the method declaration. Do not paraphrase or weaken
+contracts to make verification easier — that is rejected by the diff checker.

--- a/modules/synth/src/main/resources/specrest/synth/prompts/repair.system.txt
+++ b/modules/synth/src/main/resources/specrest/synth/prompts/repair.system.txt
@@ -1,0 +1,13 @@
+You are an expert Dafny programmer fixing a verified implementation.
+Your previous attempt failed verification. You will be shown the candidate body
+and the verifier's diagnosis. Produce a corrected method body.
+
+Rules:
+1. You MUST NOT modify the method signature, requires, ensures, or modifies clauses.
+2. You MUST address the specific verifier failure described below.
+3. You MAY add local variables, assertions, loop invariants, and ghost code.
+4. You MAY define helper lemmas inline before the method.
+5. You MUST NOT introduce new {:extern} declarations.
+
+Return your COMPLETE corrected body inside a single ```dafny fenced block.
+Do not weaken contracts — the diff checker will reject any signature change.

--- a/modules/synth/src/main/scala/specrest/synth/Cache.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Cache.scala
@@ -1,0 +1,94 @@
+package specrest.synth
+
+import cats.effect.IO
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.parser
+import io.circe.syntax.EncoderOps
+import specrest.convention.dafny.DafnyMethodHeader
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+
+final case class CacheKey(value: String)
+
+final case class CacheEntry(
+    candidate: String,
+    body: String,
+    usage: TokenUsage,
+    model: String,
+    promptVersion: String
+)
+
+object CacheEntry:
+  given Encoder[TokenUsage] = deriveEncoder
+  given Decoder[TokenUsage] = deriveDecoder
+  given Encoder[CacheEntry] = deriveEncoder
+  given Decoder[CacheEntry] = deriveDecoder
+
+final class Cache(root: Path):
+  def lookup(key: CacheKey): IO[Option[CacheEntry]] =
+    IO.blocking {
+      val target = pathFor(key)
+      if !Files.exists(target) then None
+      else
+        val text = Files.readString(target, StandardCharsets.UTF_8)
+        parser.decode[CacheEntry](text).toOption
+    }
+
+  def store(key: CacheKey, entry: CacheEntry): IO[Unit] =
+    IO.blocking {
+      val target = pathFor(key)
+      Option(target.getParent).foreach(Files.createDirectories(_))
+      val tmp     = target.resolveSibling(s"${target.getFileName.toString}.tmp")
+      val payload = entry.asJson.spaces2.getBytes(StandardCharsets.UTF_8)
+      Files.write(tmp, payload)
+      Files.move(
+        tmp,
+        target,
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.ATOMIC_MOVE
+      )
+      ()
+    }
+
+  private def pathFor(key: CacheKey): Path =
+    val prefix = key.value.take(2)
+    root.resolve(prefix).resolve(s"${key.value}.json")
+
+object Cache:
+  def make(root: Path): IO[Cache] =
+    IO.blocking {
+      Files.createDirectories(root)
+      new Cache(root)
+    }
+
+  def disabled: Option[Cache] = None
+
+  def keyFor(
+      header: DafnyMethodHeader,
+      model: String,
+      temperature: Double,
+      promptVersion: String = SynthPromptVersion
+  ): CacheKey =
+    val parts = List(
+      header.signature,
+      header.requiresClauses.mkString("\n"),
+      header.ensuresClauses.mkString("\n"),
+      header.modifiesClauses.mkString("\n"),
+      model,
+      f"$temperature%.4f",
+      promptVersion
+    )
+    val joined = parts.mkString("")
+    val digest = MessageDigest.getInstance("SHA-256")
+    val bytes  = digest.digest(joined.getBytes(StandardCharsets.UTF_8))
+    CacheKey(bytes.map(b => f"${b & 0xff}%02x").mkString)
+
+  def defaultRoot(workdir: Path): Path =
+    workdir.resolve(".spec-to-rest").resolve("synth-cache")

--- a/modules/synth/src/main/scala/specrest/synth/Cache.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Cache.scala
@@ -45,7 +45,8 @@ final class Cache(root: Path):
     IO.blocking {
       val target = pathFor(key)
       Option(target.getParent).foreach(Files.createDirectories(_))
-      val tmp     = target.resolveSibling(s"${target.getFileName.toString}.tmp")
+      val unique  = s"${java.util.UUID.randomUUID().toString}"
+      val tmp     = target.resolveSibling(s"${target.getFileName.toString}.$unique.tmp")
       val payload = entry.asJson.spaces2.getBytes(StandardCharsets.UTF_8)
       Files.write(tmp, payload)
       Files.move(
@@ -77,15 +78,15 @@ object Cache:
       promptVersion: String = SynthPromptVersion
   ): CacheKey =
     val parts = List(
-      header.signature,
-      header.requiresClauses.mkString("\n"),
-      header.ensuresClauses.mkString("\n"),
-      header.modifiesClauses.mkString("\n"),
-      model,
-      f"$temperature%.4f",
-      promptVersion
+      s"sig=${header.signature}",
+      s"req#${header.requiresClauses.length}=" + header.requiresClauses.mkString("\n"),
+      s"ens#${header.ensuresClauses.length}=" + header.ensuresClauses.mkString("\n"),
+      s"mod#${header.modifiesClauses.length}=" + header.modifiesClauses.mkString("\n"),
+      s"model=$model",
+      s"temp=${java.lang.Double.toString(temperature)}",
+      s"pv=$promptVersion"
     )
-    val joined = parts.mkString("")
+    val joined = parts.mkString("\u001f")
     val digest = MessageDigest.getInstance("SHA-256")
     val bytes  = digest.digest(joined.getBytes(StandardCharsets.UTF_8))
     CacheKey(bytes.map(b => f"${b & 0xff}%02x").mkString)

--- a/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
@@ -72,8 +72,13 @@ object DiffChecker:
       }
     if start < 0 then None
     else
-      val rest      = lines.drop(start + 1)
-      val collected = collectClauseLines(rest, Nil)
+      val rest         = lines.drop(start + 1).mkString("\n")
+      val bodyStart    = findBodyOpener(rest)
+      val clauseRegion = if bodyStart < 0 then rest else rest.substring(0, bodyStart)
+      val collected = clauseRegion.linesIterator
+        .map(_.trim)
+        .filter(_.nonEmpty)
+        .toList
       val req = collected.collect {
         case l if l.startsWith("requires ") => l.stripPrefix("requires ")
       }
@@ -85,21 +90,44 @@ object DiffChecker:
       }
       Some(FoundClauses(req, ens, mod))
 
-  @scala.annotation.tailrec
-  private def collectClauseLines(lines: List[String], acc: List[String]): List[String] =
-    lines match
-      case Nil => acc.reverse
-      case head :: tail =>
-        val braceIdx = head.indexOf('{')
-        val (toAccept, stop) =
-          if braceIdx < 0 then (head, false)
-          else (head.substring(0, braceIdx), true)
-        val trimmed = toAccept.trim
-        val nextAcc =
-          if trimmed.isEmpty then acc
-          else trimmed :: acc
-        if stop then nextAcc.reverse
-        else collectClauseLines(tail, nextAcc)
+  private enum ScanMode derives CanEqual:
+    case Code, LineComment, BlockComment, StringLit
+
+  private def findBodyOpener(text: String): Int =
+    @scala.annotation.tailrec
+    def loop(i: Int, depth: Int, candidate: Int, mode: ScanMode): Int =
+      if i >= text.length then candidate
+      else
+        val c = text.charAt(i)
+        mode match
+          case ScanMode.LineComment =>
+            if c == '\n' then loop(i + 1, depth, candidate, ScanMode.Code)
+            else loop(i + 1, depth, candidate, ScanMode.LineComment)
+          case ScanMode.BlockComment =>
+            if c == '*' && i + 1 < text.length && text.charAt(i + 1) == '/' then
+              loop(i + 2, depth, candidate, ScanMode.Code)
+            else loop(i + 1, depth, candidate, ScanMode.BlockComment)
+          case ScanMode.StringLit =>
+            if c == '\\' && i + 1 < text.length then
+              loop(i + 2, depth, candidate, ScanMode.StringLit)
+            else if c == '"' then loop(i + 1, depth, candidate, ScanMode.Code)
+            else loop(i + 1, depth, candidate, ScanMode.StringLit)
+          case ScanMode.Code =>
+            c match
+              case '"' => loop(i + 1, depth, candidate, ScanMode.StringLit)
+              case '/' if i + 1 < text.length && text.charAt(i + 1) == '/' =>
+                loop(i + 2, depth, candidate, ScanMode.LineComment)
+              case '/' if i + 1 < text.length && text.charAt(i + 1) == '*' =>
+                loop(i + 2, depth, candidate, ScanMode.BlockComment)
+              case '{' =>
+                val newCand = if depth == 0 && candidate < 0 then i else candidate
+                loop(i + 1, depth + 1, newCand, ScanMode.Code)
+              case '}' =>
+                val newDepth = depth - 1
+                val newCand  = if newDepth <= 0 then -1 else candidate
+                loop(i + 1, newDepth, newCand, ScanMode.Code)
+              case _ => loop(i + 1, depth, candidate, ScanMode.Code)
+    loop(0, 0, -1, ScanMode.Code)
 
   private def normalize(clause: String): String =
     val trimmed = clause.trim.replaceAll("\\s+", " ")

--- a/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
@@ -62,24 +62,44 @@ object DiffChecker:
   )
 
   private def extractClauses(candidate: String, methodName: String): Option[FoundClauses] =
-    val lines = candidate.linesIterator.toList
-    val start = lines.indexWhere(_.trim.startsWith(s"method $methodName"))
+    val lines  = candidate.linesIterator.toList
+    val prefix = s"method $methodName"
+    val start = lines.indexWhere: line =>
+      val t = line.trim
+      t.startsWith(prefix) && {
+        val nextChar = t.lift(prefix.length)
+        nextChar.forall(c => c == '(' || c == '<' || c == ' ')
+      }
     if start < 0 then None
     else
-      val rest = lines.drop(start + 1)
-      val clauses = rest.takeWhile: line =>
-        val t = line.trim
-        !t.startsWith("{") && t.nonEmpty
-      val req = clauses.collect {
-        case l if l.trim.startsWith("requires ") => l.trim.stripPrefix("requires ")
+      val rest      = lines.drop(start + 1)
+      val collected = collectClauseLines(rest, Nil)
+      val req = collected.collect {
+        case l if l.startsWith("requires ") => l.stripPrefix("requires ")
       }
-      val ens = clauses.collect {
-        case l if l.trim.startsWith("ensures ") => l.trim.stripPrefix("ensures ")
+      val ens = collected.collect {
+        case l if l.startsWith("ensures ") => l.stripPrefix("ensures ")
       }
-      val mod = clauses.collect {
-        case l if l.trim.startsWith("modifies ") => l.trim.stripPrefix("modifies ")
+      val mod = collected.collect {
+        case l if l.startsWith("modifies ") => l.stripPrefix("modifies ")
       }
       Some(FoundClauses(req, ens, mod))
+
+  @scala.annotation.tailrec
+  private def collectClauseLines(lines: List[String], acc: List[String]): List[String] =
+    lines match
+      case Nil => acc.reverse
+      case head :: tail =>
+        val braceIdx = head.indexOf('{')
+        val (toAccept, stop) =
+          if braceIdx < 0 then (head, false)
+          else (head.substring(0, braceIdx), true)
+        val trimmed = toAccept.trim
+        val nextAcc =
+          if trimmed.isEmpty then acc
+          else trimmed :: acc
+        if stop then nextAcc.reverse
+        else collectClauseLines(tail, nextAcc)
 
   private def normalize(clause: String): String =
     val trimmed = clause.trim.replaceAll("\\s+", " ")

--- a/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
@@ -1,0 +1,106 @@
+package specrest.synth
+
+import specrest.convention.dafny.DafnyMethodHeader
+
+final case class DiffViolation(message: String, diff: String)
+
+object DiffChecker:
+
+  def check(header: DafnyMethodHeader, candidate: String): Either[DiffViolation, Unit] =
+    if containsForbiddenExtern(candidate) then
+      Left(
+        DiffViolation(
+          "candidate introduces a new {:extern} declaration",
+          extractExternLines(candidate).mkString("\n")
+        )
+      )
+    else
+      val name        = methodNameOf(header.signature)
+      val candClauses = extractClauses(candidate, name)
+      candClauses match
+        case None =>
+          Left(DiffViolation(s"could not locate method '$name' in candidate", ""))
+        case Some(found) =>
+          val expected = ClauseSet(
+            normalizeAll(header.requiresClauses),
+            normalizeAll(header.ensuresClauses),
+            normalizeAll(header.modifiesClauses)
+          )
+          val actual = ClauseSet(
+            normalizeAll(found.requires),
+            normalizeAll(found.ensures),
+            normalizeAll(found.modifies)
+          )
+          if expected == actual then Right(())
+          else Left(DiffViolation("contracts changed", renderDiff(expected, actual)))
+
+  private def containsForbiddenExtern(candidate: String): Boolean =
+    candidate.contains("{:extern")
+
+  private def extractExternLines(candidate: String): List[String] =
+    candidate.linesIterator.filter(_.contains("{:extern")).toList
+
+  private def methodNameOf(signature: String): String =
+    val afterMethod = signature.indexOf("method ")
+    if afterMethod < 0 then ""
+    else
+      val nameStart = afterMethod + "method ".length
+      val nameEnd   = signature.indexWhere(c => c == '(' || c == '<' || c == ' ', nameStart)
+      if nameEnd < 0 then signature.substring(nameStart).trim
+      else signature.substring(nameStart, nameEnd).trim
+
+  final private case class ClauseSet(
+      requires: List[String],
+      ensures: List[String],
+      modifies: List[String]
+  ) derives CanEqual
+
+  final private case class FoundClauses(
+      requires: List[String],
+      ensures: List[String],
+      modifies: List[String]
+  )
+
+  private def extractClauses(candidate: String, methodName: String): Option[FoundClauses] =
+    val lines = candidate.linesIterator.toList
+    val start = lines.indexWhere(_.trim.startsWith(s"method $methodName"))
+    if start < 0 then None
+    else
+      val rest = lines.drop(start + 1)
+      val clauses = rest.takeWhile: line =>
+        val t = line.trim
+        !t.startsWith("{") && t.nonEmpty
+      val req = clauses.collect {
+        case l if l.trim.startsWith("requires ") => l.trim.stripPrefix("requires ")
+      }
+      val ens = clauses.collect {
+        case l if l.trim.startsWith("ensures ") => l.trim.stripPrefix("ensures ")
+      }
+      val mod = clauses.collect {
+        case l if l.trim.startsWith("modifies ") => l.trim.stripPrefix("modifies ")
+      }
+      Some(FoundClauses(req, ens, mod))
+
+  private def normalize(clause: String): String =
+    val trimmed = clause.trim.replaceAll("\\s+", " ")
+    if trimmed.endsWith(";") then trimmed.dropRight(1).trim else trimmed
+
+  private def normalizeAll(clauses: List[String]): List[String] =
+    clauses.map(normalize).sorted
+
+  private def renderDiff(expected: ClauseSet, actual: ClauseSet): String =
+    val parts = List(
+      diffSection("requires", expected.requires, actual.requires),
+      diffSection("ensures", expected.ensures, actual.ensures),
+      diffSection("modifies", expected.modifies, actual.modifies)
+    ).filter(_.nonEmpty)
+    parts.mkString("\n")
+
+  private def diffSection(label: String, expected: List[String], actual: List[String]): String =
+    val missing = expected.filterNot(actual.contains)
+    val extra   = actual.filterNot(expected.contains)
+    if missing.isEmpty && extra.isEmpty then ""
+    else
+      val m = missing.map(c => s"- $label $c")
+      val e = extra.map(c => s"+ $label $c")
+      (m ++ e).mkString("\n")

--- a/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
@@ -2,52 +2,24 @@ package specrest.synth
 
 import specrest.convention.dafny.DafnyMethodHeader
 
+import scala.annotation.tailrec
+
 final case class DiffViolation(message: String, diff: String)
 
 object DiffChecker:
 
   def check(header: DafnyMethodHeader, candidate: String): Either[DiffViolation, Unit] =
-    if containsForbiddenExtern(candidate) then
-      Left(
-        DiffViolation(
-          "candidate introduces a new {:extern} declaration",
-          extractExternLines(candidate).mkString("\n")
-        )
-      )
-    else
-      val name        = methodNameOf(header.signature)
-      val candClauses = extractClauses(candidate, name)
-      candClauses match
-        case None =>
-          Left(DiffViolation(s"could not locate method '$name' in candidate", ""))
-        case Some(found) =>
-          val expected = ClauseSet(
-            normalizeAll(header.requiresClauses),
-            normalizeAll(header.ensuresClauses),
-            normalizeAll(header.modifiesClauses)
-          )
-          val actual = ClauseSet(
-            normalizeAll(found.requires),
-            normalizeAll(found.ensures),
-            normalizeAll(found.modifies)
-          )
-          if expected == actual then Right(())
-          else Left(DiffViolation("contracts changed", renderDiff(expected, actual)))
+    forbiddenExtern(candidate) match
+      case Some(violation) => Left(violation)
+      case None =>
+        val name     = methodNameOf(header.signature)
+        val expected = canonical(header)
+        parseCandidate(candidate, name) match
+          case None                               => Left(notFound(name))
+          case Some(actual) if actual == expected => Right(())
+          case Some(actual)                       => Left(contractsChanged(expected, actual))
 
-  private def containsForbiddenExtern(candidate: String): Boolean =
-    candidate.contains("{:extern")
-
-  private def extractExternLines(candidate: String): List[String] =
-    candidate.linesIterator.filter(_.contains("{:extern")).toList
-
-  private def methodNameOf(signature: String): String =
-    val afterMethod = signature.indexOf("method ")
-    if afterMethod < 0 then ""
-    else
-      val nameStart = afterMethod + "method ".length
-      val nameEnd   = signature.indexWhere(c => c == '(' || c == '<' || c == ' ', nameStart)
-      if nameEnd < 0 then signature.substring(nameStart).trim
-      else signature.substring(nameStart, nameEnd).trim
+  // ── canonical and observed clause sets ────────────────────────────────────
 
   final private case class ClauseSet(
       requires: List[String],
@@ -55,100 +27,103 @@ object DiffChecker:
       modifies: List[String]
   ) derives CanEqual
 
-  final private case class FoundClauses(
-      requires: List[String],
-      ensures: List[String],
-      modifies: List[String]
+  private def canonical(h: DafnyMethodHeader): ClauseSet = ClauseSet(
+    h.requiresClauses.map(normalize).sorted,
+    h.ensuresClauses.map(normalize).sorted,
+    h.modifiesClauses.map(normalize).sorted
   )
 
-  private def extractClauses(candidate: String, methodName: String): Option[FoundClauses] =
-    val lines  = candidate.linesIterator.toList
-    val prefix = s"method $methodName"
-    val start = lines.indexWhere: line =>
-      val t = line.trim
-      t.startsWith(prefix) && {
-        val nextChar = t.lift(prefix.length)
-        nextChar.forall(c => c == '(' || c == '<' || c == ' ')
-      }
-    if start < 0 then None
-    else
-      val rest         = lines.drop(start + 1).mkString("\n")
-      val bodyStart    = findBodyOpener(rest)
-      val clauseRegion = if bodyStart < 0 then rest else rest.substring(0, bodyStart)
-      val collected = clauseRegion.linesIterator
-        .map(_.trim)
-        .filter(_.nonEmpty)
-        .toList
-      val req = collected.collect {
-        case l if l.startsWith("requires ") => l.stripPrefix("requires ")
-      }
-      val ens = collected.collect {
-        case l if l.startsWith("ensures ") => l.stripPrefix("ensures ")
-      }
-      val mod = collected.collect {
-        case l if l.startsWith("modifies ") => l.stripPrefix("modifies ")
-      }
-      Some(FoundClauses(req, ens, mod))
-
-  private enum ScanMode derives CanEqual:
-    case Code, LineComment, BlockComment, StringLit
-
-  private def findBodyOpener(text: String): Int =
-    @scala.annotation.tailrec
-    def loop(i: Int, depth: Int, candidate: Int, mode: ScanMode): Int =
-      if i >= text.length then candidate
-      else
-        val c = text.charAt(i)
-        mode match
-          case ScanMode.LineComment =>
-            if c == '\n' then loop(i + 1, depth, candidate, ScanMode.Code)
-            else loop(i + 1, depth, candidate, ScanMode.LineComment)
-          case ScanMode.BlockComment =>
-            if c == '*' && i + 1 < text.length && text.charAt(i + 1) == '/' then
-              loop(i + 2, depth, candidate, ScanMode.Code)
-            else loop(i + 1, depth, candidate, ScanMode.BlockComment)
-          case ScanMode.StringLit =>
-            if c == '\\' && i + 1 < text.length then
-              loop(i + 2, depth, candidate, ScanMode.StringLit)
-            else if c == '"' then loop(i + 1, depth, candidate, ScanMode.Code)
-            else loop(i + 1, depth, candidate, ScanMode.StringLit)
-          case ScanMode.Code =>
-            c match
-              case '"' => loop(i + 1, depth, candidate, ScanMode.StringLit)
-              case '/' if i + 1 < text.length && text.charAt(i + 1) == '/' =>
-                loop(i + 2, depth, candidate, ScanMode.LineComment)
-              case '/' if i + 1 < text.length && text.charAt(i + 1) == '*' =>
-                loop(i + 2, depth, candidate, ScanMode.BlockComment)
-              case '{' =>
-                val newCand = if depth == 0 && candidate < 0 then i else candidate
-                loop(i + 1, depth + 1, newCand, ScanMode.Code)
-              case '}' =>
-                val newDepth = depth - 1
-                val newCand  = if newDepth <= 0 then -1 else candidate
-                loop(i + 1, newDepth, newCand, ScanMode.Code)
-              case _ => loop(i + 1, depth, candidate, ScanMode.Code)
-    loop(0, 0, -1, ScanMode.Code)
-
   private def normalize(clause: String): String =
-    val trimmed = clause.trim.replaceAll("\\s+", " ")
-    if trimmed.endsWith(";") then trimmed.dropRight(1).trim else trimmed
+    clause.trim.replaceAll("\\s+", " ").stripSuffix(";").trim
 
-  private def normalizeAll(clauses: List[String]): List[String] =
-    clauses.map(normalize).sorted
+  // ── candidate parsing ─────────────────────────────────────────────────────
+  //
+  // Dafny formats spec clauses one-per-line in our generator output, and the
+  // LLM is told to copy them verbatim. A clause line is balanced (set literals
+  // and forall triggers like `{TODO, DONE}` open and close on the same line).
+  // The method body opens on a line whose `{` does *not* close on that line —
+  // either standalone `{` or `modifies st {`. That's the termination signal,
+  // and it's local to a single line, so multi-method inputs don't confuse it.
+
+  private def parseCandidate(candidate: String, name: String): Option[ClauseSet] =
+    locateMethod(candidate, name).map(specLines).map(classify)
+
+  private def locateMethod(candidate: String, name: String): Option[List[String]] =
+    val anchor = s"""\\bmethod\\s+${java.util.regex.Pattern.quote(name)}(?=[\\s(<])""".r
+    val lines  = candidate.linesIterator.toList
+    val idx    = lines.indexWhere(line => anchor.findFirstIn(line).isDefined)
+    Option.when(idx >= 0)(lines.drop(idx + 1))
+
+  /** Take lines until one contains an unbalanced `{`; trim that final line at the brace so any
+    * clause text before it (e.g. `modifies st`) survives.
+    */
+  private def specLines(after: List[String]): List[String] =
+    @tailrec def take(remaining: List[String], acc: List[String]): List[String] =
+      remaining match
+        case Nil => acc.reverse
+        case head :: rest =>
+          unbalancedOpenBraceCol(head) match
+            case None      => take(rest, head :: acc)
+            case Some(col) => (head.substring(0, col) :: acc).reverse
+    take(after, Nil)
+
+  /** Column of the first `{` on this line whose matching `}` is not on the same line, or None if
+    * every `{` on the line balances.
+    */
+  private def unbalancedOpenBraceCol(line: String): Option[Int] =
+    @tailrec def scan(i: Int, depth: Int, candidate: Int): Int =
+      if i >= line.length then candidate
+      else
+        line.charAt(i) match
+          case '{' if depth == 0 => scan(i + 1, 1, i)
+          case '{'               => scan(i + 1, depth + 1, candidate)
+          case '}' if depth == 1 => scan(i + 1, 0, -1)
+          case '}'               => scan(i + 1, depth - 1, candidate)
+          case _                 => scan(i + 1, depth, candidate)
+    scan(0, 0, -1) match
+      case n if n < 0 => None
+      case n          => Some(n)
+
+  private def classify(lines: List[String]): ClauseSet =
+    def collect(kw: String): List[String] =
+      lines.flatMap: line =>
+        val t = line.trim
+        if t.startsWith(kw) then List(normalize(t.substring(kw.length))) else Nil
+    ClauseSet(
+      collect("requires ").sorted,
+      collect("ensures ").sorted,
+      collect("modifies ").sorted
+    )
+
+  // ── failure-path constructors ─────────────────────────────────────────────
+
+  private def forbiddenExtern(candidate: String): Option[DiffViolation] =
+    val externLines = candidate.linesIterator.filter(_.contains("{:extern")).toList
+    Option.when(externLines.nonEmpty):
+      DiffViolation(
+        "candidate introduces a new {:extern} declaration",
+        externLines.mkString("\n")
+      )
+
+  private def notFound(name: String): DiffViolation =
+    DiffViolation(s"could not locate method '$name' in candidate", "")
+
+  private def contractsChanged(expected: ClauseSet, actual: ClauseSet): DiffViolation =
+    DiffViolation("contracts changed", renderDiff(expected, actual))
 
   private def renderDiff(expected: ClauseSet, actual: ClauseSet): String =
-    val parts = List(
+    List(
       diffSection("requires", expected.requires, actual.requires),
       diffSection("ensures", expected.ensures, actual.ensures),
       diffSection("modifies", expected.modifies, actual.modifies)
-    ).filter(_.nonEmpty)
-    parts.mkString("\n")
+    ).filter(_.nonEmpty).mkString("\n")
 
-  private def diffSection(label: String, expected: List[String], actual: List[String]): String =
-    val missing = expected.filterNot(actual.contains)
-    val extra   = actual.filterNot(expected.contains)
-    if missing.isEmpty && extra.isEmpty then ""
-    else
-      val m = missing.map(c => s"- $label $c")
-      val e = extra.map(c => s"+ $label $c")
-      (m ++ e).mkString("\n")
+  private def diffSection(label: String, want: List[String], got: List[String]): String =
+    val missing = want.filterNot(got.contains).map(c => s"- $label $c")
+    val extra   = got.filterNot(want.contains).map(c => s"+ $label $c")
+    (missing ++ extra).mkString("\n")
+
+  private val MethodNamePattern = """method\s+([A-Za-z_]\w*)""".r
+
+  private def methodNameOf(signature: String): String =
+    MethodNamePattern.findFirstMatchIn(signature).map(_.group(1)).getOrElse("")

--- a/modules/synth/src/main/scala/specrest/synth/FewShot.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FewShot.scala
@@ -1,0 +1,40 @@
+package specrest.synth
+
+import specrest.convention.OperationKind
+
+import scala.io.Source
+import scala.util.Using
+
+object FewShot:
+
+  private val resourceRoot = "/specrest/synth/few-shot"
+
+  enum Snippet derives CanEqual:
+    case MapInsertFresh, MapUpdateExisting, MapDelete, SeqSum, StateModify
+
+  def fileName(s: Snippet): String = s match
+    case Snippet.MapInsertFresh    => "map_insert_fresh.dfy"
+    case Snippet.MapUpdateExisting => "map_update_existing.dfy"
+    case Snippet.MapDelete         => "map_delete.dfy"
+    case Snippet.SeqSum            => "seq_sum.dfy"
+    case Snippet.StateModify       => "state_modify.dfy"
+
+  def text(s: Snippet): String =
+    val name     = fileName(s)
+    val resource = s"$resourceRoot/$name"
+    val stream = Option(getClass.getResourceAsStream(resource))
+      .getOrElse(sys.error(s"Few-shot resource not found: $resource"))
+    Using.resource(stream): in =>
+      Source.fromInputStream(in, "UTF-8").mkString
+
+  def selectFor(kind: OperationKind): List[Snippet] = kind match
+    case OperationKind.Create        => List(Snippet.MapInsertFresh, Snippet.StateModify)
+    case OperationKind.Read          => List(Snippet.MapUpdateExisting)
+    case OperationKind.Replace       => List(Snippet.MapUpdateExisting, Snippet.StateModify)
+    case OperationKind.PartialUpdate => List(Snippet.MapUpdateExisting, Snippet.StateModify)
+    case OperationKind.Delete        => List(Snippet.MapDelete)
+    case OperationKind.CreateChild   => List(Snippet.MapInsertFresh)
+    case OperationKind.FilteredRead  => List(Snippet.SeqSum)
+    case OperationKind.SideEffect    => List(Snippet.StateModify, Snippet.SeqSum)
+    case OperationKind.BatchMutation => List(Snippet.SeqSum, Snippet.MapInsertFresh)
+    case OperationKind.Transition    => List(Snippet.StateModify)

--- a/modules/synth/src/main/scala/specrest/synth/LlmProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/LlmProvider.scala
@@ -1,0 +1,25 @@
+package specrest.synth
+
+import cats.effect.IO
+
+trait LlmProvider:
+  def name: String
+  def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]]
+
+final case class LlmRequest(
+    system: String,
+    userMessage: String,
+    model: String,
+    maxTokens: Int,
+    temperature: Double
+)
+
+final case class LlmResponse(
+    text: String,
+    usage: TokenUsage,
+    model: String
+)
+
+final case class TokenUsage(inputTokens: Int, outputTokens: Int)
+
+final case class ProviderError(message: String, status: Option[Int] = None)

--- a/modules/synth/src/main/scala/specrest/synth/MockProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/MockProvider.scala
@@ -1,0 +1,40 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+final class MockProvider private (
+    plan: List[Either[ProviderError, LlmResponse]],
+    cursor: Ref[IO, Int],
+    callsRef: Ref[IO, List[LlmRequest]]
+) extends LlmProvider:
+  def name: String = "mock"
+
+  def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]] =
+    for
+      _ <- callsRef.update(req :: _)
+      i <- cursor.getAndUpdate(_ + 1)
+    yield
+      if i >= plan.length then
+        Left(ProviderError(s"MockProvider exhausted after $i calls"))
+      else plan(i)
+
+  def calls: IO[List[LlmRequest]] = callsRef.get.map(_.reverse)
+
+object MockProvider:
+  def of(responses: List[Either[ProviderError, LlmResponse]]): IO[MockProvider] =
+    for
+      cur <- Ref.of[IO, Int](0)
+      log <- Ref.of[IO, List[LlmRequest]](Nil)
+    yield new MockProvider(responses, cur, log)
+
+  def succeeding(
+      text: String,
+      in: Int = 100,
+      out: Int = 200,
+      model: String = "mock-model"
+  ): IO[MockProvider] =
+    of(List(Right(LlmResponse(text, TokenUsage(in, out), model))))
+
+  def failing(message: String): IO[MockProvider] =
+    of(List(Left(ProviderError(message))))

--- a/modules/synth/src/main/scala/specrest/synth/Pricing.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Pricing.scala
@@ -1,0 +1,32 @@
+package specrest.synth
+
+final case class ModelPricing(
+    model: String,
+    inputUsdPerMTok: Double,
+    outputUsdPerMTok: Double,
+    provider: String
+)
+
+object Pricing:
+
+  val table: List[ModelPricing] = List(
+    ModelPricing("claude-opus-4-7", 15.00, 75.00, "anthropic"),
+    ModelPricing("claude-opus-4-6", 15.00, 75.00, "anthropic"),
+    ModelPricing("claude-sonnet-4-6", 3.00, 15.00, "anthropic"),
+    ModelPricing("claude-sonnet-4-5", 3.00, 15.00, "anthropic"),
+    ModelPricing("claude-haiku-4-5", 0.80, 4.00, "anthropic"),
+    ModelPricing("gpt-4o", 2.50, 10.00, "openai"),
+    ModelPricing("gpt-4o-mini", 0.15, 0.60, "openai"),
+    ModelPricing("gpt-4-turbo", 10.00, 30.00, "openai")
+  )
+
+  def forModel(model: String): Option[ModelPricing] =
+    table.find(p => model == p.model || model.startsWith(s"${p.model}-"))
+
+  def cost(usage: TokenUsage, model: String): Option[Double] =
+    forModel(model).map: p =>
+      (usage.inputTokens.toDouble * p.inputUsdPerMTok +
+        usage.outputTokens.toDouble * p.outputUsdPerMTok) / 1_000_000.0
+
+  def costOrZero(usage: TokenUsage, model: String): Double =
+    cost(usage, model).getOrElse(0.0)

--- a/modules/synth/src/main/scala/specrest/synth/Pricing.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Pricing.scala
@@ -21,7 +21,13 @@ object Pricing:
   )
 
   def forModel(model: String): Option[ModelPricing] =
-    table.find(p => model == p.model || model.startsWith(s"${p.model}-"))
+    table
+      .find(_.model == model)
+      .orElse:
+        table
+          .filter(p => model.startsWith(s"${p.model}-"))
+          .sortBy(p => -p.model.length)
+          .headOption
 
   def cost(usage: TokenUsage, model: String): Option[Double] =
     forModel(model).map: p =>

--- a/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
+++ b/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
@@ -1,0 +1,144 @@
+package specrest.synth
+
+import specrest.convention.OperationClassification
+import specrest.convention.dafny.DafnyMethodHeader
+
+import scala.io.Source
+import scala.util.Using
+
+final case class Prompt(system: String, user: String)
+
+object PromptBuilder:
+
+  private val systemRoot = "/specrest/synth/prompts"
+
+  lazy val systemInitial: String = loadResource("initial.system.txt")
+  lazy val systemRepair: String  = loadResource("repair.system.txt")
+
+  def initial(
+      classification: OperationClassification,
+      header: DafnyMethodHeader,
+      skeleton: String
+  ): Prompt =
+    val sections = List(
+      methodSignatureSection(header),
+      domainSection(classification, header),
+      typeDefinitionsSection(skeleton),
+      fewShotSection(classification),
+      taskSection(classification.operationName)
+    )
+    Prompt(systemInitial, sections.mkString("\n\n"))
+
+  def repair(
+      classification: OperationClassification,
+      header: DafnyMethodHeader,
+      skeleton: String,
+      previousBody: String,
+      error: VerifierError
+  ): Prompt =
+    val sections = List(
+      previousAttemptSection(previousBody),
+      verifierErrorSection(error),
+      diagnosisSection(error),
+      methodSignatureSection(header),
+      taskSection(classification.operationName)
+    )
+    Prompt(systemRepair, sections.mkString("\n\n"))
+
+  private def methodSignatureSection(header: DafnyMethodHeader): String =
+    val clauses =
+      (header.requiresClauses.map(c => s"  requires $c") ++
+        header.ensuresClauses.map(c => s"  ensures $c") ++
+        header.modifiesClauses.map(c => s"  modifies $c")).mkString("\n")
+    s"""## Method Signature (immutable)
+       |```dafny
+       |${header.signature}
+       |$clauses
+       |```""".stripMargin
+
+  private def domainSection(
+      c: OperationClassification,
+      header: DafnyMethodHeader
+  ): String =
+    val ensuresSummary =
+      if header.ensuresClauses.isEmpty then "no postconditions specified"
+      else header.ensuresClauses.mkString("; ")
+    s"""## Domain Description
+       |Operation `${c.operationName}` is classified as ${c.kind} (HTTP ${c.method}, rule ${c
+        .matchedRule}).
+       |Postcondition summary: $ensuresSummary""".stripMargin
+
+  private def typeDefinitionsSection(skeleton: String): String =
+    val typeBlock = extractTypeBlock(skeleton)
+    s"""## Type Definitions
+       |```dafny
+       |$typeBlock
+       |```""".stripMargin
+
+  private def extractTypeBlock(skeleton: String): String =
+    val lines       = skeleton.linesIterator.toList
+    val firstMethod = lines.indexWhere(_.trim.startsWith("method "))
+    val end         = if firstMethod < 0 then lines.length else firstMethod
+    lines.take(end).mkString("\n").trim
+
+  private def fewShotSection(c: OperationClassification): String =
+    val snippets = FewShot.selectFor(c.kind).take(2)
+    val rendered = snippets
+      .map: s =>
+        s"""```dafny
+           |${FewShot.text(s).stripLineEnd}
+           |```""".stripMargin
+      .mkString("\n\n")
+    s"""## Similar Verified Examples
+       |$rendered""".stripMargin
+
+  private def taskSection(name: String): String =
+    s"""## Your Task
+       |Produce the complete method body for `$name`. Return your code inside a single
+       |```dafny fenced block. Include any helper lemmas BEFORE the method declaration.""".stripMargin
+
+  private def previousAttemptSection(body: String): String =
+    s"""## Previous Attempt (FAILED)
+       |```dafny
+       |$body
+       |```""".stripMargin
+
+  private def verifierErrorSection(e: VerifierError): String =
+    val lineSuffix = e.line.fold("")(l => s" at line $l")
+    s"""## Verifier Error
+       |**${e.category}**$lineSuffix: ${e.message}""".stripMargin
+
+  private def diagnosisSection(e: VerifierError): String =
+    val cx     = e.counterexample.fold("")(c => s"\n\nCounterexample:\n```\n$c\n```")
+    val clause = e.relatedClause.fold("")(c => s"\n\nRelated clause: `$c`")
+    s"""## Diagnosis
+       |${repairHint(e.category)}$clause$cx""".stripMargin
+
+  private def repairHint(category: String): String = category match
+    case "postcondition_violation" =>
+      "The implementation does not establish the ensures clause on at least one return path. Add intermediate assertions or branch logic that closes the gap."
+    case "precondition_violation" =>
+      "A method/function call does not establish its requires clause. Add a guard or assertion that proves the precondition holds at the call site."
+    case "loop_invariant_failure" =>
+      "Either strengthen the loop invariant or fix the body so the invariant is preserved."
+    case "loop_invariant_not_established" =>
+      "The invariant is not true on entry. Fix initialization or weaken the invariant."
+    case "decreases_failure" =>
+      "Adjust the decreases expression so it strictly decreases on each iteration / recursive call."
+    case "assertion_failure" =>
+      "An intermediate assertion does not hold. Remove it if redundant or strengthen the local reasoning."
+    case "type_error" =>
+      "Fix the type annotation to match the declared parameter / return types."
+    case "syntax_error" =>
+      "The previous response is not valid Dafny. Re-emit a syntactically valid body."
+    case "timeout" =>
+      "The verification condition is too complex; simplify the body or add ghost annotations to break the proof into smaller steps."
+    case _ =>
+      "Inspect the failing clause and adjust the body so verification succeeds."
+
+  private def loadResource(name: String): String =
+    val path = s"$systemRoot/$name"
+    val stream = Option(getClass.getResourceAsStream(path))
+      .getOrElse(sys.error(s"Prompt resource not found: $path"))
+    Using.resource(stream): in =>
+      Source.fromInputStream(in, "UTF-8").mkString

--- a/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
@@ -1,0 +1,88 @@
+package specrest.synth
+
+import scala.annotation.tailrec
+
+final case class ParseError(message: String)
+
+object ResponseParser:
+
+  def extractCodeBlock(response: String): Either[ParseError, String] =
+    val fences = List("```dafny", "```Dafny", "```csharp", "```cs", "```")
+    val opened = fences.iterator
+      .flatMap(tag => indexAfterTag(response, tag).iterator)
+      .nextOption()
+    opened match
+      case None => Left(ParseError("no fenced code block found in LLM response"))
+      case Some((tag, start)) =>
+        val end = response.indexOf("```", start)
+        if end < 0 then Left(ParseError(s"unterminated fenced block (opened with $tag)"))
+        else Right(response.substring(start, end).stripPrefix("\n").stripSuffix("\n"))
+
+  def extractMethodBody(code: String, methodName: String): Either[ParseError, String] =
+    val needle = s"method $methodName"
+    val idx    = code.indexOf(needle)
+    if idx < 0 then
+      val firstBrace = code.indexOf('{')
+      if firstBrace < 0 then Right(code.trim)
+      else extractFirstBraceBlock(code, firstBrace)
+    else
+      val openBrace = code.indexOf('{', idx)
+      if openBrace < 0 then
+        Left(ParseError(s"could not locate body opening '{' for method $methodName"))
+      else extractFirstBraceBlock(code, openBrace)
+
+  private def indexAfterTag(s: String, tag: String): Option[(String, Int)] =
+    val i = s.indexOf(tag)
+    if i < 0 then None
+    else
+      val after = i + tag.length
+      val nl    = s.indexOf('\n', after)
+      Some((tag, if nl < 0 then after else nl + 1))
+
+  private def extractFirstBraceBlock(s: String, openIdx: Int): Either[ParseError, String] =
+    if openIdx < 0 || openIdx >= s.length || s.charAt(openIdx) != '{' then
+      Left(ParseError("expected '{' at start of method body"))
+    else
+      matchingClose(s, openIdx) match
+        case None      => Left(ParseError("unmatched '{' in method body"))
+        case Some(end) => Right(s.substring(openIdx + 1, end).stripPrefix("\n").stripSuffix("\n"))
+
+  private enum ScanMode derives CanEqual:
+    case Code, LineComment, BlockComment, StringLit
+
+  @tailrec
+  private def matchingClose(
+      s: String,
+      i: Int,
+      depth: Int,
+      mode: ScanMode
+  ): Option[Int] =
+    if i >= s.length then None
+    else
+      val c = s.charAt(i)
+      mode match
+        case ScanMode.LineComment =>
+          if c == '\n' then matchingClose(s, i + 1, depth, ScanMode.Code)
+          else matchingClose(s, i + 1, depth, ScanMode.LineComment)
+        case ScanMode.BlockComment =>
+          if c == '*' && i + 1 < s.length && s.charAt(i + 1) == '/' then
+            matchingClose(s, i + 2, depth, ScanMode.Code)
+          else matchingClose(s, i + 1, depth, ScanMode.BlockComment)
+        case ScanMode.StringLit =>
+          if c == '\\' && i + 1 < s.length then matchingClose(s, i + 2, depth, ScanMode.StringLit)
+          else if c == '"' then matchingClose(s, i + 1, depth, ScanMode.Code)
+          else matchingClose(s, i + 1, depth, ScanMode.StringLit)
+        case ScanMode.Code =>
+          c match
+            case '"' => matchingClose(s, i + 1, depth, ScanMode.StringLit)
+            case '/' if i + 1 < s.length && s.charAt(i + 1) == '/' =>
+              matchingClose(s, i + 2, depth, ScanMode.LineComment)
+            case '/' if i + 1 < s.length && s.charAt(i + 1) == '*' =>
+              matchingClose(s, i + 2, depth, ScanMode.BlockComment)
+            case '{'               => matchingClose(s, i + 1, depth + 1, ScanMode.Code)
+            case '}' if depth == 1 => Some(i)
+            case '}'               => matchingClose(s, i + 1, depth - 1, ScanMode.Code)
+            case _                 => matchingClose(s, i + 1, depth, ScanMode.Code)
+
+  private def matchingClose(s: String, openIdx: Int): Option[Int] =
+    matchingClose(s, openIdx + 1, 1, ScanMode.Code)

--- a/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
@@ -22,9 +22,11 @@ object ResponseParser:
     val needle = s"method $methodName"
     val idx    = code.indexOf(needle)
     if idx < 0 then
-      val firstBrace = code.indexOf('{')
-      if firstBrace < 0 then Right(code.trim)
-      else extractFirstBraceBlock(code, firstBrace)
+      val trimmed = code.trim
+      if trimmed.startsWith("{") then
+        val firstBrace = code.indexOf('{')
+        extractFirstBraceBlock(code, firstBrace)
+      else Right(trimmed)
     else
       val openBrace = code.indexOf('{', idx)
       if openBrace < 0 then

--- a/modules/synth/src/main/scala/specrest/synth/SynthError.scala
+++ b/modules/synth/src/main/scala/specrest/synth/SynthError.scala
@@ -1,0 +1,15 @@
+package specrest.synth
+
+sealed trait SynthError derives CanEqual:
+  def message: String
+
+final case class ProviderFailure(error: ProviderError) extends SynthError:
+  def message: String = error.message
+
+final case class ResponseParseFailure(error: ParseError) extends SynthError:
+  def message: String = error.message
+
+final case class DiffCheckFailure(error: DiffViolation) extends SynthError:
+  def message: String = error.message
+
+final case class CacheFailure(message: String) extends SynthError

--- a/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
@@ -1,0 +1,110 @@
+package specrest.synth
+
+import cats.effect.IO
+import specrest.convention.OperationClassification
+import specrest.convention.dafny.DafnyMethodHeader
+
+final case class SynthRequest(
+    classification: OperationClassification,
+    header: DafnyMethodHeader,
+    skeleton: String,
+    model: String,
+    temperature: Double = 0.0,
+    maxTokens: Int = 2048
+)
+
+final case class SynthResult(
+    body: String,
+    fullCandidate: String,
+    usage: TokenUsage,
+    costUsd: Double,
+    cached: Boolean,
+    model: String
+)
+
+final class Synthesizer(
+    provider: LlmProvider,
+    cache: Option[Cache],
+    tracker: Tracker
+):
+
+  def synthesize(req: SynthRequest): IO[Either[SynthError, SynthResult]] =
+    val key = Cache.keyFor(req.header, req.model, req.temperature)
+    cacheLookup(key).flatMap:
+      case Some(entry) => onCacheHit(req, entry)
+      case None        => runUncached(req, key)
+
+  private def cacheLookup(key: CacheKey): IO[Option[CacheEntry]] =
+    cache match
+      case Some(c) => c.lookup(key)
+      case None    => IO.pure(None)
+
+  private def onCacheHit(
+      req: SynthRequest,
+      entry: CacheEntry
+  ): IO[Either[SynthError, SynthResult]] =
+    val cost = Pricing.costOrZero(entry.usage, entry.model)
+    val rec =
+      CallRecord(req.classification.operationName, entry.model, entry.usage, cost, cached = true)
+    tracker.record(rec).as(
+      Right(SynthResult(entry.body, entry.candidate, entry.usage, cost, cached = true, entry.model))
+    )
+
+  private def runUncached(req: SynthRequest, key: CacheKey): IO[Either[SynthError, SynthResult]] =
+    val prompt = PromptBuilder.initial(req.classification, req.header, req.skeleton)
+    val llmReq = LlmRequest(prompt.system, prompt.user, req.model, req.maxTokens, req.temperature)
+    provider.complete(llmReq).flatMap:
+      case Left(err) =>
+        IO.pure(Left(ProviderFailure(err)))
+      case Right(resp) =>
+        afterLlmCall(req, key, resp)
+
+  private def afterLlmCall(
+      req: SynthRequest,
+      key: CacheKey,
+      resp: LlmResponse
+  ): IO[Either[SynthError, SynthResult]] =
+    val parsed =
+      for
+        block <- ResponseParser.extractCodeBlock(resp.text)
+        body  <- ResponseParser.extractMethodBody(block, req.classification.operationName)
+      yield (block, body)
+    parsed match
+      case Left(perr) =>
+        recordFailure(req, resp).as(Left(ResponseParseFailure(perr)))
+      case Right((block, body)) =>
+        DiffChecker.check(req.header, block) match
+          case Left(diff) =>
+            recordFailure(req, resp).as(Left(DiffCheckFailure(diff)))
+          case Right(()) =>
+            persistAndRecord(req, key, resp, block, body)
+
+  private def recordFailure(req: SynthRequest, resp: LlmResponse): IO[Unit] =
+    val cost = Pricing.costOrZero(resp.usage, resp.model)
+    tracker.record(
+      CallRecord(req.classification.operationName, resp.model, resp.usage, cost, cached = false)
+    )
+
+  private def persistAndRecord(
+      req: SynthRequest,
+      key: CacheKey,
+      resp: LlmResponse,
+      block: String,
+      body: String
+  ): IO[Either[SynthError, SynthResult]] =
+    val cost  = Pricing.costOrZero(resp.usage, resp.model)
+    val entry = CacheEntry(block, body, resp.usage, resp.model, SynthPromptVersion)
+    val store = cache match
+      case Some(c) => c.store(key, entry).attempt.map(_.left.toOption.map(e =>
+          CacheFailure(s"cache write failed: ${e.getMessage}")
+        ))
+      case None => IO.pure(None)
+    val rec =
+      CallRecord(req.classification.operationName, resp.model, resp.usage, cost, cached = false)
+    for
+      _      <- tracker.record(rec)
+      cacheE <- store
+    yield cacheE match
+      case Some(failure) => Left(failure)
+      case None =>
+        Right(SynthResult(body, block, resp.usage, cost, cached = false, resp.model))

--- a/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
@@ -55,7 +55,14 @@ final class Synthesizer(
     val llmReq = LlmRequest(prompt.system, prompt.user, req.model, req.maxTokens, req.temperature)
     provider.complete(llmReq).flatMap:
       case Left(err) =>
-        IO.pure(Left(ProviderFailure(err)))
+        val failed = CallRecord(
+          req.classification.operationName,
+          req.model,
+          TokenUsage(0, 0),
+          costUsd = 0.0,
+          cached = false
+        )
+        tracker.record(failed).as(Left(ProviderFailure(err)))
       case Right(resp) =>
         afterLlmCall(req, key, resp)
 
@@ -94,17 +101,18 @@ final class Synthesizer(
   ): IO[Either[SynthError, SynthResult]] =
     val cost  = Pricing.costOrZero(resp.usage, resp.model)
     val entry = CacheEntry(block, body, resp.usage, resp.model, SynthPromptVersion)
-    val store = cache match
-      case Some(c) => c.store(key, entry).attempt.map(_.left.toOption.map(e =>
-          CacheFailure(s"cache write failed: ${e.getMessage}")
-        ))
-      case None => IO.pure(None)
     val rec =
       CallRecord(req.classification.operationName, resp.model, resp.usage, cost, cached = false)
+    val storeBestEffort: IO[Unit] = cache match
+      case Some(c) =>
+        c.store(key, entry).attempt.flatMap:
+          case Right(_) => IO.unit
+          case Left(e) =>
+            IO.consoleForIO.errorln(
+              s"warning: cache write failed for ${req.classification.operationName}: ${e.getMessage}"
+            )
+      case None => IO.unit
     for
-      _      <- tracker.record(rec)
-      cacheE <- store
-    yield cacheE match
-      case Some(failure) => Left(failure)
-      case None =>
-        Right(SynthResult(body, block, resp.usage, cost, cached = false, resp.model))
+      _ <- tracker.record(rec)
+      _ <- storeBestEffort
+    yield Right(SynthResult(body, block, resp.usage, cost, cached = false, resp.model))

--- a/modules/synth/src/main/scala/specrest/synth/Tracker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Tracker.scala
@@ -1,0 +1,39 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+final case class CallRecord(
+    operationName: String,
+    model: String,
+    usage: TokenUsage,
+    costUsd: Double,
+    cached: Boolean
+)
+
+final case class CostSummary(
+    operations: Int,
+    inputTokens: Long,
+    outputTokens: Long,
+    totalUsd: Double,
+    cachedHits: Int
+)
+
+final class Tracker private (records: Ref[IO, List[CallRecord]]):
+  def record(r: CallRecord): IO[Unit] =
+    records.update(r :: _)
+
+  def all: IO[List[CallRecord]] = records.get.map(_.reverse)
+
+  def summary: IO[CostSummary] =
+    records.get.map: rs =>
+      CostSummary(
+        operations = rs.size,
+        inputTokens = rs.map(_.usage.inputTokens.toLong).sum,
+        outputTokens = rs.map(_.usage.outputTokens.toLong).sum,
+        totalUsd = rs.map(_.costUsd).sum,
+        cachedHits = rs.count(_.cached)
+      )
+
+object Tracker:
+  def empty: IO[Tracker] = Ref.of[IO, List[CallRecord]](Nil).map(new Tracker(_))

--- a/modules/synth/src/main/scala/specrest/synth/VerifierError.scala
+++ b/modules/synth/src/main/scala/specrest/synth/VerifierError.scala
@@ -1,0 +1,9 @@
+package specrest.synth
+
+final case class VerifierError(
+    category: String,
+    message: String,
+    line: Option[Int] = None,
+    relatedClause: Option[String] = None,
+    counterexample: Option[String] = None
+)

--- a/modules/synth/src/main/scala/specrest/synth/package.scala
+++ b/modules/synth/src/main/scala/specrest/synth/package.scala
@@ -1,0 +1,4 @@
+package specrest
+
+package object synth:
+  val SynthPromptVersion: String = "v1"

--- a/modules/synth/src/main/scala/specrest/synth/providers/AnthropicProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/providers/AnthropicProvider.scala
@@ -33,13 +33,12 @@ final class AnthropicProvider(client: AnthropicClient) extends LlmProvider:
         .flatMap(b => b.text().toScala.iterator)
         .map(_.text())
         .mkString
-      val usage         = message.usage()
-      val responseModel = req.model
+      val usage = message.usage()
       Right(
         LlmResponse(
           text,
           TokenUsage(usage.inputTokens().toInt, usage.outputTokens().toInt),
-          responseModel
+          message.model().toString
         )
       ): Either[ProviderError, LlmResponse]
     }.handleErrorWith {

--- a/modules/synth/src/main/scala/specrest/synth/providers/AnthropicProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/providers/AnthropicProvider.scala
@@ -1,0 +1,66 @@
+package specrest.synth.providers
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import com.anthropic.client.AnthropicClient
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.errors.AnthropicException
+import com.anthropic.models.messages.MessageCreateParams
+import specrest.synth.LlmProvider
+import specrest.synth.LlmRequest
+import specrest.synth.LlmResponse
+import specrest.synth.ProviderError
+import specrest.synth.TokenUsage
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+import scala.util.control.NonFatal
+
+final class AnthropicProvider(client: AnthropicClient) extends LlmProvider:
+  def name: String = "anthropic"
+
+  def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]] =
+    IO.blocking {
+      val params = MessageCreateParams
+        .builder()
+        .model(req.model)
+        .maxTokens(req.maxTokens.toLong)
+        .system(req.system)
+        .addUserMessage(req.userMessage)
+        .build()
+      val message = client.messages().create(params)
+      val text = message.content().asScala.iterator
+        .flatMap(b => b.text().toScala.iterator)
+        .map(_.text())
+        .mkString
+      val usage         = message.usage()
+      val responseModel = req.model
+      Right(
+        LlmResponse(
+          text,
+          TokenUsage(usage.inputTokens().toInt, usage.outputTokens().toInt),
+          responseModel
+        )
+      ): Either[ProviderError, LlmResponse]
+    }.handleErrorWith {
+      case e: AnthropicException =>
+        IO.pure(Left(ProviderError(s"anthropic API error: ${e.getMessage}", None)))
+      case NonFatal(e) =>
+        IO.pure(Left(ProviderError(s"anthropic call failed: ${e.getMessage}", None)))
+    }
+
+object AnthropicProvider:
+  def make(apiKey: String): Resource[IO, AnthropicProvider] =
+    Resource
+      .make(IO.blocking[AnthropicClient](AnthropicOkHttpClient.builder().apiKey(apiKey).build()))(
+        c =>
+          IO.blocking(c.close()).handleError(_ => ())
+      )
+      .map(new AnthropicProvider(_))
+
+  def fromEnv: Resource[IO, AnthropicProvider] =
+    Resource
+      .make(IO.blocking[AnthropicClient](AnthropicOkHttpClient.fromEnv()))(c =>
+        IO.blocking(c.close()).handleError(_ => ())
+      )
+      .map(new AnthropicProvider(_))

--- a/modules/synth/src/main/scala/specrest/synth/providers/OpenAIProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/providers/OpenAIProvider.scala
@@ -1,0 +1,63 @@
+package specrest.synth.providers
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import com.openai.client.OpenAIClient
+import com.openai.client.okhttp.OpenAIOkHttpClient
+import com.openai.errors.OpenAIException
+import com.openai.models.chat.completions.ChatCompletionCreateParams
+import specrest.synth.LlmProvider
+import specrest.synth.LlmRequest
+import specrest.synth.LlmResponse
+import specrest.synth.ProviderError
+import specrest.synth.TokenUsage
+
+import scala.jdk.CollectionConverters.*
+import scala.jdk.OptionConverters.*
+import scala.util.control.NonFatal
+
+final class OpenAIProvider(client: OpenAIClient) extends LlmProvider:
+  def name: String = "openai"
+
+  def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]] =
+    IO.blocking {
+      val params = ChatCompletionCreateParams
+        .builder()
+        .model(req.model)
+        .maxCompletionTokens(req.maxTokens.toLong)
+        .temperature(req.temperature)
+        .addSystemMessage(req.system)
+        .addUserMessage(req.userMessage)
+        .build()
+      val response = client.chat().completions().create(params)
+      val text = response.choices().asScala.iterator
+        .flatMap(c => c.message().content().toScala.iterator)
+        .mkString
+      val (in, out) = response.usage().toScala match
+        case Some(u) => (u.promptTokens().toInt, u.completionTokens().toInt)
+        case None    => (0, 0)
+      Right(LlmResponse(text, TokenUsage(in, out), response.model())): Either[
+        ProviderError,
+        LlmResponse
+      ]
+    }.handleErrorWith {
+      case e: OpenAIException =>
+        IO.pure(Left(ProviderError(s"openai API error: ${e.getMessage}", None)))
+      case NonFatal(e) =>
+        IO.pure(Left(ProviderError(s"openai call failed: ${e.getMessage}", None)))
+    }
+
+object OpenAIProvider:
+  def make(apiKey: String): Resource[IO, OpenAIProvider] =
+    Resource
+      .make(IO.blocking[OpenAIClient](OpenAIOkHttpClient.builder().apiKey(apiKey).build()))(c =>
+        IO.blocking(c.close()).handleError(_ => ())
+      )
+      .map(new OpenAIProvider(_))
+
+  def fromEnv: Resource[IO, OpenAIProvider] =
+    Resource
+      .make(IO.blocking[OpenAIClient](OpenAIOkHttpClient.fromEnv()))(c =>
+        IO.blocking(c.close()).handleError(_ => ())
+      )
+      .map(new OpenAIProvider(_))

--- a/modules/synth/src/test/scala/specrest/synth/AnthropicProviderIntegrationTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/AnthropicProviderIntegrationTest.scala
@@ -1,0 +1,26 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+import specrest.synth.providers.AnthropicProvider
+
+class AnthropicProviderIntegrationTest extends CatsEffectSuite:
+
+  test("real Anthropic call returns non-empty text and usage (gated on ANTHROPIC_API_KEY)") {
+    assume(sys.env.contains("ANTHROPIC_API_KEY"), "ANTHROPIC_API_KEY not set; skipping")
+    AnthropicProvider.fromEnv.use { provider =>
+      val req = LlmRequest(
+        system = "You are a terse assistant. Reply with a single short sentence.",
+        userMessage = "Say hello.",
+        model = "claude-haiku-4-5",
+        maxTokens = 64,
+        temperature = 1.0
+      )
+      provider.complete(req).map {
+        case Left(err) => fail(s"expected Right, got $err")
+        case Right(resp) =>
+          assert(resp.text.nonEmpty)
+          assert(resp.usage.inputTokens > 0)
+          assert(resp.usage.outputTokens > 0)
+      }
+    }
+  }

--- a/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
@@ -1,9 +1,12 @@
 package specrest.synth
 
+import cats.effect.IO
+import cats.effect.kernel.Resource
 import munit.CatsEffectSuite
 import specrest.convention.dafny.DafnyMethodHeader
 
 import java.nio.file.Files
+import java.nio.file.Path
 
 class CacheTest extends CatsEffectSuite:
 
@@ -23,18 +26,27 @@ class CacheTest extends CatsEffectSuite:
     promptVersion = "v1"
   )
 
+  private def tempDir(prefix: String): Resource[IO, Path] =
+    Resource.make(IO.blocking(Files.createTempDirectory(prefix))): dir =>
+      IO.blocking {
+        import scala.jdk.StreamConverters.*
+        scala.util.Using.resource(Files.walk(dir)): stream =>
+          stream.toScala(List).reverse.foreach: p =>
+            val _ = Files.deleteIfExists(p)
+      }
+
   test("round-trip: store then lookup returns same entry"):
-    val temp = Files.createTempDirectory("synth-cache-test")
-    Cache.make(temp).flatMap: cache =>
-      val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
-      cache.store(key, entry) *>
-        cache.lookup(key).map(r => assertEquals(r, Some(entry)))
+    tempDir("synth-cache-test").use: temp =>
+      Cache.make(temp).flatMap: cache =>
+        val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
+        cache.store(key, entry) *>
+          cache.lookup(key).map(r => assertEquals(r, Some(entry)))
 
   test("lookup miss returns None"):
-    val temp = Files.createTempDirectory("synth-cache-test-miss")
-    Cache.make(temp).flatMap: cache =>
-      val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
-      cache.lookup(key).map(r => assertEquals(r, None))
+    tempDir("synth-cache-test-miss").use: temp =>
+      Cache.make(temp).flatMap: cache =>
+        val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
+        cache.lookup(key).map(r => assertEquals(r, None))
 
   test("different model produces different key"):
     val k1 = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
@@ -50,3 +62,10 @@ class CacheTest extends CatsEffectSuite:
     val k1 = Cache.keyFor(header, "m", 0.0)
     val k2 = Cache.keyFor(header, "m", 0.0)
     assertEquals(k1, k2)
+
+  test("clause boundary shift produces a distinct key"):
+    val a  = header.copy(requiresClauses = List("xE"), ensuresClauses = List("y"))
+    val b  = header.copy(requiresClauses = List("x"), ensuresClauses = List("Ey"))
+    val ka = Cache.keyFor(a, "m", 0.0)
+    val kb = Cache.keyFor(b, "m", 0.0)
+    assertNotEquals(ka, kb)

--- a/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
@@ -1,0 +1,52 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+import specrest.convention.dafny.DafnyMethodHeader
+
+import java.nio.file.Files
+
+class CacheTest extends CatsEffectSuite:
+
+  private val header = DafnyMethodHeader(
+    "Increment",
+    "method Increment(st: ServiceState)",
+    requiresClauses = List("ServiceStateInv(st)"),
+    ensuresClauses = List("st.count == old(st.count) + 1"),
+    modifiesClauses = List("st")
+  )
+
+  private val entry = CacheEntry(
+    candidate = "method Increment(...) { ... }",
+    body = "  st.count := st.count + 1;",
+    usage = TokenUsage(120, 80),
+    model = "claude-sonnet-4-6",
+    promptVersion = "v1"
+  )
+
+  test("round-trip: store then lookup returns same entry"):
+    val temp = Files.createTempDirectory("synth-cache-test")
+    Cache.make(temp).flatMap: cache =>
+      val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
+      cache.store(key, entry) *>
+        cache.lookup(key).map(r => assertEquals(r, Some(entry)))
+
+  test("lookup miss returns None"):
+    val temp = Files.createTempDirectory("synth-cache-test-miss")
+    Cache.make(temp).flatMap: cache =>
+      val key = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
+      cache.lookup(key).map(r => assertEquals(r, None))
+
+  test("different model produces different key"):
+    val k1 = Cache.keyFor(header, "claude-sonnet-4-6", 0.0)
+    val k2 = Cache.keyFor(header, "claude-haiku-4-5", 0.0)
+    assertNotEquals(k1, k2)
+
+  test("different prompt version produces different key"):
+    val k1 = Cache.keyFor(header, "m", 0.0, "v1")
+    val k2 = Cache.keyFor(header, "m", 0.0, "v2")
+    assertNotEquals(k1, k2)
+
+  test("identical inputs produce identical keys"):
+    val k1 = Cache.keyFor(header, "m", 0.0)
+    val k2 = Cache.keyFor(header, "m", 0.0)
+    assertEquals(k1, k2)

--- a/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
@@ -80,3 +80,40 @@ class DiffCheckerTest extends CatsEffectSuite:
   test("missing method declaration fails"):
     val r = DiffChecker.check(header, "{ no method here }")
     assert(r.isLeft)
+
+  test("clause containing a set literal is not truncated at the inner '{'"):
+    val setHeader = DafnyMethodHeader(
+      name = "Archive",
+      signature = "method Archive(st: ServiceState, id: int)",
+      requiresClauses = List("id in st.todos", "st.todos[id].status in {TODO, DONE}"),
+      ensuresClauses = List("st.todos[id].status == ARCHIVED"),
+      modifiesClauses = List("st")
+    )
+    val candidate =
+      """method Archive(st: ServiceState, id: int)
+        |  requires id in st.todos
+        |  requires st.todos[id].status in {TODO, DONE}
+        |  ensures st.todos[id].status == ARCHIVED
+        |  modifies st
+        |{
+        |  st.todos := st.todos[id := st.todos[id].(status := ARCHIVED)];
+        |}""".stripMargin
+    assertEquals(DiffChecker.check(setHeader, candidate), Right(()))
+
+  test("clause containing nested braces (forall trigger) is preserved"):
+    val triggerHeader = DafnyMethodHeader(
+      name = "Quant",
+      signature = "method Quant(st: ServiceState)",
+      requiresClauses = List("forall x :: x in st.s ==> {x} != {}"),
+      ensuresClauses = List("st.s == old(st.s)"),
+      modifiesClauses = List("st")
+    )
+    val candidate =
+      """method Quant(st: ServiceState)
+        |  requires forall x :: x in st.s ==> {x} != {}
+        |  ensures st.s == old(st.s)
+        |  modifies st
+        |{
+        |  return;
+        |}""".stripMargin
+    assertEquals(DiffChecker.check(triggerHeader, candidate), Right(()))

--- a/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
@@ -1,9 +1,9 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 import specrest.convention.dafny.DafnyMethodHeader
 
-class DiffCheckerTest extends FunSuite:
+class DiffCheckerTest extends CatsEffectSuite:
 
   private val header = DafnyMethodHeader(
     name = "Increment",

--- a/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
@@ -1,0 +1,82 @@
+package specrest.synth
+
+import munit.FunSuite
+import specrest.convention.dafny.DafnyMethodHeader
+
+class DiffCheckerTest extends FunSuite:
+
+  private val header = DafnyMethodHeader(
+    name = "Increment",
+    signature = "method Increment(st: ServiceState)",
+    requiresClauses = List("ServiceStateInv(st)"),
+    ensuresClauses = List("st.count == old(st.count) + 1", "ServiceStateInv(st)"),
+    modifiesClauses = List("st")
+  )
+
+  test("matching clauses pass"):
+    val candidate =
+      """method Increment(st: ServiceState)
+        |  requires ServiceStateInv(st)
+        |  ensures st.count == old(st.count) + 1
+        |  ensures ServiceStateInv(st)
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}""".stripMargin
+    assertEquals(DiffChecker.check(header, candidate), Right(()))
+
+  test("missing ensures clause fails"):
+    val candidate =
+      """method Increment(st: ServiceState)
+        |  requires ServiceStateInv(st)
+        |  ensures st.count == old(st.count) + 1
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}""".stripMargin
+    DiffChecker.check(header, candidate) match
+      case Right(_) => fail("expected diff violation")
+      case Left(violation) =>
+        assert(violation.diff.contains("ServiceStateInv(st)"))
+
+  test("weakened postcondition fails"):
+    val candidate =
+      """method Increment(st: ServiceState)
+        |  requires ServiceStateInv(st)
+        |  ensures st.count >= old(st.count)
+        |  ensures ServiceStateInv(st)
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}""".stripMargin
+    assert(DiffChecker.check(header, candidate).isLeft)
+
+  test("introducing {:extern} declaration is rejected"):
+    val candidate =
+      """function {:extern "Mod", "fn"} bad(): int
+        |
+        |method Increment(st: ServiceState)
+        |  requires ServiceStateInv(st)
+        |  ensures st.count == old(st.count) + 1
+        |  ensures ServiceStateInv(st)
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}""".stripMargin
+    DiffChecker.check(header, candidate) match
+      case Right(_) => fail("expected extern violation")
+      case Left(v)  => assert(v.message.contains("extern"))
+
+  test("normalization tolerates whitespace and trailing semicolons"):
+    val candidate =
+      """method Increment(st: ServiceState)
+        |  requires    ServiceStateInv(st);
+        |  ensures   st.count == old(st.count) + 1
+        |  ensures ServiceStateInv(st);
+        |  modifies   st
+        |{ st.count := st.count + 1; }""".stripMargin
+    assertEquals(DiffChecker.check(header, candidate), Right(()))
+
+  test("missing method declaration fails"):
+    val r = DiffChecker.check(header, "{ no method here }")
+    assert(r.isLeft)

--- a/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DiffCheckerTest.scala
@@ -100,6 +100,44 @@ class DiffCheckerTest extends CatsEffectSuite:
         |}""".stripMargin
     assertEquals(DiffChecker.check(setHeader, candidate), Right(()))
 
+  test("multi-method input — clauses are scoped to the named method (cubic round 3)"):
+    val fooHeader = DafnyMethodHeader(
+      name = "Foo",
+      signature = "method Foo()",
+      requiresClauses = List("P"),
+      ensuresClauses = Nil,
+      modifiesClauses = Nil
+    )
+    val candidate =
+      """method Foo()
+        |  requires P
+        |{
+        |  return;
+        |}
+        |
+        |method Bar()
+        |  requires Q
+        |  modifies somethingElse
+        |{
+        |  return;
+        |}""".stripMargin
+    assertEquals(DiffChecker.check(fooHeader, candidate), Right(()))
+
+  test("modifies-with-trailing-brace on same line is split correctly"):
+    val sameLineHeader = DafnyMethodHeader(
+      name = "Inline",
+      signature = "method Inline(st: ServiceState)",
+      requiresClauses = Nil,
+      ensuresClauses = Nil,
+      modifiesClauses = List("st")
+    )
+    val candidate =
+      """method Inline(st: ServiceState)
+        |  modifies st {
+        |  return;
+        |}""".stripMargin
+    assertEquals(DiffChecker.check(sameLineHeader, candidate), Right(()))
+
   test("clause containing nested braces (forall trigger) is preserved"):
     val triggerHeader = DafnyMethodHeader(
       name = "Quant",

--- a/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
@@ -1,9 +1,9 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 import specrest.convention.OperationKind
 
-class FewShotTest extends FunSuite:
+class FewShotTest extends CatsEffectSuite:
 
   test("each snippet kind loads from resources"):
     FewShot.Snippet.values.foreach: s =>
@@ -15,11 +15,17 @@ class FewShotTest extends FunSuite:
     val picks = FewShot.selectFor(OperationKind.Create)
     assert(picks.contains(FewShot.Snippet.MapInsertFresh), s"got $picks")
 
-  test("Delete operations get the map_delete example"):
-    assertEquals(FewShot.selectFor(OperationKind.Delete), List(FewShot.Snippet.MapDelete))
-
-  test("Read operations get the map_update_existing example"):
-    assertEquals(
-      FewShot.selectFor(OperationKind.Read),
+  List(
+    (
+      "Delete operations get the map_delete example",
+      OperationKind.Delete,
+      List(FewShot.Snippet.MapDelete)
+    ),
+    (
+      "Read operations get the map_update_existing example",
+      OperationKind.Read,
       List(FewShot.Snippet.MapUpdateExisting)
     )
+  ).foreach: (name, kind, expected) =>
+    test(name):
+      assertEquals(FewShot.selectFor(kind), expected)

--- a/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
@@ -1,0 +1,25 @@
+package specrest.synth
+
+import munit.FunSuite
+import specrest.convention.OperationKind
+
+class FewShotTest extends FunSuite:
+
+  test("each snippet kind loads from resources"):
+    FewShot.Snippet.values.foreach: s =>
+      val text = FewShot.text(s)
+      assert(text.nonEmpty, s"empty snippet: $s")
+      assert(text.contains("method") || text.contains("function"), s"no Dafny declaration in $s")
+
+  test("Create operations get a map_insert example"):
+    val picks = FewShot.selectFor(OperationKind.Create)
+    assert(picks.contains(FewShot.Snippet.MapInsertFresh), s"got $picks")
+
+  test("Delete operations get the map_delete example"):
+    assertEquals(FewShot.selectFor(OperationKind.Delete), List(FewShot.Snippet.MapDelete))
+
+  test("Read operations get the map_update_existing example"):
+    assertEquals(
+      FewShot.selectFor(OperationKind.Read),
+      List(FewShot.Snippet.MapUpdateExisting)
+    )

--- a/modules/synth/src/test/scala/specrest/synth/Fixtures.scala
+++ b/modules/synth/src/test/scala/specrest/synth/Fixtures.scala
@@ -1,0 +1,42 @@
+package specrest.synth
+
+import cats.effect.IO
+import specrest.convention.Classify
+import specrest.convention.OperationClassification
+import specrest.convention.dafny.DafnyMethodHeader
+import specrest.convention.dafny.DafnyOutput
+import specrest.convention.dafny.Generator as DafnyGenerator
+import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object Fixtures:
+
+  def loadIR(name: String): IO[ServiceIRFull] =
+    IO.blocking(Files.readString(Paths.get(s"fixtures/spec/$name.spec")))
+      .flatMap: src =>
+        Parse.parseSpec(src).flatMap:
+          case Left(e) => IO.raiseError(new AssertionError(s"parse failed: $e"))
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).flatMap:
+              case Left(e)   => IO.raiseError(new AssertionError(s"build failed: ${e.message}"))
+              case Right(ir) => IO.pure(ir)
+
+  def loadHeader(
+      specName: String,
+      opName: String
+  ): IO[(OperationClassification, DafnyMethodHeader, String)] =
+    loadIR(specName).map: ir =>
+      val classifications = Classify.classifyOperations(ir)
+      val c = classifications
+        .find(_.operationName == opName)
+        .getOrElse(throw new AssertionError(s"operation $opName not found"))
+      val out: DafnyOutput =
+        DafnyGenerator.generate(ir).toOption.getOrElse(throw new AssertionError("dafny gen failed"))
+      val h = out.methods
+        .find(_.name == opName)
+        .getOrElse(throw new AssertionError(s"header $opName missing"))
+      (c, h, out.text)

--- a/modules/synth/src/test/scala/specrest/synth/PricingTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/PricingTest.scala
@@ -1,0 +1,27 @@
+package specrest.synth
+
+import munit.FunSuite
+
+class PricingTest extends FunSuite:
+
+  test("known model maps to its pricing row"):
+    assertEquals(
+      Pricing.forModel("claude-sonnet-4-6").map(_.inputUsdPerMTok),
+      Some(3.00)
+    )
+
+  test("date-suffixed variant matches base model pricing"):
+    assertEquals(
+      Pricing.forModel("claude-haiku-4-5-20251001").map(_.outputUsdPerMTok),
+      Some(4.00)
+    )
+
+  test("unknown model returns None"):
+    assertEquals(Pricing.forModel("not-a-model"), None)
+
+  test("cost computes input * input-rate + output * output-rate per million"):
+    val u = TokenUsage(1_000_000, 0)
+    assertEquals(Pricing.cost(u, "claude-sonnet-4-6"), Some(3.00))
+
+  test("costOrZero returns 0 for unknown model"):
+    assertEquals(Pricing.costOrZero(TokenUsage(100, 100), "unknown"), 0.0)

--- a/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
@@ -1,0 +1,50 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+
+class PromptBuilderTest extends CatsEffectSuite:
+
+  test("initial prompt for safe_counter Increment contains all required sections"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, header, skeleton) =>
+        val p = PromptBuilder.initial(c, header, skeleton)
+        assert(p.system.contains("Dafny"), "system prompt mentions Dafny")
+        assert(p.system.contains("MUST NOT modify the method signature"))
+        val u = p.user
+        List(
+          "## Method Signature",
+          "## Domain Description",
+          "## Type Definitions",
+          "## Similar Verified Examples",
+          "## Your Task"
+        ).foreach: section =>
+          assert(u.contains(section), s"missing section $section in:\n$u")
+        assert(u.contains("Increment"), "operation name appears")
+        assert(u.contains(header.signature), "signature appears verbatim")
+
+  test("initial prompt for url_shortener Shorten includes few-shot map_insert pattern"):
+    Fixtures.loadHeader("url_shortener", "Shorten").map:
+      case (c, h, skel) =>
+        val p = PromptBuilder.initial(c, h, skel)
+        assert(p.user.contains("```dafny"), "few-shot block uses dafny fence")
+        assert(p.user.contains("Insert"), "map_insert_fresh few-shot present")
+
+  test("repair prompt embeds verifier error and previous body"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, h, skel) =>
+        val err = VerifierError(
+          category = "postcondition_violation",
+          message = "ensures clause not established",
+          line = Some(42),
+          relatedClause = Some("st.count == old(st.count) + 1")
+        )
+        val p = PromptBuilder.repair(c, h, skel, "{ st.count := st.count; }", err)
+        assert(p.user.contains("FAILED"))
+        assert(p.user.contains("postcondition_violation"))
+        assert(p.user.contains("line 42"))
+        assert(p.user.contains("st.count := st.count"), "previous body verbatim")
+        assert(p.user.contains("st.count == old(st.count) + 1"))
+
+  test("system prompt forbids new {:extern} declarations"):
+    val s = PromptBuilder.systemInitial
+    assert(s.contains("{:extern}"))

--- a/modules/synth/src/test/scala/specrest/synth/ResponseParserTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/ResponseParserTest.scala
@@ -1,0 +1,78 @@
+package specrest.synth
+
+import munit.FunSuite
+
+class ResponseParserTest extends FunSuite:
+
+  test("extracts code block from ```dafny fence"):
+    val resp =
+      """Here is the body:
+        |```dafny
+        |method Foo() {
+        |  return 0;
+        |}
+        |```
+        |Hope it helps.""".stripMargin
+    assertEquals(
+      ResponseParser.extractCodeBlock(resp).map(_.trim),
+      Right("method Foo() {\n  return 0;\n}")
+    )
+
+  test("falls back to plain ``` fence"):
+    val resp = "```\nbody\n```"
+    assertEquals(ResponseParser.extractCodeBlock(resp), Right("body"))
+
+  test("rejects response without any fenced block"):
+    assert(ResponseParser.extractCodeBlock("no fence here").isLeft)
+
+  test("rejects unterminated fence"):
+    assert(ResponseParser.extractCodeBlock("```dafny\nopen forever").isLeft)
+
+  test("extractMethodBody finds method by name and returns its braces content"):
+    val code =
+      """method Increment(st: ServiceState)
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}""".stripMargin
+    assertEquals(
+      ResponseParser.extractMethodBody(code, "Increment"),
+      Right("  st.count := st.count + 1;")
+    )
+
+  test("extractMethodBody handles nested braces"):
+    val code =
+      """method Foo() {
+        |  if (true) { x := 1; } else { x := 2; }
+        |}""".stripMargin
+    assertEquals(
+      ResponseParser.extractMethodBody(code, "Foo"),
+      Right("  if (true) { x := 1; } else { x := 2; }")
+    )
+
+  test("extractMethodBody skips braces inside string literals"):
+    val code =
+      """method Foo() {
+        |  s := "}{nope";
+        |  t := 1;
+        |}""".stripMargin
+    assertEquals(
+      ResponseParser.extractMethodBody(code, "Foo"),
+      Right("""  s := "}{nope";
+              |  t := 1;""".stripMargin)
+    )
+
+  test("extractMethodBody skips braces inside line comments"):
+    val code =
+      """method Foo() {
+        |  // }} ignore
+        |  x := 1;
+        |}""".stripMargin
+    assertEquals(
+      ResponseParser.extractMethodBody(code, "Foo"),
+      Right("  // }} ignore\n  x := 1;")
+    )
+
+  test("extractMethodBody falls back to first { when method name absent"):
+    val code = "{\n  x := 1;\n}"
+    assertEquals(ResponseParser.extractMethodBody(code, "Foo"), Right("  x := 1;"))

--- a/modules/synth/src/test/scala/specrest/synth/SynthesizerTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/SynthesizerTest.scala
@@ -1,0 +1,127 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+
+import java.nio.file.Files
+
+class SynthesizerTest extends CatsEffectSuite:
+
+  private val mockResponseValid =
+    """Here is the body.
+      |
+      |```dafny
+      |method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count + 1;
+      |}
+      |```
+      |""".stripMargin
+
+  test("happy path: provider returns valid Dafny → result has body and tracked cost"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, header, skel) =>
+        for
+          provider <- MockProvider.succeeding(
+                        mockResponseValid,
+                        in = 100,
+                        out = 200,
+                        model = "claude-sonnet-4-6"
+                      )
+          tracker <- Tracker.empty
+          synth    = new Synthesizer(provider, None, tracker)
+          req      = SynthRequest(c, header, skel, "claude-sonnet-4-6")
+          result  <- synth.synthesize(req)
+          summary <- tracker.summary
+          calls   <- provider.calls
+        yield result match
+          case Left(err) => fail(s"expected Right, got $err")
+          case Right(r) =>
+            assert(r.body.contains("st.count := st.count + 1"))
+            assertEquals(r.usage, TokenUsage(100, 200))
+            assert(r.costUsd > 0.0)
+            assertEquals(r.cached, false)
+            assertEquals(summary.operations, 1)
+            assertEquals(summary.cachedHits, 0)
+            assertEquals(calls.length, 1)
+
+  test("cache hit avoids LLM call"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, header, skel) =>
+        val temp = Files.createTempDirectory("synth-cache-hit")
+        for
+          provider <- MockProvider.succeeding(
+                        mockResponseValid,
+                        in = 100,
+                        out = 200,
+                        model = "claude-sonnet-4-6"
+                      )
+          tracker <- Tracker.empty
+          cache   <- Cache.make(temp)
+          synth    = new Synthesizer(provider, Some(cache), tracker)
+          req      = SynthRequest(c, header, skel, "claude-sonnet-4-6")
+          first   <- synth.synthesize(req)
+          second  <- synth.synthesize(req)
+          summary <- tracker.summary
+          calls   <- provider.calls
+        yield
+          assert(first.isRight)
+          second match
+            case Left(err) => fail(s"expected cached Right, got $err")
+            case Right(r2) =>
+              assertEquals(r2.cached, true)
+              assertEquals(calls.length, 1, "second call must hit cache")
+              assertEquals(summary.operations, 2)
+              assertEquals(summary.cachedHits, 1)
+
+  test("provider error surfaces as ProviderFailure"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, header, skel) =>
+        for
+          provider <- MockProvider.failing("network down")
+          tracker  <- Tracker.empty
+          synth     = new Synthesizer(provider, None, tracker)
+          result   <- synth.synthesize(SynthRequest(c, header, skel, "claude-sonnet-4-6"))
+        yield result match
+          case Right(_) => fail("expected provider failure")
+          case Left(err: ProviderFailure) =>
+            assert(err.message.contains("network down"))
+          case Left(other) => fail(s"expected ProviderFailure, got $other")
+
+  test("unparseable LLM output surfaces as ResponseParseFailure"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, header, skel) =>
+        for
+          provider <- MockProvider.succeeding("no fenced block here", model = "claude-sonnet-4-6")
+          tracker  <- Tracker.empty
+          synth     = new Synthesizer(provider, None, tracker)
+          result   <- synth.synthesize(SynthRequest(c, header, skel, "claude-sonnet-4-6"))
+        yield result match
+          case Left(_: ResponseParseFailure) => ()
+          case other                         => fail(s"expected ResponseParseFailure, got $other")
+
+  test("LLM that weakens postcondition surfaces as DiffCheckFailure"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, header, skel) =>
+        val weakened =
+          """```dafny
+            |method Increment(st: ServiceState)
+            |  requires ServiceStateInv(st)
+            |  ensures st.count >= old(st.count)
+            |  ensures ServiceStateInv(st)
+            |  modifies st
+            |{
+            |  st.count := st.count + 1;
+            |}
+            |```""".stripMargin
+        for
+          provider <- MockProvider.succeeding(weakened, model = "claude-sonnet-4-6")
+          tracker  <- Tracker.empty
+          synth     = new Synthesizer(provider, None, tracker)
+          result   <- synth.synthesize(SynthRequest(c, header, skel, "claude-sonnet-4-6"))
+        yield result match
+          case Left(_: DiffCheckFailure) => ()
+          case other                     => fail(s"expected DiffCheckFailure, got $other")


### PR DESCRIPTION
## Summary

- New `modules/synth/` module wraps the official `com.anthropic:anthropic-java` (2.30.0) and `com.openai:openai-java` (4.35.0) SDKs behind a small `LlmProvider` trait. CE3 idiomatic — every call is `IO[Either[ProviderError, LlmResponse]]`, clients are `Resource`-managed.
- `PromptBuilder` produces `Prompt(system, user)` from `(OperationClassification, DafnyMethodHeader, skeleton)`. System prompts and few-shot Dafny snippets live as resource files; few-shot selection is keyed on `OperationKind`. Repair prompts are wired (used by #29 once the CEGIS loop lands).
- `ResponseParser` extracts the Dafny code block (with `dafny`/`csharp`/plain fence fallbacks) and the named method's body via a brace-aware, comment- and string-aware scanner. `DiffChecker` rejects any contract change and any new `{:extern}` declaration.
- `Cache` is filesystem-backed with SHA-256 keys over `(signature + requires + ensures + modifies + model + temperature + SynthPromptVersion)` and atomic temp-rename writes. `Tracker` is a `Ref`-backed cost ledger.
- CLI: `inspect --format dafny-prompt [--operation NAME]` renders the constructed prompt with no network call. `synth try <spec> --operation NAME [--model M] [--no-cache] [--temperature T]` invokes the provider for one candidate body, prints body to stdout + cost line to stderr.
- Tests: 38 unit tests (`PromptBuilderTest`, `ResponseParserTest`, `DiffCheckerTest`, `CacheTest`, `SynthesizerTest`, `FewShotTest`, `PricingTest`) plus one `AnthropicProviderIntegrationTest` gated on `ANTHROPIC_API_KEY`. CLI smoke covers `dafny-prompt` rendering paths. Full project test count goes from 661 to 699 (38 added, 1 skipped).
- Docs: new `docs/content/docs/synth/llm-integration.mdx` describes the module, CLI flags, env vars, cache layout, cost-tracking format, and Anthropic temperature caveat. Phase-6 row in `architecture.mdx` lists #28 alongside #31/#32. Status banner in `03_llm_verifier_synthesis.md` flipped to "shipped" for M6.3.

### Provider notes

- The Anthropic Messages API rejects `temperature != 1.0` on models released after Claude Opus 4.6. `AnthropicProvider` therefore omits `.temperature(...)` from the SDK builder; newer models default to 1.0 and older ones are unaffected. `--temperature` is honoured by `OpenAIProvider`.
- Provider routing keys on model prefix: `gpt-*` (case-insensitive) → OpenAI; otherwise Anthropic.

### What's NOT in this PR (deferred)

| Concern | Tracked in |
|---|---|
| `dafny verify` invocation, sandboxing, error parsing | #29 |
| CEGIS iteration loop, repair-prompt invocation | #29 |
| Dafny → Python / Go splice + post-process | #27 |
| Decomposition / model-escalation / skeleton fallback | #30 |
| `compile` integrating synth output | #29 |
| Few-shot examples machine-verified by `dafny verify` in CI | #29 |

### Native-image

`sbt nativeImage` couldn't run locally (the GraalVM `native-image` binary isn't on this box). Please verify in CI. The synth module uses `IO.blocking` only — no async/reactive types — and both SDKs publish reachability metadata in their jars. If anything breaks, the fix is to wire those configs through `modules/cli/src/main/resources/META-INF/native-image/`.

## Test plan

- [ ] `sbt scalafmtCheckAll` clean
- [ ] `sbt "scalafixAll --check"` clean
- [ ] `sbt test` — full suite green (locally: 699 passed, 1 skipped — the integration test needs `ANTHROPIC_API_KEY`)
- [ ] `cd docs && npm run build` — Fumadocs production build + link check passes
- [ ] `sbt nativeImage` — CI smoke (couldn't run locally, see above)
- [ ] Manual: `sbt "cli/run inspect fixtures/spec/url_shortener.spec --format dafny-prompt --operation Shorten"` — exits 0, renders system + user sections
- [ ] Manual: `sbt "cli/run synth try fixtures/spec/url_shortener.spec --operation Delete"` — exits 1 with "DIRECT_EMIT" message
- [ ] Manual (with key): `ANTHROPIC_API_KEY=… sbt "cli/run synth try fixtures/spec/url_shortener.spec --operation Shorten"` — exits 0, prints body + cost line

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the LLM synthesis layer with Anthropic/OpenAI integration, prompt building, response parsing, diff-checking, caching, and cost tracking, plus CLI commands to render prompts and generate one candidate body. Also rewrites the diff checker to a line-balanced approach that fixes multi‑method inputs and same‑line brace cases.

- **New Features**
  - New `modules/synth/` with `LlmProvider` wrapping `com.anthropic:anthropic-java` and `com.openai:openai-java` behind CE3 `IO`/`Resource`.
  - `PromptBuilder` builds `Prompt(system, user)` from classification + Dafny header + skeleton with few-shot snippets; repair prompts wired.
  - `ResponseParser` extracts the Dafny fenced block and the target method’s body; `DiffChecker` forbids contract changes and new `{:extern}`.
  - Filesystem cache with SHA‑256 keys over signature/clauses/model/temperature/prompt-version and atomic writes; `Tracker` records token usage and USD via `Pricing`.
  - Provider routing: `gpt-*` → OpenAI; otherwise Anthropic. Anthropic omits temperature (API default 1.0); OpenAI honours it.
  - CLI: `inspect --format dafny-prompt [--operation NAME]` renders prompts; `synth try --operation NAME [--model] [--temperature] [--max-tokens] [--no-cache]` prints the parsed body + a cost line. Exit codes split provider vs parse/diff vs cache errors.
  - Docs for the new module and CLI and updated architecture; integration test gated on `ANTHROPIC_API_KEY` and unit tests including clause‑brace regressions.

- **Bug Fixes**
  - Cache: collision-proof keying (labeled, length‑prefixed fields; U+001F join), full‑precision temperature, UUID‑suffixed temp files; writes are best‑effort.
  - Pricing: exact‑match first, then longest base‑prefix; fixes `gpt-4o-mini-*` mispricing.
  - Parser/Diff: rewritten `DiffChecker` uses per‑line unbalanced‑brace detection with tighter method matching; fixes multi‑method inputs and `modifies … {` on same line, preserves set literals and forall triggers.
  - Tracking: record zero‑usage attempts on provider failures; Anthropic model name now taken from the API response.
  - Docs: clarify Anthropic temperature behavior.

<sup>Written for commit 6232c7fc4f93cc5cade998d5fb162164e63bdf06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New synth workflow: `synth try` command (Anthropic/OpenAI providers), model/temperature/max-tokens flags, `--no-cache`/`--cache-dir`, and cost/token reporting
  * `inspect --format dafny-prompt` and optional `--operation` to preview prompts (no network)
  * Filesystem cache for synthesis results and few-shot example snippets included

* **Documentation**
  * Added comprehensive "Synthesis" docs, integration guide, and updated architecture/roadmap pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->