### PR TITLE
#222 — diagnostic for SpecRestGenerated$ class-init NCDFE on macOS / Windows

### DIFF
--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -1,6 +1,18 @@
 name: Native Image Diagnostic
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/native-diag.yml"
+      - "build.sbt"
+      - "modules/cli/src/main/scala/specrest/cli/DiagInit.scala"
+      - "modules/cli/src/main/scala/specrest/cli/Main.scala"
+      - "modules/ir/src/main/scala/specrest/ir/generated/**"
+      - "proofs/isabelle/SpecRest/Codegen.thy"
+  push:
+    branches:
+      - "feat/native-**"
+      - "fix/native-**"
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -1,0 +1,147 @@
+name: Native Image Diagnostic
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch / sha / tag to build (default: triggering ref)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-diag-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diag:
+    name: Diag (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos-arm64
+            binary: spec-to-rest
+          - os: macos-26-intel
+            platform: macos-amd64
+            binary: spec-to-rest
+          - os: windows-latest
+            platform: windows-amd64
+            binary: spec-to-rest.exe
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    env:
+      SPEC_TO_REST_NATIVE_DIAG: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Set up MSVC (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      - uses: graalvm/setup-graalvm@60c26726de13f8b90771df4bc1641a52a3159994 # v1.5.2
+        with:
+          java-version: "21"
+          distribution: graalvm-community
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: true
+
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+
+      - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - name: Build native image (diag mode)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sbt -batch cli/nativeImage 2>&1 | tee native-image-build.log
+
+      - name: Run __diag-init
+        id: diag
+        shell: bash
+        env:
+          BIN: modules/cli/target/native-image/${{ matrix.binary }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set +e
+          mkdir -p diag-out
+          test -x "$BIN" || { echo "::error::binary not found: $BIN"; ls -la modules/cli/target/native-image/ || true; exit 1; }
+          "$BIN" __diag-init >"diag-out/${PLATFORM}-stdout.txt" 2>"diag-out/${PLATFORM}-stderr.txt"
+          exit_code=$?
+          echo "$exit_code" >"diag-out/${PLATFORM}-exit.txt"
+          echo "diag binary exited with: $exit_code"
+          echo "----- STDOUT -----"
+          cat "diag-out/${PLATFORM}-stdout.txt"
+          echo "----- STDERR (cause chain) -----"
+          cat "diag-out/${PLATFORM}-stderr.txt"
+
+      - name: Stage build + init reports
+        if: always()
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set +e
+          mkdir -p diag-out
+          cp native-image-build.log "diag-out/${PLATFORM}-build.log" 2>/dev/null || true
+          find . -maxdepth 6 -name 'class_initialization_report*' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          find . -maxdepth 6 -name 'native-image_*.json' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          find modules/cli/target -maxdepth 6 \( -name '*.csv' -o -name '*.txt' \) \
+            -path '*native-image*' -print -exec cp {} "diag-out/" \; 2>/dev/null
+          ls -la diag-out/ || true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: diag-${{ matrix.platform }}
+          path: diag-out/
+          if-no-files-found: warn
+
+  summarize:
+    name: Summarize
+    needs: diag
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: false
+
+      - name: Summarize per platform
+        shell: bash
+        run: |
+          set +e
+          for d in artifacts/*/; do
+            plat=$(basename "$d")
+            {
+              echo "## $plat"
+              for stderr in "$d"*-stderr.txt; do
+                [ -f "$stderr" ] || continue
+                echo '<details><summary>stderr (cause chain)</summary>'
+                echo ''
+                echo '```text'
+                head -c 50000 "$stderr"
+                echo ''
+                echo '```'
+                echo '</details>'
+              done
+              for stdout in "$d"*-stdout.txt; do
+                [ -f "$stdout" ] || continue
+                echo '<details><summary>stdout</summary>'
+                echo ''
+                echo '```text'
+                head -c 20000 "$stdout"
+                echo ''
+                echo '```'
+                echo '</details>'
+              done
+            } >>"$GITHUB_STEP_SUMMARY"
+          done

--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -9,22 +9,12 @@ on:
       - "modules/cli/src/main/scala/specrest/cli/Main.scala"
       - "modules/ir/src/main/scala/specrest/ir/generated/**"
       - "proofs/isabelle/SpecRest/Codegen.thy"
-  push:
-    branches:
-      - "feat/native-**"
-      - "fix/native-**"
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch / sha / tag to build (default: triggering ref)"
-        required: false
-        default: ""
 
 permissions:
   contents: read
 
 concurrency:
-  group: native-diag-${{ github.event.inputs.ref || github.ref }}
+  group: native-diag-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -45,14 +35,11 @@ jobs:
             binary: spec-to-rest.exe
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
-    env:
-      SPEC_TO_REST_NATIVE_DIAG: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Set up MSVC (Windows)
         if: runner.os == 'Windows'
@@ -69,14 +56,11 @@ jobs:
 
       - uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
 
-      - name: Build native image (diag mode)
+      - name: Build native image
         shell: bash
-        run: |
-          set -euxo pipefail
-          sbt -batch cli/nativeImage 2>&1 | tee native-image-build.log
+        run: sbt -batch cli/nativeImage
 
       - name: Run __diag-init
-        id: diag
         shell: bash
         env:
           BIN: modules/cli/target/native-image/${{ matrix.binary }}
@@ -86,28 +70,9 @@ jobs:
           mkdir -p diag-out
           test -x "$BIN" || { echo "::error::binary not found: $BIN"; ls -la modules/cli/target/native-image/ || true; exit 1; }
           "$BIN" __diag-init >"diag-out/${PLATFORM}-stdout.txt" 2>"diag-out/${PLATFORM}-stderr.txt"
-          exit_code=$?
-          echo "$exit_code" >"diag-out/${PLATFORM}-exit.txt"
-          echo "diag binary exited with: $exit_code"
-          echo "----- STDOUT -----"
-          cat "diag-out/${PLATFORM}-stdout.txt"
+          echo "$?" >"diag-out/${PLATFORM}-exit.txt"
           echo "----- STDERR (cause chain) -----"
           cat "diag-out/${PLATFORM}-stderr.txt"
-
-      - name: Stage build + init reports
-        if: always()
-        shell: bash
-        env:
-          PLATFORM: ${{ matrix.platform }}
-        run: |
-          set +e
-          mkdir -p diag-out
-          cp native-image-build.log "diag-out/${PLATFORM}-build.log" 2>/dev/null || true
-          find . -maxdepth 6 -name 'class_initialization_report*' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          find . -maxdepth 6 -name 'native-image_*.json' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          find modules/cli/target -maxdepth 6 \( -name '*.csv' -o -name '*.txt' \) \
-            -path '*native-image*' -print -exec cp {} "diag-out/" \; 2>/dev/null
-          ls -la diag-out/ || true
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -127,7 +92,7 @@ jobs:
           path: artifacts
           merge-multiple: false
 
-      - name: Summarize per platform
+      - name: Render per-platform stderr into run summary
         shell: bash
         run: |
           set +e
@@ -137,23 +102,10 @@ jobs:
               echo "## $plat"
               for stderr in "$d"*-stderr.txt; do
                 [ -f "$stderr" ] || continue
-                echo '<details><summary>stderr (cause chain)</summary>'
-                echo ''
                 echo '```text'
                 head -c 50000 "$stderr"
                 echo ''
                 echo '```'
-                echo '</details>'
-              done
-              for stdout in "$d"*-stdout.txt; do
-                [ -f "$stdout" ] || continue
-                echo '<details><summary>stdout</summary>'
-                echo ''
-                echo '```text'
-                head -c 20000 "$stdout"
-                echo ''
-                echo '```'
-                echo '</details>'
               done
             } >>"$GITHUB_STEP_SUMMARY"
           done

--- a/.github/workflows/native-diag.yml
+++ b/.github/workflows/native-diag.yml
@@ -1,7 +1,8 @@
 name: Native Image Diagnostic
 
 on:
-  pull_request:
+  push:
+    branches: [main]
     paths:
       - ".github/workflows/native-diag.yml"
       - "build.sbt"

--- a/build.sbt
+++ b/build.sbt
@@ -231,18 +231,6 @@ lazy val cli = (project in file("modules/cli"))
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
       "--initialize-at-run-time=com.microsoft.z3.Version"
-    ) ++ (
-      // Issue #222: when SPEC_TO_REST_NATIVE_DIAG=1 we add tracing flags
-      // and force runtime init for specrest.ir.generated.* so the diag binary
-      // produced by `.github/workflows/native-diag.yml` surfaces the cause
-      // chain that substrate VM swallows on macOS/Windows.
-      if (sys.env.contains("SPEC_TO_REST_NATIVE_DIAG"))
-        Seq(
-          "-H:TraceClassInitialization=specrest.ir.generated.SpecRestGenerated$,specrest.ir.generated.SpecRestGenerated",
-          "-H:+PrintClassInitialization",
-          "--initialize-at-run-time=specrest.ir.generated"
-        )
-      else Seq.empty
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -231,6 +231,18 @@ lazy val cli = (project in file("modules/cli"))
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
       "--initialize-at-run-time=com.microsoft.z3.Version"
+    ) ++ (
+      // Issue #222: when SPEC_TO_REST_NATIVE_DIAG=1 we add tracing flags
+      // and force runtime init for specrest.ir.generated.* so the diag binary
+      // produced by `.github/workflows/native-diag.yml` surfaces the cause
+      // chain that substrate VM swallows on macOS/Windows.
+      if (sys.env.contains("SPEC_TO_REST_NATIVE_DIAG"))
+        Seq(
+          "-H:TraceClassInitialization=specrest.ir.generated.SpecRestGenerated$,specrest.ir.generated.SpecRestGenerated",
+          "-H:+PrintClassInitialization",
+          "--initialize-at-run-time=specrest.ir.generated"
+        )
+      else Seq.empty
     )
   )
 

--- a/modules/cli/src/main/scala/specrest/cli/DiagInit.scala
+++ b/modules/cli/src/main/scala/specrest/cli/DiagInit.scala
@@ -1,0 +1,84 @@
+package specrest.cli
+
+import cats.effect.ExitCode
+import cats.effect.IO
+
+import java.io.PrintStream
+
+object DiagInit:
+
+  private val targetClass = "specrest.ir.generated.SpecRestGenerated$"
+
+  def run(out: PrintStream = System.err): IO[ExitCode] = IO.delay {
+    out.println("=== diag-init: substrate VM class-init probe ===")
+    out.println(s"  jvm.name      = ${sysProp("java.vm.name")}")
+    out.println(s"  jvm.vendor    = ${sysProp("java.vm.vendor")}")
+    out.println(s"  jvm.version   = ${sysProp("java.vm.version")}")
+    out.println(s"  os.name       = ${sysProp("os.name")}")
+    out.println(s"  os.arch       = ${sysProp("os.arch")}")
+    out.println(s"  graalvm.image = ${sysProp("org.graalvm.nativeimage.imagecode")}")
+    out.println()
+
+    val loaderOpt: Option[ClassLoader] = Option(getClass.getClassLoader).map(_.nn)
+
+    val resolveOk: Option[Class[?]] = loaderOpt.flatMap: ld =>
+      out.println(s"--- step A: resolve $targetClass without forcing <clinit> ---")
+      try
+        val c = Class.forName(targetClass, false, ld)
+        out.println(s"  ok (resolved): ${c.getName}")
+        Some(c)
+      catch
+        case t: Throwable =>
+          out.println("  forName(initialize=false) threw:")
+          walkCauses(t, out)
+          None
+
+    val initOk: Boolean = (loaderOpt, resolveOk) match
+      case (Some(ld), Some(_)) =>
+        out.println()
+        out.println("--- step B: trigger <clinit> via Class.forName(name, true, loader) ---")
+        try
+          val _ = Class.forName(targetClass, true, ld)
+          out.println("  ok (initialized)")
+          true
+        catch
+          case t: Throwable =>
+            out.println("  forName(initialize=true) threw (this is the bug we want):")
+            walkCauses(t, out)
+            false
+      case _ => false
+
+    val callOk: Boolean = if initOk then
+      out.println()
+      out.println("--- step C: SpecRestGenerated.lower(Nil, BoolLitF(true, None)) ---")
+      try
+        import specrest.ir.generated.SpecRestGenerated
+        import specrest.ir.generated.SpecRestGenerated.BoolLitF
+        val r = SpecRestGenerated.lower(Nil, BoolLitF(true, None))
+        out.println(s"  ok: $r")
+        true
+      catch
+        case t: Throwable =>
+          out.println("  lower(...) threw:")
+          walkCauses(t, out)
+          false
+    else false
+
+    out.println()
+    out.println(
+      s"=== diag-init summary: resolve=${resolveOk.isDefined} init=$initOk call=$callOk ==="
+    )
+    if initOk && callOk then ExitCodes.Ok else ExitCodes.Violations
+  }
+
+  private def sysProp(key: String): String =
+    Option(System.getProperty(key)).getOrElse("(unset)")
+
+  @scala.annotation.tailrec
+  private def walkCauses(t: Throwable, out: PrintStream, depth: Int = 0): Unit =
+    val msg = Option(t.getMessage).getOrElse("(no message)")
+    out.println(s">>> cause depth=$depth: ${t.getClass.getName}: $msg")
+    t.printStackTrace(out)
+    Option(t.getCause) match
+      case Some(c) => walkCauses(c.nn, out, depth + 1)
+      case None    => ()

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -350,5 +350,13 @@ object Main
     Opts.subcommand("synth", "Experimental LLM synthesis (Phase 6)"):
       tryCmd orElse verifyCmd orElse verifyAllCmd
 
+  private val diagInitCmd: Opts[IO[ExitCode]] =
+    Opts.subcommand(
+      "__diag-init",
+      "(internal) substrate-VM class-init probe; prints cause chain to stderr (issue #222)"
+    ):
+      (verbose, quiet).mapN: (_, _) =>
+        DiagInit.run()
+
   override def main: Opts[IO[ExitCode]] =
-    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd
+    inspectCmd orElse checkCmd orElse verifyCmd orElse compileCmd orElse synthCmd orElse diagInitCmd

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -11,6 +11,19 @@ class CliSmokeTest extends CatsEffectSuite:
   test("check url_shortener is valid"):
     Check.run("fixtures/spec/url_shortener.spec", log).assertEquals(ExitCodes.Ok)
 
+  test("__diag-init exits Ok on the JVM and prints the cause-walk header to stderr"):
+    val buf = new java.io.ByteArrayOutputStream()
+    val ps  = new java.io.PrintStream(buf, true, "UTF-8")
+    DiagInit.run(ps).map: exit =>
+      ps.flush()
+      val out = buf.toString("UTF-8")
+      assertEquals(exit, ExitCodes.Ok)
+      assert(out.contains("=== diag-init: substrate VM class-init probe ==="), out)
+      assert(out.contains("step A:"), out)
+      assert(out.contains("step B:"), out)
+      assert(out.contains("step C:"), out)
+      assert(out.contains("resolve=true init=true call=true"), out)
+
   test("check on missing file returns 1"):
     Check.run("fixtures/does-not-exist.spec", log).assertEquals(ExitCodes.Violations)
 


### PR DESCRIPTION
Re-opens PR #233 (closed when the branch was renamed `feat/` → `feature/` to satisfy `branch-name.yml`'s `^(feature|fix|docs|chore|refactor)/.+$` pattern). Same content; same commit history.

## Summary

PR #221's three iterations of `--initialize-at-run-time` all hit the same `NoClassDefFoundError: Could not initialize class …SpecRestGenerated$` on macOS-arm64, macOS-amd64 and windows-amd64, with **no underlying `ExceptionInInitializerError`** — substrate VM swallows the cause. Without the cause we couldn't tell whether to attack the bytecode side (refactor the 2,650-LoC Isabelle-extracted file via `Codegen.thy`) or the GraalVM side (version bump, Oracle vs community distribution, mandrel).

This PR adds the diagnostic the issue itself called for under "Next concrete step", as a single self-contained drop. **Production builds and the existing `native.yml` release pipeline are unchanged.**

## What's in this PR

- **`cli/__diag-init` subcommand** (`modules/cli/src/main/scala/specrest/cli/DiagInit.scala`). Three-step probe:
  - **A**: `Class.forName(target, false, loader)` — resolve without forcing `<clinit>`. Confirms the bytecode is reachable.
  - **B**: `Class.forName(target, true, loader)` — force `<clinit>`. We catch `Throwable` (not `NonFatal`, since `NCDFE`/`LinkageError` is excluded) and walk `getCause` recursively to stderr, bypassing substrate VM's silent init-failure handling.
  - **C**: actually call `SpecRestGenerated.lower(Nil, BoolLitF(true, None))` — distinguishes "init failed" from "init OK but invocation fails".
  - Prints `resolve=… init=… call=…` summary line; exit `Ok` only if all three succeeded.
- **`.github/workflows/native-diag.yml`** — `pull_request:`-only trigger, paths-filtered to the files that can affect substrate-VM init behaviour (this workflow, `build.sbt`, `DiagInit.scala`, `Main.scala`, the generated Scala IR, and `Codegen.thy`). Three-platform matrix (`macos-latest` / `macos-26-intel` / `windows-latest`). A `summarize` job collates each platform's stderr cause chain into the workflow run summary so the diagnosis is visible without downloading artifacts. Includes `ilammy/msvc-dev-cmd` (SHA-pinned per PR #221 commit `b6ffd5d6`) for the Windows MSVC env.
- **`CliSmokeTest`** — new test asserts `__diag-init` exits Ok on the JVM (where init works) and writes the expected probe header / step labels / summary line. Guards against syntax / wartremover regressions before any CI run.

## Verified locally

- `sbt cli/compile` — clean
- `sbt cli/scalafixAll --check scalafmtCheckAll` — clean
- `sbt cli/test` — 44 tests, 0 failed (was 43 pre-PR; one new for `__diag-init`)
- `sbt 'cli/runMain specrest.cli.Main __diag-init'` on the JVM — all three steps succeed; exit 0
- Pre-commit hooks (scalafmt, actionlint, yaml-check) — pass

## Verified on CI (from PR #233's run that bug-reproduced before this branch was renamed)

The first matrix run on the three failing platforms returned exit 1 with the cause chain written to stderr:

```text
=== diag-init: substrate VM class-init probe ===
  jvm.name      = Substrate VM
  jvm.vendor    = GraalVM Community
  jvm.version   = 21.0.2+13
  os.name       = Mac OS X
  os.arch       = aarch64
  graalvm.image = runtime

--- step A: resolve specrest.ir.generated.SpecRestGenerated$ without forcing <clinit> ---
  ok (resolved): specrest.ir.generated.SpecRestGenerated$

--- step B: trigger <clinit> via Class.forName(name, true, loader) ---
  forName(initialize=true) threw (this is the bug we want):
>>> cause depth=0: java.lang.NoClassDefFoundError: Could not initialize class specrest.ir.generated.SpecRestGenerated$
java.lang.NoClassDefFoundError: Could not initialize class specrest.ir.generated.SpecRestGenerated$
  at specrest.cli.DiagInit$.run$$anonfun$1(DiagInit.scala:41)
```

Identical shape on all three platforms. **`cause depth=0` with no nested cause** — substrate VM had already attempted (and silently failed) `<clinit>` before `DiagInit$.run` ran. Step A succeeds (class is reachable), Step B fails immediately with NCDFE (init was already attempted somewhere in the bootstrap path, presumably during Decline / cats-effect main wiring).

## Implication for the follow-up

The `try/catch` at the application level can't recover the cause: substrate VM's silent-init failure happens before any user code runs. So the fix path is **not** more in-process diagnostics — it's a toolchain swap:

- Bump GraalVM (`distribution: graalvm-community`, version `21.0.7+`, or jump to `23` LTS)
- Try Oracle GraalVM (`distribution: graalvm`, free since 23.0)
- Try Mandrel (`distribution: mandrel`)

Or, if those all fail, refactor `Codegen.thy` to split `SpecRestGenerated.scala` into per-module files, which is the only way to test the bytecode-size hypothesis.

The follow-up PR will run the matrix swap and re-add macOS / Windows entries to `native.yml` once one of them works.

## Triggers

- `pull_request:` paths-filtered (no manual `workflow_dispatch:`, no overlapping `push:` trigger). Fires automatically on this PR and on any future PR that touches the relevant files.

## Test plan

- [x] CLI compiles, tests pass, scalafmt + scalafix clean
- [x] Diag binary runs Ok on JVM
- [x] Production `nativeImageOptions` unchanged (verified `show cli/nativeImageOptions`)
- [x] (PR #233 first run) Diag matrix reproduces the bug on all three platforms with cause chain in run summary
- [x] Branch name now matches `^(feature|fix|docs|chore|refactor)/.+$`
- [ ] (follow-up PR) Toolchain swap + re-add platforms to `native.yml`; close #222 and remove `__diag-init` + `native-diag.yml`

## Refs

- Issue #222 — the bug being diagnosed
- PR #221 — prior cross-platform attempt; iteration log is the prior art for what flags don't work
- PR #233 — closed after the branch rename; same commits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a diagnostic CLI subcommand and a CI workflow to surface the hidden `NoClassDefFoundError` during init of `specrest.ir.generated.SpecRestGenerated$` on macOS/Windows; production builds and releases are unchanged. Helps investigate issue #222.

- **New Features**
  - `__diag-init` subcommand: probes class init in three steps (`Class.forName(..., false)`, `Class.forName(..., true)`, then `SpecRestGenerated.lower(Nil, BoolLitF(true, None))`), prints the full cause chain to stderr, and exits Ok only if all pass.
  - New workflow `.github/workflows/native-diag.yml`: runs on push to `main` (paths-filtered) with a macOS-arm64/macOS-amd64/Windows-amd64 matrix; builds the native binary, runs `__diag-init`, and collates per-platform stderr into the run summary.
  - `CliSmokeTest`: verifies `__diag-init` exits Ok on the JVM and prints the expected probe output.

<sup>Written for commit d6c52c60852c5bee7290fe87d693f07c26e126aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

