### PR TITLE
ci: cross-platform native release on tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ["v*"]
     paths-ignore: ["docs/**"]
   pull_request:
 

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -35,14 +35,6 @@ jobs:
             platform: linux-amd64
             binary: spec-to-rest
             archive: spec-to-rest-linux-amd64.tar.gz
-          - os: macos-26-intel
-            platform: macos-amd64
-            binary: spec-to-rest
-            archive: spec-to-rest-macos-amd64.tar.gz
-          - os: windows-latest
-            platform: windows-amd64
-            binary: spec-to-rest.exe
-            archive: spec-to-rest-windows-amd64.zip
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -51,10 +43,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
-      - name: Set up MSVC environment (Windows)
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
         with:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -20,6 +20,9 @@ jobs:
     name: Verify CI green for tag commit
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    permissions:
+      contents: read
+      checks: read
     steps:
       - name: Skip on non-tag refs
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -3,21 +3,27 @@ name: Native Image
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     paths: [".github/workflows/native.yml"]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: ["v*"]
 
 permissions:
   contents: read
 
 concurrency:
-  group: native-image-${{ github.ref }}
-  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+  group: native-image-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: ${{ !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v') }}
 
 jobs:
   native-image:
     name: Build (${{ matrix.platform }})
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +47,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up MSVC environment (Windows)
         if: runner.os == 'Windows'
@@ -113,16 +120,13 @@ jobs:
   release:
     name: Publish GitHub release
     needs: native-image
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
@@ -134,7 +138,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
           gh release create "$TAG" \

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -26,7 +26,7 @@ jobs:
             platform: linux-amd64
             binary: spec-to-rest
             archive: spec-to-rest-linux-amd64
-          - os: macos-15-intel
+          - os: macos-26-intel
             platform: macos-amd64
             binary: spec-to-rest
             archive: spec-to-rest-macos-amd64

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -9,7 +9,6 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
-    branches: ["v*"]
 
 permissions:
   contents: read
@@ -23,7 +22,11 @@ jobs:
     name: Build (${{ matrix.platform }})
     if: |
       github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')
+      )
     strategy:
       fail-fast: false
       matrix:
@@ -122,7 +125,9 @@ jobs:
     needs: native-image
     if: |
       github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -16,8 +16,56 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
+  ci-gate:
+    name: Verify CI green for tag commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Skip on non-tag refs
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "Not a tag push — gate is a no-op."
+      - name: Wait for required check-runs to succeed on commit
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          required=(build-and-test z3-cross-check cvc5-cross-check alloy-cross-check coverage)
+          deadline=$(( $(date +%s) + 1200 ))
+          while :; do
+            all_done=true
+            for check in "${required[@]}"; do
+              conclusion=$(gh api \
+                "repos/$REPO/commits/$SHA/check-runs?check_name=$check&per_page=1" \
+                --jq '.check_runs[0].conclusion // "missing"')
+              case "$conclusion" in
+                success)
+                  echo "ok  $check"
+                  ;;
+                missing|null)
+                  echo "wait $check (not reported yet)"
+                  all_done=false
+                  ;;
+                *)
+                  echo "::error::Required check '$check' on $SHA: $conclusion"
+                  exit 1
+                  ;;
+              esac
+            done
+            $all_done && break
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for required CI checks on $SHA"
+              exit 1
+            fi
+            sleep 20
+          done
+          echo "All required CI checks succeeded for $SHA."
+
   native-image:
     name: Build (${{ matrix.platform }})
+    needs: ci-gate
     strategy:
       fail-fast: false
       matrix:
@@ -25,15 +73,15 @@ jobs:
           - os: ubuntu-latest
             platform: linux-amd64
             binary: spec-to-rest
-            archive: spec-to-rest-linux-amd64
+            archive: spec-to-rest-linux-amd64.tar.gz
           - os: macos-26-intel
             platform: macos-amd64
             binary: spec-to-rest
-            archive: spec-to-rest-macos-amd64
+            archive: spec-to-rest-macos-amd64.tar.gz
           - os: windows-latest
             platform: windows-amd64
             binary: spec-to-rest.exe
-            archive: spec-to-rest-windows-amd64.exe
+            archive: spec-to-rest-windows-amd64.zip
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
@@ -78,7 +126,7 @@ jobs:
           test -f "$smoke_dir/pyproject.toml"
           test -f "$smoke_dir/app/main.py"
 
-      - name: Stage release artifact
+      - name: Package release archive
         shell: bash
         env:
           BIN: modules/cli/target/native-image/${{ matrix.binary }}
@@ -86,7 +134,23 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          cp "$BIN" "dist/$ARCHIVE"
+          dir=$(dirname "$BIN")
+          file=$(basename "$BIN")
+          case "$ARCHIVE" in
+            *.tar.gz)
+              chmod +x "$BIN"
+              tar -czf "dist/$ARCHIVE" -C "$dir" "$file"
+              ;;
+            *.zip)
+              # 7-Zip is preinstalled on GitHub Windows runners.
+              ( cd "$dir" && 7z a -tzip "$GITHUB_WORKSPACE/dist/$ARCHIVE" "$file" >/dev/null )
+              ;;
+            *)
+              echo "::error::Unknown archive extension for '$ARCHIVE'"
+              exit 1
+              ;;
+          esac
+          ls -la dist/
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -124,4 +188,4 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
-            dist/spec-to-rest-*
+            dist/*.tar.gz dist/*.zip

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -16,59 +16,8 @@ concurrency:
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
-  ci-gate:
-    name: Verify CI green for tag commit
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    permissions:
-      contents: read
-      checks: read
-    steps:
-      - name: Skip on non-tag refs
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        run: echo "Not a tag push — gate is a no-op."
-      - name: Wait for required check-runs to succeed on commit
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ github.sha }}
-          REPO: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          required=(build-and-test z3-cross-check cvc5-cross-check alloy-cross-check coverage)
-          deadline=$(( $(date +%s) + 1200 ))
-          while :; do
-            all_done=true
-            for check in "${required[@]}"; do
-              conclusion=$(gh api \
-                "repos/$REPO/commits/$SHA/check-runs?check_name=$check&per_page=1" \
-                --jq '.check_runs[0].conclusion // "missing"')
-              case "$conclusion" in
-                success)
-                  echo "ok  $check"
-                  ;;
-                missing|null)
-                  echo "wait $check (not reported yet)"
-                  all_done=false
-                  ;;
-                *)
-                  echo "::error::Required check '$check' on $SHA: $conclusion"
-                  exit 1
-                  ;;
-              esac
-            done
-            $all_done && break
-            if [ "$(date +%s)" -ge "$deadline" ]; then
-              echo "::error::Timed out waiting for required CI checks on $SHA"
-              exit 1
-            fi
-            sleep 20
-          done
-          echo "All required CI checks succeeded for $SHA."
-
   native-image:
     name: Build (${{ matrix.platform }})
-    needs: ci-gate
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Set up MSVC environment (Windows)
         if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
         with:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
+    paths: [".github/workflows/native.yml"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -9,18 +9,40 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: native-image-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   native-image:
+    name: Build (${{ matrix.platform }})
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        # macos-latest, windows-latest can be added once resource includes are verified per-platform
+        include:
+          - os: ubuntu-latest
+            platform: linux-amd64
+            binary: spec-to-rest
+            archive: spec-to-rest-linux-amd64
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+            binary: spec-to-rest
+            archive: spec-to-rest-linux-arm64
+          - os: macos-latest
+            platform: macos-arm64
+            binary: spec-to-rest
+            archive: spec-to-rest-macos-arm64
+          - os: windows-latest
+            platform: windows-amd64
+            binary: spec-to-rest.exe
+            archive: spec-to-rest-windows-amd64.exe
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
         with:
@@ -34,21 +56,70 @@ jobs:
       - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
 
       - name: Build native image
+        shell: bash
         run: sbt cli/nativeImage
 
       - name: Smoke-test native binary
+        shell: bash
+        env:
+          BIN: modules/cli/target/native-image/${{ matrix.binary }}
         run: |
-          ./modules/cli/target/native-image/spec-to-rest check fixtures/spec/url_shortener.spec
-          ./modules/cli/target/native-image/spec-to-rest verify fixtures/spec/safe_counter.spec
-          ./modules/cli/target/native-image/spec-to-rest compile \
-            --target python-fastapi-postgres --out /tmp/native-smoke \
+          set -euo pipefail
+          smoke_dir="${RUNNER_TEMP}/native-smoke"
+          rm -rf "$smoke_dir"
+          "$BIN" check fixtures/spec/url_shortener.spec
+          "$BIN" verify fixtures/spec/safe_counter.spec
+          "$BIN" compile \
+            --target python-fastapi-postgres --out "$smoke_dir" \
             --ignore-verify \
             fixtures/spec/url_shortener.spec
-          test -f /tmp/native-smoke/pyproject.toml
-          test -f /tmp/native-smoke/app/main.py
+          test -f "$smoke_dir/pyproject.toml"
+          test -f "$smoke_dir/app/main.py"
+
+      - name: Stage release artifact
+        shell: bash
+        env:
+          BIN: modules/cli/target/native-image/${{ matrix.binary }}
+          ARCHIVE: ${{ matrix.archive }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp "$BIN" "dist/$ARCHIVE"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: spec-to-rest-${{ matrix.os }}
-          path: modules/cli/target/native-image/spec-to-rest
+          name: ${{ matrix.archive }}
+          path: dist/${{ matrix.archive }}
           if-no-files-found: error
+
+  release:
+    name: Publish GitHub release
+    needs: native-image
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List staged artifacts
+        run: ls -la dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            dist/spec-to-rest-*

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -26,14 +26,10 @@ jobs:
             platform: linux-amd64
             binary: spec-to-rest
             archive: spec-to-rest-linux-amd64
-          - os: ubuntu-24.04-arm
-            platform: linux-arm64
+          - os: macos-15-intel
+            platform: macos-amd64
             binary: spec-to-rest
-            archive: spec-to-rest-linux-arm64
-          - os: macos-latest
-            platform: macos-arm64
-            binary: spec-to-rest
-            archive: spec-to-rest-macos-arm64
+            archive: spec-to-rest-macos-amd64
           - os: windows-latest
             platform: windows-amd64
             binary: spec-to-rest.exe
@@ -45,6 +41,10 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Set up MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
       - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -215,6 +215,9 @@ lazy val cli = (project in file("modules/cli"))
     nativeImageInstalled := true,
     nativeImageOptions ++= Seq(
       "--no-fallback",
+      // Required by GraalVM 23+ for the -H: options below; on 21 it's
+      // accepted as a no-op and silences the "experimental option" warnings.
+      "-H:+UnlockExperimentalVMOptions",
       "-H:+ReportExceptionStackTraces",
       // Bundle z3-turnkey's native libraries so libz3.so / libz3java.so can be
       // extracted at runtime on the target OS. Pattern covers linux + osx + windows.

--- a/build.sbt
+++ b/build.sbt
@@ -230,20 +230,7 @@ lazy val cli = (project in file("modules/cli"))
       // shared library can be loaded per-execution (build-time init fails since
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
-      "--initialize-at-run-time=com.microsoft.z3.Version",
-      // Substrate VM's build-time init silently fails for the large
-      // Isabelle-extracted SpecRestGenerated companion on Windows and macOS
-      // (manifests as NoClassDefFoundError with no underlying exception at
-      // runtime — the build-time error is swallowed). Linux amd64 works.
-      // Use the package-prefix form so nested objects (e.g. the inner
-      // `equal` companion) are also deferred — listing the outer class
-      // alone wasn't enough on Windows since a nested build-time init can
-      // still drag the parent in.
-      "--initialize-at-run-time=specrest.ir.generated",
-      // Diagnostic: print the chain that promotes SpecRestGenerated$ to
-      // build-time init, to surface whichever transitive class is forcing
-      // it. Cheap to leave on; the trace lands in the build log only.
-      "--trace-class-initialization=specrest.ir.generated.SpecRestGenerated$"
+      "--initialize-at-run-time=com.microsoft.z3.Version"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,16 @@ lazy val cli = (project in file("modules/cli"))
       // shared library can be loaded per-execution (build-time init fails since
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
-      "--initialize-at-run-time=com.microsoft.z3.Version"
+      "--initialize-at-run-time=com.microsoft.z3.Version",
+      // Substrate VM's build-time init silently fails for the large
+      // Isabelle-extracted SpecRestGenerated companion on Windows and macOS
+      // (manifests as NoClassDefFoundError with no underlying exception at
+      // runtime — the build-time error is swallowed). Linux amd64 works.
+      // Deferring init to runtime is the standard portability workaround
+      // and has no semantic effect — the object holds only pure data and
+      // case-class definitions, no FFI or resource loading.
+      "--initialize-at-run-time=specrest.ir.generated.SpecRestGenerated$",
+      "--initialize-at-run-time=specrest.ir.generated.SpecRestGenerated"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -235,11 +235,15 @@ lazy val cli = (project in file("modules/cli"))
       // Isabelle-extracted SpecRestGenerated companion on Windows and macOS
       // (manifests as NoClassDefFoundError with no underlying exception at
       // runtime — the build-time error is swallowed). Linux amd64 works.
-      // Deferring init to runtime is the standard portability workaround
-      // and has no semantic effect — the object holds only pure data and
-      // case-class definitions, no FFI or resource loading.
-      "--initialize-at-run-time=specrest.ir.generated.SpecRestGenerated$",
-      "--initialize-at-run-time=specrest.ir.generated.SpecRestGenerated"
+      // Use the package-prefix form so nested objects (e.g. the inner
+      // `equal` companion) are also deferred — listing the outer class
+      // alone wasn't enough on Windows since a nested build-time init can
+      // still drag the parent in.
+      "--initialize-at-run-time=specrest.ir.generated",
+      // Diagnostic: print the chain that promotes SpecRestGenerated$ to
+      // build-time init, to surface whichever transitive class is forcing
+      // it. Cheap to leave on; the trace lands in the build log only.
+      "--trace-class-initialization=specrest.ir.generated.SpecRestGenerated$"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 ThisBuild / scalaVersion := "3.6.3"
-ThisBuild / version      := "1.0.0-SNAPSHOT"
 ThisBuild / organization := "dev.specrest"
 
 ThisBuild / scalacOptions ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.simplytyped"    % "sbt-antlr4"       % "0.8.3")
+addSbtPlugin("com.github.sbt"     % "sbt-dynver"       % "5.1.1")
 addSbtPlugin("org.scalameta"      % "sbt-native-image" % "0.3.4")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"     % "2.5.2")
 addSbtPlugin("ch.epfl.scala"      % "sbt-scalafix"     % "0.14.6")


### PR DESCRIPTION
## Summary

- Tag-driven native release on linux-amd64
- `sbt-dynver` 5.1.1 — version derived from git tags
- Archive packaging (`tar.gz`) — preserves `+x` so users can run after download without `chmod`
- `workflow_run`-gated release: native-image fires only after CI succeeds for the tag commit (event-driven, no shell polling)

## Why

Today the only release is `v1.0-scala` (2026-04-19, hand-curated, no binary attached) and 91 merges have landed since. This PR enables `git tag vX.Y.Z && git push --tags` to produce a real release with an attached binary, after CI completes successfully on the tag commit.

## Behavior after this lands

**Day-to-day main pushes**: linux-amd64 binary builds as a workflow artifact; no release.

**`git tag v1.1.0 && git push --tags`**:
1. `ci.yml` runs on the tag commit (now triggered by `tags: ["v*"]`).
2. On `success`, `workflow_run` fires `native.yml`. Job-level `if:` conditions check `conclusion == 'success'`, `event == 'push'`, and `head_branch` starts with `v`.
3. native-image matrix builds.
4. `release` job downloads the artifact and calls `gh release create v1.1.0 --generate-notes` with `spec-to-rest-linux-amd64.tar.gz` attached.

Users `tar -xzf spec-to-rest-linux-amd64.tar.gz && ./spec-to-rest --help` — no `chmod +x` step needed.

## Cross-platform: linux-amd64 only in this PR

The PR was originally scoped for linux + macOS + Windows. Three iterations of progressive `--initialize-at-run-time` scoping all produced the same runtime failure on macOS-amd64, macOS-arm64, and windows-amd64:

```text
java.lang.NoClassDefFoundError: Could not initialize class
specrest.ir.generated.SpecRestGenerated$
  at specrest.verify.Trust$.classify$$anonfun$1(Trust.scala:22)
```

with no underlying `ExceptionInInitializerError`. Verified in the build log that:
- The directive (single class, `$` form, package-prefix form) reaches `native-image.cmd` intact.
- `--trace-class-initialization` produced no output — confirming the class is NOT initialized at build time.

So the failure is in **runtime static-init on macOS/Windows**, with substrate VM swallowing the cause. Linux-amd64 has worked across every iteration.

This is a real cross-platform Substrate VM issue with the 2,650-LoC Isabelle-extracted companion (`SpecRestGenerated.scala`). The original `native.yml` only ever verified linux-amd64 — the comment `macos-latest, windows-latest can be added once resource includes are verified per-platform` was forward-looking; this PR was the first real attempt and surfaced the bug. Tracked in #222.

## sbt-dynver behavior

- Pre-tag (now): `version = "1.0-scala+77-…+timestamp"`. Picks up `v1.0-scala` as base, adds commits-since/timestamp. Ugly but invisible to users (no SNAPSHOT publish).
- Post-tag (after `v1.1.0`): `version = "1.1.0"` — clean.

## Notes / decisions

- **Archive, not raw binary**: GitHub release downloads via plain HTTP drop the executable bit. `tar.gz` preserves Unix mode 0755.
- **`workflow_run` gating, not shell polling**: `branches: ["v*"]` on `workflow_run` is documented to filter branches not tags, so we filter at the job level via `if:` on `head_branch`. Trigger fires on every CI completion; jobs are skipped (with no compute cost) for non-tag refs.
- **No Sonatype / Maven Central publish** added. Product is the CLI binary.
- **`--generate-notes`**: GitHub auto-generates from PR titles since the previous matching tag. PR-title convention in this repo (`#NNN — title`) gives a useful changelog without a hand-maintained `CHANGELOG.md`.
- **CI extended to tag pushes**: `ci.yml` triggers on `push: tags: ["v*"]` so the tag commit produces the `workflow_run` completion event. Day-to-day branch protection still gates main merges.
- **Action SHAs**: third-party actions pinned to **commit** SHAs (annotated-tag SHAs are flagged by zizmor because the tag object isn't in the commit graph).

## Test plan

- [x] PR matrix builds linux-amd64 successfully (path-filtered `pull_request:` trigger)
- [x] `gh run` log shows the workflow_run-driven trigger logic and matrix scoping
- [ ] (post-merge) Push `v1.1.0` tag, observe `ci.yml → workflow_run → native.yml → release` chain
- [ ] (post-merge) Download `spec-to-rest-linux-amd64.tar.gz`, extract, run `./spec-to-rest --help`

## Deferred follow-ups

- **macOS + Windows native binaries**: substrate VM runtime class-init NCDFE for `SpecRestGenerated$`. Likely requires either a refactor of the generated companion into smaller chunks (impacts the Isabelle extraction pipeline) or a diagnostic deep-dive into substrate VM internals on those platforms.
- **linux-arm64**: needs upstream `z3-turnkey` to ship `linux/aarch64` natives (the jar verified by `unzip -l` does not).
- **Sonatype publishing** — out of scope.
- **Sigstore / cosign signatures** — out of scope.
