### PR TITLE
fix: native.yml release pipeline (tag-only filter + restored checkout)

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -22,7 +22,8 @@ jobs:
       github.event_name != 'workflow_run' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push'
+        github.event.workflow_run.event == 'push' &&
+        startsWith(github.event.workflow_run.head_branch, 'v')
       )
     strategy:
       fail-fast: false

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -118,6 +118,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist


### PR DESCRIPTION
## Summary

Two related workflow fixes uncovered while testing the v2.0.0 release pipeline:

1. **`native-image` filter to tag-only** — when a commit is both merged to main AND tagged within seconds (the v2.0.0 release pattern: merge → tag latest HEAD), two CI runs fire on the same SHA and each completion triggers `workflow_run` on `native.yml`. The matrix would run twice — once for the main upstream (whose result is then refused by the release job's filter) and once for the tag upstream. The first is ~5–7 min of wasted compute and queues the meaningful tag-triggered run. Adding `startsWith(workflow_run.head_branch, 'v')` to the `native-image` `if:` matches the existing release-job filter so the matrix runs only when a binary will actually be released.

2. **Restore `actions/checkout` in the release job** — `gh release create` shells out to git internally (it discovers the repo context from `.git` even with `--generate-notes`, which itself only needs API access). I'd dropped the checkout step during the workflow_run refactor on the assumption "release just needs artifacts and the tag." The v2.0.0 attempt confirmed otherwise:

   ```text
   failed to run git: fatal: not a git repository
   ```

   Add `actions/checkout` pinned to `github.event.workflow_run.head_sha` so the release job operates on the tag commit (workflow_run runs from the default branch's ref by default; explicit ref ensures we checkout the right SHA).

## Trade-off (filter)

Regular main pushes no longer trigger native-image. CI + Quality + cross-checks still cover compile, test, and verifier soundness. Native-image breakage would only surface at tag-time. For this project's release cadence (`v1.0-scala` was the only prior release), that's acceptable.

`workflow_dispatch` and `pull_request: paths` triggers are unaffected — manual smoke and PR-time syntax check still work.

## Test plan

- [x] actionlint via pre-commit
- [ ] (post-merge) Re-tag and re-push v2.0.0 to verify the release job now produces a release with `spec-to-rest-linux-amd64.tar.gz` attached
- [ ] (post-merge) Push any commit to main; observe **no** Native Image run fires
