### PR TITLE
chore(test): standardize stragglers on CatsEffectSuite

### DIFF
--- a/modules/codegen/src/test/scala/specrest/codegen/CodegenSmokeTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/CodegenSmokeTest.scala
@@ -1,6 +1,6 @@
 package specrest.codegen
 
-class CodegenSmokeTest extends munit.FunSuite:
+class CodegenSmokeTest extends munit.CatsEffectSuite:
 
   private val engine = new TemplateEngine
 

--- a/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/GoldenRoundtripTest.scala
@@ -5,7 +5,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.*
 
-class GoldenRoundtripTest extends munit.FunSuite:
+class GoldenRoundtripTest extends munit.CatsEffectSuite:
 
   private val goldenDir: Path = Paths.get("fixtures/golden/ir")
 

--- a/modules/synth/src/test/scala/specrest/synth/PricingTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/PricingTest.scala
@@ -1,8 +1,8 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 
-class PricingTest extends FunSuite:
+class PricingTest extends CatsEffectSuite:
 
   test("known model maps to its pricing row"):
     assertEquals(

--- a/modules/synth/src/test/scala/specrest/synth/ResponseParserTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/ResponseParserTest.scala
@@ -1,8 +1,8 @@
 package specrest.synth
 
-import munit.FunSuite
+import munit.CatsEffectSuite
 
-class ResponseParserTest extends FunSuite:
+class ResponseParserTest extends CatsEffectSuite:
 
   test("extracts code block from ```dafny fence"):
     val resp =

--- a/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
@@ -2,7 +2,7 @@ package specrest.verify
 
 import specrest.ir.generated.SpecRestGenerated.*
 
-class ClassifierTest extends munit.FunSuite:
+class ClassifierTest extends munit.CatsEffectSuite:
 
   private def intLit(n: Long): expr_full = IntLitF(int_of_integer(BigInt(n)), None)
   private def id(s: String): expr_full   = IdentifierF(s, None)

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
@@ -1,6 +1,6 @@
 package specrest.verify.z3
 
-class SmtLibRenderTest extends munit.FunSuite:
+class SmtLibRenderTest extends munit.CatsEffectSuite:
 
   test("empty script renders minimal SMT-LIB"):
     val script = Z3Script(


### PR DESCRIPTION
## Summary
- Per the project rule "every new test extends CatsEffectSuite," swap the six remaining test files that still extended plain `munit.FunSuite` to extend `munit.CatsEffectSuite` instead.
- `CatsEffectSuite` is a strict superset of `FunSuite` (it extends it), so this is a pure base-class swap with zero behavior change. The bodies of all six tests stay synchronous.
- Two further `FunSuite` files under `modules/verify/.../cert/generated/` remain untouched: they are Isabelle-extracted Scala and off-limits.

Files touched:
- `modules/codegen/.../CodegenSmokeTest.scala`
- `modules/synth/.../PricingTest.scala`
- `modules/synth/.../ResponseParserTest.scala`
- `modules/verify/.../ClassifierTest.scala`
- `modules/verify/.../z3/SmtLibRenderTest.scala`
- `modules/ir/.../GoldenRoundtripTest.scala`

## Test plan
- [x] `sbt scalafixAll scalafmtCheckAll` — clean
- [x] `sbt codegen/test synth/test verify/test ir/test` — all green (codegen + synth + verify 163/163 + ir 43/43)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the remaining test suites to `munit.CatsEffectSuite` to align with the project rule. This is a base-class swap from `munit.FunSuite` with no behavior changes.

- **Refactors**
  - Switched six tests to `munit.CatsEffectSuite`: CodegenSmokeTest, PricingTest, ResponseParserTest, ClassifierTest, SmtLibRenderTest, GoldenRoundtripTest.
  - Left two generated tests in `modules/verify/.../cert/generated/` as `munit.FunSuite` (Isabelle-extracted).

<sup>Written for commit f5df86827436b50e1a007b9b5ba2fc8a87fe0ff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test infrastructure to support enhanced testing capabilities across multiple test suites.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/240)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->