### PR TITLE
Prep ecommerce fixture for M7.6 (#57): LineItem.order_id FK + Product.active

### DIFF
--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -151,6 +151,27 @@
             "endLine" : 37,
             "endCol" : 31
           }
+        },
+        {
+          "kind" : "Field",
+          "name" : "active",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Bool",
+            "span" : {
+              "startLine" : 38,
+              "startCol" : 12,
+              "endLine" : 38,
+              "endCol" : 16
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 38,
+            "startCol" : 4,
+            "endLine" : 38,
+            "endCol" : 16
+          }
         }
       ],
       "invariants" : [
@@ -161,9 +182,9 @@
             "kind" : "Identifier",
             "name" : "price",
             "span" : {
-              "startLine" : 39,
+              "startLine" : 40,
               "startCol" : 15,
-              "endLine" : 39,
+              "endLine" : 40,
               "endCol" : 20
             }
           },
@@ -171,16 +192,16 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 39,
+              "startLine" : 40,
               "startCol" : 23,
-              "endLine" : 39,
+              "endLine" : 40,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 39,
+            "startLine" : 40,
             "startCol" : 15,
-            "endLine" : 39,
+            "endLine" : 40,
             "endCol" : 24
           }
         }
@@ -188,7 +209,7 @@
       "span" : {
         "startLine" : 33,
         "startCol" : 2,
-        "endLine" : 40,
+        "endLine" : 41,
         "endCol" : 3
       }
     },
@@ -204,9 +225,9 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 43,
+              "startLine" : 44,
               "startCol" : 8,
-              "endLine" : 43,
+              "endLine" : 44,
               "endCol" : 11
             }
           },
@@ -217,9 +238,9 @@
               "kind" : "Identifier",
               "name" : "value",
               "span" : {
-                "startLine" : 43,
+                "startLine" : 44,
                 "startCol" : 18,
-                "endLine" : 43,
+                "endLine" : 44,
                 "endCol" : 23
               }
             },
@@ -227,24 +248,45 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 43,
+                "startLine" : 44,
                 "startCol" : 26,
-                "endLine" : 43,
+                "endLine" : 44,
                 "endCol" : 27
               }
             },
             "span" : {
-              "startLine" : 43,
+              "startLine" : 44,
               "startCol" : 18,
-              "endLine" : 43,
+              "endLine" : 44,
               "endCol" : 27
             }
           },
           "span" : {
-            "startLine" : 43,
+            "startLine" : 44,
             "startCol" : 4,
-            "endLine" : 43,
+            "endLine" : 44,
             "endCol" : 27
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "order_id",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "OrderId",
+            "span" : {
+              "startLine" : 45,
+              "startCol" : 14,
+              "endLine" : 45,
+              "endCol" : 21
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 45,
+            "startCol" : 4,
+            "endLine" : 45,
+            "endCol" : 21
           }
         },
         {
@@ -254,17 +296,17 @@
             "kind" : "NamedType",
             "name" : "SKU",
             "span" : {
-              "startLine" : 44,
+              "startLine" : 46,
               "startCol" : 17,
-              "endLine" : 44,
+              "endLine" : 46,
               "endCol" : 20
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 44,
+            "startLine" : 46,
             "startCol" : 4,
-            "endLine" : 44,
+            "endLine" : 46,
             "endCol" : 20
           }
         },
@@ -275,17 +317,17 @@
             "kind" : "NamedType",
             "name" : "Quantity",
             "span" : {
-              "startLine" : 45,
+              "startLine" : 47,
               "startCol" : 14,
-              "endLine" : 45,
+              "endLine" : 47,
               "endCol" : 22
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 45,
+            "startLine" : 47,
             "startCol" : 4,
-            "endLine" : 45,
+            "endLine" : 47,
             "endCol" : 22
           }
         },
@@ -296,17 +338,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 46,
+              "startLine" : 48,
               "startCol" : 16,
-              "endLine" : 46,
+              "endLine" : 48,
               "endCol" : 21
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 46,
+            "startLine" : 48,
             "startCol" : 4,
-            "endLine" : 46,
+            "endLine" : 48,
             "endCol" : 21
           }
         },
@@ -317,17 +359,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 47,
+              "startLine" : 49,
               "startCol" : 16,
-              "endLine" : 47,
+              "endLine" : 49,
               "endCol" : 21
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 47,
+            "startLine" : 49,
             "startCol" : 4,
-            "endLine" : 47,
+            "endLine" : 49,
             "endCol" : 21
           }
         }
@@ -340,9 +382,9 @@
             "kind" : "Identifier",
             "name" : "line_total",
             "span" : {
-              "startLine" : 49,
+              "startLine" : 51,
               "startCol" : 15,
-              "endLine" : 49,
+              "endLine" : 51,
               "endCol" : 25
             }
           },
@@ -353,9 +395,9 @@
               "kind" : "Identifier",
               "name" : "unit_price",
               "span" : {
-                "startLine" : 49,
+                "startLine" : 51,
                 "startCol" : 28,
-                "endLine" : 49,
+                "endLine" : 51,
                 "endCol" : 38
               }
             },
@@ -363,23 +405,23 @@
               "kind" : "Identifier",
               "name" : "quantity",
               "span" : {
-                "startLine" : 49,
+                "startLine" : 51,
                 "startCol" : 41,
-                "endLine" : 49,
+                "endLine" : 51,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 49,
+              "startLine" : 51,
               "startCol" : 28,
-              "endLine" : 49,
+              "endLine" : 51,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 49,
+            "startLine" : 51,
             "startCol" : 15,
-            "endLine" : 49,
+            "endLine" : 51,
             "endCol" : 49
           }
         },
@@ -390,9 +432,9 @@
             "kind" : "Identifier",
             "name" : "unit_price",
             "span" : {
-              "startLine" : 50,
+              "startLine" : 52,
               "startCol" : 15,
-              "endLine" : 50,
+              "endLine" : 52,
               "endCol" : 25
             }
           },
@@ -400,24 +442,24 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 50,
+              "startLine" : 52,
               "startCol" : 28,
-              "endLine" : 50,
+              "endLine" : 52,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 50,
+            "startLine" : 52,
             "startCol" : 15,
-            "endLine" : 50,
+            "endLine" : 52,
             "endCol" : 29
           }
         }
       ],
       "span" : {
-        "startLine" : 42,
+        "startLine" : 43,
         "startCol" : 2,
-        "endLine" : 51,
+        "endLine" : 53,
         "endCol" : 3
       }
     },
@@ -433,17 +475,17 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 54,
+              "startLine" : 56,
               "startCol" : 8,
-              "endLine" : 54,
+              "endLine" : 56,
               "endCol" : 15
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 54,
+            "startLine" : 56,
             "startCol" : 4,
-            "endLine" : 54,
+            "endLine" : 56,
             "endCol" : 15
           }
         },
@@ -454,17 +496,17 @@
             "kind" : "NamedType",
             "name" : "CustomerId",
             "span" : {
-              "startLine" : 55,
+              "startLine" : 57,
               "startCol" : 17,
-              "endLine" : 55,
+              "endLine" : 57,
               "endCol" : 27
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 55,
+            "startLine" : 57,
             "startCol" : 4,
-            "endLine" : 55,
+            "endLine" : 57,
             "endCol" : 27
           }
         },
@@ -475,17 +517,17 @@
             "kind" : "NamedType",
             "name" : "OrderStatus",
             "span" : {
-              "startLine" : 56,
+              "startLine" : 58,
               "startCol" : 12,
-              "endLine" : 56,
+              "endLine" : 58,
               "endCol" : 23
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 56,
+            "startLine" : 58,
             "startCol" : 4,
-            "endLine" : 56,
+            "endLine" : 58,
             "endCol" : 23
           }
         },
@@ -498,24 +540,24 @@
               "kind" : "NamedType",
               "name" : "LineItem",
               "span" : {
-                "startLine" : 57,
+                "startLine" : 59,
                 "startCol" : 15,
-                "endLine" : 57,
+                "endLine" : 59,
                 "endCol" : 23
               }
             },
             "span" : {
-              "startLine" : 57,
+              "startLine" : 59,
               "startCol" : 11,
-              "endLine" : 57,
+              "endLine" : 59,
               "endCol" : 24
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 57,
+            "startLine" : 59,
             "startCol" : 4,
-            "endLine" : 57,
+            "endLine" : 59,
             "endCol" : 24
           }
         },
@@ -526,17 +568,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 58,
+              "startLine" : 60,
               "startCol" : 14,
-              "endLine" : 58,
+              "endLine" : 60,
               "endCol" : 19
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 58,
+            "startLine" : 60,
             "startCol" : 4,
-            "endLine" : 58,
+            "endLine" : 60,
             "endCol" : 19
           }
         },
@@ -547,17 +589,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 59,
+              "startLine" : 61,
               "startCol" : 9,
-              "endLine" : 59,
+              "endLine" : 61,
               "endCol" : 14
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 59,
+            "startLine" : 61,
             "startCol" : 4,
-            "endLine" : 59,
+            "endLine" : 61,
             "endCol" : 14
           }
         },
@@ -568,17 +610,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 60,
+              "startLine" : 62,
               "startCol" : 11,
-              "endLine" : 60,
+              "endLine" : 62,
               "endCol" : 16
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 60,
+            "startLine" : 62,
             "startCol" : 4,
-            "endLine" : 60,
+            "endLine" : 62,
             "endCol" : 16
           }
         },
@@ -589,17 +631,17 @@
             "kind" : "NamedType",
             "name" : "DateTime",
             "span" : {
-              "startLine" : 61,
+              "startLine" : 63,
               "startCol" : 16,
-              "endLine" : 61,
+              "endLine" : 63,
               "endCol" : 24
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 61,
+            "startLine" : 63,
             "startCol" : 4,
-            "endLine" : 61,
+            "endLine" : 63,
             "endCol" : 24
           }
         },
@@ -610,17 +652,17 @@
             "kind" : "NamedType",
             "name" : "DateTime",
             "span" : {
-              "startLine" : 62,
+              "startLine" : 64,
               "startCol" : 16,
-              "endLine" : 62,
+              "endLine" : 64,
               "endCol" : 24
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 62,
+            "startLine" : 64,
             "startCol" : 4,
-            "endLine" : 62,
+            "endLine" : 64,
             "endCol" : 24
           }
         },
@@ -633,24 +675,24 @@
               "kind" : "NamedType",
               "name" : "DateTime",
               "span" : {
-                "startLine" : 63,
+                "startLine" : 65,
                 "startCol" : 23,
-                "endLine" : 63,
+                "endLine" : 65,
                 "endCol" : 31
               }
             },
             "span" : {
-              "startLine" : 63,
+              "startLine" : 65,
               "startCol" : 16,
-              "endLine" : 63,
+              "endLine" : 65,
               "endCol" : 32
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 63,
+            "startLine" : 65,
             "startCol" : 4,
-            "endLine" : 63,
+            "endLine" : 65,
             "endCol" : 32
           }
         },
@@ -663,24 +705,24 @@
               "kind" : "NamedType",
               "name" : "DateTime",
               "span" : {
-                "startLine" : 64,
+                "startLine" : 66,
                 "startCol" : 25,
-                "endLine" : 64,
+                "endLine" : 66,
                 "endCol" : 33
               }
             },
             "span" : {
-              "startLine" : 64,
+              "startLine" : 66,
               "startCol" : 18,
-              "endLine" : 64,
+              "endLine" : 66,
               "endCol" : 34
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 64,
+            "startLine" : 66,
             "startCol" : 4,
-            "endLine" : 64,
+            "endLine" : 66,
             "endCol" : 34
           }
         }
@@ -693,9 +735,9 @@
             "kind" : "Identifier",
             "name" : "subtotal",
             "span" : {
-              "startLine" : 66,
+              "startLine" : 68,
               "startCol" : 15,
-              "endLine" : 66,
+              "endLine" : 68,
               "endCol" : 23
             }
           },
@@ -705,9 +747,9 @@
               "kind" : "Identifier",
               "name" : "sum",
               "span" : {
-                "startLine" : 66,
+                "startLine" : 68,
                 "startCol" : 26,
-                "endLine" : 66,
+                "endLine" : 68,
                 "endCol" : 29
               }
             },
@@ -716,9 +758,9 @@
                 "kind" : "Identifier",
                 "name" : "items",
                 "span" : {
-                  "startLine" : 66,
+                  "startLine" : 68,
                   "startCol" : 30,
-                  "endLine" : 66,
+                  "endLine" : 68,
                   "endCol" : 35
                 }
               },
@@ -731,39 +773,39 @@
                     "kind" : "Identifier",
                     "name" : "i",
                     "span" : {
-                      "startLine" : 66,
+                      "startLine" : 68,
                       "startCol" : 42,
-                      "endLine" : 66,
+                      "endLine" : 68,
                       "endCol" : 43
                     }
                   },
                   "field" : "line_total",
                   "span" : {
-                    "startLine" : 66,
+                    "startLine" : 68,
                     "startCol" : 42,
-                    "endLine" : 66,
+                    "endLine" : 68,
                     "endCol" : 54
                   }
                 },
                 "span" : {
-                  "startLine" : 66,
+                  "startLine" : 68,
                   "startCol" : 37,
-                  "endLine" : 66,
+                  "endLine" : 68,
                   "endCol" : 54
                 }
               }
             ],
             "span" : {
-              "startLine" : 66,
+              "startLine" : 68,
               "startCol" : 26,
-              "endLine" : 66,
+              "endLine" : 68,
               "endCol" : 55
             }
           },
           "span" : {
-            "startLine" : 66,
+            "startLine" : 68,
             "startCol" : 15,
-            "endLine" : 66,
+            "endLine" : 68,
             "endCol" : 55
           }
         },
@@ -774,9 +816,9 @@
             "kind" : "Identifier",
             "name" : "total",
             "span" : {
-              "startLine" : 67,
+              "startLine" : 69,
               "startCol" : 15,
-              "endLine" : 67,
+              "endLine" : 69,
               "endCol" : 20
             }
           },
@@ -787,9 +829,9 @@
               "kind" : "Identifier",
               "name" : "subtotal",
               "span" : {
-                "startLine" : 67,
+                "startLine" : 69,
                 "startCol" : 23,
-                "endLine" : 67,
+                "endLine" : 69,
                 "endCol" : 31
               }
             },
@@ -797,23 +839,23 @@
               "kind" : "Identifier",
               "name" : "tax",
               "span" : {
-                "startLine" : 67,
+                "startLine" : 69,
                 "startCol" : 34,
-                "endLine" : 67,
+                "endLine" : 69,
                 "endCol" : 37
               }
             },
             "span" : {
-              "startLine" : 67,
+              "startLine" : 69,
               "startCol" : 23,
-              "endLine" : 67,
+              "endLine" : 69,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 67,
+            "startLine" : 69,
             "startCol" : 15,
-            "endLine" : 67,
+            "endLine" : 69,
             "endCol" : 37
           }
         },
@@ -830,16 +872,16 @@
                 "kind" : "Identifier",
                 "name" : "items",
                 "span" : {
-                  "startLine" : 68,
+                  "startLine" : 70,
                   "startCol" : 16,
-                  "endLine" : 68,
+                  "endLine" : 70,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 68,
+                "startLine" : 70,
                 "startCol" : 15,
-                "endLine" : 68,
+                "endLine" : 70,
                 "endCol" : 21
               }
             },
@@ -847,16 +889,16 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 68,
+                "startLine" : 70,
                 "startCol" : 24,
-                "endLine" : 68,
+                "endLine" : 70,
                 "endCol" : 25
               }
             },
             "span" : {
-              "startLine" : 68,
+              "startLine" : 70,
               "startCol" : 15,
-              "endLine" : 68,
+              "endLine" : 70,
               "endCol" : 25
             }
           },
@@ -867,9 +909,9 @@
               "kind" : "Identifier",
               "name" : "total",
               "span" : {
-                "startLine" : 68,
+                "startLine" : 70,
                 "startCol" : 34,
-                "endLine" : 68,
+                "endLine" : 70,
                 "endCol" : 39
               }
             },
@@ -877,23 +919,23 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 68,
+                "startLine" : 70,
                 "startCol" : 42,
-                "endLine" : 68,
+                "endLine" : 70,
                 "endCol" : 43
               }
             },
             "span" : {
-              "startLine" : 68,
+              "startLine" : 70,
               "startCol" : 34,
-              "endLine" : 68,
+              "endLine" : 70,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 68,
+            "startLine" : 70,
             "startCol" : 15,
-            "endLine" : 68,
+            "endLine" : 70,
             "endCol" : 43
           }
         },
@@ -907,9 +949,9 @@
               "kind" : "Identifier",
               "name" : "status",
               "span" : {
-                "startLine" : 69,
+                "startLine" : 71,
                 "startCol" : 15,
-                "endLine" : 69,
+                "endLine" : 71,
                 "endCol" : 21
               }
             },
@@ -917,16 +959,16 @@
               "kind" : "Identifier",
               "name" : "SHIPPED",
               "span" : {
-                "startLine" : 69,
+                "startLine" : 71,
                 "startCol" : 24,
-                "endLine" : 69,
+                "endLine" : 71,
                 "endCol" : 31
               }
             },
             "span" : {
-              "startLine" : 69,
+              "startLine" : 71,
               "startCol" : 15,
-              "endLine" : 69,
+              "endLine" : 71,
               "endCol" : 31
             }
           },
@@ -937,32 +979,32 @@
               "kind" : "Identifier",
               "name" : "shipped_at",
               "span" : {
-                "startLine" : 69,
+                "startLine" : 71,
                 "startCol" : 40,
-                "endLine" : 69,
+                "endLine" : 71,
                 "endCol" : 50
               }
             },
             "right" : {
               "kind" : "NoneLit",
               "span" : {
-                "startLine" : 69,
+                "startLine" : 71,
                 "startCol" : 54,
-                "endLine" : 69,
+                "endLine" : 71,
                 "endCol" : 58
               }
             },
             "span" : {
-              "startLine" : 69,
+              "startLine" : 71,
               "startCol" : 40,
-              "endLine" : 69,
+              "endLine" : 71,
               "endCol" : 58
             }
           },
           "span" : {
-            "startLine" : 69,
+            "startLine" : 71,
             "startCol" : 15,
-            "endLine" : 69,
+            "endLine" : 71,
             "endCol" : 58
           }
         },
@@ -976,9 +1018,9 @@
               "kind" : "Identifier",
               "name" : "status",
               "span" : {
-                "startLine" : 70,
+                "startLine" : 72,
                 "startCol" : 15,
-                "endLine" : 70,
+                "endLine" : 72,
                 "endCol" : 21
               }
             },
@@ -986,16 +1028,16 @@
               "kind" : "Identifier",
               "name" : "DELIVERED",
               "span" : {
-                "startLine" : 70,
+                "startLine" : 72,
                 "startCol" : 24,
-                "endLine" : 70,
+                "endLine" : 72,
                 "endCol" : 33
               }
             },
             "span" : {
-              "startLine" : 70,
+              "startLine" : 72,
               "startCol" : 15,
-              "endLine" : 70,
+              "endLine" : 72,
               "endCol" : 33
             }
           },
@@ -1006,32 +1048,32 @@
               "kind" : "Identifier",
               "name" : "delivered_at",
               "span" : {
-                "startLine" : 70,
+                "startLine" : 72,
                 "startCol" : 42,
-                "endLine" : 70,
+                "endLine" : 72,
                 "endCol" : 54
               }
             },
             "right" : {
               "kind" : "NoneLit",
               "span" : {
-                "startLine" : 70,
+                "startLine" : 72,
                 "startCol" : 58,
-                "endLine" : 70,
+                "endLine" : 72,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 70,
+              "startLine" : 72,
               "startCol" : 42,
-              "endLine" : 70,
+              "endLine" : 72,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 70,
+            "startLine" : 72,
             "startCol" : 15,
-            "endLine" : 70,
+            "endLine" : 72,
             "endCol" : 62
           }
         },
@@ -1045,25 +1087,25 @@
               "kind" : "Identifier",
               "name" : "delivered_at",
               "span" : {
-                "startLine" : 71,
+                "startLine" : 73,
                 "startCol" : 15,
-                "endLine" : 71,
+                "endLine" : 73,
                 "endCol" : 27
               }
             },
             "right" : {
               "kind" : "NoneLit",
               "span" : {
-                "startLine" : 71,
+                "startLine" : 73,
                 "startCol" : 31,
-                "endLine" : 71,
+                "endLine" : 73,
                 "endCol" : 35
               }
             },
             "span" : {
-              "startLine" : 71,
+              "startLine" : 73,
               "startCol" : 15,
-              "endLine" : 71,
+              "endLine" : 73,
               "endCol" : 35
             }
           },
@@ -1074,40 +1116,40 @@
               "kind" : "Identifier",
               "name" : "shipped_at",
               "span" : {
-                "startLine" : 71,
+                "startLine" : 73,
                 "startCol" : 44,
-                "endLine" : 71,
+                "endLine" : 73,
                 "endCol" : 54
               }
             },
             "right" : {
               "kind" : "NoneLit",
               "span" : {
-                "startLine" : 71,
+                "startLine" : 73,
                 "startCol" : 58,
-                "endLine" : 71,
+                "endLine" : 73,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 71,
+              "startLine" : 73,
               "startCol" : 44,
-              "endLine" : 71,
+              "endLine" : 73,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 71,
+            "startLine" : 73,
             "startCol" : 15,
-            "endLine" : 71,
+            "endLine" : 73,
             "endCol" : 62
           }
         }
       ],
       "span" : {
-        "startLine" : 53,
+        "startLine" : 55,
         "startCol" : 2,
-        "endLine" : 72,
+        "endLine" : 74,
         "endCol" : 3
       }
     },
@@ -1123,9 +1165,9 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 75,
+              "startLine" : 77,
               "startCol" : 8,
-              "endLine" : 75,
+              "endLine" : 77,
               "endCol" : 11
             }
           },
@@ -1136,9 +1178,9 @@
               "kind" : "Identifier",
               "name" : "value",
               "span" : {
-                "startLine" : 75,
+                "startLine" : 77,
                 "startCol" : 18,
-                "endLine" : 75,
+                "endLine" : 77,
                 "endCol" : 23
               }
             },
@@ -1146,23 +1188,23 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 75,
+                "startLine" : 77,
                 "startCol" : 26,
-                "endLine" : 75,
+                "endLine" : 77,
                 "endCol" : 27
               }
             },
             "span" : {
-              "startLine" : 75,
+              "startLine" : 77,
               "startCol" : 18,
-              "endLine" : 75,
+              "endLine" : 77,
               "endCol" : 27
             }
           },
           "span" : {
-            "startLine" : 75,
+            "startLine" : 77,
             "startCol" : 4,
-            "endLine" : 75,
+            "endLine" : 77,
             "endCol" : 27
           }
         },
@@ -1173,17 +1215,17 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 76,
+              "startLine" : 78,
               "startCol" : 14,
-              "endLine" : 76,
+              "endLine" : 78,
               "endCol" : 21
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 76,
+            "startLine" : 78,
             "startCol" : 4,
-            "endLine" : 76,
+            "endLine" : 78,
             "endCol" : 21
           }
         },
@@ -1194,17 +1236,17 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 77,
+              "startLine" : 79,
               "startCol" : 12,
-              "endLine" : 77,
+              "endLine" : 79,
               "endCol" : 17
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 77,
+            "startLine" : 79,
             "startCol" : 4,
-            "endLine" : 77,
+            "endLine" : 79,
             "endCol" : 17
           }
         },
@@ -1215,17 +1257,17 @@
             "kind" : "NamedType",
             "name" : "PaymentStatus",
             "span" : {
-              "startLine" : 78,
+              "startLine" : 80,
               "startCol" : 12,
-              "endLine" : 78,
+              "endLine" : 80,
               "endCol" : 25
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 78,
+            "startLine" : 80,
             "startCol" : 4,
-            "endLine" : 78,
+            "endLine" : 80,
             "endCol" : 25
           }
         },
@@ -1236,17 +1278,17 @@
             "kind" : "NamedType",
             "name" : "DateTime",
             "span" : {
-              "startLine" : 79,
+              "startLine" : 81,
               "startCol" : 16,
-              "endLine" : 79,
+              "endLine" : 81,
               "endCol" : 24
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 79,
+            "startLine" : 81,
             "startCol" : 4,
-            "endLine" : 79,
+            "endLine" : 81,
             "endCol" : 24
           }
         }
@@ -1259,9 +1301,9 @@
             "kind" : "Identifier",
             "name" : "amount",
             "span" : {
-              "startLine" : 81,
+              "startLine" : 83,
               "startCol" : 15,
-              "endLine" : 81,
+              "endLine" : 83,
               "endCol" : 21
             }
           },
@@ -1269,24 +1311,24 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 81,
+              "startLine" : 83,
               "startCol" : 24,
-              "endLine" : 81,
+              "endLine" : 83,
               "endCol" : 25
             }
           },
           "span" : {
-            "startLine" : 81,
+            "startLine" : 83,
             "startCol" : 15,
-            "endLine" : 81,
+            "endLine" : 83,
             "endCol" : 25
           }
         }
       ],
       "span" : {
-        "startLine" : 74,
+        "startLine" : 76,
         "startCol" : 2,
-        "endLine" : 82,
+        "endLine" : 84,
         "endCol" : 3
       }
     },
@@ -1302,17 +1344,17 @@
             "kind" : "NamedType",
             "name" : "SKU",
             "span" : {
-              "startLine" : 85,
+              "startLine" : 87,
               "startCol" : 9,
-              "endLine" : 85,
+              "endLine" : 87,
               "endCol" : 12
             }
           },
           "constraint" : null,
           "span" : {
-            "startLine" : 85,
+            "startLine" : 87,
             "startCol" : 4,
-            "endLine" : 85,
+            "endLine" : 87,
             "endCol" : 12
           }
         },
@@ -1323,9 +1365,9 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 86,
+              "startLine" : 88,
               "startCol" : 15,
-              "endLine" : 86,
+              "endLine" : 88,
               "endCol" : 18
             }
           },
@@ -1336,9 +1378,9 @@
               "kind" : "Identifier",
               "name" : "value",
               "span" : {
-                "startLine" : 86,
+                "startLine" : 88,
                 "startCol" : 25,
-                "endLine" : 86,
+                "endLine" : 88,
                 "endCol" : 30
               }
             },
@@ -1346,23 +1388,23 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 86,
+                "startLine" : 88,
                 "startCol" : 34,
-                "endLine" : 86,
+                "endLine" : 88,
                 "endCol" : 35
               }
             },
             "span" : {
-              "startLine" : 86,
+              "startLine" : 88,
               "startCol" : 25,
-              "endLine" : 86,
+              "endLine" : 88,
               "endCol" : 35
             }
           },
           "span" : {
-            "startLine" : 86,
+            "startLine" : 88,
             "startCol" : 4,
-            "endLine" : 86,
+            "endLine" : 88,
             "endCol" : 35
           }
         },
@@ -1373,9 +1415,9 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 87,
+              "startLine" : 89,
               "startCol" : 14,
-              "endLine" : 87,
+              "endLine" : 89,
               "endCol" : 17
             }
           },
@@ -1386,9 +1428,9 @@
               "kind" : "Identifier",
               "name" : "value",
               "span" : {
-                "startLine" : 87,
+                "startLine" : 89,
                 "startCol" : 24,
-                "endLine" : 87,
+                "endLine" : 89,
                 "endCol" : 29
               }
             },
@@ -1396,23 +1438,23 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 87,
+                "startLine" : 89,
                 "startCol" : 33,
-                "endLine" : 87,
+                "endLine" : 89,
                 "endCol" : 34
               }
             },
             "span" : {
-              "startLine" : 87,
+              "startLine" : 89,
               "startCol" : 24,
-              "endLine" : 87,
+              "endLine" : 89,
               "endCol" : 34
             }
           },
           "span" : {
-            "startLine" : 87,
+            "startLine" : 89,
             "startCol" : 4,
-            "endLine" : 87,
+            "endLine" : 89,
             "endCol" : 34
           }
         }
@@ -1425,9 +1467,9 @@
             "kind" : "Identifier",
             "name" : "available",
             "span" : {
-              "startLine" : 89,
+              "startLine" : 91,
               "startCol" : 15,
-              "endLine" : 89,
+              "endLine" : 91,
               "endCol" : 24
             }
           },
@@ -1435,16 +1477,16 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 89,
+              "startLine" : 91,
               "startCol" : 28,
-              "endLine" : 89,
+              "endLine" : 91,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 89,
+            "startLine" : 91,
             "startCol" : 15,
-            "endLine" : 89,
+            "endLine" : 91,
             "endCol" : 29
           }
         },
@@ -1455,9 +1497,9 @@
             "kind" : "Identifier",
             "name" : "reserved",
             "span" : {
-              "startLine" : 90,
+              "startLine" : 92,
               "startCol" : 15,
-              "endLine" : 90,
+              "endLine" : 92,
               "endCol" : 23
             }
           },
@@ -1465,24 +1507,24 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 90,
+              "startLine" : 92,
               "startCol" : 27,
-              "endLine" : 90,
+              "endLine" : 92,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 90,
+            "startLine" : 92,
             "startCol" : 15,
-            "endLine" : 90,
+            "endLine" : 92,
             "endCol" : 28
           }
         }
       ],
       "span" : {
-        "startLine" : 84,
+        "startLine" : 86,
         "startCol" : 2,
-        "endLine" : 91,
+        "endLine" : 93,
         "endCol" : 3
       }
     }
@@ -1871,9 +1913,9 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 96,
+              "startLine" : 98,
               "startCol" : 12,
-              "endLine" : 96,
+              "endLine" : 98,
               "endCol" : 19
             }
           },
@@ -1882,23 +1924,23 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 96,
+              "startLine" : 98,
               "startCol" : 28,
-              "endLine" : 96,
+              "endLine" : 98,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 96,
+            "startLine" : 98,
             "startCol" : 12,
-            "endLine" : 96,
+            "endLine" : 98,
             "endCol" : 33
           }
         },
         "span" : {
-          "startLine" : 96,
+          "startLine" : 98,
           "startCol" : 4,
-          "endLine" : 96,
+          "endLine" : 98,
           "endCol" : 33
         }
       },
@@ -1911,86 +1953,6 @@
             "kind" : "NamedType",
             "name" : "SKU",
             "span" : {
-              "startLine" : 97,
-              "startCol" : 14,
-              "endLine" : 97,
-              "endCol" : 17
-            }
-          },
-          "multiplicity" : "lone",
-          "toType" : {
-            "kind" : "NamedType",
-            "name" : "Product",
-            "span" : {
-              "startLine" : 97,
-              "startCol" : 26,
-              "endLine" : 97,
-              "endCol" : 33
-            }
-          },
-          "span" : {
-            "startLine" : 97,
-            "startCol" : 14,
-            "endLine" : 97,
-            "endCol" : 33
-          }
-        },
-        "span" : {
-          "startLine" : 97,
-          "startCol" : 4,
-          "endLine" : 97,
-          "endCol" : 33
-        }
-      },
-      {
-        "kind" : "StateField",
-        "name" : "inventory",
-        "typeExpr" : {
-          "kind" : "RelationType",
-          "fromType" : {
-            "kind" : "NamedType",
-            "name" : "SKU",
-            "span" : {
-              "startLine" : 98,
-              "startCol" : 15,
-              "endLine" : 98,
-              "endCol" : 18
-            }
-          },
-          "multiplicity" : "lone",
-          "toType" : {
-            "kind" : "NamedType",
-            "name" : "InventoryEntry",
-            "span" : {
-              "startLine" : 98,
-              "startCol" : 27,
-              "endLine" : 98,
-              "endCol" : 41
-            }
-          },
-          "span" : {
-            "startLine" : 98,
-            "startCol" : 15,
-            "endLine" : 98,
-            "endCol" : 41
-          }
-        },
-        "span" : {
-          "startLine" : 98,
-          "startCol" : 4,
-          "endLine" : 98,
-          "endCol" : 41
-        }
-      },
-      {
-        "kind" : "StateField",
-        "name" : "payments",
-        "typeExpr" : {
-          "kind" : "RelationType",
-          "fromType" : {
-            "kind" : "NamedType",
-            "name" : "Int",
-            "span" : {
               "startLine" : 99,
               "startCol" : 14,
               "endLine" : 99,
@@ -2000,7 +1962,7 @@
           "multiplicity" : "lone",
           "toType" : {
             "kind" : "NamedType",
-            "name" : "Payment",
+            "name" : "Product",
             "span" : {
               "startLine" : 99,
               "startCol" : 26,
@@ -2024,21 +1986,101 @@
       },
       {
         "kind" : "StateField",
-        "name" : "next_order_id",
+        "name" : "inventory",
         "typeExpr" : {
-          "kind" : "NamedType",
-          "name" : "OrderId",
+          "kind" : "RelationType",
+          "fromType" : {
+            "kind" : "NamedType",
+            "name" : "SKU",
+            "span" : {
+              "startLine" : 100,
+              "startCol" : 15,
+              "endLine" : 100,
+              "endCol" : 18
+            }
+          },
+          "multiplicity" : "lone",
+          "toType" : {
+            "kind" : "NamedType",
+            "name" : "InventoryEntry",
+            "span" : {
+              "startLine" : 100,
+              "startCol" : 27,
+              "endLine" : 100,
+              "endCol" : 41
+            }
+          },
           "span" : {
             "startLine" : 100,
-            "startCol" : 19,
+            "startCol" : 15,
             "endLine" : 100,
-            "endCol" : 26
+            "endCol" : 41
           }
         },
         "span" : {
           "startLine" : 100,
           "startCol" : 4,
           "endLine" : 100,
+          "endCol" : 41
+        }
+      },
+      {
+        "kind" : "StateField",
+        "name" : "payments",
+        "typeExpr" : {
+          "kind" : "RelationType",
+          "fromType" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 101,
+              "startCol" : 14,
+              "endLine" : 101,
+              "endCol" : 17
+            }
+          },
+          "multiplicity" : "lone",
+          "toType" : {
+            "kind" : "NamedType",
+            "name" : "Payment",
+            "span" : {
+              "startLine" : 101,
+              "startCol" : 26,
+              "endLine" : 101,
+              "endCol" : 33
+            }
+          },
+          "span" : {
+            "startLine" : 101,
+            "startCol" : 14,
+            "endLine" : 101,
+            "endCol" : 33
+          }
+        },
+        "span" : {
+          "startLine" : 101,
+          "startCol" : 4,
+          "endLine" : 101,
+          "endCol" : 33
+        }
+      },
+      {
+        "kind" : "StateField",
+        "name" : "next_order_id",
+        "typeExpr" : {
+          "kind" : "NamedType",
+          "name" : "OrderId",
+          "span" : {
+            "startLine" : 102,
+            "startCol" : 19,
+            "endLine" : 102,
+            "endCol" : 26
+          }
+        },
+        "span" : {
+          "startLine" : 102,
+          "startCol" : 4,
+          "endLine" : 102,
           "endCol" : 26
         }
       },
@@ -2049,24 +2091,24 @@
           "kind" : "NamedType",
           "name" : "Int",
           "span" : {
-            "startLine" : 101,
+            "startLine" : 103,
             "startCol" : 21,
-            "endLine" : 101,
+            "endLine" : 103,
             "endCol" : 24
           }
         },
         "span" : {
-          "startLine" : 101,
+          "startLine" : 103,
           "startCol" : 4,
-          "endLine" : 101,
+          "endLine" : 103,
           "endCol" : 24
         }
       }
     ],
     "span" : {
-      "startLine" : 95,
+      "startLine" : 97,
       "startCol" : 2,
-      "endLine" : 102,
+      "endLine" : 104,
       "endCol" : 3
     }
   },
@@ -2082,16 +2124,16 @@
             "kind" : "NamedType",
             "name" : "CustomerId",
             "span" : {
-              "startLine" : 123,
+              "startLine" : 125,
               "startCol" : 25,
-              "endLine" : 123,
+              "endLine" : 125,
               "endCol" : 35
             }
           },
           "span" : {
-            "startLine" : 123,
+            "startLine" : 125,
             "startCol" : 12,
-            "endLine" : 123,
+            "endLine" : 125,
             "endCol" : 35
           }
         }
@@ -2104,16 +2146,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 124,
+              "startLine" : 126,
               "startCol" : 19,
-              "endLine" : 124,
+              "endLine" : 126,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 124,
+            "startLine" : 126,
             "startCol" : 12,
-            "endLine" : 124,
+            "endLine" : 126,
             "endCol" : 24
           }
         }
@@ -2123,103 +2165,14 @@
           "kind" : "BoolLit",
           "value" : true,
           "span" : {
-            "startLine" : 127,
+            "startLine" : 129,
             "startCol" : 6,
-            "endLine" : 127,
+            "endLine" : 129,
             "endCol" : 10
           }
         }
       ],
       "ensures" : [
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Identifier",
-              "name" : "order",
-              "span" : {
-                "startLine" : 130,
-                "startCol" : 6,
-                "endLine" : 130,
-                "endCol" : 11
-              }
-            },
-            "field" : "id",
-            "span" : {
-              "startLine" : 130,
-              "startCol" : 6,
-              "endLine" : 130,
-              "endCol" : 14
-            }
-          },
-          "right" : {
-            "kind" : "Pre",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "next_order_id",
-              "span" : {
-                "startLine" : 130,
-                "startCol" : 21,
-                "endLine" : 130,
-                "endCol" : 34
-              }
-            },
-            "span" : {
-              "startLine" : 130,
-              "startCol" : 17,
-              "endLine" : 130,
-              "endCol" : 35
-            }
-          },
-          "span" : {
-            "startLine" : 130,
-            "startCol" : 6,
-            "endLine" : 130,
-            "endCol" : 35
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Identifier",
-              "name" : "order",
-              "span" : {
-                "startLine" : 131,
-                "startCol" : 6,
-                "endLine" : 131,
-                "endCol" : 11
-              }
-            },
-            "field" : "customer_id",
-            "span" : {
-              "startLine" : 131,
-              "startCol" : 6,
-              "endLine" : 131,
-              "endCol" : 23
-            }
-          },
-          "right" : {
-            "kind" : "Identifier",
-            "name" : "customer_id",
-            "span" : {
-              "startLine" : 131,
-              "startCol" : 26,
-              "endLine" : 131,
-              "endCol" : 37
-            }
-          },
-          "span" : {
-            "startLine" : 131,
-            "startCol" : 6,
-            "endLine" : 131,
-            "endCol" : 37
-          }
-        },
         {
           "kind" : "BinaryOp",
           "op" : "=",
@@ -2235,29 +2188,38 @@
                 "endCol" : 11
               }
             },
-            "field" : "status",
+            "field" : "id",
             "span" : {
               "startLine" : 132,
               "startCol" : 6,
               "endLine" : 132,
-              "endCol" : 18
+              "endCol" : 14
             }
           },
           "right" : {
-            "kind" : "Identifier",
-            "name" : "DRAFT",
+            "kind" : "Pre",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_order_id",
+              "span" : {
+                "startLine" : 132,
+                "startCol" : 21,
+                "endLine" : 132,
+                "endCol" : 34
+              }
+            },
             "span" : {
               "startLine" : 132,
-              "startCol" : 21,
+              "startCol" : 17,
               "endLine" : 132,
-              "endCol" : 26
+              "endCol" : 35
             }
           },
           "span" : {
             "startLine" : 132,
             "startCol" : 6,
             "endLine" : 132,
-            "endCol" : 26
+            "endCol" : 35
           }
         },
         {
@@ -2275,30 +2237,29 @@
                 "endCol" : 11
               }
             },
-            "field" : "items",
+            "field" : "customer_id",
             "span" : {
               "startLine" : 133,
               "startCol" : 6,
               "endLine" : 133,
-              "endCol" : 17
+              "endCol" : 23
             }
           },
           "right" : {
-            "kind" : "SetLiteral",
-            "elements" : [
-            ],
+            "kind" : "Identifier",
+            "name" : "customer_id",
             "span" : {
               "startLine" : 133,
-              "startCol" : 20,
+              "startCol" : 26,
               "endLine" : 133,
-              "endCol" : 22
+              "endCol" : 37
             }
           },
           "span" : {
             "startLine" : 133,
             "startCol" : 6,
             "endLine" : 133,
-            "endCol" : 22
+            "endCol" : 37
           }
         },
         {
@@ -2316,29 +2277,29 @@
                 "endCol" : 11
               }
             },
-            "field" : "subtotal",
+            "field" : "status",
             "span" : {
               "startLine" : 134,
               "startCol" : 6,
               "endLine" : 134,
-              "endCol" : 20
+              "endCol" : 18
             }
           },
           "right" : {
-            "kind" : "IntLit",
-            "value" : 0,
+            "kind" : "Identifier",
+            "name" : "DRAFT",
             "span" : {
               "startLine" : 134,
-              "startCol" : 23,
+              "startCol" : 21,
               "endLine" : 134,
-              "endCol" : 24
+              "endCol" : 26
             }
           },
           "span" : {
             "startLine" : 134,
             "startCol" : 6,
             "endLine" : 134,
-            "endCol" : 24
+            "endCol" : 26
           }
         },
         {
@@ -2356,29 +2317,30 @@
                 "endCol" : 11
               }
             },
-            "field" : "tax",
+            "field" : "items",
             "span" : {
               "startLine" : 135,
               "startCol" : 6,
               "endLine" : 135,
-              "endCol" : 15
+              "endCol" : 17
             }
           },
           "right" : {
-            "kind" : "IntLit",
-            "value" : 0,
+            "kind" : "SetLiteral",
+            "elements" : [
+            ],
             "span" : {
               "startLine" : 135,
-              "startCol" : 18,
+              "startCol" : 20,
               "endLine" : 135,
-              "endCol" : 19
+              "endCol" : 22
             }
           },
           "span" : {
             "startLine" : 135,
             "startCol" : 6,
             "endLine" : 135,
-            "endCol" : 19
+            "endCol" : 22
           }
         },
         {
@@ -2396,12 +2358,12 @@
                 "endCol" : 11
               }
             },
-            "field" : "total",
+            "field" : "subtotal",
             "span" : {
               "startLine" : 136,
               "startCol" : 6,
               "endLine" : 136,
-              "endCol" : 17
+              "endCol" : 20
             }
           },
           "right" : {
@@ -2409,15 +2371,95 @@
             "value" : 0,
             "span" : {
               "startLine" : 136,
-              "startCol" : 20,
+              "startCol" : 23,
               "endLine" : 136,
-              "endCol" : 21
+              "endCol" : 24
             }
           },
           "span" : {
             "startLine" : 136,
             "startCol" : 6,
             "endLine" : 136,
+            "endCol" : 24
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "order",
+              "span" : {
+                "startLine" : 137,
+                "startCol" : 6,
+                "endLine" : 137,
+                "endCol" : 11
+              }
+            },
+            "field" : "tax",
+            "span" : {
+              "startLine" : 137,
+              "startCol" : 6,
+              "endLine" : 137,
+              "endCol" : 15
+            }
+          },
+          "right" : {
+            "kind" : "IntLit",
+            "value" : 0,
+            "span" : {
+              "startLine" : 137,
+              "startCol" : 18,
+              "endLine" : 137,
+              "endCol" : 19
+            }
+          },
+          "span" : {
+            "startLine" : 137,
+            "startCol" : 6,
+            "endLine" : 137,
+            "endCol" : 19
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "order",
+              "span" : {
+                "startLine" : 138,
+                "startCol" : 6,
+                "endLine" : 138,
+                "endCol" : 11
+              }
+            },
+            "field" : "total",
+            "span" : {
+              "startLine" : 138,
+              "startCol" : 6,
+              "endLine" : 138,
+              "endCol" : 17
+            }
+          },
+          "right" : {
+            "kind" : "IntLit",
+            "value" : 0,
+            "span" : {
+              "startLine" : 138,
+              "startCol" : 20,
+              "endLine" : 138,
+              "endCol" : 21
+            }
+          },
+          "span" : {
+            "startLine" : 138,
+            "startCol" : 6,
+            "endLine" : 138,
             "endCol" : 21
           }
         },
@@ -2430,16 +2472,16 @@
               "kind" : "Identifier",
               "name" : "next_order_id",
               "span" : {
-                "startLine" : 137,
+                "startLine" : 139,
                 "startCol" : 6,
-                "endLine" : 137,
+                "endLine" : 139,
                 "endCol" : 19
               }
             },
             "span" : {
-              "startLine" : 137,
+              "startLine" : 139,
               "startCol" : 6,
-              "endLine" : 137,
+              "endLine" : 139,
               "endCol" : 20
             }
           },
@@ -2452,16 +2494,16 @@
                 "kind" : "Identifier",
                 "name" : "next_order_id",
                 "span" : {
-                  "startLine" : 137,
+                  "startLine" : 139,
                   "startCol" : 27,
-                  "endLine" : 137,
+                  "endLine" : 139,
                   "endCol" : 40
                 }
               },
               "span" : {
-                "startLine" : 137,
+                "startLine" : 139,
                 "startCol" : 23,
-                "endLine" : 137,
+                "endLine" : 139,
                 "endCol" : 41
               }
             },
@@ -2469,23 +2511,23 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 137,
+                "startLine" : 139,
                 "startCol" : 44,
-                "endLine" : 137,
+                "endLine" : 139,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 137,
+              "startLine" : 139,
               "startCol" : 23,
-              "endLine" : 137,
+              "endLine" : 139,
               "endCol" : 45
             }
           },
           "span" : {
-            "startLine" : 137,
+            "startLine" : 139,
             "startCol" : 6,
-            "endLine" : 137,
+            "endLine" : 139,
             "endCol" : 45
           }
         },
@@ -2498,16 +2540,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 138,
+                "startLine" : 140,
                 "startCol" : 6,
-                "endLine" : 138,
+                "endLine" : 140,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 138,
+              "startLine" : 140,
               "startCol" : 6,
-              "endLine" : 138,
+              "endLine" : 140,
               "endCol" : 13
             }
           },
@@ -2520,16 +2562,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 138,
+                  "startLine" : 140,
                   "startCol" : 20,
-                  "endLine" : 138,
+                  "endLine" : 140,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 138,
+                "startLine" : 140,
                 "startCol" : 16,
-                "endLine" : 138,
+                "endLine" : 140,
                 "endCol" : 27
               }
             },
@@ -2543,17 +2585,17 @@
                       "kind" : "Identifier",
                       "name" : "order",
                       "span" : {
-                        "startLine" : 138,
+                        "startLine" : 140,
                         "startCol" : 31,
-                        "endLine" : 138,
+                        "endLine" : 140,
                         "endCol" : 36
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 138,
+                      "startLine" : 140,
                       "startCol" : 31,
-                      "endLine" : 138,
+                      "endLine" : 140,
                       "endCol" : 39
                     }
                   },
@@ -2561,46 +2603,46 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 138,
+                      "startLine" : 140,
                       "startCol" : 43,
-                      "endLine" : 138,
+                      "endLine" : 140,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 138,
+                    "startLine" : 140,
                     "startCol" : 31,
-                    "endLine" : 138,
+                    "endLine" : 140,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 138,
+                "startLine" : 140,
                 "startCol" : 30,
-                "endLine" : 138,
+                "endLine" : 140,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 138,
+              "startLine" : 140,
               "startCol" : 16,
-              "endLine" : 138,
+              "endLine" : 140,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 138,
+            "startLine" : 140,
             "startCol" : 6,
-            "endLine" : 138,
+            "endLine" : 140,
             "endCol" : 49
           }
         }
       ],
       "span" : {
-        "startLine" : 122,
+        "startLine" : 124,
         "startCol" : 2,
-        "endLine" : 139,
+        "endLine" : 141,
         "endCol" : 3
       }
     },
@@ -2615,16 +2657,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 142,
+              "startLine" : 144,
               "startCol" : 22,
-              "endLine" : 142,
+              "endLine" : 144,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 142,
+            "startLine" : 144,
             "startCol" : 12,
-            "endLine" : 142,
+            "endLine" : 144,
             "endCol" : 29
           }
         },
@@ -2635,16 +2677,16 @@
             "kind" : "NamedType",
             "name" : "SKU",
             "span" : {
-              "startLine" : 142,
+              "startLine" : 144,
               "startCol" : 36,
-              "endLine" : 142,
+              "endLine" : 144,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 142,
+            "startLine" : 144,
             "startCol" : 31,
-            "endLine" : 142,
+            "endLine" : 144,
             "endCol" : 39
           }
         },
@@ -2655,16 +2697,16 @@
             "kind" : "NamedType",
             "name" : "Quantity",
             "span" : {
-              "startLine" : 142,
+              "startLine" : 144,
               "startCol" : 51,
-              "endLine" : 142,
+              "endLine" : 144,
               "endCol" : 59
             }
           },
           "span" : {
-            "startLine" : 142,
+            "startLine" : 144,
             "startCol" : 41,
-            "endLine" : 142,
+            "endLine" : 144,
             "endCol" : 59
           }
         }
@@ -2677,16 +2719,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 143,
+              "startLine" : 145,
               "startCol" : 19,
-              "endLine" : 143,
+              "endLine" : 145,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 143,
+            "startLine" : 145,
             "startCol" : 12,
-            "endLine" : 143,
+            "endLine" : 145,
             "endCol" : 24
           }
         }
@@ -2699,9 +2741,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 146,
+              "startLine" : 148,
               "startCol" : 6,
-              "endLine" : 146,
+              "endLine" : 148,
               "endCol" : 14
             }
           },
@@ -2709,16 +2751,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 146,
+              "startLine" : 148,
               "startCol" : 18,
-              "endLine" : 146,
+              "endLine" : 148,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 146,
+            "startLine" : 148,
             "startCol" : 6,
-            "endLine" : 146,
+            "endLine" : 148,
             "endCol" : 24
           }
         },
@@ -2733,9 +2775,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 147,
+                  "startLine" : 149,
                   "startCol" : 6,
-                  "endLine" : 147,
+                  "endLine" : 149,
                   "endCol" : 12
                 }
               },
@@ -2743,24 +2785,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 147,
+                  "startLine" : 149,
                   "startCol" : 13,
-                  "endLine" : 147,
+                  "endLine" : 149,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 147,
+                "startLine" : 149,
                 "startCol" : 6,
-                "endLine" : 147,
+                "endLine" : 149,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 147,
+              "startLine" : 149,
               "startCol" : 6,
-              "endLine" : 147,
+              "endLine" : 149,
               "endCol" : 29
             }
           },
@@ -2768,16 +2810,16 @@
             "kind" : "Identifier",
             "name" : "DRAFT",
             "span" : {
-              "startLine" : 147,
+              "startLine" : 149,
               "startCol" : 32,
-              "endLine" : 147,
+              "endLine" : 149,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 147,
+            "startLine" : 149,
             "startCol" : 6,
-            "endLine" : 147,
+            "endLine" : 149,
             "endCol" : 37
           }
         },
@@ -2788,9 +2830,9 @@
             "kind" : "Identifier",
             "name" : "sku",
             "span" : {
-              "startLine" : 148,
+              "startLine" : 150,
               "startCol" : 6,
-              "endLine" : 148,
+              "endLine" : 150,
               "endCol" : 9
             }
           },
@@ -2798,16 +2840,16 @@
             "kind" : "Identifier",
             "name" : "products",
             "span" : {
-              "startLine" : 148,
+              "startLine" : 150,
               "startCol" : 13,
-              "endLine" : 148,
+              "endLine" : 150,
               "endCol" : 21
             }
           },
           "span" : {
-            "startLine" : 148,
+            "startLine" : 150,
             "startCol" : 6,
-            "endLine" : 148,
+            "endLine" : 150,
             "endCol" : 21
           }
         },
@@ -2818,9 +2860,9 @@
             "kind" : "Identifier",
             "name" : "sku",
             "span" : {
-              "startLine" : 149,
+              "startLine" : 151,
               "startCol" : 6,
-              "endLine" : 149,
+              "endLine" : 151,
               "endCol" : 9
             }
           },
@@ -2828,16 +2870,16 @@
             "kind" : "Identifier",
             "name" : "inventory",
             "span" : {
-              "startLine" : 149,
+              "startLine" : 151,
               "startCol" : 13,
-              "endLine" : 149,
+              "endLine" : 151,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 149,
+            "startLine" : 151,
             "startCol" : 6,
-            "endLine" : 149,
+            "endLine" : 151,
             "endCol" : 22
           }
         },
@@ -2852,9 +2894,9 @@
                 "kind" : "Identifier",
                 "name" : "inventory",
                 "span" : {
-                  "startLine" : 150,
+                  "startLine" : 152,
                   "startCol" : 6,
-                  "endLine" : 150,
+                  "endLine" : 152,
                   "endCol" : 15
                 }
               },
@@ -2862,24 +2904,24 @@
                 "kind" : "Identifier",
                 "name" : "sku",
                 "span" : {
-                  "startLine" : 150,
+                  "startLine" : 152,
                   "startCol" : 16,
-                  "endLine" : 150,
+                  "endLine" : 152,
                   "endCol" : 19
                 }
               },
               "span" : {
-                "startLine" : 150,
+                "startLine" : 152,
                 "startCol" : 6,
-                "endLine" : 150,
+                "endLine" : 152,
                 "endCol" : 20
               }
             },
             "field" : "available",
             "span" : {
-              "startLine" : 150,
+              "startLine" : 152,
               "startCol" : 6,
-              "endLine" : 150,
+              "endLine" : 152,
               "endCol" : 30
             }
           },
@@ -2887,16 +2929,16 @@
             "kind" : "Identifier",
             "name" : "quantity",
             "span" : {
-              "startLine" : 150,
+              "startLine" : 152,
               "startCol" : 34,
-              "endLine" : 150,
+              "endLine" : 152,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 150,
+            "startLine" : 152,
             "startCol" : 6,
-            "endLine" : 150,
+            "endLine" : 152,
             "endCol" : 42
           }
         }
@@ -2911,9 +2953,9 @@
               "kind" : "Identifier",
               "name" : "products",
               "span" : {
-                "startLine" : 153,
+                "startLine" : 155,
                 "startCol" : 20,
-                "endLine" : 153,
+                "endLine" : 155,
                 "endCol" : 28
               }
             },
@@ -2921,16 +2963,16 @@
               "kind" : "Identifier",
               "name" : "sku",
               "span" : {
-                "startLine" : 153,
+                "startLine" : 155,
                 "startCol" : 29,
-                "endLine" : 153,
+                "endLine" : 155,
                 "endCol" : 32
               }
             },
             "span" : {
-              "startLine" : 153,
+              "startLine" : 155,
               "startCol" : 20,
-              "endLine" : 153,
+              "endLine" : 155,
               "endCol" : 33
             }
           },
@@ -2942,21 +2984,40 @@
               "typeName" : "LineItem",
               "fields" : [
                 {
+                  "name" : "order_id",
+                  "value" : {
+                    "kind" : "Identifier",
+                    "name" : "order_id",
+                    "span" : {
+                      "startLine" : 157,
+                      "startCol" : 19,
+                      "endLine" : 157,
+                      "endCol" : 27
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 157,
+                    "startCol" : 8,
+                    "endLine" : 157,
+                    "endCol" : 27
+                  }
+                },
+                {
                   "name" : "product_sku",
                   "value" : {
                     "kind" : "Identifier",
                     "name" : "sku",
                     "span" : {
-                      "startLine" : 155,
+                      "startLine" : 158,
                       "startCol" : 22,
-                      "endLine" : 155,
+                      "endLine" : 158,
                       "endCol" : 25
                     }
                   },
                   "span" : {
-                    "startLine" : 155,
+                    "startLine" : 158,
                     "startCol" : 8,
-                    "endLine" : 155,
+                    "endLine" : 158,
                     "endCol" : 25
                   }
                 },
@@ -2966,16 +3027,16 @@
                     "kind" : "Identifier",
                     "name" : "quantity",
                     "span" : {
-                      "startLine" : 156,
+                      "startLine" : 159,
                       "startCol" : 19,
-                      "endLine" : 156,
+                      "endLine" : 159,
                       "endCol" : 27
                     }
                   },
                   "span" : {
-                    "startLine" : 156,
+                    "startLine" : 159,
                     "startCol" : 8,
-                    "endLine" : 156,
+                    "endLine" : 159,
                     "endCol" : 27
                   }
                 },
@@ -2987,24 +3048,24 @@
                       "kind" : "Identifier",
                       "name" : "product",
                       "span" : {
-                        "startLine" : 157,
+                        "startLine" : 160,
                         "startCol" : 21,
-                        "endLine" : 157,
+                        "endLine" : 160,
                         "endCol" : 28
                       }
                     },
                     "field" : "price",
                     "span" : {
-                      "startLine" : 157,
+                      "startLine" : 160,
                       "startCol" : 21,
-                      "endLine" : 157,
+                      "endLine" : 160,
                       "endCol" : 34
                     }
                   },
                   "span" : {
-                    "startLine" : 157,
+                    "startLine" : 160,
                     "startCol" : 8,
-                    "endLine" : 157,
+                    "endLine" : 160,
                     "endCol" : 34
                   }
                 },
@@ -3019,17 +3080,17 @@
                         "kind" : "Identifier",
                         "name" : "product",
                         "span" : {
-                          "startLine" : 158,
+                          "startLine" : 161,
                           "startCol" : 21,
-                          "endLine" : 158,
+                          "endLine" : 161,
                           "endCol" : 28
                         }
                       },
                       "field" : "price",
                       "span" : {
-                        "startLine" : 158,
+                        "startLine" : 161,
                         "startCol" : 21,
-                        "endLine" : 158,
+                        "endLine" : 161,
                         "endCol" : 34
                       }
                     },
@@ -3037,31 +3098,31 @@
                       "kind" : "Identifier",
                       "name" : "quantity",
                       "span" : {
-                        "startLine" : 158,
+                        "startLine" : 161,
                         "startCol" : 37,
-                        "endLine" : 158,
+                        "endLine" : 161,
                         "endCol" : 45
                       }
                     },
                     "span" : {
-                      "startLine" : 158,
+                      "startLine" : 161,
                       "startCol" : 21,
-                      "endLine" : 158,
+                      "endLine" : 161,
                       "endCol" : 45
                     }
                   },
                   "span" : {
-                    "startLine" : 158,
+                    "startLine" : 161,
                     "startCol" : 8,
-                    "endLine" : 158,
+                    "endLine" : 161,
                     "endCol" : 45
                   }
                 }
               ],
               "span" : {
-                "startLine" : 154,
+                "startLine" : 156,
                 "startCol" : 17,
-                "endLine" : 159,
+                "endLine" : 162,
                 "endCol" : 7
               }
             },
@@ -3072,9 +3133,9 @@
                 "kind" : "Identifier",
                 "name" : "order",
                 "span" : {
-                  "startLine" : 160,
+                  "startLine" : 163,
                   "startCol" : 8,
-                  "endLine" : 160,
+                  "endLine" : 163,
                   "endCol" : 13
                 }
               },
@@ -3088,16 +3149,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 160,
+                        "startLine" : 163,
                         "startCol" : 20,
-                        "endLine" : 160,
+                        "endLine" : 163,
                         "endCol" : 26
                       }
                     },
                     "span" : {
-                      "startLine" : 160,
+                      "startLine" : 163,
                       "startCol" : 16,
-                      "endLine" : 160,
+                      "endLine" : 163,
                       "endCol" : 27
                     }
                   },
@@ -3105,16 +3166,16 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 160,
+                      "startLine" : 163,
                       "startCol" : 28,
-                      "endLine" : 160,
+                      "endLine" : 163,
                       "endCol" : 36
                     }
                   },
                   "span" : {
-                    "startLine" : 160,
+                    "startLine" : 163,
                     "startCol" : 16,
-                    "endLine" : 160,
+                    "endLine" : 163,
                     "endCol" : 37
                   }
                 },
@@ -3134,16 +3195,16 @@
                               "kind" : "Identifier",
                               "name" : "orders",
                               "span" : {
-                                "startLine" : 161,
+                                "startLine" : 164,
                                 "startCol" : 22,
-                                "endLine" : 161,
+                                "endLine" : 164,
                                 "endCol" : 28
                               }
                             },
                             "span" : {
-                              "startLine" : 161,
+                              "startLine" : 164,
                               "startCol" : 18,
-                              "endLine" : 161,
+                              "endLine" : 164,
                               "endCol" : 29
                             }
                           },
@@ -3151,24 +3212,24 @@
                             "kind" : "Identifier",
                             "name" : "order_id",
                             "span" : {
-                              "startLine" : 161,
+                              "startLine" : 164,
                               "startCol" : 30,
-                              "endLine" : 161,
+                              "endLine" : 164,
                               "endCol" : 38
                             }
                           },
                           "span" : {
-                            "startLine" : 161,
+                            "startLine" : 164,
                             "startCol" : 18,
-                            "endLine" : 161,
+                            "endLine" : 164,
                             "endCol" : 39
                           }
                         },
                         "field" : "items",
                         "span" : {
-                          "startLine" : 161,
+                          "startLine" : 164,
                           "startCol" : 18,
-                          "endLine" : 161,
+                          "endLine" : 164,
                           "endCol" : 45
                         }
                       },
@@ -3179,31 +3240,31 @@
                             "kind" : "Identifier",
                             "name" : "item",
                             "span" : {
-                              "startLine" : 161,
+                              "startLine" : 164,
                               "startCol" : 49,
-                              "endLine" : 161,
+                              "endLine" : 164,
                               "endCol" : 53
                             }
                           }
                         ],
                         "span" : {
-                          "startLine" : 161,
+                          "startLine" : 164,
                           "startCol" : 48,
-                          "endLine" : 161,
+                          "endLine" : 164,
                           "endCol" : 54
                         }
                       },
                       "span" : {
-                        "startLine" : 161,
+                        "startLine" : 164,
                         "startCol" : 18,
-                        "endLine" : 161,
+                        "endLine" : 164,
                         "endCol" : 54
                       }
                     },
                     "span" : {
-                      "startLine" : 161,
+                      "startLine" : 164,
                       "startCol" : 10,
-                      "endLine" : 161,
+                      "endLine" : 164,
                       "endCol" : 54
                     }
                   },
@@ -3222,16 +3283,16 @@
                               "kind" : "Identifier",
                               "name" : "orders",
                               "span" : {
-                                "startLine" : 162,
+                                "startLine" : 165,
                                 "startCol" : 25,
-                                "endLine" : 162,
+                                "endLine" : 165,
                                 "endCol" : 31
                               }
                             },
                             "span" : {
-                              "startLine" : 162,
+                              "startLine" : 165,
                               "startCol" : 21,
-                              "endLine" : 162,
+                              "endLine" : 165,
                               "endCol" : 32
                             }
                           },
@@ -3239,24 +3300,24 @@
                             "kind" : "Identifier",
                             "name" : "order_id",
                             "span" : {
-                              "startLine" : 162,
+                              "startLine" : 165,
                               "startCol" : 33,
-                              "endLine" : 162,
+                              "endLine" : 165,
                               "endCol" : 41
                             }
                           },
                           "span" : {
-                            "startLine" : 162,
+                            "startLine" : 165,
                             "startCol" : 21,
-                            "endLine" : 162,
+                            "endLine" : 165,
                             "endCol" : 42
                           }
                         },
                         "field" : "subtotal",
                         "span" : {
-                          "startLine" : 162,
+                          "startLine" : 165,
                           "startCol" : 21,
-                          "endLine" : 162,
+                          "endLine" : 165,
                           "endCol" : 51
                         }
                       },
@@ -3266,31 +3327,31 @@
                           "kind" : "Identifier",
                           "name" : "item",
                           "span" : {
-                            "startLine" : 162,
+                            "startLine" : 165,
                             "startCol" : 54,
-                            "endLine" : 162,
+                            "endLine" : 165,
                             "endCol" : 58
                           }
                         },
                         "field" : "line_total",
                         "span" : {
-                          "startLine" : 162,
+                          "startLine" : 165,
                           "startCol" : 54,
-                          "endLine" : 162,
+                          "endLine" : 165,
                           "endCol" : 69
                         }
                       },
                       "span" : {
-                        "startLine" : 162,
+                        "startLine" : 165,
                         "startCol" : 21,
-                        "endLine" : 162,
+                        "endLine" : 165,
                         "endCol" : 69
                       }
                     },
                     "span" : {
-                      "startLine" : 162,
+                      "startLine" : 165,
                       "startCol" : 10,
-                      "endLine" : 162,
+                      "endLine" : 165,
                       "endCol" : 69
                     }
                   },
@@ -3312,16 +3373,16 @@
                                 "kind" : "Identifier",
                                 "name" : "orders",
                                 "span" : {
-                                  "startLine" : 163,
+                                  "startLine" : 166,
                                   "startCol" : 22,
-                                  "endLine" : 163,
+                                  "endLine" : 166,
                                   "endCol" : 28
                                 }
                               },
                               "span" : {
-                                "startLine" : 163,
+                                "startLine" : 166,
                                 "startCol" : 18,
-                                "endLine" : 163,
+                                "endLine" : 166,
                                 "endCol" : 29
                               }
                             },
@@ -3329,24 +3390,24 @@
                               "kind" : "Identifier",
                               "name" : "order_id",
                               "span" : {
-                                "startLine" : 163,
+                                "startLine" : 166,
                                 "startCol" : 30,
-                                "endLine" : 163,
+                                "endLine" : 166,
                                 "endCol" : 38
                               }
                             },
                             "span" : {
-                              "startLine" : 163,
+                              "startLine" : 166,
                               "startCol" : 18,
-                              "endLine" : 163,
+                              "endLine" : 166,
                               "endCol" : 39
                             }
                           },
                           "field" : "subtotal",
                           "span" : {
-                            "startLine" : 163,
+                            "startLine" : 166,
                             "startCol" : 18,
-                            "endLine" : 163,
+                            "endLine" : 166,
                             "endCol" : 48
                           }
                         },
@@ -3356,24 +3417,24 @@
                             "kind" : "Identifier",
                             "name" : "item",
                             "span" : {
-                              "startLine" : 163,
+                              "startLine" : 166,
                               "startCol" : 51,
-                              "endLine" : 163,
+                              "endLine" : 166,
                               "endCol" : 55
                             }
                           },
                           "field" : "line_total",
                           "span" : {
-                            "startLine" : 163,
+                            "startLine" : 166,
                             "startCol" : 51,
-                            "endLine" : 163,
+                            "endLine" : 166,
                             "endCol" : 66
                           }
                         },
                         "span" : {
-                          "startLine" : 163,
+                          "startLine" : 166,
                           "startCol" : 18,
-                          "endLine" : 163,
+                          "endLine" : 166,
                           "endCol" : 66
                         }
                       },
@@ -3387,16 +3448,16 @@
                               "kind" : "Identifier",
                               "name" : "orders",
                               "span" : {
-                                "startLine" : 164,
+                                "startLine" : 167,
                                 "startCol" : 24,
-                                "endLine" : 164,
+                                "endLine" : 167,
                                 "endCol" : 30
                               }
                             },
                             "span" : {
-                              "startLine" : 164,
+                              "startLine" : 167,
                               "startCol" : 20,
-                              "endLine" : 164,
+                              "endLine" : 167,
                               "endCol" : 31
                             }
                           },
@@ -3404,67 +3465,67 @@
                             "kind" : "Identifier",
                             "name" : "order_id",
                             "span" : {
-                              "startLine" : 164,
+                              "startLine" : 167,
                               "startCol" : 32,
-                              "endLine" : 164,
+                              "endLine" : 167,
                               "endCol" : 40
                             }
                           },
                           "span" : {
-                            "startLine" : 164,
+                            "startLine" : 167,
                             "startCol" : 20,
-                            "endLine" : 164,
+                            "endLine" : 167,
                             "endCol" : 41
                           }
                         },
                         "field" : "tax",
                         "span" : {
-                          "startLine" : 164,
+                          "startLine" : 167,
                           "startCol" : 20,
-                          "endLine" : 164,
+                          "endLine" : 167,
                           "endCol" : 45
                         }
                       },
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 166,
                         "startCol" : 18,
-                        "endLine" : 164,
+                        "endLine" : 167,
                         "endCol" : 45
                       }
                     },
                     "span" : {
-                      "startLine" : 163,
+                      "startLine" : 166,
                       "startCol" : 10,
-                      "endLine" : 164,
+                      "endLine" : 167,
                       "endCol" : 45
                     }
                   }
                 ],
                 "span" : {
-                  "startLine" : 160,
+                  "startLine" : 163,
                   "startCol" : 16,
-                  "endLine" : 165,
+                  "endLine" : 168,
                   "endCol" : 9
                 }
               },
               "span" : {
-                "startLine" : 160,
+                "startLine" : 163,
                 "startCol" : 8,
-                "endLine" : 165,
+                "endLine" : 168,
                 "endCol" : 9
               }
             },
             "span" : {
-              "startLine" : 154,
+              "startLine" : 156,
               "startCol" : 6,
-              "endLine" : 165,
+              "endLine" : 168,
               "endCol" : 9
             }
           },
           "span" : {
-            "startLine" : 153,
+            "startLine" : 155,
             "startCol" : 6,
-            "endLine" : 165,
+            "endLine" : 168,
             "endCol" : 9
           }
         },
@@ -3477,16 +3538,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 166,
+                "startLine" : 169,
                 "startCol" : 8,
-                "endLine" : 166,
+                "endLine" : 169,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 166,
+              "startLine" : 169,
               "startCol" : 8,
-              "endLine" : 166,
+              "endLine" : 169,
               "endCol" : 15
             }
           },
@@ -3499,16 +3560,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 166,
+                  "startLine" : 169,
                   "startCol" : 22,
-                  "endLine" : 166,
+                  "endLine" : 169,
                   "endCol" : 28
                 }
               },
               "span" : {
-                "startLine" : 166,
+                "startLine" : 169,
                 "startCol" : 18,
-                "endLine" : 166,
+                "endLine" : 169,
                 "endCol" : 29
               }
             },
@@ -3520,9 +3581,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 166,
+                      "startLine" : 169,
                       "startCol" : 33,
-                      "endLine" : 166,
+                      "endLine" : 169,
                       "endCol" : 41
                     }
                   },
@@ -3530,38 +3591,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 166,
+                      "startLine" : 169,
                       "startCol" : 45,
-                      "endLine" : 166,
+                      "endLine" : 169,
                       "endCol" : 50
                     }
                   },
                   "span" : {
-                    "startLine" : 166,
+                    "startLine" : 169,
                     "startCol" : 33,
-                    "endLine" : 166,
+                    "endLine" : 169,
                     "endCol" : 41
                   }
                 }
               ],
               "span" : {
-                "startLine" : 166,
+                "startLine" : 169,
                 "startCol" : 32,
-                "endLine" : 166,
+                "endLine" : 169,
                 "endCol" : 51
               }
             },
             "span" : {
-              "startLine" : 166,
+              "startLine" : 169,
               "startCol" : 18,
-              "endLine" : 166,
+              "endLine" : 169,
               "endCol" : 51
             }
           },
           "span" : {
-            "startLine" : 166,
+            "startLine" : 169,
             "startCol" : 8,
-            "endLine" : 166,
+            "endLine" : 169,
             "endCol" : 51
           }
         },
@@ -3578,16 +3639,16 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 167,
+                    "startLine" : 170,
                     "startCol" : 8,
-                    "endLine" : 167,
+                    "endLine" : 170,
                     "endCol" : 17
                   }
                 },
                 "span" : {
-                  "startLine" : 167,
+                  "startLine" : 170,
                   "startCol" : 8,
-                  "endLine" : 167,
+                  "endLine" : 170,
                   "endCol" : 18
                 }
               },
@@ -3595,24 +3656,24 @@
                 "kind" : "Identifier",
                 "name" : "sku",
                 "span" : {
-                  "startLine" : 167,
+                  "startLine" : 170,
                   "startCol" : 19,
-                  "endLine" : 167,
+                  "endLine" : 170,
                   "endCol" : 22
                 }
               },
               "span" : {
-                "startLine" : 167,
+                "startLine" : 170,
                 "startCol" : 8,
-                "endLine" : 167,
+                "endLine" : 170,
                 "endCol" : 23
               }
             },
             "field" : "reserved",
             "span" : {
-              "startLine" : 167,
+              "startLine" : 170,
               "startCol" : 8,
-              "endLine" : 167,
+              "endLine" : 170,
               "endCol" : 32
             }
           },
@@ -3629,16 +3690,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 168,
+                      "startLine" : 171,
                       "startCol" : 14,
-                      "endLine" : 168,
+                      "endLine" : 171,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 168,
+                    "startLine" : 171,
                     "startCol" : 10,
-                    "endLine" : 168,
+                    "endLine" : 171,
                     "endCol" : 24
                   }
                 },
@@ -3646,24 +3707,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 168,
+                    "startLine" : 171,
                     "startCol" : 25,
-                    "endLine" : 168,
+                    "endLine" : 171,
                     "endCol" : 28
                   }
                 },
                 "span" : {
-                  "startLine" : 168,
+                  "startLine" : 171,
                   "startCol" : 10,
-                  "endLine" : 168,
+                  "endLine" : 171,
                   "endCol" : 29
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 168,
+                "startLine" : 171,
                 "startCol" : 10,
-                "endLine" : 168,
+                "endLine" : 171,
                 "endCol" : 38
               }
             },
@@ -3671,23 +3732,23 @@
               "kind" : "Identifier",
               "name" : "quantity",
               "span" : {
-                "startLine" : 168,
+                "startLine" : 171,
                 "startCol" : 41,
-                "endLine" : 168,
+                "endLine" : 171,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 168,
+              "startLine" : 171,
               "startCol" : 10,
-              "endLine" : 168,
+              "endLine" : 171,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 167,
+            "startLine" : 170,
             "startCol" : 8,
-            "endLine" : 168,
+            "endLine" : 171,
             "endCol" : 49
           }
         },
@@ -3704,16 +3765,16 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 169,
+                    "startLine" : 172,
                     "startCol" : 8,
-                    "endLine" : 169,
+                    "endLine" : 172,
                     "endCol" : 17
                   }
                 },
                 "span" : {
-                  "startLine" : 169,
+                  "startLine" : 172,
                   "startCol" : 8,
-                  "endLine" : 169,
+                  "endLine" : 172,
                   "endCol" : 18
                 }
               },
@@ -3721,24 +3782,24 @@
                 "kind" : "Identifier",
                 "name" : "sku",
                 "span" : {
-                  "startLine" : 169,
+                  "startLine" : 172,
                   "startCol" : 19,
-                  "endLine" : 169,
+                  "endLine" : 172,
                   "endCol" : 22
                 }
               },
               "span" : {
-                "startLine" : 169,
+                "startLine" : 172,
                 "startCol" : 8,
-                "endLine" : 169,
+                "endLine" : 172,
                 "endCol" : 23
               }
             },
             "field" : "available",
             "span" : {
-              "startLine" : 169,
+              "startLine" : 172,
               "startCol" : 8,
-              "endLine" : 169,
+              "endLine" : 172,
               "endCol" : 33
             }
           },
@@ -3755,16 +3816,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 170,
+                      "startLine" : 173,
                       "startCol" : 14,
-                      "endLine" : 170,
+                      "endLine" : 173,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 170,
+                    "startLine" : 173,
                     "startCol" : 10,
-                    "endLine" : 170,
+                    "endLine" : 173,
                     "endCol" : 24
                   }
                 },
@@ -3772,24 +3833,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 170,
+                    "startLine" : 173,
                     "startCol" : 25,
-                    "endLine" : 170,
+                    "endLine" : 173,
                     "endCol" : 28
                   }
                 },
                 "span" : {
-                  "startLine" : 170,
+                  "startLine" : 173,
                   "startCol" : 10,
-                  "endLine" : 170,
+                  "endLine" : 173,
                   "endCol" : 29
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 170,
+                "startLine" : 173,
                 "startCol" : 10,
-                "endLine" : 170,
+                "endLine" : 173,
                 "endCol" : 39
               }
             },
@@ -3797,31 +3858,31 @@
               "kind" : "Identifier",
               "name" : "quantity",
               "span" : {
-                "startLine" : 170,
+                "startLine" : 173,
                 "startCol" : 42,
-                "endLine" : 170,
+                "endLine" : 173,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 170,
+              "startLine" : 173,
               "startCol" : 10,
-              "endLine" : 170,
+              "endLine" : 173,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 169,
+            "startLine" : 172,
             "startCol" : 8,
-            "endLine" : 170,
+            "endLine" : 173,
             "endCol" : 50
           }
         }
       ],
       "span" : {
-        "startLine" : 141,
+        "startLine" : 143,
         "startCol" : 2,
-        "endLine" : 171,
+        "endLine" : 174,
         "endCol" : 3
       }
     },
@@ -3836,16 +3897,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 174,
+              "startLine" : 177,
               "startCol" : 22,
-              "endLine" : 174,
+              "endLine" : 177,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 174,
+            "startLine" : 177,
             "startCol" : 12,
-            "endLine" : 174,
+            "endLine" : 177,
             "endCol" : 29
           }
         },
@@ -3856,16 +3917,16 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 174,
+              "startLine" : 177,
               "startCol" : 40,
-              "endLine" : 174,
+              "endLine" : 177,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 174,
+            "startLine" : 177,
             "startCol" : 31,
-            "endLine" : 174,
+            "endLine" : 177,
             "endCol" : 43
           }
         }
@@ -3878,16 +3939,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 175,
+              "startLine" : 178,
               "startCol" : 19,
-              "endLine" : 175,
+              "endLine" : 178,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 175,
+            "startLine" : 178,
             "startCol" : 12,
-            "endLine" : 175,
+            "endLine" : 178,
             "endCol" : 24
           }
         }
@@ -3900,9 +3961,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 178,
+              "startLine" : 181,
               "startCol" : 6,
-              "endLine" : 178,
+              "endLine" : 181,
               "endCol" : 14
             }
           },
@@ -3910,16 +3971,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 178,
+              "startLine" : 181,
               "startCol" : 18,
-              "endLine" : 178,
+              "endLine" : 181,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 178,
+            "startLine" : 181,
             "startCol" : 6,
-            "endLine" : 178,
+            "endLine" : 181,
             "endCol" : 24
           }
         },
@@ -3934,9 +3995,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 179,
+                  "startLine" : 182,
                   "startCol" : 6,
-                  "endLine" : 179,
+                  "endLine" : 182,
                   "endCol" : 12
                 }
               },
@@ -3944,24 +4005,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 179,
+                  "startLine" : 182,
                   "startCol" : 13,
-                  "endLine" : 179,
+                  "endLine" : 182,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 179,
+                "startLine" : 182,
                 "startCol" : 6,
-                "endLine" : 179,
+                "endLine" : 182,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 179,
+              "startLine" : 182,
               "startCol" : 6,
-              "endLine" : 179,
+              "endLine" : 182,
               "endCol" : 29
             }
           },
@@ -3969,16 +4030,16 @@
             "kind" : "Identifier",
             "name" : "DRAFT",
             "span" : {
-              "startLine" : 179,
+              "startLine" : 182,
               "startCol" : 32,
-              "endLine" : 179,
+              "endLine" : 182,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 179,
+            "startLine" : 182,
             "startCol" : 6,
-            "endLine" : 179,
+            "endLine" : 182,
             "endCol" : 37
           }
         },
@@ -3996,9 +4057,9 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 180,
+                      "startLine" : 183,
                       "startCol" : 16,
-                      "endLine" : 180,
+                      "endLine" : 183,
                       "endCol" : 22
                     }
                   },
@@ -4006,32 +4067,32 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 180,
+                      "startLine" : 183,
                       "startCol" : 23,
-                      "endLine" : 180,
+                      "endLine" : 183,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 180,
+                    "startLine" : 183,
                     "startCol" : 16,
-                    "endLine" : 180,
+                    "endLine" : 183,
                     "endCol" : 32
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 180,
+                  "startLine" : 183,
                   "startCol" : 16,
-                  "endLine" : 180,
+                  "endLine" : 183,
                   "endCol" : 38
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 180,
+                "startLine" : 183,
                 "startCol" : 11,
-                "endLine" : 180,
+                "endLine" : 183,
                 "endCol" : 38
               }
             }
@@ -4045,17 +4106,17 @@
                 "kind" : "Identifier",
                 "name" : "i",
                 "span" : {
-                  "startLine" : 180,
+                  "startLine" : 183,
                   "startCol" : 41,
-                  "endLine" : 180,
+                  "endLine" : 183,
                   "endCol" : 42
                 }
               },
               "field" : "id",
               "span" : {
-                "startLine" : 180,
+                "startLine" : 183,
                 "startCol" : 41,
-                "endLine" : 180,
+                "endLine" : 183,
                 "endCol" : 45
               }
             },
@@ -4063,23 +4124,23 @@
               "kind" : "Identifier",
               "name" : "item_id",
               "span" : {
-                "startLine" : 180,
+                "startLine" : 183,
                 "startCol" : 48,
-                "endLine" : 180,
+                "endLine" : 183,
                 "endCol" : 55
               }
             },
             "span" : {
-              "startLine" : 180,
+              "startLine" : 183,
               "startCol" : 41,
-              "endLine" : 180,
+              "endLine" : 183,
               "endCol" : 55
             }
           },
           "span" : {
-            "startLine" : 180,
+            "startLine" : 183,
             "startCol" : 6,
-            "endLine" : 180,
+            "endLine" : 183,
             "endCol" : 55
           }
         }
@@ -4101,16 +4162,16 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 183,
+                      "startLine" : 186,
                       "startCol" : 34,
-                      "endLine" : 183,
+                      "endLine" : 186,
                       "endCol" : 40
                     }
                   },
                   "span" : {
-                    "startLine" : 183,
+                    "startLine" : 186,
                     "startCol" : 30,
-                    "endLine" : 183,
+                    "endLine" : 186,
                     "endCol" : 41
                   }
                 },
@@ -4118,24 +4179,24 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 183,
+                    "startLine" : 186,
                     "startCol" : 42,
-                    "endLine" : 183,
+                    "endLine" : 186,
                     "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 183,
+                  "startLine" : 186,
                   "startCol" : 30,
-                  "endLine" : 183,
+                  "endLine" : 186,
                   "endCol" : 51
                 }
               },
               "field" : "items",
               "span" : {
-                "startLine" : 183,
+                "startLine" : 186,
                 "startCol" : 30,
-                "endLine" : 183,
+                "endLine" : 186,
                 "endCol" : 57
               }
             },
@@ -4148,17 +4209,17 @@
                   "kind" : "Identifier",
                   "name" : "i",
                   "span" : {
-                    "startLine" : 184,
+                    "startLine" : 187,
                     "startCol" : 22,
-                    "endLine" : 184,
+                    "endLine" : 187,
                     "endCol" : 23
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 184,
+                  "startLine" : 187,
                   "startCol" : 22,
-                  "endLine" : 184,
+                  "endLine" : 187,
                   "endCol" : 26
                 }
               },
@@ -4166,23 +4227,23 @@
                 "kind" : "Identifier",
                 "name" : "item_id",
                 "span" : {
-                  "startLine" : 184,
+                  "startLine" : 187,
                   "startCol" : 29,
-                  "endLine" : 184,
+                  "endLine" : 187,
                   "endCol" : 36
                 }
               },
               "span" : {
-                "startLine" : 184,
+                "startLine" : 187,
                 "startCol" : 22,
-                "endLine" : 184,
+                "endLine" : 187,
                 "endCol" : 36
               }
             },
             "span" : {
-              "startLine" : 183,
+              "startLine" : 186,
               "startCol" : 21,
-              "endLine" : 184,
+              "endLine" : 187,
               "endCol" : 36
             }
           },
@@ -4193,9 +4254,9 @@
               "kind" : "Identifier",
               "name" : "order",
               "span" : {
-                "startLine" : 185,
+                "startLine" : 188,
                 "startCol" : 8,
-                "endLine" : 185,
+                "endLine" : 188,
                 "endCol" : 13
               }
             },
@@ -4209,16 +4270,16 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 185,
+                      "startLine" : 188,
                       "startCol" : 20,
-                      "endLine" : 185,
+                      "endLine" : 188,
                       "endCol" : 26
                     }
                   },
                   "span" : {
-                    "startLine" : 185,
+                    "startLine" : 188,
                     "startCol" : 16,
-                    "endLine" : 185,
+                    "endLine" : 188,
                     "endCol" : 27
                   }
                 },
@@ -4226,16 +4287,16 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 185,
+                    "startLine" : 188,
                     "startCol" : 28,
-                    "endLine" : 185,
+                    "endLine" : 188,
                     "endCol" : 36
                   }
                 },
                 "span" : {
-                  "startLine" : 185,
+                  "startLine" : 188,
                   "startCol" : 16,
-                  "endLine" : 185,
+                  "endLine" : 188,
                   "endCol" : 37
                 }
               },
@@ -4255,16 +4316,16 @@
                             "kind" : "Identifier",
                             "name" : "orders",
                             "span" : {
-                              "startLine" : 186,
+                              "startLine" : 189,
                               "startCol" : 22,
-                              "endLine" : 186,
+                              "endLine" : 189,
                               "endCol" : 28
                             }
                           },
                           "span" : {
-                            "startLine" : 186,
+                            "startLine" : 189,
                             "startCol" : 18,
-                            "endLine" : 186,
+                            "endLine" : 189,
                             "endCol" : 29
                           }
                         },
@@ -4272,24 +4333,24 @@
                           "kind" : "Identifier",
                           "name" : "order_id",
                           "span" : {
-                            "startLine" : 186,
+                            "startLine" : 189,
                             "startCol" : 30,
-                            "endLine" : 186,
+                            "endLine" : 189,
                             "endCol" : 38
                           }
                         },
                         "span" : {
-                          "startLine" : 186,
+                          "startLine" : 189,
                           "startCol" : 18,
-                          "endLine" : 186,
+                          "endLine" : 189,
                           "endCol" : 39
                         }
                       },
                       "field" : "items",
                       "span" : {
-                        "startLine" : 186,
+                        "startLine" : 189,
                         "startCol" : 18,
-                        "endLine" : 186,
+                        "endLine" : 189,
                         "endCol" : 45
                       }
                     },
@@ -4300,31 +4361,31 @@
                           "kind" : "Identifier",
                           "name" : "removed",
                           "span" : {
-                            "startLine" : 186,
+                            "startLine" : 189,
                             "startCol" : 49,
-                            "endLine" : 186,
+                            "endLine" : 189,
                             "endCol" : 56
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 186,
+                        "startLine" : 189,
                         "startCol" : 48,
-                        "endLine" : 186,
+                        "endLine" : 189,
                         "endCol" : 57
                       }
                     },
                     "span" : {
-                      "startLine" : 186,
+                      "startLine" : 189,
                       "startCol" : 18,
-                      "endLine" : 186,
+                      "endLine" : 189,
                       "endCol" : 57
                     }
                   },
                   "span" : {
-                    "startLine" : 186,
+                    "startLine" : 189,
                     "startCol" : 10,
-                    "endLine" : 186,
+                    "endLine" : 189,
                     "endCol" : 57
                   }
                 },
@@ -4343,16 +4404,16 @@
                             "kind" : "Identifier",
                             "name" : "orders",
                             "span" : {
-                              "startLine" : 187,
+                              "startLine" : 190,
                               "startCol" : 25,
-                              "endLine" : 187,
+                              "endLine" : 190,
                               "endCol" : 31
                             }
                           },
                           "span" : {
-                            "startLine" : 187,
+                            "startLine" : 190,
                             "startCol" : 21,
-                            "endLine" : 187,
+                            "endLine" : 190,
                             "endCol" : 32
                           }
                         },
@@ -4360,24 +4421,24 @@
                           "kind" : "Identifier",
                           "name" : "order_id",
                           "span" : {
-                            "startLine" : 187,
+                            "startLine" : 190,
                             "startCol" : 33,
-                            "endLine" : 187,
+                            "endLine" : 190,
                             "endCol" : 41
                           }
                         },
                         "span" : {
-                          "startLine" : 187,
+                          "startLine" : 190,
                           "startCol" : 21,
-                          "endLine" : 187,
+                          "endLine" : 190,
                           "endCol" : 42
                         }
                       },
                       "field" : "subtotal",
                       "span" : {
-                        "startLine" : 187,
+                        "startLine" : 190,
                         "startCol" : 21,
-                        "endLine" : 187,
+                        "endLine" : 190,
                         "endCol" : 51
                       }
                     },
@@ -4387,31 +4448,31 @@
                         "kind" : "Identifier",
                         "name" : "removed",
                         "span" : {
-                          "startLine" : 187,
+                          "startLine" : 190,
                           "startCol" : 54,
-                          "endLine" : 187,
+                          "endLine" : 190,
                           "endCol" : 61
                         }
                       },
                       "field" : "line_total",
                       "span" : {
-                        "startLine" : 187,
+                        "startLine" : 190,
                         "startCol" : 54,
-                        "endLine" : 187,
+                        "endLine" : 190,
                         "endCol" : 72
                       }
                     },
                     "span" : {
-                      "startLine" : 187,
+                      "startLine" : 190,
                       "startCol" : 21,
-                      "endLine" : 187,
+                      "endLine" : 190,
                       "endCol" : 72
                     }
                   },
                   "span" : {
-                    "startLine" : 187,
+                    "startLine" : 190,
                     "startCol" : 10,
-                    "endLine" : 187,
+                    "endLine" : 190,
                     "endCol" : 72
                   }
                 },
@@ -4430,16 +4491,16 @@
                             "kind" : "Identifier",
                             "name" : "orders",
                             "span" : {
-                              "startLine" : 188,
+                              "startLine" : 191,
                               "startCol" : 22,
-                              "endLine" : 188,
+                              "endLine" : 191,
                               "endCol" : 28
                             }
                           },
                           "span" : {
-                            "startLine" : 188,
+                            "startLine" : 191,
                             "startCol" : 18,
-                            "endLine" : 188,
+                            "endLine" : 191,
                             "endCol" : 29
                           }
                         },
@@ -4447,24 +4508,24 @@
                           "kind" : "Identifier",
                           "name" : "order_id",
                           "span" : {
-                            "startLine" : 188,
+                            "startLine" : 191,
                             "startCol" : 30,
-                            "endLine" : 188,
+                            "endLine" : 191,
                             "endCol" : 38
                           }
                         },
                         "span" : {
-                          "startLine" : 188,
+                          "startLine" : 191,
                           "startCol" : 18,
-                          "endLine" : 188,
+                          "endLine" : 191,
                           "endCol" : 39
                         }
                       },
                       "field" : "subtotal",
                       "span" : {
-                        "startLine" : 188,
+                        "startLine" : 191,
                         "startCol" : 18,
-                        "endLine" : 188,
+                        "endLine" : 191,
                         "endCol" : 48
                       }
                     },
@@ -4477,17 +4538,17 @@
                           "kind" : "Identifier",
                           "name" : "removed",
                           "span" : {
-                            "startLine" : 188,
+                            "startLine" : 191,
                             "startCol" : 51,
-                            "endLine" : 188,
+                            "endLine" : 191,
                             "endCol" : 58
                           }
                         },
                         "field" : "line_total",
                         "span" : {
-                          "startLine" : 188,
+                          "startLine" : 191,
                           "startCol" : 51,
-                          "endLine" : 188,
+                          "endLine" : 191,
                           "endCol" : 69
                         }
                       },
@@ -4501,16 +4562,16 @@
                               "kind" : "Identifier",
                               "name" : "orders",
                               "span" : {
-                                "startLine" : 189,
+                                "startLine" : 192,
                                 "startCol" : 24,
-                                "endLine" : 189,
+                                "endLine" : 192,
                                 "endCol" : 30
                               }
                             },
                             "span" : {
-                              "startLine" : 189,
+                              "startLine" : 192,
                               "startCol" : 20,
-                              "endLine" : 189,
+                              "endLine" : 192,
                               "endCol" : 31
                             }
                           },
@@ -4518,67 +4579,67 @@
                             "kind" : "Identifier",
                             "name" : "order_id",
                             "span" : {
-                              "startLine" : 189,
+                              "startLine" : 192,
                               "startCol" : 32,
-                              "endLine" : 189,
+                              "endLine" : 192,
                               "endCol" : 40
                             }
                           },
                           "span" : {
-                            "startLine" : 189,
+                            "startLine" : 192,
                             "startCol" : 20,
-                            "endLine" : 189,
+                            "endLine" : 192,
                             "endCol" : 41
                           }
                         },
                         "field" : "tax",
                         "span" : {
-                          "startLine" : 189,
+                          "startLine" : 192,
                           "startCol" : 20,
-                          "endLine" : 189,
+                          "endLine" : 192,
                           "endCol" : 45
                         }
                       },
                       "span" : {
-                        "startLine" : 188,
+                        "startLine" : 191,
                         "startCol" : 51,
-                        "endLine" : 189,
+                        "endLine" : 192,
                         "endCol" : 45
                       }
                     },
                     "span" : {
-                      "startLine" : 188,
+                      "startLine" : 191,
                       "startCol" : 18,
-                      "endLine" : 189,
+                      "endLine" : 192,
                       "endCol" : 45
                     }
                   },
                   "span" : {
-                    "startLine" : 188,
+                    "startLine" : 191,
                     "startCol" : 10,
-                    "endLine" : 189,
+                    "endLine" : 192,
                     "endCol" : 45
                   }
                 }
               ],
               "span" : {
-                "startLine" : 185,
+                "startLine" : 188,
                 "startCol" : 16,
-                "endLine" : 190,
+                "endLine" : 193,
                 "endCol" : 9
               }
             },
             "span" : {
-              "startLine" : 185,
+              "startLine" : 188,
               "startCol" : 8,
-              "endLine" : 190,
+              "endLine" : 193,
               "endCol" : 9
             }
           },
           "span" : {
-            "startLine" : 183,
+            "startLine" : 186,
             "startCol" : 6,
-            "endLine" : 190,
+            "endLine" : 193,
             "endCol" : 9
           }
         },
@@ -4591,16 +4652,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 191,
+                "startLine" : 194,
                 "startCol" : 8,
-                "endLine" : 191,
+                "endLine" : 194,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 191,
+              "startLine" : 194,
               "startCol" : 8,
-              "endLine" : 191,
+              "endLine" : 194,
               "endCol" : 15
             }
           },
@@ -4613,16 +4674,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 191,
+                  "startLine" : 194,
                   "startCol" : 22,
-                  "endLine" : 191,
+                  "endLine" : 194,
                   "endCol" : 28
                 }
               },
               "span" : {
-                "startLine" : 191,
+                "startLine" : 194,
                 "startCol" : 18,
-                "endLine" : 191,
+                "endLine" : 194,
                 "endCol" : 29
               }
             },
@@ -4634,9 +4695,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 191,
+                      "startLine" : 194,
                       "startCol" : 33,
-                      "endLine" : 191,
+                      "endLine" : 194,
                       "endCol" : 41
                     }
                   },
@@ -4644,38 +4705,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 191,
+                      "startLine" : 194,
                       "startCol" : 45,
-                      "endLine" : 191,
+                      "endLine" : 194,
                       "endCol" : 50
                     }
                   },
                   "span" : {
-                    "startLine" : 191,
+                    "startLine" : 194,
                     "startCol" : 33,
-                    "endLine" : 191,
+                    "endLine" : 194,
                     "endCol" : 41
                   }
                 }
               ],
               "span" : {
-                "startLine" : 191,
+                "startLine" : 194,
                 "startCol" : 32,
-                "endLine" : 191,
+                "endLine" : 194,
                 "endCol" : 51
               }
             },
             "span" : {
-              "startLine" : 191,
+              "startLine" : 194,
               "startCol" : 18,
-              "endLine" : 191,
+              "endLine" : 194,
               "endCol" : 51
             }
           },
           "span" : {
-            "startLine" : 191,
+            "startLine" : 194,
             "startCol" : 8,
-            "endLine" : 191,
+            "endLine" : 194,
             "endCol" : 51
           }
         },
@@ -4692,16 +4753,16 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 192,
+                    "startLine" : 195,
                     "startCol" : 8,
-                    "endLine" : 192,
+                    "endLine" : 195,
                     "endCol" : 17
                   }
                 },
                 "span" : {
-                  "startLine" : 192,
+                  "startLine" : 195,
                   "startCol" : 8,
-                  "endLine" : 192,
+                  "endLine" : 195,
                   "endCol" : 18
                 }
               },
@@ -4711,32 +4772,32 @@
                   "kind" : "Identifier",
                   "name" : "removed",
                   "span" : {
-                    "startLine" : 192,
+                    "startLine" : 195,
                     "startCol" : 19,
-                    "endLine" : 192,
+                    "endLine" : 195,
                     "endCol" : 26
                   }
                 },
                 "field" : "product_sku",
                 "span" : {
-                  "startLine" : 192,
+                  "startLine" : 195,
                   "startCol" : 19,
-                  "endLine" : 192,
+                  "endLine" : 195,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 192,
+                "startLine" : 195,
                 "startCol" : 8,
-                "endLine" : 192,
+                "endLine" : 195,
                 "endCol" : 39
               }
             },
             "field" : "reserved",
             "span" : {
-              "startLine" : 192,
+              "startLine" : 195,
               "startCol" : 8,
-              "endLine" : 192,
+              "endLine" : 195,
               "endCol" : 48
             }
           },
@@ -4753,16 +4814,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 193,
+                      "startLine" : 196,
                       "startCol" : 14,
-                      "endLine" : 193,
+                      "endLine" : 196,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 193,
+                    "startLine" : 196,
                     "startCol" : 10,
-                    "endLine" : 193,
+                    "endLine" : 196,
                     "endCol" : 24
                   }
                 },
@@ -4772,32 +4833,32 @@
                     "kind" : "Identifier",
                     "name" : "removed",
                     "span" : {
-                      "startLine" : 193,
+                      "startLine" : 196,
                       "startCol" : 25,
-                      "endLine" : 193,
+                      "endLine" : 196,
                       "endCol" : 32
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 193,
+                    "startLine" : 196,
                     "startCol" : 25,
-                    "endLine" : 193,
+                    "endLine" : 196,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 193,
+                  "startLine" : 196,
                   "startCol" : 10,
-                  "endLine" : 193,
+                  "endLine" : 196,
                   "endCol" : 45
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 193,
+                "startLine" : 196,
                 "startCol" : 10,
-                "endLine" : 193,
+                "endLine" : 196,
                 "endCol" : 54
               }
             },
@@ -4807,31 +4868,31 @@
                 "kind" : "Identifier",
                 "name" : "removed",
                 "span" : {
-                  "startLine" : 193,
+                  "startLine" : 196,
                   "startCol" : 57,
-                  "endLine" : 193,
+                  "endLine" : 196,
                   "endCol" : 64
                 }
               },
               "field" : "quantity",
               "span" : {
-                "startLine" : 193,
+                "startLine" : 196,
                 "startCol" : 57,
-                "endLine" : 193,
+                "endLine" : 196,
                 "endCol" : 73
               }
             },
             "span" : {
-              "startLine" : 193,
+              "startLine" : 196,
               "startCol" : 10,
-              "endLine" : 193,
+              "endLine" : 196,
               "endCol" : 73
             }
           },
           "span" : {
-            "startLine" : 192,
+            "startLine" : 195,
             "startCol" : 8,
-            "endLine" : 193,
+            "endLine" : 196,
             "endCol" : 73
           }
         },
@@ -4848,16 +4909,16 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 194,
+                    "startLine" : 197,
                     "startCol" : 8,
-                    "endLine" : 194,
+                    "endLine" : 197,
                     "endCol" : 17
                   }
                 },
                 "span" : {
-                  "startLine" : 194,
+                  "startLine" : 197,
                   "startCol" : 8,
-                  "endLine" : 194,
+                  "endLine" : 197,
                   "endCol" : 18
                 }
               },
@@ -4867,32 +4928,32 @@
                   "kind" : "Identifier",
                   "name" : "removed",
                   "span" : {
-                    "startLine" : 194,
+                    "startLine" : 197,
                     "startCol" : 19,
-                    "endLine" : 194,
+                    "endLine" : 197,
                     "endCol" : 26
                   }
                 },
                 "field" : "product_sku",
                 "span" : {
-                  "startLine" : 194,
+                  "startLine" : 197,
                   "startCol" : 19,
-                  "endLine" : 194,
+                  "endLine" : 197,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 194,
+                "startLine" : 197,
                 "startCol" : 8,
-                "endLine" : 194,
+                "endLine" : 197,
                 "endCol" : 39
               }
             },
             "field" : "available",
             "span" : {
-              "startLine" : 194,
+              "startLine" : 197,
               "startCol" : 8,
-              "endLine" : 194,
+              "endLine" : 197,
               "endCol" : 49
             }
           },
@@ -4909,16 +4970,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 195,
+                      "startLine" : 198,
                       "startCol" : 14,
-                      "endLine" : 195,
+                      "endLine" : 198,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 195,
+                    "startLine" : 198,
                     "startCol" : 10,
-                    "endLine" : 195,
+                    "endLine" : 198,
                     "endCol" : 24
                   }
                 },
@@ -4928,32 +4989,32 @@
                     "kind" : "Identifier",
                     "name" : "removed",
                     "span" : {
-                      "startLine" : 195,
+                      "startLine" : 198,
                       "startCol" : 25,
-                      "endLine" : 195,
+                      "endLine" : 198,
                       "endCol" : 32
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 195,
+                    "startLine" : 198,
                     "startCol" : 25,
-                    "endLine" : 195,
+                    "endLine" : 198,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 195,
+                  "startLine" : 198,
                   "startCol" : 10,
-                  "endLine" : 195,
+                  "endLine" : 198,
                   "endCol" : 45
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 195,
+                "startLine" : 198,
                 "startCol" : 10,
-                "endLine" : 195,
+                "endLine" : 198,
                 "endCol" : 55
               }
             },
@@ -4963,39 +5024,39 @@
                 "kind" : "Identifier",
                 "name" : "removed",
                 "span" : {
-                  "startLine" : 195,
+                  "startLine" : 198,
                   "startCol" : 58,
-                  "endLine" : 195,
+                  "endLine" : 198,
                   "endCol" : 65
                 }
               },
               "field" : "quantity",
               "span" : {
-                "startLine" : 195,
+                "startLine" : 198,
                 "startCol" : 58,
-                "endLine" : 195,
+                "endLine" : 198,
                 "endCol" : 74
               }
             },
             "span" : {
-              "startLine" : 195,
+              "startLine" : 198,
               "startCol" : 10,
-              "endLine" : 195,
+              "endLine" : 198,
               "endCol" : 74
             }
           },
           "span" : {
-            "startLine" : 194,
+            "startLine" : 197,
             "startCol" : 8,
-            "endLine" : 195,
+            "endLine" : 198,
             "endCol" : 74
           }
         }
       ],
       "span" : {
-        "startLine" : 173,
+        "startLine" : 176,
         "startCol" : 2,
-        "endLine" : 196,
+        "endLine" : 199,
         "endCol" : 3
       }
     },
@@ -5010,16 +5071,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 199,
+              "startLine" : 202,
               "startCol" : 22,
-              "endLine" : 199,
+              "endLine" : 202,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 199,
+            "startLine" : 202,
             "startCol" : 12,
-            "endLine" : 199,
+            "endLine" : 202,
             "endCol" : 29
           }
         }
@@ -5032,16 +5093,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 200,
+              "startLine" : 203,
               "startCol" : 19,
-              "endLine" : 200,
+              "endLine" : 203,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 200,
+            "startLine" : 203,
             "startCol" : 12,
-            "endLine" : 200,
+            "endLine" : 203,
             "endCol" : 24
           }
         }
@@ -5054,9 +5115,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 203,
+              "startLine" : 206,
               "startCol" : 6,
-              "endLine" : 203,
+              "endLine" : 206,
               "endCol" : 14
             }
           },
@@ -5064,16 +5125,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 203,
+              "startLine" : 206,
               "startCol" : 18,
-              "endLine" : 203,
+              "endLine" : 206,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 203,
+            "startLine" : 206,
             "startCol" : 6,
-            "endLine" : 203,
+            "endLine" : 206,
             "endCol" : 24
           }
         },
@@ -5088,9 +5149,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 204,
+                  "startLine" : 207,
                   "startCol" : 6,
-                  "endLine" : 204,
+                  "endLine" : 207,
                   "endCol" : 12
                 }
               },
@@ -5098,24 +5159,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 204,
+                  "startLine" : 207,
                   "startCol" : 13,
-                  "endLine" : 204,
+                  "endLine" : 207,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 204,
+                "startLine" : 207,
                 "startCol" : 6,
-                "endLine" : 204,
+                "endLine" : 207,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 204,
+              "startLine" : 207,
               "startCol" : 6,
-              "endLine" : 204,
+              "endLine" : 207,
               "endCol" : 29
             }
           },
@@ -5123,16 +5184,16 @@
             "kind" : "Identifier",
             "name" : "DRAFT",
             "span" : {
-              "startLine" : 204,
+              "startLine" : 207,
               "startCol" : 32,
-              "endLine" : 204,
+              "endLine" : 207,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 204,
+            "startLine" : 207,
             "startCol" : 6,
-            "endLine" : 204,
+            "endLine" : 207,
             "endCol" : 37
           }
         },
@@ -5150,9 +5211,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 205,
+                    "startLine" : 208,
                     "startCol" : 7,
-                    "endLine" : 205,
+                    "endLine" : 208,
                     "endCol" : 13
                   }
                 },
@@ -5160,31 +5221,31 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 205,
+                    "startLine" : 208,
                     "startCol" : 14,
-                    "endLine" : 205,
+                    "endLine" : 208,
                     "endCol" : 22
                   }
                 },
                 "span" : {
-                  "startLine" : 205,
+                  "startLine" : 208,
                   "startCol" : 7,
-                  "endLine" : 205,
+                  "endLine" : 208,
                   "endCol" : 23
                 }
               },
               "field" : "items",
               "span" : {
-                "startLine" : 205,
+                "startLine" : 208,
                 "startCol" : 7,
-                "endLine" : 205,
+                "endLine" : 208,
                 "endCol" : 29
               }
             },
             "span" : {
-              "startLine" : 205,
+              "startLine" : 208,
               "startCol" : 6,
-              "endLine" : 205,
+              "endLine" : 208,
               "endCol" : 29
             }
           },
@@ -5192,16 +5253,16 @@
             "kind" : "IntLit",
             "value" : 0,
             "span" : {
-              "startLine" : 205,
+              "startLine" : 208,
               "startCol" : 32,
-              "endLine" : 205,
+              "endLine" : 208,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 205,
+            "startLine" : 208,
             "startCol" : 6,
-            "endLine" : 205,
+            "endLine" : 208,
             "endCol" : 33
           }
         }
@@ -5214,9 +5275,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 208,
+              "startLine" : 211,
               "startCol" : 6,
-              "endLine" : 208,
+              "endLine" : 211,
               "endCol" : 11
             }
           },
@@ -5230,16 +5291,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 208,
+                    "startLine" : 211,
                     "startCol" : 18,
-                    "endLine" : 208,
+                    "endLine" : 211,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 208,
+                  "startLine" : 211,
                   "startCol" : 14,
-                  "endLine" : 208,
+                  "endLine" : 211,
                   "endCol" : 25
                 }
               },
@@ -5247,16 +5308,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 208,
+                  "startLine" : 211,
                   "startCol" : 26,
-                  "endLine" : 208,
+                  "endLine" : 211,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 208,
+                "startLine" : 211,
                 "startCol" : 14,
-                "endLine" : 208,
+                "endLine" : 211,
                 "endCol" : 35
               }
             },
@@ -5267,31 +5328,31 @@
                   "kind" : "Identifier",
                   "name" : "PLACED",
                   "span" : {
-                    "startLine" : 208,
+                    "startLine" : 211,
                     "startCol" : 52,
-                    "endLine" : 208,
+                    "endLine" : 211,
                     "endCol" : 58
                   }
                 },
                 "span" : {
-                  "startLine" : 208,
+                  "startLine" : 211,
                   "startCol" : 43,
-                  "endLine" : 208,
+                  "endLine" : 211,
                   "endCol" : 58
                 }
               }
             ],
             "span" : {
-              "startLine" : 208,
+              "startLine" : 211,
               "startCol" : 14,
-              "endLine" : 208,
+              "endLine" : 211,
               "endCol" : 60
             }
           },
           "span" : {
-            "startLine" : 208,
+            "startLine" : 211,
             "startCol" : 6,
-            "endLine" : 208,
+            "endLine" : 211,
             "endCol" : 60
           }
         },
@@ -5304,16 +5365,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 209,
+                "startLine" : 212,
                 "startCol" : 6,
-                "endLine" : 209,
+                "endLine" : 212,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 209,
+              "startLine" : 212,
               "startCol" : 6,
-              "endLine" : 209,
+              "endLine" : 212,
               "endCol" : 13
             }
           },
@@ -5326,16 +5387,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 209,
+                  "startLine" : 212,
                   "startCol" : 20,
-                  "endLine" : 209,
+                  "endLine" : 212,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 209,
+                "startLine" : 212,
                 "startCol" : 16,
-                "endLine" : 209,
+                "endLine" : 212,
                 "endCol" : 27
               }
             },
@@ -5347,9 +5408,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 209,
+                      "startLine" : 212,
                       "startCol" : 31,
-                      "endLine" : 209,
+                      "endLine" : 212,
                       "endCol" : 39
                     }
                   },
@@ -5357,38 +5418,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 209,
+                      "startLine" : 212,
                       "startCol" : 43,
-                      "endLine" : 209,
+                      "endLine" : 212,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 209,
+                    "startLine" : 212,
                     "startCol" : 31,
-                    "endLine" : 209,
+                    "endLine" : 212,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 209,
+                "startLine" : 212,
                 "startCol" : 30,
-                "endLine" : 209,
+                "endLine" : 212,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 209,
+              "startLine" : 212,
               "startCol" : 16,
-              "endLine" : 209,
+              "endLine" : 212,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 209,
+            "startLine" : 212,
             "startCol" : 6,
-            "endLine" : 209,
+            "endLine" : 212,
             "endCol" : 49
           }
         },
@@ -5401,16 +5462,16 @@
               "kind" : "Identifier",
               "name" : "inventory",
               "span" : {
-                "startLine" : 210,
+                "startLine" : 213,
                 "startCol" : 6,
-                "endLine" : 210,
+                "endLine" : 213,
                 "endCol" : 15
               }
             },
             "span" : {
-              "startLine" : 210,
+              "startLine" : 213,
               "startCol" : 6,
-              "endLine" : 210,
+              "endLine" : 213,
               "endCol" : 16
             }
           },
@@ -5418,24 +5479,24 @@
             "kind" : "Identifier",
             "name" : "inventory",
             "span" : {
-              "startLine" : 210,
+              "startLine" : 213,
               "startCol" : 19,
-              "endLine" : 210,
+              "endLine" : 213,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 210,
+            "startLine" : 213,
             "startCol" : 6,
-            "endLine" : 210,
+            "endLine" : 213,
             "endCol" : 28
           }
         }
       ],
       "span" : {
-        "startLine" : 198,
+        "startLine" : 201,
         "startCol" : 2,
-        "endLine" : 211,
+        "endLine" : 214,
         "endCol" : 3
       }
     },
@@ -5450,16 +5511,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 214,
+              "startLine" : 217,
               "startCol" : 22,
-              "endLine" : 214,
+              "endLine" : 217,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 214,
+            "startLine" : 217,
             "startCol" : 12,
-            "endLine" : 214,
+            "endLine" : 217,
             "endCol" : 29
           }
         },
@@ -5470,16 +5531,16 @@
             "kind" : "NamedType",
             "name" : "Money",
             "span" : {
-              "startLine" : 214,
+              "startLine" : 217,
               "startCol" : 39,
-              "endLine" : 214,
+              "endLine" : 217,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 214,
+            "startLine" : 217,
             "startCol" : 31,
-            "endLine" : 214,
+            "endLine" : 217,
             "endCol" : 44
           }
         }
@@ -5492,16 +5553,16 @@
             "kind" : "NamedType",
             "name" : "Payment",
             "span" : {
-              "startLine" : 215,
+              "startLine" : 218,
               "startCol" : 21,
-              "endLine" : 215,
+              "endLine" : 218,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 215,
+            "startLine" : 218,
             "startCol" : 12,
-            "endLine" : 215,
+            "endLine" : 218,
             "endCol" : 28
           }
         }
@@ -5514,9 +5575,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 218,
+              "startLine" : 221,
               "startCol" : 6,
-              "endLine" : 218,
+              "endLine" : 221,
               "endCol" : 14
             }
           },
@@ -5524,16 +5585,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 218,
+              "startLine" : 221,
               "startCol" : 18,
-              "endLine" : 218,
+              "endLine" : 221,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 218,
+            "startLine" : 221,
             "startCol" : 6,
-            "endLine" : 218,
+            "endLine" : 221,
             "endCol" : 24
           }
         },
@@ -5548,9 +5609,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 222,
                   "startCol" : 6,
-                  "endLine" : 219,
+                  "endLine" : 222,
                   "endCol" : 12
                 }
               },
@@ -5558,24 +5619,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 222,
                   "startCol" : 13,
-                  "endLine" : 219,
+                  "endLine" : 222,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 219,
+                "startLine" : 222,
                 "startCol" : 6,
-                "endLine" : 219,
+                "endLine" : 222,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 219,
+              "startLine" : 222,
               "startCol" : 6,
-              "endLine" : 219,
+              "endLine" : 222,
               "endCol" : 29
             }
           },
@@ -5583,16 +5644,16 @@
             "kind" : "Identifier",
             "name" : "PLACED",
             "span" : {
-              "startLine" : 219,
+              "startLine" : 222,
               "startCol" : 32,
-              "endLine" : 219,
+              "endLine" : 222,
               "endCol" : 38
             }
           },
           "span" : {
-            "startLine" : 219,
+            "startLine" : 222,
             "startCol" : 6,
-            "endLine" : 219,
+            "endLine" : 222,
             "endCol" : 38
           }
         },
@@ -5603,9 +5664,9 @@
             "kind" : "Identifier",
             "name" : "amount",
             "span" : {
-              "startLine" : 220,
+              "startLine" : 223,
               "startCol" : 6,
-              "endLine" : 220,
+              "endLine" : 223,
               "endCol" : 12
             }
           },
@@ -5617,9 +5678,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 220,
+                  "startLine" : 223,
                   "startCol" : 15,
-                  "endLine" : 220,
+                  "endLine" : 223,
                   "endCol" : 21
                 }
               },
@@ -5627,31 +5688,31 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 220,
+                  "startLine" : 223,
                   "startCol" : 22,
-                  "endLine" : 220,
+                  "endLine" : 223,
                   "endCol" : 30
                 }
               },
               "span" : {
-                "startLine" : 220,
+                "startLine" : 223,
                 "startCol" : 15,
-                "endLine" : 220,
+                "endLine" : 223,
                 "endCol" : 31
               }
             },
             "field" : "total",
             "span" : {
-              "startLine" : 220,
+              "startLine" : 223,
               "startCol" : 15,
-              "endLine" : 220,
+              "endLine" : 223,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 220,
+            "startLine" : 223,
             "startCol" : 6,
-            "endLine" : 220,
+            "endLine" : 223,
             "endCol" : 37
           }
         }
@@ -5666,17 +5727,17 @@
               "kind" : "Identifier",
               "name" : "payment",
               "span" : {
-                "startLine" : 223,
+                "startLine" : 226,
                 "startCol" : 6,
-                "endLine" : 223,
+                "endLine" : 226,
                 "endCol" : 13
               }
             },
             "field" : "order_id",
             "span" : {
-              "startLine" : 223,
+              "startLine" : 226,
               "startCol" : 6,
-              "endLine" : 223,
+              "endLine" : 226,
               "endCol" : 22
             }
           },
@@ -5684,16 +5745,16 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 223,
+              "startLine" : 226,
               "startCol" : 25,
-              "endLine" : 223,
+              "endLine" : 226,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 223,
+            "startLine" : 226,
             "startCol" : 6,
-            "endLine" : 223,
+            "endLine" : 226,
             "endCol" : 33
           }
         },
@@ -5706,17 +5767,17 @@
               "kind" : "Identifier",
               "name" : "payment",
               "span" : {
-                "startLine" : 224,
+                "startLine" : 227,
                 "startCol" : 6,
-                "endLine" : 224,
+                "endLine" : 227,
                 "endCol" : 13
               }
             },
             "field" : "amount",
             "span" : {
-              "startLine" : 224,
+              "startLine" : 227,
               "startCol" : 6,
-              "endLine" : 224,
+              "endLine" : 227,
               "endCol" : 20
             }
           },
@@ -5724,16 +5785,16 @@
             "kind" : "Identifier",
             "name" : "amount",
             "span" : {
-              "startLine" : 224,
+              "startLine" : 227,
               "startCol" : 23,
-              "endLine" : 224,
+              "endLine" : 227,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 224,
+            "startLine" : 227,
             "startCol" : 6,
-            "endLine" : 224,
+            "endLine" : 227,
             "endCol" : 29
           }
         },
@@ -5746,17 +5807,17 @@
               "kind" : "Identifier",
               "name" : "payment",
               "span" : {
-                "startLine" : 225,
+                "startLine" : 228,
                 "startCol" : 6,
-                "endLine" : 225,
+                "endLine" : 228,
                 "endCol" : 13
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 225,
+              "startLine" : 228,
               "startCol" : 6,
-              "endLine" : 225,
+              "endLine" : 228,
               "endCol" : 20
             }
           },
@@ -5764,16 +5825,16 @@
             "kind" : "Identifier",
             "name" : "CAPTURED",
             "span" : {
-              "startLine" : 225,
+              "startLine" : 228,
               "startCol" : 23,
-              "endLine" : 225,
+              "endLine" : 228,
               "endCol" : 31
             }
           },
           "span" : {
-            "startLine" : 225,
+            "startLine" : 228,
             "startCol" : 6,
-            "endLine" : 225,
+            "endLine" : 228,
             "endCol" : 31
           }
         },
@@ -5790,16 +5851,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 226,
+                    "startLine" : 229,
                     "startCol" : 6,
-                    "endLine" : 226,
+                    "endLine" : 229,
                     "endCol" : 12
                   }
                 },
                 "span" : {
-                  "startLine" : 226,
+                  "startLine" : 229,
                   "startCol" : 6,
-                  "endLine" : 226,
+                  "endLine" : 229,
                   "endCol" : 13
                 }
               },
@@ -5807,24 +5868,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 226,
+                  "startLine" : 229,
                   "startCol" : 14,
-                  "endLine" : 226,
+                  "endLine" : 229,
                   "endCol" : 22
                 }
               },
               "span" : {
-                "startLine" : 226,
+                "startLine" : 229,
                 "startCol" : 6,
-                "endLine" : 226,
+                "endLine" : 229,
                 "endCol" : 23
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 226,
+              "startLine" : 229,
               "startCol" : 6,
-              "endLine" : 226,
+              "endLine" : 229,
               "endCol" : 30
             }
           },
@@ -5832,16 +5893,16 @@
             "kind" : "Identifier",
             "name" : "PAID",
             "span" : {
-              "startLine" : 226,
+              "startLine" : 229,
               "startCol" : 33,
-              "endLine" : 226,
+              "endLine" : 229,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 226,
+            "startLine" : 229,
             "startCol" : 6,
-            "endLine" : 226,
+            "endLine" : 229,
             "endCol" : 37
           }
         },
@@ -5854,16 +5915,16 @@
               "kind" : "Identifier",
               "name" : "payments",
               "span" : {
-                "startLine" : 227,
+                "startLine" : 230,
                 "startCol" : 6,
-                "endLine" : 227,
+                "endLine" : 230,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 227,
+              "startLine" : 230,
               "startCol" : 6,
-              "endLine" : 227,
+              "endLine" : 230,
               "endCol" : 15
             }
           },
@@ -5876,16 +5937,16 @@
                 "kind" : "Identifier",
                 "name" : "payments",
                 "span" : {
-                  "startLine" : 227,
+                  "startLine" : 230,
                   "startCol" : 22,
-                  "endLine" : 227,
+                  "endLine" : 230,
                   "endCol" : 30
                 }
               },
               "span" : {
-                "startLine" : 227,
+                "startLine" : 230,
                 "startCol" : 18,
-                "endLine" : 227,
+                "endLine" : 230,
                 "endCol" : 31
               }
             },
@@ -5899,17 +5960,17 @@
                       "kind" : "Identifier",
                       "name" : "payment",
                       "span" : {
-                        "startLine" : 227,
+                        "startLine" : 230,
                         "startCol" : 35,
-                        "endLine" : 227,
+                        "endLine" : 230,
                         "endCol" : 42
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 227,
+                      "startLine" : 230,
                       "startCol" : 35,
-                      "endLine" : 227,
+                      "endLine" : 230,
                       "endCol" : 45
                     }
                   },
@@ -5917,38 +5978,38 @@
                     "kind" : "Identifier",
                     "name" : "payment",
                     "span" : {
-                      "startLine" : 227,
+                      "startLine" : 230,
                       "startCol" : 49,
-                      "endLine" : 227,
+                      "endLine" : 230,
                       "endCol" : 56
                     }
                   },
                   "span" : {
-                    "startLine" : 227,
+                    "startLine" : 230,
                     "startCol" : 35,
-                    "endLine" : 227,
+                    "endLine" : 230,
                     "endCol" : 45
                   }
                 }
               ],
               "span" : {
-                "startLine" : 227,
+                "startLine" : 230,
                 "startCol" : 34,
-                "endLine" : 227,
+                "endLine" : 230,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 227,
+              "startLine" : 230,
               "startCol" : 18,
-              "endLine" : 227,
+              "endLine" : 230,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 227,
+            "startLine" : 230,
             "startCol" : 6,
-            "endLine" : 227,
+            "endLine" : 230,
             "endCol" : 57
           }
         },
@@ -5961,16 +6022,16 @@
               "kind" : "Identifier",
               "name" : "next_payment_id",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 231,
                 "startCol" : 6,
-                "endLine" : 228,
+                "endLine" : 231,
                 "endCol" : 21
               }
             },
             "span" : {
-              "startLine" : 228,
+              "startLine" : 231,
               "startCol" : 6,
-              "endLine" : 228,
+              "endLine" : 231,
               "endCol" : 22
             }
           },
@@ -5983,16 +6044,16 @@
                 "kind" : "Identifier",
                 "name" : "next_payment_id",
                 "span" : {
-                  "startLine" : 228,
+                  "startLine" : 231,
                   "startCol" : 29,
-                  "endLine" : 228,
+                  "endLine" : 231,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 228,
+                "startLine" : 231,
                 "startCol" : 25,
-                "endLine" : 228,
+                "endLine" : 231,
                 "endCol" : 45
               }
             },
@@ -6000,31 +6061,31 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 228,
+                "startLine" : 231,
                 "startCol" : 48,
-                "endLine" : 228,
+                "endLine" : 231,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 228,
+              "startLine" : 231,
               "startCol" : 25,
-              "endLine" : 228,
+              "endLine" : 231,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 228,
+            "startLine" : 231,
             "startCol" : 6,
-            "endLine" : 228,
+            "endLine" : 231,
             "endCol" : 49
           }
         }
       ],
       "span" : {
-        "startLine" : 213,
+        "startLine" : 216,
         "startCol" : 2,
-        "endLine" : 229,
+        "endLine" : 232,
         "endCol" : 3
       }
     },
@@ -6039,16 +6100,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 232,
+              "startLine" : 235,
               "startCol" : 22,
-              "endLine" : 232,
+              "endLine" : 235,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 232,
+            "startLine" : 235,
             "startCol" : 12,
-            "endLine" : 232,
+            "endLine" : 235,
             "endCol" : 29
           }
         }
@@ -6061,16 +6122,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 233,
+              "startLine" : 236,
               "startCol" : 19,
-              "endLine" : 233,
+              "endLine" : 236,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 233,
+            "startLine" : 236,
             "startCol" : 12,
-            "endLine" : 233,
+            "endLine" : 236,
             "endCol" : 24
           }
         }
@@ -6083,9 +6144,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 236,
+              "startLine" : 239,
               "startCol" : 6,
-              "endLine" : 236,
+              "endLine" : 239,
               "endCol" : 14
             }
           },
@@ -6093,16 +6154,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 236,
+              "startLine" : 239,
               "startCol" : 18,
-              "endLine" : 236,
+              "endLine" : 239,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 236,
+            "startLine" : 239,
             "startCol" : 6,
-            "endLine" : 236,
+            "endLine" : 239,
             "endCol" : 24
           }
         },
@@ -6117,9 +6178,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 237,
+                  "startLine" : 240,
                   "startCol" : 6,
-                  "endLine" : 237,
+                  "endLine" : 240,
                   "endCol" : 12
                 }
               },
@@ -6127,24 +6188,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 237,
+                  "startLine" : 240,
                   "startCol" : 13,
-                  "endLine" : 237,
+                  "endLine" : 240,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 237,
+                "startLine" : 240,
                 "startCol" : 6,
-                "endLine" : 237,
+                "endLine" : 240,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 237,
+              "startLine" : 240,
               "startCol" : 6,
-              "endLine" : 237,
+              "endLine" : 240,
               "endCol" : 29
             }
           },
@@ -6152,16 +6213,16 @@
             "kind" : "Identifier",
             "name" : "PAID",
             "span" : {
-              "startLine" : 237,
+              "startLine" : 240,
               "startCol" : 32,
-              "endLine" : 237,
+              "endLine" : 240,
               "endCol" : 36
             }
           },
           "span" : {
-            "startLine" : 237,
+            "startLine" : 240,
             "startCol" : 6,
-            "endLine" : 237,
+            "endLine" : 240,
             "endCol" : 36
           }
         }
@@ -6174,9 +6235,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 240,
+              "startLine" : 243,
               "startCol" : 6,
-              "endLine" : 240,
+              "endLine" : 243,
               "endCol" : 11
             }
           },
@@ -6190,16 +6251,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 240,
+                    "startLine" : 243,
                     "startCol" : 18,
-                    "endLine" : 240,
+                    "endLine" : 243,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 240,
+                  "startLine" : 243,
                   "startCol" : 14,
-                  "endLine" : 240,
+                  "endLine" : 243,
                   "endCol" : 25
                 }
               },
@@ -6207,16 +6268,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 240,
+                  "startLine" : 243,
                   "startCol" : 26,
-                  "endLine" : 240,
+                  "endLine" : 243,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 240,
+                "startLine" : 243,
                 "startCol" : 14,
-                "endLine" : 240,
+                "endLine" : 243,
                 "endCol" : 35
               }
             },
@@ -6227,16 +6288,16 @@
                   "kind" : "Identifier",
                   "name" : "SHIPPED",
                   "span" : {
-                    "startLine" : 241,
+                    "startLine" : 244,
                     "startCol" : 17,
-                    "endLine" : 241,
+                    "endLine" : 244,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 241,
+                  "startLine" : 244,
                   "startCol" : 8,
-                  "endLine" : 241,
+                  "endLine" : 244,
                   "endCol" : 24
                 }
               },
@@ -6250,47 +6311,47 @@
                       "kind" : "Identifier",
                       "name" : "now",
                       "span" : {
-                        "startLine" : 242,
+                        "startLine" : 245,
                         "startCol" : 26,
-                        "endLine" : 242,
+                        "endLine" : 245,
                         "endCol" : 29
                       }
                     },
                     "args" : [
                     ],
                     "span" : {
-                      "startLine" : 242,
+                      "startLine" : 245,
                       "startCol" : 26,
-                      "endLine" : 242,
+                      "endLine" : 245,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 242,
+                    "startLine" : 245,
                     "startCol" : 21,
-                    "endLine" : 242,
+                    "endLine" : 245,
                     "endCol" : 32
                   }
                 },
                 "span" : {
-                  "startLine" : 242,
+                  "startLine" : 245,
                   "startCol" : 8,
-                  "endLine" : 242,
+                  "endLine" : 245,
                   "endCol" : 32
                 }
               }
             ],
             "span" : {
-              "startLine" : 240,
+              "startLine" : 243,
               "startCol" : 14,
-              "endLine" : 243,
+              "endLine" : 246,
               "endCol" : 7
             }
           },
           "span" : {
-            "startLine" : 240,
+            "startLine" : 243,
             "startCol" : 6,
-            "endLine" : 243,
+            "endLine" : 246,
             "endCol" : 7
           }
         },
@@ -6303,16 +6364,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 244,
+                "startLine" : 247,
                 "startCol" : 6,
-                "endLine" : 244,
+                "endLine" : 247,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 244,
+              "startLine" : 247,
               "startCol" : 6,
-              "endLine" : 244,
+              "endLine" : 247,
               "endCol" : 13
             }
           },
@@ -6325,16 +6386,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 244,
+                  "startLine" : 247,
                   "startCol" : 20,
-                  "endLine" : 244,
+                  "endLine" : 247,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 244,
+                "startLine" : 247,
                 "startCol" : 16,
-                "endLine" : 244,
+                "endLine" : 247,
                 "endCol" : 27
               }
             },
@@ -6346,9 +6407,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 244,
+                      "startLine" : 247,
                       "startCol" : 31,
-                      "endLine" : 244,
+                      "endLine" : 247,
                       "endCol" : 39
                     }
                   },
@@ -6356,38 +6417,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 244,
+                      "startLine" : 247,
                       "startCol" : 43,
-                      "endLine" : 244,
+                      "endLine" : 247,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 244,
+                    "startLine" : 247,
                     "startCol" : 31,
-                    "endLine" : 244,
+                    "endLine" : 247,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 244,
+                "startLine" : 247,
                 "startCol" : 30,
-                "endLine" : 244,
+                "endLine" : 247,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 244,
+              "startLine" : 247,
               "startCol" : 16,
-              "endLine" : 244,
+              "endLine" : 247,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 244,
+            "startLine" : 247,
             "startCol" : 6,
-            "endLine" : 244,
+            "endLine" : 247,
             "endCol" : 49
           }
         },
@@ -6403,25 +6464,25 @@
                   "kind" : "Identifier",
                   "name" : "order",
                   "span" : {
-                    "startLine" : 245,
+                    "startLine" : 248,
                     "startCol" : 18,
-                    "endLine" : 245,
+                    "endLine" : 248,
                     "endCol" : 23
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 245,
+                  "startLine" : 248,
                   "startCol" : 18,
-                  "endLine" : 245,
+                  "endLine" : 248,
                   "endCol" : 29
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 245,
+                "startLine" : 248,
                 "startCol" : 10,
-                "endLine" : 245,
+                "endLine" : 248,
                 "endCol" : 29
               }
             }
@@ -6439,16 +6500,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 246,
+                      "startLine" : 249,
                       "startCol" : 8,
-                      "endLine" : 246,
+                      "endLine" : 249,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 249,
                     "startCol" : 8,
-                    "endLine" : 246,
+                    "endLine" : 249,
                     "endCol" : 18
                   }
                 },
@@ -6458,32 +6519,32 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 246,
+                      "startLine" : 249,
                       "startCol" : 19,
-                      "endLine" : 246,
+                      "endLine" : 249,
                       "endCol" : 23
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 249,
                     "startCol" : 19,
-                    "endLine" : 246,
+                    "endLine" : 249,
                     "endCol" : 35
                   }
                 },
                 "span" : {
-                  "startLine" : 246,
+                  "startLine" : 249,
                   "startCol" : 8,
-                  "endLine" : 246,
+                  "endLine" : 249,
                   "endCol" : 36
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 246,
+                "startLine" : 249,
                 "startCol" : 8,
-                "endLine" : 246,
+                "endLine" : 249,
                 "endCol" : 45
               }
             },
@@ -6500,16 +6561,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 247,
+                        "startLine" : 250,
                         "startCol" : 14,
-                        "endLine" : 247,
+                        "endLine" : 250,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 247,
+                      "startLine" : 250,
                       "startCol" : 10,
-                      "endLine" : 247,
+                      "endLine" : 250,
                       "endCol" : 24
                     }
                   },
@@ -6519,32 +6580,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 247,
+                        "startLine" : 250,
                         "startCol" : 25,
-                        "endLine" : 247,
+                        "endLine" : 250,
                         "endCol" : 29
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 247,
+                      "startLine" : 250,
                       "startCol" : 25,
-                      "endLine" : 247,
+                      "endLine" : 250,
                       "endCol" : 41
                     }
                   },
                   "span" : {
-                    "startLine" : 247,
+                    "startLine" : 250,
                     "startCol" : 10,
-                    "endLine" : 247,
+                    "endLine" : 250,
                     "endCol" : 42
                   }
                 },
                 "field" : "reserved",
                 "span" : {
-                  "startLine" : 247,
+                  "startLine" : 250,
                   "startCol" : 10,
-                  "endLine" : 247,
+                  "endLine" : 250,
                   "endCol" : 51
                 }
               },
@@ -6554,46 +6615,46 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 247,
+                    "startLine" : 250,
                     "startCol" : 54,
-                    "endLine" : 247,
+                    "endLine" : 250,
                     "endCol" : 58
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 247,
+                  "startLine" : 250,
                   "startCol" : 54,
-                  "endLine" : 247,
+                  "endLine" : 250,
                   "endCol" : 67
                 }
               },
               "span" : {
-                "startLine" : 247,
+                "startLine" : 250,
                 "startCol" : 10,
-                "endLine" : 247,
+                "endLine" : 250,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 246,
+              "startLine" : 249,
               "startCol" : 8,
-              "endLine" : 247,
+              "endLine" : 250,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 245,
+            "startLine" : 248,
             "startCol" : 6,
-            "endLine" : 247,
+            "endLine" : 250,
             "endCol" : 67
           }
         }
       ],
       "span" : {
-        "startLine" : 231,
+        "startLine" : 234,
         "startCol" : 2,
-        "endLine" : 248,
+        "endLine" : 251,
         "endCol" : 3
       }
     },
@@ -6608,16 +6669,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 251,
+              "startLine" : 254,
               "startCol" : 22,
-              "endLine" : 251,
+              "endLine" : 254,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 251,
+            "startLine" : 254,
             "startCol" : 12,
-            "endLine" : 251,
+            "endLine" : 254,
             "endCol" : 29
           }
         }
@@ -6630,16 +6691,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 252,
+              "startLine" : 255,
               "startCol" : 19,
-              "endLine" : 252,
+              "endLine" : 255,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 252,
+            "startLine" : 255,
             "startCol" : 12,
-            "endLine" : 252,
+            "endLine" : 255,
             "endCol" : 24
           }
         }
@@ -6652,9 +6713,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 255,
+              "startLine" : 258,
               "startCol" : 6,
-              "endLine" : 255,
+              "endLine" : 258,
               "endCol" : 14
             }
           },
@@ -6662,16 +6723,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 255,
+              "startLine" : 258,
               "startCol" : 18,
-              "endLine" : 255,
+              "endLine" : 258,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 255,
+            "startLine" : 258,
             "startCol" : 6,
-            "endLine" : 255,
+            "endLine" : 258,
             "endCol" : 24
           }
         },
@@ -6686,9 +6747,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 256,
+                  "startLine" : 259,
                   "startCol" : 6,
-                  "endLine" : 256,
+                  "endLine" : 259,
                   "endCol" : 12
                 }
               },
@@ -6696,24 +6757,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 256,
+                  "startLine" : 259,
                   "startCol" : 13,
-                  "endLine" : 256,
+                  "endLine" : 259,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 256,
+                "startLine" : 259,
                 "startCol" : 6,
-                "endLine" : 256,
+                "endLine" : 259,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 256,
+              "startLine" : 259,
               "startCol" : 6,
-              "endLine" : 256,
+              "endLine" : 259,
               "endCol" : 29
             }
           },
@@ -6721,16 +6782,16 @@
             "kind" : "Identifier",
             "name" : "SHIPPED",
             "span" : {
-              "startLine" : 256,
+              "startLine" : 259,
               "startCol" : 32,
-              "endLine" : 256,
+              "endLine" : 259,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 256,
+            "startLine" : 259,
             "startCol" : 6,
-            "endLine" : 256,
+            "endLine" : 259,
             "endCol" : 39
           }
         }
@@ -6743,9 +6804,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 259,
+              "startLine" : 262,
               "startCol" : 6,
-              "endLine" : 259,
+              "endLine" : 262,
               "endCol" : 11
             }
           },
@@ -6759,16 +6820,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 259,
+                    "startLine" : 262,
                     "startCol" : 18,
-                    "endLine" : 259,
+                    "endLine" : 262,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 259,
+                  "startLine" : 262,
                   "startCol" : 14,
-                  "endLine" : 259,
+                  "endLine" : 262,
                   "endCol" : 25
                 }
               },
@@ -6776,16 +6837,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 259,
+                  "startLine" : 262,
                   "startCol" : 26,
-                  "endLine" : 259,
+                  "endLine" : 262,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 259,
+                "startLine" : 262,
                 "startCol" : 14,
-                "endLine" : 259,
+                "endLine" : 262,
                 "endCol" : 35
               }
             },
@@ -6796,16 +6857,16 @@
                   "kind" : "Identifier",
                   "name" : "DELIVERED",
                   "span" : {
-                    "startLine" : 260,
+                    "startLine" : 263,
                     "startCol" : 17,
-                    "endLine" : 260,
+                    "endLine" : 263,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 260,
+                  "startLine" : 263,
                   "startCol" : 8,
-                  "endLine" : 260,
+                  "endLine" : 263,
                   "endCol" : 26
                 }
               },
@@ -6819,47 +6880,47 @@
                       "kind" : "Identifier",
                       "name" : "now",
                       "span" : {
-                        "startLine" : 261,
+                        "startLine" : 264,
                         "startCol" : 28,
-                        "endLine" : 261,
+                        "endLine" : 264,
                         "endCol" : 31
                       }
                     },
                     "args" : [
                     ],
                     "span" : {
-                      "startLine" : 261,
+                      "startLine" : 264,
                       "startCol" : 28,
-                      "endLine" : 261,
+                      "endLine" : 264,
                       "endCol" : 33
                     }
                   },
                   "span" : {
-                    "startLine" : 261,
+                    "startLine" : 264,
                     "startCol" : 23,
-                    "endLine" : 261,
+                    "endLine" : 264,
                     "endCol" : 34
                   }
                 },
                 "span" : {
-                  "startLine" : 261,
+                  "startLine" : 264,
                   "startCol" : 8,
-                  "endLine" : 261,
+                  "endLine" : 264,
                   "endCol" : 34
                 }
               }
             ],
             "span" : {
-              "startLine" : 259,
+              "startLine" : 262,
               "startCol" : 14,
-              "endLine" : 262,
+              "endLine" : 265,
               "endCol" : 7
             }
           },
           "span" : {
-            "startLine" : 259,
+            "startLine" : 262,
             "startCol" : 6,
-            "endLine" : 262,
+            "endLine" : 265,
             "endCol" : 7
           }
         },
@@ -6872,16 +6933,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 263,
+                "startLine" : 266,
                 "startCol" : 6,
-                "endLine" : 263,
+                "endLine" : 266,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 263,
+              "startLine" : 266,
               "startCol" : 6,
-              "endLine" : 263,
+              "endLine" : 266,
               "endCol" : 13
             }
           },
@@ -6894,16 +6955,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 266,
                   "startCol" : 20,
-                  "endLine" : 263,
+                  "endLine" : 266,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 263,
+                "startLine" : 266,
                 "startCol" : 16,
-                "endLine" : 263,
+                "endLine" : 266,
                 "endCol" : 27
               }
             },
@@ -6915,9 +6976,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 263,
+                      "startLine" : 266,
                       "startCol" : 31,
-                      "endLine" : 263,
+                      "endLine" : 266,
                       "endCol" : 39
                     }
                   },
@@ -6925,46 +6986,46 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 263,
+                      "startLine" : 266,
                       "startCol" : 43,
-                      "endLine" : 263,
+                      "endLine" : 266,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 266,
                     "startCol" : 31,
-                    "endLine" : 263,
+                    "endLine" : 266,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 263,
+                "startLine" : 266,
                 "startCol" : 30,
-                "endLine" : 263,
+                "endLine" : 266,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 263,
+              "startLine" : 266,
               "startCol" : 16,
-              "endLine" : 263,
+              "endLine" : 266,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 263,
+            "startLine" : 266,
             "startCol" : 6,
-            "endLine" : 263,
+            "endLine" : 266,
             "endCol" : 49
           }
         }
       ],
       "span" : {
-        "startLine" : 250,
+        "startLine" : 253,
         "startCol" : 2,
-        "endLine" : 264,
+        "endLine" : 267,
         "endCol" : 3
       }
     },
@@ -6979,16 +7040,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 267,
+              "startLine" : 270,
               "startCol" : 22,
-              "endLine" : 267,
+              "endLine" : 270,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 267,
+            "startLine" : 270,
             "startCol" : 12,
-            "endLine" : 267,
+            "endLine" : 270,
             "endCol" : 29
           }
         }
@@ -7001,16 +7062,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 268,
+              "startLine" : 271,
               "startCol" : 19,
-              "endLine" : 268,
+              "endLine" : 271,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 268,
+            "startLine" : 271,
             "startCol" : 12,
-            "endLine" : 268,
+            "endLine" : 271,
             "endCol" : 24
           }
         }
@@ -7023,9 +7084,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 271,
+              "startLine" : 274,
               "startCol" : 6,
-              "endLine" : 271,
+              "endLine" : 274,
               "endCol" : 14
             }
           },
@@ -7033,16 +7094,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 271,
+              "startLine" : 274,
               "startCol" : 18,
-              "endLine" : 271,
+              "endLine" : 274,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 271,
+            "startLine" : 274,
             "startCol" : 6,
-            "endLine" : 271,
+            "endLine" : 274,
             "endCol" : 24
           }
         },
@@ -7057,9 +7118,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 272,
+                  "startLine" : 275,
                   "startCol" : 6,
-                  "endLine" : 272,
+                  "endLine" : 275,
                   "endCol" : 12
                 }
               },
@@ -7067,24 +7128,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 272,
+                  "startLine" : 275,
                   "startCol" : 13,
-                  "endLine" : 272,
+                  "endLine" : 275,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 272,
+                "startLine" : 275,
                 "startCol" : 6,
-                "endLine" : 272,
+                "endLine" : 275,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 272,
+              "startLine" : 275,
               "startCol" : 6,
-              "endLine" : 272,
+              "endLine" : 275,
               "endCol" : 29
             }
           },
@@ -7095,9 +7156,9 @@
                 "kind" : "Identifier",
                 "name" : "DRAFT",
                 "span" : {
-                  "startLine" : 272,
+                  "startLine" : 275,
                   "startCol" : 34,
-                  "endLine" : 272,
+                  "endLine" : 275,
                   "endCol" : 39
                 }
               },
@@ -7105,9 +7166,9 @@
                 "kind" : "Identifier",
                 "name" : "PLACED",
                 "span" : {
-                  "startLine" : 272,
+                  "startLine" : 275,
                   "startCol" : 41,
-                  "endLine" : 272,
+                  "endLine" : 275,
                   "endCol" : 47
                 }
               },
@@ -7115,24 +7176,24 @@
                 "kind" : "Identifier",
                 "name" : "PAID",
                 "span" : {
-                  "startLine" : 272,
+                  "startLine" : 275,
                   "startCol" : 49,
-                  "endLine" : 272,
+                  "endLine" : 275,
                   "endCol" : 53
                 }
               }
             ],
             "span" : {
-              "startLine" : 272,
+              "startLine" : 275,
               "startCol" : 33,
-              "endLine" : 272,
+              "endLine" : 275,
               "endCol" : 54
             }
           },
           "span" : {
-            "startLine" : 272,
+            "startLine" : 275,
             "startCol" : 6,
-            "endLine" : 272,
+            "endLine" : 275,
             "endCol" : 54
           }
         }
@@ -7145,9 +7206,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 275,
+              "startLine" : 278,
               "startCol" : 6,
-              "endLine" : 275,
+              "endLine" : 278,
               "endCol" : 11
             }
           },
@@ -7161,16 +7222,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 275,
+                    "startLine" : 278,
                     "startCol" : 18,
-                    "endLine" : 275,
+                    "endLine" : 278,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 278,
                   "startCol" : 14,
-                  "endLine" : 275,
+                  "endLine" : 278,
                   "endCol" : 25
                 }
               },
@@ -7178,16 +7239,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 278,
                   "startCol" : 26,
-                  "endLine" : 275,
+                  "endLine" : 278,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 275,
+                "startLine" : 278,
                 "startCol" : 14,
-                "endLine" : 275,
+                "endLine" : 278,
                 "endCol" : 35
               }
             },
@@ -7198,31 +7259,31 @@
                   "kind" : "Identifier",
                   "name" : "CANCELLED",
                   "span" : {
-                    "startLine" : 275,
+                    "startLine" : 278,
                     "startCol" : 52,
-                    "endLine" : 275,
+                    "endLine" : 278,
                     "endCol" : 61
                   }
                 },
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 278,
                   "startCol" : 43,
-                  "endLine" : 275,
+                  "endLine" : 278,
                   "endCol" : 61
                 }
               }
             ],
             "span" : {
-              "startLine" : 275,
+              "startLine" : 278,
               "startCol" : 14,
-              "endLine" : 275,
+              "endLine" : 278,
               "endCol" : 63
             }
           },
           "span" : {
-            "startLine" : 275,
+            "startLine" : 278,
             "startCol" : 6,
-            "endLine" : 275,
+            "endLine" : 278,
             "endCol" : 63
           }
         },
@@ -7235,16 +7296,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 276,
+                "startLine" : 279,
                 "startCol" : 6,
-                "endLine" : 276,
+                "endLine" : 279,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 276,
+              "startLine" : 279,
               "startCol" : 6,
-              "endLine" : 276,
+              "endLine" : 279,
               "endCol" : 13
             }
           },
@@ -7257,16 +7318,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 276,
+                  "startLine" : 279,
                   "startCol" : 20,
-                  "endLine" : 276,
+                  "endLine" : 279,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 276,
+                "startLine" : 279,
                 "startCol" : 16,
-                "endLine" : 276,
+                "endLine" : 279,
                 "endCol" : 27
               }
             },
@@ -7278,9 +7339,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 276,
+                      "startLine" : 279,
                       "startCol" : 31,
-                      "endLine" : 276,
+                      "endLine" : 279,
                       "endCol" : 39
                     }
                   },
@@ -7288,38 +7349,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 276,
+                      "startLine" : 279,
                       "startCol" : 43,
-                      "endLine" : 276,
+                      "endLine" : 279,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 276,
+                    "startLine" : 279,
                     "startCol" : 31,
-                    "endLine" : 276,
+                    "endLine" : 279,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 276,
+                "startLine" : 279,
                 "startCol" : 30,
-                "endLine" : 276,
+                "endLine" : 279,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 276,
+              "startLine" : 279,
               "startCol" : 16,
-              "endLine" : 276,
+              "endLine" : 279,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 276,
+            "startLine" : 279,
             "startCol" : 6,
-            "endLine" : 276,
+            "endLine" : 279,
             "endCol" : 49
           }
         },
@@ -7339,16 +7400,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 277,
+                        "startLine" : 280,
                         "startCol" : 22,
-                        "endLine" : 277,
+                        "endLine" : 280,
                         "endCol" : 28
                       }
                     },
                     "span" : {
-                      "startLine" : 277,
+                      "startLine" : 280,
                       "startCol" : 18,
-                      "endLine" : 277,
+                      "endLine" : 280,
                       "endCol" : 29
                     }
                   },
@@ -7356,32 +7417,32 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 277,
+                      "startLine" : 280,
                       "startCol" : 30,
-                      "endLine" : 277,
+                      "endLine" : 280,
                       "endCol" : 38
                     }
                   },
                   "span" : {
-                    "startLine" : 277,
+                    "startLine" : 280,
                     "startCol" : 18,
-                    "endLine" : 277,
+                    "endLine" : 280,
                     "endCol" : 39
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 277,
+                  "startLine" : 280,
                   "startCol" : 18,
-                  "endLine" : 277,
+                  "endLine" : 280,
                   "endCol" : 45
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 277,
+                "startLine" : 280,
                 "startCol" : 10,
-                "endLine" : 277,
+                "endLine" : 280,
                 "endCol" : 45
               }
             }
@@ -7402,16 +7463,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 278,
+                        "startLine" : 281,
                         "startCol" : 8,
-                        "endLine" : 278,
+                        "endLine" : 281,
                         "endCol" : 17
                       }
                     },
                     "span" : {
-                      "startLine" : 278,
+                      "startLine" : 281,
                       "startCol" : 8,
-                      "endLine" : 278,
+                      "endLine" : 281,
                       "endCol" : 18
                     }
                   },
@@ -7421,32 +7482,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 278,
+                        "startLine" : 281,
                         "startCol" : 19,
-                        "endLine" : 278,
+                        "endLine" : 281,
                         "endCol" : 23
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 278,
+                      "startLine" : 281,
                       "startCol" : 19,
-                      "endLine" : 278,
+                      "endLine" : 281,
                       "endCol" : 35
                     }
                   },
                   "span" : {
-                    "startLine" : 278,
+                    "startLine" : 281,
                     "startCol" : 8,
-                    "endLine" : 278,
+                    "endLine" : 281,
                     "endCol" : 36
                   }
                 },
                 "field" : "available",
                 "span" : {
-                  "startLine" : 278,
+                  "startLine" : 281,
                   "startCol" : 8,
-                  "endLine" : 278,
+                  "endLine" : 281,
                   "endCol" : 46
                 }
               },
@@ -7463,16 +7524,16 @@
                         "kind" : "Identifier",
                         "name" : "inventory",
                         "span" : {
-                          "startLine" : 279,
+                          "startLine" : 282,
                           "startCol" : 14,
-                          "endLine" : 279,
+                          "endLine" : 282,
                           "endCol" : 23
                         }
                       },
                       "span" : {
-                        "startLine" : 279,
+                        "startLine" : 282,
                         "startCol" : 10,
-                        "endLine" : 279,
+                        "endLine" : 282,
                         "endCol" : 24
                       }
                     },
@@ -7482,32 +7543,32 @@
                         "kind" : "Identifier",
                         "name" : "item",
                         "span" : {
-                          "startLine" : 279,
+                          "startLine" : 282,
                           "startCol" : 25,
-                          "endLine" : 279,
+                          "endLine" : 282,
                           "endCol" : 29
                         }
                       },
                       "field" : "product_sku",
                       "span" : {
-                        "startLine" : 279,
+                        "startLine" : 282,
                         "startCol" : 25,
-                        "endLine" : 279,
+                        "endLine" : 282,
                         "endCol" : 41
                       }
                     },
                     "span" : {
-                      "startLine" : 279,
+                      "startLine" : 282,
                       "startCol" : 10,
-                      "endLine" : 279,
+                      "endLine" : 282,
                       "endCol" : 42
                     }
                   },
                   "field" : "available",
                   "span" : {
-                    "startLine" : 279,
+                    "startLine" : 282,
                     "startCol" : 10,
-                    "endLine" : 279,
+                    "endLine" : 282,
                     "endCol" : 52
                   }
                 },
@@ -7517,31 +7578,31 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 279,
+                      "startLine" : 282,
                       "startCol" : 55,
-                      "endLine" : 279,
+                      "endLine" : 282,
                       "endCol" : 59
                     }
                   },
                   "field" : "quantity",
                   "span" : {
-                    "startLine" : 279,
+                    "startLine" : 282,
                     "startCol" : 55,
-                    "endLine" : 279,
+                    "endLine" : 282,
                     "endCol" : 68
                   }
                 },
                 "span" : {
-                  "startLine" : 279,
+                  "startLine" : 282,
                   "startCol" : 10,
-                  "endLine" : 279,
+                  "endLine" : 282,
                   "endCol" : 68
                 }
               },
               "span" : {
-                "startLine" : 278,
+                "startLine" : 281,
                 "startCol" : 8,
-                "endLine" : 279,
+                "endLine" : 282,
                 "endCol" : 68
               }
             },
@@ -7558,16 +7619,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 280,
+                        "startLine" : 283,
                         "startCol" : 12,
-                        "endLine" : 280,
+                        "endLine" : 283,
                         "endCol" : 21
                       }
                     },
                     "span" : {
-                      "startLine" : 280,
+                      "startLine" : 283,
                       "startCol" : 12,
-                      "endLine" : 280,
+                      "endLine" : 283,
                       "endCol" : 22
                     }
                   },
@@ -7577,32 +7638,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 280,
+                        "startLine" : 283,
                         "startCol" : 23,
-                        "endLine" : 280,
+                        "endLine" : 283,
                         "endCol" : 27
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 280,
+                      "startLine" : 283,
                       "startCol" : 23,
-                      "endLine" : 280,
+                      "endLine" : 283,
                       "endCol" : 39
                     }
                   },
                   "span" : {
-                    "startLine" : 280,
+                    "startLine" : 283,
                     "startCol" : 12,
-                    "endLine" : 280,
+                    "endLine" : 283,
                     "endCol" : 40
                   }
                 },
                 "field" : "reserved",
                 "span" : {
-                  "startLine" : 280,
+                  "startLine" : 283,
                   "startCol" : 12,
-                  "endLine" : 280,
+                  "endLine" : 283,
                   "endCol" : 49
                 }
               },
@@ -7619,16 +7680,16 @@
                         "kind" : "Identifier",
                         "name" : "inventory",
                         "span" : {
-                          "startLine" : 281,
+                          "startLine" : 284,
                           "startCol" : 14,
-                          "endLine" : 281,
+                          "endLine" : 284,
                           "endCol" : 23
                         }
                       },
                       "span" : {
-                        "startLine" : 281,
+                        "startLine" : 284,
                         "startCol" : 10,
-                        "endLine" : 281,
+                        "endLine" : 284,
                         "endCol" : 24
                       }
                     },
@@ -7638,32 +7699,32 @@
                         "kind" : "Identifier",
                         "name" : "item",
                         "span" : {
-                          "startLine" : 281,
+                          "startLine" : 284,
                           "startCol" : 25,
-                          "endLine" : 281,
+                          "endLine" : 284,
                           "endCol" : 29
                         }
                       },
                       "field" : "product_sku",
                       "span" : {
-                        "startLine" : 281,
+                        "startLine" : 284,
                         "startCol" : 25,
-                        "endLine" : 281,
+                        "endLine" : 284,
                         "endCol" : 41
                       }
                     },
                     "span" : {
-                      "startLine" : 281,
+                      "startLine" : 284,
                       "startCol" : 10,
-                      "endLine" : 281,
+                      "endLine" : 284,
                       "endCol" : 42
                     }
                   },
                   "field" : "reserved",
                   "span" : {
-                    "startLine" : 281,
+                    "startLine" : 284,
                     "startCol" : 10,
-                    "endLine" : 281,
+                    "endLine" : 284,
                     "endCol" : 51
                   }
                 },
@@ -7673,45 +7734,45 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 281,
+                      "startLine" : 284,
                       "startCol" : 54,
-                      "endLine" : 281,
+                      "endLine" : 284,
                       "endCol" : 58
                     }
                   },
                   "field" : "quantity",
                   "span" : {
-                    "startLine" : 281,
+                    "startLine" : 284,
                     "startCol" : 54,
-                    "endLine" : 281,
+                    "endLine" : 284,
                     "endCol" : 67
                   }
                 },
                 "span" : {
-                  "startLine" : 281,
+                  "startLine" : 284,
                   "startCol" : 10,
-                  "endLine" : 281,
+                  "endLine" : 284,
                   "endCol" : 67
                 }
               },
               "span" : {
-                "startLine" : 280,
+                "startLine" : 283,
                 "startCol" : 12,
-                "endLine" : 281,
+                "endLine" : 284,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 278,
+              "startLine" : 281,
               "startCol" : 8,
-              "endLine" : 281,
+              "endLine" : 284,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 277,
+            "startLine" : 280,
             "startCol" : 6,
-            "endLine" : 281,
+            "endLine" : 284,
             "endCol" : 67
           }
         },
@@ -7729,9 +7790,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 282,
+                    "startLine" : 285,
                     "startCol" : 6,
-                    "endLine" : 282,
+                    "endLine" : 285,
                     "endCol" : 12
                   }
                 },
@@ -7739,24 +7800,24 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 282,
+                    "startLine" : 285,
                     "startCol" : 13,
-                    "endLine" : 282,
+                    "endLine" : 285,
                     "endCol" : 21
                   }
                 },
                 "span" : {
-                  "startLine" : 282,
+                  "startLine" : 285,
                   "startCol" : 6,
-                  "endLine" : 282,
+                  "endLine" : 285,
                   "endCol" : 22
                 }
               },
               "field" : "status",
               "span" : {
-                "startLine" : 282,
+                "startLine" : 285,
                 "startCol" : 6,
-                "endLine" : 282,
+                "endLine" : 285,
                 "endCol" : 29
               }
             },
@@ -7764,16 +7825,16 @@
               "kind" : "Identifier",
               "name" : "PAID",
               "span" : {
-                "startLine" : 282,
+                "startLine" : 285,
                 "startCol" : 32,
-                "endLine" : 282,
+                "endLine" : 285,
                 "endCol" : 36
               }
             },
             "span" : {
-              "startLine" : 282,
+              "startLine" : 285,
               "startCol" : 6,
-              "endLine" : 282,
+              "endLine" : 285,
               "endCol" : 36
             }
           },
@@ -7789,24 +7850,24 @@
                     "kind" : "Identifier",
                     "name" : "payments",
                     "span" : {
-                      "startLine" : 283,
+                      "startLine" : 286,
                       "startCol" : 18,
-                      "endLine" : 283,
+                      "endLine" : 286,
                       "endCol" : 26
                     }
                   },
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 286,
                     "startCol" : 18,
-                    "endLine" : 283,
+                    "endLine" : 286,
                     "endCol" : 27
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 283,
+                  "startLine" : 286,
                   "startCol" : 13,
-                  "endLine" : 283,
+                  "endLine" : 286,
                   "endCol" : 27
                 }
               }
@@ -7824,9 +7885,9 @@
                     "kind" : "Identifier",
                     "name" : "p",
                     "span" : {
-                      "startLine" : 284,
+                      "startLine" : 287,
                       "startCol" : 10,
-                      "endLine" : 284,
+                      "endLine" : 287,
                       "endCol" : 11
                     }
                   },
@@ -7836,23 +7897,23 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 284,
+                        "startLine" : 287,
                         "startCol" : 23,
-                        "endLine" : 284,
+                        "endLine" : 287,
                         "endCol" : 31
                       }
                     },
                     "span" : {
-                      "startLine" : 284,
+                      "startLine" : 287,
                       "startCol" : 19,
-                      "endLine" : 284,
+                      "endLine" : 287,
                       "endCol" : 32
                     }
                   },
                   "span" : {
-                    "startLine" : 284,
+                    "startLine" : 287,
                     "startCol" : 10,
-                    "endLine" : 284,
+                    "endLine" : 287,
                     "endCol" : 32
                   }
                 },
@@ -7869,16 +7930,16 @@
                           "kind" : "Identifier",
                           "name" : "payments",
                           "span" : {
-                            "startLine" : 285,
+                            "startLine" : 288,
                             "startCol" : 14,
-                            "endLine" : 285,
+                            "endLine" : 288,
                             "endCol" : 22
                           }
                         },
                         "span" : {
-                          "startLine" : 285,
+                          "startLine" : 288,
                           "startCol" : 14,
-                          "endLine" : 285,
+                          "endLine" : 288,
                           "endCol" : 23
                         }
                       },
@@ -7886,24 +7947,24 @@
                         "kind" : "Identifier",
                         "name" : "p",
                         "span" : {
-                          "startLine" : 285,
+                          "startLine" : 288,
                           "startCol" : 24,
-                          "endLine" : 285,
+                          "endLine" : 288,
                           "endCol" : 25
                         }
                       },
                       "span" : {
-                        "startLine" : 285,
+                        "startLine" : 288,
                         "startCol" : 14,
-                        "endLine" : 285,
+                        "endLine" : 288,
                         "endCol" : 26
                       }
                     },
                     "field" : "order_id",
                     "span" : {
-                      "startLine" : 285,
+                      "startLine" : 288,
                       "startCol" : 14,
-                      "endLine" : 285,
+                      "endLine" : 288,
                       "endCol" : 35
                     }
                   },
@@ -7911,23 +7972,23 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 285,
+                      "startLine" : 288,
                       "startCol" : 38,
-                      "endLine" : 285,
+                      "endLine" : 288,
                       "endCol" : 46
                     }
                   },
                   "span" : {
-                    "startLine" : 285,
+                    "startLine" : 288,
                     "startCol" : 14,
-                    "endLine" : 285,
+                    "endLine" : 288,
                     "endCol" : 46
                   }
                 },
                 "span" : {
-                  "startLine" : 284,
+                  "startLine" : 287,
                   "startCol" : 10,
-                  "endLine" : 285,
+                  "endLine" : 288,
                   "endCol" : 46
                 }
               },
@@ -7944,16 +8005,16 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 286,
+                          "startLine" : 289,
                           "startCol" : 14,
-                          "endLine" : 286,
+                          "endLine" : 289,
                           "endCol" : 22
                         }
                       },
                       "span" : {
-                        "startLine" : 286,
+                        "startLine" : 289,
                         "startCol" : 14,
-                        "endLine" : 286,
+                        "endLine" : 289,
                         "endCol" : 23
                       }
                     },
@@ -7961,24 +8022,24 @@
                       "kind" : "Identifier",
                       "name" : "p",
                       "span" : {
-                        "startLine" : 286,
+                        "startLine" : 289,
                         "startCol" : 24,
-                        "endLine" : 286,
+                        "endLine" : 289,
                         "endCol" : 25
                       }
                     },
                     "span" : {
-                      "startLine" : 286,
+                      "startLine" : 289,
                       "startCol" : 14,
-                      "endLine" : 286,
+                      "endLine" : 289,
                       "endCol" : 26
                     }
                   },
                   "field" : "status",
                   "span" : {
-                    "startLine" : 286,
+                    "startLine" : 289,
                     "startCol" : 14,
-                    "endLine" : 286,
+                    "endLine" : 289,
                     "endCol" : 33
                   }
                 },
@@ -7986,45 +8047,45 @@
                   "kind" : "Identifier",
                   "name" : "REFUNDED",
                   "span" : {
-                    "startLine" : 286,
+                    "startLine" : 289,
                     "startCol" : 36,
-                    "endLine" : 286,
+                    "endLine" : 289,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 286,
+                  "startLine" : 289,
                   "startCol" : 14,
-                  "endLine" : 286,
+                  "endLine" : 289,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 284,
+                "startLine" : 287,
                 "startCol" : 10,
-                "endLine" : 286,
+                "endLine" : 289,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 283,
+              "startLine" : 286,
               "startCol" : 8,
-              "endLine" : 286,
+              "endLine" : 289,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 282,
+            "startLine" : 285,
             "startCol" : 6,
-            "endLine" : 286,
+            "endLine" : 289,
             "endCol" : 44
           }
         }
       ],
       "span" : {
-        "startLine" : 266,
+        "startLine" : 269,
         "startCol" : 2,
-        "endLine" : 287,
+        "endLine" : 290,
         "endCol" : 3
       }
     },
@@ -8039,16 +8100,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 290,
+              "startLine" : 293,
               "startCol" : 22,
-              "endLine" : 290,
+              "endLine" : 293,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 290,
+            "startLine" : 293,
             "startCol" : 12,
-            "endLine" : 290,
+            "endLine" : 293,
             "endCol" : 29
           }
         }
@@ -8061,16 +8122,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 291,
+              "startLine" : 294,
               "startCol" : 19,
-              "endLine" : 291,
+              "endLine" : 294,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 291,
+            "startLine" : 294,
             "startCol" : 12,
-            "endLine" : 291,
+            "endLine" : 294,
             "endCol" : 24
           }
         }
@@ -8083,9 +8144,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 294,
+              "startLine" : 297,
               "startCol" : 6,
-              "endLine" : 294,
+              "endLine" : 297,
               "endCol" : 14
             }
           },
@@ -8093,16 +8154,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 294,
+              "startLine" : 297,
               "startCol" : 18,
-              "endLine" : 294,
+              "endLine" : 297,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 294,
+            "startLine" : 297,
             "startCol" : 6,
-            "endLine" : 294,
+            "endLine" : 297,
             "endCol" : 24
           }
         },
@@ -8117,9 +8178,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 295,
+                  "startLine" : 298,
                   "startCol" : 6,
-                  "endLine" : 295,
+                  "endLine" : 298,
                   "endCol" : 12
                 }
               },
@@ -8127,24 +8188,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 295,
+                  "startLine" : 298,
                   "startCol" : 13,
-                  "endLine" : 295,
+                  "endLine" : 298,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 295,
+                "startLine" : 298,
                 "startCol" : 6,
-                "endLine" : 295,
+                "endLine" : 298,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 295,
+              "startLine" : 298,
               "startCol" : 6,
-              "endLine" : 295,
+              "endLine" : 298,
               "endCol" : 29
             }
           },
@@ -8152,16 +8213,16 @@
             "kind" : "Identifier",
             "name" : "DELIVERED",
             "span" : {
-              "startLine" : 295,
+              "startLine" : 298,
               "startCol" : 32,
-              "endLine" : 295,
+              "endLine" : 298,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 295,
+            "startLine" : 298,
             "startCol" : 6,
-            "endLine" : 295,
+            "endLine" : 298,
             "endCol" : 41
           }
         },
@@ -8176,9 +8237,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 296,
+                  "startLine" : 299,
                   "startCol" : 6,
-                  "endLine" : 296,
+                  "endLine" : 299,
                   "endCol" : 12
                 }
               },
@@ -8186,40 +8247,40 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 296,
+                  "startLine" : 299,
                   "startCol" : 13,
-                  "endLine" : 296,
+                  "endLine" : 299,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 296,
+                "startLine" : 299,
                 "startCol" : 6,
-                "endLine" : 296,
+                "endLine" : 299,
                 "endCol" : 22
               }
             },
             "field" : "delivered_at",
             "span" : {
-              "startLine" : 296,
+              "startLine" : 299,
               "startCol" : 6,
-              "endLine" : 296,
+              "endLine" : 299,
               "endCol" : 35
             }
           },
           "right" : {
             "kind" : "NoneLit",
             "span" : {
-              "startLine" : 296,
+              "startLine" : 299,
               "startCol" : 39,
-              "endLine" : 296,
+              "endLine" : 299,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 296,
+            "startLine" : 299,
             "startCol" : 6,
-            "endLine" : 296,
+            "endLine" : 299,
             "endCol" : 43
           }
         },
@@ -8235,18 +8296,18 @@
                 "kind" : "Identifier",
                 "name" : "now",
                 "span" : {
-                  "startLine" : 297,
+                  "startLine" : 300,
                   "startCol" : 6,
-                  "endLine" : 297,
+                  "endLine" : 300,
                   "endCol" : 9
                 }
               },
               "args" : [
               ],
               "span" : {
-                "startLine" : 297,
+                "startLine" : 300,
                 "startCol" : 6,
-                "endLine" : 297,
+                "endLine" : 300,
                 "endCol" : 11
               }
             },
@@ -8258,9 +8319,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 297,
+                    "startLine" : 300,
                     "startCol" : 14,
-                    "endLine" : 297,
+                    "endLine" : 300,
                     "endCol" : 20
                   }
                 },
@@ -8268,31 +8329,31 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 297,
+                    "startLine" : 300,
                     "startCol" : 21,
-                    "endLine" : 297,
+                    "endLine" : 300,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 297,
+                  "startLine" : 300,
                   "startCol" : 14,
-                  "endLine" : 297,
+                  "endLine" : 300,
                   "endCol" : 30
                 }
               },
               "field" : "delivered_at",
               "span" : {
-                "startLine" : 297,
+                "startLine" : 300,
                 "startCol" : 14,
-                "endLine" : 297,
+                "endLine" : 300,
                 "endCol" : 43
               }
             },
             "span" : {
-              "startLine" : 297,
+              "startLine" : 300,
               "startCol" : 6,
-              "endLine" : 297,
+              "endLine" : 300,
               "endCol" : 43
             }
           },
@@ -8302,9 +8363,9 @@
               "kind" : "Identifier",
               "name" : "days",
               "span" : {
-                "startLine" : 297,
+                "startLine" : 300,
                 "startCol" : 47,
-                "endLine" : 297,
+                "endLine" : 300,
                 "endCol" : 51
               }
             },
@@ -8313,24 +8374,24 @@
                 "kind" : "IntLit",
                 "value" : 30,
                 "span" : {
-                  "startLine" : 297,
+                  "startLine" : 300,
                   "startCol" : 52,
-                  "endLine" : 297,
+                  "endLine" : 300,
                   "endCol" : 54
                 }
               }
             ],
             "span" : {
-              "startLine" : 297,
+              "startLine" : 300,
               "startCol" : 47,
-              "endLine" : 297,
+              "endLine" : 300,
               "endCol" : 55
             }
           },
           "span" : {
-            "startLine" : 297,
+            "startLine" : 300,
             "startCol" : 6,
-            "endLine" : 297,
+            "endLine" : 300,
             "endCol" : 55
           }
         }
@@ -8343,9 +8404,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 300,
+              "startLine" : 303,
               "startCol" : 6,
-              "endLine" : 300,
+              "endLine" : 303,
               "endCol" : 11
             }
           },
@@ -8359,16 +8420,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 300,
+                    "startLine" : 303,
                     "startCol" : 18,
-                    "endLine" : 300,
+                    "endLine" : 303,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 303,
                   "startCol" : 14,
-                  "endLine" : 300,
+                  "endLine" : 303,
                   "endCol" : 25
                 }
               },
@@ -8376,16 +8437,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 303,
                   "startCol" : 26,
-                  "endLine" : 300,
+                  "endLine" : 303,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 300,
+                "startLine" : 303,
                 "startCol" : 14,
-                "endLine" : 300,
+                "endLine" : 303,
                 "endCol" : 35
               }
             },
@@ -8396,31 +8457,31 @@
                   "kind" : "Identifier",
                   "name" : "RETURNED",
                   "span" : {
-                    "startLine" : 300,
+                    "startLine" : 303,
                     "startCol" : 52,
-                    "endLine" : 300,
+                    "endLine" : 303,
                     "endCol" : 60
                   }
                 },
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 303,
                   "startCol" : 43,
-                  "endLine" : 300,
+                  "endLine" : 303,
                   "endCol" : 60
                 }
               }
             ],
             "span" : {
-              "startLine" : 300,
+              "startLine" : 303,
               "startCol" : 14,
-              "endLine" : 300,
+              "endLine" : 303,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 300,
+            "startLine" : 303,
             "startCol" : 6,
-            "endLine" : 300,
+            "endLine" : 303,
             "endCol" : 62
           }
         },
@@ -8433,16 +8494,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 301,
+                "startLine" : 304,
                 "startCol" : 6,
-                "endLine" : 301,
+                "endLine" : 304,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 301,
+              "startLine" : 304,
               "startCol" : 6,
-              "endLine" : 301,
+              "endLine" : 304,
               "endCol" : 13
             }
           },
@@ -8455,16 +8516,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 301,
+                  "startLine" : 304,
                   "startCol" : 20,
-                  "endLine" : 301,
+                  "endLine" : 304,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 301,
+                "startLine" : 304,
                 "startCol" : 16,
-                "endLine" : 301,
+                "endLine" : 304,
                 "endCol" : 27
               }
             },
@@ -8476,9 +8537,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 301,
+                      "startLine" : 304,
                       "startCol" : 31,
-                      "endLine" : 301,
+                      "endLine" : 304,
                       "endCol" : 39
                     }
                   },
@@ -8486,38 +8547,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 301,
+                      "startLine" : 304,
                       "startCol" : 43,
-                      "endLine" : 301,
+                      "endLine" : 304,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 301,
+                    "startLine" : 304,
                     "startCol" : 31,
-                    "endLine" : 301,
+                    "endLine" : 304,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 301,
+                "startLine" : 304,
                 "startCol" : 30,
-                "endLine" : 301,
+                "endLine" : 304,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 301,
+              "startLine" : 304,
               "startCol" : 16,
-              "endLine" : 301,
+              "endLine" : 304,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 301,
+            "startLine" : 304,
             "startCol" : 6,
-            "endLine" : 301,
+            "endLine" : 304,
             "endCol" : 49
           }
         },
@@ -8537,16 +8598,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 302,
+                        "startLine" : 305,
                         "startCol" : 22,
-                        "endLine" : 302,
+                        "endLine" : 305,
                         "endCol" : 28
                       }
                     },
                     "span" : {
-                      "startLine" : 302,
+                      "startLine" : 305,
                       "startCol" : 18,
-                      "endLine" : 302,
+                      "endLine" : 305,
                       "endCol" : 29
                     }
                   },
@@ -8554,32 +8615,32 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 302,
+                      "startLine" : 305,
                       "startCol" : 30,
-                      "endLine" : 302,
+                      "endLine" : 305,
                       "endCol" : 38
                     }
                   },
                   "span" : {
-                    "startLine" : 302,
+                    "startLine" : 305,
                     "startCol" : 18,
-                    "endLine" : 302,
+                    "endLine" : 305,
                     "endCol" : 39
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 302,
+                  "startLine" : 305,
                   "startCol" : 18,
-                  "endLine" : 302,
+                  "endLine" : 305,
                   "endCol" : 45
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 302,
+                "startLine" : 305,
                 "startCol" : 10,
-                "endLine" : 302,
+                "endLine" : 305,
                 "endCol" : 45
               }
             }
@@ -8597,16 +8658,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 303,
+                      "startLine" : 306,
                       "startCol" : 8,
-                      "endLine" : 303,
+                      "endLine" : 306,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 303,
+                    "startLine" : 306,
                     "startCol" : 8,
-                    "endLine" : 303,
+                    "endLine" : 306,
                     "endCol" : 18
                   }
                 },
@@ -8616,32 +8677,32 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 303,
+                      "startLine" : 306,
                       "startCol" : 19,
-                      "endLine" : 303,
+                      "endLine" : 306,
                       "endCol" : 23
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 303,
+                    "startLine" : 306,
                     "startCol" : 19,
-                    "endLine" : 303,
+                    "endLine" : 306,
                     "endCol" : 35
                   }
                 },
                 "span" : {
-                  "startLine" : 303,
+                  "startLine" : 306,
                   "startCol" : 8,
-                  "endLine" : 303,
+                  "endLine" : 306,
                   "endCol" : 36
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 303,
+                "startLine" : 306,
                 "startCol" : 8,
-                "endLine" : 303,
+                "endLine" : 306,
                 "endCol" : 46
               }
             },
@@ -8658,16 +8719,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 304,
+                        "startLine" : 307,
                         "startCol" : 14,
-                        "endLine" : 304,
+                        "endLine" : 307,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 304,
+                      "startLine" : 307,
                       "startCol" : 10,
-                      "endLine" : 304,
+                      "endLine" : 307,
                       "endCol" : 24
                     }
                   },
@@ -8677,32 +8738,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 304,
+                        "startLine" : 307,
                         "startCol" : 25,
-                        "endLine" : 304,
+                        "endLine" : 307,
                         "endCol" : 29
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 304,
+                      "startLine" : 307,
                       "startCol" : 25,
-                      "endLine" : 304,
+                      "endLine" : 307,
                       "endCol" : 41
                     }
                   },
                   "span" : {
-                    "startLine" : 304,
+                    "startLine" : 307,
                     "startCol" : 10,
-                    "endLine" : 304,
+                    "endLine" : 307,
                     "endCol" : 42
                   }
                 },
                 "field" : "available",
                 "span" : {
-                  "startLine" : 304,
+                  "startLine" : 307,
                   "startCol" : 10,
-                  "endLine" : 304,
+                  "endLine" : 307,
                   "endCol" : 52
                 }
               },
@@ -8712,38 +8773,38 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 304,
+                    "startLine" : 307,
                     "startCol" : 55,
-                    "endLine" : 304,
+                    "endLine" : 307,
                     "endCol" : 59
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 304,
+                  "startLine" : 307,
                   "startCol" : 55,
-                  "endLine" : 304,
+                  "endLine" : 307,
                   "endCol" : 68
                 }
               },
               "span" : {
-                "startLine" : 304,
+                "startLine" : 307,
                 "startCol" : 10,
-                "endLine" : 304,
+                "endLine" : 307,
                 "endCol" : 68
               }
             },
             "span" : {
-              "startLine" : 303,
+              "startLine" : 306,
               "startCol" : 8,
-              "endLine" : 304,
+              "endLine" : 307,
               "endCol" : 68
             }
           },
           "span" : {
-            "startLine" : 302,
+            "startLine" : 305,
             "startCol" : 6,
-            "endLine" : 304,
+            "endLine" : 307,
             "endCol" : 68
           }
         },
@@ -8759,24 +8820,24 @@
                   "kind" : "Identifier",
                   "name" : "payments",
                   "span" : {
-                    "startLine" : 305,
+                    "startLine" : 308,
                     "startCol" : 16,
-                    "endLine" : 305,
+                    "endLine" : 308,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 305,
+                  "startLine" : 308,
                   "startCol" : 16,
-                  "endLine" : 305,
+                  "endLine" : 308,
                   "endCol" : 25
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 305,
+                "startLine" : 308,
                 "startCol" : 11,
-                "endLine" : 305,
+                "endLine" : 308,
                 "endCol" : 25
               }
             }
@@ -8797,9 +8858,9 @@
                     "kind" : "Identifier",
                     "name" : "p",
                     "span" : {
-                      "startLine" : 306,
+                      "startLine" : 309,
                       "startCol" : 8,
-                      "endLine" : 306,
+                      "endLine" : 309,
                       "endCol" : 9
                     }
                   },
@@ -8809,23 +8870,23 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 306,
+                        "startLine" : 309,
                         "startCol" : 21,
-                        "endLine" : 306,
+                        "endLine" : 309,
                         "endCol" : 29
                       }
                     },
                     "span" : {
-                      "startLine" : 306,
+                      "startLine" : 309,
                       "startCol" : 17,
-                      "endLine" : 306,
+                      "endLine" : 309,
                       "endCol" : 30
                     }
                   },
                   "span" : {
-                    "startLine" : 306,
+                    "startLine" : 309,
                     "startCol" : 8,
-                    "endLine" : 306,
+                    "endLine" : 309,
                     "endCol" : 30
                   }
                 },
@@ -8842,16 +8903,16 @@
                           "kind" : "Identifier",
                           "name" : "payments",
                           "span" : {
-                            "startLine" : 307,
+                            "startLine" : 310,
                             "startCol" : 12,
-                            "endLine" : 307,
+                            "endLine" : 310,
                             "endCol" : 20
                           }
                         },
                         "span" : {
-                          "startLine" : 307,
+                          "startLine" : 310,
                           "startCol" : 12,
-                          "endLine" : 307,
+                          "endLine" : 310,
                           "endCol" : 21
                         }
                       },
@@ -8859,24 +8920,24 @@
                         "kind" : "Identifier",
                         "name" : "p",
                         "span" : {
-                          "startLine" : 307,
+                          "startLine" : 310,
                           "startCol" : 22,
-                          "endLine" : 307,
+                          "endLine" : 310,
                           "endCol" : 23
                         }
                       },
                       "span" : {
-                        "startLine" : 307,
+                        "startLine" : 310,
                         "startCol" : 12,
-                        "endLine" : 307,
+                        "endLine" : 310,
                         "endCol" : 24
                       }
                     },
                     "field" : "order_id",
                     "span" : {
-                      "startLine" : 307,
+                      "startLine" : 310,
                       "startCol" : 12,
-                      "endLine" : 307,
+                      "endLine" : 310,
                       "endCol" : 33
                     }
                   },
@@ -8884,23 +8945,23 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 307,
+                      "startLine" : 310,
                       "startCol" : 36,
-                      "endLine" : 307,
+                      "endLine" : 310,
                       "endCol" : 44
                     }
                   },
                   "span" : {
-                    "startLine" : 307,
+                    "startLine" : 310,
                     "startCol" : 12,
-                    "endLine" : 307,
+                    "endLine" : 310,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 306,
+                  "startLine" : 309,
                   "startCol" : 8,
-                  "endLine" : 307,
+                  "endLine" : 310,
                   "endCol" : 44
                 }
               },
@@ -8917,16 +8978,16 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 308,
+                          "startLine" : 311,
                           "startCol" : 12,
-                          "endLine" : 308,
+                          "endLine" : 311,
                           "endCol" : 20
                         }
                       },
                       "span" : {
-                        "startLine" : 308,
+                        "startLine" : 311,
                         "startCol" : 12,
-                        "endLine" : 308,
+                        "endLine" : 311,
                         "endCol" : 21
                       }
                     },
@@ -8934,24 +8995,24 @@
                       "kind" : "Identifier",
                       "name" : "p",
                       "span" : {
-                        "startLine" : 308,
+                        "startLine" : 311,
                         "startCol" : 22,
-                        "endLine" : 308,
+                        "endLine" : 311,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 308,
+                      "startLine" : 311,
                       "startCol" : 12,
-                      "endLine" : 308,
+                      "endLine" : 311,
                       "endCol" : 24
                     }
                   },
                   "field" : "status",
                   "span" : {
-                    "startLine" : 308,
+                    "startLine" : 311,
                     "startCol" : 12,
-                    "endLine" : 308,
+                    "endLine" : 311,
                     "endCol" : 31
                   }
                 },
@@ -8959,23 +9020,23 @@
                   "kind" : "Identifier",
                   "name" : "REFUNDED",
                   "span" : {
-                    "startLine" : 308,
+                    "startLine" : 311,
                     "startCol" : 34,
-                    "endLine" : 308,
+                    "endLine" : 311,
                     "endCol" : 42
                   }
                 },
                 "span" : {
-                  "startLine" : 308,
+                  "startLine" : 311,
                   "startCol" : 12,
-                  "endLine" : 308,
+                  "endLine" : 311,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 306,
+                "startLine" : 309,
                 "startCol" : 8,
-                "endLine" : 308,
+                "endLine" : 311,
                 "endCol" : 42
               }
             },
@@ -8992,16 +9053,16 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 309,
+                        "startLine" : 312,
                         "startCol" : 12,
-                        "endLine" : 309,
+                        "endLine" : 312,
                         "endCol" : 20
                       }
                     },
                     "span" : {
-                      "startLine" : 309,
+                      "startLine" : 312,
                       "startCol" : 12,
-                      "endLine" : 309,
+                      "endLine" : 312,
                       "endCol" : 21
                     }
                   },
@@ -9009,24 +9070,24 @@
                     "kind" : "Identifier",
                     "name" : "p",
                     "span" : {
-                      "startLine" : 309,
+                      "startLine" : 312,
                       "startCol" : 22,
-                      "endLine" : 309,
+                      "endLine" : 312,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 309,
+                    "startLine" : 312,
                     "startCol" : 12,
-                    "endLine" : 309,
+                    "endLine" : 312,
                     "endCol" : 24
                   }
                 },
                 "field" : "amount",
                 "span" : {
-                  "startLine" : 309,
+                  "startLine" : 312,
                   "startCol" : 12,
-                  "endLine" : 309,
+                  "endLine" : 312,
                   "endCol" : 31
                 }
               },
@@ -9040,16 +9101,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 309,
+                        "startLine" : 312,
                         "startCol" : 38,
-                        "endLine" : 309,
+                        "endLine" : 312,
                         "endCol" : 44
                       }
                     },
                     "span" : {
-                      "startLine" : 309,
+                      "startLine" : 312,
                       "startCol" : 34,
-                      "endLine" : 309,
+                      "endLine" : 312,
                       "endCol" : 45
                     }
                   },
@@ -9057,53 +9118,53 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 309,
+                      "startLine" : 312,
                       "startCol" : 46,
-                      "endLine" : 309,
+                      "endLine" : 312,
                       "endCol" : 54
                     }
                   },
                   "span" : {
-                    "startLine" : 309,
+                    "startLine" : 312,
                     "startCol" : 34,
-                    "endLine" : 309,
+                    "endLine" : 312,
                     "endCol" : 55
                   }
                 },
                 "field" : "total",
                 "span" : {
-                  "startLine" : 309,
+                  "startLine" : 312,
                   "startCol" : 34,
-                  "endLine" : 309,
+                  "endLine" : 312,
                   "endCol" : 61
                 }
               },
               "span" : {
-                "startLine" : 309,
+                "startLine" : 312,
                 "startCol" : 12,
-                "endLine" : 309,
+                "endLine" : 312,
                 "endCol" : 61
               }
             },
             "span" : {
-              "startLine" : 306,
+              "startLine" : 309,
               "startCol" : 8,
-              "endLine" : 309,
+              "endLine" : 312,
               "endCol" : 61
             }
           },
           "span" : {
-            "startLine" : 305,
+            "startLine" : 308,
             "startCol" : 6,
-            "endLine" : 309,
+            "endLine" : 312,
             "endCol" : 61
           }
         }
       ],
       "span" : {
-        "startLine" : 289,
+        "startLine" : 292,
         "startCol" : 2,
-        "endLine" : 310,
+        "endLine" : 313,
         "endCol" : 3
       }
     },
@@ -9118,16 +9179,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 313,
+              "startLine" : 316,
               "startCol" : 22,
-              "endLine" : 313,
+              "endLine" : 316,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 313,
+            "startLine" : 316,
             "startCol" : 12,
-            "endLine" : 313,
+            "endLine" : 316,
             "endCol" : 29
           }
         }
@@ -9140,16 +9201,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 314,
+              "startLine" : 317,
               "startCol" : 19,
-              "endLine" : 314,
+              "endLine" : 317,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 314,
+            "startLine" : 317,
             "startCol" : 12,
-            "endLine" : 314,
+            "endLine" : 317,
             "endCol" : 24
           }
         }
@@ -9162,9 +9223,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 317,
+              "startLine" : 320,
               "startCol" : 6,
-              "endLine" : 317,
+              "endLine" : 320,
               "endCol" : 14
             }
           },
@@ -9172,16 +9233,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 317,
+              "startLine" : 320,
               "startCol" : 18,
-              "endLine" : 317,
+              "endLine" : 320,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 317,
+            "startLine" : 320,
             "startCol" : 6,
-            "endLine" : 317,
+            "endLine" : 320,
             "endCol" : 24
           }
         }
@@ -9194,9 +9255,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 320,
+              "startLine" : 323,
               "startCol" : 6,
-              "endLine" : 320,
+              "endLine" : 323,
               "endCol" : 11
             }
           },
@@ -9206,9 +9267,9 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 320,
+                "startLine" : 323,
                 "startCol" : 14,
-                "endLine" : 320,
+                "endLine" : 323,
                 "endCol" : 20
               }
             },
@@ -9216,23 +9277,23 @@
               "kind" : "Identifier",
               "name" : "order_id",
               "span" : {
-                "startLine" : 320,
+                "startLine" : 323,
                 "startCol" : 21,
-                "endLine" : 320,
+                "endLine" : 323,
                 "endCol" : 29
               }
             },
             "span" : {
-              "startLine" : 320,
+              "startLine" : 323,
               "startCol" : 14,
-              "endLine" : 320,
+              "endLine" : 323,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 320,
+            "startLine" : 323,
             "startCol" : 6,
-            "endLine" : 320,
+            "endLine" : 323,
             "endCol" : 30
           }
         },
@@ -9245,16 +9306,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 321,
+                "startLine" : 324,
                 "startCol" : 6,
-                "endLine" : 321,
+                "endLine" : 324,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 321,
+              "startLine" : 324,
               "startCol" : 6,
-              "endLine" : 321,
+              "endLine" : 324,
               "endCol" : 13
             }
           },
@@ -9262,24 +9323,24 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 321,
+              "startLine" : 324,
               "startCol" : 16,
-              "endLine" : 321,
+              "endLine" : 324,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 321,
+            "startLine" : 324,
             "startCol" : 6,
-            "endLine" : 321,
+            "endLine" : 324,
             "endCol" : 22
           }
         }
       ],
       "span" : {
-        "startLine" : 312,
+        "startLine" : 315,
         "startCol" : 2,
-        "endLine" : 322,
+        "endLine" : 325,
         "endCol" : 3
       }
     },
@@ -9296,23 +9357,23 @@
               "kind" : "NamedType",
               "name" : "CustomerId",
               "span" : {
-                "startLine" : 325,
+                "startLine" : 328,
                 "startCol" : 32,
-                "endLine" : 325,
+                "endLine" : 328,
                 "endCol" : 42
               }
             },
             "span" : {
-              "startLine" : 325,
+              "startLine" : 328,
               "startCol" : 25,
-              "endLine" : 325,
+              "endLine" : 328,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 325,
+            "startLine" : 328,
             "startCol" : 12,
-            "endLine" : 325,
+            "endLine" : 328,
             "endCol" : 43
           }
         },
@@ -9325,23 +9386,23 @@
               "kind" : "NamedType",
               "name" : "OrderStatus",
               "span" : {
-                "startLine" : 326,
+                "startLine" : 329,
                 "startCol" : 34,
-                "endLine" : 326,
+                "endLine" : 329,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 326,
+              "startLine" : 329,
               "startCol" : 27,
-              "endLine" : 326,
+              "endLine" : 329,
               "endCol" : 46
             }
           },
           "span" : {
-            "startLine" : 326,
+            "startLine" : 329,
             "startCol" : 12,
-            "endLine" : 326,
+            "endLine" : 329,
             "endCol" : 46
           }
         }
@@ -9356,23 +9417,23 @@
               "kind" : "NamedType",
               "name" : "Order",
               "span" : {
-                "startLine" : 327,
+                "startLine" : 330,
                 "startCol" : 25,
-                "endLine" : 327,
+                "endLine" : 330,
                 "endCol" : 30
               }
             },
             "span" : {
-              "startLine" : 327,
+              "startLine" : 330,
               "startCol" : 21,
-              "endLine" : 327,
+              "endLine" : 330,
               "endCol" : 31
             }
           },
           "span" : {
-            "startLine" : 327,
+            "startLine" : 330,
             "startCol" : 12,
-            "endLine" : 327,
+            "endLine" : 330,
             "endCol" : 31
           }
         }
@@ -9382,9 +9443,9 @@
           "kind" : "BoolLit",
           "value" : true,
           "span" : {
-            "startLine" : 330,
+            "startLine" : 333,
             "startCol" : 6,
-            "endLine" : 330,
+            "endLine" : 333,
             "endCol" : 10
           }
         }
@@ -9400,17 +9461,17 @@
                 "kind" : "Identifier",
                 "name" : "results",
                 "span" : {
-                  "startLine" : 333,
+                  "startLine" : 336,
                   "startCol" : 15,
-                  "endLine" : 333,
+                  "endLine" : 336,
                   "endCol" : 22
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 333,
+                "startLine" : 336,
                 "startCol" : 10,
-                "endLine" : 333,
+                "endLine" : 336,
                 "endCol" : 22
               }
             }
@@ -9428,9 +9489,9 @@
                   "kind" : "Identifier",
                   "name" : "o",
                   "span" : {
-                    "startLine" : 334,
+                    "startLine" : 337,
                     "startCol" : 8,
-                    "endLine" : 334,
+                    "endLine" : 337,
                     "endCol" : 9
                   }
                 },
@@ -9440,9 +9501,9 @@
                     "kind" : "Identifier",
                     "name" : "ran",
                     "span" : {
-                      "startLine" : 334,
+                      "startLine" : 337,
                       "startCol" : 13,
-                      "endLine" : 334,
+                      "endLine" : 337,
                       "endCol" : 16
                     }
                   },
@@ -9451,24 +9512,24 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 334,
+                        "startLine" : 337,
                         "startCol" : 17,
-                        "endLine" : 334,
+                        "endLine" : 337,
                         "endCol" : 23
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 334,
+                    "startLine" : 337,
                     "startCol" : 13,
-                    "endLine" : 334,
+                    "endLine" : 337,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 334,
+                  "startLine" : 337,
                   "startCol" : 8,
-                  "endLine" : 334,
+                  "endLine" : 337,
                   "endCol" : 24
                 }
               },
@@ -9482,25 +9543,25 @@
                     "kind" : "Identifier",
                     "name" : "customer_id",
                     "span" : {
-                      "startLine" : 335,
+                      "startLine" : 338,
                       "startCol" : 13,
-                      "endLine" : 335,
+                      "endLine" : 338,
                       "endCol" : 24
                     }
                   },
                   "right" : {
                     "kind" : "NoneLit",
                     "span" : {
-                      "startLine" : 335,
+                      "startLine" : 338,
                       "startCol" : 27,
-                      "endLine" : 335,
+                      "endLine" : 338,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 335,
+                    "startLine" : 338,
                     "startCol" : 13,
-                    "endLine" : 335,
+                    "endLine" : 338,
                     "endCol" : 31
                   }
                 },
@@ -9513,17 +9574,17 @@
                       "kind" : "Identifier",
                       "name" : "o",
                       "span" : {
-                        "startLine" : 335,
+                        "startLine" : 338,
                         "startCol" : 35,
-                        "endLine" : 335,
+                        "endLine" : 338,
                         "endCol" : 36
                       }
                     },
                     "field" : "customer_id",
                     "span" : {
-                      "startLine" : 335,
+                      "startLine" : 338,
                       "startCol" : 35,
-                      "endLine" : 335,
+                      "endLine" : 338,
                       "endCol" : 48
                     }
                   },
@@ -9531,30 +9592,30 @@
                     "kind" : "Identifier",
                     "name" : "customer_id",
                     "span" : {
-                      "startLine" : 335,
+                      "startLine" : 338,
                       "startCol" : 51,
-                      "endLine" : 335,
+                      "endLine" : 338,
                       "endCol" : 62
                     }
                   },
                   "span" : {
-                    "startLine" : 335,
+                    "startLine" : 338,
                     "startCol" : 35,
-                    "endLine" : 335,
+                    "endLine" : 338,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 335,
+                  "startLine" : 338,
                   "startCol" : 13,
-                  "endLine" : 335,
+                  "endLine" : 338,
                   "endCol" : 62
                 }
               },
               "span" : {
-                "startLine" : 334,
+                "startLine" : 337,
                 "startCol" : 8,
-                "endLine" : 335,
+                "endLine" : 338,
                 "endCol" : 63
               }
             },
@@ -9568,25 +9629,25 @@
                   "kind" : "Identifier",
                   "name" : "status_filter",
                   "span" : {
-                    "startLine" : 336,
+                    "startLine" : 339,
                     "startCol" : 13,
-                    "endLine" : 336,
+                    "endLine" : 339,
                     "endCol" : 26
                   }
                 },
                 "right" : {
                   "kind" : "NoneLit",
                   "span" : {
-                    "startLine" : 336,
+                    "startLine" : 339,
                     "startCol" : 29,
-                    "endLine" : 336,
+                    "endLine" : 339,
                     "endCol" : 33
                   }
                 },
                 "span" : {
-                  "startLine" : 336,
+                  "startLine" : 339,
                   "startCol" : 13,
-                  "endLine" : 336,
+                  "endLine" : 339,
                   "endCol" : 33
                 }
               },
@@ -9599,17 +9660,17 @@
                     "kind" : "Identifier",
                     "name" : "o",
                     "span" : {
-                      "startLine" : 336,
+                      "startLine" : 339,
                       "startCol" : 37,
-                      "endLine" : 336,
+                      "endLine" : 339,
                       "endCol" : 38
                     }
                   },
                   "field" : "status",
                   "span" : {
-                    "startLine" : 336,
+                    "startLine" : 339,
                     "startCol" : 37,
-                    "endLine" : 336,
+                    "endLine" : 339,
                     "endCol" : 45
                   }
                 },
@@ -9617,37 +9678,37 @@
                   "kind" : "Identifier",
                   "name" : "status_filter",
                   "span" : {
-                    "startLine" : 336,
+                    "startLine" : 339,
                     "startCol" : 48,
-                    "endLine" : 336,
+                    "endLine" : 339,
                     "endCol" : 61
                   }
                 },
                 "span" : {
-                  "startLine" : 336,
+                  "startLine" : 339,
                   "startCol" : 37,
-                  "endLine" : 336,
+                  "endLine" : 339,
                   "endCol" : 61
                 }
               },
               "span" : {
-                "startLine" : 336,
+                "startLine" : 339,
                 "startCol" : 13,
-                "endLine" : 336,
+                "endLine" : 339,
                 "endCol" : 61
               }
             },
             "span" : {
-              "startLine" : 334,
+              "startLine" : 337,
               "startCol" : 8,
-              "endLine" : 336,
+              "endLine" : 339,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 333,
+            "startLine" : 336,
             "startCol" : 6,
-            "endLine" : 336,
+            "endLine" : 339,
             "endCol" : 62
           }
         },
@@ -9660,16 +9721,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 337,
+                "startLine" : 340,
                 "startCol" : 6,
-                "endLine" : 337,
+                "endLine" : 340,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 337,
+              "startLine" : 340,
               "startCol" : 6,
-              "endLine" : 337,
+              "endLine" : 340,
               "endCol" : 13
             }
           },
@@ -9677,24 +9738,24 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 337,
+              "startLine" : 340,
               "startCol" : 16,
-              "endLine" : 337,
+              "endLine" : 340,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 337,
+            "startLine" : 340,
             "startCol" : 6,
-            "endLine" : 337,
+            "endLine" : 340,
             "endCol" : 22
           }
         }
       ],
       "span" : {
-        "startLine" : 324,
+        "startLine" : 327,
         "startCol" : 2,
-        "endLine" : 338,
+        "endLine" : 341,
         "endCol" : 3
       }
     }
@@ -9713,9 +9774,9 @@
           "via" : "PlaceOrder",
           "guard" : null,
           "span" : {
-            "startLine" : 110,
+            "startLine" : 112,
             "startCol" : 4,
-            "endLine" : 110,
+            "endLine" : 112,
             "endCol" : 43
           }
         },
@@ -9726,9 +9787,9 @@
           "via" : "CancelOrder",
           "guard" : null,
           "span" : {
-            "startLine" : 111,
+            "startLine" : 113,
             "startCol" : 4,
-            "endLine" : 111,
+            "endLine" : 113,
             "endCol" : 44
           }
         },
@@ -9743,9 +9804,9 @@
               "kind" : "Identifier",
               "name" : "paymentCaptured",
               "span" : {
-                "startLine" : 112,
+                "startLine" : 114,
                 "startCol" : 56,
-                "endLine" : 112,
+                "endLine" : 114,
                 "endCol" : 71
               }
             },
@@ -9754,24 +9815,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 112,
+                  "startLine" : 114,
                   "startCol" : 72,
-                  "endLine" : 112,
+                  "endLine" : 114,
                   "endCol" : 80
                 }
               }
             ],
             "span" : {
-              "startLine" : 112,
+              "startLine" : 114,
               "startCol" : 56,
-              "endLine" : 112,
+              "endLine" : 114,
               "endCol" : 81
             }
           },
           "span" : {
-            "startLine" : 112,
+            "startLine" : 114,
             "startCol" : 4,
-            "endLine" : 112,
+            "endLine" : 114,
             "endCol" : 81
           }
         },
@@ -9782,9 +9843,9 @@
           "via" : "CancelOrder",
           "guard" : null,
           "span" : {
-            "startLine" : 113,
+            "startLine" : 115,
             "startCol" : 4,
-            "endLine" : 113,
+            "endLine" : 115,
             "endCol" : 44
           }
         },
@@ -9795,9 +9856,9 @@
           "via" : "ShipOrder",
           "guard" : null,
           "span" : {
-            "startLine" : 114,
+            "startLine" : 116,
             "startCol" : 4,
-            "endLine" : 114,
+            "endLine" : 116,
             "endCol" : 42
           }
         },
@@ -9812,9 +9873,9 @@
               "kind" : "Identifier",
               "name" : "refundIssued",
               "span" : {
-                "startLine" : 115,
+                "startLine" : 117,
                 "startCol" : 56,
-                "endLine" : 115,
+                "endLine" : 117,
                 "endCol" : 68
               }
             },
@@ -9823,24 +9884,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 115,
+                  "startLine" : 117,
                   "startCol" : 69,
-                  "endLine" : 115,
+                  "endLine" : 117,
                   "endCol" : 77
                 }
               }
             ],
             "span" : {
-              "startLine" : 115,
+              "startLine" : 117,
               "startCol" : 56,
-              "endLine" : 115,
+              "endLine" : 117,
               "endCol" : 78
             }
           },
           "span" : {
-            "startLine" : 115,
+            "startLine" : 117,
             "startCol" : 4,
-            "endLine" : 115,
+            "endLine" : 117,
             "endCol" : 78
           }
         },
@@ -9851,9 +9912,9 @@
           "via" : "ConfirmDelivery",
           "guard" : null,
           "span" : {
-            "startLine" : 116,
+            "startLine" : 118,
             "startCol" : 4,
-            "endLine" : 116,
+            "endLine" : 118,
             "endCol" : 48
           }
         },
@@ -9868,9 +9929,9 @@
               "kind" : "Identifier",
               "name" : "withinReturnWindow",
               "span" : {
-                "startLine" : 117,
+                "startLine" : 119,
                 "startCol" : 57,
-                "endLine" : 117,
+                "endLine" : 119,
                 "endCol" : 75
               }
             },
@@ -9879,32 +9940,32 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 117,
+                  "startLine" : 119,
                   "startCol" : 76,
-                  "endLine" : 117,
+                  "endLine" : 119,
                   "endCol" : 84
                 }
               }
             ],
             "span" : {
-              "startLine" : 117,
+              "startLine" : 119,
               "startCol" : 57,
-              "endLine" : 117,
+              "endLine" : 119,
               "endCol" : 85
             }
           },
           "span" : {
-            "startLine" : 117,
+            "startLine" : 119,
             "startCol" : 4,
-            "endLine" : 117,
+            "endLine" : 119,
             "endCol" : 85
           }
         }
       ],
       "span" : {
-        "startLine" : 106,
+        "startLine" : 108,
         "startCol" : 2,
-        "endLine" : 118,
+        "endLine" : 120,
         "endCol" : 3
       }
     }
@@ -9923,17 +9984,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 343,
+                "startLine" : 346,
                 "startCol" : 15,
-                "endLine" : 343,
+                "endLine" : 346,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 343,
+              "startLine" : 346,
               "startCol" : 8,
-              "endLine" : 343,
+              "endLine" : 346,
               "endCol" : 21
             }
           }
@@ -9949,9 +10010,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 344,
+                  "startLine" : 347,
                   "startCol" : 6,
-                  "endLine" : 344,
+                  "endLine" : 347,
                   "endCol" : 12
                 }
               },
@@ -9959,24 +10020,24 @@
                 "kind" : "Identifier",
                 "name" : "oid",
                 "span" : {
-                  "startLine" : 344,
+                  "startLine" : 347,
                   "startCol" : 13,
-                  "endLine" : 344,
+                  "endLine" : 347,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 344,
+                "startLine" : 347,
                 "startCol" : 6,
-                "endLine" : 344,
+                "endLine" : 347,
                 "endCol" : 17
               }
             },
             "field" : "total",
             "span" : {
-              "startLine" : 344,
+              "startLine" : 347,
               "startCol" : 6,
-              "endLine" : 344,
+              "endLine" : 347,
               "endCol" : 23
             }
           },
@@ -9989,9 +10050,9 @@
                 "kind" : "Identifier",
                 "name" : "sum",
                 "span" : {
-                  "startLine" : 345,
+                  "startLine" : 348,
                   "startCol" : 8,
-                  "endLine" : 345,
+                  "endLine" : 348,
                   "endCol" : 11
                 }
               },
@@ -10004,9 +10065,9 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 345,
+                        "startLine" : 348,
                         "startCol" : 12,
-                        "endLine" : 345,
+                        "endLine" : 348,
                         "endCol" : 18
                       }
                     },
@@ -10014,24 +10075,24 @@
                       "kind" : "Identifier",
                       "name" : "oid",
                       "span" : {
-                        "startLine" : 345,
+                        "startLine" : 348,
                         "startCol" : 19,
-                        "endLine" : 345,
+                        "endLine" : 348,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 345,
+                      "startLine" : 348,
                       "startCol" : 12,
-                      "endLine" : 345,
+                      "endLine" : 348,
                       "endCol" : 23
                     }
                   },
                   "field" : "items",
                   "span" : {
-                    "startLine" : 345,
+                    "startLine" : 348,
                     "startCol" : 12,
-                    "endLine" : 345,
+                    "endLine" : 348,
                     "endCol" : 29
                   }
                 },
@@ -10044,32 +10105,32 @@
                       "kind" : "Identifier",
                       "name" : "i",
                       "span" : {
-                        "startLine" : 345,
+                        "startLine" : 348,
                         "startCol" : 36,
-                        "endLine" : 345,
+                        "endLine" : 348,
                         "endCol" : 37
                       }
                     },
                     "field" : "line_total",
                     "span" : {
-                      "startLine" : 345,
+                      "startLine" : 348,
                       "startCol" : 36,
-                      "endLine" : 345,
+                      "endLine" : 348,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 345,
+                    "startLine" : 348,
                     "startCol" : 31,
-                    "endLine" : 345,
+                    "endLine" : 348,
                     "endCol" : 48
                   }
                 }
               ],
               "span" : {
-                "startLine" : 345,
+                "startLine" : 348,
                 "startCol" : 8,
-                "endLine" : 345,
+                "endLine" : 348,
                 "endCol" : 49
               }
             },
@@ -10081,9 +10142,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 345,
+                    "startLine" : 348,
                     "startCol" : 52,
-                    "endLine" : 345,
+                    "endLine" : 348,
                     "endCol" : 58
                   }
                 },
@@ -10091,52 +10152,52 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 345,
+                    "startLine" : 348,
                     "startCol" : 59,
-                    "endLine" : 345,
+                    "endLine" : 348,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 345,
+                  "startLine" : 348,
                   "startCol" : 52,
-                  "endLine" : 345,
+                  "endLine" : 348,
                   "endCol" : 63
                 }
               },
               "field" : "tax",
               "span" : {
-                "startLine" : 345,
+                "startLine" : 348,
                 "startCol" : 52,
-                "endLine" : 345,
+                "endLine" : 348,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 345,
+              "startLine" : 348,
               "startCol" : 8,
-              "endLine" : 345,
+              "endLine" : 348,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 344,
+            "startLine" : 347,
             "startCol" : 6,
-            "endLine" : 345,
+            "endLine" : 348,
             "endCol" : 67
           }
         },
         "span" : {
-          "startLine" : 343,
+          "startLine" : 346,
           "startCol" : 4,
-          "endLine" : 345,
+          "endLine" : 348,
           "endCol" : 67
         }
       },
       "span" : {
-        "startLine" : 342,
+        "startLine" : 345,
         "startCol" : 2,
-        "endLine" : 345,
+        "endLine" : 348,
         "endCol" : 67
       }
     },
@@ -10153,17 +10214,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 348,
+                "startLine" : 351,
                 "startCol" : 15,
-                "endLine" : 348,
+                "endLine" : 351,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 348,
+              "startLine" : 351,
               "startCol" : 8,
-              "endLine" : 348,
+              "endLine" : 351,
               "endCol" : 21
             }
           }
@@ -10182,9 +10243,9 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 349,
+                      "startLine" : 352,
                       "startCol" : 18,
-                      "endLine" : 349,
+                      "endLine" : 352,
                       "endCol" : 24
                     }
                   },
@@ -10192,32 +10253,32 @@
                     "kind" : "Identifier",
                     "name" : "oid",
                     "span" : {
-                      "startLine" : 349,
+                      "startLine" : 352,
                       "startCol" : 25,
-                      "endLine" : 349,
+                      "endLine" : 352,
                       "endCol" : 28
                     }
                   },
                   "span" : {
-                    "startLine" : 349,
+                    "startLine" : 352,
                     "startCol" : 18,
-                    "endLine" : 349,
+                    "endLine" : 352,
                     "endCol" : 29
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 349,
+                  "startLine" : 352,
                   "startCol" : 18,
-                  "endLine" : 349,
+                  "endLine" : 352,
                   "endCol" : 35
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 349,
+                "startLine" : 352,
                 "startCol" : 10,
-                "endLine" : 349,
+                "endLine" : 352,
                 "endCol" : 35
               }
             }
@@ -10231,17 +10292,17 @@
                 "kind" : "Identifier",
                 "name" : "item",
                 "span" : {
-                  "startLine" : 350,
+                  "startLine" : 353,
                   "startCol" : 8,
-                  "endLine" : 350,
+                  "endLine" : 353,
                   "endCol" : 12
                 }
               },
               "field" : "line_total",
               "span" : {
-                "startLine" : 350,
+                "startLine" : 353,
                 "startCol" : 8,
-                "endLine" : 350,
+                "endLine" : 353,
                 "endCol" : 23
               }
             },
@@ -10254,17 +10315,17 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 350,
+                    "startLine" : 353,
                     "startCol" : 26,
-                    "endLine" : 350,
+                    "endLine" : 353,
                     "endCol" : 30
                   }
                 },
                 "field" : "unit_price",
                 "span" : {
-                  "startLine" : 350,
+                  "startLine" : 353,
                   "startCol" : 26,
-                  "endLine" : 350,
+                  "endLine" : 353,
                   "endCol" : 41
                 }
               },
@@ -10274,52 +10335,52 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 350,
+                    "startLine" : 353,
                     "startCol" : 44,
-                    "endLine" : 350,
+                    "endLine" : 353,
                     "endCol" : 48
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 350,
+                  "startLine" : 353,
                   "startCol" : 44,
-                  "endLine" : 350,
+                  "endLine" : 353,
                   "endCol" : 57
                 }
               },
               "span" : {
-                "startLine" : 350,
+                "startLine" : 353,
                 "startCol" : 26,
-                "endLine" : 350,
+                "endLine" : 353,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 350,
+              "startLine" : 353,
               "startCol" : 8,
-              "endLine" : 350,
+              "endLine" : 353,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 349,
+            "startLine" : 352,
             "startCol" : 6,
-            "endLine" : 350,
+            "endLine" : 353,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 348,
+          "startLine" : 351,
           "startCol" : 4,
-          "endLine" : 350,
+          "endLine" : 353,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 347,
+        "startLine" : 350,
         "startCol" : 2,
-        "endLine" : 350,
+        "endLine" : 353,
         "endCol" : 57
       }
     },
@@ -10336,17 +10397,17 @@
               "kind" : "Identifier",
               "name" : "inventory",
               "span" : {
-                "startLine" : 353,
+                "startLine" : 356,
                 "startCol" : 15,
-                "endLine" : 353,
+                "endLine" : 356,
                 "endCol" : 24
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 353,
+              "startLine" : 356,
               "startCol" : 8,
-              "endLine" : 353,
+              "endLine" : 356,
               "endCol" : 24
             }
           }
@@ -10365,9 +10426,9 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 354,
+                    "startLine" : 357,
                     "startCol" : 6,
-                    "endLine" : 354,
+                    "endLine" : 357,
                     "endCol" : 15
                   }
                 },
@@ -10375,24 +10436,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 354,
+                    "startLine" : 357,
                     "startCol" : 16,
-                    "endLine" : 354,
+                    "endLine" : 357,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 354,
+                  "startLine" : 357,
                   "startCol" : 6,
-                  "endLine" : 354,
+                  "endLine" : 357,
                   "endCol" : 20
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 354,
+                "startLine" : 357,
                 "startCol" : 6,
-                "endLine" : 354,
+                "endLine" : 357,
                 "endCol" : 30
               }
             },
@@ -10400,16 +10461,16 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 354,
+                "startLine" : 357,
                 "startCol" : 34,
-                "endLine" : 354,
+                "endLine" : 357,
                 "endCol" : 35
               }
             },
             "span" : {
-              "startLine" : 354,
+              "startLine" : 357,
               "startCol" : 6,
-              "endLine" : 354,
+              "endLine" : 357,
               "endCol" : 35
             }
           },
@@ -10424,9 +10485,9 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 355,
+                    "startLine" : 358,
                     "startCol" : 10,
-                    "endLine" : 355,
+                    "endLine" : 358,
                     "endCol" : 19
                   }
                 },
@@ -10434,24 +10495,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 355,
+                    "startLine" : 358,
                     "startCol" : 20,
-                    "endLine" : 355,
+                    "endLine" : 358,
                     "endCol" : 23
                   }
                 },
                 "span" : {
-                  "startLine" : 355,
+                  "startLine" : 358,
                   "startCol" : 10,
-                  "endLine" : 355,
+                  "endLine" : 358,
                   "endCol" : 24
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 355,
+                "startLine" : 358,
                 "startCol" : 10,
-                "endLine" : 355,
+                "endLine" : 358,
                 "endCol" : 33
               }
             },
@@ -10459,37 +10520,37 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 355,
+                "startLine" : 358,
                 "startCol" : 37,
-                "endLine" : 355,
+                "endLine" : 358,
                 "endCol" : 38
               }
             },
             "span" : {
-              "startLine" : 355,
+              "startLine" : 358,
               "startCol" : 10,
-              "endLine" : 355,
+              "endLine" : 358,
               "endCol" : 38
             }
           },
           "span" : {
-            "startLine" : 354,
+            "startLine" : 357,
             "startCol" : 6,
-            "endLine" : 355,
+            "endLine" : 358,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 353,
+          "startLine" : 356,
           "startCol" : 4,
-          "endLine" : 355,
+          "endLine" : 358,
           "endCol" : 38
         }
       },
       "span" : {
-        "startLine" : 352,
+        "startLine" : 355,
         "startCol" : 2,
-        "endLine" : 355,
+        "endLine" : 358,
         "endCol" : 38
       }
     },
@@ -10506,17 +10567,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 358,
+                "startLine" : 361,
                 "startCol" : 15,
-                "endLine" : 358,
+                "endLine" : 361,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 358,
+              "startLine" : 361,
               "startCol" : 8,
-              "endLine" : 358,
+              "endLine" : 361,
               "endCol" : 21
             }
           }
@@ -10535,9 +10596,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 359,
+                    "startLine" : 362,
                     "startCol" : 6,
-                    "endLine" : 359,
+                    "endLine" : 362,
                     "endCol" : 12
                   }
                 },
@@ -10545,24 +10606,24 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 359,
+                    "startLine" : 362,
                     "startCol" : 13,
-                    "endLine" : 359,
+                    "endLine" : 362,
                     "endCol" : 16
                   }
                 },
                 "span" : {
-                  "startLine" : 359,
+                  "startLine" : 362,
                   "startCol" : 6,
-                  "endLine" : 359,
+                  "endLine" : 362,
                   "endCol" : 17
                 }
               },
               "field" : "status",
               "span" : {
-                "startLine" : 359,
+                "startLine" : 362,
                 "startCol" : 6,
-                "endLine" : 359,
+                "endLine" : 362,
                 "endCol" : 24
               }
             },
@@ -10573,9 +10634,9 @@
                   "kind" : "Identifier",
                   "name" : "DRAFT",
                   "span" : {
-                    "startLine" : 359,
+                    "startLine" : 362,
                     "startCol" : 33,
-                    "endLine" : 359,
+                    "endLine" : 362,
                     "endCol" : 38
                   }
                 },
@@ -10583,24 +10644,24 @@
                   "kind" : "Identifier",
                   "name" : "CANCELLED",
                   "span" : {
-                    "startLine" : 359,
+                    "startLine" : 362,
                     "startCol" : 40,
-                    "endLine" : 359,
+                    "endLine" : 362,
                     "endCol" : 49
                   }
                 }
               ],
               "span" : {
-                "startLine" : 359,
+                "startLine" : 362,
                 "startCol" : 32,
-                "endLine" : 359,
+                "endLine" : 362,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 359,
+              "startLine" : 362,
               "startCol" : 6,
-              "endLine" : 359,
+              "endLine" : 362,
               "endCol" : 50
             }
           },
@@ -10618,9 +10679,9 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 359,
+                      "startLine" : 362,
                       "startCol" : 60,
-                      "endLine" : 359,
+                      "endLine" : 362,
                       "endCol" : 66
                     }
                   },
@@ -10628,31 +10689,31 @@
                     "kind" : "Identifier",
                     "name" : "oid",
                     "span" : {
-                      "startLine" : 359,
+                      "startLine" : 362,
                       "startCol" : 67,
-                      "endLine" : 359,
+                      "endLine" : 362,
                       "endCol" : 70
                     }
                   },
                   "span" : {
-                    "startLine" : 359,
+                    "startLine" : 362,
                     "startCol" : 60,
-                    "endLine" : 359,
+                    "endLine" : 362,
                     "endCol" : 71
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 359,
+                  "startLine" : 362,
                   "startCol" : 60,
-                  "endLine" : 359,
+                  "endLine" : 362,
                   "endCol" : 77
                 }
               },
               "span" : {
-                "startLine" : 359,
+                "startLine" : 362,
                 "startCol" : 59,
-                "endLine" : 359,
+                "endLine" : 362,
                 "endCol" : 77
               }
             },
@@ -10660,37 +10721,37 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 359,
+                "startLine" : 362,
                 "startCol" : 80,
-                "endLine" : 359,
+                "endLine" : 362,
                 "endCol" : 81
               }
             },
             "span" : {
-              "startLine" : 359,
+              "startLine" : 362,
               "startCol" : 59,
-              "endLine" : 359,
+              "endLine" : 362,
               "endCol" : 81
             }
           },
           "span" : {
-            "startLine" : 359,
+            "startLine" : 362,
             "startCol" : 6,
-            "endLine" : 359,
+            "endLine" : 362,
             "endCol" : 81
           }
         },
         "span" : {
-          "startLine" : 358,
+          "startLine" : 361,
           "startCol" : 4,
-          "endLine" : 359,
+          "endLine" : 362,
           "endCol" : 81
         }
       },
       "span" : {
-        "startLine" : 357,
+        "startLine" : 360,
         "startCol" : 2,
-        "endLine" : 359,
+        "endLine" : 362,
         "endCol" : 81
       }
     },
@@ -10707,17 +10768,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 362,
+                "startLine" : 365,
                 "startCol" : 15,
-                "endLine" : 362,
+                "endLine" : 365,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 362,
+              "startLine" : 365,
               "startCol" : 8,
-              "endLine" : 362,
+              "endLine" : 365,
               "endCol" : 21
             }
           }
@@ -10736,9 +10797,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 363,
+                    "startLine" : 366,
                     "startCol" : 6,
-                    "endLine" : 363,
+                    "endLine" : 366,
                     "endCol" : 12
                   }
                 },
@@ -10746,24 +10807,24 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 363,
+                    "startLine" : 366,
                     "startCol" : 13,
-                    "endLine" : 363,
+                    "endLine" : 366,
                     "endCol" : 16
                   }
                 },
                 "span" : {
-                  "startLine" : 363,
+                  "startLine" : 366,
                   "startCol" : 6,
-                  "endLine" : 363,
+                  "endLine" : 366,
                   "endCol" : 17
                 }
               },
               "field" : "status",
               "span" : {
-                "startLine" : 363,
+                "startLine" : 366,
                 "startCol" : 6,
-                "endLine" : 363,
+                "endLine" : 366,
                 "endCol" : 24
               }
             },
@@ -10774,9 +10835,9 @@
                   "kind" : "Identifier",
                   "name" : "PAID",
                   "span" : {
-                    "startLine" : 363,
+                    "startLine" : 366,
                     "startCol" : 29,
-                    "endLine" : 363,
+                    "endLine" : 366,
                     "endCol" : 33
                   }
                 },
@@ -10784,9 +10845,9 @@
                   "kind" : "Identifier",
                   "name" : "SHIPPED",
                   "span" : {
-                    "startLine" : 363,
+                    "startLine" : 366,
                     "startCol" : 35,
-                    "endLine" : 363,
+                    "endLine" : 366,
                     "endCol" : 42
                   }
                 },
@@ -10794,24 +10855,24 @@
                   "kind" : "Identifier",
                   "name" : "DELIVERED",
                   "span" : {
-                    "startLine" : 363,
+                    "startLine" : 366,
                     "startCol" : 44,
-                    "endLine" : 363,
+                    "endLine" : 366,
                     "endCol" : 53
                   }
                 }
               ],
               "span" : {
-                "startLine" : 363,
+                "startLine" : 366,
                 "startCol" : 28,
-                "endLine" : 363,
+                "endLine" : 366,
                 "endCol" : 54
               }
             },
             "span" : {
-              "startLine" : 363,
+              "startLine" : 366,
               "startCol" : 6,
-              "endLine" : 363,
+              "endLine" : 366,
               "endCol" : 54
             }
           },
@@ -10825,17 +10886,17 @@
                   "kind" : "Identifier",
                   "name" : "payments",
                   "span" : {
-                    "startLine" : 364,
+                    "startLine" : 367,
                     "startCol" : 20,
-                    "endLine" : 364,
+                    "endLine" : 367,
                     "endCol" : 28
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 364,
+                  "startLine" : 367,
                   "startCol" : 13,
-                  "endLine" : 364,
+                  "endLine" : 367,
                   "endCol" : 28
                 }
               }
@@ -10854,9 +10915,9 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 365,
+                        "startLine" : 368,
                         "startCol" : 10,
-                        "endLine" : 365,
+                        "endLine" : 368,
                         "endCol" : 18
                       }
                     },
@@ -10864,24 +10925,24 @@
                       "kind" : "Identifier",
                       "name" : "pid",
                       "span" : {
-                        "startLine" : 365,
+                        "startLine" : 368,
                         "startCol" : 19,
-                        "endLine" : 365,
+                        "endLine" : 368,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 365,
+                      "startLine" : 368,
                       "startCol" : 10,
-                      "endLine" : 365,
+                      "endLine" : 368,
                       "endCol" : 23
                     }
                   },
                   "field" : "order_id",
                   "span" : {
-                    "startLine" : 365,
+                    "startLine" : 368,
                     "startCol" : 10,
-                    "endLine" : 365,
+                    "endLine" : 368,
                     "endCol" : 32
                   }
                 },
@@ -10889,16 +10950,16 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 365,
+                    "startLine" : 368,
                     "startCol" : 35,
-                    "endLine" : 365,
+                    "endLine" : 368,
                     "endCol" : 38
                   }
                 },
                 "span" : {
-                  "startLine" : 365,
+                  "startLine" : 368,
                   "startCol" : 10,
-                  "endLine" : 365,
+                  "endLine" : 368,
                   "endCol" : 38
                 }
               },
@@ -10913,9 +10974,9 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 366,
+                        "startLine" : 369,
                         "startCol" : 14,
-                        "endLine" : 366,
+                        "endLine" : 369,
                         "endCol" : 22
                       }
                     },
@@ -10923,24 +10984,24 @@
                       "kind" : "Identifier",
                       "name" : "pid",
                       "span" : {
-                        "startLine" : 366,
+                        "startLine" : 369,
                         "startCol" : 23,
-                        "endLine" : 366,
+                        "endLine" : 369,
                         "endCol" : 26
                       }
                     },
                     "span" : {
-                      "startLine" : 366,
+                      "startLine" : 369,
                       "startCol" : 14,
-                      "endLine" : 366,
+                      "endLine" : 369,
                       "endCol" : 27
                     }
                   },
                   "field" : "status",
                   "span" : {
-                    "startLine" : 366,
+                    "startLine" : 369,
                     "startCol" : 14,
-                    "endLine" : 366,
+                    "endLine" : 369,
                     "endCol" : 34
                   }
                 },
@@ -10948,51 +11009,51 @@
                   "kind" : "Identifier",
                   "name" : "CAPTURED",
                   "span" : {
-                    "startLine" : 366,
+                    "startLine" : 369,
                     "startCol" : 37,
-                    "endLine" : 366,
+                    "endLine" : 369,
                     "endCol" : 45
                   }
                 },
                 "span" : {
-                  "startLine" : 366,
+                  "startLine" : 369,
                   "startCol" : 14,
-                  "endLine" : 366,
+                  "endLine" : 369,
                   "endCol" : 45
                 }
               },
               "span" : {
-                "startLine" : 365,
+                "startLine" : 368,
                 "startCol" : 10,
-                "endLine" : 366,
+                "endLine" : 369,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 364,
+              "startLine" : 367,
               "startCol" : 8,
-              "endLine" : 366,
+              "endLine" : 369,
               "endCol" : 45
             }
           },
           "span" : {
-            "startLine" : 363,
+            "startLine" : 366,
             "startCol" : 6,
-            "endLine" : 366,
+            "endLine" : 369,
             "endCol" : 45
           }
         },
         "span" : {
-          "startLine" : 362,
+          "startLine" : 365,
           "startCol" : 4,
-          "endLine" : 366,
+          "endLine" : 369,
           "endCol" : 45
         }
       },
       "span" : {
-        "startLine" : 361,
+        "startLine" : 364,
         "startCol" : 2,
-        "endLine" : 366,
+        "endLine" : 369,
         "endCol" : 45
       }
     },
@@ -11009,17 +11070,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 369,
+                "startLine" : 372,
                 "startCol" : 15,
-                "endLine" : 369,
+                "endLine" : 372,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 369,
+              "startLine" : 372,
               "startCol" : 8,
-              "endLine" : 369,
+              "endLine" : 372,
               "endCol" : 21
             }
           }
@@ -11038,9 +11099,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 370,
+                    "startLine" : 373,
                     "startCol" : 6,
-                    "endLine" : 370,
+                    "endLine" : 373,
                     "endCol" : 12
                   }
                 },
@@ -11048,24 +11109,24 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 370,
+                    "startLine" : 373,
                     "startCol" : 13,
-                    "endLine" : 370,
+                    "endLine" : 373,
                     "endCol" : 16
                   }
                 },
                 "span" : {
-                  "startLine" : 370,
+                  "startLine" : 373,
                   "startCol" : 6,
-                  "endLine" : 370,
+                  "endLine" : 373,
                   "endCol" : 17
                 }
               },
               "field" : "status",
               "span" : {
-                "startLine" : 370,
+                "startLine" : 373,
                 "startCol" : 6,
-                "endLine" : 370,
+                "endLine" : 373,
                 "endCol" : 24
               }
             },
@@ -11073,16 +11134,16 @@
               "kind" : "Identifier",
               "name" : "CANCELLED",
               "span" : {
-                "startLine" : 370,
+                "startLine" : 373,
                 "startCol" : 27,
-                "endLine" : 370,
+                "endLine" : 373,
                 "endCol" : 36
               }
             },
             "span" : {
-              "startLine" : 370,
+              "startLine" : 373,
               "startCol" : 6,
-              "endLine" : 370,
+              "endLine" : 373,
               "endCol" : 36
             }
           },
@@ -11096,17 +11157,17 @@
                   "kind" : "Identifier",
                   "name" : "payments",
                   "span" : {
-                    "startLine" : 371,
+                    "startLine" : 374,
                     "startCol" : 20,
-                    "endLine" : 371,
+                    "endLine" : 374,
                     "endCol" : 28
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 371,
+                  "startLine" : 374,
                   "startCol" : 13,
-                  "endLine" : 371,
+                  "endLine" : 374,
                   "endCol" : 28
                 }
               }
@@ -11125,9 +11186,9 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 372,
+                        "startLine" : 375,
                         "startCol" : 10,
-                        "endLine" : 372,
+                        "endLine" : 375,
                         "endCol" : 18
                       }
                     },
@@ -11135,24 +11196,24 @@
                       "kind" : "Identifier",
                       "name" : "pid",
                       "span" : {
-                        "startLine" : 372,
+                        "startLine" : 375,
                         "startCol" : 19,
-                        "endLine" : 372,
+                        "endLine" : 375,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 372,
+                      "startLine" : 375,
                       "startCol" : 10,
-                      "endLine" : 372,
+                      "endLine" : 375,
                       "endCol" : 23
                     }
                   },
                   "field" : "order_id",
                   "span" : {
-                    "startLine" : 372,
+                    "startLine" : 375,
                     "startCol" : 10,
-                    "endLine" : 372,
+                    "endLine" : 375,
                     "endCol" : 32
                   }
                 },
@@ -11160,16 +11221,16 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 372,
+                    "startLine" : 375,
                     "startCol" : 35,
-                    "endLine" : 372,
+                    "endLine" : 375,
                     "endCol" : 38
                   }
                 },
                 "span" : {
-                  "startLine" : 372,
+                  "startLine" : 375,
                   "startCol" : 10,
-                  "endLine" : 372,
+                  "endLine" : 375,
                   "endCol" : 38
                 }
               },
@@ -11187,9 +11248,9 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 372,
+                          "startLine" : 375,
                           "startCol" : 43,
-                          "endLine" : 372,
+                          "endLine" : 375,
                           "endCol" : 51
                         }
                       },
@@ -11197,24 +11258,24 @@
                         "kind" : "Identifier",
                         "name" : "pid",
                         "span" : {
-                          "startLine" : 372,
+                          "startLine" : 375,
                           "startCol" : 52,
-                          "endLine" : 372,
+                          "endLine" : 375,
                           "endCol" : 55
                         }
                       },
                       "span" : {
-                        "startLine" : 372,
+                        "startLine" : 375,
                         "startCol" : 43,
-                        "endLine" : 372,
+                        "endLine" : 375,
                         "endCol" : 56
                       }
                     },
                     "field" : "status",
                     "span" : {
-                      "startLine" : 372,
+                      "startLine" : 375,
                       "startCol" : 43,
-                      "endLine" : 372,
+                      "endLine" : 375,
                       "endCol" : 63
                     }
                   },
@@ -11222,16 +11283,16 @@
                     "kind" : "Identifier",
                     "name" : "CAPTURED",
                     "span" : {
-                      "startLine" : 372,
+                      "startLine" : 375,
                       "startCol" : 66,
-                      "endLine" : 372,
+                      "endLine" : 375,
                       "endCol" : 74
                     }
                   },
                   "span" : {
-                    "startLine" : 372,
+                    "startLine" : 375,
                     "startCol" : 43,
-                    "endLine" : 372,
+                    "endLine" : 375,
                     "endCol" : 74
                   }
                 },
@@ -11245,17 +11306,17 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 374,
+                          "startLine" : 377,
                           "startCol" : 22,
-                          "endLine" : 374,
+                          "endLine" : 377,
                           "endCol" : 30
                         }
                       },
                       "bindingKind" : "in",
                       "span" : {
-                        "startLine" : 374,
+                        "startLine" : 377,
                         "startCol" : 15,
-                        "endLine" : 374,
+                        "endLine" : 377,
                         "endCol" : 30
                       }
                     }
@@ -11274,9 +11335,9 @@
                             "kind" : "Identifier",
                             "name" : "payments",
                             "span" : {
-                              "startLine" : 375,
+                              "startLine" : 378,
                               "startCol" : 12,
-                              "endLine" : 375,
+                              "endLine" : 378,
                               "endCol" : 20
                             }
                           },
@@ -11284,24 +11345,24 @@
                             "kind" : "Identifier",
                             "name" : "rid",
                             "span" : {
-                              "startLine" : 375,
+                              "startLine" : 378,
                               "startCol" : 21,
-                              "endLine" : 375,
+                              "endLine" : 378,
                               "endCol" : 24
                             }
                           },
                           "span" : {
-                            "startLine" : 375,
+                            "startLine" : 378,
                             "startCol" : 12,
-                            "endLine" : 375,
+                            "endLine" : 378,
                             "endCol" : 25
                           }
                         },
                         "field" : "order_id",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 378,
                           "startCol" : 12,
-                          "endLine" : 375,
+                          "endLine" : 378,
                           "endCol" : 34
                         }
                       },
@@ -11309,16 +11370,16 @@
                         "kind" : "Identifier",
                         "name" : "oid",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 378,
                           "startCol" : 37,
-                          "endLine" : 375,
+                          "endLine" : 378,
                           "endCol" : 40
                         }
                       },
                       "span" : {
-                        "startLine" : 375,
+                        "startLine" : 378,
                         "startCol" : 12,
-                        "endLine" : 375,
+                        "endLine" : 378,
                         "endCol" : 40
                       }
                     },
@@ -11333,9 +11394,9 @@
                             "kind" : "Identifier",
                             "name" : "payments",
                             "span" : {
-                              "startLine" : 375,
+                              "startLine" : 378,
                               "startCol" : 45,
-                              "endLine" : 375,
+                              "endLine" : 378,
                               "endCol" : 53
                             }
                           },
@@ -11343,24 +11404,24 @@
                             "kind" : "Identifier",
                             "name" : "rid",
                             "span" : {
-                              "startLine" : 375,
+                              "startLine" : 378,
                               "startCol" : 54,
-                              "endLine" : 375,
+                              "endLine" : 378,
                               "endCol" : 57
                             }
                           },
                           "span" : {
-                            "startLine" : 375,
+                            "startLine" : 378,
                             "startCol" : 45,
-                            "endLine" : 375,
+                            "endLine" : 378,
                             "endCol" : 58
                           }
                         },
                         "field" : "status",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 378,
                           "startCol" : 45,
-                          "endLine" : 375,
+                          "endLine" : 378,
                           "endCol" : 65
                         }
                       },
@@ -11368,72 +11429,72 @@
                         "kind" : "Identifier",
                         "name" : "REFUNDED",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 378,
                           "startCol" : 68,
-                          "endLine" : 375,
+                          "endLine" : 378,
                           "endCol" : 76
                         }
                       },
                       "span" : {
-                        "startLine" : 375,
+                        "startLine" : 378,
                         "startCol" : 45,
-                        "endLine" : 375,
+                        "endLine" : 378,
                         "endCol" : 76
                       }
                     },
                     "span" : {
-                      "startLine" : 375,
+                      "startLine" : 378,
                       "startCol" : 12,
-                      "endLine" : 375,
+                      "endLine" : 378,
                       "endCol" : 76
                     }
                   },
                   "span" : {
-                    "startLine" : 374,
+                    "startLine" : 377,
                     "startCol" : 10,
-                    "endLine" : 375,
+                    "endLine" : 378,
                     "endCol" : 76
                   }
                 },
                 "span" : {
-                  "startLine" : 372,
+                  "startLine" : 375,
                   "startCol" : 43,
-                  "endLine" : 375,
+                  "endLine" : 378,
                   "endCol" : 76
                 }
               },
               "span" : {
-                "startLine" : 372,
+                "startLine" : 375,
                 "startCol" : 10,
-                "endLine" : 375,
+                "endLine" : 378,
                 "endCol" : 76
               }
             },
             "span" : {
-              "startLine" : 371,
+              "startLine" : 374,
               "startCol" : 9,
-              "endLine" : 375,
+              "endLine" : 378,
               "endCol" : 76
             }
           },
           "span" : {
-            "startLine" : 370,
+            "startLine" : 373,
             "startCol" : 6,
-            "endLine" : 375,
+            "endLine" : 378,
             "endCol" : 77
           }
         },
         "span" : {
-          "startLine" : 369,
+          "startLine" : 372,
           "startCol" : 4,
-          "endLine" : 375,
+          "endLine" : 378,
           "endCol" : 77
         }
       },
       "span" : {
-        "startLine" : 368,
+        "startLine" : 371,
         "startCol" : 2,
-        "endLine" : 375,
+        "endLine" : 378,
         "endCol" : 77
       }
     }
@@ -11562,16 +11623,16 @@
           "kind" : "StringLit",
           "value" : "/orders",
           "span" : {
-            "startLine" : 380,
+            "startLine" : 383,
             "startCol" : 33,
-            "endLine" : 380,
+            "endLine" : 383,
             "endCol" : 42
           }
         },
         "span" : {
-          "startLine" : 380,
+          "startLine" : 383,
           "startCol" : 4,
-          "endLine" : 380,
+          "endLine" : 383,
           "endCol" : 42
         }
       },
@@ -11584,16 +11645,16 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 381,
+            "startLine" : 384,
             "startCol" : 43,
-            "endLine" : 381,
+            "endLine" : 384,
             "endCol" : 46
           }
         },
         "span" : {
-          "startLine" : 381,
+          "startLine" : 384,
           "startCol" : 4,
-          "endLine" : 381,
+          "endLine" : 384,
           "endCol" : 46
         }
       },
@@ -11606,16 +11667,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 383,
+            "startLine" : 386,
             "startCol" : 30,
-            "endLine" : 383,
+            "endLine" : 386,
             "endCol" : 36
           }
         },
         "span" : {
-          "startLine" : 383,
+          "startLine" : 386,
           "startCol" : 4,
-          "endLine" : 383,
+          "endLine" : 386,
           "endCol" : 36
         }
       },
@@ -11628,16 +11689,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/items",
           "span" : {
-            "startLine" : 384,
+            "startLine" : 387,
             "startCol" : 28,
-            "endLine" : 384,
+            "endLine" : 387,
             "endCol" : 54
           }
         },
         "span" : {
-          "startLine" : 384,
+          "startLine" : 387,
           "startCol" : 4,
-          "endLine" : 384,
+          "endLine" : 387,
           "endCol" : 54
         }
       },
@@ -11650,16 +11711,16 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 385,
+            "startLine" : 388,
             "startCol" : 38,
-            "endLine" : 385,
+            "endLine" : 388,
             "endCol" : 41
           }
         },
         "span" : {
-          "startLine" : 385,
+          "startLine" : 388,
           "startCol" : 4,
-          "endLine" : 385,
+          "endLine" : 388,
           "endCol" : 41
         }
       },
@@ -11672,16 +11733,16 @@
           "kind" : "StringLit",
           "value" : "DELETE",
           "span" : {
-            "startLine" : 387,
+            "startLine" : 390,
             "startCol" : 33,
-            "endLine" : 387,
+            "endLine" : 390,
             "endCol" : 41
           }
         },
         "span" : {
-          "startLine" : 387,
+          "startLine" : 390,
           "startCol" : 4,
-          "endLine" : 387,
+          "endLine" : 390,
           "endCol" : 41
         }
       },
@@ -11694,16 +11755,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/items/{item_id}",
           "span" : {
-            "startLine" : 388,
+            "startLine" : 391,
             "startCol" : 31,
-            "endLine" : 388,
+            "endLine" : 391,
             "endCol" : 67
           }
         },
         "span" : {
-          "startLine" : 388,
+          "startLine" : 391,
           "startCol" : 4,
-          "endLine" : 388,
+          "endLine" : 391,
           "endCol" : 67
         }
       },
@@ -11716,16 +11777,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 390,
+            "startLine" : 393,
             "startCol" : 29,
-            "endLine" : 390,
+            "endLine" : 393,
             "endCol" : 35
           }
         },
         "span" : {
-          "startLine" : 390,
+          "startLine" : 393,
           "startCol" : 4,
-          "endLine" : 390,
+          "endLine" : 393,
           "endCol" : 35
         }
       },
@@ -11738,16 +11799,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/place",
           "span" : {
-            "startLine" : 391,
+            "startLine" : 394,
             "startCol" : 27,
-            "endLine" : 391,
+            "endLine" : 394,
             "endCol" : 53
           }
         },
         "span" : {
-          "startLine" : 391,
+          "startLine" : 394,
           "startCol" : 4,
-          "endLine" : 391,
+          "endLine" : 394,
           "endCol" : 53
         }
       },
@@ -11760,16 +11821,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 393,
+            "startLine" : 396,
             "startCol" : 32,
-            "endLine" : 393,
+            "endLine" : 396,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 393,
+          "startLine" : 396,
           "startCol" : 4,
-          "endLine" : 393,
+          "endLine" : 396,
           "endCol" : 38
         }
       },
@@ -11782,16 +11843,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/payments",
           "span" : {
-            "startLine" : 394,
+            "startLine" : 397,
             "startCol" : 30,
-            "endLine" : 394,
+            "endLine" : 397,
             "endCol" : 59
           }
         },
         "span" : {
-          "startLine" : 394,
+          "startLine" : 397,
           "startCol" : 4,
-          "endLine" : 394,
+          "endLine" : 397,
           "endCol" : 59
         }
       },
@@ -11804,16 +11865,16 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 395,
+            "startLine" : 398,
             "startCol" : 40,
-            "endLine" : 395,
+            "endLine" : 398,
             "endCol" : 43
           }
         },
         "span" : {
-          "startLine" : 395,
+          "startLine" : 398,
           "startCol" : 4,
-          "endLine" : 395,
+          "endLine" : 398,
           "endCol" : 43
         }
       },
@@ -11826,16 +11887,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 397,
+            "startLine" : 400,
             "startCol" : 28,
-            "endLine" : 397,
+            "endLine" : 400,
             "endCol" : 34
           }
         },
         "span" : {
-          "startLine" : 397,
+          "startLine" : 400,
           "startCol" : 4,
-          "endLine" : 397,
+          "endLine" : 400,
           "endCol" : 34
         }
       },
@@ -11848,16 +11909,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/ship",
           "span" : {
-            "startLine" : 398,
+            "startLine" : 401,
             "startCol" : 26,
-            "endLine" : 398,
+            "endLine" : 401,
             "endCol" : 51
           }
         },
         "span" : {
-          "startLine" : 398,
+          "startLine" : 401,
           "startCol" : 4,
-          "endLine" : 398,
+          "endLine" : 401,
           "endCol" : 51
         }
       },
@@ -11870,16 +11931,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 400,
+            "startLine" : 403,
             "startCol" : 34,
-            "endLine" : 400,
+            "endLine" : 403,
             "endCol" : 40
           }
         },
         "span" : {
-          "startLine" : 400,
+          "startLine" : 403,
           "startCol" : 4,
-          "endLine" : 400,
+          "endLine" : 403,
           "endCol" : 40
         }
       },
@@ -11892,16 +11953,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/deliver",
           "span" : {
-            "startLine" : 401,
+            "startLine" : 404,
             "startCol" : 32,
-            "endLine" : 401,
+            "endLine" : 404,
             "endCol" : 60
           }
         },
         "span" : {
-          "startLine" : 401,
+          "startLine" : 404,
           "startCol" : 4,
-          "endLine" : 401,
+          "endLine" : 404,
           "endCol" : 60
         }
       },
@@ -11914,16 +11975,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 403,
+            "startLine" : 406,
             "startCol" : 30,
-            "endLine" : 403,
+            "endLine" : 406,
             "endCol" : 36
           }
         },
         "span" : {
-          "startLine" : 403,
+          "startLine" : 406,
           "startCol" : 4,
-          "endLine" : 403,
+          "endLine" : 406,
           "endCol" : 36
         }
       },
@@ -11936,16 +11997,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/cancel",
           "span" : {
-            "startLine" : 404,
+            "startLine" : 407,
             "startCol" : 28,
-            "endLine" : 404,
+            "endLine" : 407,
             "endCol" : 55
           }
         },
         "span" : {
-          "startLine" : 404,
+          "startLine" : 407,
           "startCol" : 4,
-          "endLine" : 404,
+          "endLine" : 407,
           "endCol" : 55
         }
       },
@@ -11958,16 +12019,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 406,
+            "startLine" : 409,
             "startCol" : 32,
-            "endLine" : 406,
+            "endLine" : 409,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 406,
+          "startLine" : 409,
           "startCol" : 4,
-          "endLine" : 406,
+          "endLine" : 409,
           "endCol" : 38
         }
       },
@@ -11980,16 +12041,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}/return",
           "span" : {
-            "startLine" : 407,
+            "startLine" : 410,
             "startCol" : 30,
-            "endLine" : 407,
+            "endLine" : 410,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 407,
+          "startLine" : 410,
           "startCol" : 4,
-          "endLine" : 407,
+          "endLine" : 410,
           "endCol" : 57
         }
       },
@@ -12002,16 +12063,16 @@
           "kind" : "StringLit",
           "value" : "/orders/{order_id}",
           "span" : {
-            "startLine" : 409,
+            "startLine" : 412,
             "startCol" : 25,
-            "endLine" : 409,
+            "endLine" : 412,
             "endCol" : 45
           }
         },
         "span" : {
-          "startLine" : 409,
+          "startLine" : 412,
           "startCol" : 4,
-          "endLine" : 409,
+          "endLine" : 412,
           "endCol" : 45
         }
       },
@@ -12024,31 +12085,31 @@
           "kind" : "StringLit",
           "value" : "/orders",
           "span" : {
-            "startLine" : 410,
+            "startLine" : 413,
             "startCol" : 27,
-            "endLine" : 410,
+            "endLine" : 413,
             "endCol" : 36
           }
         },
         "span" : {
-          "startLine" : 410,
+          "startLine" : 413,
           "startCol" : 4,
-          "endLine" : 410,
+          "endLine" : 413,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 379,
+      "startLine" : 382,
       "startCol" : 2,
-      "endLine" : 411,
+      "endLine" : 414,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 412,
+    "endLine" : 415,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/ecommerce.spec
+++ b/fixtures/spec/ecommerce.spec
@@ -35,12 +35,14 @@ service OrderService {
     name: String where len(value) >= 1
     price: Money
     description: Option[String]
+    active: Bool
 
     invariant: price > 0
   }
 
   entity LineItem {
     id: Int where value > 0
+    order_id: OrderId
     product_sku: SKU
     quantity: Quantity
     unit_price: Money
@@ -152,6 +154,7 @@ service OrderService {
     ensures:
       let product = products[sku] in
       let item = LineItem {
+        order_id = order_id,
         product_sku = sku,
         quantity = quantity,
         unit_price = product.price,


### PR DESCRIPTION
## Summary

- Adds `LineItem.order_id: OrderId` to the ecommerce fixture so schema derivation emits `line_items.order_id BIGINT` with FK back to `orders.id` (CASCADE). This is the back-pointer the canonical `recalc_order_total` aggregate trigger needs.
- Updates `AddLineItem.ensures` so the constructor binds `order_id = order_id` (matches existing field-assignment pattern).
- Adds `Product.active: Bool` so the partial-index AC (#57) has a real boolean column to target (`WHERE active = true`).

Pure fixture-prep PR. No code changes. Unblocks both M7.6 acceptance criteria; the trigger detector + partial-index emitter remain to be implemented in #57 itself.

## Why

Per the M7.6 analysis (#57): the canonical `recalc_order_total` example from research doc §3.6 assumes a child `line_items` table with `order_id` FK. Without `LineItem.order_id` the schema deriver maps `Order.items: Set[LineItem]` to a `JSONB` column on `orders`, leaving no back-pointer for a trigger to recompute from. Similarly the partial-index AC says "boolean or status column (e.g. WHERE active = true)" but no fixture had a boolean field.

Both ACs are still buildable against the existing topology after this change — the JSONB column on `orders` remains as a denormalised cache; the new `line_items` table is the trigger target.

## Test plan

- [x] `convention/test` — 64/64 pass
- [x] `profile/test` — 19/19 pass
- [x] `codegen/test` — 116/116 pass (including ecommerce-touching `EmitTest` cases)
- [x] `lint/test` — 31/31 pass (ecommerce already excluded from lint-clean fixtures for unrelated reasons)
- [x] `testgen/test` — 231/231 pass; `SkipRateProbeTest` clause count unchanged (76, 2 skipped — field additions don't add clauses)
- [x] `cli/test` — 54/54 pass
- [x] `verify fixtures/spec/ecommerce.spec` — same 89 skipped / 0 failed as before (pre-existing translator/soundness coverage limits)
- [x] `compile` to all three deployment profiles — `python-fastapi-postgres`, `go-chi-postgres`, `ts-express-postgres` — each produces:
  - `line_items.order_id` column with FK to `orders.id` and an index `idx_line_items_order_id`
  - `products.active` BOOLEAN NOT NULL column (Prisma: `active Boolean @db.Boolean`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preps the ecommerce fixture for M7.6 (#57) by adding a line-item back-pointer to orders and a boolean active flag on products. Regenerates the ecommerce IR golden to match these fields.

- **New Features**
  - Add `LineItem.order_id: OrderId`; emits `line_items.order_id` FK to `orders.id` (CASCADE) with an index.
  - Bind `order_id` in `AddLineItem.ensures` so new items reference the parent order.
  - Add `Product.active: Bool` to target the partial index (`WHERE active = true`).

<sup>Written for commit 5fe154745d95cfc478698fdc6d2eb0c7be3761c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated ecommerce service specifications to enhance product status tracking and order-line item associations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/242)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->