### PR TITLE
fix: native.yml trigger redundancy on main pushes

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-image-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: native-image-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: ${{ !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v') }}
 
 jobs:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -1,8 +1,6 @@
 name: Native Image
 
 on:
-  push:
-    branches: [main]
   pull_request:
     paths: [".github/workflows/native.yml"]
   workflow_dispatch:
@@ -14,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-image-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: native-image-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: ${{ !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v') }}
 
 jobs:
@@ -24,8 +22,7 @@ jobs:
       github.event_name != 'workflow_run' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        startsWith(github.event.workflow_run.head_branch, 'v')
+        github.event.workflow_run.event == 'push'
       )
     strategy:
       fail-fast: false

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: native-image-${{ github.event.workflow_run.head_sha || github.sha }}
+  group: native-image-${{ github.event_name }}-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: ${{ !startsWith(github.event.workflow_run.head_branch || github.ref_name, 'v') }}
 
 jobs:


### PR DESCRIPTION
## Summary

Two-step fix for the native-image trigger redundancy uncovered after #221 merged:

1. **First commit** — scope the concurrency group by `event_name` so the push-triggered and workflow_run-triggered runs no longer cancel each other on main pushes.
2. **Second commit** — drop the `push: branches: [main]` trigger entirely. native.yml's only automatic entry is `workflow_run` on CI completion. One run per CI completion, no duplicate jobs, no skipped-job noise.

## Why two commits?

The first commit was the minimal fix to stop main-push native-image runs from being silently cancelled. After looking at the resulting state, the simpler answer is that the second trigger was never adding value — it just ran for ~18s before skipping. Easier to remove than to dance around with concurrency lanes.

## Behavior after this lands

| event | what fires |
|---|---|
| push to main | ci.yml → on success → workflow_run → native.yml matrix (smoke) |
| push tag `v*` | ci.yml (now triggered on tags too, per #221) → on success → workflow_run → native.yml matrix → release |
| PR touching native.yml | pull_request:paths fires native.yml (syntax check) |
| `gh workflow run native.yml` | workflow_dispatch fires native.yml |

One run per CI completion. The native-image `if:` condition no longer demands `startsWith(head_branch, 'v')` — that's the release job's filter; the matrix itself runs for any successful CI completion (smoke on main, smoke + release on tag).

## Trade-off

Main-push native-image feedback goes from ~5 min (parallel with CI) to ~10 min (after CI). For a ~90-merges/month repo that's negligible compared to the ongoing clarity win and the elimination of the wasted-compute / wasted-actions-log skipped runs.

## Test plan

- [x] actionlint via pre-commit
- [ ] (post-merge) Push any commit to main; observe a **single** Native Image run that follows CI completion (no parallel push-triggered run, no skipped workflow_run-triggered run)
