### PR TITLE
Closes #30 — M6.6 graduated fallback (L1 prompt ladder + L3 model escalation + L4 skeleton + L5 report; L2 deferred to #227)

### DIFF
--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -18,7 +18,7 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering — **shipped**,
 > [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop — **shipped**,
 > [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation — **shipped (Python)**,
-> [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy.
+> [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy — **shipped (L1 prompt-strategy ladder + L3 model escalation + L4 skeleton emit + L5 synthesis report; L2 decomposition deferred)**.
 > The Scala implementation lives in `modules/synth/` (`PromptBuilder`,
 > `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, `CegisLoop`,
 > `DafnyVerifier`, plus Anthropic / OpenAI providers wrapping the official Java

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Synthesis Pipeline (M6.3 – M6.5)
-description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, the CEGIS feedback loop wired to `dafny verify`, and `compile --with-synthesis` that translates verified bodies to the target language.
+title: Synthesis Pipeline (M6.3 – M6.6)
+description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, the CEGIS feedback loop wired to `dafny verify`, the graduated-fallback orchestrator, and `compile --with-synthesis` that translates verified bodies (or labelled skeletons) to the target language.
 ---
 
 `modules/synth/` is the Phase 6 LLM-and-Dafny synthesis layer. It takes the
@@ -359,12 +359,119 @@ Persistence is intentionally out of scope here. The kernel `ServiceState`
 is held per-request by `make_state()`; bridging it to SQLAlchemy / Postgres
 on a `commit` boundary is tracked as a follow-up issue.
 
+## Graduated fallback (M6.6)
+
+When CEGIS aborts on its first attempt, M6.6's `FallbackOrchestrator`
+escalates along two axes before giving up: prompt strategy (`ZeroShot` →
+`ChainOfThought` → `PlanThenImplement`) and model (configured model →
+each `--escalate-to MODEL`, in order). All attempts share one budget
+envelope (`sharedCostCapUsd`, default $1.00). When every attempt fails,
+the orchestrator emits a labelled fallback skeleton — a Dafny body with
+`expect false, "FALLBACK SKELETON [op=...]: not verified — ..."` plus
+havoc-assigned (`out := *;`) return params — which translates cleanly
+to Python under `dafny translate --no-verify` and halts at runtime with
+`_dafny.HaltException` carrying the strategy/model/reason payload.
+
+```mermaid
+flowchart TD
+  CEGIS["CEGIS Loop"]
+  CEGIS -->|ok| V["Verified — cache to verified/"]
+  CEGIS -->|abort| L1["L1: Prompt-strategy ladder<br/>ZeroShot → ChainOfThought → PlanThenImplement"]
+  L1 -->|abort| L3["L3: Model-escalation ladder<br/>configured model → --escalate-to ..."]
+  L3 -->|abort| L4["L4: Skeleton — expect false + havoc returns<br/>cache to skeletons/"]
+  L1 -->|ok| V
+  L3 -->|ok| V
+  L4 --> Report["L5: Synthesis Report — green / yellow / red per op"]
+  V --> Report
+```
+
+L2 (operation decomposition) is intentionally not in M6.6; it is a
+research-grade problem and tracked separately.
+
+### `synth verify --fallback`
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-... DAFNY_BIN=/usr/local/bin/dafny \
+  sbt "cli/run synth verify fixtures/spec/url_shortener.spec \
+       --operation Shorten --fallback --escalate-to claude-opus-4-7"
+```
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--fallback` | off | Enable the orchestrator. Without it, `synth verify` is strict CEGIS as before. |
+| `--escalate-to MODEL` | _empty_ | Repeat for a multi-step ladder (e.g. `--escalate-to opus --escalate-to gpt-5`). |
+
+Stdout is the verified body OR the labelled skeleton (one Dafny block,
+splice-ready). Stderr summary line example:
+
+```text
+[synth-verify] op=Shorten VERIFIED-ESCALATED attempts=2 strategy=ChainOfThought model=claude-opus-4-7 iter=1
+```
+
+or
+
+```text
+[synth-verify] op=Shorten SKELETON attempts=4 reason=stuck on postcondition_violation
+```
+
+Verified bodies persist to `synth-cache/verified/` exactly like strict
+CEGIS. Fallback skeletons persist to `synth-cache/skeletons/` (separate
+namespace; the two never mix).
+
+### `synth verify-all`
+
+Runs the orchestrator across every `LLM_SYNTHESIS` operation in the spec
+and prints a synthesis report to stderr.
+
+```bash
+sbt "cli/run synth verify-all fixtures/spec/url_shortener.spec \
+       --escalate-to claude-opus-4-7"
+```
+
+```text
+Synthesis Report
+  Operation                  Verdict              Strategy          Model                   iter   $cost
+  ------------------------------------------------------------------------------------------------
+  Shorten                    VERIFIED             ZeroShot          claude-sonnet-4-6          1  $0.0023
+  Resolve                    VERIFIED-ESCALATED   ChainOfThought    claude-opus-4-7            2  $0.0510
+  ListAll                    SKELETON             PlanThenImplement claude-opus-4-7            0  $0.1010
+  ------------------------------------------------------------------------------------------------
+  total=3 verified=1 escalated=1 skeleton=1  cost=$0.1543  in=2100tok out=4200tok
+```
+
+Exit codes: `0` if every op verified or escalated successfully (no
+skeletons); `1` if any op fell back to a skeleton; the report prints
+either way so partial progress is visible.
+
+### `compile --with-synthesis --allow-skeletons`
+
+Default `compile --with-synthesis` is unchanged: strict cache-only,
+hard-error on miss in `verified/`. The new opt-in `--allow-skeletons`
+flag relaxes the gate — when a verified body is missing, the compiler
+falls back to `synth-cache/skeletons/<key>.json` if present, emits a
+warning per op, and proceeds. The kernel files translate identically
+(skeleton bodies are well-typed Dafny under `--no-verify`); only at
+runtime does the handler raise `_dafny.HaltException` from inside the
+kernel call.
+
+```bash
+sbt "cli/run compile fixtures/spec/url_shortener.spec \
+       --target python-fastapi-postgres --out /tmp/out \
+       --with-synthesis --allow-skeletons"
+```
+
+This is intended as a "ship a partially-verified service for testing,
+finish the proofs later" workflow. The HaltException payload includes
+the operation name, the final attempted strategy/model, and the abort
+reason — enough to point a developer at what to fix.
+
 ## What's still deferred
 
 | Concern | Tracked in |
 |---|---|
-| Decomposition, model-escalation, skeleton fallback (graduated fallback) | [#30](https://github.com/HardMax71/spec_to_rest/issues/30) |
+| Operation decomposition (L2 fallback — extract sub-methods, verify independently, compose) | follow-up (M6.7) |
 | Dafny `ServiceState` ↔ SQLAlchemy / Postgres reconciliation | follow-up |
 | Go / Java targets for `--with-synthesis` (Python only today) | follow-up |
 | Few-shot examples machine-verified by `dafny verify` in CI | follow-up |
 | Counterexample formatting (Z3 model → human-readable) | follow-up |
+| Cross-family escalation (Anthropic → OpenAI) within one `--fallback` run | follow-up |

--- a/docs/content/docs/targets/python-fastapi-postgres.mdx
+++ b/docs/content/docs/targets/python-fastapi-postgres.mdx
@@ -384,8 +384,15 @@ What this target does **not** generate today, with tracking issues:
   integration, [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) the
   CEGIS feedback loop, and
   [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) Dafny→Python
-  compilation — all shipped.
-  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) (graduated
-  fallback when CEGIS can't converge) is still open: today an op without a
-  cached verified body causes `compile --with-synthesis` to exit `1` with an
-  error pointing at `synth verify`.
+  compilation, and
+  [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) the graduated
+  fallback (prompt-strategy ladder + model escalation + skeleton emit + synthesis
+  report) — all shipped. Today, when no `verified/` cache entry exists for an
+  op, `compile --with-synthesis` exits `1` and points at `synth verify`; with
+  the new opt-in `--allow-skeletons` flag, the compiler instead consults
+  `synth-cache/skeletons/` (populated by `synth verify --fallback` or
+  `synth verify-all`), emits a warning per op, and ships a project that compiles
+  but halts at runtime inside the unverified handler with a
+  `_dafny.HaltException` carrying the operation, strategy, model, and reason.
+  L2 (operation decomposition) is the only remaining graduated-fallback
+  level not yet shipped.

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -44,7 +44,8 @@ final case class CompileOptions(
     synthesisTemperature: Double = 1.0,
     synthesisCacheDir: Option[String] = None,
     dafnyBin: Option[String] = None,
-    dafnyTranslateTimeoutSec: Int = 60
+    dafnyTranslateTimeoutSec: Int = 60,
+    allowSkeletons: Boolean = false
 )
 
 object Compile:
@@ -213,40 +214,119 @@ object Compile:
       opts: CompileOptions,
       log: Logger
   ): IO[Either[ExitCode, Map[String, String]]] =
-    if !Files.isDirectory(verifiedRoot) then
+    val cacheRoot =
+      opts.synthesisCacheDir.map(Paths.get(_)).getOrElse(Cache.defaultRoot(Paths.get("")))
+    val skeletonsRoot      = Cache.skeletonsRoot(cacheRoot)
+    val skeletonsAvailable = opts.allowSkeletons && Files.isDirectory(skeletonsRoot)
+    if !Files.isDirectory(verifiedRoot) && !skeletonsAvailable then
       IO.delay(
         log.error(
           s"$specFile: no verified-body cache at $verifiedRoot; run `synth verify` for each LLM_SYNTHESIS op first"
         )
       ).as(Left(ExitCodes.Violations))
     else
-      Cache.make(verifiedRoot).flatMap: cache =>
-        synthOps
-          .foldLeft[IO[Either[ExitCode, Map[String, String]]]](IO.pure(Right(Map.empty))):
-            (accIO, c) =>
-              accIO.flatMap:
-                case Left(code) => IO.pure(Left(code))
-                case Right(acc) =>
-                  methods.find(_.name == c.operationName) match
-                    case None =>
-                      IO.delay(
-                        log.error(
-                          s"$specFile: Dafny header missing for synthesised op '${c.operationName}'"
-                        )
-                      ).as(Left(ExitCodes.Translator))
-                    case Some(header) =>
-                      val key = Cache.keyFor(header, opts.synthesisModel, opts.synthesisTemperature)
-                      cache.lookup(key).map:
-                        case None =>
-                          log.error(
-                            s"$specFile: no verified body cached for '${c.operationName}' " +
-                              s"(model=${opts.synthesisModel}, temp=${opts.synthesisTemperature}). " +
-                              s"Run: cli/run synth verify $specFile --operation ${c.operationName} " +
-                              s"--model ${opts.synthesisModel} --temperature ${opts.synthesisTemperature}"
-                          )
-                          Left(ExitCodes.Violations)
-                        case Some(entry) =>
-                          Right(acc + (c.operationName -> entry.body))
+      val verifiedCacheIO: IO[Option[Cache]] =
+        if Files.isDirectory(verifiedRoot) then Cache.make(verifiedRoot).map(Some(_))
+        else IO.pure(None)
+      val skeletonCacheIO: IO[Option[Cache]] =
+        if skeletonsAvailable then Cache.make(skeletonsRoot).map(Some(_))
+        else IO.pure(None)
+      for
+        verifiedCache <- verifiedCacheIO
+        skeletonCache <- skeletonCacheIO
+        result <- foldVerifiedAndSkeleton(
+                    specFile,
+                    synthOps,
+                    methods,
+                    verifiedCache,
+                    skeletonCache,
+                    opts,
+                    log
+                  )
+      yield result
+
+  private def foldVerifiedAndSkeleton(
+      specFile: String,
+      synthOps: List[specrest.convention.OperationClassification],
+      methods: List[specrest.convention.dafny.DafnyMethodHeader],
+      verifiedCache: Option[Cache],
+      skeletonCache: Option[Cache],
+      opts: CompileOptions,
+      log: Logger
+  ): IO[Either[ExitCode, Map[String, String]]] =
+    synthOps.foldLeft[IO[Either[ExitCode, Map[String, String]]]](IO.pure(Right(Map.empty))):
+      (accIO, c) =>
+        accIO.flatMap:
+          case Left(code) => IO.pure(Left(code))
+          case Right(acc) =>
+            methods.find(_.name == c.operationName) match
+              case None =>
+                IO.delay(
+                  log.error(
+                    s"$specFile: Dafny header missing for synthesised op '${c.operationName}'"
+                  )
+                ).as(Left(ExitCodes.Translator))
+              case Some(header) =>
+                val key = Cache.keyFor(header, opts.synthesisModel, opts.synthesisTemperature)
+                lookupOpBody(
+                  specFile,
+                  c.operationName,
+                  key,
+                  verifiedCache,
+                  skeletonCache,
+                  opts,
+                  log
+                ).map:
+                  case Right(body) => Right(acc + (c.operationName -> body))
+                  case Left(code)  => Left(code)
+
+  private def lookupOpBody(
+      specFile: String,
+      opName: String,
+      key: specrest.synth.CacheKey,
+      verifiedCache: Option[Cache],
+      skeletonCache: Option[Cache],
+      opts: CompileOptions,
+      log: Logger
+  ): IO[Either[ExitCode, String]] =
+    val verifiedLookup = verifiedCache match
+      case Some(c) => c.lookup(key)
+      case None    => IO.pure(None)
+    verifiedLookup.flatMap:
+      case Some(entry) => IO.pure(Right(entry.body))
+      case None =>
+        if !opts.allowSkeletons then
+          IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
+            .as(Left(ExitCodes.Violations))
+        else
+          val skeletonLookup = skeletonCache match
+            case Some(c) => c.lookup(key)
+            case None    => IO.pure(None)
+          skeletonLookup.flatMap:
+            case Some(entry) =>
+              IO.delay(
+                log.warn(
+                  s"$specFile: '$opName' falling back to unverified skeleton body " +
+                    "(--allow-skeletons set); the generated handler will halt at runtime " +
+                    "with a Dafny HaltException when invoked"
+                )
+              ).as(Right(entry.body))
+            case None =>
+              IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
+                .as(Left(ExitCodes.Violations))
+
+  private def missingVerifiedBodyError(
+      specFile: String,
+      opName: String,
+      opts: CompileOptions,
+      log: Logger
+  ): Unit =
+    log.error(
+      s"$specFile: no verified body cached for '$opName' " +
+        s"(model=${opts.synthesisModel}, temp=${opts.synthesisTemperature}). " +
+        s"Run: cli/run synth verify $specFile --operation $opName " +
+        s"--model ${opts.synthesisModel} --temperature ${opts.synthesisTemperature}"
+    )
 
   private def resolveDafnyAndTranslate(
       specFile: String,

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -219,11 +219,15 @@ object Compile:
     val skeletonsRoot      = Cache.skeletonsRoot(cacheRoot)
     val skeletonsAvailable = opts.allowSkeletons && Files.isDirectory(skeletonsRoot)
     if !Files.isDirectory(verifiedRoot) && !skeletonsAvailable then
-      IO.delay(
-        log.error(
-          s"$specFile: no verified-body cache at $verifiedRoot; run `synth verify` for each LLM_SYNTHESIS op first"
-        )
-      ).as(Left(ExitCodes.Violations))
+      val msg =
+        if opts.allowSkeletons then
+          s"$specFile: --with-synthesis --allow-skeletons set but neither $verifiedRoot " +
+            s"nor $skeletonsRoot exists; run `synth verify --fallback` (or `synth verify-all`) for " +
+            "each LLM_SYNTHESIS op to populate at least one cache namespace"
+        else
+          s"$specFile: no verified-body cache at $verifiedRoot; run `synth verify` for each " +
+            "LLM_SYNTHESIS op first (or pass --allow-skeletons to consume `synth verify --fallback` skeletons)"
+      IO.delay(log.error(msg)).as(Left(ExitCodes.Violations))
     else
       val verifiedCacheIO: IO[Option[Cache]] =
         if Files.isDirectory(verifiedRoot) then Cache.make(verifiedRoot).map(Some(_))
@@ -293,8 +297,9 @@ object Compile:
       case Some(c) => c.lookup(key)
       case None    => IO.pure(None)
     verifiedLookup.flatMap:
-      case Some(entry) => IO.pure(Right(entry.body))
-      case None =>
+      case Some(entry) if entry.outcome == specrest.synth.CacheOutcome.Verified =>
+        IO.pure(Right(entry.body))
+      case _ =>
         if !opts.allowSkeletons then
           IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
             .as(Left(ExitCodes.Violations))

--- a/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
+++ b/modules/cli/src/main/scala/specrest/cli/ExitCodes.scala
@@ -6,6 +6,7 @@ import specrest.synth.AbortReason
 import specrest.synth.CacheFailure
 import specrest.synth.CegisOutcome
 import specrest.synth.DiffCheckFailure
+import specrest.synth.FallbackOutcome
 import specrest.synth.ProviderFailure
 import specrest.synth.ResponseParseFailure
 import specrest.synth.SynthError
@@ -39,6 +40,10 @@ object ExitCodes:
         case _: AbortReason.SpliceFailed           => Translator
         case _: AbortReason.ProviderFailed         => Backend
         case _: AbortReason.VerifierBackendFailure => Backend
+
+  def forFallbackOutcome(o: FallbackOutcome): ExitCode = o match
+    case _: FallbackOutcome.Verified     => Ok
+    case _: FallbackOutcome.SkeletonOnly => Violations
 
   def forVerifyError(e: VerifyError): ExitCode = e match
     case _: VerifyError.Parse           => Violations

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -178,6 +178,12 @@ object Main
       .mapValidated: n =>
         if n > 0 then cats.data.Validated.valid(n)
         else cats.data.Validated.invalidNel(s"--dafny-translate-timeout must be > 0 (got $n)")
+    val allowSkeletons = Opts
+      .flag(
+        "allow-skeletons",
+        "fall back to unverified skeleton bodies (from `synth verify --fallback`) when the verified cache misses; the generated handler halts at runtime when invoked"
+      )
+      .orFalse
     Opts.subcommand("compile", "Emit project files for a spec"):
       (
         specFile,
@@ -192,9 +198,10 @@ object Main
         synthesisCacheDir,
         compileDafnyBin,
         compileTranslateTimeout,
+        allowSkeletons,
         verbose,
         quiet
-      ).mapN: (spec, t, o, iv, wt, ss, ws, sm, stp, scd, db, dtt, v, q) =>
+      ).mapN: (spec, t, o, iv, wt, ss, ws, sm, stp, scd, db, dtt, ask, v, q) =>
         Compile.run(
           spec,
           CompileOptions(
@@ -208,7 +215,8 @@ object Main
             synthesisTemperature = stp,
             synthesisCacheDir = scd,
             dafnyBin = db,
-            dafnyTranslateTimeoutSec = dtt
+            dafnyTranslateTimeoutSec = dtt,
+            allowSkeletons = ask
           ),
           Logger.fromFlags(verbose = v, quiet = q)
         )
@@ -259,6 +267,19 @@ object Main
               SynthOptions(op, m, t, mt, nc, cd),
               Logger.fromFlags(verbose = v, quiet = q)
             )
+    val fallbackFlag = Opts
+      .flag(
+        "fallback",
+        "after CEGIS aborts, try alternate prompt strategies and escalate the model; emit a labelled skeleton if all attempts fail"
+      )
+      .orFalse
+    val escalateTo = Opts
+      .options[String](
+        "escalate-to",
+        "model to escalate to after the configured model exhausts the prompt-strategy ladder " +
+          "(repeat for a multi-step ladder)"
+      )
+      .orEmpty
     val verifyCmd: Opts[IO[ExitCode]] =
       Opts.subcommand(
         "verify",
@@ -276,16 +297,43 @@ object Main
           dafnyTimeout,
           maxIter,
           maxCost,
+          fallbackFlag,
+          escalateTo,
           verbose,
           quiet
-        ).mapN: (spec, op, m, t, mt, nc, cd, db, dt, mi, mc, v, q) =>
+        ).mapN: (spec, op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc, v, q) =>
           Synth.runVerify(
             spec,
-            SynthVerifyOptions(op, m, t, mt, nc, cd, db, dt, mi, mc),
+            SynthVerifyOptions(op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc),
+            Logger.fromFlags(verbose = v, quiet = q)
+          )
+    val verifyAllCmd: Opts[IO[ExitCode]] =
+      Opts.subcommand(
+        "verify-all",
+        "Run the fallback orchestrator across every LLM_SYNTHESIS op and print a synthesis report"
+      ):
+        (
+          specFile,
+          model,
+          temperature,
+          maxTokens,
+          noCache,
+          cacheDir,
+          dafnyBin,
+          dafnyTimeout,
+          maxIter,
+          maxCost,
+          escalateTo,
+          verbose,
+          quiet
+        ).mapN: (spec, m, t, mt, nc, cd, db, dt, mi, mc, esc, v, q) =>
+          Synth.runVerifyAll(
+            spec,
+            SynthVerifyAllOptions(m, t, mt, nc, cd, db, dt, mi, mc, esc),
             Logger.fromFlags(verbose = v, quiet = q)
           )
     Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
-      tryCmd orElse verifyCmd
+      tryCmd orElse verifyCmd orElse verifyAllCmd
 
   override def main: Opts[IO[ExitCode]] =
     inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -475,31 +475,33 @@ object Synth:
       log: Logger
   ): IO[ExitCode] =
     classifications
-      .foldLeft[IO[List[OpOutcome]]](IO.pure(Nil)): (accIO, c) =>
-        accIO.flatMap: acc =>
-          dafny.methods.find(_.name == c.operationName) match
-            case None =>
-              IO.delay(log.error(s"$specFile: no Dafny header for '${c.operationName}'")).as(acc)
-            case Some(header) =>
-              val req = SynthRequest(
-                c,
-                header,
-                dafny.text,
-                model = opts.model,
-                temperature = opts.temperature,
-                maxTokens = opts.maxTokens
-              )
-              orch.run(req).map: outcome =>
-                acc :+ OpOutcome.fromFallback(c.operationName, outcome)
-      .flatMap: ops =>
-        val report   = SynthesisReport(ops)
-        val rendered = Reporter.render(report, useColor = false)
-        IO.blocking {
-          err.println(rendered)
-        }.as(exitCodeForReport(report))
+      .foldLeft[IO[Either[ExitCode, List[OpOutcome]]]](IO.pure(Right(Nil))): (accIO, c) =>
+        accIO.flatMap:
+          case Left(code) => IO.pure(Left(code))
+          case Right(acc) =>
+            dafny.methods.find(_.name == c.operationName) match
+              case None =>
+                IO.delay(log.error(s"$specFile: no Dafny header for '${c.operationName}'"))
+                  .as(Left(ExitCodes.Translator))
+              case Some(header) =>
+                val req = SynthRequest(
+                  c,
+                  header,
+                  dafny.text,
+                  model = opts.model,
+                  temperature = opts.temperature,
+                  maxTokens = opts.maxTokens
+                )
+                orch.run(req).map: outcome =>
+                  Right(acc :+ OpOutcome.fromFallback(c.operationName, outcome))
+      .flatMap:
+        case Left(code) => IO.pure(code)
+        case Right(ops) =>
+          val report   = SynthesisReport(ops)
+          val rendered = Reporter.render(report, useColor = false)
+          IO.blocking {
+            err.println(rendered)
+          }.as(exitCodeForReport(report))
 
   private def exitCodeForReport(report: SynthesisReport): ExitCode =
-    val totals = report.totals
-    if totals.skeleton == 0 && totals.verifiedEscalated == 0 then ExitCodes.Ok
-    else if totals.skeleton == 0 then ExitCodes.Ok
-    else ExitCodes.Violations
+    if report.totals.skeleton == 0 then ExitCodes.Ok else ExitCodes.Violations

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -18,9 +18,16 @@ import specrest.synth.CegisBudget
 import specrest.synth.CegisLoop
 import specrest.synth.CegisOutcome
 import specrest.synth.DafnyCli
+import specrest.synth.FallbackBudget
+import specrest.synth.FallbackOrchestrator
+import specrest.synth.FallbackOutcome
 import specrest.synth.LlmProvider
+import specrest.synth.OpOutcome
+import specrest.synth.PromptStrategy
+import specrest.synth.Reporter
 import specrest.synth.SynthRequest
 import specrest.synth.SynthResult
+import specrest.synth.SynthesisReport
 import specrest.synth.Synthesizer
 import specrest.synth.Tracker
 import specrest.synth.providers.AnthropicProvider
@@ -48,7 +55,22 @@ final case class SynthVerifyOptions(
     dafnyBin: Option[String],
     dafnyTimeoutSec: Int,
     maxIter: Int,
-    maxCostUsd: Double
+    maxCostUsd: Double,
+    fallback: Boolean = false,
+    escalateTo: List[String] = Nil
+)
+
+final case class SynthVerifyAllOptions(
+    model: String,
+    temperature: Double,
+    maxTokens: Int,
+    noCache: Boolean,
+    cacheDir: Option[String],
+    dafnyBin: Option[String],
+    dafnyTimeoutSec: Int,
+    maxIter: Int,
+    maxCostUsd: Double,
+    escalateTo: List[String] = Nil
 )
 
 object Synth:
@@ -236,17 +258,40 @@ object Synth:
         )
         val resources =
           for
-            provider <- providerResource(opts.model)
-            cache    <- Resource.eval(verifiedCacheResource(opts))
-            verifier <- DafnyCli.make(binary)
-          yield (provider, cache, verifier)
-        resources.use: (provider, cache, verifier) =>
+            provider  <- providerResource(opts.model)
+            cache     <- Resource.eval(verifiedCacheResource(opts))
+            skelCache <- Resource.eval(skeletonCacheResource(opts))
+            verifier  <- DafnyCli.make(binary)
+          yield (provider, cache, skelCache, verifier)
+        resources.use: (provider, cache, skelCache, verifier) =>
           Tracker.empty.flatMap: tracker =>
-            val loop =
-              new CegisLoop(provider, verifier, cache, tracker, budget, opts.dafnyTimeoutSec)
-            loop.run(req).flatMap: outcome =>
-              emitOutcome(outcome, c.operationName, out, err) *> tracker.summary.flatMap: s =>
-                emitSummary(s, err).as(ExitCodes.forCegisOutcome(outcome))
+            if opts.fallback then
+              val fb = FallbackBudget.Default.copy(
+                modelLadder =
+                  if opts.escalateTo.isEmpty then List(opts.model)
+                  else opts.model :: opts.escalateTo,
+                sharedCostCapUsd = opts.maxCostUsd
+              )
+              val orch = new FallbackOrchestrator(
+                provider,
+                verifier,
+                cache,
+                skelCache,
+                tracker,
+                budget,
+                fb,
+                opts.dafnyTimeoutSec
+              )
+              orch.run(req).flatMap: outcome =>
+                emitFallbackOutcome(outcome, c.operationName, out, err) *>
+                  tracker.summary.flatMap: s =>
+                    emitSummary(s, err).as(ExitCodes.forFallbackOutcome(outcome))
+            else
+              val loop =
+                new CegisLoop(provider, verifier, cache, tracker, budget, opts.dafnyTimeoutSec)
+              loop.run(req).flatMap: outcome =>
+                emitOutcome(outcome, c.operationName, out, err) *> tracker.summary.flatMap: s =>
+                  emitSummary(s, err).as(ExitCodes.forCegisOutcome(outcome))
 
   private def verifiedCacheResource(opts: SynthVerifyOptions): IO[Option[Cache]] =
     if opts.noCache then IO.pure(None)
@@ -254,7 +299,15 @@ object Synth:
       val baseRoot = opts.cacheDir match
         case Some(p) => Paths.get(p)
         case None    => Cache.defaultRoot(Paths.get(""))
-      Cache.make(baseRoot.resolve("verified")).map(Some(_))
+      Cache.make(Cache.verifiedRoot(baseRoot)).map(Some(_))
+
+  private def skeletonCacheResource(opts: SynthVerifyOptions): IO[Option[Cache]] =
+    if opts.noCache then IO.pure(None)
+    else
+      val baseRoot = opts.cacheDir match
+        case Some(p) => Paths.get(p)
+        case None    => Cache.defaultRoot(Paths.get(""))
+      Cache.make(Cache.skeletonsRoot(baseRoot)).map(Some(_))
 
   private def emitOutcome(
       outcome: CegisOutcome,
@@ -289,3 +342,164 @@ object Synth:
           f"cost=$$${s.totalUsd}%.4f calls=${s.operations} cachedHits=${s.cachedHits}"
       )
     }
+
+  private def emitFallbackOutcome(
+      outcome: FallbackOutcome,
+      opName: String,
+      out: PrintStream,
+      err: PrintStream
+  ): IO[Unit] =
+    IO.blocking {
+      outcome match
+        case v: FallbackOutcome.Verified =>
+          out.println(v.body)
+          val verdict = if v.attempts.length == 1 then "VERIFIED" else "VERIFIED-ESCALATED"
+          err.println(
+            s"[synth-verify] op=$opName $verdict attempts=${v.attempts.length} " +
+              s"strategy=${PromptStrategy.displayName(v.finalStrategy)} model=${v.finalModel} " +
+              s"iter=${v.cegisIterations}"
+          )
+        case s: FallbackOutcome.SkeletonOnly =>
+          out.println(s.body)
+          err.println(
+            s"[synth-verify] op=$opName SKELETON attempts=${s.attempts.length} reason=${s.reason}"
+          )
+    }
+
+  def runVerifyAll(
+      specFile: String,
+      opts: SynthVerifyAllOptions,
+      log: Logger,
+      err: PrintStream = System.err
+  ): IO[ExitCode] =
+    Check.readSource(specFile, log).flatMap:
+      case Left(code) => IO.pure(code)
+      case Right(source) =>
+        Parse.parseSpec(source).flatMap:
+          case Left(VerifyError.Parse(errors)) =>
+            IO.delay {
+              errors.foreach: e =>
+                log.error(s"$specFile:${e.line}:${e.column}: ${e.message}")
+            }.as(ExitCodes.Violations)
+          case Right(parsed) =>
+            Builder.buildIR(parsed.tree).flatMap:
+              case Left(buildErr) =>
+                IO.delay(log.error(Check.renderBuildError(specFile, buildErr)))
+                  .as(ExitCodes.Violations)
+              case Right(ir) => runVerifyAllWithIR(specFile, ir, opts, log, err)
+
+  private def runVerifyAllWithIR(
+      specFile: String,
+      ir: ServiceIRFull,
+      opts: SynthVerifyAllOptions,
+      log: Logger,
+      err: PrintStream
+  ): IO[ExitCode] =
+    val classifications = Classify
+      .classifyOperations(ir)
+      .filter(_.strategy == SynthesisStrategy.LlmSynthesis)
+    if classifications.isEmpty then
+      IO.delay(
+        log.warn(s"$specFile: no LLM_SYNTHESIS operations to verify; nothing to do")
+      ).as(ExitCodes.Ok)
+    else
+      DafnyCli.resolveBinary(opts.dafnyBin).flatMap:
+        case Left(msg) => IO.delay(log.error(s"$specFile: $msg")).as(ExitCodes.Backend)
+        case Right(binary) =>
+          DafnyGenerator.generate(ir) match
+            case Left(dErr) =>
+              IO.delay(log.error(s"$specFile: Dafny generation failed: ${dErr.message}"))
+                .as(ExitCodes.Translator)
+            case Right(dafny) =>
+              executeVerifyAll(specFile, classifications, dafny, opts, binary, log, err)
+
+  private def executeVerifyAll(
+      specFile: String,
+      classifications: List[OperationClassification],
+      dafny: specrest.convention.dafny.DafnyOutput,
+      opts: SynthVerifyAllOptions,
+      binary: String,
+      log: Logger,
+      err: PrintStream
+  ): IO[ExitCode] =
+    val budget = CegisBudget.Default.copy(
+      maxIterations = opts.maxIter,
+      maxCostUsd = opts.maxCostUsd
+    )
+    val verifyOpts = SynthVerifyOptions(
+      operation = "",
+      model = opts.model,
+      temperature = opts.temperature,
+      maxTokens = opts.maxTokens,
+      noCache = opts.noCache,
+      cacheDir = opts.cacheDir,
+      dafnyBin = opts.dafnyBin,
+      dafnyTimeoutSec = opts.dafnyTimeoutSec,
+      maxIter = opts.maxIter,
+      maxCostUsd = opts.maxCostUsd
+    )
+    val resources =
+      for
+        provider  <- providerResource(opts.model)
+        cache     <- Resource.eval(verifiedCacheResource(verifyOpts))
+        skelCache <- Resource.eval(skeletonCacheResource(verifyOpts))
+        verifier  <- DafnyCli.make(binary)
+      yield (provider, cache, skelCache, verifier)
+    resources.use: (provider, cache, skelCache, verifier) =>
+      Tracker.empty.flatMap: tracker =>
+        val fb = FallbackBudget.Default.copy(
+          modelLadder =
+            if opts.escalateTo.isEmpty then List(opts.model)
+            else opts.model :: opts.escalateTo,
+          sharedCostCapUsd = opts.maxCostUsd
+        )
+        val orch = new FallbackOrchestrator(
+          provider,
+          verifier,
+          cache,
+          skelCache,
+          tracker,
+          budget,
+          fb,
+          opts.dafnyTimeoutSec
+        )
+        runOrchestrationLoop(specFile, classifications, dafny, orch, opts, err, log)
+
+  private def runOrchestrationLoop(
+      specFile: String,
+      classifications: List[OperationClassification],
+      dafny: specrest.convention.dafny.DafnyOutput,
+      orch: FallbackOrchestrator,
+      opts: SynthVerifyAllOptions,
+      err: PrintStream,
+      log: Logger
+  ): IO[ExitCode] =
+    classifications
+      .foldLeft[IO[List[OpOutcome]]](IO.pure(Nil)): (accIO, c) =>
+        accIO.flatMap: acc =>
+          dafny.methods.find(_.name == c.operationName) match
+            case None =>
+              IO.delay(log.error(s"$specFile: no Dafny header for '${c.operationName}'")).as(acc)
+            case Some(header) =>
+              val req = SynthRequest(
+                c,
+                header,
+                dafny.text,
+                model = opts.model,
+                temperature = opts.temperature,
+                maxTokens = opts.maxTokens
+              )
+              orch.run(req).map: outcome =>
+                acc :+ OpOutcome.fromFallback(c.operationName, outcome)
+      .flatMap: ops =>
+        val report   = SynthesisReport(ops)
+        val rendered = Reporter.render(report, useColor = false)
+        IO.blocking {
+          err.println(rendered)
+        }.as(exitCodeForReport(report))
+
+  private def exitCodeForReport(report: SynthesisReport): ExitCode =
+    val totals = report.totals
+    if totals.skeleton == 0 && totals.verifiedEscalated == 0 then ExitCodes.Ok
+    else if totals.skeleton == 0 then ExitCodes.Ok
+    else ExitCodes.Violations

--- a/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
@@ -7,6 +7,8 @@ import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.synth.Cache
 import specrest.synth.CacheEntry
+import specrest.synth.CacheOutcome
+import specrest.synth.SkeletonGenerator
 import specrest.synth.TokenUsage
 
 import java.nio.file.Files
@@ -99,5 +101,72 @@ class CompileSynthesisTest extends CatsEffectSuite:
         yield ()
 
       seed *> Compile
+        .run("fixtures/spec/url_shortener.spec", opts, log)
+        .map(code => assertEquals(code, ExitCodes.Violations))
+
+  test("--allow-skeletons + skeletons cache populated → compile succeeds with warning"):
+    withTempDir: dir =>
+      val cacheDir      = dir.resolve("synth-cache")
+      val skeletonsRoot = Cache.skeletonsRoot(cacheDir)
+      val opts =
+        baseOpts(dir.toString, Some(cacheDir.toString)).copy(allowSkeletons = true)
+      val seedAll: IO[Unit] =
+        for
+          _       <- IO.blocking(Files.createDirectories(skeletonsRoot))
+          source  <- IO.blocking(Files.readString(Paths.get("fixtures/spec/url_shortener.spec")))
+          parsedE <- Parse.parseSpec(source)
+          parsed   = parsedE.toOption.getOrElse(fail("parse failed"))
+          builtE  <- Builder.buildIR(parsed.tree)
+          built    = builtE.toOption.getOrElse(fail("build failed"))
+          dafny    = DafnyGenerator.generate(built).getOrElse(fail("dafny gen failed"))
+          cache   <- Cache.make(skeletonsRoot)
+          // Seed every LLM_SYNTHESIS op with a skeleton entry.
+          synthOps = specrest.convention.Classify
+                       .classifyOperations(built)
+                       .filter(_.strategy == specrest.convention.SynthesisStrategy.LlmSynthesis)
+          _ <- synthOps.foldLeft(IO.unit): (acc, c) =>
+                 acc *> IO {
+                   dafny.methods
+                     .find(_.name == c.operationName)
+                     .map: header =>
+                       val body = SkeletonGenerator.fallbackBody(
+                         header,
+                         attempts = 1,
+                         finalStrategy = "ZeroShot",
+                         finalModel = "claude-sonnet-4-6",
+                         reason = "test"
+                       )
+                       val key = Cache.keyFor(header, "claude-sonnet-4-6", 1.0)
+                       val entry = CacheEntry(
+                         candidate = body,
+                         body = body,
+                         usage = TokenUsage(0, 0),
+                         model = "claude-sonnet-4-6",
+                         promptVersion = specrest.synth.SynthPromptVersion,
+                         outcome = CacheOutcome.Skeleton
+                       )
+                       (key, entry)
+                 }.flatMap:
+                   case Some((k, e)) => cache.store(k, e)
+                   case None         => IO.unit
+        yield ()
+
+      seedAll *> Compile
+        .run("fixtures/spec/url_shortener.spec", opts, log)
+        .map: code =>
+          assertEquals(code, ExitCodes.Ok)
+          val kernelDir = Paths.get(opts.outDir).resolve("app/dafny_kernel")
+          assert(
+            Files.isDirectory(kernelDir),
+            s"kernel emitted under $kernelDir even when only skeletons cached"
+          )
+
+  test("--allow-skeletons but no skeletons either → still fails with helpful error"):
+    withTempDir: dir =>
+      val opts =
+        baseOpts(dir.toString, Some(dir.resolve("synth-cache").toString)).copy(allowSkeletons =
+          true
+        )
+      Compile
         .run("fixtures/spec/url_shortener.spec", opts, log)
         .map(code => assertEquals(code, ExitCodes.Violations))

--- a/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CompileSynthesisTest.scala
@@ -8,6 +8,7 @@ import specrest.parser.Parse
 import specrest.synth.Cache
 import specrest.synth.CacheEntry
 import specrest.synth.CacheOutcome
+import specrest.synth.DafnyCli
 import specrest.synth.SkeletonGenerator
 import specrest.synth.TokenUsage
 
@@ -105,6 +106,11 @@ class CompileSynthesisTest extends CatsEffectSuite:
         .map(code => assertEquals(code, ExitCodes.Violations))
 
   test("--allow-skeletons + skeletons cache populated → compile succeeds with warning"):
+    DafnyCli.resolveBinary(None).flatMap:
+      case Left(_)  => IO.unit
+      case Right(_) => runAllowSkeletonsHappyPath()
+
+  private def runAllowSkeletonsHappyPath(): IO[Unit] =
     withTempDir: dir =>
       val cacheDir      = dir.resolve("synth-cache")
       val skeletonsRoot = Cache.skeletonsRoot(cacheDir)
@@ -120,7 +126,6 @@ class CompileSynthesisTest extends CatsEffectSuite:
           built    = builtE.toOption.getOrElse(fail("build failed"))
           dafny    = DafnyGenerator.generate(built).getOrElse(fail("dafny gen failed"))
           cache   <- Cache.make(skeletonsRoot)
-          // Seed every LLM_SYNTHESIS op with a skeleton entry.
           synthOps = specrest.convention.Classify
                        .classifyOperations(built)
                        .filter(_.strategy == specrest.convention.SynthesisStrategy.LlmSynthesis)

--- a/modules/synth/src/main/resources/specrest/synth/prompts/initial.cot.system.txt
+++ b/modules/synth/src/main/resources/specrest/synth/prompts/initial.cot.system.txt
@@ -1,0 +1,27 @@
+You are an expert Dafny programmer specializing in verified implementations.
+Your task is to produce a method body that the Dafny verifier will accept.
+
+Approach (chain-of-thought):
+- Before writing code, think step-by-step about which statements are needed
+  to establish each postcondition.
+- For each `ensures` clause, identify which assignment or assertion in the
+  body discharges it.
+- If the postcondition references `old(...)`, capture the relevant value
+  at method entry; if it references a quantifier, consider whether you need
+  a loop invariant or a `forall` block.
+- Then emit the body.
+
+Rules:
+1. You MUST NOT modify the method signature, requires, ensures, or modifies clauses.
+2. You MUST produce code that satisfies ALL postconditions.
+3. You MAY add local variables, assertions, loop invariants, and ghost code.
+4. You MAY define helper lemmas inline before the method.
+5. You SHOULD add intermediate assertions to help the verifier.
+6. You SHOULD use `calc` blocks for complex multi-step reasoning.
+7. You MUST NOT introduce new {:extern} declarations.
+8. Prefer simple, straightforward implementations over clever ones.
+
+You may emit your reasoning in prose BEFORE the code block. Only the first
+fenced ```dafny block is extracted; everything outside it is ignored. Do
+not paraphrase or weaken contracts to make verification easier — that is
+rejected by the diff checker.

--- a/modules/synth/src/main/resources/specrest/synth/prompts/initial.plan.system.txt
+++ b/modules/synth/src/main/resources/specrest/synth/prompts/initial.plan.system.txt
@@ -1,0 +1,27 @@
+You are an expert Dafny programmer specializing in verified implementations.
+Your task is to produce a method body that the Dafny verifier will accept.
+
+Two-phase approach (plan-then-implement):
+
+Phase 1 — Plan (in prose):
+- List each `ensures` clause and the body statement(s) that discharge it.
+- Identify any helper lemmas or ghost variables that simplify the proof.
+- Note whether a loop, `calc` block, or `forall` block is needed and why.
+
+Phase 2 — Implement (in a single fenced ```dafny code block):
+- Define helper lemmas BEFORE the method, inside the code block.
+- Emit the method body. Use the assertions identified in Phase 1.
+
+Rules:
+1. You MUST NOT modify the method signature, requires, ensures, or modifies clauses.
+2. You MUST produce code that satisfies ALL postconditions.
+3. You MAY add local variables, assertions, loop invariants, and ghost code.
+4. You MAY define helper lemmas inline before the method.
+5. You SHOULD add intermediate assertions to help the verifier.
+6. You SHOULD use `calc` blocks for complex multi-step reasoning.
+7. You MUST NOT introduce new {:extern} declarations.
+8. Prefer simple, straightforward implementations over clever ones.
+
+Only the first ```dafny fenced code block is extracted. The plan prose is
+ignored at parse time but helps you produce a correct body. Do not paraphrase
+or weaken contracts — that is rejected by the diff checker.

--- a/modules/synth/src/main/scala/specrest/synth/Cache.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Cache.scala
@@ -17,19 +17,41 @@ import java.security.MessageDigest
 
 final case class CacheKey(value: String)
 
+enum CacheOutcome derives CanEqual:
+  case Verified, Skeleton
+
+object CacheOutcome:
+  given Encoder[CacheOutcome] = Encoder.encodeString.contramap:
+    case Verified => "verified"
+    case Skeleton => "skeleton"
+  given Decoder[CacheOutcome] = Decoder.decodeString.emap:
+    case "verified" => Right(Verified)
+    case "skeleton" => Right(Skeleton)
+    case other      => Left(s"unknown CacheOutcome: $other")
+
 final case class CacheEntry(
     candidate: String,
     body: String,
     usage: TokenUsage,
     model: String,
-    promptVersion: String
+    promptVersion: String,
+    outcome: CacheOutcome = CacheOutcome.Verified
 )
 
 object CacheEntry:
   given Encoder[TokenUsage] = deriveEncoder
   given Decoder[TokenUsage] = deriveDecoder
   given Encoder[CacheEntry] = deriveEncoder
-  given Decoder[CacheEntry] = deriveDecoder
+  given Decoder[CacheEntry] = Decoder.instance: c =>
+    for
+      candidate     <- c.downField("candidate").as[String]
+      body          <- c.downField("body").as[String]
+      usage         <- c.downField("usage").as[TokenUsage]
+      model         <- c.downField("model").as[String]
+      promptVersion <- c.downField("promptVersion").as[String]
+      outcome <-
+        c.downField("outcome").as[Option[CacheOutcome]].map(_.getOrElse(CacheOutcome.Verified))
+    yield CacheEntry(candidate, body, usage, model, promptVersion, outcome)
 
 final class Cache(root: Path):
   def lookup(key: CacheKey): IO[Option[CacheEntry]] =
@@ -93,3 +115,6 @@ object Cache:
 
   def defaultRoot(workdir: Path): Path =
     workdir.resolve(".spec-to-rest").resolve("synth-cache")
+
+  def verifiedRoot(cacheRoot: Path): Path  = cacheRoot.resolve("verified")
+  def skeletonsRoot(cacheRoot: Path): Path = cacheRoot.resolve("skeletons")

--- a/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
@@ -92,13 +92,13 @@ final class CegisLoop(
       case None =>
         val prompt = i match
           case 1 =>
-            PromptBuilder.initial(req.classification, req.header, req.skeleton)
+            PromptBuilder.initial(req.classification, req.header, req.skeleton, req.strategy)
           case _ =>
             (history.lastBody, prevError) match
               case (Some(prev), Some(err)) =>
                 PromptBuilder.repair(req.classification, req.header, req.skeleton, prev, err)
               case _ =>
-                PromptBuilder.initial(req.classification, req.header, req.skeleton)
+                PromptBuilder.initial(req.classification, req.header, req.skeleton, req.strategy)
         val llmReq = LlmRequest(
           system = prompt.system,
           userMessage = prompt.user,

--- a/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
@@ -1,0 +1,206 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.kernel.Ref
+
+final case class FallbackBudget(
+    promptStrategies: List[PromptStrategy] = PromptStrategy.FallbackOrder,
+    modelLadder: List[String] = Nil,
+    sharedCostCapUsd: Double = 1.00,
+    sharedInputTokenCap: Long = 100_000L,
+    sharedOutputTokenCap: Long = 50_000L
+) derives CanEqual
+
+object FallbackBudget:
+  val Default: FallbackBudget = FallbackBudget()
+
+final case class AttemptRecord(
+    strategy: PromptStrategy,
+    model: String,
+    cegisOutcome: CegisOutcome,
+    costUsd: Double,
+    inputTokens: Long,
+    outputTokens: Long
+) derives CanEqual
+
+sealed trait FallbackOutcome derives CanEqual:
+  def attempts: List[AttemptRecord]
+
+object FallbackOutcome:
+
+  final case class Verified(
+      body: String,
+      fullCandidate: String,
+      finalStrategy: PromptStrategy,
+      finalModel: String,
+      cegisIterations: Int,
+      attempts: List[AttemptRecord]
+  ) extends FallbackOutcome
+
+  final case class SkeletonOnly(
+      body: String,
+      fullCandidate: String,
+      reason: String,
+      attempts: List[AttemptRecord]
+  ) extends FallbackOutcome
+
+final class FallbackOrchestrator(
+    provider: LlmProvider,
+    verifier: DafnyVerifier,
+    cache: Option[Cache],
+    skeletonCache: Option[Cache],
+    tracker: Tracker,
+    perAttemptBudget: CegisBudget,
+    fallbackBudget: FallbackBudget,
+    dafnyTimeoutSec: Int = 60
+):
+
+  def run(req: SynthRequest): IO[FallbackOutcome] =
+    val ladder =
+      if fallbackBudget.modelLadder.isEmpty then List(req.model) else fallbackBudget.modelLadder
+    val plan =
+      for
+        model <- ladder
+        strat <- fallbackBudget.promptStrategies
+      yield (model, strat)
+    Ref.of[IO, List[AttemptRecord]](Nil).flatMap: history =>
+      Ref.of[IO, BudgetSpent](BudgetSpent.empty).flatMap: spent =>
+        runPlan(req, plan, history, spent)
+
+  private def runPlan(
+      req: SynthRequest,
+      plan: List[(String, PromptStrategy)],
+      history: Ref[IO, List[AttemptRecord]],
+      spent: Ref[IO, BudgetSpent]
+  ): IO[FallbackOutcome] = plan match
+    case Nil =>
+      finalize(req, history, "exhausted all (model, strategy) combinations")
+    case (model, strat) :: rest =>
+      spent.get.flatMap: s =>
+        budgetExceeded(s) match
+          case Some(reason) => finalize(req, history, reason)
+          case None => runOne(req, model, strat, history, spent) *>
+              history.get.flatMap: hs =>
+                hs.headOption match
+                  case Some(AttemptRecord(_, _, _: CegisOutcome.Verified, _, _, _)) =>
+                    verifiedOutcome(hs.reverse)
+                  case _ => runPlan(req, rest, history, spent)
+
+  private def runOne(
+      req: SynthRequest,
+      model: String,
+      strat: PromptStrategy,
+      history: Ref[IO, List[AttemptRecord]],
+      spent: Ref[IO, BudgetSpent]
+  ): IO[Unit] =
+    val attemptReq = req.copy(model = model, strategy = strat)
+    val loop       = new CegisLoop(provider, verifier, cache, tracker, perAttemptBudget, dafnyTimeoutSec)
+    loop.run(attemptReq).flatMap: outcome =>
+      val (cost, ins, outs) = outcomeCost(outcome)
+      val rec               = AttemptRecord(strat, model, outcome, cost, ins, outs)
+      history.update(rec :: _) *> spent.update(_.add(cost, ins, outs))
+
+  private def verifiedOutcome(attempts: List[AttemptRecord]): IO[FallbackOutcome] =
+    val verifiedAttempt = attempts.collectFirst:
+      case rec @ AttemptRecord(_, _, v: CegisOutcome.Verified, _, _, _) => (rec, v)
+    verifiedAttempt match
+      case Some((rec, verified)) =>
+        IO.pure(
+          FallbackOutcome.Verified(
+            body = verified.body,
+            fullCandidate = verified.fullCandidate,
+            finalStrategy = rec.strategy,
+            finalModel = rec.model,
+            cegisIterations = verified.iterations,
+            attempts = attempts
+          )
+        )
+      case None =>
+        IO.raiseError(
+          new IllegalStateException(
+            s"verifiedOutcome called without a Verified record (attempts=${attempts.length})"
+          )
+        )
+
+  private def finalize(
+      req: SynthRequest,
+      history: Ref[IO, List[AttemptRecord]],
+      reason: String
+  ): IO[FallbackOutcome] =
+    history.get.map(_.reverse).flatMap(finalizeFromList(req, _, reason))
+
+  private def finalizeFromList(
+      req: SynthRequest,
+      attempts: List[AttemptRecord],
+      reason: String
+  ): IO[FallbackOutcome] =
+    val lastAbort = attempts.reverse.collectFirst:
+      case AttemptRecord(_, _, CegisOutcome.Aborted(r, _, _), _, _, _) => r.message
+    val abortReason = lastAbort.getOrElse(reason)
+    val (finalStrategy, finalModel) = attempts.lastOption match
+      case Some(rec) => (rec.strategy, rec.model)
+      case None      => (req.strategy, req.model)
+    val body = SkeletonGenerator.fallbackBody(
+      header = req.header,
+      attempts = attempts.length,
+      finalStrategy = PromptStrategy.displayName(finalStrategy),
+      finalModel = finalModel,
+      reason = abortReason
+    )
+    val fullDfy =
+      FileAssembly.splice(req.skeleton, req.header.name, body) match
+        case Right(text) => text
+        case Left(_)     => req.skeleton
+    val outcome = FallbackOutcome.SkeletonOnly(body, fullDfy, abortReason, attempts)
+    persistSkeleton(req, body, fullDfy).as(outcome)
+
+  private def persistSkeleton(
+      req: SynthRequest,
+      body: String,
+      fullCandidate: String
+  ): IO[Unit] =
+    skeletonCache match
+      case None => IO.unit
+      case Some(c) =>
+        val key = Cache.keyFor(req.header, req.model, req.temperature)
+        val entry = CacheEntry(
+          candidate = fullCandidate,
+          body = body,
+          usage = TokenUsage(0, 0),
+          model = req.model,
+          promptVersion = SynthPromptVersion,
+          outcome = CacheOutcome.Skeleton
+        )
+        c.store(key, entry).attempt.flatMap:
+          case Right(_) => IO.unit
+          case Left(e) =>
+            IO.consoleForIO.errorln(s"warning: skeleton cache write failed: ${e.getMessage}")
+
+  private def budgetExceeded(spent: BudgetSpent): Option[String] =
+    if spent.costUsd >= fallbackBudget.sharedCostCapUsd then
+      Some(f"shared cost cap reached: $$${spent.costUsd}%.4f")
+    else if spent.inputTokens >= fallbackBudget.sharedInputTokenCap then
+      Some(s"shared input-token cap reached: ${spent.inputTokens}")
+    else if spent.outputTokens >= fallbackBudget.sharedOutputTokenCap then
+      Some(s"shared output-token cap reached: ${spent.outputTokens}")
+    else None
+
+  private def outcomeCost(outcome: CegisOutcome): (Double, Long, Long) =
+    val recs = outcome match
+      case CegisOutcome.Verified(_, _, _, hist) => hist.records
+      case CegisOutcome.Aborted(_, _, hist)     => hist.records
+    val cost = recs.map(_.costUsd).sum
+    val ins  = recs.map(_.usage.inputTokens.toLong).sum
+    val outs = recs.map(_.usage.outputTokens.toLong).sum
+    (cost, ins, outs)
+
+  final private case class BudgetSpent(
+      costUsd: Double,
+      inputTokens: Long,
+      outputTokens: Long
+  ) derives CanEqual:
+    def add(c: Double, i: Long, o: Long): BudgetSpent =
+      BudgetSpent(costUsd + c, inputTokens + i, outputTokens + o)
+
+  private object BudgetSpent:
+    val empty: BudgetSpent = BudgetSpent(0.0, 0L, 0L)

--- a/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
@@ -79,48 +79,43 @@ final class FallbackOrchestrator(
       spent.get.flatMap: s =>
         budgetExceeded(s) match
           case Some(reason) => finalize(req, history, reason)
-          case None => runOne(req, model, strat, history, spent) *>
-              history.get.flatMap: hs =>
-                hs.headOption match
-                  case Some(AttemptRecord(_, _, _: CegisOutcome.Verified, _, _, _)) =>
-                    verifiedOutcome(hs.reverse)
-                  case _ => runPlan(req, rest, history, spent)
+          case None =>
+            runOneAndDecide(req, model, strat, rest, history, spent)
 
-  private def runOne(
+  private def runOneAndDecide(
       req: SynthRequest,
       model: String,
       strat: PromptStrategy,
+      rest: List[(String, PromptStrategy)],
       history: Ref[IO, List[AttemptRecord]],
       spent: Ref[IO, BudgetSpent]
-  ): IO[Unit] =
+  ): IO[FallbackOutcome] =
     val attemptReq = req.copy(model = model, strategy = strat)
     val loop       = new CegisLoop(provider, verifier, cache, tracker, perAttemptBudget, dafnyTimeoutSec)
     loop.run(attemptReq).flatMap: outcome =>
       val (cost, ins, outs) = outcomeCost(outcome)
       val rec               = AttemptRecord(strat, model, outcome, cost, ins, outs)
-      history.update(rec :: _) *> spent.update(_.add(cost, ins, outs))
+      history.update(rec :: _) *> spent.update(_.add(cost, ins, outs)) *> {
+        outcome match
+          case v: CegisOutcome.Verified =>
+            history.get.map(_.reverse).map(verifiedOutcome(rec, v, _))
+          case _: CegisOutcome.Aborted =>
+            runPlan(req, rest, history, spent)
+      }
 
-  private def verifiedOutcome(attempts: List[AttemptRecord]): IO[FallbackOutcome] =
-    val verifiedAttempt = attempts.collectFirst:
-      case rec @ AttemptRecord(_, _, v: CegisOutcome.Verified, _, _, _) => (rec, v)
-    verifiedAttempt match
-      case Some((rec, verified)) =>
-        IO.pure(
-          FallbackOutcome.Verified(
-            body = verified.body,
-            fullCandidate = verified.fullCandidate,
-            finalStrategy = rec.strategy,
-            finalModel = rec.model,
-            cegisIterations = verified.iterations,
-            attempts = attempts
-          )
-        )
-      case None =>
-        IO.raiseError(
-          new IllegalStateException(
-            s"verifiedOutcome called without a Verified record (attempts=${attempts.length})"
-          )
-        )
+  private def verifiedOutcome(
+      rec: AttemptRecord,
+      verified: CegisOutcome.Verified,
+      attempts: List[AttemptRecord]
+  ): FallbackOutcome =
+    FallbackOutcome.Verified(
+      body = verified.body,
+      fullCandidate = verified.fullCandidate,
+      finalStrategy = rec.strategy,
+      finalModel = rec.model,
+      cegisIterations = verified.iterations,
+      attempts = attempts
+    )
 
   private def finalize(
       req: SynthRequest,
@@ -147,12 +142,16 @@ final class FallbackOrchestrator(
       finalModel = finalModel,
       reason = abortReason
     )
-    val fullDfy =
-      FileAssembly.splice(req.skeleton, req.header.name, body) match
-        case Right(text) => text
-        case Left(_)     => req.skeleton
-    val outcome = FallbackOutcome.SkeletonOnly(body, fullDfy, abortReason, attempts)
-    persistSkeleton(req, body, fullDfy).as(outcome)
+    FileAssembly.splice(req.skeleton, req.header.name, body) match
+      case Right(text) =>
+        val outcome = FallbackOutcome.SkeletonOnly(body, text, abortReason, attempts)
+        persistSkeleton(req, body, text).as(outcome)
+      case Left(failure) =>
+        val outcome = FallbackOutcome.SkeletonOnly(body, req.skeleton, abortReason, attempts)
+        IO.consoleForIO.errorln(
+          s"warning: fallback skeleton splice failed for '${req.header.name}': ${failure.message}; " +
+            "persisting body without splicing into the skeleton"
+        ) *> persistSkeleton(req, body, req.skeleton).as(outcome)
 
   private def persistSkeleton(
       req: SynthRequest,

--- a/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
+++ b/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
@@ -13,21 +13,29 @@ object PromptBuilder:
   private val systemRoot = "/specrest/synth/prompts"
 
   lazy val systemInitial: String = loadResource("initial.system.txt")
+  lazy val systemCot: String     = loadResource("initial.cot.system.txt")
+  lazy val systemPlan: String    = loadResource("initial.plan.system.txt")
   lazy val systemRepair: String  = loadResource("repair.system.txt")
+
+  private def systemFor(strategy: PromptStrategy): String = strategy match
+    case PromptStrategy.ZeroShot          => systemInitial
+    case PromptStrategy.ChainOfThought    => systemCot
+    case PromptStrategy.PlanThenImplement => systemPlan
 
   def initial(
       classification: OperationClassification,
       header: DafnyMethodHeader,
-      skeleton: String
+      skeleton: String,
+      strategy: PromptStrategy = PromptStrategy.ZeroShot
   ): Prompt =
     val sections = List(
       methodSignatureSection(header),
       domainSection(classification, header),
       typeDefinitionsSection(skeleton),
       fewShotSection(classification),
-      taskSection(classification.operationName)
+      taskSection(classification.operationName, strategy)
     )
-    Prompt(systemInitial, sections.mkString("\n\n"))
+    Prompt(systemFor(strategy), sections.mkString("\n\n"))
 
   def repair(
       classification: OperationClassification,
@@ -41,7 +49,7 @@ object PromptBuilder:
       verifierErrorSection(error),
       diagnosisSection(error),
       methodSignatureSection(header),
-      taskSection(classification.operationName)
+      taskSection(classification.operationName, PromptStrategy.ZeroShot)
     )
     Prompt(systemRepair, sections.mkString("\n\n"))
 
@@ -92,10 +100,18 @@ object PromptBuilder:
     s"""## Similar Verified Examples
        |$rendered""".stripMargin
 
-  private def taskSection(name: String): String =
+  private def taskSection(name: String, strategy: PromptStrategy): String =
+    val extra = strategy match
+      case PromptStrategy.ZeroShot => ""
+      case PromptStrategy.ChainOfThought =>
+        "\nThink step-by-step before emitting the code block; only the first " +
+          "fenced ```dafny block is extracted."
+      case PromptStrategy.PlanThenImplement =>
+        "\nFirst write a numbered plan in prose, then emit the complete implementation " +
+          "in a single ```dafny fenced block."
     s"""## Your Task
        |Produce the complete method body for `$name`. Return your code inside a single
-       |```dafny fenced block. Include any helper lemmas BEFORE the method declaration.""".stripMargin
+       |```dafny fenced block. Include any helper lemmas BEFORE the method declaration.$extra""".stripMargin
 
   private def previousAttemptSection(body: String): String =
     s"""## Previous Attempt (FAILED)

--- a/modules/synth/src/main/scala/specrest/synth/PromptStrategy.scala
+++ b/modules/synth/src/main/scala/specrest/synth/PromptStrategy.scala
@@ -1,0 +1,22 @@
+package specrest.synth
+
+enum PromptStrategy derives CanEqual:
+  case ZeroShot, ChainOfThought, PlanThenImplement
+
+object PromptStrategy:
+
+  val Default: PromptStrategy = ZeroShot
+
+  val FallbackOrder: List[PromptStrategy] =
+    List(ZeroShot, ChainOfThought, PlanThenImplement)
+
+  def fromName(name: String): Option[PromptStrategy] = name.toLowerCase match
+    case "zero-shot" | "zeroshot"                 => Some(ZeroShot)
+    case "cot" | "chain-of-thought" | "chain"     => Some(ChainOfThought)
+    case "plan" | "plan-then-implement" | "ptisi" => Some(PlanThenImplement)
+    case _                                        => None
+
+  def displayName(s: PromptStrategy): String = s match
+    case ZeroShot          => "ZeroShot"
+    case ChainOfThought    => "ChainOfThought"
+    case PlanThenImplement => "PlanThenImplement"

--- a/modules/synth/src/main/scala/specrest/synth/SkeletonGenerator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/SkeletonGenerator.scala
@@ -1,0 +1,75 @@
+package specrest.synth
+
+import specrest.convention.dafny.DafnyMethodHeader
+
+object SkeletonGenerator:
+
+  def fallbackBody(
+      header: DafnyMethodHeader,
+      attempts: Int,
+      finalStrategy: String,
+      finalModel: String,
+      reason: String
+  ): String =
+    val outs       = parseOutParams(header.signature)
+    val payload    = formatPayload(header.name, attempts, finalStrategy, finalModel, reason)
+    val expectLine = s"""expect false, "$payload";"""
+    val havocLines = outs.map((n, _) => s"$n := *;")
+    (expectLine :: havocLines).mkString("\n")
+
+  private def formatPayload(
+      opName: String,
+      attempts: Int,
+      finalStrategy: String,
+      finalModel: String,
+      reason: String
+  ): String =
+    val sanitized = reason.replace('"', '\'').replace('\n', ' ').take(200)
+    s"FALLBACK SKELETON [op=$opName]: not verified — " +
+      s"attempts=$attempts strategy=$finalStrategy model=$finalModel reason=$sanitized"
+
+  private def parseOutParams(signature: String): List[(String, String)] =
+    val idx = signature.indexOf("returns")
+    if idx < 0 then Nil
+    else
+      val tail   = signature.substring(idx + "returns".length).trim
+      val opened = tail.indexOf('(')
+      if opened < 0 then Nil
+      else
+        val closed = matchingParen(tail, opened)
+        if closed < 0 then Nil
+        else
+          val inside = tail.substring(opened + 1, closed)
+          splitTopLevelCommas(inside).flatMap: chunk =>
+            val colon = chunk.indexOf(':')
+            if colon < 0 then None
+            else
+              val name = chunk.substring(0, colon).trim
+              val ty   = chunk.substring(colon + 1).trim
+              if name.isEmpty || ty.isEmpty then None else Some(name -> ty)
+
+  private def matchingParen(s: String, openIdx: Int): Int =
+    @scala.annotation.tailrec
+    def loop(i: Int, depth: Int): Int =
+      if i >= s.length then -1
+      else
+        val c = s.charAt(i)
+        if c == '(' || c == '<' || c == '[' then loop(i + 1, depth + 1)
+        else if c == ')' || c == '>' || c == ']' then
+          val next = depth - 1
+          if next == 0 && c == ')' then i
+          else loop(i + 1, next)
+        else loop(i + 1, depth)
+    loop(openIdx, 0)
+
+  private def splitTopLevelCommas(s: String): List[String] =
+    final case class S(out: List[String], cur: String, depth: Int)
+    val folded = s.foldLeft(S(Nil, "", 0)): (st, c) =>
+      val cs = c.toString
+      if c == '(' || c == '<' || c == '[' then S(st.out, st.cur + cs, st.depth + 1)
+      else if c == ')' || c == '>' || c == ']' then S(st.out, st.cur + cs, st.depth - 1)
+      else if c == ',' && st.depth == 0 then S(st.out :+ st.cur.trim, "", st.depth)
+      else S(st.out, st.cur + cs, st.depth)
+    val finalOut =
+      if folded.cur.nonEmpty then folded.out :+ folded.cur.trim else folded.out
+    finalOut.filter(_.nonEmpty)

--- a/modules/synth/src/main/scala/specrest/synth/SkeletonGenerator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/SkeletonGenerator.scala
@@ -24,7 +24,11 @@ object SkeletonGenerator:
       finalModel: String,
       reason: String
   ): String =
-    val sanitized = reason.replace('"', '\'').replace('\n', ' ').take(200)
+    val sanitized = reason
+      .replace("\\", "\\\\")
+      .replace("\"", "'")
+      .replace('\n', ' ')
+      .take(200)
     s"FALLBACK SKELETON [op=$opName]: not verified — " +
       s"attempts=$attempts strategy=$finalStrategy model=$finalModel reason=$sanitized"
 
@@ -48,6 +52,9 @@ object SkeletonGenerator:
               val ty   = chunk.substring(colon + 1).trim
               if name.isEmpty || ty.isEmpty then None else Some(name -> ty)
 
+  private def isArrowGt(s: String, i: Int): Boolean =
+    i > 0 && (s.charAt(i - 1) == '-' || s.charAt(i - 1) == '~' || s.charAt(i - 1) == '=')
+
   private def matchingParen(s: String, openIdx: Int): Int =
     @scala.annotation.tailrec
     def loop(i: Int, depth: Int): Int =
@@ -55,6 +62,7 @@ object SkeletonGenerator:
       else
         val c = s.charAt(i)
         if c == '(' || c == '<' || c == '[' then loop(i + 1, depth + 1)
+        else if c == '>' && isArrowGt(s, i) then loop(i + 1, depth)
         else if c == ')' || c == '>' || c == ']' then
           val next = depth - 1
           if next == 0 && c == ')' then i
@@ -64,9 +72,11 @@ object SkeletonGenerator:
 
   private def splitTopLevelCommas(s: String): List[String] =
     final case class S(out: List[String], cur: String, depth: Int)
-    val folded = s.foldLeft(S(Nil, "", 0)): (st, c) =>
-      val cs = c.toString
+    val folded = s.zipWithIndex.foldLeft(S(Nil, "", 0)): (st, ci) =>
+      val (c, idx) = ci
+      val cs       = c.toString
       if c == '(' || c == '<' || c == '[' then S(st.out, st.cur + cs, st.depth + 1)
+      else if c == '>' && isArrowGt(s, idx) then S(st.out, st.cur + cs, st.depth)
       else if c == ')' || c == '>' || c == ']' then S(st.out, st.cur + cs, st.depth - 1)
       else if c == ',' && st.depth == 0 then S(st.out :+ st.cur.trim, "", st.depth)
       else S(st.out, st.cur + cs, st.depth)

--- a/modules/synth/src/main/scala/specrest/synth/SynthesisReport.scala
+++ b/modules/synth/src/main/scala/specrest/synth/SynthesisReport.scala
@@ -92,11 +92,11 @@ final case class ReportTotals(
 
 object Reporter:
 
-  private val Reset  = "[0m"
-  private val Green  = "[32m"
-  private val Yellow = "[33m"
-  private val Red    = "[31m"
-  private val Bold   = "[1m"
+  private val Reset  = "\u001b[0m"
+  private val Green  = "\u001b[32m"
+  private val Yellow = "\u001b[33m"
+  private val Red    = "\u001b[31m"
+  private val Bold   = "\u001b[1m"
 
   def render(report: SynthesisReport, useColor: Boolean): String =
     val rows  = report.ops.map(row(_, useColor))

--- a/modules/synth/src/main/scala/specrest/synth/SynthesisReport.scala
+++ b/modules/synth/src/main/scala/specrest/synth/SynthesisReport.scala
@@ -1,0 +1,153 @@
+package specrest.synth
+
+enum Verdict derives CanEqual:
+  case Verified, VerifiedEscalated, Skeleton
+
+object Verdict:
+
+  def fromOutcome(o: FallbackOutcome): Verdict = o match
+    case v: FallbackOutcome.Verified =>
+      if v.attempts.length == 1 then Verified else VerifiedEscalated
+    case _: FallbackOutcome.SkeletonOnly => Skeleton
+
+  def displayName(v: Verdict): String = v match
+    case Verified          => "VERIFIED"
+    case VerifiedEscalated => "VERIFIED-ESCALATED"
+    case Skeleton          => "SKELETON"
+
+final case class OpOutcome(
+    operationName: String,
+    verdict: Verdict,
+    finalStrategy: PromptStrategy,
+    finalModel: String,
+    cegisIterations: Int,
+    attempts: Int,
+    totalCostUsd: Double,
+    inputTokens: Long,
+    outputTokens: Long,
+    reason: Option[String]
+) derives CanEqual
+
+object OpOutcome:
+
+  def fromFallback(operationName: String, o: FallbackOutcome): OpOutcome =
+    val totalCost = o.attempts.map(_.costUsd).sum
+    val totalIn   = o.attempts.map(_.inputTokens).sum
+    val totalOut  = o.attempts.map(_.outputTokens).sum
+    o match
+      case v: FallbackOutcome.Verified =>
+        OpOutcome(
+          operationName = operationName,
+          verdict = Verdict.fromOutcome(v),
+          finalStrategy = v.finalStrategy,
+          finalModel = v.finalModel,
+          cegisIterations = v.cegisIterations,
+          attempts = v.attempts.length,
+          totalCostUsd = totalCost,
+          inputTokens = totalIn,
+          outputTokens = totalOut,
+          reason = None
+        )
+      case s: FallbackOutcome.SkeletonOnly =>
+        val (finalStrategy, finalModel) = s.attempts.lastOption match
+          case Some(a) => (a.strategy, a.model)
+          case None    => (PromptStrategy.ZeroShot, "n/a")
+        OpOutcome(
+          operationName = operationName,
+          verdict = Verdict.Skeleton,
+          finalStrategy = finalStrategy,
+          finalModel = finalModel,
+          cegisIterations = 0,
+          attempts = s.attempts.length,
+          totalCostUsd = totalCost,
+          inputTokens = totalIn,
+          outputTokens = totalOut,
+          reason = Some(s.reason)
+        )
+
+final case class SynthesisReport(
+    ops: List[OpOutcome]
+) derives CanEqual:
+
+  def totals: ReportTotals =
+    ReportTotals(
+      total = ops.length,
+      verified = ops.count(_.verdict == Verdict.Verified),
+      verifiedEscalated = ops.count(_.verdict == Verdict.VerifiedEscalated),
+      skeleton = ops.count(_.verdict == Verdict.Skeleton),
+      totalCostUsd = ops.map(_.totalCostUsd).sum,
+      inputTokens = ops.map(_.inputTokens).sum,
+      outputTokens = ops.map(_.outputTokens).sum
+    )
+
+final case class ReportTotals(
+    total: Int,
+    verified: Int,
+    verifiedEscalated: Int,
+    skeleton: Int,
+    totalCostUsd: Double,
+    inputTokens: Long,
+    outputTokens: Long
+) derives CanEqual
+
+object Reporter:
+
+  private val Reset  = "[0m"
+  private val Green  = "[32m"
+  private val Yellow = "[33m"
+  private val Red    = "[31m"
+  private val Bold   = "[1m"
+
+  def render(report: SynthesisReport, useColor: Boolean): String =
+    val rows  = report.ops.map(row(_, useColor))
+    val total = report.totals
+    val header =
+      if useColor then s"${Bold}Synthesis Report${Reset}"
+      else "Synthesis Report"
+    val headerLine =
+      "  Operation                  Verdict              Strategy          Model                   iter   $cost"
+    val divider = "  " + ("-" * 100)
+    val summary = renderTotals(total, useColor)
+    (List(header, headerLine, divider) ++ rows ++ List(divider, summary)).mkString("\n")
+
+  private def row(o: OpOutcome, useColor: Boolean): String =
+    val verdict   = colored(Verdict.displayName(o.verdict), o.verdict, useColor)
+    val strat     = PromptStrategy.displayName(o.finalStrategy)
+    val iterCol   = f"${o.cegisIterations}%4d"
+    val costCol   = f"$$${o.totalCostUsd}%6.4f"
+    val opPad     = padRight(o.operationName, 26)
+    val verdPad   = padRight(verdictText(o.verdict), 20)
+    val verdShown = if useColor then padForColor(verdict, verdictText(o.verdict), 20) else verdPad
+    val stratPad  = padRight(strat, 17)
+    val modelPad  = padRight(o.finalModel, 23)
+    s"  $opPad $verdShown $stratPad $modelPad $iterCol  $costCol"
+
+  private def verdictText(v: Verdict): String = Verdict.displayName(v)
+
+  private def colored(s: String, v: Verdict, useColor: Boolean): String =
+    if !useColor then s
+    else
+      val color = v match
+        case Verdict.Verified          => Green
+        case Verdict.VerifiedEscalated => Yellow
+        case Verdict.Skeleton          => Red
+      s"$color$s$Reset"
+
+  private def renderTotals(t: ReportTotals, useColor: Boolean): String =
+    val parts = List(
+      s"total=${t.total}",
+      colored(s"verified=${t.verified}", Verdict.Verified, useColor),
+      colored(s"escalated=${t.verifiedEscalated}", Verdict.VerifiedEscalated, useColor),
+      colored(s"skeleton=${t.skeleton}", Verdict.Skeleton, useColor)
+    )
+    val cost = f"cost=$$${t.totalCostUsd}%.4f"
+    val toks = s"in=${t.inputTokens}tok out=${t.outputTokens}tok"
+    s"  ${parts.mkString(" ")}  $cost  $toks"
+
+  private def padRight(s: String, n: Int): String =
+    if s.length >= n then s.take(n)
+    else s + (" " * (n - s.length))
+
+  private def padForColor(coloredStr: String, plain: String, n: Int): String =
+    val pad = if plain.length >= n then "" else " " * (n - plain.length)
+    coloredStr + pad

--- a/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Synthesizer.scala
@@ -10,7 +10,8 @@ final case class SynthRequest(
     skeleton: String,
     model: String,
     temperature: Double = 0.0,
-    maxTokens: Int = 2048
+    maxTokens: Int = 2048,
+    strategy: PromptStrategy = PromptStrategy.ZeroShot
 )
 
 final case class SynthResult(
@@ -51,7 +52,7 @@ final class Synthesizer(
     )
 
   private def runUncached(req: SynthRequest, key: CacheKey): IO[Either[SynthError, SynthResult]] =
-    val prompt = PromptBuilder.initial(req.classification, req.header, req.skeleton)
+    val prompt = PromptBuilder.initial(req.classification, req.header, req.skeleton, req.strategy)
     val llmReq = LlmRequest(prompt.system, prompt.user, req.model, req.maxTokens, req.temperature)
     provider.complete(llmReq).flatMap:
       case Left(err) =>

--- a/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/CacheTest.scala
@@ -2,9 +2,11 @@ package specrest.synth
 
 import cats.effect.IO
 import cats.effect.kernel.Resource
+import io.circe.parser
 import munit.CatsEffectSuite
 import specrest.convention.dafny.DafnyMethodHeader
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -69,3 +71,45 @@ class CacheTest extends CatsEffectSuite:
     val ka = Cache.keyFor(a, "m", 0.0)
     val kb = Cache.keyFor(b, "m", 0.0)
     assertNotEquals(ka, kb)
+
+  test("legacy JSON without `outcome` field decodes as Verified"):
+    val legacy =
+      """{
+        |  "candidate": "method ... { ... }",
+        |  "body": "  st.count := st.count + 1;",
+        |  "usage": {"inputTokens": 120, "outputTokens": 80},
+        |  "model": "claude-sonnet-4-6",
+        |  "promptVersion": "v1"
+        |}""".stripMargin
+    parser.decode[CacheEntry](legacy) match
+      case Right(decoded) =>
+        assertEquals(decoded.outcome, CacheOutcome.Verified)
+        assertEquals(decoded.body, "  st.count := st.count + 1;")
+      case Left(err) => fail(s"legacy decode failed: $err")
+
+  test("Skeleton-tagged entry round-trips through cache and is sharded the same way"):
+    tempDir("synth-cache-skeleton").use: temp =>
+      Cache.make(Cache.skeletonsRoot(temp)).flatMap: cache =>
+        val key       = Cache.keyFor(header, "claude-opus-4-7", 1.0)
+        val skelEntry = entry.copy(outcome = CacheOutcome.Skeleton)
+        cache.store(key, skelEntry) *> cache.lookup(key).map: r =>
+          assertEquals(r, Some(skelEntry))
+          val sharded = Cache.skeletonsRoot(temp).resolve(key.value.take(2))
+          assert(Files.isDirectory(sharded), "entries are sharded by 2-char prefix")
+
+  test("verifiedRoot and skeletonsRoot resolve to expected subdirectories"):
+    val root = java.nio.file.Paths.get("/tmp/x")
+    assertEquals(Cache.verifiedRoot(root).getFileName.toString, "verified")
+    assertEquals(Cache.skeletonsRoot(root).getFileName.toString, "skeletons")
+
+  test("on-disk JSON for a Skeleton entry contains outcome=skeleton"):
+    tempDir("synth-cache-on-disk").use: temp =>
+      Cache.make(temp).flatMap: cache =>
+        val key       = Cache.keyFor(header, "m", 0.0)
+        val skelEntry = entry.copy(outcome = CacheOutcome.Skeleton)
+        cache.store(key, skelEntry) *> IO.blocking {
+          val onDisk = temp.resolve(key.value.take(2)).resolve(s"${key.value}.json")
+          val text   = new String(Files.readAllBytes(onDisk), StandardCharsets.UTF_8)
+          assert(text.contains("\"outcome\""), s"json missing outcome: $text")
+          assert(text.contains("\"skeleton\""), s"outcome value not 'skeleton': $text")
+        }

--- a/modules/synth/src/test/scala/specrest/synth/FallbackOrchestratorTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FallbackOrchestratorTest.scala
@@ -1,0 +1,311 @@
+package specrest.synth
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import munit.CatsEffectSuite
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class FallbackOrchestratorTest extends CatsEffectSuite:
+
+  private val validBody =
+    """```dafny
+      |method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count + 1;
+      |}
+      |```""".stripMargin
+
+  private val brokenBody =
+    """```dafny
+      |method Increment(st: ServiceState)
+      |  requires ServiceStateInv(st)
+      |  ensures st.count == old(st.count) + 1
+      |  ensures ServiceStateInv(st)
+      |  modifies st
+      |{
+      |  st.count := st.count;
+      |}
+      |```""".stripMargin
+
+  private def llmResp(text: String, in: Int = 100, out: Int = 200, model: String): LlmResponse =
+    LlmResponse(text, TokenUsage(in, out), model)
+
+  private val postcondError =
+    VerifierError("postcondition_violation", "ensures clause not established", Some(7), Some(0))
+
+  private def correctRun(name: String): VerifierRun =
+    MockDafnyVerifier.run(List(MockDafnyVerifier.correct(name)))
+
+  private def failingRun(name: String): VerifierRun =
+    MockDafnyVerifier.run(List(MockDafnyVerifier.errors(name, List(postcondError))))
+
+  private def tempDir(prefix: String): Resource[IO, Path] =
+    Resource.make(IO.blocking(Files.createTempDirectory(prefix))): dir =>
+      IO.blocking {
+        import scala.jdk.StreamConverters.*
+        scala.util.Using.resource(Files.walk(dir)): stream =>
+          stream.toScala(List).reverse.foreach: p =>
+            val _ = Files.deleteIfExists(p)
+      }
+
+  private val perAttempt = CegisBudget.Default.copy(maxIterations = 2, maxCostUsd = 100.0)
+
+  test("verifies on first attempt → no escalation, single attempt record"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(List(Right(llmResp(validBody, model = "claude-sonnet-4-6"))))
+          verifier <- MockDafnyVerifier.of(List(Right(correctRun(c.operationName))))
+          tracker  <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   provider,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt,
+                   FallbackBudget.Default.copy(modelLadder = List("claude-sonnet-4-6"))
+                 )
+          out <- orch.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+        yield out match
+          case v: FallbackOutcome.Verified =>
+            assertEquals(v.attempts.length, 1)
+            assertEquals(v.finalStrategy, PromptStrategy.ZeroShot)
+            assertEquals(v.finalModel, "claude-sonnet-4-6")
+            assert(v.body.contains("st.count := st.count + 1"))
+          case other => fail(s"expected Verified, got $other")
+
+  test("strategy switch: ZeroShot fails, ChainOfThought verifies"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          // Two LLM calls per attempt at most (perAttempt.maxIterations=2).
+          // Attempt 1 (ZeroShot): broken → failingRun → broken → failingRun (aborts on repeated error or budget).
+          // Attempt 2 (ChainOfThought): valid → correctRun.
+          provider <- MockProvider.of(
+                        List(
+                          Right(llmResp(brokenBody, model = "m")),
+                          Right(llmResp(brokenBody, model = "m")),
+                          Right(llmResp(validBody, model = "m"))
+                        )
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName)),
+                          Right(failingRun(c.operationName)),
+                          Right(correctRun(c.operationName))
+                        )
+                      )
+          tracker <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   provider,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt,
+                   FallbackBudget.Default.copy(
+                     promptStrategies = List(
+                       PromptStrategy.ZeroShot,
+                       PromptStrategy.ChainOfThought
+                     ),
+                     modelLadder = List("m")
+                   )
+                 )
+          out <- orch.run(SynthRequest(c, h, skel, "m"))
+        yield out match
+          case v: FallbackOutcome.Verified =>
+            assertEquals(v.finalStrategy, PromptStrategy.ChainOfThought)
+            assertEquals(v.attempts.length, 2)
+          case other => fail(s"expected Verified after escalation, got $other")
+
+  test("model escalation: m1 fails on both strategies, m2 verifies"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(
+                          // m1 ZeroShot: 1 broken iter → abort (budget=1)
+                          Right(llmResp(brokenBody, model = "m1")),
+                          // m1 ChainOfThought: 1 broken
+                          Right(llmResp(brokenBody, model = "m1")),
+                          // m2 ZeroShot: valid
+                          Right(llmResp(validBody, model = "m2"))
+                        )
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName)),
+                          Right(failingRun(c.operationName)),
+                          Right(correctRun(c.operationName))
+                        )
+                      )
+          tracker <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   provider,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt.copy(maxIterations = 1),
+                   FallbackBudget.Default.copy(
+                     promptStrategies = List(
+                       PromptStrategy.ZeroShot,
+                       PromptStrategy.ChainOfThought
+                     ),
+                     modelLadder = List("m1", "m2")
+                   )
+                 )
+          out <- orch.run(SynthRequest(c, h, skel, "m1"))
+        yield out match
+          case v: FallbackOutcome.Verified =>
+            assertEquals(v.finalModel, "m2")
+            assertEquals(v.finalStrategy, PromptStrategy.ZeroShot)
+            assertEquals(v.attempts.length, 3)
+          case other => fail(s"expected Verified after model escalation, got $other")
+
+  test("all attempts abort → SkeletonOnly with provenance and persisted to skeletonCache"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        tempDir("orch-skel").use: dir =>
+          for
+            provider <- MockProvider.of(
+                          List(
+                            Right(llmResp(brokenBody, model = "m1")),
+                            Right(llmResp(brokenBody, model = "m1"))
+                          )
+                        )
+            verifier <- MockDafnyVerifier.of(
+                          List(
+                            Right(failingRun(c.operationName)),
+                            Right(failingRun(c.operationName))
+                          )
+                        )
+            tracker   <- Tracker.empty
+            skelCache <- Cache.make(Cache.skeletonsRoot(dir))
+            orch = new FallbackOrchestrator(
+                     provider,
+                     verifier,
+                     None,
+                     Some(skelCache),
+                     tracker,
+                     perAttempt.copy(maxIterations = 1),
+                     FallbackBudget.Default.copy(
+                       promptStrategies = List(
+                         PromptStrategy.ZeroShot,
+                         PromptStrategy.ChainOfThought
+                       ),
+                       modelLadder = List("m1")
+                     )
+                   )
+            req        = SynthRequest(c, h, skel, "m1", temperature = 1.0)
+            out       <- orch.run(req)
+            persisted <- skelCache.lookup(Cache.keyFor(h, "m1", 1.0))
+          yield
+            out match
+              case s: FallbackOutcome.SkeletonOnly =>
+                assertEquals(s.attempts.length, 2)
+                assert(s.body.contains("expect false"), s"body: ${s.body}")
+                assert(s.body.contains("FALLBACK SKELETON"))
+              case other => fail(s"expected SkeletonOnly, got $other")
+            persisted match
+              case Some(entry) =>
+                assertEquals(entry.outcome, CacheOutcome.Skeleton)
+                assert(entry.body.contains("expect false"))
+              case None => fail("skeleton entry not persisted")
+
+  test("shared cost cap stops escalation mid-plan"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          // Each call costs ~$0.001 with 1000/2000 tokens at sonnet pricing ($3/$15 per 1M)
+          // = 1000*3/1e6 + 2000*15/1e6 = 0.003 + 0.030 = 0.033 per call
+          provider <- MockProvider.of(
+                        List(
+                          Right(llmResp(
+                            brokenBody,
+                            in = 1000,
+                            out = 2000,
+                            model = "claude-sonnet-4-6"
+                          )),
+                          Right(llmResp(
+                            brokenBody,
+                            in = 1000,
+                            out = 2000,
+                            model = "claude-sonnet-4-6"
+                          )),
+                          Right(llmResp(
+                            brokenBody,
+                            in = 1000,
+                            out = 2000,
+                            model = "claude-sonnet-4-6"
+                          ))
+                        )
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName)),
+                          Right(failingRun(c.operationName)),
+                          Right(failingRun(c.operationName))
+                        )
+                      )
+          tracker <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   provider,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt.copy(maxIterations = 1),
+                   FallbackBudget.Default.copy(
+                     // After 2 attempts at $0.033 each = $0.066, cap of $0.05 should stop us.
+                     sharedCostCapUsd = 0.05,
+                     promptStrategies = List(
+                       PromptStrategy.ZeroShot,
+                       PromptStrategy.ChainOfThought,
+                       PromptStrategy.PlanThenImplement
+                     ),
+                     modelLadder = List("claude-sonnet-4-6")
+                   )
+                 )
+          out           <- orch.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          providerCalls <- provider.calls
+        yield out match
+          case s: FallbackOutcome.SkeletonOnly =>
+            assert(
+              s.attempts.length < 3,
+              s"should stop before exhausting plan, attempts=${s.attempts.length}"
+            )
+            assertEquals(providerCalls.length, s.attempts.length)
+          case other => fail(s"expected SkeletonOnly after budget cap, got $other")
+
+  test("when no modelLadder provided, falls back to req.model"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(List(Right(llmResp(validBody, model = "from-req"))))
+          verifier <- MockDafnyVerifier.of(List(Right(correctRun(c.operationName))))
+          tracker  <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   provider,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt,
+                   FallbackBudget.Default.copy(
+                     modelLadder = Nil,
+                     promptStrategies = List(PromptStrategy.ZeroShot)
+                   )
+                 )
+          out <- orch.run(SynthRequest(c, h, skel, "from-req"))
+        yield out match
+          case v: FallbackOutcome.Verified =>
+            assertEquals(v.finalModel, "from-req")
+          case other => fail(s"expected Verified, got $other")

--- a/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
@@ -48,3 +48,18 @@ class PromptBuilderTest extends CatsEffectSuite:
   test("system prompt forbids new {:extern} declarations"):
     val s = PromptBuilder.systemInitial
     assert(s.contains("{:extern}"))
+
+  test("ChainOfThought strategy swaps the system prompt and adds task-section hint"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, header, skel) =>
+        val p = PromptBuilder.initial(c, header, skel, PromptStrategy.ChainOfThought)
+        assert(p.system.contains("chain-of-thought"), "system mentions strategy")
+        assert(p.user.contains("step-by-step"), "task section nudges step-by-step")
+
+  test("PlanThenImplement strategy swaps the system prompt and adds plan hint"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, header, skel) =>
+        val p = PromptBuilder.initial(c, header, skel, PromptStrategy.PlanThenImplement)
+        assert(p.system.contains("Phase 1"), "system describes two-phase approach")
+        assert(p.system.contains("Phase 2"))
+        assert(p.user.contains("numbered plan"), "task section nudges numbered plan")

--- a/modules/synth/src/test/scala/specrest/synth/SkeletonGeneratorTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/SkeletonGeneratorTest.scala
@@ -78,6 +78,36 @@ class SkeletonGeneratorTest extends CatsEffectSuite:
     assert(body.contains("a := *;"), body)
     assert(body.contains("b := *;"), body)
 
+  test("arrow types (->, ~>, ==>) are not treated as generic closers"):
+    val arrowSig =
+      "method H(st: ServiceState) returns (f: int -> int, g: int ~> bool, h: int ==> int)"
+    val body = SkeletonGenerator.fallbackBody(
+      header(arrowSig),
+      attempts = 1,
+      finalStrategy = "ZeroShot",
+      finalModel = "x",
+      reason = "y"
+    )
+    assert(body.contains("f := *;"), s"missing 'f := *;': $body")
+    assert(body.contains("g := *;"), s"missing 'g := *;': $body")
+    assert(body.contains("h := *;"), s"missing 'h := *;': $body")
+
+  test("backslashes in reason are escaped so the Dafny string stays valid"):
+    val body = SkeletonGenerator.fallbackBody(
+      header("method Foo(st: ServiceState)"),
+      attempts = 1,
+      finalStrategy = "ZeroShot",
+      finalModel = "x",
+      reason = "C:\\Users\\test\\path"
+    )
+    val firstLine = body.linesIterator.toList.head
+    assert(firstLine.contains("\\\\"), s"backslashes not escaped: $firstLine")
+    assertEquals(
+      firstLine.count(_ == '"'),
+      2,
+      s"escaped backslashes preserved exact-2 quote count: $firstLine"
+    )
+
   test("reason gets newline/quote-sanitized and truncated"):
     val verbose = "line1\n\"quoted\"\n" + ("x" * 500)
     val body = SkeletonGenerator.fallbackBody(

--- a/modules/synth/src/test/scala/specrest/synth/SkeletonGeneratorTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/SkeletonGeneratorTest.scala
@@ -1,0 +1,98 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+import specrest.convention.dafny.DafnyMethodHeader
+
+class SkeletonGeneratorTest extends CatsEffectSuite:
+
+  private def header(sig: String): DafnyMethodHeader =
+    DafnyMethodHeader(
+      name = "Op",
+      signature = sig,
+      requiresClauses = Nil,
+      ensuresClauses = Nil,
+      modifiesClauses = Nil
+    )
+
+  test("emits expect false with op-name and reason payload"):
+    val body = SkeletonGenerator.fallbackBody(
+      header("method Foo(st: ServiceState)"),
+      attempts = 3,
+      finalStrategy = "ChainOfThought",
+      finalModel = "claude-opus-4-7",
+      reason = "budget exhausted: Cost"
+    )
+    assert(body.startsWith("""expect false, """"))
+    assert(body.contains("FALLBACK SKELETON"))
+    assert(body.contains("[op=Op]"))
+    assert(body.contains("attempts=3"))
+    assert(body.contains("strategy=ChainOfThought"))
+    assert(body.contains("model=claude-opus-4-7"))
+    assert(body.contains("reason=budget exhausted: Cost"))
+
+  test("no out-params → just the expect line"):
+    val body = SkeletonGenerator.fallbackBody(
+      header("method Delete(st: ServiceState, code: ShortCode)"),
+      attempts = 1,
+      finalStrategy = "ZeroShot",
+      finalModel = "claude-sonnet-4-6",
+      reason = "stuck"
+    )
+    val lines = body.linesIterator.toList
+    assertEquals(lines.length, 1, s"expected one line, got: $body")
+    assert(lines.head.startsWith("expect false"))
+
+  test("single out-param havoced"):
+    val body = SkeletonGenerator.fallbackBody(
+      header("method ListAll(st: ServiceState) returns (entries: set<UrlMapping>)"),
+      attempts = 2,
+      finalStrategy = "ZeroShot",
+      finalModel = "claude-sonnet-4-6",
+      reason = "stuck"
+    )
+    assert(body.contains("entries := *;"))
+
+  test("multiple out-params with nested generic types"):
+    val body = SkeletonGenerator.fallbackBody(
+      header(
+        "method Shorten(st: ServiceState, url: LongURL) returns (code: ShortCode, short_url: string)"
+      ),
+      attempts = 4,
+      finalStrategy = "PlanThenImplement",
+      finalModel = "claude-opus-4-7",
+      reason = "stuck on postcondition_violation"
+    )
+    assert(body.contains("code := *;"))
+    assert(body.contains("short_url := *;"))
+
+  test("nested generics in out-params do not confuse the comma splitter"):
+    val body = SkeletonGenerator.fallbackBody(
+      header(
+        "method Q(st: ServiceState) returns (a: map<int, seq<string>>, b: set<(int, int)>)"
+      ),
+      attempts = 1,
+      finalStrategy = "ZeroShot",
+      finalModel = "x",
+      reason = "y"
+    )
+    assert(body.contains("a := *;"), body)
+    assert(body.contains("b := *;"), body)
+
+  test("reason gets newline/quote-sanitized and truncated"):
+    val verbose = "line1\n\"quoted\"\n" + ("x" * 500)
+    val body = SkeletonGenerator.fallbackBody(
+      header("method Foo(st: ServiceState)"),
+      attempts = 1,
+      finalStrategy = "ZeroShot",
+      finalModel = "x",
+      reason = verbose
+    )
+    val firstLine = body.linesIterator.toList.head
+    assert(!body.contains("\n\"quoted\""), "newlines should be collapsed in payload")
+    assertEquals(
+      firstLine.count(_ == '"'),
+      2,
+      s"first line must have exactly two quote chars (the wrapper); got: $firstLine"
+    )
+    assert(firstLine.endsWith("\";"), s"line should end with quote+semicolon: $firstLine")
+    assert(body.length < 400, s"reason should be truncated, got len=${body.length}")

--- a/modules/synth/src/test/scala/specrest/synth/SynthesisReportTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/SynthesisReportTest.scala
@@ -24,41 +24,49 @@ class SynthesisReportTest extends CatsEffectSuite:
       outputTokens = 100
     )
 
-  test("Verdict.fromOutcome maps single-attempt Verified to Verified"):
-    val v = FallbackOutcome.Verified(
-      "body",
-      "full",
-      PromptStrategy.ZeroShot,
-      "m",
-      cegisIterations = 1,
-      attempts = List(verifiedAttempt("m", 0.001))
+  private val verdictCases: List[(String, FallbackOutcome, Verdict)] = List(
+    (
+      "single-attempt Verified -> Verified",
+      FallbackOutcome.Verified(
+        "body",
+        "full",
+        PromptStrategy.ZeroShot,
+        "m",
+        cegisIterations = 1,
+        attempts = List(verifiedAttempt("m", 0.001))
+      ),
+      Verdict.Verified
+    ),
+    (
+      "multi-attempt Verified -> VerifiedEscalated",
+      FallbackOutcome.Verified(
+        "body",
+        "full",
+        PromptStrategy.ChainOfThought,
+        "m2",
+        cegisIterations = 1,
+        attempts = List(
+          abortedAttempt("m1", 0.01, AbortReason.BudgetExhausted(BudgetKind.MaxIterations)),
+          verifiedAttempt("m2", 0.005)
+        )
+      ),
+      Verdict.VerifiedEscalated
+    ),
+    (
+      "SkeletonOnly -> Skeleton",
+      FallbackOutcome.SkeletonOnly(
+        "expect false",
+        "full",
+        reason = "budget exhausted",
+        attempts = List(abortedAttempt("m", 0.01, AbortReason.BudgetExhausted(BudgetKind.Cost)))
+      ),
+      Verdict.Skeleton
     )
-    assertEquals(Verdict.fromOutcome(v), Verdict.Verified)
+  )
 
-  test("Verdict.fromOutcome maps multi-attempt Verified to VerifiedEscalated"):
-    val v = FallbackOutcome.Verified(
-      "body",
-      "full",
-      PromptStrategy.ChainOfThought,
-      "m2",
-      cegisIterations = 1,
-      attempts = List(
-        abortedAttempt("m1", 0.01, AbortReason.BudgetExhausted(BudgetKind.MaxIterations)),
-        verifiedAttempt("m2", 0.005)
-      )
-    )
-    assertEquals(Verdict.fromOutcome(v), Verdict.VerifiedEscalated)
-
-  test("Verdict.fromOutcome maps SkeletonOnly to Skeleton"):
-    val s = FallbackOutcome.SkeletonOnly(
-      "expect false",
-      "full",
-      reason = "budget exhausted",
-      attempts = List(
-        abortedAttempt("m", 0.01, AbortReason.BudgetExhausted(BudgetKind.Cost))
-      )
-    )
-    assertEquals(Verdict.fromOutcome(s), Verdict.Skeleton)
+  verdictCases.foreach: (name, outcome, expected) =>
+    test(s"Verdict.fromOutcome: $name"):
+      assertEquals(Verdict.fromOutcome(outcome), expected)
 
   test("OpOutcome.fromFallback aggregates token + cost across attempts"):
     val out = FallbackOutcome.Verified(
@@ -128,8 +136,7 @@ class SynthesisReportTest extends CatsEffectSuite:
     assert(rendered.contains("escalated=1"))
     assert(rendered.contains("skeleton=1"))
     assert(rendered.contains("cost=$0.1510"), s"missing cost line in:\n$rendered")
-    // No ANSI codes when useColor=false
-    assert(!rendered.contains("[3"), s"plain mode should not emit ANSI: $rendered")
+    assert(!rendered.contains("\u001b"), s"plain mode should not emit ANSI ESC: $rendered")
 
   test("Reporter.render with color wraps verdict in ANSI escapes"):
     val ops = List(
@@ -147,5 +154,5 @@ class SynthesisReportTest extends CatsEffectSuite:
       )
     )
     val rendered = Reporter.render(SynthesisReport(ops), useColor = true)
-    assert(rendered.contains("[31m"), "red ANSI for SKELETON missing")
-    assert(rendered.contains("[0m"), "reset code missing")
+    assert(rendered.contains("\u001b[31m"), "red ANSI for SKELETON missing")
+    assert(rendered.contains("\u001b[0m"), "reset code missing")

--- a/modules/synth/src/test/scala/specrest/synth/SynthesisReportTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/SynthesisReportTest.scala
@@ -1,0 +1,151 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+
+class SynthesisReportTest extends CatsEffectSuite:
+
+  private def verifiedAttempt(model: String, cost: Double): AttemptRecord =
+    AttemptRecord(
+      strategy = PromptStrategy.ZeroShot,
+      model = model,
+      cegisOutcome = CegisOutcome.Verified("body", "full", iterations = 1, CegisHistory.empty),
+      costUsd = cost,
+      inputTokens = 100,
+      outputTokens = 200
+    )
+
+  private def abortedAttempt(model: String, cost: Double, reason: AbortReason): AttemptRecord =
+    AttemptRecord(
+      strategy = PromptStrategy.ChainOfThought,
+      model = model,
+      cegisOutcome = CegisOutcome.Aborted(reason, None, CegisHistory.empty),
+      costUsd = cost,
+      inputTokens = 50,
+      outputTokens = 100
+    )
+
+  test("Verdict.fromOutcome maps single-attempt Verified to Verified"):
+    val v = FallbackOutcome.Verified(
+      "body",
+      "full",
+      PromptStrategy.ZeroShot,
+      "m",
+      cegisIterations = 1,
+      attempts = List(verifiedAttempt("m", 0.001))
+    )
+    assertEquals(Verdict.fromOutcome(v), Verdict.Verified)
+
+  test("Verdict.fromOutcome maps multi-attempt Verified to VerifiedEscalated"):
+    val v = FallbackOutcome.Verified(
+      "body",
+      "full",
+      PromptStrategy.ChainOfThought,
+      "m2",
+      cegisIterations = 1,
+      attempts = List(
+        abortedAttempt("m1", 0.01, AbortReason.BudgetExhausted(BudgetKind.MaxIterations)),
+        verifiedAttempt("m2", 0.005)
+      )
+    )
+    assertEquals(Verdict.fromOutcome(v), Verdict.VerifiedEscalated)
+
+  test("Verdict.fromOutcome maps SkeletonOnly to Skeleton"):
+    val s = FallbackOutcome.SkeletonOnly(
+      "expect false",
+      "full",
+      reason = "budget exhausted",
+      attempts = List(
+        abortedAttempt("m", 0.01, AbortReason.BudgetExhausted(BudgetKind.Cost))
+      )
+    )
+    assertEquals(Verdict.fromOutcome(s), Verdict.Skeleton)
+
+  test("OpOutcome.fromFallback aggregates token + cost across attempts"):
+    val out = FallbackOutcome.Verified(
+      "body",
+      "full",
+      PromptStrategy.ChainOfThought,
+      "m2",
+      cegisIterations = 2,
+      attempts = List(
+        abortedAttempt("m1", 0.01, AbortReason.BudgetExhausted(BudgetKind.MaxIterations)),
+        verifiedAttempt("m2", 0.005)
+      )
+    )
+    val op = OpOutcome.fromFallback("Shorten", out)
+    assertEquals(op.attempts, 2)
+    assertEqualsDouble(op.totalCostUsd, 0.015, 0.0001)
+    assertEquals(op.inputTokens, 150L)
+    assertEquals(op.outputTokens, 300L)
+    assertEquals(op.finalStrategy, PromptStrategy.ChainOfThought)
+    assertEquals(op.finalModel, "m2")
+
+  test("Reporter.render plain-text emits one row per op + a totals line"):
+    val ops = List(
+      OpOutcome(
+        "Shorten",
+        Verdict.Verified,
+        PromptStrategy.ZeroShot,
+        "claude-sonnet-4-6",
+        1,
+        1,
+        0.001,
+        100,
+        200,
+        None
+      ),
+      OpOutcome(
+        "Resolve",
+        Verdict.VerifiedEscalated,
+        PromptStrategy.ChainOfThought,
+        "claude-opus-4-7",
+        2,
+        2,
+        0.05,
+        500,
+        1000,
+        None
+      ),
+      OpOutcome(
+        "Analytics",
+        Verdict.Skeleton,
+        PromptStrategy.PlanThenImplement,
+        "claude-opus-4-7",
+        0,
+        4,
+        0.10,
+        1500,
+        3000,
+        Some("stuck on postcondition_violation")
+      )
+    )
+    val rendered = Reporter.render(SynthesisReport(ops), useColor = false)
+    assert(rendered.contains("Shorten"))
+    assert(rendered.contains("VERIFIED"))
+    assert(rendered.contains("VERIFIED-ESCALATED"))
+    assert(rendered.contains("SKELETON"))
+    assert(rendered.contains("verified=1"))
+    assert(rendered.contains("escalated=1"))
+    assert(rendered.contains("skeleton=1"))
+    assert(rendered.contains("cost=$0.1510"), s"missing cost line in:\n$rendered")
+    // No ANSI codes when useColor=false
+    assert(!rendered.contains("[3"), s"plain mode should not emit ANSI: $rendered")
+
+  test("Reporter.render with color wraps verdict in ANSI escapes"):
+    val ops = List(
+      OpOutcome(
+        "Foo",
+        Verdict.Skeleton,
+        PromptStrategy.ZeroShot,
+        "m",
+        0,
+        1,
+        0.01,
+        50,
+        100,
+        Some("x")
+      )
+    )
+    val rendered = Reporter.render(SynthesisReport(ops), useColor = true)
+    assert(rendered.contains("[31m"), "red ANSI for SKELETON missing")
+    assert(rendered.contains("[0m"), "reset code missing")


### PR DESCRIPTION
## Summary

Final Phase 6 wedge. Adds an opt-in fallback orchestrator that wraps `CegisLoop`, escalates along two axes (prompt strategy → model) under one shared budget, then emits a labelled Dafny skeleton when every attempt aborts. Plus a synthesis report and a `compile --with-synthesis --allow-skeletons` path so partially-verified specs ship a runnable project.

L2 (operation decomposition) is deferred to #227 — research-grade and out of scope here. L1 + L3 + L4 + L5 together meet the AC1 / AC2 / AC3 of #30.

## What ships

- **L1 — prompt-strategy ladder.** `PromptStrategy.{ZeroShot, ChainOfThought, PlanThenImplement}`. `PromptBuilder.initial` takes a strategy parameter; new system prompts `initial.cot.system.txt` and `initial.plan.system.txt` carry the variant instructions.
- **L3 — model escalation.** `synth verify --fallback --escalate-to MODEL` (repeat for a multi-step ladder). New `synth verify-all` subcommand iterates every LLM_SYNTHESIS op in the spec.
- **L4 — labelled fallback skeleton.** `SkeletonGenerator` emits Dafny like:
  ```dafny
  expect false, "FALLBACK SKELETON [op=Shorten]: not verified — attempts=4 strategy=PlanThenImplement model=claude-opus-4-7 reason=stuck on postcondition_violation";
  code := *;
  short_url := *;
  ```
  `dafny translate --no-verify` accepts it; the runtime halts via `_dafny.HaltException` with the strategy/model/reason payload.
- **L5 — synthesis report.** Per-op verdict table (VERIFIED / VERIFIED-ESCALATED / SKELETON) with ANSI color when `useColor=true`, plain otherwise.

## Cache schema

- `CacheEntry` extended with `outcome: CacheOutcome = Verified`. Default preserves M6.5 entries — legacy JSON without the field decodes as `Verified` (verified by a regression test in `CacheTest`).
- New `synth-cache/skeletons/` namespace populated by the orchestrator when all attempts abort. `Cache.skeletonsRoot` and `Cache.verifiedRoot` are the canonical accessors.

## CLI surface

| Command | Default | New |
|---|---|---|
| `synth verify` | strict CEGIS, unchanged | `--fallback`, `--escalate-to MODEL` |
| `synth verify-all` | n/a | runs orchestrator across every LLM_SYNTHESIS op + prints report |
| `compile --with-synthesis` | strict cache-only, unchanged | `--allow-skeletons` falls back to `skeletons/` namespace, warns per op |

## Tests

- `SkeletonGeneratorTest` (6 cases) — payload, sanitization, signature parsing for nested generics.
- `FallbackOrchestratorTest` (6 cases) — verify-on-first / strategy-switch / model-switch / all-abort-skeleton-and-persist / shared-budget-stops-mid-plan / empty-modelLadder-falls-back-to-req-model.
- `SynthesisReportTest` (6 cases) — verdict mapping, plain-text rendering, ANSI rendering, aggregation.
- `CacheTest` (4 new cases) — legacy-JSON decode, skeleton round-trip with sharding, namespace helpers, on-disk JSON contains `outcome:"skeleton"`.
- `PromptBuilderTest` (2 new cases) — ChainOfThought + PlanThenImplement strategies switch the system prompt and inject task-section hints.
- `CompileSynthesisTest` (2 new cases) — `--allow-skeletons` happy path (skeletons cache populated → compile succeeds, kernel emitted), `--allow-skeletons` with empty caches (still fails with helpful error).

`sbt test` green, `sbt scalafmtCheckAll` clean, `sbt scalafixAll --check` clean, `(cd docs && npm run build)` clean.

## End-to-end smoke (manual)

```bash
# Seed the skeletons cache for url_shortener (Shorten / Resolve / ListAll):
sbt "cli/Test/runMain ..."  # via a temporary test main, removed before commit

sbt "cli/run compile fixtures/spec/url_shortener.spec --target python-fastapi-postgres \
       --out /tmp/m66 --with-synthesis --allow-skeletons \
       --synthesis-cache-dir /tmp/m66_cache --ignore-verify"
# ✔ wrote 37 files to /tmp/m66
# ⚠ 'Shorten' / 'Resolve' / 'ListAll' falling back to unverified skeleton body...

cd /tmp/m66 && python3 -c "from app.dafny_kernel import module_; module_.default__.Shorten(state, url)"
# Shorten halted: HaltException: ... FALLBACK SKELETON [op=Shorten]: not verified — ...
```

## Test plan

- [ ] `sbt test` green on CI
- [ ] `sbt scalafmtCheckAll && sbt 'scalafixAll --check'` clean on CI
- [ ] Docs build clean on CI
- [ ] PR title format `Closes #30 …` triggers GitHub auto-close (M6.5 lesson learned: `#27 —` em-dash form does not)

## Follow-ups

- **#227 — M6.7 — Operation Decomposition (L2 fallback).** Opened as part of this PR. Research-grade; deliberately out of scope here.
- Cross-family LLM escalation (Anthropic ↔ OpenAI within one `--fallback` run) tracked in the deferred table in `docs/content/docs/synth/llm-integration.mdx`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in graduated fallback for synthesis: after CEGIS aborts, escalate prompt strategy and then model under a shared budget; if all fail, emit a labelled Dafny skeleton. Includes a per-spec synthesis report and a compiler path to ship projects using skeletons. Meets #30 (L1/L3/L4/L5); L2 decomposition is deferred to #227.

- **New Features**
  - L1 prompt ladder: `PromptStrategy.{ZeroShot, ChainOfThought, PlanThenImplement}` with new system prompts; `PromptBuilder.initial(..., strategy)`.
  - L3 model escalation: `synth verify --fallback --escalate-to MODEL` (repeatable). `synth verify-all` runs all `LLM_SYNTHESIS` ops and prints a report.
  - L4 skeleton emit: `SkeletonGenerator` outputs `expect false, "FALLBACK SKELETON [op=...] ...";` plus havoc for returns; runtime halts with `_dafny.HaltException` carrying op/strategy/model/reason.
  - L5 synthesis report: per-op verdicts (VERIFIED / VERIFIED-ESCALATED / SKELETON); exit is non-zero if any skeletons.
  - Compiler fallback: `compile --with-synthesis --allow-skeletons` consults `synth-cache/skeletons/` when `verified/` misses and warns per op.
  - Cache schema: `CacheEntry.outcome` defaults to `Verified`; new `synth-cache/skeletons/` alongside `verified/`.

- **Bug Fixes**
  - Verified-cache reads now require `entry.outcome == CacheOutcome.Verified`; skeletons misfiled under `verified/` are ignored. Error text improved when both caches are missing, with guidance for `--allow-skeletons` and `synth verify --fallback`.
  - `synth verify-all` fails fast on missing Dafny headers and sets exit code based only on whether any ops fell back to skeletons.
  - ANSI coloring in the report uses explicit escape sequences; tests assert full `\u001b[31m`/`\u001b[0m` sequences.
  - Orchestrator no longer uses defensive throws; splice failures are logged and skeleton bodies are still persisted.
  - Skeleton payload sanitizes backslashes and the out-param parser handles arrow types (`->`, `~>`, `==>`) in signatures; added regression tests for both.
  - CI stability: the `--allow-skeletons` compile test runs only when `dafny` is available.

<sup>Written for commit ef3011f84db583ed9d296b629cf5371b7b0a466c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-skeletons` flag for `compile` to emit unverified fallbacks when verified bodies unavailable.
  * Added `--fallback` and `--escalate-to` options for `synth verify` to enable prompt/model escalation.
  * Added `synth verify-all` subcommand to run fallback verification across all synthesis operations and generate a summary report.
  * Introduced multiple prompt strategies (Chain-of-Thought, Plan-Then-Implement) for improved code generation.
  * Implemented graduated fallback that halts at runtime when synthesis cannot be verified.

* **Documentation**
  * Updated synthesis and target documentation to describe fallback behavior, new CLI options, and runtime semantics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/228)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->