### PR TITLE
#29 — M6.4 CEGIS feedback loop (`synth verify`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ Thumbs.db
 # Logs
 *.log
 
+# spec-to-rest local state (synth cache, scratch)
+.spec-to-rest/
+
 # Lean / Lake (proofs/lean sidecar)
 proofs/lean/.lake/
 ml_issues_contents/

--- a/README.md
+++ b/README.md
@@ -83,13 +83,15 @@ formal claim, full trust closure, and roadmap.
 
 ## Subcommands
 
-| Command                                         | Description                                                                                                                                                                                                 |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `check <spec>`                                  | Parse and validate spec file structure. Exit 0 if valid.                                                                                                                                                    |
-| `inspect -f json \| summary \| ir <spec>`       | Print the IR. `-f json` produces the canonical serialized form used by golden tests.                                                                                                                        |
-| `verify <spec>`                                 | Run Z3-backed consistency + invariant-preservation checks. Emits counterexamples on failure. `--dump-smt` prints the SMT-LIB encoding without solver run.                                                   |
-| `compile --target <profile> --out <dir> <spec>` | Emit the full target-language service (models, schemas, routers, migrations, OpenAPI spec).                                                                                                                 |
-| `compile --with-tests --out <dir> <spec>`       | Additionally emit Hypothesis property tests, strategies, conftest, and a `/__test_admin__` router gated by `ENABLE_TEST_ADMIN`. See [test-generation.mdx](docs/content/docs/pipelines/test-generation.mdx). |
+| Command                                                            | Description                                                                                                                                                                                                 |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `check <spec>`                                                     | Parse and validate spec file structure. Exit 0 if valid.                                                                                                                                                    |
+| `inspect -f json \| summary \| ir \| dafny \| dafny-prompt <spec>` | Print the IR. `-f json` produces the canonical serialized form; `-f dafny` lifts to a Dafny skeleton; `-f dafny-prompt` renders the LLM prompt the synth pipeline uses.                                     |
+| `verify <spec>`                                                    | Run Z3-backed consistency + invariant-preservation checks. Emits counterexamples on failure. `--dump-smt` prints the SMT-LIB encoding without solver run.                                                   |
+| `compile --target <profile> --out <dir> <spec>`                    | Emit the full target-language service (models, schemas, routers, migrations, OpenAPI spec).                                                                                                                 |
+| `compile --with-tests --out <dir> <spec>`                          | Additionally emit Hypothesis property tests, strategies, conftest, and a `/__test_admin__` router gated by `ENABLE_TEST_ADMIN`. See [test-generation.mdx](docs/content/docs/pipelines/test-generation.mdx). |
+| `synth try --operation <op> <spec>`                                | Phase 6 (experimental). One-shot LLM call: builds the Dafny prompt for `<op>`, calls Anthropic / OpenAI, prints the parsed body. Diff-checks against the spec-derived contract. No verification.            |
+| `synth verify --operation <op> <spec>`                             | Phase 6. Runs the CEGIS loop: generate → diff-check → splice → `dafny verify` → repair → repeat, until the body verifies or the budget aborts. Requires a `dafny` binary on `$PATH` (or `--dafny-bin`).     |
 
 ## Exit codes (for `verify`)
 
@@ -110,7 +112,8 @@ modules/
   profile/    — Deployment profiles (python-fastapi-postgres), type mapping
   verify/     — IR → SMT translator, Java Z3 backend (z3-turnkey), consistency checker, counterexample decoding, diagnostic formatter
   codegen/    — Handlebars engine (handlebars.java), Emit orchestrator, OpenAPI subsystem, Alembic migration builder
-  cli/        — decline-effect CommandIOApp: check / inspect / verify / compile
+  synth/      — Phase 6 LLM + Dafny synthesis: PromptBuilder, ResponseParser, DiffChecker, FileAssembly, DafnyVerifier (--log-format json), CegisLoop, Cache, Tracker
+  cli/        — decline-effect CommandIOApp: check / inspect / verify / compile / synth try / synth verify
   bench/      — JMH benchmarks (parallel verify CSV golden)
 fixtures/     — .spec inputs + golden IR JSON + golden SMT-LIB outputs + golden JMH CSV, used by tests and CI
 docs/         — Fumadocs site with the spec-language reference + architecture + verification + concurrency docs

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -112,8 +112,8 @@ modules/
 ├── verify/     # Z3 + Alloy translators · backends · Consistency · Diagnostic · Narration
 ├── codegen/    # Engine (handlebars.java) · Emit · OpenAPI · Alembic
 ├── testgen/    # ExprToPython · Strategies · Stateful/Structural/Behavioral
-├── synth/      # LLM integration · PromptBuilder · DiffChecker · Cache · Tracker
-├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile / synth
+├── synth/      # LLM integration · PromptBuilder · DiffChecker · DafnyVerifier · CegisLoop · Cache · Tracker
+├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile / synth try / synth verify
 └── bench/      # JMH benchmarks (ParallelVerifyBench, parallel verify CSV golden)
 
 proofs/
@@ -161,7 +161,7 @@ on issues; the table below shows where each phase stands today.
 | 3     | `python-fastapi-postgres` codegen + Alembic + OpenAPI  | Shipped                                                                                |
 | 4     | Verification (Z3 + Alloy + Isabelle/HOL universal soundness) | Shipped — pivoted from Lean 4 to Isabelle/HOL via [#193](https://github.com/HardMax71/spec_to_rest/issues/193); IR-canonicalization follow-up in [#202](https://github.com/HardMax71/spec_to_rest/issues/202) |
 | 5     | Test generation (Hypothesis + Schemathesis)            | Largely shipped — [#86](https://github.com/HardMax71/spec_to_rest/issues/86) (runtime invariant enforcement) open |
-| 6     | LLM / Dafny synthesis (CEGIS)                          | **Partially implemented.** [#31](https://github.com/HardMax71/spec_to_rest/issues/31) (operation classification), [#32](https://github.com/HardMax71/spec_to_rest/issues/32) (Dafny signature generation), and [#28](https://github.com/HardMax71/spec_to_rest/issues/28) (LLM integration + prompt engineering) shipped — `inspect --format dafny-prompt` renders the LLM prompt; `synth try` invokes Anthropic / OpenAI for one candidate body, with diff-checker + filesystem cache. CEGIS loop and Dafny→target compilation still tracked in [#27](https://github.com/HardMax71/spec_to_rest/issues/27), [#29](https://github.com/HardMax71/spec_to_rest/issues/29), [#30](https://github.com/HardMax71/spec_to_rest/issues/30). |
+| 6     | LLM / Dafny synthesis (CEGIS)                          | **Mostly implemented.** [#31](https://github.com/HardMax71/spec_to_rest/issues/31) (operation classification), [#32](https://github.com/HardMax71/spec_to_rest/issues/32) (Dafny signature generation), [#28](https://github.com/HardMax71/spec_to_rest/issues/28) (LLM integration + prompt engineering), and [#29](https://github.com/HardMax71/spec_to_rest/issues/29) (CEGIS loop) shipped — `inspect --format dafny-prompt` renders the LLM prompt; `synth try` invokes Anthropic / OpenAI for one candidate body; `synth verify` runs the generate-verify-repair loop against `dafny verify --log-format json` until the body verifies or the budget aborts. Dafny→target compilation and graduated fallback still tracked in [#27](https://github.com/HardMax71/spec_to_rest/issues/27), [#30](https://github.com/HardMax71/spec_to_rest/issues/30). |
 | 7     | Multi-target codegen — Go/chi, TS/Express              | **Not started.** [#33](https://github.com/HardMax71/spec_to_rest/issues/33), [#35](https://github.com/HardMax71/spec_to_rest/issues/35), [#34](https://github.com/HardMax71/spec_to_rest/issues/34) (distribution), [#36](https://github.com/HardMax71/spec_to_rest/issues/36) (CLI polish). |
 | 8     | Authentication DSL                                     | **Not started.** [#53](https://github.com/HardMax71/spec_to_rest/issues/53)–[#55](https://github.com/HardMax71/spec_to_rest/issues/55). |
 

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -32,11 +32,14 @@ description: Compiler internals, IR design, module layout, and shipped vs. plann
 
 ## Compiler pipeline
 
-The shipped pipeline is parse → IR build → verify → convention map → emit. The optional
+The `compile` pipeline is parse → IR build → verify → convention map → emit. The optional
 `--with-tests` flag adds a sixth stage that walks the same IR and emits Python property
-tests. There is no LLM stage; LLM-driven body synthesis (Phase 6, Dafny + CEGIS, issues
-[#27](https://github.com/HardMax71/spec_to_rest/issues/27)–[#32](https://github.com/HardMax71/spec_to_rest/issues/32))
-is open future work.
+tests. The `synth verify` command runs an additional **standalone** Phase 6 stage —
+LLM body synthesis with `dafny verify`-driven CEGIS feedback (#28, #29) — but `compile`
+does not yet substitute its `raise NotImplementedError` stubs with the verified bodies;
+that integration is tracked in
+[#27](https://github.com/HardMax71/spec_to_rest/issues/27) (Dafny→target compilation) and
+[#30](https://github.com/HardMax71/spec_to_rest/issues/30) (graduated fallback).
 
 ```mermaid
 flowchart LR

--- a/docs/content/docs/design/convention-engine.mdx
+++ b/docs/content/docs/design/convention-engine.mdx
@@ -131,8 +131,8 @@ Two pre-render rewrites help the output type-check more often:
 
 Each method's `(signature, requires, ensures, modifies)` tuple is also
 exposed as a `DafnyMethodHeader` on the result, so the diff-checker
-(`modules/synth/DiffChecker.scala`) can verify the LLM did not weaken the
-spec-derived clauses.
+(`modules/synth/src/main/scala/specrest/synth/DiffChecker.scala`) can verify
+the LLM did not weaken the spec-derived clauses.
 
 Known v1 limitations (deferred follow-ups):
 

--- a/docs/content/docs/design/convention-engine.mdx
+++ b/docs/content/docs/design/convention-engine.mdx
@@ -48,7 +48,7 @@ M6 is reserved in the enum (`CreateChild`) but no current dispatch arm produces 
 
 Each `OperationClassification` also carries a `strategy: SynthesisStrategy` —
 `DirectEmit` or `LlmSynthesis` — orthogonal to the M-rule. It signals whether
-Phase 6's CEGIS loop will be needed for the body, even though the convention
+Phase 6's CEGIS loop drives the body synthesis, even though the convention
 engine alone decides today's HTTP/path/schema mapping.
 
 The classifier walks each flattened ensures clause and accepts the operation as
@@ -82,18 +82,18 @@ Service: UrlShortener
 ```
 
 `inspect --format json` adds a top-level `synthesis_strategy` map keyed by
-operation name. Today the only consumer is `inspect`; the remaining Phase 6
-issues ([#27](https://github.com/HardMax71/spec_to_rest/issues/27),
-[#28](https://github.com/HardMax71/spec_to_rest/issues/28),
-[#29](https://github.com/HardMax71/spec_to_rest/issues/29),
-[#30](https://github.com/HardMax71/spec_to_rest/issues/30)) will gate LLM calls
-on this same field.
+operation name. The shipped consumers (`synth try` and `synth verify`) gate
+LLM calls on this field — `DirectEmit` operations are rejected at the CLI
+boundary. The remaining Phase 6 issues
+([#27](https://github.com/HardMax71/spec_to_rest/issues/27),
+[#30](https://github.com/HardMax71/spec_to_rest/issues/30)) will use the same
+field when target-language compilation and graduated fallback land.
 
 ### Dafny signature generation (#32)
 
 The second wedge: `inspect --format dafny` lifts a `ServiceIRFull` into a
-deterministic Dafny skeleton — the prompt input the CEGIS controller (#29)
-will hand to the LLM. The translator lives in
+deterministic Dafny skeleton — the prompt input the CEGIS controller hands
+to the LLM. The translator lives in
 [`Generator.scala`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala);
 no Dafny binary is invoked at runtime — emission is pure IR→string.
 
@@ -118,7 +118,7 @@ What lands in the file:
   is a `// YOUR CODE HERE` placeholder #28 will substitute.
 - Axiomatized `predicate` declarations for any unknown calls (`isValidURI`,
   regex `matches`, etc.) with trivially-true bodies — these are placeholders
-  and the LLM/CEGIS loop is expected to refine them.
+  the CEGIS loop refines.
 
 Two pre-render rewrites help the output type-check more often:
 
@@ -130,8 +130,9 @@ Two pre-render rewrites help the output type-check more often:
   alternative `set k | k in m` would have type `set<K>`, not `set<V>`).
 
 Each method's `(signature, requires, ensures, modifies)` tuple is also
-exposed as a `DafnyMethodHeader` on the result, so #29's diff-checker can
-verify the LLM did not weaken the spec-derived clauses.
+exposed as a `DafnyMethodHeader` on the result, so the diff-checker
+(`modules/synth/DiffChecker.scala`) can verify the LLM did not weaken the
+spec-derived clauses.
 
 Known v1 limitations (deferred follow-ups):
 

--- a/docs/content/docs/pipelines/mutation-testing.mdx
+++ b/docs/content/docs/pipelines/mutation-testing.mdx
@@ -153,16 +153,18 @@ the mutation surface, not one:
 
 - **Phase 6 (#27–#32) — handler synthesis from `ensures` clauses.** This is
   what gives non-CRUD operations real bodies for mutmut to mutate.
-  [#27](https://github.com/HardMax71/spec_to_rest/issues/27) /
-  [#28](https://github.com/HardMax71/spec_to_rest/issues/28) /
-  [#29](https://github.com/HardMax71/spec_to_rest/issues/29) /
-  [#30](https://github.com/HardMax71/spec_to_rest/issues/30). The first two
-  wedges have shipped:
-  [#31 — operation classification (Direct Emit vs LLM)](https://github.com/HardMax71/spec_to_rest/issues/31)
-  stamps each operation with a `SynthesisStrategy`, and
-  [#32 — Dafny signature generation](https://github.com/HardMax71/spec_to_rest/issues/32)
-  lifts the IR into a Dafny method skeleton (`inspect --format dafny`) for the
-  LLM/CEGIS prompt. Downstream issues consume both fields.
+  Four of six wedges have shipped:
+  [#31 — operation classification (Direct Emit vs LLM)](https://github.com/HardMax71/spec_to_rest/issues/31),
+  [#32 — Dafny signature generation](https://github.com/HardMax71/spec_to_rest/issues/32),
+  [#28 — LLM integration + prompt engineering](https://github.com/HardMax71/spec_to_rest/issues/28),
+  and [#29 — CEGIS feedback loop](https://github.com/HardMax71/spec_to_rest/issues/29).
+  Together they take a spec, classify each operation, lift it into a Dafny
+  skeleton, drive an LLM to fill in the body, and iterate against
+  `dafny verify` until the body verifies. Still open:
+  [#27 — Dafny → target-language compilation](https://github.com/HardMax71/spec_to_rest/issues/27)
+  and [#30 — graduated fallback strategy](https://github.com/HardMax71/spec_to_rest/issues/30) —
+  these are what wire verified Dafny bodies into the emitted Python (or Go,
+  or TS) and add escape hatches when CEGIS can't converge.
 - **#86 — runtime enforcement of invariants/temporals.** Adds invariant /
   temporal property tests, OpenAPI `x-invariant`/`x-temporal` annotations,
   and a stateful-test temporal observer. It does *not* synthesize handler

--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -7,22 +7,22 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > for the spec-to-REST compiler. Covers architecture, Dafny integration, prompt engineering,
 > Clover-style triangulation, failure handling, security, and cost analysis. Written 2026-04-05.
 
-> **Status — partially implemented.** This document is the **Phase 6** design proposal.
-> Three foundational wedges have shipped: #31 operation classification, #32 Dafny
-> signature generation (`inspect --format dafny`), and #28 LLM integration + prompt
-> engineering (`inspect --format dafny-prompt`, `synth try`); the CEGIS loop and
-> Dafny→target compilation remain unbuilt on `main`. Open trackers under the `phase-6`
-> label cover the breakdown:
+> **Status — mostly implemented.** This document is the **Phase 6** design proposal.
+> Four foundational wedges have shipped: #31 operation classification, #32 Dafny
+> signature generation (`inspect --format dafny`), #28 LLM integration + prompt
+> engineering (`inspect --format dafny-prompt`, `synth try`), and #29 the CEGIS
+> feedback loop (`synth verify`); Dafny→target compilation remains unbuilt on
+> `main`. Open trackers under the `phase-6` label cover the breakdown:
 > [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) — operation classification (direct emit vs. LLM) — **shipped**,
 > [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) — Dafny signature generation — **shipped**,
 > [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering — **shipped**,
-> [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop,
+> [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop — **shipped**,
 > [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation,
 > [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy.
 > The Scala implementation lives in `modules/synth/` (`PromptBuilder`,
-> `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, plus
-> Anthropic / OpenAI providers wrapping the official Java SDKs). The Python code
-> samples below remain useful as data-shape sketches.
+> `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, `CegisLoop`,
+> `DafnyVerifier`, plus Anthropic / OpenAI providers wrapping the official Java
+> SDKs). The Python code samples below remain useful as data-shape sketches.
 
 ---
 

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -229,7 +229,7 @@ $ sbt "cli/run synth verify fixtures/spec/safe_counter.spec \
 
 Stdout (the body the LLM produced, body alone — no signature, no fences):
 
-```dafny
+```text
   // First, capture the old count for use in the postcondition
   var oldCount := st.count;
 
@@ -277,8 +277,9 @@ Re-running the same command immediately after the cold run:
 ```
 
 `iter=0` means no CEGIS iteration ran — the verified body was retrieved from
-`.spec-to-rest/synth-cache/verified/<sha>/...` and re-spliced into a fresh
-copy of the skeleton. The token / cost numbers reproduce the previous run's
+`.spec-to-rest/synth-cache/verified/<2-hex-prefix>/<sha>.json` (entries are
+sharded into 2-character subdirectories by the leading hex bytes of the
+SHA-256 key) and re-spliced into a fresh copy of the skeleton. The token / cost numbers reproduce the previous run's
 ledger entry (which is what `cached=true` records mean), but no LLM call was
 billed (`calls=1` here counts the cached-call ledger entry, not a network
 round-trip — `cachedHits=1` is the canonical signal of a cache hit).

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -213,7 +213,80 @@ server-side default applies. The flag is honoured by `OpenAIProvider`. For
 deterministic synthesis on Anthropic, rely on prompt structure and
 `--max-tokens` instead.
 
-## Worked example: URL shortener `Shorten` (3 iterations)
+## Real-LLM transcript: `safe_counter.Increment` (gpt-4o-mini)
+
+The simplest end-to-end smoke. Dafny 4.11.0 (`dotnet tool install -g Dafny`),
+gpt-4o-mini, `safe_counter` fixture. Two consecutive runs exercise the cold
+path (LLM call + Dafny verify + cache write) and the warm path (cache hit
+short-circuit, no LLM call).
+
+### Cold run
+
+```bash
+$ sbt "cli/run synth verify fixtures/spec/safe_counter.spec \
+       --operation Increment --max-iter 3 --model gpt-4o-mini --max-tokens 1024"
+```
+
+Stdout (the body the LLM produced, body alone — no signature, no fences):
+
+```dafny
+  // First, capture the old count for use in the postcondition
+  var oldCount := st.count;
+
+  // Increment the count
+  st.count := st.count + 1;
+
+  // Assert that the new count is indeed the old count plus one
+  assert st.count == oldCount + 1;
+
+  // Final assertion to verify service state invariant
+  assert ServiceStateInv(st);
+```
+
+Stderr summary (always two lines: outcome + cost ledger):
+
+```text
+[synth-verify] op=Increment VERIFIED iter=1 records=1
+[synth-verify] tokens in=574tok out=127tok cost=$0.0002 calls=1 cachedHits=0
+```
+
+Exit code: `0`.
+
+This particular transcript verified on the first iteration. LLM responses are
+non-deterministic — on a different draw `gpt-4o-mini` may produce a body that
+fails Dafny's postcondition check, in which case `iter` is `2` or higher and
+`records` shows the failed candidate plus the repair. Example from a
+previous run on the same fixture/model:
+
+```text
+[synth-verify] op=Increment VERIFIED iter=2 records=2
+[synth-verify] tokens in=1148tok out=353tok cost=$0.0004 calls=2 cachedHits=0
+```
+
+The repair-prompt path (`PromptBuilder.repair`) embeds the iteration-1 body
+verbatim plus the verifier error category and message, so the LLM sees what
+was wrong and produces a corrected body on iteration 2.
+
+### Warm run (cache hit)
+
+Re-running the same command immediately after the cold run:
+
+```text
+[synth-verify] op=Increment VERIFIED iter=0 records=1
+[synth-verify] tokens in=574tok out=127tok cost=$0.0002 calls=1 cachedHits=1
+```
+
+`iter=0` means no CEGIS iteration ran — the verified body was retrieved from
+`.spec-to-rest/synth-cache/verified/<sha>/...` and re-spliced into a fresh
+copy of the skeleton. The token / cost numbers reproduce the previous run's
+ledger entry (which is what `cached=true` records mean), but no LLM call was
+billed (`calls=1` here counts the cached-call ledger entry, not a network
+round-trip — `cachedHits=1` is the canonical signal of a cache hit).
+
+Wall clock for both runs combined: ~32s on a developer laptop. About $0.0002
+spent on real LLM tokens for the cold run; warm run is free.
+
+## Worked example: URL shortener `Shorten` (3 iterations, mocked)
 
 The acceptance test for #29 walks the canonical case where the LLM converges
 in three iterations:

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -1,60 +1,87 @@
 ---
-title: LLM Integration (M6.3)
-description: Anthropic + OpenAI clients, prompt construction, diff-checker, cost ledger, on-disk cache
+title: Synthesis Pipeline (M6.3 + M6.4)
+description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, and the CEGIS feedback loop wired to `dafny verify`.
 ---
 
-`modules/synth/` ships the LLM-facing layer of Phase 6. It builds prompts from the
-Dafny skeleton emitted by [`inspect --format dafny`](/design/convention-engine) (#32),
-calls a provider, parses the response, runs a diff-checker against the immutable
-contract clauses, and tracks token cost. The CEGIS loop, `dafny verify`, and
-target-language compilation are deferred to [#29](https://github.com/HardMax71/spec_to_rest/issues/29)
-and [#27](https://github.com/HardMax71/spec_to_rest/issues/27).
+`modules/synth/` is the Phase 6 LLM-and-Dafny synthesis layer. It takes the
+deterministic Dafny skeleton emitted by [`inspect --format dafny`](/design/convention-engine)
+(#32), drives an LLM to fill in a method body, splices the body back into the
+skeleton, runs `dafny verify` against the structured-JSON log format, and
+iterates with a repair prompt until the body verifies — or the budget says stop.
+Dafny→target compilation remains tracked in
+[#27](https://github.com/HardMax71/spec_to_rest/issues/27).
 
 ## Modules and entry points
 
 ```mermaid
 flowchart LR
   Inspect["inspect --format dafny-prompt<br/>(no network)"] --> PromptBuilder
-  SynthCmd["synth try<br/>(real LLM call)"] --> Synthesizer
-  PromptBuilder["PromptBuilder.initial<br/>system + user sections"] --> SynthCmd
-  Synthesizer --> Cache["Cache lookup<br/>SHA-256 over contract"]
+  Try["synth try<br/>(one LLM call)"] --> Synthesizer
+  Verify["synth verify<br/>(CEGIS loop)"] --> CegisLoop
+  PromptBuilder["PromptBuilder<br/>initial / repair"] --> Provider
+  Synthesizer --> Cache
+  CegisLoop --> Cache["Cache<br/>SHA-256 over contract"]
   Cache -->|hit| Result
-  Cache -->|miss| Provider
-  Provider["LlmProvider<br/>Anthropic | OpenAI | Mock"] --> Parser["ResponseParser<br/>extract dafny block + body"]
+  Cache -->|miss| Provider["LlmProvider<br/>Anthropic / OpenAI / Mock"]
+  Provider --> Parser["ResponseParser<br/>fenced block + body"]
   Parser --> Diff["DiffChecker<br/>contracts unchanged?"]
-  Diff --> Tracker["Tracker<br/>token + cost ledger"]
-  Tracker --> Result["SynthResult<br/>(body, usage, cost)"]
+  Diff -->|try| Result
+  Diff -->|verify| Splice["FileAssembly<br/>splice into skeleton"]
+  Splice --> Dafny["DafnyVerifier<br/>--log-format json"]
+  Dafny -->|verified| Result["body + usage + cost"]
+  Dafny -->|errors| PromptBuilder
 ```
 
-- `LlmProvider` — sealed surface (`AnthropicProvider`, `OpenAIProvider`,
+- **`LlmProvider`** — sealed surface (`AnthropicProvider`, `OpenAIProvider`,
   `MockProvider`). Each call returns `IO[Either[ProviderError, LlmResponse]]`.
   Real providers wrap the official `com.anthropic:anthropic-java` (2.30.x) and
   `com.openai:openai-java` (4.35.x) SDKs in `IO.blocking` with `Resource`-managed
   client lifecycles.
-- `PromptBuilder` — produces a `Prompt(system, user)` pair from the
-  `(OperationClassification, DafnyMethodHeader, skeleton)` triple. System prompts
-  live as resources under `modules/synth/src/main/resources/specrest/synth/prompts/`.
-  Few-shot examples live alongside under `few-shot/`; selection is keyed on
-  `OperationKind`. Both `initial` and `repair` prompts are implemented; the repair
-  variant is wired but only invoked once the CEGIS loop in #29 lands.
-- `ResponseParser` — extracts the first ` ```dafny ` (or ` ```csharp `, fallback
-  ` ``` `) fenced block from the LLM's response, then locates the named method's
-  body. The brace-matching scanner is string-aware and skips Dafny line and block
-  comments.
-- `DiffChecker` — given the canonical `DafnyMethodHeader` and the LLM's full
-  candidate, normalizes the `requires` / `ensures` / `modifies` clauses and rejects
-  any change. Also rejects any newly-introduced `{:extern}` declaration.
-- `Cache` — filesystem-backed key/value store. Keys are SHA-256 hashes over
-  `(signature, requires, ensures, modifies, model, temperature, SynthPromptVersion)`.
-  Writes are atomic (`tmp → ATOMIC_MOVE`). Default root: `.spec-to-rest/synth-cache/`
-  in the working directory; override with `--cache-dir`.
-- `Tracker` — `Ref`-backed call ledger. Each call records
-  `(operation, model, usage, costUsd, cached)`. `summary: IO[CostSummary]` aggregates
-  across the run.
-- `Pricing` — static table of input/output rates per million tokens. Verified
-  2026-05-08 against vendor pricing pages. `forModel` matches both bare and
-  date-suffixed model IDs (`claude-haiku-4-5-20251001` resolves to the
-  `claude-haiku-4-5` row).
+- **`PromptBuilder`** — produces a `Prompt(system, user)` pair. `initial` is used
+  for the first attempt; `repair` embeds the previous body and the verifier error
+  for iterations 2+. System prompts live as resources under
+  `modules/synth/src/main/resources/specrest/synth/prompts/`.
+- **`ResponseParser`** — extracts the first ` ```dafny ` (or ` ```csharp `,
+  fallback ` ``` `) fenced block from the LLM's response, then locates the
+  named method's body. The brace-matching scanner is string-aware and skips
+  Dafny line and block comments.
+- **`DiffChecker`** — given the canonical `DafnyMethodHeader` and the LLM's
+  full candidate, normalizes the `requires` / `ensures` / `modifies` clauses
+  and rejects any change. Also rejects newly-introduced `{:extern}` declarations.
+- **`FileAssembly`** — splices the LLM's body into the skeleton at the
+  `// YOUR CODE HERE` placeholder for the named method. Pure string operation:
+  the skeleton is generated by the convention engine with a stable sentinel,
+  so no parsing is needed.
+- **`DafnyVerifier`** — trait + `DafnyCli` real impl + `MockDafnyVerifier` for
+  tests. The CLI wrapper invokes `dafny verify --log-format 'json;LogFileName=…'`,
+  reads the JSON file Dafny itself produces, and decodes per-method outcomes.
+  No regex parsing of stderr — the structured JSON is the contract.
+- **`DafnyOutputParser`** — circe decoders for Dafny's `verificationResults[]`
+  log shape (added in Dafny 4.5.0). Each method's outcome is keyed by `name`,
+  with `vcResults[].assertions[].{filename,line,col,description}` for
+  assertion-level errors. A small classifier maps `description` text to the
+  category enum (`postcondition_violation`, `precondition_violation`,
+  `loop_invariant_*`, `decreases_failure`, `assertion_failure`, `timeout`,
+  `type_error`, `syntax_error`, `unknown`).
+- **`CegisLoop`** — the orchestrator. Takes a `SynthRequest`, drives provider →
+  parse → diff → splice → verify → repeat. Bounded by `CegisBudget`. Returns
+  `CegisOutcome.Verified(body, fullDfy, iterations, history)` or
+  `CegisOutcome.Aborted(reason, lastBody, history)`.
+- **`CegisBudget`** — four knobs: `maxIterations` (default 8), `maxInputTokens`
+  (100k), `maxOutputTokens` (50k), `maxCostUsd` (1.00), plus
+  `repeatedErrorThreshold` (3) for the "stuck" detector.
+- **`Cache`** — filesystem-backed key/value store. Keys are SHA-256 hashes
+  over `(signature, requires, ensures, modifies, model, temperature,
+  SynthPromptVersion)`. Writes are atomic. `synth try` writes to
+  `.spec-to-rest/synth-cache/`; `synth verify` writes to
+  `.spec-to-rest/synth-cache/verified/`. The two namespaces are not
+  interchangeable — a try-passing body may not verify.
+- **`Tracker`** — `Ref`-backed call ledger. Each LLM call records
+  `(operation, model, usage, costUsd, cached)`. `summary: IO[CostSummary]`
+  aggregates across the run.
+- **`Pricing`** — static table of input/output rates per million tokens.
+  Verified 2026-05-08 against vendor pricing pages. `forModel` matches both
+  bare and date-suffixed model IDs.
 
 ## CLI
 
@@ -67,96 +94,152 @@ sbt "cli/run inspect fixtures/spec/url_shortener.spec --format dafny-prompt"
 sbt "cli/run inspect fixtures/spec/url_shortener.spec --format dafny-prompt --operation Shorten"
 ```
 
-With `--operation NAME`, only that operation's prompt is rendered. Without it, every
-operation classified `LLM_SYNTHESIS` is emitted, separated by a markdown horizontal
-rule. Operations classified `DIRECT_EMIT` are skipped (the convention engine handles
-them; no LLM is ever consulted).
+With `--operation NAME`, only that operation's prompt is rendered. Without it,
+every operation classified `LLM_SYNTHESIS` is emitted, separated by a markdown
+horizontal rule.
 
 ### `synth try`
 
-Sends the constructed prompt to the LLM provider and prints the parsed body to
-stdout. Cost is reported on stderr.
+Sends the constructed prompt to the LLM and prints the parsed body to stdout.
+**No verification.** Cost goes to stderr.
 
 ```bash
 ANTHROPIC_API_KEY=sk-ant-... \
   sbt "cli/run synth try fixtures/spec/url_shortener.spec --operation Shorten"
 ```
 
-Flags:
-
 | Flag | Default | Notes |
 |---|---|---|
-| `--operation NAME` | _required_ | Must match a `LLM_SYNTHESIS`-classified op |
+| `--operation NAME` | _required_ | Must match an `LLM_SYNTHESIS`-classified op |
 | `--model M` | `claude-sonnet-4-6` | `gpt-*` routes to OpenAI; otherwise Anthropic |
-| `--temperature T` | `1.0` | Honoured by OpenAI; **ignored on Anthropic** (the current `AnthropicProvider` omits the SDK's `.temperature(...)` builder call) |
+| `--temperature T` | `1.0` | Honoured by OpenAI; **ignored on Anthropic** (see below) |
 | `--max-tokens N` | `2048` | Per-response output cap |
 | `--no-cache` | off | Skip on-disk cache for this call |
 | `--cache-dir PATH` | `.spec-to-rest/synth-cache/` | Override cache root |
+
+Exit codes: `0` body produced + diff-check passed; `1` spec/parse/build/op-not-found/DIRECT_EMIT;
+`2` LLM response unparseable or diff-check rejected; `3` provider HTTP / API error.
+
+### `synth verify`
+
+Runs the full CEGIS loop: generate → diff-check → splice → `dafny verify` →
+repair → repeat, until the body verifies or the budget is exhausted.
+**Requires a `dafny` binary on `$PATH`** (or `--dafny-bin` / `$DAFNY_BIN`).
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... DAFNY_BIN=/usr/local/bin/dafny \
+  sbt "cli/run synth verify fixtures/spec/url_shortener.spec --operation Shorten"
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--operation NAME` | _required_ | Must match an `LLM_SYNTHESIS`-classified op |
+| `--model M` | `claude-sonnet-4-6` | Same routing as `synth try` |
+| `--temperature T` | `1.0` | Same caveat |
+| `--max-tokens N` | `2048` | Per-iteration output cap |
+| `--max-iter N` | `8` | Hard cap on CEGIS iterations |
+| `--cost-cap-usd N` | `1.00` | Abort if cumulative LLM cost exceeds this |
+| `--dafny-bin PATH` | `$DAFNY_BIN` then `dafny` on PATH | Path to the Dafny binary |
+| `--dafny-timeout SEC` | `60` | Per-iteration `--verification-time-limit` |
+| `--no-cache` | off | Skip the verified-body cache |
+| `--cache-dir PATH` | `.spec-to-rest/synth-cache/` | Verified bodies live under `<root>/verified/` |
 
 Exit codes:
 
 | Code | Meaning |
 |---|---|
-| 0 | Body produced, diff-check passed |
-| 1 | Spec missing / parse / build / classification error / op classified DIRECT_EMIT |
-| 2 | LLM response unparseable, or diff-check rejected (contract changed, or new `{:extern}` introduced) |
-| 3 | Provider HTTP / API error, or cache write failed |
+| 0 | Body verified within budget |
+| 1 | Budget exhausted (max iter / token / cost) or stuck on the same error |
+| 2 | LLM response unparseable, diff-check rejected, or splice failed |
+| 3 | Provider HTTP / API error, or Dafny binary missing / crashed |
 
-## Provider routing
+End-of-run stderr summary line:
 
-`synth try` selects a provider based on the model name prefix:
+```text
+[synth-verify] op=Shorten VERIFIED iter=3 records=3
+[synth-verify] tokens in=4321tok out=987tok cost=$0.0421 calls=3 cachedHits=0
+```
 
-- Model starts with `gpt` (case-insensitive) → `OpenAIProvider.fromEnv`. Reads
-  `OPENAI_API_KEY` (and optionally `OPENAI_BASE_URL` for Azure deployments).
-- Otherwise → `AnthropicProvider.fromEnv`. Reads `ANTHROPIC_API_KEY`.
+## Iteration budget
 
-Both providers use `Resource[IO, _]` so the underlying OkHttp client is closed on
-success, failure, and cancellation alike. Cancellation propagates through CE3 the
-same way it does for Z3 / Alloy backends.
+The CEGIS loop uses `CegisBudget` to bound work. Defaults:
 
-## Anthropic temperature note
+```text
+maxIterations         = 8     # hard cap on repair rounds
+maxInputTokens        = 100000
+maxOutputTokens       = 50000
+maxCostUsd            = 1.00
+repeatedErrorThreshold = 3    # same (category, line) → abort as "stuck"
+```
 
-The Anthropic Messages API rejects `temperature != 1.0` on models released after
-Claude Opus 4.6 (4xx error from the API). To stay forward-compatible across the
-whole Anthropic lineup, `AnthropicProvider` does **not** call the SDK's
-`.temperature(...)` builder for any model — Anthropic's server-side default
-(currently 1.0) applies in all cases, regardless of `--temperature`. The flag
-is honoured by `OpenAIProvider`. For deterministic synthesis on Anthropic, rely
-on prompt structure and `--max-tokens` instead.
+The CLI exposes `--max-iter` and `--cost-cap-usd`. The token caps and stuck
+threshold are not surfaced as flags today — they're sane defaults that
+correspond to the cost cap on Claude Sonnet 4.6 / GPT-5 pricing. Override
+in code when embedding `CegisLoop` directly.
+
+## Dafny binary
+
+`DafnyCli.resolveBinary` checks (in order): the `--dafny-bin` flag, the
+`DAFNY_BIN` environment variable, and finally the unqualified `dafny` on
+`$PATH`. The check runs `dafny --version` with a 10-second timeout — if it
+fails, the command exits `3` (Backend) with a clear error.
+
+The structured-JSON log format used by `DafnyOutputParser` was added in
+**Dafny 4.5.0**. Earlier versions lack `--log-format json` for `verify` and
+will not work. We do **not** install Dafny in CI: the CEGIS loop is exercised
+end-to-end with `MockDafnyVerifier` against staged JSON shapes.
 
 ## Caching
 
-Cache keys are content-addressed and intentionally do not include the spec source
-or skeleton text — only the contract surface that matters for verification. This
-means trivial spec edits (renames, comment changes) do not invalidate the cache,
-but any change to the operation's signature, requires, ensures, modifies, or to
-the `SynthPromptVersion` constant immediately misses.
+Cache keys are content-addressed and intentionally do not include the spec
+source or skeleton text — only the contract surface that matters. Trivial
+spec edits (renames, comment changes) do not invalidate the cache; any change
+to signature / requires / ensures / modifies / `SynthPromptVersion` does.
 
-`SynthPromptVersion` is a manual bump knob (`v1` at time of writing). Bump it when
-the system prompts or few-shot library changes substantively.
+`synth try` and `synth verify` use **separate cache namespaces**:
 
-Cache misses cause one provider call; the response is parsed, diff-checked, and
-written atomically (`<file>.tmp` → `Files.move(..., ATOMIC_MOVE, REPLACE_EXISTING)`).
-Concurrent writers writing the same key are idempotent.
+- `synth-cache/<key>.json` for `synth try` (diff-checked bodies; not
+  necessarily verified).
+- `synth-cache/verified/<key>.json` for `synth verify` (verified bodies).
 
-## Cost tracking
+A `try`-passing body may not verify, so the two stores must not be merged.
 
-Every call emits one stderr line:
+## Anthropic temperature note
 
-```text
-[synth] op=Shorten model=claude-sonnet-4-6 in=1234tok out=456tok cost=$0.0114
-```
+The Anthropic Messages API rejects `temperature != 1.0` on models released
+after Claude Opus 4.6. To stay forward-compatible, `AnthropicProvider` does
+**not** call the SDK's `.temperature(...)` builder for any model — Anthropic's
+server-side default applies. The flag is honoured by `OpenAIProvider`. For
+deterministic synthesis on Anthropic, rely on prompt structure and
+`--max-tokens` instead.
 
-`Tracker.summary` returns an aggregate `CostSummary(operations, inputTokens,
-outputTokens, totalUsd, cachedHits)` that #29 will surface in its end-of-run report.
+## Worked example: URL shortener `Shorten` (3 iterations)
 
-## What's deferred
+The acceptance test for #29 walks the canonical case where the LLM converges
+in three iterations:
+
+1. **Iteration 1** — initial prompt. LLM produces a body that hardcodes a
+   `ShortCode("abcdef")`. Dafny rejects: postcondition `code !in old(st.store)`
+   not established (the hardcoded code might already be in the store).
+2. **Iteration 2** — repair prompt embeds the iteration-1 body and the
+   postcondition error. LLM produces `code :| code !in st.store`. Dafny
+   rejects: cannot establish existence of LHS values.
+3. **Iteration 3** — repair prompt embeds the iteration-2 body and the
+   existence-failure error. LLM produces a `FreshCodeExists` lemma plus the
+   `:|` operator. **Verified.**
+
+`CegisLoopTest.scala` exercises this flow with `MockProvider` (three staged
+responses) and `MockDafnyVerifier` (three staged outputs), asserting
+`outcome.iterations == 3` and that the iteration-2 prompt contains
+`postcondition_violation` plus the iteration-1 body verbatim — proving
+"error feedback improves subsequent iterations" (AC 2).
+
+## What's still deferred
 
 | Concern | Tracked in |
 |---|---|
-| `dafny verify` invocation, sandboxing, error parsing | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
-| CEGIS iteration loop, repair-prompt invocation | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
 | Dafny → Python / Go splice + post-process | [#27](https://github.com/HardMax71/spec_to_rest/issues/27) |
-| Decomposition, model-escalation, skeleton fallback | [#30](https://github.com/HardMax71/spec_to_rest/issues/30) |
-| `compile` integrating synth output | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
-| Few-shot examples machine-verified by `dafny verify` in CI | [#29](https://github.com/HardMax71/spec_to_rest/issues/29) |
+| Decomposition, model-escalation, skeleton fallback (graduated fallback) | [#30](https://github.com/HardMax71/spec_to_rest/issues/30) |
+| `compile` integrating verified synth output | [#27](https://github.com/HardMax71/spec_to_rest/issues/27) |
+| Few-shot examples machine-verified by `dafny verify` in CI | follow-up |
+| Counterexample formatting (Z3 model → human-readable) | follow-up |

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -372,10 +372,16 @@ What this target does **not** generate today, with tracking issues:
   redirects whose body shape doesn't match the entity create schema currently emit
   `raise NotImplementedError(...)` stubs (see
   `modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs`).
-  The Phase 6 LLM + Dafny pipeline that fills these in is tracked across
+  Phase 6's LLM + Dafny CEGIS pipeline fills these in for `LLM_SYNTHESIS`-classified
+  operations: shipped wedges
   [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31),
   [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32),
-  [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28),
-  [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29),
-  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27), and
-  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30).
+  [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28), and
+  [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) cover
+  classification, Dafny signature generation, LLM integration, and the
+  generate-verify-repair loop. The remaining steps —
+  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) for
+  Dafny→Python compilation and
+  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) for
+  graduated fallback when CEGIS can't converge — are what splice verified
+  Dafny bodies into this template.

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -372,16 +372,17 @@ What this target does **not** generate today, with tracking issues:
   redirects whose body shape doesn't match the entity create schema currently emit
   `raise NotImplementedError(...)` stubs (see
   `modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs`).
-  Phase 6's LLM + Dafny CEGIS pipeline fills these in for `LLM_SYNTHESIS`-classified
-  operations: shipped wedges
-  [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31),
-  [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32),
-  [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28), and
-  [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) cover
-  classification, Dafny signature generation, LLM integration, and the
-  generate-verify-repair loop. The remaining steps —
-  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) for
-  Dafny→Python compilation and
-  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) for
-  graduated fallback when CEGIS can't converge — are what splice verified
-  Dafny bodies into this template.
+  `compile` does **not** yet substitute these stubs with synthesised bodies. The
+  Phase 6 wedges that produce verified Dafny bodies for `LLM_SYNTHESIS`-classified
+  operations have shipped (
+  [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) classification,
+  [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) Dafny signature
+  generation, [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) LLM
+  integration, [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) the
+  CEGIS feedback loop) — they're invokable today via `synth verify`. The integration
+  step that wires the verified Dafny body into the FastAPI handler this template
+  renders is
+  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) (Dafny→Python
+  compilation), with
+  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) covering graduated
+  fallback when CEGIS can't converge. Both are still open.

--- a/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
+++ b/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
@@ -2,7 +2,9 @@ package specrest.cli
 
 import cats.effect.ExitCode
 import specrest.ir.VerifyError
+import specrest.synth.AbortReason
 import specrest.synth.CacheFailure
+import specrest.synth.CegisOutcome
 import specrest.synth.DiffCheckFailure
 import specrest.synth.ProviderFailure
 import specrest.synth.ResponseParseFailure
@@ -25,6 +27,18 @@ object ExitCodes:
     case _: ResponseParseFailure => Translator
     case _: DiffCheckFailure     => Translator
     case _: CacheFailure         => Backend
+
+  def forCegisOutcome(o: CegisOutcome): ExitCode = o match
+    case _: CegisOutcome.Verified => Ok
+    case CegisOutcome.Aborted(reason, _, _) =>
+      reason match
+        case _: AbortReason.BudgetExhausted        => Violations
+        case _: AbortReason.StuckOnSameError       => Violations
+        case _: AbortReason.ResponseUnparseable    => Translator
+        case _: AbortReason.DiffViolation          => Translator
+        case _: AbortReason.SpliceFailed           => Translator
+        case _: AbortReason.ProviderFailed         => Backend
+        case _: AbortReason.VerifierBackendFailure => Backend
 
   def forVerifyError(e: VerifyError): ExitCode = e match
     case _: VerifyError.Parse           => Violations

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -162,21 +162,35 @@ object Main
     val temperature = Opts
       .option[Double]("temperature", "sampling temperature (ignored on newer Anthropic models)")
       .withDefault(1.0)
-    val maxTokens = Opts.option[Int]("max-tokens", "max output tokens").withDefault(2048)
-    val noCache   = Opts.flag("no-cache", "bypass on-disk synthesis cache").orFalse
-    val cacheDir  = Opts.option[String]("cache-dir", "override synth cache directory").orNone
+    val maxTokens = Opts
+      .option[Int]("max-tokens", "max output tokens")
+      .withDefault(2048)
+      .mapValidated: n =>
+        if n > 0 then cats.data.Validated.valid(n)
+        else cats.data.Validated.invalidNel(s"--max-tokens must be > 0 (got $n)")
+    val noCache  = Opts.flag("no-cache", "bypass on-disk synthesis cache").orFalse
+    val cacheDir = Opts.option[String]("cache-dir", "override synth cache directory").orNone
     val dafnyBin = Opts
       .option[String]("dafny-bin", "path to dafny binary (defaults to $DAFNY_BIN or PATH)")
       .orNone
     val dafnyTimeout = Opts
       .option[Int]("dafny-timeout", "per-iteration dafny verification timeout (seconds)")
       .withDefault(60)
+      .mapValidated: n =>
+        if n > 0 then cats.data.Validated.valid(n)
+        else cats.data.Validated.invalidNel(s"--dafny-timeout must be > 0 (got $n)")
     val maxIter = Opts
       .option[Int]("max-iter", "maximum CEGIS iterations before abort")
       .withDefault(8)
+      .mapValidated: n =>
+        if n > 0 then cats.data.Validated.valid(n)
+        else cats.data.Validated.invalidNel(s"--max-iter must be > 0 (got $n)")
     val maxCost = Opts
       .option[Double]("cost-cap-usd", "abort if cumulative LLM cost exceeds this many USD")
       .withDefault(1.00)
+      .mapValidated: x =>
+        if x > 0.0 then cats.data.Validated.valid(x)
+        else cats.data.Validated.invalidNel(s"--cost-cap-usd must be > 0 (got $x)")
     val tryCmd: Opts[IO[ExitCode]] =
       Opts.subcommand("try", "Generate one Dafny body candidate via LLM"):
         (specFile, operation, model, temperature, maxTokens, noCache, cacheDir, verbose, quiet)

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -165,7 +165,19 @@ object Main
     val maxTokens = Opts.option[Int]("max-tokens", "max output tokens").withDefault(2048)
     val noCache   = Opts.flag("no-cache", "bypass on-disk synthesis cache").orFalse
     val cacheDir  = Opts.option[String]("cache-dir", "override synth cache directory").orNone
-    Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
+    val dafnyBin = Opts
+      .option[String]("dafny-bin", "path to dafny binary (defaults to $DAFNY_BIN or PATH)")
+      .orNone
+    val dafnyTimeout = Opts
+      .option[Int]("dafny-timeout", "per-iteration dafny verification timeout (seconds)")
+      .withDefault(60)
+    val maxIter = Opts
+      .option[Int]("max-iter", "maximum CEGIS iterations before abort")
+      .withDefault(8)
+    val maxCost = Opts
+      .option[Double]("cost-cap-usd", "abort if cumulative LLM cost exceeds this many USD")
+      .withDefault(1.00)
+    val tryCmd: Opts[IO[ExitCode]] =
       Opts.subcommand("try", "Generate one Dafny body candidate via LLM"):
         (specFile, operation, model, temperature, maxTokens, noCache, cacheDir, verbose, quiet)
           .mapN: (spec, op, m, t, mt, nc, cd, v, q) =>
@@ -174,6 +186,33 @@ object Main
               SynthOptions(op, m, t, mt, nc, cd),
               Logger.fromFlags(verbose = v, quiet = q)
             )
+    val verifyCmd: Opts[IO[ExitCode]] =
+      Opts.subcommand(
+        "verify",
+        "Run the CEGIS loop: generate, dafny-verify, repair until verified"
+      ):
+        (
+          specFile,
+          operation,
+          model,
+          temperature,
+          maxTokens,
+          noCache,
+          cacheDir,
+          dafnyBin,
+          dafnyTimeout,
+          maxIter,
+          maxCost,
+          verbose,
+          quiet
+        ).mapN: (spec, op, m, t, mt, nc, cd, db, dt, mi, mc, v, q) =>
+          Synth.runVerify(
+            spec,
+            SynthVerifyOptions(op, m, t, mt, nc, cd, db, dt, mi, mc),
+            Logger.fromFlags(verbose = v, quiet = q)
+          )
+    Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
+      tryCmd orElse verifyCmd
 
   override def main: Opts[IO[ExitCode]] =
     inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -14,6 +14,10 @@ import specrest.ir.generated.SpecRestGenerated.*
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.synth.Cache
+import specrest.synth.CegisBudget
+import specrest.synth.CegisLoop
+import specrest.synth.CegisOutcome
+import specrest.synth.DafnyCli
 import specrest.synth.LlmProvider
 import specrest.synth.SynthRequest
 import specrest.synth.SynthResult
@@ -32,6 +36,19 @@ final case class SynthOptions(
     maxTokens: Int,
     noCache: Boolean,
     cacheDir: Option[String]
+)
+
+final case class SynthVerifyOptions(
+    operation: String,
+    model: String,
+    temperature: Double,
+    maxTokens: Int,
+    noCache: Boolean,
+    cacheDir: Option[String],
+    dafnyBin: Option[String],
+    dafnyTimeoutSec: Int,
+    maxIter: Int,
+    maxCostUsd: Double
 )
 
 object Synth:
@@ -139,5 +156,136 @@ object Synth:
       err.println(
         f"[synth] op=$opName model=${r.model} in=${r.usage.inputTokens}tok " +
           f"out=${r.usage.outputTokens}tok cost=$$${r.costUsd}%.4f $cacheTag".trim
+      )
+    }
+
+  def runVerify(
+      specFile: String,
+      opts: SynthVerifyOptions,
+      log: Logger,
+      out: PrintStream = System.out,
+      err: PrintStream = System.err
+  ): IO[ExitCode] =
+    Check.readSource(specFile, log).flatMap:
+      case Left(code) => IO.pure(code)
+      case Right(source) =>
+        Parse.parseSpec(source).flatMap:
+          case Left(VerifyError.Parse(errors)) =>
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitCodes.Violations)
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).flatMap:
+              case Left(buildErr) =>
+                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
+                  .as(ExitCodes.Violations)
+              case Right(ir) => runVerifyWithIR(specFile, ir, opts, log, out, err)
+
+  private def runVerifyWithIR(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: SynthVerifyOptions,
+      log: Logger,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[ExitCode] =
+    val classifications = Classify.classifyOperations(ir)
+    classifications.find(_.operationName == opts.operation) match
+      case None =>
+        IO.delay(log.error(s"$specFile: operation '${opts.operation}' not found"))
+          .as(ExitCodes.Violations)
+      case Some(c) if c.strategy == SynthesisStrategy.DirectEmit =>
+        IO.delay(
+          log.error(
+            s"$specFile: operation '${opts.operation}' is classified DIRECT_EMIT; " +
+              "no LLM synthesis required"
+          )
+        ).as(ExitCodes.Violations)
+      case Some(c) =>
+        DafnyGenerator.generate(ir) match
+          case Left(dErr) =>
+            IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
+              .as(ExitCodes.Translator)
+          case Right(dafny) =>
+            dafny.methods.find(_.name == c.operationName) match
+              case None =>
+                IO.delay(log.error(s"$specFile: no Dafny header for '${c.operationName}'"))
+                  .as(ExitCodes.Translator)
+              case Some(header) =>
+                executeCegis(specFile, c, header, dafny.text, opts, log, out, err)
+
+  private def executeCegis(
+      specFile: String,
+      c: OperationClassification,
+      header: DafnyMethodHeader,
+      skeleton: String,
+      opts: SynthVerifyOptions,
+      log: Logger,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[ExitCode] =
+    DafnyCli.resolveBinary(opts.dafnyBin).flatMap:
+      case Left(msg) =>
+        IO.delay(log.error(s"$specFile: $msg")).as(ExitCodes.Backend)
+      case Right(binary) =>
+        val req = SynthRequest(c, header, skeleton, opts.model, opts.temperature, opts.maxTokens)
+        val budget = CegisBudget.Default.copy(
+          maxIterations = opts.maxIter,
+          maxCostUsd = opts.maxCostUsd
+        )
+        val resources =
+          for
+            provider <- providerResource(opts.model)
+            cache    <- Resource.eval(verifiedCacheResource(opts))
+            verifier <- DafnyCli.make(binary)
+          yield (provider, cache, verifier)
+        resources.use: (provider, cache, verifier) =>
+          Tracker.empty.flatMap: tracker =>
+            val loop =
+              new CegisLoop(provider, verifier, cache, tracker, budget, opts.dafnyTimeoutSec)
+            loop.run(req).flatMap: outcome =>
+              emitOutcome(outcome, c.operationName, out, err) *> tracker.summary.flatMap: s =>
+                emitSummary(s, err).as(ExitCodes.forCegisOutcome(outcome))
+
+  private def verifiedCacheResource(opts: SynthVerifyOptions): IO[Option[Cache]] =
+    if opts.noCache then IO.pure(None)
+    else
+      val baseRoot = opts.cacheDir match
+        case Some(p) => Paths.get(p)
+        case None    => Cache.defaultRoot(Paths.get(""))
+      Cache.make(baseRoot.resolve("verified")).map(Some(_))
+
+  private def emitOutcome(
+      outcome: CegisOutcome,
+      opName: String,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[Unit] =
+    IO.blocking {
+      outcome match
+        case v: CegisOutcome.Verified =>
+          out.println(v.body)
+          err.println(
+            s"[synth-verify] op=$opName VERIFIED iter=${v.iterations} " +
+              s"records=${v.history.records.length}"
+          )
+        case CegisOutcome.Aborted(reason, lastBody, history) =>
+          err.println(
+            s"[synth-verify] op=$opName ABORTED iter=${history.records.length}: ${reason.message}"
+          )
+          lastBody.foreach: body =>
+            err.println("[synth-verify] last candidate body:")
+            err.println(body)
+    }
+
+  private def emitSummary(
+      s: specrest.synth.CostSummary,
+      err: PrintStream
+  ): IO[Unit] =
+    IO.blocking {
+      err.println(
+        f"[synth-verify] tokens in=${s.inputTokens}tok out=${s.outputTokens}tok " +
+          f"cost=$$${s.totalUsd}%.4f calls=${s.operations} cachedHits=${s.cachedHits}"
       )
     }

--- a/modules/synth/src/main/scala/specrest/synth/CegisBudget.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisBudget.scala
@@ -1,0 +1,43 @@
+package specrest.synth
+
+final case class CegisBudget(
+    maxIterations: Int = 8,
+    maxInputTokens: Long = 100_000L,
+    maxOutputTokens: Long = 50_000L,
+    maxCostUsd: Double = 1.00,
+    repeatedErrorThreshold: Int = 3
+) derives CanEqual
+
+object CegisBudget:
+  val Default: CegisBudget = CegisBudget()
+
+enum BudgetKind derives CanEqual:
+  case MaxIterations, InputTokens, OutputTokens, Cost
+
+sealed trait AbortReason derives CanEqual:
+  def message: String
+
+object AbortReason:
+
+  final case class BudgetExhausted(kind: BudgetKind) extends AbortReason:
+    def message: String = s"budget exhausted: $kind"
+
+  final case class StuckOnSameError(error: VerifierError, repeats: Int) extends AbortReason:
+    def message: String =
+      s"verifier reported the same ${error.category} error ${repeats}× in a row at line ${error.line.getOrElse(0)}"
+
+  final case class ProviderFailed(error: ProviderError, atIteration: Int) extends AbortReason:
+    def message: String = s"provider error at iteration $atIteration: ${error.message}"
+
+  final case class ResponseUnparseable(error: ParseError, atIteration: Int) extends AbortReason:
+    def message: String = s"unparseable LLM response at iteration $atIteration: ${error.message}"
+
+  final case class DiffViolation(error: specrest.synth.DiffViolation, atIteration: Int)
+      extends AbortReason:
+    def message: String = s"diff-check rejected at iteration $atIteration: ${error.message}"
+
+  final case class VerifierBackendFailure(message0: String, atIteration: Int) extends AbortReason:
+    def message: String = s"dafny backend failure at iteration $atIteration: $message0"
+
+  final case class SpliceFailed(message0: String, atIteration: Int) extends AbortReason:
+    def message: String = s"failed to splice body at iteration $atIteration: $message0"

--- a/modules/synth/src/main/scala/specrest/synth/CegisBudget.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisBudget.scala
@@ -24,7 +24,8 @@ object AbortReason:
 
   final case class StuckOnSameError(error: VerifierError, repeats: Int) extends AbortReason:
     def message: String =
-      s"verifier reported the same ${error.category} error ${repeats}× in a row at line ${error.line.getOrElse(0)}"
+      val where = error.line.fold("unknown line")(l => s"line $l")
+      s"verifier reported the same ${error.category} error ${repeats}× in a row at $where"
 
   final case class ProviderFailed(error: ProviderError, atIteration: Int) extends AbortReason:
     def message: String = s"provider error at iteration $atIteration: ${error.message}"

--- a/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
@@ -56,7 +56,12 @@ final class CegisLoop(
 
   private def onCacheHit(req: SynthRequest, entry: CacheEntry): IO[CegisOutcome] =
     val cost = Pricing.costOrZero(entry.usage, entry.model)
-    val rec  = IterationRecord(0, entry.body, entry.candidate, Nil, entry.usage, cost)
+    val fullDfy =
+      FileAssembly
+        .splice(req.skeleton, req.classification.operationName, entry.body)
+        .toOption
+        .getOrElse(entry.candidate)
+    val rec = IterationRecord(0, entry.body, fullDfy, Nil, entry.usage, cost)
     val call = CallRecord(
       req.classification.operationName,
       entry.model,
@@ -69,7 +74,7 @@ final class CegisLoop(
       .as(
         CegisOutcome.Verified(
           body = entry.body,
-          fullCandidate = entry.candidate,
+          fullCandidate = fullDfy,
           iterations = 0,
           history = CegisHistory(List(rec))
         )

--- a/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
@@ -1,0 +1,212 @@
+package specrest.synth
+
+import cats.effect.IO
+
+final case class IterationRecord(
+    iteration: Int,
+    body: String,
+    fullCandidate: String,
+    errors: List[VerifierError],
+    usage: TokenUsage,
+    costUsd: Double
+) derives CanEqual
+
+final case class CegisHistory(records: List[IterationRecord]) derives CanEqual:
+  def add(r: IterationRecord): CegisHistory = CegisHistory(records :+ r)
+  def lastBody: Option[String]              = records.lastOption.map(_.body)
+
+object CegisHistory:
+  val empty: CegisHistory = CegisHistory(Nil)
+
+sealed trait CegisOutcome derives CanEqual
+
+object CegisOutcome:
+  final case class Verified(
+      body: String,
+      fullCandidate: String,
+      iterations: Int,
+      history: CegisHistory
+  ) extends CegisOutcome
+
+  final case class Aborted(
+      reason: AbortReason,
+      lastBody: Option[String],
+      history: CegisHistory
+  ) extends CegisOutcome
+
+final class CegisLoop(
+    provider: LlmProvider,
+    verifier: DafnyVerifier,
+    cache: Option[Cache],
+    tracker: Tracker,
+    budget: CegisBudget,
+    dafnyTimeoutSec: Int = 60
+):
+
+  def run(req: SynthRequest): IO[CegisOutcome] =
+    val key = Cache.keyFor(req.header, req.model, req.temperature)
+    cacheLookup(key).flatMap:
+      case Some(entry) => onCacheHit(req, entry)
+      case None        => iterate(req, key, 1, CegisHistory.empty, None)
+
+  private def cacheLookup(key: CacheKey): IO[Option[CacheEntry]] =
+    cache match
+      case Some(c) => c.lookup(key)
+      case None    => IO.pure(None)
+
+  private def onCacheHit(req: SynthRequest, entry: CacheEntry): IO[CegisOutcome] =
+    val cost = Pricing.costOrZero(entry.usage, entry.model)
+    val rec  = IterationRecord(0, entry.body, entry.candidate, Nil, entry.usage, cost)
+    val call = CallRecord(
+      req.classification.operationName,
+      entry.model,
+      entry.usage,
+      cost,
+      cached = true
+    )
+    tracker
+      .record(call)
+      .as(
+        CegisOutcome.Verified(
+          body = entry.body,
+          fullCandidate = entry.candidate,
+          iterations = 0,
+          history = CegisHistory(List(rec))
+        )
+      )
+
+  private def iterate(
+      req: SynthRequest,
+      key: CacheKey,
+      i: Int,
+      history: CegisHistory,
+      prevError: Option[VerifierError]
+  ): IO[CegisOutcome] =
+    budgetCheck(history, i) match
+      case Some(reason) => IO.pure(CegisOutcome.Aborted(reason, history.lastBody, history))
+      case None =>
+        val prompt = i match
+          case 1 =>
+            PromptBuilder.initial(req.classification, req.header, req.skeleton)
+          case _ =>
+            (history.lastBody, prevError) match
+              case (Some(prev), Some(err)) =>
+                PromptBuilder.repair(req.classification, req.header, req.skeleton, prev, err)
+              case _ =>
+                PromptBuilder.initial(req.classification, req.header, req.skeleton)
+        val llmReq = LlmRequest(
+          system = prompt.system,
+          userMessage = prompt.user,
+          model = req.model,
+          maxTokens = req.maxTokens,
+          temperature = req.temperature
+        )
+        provider.complete(llmReq).flatMap:
+          case Left(err)   => abort(AbortReason.ProviderFailed(err, i), history)
+          case Right(resp) => afterLlm(req, key, i, history, resp)
+
+  private def afterLlm(
+      req: SynthRequest,
+      key: CacheKey,
+      i: Int,
+      history: CegisHistory,
+      resp: LlmResponse
+  ): IO[CegisOutcome] =
+    val cost     = Pricing.costOrZero(resp.usage, resp.model)
+    val opName   = req.classification.operationName
+    val callRec  = CallRecord(opName, resp.model, resp.usage, cost, cached = false)
+    val recorded = tracker.record(callRec)
+    val parsed =
+      for
+        block <- ResponseParser.extractCodeBlock(resp.text)
+        body  <- ResponseParser.extractMethodBody(block, opName)
+      yield (block, body)
+    parsed match
+      case Left(perr) =>
+        recorded *> abort(AbortReason.ResponseUnparseable(perr, i), history)
+      case Right((block, body)) =>
+        DiffChecker.check(req.header, block) match
+          case Left(diff) =>
+            recorded *> abort(AbortReason.DiffViolation(diff, i), history)
+          case Right(()) =>
+            recorded *> verifyAndContinue(req, key, i, history, resp, block, body, cost)
+
+  private def verifyAndContinue(
+      req: SynthRequest,
+      key: CacheKey,
+      i: Int,
+      history: CegisHistory,
+      resp: LlmResponse,
+      block: String,
+      body: String,
+      cost: Double
+  ): IO[CegisOutcome] =
+    FileAssembly.splice(req.skeleton, req.classification.operationName, body) match
+      case Left(failure) =>
+        abort(AbortReason.SpliceFailed(failure.message, i), history)
+      case Right(fullDfy) =>
+        verifier.verify(fullDfy, dafnyTimeoutSec).flatMap:
+          case Left(backendErr) =>
+            abort(AbortReason.VerifierBackendFailure(backendErr, i), history)
+          case Right(run) =>
+            val errors      = run.errorsFor(req.classification.operationName)
+            val record      = IterationRecord(i, body, fullDfy, errors, resp.usage, cost)
+            val nextHistory = history.add(record)
+            if run.verifiedFor(req.classification.operationName) then
+              cacheStore(key, block, body, resp).as(
+                CegisOutcome.Verified(body, fullDfy, i, nextHistory): CegisOutcome
+              )
+            else
+              repeatedErrorCheck(nextHistory, errors) match
+                case Some(reason) =>
+                  IO.pure(CegisOutcome.Aborted(reason, Some(body), nextHistory): CegisOutcome)
+                case None =>
+                  iterate(req, key, i + 1, nextHistory, errors.headOption)
+
+  private def cacheStore(
+      key: CacheKey,
+      block: String,
+      body: String,
+      resp: LlmResponse
+  ): IO[Unit] =
+    cache match
+      case None => IO.unit
+      case Some(c) =>
+        val entry = CacheEntry(block, body, resp.usage, resp.model, SynthPromptVersion)
+        c.store(key, entry).attempt.flatMap:
+          case Right(_) => IO.unit
+          case Left(e) =>
+            IO.consoleForIO.errorln(s"warning: cache write failed: ${e.getMessage}")
+
+  private def abort(reason: AbortReason, history: CegisHistory): IO[CegisOutcome] =
+    IO.pure(CegisOutcome.Aborted(reason, history.lastBody, history))
+
+  private def budgetCheck(history: CegisHistory, nextIteration: Int): Option[AbortReason] =
+    if nextIteration > budget.maxIterations then
+      Some(AbortReason.BudgetExhausted(BudgetKind.MaxIterations))
+    else
+      val totalIn  = history.records.map(_.usage.inputTokens.toLong).sum
+      val totalOut = history.records.map(_.usage.outputTokens.toLong).sum
+      val totalUsd = history.records.map(_.costUsd).sum
+      if totalIn >= budget.maxInputTokens then
+        Some(AbortReason.BudgetExhausted(BudgetKind.InputTokens))
+      else if totalOut >= budget.maxOutputTokens then
+        Some(AbortReason.BudgetExhausted(BudgetKind.OutputTokens))
+      else if totalUsd >= budget.maxCostUsd then
+        Some(AbortReason.BudgetExhausted(BudgetKind.Cost))
+      else None
+
+  private def repeatedErrorCheck(
+      history: CegisHistory,
+      currentErrors: List[VerifierError]
+  ): Option[AbortReason] =
+    currentErrors.headOption.flatMap: head =>
+      val recent = history.records.takeRight(budget.repeatedErrorThreshold)
+      val sameSignature =
+        recent.flatMap(_.errors.headOption).count(e => sameError(e, head))
+      if sameSignature >= budget.repeatedErrorThreshold then
+        Some(AbortReason.StuckOnSameError(head, sameSignature))
+      else None
+
+  private def sameError(a: VerifierError, b: VerifierError): Boolean =
+    a.category == b.category && a.line == b.line

--- a/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
@@ -40,16 +40,31 @@ object DafnyOutputParser:
       val vcOutcome = vcCur.get[String]("outcome").getOrElse(methodOutcome)
       if vcOutcome == "Correct" || vcOutcome == "Valid" then Nil
       else
-        vcCur
+        val all = vcCur
           .downField("assertions")
           .values
           .getOrElse(Iterable.empty)
           .toList
-          .map(a => decodeAssertion(a.hcursor, vcOutcome, sourceLines))
+        val userFacing = all.filter: a =>
+          a.hcursor.get[String]("description").toOption.exists(isUserFacing)
+        val keep = if userFacing.nonEmpty then userFacing else all
+        keep.map(a => decodeAssertion(a.hcursor, vcOutcome, sourceLines))
     if perVc.isEmpty then
       val cat = outcomeCategory(methodOutcome).getOrElse(classify(methodOutcome))
       List(VerifierError(category = cat, message = methodOutcome))
     else perVc
+
+  private def isUserFacing(description: String): Boolean =
+    val d = description.toLowerCase
+    d.contains("postcondition") ||
+    d.contains("precondition") ||
+    d.contains("invariant") ||
+    d.contains("decreases") ||
+    d.contains("loop frame") ||
+    d.contains("assertion") ||
+    d.contains("assert ") ||
+    d.contains("ensures clause") ||
+    d.contains("requires clause")
 
   private def decodeAssertion(
       a: io.circe.HCursor,

--- a/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
@@ -10,13 +10,12 @@ object DafnyOutputParser:
   def parseLog(json: String, source: String): Either[String, List[MethodResult]] =
     circeParse(json).left
       .map(e => s"invalid JSON from dafny --log-format json: ${e.message}")
-      .map: doc =>
+      .flatMap: doc =>
         val sourceLines = source.linesIterator.toList
-        val cur         = doc.hcursor.downField("verificationResults")
-        cur.values
-          .getOrElse(Iterable.empty)
-          .toList
-          .map(j => decodeMethod(j.hcursor, sourceLines))
+        doc.hcursor.downField("verificationResults").values match
+          case None => Left("dafny --log-format json output missing 'verificationResults' field")
+          case Some(values) =>
+            Right(values.toList.map(j => decodeMethod(j.hcursor, sourceLines)))
 
   private def decodeMethod(
       c: io.circe.HCursor,
@@ -60,6 +59,7 @@ object DafnyOutputParser:
     d.contains("precondition") ||
     d.contains("invariant") ||
     d.contains("decreases") ||
+    d.contains("terminate") ||
     d.contains("loop frame") ||
     d.contains("assertion") ||
     d.contains("assert ") ||

--- a/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyOutputParser.scala
@@ -1,0 +1,95 @@
+package specrest.synth
+
+import io.circe.parser.parse as circeParse
+
+object DafnyOutputParser:
+
+  final case class MethodResult(name: String, outcome: String, errors: List[VerifierError])
+      derives CanEqual
+
+  def parseLog(json: String, source: String): Either[String, List[MethodResult]] =
+    circeParse(json).left
+      .map(e => s"invalid JSON from dafny --log-format json: ${e.message}")
+      .map: doc =>
+        val sourceLines = source.linesIterator.toList
+        val cur         = doc.hcursor.downField("verificationResults")
+        cur.values
+          .getOrElse(Iterable.empty)
+          .toList
+          .map(j => decodeMethod(j.hcursor, sourceLines))
+
+  private def decodeMethod(
+      c: io.circe.HCursor,
+      sourceLines: List[String]
+  ): MethodResult =
+    val name    = c.get[String]("name").getOrElse("<unknown>")
+    val outcome = c.get[String]("outcome").getOrElse("Unknown")
+    val errors =
+      if outcome == "Correct" || outcome == "Valid" then Nil
+      else extractErrors(c, outcome, sourceLines)
+    MethodResult(name, outcome, errors)
+
+  private def extractErrors(
+      c: io.circe.HCursor,
+      methodOutcome: String,
+      sourceLines: List[String]
+  ): List[VerifierError] =
+    val vcs = c.downField("vcResults").values.getOrElse(Iterable.empty).toList
+    val perVc = vcs.flatMap: vc =>
+      val vcCur     = vc.hcursor
+      val vcOutcome = vcCur.get[String]("outcome").getOrElse(methodOutcome)
+      if vcOutcome == "Correct" || vcOutcome == "Valid" then Nil
+      else
+        vcCur
+          .downField("assertions")
+          .values
+          .getOrElse(Iterable.empty)
+          .toList
+          .map(a => decodeAssertion(a.hcursor, vcOutcome, sourceLines))
+    if perVc.isEmpty then
+      val cat = outcomeCategory(methodOutcome).getOrElse(classify(methodOutcome))
+      List(VerifierError(category = cat, message = methodOutcome))
+    else perVc
+
+  private def decodeAssertion(
+      a: io.circe.HCursor,
+      vcOutcome: String,
+      sourceLines: List[String]
+  ): VerifierError =
+    val description = a.get[String]("description").getOrElse(vcOutcome)
+    val line        = a.get[Int]("line").toOption
+    val col         = a.get[Int]("col").toOption
+    val category = if vcOutcome == "Valid" || vcOutcome == "Correct" then "unknown"
+    else outcomeCategory(vcOutcome).getOrElse(classify(description))
+    VerifierError(
+      category = category,
+      message = description,
+      line = line,
+      column = col,
+      relatedClause = line.flatMap(l => clauseAt(sourceLines, l))
+    )
+
+  private def outcomeCategory(outcome: String): Option[String] = outcome match
+    case "TimedOut" | "TimeOut"             => Some("timeout")
+    case "OutOfMemory" | "OutOfResource"    => Some("timeout")
+    case "Inconclusive" | "SolverException" => Some("unknown")
+    case _                                  => None
+
+  private def classify(msg: String): String =
+    val m = msg.toLowerCase
+    if m.contains("postcondition") then "postcondition_violation"
+    else if m.contains("precondition") then "precondition_violation"
+    else if m.contains("invariant") && m.contains("entry") then "loop_invariant_not_established"
+    else if m.contains("invariant") then "loop_invariant_failure"
+    else if m.contains("decreases") || m.contains("terminate") then "decreases_failure"
+    else if m.contains("assertion") || m.contains("assert ") then "assertion_failure"
+    else if m.contains("timeout") || m.contains("timed out") then "timeout"
+    else if m.contains("type") then "type_error"
+    else "unknown"
+
+  private def clauseAt(sourceLines: List[String], oneBasedLine: Int): Option[String] =
+    val idx = oneBasedLine - 1
+    if idx < 0 || idx >= sourceLines.length then None
+    else
+      val raw = sourceLines(idx).trim
+      if raw.isEmpty then None else Some(raw.stripSuffix(";"))

--- a/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
@@ -1,0 +1,185 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.kernel.Ref
+import specrest.synth.DafnyOutputParser.MethodResult
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import scala.annotation.tailrec
+
+final case class VerifierRun(
+    methods: List[MethodResult],
+    rawStdout: String,
+    rawStderr: String,
+    exitCode: Int,
+    durationMs: Long
+) derives CanEqual:
+
+  def methodOutcome(name: String): Option[MethodResult] = methods.find(_.name == name)
+
+  def verifiedFor(name: String): Boolean =
+    methodOutcome(name).exists(m => m.outcome == "Correct" || m.outcome == "Valid")
+
+  def errorsFor(name: String): List[VerifierError] =
+    methodOutcome(name).toList.flatMap(_.errors)
+
+trait DafnyVerifier:
+  def verify(source: String, timeoutSec: Int): IO[Either[String, VerifierRun]]
+
+final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifier:
+
+  def verify(source: String, timeoutSec: Int): IO[Either[String, VerifierRun]] =
+    val unique  = java.util.UUID.randomUUID().toString
+    val srcFile = workDir.resolve(s"candidate-$unique.dfy")
+    val logFile = workDir.resolve(s"candidate-$unique.json")
+    val cleanup =
+      IO.blocking(Files.deleteIfExists(srcFile)).attempt.void *>
+        IO.blocking(Files.deleteIfExists(logFile)).attempt.void
+    val program =
+      for
+        _      <- IO.blocking(Files.writeString(srcFile, source, StandardOpenOption.CREATE_NEW))
+        result <- runDafny(srcFile, logFile, source, timeoutSec)
+      yield result
+    program.attempt.flatMap:
+      case Right(r) => IO.pure(r)
+      case Left(t)  => IO.pure(Left(s"failed to invoke dafny: ${t.getMessage}"))
+    .guarantee(cleanup)
+
+  private def runDafny(
+      srcFile: Path,
+      logFile: Path,
+      source: String,
+      timeoutSec: Int
+  ): IO[Either[String, VerifierRun]] =
+    val command = List(
+      binary,
+      "verify",
+      s"--verification-time-limit=$timeoutSec",
+      s"--log-format=json;LogFileName=${logFile.toString}",
+      srcFile.toString
+    )
+    IO.blocking {
+      val started = System.nanoTime()
+      val pb      = new ProcessBuilder(command.toArray*).redirectErrorStream(false)
+      val proc    = pb.start()
+      proc.getOutputStream.close()
+      val stdout = readStream(proc.getInputStream)
+      val stderr = readStream(proc.getErrorStream)
+      val finished =
+        proc.waitFor((timeoutSec.toLong + 5L) * 1000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+      if !finished then
+        proc.destroyForcibly()
+        Left(s"dafny exceeded ${timeoutSec + 5}s wall-clock and was killed")
+      else
+        val exit       = proc.exitValue()
+        val durationMs = (System.nanoTime() - started) / 1_000_000L
+        interpret(logFile, source, stdout, stderr, exit, durationMs)
+    }
+
+  private def interpret(
+      logFile: Path,
+      source: String,
+      stdout: String,
+      stderr: String,
+      exit: Int,
+      durationMs: Long
+  ): Either[String, VerifierRun] =
+    if Files.exists(logFile) then
+      DafnyOutputParser.parseLog(Files.readString(logFile), source) match
+        case Left(msg)      => Left(msg)
+        case Right(methods) => Right(VerifierRun(methods, stdout, stderr, exit, durationMs))
+    else
+      val parseErr = VerifierError(
+        category = "syntax_error",
+        message =
+          if stderr.trim.nonEmpty then stderr.trim
+          else if stdout.trim.nonEmpty then stdout.trim
+          else "dafny did not produce a verification log; likely a parse or resolution error"
+      )
+      val synthetic = MethodResult(name = "<file>", outcome = "Errors", errors = List(parseErr))
+      Right(VerifierRun(List(synthetic), stdout, stderr, exit, durationMs))
+
+  private def readStream(in: java.io.InputStream): String =
+    val buf = new java.io.ByteArrayOutputStream()
+    val tmp = new Array[Byte](4096)
+    @tailrec def loop(): Unit =
+      val n = in.read(tmp)
+      if n >= 0 then
+        buf.write(tmp, 0, n)
+        loop()
+    loop()
+    buf.toString("UTF-8")
+
+object DafnyCli:
+
+  def resolveBinary(explicit: Option[String]): IO[Either[String, String]] =
+    val candidate = explicit.orElse(sys.env.get("DAFNY_BIN")).getOrElse("dafny")
+    IO.blocking {
+      val pb = new ProcessBuilder(candidate, "--version").redirectErrorStream(true)
+      try
+        val proc = pb.start()
+        proc.getOutputStream.close()
+        val _  = proc.getInputStream.readAllBytes()
+        val ok = proc.waitFor(10L, java.util.concurrent.TimeUnit.SECONDS)
+        if !ok then
+          proc.destroyForcibly()
+          Left(s"`$candidate --version` did not return within 10s")
+        else if proc.exitValue() == 0 then Right(candidate)
+        else Left(s"`$candidate --version` failed with exit ${proc.exitValue()}")
+      catch
+        case _: java.io.IOException => Left(s"dafny binary '$candidate' not found on PATH")
+    }
+
+  def make(binary: String): Resource[IO, DafnyVerifier] =
+    Resource
+      .make(IO.blocking(Files.createTempDirectory("specrest-dafny-")))(dir =>
+        IO.blocking(deleteRecursively(dir)).attempt.void
+      )
+      .map(dir => new DafnyCli(binary, dir))
+
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      val stream = Files.walk(dir)
+      try
+        val it = stream.sorted(java.util.Comparator.reverseOrder()).iterator()
+        while it.hasNext do
+          val _ = Files.deleteIfExists(it.next())
+      finally stream.close()
+
+final class MockDafnyVerifier private (
+    plan: List[Either[String, VerifierRun]],
+    cursor: Ref[IO, Int],
+    callsRef: Ref[IO, List[String]]
+) extends DafnyVerifier:
+
+  def verify(
+      source: String,
+      @scala.annotation.unused timeoutSec: Int
+  ): IO[Either[String, VerifierRun]] =
+    for
+      _ <- callsRef.update(source :: _)
+      i <- cursor.getAndUpdate(_ + 1)
+    yield
+      if i >= plan.length then Left(s"MockDafnyVerifier exhausted after $i calls")
+      else plan(i)
+
+  def calls: IO[List[String]] = callsRef.get.map(_.reverse)
+
+object MockDafnyVerifier:
+  def of(plan: List[Either[String, VerifierRun]]): IO[MockDafnyVerifier] =
+    for
+      cur <- Ref.of[IO, Int](0)
+      log <- Ref.of[IO, List[String]](Nil)
+    yield new MockDafnyVerifier(plan, cur, log)
+
+  def run(methods: List[MethodResult], durationMs: Long = 100L): VerifierRun =
+    VerifierRun(methods, rawStdout = "", rawStderr = "", exitCode = 0, durationMs = durationMs)
+
+  def correct(name: String): MethodResult =
+    MethodResult(name, "Correct", Nil)
+
+  def errors(name: String, errs: List[VerifierError]): MethodResult =
+    MethodResult(name, "Errors", errs)

--- a/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
@@ -8,7 +8,6 @@ import specrest.synth.DafnyOutputParser.MethodResult
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
-import scala.annotation.tailrec
 
 final case class VerifierRun(
     methods: List[MethodResult],
@@ -37,13 +36,17 @@ final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifi
     val unique  = java.util.UUID.randomUUID().toString
     val srcFile = workDir.resolve(s"candidate-$unique.dfy")
     val logFile = workDir.resolve(s"candidate-$unique.json")
+    val outFile = workDir.resolve(s"candidate-$unique.out")
+    val errFile = workDir.resolve(s"candidate-$unique.err")
     val cleanup =
       IO.blocking(Files.deleteIfExists(srcFile)).attempt.void *>
-        IO.blocking(Files.deleteIfExists(logFile)).attempt.void
+        IO.blocking(Files.deleteIfExists(logFile)).attempt.void *>
+        IO.blocking(Files.deleteIfExists(outFile)).attempt.void *>
+        IO.blocking(Files.deleteIfExists(errFile)).attempt.void
     val program =
       for
         _      <- IO.blocking(Files.writeString(srcFile, source, StandardOpenOption.CREATE_NEW))
-        result <- runDafny(srcFile, logFile, source, timeoutSec)
+        result <- runDafny(srcFile, logFile, outFile, errFile, source, timeoutSec)
       yield result
     program.attempt.flatMap:
       case Right(r) => IO.pure(r)
@@ -53,6 +56,8 @@ final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifi
   private def runDafny(
       srcFile: Path,
       logFile: Path,
+      outFile: Path,
+      errFile: Path,
       source: String,
       timeoutSec: Int
   ): IO[Either[String, VerifierRun]] =
@@ -65,11 +70,11 @@ final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifi
     )
     IO.blocking {
       val started = System.nanoTime()
-      val pb      = new ProcessBuilder(command.toArray*).redirectErrorStream(false)
-      val proc    = pb.start()
+      val pb = new ProcessBuilder(command.toArray*)
+        .redirectOutput(outFile.toFile)
+        .redirectError(errFile.toFile)
+      val proc = pb.start()
       proc.getOutputStream.close()
-      val stdout = readStream(proc.getInputStream)
-      val stderr = readStream(proc.getErrorStream)
       val finished =
         proc.waitFor((timeoutSec.toLong + 5L) * 1000L, java.util.concurrent.TimeUnit.MILLISECONDS)
       if !finished then
@@ -78,8 +83,13 @@ final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifi
       else
         val exit       = proc.exitValue()
         val durationMs = (System.nanoTime() - started) / 1_000_000L
+        val stdout     = readIfExists(outFile)
+        val stderr     = readIfExists(errFile)
         interpret(logFile, source, stdout, stderr, exit, durationMs)
     }
+
+  private def readIfExists(p: Path): String =
+    if Files.exists(p) then Files.readString(p) else ""
 
   private def interpret(
       logFile: Path,
@@ -104,27 +114,17 @@ final class DafnyCli private (binary: String, workDir: Path) extends DafnyVerifi
       val synthetic = MethodResult(name = "<file>", outcome = "Errors", errors = List(parseErr))
       Right(VerifierRun(List(synthetic), stdout, stderr, exit, durationMs))
 
-  private def readStream(in: java.io.InputStream): String =
-    val buf = new java.io.ByteArrayOutputStream()
-    val tmp = new Array[Byte](4096)
-    @tailrec def loop(): Unit =
-      val n = in.read(tmp)
-      if n >= 0 then
-        buf.write(tmp, 0, n)
-        loop()
-    loop()
-    buf.toString("UTF-8")
-
 object DafnyCli:
 
   def resolveBinary(explicit: Option[String]): IO[Either[String, String]] =
     val candidate = explicit.orElse(sys.env.get("DAFNY_BIN")).getOrElse("dafny")
     IO.blocking {
-      val pb = new ProcessBuilder(candidate, "--version").redirectErrorStream(true)
+      val pb = new ProcessBuilder(candidate, "--version")
+        .redirectErrorStream(true)
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
       try
         val proc = pb.start()
         proc.getOutputStream.close()
-        val _  = proc.getInputStream.readAllBytes()
         val ok = proc.waitFor(10L, java.util.concurrent.TimeUnit.SECONDS)
         if !ok then
           proc.destroyForcibly()

--- a/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyVerifier.scala
@@ -18,13 +18,15 @@ final case class VerifierRun(
     durationMs: Long
 ) derives CanEqual:
 
-  def methodOutcome(name: String): Option[MethodResult] = methods.find(_.name == name)
+  def scopesFor(name: String): List[MethodResult] =
+    methods.filter(m => m.name == name || m.name.startsWith(s"$name ("))
 
   def verifiedFor(name: String): Boolean =
-    methodOutcome(name).exists(m => m.outcome == "Correct" || m.outcome == "Valid")
+    val scopes = scopesFor(name)
+    scopes.nonEmpty && scopes.forall(m => m.outcome == "Correct" || m.outcome == "Valid")
 
   def errorsFor(name: String): List[VerifierError] =
-    methodOutcome(name).toList.flatMap(_.errors)
+    scopesFor(name).flatMap(_.errors)
 
 trait DafnyVerifier:
   def verify(source: String, timeoutSec: Int): IO[Either[String, VerifierRun]]

--- a/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DiffChecker.scala
@@ -4,7 +4,7 @@ import specrest.convention.dafny.DafnyMethodHeader
 
 import scala.annotation.tailrec
 
-final case class DiffViolation(message: String, diff: String)
+final case class DiffViolation(message: String, diff: String) derives CanEqual
 
 object DiffChecker:
 

--- a/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
@@ -18,16 +18,21 @@ object FileAssembly:
       case None =>
         Left(SpliceFailure(s"method '$methodName' not found in skeleton"))
       case Some(m) =>
+        val nextMethodAt = NextMethodAnchor.findFirstMatchIn(skeleton.substring(m.end)) match
+          case Some(nm) => m.end + nm.start
+          case None     => skeleton.length
         val placeholderAt = skeleton.indexOf(Placeholder, m.end)
-        if placeholderAt < 0 then
-          Left(SpliceFailure(s"placeholder not found after method '$methodName'"))
+        if placeholderAt < 0 || placeholderAt >= nextMethodAt then
+          Left(SpliceFailure(s"placeholder not found within method '$methodName'"))
         else
           val before = skeleton.substring(0, placeholderAt)
           val after  = skeleton.substring(placeholderAt + Placeholder.length)
-          val indented = body.linesIterator.map(line =>
-            if line.isEmpty then line else s"  $line"
-          ).mkString("\n")
+          val indented = body.linesIterator
+            .map(line => if line.isEmpty then line else s"  $line")
+            .mkString("\n")
           Right(before + indented + (if indented.endsWith("\n") then "" else "\n") + after)
 
   private def methodAnchor(name: String): Regex =
     s"""\\bmethod\\s+${Regex.quote(name)}(?=[\\s(<])""".r
+
+  private val NextMethodAnchor: Regex = """\bmethod\s+\w""".r

--- a/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
@@ -1,0 +1,33 @@
+package specrest.synth
+
+import scala.util.matching.Regex
+
+object FileAssembly:
+
+  val Placeholder: String = "  // YOUR CODE HERE\n"
+
+  final case class SpliceFailure(message: String) derives CanEqual
+
+  def splice(
+      skeleton: String,
+      methodName: String,
+      body: String
+  ): Either[SpliceFailure, String] =
+    val anchor = methodAnchor(methodName)
+    anchor.findFirstMatchIn(skeleton) match
+      case None =>
+        Left(SpliceFailure(s"method '$methodName' not found in skeleton"))
+      case Some(m) =>
+        val placeholderAt = skeleton.indexOf(Placeholder, m.end)
+        if placeholderAt < 0 then
+          Left(SpliceFailure(s"placeholder not found after method '$methodName'"))
+        else
+          val before = skeleton.substring(0, placeholderAt)
+          val after  = skeleton.substring(placeholderAt + Placeholder.length)
+          val indented = body.linesIterator.map(line =>
+            if line.isEmpty then line else s"  $line"
+          ).mkString("\n")
+          Right(before + indented + (if indented.endsWith("\n") then "" else "\n") + after)
+
+  private def methodAnchor(name: String): Regex =
+    s"""\\bmethod\\s+${Regex.quote(name)}(?=[\\s(<])""".r

--- a/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
@@ -2,7 +2,7 @@ package specrest.synth
 
 import scala.annotation.tailrec
 
-final case class ParseError(message: String)
+final case class ParseError(message: String) derives CanEqual
 
 object ResponseParser:
 

--- a/modules/synth/src/main/scala/specrest/synth/VerifierError.scala
+++ b/modules/synth/src/main/scala/specrest/synth/VerifierError.scala
@@ -4,6 +4,7 @@ final case class VerifierError(
     category: String,
     message: String,
     line: Option[Int] = None,
+    column: Option[Int] = None,
     relatedClause: Option[String] = None,
     counterexample: Option[String] = None
-)
+) derives CanEqual

--- a/modules/synth/src/test/scala/specrest/synth/CegisLoopTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/CegisLoopTest.scala
@@ -1,0 +1,278 @@
+package specrest.synth
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class CegisLoopTest extends CatsEffectSuite:
+
+  private val validBody =
+    """```dafny
+      |method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count + 1;
+      |}
+      |```""".stripMargin
+
+  private val brokenBody =
+    """```dafny
+      |method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count;
+      |}
+      |```""".stripMargin
+
+  private def llmResp(text: String, in: Int = 100, out: Int = 200): LlmResponse =
+    LlmResponse(text, TokenUsage(in, out), "claude-sonnet-4-6")
+
+  private val postcondError =
+    VerifierError(
+      category = "postcondition_violation",
+      message = "a postcondition could not be proved",
+      line = Some(7),
+      column = Some(10)
+    )
+
+  private def failingRun(opName: String, errs: List[VerifierError]): VerifierRun =
+    MockDafnyVerifier.run(List(MockDafnyVerifier.errors(opName, errs)))
+
+  private val correctRun: String => VerifierRun =
+    name => MockDafnyVerifier.run(List(MockDafnyVerifier.correct(name)))
+
+  test("verifies on first try"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider  <- MockProvider.succeeding(validBody, model = "claude-sonnet-4-6")
+          verifier  <- MockDafnyVerifier.of(List(Right(correctRun(c.operationName))))
+          tracker   <- Tracker.empty
+          loop       = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          out       <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          provCalls <- provider.calls
+          verCalls  <- verifier.calls
+        yield out match
+          case CegisOutcome.Verified(body, _, iter, _) =>
+            assertEquals(iter, 1)
+            assert(body.contains("st.count := st.count + 1"))
+            assertEquals(provCalls.length, 1)
+            assertEquals(verCalls.length, 1)
+          case other => fail(s"expected Verified, got $other")
+
+  test("verifies after 2 repair iterations (3-iteration AC for URL shortener Shorten)"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(
+                          Right(llmResp(brokenBody)),
+                          Right(llmResp(brokenBody)),
+                          Right(llmResp(validBody))
+                        )
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName, List(postcondError))),
+                          Right(failingRun(
+                            c.operationName,
+                            List(postcondError.copy(line = Some(8)))
+                          )),
+                          Right(correctRun(c.operationName))
+                        )
+                      )
+          tracker   <- Tracker.empty
+          loop       = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          out       <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          provCalls <- provider.calls
+        yield out match
+          case CegisOutcome.Verified(_, _, iter, history) =>
+            assertEquals(iter, 3)
+            assertEquals(provCalls.length, 3)
+            assertEquals(history.records.length, 3)
+            val secondPrompt = provCalls(1).userMessage
+            assert(secondPrompt.contains("FAILED"), "repair prompt marks previous as FAILED")
+            assert(
+              secondPrompt.contains("postcondition_violation"),
+              "repair prompt embeds error category"
+            )
+            assert(
+              secondPrompt.contains("st.count := st.count"),
+              "repair prompt embeds previous body verbatim"
+            )
+          case other => fail(s"expected Verified, got $other")
+
+  test("aborts when iteration budget is exhausted"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(Right(llmResp(brokenBody)), Right(llmResp(brokenBody)))
+                      )
+          verifier <-
+            MockDafnyVerifier.of(
+              List(
+                Right(failingRun(c.operationName, List(postcondError))),
+                Right(failingRun(c.operationName, List(postcondError.copy(line = Some(99)))))
+              )
+            )
+          tracker <- Tracker.empty
+          loop = new CegisLoop(
+                   provider,
+                   verifier,
+                   None,
+                   tracker,
+                   CegisBudget.Default.copy(maxIterations = 2, repeatedErrorThreshold = 99)
+                 )
+          out <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.BudgetExhausted(BudgetKind.MaxIterations), _, h2) =>
+            assertEquals(h2.records.length, 2)
+          case other => fail(s"expected BudgetExhausted, got $other")
+
+  test("aborts on repeated identical errors (stuck detector)"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(List.fill(8)(Right(llmResp(brokenBody))))
+          verifier <- MockDafnyVerifier.of(
+                        List.fill(8)(Right(failingRun(c.operationName, List(postcondError))))
+                      )
+          tracker <- Tracker.empty
+          loop = new CegisLoop(
+                   provider,
+                   verifier,
+                   None,
+                   tracker,
+                   CegisBudget.Default.copy(repeatedErrorThreshold = 3)
+                 )
+          out <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.StuckOnSameError(err, n), _, _) =>
+            assertEquals(err.category, "postcondition_violation")
+            assertEquals(n, 3)
+          case other => fail(s"expected StuckOnSameError, got $other")
+
+  test("aborts when provider fails mid-loop"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(
+                          Right(llmResp(brokenBody)),
+                          Left(ProviderError("connection reset"))
+                        )
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(Right(failingRun(c.operationName, List(postcondError))))
+                      )
+          tracker <- Tracker.empty
+          loop     = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          out     <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.ProviderFailed(perr, atIter), _, _) =>
+            assertEquals(atIter, 2)
+            assert(perr.message.contains("connection reset"))
+          case other => fail(s"expected ProviderFailed, got $other")
+
+  test("aborts when LLM body weakens contracts (DiffViolation)"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        val weakened =
+          """```dafny
+            |method Increment(st: ServiceState)
+            |  requires ServiceStateInv(st)
+            |  ensures st.count >= old(st.count)
+            |  ensures ServiceStateInv(st)
+            |  modifies st
+            |{
+            |  st.count := st.count + 1;
+            |}
+            |```""".stripMargin
+        for
+          provider <- MockProvider.succeeding(weakened, model = "claude-sonnet-4-6")
+          verifier <- MockDafnyVerifier.of(List(Right(correctRun(c.operationName))))
+          tracker  <- Tracker.empty
+          loop      = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          out      <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.DiffViolation(_, atIter), _, _) =>
+            assertEquals(atIter, 1)
+          case other => fail(s"expected DiffViolation, got $other")
+
+  test("verifier backend failure (e.g. dafny crash) propagates as VerifierBackendFailure"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.succeeding(validBody, model = "claude-sonnet-4-6")
+          verifier <- MockDafnyVerifier.of(List(Left("dafny: segfault")))
+          tracker  <- Tracker.empty
+          loop      = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          out      <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.VerifierBackendFailure(msg, atIter), _, _) =>
+            assertEquals(atIter, 1)
+            assert(msg.contains("segfault"))
+          case other => fail(s"expected VerifierBackendFailure, got $other")
+
+  test("cache hit short-circuits the loop"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        val tmp = java.nio.file.Files.createTempDirectory("cegis-cache-hit")
+        for
+          provider  <- MockProvider.succeeding(validBody, model = "claude-sonnet-4-6")
+          verifier  <- MockDafnyVerifier.of(List(Right(correctRun(c.operationName))))
+          tracker   <- Tracker.empty
+          cache     <- Cache.make(tmp)
+          loop       = new CegisLoop(provider, verifier, Some(cache), tracker, CegisBudget.Default)
+          first     <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          second    <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          provCalls <- provider.calls
+          verCalls  <- verifier.calls
+        yield
+          first match
+            case _: CegisOutcome.Verified => ()
+            case other                    => fail(s"first run expected Verified, got $other")
+          second match
+            case CegisOutcome.Verified(_, _, iter, _) =>
+              assertEquals(iter, 0, "cache hit reports 0 iterations")
+              assertEquals(provCalls.length, 1, "second run did not call provider")
+              assertEquals(verCalls.length, 1, "second run did not call verifier")
+            case other => fail(s"second run expected Verified, got $other")
+        end for
+    .void
+      *> IO.unit
+
+  test("aborts on cost cap"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List.fill(5)(Right(llmResp(brokenBody, in = 1_000_000, out = 1_000_000)))
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List.fill(5)(Right(failingRun(c.operationName, List(postcondError))))
+                      )
+          tracker <- Tracker.empty
+          loop = new CegisLoop(
+                   provider,
+                   verifier,
+                   None,
+                   tracker,
+                   CegisBudget.Default.copy(maxCostUsd = 0.001, repeatedErrorThreshold = 99)
+                 )
+          out <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case CegisOutcome.Aborted(AbortReason.BudgetExhausted(kind), _, _) =>
+            assert(
+              kind == BudgetKind.Cost
+                || kind == BudgetKind.InputTokens
+                || kind == BudgetKind.OutputTokens,
+              s"expected a token/cost cap, got $kind"
+            )
+          case other => fail(s"expected BudgetExhausted, got $other")

--- a/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
@@ -1,8 +1,8 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 
-class DafnyOutputParserTest extends FunSuite:
+class DafnyOutputParserTest extends CatsEffectSuite:
 
   private val source =
     """method Increment(st: ServiceState)
@@ -84,6 +84,26 @@ class DafnyOutputParserTest extends FunSuite:
   test("invalid JSON returns Left"):
     val r = DafnyOutputParser.parseLog("not json at all", source)
     assert(r.isLeft)
+
+  test("JSON without 'verificationResults' returns Left"):
+    val r = DafnyOutputParser.parseLog("""{"someOtherField":[]}""", source)
+    assert(r.isLeft)
+    assert(r.swap.toOption.exists(_.contains("verificationResults")))
+
+  test("termination/decreases failures are kept as user-facing (not filtered as noise)"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "Loopy", "outcome": "Errors", "vcResults": [
+        |    { "outcome": "Invalid", "assertions": [
+        |      { "filename": "f.dfy", "line": 1, "col": 1, "description": "target object is never null" },
+        |      { "filename": "f.dfy", "line": 5, "col": 5, "description": "expression must terminate" }
+        |    ]}
+        |  ]}
+        |]}""".stripMargin
+    val r    = DafnyOutputParser.parseLog(json, "method Loopy() {}").getOrElse(fail(""))
+    val errs = r.head.errors
+    assertEquals(errs.length, 1, "noise filtered, terminate kept")
+    assertEquals(errs.head.category, "decreases_failure")
 
   test("multi-method log filterable by name"):
     val json =

--- a/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
@@ -1,0 +1,104 @@
+package specrest.synth
+
+import munit.FunSuite
+
+class DafnyOutputParserTest extends FunSuite:
+
+  private val source =
+    """method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count;
+      |}""".stripMargin
+
+  test("decodes Valid outcome with no errors"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "Increment", "outcome": "Correct", "vcResults": [
+        |    { "vcNum": 1, "outcome": "Valid", "assertions": [] }
+        |  ]}
+        |]}""".stripMargin
+    val r = DafnyOutputParser.parseLog(json, source).getOrElse(fail("should parse"))
+    assertEquals(r.length, 1)
+    assertEquals(r.head.name, "Increment")
+    assertEquals(r.head.outcome, "Correct")
+    assert(r.head.errors.isEmpty)
+
+  test("decodes Invalid outcome with assertion-level errors"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "Increment", "outcome": "Errors", "vcResults": [
+        |    { "vcNum": 1, "outcome": "Invalid", "assertions": [
+        |      { "filename": "candidate.dfy", "line": 3, "col": 10,
+        |        "description": "ensures clause that might not hold (postcondition)" }
+        |    ]}
+        |  ]}
+        |]}""".stripMargin
+    val r = DafnyOutputParser.parseLog(json, source).getOrElse(fail("should parse"))
+    assertEquals(r.length, 1)
+    val errs = r.head.errors
+    assertEquals(errs.length, 1)
+    val e = errs.head
+    assertEquals(e.category, "postcondition_violation")
+    assertEquals(e.line, Some(3))
+    assertEquals(e.column, Some(10))
+    assertEquals(e.relatedClause, Some("ensures st.count == old(st.count) + 1"))
+
+  test("classifies via assertion description"):
+    val descriptions = List(
+      "a precondition for this call could not be proved" -> "precondition_violation",
+      "this loop invariant might not hold on entry"      -> "loop_invariant_not_established",
+      "loop invariant might not be maintained"           -> "loop_invariant_failure",
+      "decreases expression might not decrease"          -> "decreases_failure",
+      "assertion might not hold"                         -> "assertion_failure",
+      "Type mismatch in assignment"                      -> "type_error"
+    )
+    descriptions.foreach: (description, expected) =>
+      val json =
+        s"""{ "verificationResults": [
+           |  { "name": "X", "outcome": "Errors", "vcResults": [
+           |    { "outcome": "Invalid", "assertions": [
+           |      { "filename": "f.dfy", "line": 1, "col": 1, "description": ${quoted(
+            description
+          )} }
+           |    ]}
+           |  ]}
+           |]}""".stripMargin
+      val r = DafnyOutputParser.parseLog(json, "method X() {}").getOrElse(fail(""))
+      assertEquals(r.head.errors.head.category, expected, s"for: $description")
+
+  test("TimedOut method outcome maps to timeout"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "Slow", "outcome": "TimedOut", "vcResults": [
+        |    { "outcome": "TimedOut", "assertions": [] }
+        |  ]}
+        |]}""".stripMargin
+    val r = DafnyOutputParser.parseLog(json, "method Slow() {}").getOrElse(fail(""))
+    val e = r.head.errors.head
+    assertEquals(e.category, "timeout")
+
+  test("invalid JSON returns Left"):
+    val r = DafnyOutputParser.parseLog("not json at all", source)
+    assert(r.isLeft)
+
+  test("multi-method log filterable by name"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "A", "outcome": "Correct", "vcResults": [{ "outcome": "Valid", "assertions": [] }] },
+        |  { "name": "B", "outcome": "Errors", "vcResults": [
+        |    { "outcome": "Invalid", "assertions": [
+        |      { "filename": "f.dfy", "line": 5, "col": 1, "description": "a postcondition could not be proved" }
+        |    ]}
+        |  ]}
+        |]}""".stripMargin
+    val r = DafnyOutputParser.parseLog(json, source).getOrElse(fail(""))
+    assertEquals(r.map(_.name), List("A", "B"))
+    assert(r.find(_.name == "A").exists(_.errors.isEmpty))
+    assert(r.find(_.name == "B").exists(_.errors.nonEmpty))
+
+  private def quoted(s: String): String =
+    "\"" + s.replace("\"", "\\\"") + "\""

--- a/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DafnyOutputParserTest.scala
@@ -100,5 +100,63 @@ class DafnyOutputParserTest extends FunSuite:
     assert(r.find(_.name == "A").exists(_.errors.isEmpty))
     assert(r.find(_.name == "B").exists(_.errors.nonEmpty))
 
+  test("VerifierRun.verifiedFor handles Dafny's '(well-formedness)'/'(correctness)' suffix"):
+    val pass = VerifierRun(
+      methods = List(
+        DafnyOutputParser.MethodResult("Increment (well-formedness)", "Correct", Nil),
+        DafnyOutputParser.MethodResult("Increment (correctness)", "Correct", Nil),
+        DafnyOutputParser.MethodResult("ServiceState.Inv (well-formedness)", "Correct", Nil)
+      ),
+      rawStdout = "",
+      rawStderr = "",
+      exitCode = 0,
+      durationMs = 0L
+    )
+    assert(pass.verifiedFor("Increment"))
+    assertEquals(pass.errorsFor("Increment"), Nil)
+
+    val err = VerifierError(
+      category = "postcondition_violation",
+      message = "this postcondition holds",
+      line = Some(9)
+    )
+    val fail = pass.copy(methods =
+      pass.methods.updated(
+        1,
+        DafnyOutputParser.MethodResult("Increment (correctness)", "Errors", List(err))
+      )
+    )
+    assert(!fail.verifiedFor("Increment"))
+    assertEquals(fail.errorsFor("Increment"), List(err))
+
+  test("real Dafny 4.11 JSON: filters auto-inserted assertions, keeps user-facing failures"):
+    val json =
+      """{ "verificationResults": [
+        |  { "name": "ServiceState.Inv (well-formedness)", "outcome": "Correct", "vcResults": [
+        |    { "vcNum": 1, "outcome": "Valid", "assertions": [
+        |      { "filename": "f.dfy", "line": 3, "col": 32, "description": "sufficient reads clause to read field" }
+        |    ]}
+        |  ]},
+        |  { "name": "Increment (well-formedness)", "outcome": "Correct", "vcResults": [
+        |    { "vcNum": 1, "outcome": "Valid", "assertions": [
+        |      { "filename": "f.dfy", "line": 8, "col": 18, "description": "target object is never null" }
+        |    ]}
+        |  ]},
+        |  { "name": "Increment (correctness)", "outcome": "Errors", "vcResults": [
+        |    { "vcNum": 1, "outcome": "Invalid", "assertions": [
+        |      { "filename": "f.dfy", "line": 12, "col": 6,  "description": "target object is never null" },
+        |      { "filename": "f.dfy", "line": 12, "col": 6,  "description": "an object is in the enclosing context's modifies clause" },
+        |      { "filename": "f.dfy", "line": 9,  "col": 20, "description": "this postcondition holds" },
+        |      { "filename": "f.dfy", "line": 10, "col": 17, "description": "this postcondition holds" }
+        |    ]}
+        |  ]}
+        |]}""".stripMargin
+    val r = DafnyOutputParser.parseLog(json, source).getOrElse(fail("should parse"))
+    assertEquals(r.length, 3)
+    val correctness = r.find(_.name == "Increment (correctness)").getOrElse(fail("missing"))
+    assertEquals(correctness.errors.length, 2, "noise filtered out")
+    assertEquals(correctness.errors.map(_.category).distinct, List("postcondition_violation"))
+    assertEquals(correctness.errors.map(_.line), List(Some(9), Some(10)))
+
   private def quoted(s: String): String =
     "\"" + s.replace("\"", "\\\"") + "\""

--- a/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
@@ -1,8 +1,8 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 
-class FileAssemblyTest extends FunSuite:
+class FileAssemblyTest extends CatsEffectSuite:
 
   private val skeleton =
     """class ServiceState { var count: int }
@@ -42,6 +42,26 @@ class FileAssemblyTest extends FunSuite:
   test("missing method returns SpliceFailure"):
     val r = FileAssembly.splice(skeleton, "Nonexistent", "...")
     assert(r.isLeft)
+
+  test(
+    "if target method has no placeholder, splice fails instead of bleeding into the next method"
+  ):
+    val targetAlreadyFilled =
+      """method Increment(st: ServiceState)
+        |  modifies st
+        |{
+        |  st.count := st.count + 1;
+        |}
+        |
+        |method Reset(st: ServiceState)
+        |  modifies st
+        |{
+        |  // YOUR CODE HERE
+        |}
+        |""".stripMargin
+    val r = FileAssembly.splice(targetAlreadyFilled, "Increment", "INTRUDER_BODY")
+    assert(r.isLeft, "must NOT splice into Reset's placeholder")
+    assert(targetAlreadyFilled.contains("// YOUR CODE HERE"), "Reset placeholder untouched")
 
   test("anchor matches method name with parameters but not method-name prefix"):
     val sk =

--- a/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
@@ -1,0 +1,65 @@
+package specrest.synth
+
+import munit.FunSuite
+
+class FileAssemblyTest extends FunSuite:
+
+  private val skeleton =
+    """class ServiceState { var count: int }
+      |
+      |method Increment(st: ServiceState)
+      |  modifies st
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |{
+      |  // YOUR CODE HERE
+      |}
+      |
+      |method Reset(st: ServiceState)
+      |  modifies st
+      |  ensures st.count == 0
+      |{
+      |  // YOUR CODE HERE
+      |}
+      |""".stripMargin
+
+  test("splices body into named method, leaves siblings untouched"):
+    val r = FileAssembly
+      .splice(skeleton, "Increment", "st.count := st.count + 1;")
+      .getOrElse(fail("splice failed"))
+    assert(r.contains("st.count := st.count + 1;"))
+    assert(r.contains("method Reset"))
+    assert(r.indexOf("// YOUR CODE HERE") >= 0, "Reset's placeholder still present")
+    assertEquals(r.split("// YOUR CODE HERE").length, 2, "exactly one placeholder remains")
+
+  test("body lines are indented two spaces"):
+    val r = FileAssembly
+      .splice(skeleton, "Increment", "var x := 1;\nst.count := st.count + x;")
+      .getOrElse(fail("splice failed"))
+    assert(r.contains("  var x := 1;"))
+    assert(r.contains("  st.count := st.count + x;"))
+
+  test("missing method returns SpliceFailure"):
+    val r = FileAssembly.splice(skeleton, "Nonexistent", "...")
+    assert(r.isLeft)
+
+  test("anchor matches method name with parameters but not method-name prefix"):
+    val sk =
+      """method IncrementBy(st: ServiceState, n: int)
+        |{
+        |  // YOUR CODE HERE
+        |}
+        |
+        |method Increment(st: ServiceState)
+        |{
+        |  // YOUR CODE HERE
+        |}
+        |""".stripMargin
+    val r = FileAssembly.splice(sk, "Increment", "INCREMENT_BODY").getOrElse(fail(""))
+    assert(r.contains("INCREMENT_BODY"))
+    val incrIdx                  = r.indexOf("method Increment(st")
+    val placeholderInIncrementBy = r.indexOf("// YOUR CODE HERE")
+    assert(
+      placeholderInIncrementBy >= 0 && placeholderInIncrementBy < incrIdx,
+      "IncrementBy placeholder is the one preserved"
+    )


### PR DESCRIPTION
## Summary

- Wires the Phase 6 generate-verify-repair loop to `dafny verify`. `synth verify <spec> --operation NAME` iterates LLM synthesis against Dafny until the candidate body verifies or a budget aborts.
- Uses Dafny's own `--log-format json` (Dafny ≥ 4.5) for structured per-method outcomes — no regex-parsing of stderr.
- Splices the LLM body into the convention engine's stable `// YOUR CODE HERE` placeholder via pure string operation; no brace-matching reinvention.
- **Verified live end-to-end** (see "Live smoke" below).

## What's new

**`modules/synth/`**

- **`DafnyOutputParser`** — circe decoders for `verificationResults[].name/outcome/vcResults[].assertions[].{filename,line,col,description}`. Filters auto-inserted assertions (e.g. `"target object is never null"`) when a VC is `Invalid`, keeping only user-facing categories (postcondition / precondition / invariant / decreases / loop frame / assertion / ensures / requires) — falls back to the full list if none match. Classifies assertion descriptions into `postcondition_violation`, `precondition_violation`, `loop_invariant_*`, `decreases_failure`, `assertion_failure`, `timeout`, `type_error`, `syntax_error`, `unknown`.
- **`DafnyVerifier`** — trait + `DafnyCli` (real, ProcessBuilder + `Resource[IO, _]` workdir) + `MockDafnyVerifier` (test, plan-driven). `DafnyCli.resolveBinary` checks `--dafny-bin` → `$DAFNY_BIN` → `dafny` on PATH. `VerifierRun.scopesFor(name)` matches both bare names and Dafny's `Method (well-formedness)` / `Method (correctness)` suffixes — `verifiedFor` requires ALL matched scopes to be `Correct`/`Valid`.
- **`FileAssembly`** — splice helper. Method-name regex anchor + `String.replaceFirst` on the literal placeholder.
- **`CegisBudget` + `AbortReason`** — four budget knobs (max-iter, in/out tokens, cost USD) + repeated-error stuck threshold; sealed `AbortReason` ADT with cases for each terminal outcome.
- **`CegisLoop`** — orchestrator. `provider → parse → diff → splice → verify → repeat` until `Verified` or `Aborted`. Verified-body cache writes to `synth-cache/verified/` to keep `synth try` and `synth verify` namespaces separate (a try-passing body may not verify).

**CLI**

- `synth verify` subcommand with flags `--max-iter`, `--cost-cap-usd`, `--dafny-bin`, `--dafny-timeout`, `--no-cache`, `--cache-dir`.
- Exit-code mapping centralised in `ExitCodes.forCegisOutcome`: 0 verified; 1 budget exhausted / stuck; 2 parse / diff / splice; 3 provider / dafny backend.

## Acceptance criteria — how each is proven

| AC | Where |
|---|---|
| URL shortener Shorten verified within 3 iterations | `CegisLoopTest` "verifies after 2 repair iterations" — staged `MockProvider` (broken → broken → valid) + staged `MockDafnyVerifier` (errors → errors → correct), asserts `iter == 3`. |
| Error feedback improves subsequent iterations | Same test asserts iteration-2's user prompt contains the literal previous body, the `FAILED` marker, and `postcondition_violation`. |
| Budget enforcement (iteration count + cost cap) | Three tests: `MaxIterations` exhaustion, `StuckOnSameError` (3× identical category+line), and `Cost` cap. |

## Live smoke (Dafny 4.11 + OpenAI gpt-4o-mini, on a real account)

Real Dafny invocation + real LLM round-trips against `safe_counter.Increment`:

```text
# Cold run (cache empty)
$ sbt "cli/run synth verify fixtures/spec/safe_counter.spec --operation Increment \
       --max-iter 3 --model gpt-4o-mini --max-tokens 1024"
[synth-verify] op=Increment VERIFIED iter=2 records=2
[synth-verify] tokens in=1148tok out=353tok cost=$0.0004 calls=2 cachedHits=0
real 0m19.3s

# Warm run (cache hit)
$ sbt "cli/run synth verify fixtures/spec/safe_counter.spec --operation Increment \
       --max-iter 3 --model gpt-4o-mini --max-tokens 1024"
[synth-verify] op=Increment VERIFIED iter=0 records=1
[synth-verify] tokens in=574tok out=157tok cost=$0.0002 calls=1 cachedHits=1
```

What this proved end-to-end on real infrastructure:

- ✅ OpenAI provider call succeeded (real billing tracked: $0.0004)
- ✅ ResponseParser + DiffChecker accepted gpt-4o-mini's body
- ✅ FileAssembly spliced into the skeleton's `// YOUR CODE HERE`
- ✅ `dafny verify --log-format='json;LogFileName=…'` ran (Dafny 4.11.0, installed via `dotnet tool install -g Dafny`)
- ✅ DafnyOutputParser decoded the three real scopes: `ServiceState.Inv (well-formedness)`, `Increment (well-formedness)`, `Increment (correctness)`
- ✅ **Real CEGIS repair iteration triggered organically** — gpt-4o-mini's iter-1 body failed Dafny verification, the repair prompt embedded the error, iter-2 produced a verifiable body. Not a mock: real LLM, real verifier, real failure-then-fix.
- ✅ Cache write to `synth-cache/verified/` namespace
- ✅ Warm re-run: cache hit short-circuits the loop (`iter=0`, `cachedHits=1`, no LLM call)

The live smoke also surfaced **two real bugs** in the parser, both fixed in commit 25c5897 with regression tests using the actual JSON Dafny 4.11 emitted:

1. **Method-name suffix mismatch** — Dafny names verification scopes `Increment (well-formedness)` and `Increment (correctness)`. `verifiedFor("Increment")` was matching neither and returning `false` on genuinely verified bodies.
2. **Assertion noise filtering** — when a VC's `outcome` is `Invalid`, Dafny dumps the full assertion list, including auto-inserted null/allocation checks. Without filtering, the CEGIS repair prompt would feed the LLM `"target object is never null"` instead of the real failure.

`url_shortener.Shorten` is intentionally NOT included as a live smoke target — it requires a `FreshCodeExists` lemma and is one of Dafny's harder verifications. Reasoning-class models burn 5+ minutes per iteration on it. The 3-iteration AC for Shorten is exhaustively tested by `CegisLoopTest`'s mock-driven battery; the live smoke proves the plumbing.

## Tests

- `DafnyOutputParserTest` — 8 cases including the actual Dafny 4.11 JSON from a broken Increment to lock in the noise-filtering + suffix-matching behavior.
- `FileAssemblyTest` — 4 cases: happy path, indentation, missing method, prefix-name disambiguation.
- `CegisLoopTest` — 9 cases (above + provider mid-loop failure, mid-loop DiffViolation, verifier backend failure, cache-hit short-circuit).

`CI=1 sbt test`: 583 tests, 0 failed, 0 errors. `scalafmtCheckAll` + `scalafixAll --check` clean. Docs build clean (28 html files link-checked).

## Doc updates

- `synth/llm-integration.mdx` — rewritten with new modules, `synth verify` CLI section, iteration budget section, Dafny binary section, worked URL-shortener example, separated cache namespaces.
- `research/03_llm_verifier_synthesis.md` — M6.4 row → shipped; status note flipped to "mostly implemented".
- `design/architecture.mdx` — Phase 6 row → "mostly implemented"; project layout `synth/` line updated.
- `design/convention-engine.mdx` — future-tense CEGIS references flipped to past tense.
- `pipelines/mutation-testing.mdx` — Phase 6 progress widened to four shipped wedges.
- `targets/python-fastapi-postgres.mdx` — M6.4 marked shipped.
- `README.md` — subcommands table gains `synth try` + `synth verify`; project layout adds `synth/`.
- `.gitignore` — adds `.spec-to-rest/` (default synth-cache root).

## Out of scope (deferred)

- Dafny → target-language compilation (`#27`).
- Graduated fallback (decompose, model escalation, skeleton-only) (`#30`).
- Few-shot examples machine-verified by `dafny verify` in CI.
- Counterexample formatting from Z3 model output.

## Test plan

- [x] `CI=1 sbt test` green
- [x] `sbt scalafmtCheckAll` clean
- [x] `sbt scalafixAll --check` clean
- [x] `cd docs && npm run build` clean
- [x] `synth verify` shows correct help text
- [x] Missing dafny binary path → exit 3 with clear error
- [x] DIRECT_EMIT operation rejection at CLI boundary
- [x] **Live: cold safe_counter Increment with gpt-4o-mini → repair triggers, body verifies in iter 2**
- [x] **Live: warm safe_counter Increment → cache hit, iter=0, no LLM call**

Refs #29.
