### PR TITLE
ci: unblock dependabot PRs (branch-name skip + Go 1.25)

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   check-branch-name:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: "1.22"
+          go-version: "1.25"
 
       - name: Emit Go project from url_shortener.spec
         run: |


### PR DESCRIPTION
## Summary

- **branch-name.yml**: Skip the job when actor is `dependabot[bot]`. The pattern `^(feature|fix|docs|chore|refactor)/.+$` enforces convention on human-authored PRs but rejects dependabot's `dependabot/<ecosystem>/...` branches. Skipping for dependabot preserves intent and unblocks #245 and #246.
- **go-build.yml**: Bump `go-version` `"1.22"` → `"1.25"`. The codegen template pins `github.com/jackc/pgx/v5 v5.9.2` (`modules/profile/.../GoChiPostgres.scala:24`), which requires Go ≥ 1.25. Previously `actions/setup-go v5.5.0` let Go silently switch toolchains; `v6.4.0` (the bump dependabot proposes in #246) sets `GOTOOLCHAIN=local`, exposing the latent inconsistency. Aligning the workflow with what the generated module actually needs is the cleanest fix.

## Background

Dependabot opened two PRs today:

- **#245** (docs npm bump) — only failure is `check-branch-name`.
- **#246** (actions group bump) — `check-branch-name` + the Go pgx/Go-version mismatch above + a separate `NoClassDefFoundError: SpecRestGenerated\$` in native-image macOS/Windows smoke tests that this PR does NOT address (it's an unrelated graalvm 1.5.3 question or pre-existing platform issue).

## Test plan

- [ ] CI passes on this branch (`branch-name` job should now show `skipped` for dependabot actor; for human PRs it still runs)
- [ ] After merge, rebase #245 and #246 onto main; `check-branch-name` no longer blocks them
- [ ] `go-build` job (which runs only on go-template-touching changes) verified next time it triggers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks Dependabot PRs by skipping the branch-name check for `dependabot[bot]` and updating the CI Go version to 1.25. This keeps naming rules for human PRs and fixes a toolchain mismatch with `github.com/jackc/pgx/v5`, unblocking #245 and #246.

- **Bug Fixes**
  - `.github/workflows/branch-name.yml`: Skip job when `github.actor` is `dependabot[bot]` to allow `dependabot/<ecosystem>/...` branches.
  - `.github/workflows/go-build.yml`: Set `go-version: "1.25"` to satisfy `pgx` v5.9.2 and avoid failures when `actions/setup-go` enforces `GOTOOLCHAIN=local` (as in #246).

<sup>Written for commit be91dfa36f39c7fc1dd9c7f234e948276d6f23a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

