### PR TITLE
Closes #229 — M6.7 hint-augmentation (DafnyPro-style proof-pattern injection)

### DIFF
--- a/docs/content/docs/research/03_llm_verifier_synthesis.md
+++ b/docs/content/docs/research/03_llm_verifier_synthesis.md
@@ -18,7 +18,8 @@ description: "CEGIS-based synthesis with Dafny verification and LLM generation"
 > [M6.3 (#28)](https://github.com/HardMax71/spec_to_rest/issues/28) — LLM integration + prompt engineering — **shipped**,
 > [M6.4 (#29)](https://github.com/HardMax71/spec_to_rest/issues/29) — CEGIS feedback loop — **shipped**,
 > [M6.5 (#27)](https://github.com/HardMax71/spec_to_rest/issues/27) — Dafny → target-language compilation — **shipped (Python)**,
-> [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy — **shipped (L1 prompt-strategy ladder + L3 model escalation + L4 skeleton emit + L5 synthesis report; L2 decomposition deferred)**.
+> [M6.6 (#30)](https://github.com/HardMax71/spec_to_rest/issues/30) — graduated fallback strategy — **shipped (L1 prompt-strategy ladder + L3 model escalation + L4 skeleton emit + L5 synthesis report)**.
+> [M6.7 (#227)](https://github.com/HardMax71/spec_to_rest/issues/227) — operation decomposition (L2) — **closed without shipping** based on 2025–2026 empirical evidence (7% verification ceiling on compositional Dafny, Pass@4 plateau). Engineering effort redirected to **hint-augmentation** (DafnyPro-style, single-function +16pp). See [12_compositional_synthesis_findings.md](/research/12_compositional_synthesis_findings) for the full decision-of-record.
 > The Scala implementation lives in `modules/synth/` (`PromptBuilder`,
 > `ResponseParser`, `DiffChecker`, `Cache`, `Tracker`, `Synthesizer`, `CegisLoop`,
 > `DafnyVerifier`, plus Anthropic / OpenAI providers wrapping the official Java

--- a/docs/content/docs/research/12_compositional_synthesis_findings.md
+++ b/docs/content/docs/research/12_compositional_synthesis_findings.md
@@ -88,7 +88,7 @@ The most relevant SOTA *technique* for our use case — applicable today, no tra
 |---|---|
 | **Hint-augmentation** | Maintain a curated repository of verified Dafny patterns (loop invariants, frame conditions, decreases templates). On verifier failure, retrieve the most-relevant patterns by error category and inject them as in-context examples in the repair prompt. |
 | **Diff-checker** | Structural comparison flags which assertions failed, targets repair feedback rather than blind resampling. |
-| **Pruner** | Filter syntactically/typeically malformed candidates before SMT verification. |
+| **Pruner** | Filter syntactically/typically malformed candidates before SMT verification. |
 
 Result: **Claude Sonnet 3.5 + DafnyPro = 86% on DafnyBench**, a +16pp improvement over the base model — and the largest single-paper jump on the single-function benchmark.
 

--- a/docs/content/docs/research/12_compositional_synthesis_findings.md
+++ b/docs/content/docs/research/12_compositional_synthesis_findings.md
@@ -1,0 +1,159 @@
+---
+title: Compositional Synthesis Findings (M6.7 research brief)
+description: Why we pivoted M6.7 from operation decomposition to hint-augmentation — empirical evidence from DafnyComp, Re:Form, and DafnyPro plus the failure-mode analysis that informed the decision.
+---
+
+> **Status:** decision-of-record. Authored 2026-05-10 alongside [issue #227](https://github.com/HardMax71/spec_to_rest/issues/227). Read this if you want to understand why our M6.6 graduated-fallback ladder skips the L2 (decomposition) level and why M6.7 instead targets monolithic synthesis improvements via DafnyPro-style hint-augmentation.
+
+## TL;DR
+
+When M6.6 shipped the graduated-fallback orchestrator (L1 prompt strategies → L3 model escalation → L4 skeleton emit), level **L2 — operation decomposition** was deferred under the explicit caveat that compositional verification with LLMs is research-grade. Three benchmark papers published between July 2025 and POPL 2026 turned that caveat into hard data:
+
+- LLMs hit a **3.69% Pass@1 / 7% Pass@8 ceiling** on multi-function Dafny programs (DafnyComp, 13 frontier models).
+- Sampling more candidates does **not** rescue the result — Pass@4 → Pass@8 yields +0.8% on average. The plateau is architectural, not search-budget bound.
+- The current state of the art for compositional Dafny is **14.0% Pass@1 with RL-trained 14B models** (Re:Form), still far below useful production thresholds and unavailable as an inference-time technique.
+- In contrast, the same period's leading **monolithic** technique (DafnyPro hint-augmentation) gives **+16pp on DafnyBench** with Claude Sonnet 3.5 — a proven, inference-time intervention orthogonal to model choice.
+
+We therefore close [#227](https://github.com/HardMax71/spec_to_rest/issues/227) without shipping operation decomposition and redirect M6.7 engineering effort to hint-augmentation, which raises the success rate on the case we already handle (monolithic synthesis through CEGIS) rather than chasing a 7% ceiling on cases we don't.
+
+## What L2 was supposed to do
+
+The graduated-fallback design from `03_llm_verifier_synthesis.md` §8.1 defined a five-level escalation:
+
+```mermaid
+flowchart TD
+  CEGIS["CEGIS Loop"] -->|fail| L1["L1: Retry with prompt variants<br/>ZeroShot · ChainOfThought · PlanThenImplement"]
+  L1 -->|fail| L2["L2: Decompose into sub-methods<br/>verify each independently · compose<br/><b>(this brief recommends not shipping)</b>"]
+  L2 -->|fail| L3["L3: Escalate model<br/>configured → opus → ..."]
+  L3 -->|fail| L4["L4: Skeleton with TODOs<br/>compiles but unverified"]
+  L4 --> L5["L5: Synthesis report"]
+```
+
+The reasoning was: when monolithic synthesis fails because the operation is *complex*, an LLM might propose a useful decomposition into sub-methods, each of which is small enough that the same CEGIS pipeline can verify it. Compose the verified subs to get a verified parent. The research/03 example was `ShipOrder = UpdateOrderStatus + DecrementInventory`.
+
+This is a clean architectural idea. The problem is that the empirical evidence — finally available in 2025–2026 — says it does not work.
+
+## The empirical picture
+
+### DafnyComp (Xu et al., [arXiv:2509.23061](https://arxiv.org/abs/2509.23061), Sept 2025)
+
+Direct, decisive evidence on the planned pipeline shape. The benchmark synthesizes 300 multi-function Dafny programs by chaining 2–5 functions from `LeetCodeDataset`, with type-compatible interfaces and real data dependencies. 13 frontier models were evaluated zero-shot (GPT-4o, GPT-4-turbo, Claude 3.5, Claude 3.7, Gemini 2.5, DeepSeek-v3.1, Qwen, plus reasoning-specialized variants QwQ-32B and DeepSeek-R1).
+
+Headline results:
+
+| Metric | DafnyBench (single-function) | DafnyComp (2–5 functions) | Δ |
+|---|---|---|---|
+| Syntax correctness | ~99% | 95.67% | −3.3pp |
+| **Verification success (Pass@1)** | **58%** | **3.69%** | **−54pp** |
+| Best-model Pass@8 | — | 7% (Claude 3.5) | — |
+| Pass@4 → Pass@8 marginal | — | +0.8% avg | plateau |
+
+A **14.4× verification-rate drop for a 3.2× function-count increase**. The compositional axis dominates everything — model choice, sampling budget, reasoning specialization — by a wide margin.
+
+The paper's failure-mode breakdown (% of failed cases attributable to each cause) is the closest thing to a root-cause analysis we have:
+
+| Failure mode | Share | Description |
+|---|---|---|
+| **Specification fragility** | **39.2%** | Sub-functions with locally-correct but weakly-framed contracts cannot propagate properties through call sites. The downstream caller needs `ensures result >= 0`; the callee only ensured "what it computes," not the bound the caller depends on. |
+| Implementation–proof misalignment | 21.7% | Plausible-looking invariants generated independently of the actual code path; pattern-matched rather than proven. |
+| Reasoning instability | 14.1% | Inductive reasoning collapses across iterations: loop invariants fail to accumulate, recursive termination arguments break. |
+| Other | 25.0% | Misc. |
+
+The 39.2% category — *contract fragility under composition* — is precisely the failure mode our linear-L2 design produces. We would generate sub-method bodies that each verify against their proposed sub-contracts, but the chain of contracts would not imply the parent's `ensures`.
+
+The Pass@4 plateau is the second decisive finding. Marginal verification gain from Pass@4 → Pass@8 averages 0.8% across all 13 models. This means the standard "throw more samples at it" mitigation that works for code generation does *not* work here: more candidates explore the syntactic space (syntax correctness keeps rising) without reaching new semantic cells. The authors interpret this as evidence that current transformers lack the inductive biases for compositional formal reasoning.
+
+### Re:Form (Yan et al., [arXiv:2507.16331](https://arxiv.org/abs/2507.16331), Jul 2025)
+
+The current state of the art for compositional Dafny verification — and it requires RL training, not inference-time tricks.
+
+| Approach | DafnyComp Pass@1 |
+|---|---|
+| Claude 3.5 (zero-shot baseline) | 2.7% |
+| 14B model + SFT (3,000 examples) | 8.3% |
+| 14B model + SFT + RL (GRPO) | **14.0%** |
+
+Re:Form's recipe — SFT to "activate patterns," then GRPO with three reward components (syntax, verification, **subset rewards**) — establishes today's ceiling. The subset reward ingredient is the most novel: it prevents the model from gaming verification rewards by producing trivially-true specifications (e.g. omitting unverifiable clauses). The authors explicitly note that *"verification rewards alone caused mode collapse."*
+
+Two implications for our pipeline:
+
+1. **No inference-time technique reaches this ceiling.** Our orchestrator is inference-only; we don't train models. So 14% is a north star, not a budget.
+2. **Pass@128 needed for stronger gains.** Re:Form's RL gains widen at Pass@128. Our `CegisBudget.maxIterations` is 8. We can't credibly close that gap without changing the budget by an order of magnitude.
+
+### DafnyPro (POPL 2026, [arXiv:2601.05385](https://arxiv.org/abs/2601.05385))
+
+The most relevant SOTA *technique* for our use case — applicable today, no training. DafnyPro's contribution is three orthogonal interventions on top of any frontier model:
+
+| Component | Mechanism |
+|---|---|
+| **Hint-augmentation** | Maintain a curated repository of verified Dafny patterns (loop invariants, frame conditions, decreases templates). On verifier failure, retrieve the most-relevant patterns by error category and inject them as in-context examples in the repair prompt. |
+| **Diff-checker** | Structural comparison flags which assertions failed, targets repair feedback rather than blind resampling. |
+| **Pruner** | Filter syntactically/typeically malformed candidates before SMT verification. |
+
+Result: **Claude Sonnet 3.5 + DafnyPro = 86% on DafnyBench**, a +16pp improvement over the base model — and the largest single-paper jump on the single-function benchmark.
+
+DafnyPro is **single-function only**. The paper does not address the compositional case. But the diff-checker we already shipped in M6.4 (`DiffChecker.scala`), and the pruner is implicit in our `ResponseParser` rejection of unparseable bodies. The missing ingredient is **hint-augmentation**, and that's where the +16pp delta lives.
+
+### Other 2025–2026 work checked
+
+- **VERINA** ([arXiv:2505.23135](https://arxiv.org/pdf/2505.23135), May 2025) — Dafny + Lean benchmark; confirms the compositional gap, no inference-time technique advances the SOTA.
+- **VeriCoding** ([arXiv:2509.22908](https://arxiv.org/pdf/2509.22908), Sept 2025) — multi-method verified synthesis benchmark; supports the same pattern.
+- **Clover** (SAIV 2024, [Stanford](https://theory.stanford.edu/~barrett/pubs/SSP+24.pdf)) — closed-loop monolithic synthesis with feedback. The original CEGIS-with-Dafny paradigm. Reports 87% acceptance / 100% rejection on ground-truth single-function programs. Not compositional.
+- **DafnyBench** ([Loughridge et al.](https://namin.seas.harvard.edu/pubs/dafnybench.pdf), Harvard 2024) — the underlying single-function benchmark. ~58% baseline against which DafnyPro measured its +16pp delta.
+- **"LLM-Based Code Translation Needs Formal Compositional Reasoning"** ([Anshumaan et al.](https://openreview.net/forum?id=wGj8LU2EOf), 2025) — design points for injecting formal signals into translation; explicitly treats compositional reasoning as a known gap to fill, not a solved problem.
+- **Autoformalization survey** ([Weng et al., arXiv:2505.23486](https://arxiv.org/abs/2505.23486)) — explicitly notes "systems that can generalize compositionally" remains an open problem.
+
+There is no evidence from any 2024–2026 source that an *inference-time* decomposition strategy beats *monolithic* prompting on compositional Dafny. We searched.
+
+## What this means for our pipeline
+
+Mapping the data onto the M6.6 pipeline as currently shipped:
+
+- M6.4 CEGIS loop with verifier feedback — analogous to Clover, 58% baseline on single-function.
+- M6.6 L1 (prompt strategies) + L3 (model escalation) — small marginal gains; per the DafnyComp Pass@k plateau, not transformative.
+- M6.6 L4 (skeleton fallback) — the "always ships something" guarantee.
+- The unimplemented L2 — would inherit the 7% compositional ceiling. For our 3-LLM_SYNTHESIS-op `url_shortener.spec`, expected ops verified through L2: **0.07 × 3 = 0.21 ops per spec** in the best case (Claude 3.5 Pass@8). **0.11** under Pass@1.
+
+That is, statistically, *less than one op per spec* would benefit from L2 even on the most generous interpretation. Most users wouldn't see L2 fire successfully on any of their specs.
+
+Cost to ship that: ~1000 LoC, ~1 week of engineering, dilution of the M6.5/M6.6 narrative (we'd be shipping research-grade code into a production-shaped tool).
+
+## Decision: pivot M6.7 to hint-augmentation
+
+Instead of L2, M6.7 implements a hint-augmentation module modelled on DafnyPro:
+
+- **`HintLibrary`** — a small, hand-curated repository of Dafny proof patterns indexed by `VerifierError.category` (`postcondition_violation`, `loop_invariant_failure`, `decreases_failure`, `precondition_violation`, etc.). Each hint is a short Dafny snippet showing how a similar issue was resolved.
+- **PromptBuilder integration** — when `CegisLoop` repairs after a failed verification, the most relevant hints for the failure category are injected as in-context examples in the repair prompt.
+- **CLI flag** — `synth verify --with-hints` (default ON when `--fallback` is enabled, off for strict CEGIS so the M6.4 contract is preserved).
+
+Expected leverage based on DafnyPro's reported +16pp:
+
+| Pipeline stage | Without hints (today) | With hints (target) |
+|---|---|---|
+| Single-op CEGIS verification rate | ~CEGIS baseline | +up to 16pp on the same ops |
+| L4 skeleton-fallback rate | unchanged | strictly less (more ops verify before falling through) |
+
+We do **not** claim the +16pp delta will reproduce on our specific spec/op shapes — DafnyPro's number is on DafnyBench, which is a different distribution. We claim the *mechanism* is sound (proven) and the implementation cost is modest (~750 LoC), so it's the right next bet.
+
+We also **do not** ship a pass-rate AC — there is no real-LLM A/B test in CI (cost + flakiness). Instead we ship deterministic mock-driven tests that prove the *plumbing* (hint retrieved, hint injected, prompt contains snippet) and treat the empirical-uplift question as a follow-up that requires real LLM budget.
+
+## What's deferred
+
+- **L2 / operation decomposition** — closed as wontfix-now. Re-open if (a) a published inference-time technique reaches >50% on DafnyComp, or (b) we want to invest in RL training infrastructure (out of scope for this project).
+- **Pass@128 scaling** — Re:Form-level sampling budgets are out of scope; would require a `CegisBudget.maxIterations >= 64` configuration and a much larger cost cap.
+- **Cross-family LLM escalation** (Anthropic ↔ OpenAI within one fallback run) — already in M6.6 backlog; orthogonal to compositional question.
+- **Automatic hint discovery** — DafnyPro hand-curates hints from the training corpus; we hand-curate from successful CEGIS runs in our codebase. Auto-mining from a verified-bodies cache is a follow-up if the manual library proves valuable.
+
+## Sources
+
+| Paper | Year | Why we cited it |
+|---|---|---|
+| [DafnyComp (arXiv:2509.23061)](https://arxiv.org/abs/2509.23061) | 2025 | The 7% / Pass@4 plateau evidence; failure-mode breakdown |
+| [Re:Form (arXiv:2507.16331)](https://arxiv.org/abs/2507.16331) | 2025 | Compositional Dafny SOTA at 14% via RL training |
+| [DafnyPro (arXiv:2601.05385)](https://arxiv.org/abs/2601.05385) | 2026 | Hint-augmentation +16pp on monolithic — the technique we adopt |
+| [DafnyBench](https://namin.seas.harvard.edu/pubs/dafnybench.pdf) | 2024 | Single-function 58% baseline |
+| [Clover (SAIV 2024)](https://theory.stanford.edu/~barrett/pubs/SSP+24.pdf) | 2024 | Origin of the closed-loop CEGIS pattern we already use |
+| [VERINA (arXiv:2505.23135)](https://arxiv.org/pdf/2505.23135) | 2025 | Independent corroboration of compositional gap |
+| [VeriCoding (arXiv:2509.22908)](https://arxiv.org/pdf/2509.22908) | 2025 | Multi-method verified synthesis benchmark |
+| [LLM-Based Code Translation Needs Compositional Reasoning](https://openreview.net/forum?id=wGj8LU2EOf) | 2025 | Treats compositional reasoning as an open gap |
+| [Autoformalization survey (arXiv:2505.23486)](https://arxiv.org/abs/2505.23486) | 2025 | Notes compositional generalization remains open |

--- a/docs/content/docs/research/meta.json
+++ b/docs/content/docs/research/meta.json
@@ -14,6 +14,7 @@
     "09_dsl_compiler_frameworks",
     "10_translator_soundness",
     "11_tcb_audit",
+    "12_compositional_synthesis_findings",
     "spec_to_test_tools_research"
   ]
 }

--- a/docs/content/docs/synth/llm-integration.mdx
+++ b/docs/content/docs/synth/llm-integration.mdx
@@ -1,6 +1,6 @@
 ---
-title: Synthesis Pipeline (M6.3 – M6.6)
-description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, the CEGIS feedback loop wired to `dafny verify`, the graduated-fallback orchestrator, and `compile --with-synthesis` that translates verified bodies (or labelled skeletons) to the target language.
+title: Synthesis Pipeline (M6.3 – M6.7)
+description: LLM clients, prompt construction, diff-checker, cost ledger, on-disk cache, the CEGIS feedback loop wired to `dafny verify`, the graduated-fallback orchestrator, DafnyPro-style hint-augmentation, and `compile --with-synthesis` that translates verified bodies (or labelled skeletons) to the target language.
 ---
 
 `modules/synth/` is the Phase 6 LLM-and-Dafny synthesis layer. It takes the
@@ -465,11 +465,60 @@ finish the proofs later" workflow. The HaltException payload includes
 the operation name, the final attempted strategy/model, and the abort
 reason — enough to point a developer at what to fix.
 
+## Hint-Augmentation (M6.7)
+
+DafnyPro (POPL 2026) reports +16pp on the single-function DafnyBench
+when Claude Sonnet 3.5 is augmented with a curated repository of
+verified Dafny proof patterns retrieved by error category and injected
+into the repair prompt. M6.7 ships that mechanism as the chosen
+direction after the L2 / decomposition path was closed under the
+2025–2026 evidence summarised in
+[research/12](/research/12_compositional_synthesis_findings).
+
+### `HintLibrary`
+
+`modules/synth/src/main/scala/specrest/synth/HintLibrary.scala` exposes
+12 hand-curated Dafny snippets indexed by `VerifierError.category`:
+
+| Category | Hints |
+|---|---|
+| `postcondition_violation` | `postcondition_capture_old`, `postcondition_branch_assert`, `postcondition_helper_lemma` |
+| `precondition_violation` | `precondition_guard`, `precondition_strengthen_local` |
+| `loop_invariant_failure` | `loop_invariant_strengthen` |
+| `loop_invariant_not_established` | `loop_invariant_initially`, `loop_init_before_loop` |
+| `decreases_failure` | `decreases_metric`, `decreases_lexicographic` |
+| `assertion_failure` | `assertion_intermediate_lemma` |
+| `timeout` | `timeout_split_proof` |
+
+Each hint is a `.dfy` resource at
+`modules/synth/src/main/resources/specrest/synth/hints/`. The first
+line is the rationale comment; the rest is a small (3–15 line) Dafny
+snippet. `HintLibrary.forCategory(cat, limit = 2)` returns the
+relevant entries; `PromptBuilder.repair(..., withHints = true)` injects
+them into a `## Suggested Patterns` section of the repair prompt.
+
+### CLI
+
+| Flag | Default | Behaviour |
+|---|---|---|
+| `--with-hints` | implicit | force hints ON for this run |
+| `--no-hints` | implicit | force hints OFF for this run |
+| (neither) | inferred | ON when `--fallback` is set; ON for `verify-all`; OFF for strict `synth verify` |
+
+### What this is NOT
+
+We do **not** claim DafnyPro's +16pp will reproduce on our specific
+spec/op shapes. The CI tests are mock-driven and prove only the
+plumbing (hint retrieved by category, snippet injected verbatim,
+section gracefully omitted when no match). Real-LLM A/B is left as a
+follow-up that requires non-trivial test budget and a stable spec
+fixture.
+
 ## What's still deferred
 
 | Concern | Tracked in |
 |---|---|
-| Operation decomposition (L2 fallback — extract sub-methods, verify independently, compose) | follow-up (M6.7) |
+| Operation decomposition (L2 fallback) | [#227](https://github.com/HardMax71/spec_to_rest/issues/227) closed wontfix-with-pivot — see [research/12](/research/12_compositional_synthesis_findings) |
 | Dafny `ServiceState` ↔ SQLAlchemy / Postgres reconciliation | follow-up |
 | Go / Java targets for `--with-synthesis` (Python only today) | follow-up |
 | Few-shot examples machine-verified by `dafny verify` in CI | follow-up |

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -280,6 +280,17 @@ object Main
           "(repeat for a multi-step ladder)"
       )
       .orEmpty
+    val withHintsFlag = Opts
+      .flag(
+        "with-hints",
+        "inject DafnyPro-style proof patterns into the repair prompt (default ON for --fallback / verify-all, OFF for strict CEGIS)"
+      )
+      .orFalse
+    val noHintsFlag = Opts.flag("no-hints", "disable hint-augmentation injection").orFalse
+    val hintsTriState: Opts[Option[Boolean]] = (withHintsFlag, noHintsFlag).mapN: (yes, no) =>
+      if yes && !no then Some(true)
+      else if no && !yes then Some(false)
+      else None
     val verifyCmd: Opts[IO[ExitCode]] =
       Opts.subcommand(
         "verify",
@@ -299,12 +310,13 @@ object Main
           maxCost,
           fallbackFlag,
           escalateTo,
+          hintsTriState,
           verbose,
           quiet
-        ).mapN: (spec, op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc, v, q) =>
+        ).mapN: (spec, op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc, hints, v, q) =>
           Synth.runVerify(
             spec,
-            SynthVerifyOptions(op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc),
+            SynthVerifyOptions(op, m, t, mt, nc, cd, db, dt, mi, mc, fb, esc, hints),
             Logger.fromFlags(verbose = v, quiet = q)
           )
     val verifyAllCmd: Opts[IO[ExitCode]] =
@@ -324,12 +336,13 @@ object Main
           maxIter,
           maxCost,
           escalateTo,
+          hintsTriState,
           verbose,
           quiet
-        ).mapN: (spec, m, t, mt, nc, cd, db, dt, mi, mc, esc, v, q) =>
+        ).mapN: (spec, m, t, mt, nc, cd, db, dt, mi, mc, esc, hints, v, q) =>
           Synth.runVerifyAll(
             spec,
-            SynthVerifyAllOptions(m, t, mt, nc, cd, db, dt, mi, mc, esc),
+            SynthVerifyAllOptions(m, t, mt, nc, cd, db, dt, mi, mc, esc, hints),
             Logger.fromFlags(verbose = v, quiet = q)
           )
     Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -287,10 +287,12 @@ object Main
       )
       .orFalse
     val noHintsFlag = Opts.flag("no-hints", "disable hint-augmentation injection").orFalse
-    val hintsTriState: Opts[Option[Boolean]] = (withHintsFlag, noHintsFlag).mapN: (yes, no) =>
-      if yes && !no then Some(true)
-      else if no && !yes then Some(false)
-      else None
+    val hintsTriState: Opts[Option[Boolean]] = (withHintsFlag, noHintsFlag).tupled.mapValidated:
+      case (true, true) =>
+        cats.data.Validated.invalidNel("--with-hints and --no-hints are mutually exclusive")
+      case (true, false)  => cats.data.Validated.valid(Some(true))
+      case (false, true)  => cats.data.Validated.valid(Some(false))
+      case (false, false) => cats.data.Validated.valid(None)
     val verifyCmd: Opts[IO[ExitCode]] =
       Opts.subcommand(
         "verify",

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -57,8 +57,10 @@ final case class SynthVerifyOptions(
     maxIter: Int,
     maxCostUsd: Double,
     fallback: Boolean = false,
-    escalateTo: List[String] = Nil
-)
+    escalateTo: List[String] = Nil,
+    withHints: Option[Boolean] = None
+):
+  def hintsEnabled: Boolean = withHints.getOrElse(fallback)
 
 final case class SynthVerifyAllOptions(
     model: String,
@@ -70,8 +72,10 @@ final case class SynthVerifyAllOptions(
     dafnyTimeoutSec: Int,
     maxIter: Int,
     maxCostUsd: Double,
-    escalateTo: List[String] = Nil
-)
+    escalateTo: List[String] = Nil,
+    withHints: Option[Boolean] = None
+):
+  def hintsEnabled: Boolean = withHints.getOrElse(true)
 
 object Synth:
 
@@ -280,7 +284,8 @@ object Synth:
                 tracker,
                 budget,
                 fb,
-                opts.dafnyTimeoutSec
+                opts.dafnyTimeoutSec,
+                opts.hintsEnabled
               )
               orch.run(req).flatMap: outcome =>
                 emitFallbackOutcome(outcome, c.operationName, out, err) *>
@@ -288,7 +293,15 @@ object Synth:
                     emitSummary(s, err).as(ExitCodes.forFallbackOutcome(outcome))
             else
               val loop =
-                new CegisLoop(provider, verifier, cache, tracker, budget, opts.dafnyTimeoutSec)
+                new CegisLoop(
+                  provider,
+                  verifier,
+                  cache,
+                  tracker,
+                  budget,
+                  opts.dafnyTimeoutSec,
+                  opts.hintsEnabled
+                )
               loop.run(req).flatMap: outcome =>
                 emitOutcome(outcome, c.operationName, out, err) *> tracker.summary.flatMap: s =>
                   emitSummary(s, err).as(ExitCodes.forCegisOutcome(outcome))
@@ -461,7 +474,8 @@ object Synth:
           tracker,
           budget,
           fb,
-          opts.dafnyTimeoutSec
+          opts.dafnyTimeoutSec,
+          opts.hintsEnabled
         )
         runOrchestrationLoop(specFile, classifications, dafny, orch, opts, err, log)
 

--- a/modules/synth/src/main/resources/specrest/synth/hints/assertion_intermediate_lemma.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/assertion_intermediate_lemma.dfy
@@ -1,0 +1,14 @@
+// Pattern: when an inline assertion fails, factor the proof into an
+// intermediate lemma. The lemma's pre/post forces the verifier to follow
+// the explicit reasoning chain rather than rediscover it from context.
+lemma SubsetTransitive(a: set<int>, b: set<int>, c: set<int>)
+  requires a <= b && b <= c
+  ensures a <= c
+{ /* trivial — Dafny derives this from the requires */ }
+
+method UseIt(x: set<int>, y: set<int>, z: set<int>)
+  requires x <= y && y <= z
+{
+  SubsetTransitive(x, y, z);
+  assert x <= z;     // discharged by the lemma's postcondition
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/decreases_lexicographic.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/decreases_lexicographic.dfy
@@ -1,14 +1,13 @@
 // Pattern: when a single metric does not strictly decrease but a tuple
-// does, use a lexicographic decreases clause. Useful for nested loops
+// does, use a lexicographic `decreases` clause. Useful for nested loops
 // or recursion that shrinks one dimension while another temporarily grows.
 while !done
-  invariant 0 <= outer && 0 <= inner
-  decreases outer, |remaining|     // outer decreases primarily;
-                                    // |remaining| decreases when outer is fixed
+  invariant 0 <= outer && 0 <= |remaining|
+  decreases outer, |remaining|     // primary metric: outer; secondary: |remaining|
 {
   if needs_reset {
     outer := outer - 1;
-    remaining := initial_pool;     // OK: outer dropped, lex still <
+    remaining := initial_pool;     // OK: outer dropped, lex pair still <
   } else {
     remaining := remaining[1..];   // outer fixed, |remaining| dropped
   }

--- a/modules/synth/src/main/resources/specrest/synth/hints/decreases_lexicographic.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/decreases_lexicographic.dfy
@@ -1,0 +1,15 @@
+// Pattern: when a single metric does not strictly decrease but a tuple
+// does, use a lexicographic decreases clause. Useful for nested loops
+// or recursion that shrinks one dimension while another temporarily grows.
+while !done
+  invariant 0 <= outer && 0 <= inner
+  decreases outer, |remaining|     // outer decreases primarily;
+                                    // |remaining| decreases when outer is fixed
+{
+  if needs_reset {
+    outer := outer - 1;
+    remaining := initial_pool;     // OK: outer dropped, lex still <
+  } else {
+    remaining := remaining[1..];   // outer fixed, |remaining| dropped
+  }
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/decreases_metric.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/decreases_metric.dfy
@@ -1,0 +1,20 @@
+// Pattern: a 'decreases' clause must produce a value that is strictly
+// less in the well-founded order on each iteration / recursive call.
+// For collections, '|s| - i' or 's[i..]' work; for natural recursion,
+// the parameter itself decreases. Avoid 'decreases *' (unbounded).
+while i < |xs|
+  invariant 0 <= i <= |xs|
+  decreases |xs| - i        // strictly decreases as i grows toward |xs|
+{
+  i := i + 1;
+}
+
+method Sum(xs: seq<int>) returns (r: int)
+  decreases |xs|              // structural recursion on sequence length
+{
+  if |xs| == 0 { r := 0; }
+  else {
+    var rest := Sum(xs[1..]);
+    r := xs[0] + rest;
+  }
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/loop_init_before_loop.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/loop_init_before_loop.dfy
@@ -1,0 +1,14 @@
+// Pattern: when the invariant uses a fresh local variable, that variable
+// must be declared and initialised BEFORE the while-loop, not first
+// touched inside the body. The invariant is checked at loop entry —
+// before any iteration has run.
+var acc: int := 0;             // declare + init BEFORE the while
+var i := 0;
+while i < n
+  invariant acc == seq_sum(s, 0, i)   // valid at i=0 because acc == 0 == seq_sum(s, 0, 0)
+  invariant 0 <= i <= n
+  decreases n - i
+{
+  acc := acc + s[i];
+  i := i + 1;
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/loop_invariant_initially.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/loop_invariant_initially.dfy
@@ -1,0 +1,13 @@
+// Pattern: when an invariant fails ON ENTRY (before the first iteration),
+// the fix is to either (a) initialize the relevant variables to a value
+// that satisfies the invariant before the loop, or (b) weaken the
+// invariant so the trivial pre-loop state satisfies it.
+var seen: set<K> := {};   // initialise so 'seen' subset of st.store starts trivially
+var i := 0;
+while i < |xs|
+  invariant seen <= st.store.Keys   // satisfied at i=0 by seen=={}
+  invariant 0 <= i <= |xs|
+{
+  seen := seen + {xs[i].key};
+  i := i + 1;
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/loop_invariant_strengthen.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/loop_invariant_strengthen.dfy
@@ -1,0 +1,16 @@
+// Pattern: when a loop invariant fails preservation, often a STRONGER
+// invariant works because it gives the verifier the missing information
+// it needs to re-derive the original after one iteration. Common
+// strengthenings: bound the loop counter, relate the accumulator to a
+// prefix expression, freeze unmodified collection elements.
+var i := 0;
+var acc := 0;
+while i < |s|
+  invariant 0 <= i <= |s|                   // counter bound
+  invariant acc == sum(s, 0, i)             // accumulator vs prefix
+  invariant forall j :: 0 <= j < i ==> s[j] == old(s[j])  // freeze prefix
+  decreases |s| - i
+{
+  acc := acc + s[i];
+  i := i + 1;
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/postcondition_branch_assert.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/postcondition_branch_assert.dfy
@@ -1,0 +1,13 @@
+// Pattern: when the postcondition has a disjunctive shape (e.g.
+// `result.Success? ==> P || result.Failure?`), explicitly assert
+// each branch's invariant inside the corresponding control-flow path.
+// This pushes the disjunction obligation down to local arithmetic
+// the SMT solver handles directly.
+if cond {
+  // ... establish branch A ...
+  assert branchA_inv;
+} else {
+  // ... establish branch B ...
+  assert branchB_inv;
+}
+// post: branchA_inv || branchB_inv  -- discharged by case split

--- a/modules/synth/src/main/resources/specrest/synth/hints/postcondition_capture_old.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/postcondition_capture_old.dfy
@@ -1,0 +1,9 @@
+// Pattern: capture old(...) values into ghost-friendly local vars at the
+// beginning of the body, then reference those locals in assertions that
+// discharge the postcondition. The verifier finds a chain of equalities
+// easier to follow than nested old(...) terms scattered through the proof.
+ghost var oldStore := old(st.store);
+ghost var oldCount := old(st.count);
+// ... mutate state ...
+assert st.store == oldStore[code := url];
+assert st.count == oldCount + 1;

--- a/modules/synth/src/main/resources/specrest/synth/hints/postcondition_helper_lemma.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/postcondition_helper_lemma.dfy
@@ -1,0 +1,17 @@
+// Pattern: when the postcondition involves quantifiers over collection
+// state, extract a helper lemma that proves the property for one element.
+// Calling the lemma after each mutation discharges the forall obligation
+// without the verifier having to instantiate the quantifier itself.
+lemma {:axiom} ElementPreservedAfterInsert(s: map<K, V>, k: K, v: V, k': K)
+  requires k' in s && k' != k
+  ensures s[k := v][k'] == s[k']
+
+method Insert(st: ServiceState, k: K, v: V)
+  modifies st
+  ensures forall k' :: k' in old(st.m) && k' != k ==> st.m[k'] == old(st.m)[k']
+{
+  st.m := st.m[k := v];
+  forall k' | k' in old(st.m) && k' != k
+    ensures st.m[k'] == old(st.m)[k']
+  { ElementPreservedAfterInsert(old(st.m), k, v, k'); }
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/postcondition_helper_lemma.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/postcondition_helper_lemma.dfy
@@ -1,12 +1,20 @@
 // Pattern: when the postcondition involves quantifiers over collection
 // state, extract a helper lemma that proves the property for one element.
 // Calling the lemma after each mutation discharges the forall obligation
-// without the verifier having to instantiate the quantifier itself.
-lemma {:axiom} ElementPreservedAfterInsert(s: map<K, V>, k: K, v: V, k': K)
+// without the verifier having to instantiate the quantifier itself. The
+// lemma is proven by the verifier — DO NOT use {:axiom}, which would
+// trust the property unsoundly and let the synthesizer "verify" with a
+// false fact.
+lemma ElementPreservedAfterInsert<K(==), V>(s: map<K, V>, k: K, v: V, k': K)
   requires k' in s && k' != k
-  ensures s[k := v][k'] == s[k']
+  ensures (s[k := v])[k'] == s[k']
+{
+  // Proven by Dafny from the definition of map update; no body needed
+  // for this trivial case, but the lemma block is REQUIRED to make the
+  // claim a discharged proof obligation rather than an axiom.
+}
 
-method Insert(st: ServiceState, k: K, v: V)
+method Insert<K(==), V>(st: ServiceState, k: K, v: V)
   modifies st
   ensures forall k' :: k' in old(st.m) && k' != k ==> st.m[k'] == old(st.m)[k']
 {

--- a/modules/synth/src/main/resources/specrest/synth/hints/precondition_guard.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/precondition_guard.dfy
@@ -1,0 +1,10 @@
+// Pattern: when calling a method whose precondition isn't obviously
+// satisfied, add a guard (if-block) that checks the condition explicitly
+// and either proves the precondition holds in that branch or returns early.
+// This converts an unprovable global precondition into a local assertion.
+if k in st.store {
+  assert k in st.store;  // precondition for InternalLookup
+  result := InternalLookup(st, k);
+} else {
+  result := DefaultValue;
+}

--- a/modules/synth/src/main/resources/specrest/synth/hints/precondition_strengthen_local.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/precondition_strengthen_local.dfy
@@ -1,0 +1,10 @@
+// Pattern: a precondition that the verifier cannot establish at a call
+// site often becomes provable when restated as an assertion immediately
+// before the call, with the assertion proven by a small local argument
+// (e.g. a chain of equalities or a previously-established invariant).
+assert ServiceStateInv(st);     // recover the invariant we just preserved
+assert k in st.store by {
+  assert old(k in st.store);    // prior fact
+  assert st.store == old(st.store);  // not mutated in this branch
+}
+ChildOperation(st, k);

--- a/modules/synth/src/main/resources/specrest/synth/hints/timeout_split_proof.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/hints/timeout_split_proof.dfy
@@ -1,0 +1,14 @@
+// Pattern: when verification times out, the SMT solver is exploring too
+// large a search space. Split the proof: introduce intermediate assertions
+// that act as proof checkpoints, and use {:split_here} to partition
+// verification conditions. Often a single {:split_here} cuts solver time
+// by 10x without changing the algorithm.
+method ComplexUpdate(st: ServiceState, k: K, v: V)
+  modifies st
+  ensures Inv1(st) && Inv2(st) && Inv3(st)
+{
+  // ... mutate state ...
+  assert Inv1(st);
+  assert {:split_here} Inv2(st);   // verifier proves Inv1 in one batch,
+  assert Inv3(st);                  // Inv2 and Inv3 in another
+}

--- a/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
@@ -40,7 +40,8 @@ final class CegisLoop(
     cache: Option[Cache],
     tracker: Tracker,
     budget: CegisBudget,
-    dafnyTimeoutSec: Int = 60
+    dafnyTimeoutSec: Int = 60,
+    withHints: Boolean = false
 ):
 
   def run(req: SynthRequest): IO[CegisOutcome] =
@@ -96,7 +97,14 @@ final class CegisLoop(
           case _ =>
             (history.lastBody, prevError) match
               case (Some(prev), Some(err)) =>
-                PromptBuilder.repair(req.classification, req.header, req.skeleton, prev, err)
+                PromptBuilder.repair(
+                  req.classification,
+                  req.header,
+                  req.skeleton,
+                  prev,
+                  err,
+                  withHints
+                )
               case _ =>
                 PromptBuilder.initial(req.classification, req.header, req.skeleton, req.strategy)
         val llmReq = LlmRequest(

--- a/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FallbackOrchestrator.scala
@@ -52,7 +52,8 @@ final class FallbackOrchestrator(
     tracker: Tracker,
     perAttemptBudget: CegisBudget,
     fallbackBudget: FallbackBudget,
-    dafnyTimeoutSec: Int = 60
+    dafnyTimeoutSec: Int = 60,
+    withHints: Boolean = false
 ):
 
   def run(req: SynthRequest): IO[FallbackOutcome] =
@@ -91,7 +92,15 @@ final class FallbackOrchestrator(
       spent: Ref[IO, BudgetSpent]
   ): IO[FallbackOutcome] =
     val attemptReq = req.copy(model = model, strategy = strat)
-    val loop       = new CegisLoop(provider, verifier, cache, tracker, perAttemptBudget, dafnyTimeoutSec)
+    val loop = new CegisLoop(
+      provider,
+      verifier,
+      cache,
+      tracker,
+      perAttemptBudget,
+      dafnyTimeoutSec,
+      withHints
+    )
     loop.run(attemptReq).flatMap: outcome =>
       val (cost, ins, outs) = outcomeCost(outcome)
       val rec               = AttemptRecord(strat, model, outcome, cost, ins, outs)

--- a/modules/synth/src/main/scala/specrest/synth/HintLibrary.scala
+++ b/modules/synth/src/main/scala/specrest/synth/HintLibrary.scala
@@ -1,0 +1,90 @@
+package specrest.synth
+
+import scala.io.Source
+import scala.util.Using
+
+final case class Hint(
+    name: String,
+    category: String,
+    description: String
+) derives CanEqual:
+  lazy val snippet: String = HintLibrary.loadSnippet(name)
+
+object HintLibrary:
+
+  private val resourceRoot = "/specrest/synth/hints"
+
+  val all: List[Hint] = List(
+    Hint(
+      "postcondition_capture_old",
+      "postcondition_violation",
+      "Save old(...) values into ghost-friendly local vars at method entry; reference these in postcondition assertions."
+    ),
+    Hint(
+      "postcondition_branch_assert",
+      "postcondition_violation",
+      "Push a disjunctive postcondition into per-branch asserts so the verifier handles each side independently."
+    ),
+    Hint(
+      "postcondition_helper_lemma",
+      "postcondition_violation",
+      "Extract a forall-over-collection postcondition into a helper lemma the body invokes element-wise."
+    ),
+    Hint(
+      "precondition_guard",
+      "precondition_violation",
+      "Guard a method call with an `if` block that proves the callee's precondition holds in that branch."
+    ),
+    Hint(
+      "precondition_strengthen_local",
+      "precondition_violation",
+      "Restate a hard-to-establish callee precondition as a local assertion proven from prior facts."
+    ),
+    Hint(
+      "loop_invariant_strengthen",
+      "loop_invariant_failure",
+      "Strengthen the loop invariant with counter bounds, accumulator-vs-prefix relations, and prefix-freeze clauses."
+    ),
+    Hint(
+      "loop_invariant_initially",
+      "loop_invariant_not_established",
+      "Initialise locals before the loop so the invariant trivially holds at entry, or weaken the invariant."
+    ),
+    Hint(
+      "loop_init_before_loop",
+      "loop_invariant_not_established",
+      "Declare and assign loop-state locals BEFORE the while; entry-state must satisfy the invariant unaided."
+    ),
+    Hint(
+      "decreases_metric",
+      "decreases_failure",
+      "Pick a metric (e.g. `|s| - i` or sequence length) that strictly decreases on each iteration / recursive call."
+    ),
+    Hint(
+      "decreases_lexicographic",
+      "decreases_failure",
+      "Use a tuple `decreases a, b` when a single metric doesn't shrink monotonically but a lexicographic pair does."
+    ),
+    Hint(
+      "assertion_intermediate_lemma",
+      "assertion_failure",
+      "Factor a stuck inline assertion into an intermediate lemma whose post the call site can directly cite."
+    ),
+    Hint(
+      "timeout_split_proof",
+      "timeout",
+      "Insert `{:split_here}` markers between groups of postconditions so the SMT solver verifies them in batches."
+    )
+  )
+
+  def forCategory(category: String, limit: Int = 2): List[Hint] =
+    all.filter(_.category == category).take(limit)
+
+  def categories: Set[String] = all.map(_.category).toSet
+
+  def loadSnippet(name: String): String =
+    val path = s"$resourceRoot/$name.dfy"
+    val stream = Option(getClass.getResourceAsStream(path))
+      .getOrElse(sys.error(s"Hint resource not found: $path"))
+    Using.resource(stream): in =>
+      Source.fromInputStream(in, "UTF-8").mkString

--- a/modules/synth/src/main/scala/specrest/synth/HintLibrary.scala
+++ b/modules/synth/src/main/scala/specrest/synth/HintLibrary.scala
@@ -86,5 +86,4 @@ object HintLibrary:
     val path = s"$resourceRoot/$name.dfy"
     val stream = Option(getClass.getResourceAsStream(path))
       .getOrElse(sys.error(s"Hint resource not found: $path"))
-    Using.resource(stream): in =>
-      Source.fromInputStream(in, "UTF-8").mkString
+    Using.resource(Source.fromInputStream(stream, "UTF-8"))(_.mkString)

--- a/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
+++ b/modules/synth/src/main/scala/specrest/synth/PromptBuilder.scala
@@ -42,15 +42,18 @@ object PromptBuilder:
       header: DafnyMethodHeader,
       skeleton: String,
       previousBody: String,
-      error: VerifierError
+      error: VerifierError,
+      withHints: Boolean = false
   ): Prompt =
+    val hints = if withHints then HintLibrary.forCategory(error.category) else Nil
     val sections = List(
       previousAttemptSection(previousBody),
       verifierErrorSection(error),
       diagnosisSection(error),
+      hintsSection(hints),
       methodSignatureSection(header),
       taskSection(classification.operationName, PromptStrategy.ZeroShot)
-    )
+    ).filter(_.nonEmpty)
     Prompt(systemRepair, sections.mkString("\n\n"))
 
   private def methodSignatureSection(header: DafnyMethodHeader): String =
@@ -129,6 +132,21 @@ object PromptBuilder:
     val clause = e.relatedClause.fold("")(c => s"\n\nRelated clause: `$c`")
     s"""## Diagnosis
        |${repairHint(e.category)}$clause$cx""".stripMargin
+
+  private def hintsSection(hints: List[Hint]): String =
+    if hints.isEmpty then ""
+    else
+      val rendered = hints
+        .map: h =>
+          s"""**${h.name}** — ${h.description}
+             |```dafny
+             |${h.snippet.stripLineEnd}
+             |```""".stripMargin
+        .mkString("\n\n")
+      s"""## Suggested Patterns
+         |These verified Dafny patterns commonly resolve this error category. Adapt the relevant one to your method's contract; do NOT copy them verbatim if they do not apply.
+         |
+         |$rendered""".stripMargin
 
   private def repairHint(category: String): String = category match
     case "postcondition_violation" =>

--- a/modules/synth/src/test/scala/specrest/synth/CegisLoopTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/CegisLoopTest.scala
@@ -248,6 +248,61 @@ class CegisLoopTest extends CatsEffectSuite:
     .void
       *> IO.unit
 
+  test("withHints=true threads category-matched snippets into the repair prompt"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(Right(llmResp(brokenBody)), Right(llmResp(validBody)))
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName, List(postcondError))),
+                          Right(correctRun(c.operationName))
+                        )
+                      )
+          tracker <- Tracker.empty
+          loop = new CegisLoop(
+                   provider,
+                   verifier,
+                   None,
+                   tracker,
+                   CegisBudget.Default,
+                   dafnyTimeoutSec = 60,
+                   withHints = true
+                 )
+          _         <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          provCalls <- provider.calls
+        yield
+          assert(
+            provCalls.length >= 2,
+            s"expected at least one repair call, got ${provCalls.length}"
+          )
+          val repair = provCalls(1).userMessage
+          assert(repair.contains("Suggested Patterns"), "repair prompt has hints section")
+          assert(repair.contains("postcondition_capture_old"), "first hint is injected")
+
+  test("withHints=false (default) means no hints in the repair prompt"):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          provider <- MockProvider.of(
+                        List(Right(llmResp(brokenBody)), Right(llmResp(validBody)))
+                      )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(c.operationName, List(postcondError))),
+                          Right(correctRun(c.operationName))
+                        )
+                      )
+          tracker   <- Tracker.empty
+          loop       = new CegisLoop(provider, verifier, None, tracker, CegisBudget.Default)
+          _         <- loop.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          provCalls <- provider.calls
+        yield
+          val repair = provCalls(1).userMessage
+          assert(!repair.contains("Suggested Patterns"), "no hints injected when flag off")
+
   test("aborts on cost cap"):
     Fixtures.loadHeader("safe_counter", "Increment").flatMap:
       case (c, h, skel) =>

--- a/modules/synth/src/test/scala/specrest/synth/HintLibraryTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/HintLibraryTest.scala
@@ -1,0 +1,50 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+
+class HintLibraryTest extends CatsEffectSuite:
+
+  test("library covers every category that PromptBuilder.repair classifies"):
+    val expected = Set(
+      "postcondition_violation",
+      "precondition_violation",
+      "loop_invariant_failure",
+      "loop_invariant_not_established",
+      "decreases_failure",
+      "assertion_failure",
+      "timeout"
+    )
+    val missing = expected -- HintLibrary.categories
+    assert(missing.isEmpty, s"hint library missing categories: $missing")
+
+  test("each hint resource loads and is non-empty Dafny-shaped text"):
+    HintLibrary.all.foreach: hint =>
+      val text = hint.snippet
+      assert(text.nonEmpty, s"hint ${hint.name} loaded as empty")
+      assert(
+        text.startsWith("//"),
+        s"hint ${hint.name} should open with a `//` rationale comment, got: ${text.take(40)}"
+      )
+
+  test("forCategory returns only matches and respects the limit"):
+    val postconds = HintLibrary.forCategory("postcondition_violation", limit = 2)
+    assertEquals(postconds.length, 2)
+    assert(postconds.forall(_.category == "postcondition_violation"))
+
+  test("forCategory caps at the available count when fewer hints exist"):
+    val timeoutHints = HintLibrary.forCategory("timeout", limit = 5)
+    assertEquals(timeoutHints.length, 1)
+    assertEquals(timeoutHints.head.name, "timeout_split_proof")
+
+  test("forCategory returns Nil for unknown category"):
+    val unknown = HintLibrary.forCategory("does_not_exist")
+    assertEquals(unknown, List.empty[Hint])
+
+  test("hint names are unique across the library"):
+    val names = HintLibrary.all.map(_.name)
+    assertEquals(names.length, names.distinct.length, s"duplicate hint names: $names")
+
+  test("descriptions are short and informative"):
+    HintLibrary.all.foreach: hint =>
+      assert(hint.description.length >= 20, s"description too short: ${hint.name}")
+      assert(hint.description.length <= 200, s"description too long: ${hint.name}")

--- a/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/PromptBuilderTest.scala
@@ -63,3 +63,43 @@ class PromptBuilderTest extends CatsEffectSuite:
         assert(p.system.contains("Phase 1"), "system describes two-phase approach")
         assert(p.system.contains("Phase 2"))
         assert(p.user.contains("numbered plan"), "task section nudges numbered plan")
+
+  test("repair prompt with withHints=false omits the Suggested Patterns section"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, h, skel) =>
+        val err = VerifierError(
+          category = "postcondition_violation",
+          message = "ensures clause not established",
+          line = Some(7)
+        )
+        val p =
+          PromptBuilder.repair(c, h, skel, "{ st.count := st.count; }", err, withHints = false)
+        assert(!p.user.contains("Suggested Patterns"))
+
+  test("repair prompt with withHints=true injects category-matched hint snippets"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, h, skel) =>
+        val err = VerifierError(
+          category = "postcondition_violation",
+          message = "ensures clause not established",
+          line = Some(7)
+        )
+        val p = PromptBuilder.repair(c, h, skel, "{ st.count := st.count; }", err, withHints = true)
+        assert(p.user.contains("## Suggested Patterns"), "hints section appears")
+        assert(p.user.contains("postcondition_capture_old"))
+        assert(p.user.contains("postcondition_branch_assert"))
+        assert(
+          p.user.contains("ghost var oldStore"),
+          "first hint's Dafny snippet is embedded verbatim"
+        )
+
+  test("repair prompt with withHints=true and unknown category gracefully omits the section"):
+    Fixtures.loadHeader("safe_counter", "Increment").map:
+      case (c, h, skel) =>
+        val err = VerifierError(
+          category = "unknown_category_we_have_no_hints_for",
+          message = "x",
+          line = None
+        )
+        val p = PromptBuilder.repair(c, h, skel, "...", err, withHints = true)
+        assert(!p.user.contains("## Suggested Patterns"))


### PR DESCRIPTION
## Summary

Replaces the originally-planned L2 / operation-decomposition path (closed in #227 wontfix-with-pivot) with the DafnyPro POPL 2026 mechanism that delivered +16pp on monolithic DafnyBench. Decision-of-record committed at [`research/12_compositional_synthesis_findings.md`](https://github.com/HardMax71/spec_to_rest/blob/main/docs/content/docs/research/12_compositional_synthesis_findings.md) (squashed into `af7f266`); hint-augmentation implementation in `a51b675`.

## What ships

- **`HintLibrary`** — 12 hand-curated Dafny proof patterns indexed by `VerifierError.category`, exposed as resource files under `modules/synth/src/main/resources/specrest/synth/hints/`. Categories covered:

| Category | Hint count | Examples |
|---|---|---|
| `postcondition_violation` | 3 | `capture_old`, `branch_assert`, `helper_lemma` |
| `precondition_violation` | 2 | `guard`, `strengthen_local` |
| `loop_invariant_failure` | 1 | `strengthen` |
| `loop_invariant_not_established` | 2 | `initially`, `init_before_loop` |
| `decreases_failure` | 2 | `metric`, `lexicographic` |
| `assertion_failure` | 1 | `intermediate_lemma` |
| `timeout` | 1 | `split_proof` |

- **`PromptBuilder.repair`** gains an optional `withHints` flag. When ON and matching hints exist, a `## Suggested Patterns` section is injected after the diagnosis section — each hint rendered as ``**name** — description`` followed by a fenced ` ```dafny ` snippet.
- **`CegisLoop`** and **`FallbackOrchestrator`** thread `withHints` through.
- **CLI:** `--with-hints` / `--no-hints` (tri-state `Option[Boolean]`). Default inferred per command:
  - `synth verify --fallback`: ON
  - `synth verify-all`: ON
  - strict `synth verify` (no `--fallback`): OFF (M6.4 contract preserved)

## Why hints (not decomposition)

- DafnyComp ([arXiv:2509.23061](https://arxiv.org/abs/2509.23061), Sept 2025) — 13 frontier models: **3.69% Pass@1 / 7% Pass@8** on multi-function Dafny. Pass@4→Pass@8 marginal +0.8% (architectural plateau, not search budget).
- Re:Form ([arXiv:2507.16331](https://arxiv.org/abs/2507.16331), Jul 2025) — RL-trained 14B is the SOTA at **14.0% Pass@1**. Inference-only techniques don't reach this.
- DafnyPro ([arXiv:2601.05385](https://arxiv.org/abs/2601.05385), POPL 2026) — hint-augmentation is **+16pp** on the single-function DafnyBench with Sonnet 3.5. Mechanism is proven, applies today, no training required, orthogonal to model choice.

For our 3-LLM_SYNTHESIS-op `url_shortener.spec`, the L2 alternative would yield **~0.21 ops verified per spec** under the most generous reading — most users see L2 fall through to L4 (skeleton). Hint-augmentation instead lifts the **monolithic** success rate, which is the case we already handle.

## Tests

- `HintLibraryTest` (7 cases) — covers every `repairHint` category; snippet load; name uniqueness; limit honoring; graceful empty result on unknown category.
- `PromptBuilderTest` (4 new cases) — hints omitted when `withHints=false`; injected when `withHints=true` with matching category; snippet body verbatim; gracefully omitted on unknown category.
- `CegisLoopTest` (2 new cases) — end-to-end thread-through proves the flag flows from constructor to provider's user prompt.

`sbt test` green (44 suites, 0 failures). `sbt scalafmtCheckAll` clean. `sbt 'scalafixAll --check'` clean. Docs build clean.

## Explicit non-claim

We do **not** claim the +16pp DafnyPro delta will reproduce on our specific spec/op shapes. CI tests are mock-driven and prove only the plumbing (hint retrieved by category, snippet injected verbatim, section gracefully omitted when no match). Real-LLM A/B is a follow-up that requires non-trivial test budget and a stable spec fixture.

## Test plan

- [ ] `sbt test` green on CI
- [ ] `sbt scalafmtCheckAll && sbt 'scalafixAll --check'` clean on CI
- [ ] Docs build clean on CI
- [ ] PR title `Closes #229` triggers GitHub auto-close on merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DafnyPro-style hint-augmentation that injects curated Dafny proof patterns into repair prompts to improve monolithic verification in the CEGIS loop. Replaces the deferred L2 decomposition for M6.7 and wires hints through the CLI, `CegisLoop`, and the fallback orchestrator (per #229).

- **New Features**
  - `HintLibrary`: 12 Dafny patterns indexed by `VerifierError.category` (resources under `specrest/synth/hints/`).
  - `PromptBuilder.repair(withHints)`: injects a “Suggested Patterns” section with matching snippets.
  - `CegisLoop` and `FallbackOrchestrator`: thread the `withHints` flag end-to-end.
  - CLI: `--with-hints` and `--no-hints` with inferred defaults (ON for `synth verify --fallback` and `synth verify-all`; OFF for strict `synth verify`).

- **Bug Fixes**
  - Removed unsafe `{:axiom}` from `postcondition_helper_lemma.dfy`; use a properly discharged lemma.
  - CLI now rejects `--with-hints` and `--no-hints` when passed together (mutually exclusive).
  - `HintLibrary.loadSnippet` uses safe `Using.resource` to close streams.
  - `decreases_lexicographic.dfy`: fixed variable naming for consistency.

<sup>Written for commit 2bdffe14f02fb0cc4faf88ca36a7539b279f876f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--with-hints` and `--no-hints` CLI flags to control hint injection during synthesis verification.
  * Introduced hint-augmentation mechanism that injects Dafny proof patterns into repair prompts based on verifier error categories.

* **Documentation**
  * Updated synthesis pipeline documentation to cover milestone M6.7 and hint-augmentation details.
  * Added research findings document detailing compositional synthesis performance and the hint-augmentation approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->