### PR TITLE
isabelle-build CI: gate Scala extraction drift on every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,10 +8,10 @@
 
 ## Proof program checklist
 
-The IR ADT lives in `proofs/isabelle/SpecRest/IR.thy` and is auto-extracted to
+The IR ADT lives in `proofs/isabelle/SpecRest/IR.thy` and is extracted to
 `modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala` by `Code_Target_Scala`.
-**Never hand-edit `SpecRestGenerated.scala`** — it is regenerated on every `isabelle build SpecRest`
-and your changes will be lost.
+**Never hand-edit `SpecRestGenerated.scala`** — the `isabelle-build` workflow re-runs the extraction
+in check mode on every PR and fails on any drift.
 
 If this PR touches any `*.thy` under `proofs/isabelle/SpecRest/`:
 
@@ -22,8 +22,8 @@ If this PR touches any `*.thy` under `proofs/isabelle/SpecRest/`:
       per-case `*_step` lemma + dispatch arm if a new `expr` constructor was added; update
       `lower_soundness` if `lower` moved.
 - [ ] Re-run `isabelle build -d proofs/isabelle/SpecRest -j 4 SpecRest` and confirm zero `sorry`.
-- [ ] Regenerate `modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala` from the
-      new extraction (run the `isabelle build` above; commit the resulting diff).
+- [ ] Regenerate `SpecRestGenerated.scala` per `proofs/isabelle/README.md` → "Regenerating
+      `SpecRestGenerated.scala`" and commit the diff. CI will fail otherwise.
 - [ ] Run `sbt compile` + `sbt test` — every consumer module reads the extracted positional case
       classes directly, so an ADT change ripples through parser/lint/convention/profile/
       codegen/testgen/verify/cli at compile time.

--- a/.github/workflows/isabelle-build.yml
+++ b/.github/workflows/isabelle-build.yml
@@ -5,10 +5,14 @@ on:
     branches: [main]
     paths:
       - "proofs/isabelle/**"
+      - "modules/ir/src/main/scala/specrest/ir/generated/**"
+      - ".scalafmt.conf"
       - ".github/workflows/isabelle-build.yml"
   pull_request:
     paths:
       - "proofs/isabelle/**"
+      - "modules/ir/src/main/scala/specrest/ir/generated/**"
+      - ".scalafmt.conf"
       - ".github/workflows/isabelle-build.yml"
 
 jobs:
@@ -53,3 +57,29 @@ jobs:
             echo "::error::sorry or oops found in Isabelle theories"
             exit 1
           fi
+
+      - name: Set up scalafmt for codegen drift check
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
+        with:
+          apps: scalafmt:3.8.3
+
+      - name: Detect Scala extraction drift
+        run: |
+          set -euo pipefail
+          target="modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala"
+          work="$(mktemp -d)"
+          isabelle export -d proofs/isabelle/SpecRest -O "$work/export" \
+            -x 'SpecRest.Codegen:code/*' SpecRest >/dev/null
+          exported="$work/export/SpecRest.Codegen/code/SpecRestGenerated.scala"
+          out="$work/SpecRestGenerated.scala"
+          {
+            printf 'package specrest.ir.generated\n\nimport scala.annotation.nowarn\n\n@nowarn\n'
+            cat "$exported"
+          } > "$out"
+          scalafmt --config .scalafmt.conf --non-interactive "$out" >/dev/null
+          if ! diff -u "$target" "$out"; then
+            echo "::error::$target is out of sync with proofs/isabelle/SpecRest."
+            echo "::error::Re-run the extraction (see proofs/isabelle/README.md → Regenerating SpecRestGenerated.scala) and commit the diff."
+            exit 1
+          fi
+          echo "OK: $target matches the freshly-extracted Scala."

--- a/proofs/isabelle/README.md
+++ b/proofs/isabelle/README.md
@@ -33,6 +33,30 @@ isabelle build -d proofs/isabelle/SpecRest -b SpecRest
 The first build downloads/compiles `HOL` and `HOL-Library` heaps (~5-10 minutes); subsequent builds
 reuse them. Heap files cache under `~/.isabelle/Isabelle2025-2/heaps/`.
 
+## Regenerating `SpecRestGenerated.scala`
+
+`Codegen.thy` runs `export_code` on every `isabelle build SpecRest`, but Isabelle writes the
+extracted Scala into the session's export area — not into the consumer tree. The committed copy at
+`modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala` is produced by:
+
+```bash
+work="$(mktemp -d)"
+isabelle build -d proofs/isabelle/SpecRest -b SpecRest
+isabelle export -d proofs/isabelle/SpecRest -O "$work" \
+  -x 'SpecRest.Codegen:code/*' SpecRest
+
+target="modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala"
+{
+  printf 'package specrest.ir.generated\n\nimport scala.annotation.nowarn\n\n@nowarn\n'
+  cat "$work/SpecRest.Codegen/code/SpecRestGenerated.scala"
+} > "$target"
+scalafmt --config .scalafmt.conf --non-interactive "$target"
+```
+
+The `isabelle-build` workflow runs this exact pipeline in `--check` mode on every PR that touches
+`proofs/isabelle/**` or the generated Scala — a `git diff` between the freshly-extracted file and
+the committed one is the gate. **A theory edit that forgets the regen step will fail CI.**
+
 ## Why the pivot
 
 See issue #193 for the full rationale. Headlines:


### PR DESCRIPTION
## Summary

- `Codegen.thy` runs `export_code` on every `isabelle build SpecRest`, but the output writes to the session export area (under `~/.isabelle/Isabelle2025-2/heaps/.../export/`) — not into `modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala`. The committed copy is hand-extracted + header-prepended + scalafmt'd. **Nothing previously checked the two stay in sync.**
- Added a `Detect Scala extraction drift` step to `.github/workflows/isabelle-build.yml` that runs `isabelle export`, prepends the standard header, runs scalafmt 3.8.3, and `diff -u`s against the committed file. Fails CI on any mismatch.
- Updated the PR template to drop the honor-system "regenerate the diff" checkbox and point at `proofs/isabelle/README.md → Regenerating SpecRestGenerated.scala`. CI is the source of truth.

## Test plan

- [x] Verified locally that a clean `isabelle export` + header injection + `scalafmt --config .scalafmt.conf` produces a byte-identical match to the currently committed `SpecRestGenerated.scala`. The recipe in `proofs/isabelle/README.md` is the same one the workflow runs.
- [x] Verified the negative direction: a one-byte mutation of the committed file produces a 2650-line diff and a non-zero exit, which triggers the workflow's `::error::` annotation and step failure.
- [ ] Watch the CI run on this PR — the new step should pass with the message `OK: ... matches the freshly-extracted Scala.`

## Notes

- `coursier/setup-action@v3.0.0` (pinned by SHA `fd1707a`) installs `scalafmt:3.8.3`, matching the `version` line in `.scalafmt.conf`.
- Trigger paths expanded to include `modules/ir/src/main/scala/specrest/ir/generated/**` and `.scalafmt.conf` so format-config bumps and direct edits to the generated file both re-run the gate.
- No changes to `Codegen.thy` itself — the existing `export_code … file_prefix "SpecRestGenerated"` declaration is what the workflow reads from.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI gate that detects drift between Isabelle’s exported Scala and the committed `SpecRestGenerated.scala`, failing PRs on mismatch. Updates the PR template and README to document the regen steps so the generated IR stays in sync.

- **New Features**
  - New `isabelle-build` step runs `isabelle export`, prepends package + `@nowarn`, formats with `scalafmt:3.8.3`, and diffs against the committed file; fails on any drift.
  - Triggers now include the generated Scala and `.scalafmt.conf` so format/config changes re-check the gate.
  - PR template points to the README’s regeneration recipe; README includes the exact commands.
  - `scalafmt:3.8.3` pinned via `coursier/setup-action@v3.0.0` for consistent formatting.

<sup>Written for commit 714b82699636402672a5ce25deada17d511bd733. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

