### PR TITLE
#222 — diagnostic for SpecRestGenerated$ class-init NCDFE on macOS / Windows

### DIFF
--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -1,6 +1,18 @@
 name: Native Image Diagnostic
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/native-diag.yml"
+      - "build.sbt"
+      - "modules/cli/src/main/scala/specrest/cli/DiagInit.scala"
+      - "modules/cli/src/main/scala/specrest/cli/Main.scala"
+      - "modules/ir/src/main/scala/specrest/ir/generated/**"
+      - "proofs/isabelle/SpecRest/Codegen.thy"
+  push:
+    branches:
+      - "feat/native-**"
+      - "fix/native-**"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -1,0 +1,147 @@
+name: Native Image Diagnostic
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch / sha / tag to build (default: triggering ref)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-diag-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diag:
+    name: Diag (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos-arm64
+            binary: spec-to-rest
+          - os: macos-26-intel
+            platform: macos-amd64
+            binary: spec-to-rest
+          - os: windows-latest
+            platform: windows-amd64
+            binary: spec-to-rest.exe
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    env:
+      SPEC_TO_REST_NATIVE_DIAG: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
+        with:
+          java-version: "21"
+          distribution: graalvm-community
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
+
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+
+      - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - name: Build native image (diag mode)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sbt -batch cli/nativeImage 2>&1 | tee native-image-build.log
+
+      - name: Run __diag-init
+        id: diag
+        shell: bash
+        env:
+          BIN: modules/cli/target/native-image/${{ matrix.binary }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set +e
+          mkdir -p diag-out
+          test -x "$BIN" || { echo "::error::binary not found: $BIN"; ls -la modules/cli/target/native-image/ || true; exit 1; }
+          "$BIN" __diag-init >"diag-out/${PLATFORM}-stdout.txt" 2>"diag-out/${PLATFORM}-stderr.txt"
+          exit_code=$?
+          echo "$exit_code" >"diag-out/${PLATFORM}-exit.txt"
+          echo "diag binary exited with: $exit_code"
+          echo "----- STDOUT -----"
+          cat "diag-out/${PLATFORM}-stdout.txt"
+          echo "----- STDERR (cause chain) -----"
+          cat "diag-out/${PLATFORM}-stderr.txt"
+
+      - name: Stage build + init reports
+        if: always()
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set +e
+          mkdir -p diag-out
+          cp native-image-build.log "diag-out/${PLATFORM}-build.log" 2>/dev/null || true
+          find . -maxdepth 6 -name 'class_initialization_report*' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          find . -maxdepth 6 -name 'native-image_*.json' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          find modules/cli/target -maxdepth 6 \( -name '*.csv' -o -name '*.txt' \) \
+            -path '*native-image*' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          ls -la diag-out/ || true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: diag-${{ matrix.platform }}
+          path: diag-out/
+          if-no-files-found: warn
+
+  summarize:
+    name: Summarize
+    needs: diag
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: false
+
+      - name: Summarize per platform
+        shell: bash
+        run: |
+          set +e
+          for d in artifacts/*/; do
+            plat=$(basename "$d")
+            {
+              echo "## $plat"
+              for stderr in "$d"*-stderr.txt; do
+                [ -f "$stderr" ] || continue
+                echo '<details><summary>stderr (cause chain)</summary>'
+                echo ''
+                echo '```text'
+                head -c 50000 "$stderr"
+                echo ''
+                echo '```'
+                echo '</details>'
+              done
+              for stdout in "$d"*-stdout.txt; do
+                [ -f "$stdout" ] || continue
+                echo '<details><summary>stdout</summary>'
+                echo ''
+                echo '```text'
+                head -c 20000 "$stdout"
+                echo ''
+                echo '```'
+                echo '</details>'
+              done
+            } >>"$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -9,22 +9,12 @@ on:
       - "modules/cli/src/main/scala/specrest/cli/Main.scala"
       - "modules/ir/src/main/scala/specrest/ir/generated/**"
       - "proofs/isabelle/SpecRest/Codegen.thy"
-  push:
-    branches:
-      - "feat/native-**"
-      - "fix/native-**"
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch / sha / tag to build (default: triggering ref)"
-        required: false
-        default: ""
 
 permissions:
   contents: read
 
 concurrency:
-  group: native-diag-${{ github.event.inputs.ref || github.ref }}
+  group: native-diag-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -45,14 +35,11 @@ jobs:
             binary: spec-to-rest.exe
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    env:
-      SPEC_TO_REST_NATIVE_DIAG: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up MSVC (Windows)
         if: runner.os == 'Windows'
@@ -69,14 +56,11 @@ jobs:
 
       - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
 
-      - name: Build native image (diag mode)
+      - name: Build native image
         shell: bash
-        run: |
-          set -euxo pipefail
-          sbt -batch cli/nativeImage 2>&1 | tee native-image-build.log
+        run: sbt -batch cli/nativeImage
 
       - name: Run __diag-init
-        id: diag
         shell: bash
         env:
           BIN: modules/cli/target/native-image/${{ matrix.binary }}
@@ -86,28 +70,9 @@ jobs:
           mkdir -p diag-out
           test -x "$BIN" || { echo "::error::binary not found: $BIN"; ls -la modules/cli/target/native-image/ || true; exit 1; }
           "$BIN" __diag-init >"diag-out/${PLATFORM}-stdout.txt" 2>"diag-out/${PLATFORM}-stderr.txt"
-          exit_code=$?
-          echo "$exit_code" >"diag-out/${PLATFORM}-exit.txt"
-          echo "diag binary exited with: $exit_code"
-          echo "----- STDOUT -----"
-          cat "diag-out/${PLATFORM}-stdout.txt"
+          echo "$?" >"diag-out/${PLATFORM}-exit.txt"
           echo "----- STDERR (cause chain) -----"
           cat "diag-out/${PLATFORM}-stderr.txt"
-
-      - name: Stage build + init reports
-        if: always()
-        shell: bash
-        env:
-          PLATFORM: ${{ matrix.platform }}
-        run: |
-          set +e
-          mkdir -p diag-out
-          cp native-image-build.log "diag-out/${PLATFORM}-build.log" 2>/dev/null || true
-          find . -maxdepth 6 -name 'class_initialization_report*' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          find . -maxdepth 6 -name 'native-image_*.json' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          find modules/cli/target -maxdepth 6 \( -name '*.csv' -o -name '*.txt' \) \
-            -path '*native-image*' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          ls -la diag-out/ || true
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -127,7 +92,7 @@ jobs:
           path: artifacts
           merge-multiple: false
 
-      - name: Summarize per platform
+      - name: Render per-platform stderr into run summary
         shell: bash
         run: |
           set +e
@@ -137,23 +102,10 @@ jobs:
               echo "## $plat"
               for stderr in "$d"*-stderr.txt; do
                 [ -f "$stderr" ] || continue
-                echo '<details><summary>stderr (cause chain)</summary>'
-                echo ''
                 echo '```text'
                 head -c 50000 "$stderr"
                 echo ''
                 echo '```'
-                echo '</details>'
-              done
-              for stdout in "$d"*-stdout.txt; do
-                [ -f "$stdout" ] || continue
-                echo '<details><summary>stdout</summary>'
-                echo ''
-                echo '```text'
-                head -c 20000 "$stdout"
-                echo ''
-                echo '```'
-                echo '</details>'
               done
             } >>"$GITHUB_STEP_SUMMARY"
           done

--- a/build.sbt
+++ b/build.sbt
@@ -231,18 +231,6 @@ lazy val cli = (project in file("modules/cli"))
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
       "--initialize-at-run-time=com.microsoft.z3.Version"
-    ) ++ (
-      // Issue #222: when SPEC_TO_REST_NATIVE_DIAG=1 we add tracing flags
-      // and force runtime init for specrest.ir.generated.* so the diag binary
-      // produced by `.github/workflows/native-diag.yml` surfaces the cause
-      // chain that substrate VM swallows on macOS/Windows.
-      if (sys.env.contains("SPEC_TO_REST_NATIVE_DIAG"))
-        Seq(
-          "-H:TraceClassInitialization=specrest.ir.generated.SpecRestGenerated$,specrest.ir.generated.SpecRestGenerated",
-          "-H:+PrintClassInitialization",
-          "--initialize-at-run-time=specrest.ir.generated"
-        )
-      else Seq.empty
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -231,6 +231,18 @@ lazy val cli = (project in file("modules/cli"))
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
       "--initialize-at-run-time=com.microsoft.z3.Version"
+    ) ++ (
+      // Issue #222: when SPEC_TO_REST_NATIVE_DIAG=1 we add tracing flags
+      // and force runtime init for specrest.ir.generated.* so the diag binary
+      // produced by `.github/workflows/native-diag.yml` surfaces the cause
+      // chain that substrate VM swallows on macOS/Windows.
+      if (sys.env.contains("SPEC_TO_REST_NATIVE_DIAG"))
+        Seq(
+          "-H:TraceClassInitialization=specrest.ir.generated.SpecRestGenerated$,specrest.ir.generated.SpecRestGenerated",
+          "-H:+PrintClassInitialization",
+          "--initialize-at-run-time=specrest.ir.generated"
+        )
+      else Seq.empty
     )
   )
 

--- a/modules/cli/src/main/scala/specrest/cli/DiagInit.scala
+++ b/modules/cli/src/main/scala/specrest/cli/DiagInit.scala
@@ -1,0 +1,84 @@
+package specrest.cli
+
+import cats.effect.ExitCode
+import cats.effect.IO
+
+import java.io.PrintStream
+
+object DiagInit:
+
+  private val targetClass = "specrest.ir.generated.SpecRestGenerated$"
+
+  def run(out: PrintStream = System.err): IO[ExitCode] = IO.delay {
+    out.println("=== diag-init: substrate VM class-init probe ===")
+    out.println(s"  jvm.name      = ${sysProp("java.vm.name")}")
+    out.println(s"  jvm.vendor    = ${sysProp("java.vm.vendor")}")
+    out.println(s"  jvm.version   = ${sysProp("java.vm.version")}")
+    out.println(s"  os.name       = ${sysProp("os.name")}")
+    out.println(s"  os.arch       = ${sysProp("os.arch")}")
+    out.println(s"  graalvm.image = ${sysProp("org.graalvm.nativeimage.imagecode")}")
+    out.println()
+
+    val loaderOpt: Option[ClassLoader] = Option(getClass.getClassLoader).map(_.nn)
+
+    val resolveOk: Option[Class[?]] = loaderOpt.flatMap: ld =>
+      out.println(s"--- step A: resolve $targetClass without forcing <clinit> ---")
+      try
+        val c = Class.forName(targetClass, false, ld)
+        out.println(s"  ok (resolved): ${c.getName}")
+        Some(c)
+      catch
+        case t: Throwable =>
+          out.println("  forName(initialize=false) threw:")
+          walkCauses(t, out)
+          None
+
+    val initOk: Boolean = (loaderOpt, resolveOk) match
+      case (Some(ld), Some(_)) =>
+        out.println()
+        out.println("--- step B: trigger <clinit> via Class.forName(name, true, loader) ---")
+        try
+          val _ = Class.forName(targetClass, true, ld)
+          out.println("  ok (initialized)")
+          true
+        catch
+          case t: Throwable =>
+            out.println("  forName(initialize=true) threw (this is the bug we want):")
+            walkCauses(t, out)
+            false
+      case _ => false
+
+    val callOk: Boolean = if initOk then
+      out.println()
+      out.println("--- step C: SpecRestGenerated.lower(Nil, BoolLitF(true, None)) ---")
+      try
+        import specrest.ir.generated.SpecRestGenerated
+        import specrest.ir.generated.SpecRestGenerated.BoolLitF
+        val r = SpecRestGenerated.lower(Nil, BoolLitF(true, None))
+        out.println(s"  ok: $r")
+        true
+      catch
+        case t: Throwable =>
+          out.println("  lower(...) threw:")
+          walkCauses(t, out)
+          false
+    else false
+
+    out.println()
+    out.println(
+      s"=== diag-init summary: resolve=${resolveOk.isDefined} init=$initOk call=$callOk ==="
+    )
+    if initOk && callOk then ExitCodes.Ok else ExitCodes.Violations
+  }
+
+  private def sysProp(key: String): String =
+    Option(System.getProperty(key)).getOrElse("(unset)")
+
+  @scala.annotation.tailrec
+  private def walkCauses(t: Throwable, out: PrintStream, depth: Int = 0): Unit =
+    val msg = Option(t.getMessage).getOrElse("(no message)")
+    out.println(s">>> cause depth=$depth: ${t.getClass.getName}: $msg")
+    t.printStackTrace(out)
+    Option(t.getCause) match
+      case Some(c) => walkCauses(c.nn, out, depth + 1)
+      case None    => ()

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -350,5 +350,13 @@ object Main
     Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
       tryCmd orElse verifyCmd orElse verifyAllCmd
 
+  private val diagInitCmd: Opts[IO[ExitCode]] =
+    Opts.subcommand(
+      "__diag-init",
+      "(internal) substrate-VM class-init probe; prints cause chain to stderr (issue #222)"
+    ):
+      (verbose, quiet).mapN: (_, _) =>
+        DiagInit.run()
+
   override def main: Opts[IO[ExitCode]] =
-    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd
+    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd orElse diagInitCmd

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -11,6 +11,19 @@ class CliSmokeTest extends CatsEffectSuite:
   test("check url_shortener is valid"):
     Check.run("fixtures/spec/url_shortener.spec", log).assertEquals(ExitCodes.Ok)
 
+  test("__diag-init exits Ok on the JVM and prints the cause-walk header to stderr"):
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps  = new java.io.PrintStream(buf, true, "UTF-8")
+    DiagInit.run(ps).map: exit =>
+      ps.flush()
+      val out = buf.toString("UTF-8")
+      assertEquals(exit, ExitCodes.Ok)
+      assert(out.contains("=== diag-init: substrate VM class-init probe ==="), out)
+      assert(out.contains("step A:"), out)
+      assert(out.contains("step B:"), out)
+      assert(out.contains("step C:"), out)
+      assert(out.contains("resolve=true init=true call=true"), out)
+
   test("check on missing file returns 1"):
     Check.run("fixtures/does-not-exist.spec", log).assertEquals(ExitCodes.Violations)
 


### PR DESCRIPTION
## Summary

Three iterations of `--initialize-at-run-time` in PR #221 all hit the same `NoClassDefFoundError: Could not initialize class …SpecRestGenerated$` on macOS-arm64, macOS-amd64 and windows-amd64, with **no underlying `ExceptionInInitializerError`** — substrate VM swallows the cause. Without the cause we cannot tell whether to attack the bytecode side (refactor the 2,650-LoC Isabelle-extracted file via `Codegen.thy`) or the GraalVM side (version bump, Oracle vs community distribution, mandrel).

This PR adds the diagnostic the issue itself called for under "Next concrete step", as a single self-contained drop. **Production builds and the existing `native.yml` release pipeline are unchanged** — everything new is gated behind `SPEC_TO_REST_NATIVE_DIAG=1` plus a `workflow_dispatch`-only trigger.

## What's in this PR

- **`cli/__diag-init` subcommand** — `modules/cli/src/main/scala/specrest/cli/DiagInit.scala`. Three-step probe:
  - **A**: `Class.forName(target, false, loader)` — resolve the class without forcing `<clinit>`. Confirms the bytecode is reachable in the binary.
  - **B**: `Class.forName(target, true, loader)` — force `<clinit>`. **This is where the bug surfaces**; we catch `Throwable` (not `NonFatal`, since `NCDFE`/`LinkageError` is excluded) and walk `getCause` recursively to stderr, bypassing substrate VM's silent init-failure handling.
  - **C**: actually call `SpecRestGenerated.lower(Nil, BoolLitF(true, None))` — distinguishes "init failed" from "init OK but method invocation fails".
  - Prints summary line: `resolve=… init=… call=…`, exit `Ok` only if all three succeeded.

- **Gated `nativeImageOptions` in `build.sbt`** — when `SPEC_TO_REST_NATIVE_DIAG=1` is set, append GraalVM 20.3+ trace flags (`-H:TraceClassInitialization=<class-list>` not the deprecated `-H:+TraceClassInitialization` boolean form, which is what PR #221 tried) plus `-H:+PrintClassInitialization` (writes a CSV report) plus the package-prefix `--initialize-at-run-time=specrest.ir.generated`. Verified gating with `show cli/nativeImageOptions` both with and without the env var.

- **`.github/workflows/native-diag.yml`** — `workflow_dispatch`-only matrix over `macos-latest` (arm64), `macos-26-intel` (amd64), `windows-latest` (amd64). Builds with the env var set, runs `__diag-init`, uploads `<plat>-stdout.txt`, `<plat>-stderr.txt`, `<plat>-exit.txt`, `<plat>-build.log`, and any `class_initialization_report*.csv` per platform. A `summarize` job collates each platform's stderr (the cause chain) into the workflow run summary so the diagnosis is visible without downloading artifacts. Includes `ilammy/msvc-dev-cmd` for the Windows path (SHA-pinned per the convention from PR #221 commit `b6ffd5d6`).

- **`CliSmokeTest`** — new test exercises `DiagInit.run` on the JVM (where init works), asserts exit `Ok` and that the probe header / step labels / summary line are written. Guards against syntax and wartremover regressions before any CI run is spent.

## Verified locally

- `sbt cli/compile` — clean
- `sbt cli/scalafixAll --check scalafmtCheckAll` — clean
- `sbt cli/test` — 44 tests, 0 failed (was 43 pre-PR; one new test for `__diag-init`)
- `sbt 'cli/runMain specrest.cli.Main __diag-init'` on the JVM — all three steps succeed, summary `resolve=true init=true call=true`, exit 0
- `show cli/nativeImageOptions` with and without `SPEC_TO_REST_NATIVE_DIAG=1` — gating works as intended (3 extra flags appended only when set)
- pre-commit hooks (`scalafmt`, `actionlint`, `yaml-check`) — pass

## How to use after merge

1. Go to **Actions → Native Image Diagnostic → Run workflow**, pick a ref (default: `main`).
2. Three jobs run in parallel; each writes its `__diag-init` cause chain to stderr.
3. Open the run, scroll to the summary — each platform's stderr is rendered inline as a `<details>` block.
4. The cause chain tells us which path to take in the follow-up PR (see issue #222 hypotheses):
   - Real Java exception (`NoSuchMethodError`, missing reflection entry) → reflect-config patch
   - `OutOfMemoryError` / `StackOverflowError` → split `SpecRestGenerated.scala` via `Codegen.thy`
   - Substrate-VM internal error → bump GraalVM (`distribution: graalvm`, version `21.0.7+` or `23`, or `mandrel`)

## Test plan

- [x] CLI compiles, tests pass
- [x] Diag binary runs on the JVM and exits Ok
- [x] Production `nativeImageOptions` unchanged when env var unset
- [x] Workflow YAML parses; actionlint clean
- [ ] (post-merge) Manually dispatch `Native Image Diagnostic`; review the three artifacts
- [ ] (follow-up PR) Land the actual fix based on diag output, re-add macOS/Windows to `native.yml` matrix, then close #222 and remove `__diag-init` + `native-diag.yml`

## Refs

- Issue #222 — the bug being diagnosed
- PR #221 — the prior cross-platform attempt; iteration log is the prior art for what flags don't work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native-image diagnostic to surface the real cause of `NoClassDefFoundError` when initializing `specrest.ir.generated.SpecRestGenerated$` on macOS/Windows. It runs on PRs and summarizes per‑platform stderr in CI; production builds remain unchanged to unblock #222.

- **New Features**
  - Hidden CLI probe `__diag-init` that: A) resolves the class without `<clinit>`, B) forces `<clinit>`, C) calls `SpecRestGenerated.lower(...)`; prints the full cause chain to stderr and a pass/fail summary.
  - `Native Image Diagnostic` workflow triggers on PRs touching the workflow, CLI entry, generated IR, or `Codegen.thy`; runs on macOS‑arm64, macOS‑amd64, and windows‑amd64; uploads stdout/stderr/exit and renders stderr per platform in the run summary. `CliSmokeTest` verifies the probe on the JVM.

- **Refactors**
  - Dropped the `SPEC_TO_REST_NATIVE_DIAG` build gating and related trace/runtime‑init flags; the diag binary now uses the same options as production. Removed manual dispatch and push triggers—CI runs on PRs only.

<sup>Written for commit ff182430b884aa42961d838fdb31b5ef76c08305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Actions diagnostic workflow for GraalVM native images across macOS and Windows platforms with automatic artifact collection and reporting.
  * Introduced new diagnostic CLI command to detect and report class-initialization issues during native image builds.

* **Chores**
  * Updated build configuration to support diagnostic mode for native image compilation.

* **Tests**
  * Added test coverage for the new diagnostic command.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->