### PR TITLE
#27 — M6.5 Dafny→Python translate + compile --with-synthesis

### DIFF
--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -8,16 +8,16 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > Clover-style triangulation, failure handling, security, and cost analysis. Written 2026-04-05.
 
 > **Status — mostly implemented.** This document is the **Phase 6** design proposal.
-> Four foundational wedges have shipped: #31 operation classification, #32 Dafny
+> Five wedges have shipped: #31 operation classification, #32 Dafny
 > signature generation (`inspect --format dafny`), #28 LLM integration + prompt
-> engineering (`inspect --format dafny-prompt`, `synth try`), and #29 the CEGIS
-> feedback loop (`synth verify`); Dafny→target compilation remains unbuilt on
-> `main`. Open trackers under the `phase-6` label cover the breakdown:
+> engineering (`inspect --format dafny-prompt`, `synth try`), #29 the CEGIS
+> feedback loop (`synth verify`), and #27 the Dafny→Python translator wired
+> into `compile --with-synthesis`. Open trackers under the `phase-6` label:
 > [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) — operation classification (direct emit vs. LLM) — **shipped**,
 > [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) — Dafny signature generation — **shipped**,
 > [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering — **shipped**,
 > [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop — **shipped**,
-> [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation,
+> [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation — **shipped (Python)**,
 > [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy.
 > The Scala implementation lives in `modules/synth/` (`PromptBuilder`,
 > `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, `CegisLoop`,

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Synthesis Pipeline (M6.3 + M6.4)
-description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, and the CEGIS feedback loop wired to `dafny verify`.
+title: Synthesis Pipeline (M6.3 – M6.5)
+description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, the CEGIS feedback loop wired to `dafny verify`, and `compile --with-synthesis` that translates verified bodies to the target language.
 ---
 
 `modules/synth/` is the Phase 6 LLM-and-Dafny synthesis layer. It takes the
@@ -8,8 +8,10 @@ deterministic Dafny skeleton emitted by [`inspect --format dafny`](/design/conve
 (#32), drives an LLM to fill in a method body, splices the body back into the
 skeleton, runs `dafny verify` against the structured-JSON log format, and
 iterates with a repair prompt until the body verifies — or the budget says stop.
-Dafny→target compilation remains tracked in
-[#27](https://github.com/HardMax71/spec_to_rest/issues/27).
+The verified body is then cached on disk; running `compile --with-synthesis`
+later splices every cached body for the spec, calls `dafny translate py`, and
+emits the resulting Python under `app/dafny_kernel/` of the generated project
+together with a thin handler-side adapter (M6.5, #27).
 
 ## Modules and entry points
 
@@ -308,12 +310,61 @@ responses) and `MockDafnyVerifier` (three staged outputs), asserting
 `postcondition_violation` plus the iteration-1 body verbatim — proving
 "error feedback improves subsequent iterations" (AC 2).
 
+## `compile --with-synthesis` (M6.5)
+
+When every `LLM_SYNTHESIS` operation has been verified at least once
+(`synth verify` populated `.spec-to-rest/synth-cache/verified/`), running
+`compile --with-synthesis` integrates the verified bodies into the emitted
+project:
+
+```bash
+sbt "cli/run synth verify fixtures/spec/url_shortener.spec --operation Shorten"
+sbt "cli/run synth verify fixtures/spec/url_shortener.spec --operation Resolve"
+sbt "cli/run synth verify fixtures/spec/url_shortener.spec --operation ListAll"
+sbt "cli/run compile fixtures/spec/url_shortener.spec \
+       --target python-fastapi-postgres --out /tmp/out --with-synthesis"
+```
+
+Pipeline:
+
+1. Look up each `LLM_SYNTHESIS` operation's verified body in the cache. The
+   key is `(signature, requires, ensures, modifies, model, temperature,
+   SynthPromptVersion)`. `--synthesis-model` and `--synthesis-temperature`
+   default to `claude-sonnet-4-6 / 1.0`; pass them explicitly if the body
+   was verified with a different combination.
+2. Multi-method splice every cached body into one fresh `.dfy` file using
+   the convention engine's deterministic skeleton.
+3. Invoke `dafny translate py --include-runtime --no-verify --output=…` and
+   capture every file the back-end emits. The `_dafny` runtime is bundled
+   in-tree — generated `pyproject.toml` does not pull a PyPI runtime.
+4. Lay the captured files under `<out>/app/dafny_kernel/` and emit a
+   companion `app/services/_dafny_adapter.py` with boundary helpers
+   (`make_state`, `to_dafny_seq`, `from_dafny_map`, …).
+5. The entity service template now branches on each operation's
+   `dafnyMethod`: when set, the handler hydrates a fresh `ServiceState`,
+   calls `app.dafny_kernel.module_.default__.<Op>(state, …)`, and returns
+   the result. The previous `NotImplementedError` placeholder is preserved
+   for operations with no cached body.
+
+Hard failure modes:
+
+| Condition | Exit code | Message |
+|---|---|---|
+| `--with-synthesis` set but `verified/` directory missing | 1 | "no verified-body cache at …; run `synth verify` for each LLM_SYNTHESIS op first" |
+| Cache exists but a specific op is missing | 1 | "no verified body cached for '$Op' (model=…, temp=…). Run: cli/run synth verify … --operation $Op --model …" |
+| `dafny` not on PATH (or `--dafny-bin` invalid) | 3 | "`dafny --version` failed …" |
+| `dafny translate` exits non-zero | 3 | "dafny translate py failed: $stderr" |
+
+Persistence is intentionally out of scope here. The kernel `ServiceState`
+is held per-request by `make_state()`; bridging it to SQLAlchemy / Postgres
+on a `commit` boundary is tracked as a follow-up issue.
+
 ## What's still deferred
 
 | Concern | Tracked in |
 |---|---|
-| Dafny → Python / Go splice + post-process | [#27](https://github.com/HardMax71/spec_to_rest/issues/27) |
 | Decomposition, model-escalation, skeleton fallback (graduated fallback) | [#30](https://github.com/HardMax71/spec_to_rest/issues/30) |
-| `compile` integrating verified synth output | [#27](https://github.com/HardMax71/spec_to_rest/issues/27) |
+| Dafny `ServiceState` ↔ SQLAlchemy / Postgres reconciliation | follow-up |
+| Go / Java targets for `--with-synthesis` (Python only today) | follow-up |
 | Few-shot examples machine-verified by `dafny verify` in CI | follow-up |
 | Counterexample formatting (Z3 model → human-readable) | follow-up |

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -369,20 +369,23 @@ What this target does **not** generate today, with tracking issues:
   [M7.9 (#63)](https://github.com/HardMax71/spec_to_rest/issues/63). One `docker-compose.yml`
   targeting local development.
 - **Synthesised operation bodies for non-CRUD operations** — transitions, side-effects, and
-  redirects whose body shape doesn't match the entity create schema currently emit
-  `raise NotImplementedError(...)` stubs (see
+  redirects whose body shape doesn't match the entity create schema emit
+  `raise NotImplementedError(...)` stubs by default (see
   `modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs`).
-  `compile` does **not** yet substitute these stubs with synthesised bodies. The
-  Phase 6 wedges that produce verified Dafny bodies for `LLM_SYNTHESIS`-classified
-  operations have shipped (
+  Run `synth verify` for each `LLM_SYNTHESIS`-classified operation to populate
+  `.spec-to-rest/synth-cache/verified/`, then re-run with `compile
+  --with-synthesis`: the verified Dafny bodies are translated to Python via
+  `dafny translate py`, laid under `app/dafny_kernel/`, and the matching
+  handlers call into the kernel via the boundary helpers in
+  `app/services/_dafny_adapter.py`. The full chain:
   [M6.1 (#31)](https://github.com/HardMax71/spec_to_rest/issues/31) classification,
   [M6.2 (#32)](https://github.com/HardMax71/spec_to_rest/issues/32) Dafny signature
   generation, [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) LLM
   integration, [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) the
-  CEGIS feedback loop) — they're invokable today via `synth verify`. The integration
-  step that wires the verified Dafny body into the FastAPI handler this template
-  renders is
-  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) (Dafny→Python
-  compilation), with
-  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) covering graduated
-  fallback when CEGIS can't converge. Both are still open.
+  CEGIS feedback loop, and
+  [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) Dafny→Python
+  compilation — all shipped.
+  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) (graduated
+  fallback when CEGIS can't converge) is still open: today an op without a
+  cached verified body causes `compile --with-synthesis` to exit `1` with an
+  error pointing at `synth verify`.

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -119,7 +119,7 @@ object Compile:
     val profiledBase = Annotate.buildProfiledService(ir, opts.target)
     val kernelStep: IO[Either[ExitCode, Option[KernelBundle]]] =
       if !opts.withSynthesis then IO.pure(Right(None))
-      else buildKernel(specFile, ir, opts, log).map(_.map(Some(_)))
+      else buildKernel(specFile, ir, opts, log)
 
     kernelStep.flatMap:
       case Left(code) => IO.pure(code)
@@ -166,7 +166,7 @@ object Compile:
       ir: ServiceIRFull,
       opts: CompileOptions,
       log: Logger
-  ): IO[Either[ExitCode, KernelBundle]] =
+  ): IO[Either[ExitCode, Option[KernelBundle]]] =
     val classifications = Classify.classifyOperations(ir)
     val synthOps        = classifications.filter(_.strategy == SynthesisStrategy.LlmSynthesis)
     if synthOps.isEmpty then
@@ -174,7 +174,7 @@ object Compile:
         log.warn(
           s"$specFile: --with-synthesis requested but no LLM_SYNTHESIS operations exist; emitting without kernel"
         )
-      ).as(Right(KernelBundle(DafnyKernel.empty, Map.empty)))
+      ).as(Right(None))
     else
       DafnyGenerator.generate(ir) match
         case Left(dErr) =>
@@ -203,7 +203,7 @@ object Compile:
                           .sortBy(_._1)
                           .map((n, p) => OperationBinding(n, p))
                       )
-                      KernelBundle(kernel, bindings)
+                      Some(KernelBundle(kernel, bindings))
 
   private def loadVerifiedBodies(
       specFile: String,
@@ -242,7 +242,7 @@ object Compile:
                             s"$specFile: no verified body cached for '${c.operationName}' " +
                               s"(model=${opts.synthesisModel}, temp=${opts.synthesisTemperature}). " +
                               s"Run: cli/run synth verify $specFile --operation ${c.operationName} " +
-                              s"--model ${opts.synthesisModel}"
+                              s"--model ${opts.synthesisModel} --temperature ${opts.synthesisTemperature}"
                           )
                           Left(ExitCodes.Violations)
                         case Some(entry) =>

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -3,11 +3,24 @@ package specrest.cli
 import cats.effect.ExitCode
 import cats.effect.IO
 import specrest.cli.ExitCodes.given
+import specrest.codegen.DafnyKernel
 import specrest.codegen.Emit
+import specrest.codegen.EmitOptions
+import specrest.codegen.OperationBinding
+import specrest.convention.Classify
+import specrest.convention.SynthesisStrategy
+import specrest.convention.dafny.Generator as DafnyGenerator
 import specrest.ir.VerifyError
+import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.profile.Annotate
+import specrest.synth.Cache
+import specrest.synth.DafnyCli
+import specrest.synth.DafnyTranslateCli
+import specrest.synth.FileAssembly
+import specrest.synth.TargetLanguage
+import specrest.synth.TranslatedDafny
 import specrest.testgen.FilePaths
 import specrest.testgen.Strategies
 import specrest.testgen.SupportedTargets
@@ -15,6 +28,7 @@ import specrest.testgen.TestEmit
 import specrest.verify.VerificationConfig
 
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
 import scala.util.control.NonFatal
@@ -24,7 +38,13 @@ final case class CompileOptions(
     outDir: String,
     ignoreVerify: Boolean = false,
     withTests: Boolean = false,
-    strictStrategies: Boolean = false
+    strictStrategies: Boolean = false,
+    withSynthesis: Boolean = false,
+    synthesisModel: String = "claude-sonnet-4-6",
+    synthesisTemperature: Double = 1.0,
+    synthesisCacheDir: Option[String] = None,
+    dafnyBin: Option[String] = None,
+    dafnyTranslateTimeoutSec: Int = 60
 )
 
 object Compile:
@@ -86,32 +106,163 @@ object Compile:
 
                     strictGate.flatMap:
                       case strictOk if strictOk == ExitCodes.Ok =>
-                        IO.blocking {
-                          val profiled  = Annotate.buildProfiledService(ir, opts.target)
-                          val baseFiles = Emit.emitProject(profiled)
-                          val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
-                          val files     = baseFiles ++ testFiles
-                          val outRoot   = Paths.get(opts.outDir)
-                          Files.createDirectories(outRoot)
-                          files.foreach: f =>
-                            val target = outRoot.resolve(f.path)
-                            Option(target.getParent).foreach(Files.createDirectories(_))
-                            val isUserStrategies = f.path == FilePaths.StrategiesUserFile
-                            if isUserStrategies && Files.exists(target) then ()
-                            else
-                              Files.writeString(
-                                target,
-                                f.content,
-                                StandardOpenOption.CREATE,
-                                StandardOpenOption.TRUNCATE_EXISTING
-                              )
-                          log.success(s"wrote ${files.length} files to ${opts.outDir}")
-                          ExitCodes.Ok
-                        }.handleErrorWith:
-                          case NonFatal(e) =>
-                            IO.delay(
-                              log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
-                            ).as(ExitCodes.Violations)
-                          case e => IO.raiseError(e)
+                        emitProject(specFile, ir, opts, log)
                       case strictCode => IO.pure(strictCode)
                   case gateCode => IO.pure(gateCode)
+
+  private def emitProject(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: CompileOptions,
+      log: Logger
+  ): IO[ExitCode] =
+    val profiledBase = Annotate.buildProfiledService(ir, opts.target)
+    val kernelStep: IO[Either[ExitCode, Option[KernelBundle]]] =
+      if !opts.withSynthesis then IO.pure(Right(None))
+      else buildKernel(specFile, ir, opts, log).map(_.map(Some(_)))
+
+    kernelStep.flatMap:
+      case Left(code) => IO.pure(code)
+      case Right(maybeKernel) =>
+        val profiled =
+          maybeKernel match
+            case Some(b) => Annotate.attachDafnyMethods(profiledBase, b.bindings)
+            case None    => profiledBase
+        IO.blocking {
+          val emitOpts  = EmitOptions(dafnyKernel = maybeKernel.map(_.kernel))
+          val baseFiles = Emit.emitProject(profiled, emitOpts)
+          val testFiles = if opts.withTests then TestEmit.emit(profiled) else Nil
+          val files     = baseFiles ++ testFiles
+          val outRoot   = Paths.get(opts.outDir)
+          Files.createDirectories(outRoot)
+          files.foreach: f =>
+            val target = outRoot.resolve(f.path)
+            Option(target.getParent).foreach(Files.createDirectories(_))
+            val isUserStrategies = f.path == FilePaths.StrategiesUserFile
+            if isUserStrategies && Files.exists(target) then ()
+            else
+              Files.writeString(
+                target,
+                f.content,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+              )
+          log.success(s"wrote ${files.length} files to ${opts.outDir}")
+          ExitCodes.Ok
+        }.handleErrorWith:
+          case NonFatal(e) =>
+            IO.delay(
+              log.error(s"$specFile: ${Option(e.getMessage).getOrElse(e.toString)}")
+            ).as(ExitCodes.Violations)
+          case e => IO.raiseError(e)
+
+  final private case class KernelBundle(
+      kernel: DafnyKernel,
+      bindings: Map[String, String]
+  )
+
+  private def buildKernel(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: CompileOptions,
+      log: Logger
+  ): IO[Either[ExitCode, KernelBundle]] =
+    val classifications = Classify.classifyOperations(ir)
+    val synthOps        = classifications.filter(_.strategy == SynthesisStrategy.LlmSynthesis)
+    if synthOps.isEmpty then
+      IO.delay(
+        log.warn(
+          s"$specFile: --with-synthesis requested but no LLM_SYNTHESIS operations exist; emitting without kernel"
+        )
+      ).as(Right(KernelBundle(DafnyKernel.empty, Map.empty)))
+    else
+      DafnyGenerator.generate(ir) match
+        case Left(dErr) =>
+          IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
+            .as(Left(ExitCodes.Translator))
+        case Right(dafny) =>
+          val cacheRoot =
+            opts.synthesisCacheDir.map(Paths.get(_)).getOrElse(Cache.defaultRoot(Paths.get("")))
+          val verifiedRoot = cacheRoot.resolve("verified")
+          loadVerifiedBodies(specFile, synthOps, dafny.methods, verifiedRoot, opts, log).flatMap:
+            case Left(code) => IO.pure(Left(code))
+            case Right(bodies) =>
+              FileAssembly.spliceAll(dafny.text, bodies) match
+                case Left(failure) =>
+                  IO.delay(log.error(s"$specFile: splice failed: ${failure.message}"))
+                    .as(Left(ExitCodes.Translator))
+                case Right(fullDfy) =>
+                  resolveDafnyAndTranslate(specFile, fullDfy, opts, log).map: r =>
+                    r.map: translated =>
+                      val bindings =
+                        synthOps.map(c => c.operationName -> dafnyCallable(c.operationName)).toMap
+                      val kernel = DafnyKernel(
+                        packagePath = DafnyKernel.DefaultPackagePath,
+                        files = DafnyKernel.rewritePythonImports(translated.files),
+                        bindings = bindings.toList
+                          .sortBy(_._1)
+                          .map((n, p) => OperationBinding(n, p))
+                      )
+                      KernelBundle(kernel, bindings)
+
+  private def loadVerifiedBodies(
+      specFile: String,
+      synthOps: List[specrest.convention.OperationClassification],
+      methods: List[specrest.convention.dafny.DafnyMethodHeader],
+      verifiedRoot: Path,
+      opts: CompileOptions,
+      log: Logger
+  ): IO[Either[ExitCode, Map[String, String]]] =
+    if !Files.isDirectory(verifiedRoot) then
+      IO.delay(
+        log.error(
+          s"$specFile: no verified-body cache at $verifiedRoot; run `synth verify` for each LLM_SYNTHESIS op first"
+        )
+      ).as(Left(ExitCodes.Violations))
+    else
+      Cache.make(verifiedRoot).flatMap: cache =>
+        synthOps
+          .foldLeft[IO[Either[ExitCode, Map[String, String]]]](IO.pure(Right(Map.empty))):
+            (accIO, c) =>
+              accIO.flatMap:
+                case Left(code) => IO.pure(Left(code))
+                case Right(acc) =>
+                  methods.find(_.name == c.operationName) match
+                    case None =>
+                      IO.delay(
+                        log.error(
+                          s"$specFile: Dafny header missing for synthesised op '${c.operationName}'"
+                        )
+                      ).as(Left(ExitCodes.Translator))
+                    case Some(header) =>
+                      val key = Cache.keyFor(header, opts.synthesisModel, opts.synthesisTemperature)
+                      cache.lookup(key).map:
+                        case None =>
+                          log.error(
+                            s"$specFile: no verified body cached for '${c.operationName}' " +
+                              s"(model=${opts.synthesisModel}, temp=${opts.synthesisTemperature}). " +
+                              s"Run: cli/run synth verify $specFile --operation ${c.operationName} " +
+                              s"--model ${opts.synthesisModel}"
+                          )
+                          Left(ExitCodes.Violations)
+                        case Some(entry) =>
+                          Right(acc + (c.operationName -> entry.body))
+
+  private def resolveDafnyAndTranslate(
+      specFile: String,
+      fullDfy: String,
+      opts: CompileOptions,
+      log: Logger
+  ): IO[Either[ExitCode, TranslatedDafny]] =
+    DafnyCli.resolveBinary(opts.dafnyBin).flatMap:
+      case Left(msg) =>
+        IO.delay(log.error(s"$specFile: $msg")).as(Left(ExitCodes.Backend))
+      case Right(binary) =>
+        DafnyTranslateCli.make(binary).use: translator =>
+          translator.translate(fullDfy, TargetLanguage.Python, opts.dafnyTranslateTimeoutSec).map:
+            case Left(err) =>
+              log.error(s"$specFile: dafny translate failed: $err")
+              Left(ExitCodes.Backend)
+            case Right(out) => Right(out)
+
+  private def dafnyCallable(opName: String): String = opName

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -145,14 +145,73 @@ object Main
         "fail compile if any synthesized strategy is incomplete (unhandled `where` constraint or unsupported base type) and no convention override is registered (requires --with-tests)"
       )
       .orFalse
+    val withSynthesis = Opts
+      .flag(
+        "with-synthesis",
+        "splice verified Dafny bodies (translated to the target language) into the emitted project; requires `synth verify` to have been run for each LLM_SYNTHESIS operation and a `dafny` binary on PATH"
+      )
+      .orFalse
+    val synthesisModel = Opts
+      .option[String](
+        "synthesis-model",
+        "model used for `synth verify`; must match the cached entry's model"
+      )
+      .withDefault("claude-sonnet-4-6")
+    val synthesisTemperature = Opts
+      .option[Double](
+        "synthesis-temperature",
+        "temperature used for `synth verify`; must match the cached entry's temperature"
+      )
+      .withDefault(1.0)
+    val synthesisCacheDir = Opts
+      .option[String](
+        "synthesis-cache-dir",
+        "override synth cache root (default: .spec-to-rest/synth-cache)"
+      )
+      .orNone
+    val compileDafnyBin = Opts
+      .option[String]("dafny-bin", "path to dafny binary (defaults to $DAFNY_BIN or PATH)")
+      .orNone
+    val compileTranslateTimeout = Opts
+      .option[Int]("dafny-translate-timeout", "wall-clock timeout for `dafny translate` (seconds)")
+      .withDefault(60)
+      .mapValidated: n =>
+        if n > 0 then cats.data.Validated.valid(n)
+        else cats.data.Validated.invalidNel(s"--dafny-translate-timeout must be > 0 (got $n)")
     Opts.subcommand("compile", "Emit project files for a spec"):
-      (specFile, target, outDir, ignoreVerify, withTests, strictStrategies, verbose, quiet).mapN:
-        (spec, t, o, iv, wt, ss, v, q) =>
-          Compile.run(
-            spec,
-            CompileOptions(t, o, iv, wt, ss),
-            Logger.fromFlags(verbose = v, quiet = q)
-          )
+      (
+        specFile,
+        target,
+        outDir,
+        ignoreVerify,
+        withTests,
+        strictStrategies,
+        withSynthesis,
+        synthesisModel,
+        synthesisTemperature,
+        synthesisCacheDir,
+        compileDafnyBin,
+        compileTranslateTimeout,
+        verbose,
+        quiet
+      ).mapN: (spec, t, o, iv, wt, ss, ws, sm, stp, scd, db, dtt, v, q) =>
+        Compile.run(
+          spec,
+          CompileOptions(
+            target = t,
+            outDir = o,
+            ignoreVerify = iv,
+            withTests = wt,
+            strictStrategies = ss,
+            withSynthesis = ws,
+            synthesisModel = sm,
+            synthesisTemperature = stp,
+            synthesisCacheDir = scd,
+            dafnyBin = db,
+            dafnyTranslateTimeoutSec = dtt
+          ),
+          Logger.fromFlags(verbose = v, quiet = q)
+        )
 
   private val synthCmd: Opts[IO[ExitCode]] =
     val operation = Opts.option[String]("operation", "operation to synthesize", short = "o")

--- a/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
@@ -12,6 +12,7 @@ import specrest.synth.TokenUsage
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import scala.jdk.CollectionConverters.*
 
 class CompileSynthesisTest extends CatsEffectSuite:
 
@@ -45,6 +46,30 @@ class CompileSynthesisTest extends CatsEffectSuite:
       Compile
         .run("fixtures/spec/url_shortener.spec", opts, log)
         .map(code => assertEquals(code, ExitCodes.Violations))
+
+  test("--with-synthesis on a 0-LLM_SYNTHESIS spec emits no kernel/adapter files (#27 review)"):
+    withTempDir: dir =>
+      val opts = baseOpts(dir.toString, Some(dir.resolve("synth-cache").toString))
+      for
+        code <- Compile.run("fixtures/lint/passing.spec", opts, log)
+        files <- IO.blocking:
+                   val stream = Files.walk(dir)
+                   try stream.iterator.asScala.map(dir.relativize).map(_.toString).toSet
+                   finally stream.close()
+      yield
+        assertEquals(code, ExitCodes.Ok)
+        assert(
+          files.forall(p => !p.startsWith("app/dafny_kernel")),
+          s"kernel files leaked into 0-LLM_SYNTHESIS output: ${files.filter(_.startsWith("app/dafny_kernel"))}"
+        )
+        assert(
+          !files.contains("app/services/_dafny_adapter.py"),
+          "adapter file leaked into 0-LLM_SYNTHESIS output"
+        )
+        assert(
+          !files.contains("app/services/_synth.py"),
+          "synth marker file leaked into 0-LLM_SYNTHESIS output"
+        )
 
   test("loadVerifiedBodies reports the missing operation by name"):
     withTempDir: dir =>

--- a/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
@@ -1,0 +1,78 @@
+package specrest.cli
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import specrest.convention.dafny.Generator as DafnyGenerator
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.synth.Cache
+import specrest.synth.CacheEntry
+import specrest.synth.TokenUsage
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class CompileSynthesisTest extends CatsEffectSuite:
+
+  private def log: Logger = Logger.fromFlags(verbose = false, quiet = true)
+
+  private def withTempDir(body: Path => IO[Unit]): IO[Unit] =
+    IO.blocking(Files.createTempDirectory("specrest-compile-synth-")).flatMap: dir =>
+      body(dir).guarantee(IO.blocking(deleteRecursively(dir)).attempt.void)
+
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      val stream = Files.walk(dir)
+      try
+        val it = stream.sorted(java.util.Comparator.reverseOrder()).iterator()
+        while it.hasNext do
+          val _ = Files.deleteIfExists(it.next())
+      finally stream.close()
+
+  private def baseOpts(outDir: String, cacheDir: Option[String]): CompileOptions =
+    CompileOptions(
+      target = "python-fastapi-postgres",
+      outDir = outDir,
+      ignoreVerify = true,
+      withSynthesis = true,
+      synthesisCacheDir = cacheDir
+    )
+
+  test("--with-synthesis without verified cache exits Violations and points at synth verify"):
+    withTempDir: dir =>
+      val opts = baseOpts(dir.toString, Some(dir.resolve("synth-cache").toString))
+      Compile
+        .run("fixtures/spec/url_shortener.spec", opts, log)
+        .map(code => assertEquals(code, ExitCodes.Violations))
+
+  test("loadVerifiedBodies reports the missing operation by name"):
+    withTempDir: dir =>
+      val cacheDir     = dir.resolve("synth-cache")
+      val verifiedRoot = cacheDir.resolve("verified")
+      val opts         = baseOpts(dir.toString, Some(cacheDir.toString))
+      val seed: IO[Unit] =
+        for
+          _       <- IO.blocking(Files.createDirectories(verifiedRoot))
+          source  <- IO.blocking(Files.readString(Paths.get("fixtures/spec/url_shortener.spec")))
+          parsedE <- Parse.parseSpec(source)
+          parsed   = parsedE.toOption.getOrElse(fail("parse failed"))
+          builtE  <- Builder.buildIR(parsed.tree)
+          built    = builtE.toOption.getOrElse(fail("build failed"))
+          dafny    = DafnyGenerator.generate(built).getOrElse(fail("dafny gen failed"))
+          header   = dafny.methods.find(_.name == "Shorten").getOrElse(fail("Shorten missing"))
+          cache   <- Cache.make(verifiedRoot)
+          key      = Cache.keyFor(header, "claude-sonnet-4-6", 1.0)
+          entry = CacheEntry(
+                    candidate = "stub",
+                    body = "assume false;",
+                    usage = TokenUsage(0, 0),
+                    model = "claude-sonnet-4-6",
+                    promptVersion = specrest.synth.SynthPromptVersion
+                  )
+          _ <- cache.store(key, entry)
+        yield ()
+
+      seed *> Compile
+        .run("fixtures/spec/url_shortener.spec", opts, log)
+        .map(code => assertEquals(code, ExitCodes.Violations))

--- a/modules/cli/src/test/scala/specrest/cli/SeedVerifiedCacheMain.scala
+++ b/modules/cli/src/test/scala/specrest/cli/SeedVerifiedCacheMain.scala
@@ -1,0 +1,65 @@
+package specrest.cli
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.IOApp
+import specrest.convention.dafny.Generator as DafnyGenerator
+import specrest.parser.Builder
+import specrest.parser.Parse
+import specrest.synth.Cache
+import specrest.synth.CacheEntry
+import specrest.synth.SynthPromptVersion
+import specrest.synth.TokenUsage
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+object SeedVerifiedCacheMain extends IOApp:
+
+  def run(args: List[String]): IO[ExitCode] =
+    if args.length < 4 || args.length % 2 != 0 then
+      IO.println(
+        "usage: SeedVerifiedCacheMain <spec> <cache-root> <op1> <body1> [<op2> <body2> ...]"
+      ).as(ExitCode.Error)
+    else
+      val spec = args.head
+      val root = Paths.get(args(1)).resolve("verified")
+      val pairs = args
+        .drop(2)
+        .grouped(2)
+        .collect:
+          case List(op, body) => op -> body
+        .toList
+
+      val program =
+        for
+          src    <- IO.blocking(Files.readString(Paths.get(spec)))
+          parsed <- Parse.parseSpec(src)
+          tree   <- IO.fromEither(parsed.left.map(e => new RuntimeException(s"parse: $e")))
+          irE    <- Builder.buildIR(tree.tree)
+          ir     <- IO.fromEither(irE.left.map(e => new RuntimeException(s"build: ${e.message}")))
+          dafny <- IO.fromEither(
+                     DafnyGenerator
+                       .generate(ir)
+                       .left
+                       .map(e => new RuntimeException(s"dafny gen: ${e.message}"))
+                   )
+          cache <- Cache.make(root)
+          _ <- pairs.foldLeft(IO.unit): (acc, kv) =>
+                 val (op, body) = kv
+                 dafny.methods.find(_.name == op) match
+                   case None =>
+                     acc *> IO.raiseError(new RuntimeException(s"no Dafny method '$op'"))
+                   case Some(header) =>
+                     val key = Cache.keyFor(header, "claude-sonnet-4-6", 1.0)
+                     val entry = CacheEntry(
+                       candidate = "stub",
+                       body = body,
+                       usage = TokenUsage(0, 0),
+                       model = "claude-sonnet-4-6",
+                       promptVersion = SynthPromptVersion
+                     )
+                     acc *> cache.store(key, entry) *> IO.println(s"seeded $op")
+        yield ExitCode.Success
+      program.handleErrorWith: t =>
+        IO.println(s"seed failed: ${t.getMessage}").as(ExitCode.Error)

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/_dafny_adapter.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/_dafny_adapter.py.hbs
@@ -1,0 +1,44 @@
+{{!--
+  Boundary helpers between FastAPI / Pydantic and the Dafny-translated kernel.
+  The kernel ships under ``app.dafny_kernel.module_`` with the runtime under
+  ``app.dafny_kernel._dafny``; methods land as ``@staticmethod``s on
+  ``module_.default__`` and operate on a mutable ``module_.ServiceState``.
+  Persistence (Dafny state -> SQLAlchemy) is intentionally out of scope here;
+  ServiceState is held per-request and reset between handlers. Tracked as a
+  follow-up to issue #27 in this repo.
+--}}from __future__ import annotations
+
+from typing import Any, Iterable
+
+from app.dafny_kernel import module_
+from app.dafny_kernel._dafny import Map as _DafnyMap
+from app.dafny_kernel._dafny import Seq as _DafnySeq
+from app.dafny_kernel._dafny import Set as _DafnySet
+
+
+def make_state() -> module_.ServiceState:
+    return module_.ServiceState()
+
+
+def to_dafny_seq(xs: Iterable[Any]) -> Any:
+    return _DafnySeq(list(xs))
+
+
+def from_dafny_seq(seq: Any) -> list[Any]:
+    return list(seq)
+
+
+def to_dafny_map(d: dict[Any, Any]) -> Any:
+    return _DafnyMap(d)
+
+
+def from_dafny_map(m: Any) -> dict[Any, Any]:
+    return dict(m)
+
+
+def to_dafny_set(xs: Iterable[Any]) -> Any:
+    return _DafnySet(xs)
+
+
+def from_dafny_set(s: Any) -> set[Any]:
+    return set(s)

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/_synth.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/_synth.py.hbs
@@ -1,0 +1,10 @@
+{{!--
+  Holding place for non-entity-attached LLM_SYNTHESIS operations. Today every
+  op in the URL-shortener and safe-counter fixtures is entity-bound, so this
+  file is just a marker; non-entity wiring lives in the entity-specific
+  service modules under app/services/<entity>.py.
+--}}from __future__ import annotations
+
+from app.services._dafny_adapter import make_state
+
+__all__ = ["make_state"]

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -28,7 +28,7 @@ class {{entity.entityName}}Service:
 
 {{/unless}}
 {{#if this.dafnyMethod}}
-    async def {{this.handlerName}}(self{{#if this.serviceSignatureExtraArgs}}, {{this.serviceSignatureExtraArgs}}{{/if}}) -> {{this.serviceReturnAnnotation}}:
+    async def {{this.handlerName}}(self{{#if this.kernelHandlerSignature}}, {{this.kernelHandlerSignature}}{{/if}}) -> {{this.serviceReturnAnnotation}}:
         state = make_state()
         result = _dafny_kernel.{{this.dafnyMethod}}(state{{#each this.dafnyCallArgs}}, {{this}}{{/each}})
         return result  # type: ignore[no-any-return]

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/services/entity.py.hbs
@@ -3,6 +3,10 @@ from sqlalchemy import {{join serviceImports.sqlalchemyCoreImports ", "}}
 {{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
+{{#if serviceImports.needsDafnyKernel}}
+from app.dafny_kernel.module_ import default__ as _dafny_kernel
+from app.services._dafny_adapter import make_state
+{{/if}}
 {{#if serviceImports.needsModelImport}}
 from app.models.{{snake_case entity.entityName}} import {{entity.modelClassName}}
 {{/if}}
@@ -23,7 +27,12 @@ class {{entity.entityName}}Service:
 {{#unless @first}}
 
 {{/unless}}
-{{#if (eq this.routeKind "create")}}
+{{#if this.dafnyMethod}}
+    async def {{this.handlerName}}(self{{#if this.serviceSignatureExtraArgs}}, {{this.serviceSignatureExtraArgs}}{{/if}}) -> {{this.serviceReturnAnnotation}}:
+        state = make_state()
+        result = _dafny_kernel.{{this.dafnyMethod}}(state{{#each this.dafnyCallArgs}}, {{this}}{{/each}})
+        return result  # type: ignore[no-any-return]
+{{else if (eq this.routeKind "create")}}
     async def {{this.handlerName}}(self, body: {{../entity.createSchemaName}}) -> {{../entity.readSchemaName}}:
         row = {{../entity.modelClassName}}(body)
         self._session.add(row)

--- a/modules/codegen/src/main/scala/specrest/codegen/DafnyKernel.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/DafnyKernel.scala
@@ -1,0 +1,39 @@
+package specrest.codegen
+
+final case class DafnyKernel(
+    packagePath: String,
+    files: Map[String, String],
+    bindings: List[OperationBinding]
+):
+  def fileFor(relPath: String): Option[String] = files.get(relPath)
+
+final case class OperationBinding(
+    operationName: String,
+    pythonCallable: String
+)
+
+object DafnyKernel:
+
+  val DefaultPackagePath: String = "app/dafny_kernel"
+
+  def empty: DafnyKernel = DafnyKernel(DefaultPackagePath, Map.empty, Nil)
+
+  def rewritePythonImports(files: Map[String, String]): Map[String, String] =
+    files.map: (relPath, content) =>
+      val subdirDepth = relPath.count(_ == '/')
+      val dots        = "." * (subdirDepth + 1)
+      relPath -> rewritePyFile(content, dots)
+
+  private def rewritePyFile(content: String, dots: String): String =
+    content.linesWithSeparators.map(line => rewriteLine(line, dots)).mkString
+
+  private val AbsoluteImport = """^(\s*)import\s+(_dafny|module_|System_)\s+as\s+(\2)\s*(#.*)?$""".r
+
+  private def rewriteLine(line: String, dots: String): String =
+    val stripped = if line.endsWith("\n") then line.dropRight(1) else line
+    val term     = if line.endsWith("\n") then "\n" else ""
+    stripped match
+      case AbsoluteImport(indent, name, _, comment) =>
+        val tail = Option(comment).map(c => s"  $c").getOrElse("")
+        s"${indent}from $dots import $name as $name$tail$term"
+      case _ => line

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -19,7 +19,8 @@ final case class EmittedFile(path: String, content: String)
 
 final case class EmitOptions(
     createdDate: Option[String] = None,
-    revision: Option[String] = None
+    revision: Option[String] = None,
+    dafnyKernel: Option[DafnyKernel] = None
 )
 
 final private case class StdlibImport(module: String, names: List[String])
@@ -55,7 +56,9 @@ final private case class EnrichedOperation(
     serviceReturnAnnotation: String,
     modelLookupColumn: String,
     pathParamName: String,
-    customRequestSchema: Option[CustomRequestSchema]
+    customRequestSchema: Option[CustomRequestSchema],
+    dafnyMethod: Option[String],
+    dafnyCallArgs: List[String]
 )
 
 final private case class EntityImports(
@@ -75,7 +78,8 @@ final private case class RouterTemplateImports(
 final private case class ServiceTemplateImports(
     sqlalchemyCoreImports: List[String],
     schemas: List[String],
-    needsModelImport: Boolean
+    needsModelImport: Boolean,
+    needsDafnyKernel: Boolean
 )
 
 final private case class ModelCtx(
@@ -161,7 +165,7 @@ object Emit:
   private val PostgresDialectTypes: Set[String] = Set("JSONB")
 
   def emitProject(profiled: ProfiledService, opts: EmitOptions = EmitOptions()): List[EmittedFile] =
-    val ctx        = RenderContext.buildRenderContext(profiled)
+    val ctx        = RenderContext.buildRenderContext(profiled, opts.dafnyKernel)
     val engine     = new TemplateEngine
     val typeLookup = buildTypeLookup(profiled)
     val templates  = Templates.pythonFastapiPostgres
@@ -322,6 +326,21 @@ object Emit:
       engine.renderAny(templates.testLogRedaction, ctx)
     )
 
+    ctx.dafnyKernel.foreach: kernel =>
+      val pkg = kernel.packagePath.stripSuffix("/")
+      kernel.files.toList.sortBy(_._1).foreach: (rel, content) =>
+        files += EmittedFile(s"$pkg/$rel", content)
+      if !kernel.files.contains("__init__.py") then
+        files += EmittedFile(s"$pkg/__init__.py", "from . import module_  # noqa: F401\n")
+      files += EmittedFile(
+        "app/services/_dafny_adapter.py",
+        engine.renderAny(templates.dafnyAdapter, ctx)
+      )
+      files += EmittedFile(
+        "app/services/_synth.py",
+        engine.renderAny(templates.synthService, ctx)
+      )
+
     files.result()
 
   private def schemaInputField(f: ProfiledField): SchemaFieldView =
@@ -471,6 +490,8 @@ object Emit:
       if pathParamsWithTypes.nonEmpty then pathParamsWithTypes.head.name else "id"
     val modelLookupColumn = resolveModelLookupColumn(entity, pathParamName)
 
+    val dafnyArgs = dafnyCallArguments(op, endpoint)
+
     EnrichedOperation(
       operationName = op.operationName,
       handlerName = op.handlerName,
@@ -489,8 +510,19 @@ object Emit:
       serviceReturnAnnotation = serviceReturnAnno,
       modelLookupColumn = modelLookupColumn,
       pathParamName = pathParamName,
-      customRequestSchema = customRequestSchema
+      customRequestSchema = customRequestSchema,
+      dafnyMethod = op.dafnyMethod,
+      dafnyCallArgs = dafnyArgs
     )
+
+  private def dafnyCallArguments(
+      @scala.annotation.unused op: ProfiledOperation,
+      endpoint: EndpointSpec
+  ): List[String] =
+    val pathArgs  = endpoint.pathParams.map(_.name)
+    val queryArgs = endpoint.queryParams.map(_.name)
+    val bodyArgs  = endpoint.bodyParams.map(p => s"body.${p.name}")
+    pathArgs ++ queryArgs ++ bodyArgs
 
   private def routeKindTsName(rk: RouteKind): String = rk match
     case RouteKind.Create   => "create"
@@ -591,10 +623,12 @@ object Emit:
     val schemaSet        = mutable.Set.empty[String]
 
     for op <- operations do
-      if op.routeKind == "read" || op.routeKind == "list" then
+      val routedThroughKernel = op.dafnyMethod.isDefined
+      if !routedThroughKernel && (op.routeKind == "read" || op.routeKind == "list") then
         needsSelect = true; needsModelImport = true
-      if op.routeKind == "delete" then needsSaDelete = true; needsModelImport = true
-      if op.routeKind == "create" then needsModelImport = true
+      if !routedThroughKernel && op.routeKind == "delete" then
+        needsSaDelete = true; needsModelImport = true
+      if !routedThroughKernel && op.routeKind == "create" then needsModelImport = true
       if op.routeKind == "create" || op.routeKind == "read" || op.routeKind == "list" then
         schemaSet += entity.readSchemaName
       if op.hasRequestBody && op.requestBodyType.nonEmpty then schemaSet += op.requestBodyType
@@ -606,5 +640,6 @@ object Emit:
     ServiceTemplateImports(
       sqlalchemyCoreImports = coreImports.result(),
       schemas = schemaSet.toList.sorted,
-      needsModelImport = needsModelImport
+      needsModelImport = needsModelImport,
+      needsDafnyKernel = operations.exists(_.dafnyMethod.isDefined)
     )

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -493,6 +493,14 @@ object Emit:
 
     val (kernelSig, dafnyArgs) = kernelSignatureAndArgs(endpoint, requestBodyType, typeLookup)
 
+    // When the operation is routed through the Dafny kernel, the service handler's signature
+    // is `kernelHandlerSignature` (path + query + body, in that order). The router must pass
+    // the same arg list — `serviceCallArgs` is route-kind specific and may omit some of them
+    // (e.g. RouteKind.Create's serviceCallArgs is just "body", losing path/query params).
+    val effectiveServiceCallArgs =
+      if op.dafnyMethod.isDefined then kernelRouterCallArgs(endpoint)
+      else serviceCallArgs
+
     EnrichedOperation(
       operationName = op.operationName,
       handlerName = op.handlerName,
@@ -504,7 +512,7 @@ object Emit:
       hasRequestBody = hasRequestBody,
       requestBodyType = requestBodyType,
       responseAnnotation = responseAnnotation,
-      serviceCallArgs = serviceCallArgs,
+      serviceCallArgs = effectiveServiceCallArgs,
       routeKind = routeKindTsName(routeKind),
       pathParamSignature = pathParamSignature,
       serviceSignatureExtraArgs = serviceExtraArgs,
@@ -534,6 +542,12 @@ object Emit:
       endpoint.queryParams.map(_.name) ++
       endpoint.bodyParams.map(p => s"body.${p.name}")
     ((pathSig ++ querySig ++ bodySig).mkString(", "), callArgs)
+
+  private def kernelRouterCallArgs(endpoint: EndpointSpec): String =
+    val parts = endpoint.pathParams.map(_.name) ++
+      endpoint.queryParams.map(_.name) ++
+      (if endpoint.bodyParams.nonEmpty then List("body") else Nil)
+    parts.mkString(", ")
 
   private def routeKindTsName(rk: RouteKind): String = rk match
     case RouteKind.Create   => "create"

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -58,7 +58,8 @@ final private case class EnrichedOperation(
     pathParamName: String,
     customRequestSchema: Option[CustomRequestSchema],
     dafnyMethod: Option[String],
-    dafnyCallArgs: List[String]
+    dafnyCallArgs: List[String],
+    kernelHandlerSignature: String
 )
 
 final private case class EntityImports(
@@ -490,7 +491,7 @@ object Emit:
       if pathParamsWithTypes.nonEmpty then pathParamsWithTypes.head.name else "id"
     val modelLookupColumn = resolveModelLookupColumn(entity, pathParamName)
 
-    val dafnyArgs = dafnyCallArguments(op, endpoint)
+    val (kernelSig, dafnyArgs) = kernelSignatureAndArgs(endpoint, requestBodyType, typeLookup)
 
     EnrichedOperation(
       operationName = op.operationName,
@@ -512,17 +513,27 @@ object Emit:
       pathParamName = pathParamName,
       customRequestSchema = customRequestSchema,
       dafnyMethod = op.dafnyMethod,
-      dafnyCallArgs = dafnyArgs
+      dafnyCallArgs = dafnyArgs,
+      kernelHandlerSignature = kernelSig
     )
 
-  private def dafnyCallArguments(
-      @scala.annotation.unused op: ProfiledOperation,
-      endpoint: EndpointSpec
-  ): List[String] =
-    val pathArgs  = endpoint.pathParams.map(_.name)
-    val queryArgs = endpoint.queryParams.map(_.name)
-    val bodyArgs  = endpoint.bodyParams.map(p => s"body.${p.name}")
-    pathArgs ++ queryArgs ++ bodyArgs
+  private def kernelSignatureAndArgs(
+      endpoint: EndpointSpec,
+      requestBodyType: String,
+      typeLookup: Map[String, String]
+  ): (String, List[String]) =
+    val pathSig =
+      endpoint.pathParams.map(p => s"${p.name}: ${pythonTypeForParam(p.typeExpr, typeLookup)}")
+    val querySig =
+      endpoint.queryParams.map(p => s"${p.name}: ${pythonTypeForParam(p.typeExpr, typeLookup)}")
+    val bodySig =
+      if endpoint.bodyParams.nonEmpty && requestBodyType.nonEmpty then
+        List(s"body: $requestBodyType")
+      else Nil
+    val callArgs = endpoint.pathParams.map(_.name) ++
+      endpoint.queryParams.map(_.name) ++
+      endpoint.bodyParams.map(p => s"body.${p.name}")
+    ((pathSig ++ querySig ++ bodySig).mkString(", "), callArgs)
 
   private def routeKindTsName(rk: RouteKind): String = rk match
     case RouteKind.Create   => "create"

--- a/modules/codegen/src/main/scala/specrest/codegen/Templates.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Templates.scala
@@ -30,7 +30,9 @@ final case class PythonFastapiPostgresTemplates(
     readme: String,
     ciWorkflow: String,
     testHealth: String,
-    testLogRedaction: String
+    testLogRedaction: String,
+    dafnyAdapter: String,
+    synthService: String
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
@@ -80,5 +82,7 @@ object Templates:
       readme = loadResource("README.md.hbs"),
       ciWorkflow = loadResource("github/workflows/ci.yml.hbs"),
       testHealth = loadResource("tests/test_health.py.hbs"),
-      testLogRedaction = loadResource("tests/test_log_redaction.py.hbs")
+      testLogRedaction = loadResource("tests/test_log_redaction.py.hbs"),
+      dafnyAdapter = loadResource("services/_dafny_adapter.py.hbs"),
+      synthService = loadResource("services/_synth.py.hbs")
     )

--- a/modules/codegen/src/main/scala/specrest/codegen/Types.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Types.scala
@@ -44,7 +44,8 @@ final case class RenderContext(
     entities: List[ProfiledEntity],
     operations: List[ProfiledOperation],
     endpoints: List[EndpointSpec],
-    schema: DatabaseSchema
+    schema: DatabaseSchema,
+    dafnyKernel: Option[DafnyKernel] = None
 )
 
 final case class RenderResult(fileName: String, content: String)
@@ -55,7 +56,10 @@ object RenderContext:
   import specrest.convention.Naming
   import specrest.profile.{DeploymentProfile, ProfiledService, TypeMapping}
 
-  def buildRenderContext(profiled: ProfiledService): RenderContext =
+  def buildRenderContext(
+      profiled: ProfiledService,
+      dafnyKernel: Option[DafnyKernel] = None
+  ): RenderContext =
     RenderContext(
       service = ServiceNames(
         name = profiled.ir.a,
@@ -66,7 +70,8 @@ object RenderContext:
       entities = profiled.entities,
       operations = profiled.operations,
       endpoints = profiled.endpoints,
-      schema = profiled.schema
+      schema = profiled.schema,
+      dafnyKernel = dafnyKernel
     )
 
   private def convertProfile(profile: DeploymentProfile): RenderProfile =

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -100,6 +100,37 @@ class EmitTest extends CatsEffectSuite:
         s"kernel call should reference body fields — got:\n$todoService"
       )
 
+  test("kernel-routed router call args match kernel handler signature (#27 review)"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      val profiledBase = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+      val profiled =
+        Annotate.attachDafnyMethods(
+          profiledBase,
+          Map("Shorten" -> "Shorten", "Resolve" -> "Resolve")
+        )
+      val kernel = DafnyKernel(
+        packagePath = DafnyKernel.DefaultPackagePath,
+        files = Map("module_.py" -> "# kernel\n"),
+        bindings =
+          List(OperationBinding("Shorten", "Shorten"), OperationBinding("Resolve", "Resolve"))
+      )
+      val files = Emit.emitProject(profiled, EmitOptions(dafnyKernel = Some(kernel)))
+      val router = files
+        .find(_.path == "app/routers/url_mappings.py")
+        .map(_.content)
+        .getOrElse(fail("no url_mappings router emitted"))
+      // Resolve service signature is `code: str` — router must pass `code` (it's a Read route
+      // so the prior route-kind logic happened to align, but kernel-routing is the source of truth).
+      assert(
+        router.contains("svc.resolve(code)"),
+        s"router should call svc.resolve(code) — got:\n$router"
+      )
+      // Shorten service signature is `body: ShortenRequest` — router must pass `body`.
+      assert(
+        router.contains("svc.shorten(body)"),
+        s"router should call svc.shorten(body) — got:\n$router"
+      )
+
   test("kernel-routed handler signature matches dafnyCallArgs for path+body ops (#27 review)"):
     SpecFixtures.loadIR("url_shortener").map: ir =>
       val profiledBase = Annotate.buildProfiledService(ir, "python-fastapi-postgres")

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -11,6 +11,78 @@ class EmitTest extends CatsEffectSuite:
       val files = Emit.emitProject(profiled)
       assert(files.nonEmpty, "no files emitted")
 
+  test("emitProject lays kernel files under app/dafny_kernel/ when DafnyKernel attached (#27)"):
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val kernel = DafnyKernel(
+        packagePath = DafnyKernel.DefaultPackagePath,
+        files = Map(
+          "module_.py"          -> "# kernel body\n",
+          "_dafny/__init__.py"  -> "# runtime\n",
+          "System_/__init__.py" -> "# system\n"
+        ),
+        bindings = List(
+          OperationBinding("Shorten", "app.dafny_kernel.module_.default__.Shorten")
+        )
+      )
+      val files = Emit
+        .emitProject(profiled, EmitOptions(dafnyKernel = Some(kernel)))
+        .map(f => f.path -> f.content)
+        .toMap
+      assertEquals(files.get("app/dafny_kernel/module_.py"), Some("# kernel body\n"))
+      assertEquals(files.get("app/dafny_kernel/_dafny/__init__.py"), Some("# runtime\n"))
+      assertEquals(files.get("app/dafny_kernel/System_/__init__.py"), Some("# system\n"))
+      assert(
+        files.get("app/dafny_kernel/__init__.py").exists(_.contains("from . import module_")),
+        s"missing kernel package marker: ${files.get("app/dafny_kernel/__init__.py")}"
+      )
+      assert(
+        files.contains("app/services/_dafny_adapter.py"),
+        "missing dafny adapter file"
+      )
+      assert(
+        files.contains("app/services/_synth.py"),
+        "missing synth marker file"
+      )
+
+  test("DafnyKernel.rewritePythonImports uses depth-aware dots"):
+    val rootFile =
+      """import sys
+        |
+        |import module_ as module_
+        |import _dafny as _dafny
+        |""".stripMargin
+    val nestedFile =
+      """import sys
+        |
+        |import _dafny as _dafny
+        |""".stripMargin
+    val out = DafnyKernel.rewritePythonImports(
+      Map(
+        "module_.py"          -> rootFile,
+        "System_/__init__.py" -> nestedFile
+      )
+    )
+    assert(
+      out("module_.py").contains("from . import module_ as module_"),
+      s"root file should use single-dot:\n${out("module_.py")}"
+    )
+    assert(
+      out("module_.py").contains("from . import _dafny as _dafny"),
+      s"root file should use single-dot:\n${out("module_.py")}"
+    )
+    assert(
+      out("System_/__init__.py").contains("from .. import _dafny as _dafny"),
+      s"nested file should use double-dot:\n${out("System_/__init__.py")}"
+    )
+    assert(out("module_.py").contains("import sys"), "stdlib import preserved")
+
+  test("emitProject without kernel does not emit dafny_kernel files"):
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val paths = Emit.emitProject(profiled).map(_.path).toSet
+      assert(paths.forall(p => !p.startsWith("app/dafny_kernel/")), "kernel files leaked")
+      assert(!paths.contains("app/services/_dafny_adapter.py"), "adapter leaked")
+      assert(!paths.contains("app/services/_synth.py"), "synth marker leaked")
+
   test("url_shortener emits a known file set"):
     SpecFixtures.loadProfiled("url_shortener").map: profiled =>
       val files = Emit.emitProject(profiled).map(_.path).toSet

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -3,6 +3,7 @@ package specrest.codegen
 import cats.effect.IO
 import munit.CatsEffectSuite
 import specrest.codegen.testutil.SpecFixtures
+import specrest.profile.Annotate
 
 class EmitTest extends CatsEffectSuite:
 
@@ -75,6 +76,67 @@ class EmitTest extends CatsEffectSuite:
       s"nested file should use double-dot:\n${out("System_/__init__.py")}"
     )
     assert(out("module_.py").contains("import sys"), "stdlib import preserved")
+
+  test("kernel-routed Create handler still receives `body` parameter (#27 review)"):
+    SpecFixtures.loadIR("todo_list").map: ir =>
+      val profiledBase = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+      val profiled     = Annotate.attachDafnyMethods(profiledBase, Map("CreateTodo" -> "CreateTodo"))
+      val kernel = DafnyKernel(
+        packagePath = DafnyKernel.DefaultPackagePath,
+        files = Map("module_.py" -> "# kernel\n"),
+        bindings = List(OperationBinding("CreateTodo", "CreateTodo"))
+      )
+      val files = Emit.emitProject(profiled, EmitOptions(dafnyKernel = Some(kernel)))
+      val todoService = files
+        .find(_.path == "app/services/todo.py")
+        .map(_.content)
+        .getOrElse(fail("no todo service emitted"))
+      assert(
+        todoService.contains("async def create_todo(self, body: CreateTodoRequest)"),
+        s"kernel-routed Create handler should accept `body: CreateTodoRequest` — got:\n$todoService"
+      )
+      assert(
+        todoService.contains("_dafny_kernel.CreateTodo(state, body."),
+        s"kernel call should reference body fields — got:\n$todoService"
+      )
+
+  test("kernel-routed handler signature matches dafnyCallArgs for path+body ops (#27 review)"):
+    SpecFixtures.loadIR("url_shortener").map: ir =>
+      val profiledBase = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+      val profiled =
+        Annotate.attachDafnyMethods(
+          profiledBase,
+          Map("Shorten" -> "Shorten", "Resolve" -> "Resolve")
+        )
+      val kernel = DafnyKernel(
+        packagePath = DafnyKernel.DefaultPackagePath,
+        files = Map("module_.py" -> "# kernel\n"),
+        bindings =
+          List(OperationBinding("Shorten", "Shorten"), OperationBinding("Resolve", "Resolve"))
+      )
+      val files = Emit.emitProject(profiled, EmitOptions(dafnyKernel = Some(kernel)))
+      val service = files
+        .find(_.path == "app/services/url_mapping.py")
+        .map(_.content)
+        .getOrElse(fail("no url_mapping service emitted"))
+      // Shorten: body-only op (Other route). Signature must include body, call must reference body.url.
+      assert(
+        service.contains("async def shorten(self, body: ShortenRequest)"),
+        s"shorten handler should accept body: ShortenRequest — got:\n$service"
+      )
+      assert(
+        service.contains("_dafny_kernel.Shorten(state, body.url)"),
+        s"shorten kernel call should pass body.url — got:\n$service"
+      )
+      // Resolve: path param `code: str`. Signature must include `code: str`, call must reference `code`.
+      assert(
+        service.contains("async def resolve(self, code: str)"),
+        s"resolve handler should accept code: str — got:\n$service"
+      )
+      assert(
+        service.contains("_dafny_kernel.Resolve(state, code)"),
+        s"resolve kernel call should pass code — got:\n$service"
+      )
 
   test("emitProject without kernel does not emit dafny_kernel files"):
     SpecFixtures.loadProfiled("url_shortener").map: profiled =>

--- a/modules/profile/src/main/scala/specrest/profile/Annotate.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Annotate.scala
@@ -50,6 +50,19 @@ object Annotate:
 
     ProfiledService(ir, profile, endpoints, schema, entities, operations)
 
+  def attachDafnyMethods(
+      profiled: ProfiledService,
+      bindings: Map[String, String]
+  ): ProfiledService =
+    if bindings.isEmpty then profiled
+    else
+      profiled.copy(operations =
+        profiled.operations.map: op =>
+          bindings.get(op.operationName) match
+            case Some(callable) => op.copy(dafnyMethod = Some(callable))
+            case None           => op
+      )
+
   private def profileEntity(
       entityName: String,
       tableName: String,

--- a/modules/profile/src/main/scala/specrest/profile/Types.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Types.scala
@@ -79,7 +79,8 @@ final case class ProfiledOperation(
     kind: OperationKind,
     targetEntity: Option[String],
     requestBodyFields: List[ProfiledField],
-    responseFields: List[ProfiledField]
+    responseFields: List[ProfiledField],
+    dafnyMethod: Option[String] = None
 )
 
 final case class ProfiledService(

--- a/modules/synth/src/main/scala/specrest/synth/DafnyTranslator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/DafnyTranslator.scala
@@ -1,0 +1,180 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.kernel.Ref
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import scala.jdk.CollectionConverters.*
+
+final case class TranslatedDafny(
+    target: TargetLanguage,
+    files: Map[String, String],
+    rawStdout: String,
+    rawStderr: String,
+    durationMs: Long
+) derives CanEqual
+
+trait DafnyTranslator:
+  def translate(
+      source: String,
+      target: TargetLanguage,
+      timeoutSec: Int
+  ): IO[Either[String, TranslatedDafny]]
+
+final class DafnyTranslateCli private (binary: String, workDir: Path) extends DafnyTranslator:
+
+  def translate(
+      source: String,
+      target: TargetLanguage,
+      timeoutSec: Int
+  ): IO[Either[String, TranslatedDafny]] =
+    val unique  = java.util.UUID.randomUUID().toString
+    val srcFile = workDir.resolve(s"candidate-$unique.dfy")
+    val outBase = workDir.resolve(s"candidate-$unique")
+    val outDir  = workDir.resolve(s"candidate-$unique${target.outputSuffix}")
+    val outFile = workDir.resolve(s"candidate-$unique.translate.out")
+    val errFile = workDir.resolve(s"candidate-$unique.translate.err")
+    val cleanup =
+      IO.blocking(Files.deleteIfExists(srcFile)).attempt.void *>
+        IO.blocking(deleteRecursively(outDir)).attempt.void *>
+        IO.blocking(Files.deleteIfExists(outFile)).attempt.void *>
+        IO.blocking(Files.deleteIfExists(errFile)).attempt.void
+    val program =
+      for
+        _      <- IO.blocking(Files.writeString(srcFile, source, StandardOpenOption.CREATE_NEW))
+        result <- runTranslate(srcFile, outBase, outDir, outFile, errFile, target, timeoutSec)
+      yield result
+    program.attempt.flatMap:
+      case Right(r) => IO.pure(r)
+      case Left(t)  => IO.pure(Left(s"failed to invoke dafny translate: ${t.getMessage}"))
+    .guarantee(cleanup)
+
+  private def runTranslate(
+      srcFile: Path,
+      outBase: Path,
+      outDir: Path,
+      outFile: Path,
+      errFile: Path,
+      target: TargetLanguage,
+      timeoutSec: Int
+  ): IO[Either[String, TranslatedDafny]] =
+    val command = List(
+      binary,
+      "translate",
+      target.cliFlag,
+      "--include-runtime",
+      "--no-verify",
+      s"--verification-time-limit=$timeoutSec",
+      s"--output=${outBase.toString}",
+      srcFile.toString
+    )
+    IO.blocking {
+      val started = System.nanoTime()
+      val pb = new ProcessBuilder(command.toArray*)
+        .redirectOutput(outFile.toFile)
+        .redirectError(errFile.toFile)
+      val proc = pb.start()
+      proc.getOutputStream.close()
+      val finished =
+        proc.waitFor((timeoutSec.toLong + 30L) * 1000L, java.util.concurrent.TimeUnit.MILLISECONDS)
+      if !finished then
+        proc.destroyForcibly()
+        Left(s"dafny translate exceeded ${timeoutSec + 30}s wall-clock and was killed")
+      else
+        val exit       = proc.exitValue()
+        val durationMs = (System.nanoTime() - started) / 1_000_000L
+        val stdout     = readIfExists(outFile)
+        val stderr     = readIfExists(errFile)
+        if exit != 0 then
+          val detail =
+            if stderr.trim.nonEmpty then stderr.trim
+            else if stdout.trim.nonEmpty then stdout.trim
+            else s"exit=$exit"
+          Left(s"dafny translate ${target.cliFlag} failed: $detail")
+        else if !Files.isDirectory(outDir) then
+          Left(s"dafny translate ${target.cliFlag} produced no output directory at $outDir")
+        else
+          Right(
+            TranslatedDafny(
+              target = target,
+              files = collectFiles(outDir),
+              rawStdout = stdout,
+              rawStderr = stderr,
+              durationMs = durationMs
+            )
+          )
+    }
+
+  private def collectFiles(root: Path): Map[String, String] =
+    val stream = Files.walk(root)
+    try
+      stream.iterator.asScala
+        .filter(Files.isRegularFile(_))
+        .filter(p => !p.getFileName.toString.endsWith(".dtr"))
+        .map(p => root.relativize(p).toString.replace('\\', '/') -> Files.readString(p))
+        .toMap
+    finally stream.close()
+
+  private def readIfExists(p: Path): String =
+    if Files.exists(p) then Files.readString(p) else ""
+
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      val stream = Files.walk(dir)
+      try
+        val it = stream.sorted(java.util.Comparator.reverseOrder()).iterator()
+        while it.hasNext do
+          val _ = Files.deleteIfExists(it.next())
+      finally stream.close()
+
+object DafnyTranslateCli:
+
+  def make(binary: String): Resource[IO, DafnyTranslator] =
+    Resource
+      .make(IO.blocking(Files.createTempDirectory("specrest-dafny-translate-")))(dir =>
+        IO.blocking(deleteRecursively(dir)).attempt.void
+      )
+      .map(dir => new DafnyTranslateCli(binary, dir))
+
+  private def deleteRecursively(dir: Path): Unit =
+    if Files.exists(dir) then
+      val stream = Files.walk(dir)
+      try
+        val it = stream.sorted(java.util.Comparator.reverseOrder()).iterator()
+        while it.hasNext do
+          val _ = Files.deleteIfExists(it.next())
+      finally stream.close()
+
+final class MockDafnyTranslator private (
+    plan: List[Either[String, TranslatedDafny]],
+    cursor: Ref[IO, Int],
+    callsRef: Ref[IO, List[String]]
+) extends DafnyTranslator:
+
+  def translate(
+      source: String,
+      @scala.annotation.unused target: TargetLanguage,
+      @scala.annotation.unused timeoutSec: Int
+  ): IO[Either[String, TranslatedDafny]] =
+    for
+      _ <- callsRef.update(source :: _)
+      i <- cursor.getAndUpdate(_ + 1)
+    yield
+      if i >= plan.length then Left(s"MockDafnyTranslator exhausted after $i calls")
+      else plan(i)
+
+  def calls: IO[List[String]] = callsRef.get.map(_.reverse)
+
+object MockDafnyTranslator:
+
+  def of(plan: List[Either[String, TranslatedDafny]]): IO[MockDafnyTranslator] =
+    for
+      cur <- Ref.of[IO, Int](0)
+      log <- Ref.of[IO, List[String]](Nil)
+    yield new MockDafnyTranslator(plan, cur, log)
+
+  def success(target: TargetLanguage, files: Map[String, String]): TranslatedDafny =
+    TranslatedDafny(target, files, rawStdout = "", rawStderr = "", durationMs = 0L)

--- a/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
@@ -8,6 +8,14 @@ object FileAssembly:
 
   final case class SpliceFailure(message: String) derives CanEqual
 
+  def spliceAll(
+      skeleton: String,
+      bodies: Map[String, String]
+  ): Either[SpliceFailure, String] =
+    bodies.toList.foldLeft[Either[SpliceFailure, String]](Right(skeleton)):
+      case (Left(e), _)             => Left(e)
+      case (Right(current), (n, b)) => splice(current, n, b)
+
   def splice(
       skeleton: String,
       methodName: String,

--- a/modules/synth/src/main/scala/specrest/synth/TargetLanguage.scala
+++ b/modules/synth/src/main/scala/specrest/synth/TargetLanguage.scala
@@ -1,0 +1,10 @@
+package specrest.synth
+
+enum TargetLanguage(val cliFlag: String, val outputSuffix: String) derives CanEqual:
+  case Python extends TargetLanguage("py", "-py")
+
+object TargetLanguage:
+  def fromName(name: String): Option[TargetLanguage] =
+    name.toLowerCase match
+      case "py" | "python" => Some(Python)
+      case _               => None

--- a/modules/synth/src/test/scala/specrest/synth/DafnyTranslatorTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/DafnyTranslatorTest.scala
@@ -1,0 +1,88 @@
+package specrest.synth
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+class DafnyTranslatorTest extends CatsEffectSuite:
+
+  private val sampleSource =
+    """class ServiceState { var count: int }
+      |
+      |predicate Inv(s: ServiceState) reads s { s.count >= 0 }
+      |
+      |method Inc(s: ServiceState)
+      |  modifies s
+      |  requires Inv(s)
+      |  ensures s.count == old(s.count) + 1
+      |  ensures Inv(s)
+      |{
+      |  s.count := s.count + 1;
+      |}
+      |""".stripMargin
+
+  test("MockDafnyTranslator returns staged file map"):
+    val canned =
+      MockDafnyTranslator.success(
+        TargetLanguage.Python,
+        Map(
+          "module_.py"          -> "# verified body lives here\n",
+          "_dafny/__init__.py"  -> "# runtime\n",
+          "System_/__init__.py" -> "# system\n",
+          "__main__.py"         -> "# entry\n"
+        )
+      )
+    for
+      tx       <- MockDafnyTranslator.of(List(Right(canned)))
+      result   <- tx.translate(sampleSource, TargetLanguage.Python, timeoutSec = 60)
+      recorded <- tx.calls
+    yield
+      val out = result.getOrElse(fail("expected translation success"))
+      assertEquals(out.target, TargetLanguage.Python)
+      assertEquals(
+        out.files.keySet,
+        Set("module_.py", "_dafny/__init__.py", "System_/__init__.py", "__main__.py")
+      )
+      assertEquals(recorded, List(sampleSource))
+
+  test("MockDafnyTranslator surfaces errors verbatim"):
+    for
+      tx     <- MockDafnyTranslator.of(List(Left("dafny: parse failure at line 4")))
+      result <- tx.translate(sampleSource, TargetLanguage.Python, timeoutSec = 60)
+    yield assertEquals(result, Left("dafny: parse failure at line 4"))
+
+  test("MockDafnyTranslator exhausts after the planned calls"):
+    for
+      tx <- MockDafnyTranslator.of(List(Right(MockDafnyTranslator.success(
+              TargetLanguage.Python,
+              Map.empty
+            ))))
+      _  <- tx.translate(sampleSource, TargetLanguage.Python, 60)
+      r2 <- tx.translate(sampleSource, TargetLanguage.Python, 60)
+    yield assert(r2.isLeft, s"second call should be Left, got $r2")
+
+  private def dafnyOnPath: IO[Boolean] =
+    DafnyCli.resolveBinary(None).map(_.isRight)
+
+  test("DafnyTranslateCli emits module_.py when dafny is on PATH"):
+    dafnyOnPath.flatMap:
+      case false => IO.pure(())
+      case true =>
+        DafnyCli.resolveBinary(None).flatMap:
+          case Left(msg) => IO(fail(s"unexpected: $msg"))
+          case Right(bin) =>
+            DafnyTranslateCli.make(bin).use: tx =>
+              tx.translate(sampleSource, TargetLanguage.Python, 60).map:
+                case Left(err) => fail(s"translate failed: $err")
+                case Right(out) =>
+                  assert(
+                    out.files.contains("module_.py"),
+                    s"missing module_.py in ${out.files.keys}"
+                  )
+                  assert(
+                    out.files("module_.py").contains("class ServiceState"),
+                    out.files("module_.py").take(200)
+                  )
+                  assert(
+                    out.files.contains("_dafny/__init__.py"),
+                    s"missing _dafny runtime in ${out.files.keys}"
+                  )

--- a/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FileAssemblyTest.scala
@@ -63,6 +63,24 @@ class FileAssemblyTest extends CatsEffectSuite:
     assert(r.isLeft, "must NOT splice into Reset's placeholder")
     assert(targetAlreadyFilled.contains("// YOUR CODE HERE"), "Reset placeholder untouched")
 
+  test("spliceAll fills every method and propagates the first failure"):
+    val r = FileAssembly
+      .spliceAll(
+        skeleton,
+        Map(
+          "Increment" -> "st.count := st.count + 1;",
+          "Reset"     -> "st.count := 0;"
+        )
+      )
+      .getOrElse(fail("spliceAll failed"))
+    assert(r.contains("st.count := st.count + 1;"), "Increment body present")
+    assert(r.contains("st.count := 0;"), "Reset body present")
+    assert(!r.contains("// YOUR CODE HERE"), "no placeholders remain")
+
+  test("spliceAll fails if a method is missing in the skeleton"):
+    val r = FileAssembly.spliceAll(skeleton, Map("Increment" -> "ok;", "Ghost" -> "no;"))
+    assert(r.isLeft, s"expected Left, got $r")
+
   test("anchor matches method name with parameters but not method-name prefix"):
     val sk =
       """method IncrementBy(st: ServiceState, n: int)


### PR DESCRIPTION
## Summary

- Closes the last Phase 6 wedge ([#27](https://github.com/HardMax71/spec_to_rest/issues/27)): verified Dafny bodies cached by `synth verify` are translated to Python via `dafny translate py` and spliced into the FastAPI service the convention engine emits.
- New `compile --with-synthesis` flag reads the verified-body cache, multi-method-splices each `LLM_SYNTHESIS` op's body into one Dafny source, runs the translator, and lays the result under `app/dafny_kernel/` of the generated project (with the runtime bundled — no PyPI dep).
- `services/<entity>.py` now short-circuits the CRUD branches with a `_dafny_kernel.<Op>(state, …)` call when the operation has a verified body; otherwise the existing CRUD / `NotImplementedError` paths are byte-identical.

## What's in the kernel layout

```
out/app/
├── dafny_kernel/
│   ├── __init__.py            # re-exports module_
│   ├── module_.py             # synthesised + skeleton (relative imports)
│   ├── _dafny/__init__.py     # bundled runtime
│   ├── System_/__init__.py    # bundled stdlib
│   └── __main__.py
└── services/
    ├── _dafny_adapter.py      # to/from_dafny_seq / map / set, make_state
    ├── _synth.py              # marker (non-entity-attached ops)
    └── url_mapping.py         # handler short-circuits to _dafny_kernel.<Op>
```

## Failure modes

| Condition | Exit | Message |
|---|---|---|
| `--with-synthesis` set but `verified/` cache missing | 1 | "no verified-body cache at …; run \`synth verify\` first" |
| Cache exists but a specific op missing | 1 | "no verified body cached for '\$Op' (model=…, temp=…). Run: cli/run synth verify … --operation \$Op …" |
| `dafny --version` not resolvable | 3 | Backend |
| `dafny translate py` exits non-zero | 3 | Backend |

Cache key matches `synth verify` exactly: `(signature, requires, ensures, modifies, model, temperature, SynthPromptVersion)`. Pass `--synthesis-model` / `--synthesis-temperature` if `synth verify` ran with non-default values.

## What's deferred

- **Persistence**: Dafny `ServiceState` is held per-request via `make_state()`. SQLAlchemy/Postgres reconciliation on commit boundary is a separate problem worth its own milestone — tracked as a new follow-up.
- **Go / Java targets**: Python only here. The `TargetLanguage` enum is sealed-extensible; adding `Go`/`Java` is a small extension once we have a non-Python convention profile.
- **Graduated fallback** ([#30](https://github.com/HardMax71/spec_to_rest/issues/30)): today the cache-miss exit is hard. M6.6 will swap that for the L1–L5 escalation chain.

## Test plan

- [x] `sbt scalafmtCheckAll && sbt "scalafixAll --check"` clean
- [x] `sbt "all test"` — 768+ pass, 1 pre-existing skip (`AnthropicProviderIntegrationTest`)
- [x] Manual end-to-end smoke (locally; `dafny translate py` not in CI):
  - Seeded verified cache with `safe_counter` Increment/Decrement bodies
  - `compile --with-synthesis` → kernel emitted under `app/dafny_kernel/`
  - `python3 -c "from app.dafny_kernel import module_; …"` works (Inv stays True after 2× Inc 1× Dec)
  - Same cycle on `url_shortener`: handler calls `_dafny_kernel.Shorten(state, body.url)` and gets back `(code, short_url)` from a real translated body
- [x] `cd docs && npm run build` clean (28 html files, link check ✓)
- [x] Kernel-less `compile` (no `--with-synthesis`) is byte-identical to before — verified by all existing codegen tests still passing unchanged

## Out of scope here

- Real `dafny translate` smoke in CI (mock-translator covers the wiring; CI doesn't ship a `dafny` binary). Same posture as M6.4 with `dafny verify`.
- Few-shot / counterexample formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Dafny→Python translation to `compile --with-synthesis`, wiring verified `LLM_SYNTHESIS` bodies into FastAPI so handlers call a translated kernel instead of stubs. No-op when a spec has 0 synthesis ops; handlers and routers now pass typed path/query/body params to the kernel. Completes Phase 6 M6.5 (#27) and keeps non-synth paths unchanged.

- New Features
  - New `compile --with-synthesis`: reads the verified-body cache, splices all bodies, runs `dafny translate py`, and emits the kernel under `app/dafny_kernel/` (runtime bundled).
  - Handlers short-circuit to `_dafny_kernel.<Op>(state, …)` when a verified body exists; signatures include the right path/query/body args, and routers pass the matching args to the service.
  - New `app/services/_dafny_adapter.py` (boundary helpers) and `_synth.py` marker for non-entity ops.
  - New `DafnyTranslator` (`DafnyTranslateCli`), `TargetLanguage` (Python), and `FileAssembly.spliceAll` to combine per-op bodies; kernel import rewrite is depth-aware (`from . import _dafny`).
  - CLI flags: `--with-synthesis`, `--synthesis-model`, `--synthesis-temperature`, `--synthesis-cache-dir`, `--dafny-bin`, `--dafny-translate-timeout`.
  - If a spec has no `LLM_SYNTHESIS` ops, `--with-synthesis` emits a project without kernel/adapter files.
  - Docs updated; tests cover translation, kernel emission, handler/router signatures, and CLI wiring.

- Migration
  - Run `synth verify` for each `LLM_SYNTHESIS` op, then `compile --with-synthesis` (Python target only). Requires a `dafny` binary on PATH or `--dafny-bin`.
  - Failure modes:
    - Missing verified cache or op entry → exit 1 with a hint to run `synth verify` including `--model` and `--temperature` to match the cache key.
    - `dafny` not found or translate failure → exit 3 with stderr details.
  - Persistence is out of scope: `ServiceState` is per-request for now. Go/Java targets to follow.

<sup>Written for commit ab0715b625365ec8152a6a91f2409bf24cbe35ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compilation now supports optional synthesis with `--with-synthesis` flag and configurable model/temperature parameters.
  * Synthesized Dafny-backed operations are now wired into Python FastAPI projects automatically.

* **Documentation**
  * Updated synthesis pipeline documentation to cover the complete Phase 6 workflow.
  * Updated limitations section to reflect current synthesis behavior and caching requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->