### PR TITLE
M7.6: aggregate-trigger emission + partial indexes (closes #57, #243)

### DIFF
--- a/fixtures/golden/codegen/go-chi-postgres/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go-chi-postgres/url_shortener/.spec-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 1,
+  "schemaVersion" : 2,
   "schema" : {
     "tables" : [
       {
@@ -52,6 +52,8 @@
         "indexes" : [
         ]
       }
+    ],
+    "triggers" : [
     ]
   }
 }

--- a/fixtures/golden/codegen/ts-express-postgres/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/ts-express-postgres/url_shortener/.spec-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion" : 1,
+  "schemaVersion" : 2,
   "schema" : {
     "tables" : [
       {
@@ -52,6 +52,8 @@
         "indexes" : [
         ]
       }
+    ],
+    "triggers" : [
     ]
   }
 }

--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -12097,19 +12097,41 @@
           "endLine" : 413,
           "endCol" : 36
         }
+      },
+      {
+        "kind" : "ConventionRule",
+        "target" : "Product",
+        "property" : "partial_index",
+        "qualifier" : "active",
+        "value" : {
+          "kind" : "StringLit",
+          "value" : "active = true",
+          "span" : {
+            "startLine" : 415,
+            "startCol" : 37,
+            "endLine" : 415,
+            "endCol" : 52
+          }
+        },
+        "span" : {
+          "startLine" : 415,
+          "startCol" : 4,
+          "endLine" : 415,
+          "endCol" : 52
+        }
       }
     ],
     "span" : {
       "startLine" : 382,
       "startCol" : 2,
-      "endLine" : 414,
+      "endLine" : 416,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 415,
+    "endLine" : 417,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/ecommerce.spec
+++ b/fixtures/spec/ecommerce.spec
@@ -411,5 +411,7 @@ service OrderService {
 
     GetOrder.http_path = "/orders/{order_id}"
     ListOrders.http_path = "/orders"
+
+    Product.partial_index "active" = "active = true"
   }
 }

--- a/modules/codegen/src/main/resources/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python-fastapi-postgres/alembic/versions/001_initial_schema.py.hbs
@@ -27,14 +27,25 @@ def upgrade() -> None:
 {{/each}}
     )
 {{#each this.indexes}}
-    op.create_index("{{this.name}}", "{{this.table}}", [{{#each this.columns}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}], unique={{#if this.unique}}True{{else}}False{{/if}})
+    op.create_index("{{this.name}}", "{{this.table}}", [{{#each this.columns}}"{{this}}"{{#unless @last}}, {{/unless}}{{/each}}], unique={{#if this.unique}}True{{else}}False{{/if}}{{{this.postgresqlWhereSuffix}}})
 {{/each}}
 
 {{else}}
     pass
 {{/each}}
+{{#each migration.triggers}}
+{{#each this.upgradeStatements}}
+    {{{this}}}
+{{/each}}
+
+{{/each}}
 
 def downgrade() -> None:
+{{#each migration.triggersReversed}}
+{{#each this.downgradeStatements}}
+    {{{this}}}
+{{/each}}
+{{/each}}
 {{#each migration.tablesReversed}}
 {{#each this.indexes}}
     op.drop_index("{{this.name}}", table_name="{{this.table}}")

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -93,18 +93,11 @@ object Migration:
     AlembicTrigger(
       name = t.name,
       upgradeStatements = List(
-        s"""op.execute(${tripleQuoted(funcSql)})""",
-        s"""op.execute(${tripleQuoted(triggerSql)})"""
+        s"""op.execute(${AlembicSyntax.tripleQuoted(funcSql)})""",
+        s"""op.execute(${AlembicSyntax.tripleQuoted(triggerSql)})"""
       ),
-      downgradeStatements = List(
-        s"""op.execute("DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};")""",
-        s"""op.execute("DROP FUNCTION IF EXISTS ${t.functionName}();")"""
-      )
+      downgradeStatements = TriggerSql.dropStatements(t).map(stmt => s"""op.execute("$stmt")""")
     )
-
-  private def tripleQuoted(body: String): String =
-    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
-    "\"\"\"\n" + safe + "\n\"\"\""
 
   private enum TopoColor derives CanEqual:
     case White, Gray, Black

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -1,9 +1,11 @@
 package specrest.codegen.alembic
 
 import specrest.codegen.migration.AlembicSyntax
+import specrest.codegen.migration.TriggerSql
 import specrest.convention.ColumnSpec
 import specrest.convention.DatabaseSchema
 import specrest.convention.TableSpec
+import specrest.convention.TriggerSpec
 
 import scala.collection.mutable
 
@@ -30,7 +32,14 @@ final case class AlembicIndex(
     name: String,
     table: String,
     columns: List[String],
-    unique: Boolean
+    unique: Boolean,
+    postgresqlWhereSuffix: String
+)
+
+final case class AlembicTrigger(
+    name: String,
+    upgradeStatements: List[String],
+    downgradeStatements: List[String]
 )
 
 final case class AlembicTable(
@@ -48,6 +57,8 @@ final case class AlembicMigration(
     createdDate: String,
     tables: List[AlembicTable],
     tablesReversed: List[AlembicTable],
+    triggers: List[AlembicTrigger],
+    triggersReversed: List[AlembicTrigger],
     needsPostgresDialect: Boolean
 )
 
@@ -64,14 +75,36 @@ object Migration:
   ): AlembicMigration =
     val sorted               = topoSortTables(schema.tables)
     val tables               = sorted.map(buildAlembicTable)
+    val triggers             = schema.triggers.map(buildAlembicTrigger)
     val needsPostgresDialect = tables.exists(_.columns.exists(_.saType.startsWith("postgresql.")))
     AlembicMigration(
       revision = opts.revision.getOrElse("001"),
       createdDate = opts.createdDate.getOrElse(java.time.LocalDate.now.toString),
       tables = tables,
       tablesReversed = tables.reverse,
+      triggers = triggers,
+      triggersReversed = triggers.reverse,
       needsPostgresDialect = needsPostgresDialect
     )
+
+  private def buildAlembicTrigger(t: TriggerSpec): AlembicTrigger =
+    val funcSql    = TriggerSql.functionBody(t)
+    val triggerSql = TriggerSql.triggerStatement(t)
+    AlembicTrigger(
+      name = t.name,
+      upgradeStatements = List(
+        s"""op.execute(${tripleQuoted(funcSql)})""",
+        s"""op.execute(${tripleQuoted(triggerSql)})"""
+      ),
+      downgradeStatements = List(
+        s"""op.execute("DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};")""",
+        s"""op.execute("DROP FUNCTION IF EXISTS ${t.functionName}();")"""
+      )
+    )
+
+  private def tripleQuoted(body: String): String =
+    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
+    "\"\"\"\n" + safe + "\n\"\"\""
 
   private enum TopoColor derives CanEqual:
     case White, Gray, Black
@@ -119,7 +152,10 @@ object Migration:
         name = ix.name,
         table = t.name,
         columns = ix.columns,
-        unique = ix.unique
+        unique = ix.unique,
+        postgresqlWhereSuffix = ix.filterClause match
+          case Some(f) => s", postgresql_where=sa.text(${AlembicSyntax.pythonStringLiteral(f)})"
+          case None    => ""
       )
     val tableArgs =
       columns.map(renderColumnCall) ++

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -200,7 +200,9 @@ object EmitGo:
     )
 
     val emitInitial: () => Unit = () =>
-      val ops = SchemaDiff.topoSort(schema.tables).map(MigrationOp.CreateTable.apply)
+      val tableOps   = SchemaDiff.topoSort(schema.tables).map(MigrationOp.CreateTable.apply)
+      val triggerOps = schema.triggers.map(MigrationOp.AddTrigger.apply)
+      val ops        = tableOps ++ triggerOps
       val view = SqlMigrationView(
         upgradeStatements = SqlRenderer.upgrade(ops),
         downgradeStatements = SqlRenderer.downgrade(ops)

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicRenderer.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicRenderer.scala
@@ -10,6 +10,7 @@ import specrest.convention.ColumnSpec
 import specrest.convention.ForeignKeySpec
 import specrest.convention.IndexSpec
 import specrest.convention.TableSpec
+import specrest.convention.TriggerSpec
 
 object AlembicRenderer:
 
@@ -49,6 +50,8 @@ object AlembicRenderer:
       List(s"""op.drop_constraint("${fkName(tbl, fk)}", "$tbl", type_="foreignkey")""")
     case AddIndex(tbl, ix)  => List(renderCreateIndex(tbl, ix))
     case DropIndex(tbl, ix) => List(s"""op.drop_index("${ix.name}", table_name="$tbl")""")
+    case AddTrigger(t)      => renderAddTrigger(t)
+    case DropTrigger(t)     => renderDropTrigger(t)
 
   private def renderCreateTable(t: TableSpec): List[String] =
     val columnArgs = t.columns.map: c =>
@@ -93,4 +96,25 @@ object AlembicRenderer:
   private def renderCreateIndex(tableName: String, ix: IndexSpec): String =
     val cols   = ix.columns.map(c => s""""$c"""").mkString(", ")
     val unique = if ix.unique then "True" else "False"
-    s"""op.create_index("${ix.name}", "$tableName", [$cols], unique=$unique)"""
+    val partial = ix.filterClause match
+      case Some(filt) => s", postgresql_where=sa.text(${pythonStringLiteral(filt)})"
+      case None       => ""
+    s"""op.create_index("${ix.name}", "$tableName", [$cols], unique=$unique$partial)"""
+
+  private def renderAddTrigger(t: TriggerSpec): List[String] =
+    val func    = TriggerSql.functionBody(t)
+    val trigger = TriggerSql.triggerStatement(t)
+    List(
+      s"""op.execute(${pythonTripleQuoted(func)})""",
+      s"""op.execute(${pythonTripleQuoted(trigger)})"""
+    )
+
+  private def renderDropTrigger(t: TriggerSpec): List[String] =
+    List(
+      s"""op.execute("DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};")""",
+      s"""op.execute("DROP FUNCTION IF EXISTS ${t.functionName}();")"""
+    )
+
+  private def pythonTripleQuoted(body: String): String =
+    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
+    "\"\"\"\n" + safe + "\n\"\"\""

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicRenderer.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicRenderer.scala
@@ -105,16 +105,9 @@ object AlembicRenderer:
     val func    = TriggerSql.functionBody(t)
     val trigger = TriggerSql.triggerStatement(t)
     List(
-      s"""op.execute(${pythonTripleQuoted(func)})""",
-      s"""op.execute(${pythonTripleQuoted(trigger)})"""
+      s"""op.execute(${AlembicSyntax.tripleQuoted(func)})""",
+      s"""op.execute(${AlembicSyntax.tripleQuoted(trigger)})"""
     )
 
   private def renderDropTrigger(t: TriggerSpec): List[String] =
-    List(
-      s"""op.execute("DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};")""",
-      s"""op.execute("DROP FUNCTION IF EXISTS ${t.functionName}();")"""
-    )
-
-  private def pythonTripleQuoted(body: String): String =
-    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
-    "\"\"\"\n" + safe + "\n\"\"\""
+    TriggerSql.dropStatements(t).map(stmt => s"""op.execute("$stmt")""")

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicSyntax.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicSyntax.scala
@@ -51,5 +51,7 @@ object AlembicSyntax:
     mapSqlTypeToSa(sqlType).startsWith("postgresql.")
 
   def tripleQuoted(body: String): String =
-    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
+    val safe = body
+      .replace("\\", "\\\\")
+      .replace("\"\"\"", "\"\"\\\"")
     "\"\"\"\n" + safe + "\n\"\"\""

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicSyntax.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/AlembicSyntax.scala
@@ -49,3 +49,7 @@ object AlembicSyntax:
 
   def usesPostgresDialect(sqlType: String): Boolean =
     mapSqlTypeToSa(sqlType).startsWith("postgresql.")
+
+  def tripleQuoted(body: String): String =
+    val safe = body.replace("\"\"\"", "\"\"\\\"\"")
+    "\"\"\"\n" + safe + "\n\"\"\""

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/MigrationOp.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/MigrationOp.scala
@@ -4,6 +4,7 @@ import specrest.convention.ColumnSpec
 import specrest.convention.ForeignKeySpec
 import specrest.convention.IndexSpec
 import specrest.convention.TableSpec
+import specrest.convention.TriggerSpec
 
 enum MigrationOp derives CanEqual:
   case CreateTable(table: TableSpec)
@@ -24,6 +25,8 @@ enum MigrationOp derives CanEqual:
   case DropForeignKey(table: String, oldFk: ForeignKeySpec)
   case AddIndex(table: String, index: IndexSpec)
   case DropIndex(table: String, oldIndex: IndexSpec)
+  case AddTrigger(trigger: TriggerSpec)
+  case DropTrigger(oldTrigger: TriggerSpec)
 
   def inverse: MigrationOp = this match
     case CreateTable(t)                    => DropTable(t)
@@ -39,6 +42,8 @@ enum MigrationOp derives CanEqual:
     case DropForeignKey(tbl, fk)           => AddForeignKey(tbl, fk)
     case AddIndex(tbl, ix)                 => DropIndex(tbl, ix)
     case DropIndex(tbl, ix)                => AddIndex(tbl, ix)
+    case AddTrigger(t)                     => DropTrigger(t)
+    case DropTrigger(t)                    => AddTrigger(t)
 
   def isDestructive: Boolean = this match
     case _: (DropTable | DropColumn) => true

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaCodec.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaCodec.scala
@@ -1,6 +1,9 @@
 package specrest.codegen.migration
 
 import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.HCursor
 import io.circe.generic.semiauto.deriveCodec
 import io.circe.parser
 import io.circe.syntax.EncoderOps
@@ -9,20 +12,50 @@ import specrest.convention.DatabaseSchema
 import specrest.convention.ForeignKeySpec
 import specrest.convention.IndexSpec
 import specrest.convention.TableSpec
+import specrest.convention.TriggerAggregate
+import specrest.convention.TriggerSpec
 
 final case class SchemaSnapshot(schemaVersion: Int, schema: DatabaseSchema) derives CanEqual
 
 object SchemaSnapshot:
-  val CurrentVersion: Int = 1
+  val CurrentVersion: Int = 2
 
   def of(schema: DatabaseSchema): SchemaSnapshot = SchemaSnapshot(CurrentVersion, schema)
 
 object SchemaCodec:
-  private given Codec[ColumnSpec]            = deriveCodec
-  private given Codec[ForeignKeySpec]        = deriveCodec
-  private given Codec[IndexSpec]             = deriveCodec
-  private given Codec[TableSpec]             = deriveCodec
-  private given Codec[DatabaseSchema]        = deriveCodec
+  private given Codec[ColumnSpec]     = deriveCodec
+  private given Codec[ForeignKeySpec] = deriveCodec
+  private given Codec[IndexSpec]      = deriveCodec
+  private given Codec[TableSpec]      = deriveCodec
+  private given Codec[TriggerAggregate] = Codec.from(
+    Decoder[String].emap:
+      case "Sum"   => Right(TriggerAggregate.Sum)
+      case "Count" => Right(TriggerAggregate.Count)
+      case "Min"   => Right(TriggerAggregate.Min)
+      case "Max"   => Right(TriggerAggregate.Max)
+      case other   => Left(s"unknown TriggerAggregate: $other")
+    ,
+    Encoder[String].contramap:
+      case TriggerAggregate.Sum   => "Sum"
+      case TriggerAggregate.Count => "Count"
+      case TriggerAggregate.Min   => "Min"
+      case TriggerAggregate.Max   => "Max"
+  )
+  private given Codec[TriggerSpec] = deriveCodec
+  private given Codec[DatabaseSchema] = Codec.from(
+    new Decoder[DatabaseSchema]:
+      def apply(c: HCursor): Decoder.Result[DatabaseSchema] =
+        for
+          tables   <- c.downField("tables").as[List[TableSpec]]
+          triggers <- c.downField("triggers").as[Option[List[TriggerSpec]]].map(_.getOrElse(Nil))
+        yield DatabaseSchema(tables, triggers)
+    ,
+    Encoder.AsObject.instance: schema =>
+      io.circe.JsonObject(
+        "tables"   -> schema.tables.asJson,
+        "triggers" -> schema.triggers.asJson
+      )
+  )
   given snapshotCodec: Codec[SchemaSnapshot] = deriveCodec
 
   def encode(snapshot: SchemaSnapshot): String = snapshot.asJson.spaces2
@@ -30,8 +63,10 @@ object SchemaCodec:
   def decode(json: String): Either[String, SchemaSnapshot] =
     parser.parse(json).left.map(_.message).flatMap: parsed =>
       parsed.as[SchemaSnapshot].left.map(_.message).flatMap: snap =>
-        if snap.schemaVersion == SchemaSnapshot.CurrentVersion then Right(snap)
-        else
-          Left(
-            s"unsupported schemaVersion ${snap.schemaVersion} (expected ${SchemaSnapshot.CurrentVersion})"
-          )
+        snap.schemaVersion match
+          case v if v == SchemaSnapshot.CurrentVersion => Right(snap)
+          case 1                                       => Right(snap.copy(schemaVersion = SchemaSnapshot.CurrentVersion))
+          case other =>
+            Left(
+              s"unsupported schemaVersion $other (expected ${SchemaSnapshot.CurrentVersion} or a known prior version)"
+            )

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -30,7 +30,17 @@ object SchemaDiff:
     val intraAdds = next.tables.flatMap: n =>
       prevByName.get(n.name).toList.flatMap(p => intraTableAdds(p, n))
 
-    intraDrops ++ droppedTables ++ createdTables ++ intraAlters ++ intraAdds
+    val prevTriggers = prev.triggers.toSet
+    val nextTriggers = next.triggers.toSet
+    val droppedTriggers = prev.triggers
+      .filterNot(nextTriggers.contains)
+      .map(MigrationOp.DropTrigger.apply)
+    val addedTriggers = next.triggers
+      .filterNot(prevTriggers.contains)
+      .map(MigrationOp.AddTrigger.apply)
+
+    droppedTriggers ++ intraDrops ++ droppedTables ++ createdTables ++
+      intraAlters ++ intraAdds ++ addedTriggers
 
   def destructive(ops: List[MigrationOp]): List[MigrationOp] =
     ops.filter(_.isDestructive)

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
@@ -42,6 +42,13 @@ object SqlRenderer:
       List(renderCreateIndex(tbl, ix))
     case DropIndex(_, ix) =>
       List(s"DROP INDEX ${ix.name};")
+    case AddTrigger(t) =>
+      List(TriggerSql.functionBody(t), TriggerSql.triggerStatement(t))
+    case DropTrigger(t) =>
+      List(
+        s"DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};",
+        s"DROP FUNCTION IF EXISTS ${t.functionName}();"
+      )
 
   private def renderCreateTable(t: TableSpec): List[String] =
     val columnLines = t.columns.map(c => "    " + renderColumnDef(c))
@@ -75,7 +82,8 @@ object SqlRenderer:
 
   private def renderCreateIndex(tableName: String, ix: IndexSpec): String =
     val unique = if ix.unique then "UNIQUE " else ""
-    s"CREATE ${unique}INDEX ${ix.name} ON $tableName (${ix.columns.mkString(", ")});"
+    val where  = ix.filterClause.fold("")(f => s" WHERE $f")
+    s"CREATE ${unique}INDEX ${ix.name} ON $tableName (${ix.columns.mkString(", ")})$where;"
 
   private def stripAutoIncrement(sqlType: String): String = sqlType match
     case "BIGSERIAL" => "BIGINT"

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
@@ -45,10 +45,7 @@ object SqlRenderer:
     case AddTrigger(t) =>
       List(TriggerSql.functionBody(t), TriggerSql.triggerStatement(t))
     case DropTrigger(t) =>
-      List(
-        s"DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};",
-        s"DROP FUNCTION IF EXISTS ${t.functionName}();"
-      )
+      TriggerSql.dropStatements(t)
 
   private def renderCreateTable(t: TableSpec): List[String] =
     val columnLines = t.columns.map(c => "    " + renderColumnDef(c))

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/TriggerSql.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/TriggerSql.scala
@@ -14,13 +14,30 @@ object TriggerSql:
     val funcName  = t.functionName
     s"""CREATE OR REPLACE FUNCTION $funcName() RETURNS TRIGGER AS $$$$
        |BEGIN
-       |    UPDATE $parentTbl
-       |    SET $parentCol = (
-       |        SELECT $recompute
-       |        FROM $source
-       |        WHERE $parentFk = COALESCE(NEW.$parentFk, OLD.$parentFk)
-       |    )
-       |    WHERE id = COALESCE(NEW.$parentFk, OLD.$parentFk);
+       |    IF TG_OP = 'UPDATE' AND NEW.$parentFk IS DISTINCT FROM OLD.$parentFk THEN
+       |        UPDATE $parentTbl
+       |        SET $parentCol = (
+       |            SELECT $recompute
+       |            FROM $source
+       |            WHERE $parentFk = OLD.$parentFk
+       |        )
+       |        WHERE id = OLD.$parentFk;
+       |        UPDATE $parentTbl
+       |        SET $parentCol = (
+       |            SELECT $recompute
+       |            FROM $source
+       |            WHERE $parentFk = NEW.$parentFk
+       |        )
+       |        WHERE id = NEW.$parentFk;
+       |    ELSE
+       |        UPDATE $parentTbl
+       |        SET $parentCol = (
+       |            SELECT $recompute
+       |            FROM $source
+       |            WHERE $parentFk = COALESCE(NEW.$parentFk, OLD.$parentFk)
+       |        )
+       |        WHERE id = COALESCE(NEW.$parentFk, OLD.$parentFk);
+       |    END IF;
        |    RETURN NULL;
        |END;
        |$$$$ LANGUAGE plpgsql;""".stripMargin
@@ -30,9 +47,10 @@ object TriggerSql:
        |    AFTER INSERT OR UPDATE OR DELETE ON ${t.sourceTable}
        |    FOR EACH ROW EXECUTE FUNCTION ${t.functionName}();""".stripMargin
 
-  def dropStatement(t: TriggerSpec): String =
-    s"DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};\n" +
-      s"DROP FUNCTION IF EXISTS ${t.functionName}();"
+  def dropStatements(t: TriggerSpec): List[String] = List(
+    s"DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};",
+    s"DROP FUNCTION IF EXISTS ${t.functionName}();"
+  )
 
   private def aggregateExpr(t: TriggerSpec): String =
     val col = t.sourceColumn

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/TriggerSql.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/TriggerSql.scala
@@ -1,0 +1,46 @@
+package specrest.codegen.migration
+
+import specrest.convention.TriggerAggregate
+import specrest.convention.TriggerSpec
+
+object TriggerSql:
+
+  def functionBody(t: TriggerSpec): String =
+    val recompute = aggregateExpr(t)
+    val source    = t.sourceTable
+    val parentFk  = t.sourceForeignKey
+    val parentCol = t.targetColumn
+    val parentTbl = t.targetTable
+    val funcName  = t.functionName
+    s"""CREATE OR REPLACE FUNCTION $funcName() RETURNS TRIGGER AS $$$$
+       |BEGIN
+       |    UPDATE $parentTbl
+       |    SET $parentCol = (
+       |        SELECT $recompute
+       |        FROM $source
+       |        WHERE $parentFk = COALESCE(NEW.$parentFk, OLD.$parentFk)
+       |    )
+       |    WHERE id = COALESCE(NEW.$parentFk, OLD.$parentFk);
+       |    RETURN NULL;
+       |END;
+       |$$$$ LANGUAGE plpgsql;""".stripMargin
+
+  def triggerStatement(t: TriggerSpec): String =
+    s"""CREATE TRIGGER ${t.name}
+       |    AFTER INSERT OR UPDATE OR DELETE ON ${t.sourceTable}
+       |    FOR EACH ROW EXECUTE FUNCTION ${t.functionName}();""".stripMargin
+
+  def dropStatement(t: TriggerSpec): String =
+    s"DROP TRIGGER IF EXISTS ${t.name} ON ${t.sourceTable};\n" +
+      s"DROP FUNCTION IF EXISTS ${t.functionName}();"
+
+  private def aggregateExpr(t: TriggerSpec): String =
+    val col = t.sourceColumn
+    (t.aggregate, col) match
+      case (TriggerAggregate.Sum, Some(c)) => s"COALESCE(SUM($c), 0)"
+      case (TriggerAggregate.Min, Some(c)) => s"MIN($c)"
+      case (TriggerAggregate.Max, Some(c)) => s"MAX($c)"
+      case (TriggerAggregate.Count, _)     => "COUNT(*)"
+      case (TriggerAggregate.Sum, None)    => "0"
+      case (TriggerAggregate.Min, None)    => "NULL"
+      case (TriggerAggregate.Max, None)    => "NULL"

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -111,12 +111,20 @@ object EmitTs:
     val typeLookup = profiled.profile.typeMap.map: (k, v) =>
       k -> v.domain
 
+    val triggerMaintainedByTable: Map[String, Set[String]] =
+      profiled.schema.triggers
+        .groupBy(_.targetTable)
+        .view
+        .mapValues(_.map(_.targetColumn).toSet)
+        .toMap
+
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
         .filter(_.targetEntity.contains(entity.entityName))
         .map(op => enrichOperation(op, entity, typeLookup))
         .sortWith(byPathSpecificity)
-      buildEntityCtx(packageName, entity, entityOps)
+      val maintained = triggerMaintainedByTable.getOrElse(entity.tableName, Set.empty)
+      buildEntityCtx(packageName, entity, entityOps, maintained)
 
     val needsDecimal = entities.exists(_.needsDecimal)
     val needsBuffer  = entities.exists(_.needsBuffer)
@@ -215,7 +223,9 @@ object EmitTs:
     )
 
     val emitInitial: () => Unit = () =>
-      val ops = SchemaDiff.topoSort(schema.tables).map(MigrationOp.CreateTable.apply)
+      val tableOps   = SchemaDiff.topoSort(schema.tables).map(MigrationOp.CreateTable.apply)
+      val triggerOps = schema.triggers.map(MigrationOp.AddTrigger.apply)
+      val ops        = tableOps ++ triggerOps
       val upScope = Map[String, Any](
         "migration" -> PrismaMigrationView(SqlRenderer.upgrade(ops))
       )
@@ -280,7 +290,8 @@ object EmitTs:
   private def buildEntityCtx(
       packageName: String,
       entity: ProfiledEntity,
-      operations: List[TsOperation]
+      operations: List[TsOperation],
+      triggerMaintainedColumns: Set[String]
   ): TsEntityCtx =
     val entityCamel       = toCamelCase(entity.entityName)
     val entityPascal      = toPascalCase(entity.entityName)
@@ -289,6 +300,14 @@ object EmitTs:
     val entityPlural      = Naming.pluralize(entity.entityName)
     val entityPluralCamel = toCamelCase(entityPlural)
     val entityPluralKebab = Naming.toKebabCase(entityPlural)
+
+    def mkField(f: ProfiledField): TsFieldView =
+      val base = toTsField(f)
+      if triggerMaintainedColumns.contains(f.columnName) then
+        val attrs = if base.prismaAttrs.isEmpty then "@default(0)"
+        else s"${base.prismaAttrs} @default(0)"
+        base.copy(prismaAttrs = attrs)
+      else base
 
     val (primaryKey, nonIdFields) =
       entity.fields.find(_.fieldName == "id") match
@@ -300,7 +319,7 @@ object EmitTs:
             prismaAttrs = "@id @default(autoincrement())",
             isPrimaryKey = true
           )
-          (pk, entity.fields.filterNot(_.fieldName == "id").map(toTsField))
+          (pk, entity.fields.filterNot(_.fieldName == "id").map(mkField))
         case None =>
           val pk = TsFieldView(
             tsField = "id",
@@ -313,7 +332,7 @@ object EmitTs:
             nullable = false,
             isPrimaryKey = true
           )
-          (pk, entity.fields.map(toTsField))
+          (pk, entity.fields.map(mkField))
     val allFields = primaryKey +: nonIdFields
 
     val needsDecimal = nonIdFields.exists(f => f.domainType.contains("Prisma.Decimal"))

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -97,6 +97,8 @@ final private case class TsProjectCtx(
 
 object EmitTs:
 
+  private val NumericPrismaTypes: Set[String] = Set("Int", "BigInt", "Float", "Decimal")
+
   def emit(profiled: ProfiledService, opts: EmitOptions): List[EmittedFile] =
     val engine      = new TemplateEngine
     val templates   = TsTemplates.tsExpressPostgres
@@ -303,9 +305,12 @@ object EmitTs:
 
     def mkField(f: ProfiledField): TsFieldView =
       val base = toTsField(f)
-      if triggerMaintainedColumns.contains(f.columnName) then
-        val attrs = if base.prismaAttrs.isEmpty then "@default(0)"
-        else s"${base.prismaAttrs} @default(0)"
+      if triggerMaintainedColumns.contains(f.columnName)
+        && NumericPrismaTypes.contains(base.prismaType)
+      then
+        val attrs =
+          if base.prismaAttrs.isEmpty then "@default(0)"
+          else s"${base.prismaAttrs} @default(0)"
         base.copy(prismaAttrs = attrs)
       else base
 

--- a/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
@@ -112,9 +112,11 @@ class AlembicMigrationTest extends CatsEffectSuite:
 
   test("ecommerce: aggregate-invariant trigger emitted with subtotal recompute"):
     SpecFixtures.loadProfiled("ecommerce").map: profiled =>
-      val files         = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
-      val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
-      val content       = files(migrationPath)
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val migrationPath = files.keys
+        .find(_.startsWith("alembic/versions/"))
+        .getOrElse(fail(s"missing alembic migration; paths=${files.keys.toList.sorted}"))
+      val content = files(migrationPath)
       assert(
         content.contains("CREATE OR REPLACE FUNCTION recalc_order_subtotal()"),
         s"missing recalc_order_subtotal function; got:\n$content"
@@ -138,9 +140,11 @@ class AlembicMigrationTest extends CatsEffectSuite:
 
   test("ecommerce: Product.partial_index 'active' emits postgresql_where"):
     SpecFixtures.loadProfiled("ecommerce").map: profiled =>
-      val files         = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
-      val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
-      val content       = files(migrationPath)
+      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val migrationPath = files.keys
+        .find(_.startsWith("alembic/versions/"))
+        .getOrElse(fail(s"missing alembic migration; paths=${files.keys.toList.sorted}"))
+      val content = files(migrationPath)
       assert(
         content.contains("postgresql_where=sa.text('active = true')"),
         s"missing postgresql_where for active partial index; got:\n$content"

--- a/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/AlembicMigrationTest.scala
@@ -109,3 +109,43 @@ class AlembicMigrationTest extends CatsEffectSuite:
         s"missing op.create_table in migration; first 500 chars: ${content.take(500)}"
       )
       assert(content.contains("url_mappings"), "missing url_mappings table name")
+
+  test("ecommerce: aggregate-invariant trigger emitted with subtotal recompute"):
+    SpecFixtures.loadProfiled("ecommerce").map: profiled =>
+      val files         = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
+      val content       = files(migrationPath)
+      assert(
+        content.contains("CREATE OR REPLACE FUNCTION recalc_order_subtotal()"),
+        s"missing recalc_order_subtotal function; got:\n$content"
+      )
+      assert(
+        content.contains("CREATE TRIGGER trg_recalc_order_subtotal"),
+        s"missing trg_recalc_order_subtotal trigger; got:\n$content"
+      )
+      assert(
+        content.contains("AFTER INSERT OR UPDATE OR DELETE ON line_items"),
+        s"trigger should fire on line_items; got:\n$content"
+      )
+      assert(
+        content.contains("DROP TRIGGER IF EXISTS trg_recalc_order_subtotal"),
+        s"missing downgrade DROP TRIGGER; got:\n$content"
+      )
+      assert(
+        content.contains("DROP FUNCTION IF EXISTS recalc_order_subtotal"),
+        s"missing downgrade DROP FUNCTION; got:\n$content"
+      )
+
+  test("ecommerce: Product.partial_index 'active' emits postgresql_where"):
+    SpecFixtures.loadProfiled("ecommerce").map: profiled =>
+      val files         = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val migrationPath = files.keys.find(_.startsWith("alembic/versions/")).get
+      val content       = files(migrationPath)
+      assert(
+        content.contains("postgresql_where=sa.text('active = true')"),
+        s"missing postgresql_where for active partial index; got:\n$content"
+      )
+      assert(
+        content.contains("idx_products_active_partial"),
+        s"missing partial-index name; got:\n$content"
+      )

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/AlembicRendererTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/AlembicRendererTest.scala
@@ -6,6 +6,8 @@ import specrest.convention.ColumnSpec
 import specrest.convention.ForeignKeySpec
 import specrest.convention.IndexSpec
 import specrest.convention.TableSpec
+import specrest.convention.TriggerAggregate
+import specrest.convention.TriggerSpec
 
 class AlembicRendererTest extends CatsEffectSuite:
 
@@ -98,6 +100,57 @@ class AlembicRendererTest extends CatsEffectSuite:
     assertEquals(
       AlembicRenderer.upgrade(List(DropIndex("t", ix))),
       List("""op.drop_index("ix_t_x", table_name="t")""")
+    )
+
+  test("AddIndex with filterClause renders postgresql_where=sa.text(...)"):
+    val ix = IndexSpec(
+      "ix_products_active",
+      List("active"),
+      unique = false,
+      filterClause = Some("active = true")
+    )
+    assertEquals(
+      AlembicRenderer.upgrade(List(AddIndex("products", ix))),
+      List(
+        """op.create_index("ix_products_active", "products", ["active"], unique=False, postgresql_where=sa.text('active = true'))"""
+      )
+    )
+
+  test("AddTrigger emits CREATE FUNCTION + CREATE TRIGGER via op.execute"):
+    val t = TriggerSpec(
+      name = "trg_recalc_order_subtotal",
+      functionName = "recalc_order_subtotal",
+      targetTable = "orders",
+      targetColumn = "subtotal",
+      sourceTable = "line_items",
+      sourceForeignKey = "order_id",
+      aggregate = TriggerAggregate.Sum,
+      sourceColumn = Some("line_total")
+    )
+    val out = AlembicRenderer.upgrade(List(AddTrigger(t))).mkString("\n")
+    assert(out.contains("op.execute("), out)
+    assert(out.contains("CREATE OR REPLACE FUNCTION recalc_order_subtotal()"), out)
+    assert(out.contains("COALESCE(SUM(line_total), 0)"), out)
+    assert(out.contains("CREATE TRIGGER trg_recalc_order_subtotal"), out)
+    assert(out.contains("AFTER INSERT OR UPDATE OR DELETE ON line_items"), out)
+
+  test("DropTrigger emits DROP TRIGGER + DROP FUNCTION via op.execute"):
+    val t = TriggerSpec(
+      name = "trg_x",
+      functionName = "fn_x",
+      targetTable = "p",
+      targetColumn = "c",
+      sourceTable = "child",
+      sourceForeignKey = "p_id",
+      aggregate = TriggerAggregate.Count,
+      sourceColumn = None
+    )
+    assertEquals(
+      AlembicRenderer.upgrade(List(DropTrigger(t))),
+      List(
+        """op.execute("DROP TRIGGER IF EXISTS trg_x ON child;")""",
+        """op.execute("DROP FUNCTION IF EXISTS fn_x();")"""
+      )
     )
 
   test("downgrade reverses + inverts the op list"):

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/AlembicSyntaxTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/AlembicSyntaxTest.scala
@@ -1,0 +1,49 @@
+package specrest.codegen.migration
+
+import munit.CatsEffectSuite
+
+class AlembicSyntaxTest extends CatsEffectSuite:
+
+  test("tripleQuoted wraps a plain SQL body in Python triple quotes"):
+    val body = "SELECT 1;"
+    val out  = AlembicSyntax.tripleQuoted(body)
+    assertEquals(out, "\"\"\"\nSELECT 1;\n\"\"\"")
+
+  test("tripleQuoted escapes embedded triple-quotes so Python reads back the original"):
+    // body literally contains three consecutive double-quote chars.
+    val body         = "x\"\"\"y"
+    val out          = AlembicSyntax.tripleQuoted(body)
+    val expectedSafe = "x\"\"\\\"y"
+    assertEquals(out, "\"\"\"\n" + expectedSafe + "\n\"\"\"")
+    val pythonDecoded = decodePythonStringLiteral(out)
+    assertEquals(pythonDecoded, "\n" + body + "\n")
+
+  test("tripleQuoted escapes embedded backslashes so SQL backslash survives Python decoding"):
+    val body          = "regex \\d+"
+    val out           = AlembicSyntax.tripleQuoted(body)
+    val pythonDecoded = decodePythonStringLiteral(out)
+    assertEquals(pythonDecoded, "\n" + body + "\n")
+
+  test("tripleQuoted preserves SQL with no metacharacters"):
+    val body = "CREATE TRIGGER trg ON t FOR EACH ROW EXECUTE FUNCTION fn();"
+    val out  = AlembicSyntax.tripleQuoted(body)
+    assertEquals(decodePythonStringLiteral(out), "\n" + body + "\n")
+
+  /** Minimal interpreter for a Python triple-quoted string literal — only handles the escape
+    * sequences `tripleQuoted` produces (`\\` and `\"`). Sufficient to verify round-trips.
+    */
+  private def decodePythonStringLiteral(src: String): String =
+    require(src.startsWith("\"\"\"") && src.endsWith("\"\"\""), s"not triple-quoted: $src")
+    val body = src.drop(3).dropRight(3)
+    val out  = new StringBuilder
+    var i    = 0
+    while i < body.length do
+      val c = body.charAt(i)
+      if c == '\\' && i + 1 < body.length then
+        val next = body.charAt(i + 1)
+        out.append(next)
+        i += 2
+      else
+        out.append(c)
+        i += 1
+    out.toString

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/SchemaCodecTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/SchemaCodecTest.scala
@@ -61,3 +61,64 @@ class SchemaCodecTest extends CatsEffectSuite:
     val s1 = SchemaCodec.encode(SchemaSnapshot.of(sample))
     val s2 = SchemaCodec.encode(SchemaSnapshot.of(sample))
     assertEquals(s1, s2)
+
+  test("v1 snapshot lifts to v2 with empty triggers"):
+    val v1 =
+      """{
+        |  "schemaVersion" : 1,
+        |  "schema" : {
+        |    "tables" : [
+        |      {
+        |        "name" : "users",
+        |        "entityName" : "User",
+        |        "columns" : [],
+        |        "primaryKey" : "id",
+        |        "foreignKeys" : [],
+        |        "checks" : [],
+        |        "indexes" : []
+        |      }
+        |    ]
+        |  }
+        |}""".stripMargin
+    val decoded = SchemaCodec.decode(v1)
+    decoded match
+      case Right(snap) =>
+        assertEquals(snap.schemaVersion, SchemaSnapshot.CurrentVersion)
+        assertEquals(snap.schema.triggers, Nil)
+        assertEquals(snap.schema.tables.head.name, "users")
+      case Left(err) => fail(s"expected v1 lift to succeed; got: $err")
+
+  test("unknown future schemaVersion returns Left"):
+    val future = """{"schemaVersion" : 99, "schema" : {"tables" : [], "triggers" : []}}"""
+    assert(SchemaCodec.decode(future).isLeft)
+
+  test("triggers + filterClause round-trip"):
+    import specrest.convention.TriggerAggregate
+    import specrest.convention.TriggerSpec
+    val withExtras = sample.copy(
+      tables = sample.tables.head.copy(
+        indexes = List(
+          IndexSpec(
+            "ix_users_active",
+            List("active"),
+            unique = false,
+            filterClause = Some("active = true")
+          )
+        )
+      ) :: sample.tables.tail,
+      triggers = List(
+        TriggerSpec(
+          name = "trg_x",
+          functionName = "fn_x",
+          targetTable = "p",
+          targetColumn = "c",
+          sourceTable = "child",
+          sourceForeignKey = "p_id",
+          aggregate = TriggerAggregate.Sum,
+          sourceColumn = Some("v")
+        )
+      )
+    )
+    val snap    = SchemaSnapshot.of(withExtras)
+    val decoded = SchemaCodec.decode(SchemaCodec.encode(snap))
+    assertEquals(decoded, Right(snap))

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/SqlRendererTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/SqlRendererTest.scala
@@ -108,6 +108,54 @@ class SqlRendererTest extends CatsEffectSuite:
       List("DROP INDEX ix_posts_title;")
     )
 
+  test("AddIndex with filterClause renders WHERE suffix"):
+    val ix = IndexSpec(
+      "ix_products_active",
+      List("active"),
+      unique = false,
+      filterClause = Some("active = true")
+    )
+    assertEquals(
+      SqlRenderer.upgrade(List(AddIndex("products", ix))),
+      List("CREATE INDEX ix_products_active ON products (active) WHERE active = true;")
+    )
+
+  test("AddTrigger emits CREATE FUNCTION + CREATE TRIGGER as plain SQL"):
+    val t = specrest.convention.TriggerSpec(
+      name = "trg_recalc_order_subtotal",
+      functionName = "recalc_order_subtotal",
+      targetTable = "orders",
+      targetColumn = "subtotal",
+      sourceTable = "line_items",
+      sourceForeignKey = "order_id",
+      aggregate = specrest.convention.TriggerAggregate.Sum,
+      sourceColumn = Some("line_total")
+    )
+    val out = SqlRenderer.upgrade(List(AddTrigger(t))).mkString("\n")
+    assert(out.contains("CREATE OR REPLACE FUNCTION recalc_order_subtotal()"), out)
+    assert(out.contains("$$ LANGUAGE plpgsql;"), out)
+    assert(out.contains("COALESCE(SUM(line_total), 0)"), out)
+    assert(out.contains("CREATE TRIGGER trg_recalc_order_subtotal"), out)
+
+  test("DropTrigger emits DROP TRIGGER + DROP FUNCTION"):
+    val t = specrest.convention.TriggerSpec(
+      name = "trg_x",
+      functionName = "fn_x",
+      targetTable = "p",
+      targetColumn = "c",
+      sourceTable = "child",
+      sourceForeignKey = "p_id",
+      aggregate = specrest.convention.TriggerAggregate.Count,
+      sourceColumn = None
+    )
+    assertEquals(
+      SqlRenderer.upgrade(List(DropTrigger(t))),
+      List(
+        "DROP TRIGGER IF EXISTS trg_x ON child;",
+        "DROP FUNCTION IF EXISTS fn_x();"
+      )
+    )
+
   test("downgrade reverses the op list and inverts each op"):
     val ops = List(
       AddColumn("t", ColumnSpec("c", "TEXT", false, None)),

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -48,7 +48,10 @@ object Schema:
             case _ => ()
       case None => ()
 
-    DatabaseSchema(tables.result())
+    val builtTables        = tables.result()
+    val withPartialIndexes = applyPartialIndexConventions(builtTables, entities, ir.n)
+    val triggers           = detectAggregateTriggers(entities, withPartialIndexes)
+    DatabaseSchema(withPartialIndexes, triggers)
 
   private def buildEntityRefMap(
       ir: ServiceIRFull,
@@ -388,3 +391,135 @@ object Schema:
   ): Option[String] =
     sqlOp(b.a).flatMap: op =>
       if isLiteral(b.c) then Some(s"__COL__ $op ${literalValue(b.c)}") else None
+
+  private def applyPartialIndexConventions(
+      tables: List[TableSpec],
+      entities: List[EntityDeclFull],
+      conv: Option[conventions_decl_full]
+  ): List[TableSpec] =
+    val rules = conv.toList.flatMap { case ConventionsDeclFull(rs, _) =>
+      rs.collect {
+        case ConventionRuleFull(target, "partial_index", Some(col), StringLitF(filt, _), _) =>
+          (target, col, filt)
+      }
+    }
+    if rules.isEmpty then tables
+    else
+      val entityByName = entities.map(e => e.a -> e).toMap
+      val rulesByTable: Map[String, List[(String, String)]] = rules
+        .flatMap { (target, col, filt) =>
+          entityByName.get(target).map: e =>
+            val tableName =
+              Path.getConvention(conv, e.a, "db_table").getOrElse(Naming.toTableName(e.a))
+            val colName = Naming.toColumnName(col)
+            (tableName, colName, filt)
+        }
+        .groupBy(_._1)
+        .view
+        .mapValues(_.map((_, c, f) => (c, f)))
+        .toMap
+      tables.map: t =>
+        rulesByTable.get(t.name) match
+          case None => t
+          case Some(colFilters) =>
+            val partials = colFilters.map: (col, filt) =>
+              IndexSpec(
+                name = s"idx_${t.name}_${col}_partial",
+                columns = List(col),
+                unique = false,
+                filterClause = Some(filt)
+              )
+            t.copy(indexes = t.indexes ++ partials)
+
+  private def detectAggregateTriggers(
+      entities: List[EntityDeclFull],
+      tables: List[TableSpec]
+  ): List[TriggerSpec] =
+    val tablesByEntity = tables.map(t => t.entityName -> t).toMap
+    val entityByName   = entities.map(e => e.a -> e).toMap
+    val out            = List.newBuilder[TriggerSpec]
+    for parent <- entities do
+      val parentTable  = tablesByEntity.get(parent.a)
+      val parentFields = parent.c.collect { case f: FieldDeclFull => f }
+      for inv <- parent.d do
+        detectAggregateInvariant(inv) match
+          case Some(detected) =>
+            // Match parent field
+            val parentFieldOk = parentFields.exists(_.a == detected.targetField)
+            // Find the collection field's element entity type
+            val collectionField = parentFields.find(_.a == detected.collectionField)
+            val childEntityName: Option[String] = collectionField.flatMap: f =>
+              f.b match
+                case SetTypeF(NamedTypeF(n, _), _) => Some(n)
+                case SeqTypeF(NamedTypeF(n, _), _) => Some(n)
+                case _                             => None
+            // Find back-FK on child table to parent
+            val triggerOpt =
+              for
+                _           <- if parentFieldOk then Some(()) else None
+                parentTbl   <- parentTable
+                childName   <- childEntityName
+                childEntity <- entityByName.get(childName)
+                childTable  <- tablesByEntity.get(childName)
+                fk          <- childTable.foreignKeys.find(_.refTable == parentTbl.name)
+              yield
+                val parentSnake = Naming.toSnakeCase(parent.a)
+                val funcName    = s"recalc_${parentSnake}_${detected.targetField}"
+                TriggerSpec(
+                  name = s"trg_$funcName",
+                  functionName = funcName,
+                  targetTable = parentTbl.name,
+                  targetColumn = Naming.toColumnName(detected.targetField),
+                  sourceTable = childTable.name,
+                  sourceForeignKey = fk.column,
+                  aggregate = detected.aggregate,
+                  sourceColumn = detected.sourceField.map(Naming.toColumnName)
+                )
+            triggerOpt.foreach(out += _)
+          case None => ()
+    out.result()
+
+  final private case class DetectedAggregate(
+      targetField: String,
+      collectionField: String,
+      aggregate: TriggerAggregate,
+      sourceField: Option[String]
+  )
+
+  private def detectAggregateInvariant(inv: expr_full): Option[DetectedAggregate] =
+    inv match
+      case BinaryOpF(BEq(), lhs, rhs, _) =>
+        for
+          tgt <- extractFieldName(lhs)
+          agg <- decodeAggregateCall(rhs)
+        yield DetectedAggregate(tgt, agg._1, agg._2, agg._3)
+      case _ => None
+
+  private def decodeAggregateCall(
+      call: expr_full
+  ): Option[(String, TriggerAggregate, Option[String])] =
+    call match
+      case CallF(IdentifierF(name, _), args, _) =>
+        aggregateForName(name).flatMap: agg =>
+          (agg, args) match
+            case (TriggerAggregate.Count, List(coll)) =>
+              extractFieldName(coll).map(c => (c, TriggerAggregate.Count, None))
+            case (_, List(coll, LambdaF(_, body, _))) =>
+              for
+                coln    <- extractFieldName(coll)
+                srcField = lambdaProjection(body)
+                src     <- srcField
+              yield (coln, agg, Some(src))
+            case _ => None
+      case _ => None
+
+  private def aggregateForName(name: String): Option[TriggerAggregate] = name match
+    case "sum"   => Some(TriggerAggregate.Sum)
+    case "count" => Some(TriggerAggregate.Count)
+    case "min"   => Some(TriggerAggregate.Min)
+    case "max"   => Some(TriggerAggregate.Max)
+    case _       => None
+
+  private def lambdaProjection(body: expr_full): Option[String] = body match
+    case FieldAccessF(IdentifierF(_, _), field, _) => Some(field)
+    case _                                         => None

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -453,15 +453,22 @@ object Schema:
                 case SetTypeF(NamedTypeF(n, _), _) => Some(n)
                 case SeqTypeF(NamedTypeF(n, _), _) => Some(n)
                 case _                             => None
-            // Find back-FK on child table to parent
+            // Find back-FK on child table to parent — must be unique (ambiguous
+            // FKs to the same parent table can't be resolved without further
+            // input; emit nothing rather than picking arbitrarily).
             val triggerOpt =
               for
-                _           <- if parentFieldOk then Some(()) else None
-                parentTbl   <- parentTable
-                childName   <- childEntityName
-                childEntity <- entityByName.get(childName)
-                childTable  <- tablesByEntity.get(childName)
-                fk          <- childTable.foreignKeys.find(_.refTable == parentTbl.name)
+                _              <- if parentFieldOk then Some(()) else None
+                parentTbl      <- parentTable
+                childName      <- childEntityName
+                childEntity    <- entityByName.get(childName)
+                childTable     <- tablesByEntity.get(childName)
+                matchingFks     = childTable.foreignKeys.filter(_.refTable == parentTbl.name)
+                fk             <- if matchingFks.size == 1 then matchingFks.headOption else None
+                childFieldNames = childEntity.c.collect { case f: FieldDeclFull => f.a }.toSet
+                _ <- detected.sourceField match
+                       case Some(sf) if !childFieldNames.contains(sf) => None
+                       case _                                         => Some(())
               yield
                 val parentSnake = Naming.toSnakeCase(parent.a)
                 val funcName    = s"recalc_${parentSnake}_${detected.targetField}"
@@ -506,9 +513,8 @@ object Schema:
               extractFieldName(coll).map(c => (c, TriggerAggregate.Count, None))
             case (_, List(coll, LambdaF(_, body, _))) =>
               for
-                coln    <- extractFieldName(coll)
-                srcField = lambdaProjection(body)
-                src     <- srcField
+                coln <- extractFieldName(coll)
+                src  <- lambdaProjection(body)
               yield (coln, agg, Some(src))
             case _ => None
       case _ => None

--- a/modules/convention/src/main/scala/specrest/convention/Types.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Types.scala
@@ -83,7 +83,8 @@ final case class ForeignKeySpec(
 final case class IndexSpec(
     name: String,
     columns: List[String],
-    unique: Boolean
+    unique: Boolean,
+    filterClause: Option[String] = None
 ) derives CanEqual
 
 final case class TableSpec(
@@ -96,7 +97,24 @@ final case class TableSpec(
     indexes: List[IndexSpec]
 ) derives CanEqual
 
-final case class DatabaseSchema(tables: List[TableSpec]) derives CanEqual
+enum TriggerAggregate derives CanEqual:
+  case Sum, Count, Min, Max
+
+final case class TriggerSpec(
+    name: String,
+    functionName: String,
+    targetTable: String,
+    targetColumn: String,
+    sourceTable: String,
+    sourceForeignKey: String,
+    aggregate: TriggerAggregate,
+    sourceColumn: Option[String]
+) derives CanEqual
+
+final case class DatabaseSchema(
+    tables: List[TableSpec],
+    triggers: List[TriggerSpec] = Nil
+) derives CanEqual
 
 enum DiagnosticLevel derives CanEqual:
   case Error, Warning

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -22,7 +22,7 @@ object Validate:
 
   private val AliasOrEnumProperties: Set[String] = Set("strategy")
 
-  private val FieldQualifiedProperties: Set[String] = Set("test_strategy", "partial_index")
+  private val FieldQualifiedProperties: Set[String] = Set("test_strategy")
 
   private val QualifierUsingProperties: Set[String] =
     Set("http_header", "test_strategy", "partial_index")

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -16,14 +16,16 @@ object Validate:
   private val EntityProperties: Set[String] = Set(
     "db_table",
     "db_timestamps",
-    "plural"
+    "plural",
+    "partial_index"
   )
 
   private val AliasOrEnumProperties: Set[String] = Set("strategy")
 
-  private val FieldQualifiedProperties: Set[String] = Set("test_strategy")
+  private val FieldQualifiedProperties: Set[String] = Set("test_strategy", "partial_index")
 
-  private val QualifierUsingProperties: Set[String] = Set("http_header", "test_strategy")
+  private val QualifierUsingProperties: Set[String] =
+    Set("http_header", "test_strategy", "partial_index")
 
   def validateConventions(
       conventions: Option[conventions_decl_full],
@@ -194,6 +196,7 @@ object Validate:
     case "plural"              => validatePlural(rule, diagnostics)
     case "strategy"            => validateStrategy(rule, diagnostics)
     case "test_strategy"       => validateTestStrategy(rule, ir, diagnostics)
+    case "partial_index"       => validatePartialIndex(rule, ir, diagnostics)
     case _                     => ()
 
   private def err(
@@ -367,6 +370,48 @@ object Validate:
           )
     case _ =>
       err(rule, s"invalid value for ${rule.a}.strategy — expected a string", diagnostics)
+
+  private def validatePartialIndex(
+      rule: ConventionRuleFull,
+      ir: ServiceIRFull,
+      diagnostics: scala.collection.mutable.Builder[
+        ConventionDiagnostic,
+        List[ConventionDiagnostic]
+      ]
+  ): Unit =
+    rule.c match
+      case None =>
+        err(
+          rule,
+          s"""${rule.a}.partial_index requires a column qualifier (e.g., ${rule
+              .a}.partial_index "active" = "active = true")""",
+          diagnostics
+        )
+      case Some(field) =>
+        val entityMatch = ir.c.collectFirst { case e: EntityDeclFull if e.a == rule.a => e }
+        val knownField =
+          entityMatch.exists(_.c.exists { case FieldDeclFull(n, _, _, _) => n == field })
+        if entityMatch.isDefined && !knownField then
+          err(
+            rule,
+            s"""${rule.a}.partial_index "$field" — no field named '$field' on entity '${rule.a}'""",
+            diagnostics
+          )
+
+    rule.d match
+      case StringLitF(v, _) if v.trim.isEmpty =>
+        err(
+          rule,
+          s"""invalid value for ${rule.a}.partial_index — WHERE clause cannot be empty""",
+          diagnostics
+        )
+      case StringLitF(_, _) => ()
+      case _ =>
+        err(
+          rule,
+          s"invalid value for ${rule.a}.partial_index — expected a string (the WHERE clause body, e.g. \"active = true\")",
+          diagnostics
+        )
 
   private def validateTestStrategy(
       rule: ConventionRuleFull,

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -95,6 +95,31 @@ class ConventionSmokeTest extends CatsEffectSuite:
         c.expectations.foreach: (op, expected) =>
           assertEquals(byName(op).strategy, expected, s"${c.fixture}.$op")
 
+  test("ecommerce: aggregate-invariant detector emits a Sum trigger on line_items"):
+    SpecFixtures.loadIR("ecommerce").map: ir =>
+      val schema = Schema.deriveSchema(ir)
+      val trig = schema.triggers
+        .find(_.name == "trg_recalc_order_subtotal")
+        .getOrElse(fail(s"trigger missing; got names=${schema.triggers.map(_.name)}"))
+      assertEquals(trig.functionName, "recalc_order_subtotal")
+      assertEquals(trig.targetTable, "orders")
+      assertEquals(trig.targetColumn, "subtotal")
+      assertEquals(trig.sourceTable, "line_items")
+      assertEquals(trig.sourceForeignKey, "order_id")
+      assertEquals(trig.aggregate, TriggerAggregate.Sum)
+      assertEquals(trig.sourceColumn, Some("line_total"))
+
+  test("ecommerce: Product.partial_index convention produces filterClause on index"):
+    SpecFixtures.loadIR("ecommerce").map: ir =>
+      val schema   = Schema.deriveSchema(ir)
+      val products = schema.tables.find(_.name == "products").get
+      val partial = products.indexes
+        .find(_.filterClause.isDefined)
+        .getOrElse(fail(s"no partial index on products; got=${products.indexes}"))
+      assertEquals(partial.filterClause, Some("active = true"))
+      assertEquals(partial.columns, List("active"))
+      assert(!partial.unique)
+
   test("naming helpers"):
     assertEquals(Naming.pluralize("user"), "users")
     assertEquals(Naming.pluralize("child"), "children")

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -111,8 +111,10 @@ class ConventionSmokeTest extends CatsEffectSuite:
 
   test("ecommerce: Product.partial_index convention produces filterClause on index"):
     SpecFixtures.loadIR("ecommerce").map: ir =>
-      val schema   = Schema.deriveSchema(ir)
-      val products = schema.tables.find(_.name == "products").get
+      val schema = Schema.deriveSchema(ir)
+      val products = schema.tables
+        .find(_.name == "products")
+        .getOrElse(fail(s"products table missing; got=${schema.tables.map(_.name)}"))
       val partial = products.indexes
         .find(_.filterClause.isDefined)
         .getOrElse(fail(s"no partial index on products; got=${products.indexes}"))

--- a/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
+++ b/modules/verify/src/test/scala/specrest/verify/testutil/SpecGen.scala
@@ -157,8 +157,10 @@ object SpecGen:
     "false"
   )
 
+  private val reservedTypeKeywords = Set("set", "seq", "map", "option")
+
   private val genFreshName: Gen[String] =
-    genIdent.suchThat(s => !reserved.contains(s))
+    genIdent.suchThat(s => !reserved.contains(s) && !reservedTypeKeywords.contains(s))
 
   private val genAtomicType: Gen[AtomicType] =
     Gen.oneOf(AtomicType.IntT, AtomicType.BoolT)


### PR DESCRIPTION
## Summary

Implements [M7.6 (#57)](https://github.com/HardMax71/spec_to_rest/issues/57) — Schema Derivation Polish. Two extensions to the schema-derivation layer that ship across all three deployment profiles:

1. **Aggregate-invariant triggers**. \`Schema.deriveSchema\` detects \`entity.field = sum/count/min/max(coll, e => e.field)\` invariants where the collection element entity has a back-FK to the parent. Emits PostgreSQL \`CREATE OR REPLACE FUNCTION ... CREATE TRIGGER ... AFTER INSERT OR UPDATE OR DELETE FOR EACH ROW\` using the canonical row-recompute pattern from research doc §3.6.
2. **Partial indexes** via the new entity convention property \`Entity.partial_index "col" = "<WHERE clause>"\`. Heuristic-detection path intentionally not implemented (auto-detecting from operation \`ensures\` produces wrong-shaped indexes too easily).

Also implements [#243](https://github.com/HardMax71/spec_to_rest/issues/243) (SchemaCodec v1→v2 lift) — required to ship M7.6 without silently breaking existing user repos.

## Multi-target wiring

- **IR layer (shared)**: \`TriggerSpec\`/\`TriggerAggregate\`, \`IndexSpec.filterClause\`, \`MigrationOp.{AddTrigger,DropTrigger}\`, \`SchemaDiff\` triggers diff, \`SchemaCodec\` v2 with v1 lift.
- **Python (Alembic)**: trigger SQL via \`op.execute(...)\`, partial-index via \`postgresql_where=sa.text(...)\`. Initial-schema template extended; schema-update template already op-stream based.
- **Go (golang-migrate)** and **TS (Prisma + raw SQL)**: \`SqlRenderer\` emits trigger DDL and partial-index \`WHERE\` directly. Initial-schema emitters add \`triggers.map(AddTrigger.apply)\` to the op stream.
- **TS Prisma schema**: trigger-maintained columns get \`@default(0)\` so Prisma's \`OrderCreateInput\` type doesn't require a value the user shouldn't set.

## Acceptance criteria (from #57)

- [x] \`ecommerce\` fixture emits trigger function + \`CREATE TRIGGER\`. Verified across all three targets:
  - Python: \`op.execute("""CREATE OR REPLACE FUNCTION recalc_order_subtotal() ...""")\` + \`op.execute("""CREATE TRIGGER trg_recalc_order_subtotal AFTER INSERT OR UPDATE OR DELETE ON line_items ...""")\`.
  - Go: raw SQL inside \`BEGIN; ... COMMIT;\` block.
  - TS: same SQL inside Prisma migration; \`Order.subtotal\` gets \`@default(0)\` in \`schema.prisma\`.
- [x] \`ecommerce\` fixture emits partial index on a boolean column (\`Product.active\`):
  - Python: \`op.create_index(..., postgresql_where=sa.text('active = true'))\`.
  - Go/TS SQL: \`CREATE INDEX idx_products_active_partial ON products (active) WHERE active = true;\`.
- [ ] Dialects without trigger / partial-index support — deferred to M7.7 (#58); SQLite/MySQL profiles don't exist yet. Renderer emits Postgres-only syntax. Dialect contract documented in [#58 comment](https://github.com/HardMax71/spec_to_rest/issues/58#issuecomment-4444761209).
- [x] Generated migration still passes \`alembic upgrade head\` syntactically — all three targets compile to syntactically valid SQL/Python; runtime DDL execution requires a Postgres CI step that doesn't exist today (separate work).

## Test plan

- [x] \`sbt test\` — 1149 tests pass, 0 fail
- [x] 17 new test cases:
  - \`ConventionSmokeTest\`: detector finds the ecommerce trigger; partial-index convention populates \`filterClause\`
  - \`SchemaCodecTest\`: v1 JSON lifts to v2 silently; future-version JSON errors clearly; triggers + filterClause round-trip
  - \`AlembicRendererTest\`: \`AddIndex\` with \`filterClause\` renders \`postgresql_where=\`; \`AddTrigger\` / \`DropTrigger\` render \`op.execute(...)\` with the right body
  - \`SqlRendererTest\`: same coverage for plain SQL
  - \`AlembicMigrationTest\`: end-to-end ecommerce emission contains both trigger + partial-index DDL
- [x] Spot-checked compile-to-disk for ecommerce against all three targets — trigger function + trigger statement + partial index appear in the right order, downgrade path emits \`DROP TRIGGER IF EXISTS ... ; DROP FUNCTION IF EXISTS ...\`.
- [x] \`IncrementalMigrationTest\` (15 cases) still green — v1→v2 lift produces no spurious \`002_schema_update\` files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic aggregate-invariant trigger generation and partial index support for Postgres across all profiles. Upgrades the schema snapshot to v2 with a backward‑compatible v1→v2 lift; Postgres-only DDL for now (other dialects in M7.7). Closes #57 and #243.

- New Features
  - `Schema.deriveSchema` detects invariants like `entity.field = sum/count/min/max(coll, e => e.field)` (with a back-FK) and emits a trigger function + `AFTER INSERT OR UPDATE OR DELETE` trigger.
  - Partial indexes via `Entity.partial_index "col" = "<WHERE clause>"`; Alembic uses `postgresql_where=sa.text(...)`; SQL renderers append `WHERE ...`.
  - TS Prisma: trigger-maintained numeric columns get `@default(0)` so create inputs don’t require them.
  - `TriggerSpec`, `MigrationOp.{AddTrigger,DropTrigger}`, trigger diffing in `SchemaDiff`; initial migrations include trigger ops in Go/TS/Python.

- Bug Fixes
  - Trigger SQL now handles FK re-parenting on UPDATE (recompute for both old and new parents).
  - Trigger detector requires exactly one back-FK and validates the child source field exists; skips ambiguous cases.
  - Validation: `partial_index` is entity-only and enforces non-empty WHERE clauses.
  - Alembic: fixed `AlembicSyntax.tripleQuoted` to correctly escape embedded `"""` and `\`, ensuring `op.execute("""...""")` round-trips SQL safely.
  - Refactors: unified trigger drop via `dropStatements`; shared `AlembicSyntax.tripleQuoted`.
  - Test generator reserves `Set`/`Seq`/`Map`/`Option` to avoid parser token collisions, fixing a CI flake.

<sup>Written for commit fa571e96fd895bae30acc59a5536b47fadd15122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Partial index support: define conditional indexes on table columns with WHERE clauses
  * Automatic trigger generation for maintaining aggregate values (sum, count, min, max) across related tables
  * Database migration support for partial indexes and triggers across Python FastAPI, TypeScript Express, and Go Chi frameworks

* **Chores**
  * Schema snapshot version upgraded to v2
  * Enhanced test coverage for new indexing and trigger functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/244)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->