### PR TITLE
fix: release glob picks up whatever the matrix produces

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -134,4 +134,4 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --generate-notes \
-            dist/*.tar.gz dist/*.zip
+            dist/*


### PR DESCRIPTION
## Summary

The `v1.0.0` release attempt failed at the publish step:

```text
no matches found for `dist/*.zip`
```

`gh release create` was passed both `dist/*.tar.gz dist/*.zip` as args. With Windows dropped from the matrix (per #221), no zip is ever staged; gh's own glob expansion refuses an unmatched wildcard.

Switching to `dist/*` picks up whatever the matrix produced. Linux-only today, automatic pickup of `*.zip` / `*-macos*.tar.gz` once those platforms land.

## Test plan

- [x] actionlint via pre-commit
- [ ] (post-merge) Re-tag and re-push to verify the release job completes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release job by changing the asset glob so `gh release create` uploads whatever artifacts exist and doesn’t fail when `.zip` is missing. Uses `dist/*` to support the current Linux-only matrix and future platforms.

- **Bug Fixes**
  - Replace `dist/*.tar.gz dist/*.zip` with `dist/*` in `.github/workflows/native.yml` to avoid unmatched wildcard errors and auto-pick up all built artifacts.

<sup>Written for commit 21c241994234e08ac163d2cbbeee18a96c41f2b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded GitHub release artifacts to include all distributed files, broadening the assets available for download alongside standard archive formats.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->