### PR TITLE
feat: SQLite + MySQL support for go/chi (Bun dialect switch)

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -28,14 +28,24 @@ permissions:
   contents: read
 
 concurrency:
-  group: go-build-${{ github.ref }}
+  group: go-build-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
   build:
-    name: compile go-chi-postgres -> go build + migrate
+    name: go-chi -> go build + migrate (${{ matrix.dialect }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dialect: postgres
+            migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
+          - dialect: sqlite
+            migrate_url: sqlite://url_shortener.db
+          - dialect: mysql
+            migrate_url: mysql://app:app@tcp(127.0.0.1:3306)/app
     services:
       postgres:
         image: postgres:17-alpine
@@ -50,6 +60,20 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_USER: app
+          MYSQL_PASSWORD: app
+          MYSQL_DATABASE: app
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -u app -papp --silent"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -68,10 +92,10 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Emit Go project from url_shortener.spec
+      - name: Emit Go project from url_shortener.spec (${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/url_shortener.spec --framework chi --db postgres --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/url_shortener.spec --framework chi --db ${{ matrix.dialect }} --out out --ignore-verify"
 
       - name: Inspect emitted layout
         run: |
@@ -98,10 +122,10 @@ jobs:
       - name: Install golang-migrate CLI
         run: go install -tags 'postgres mysql sqlite' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
 
-      - name: Migrate up / down / up (round-trip vs real PostgreSQL)
+      - name: Migrate up / down / up (round-trip vs real ${{ matrix.dialect }})
         working-directory: out
         env:
-          DB_URL: postgres://app:app@localhost:5432/app?sslmode=disable
+          DB_URL: ${{ matrix.migrate_url }}
         run: |
           migrate -path migrations -database "$DB_URL" up
           migrate -path migrations -database "$DB_URL" down -all

--- a/docs/content/docs/pipelines/migrations.mdx
+++ b/docs/content/docs/pipelines/migrations.mdx
@@ -21,7 +21,7 @@ The diff algorithm operates on the target-agnostic `DatabaseSchema`. Only the re
 | Target | Snapshot | Initial migration | Delta migration |
 | --- | --- | --- | --- |
 | `python-fastapi-postgres` | `.spec-snapshot.json` | `alembic/versions/001_initial_schema.py` | `alembic/versions/NNN_schema_update.py` (Alembic `op.*` calls, `def upgrade()` + `def downgrade()`) |
-| `go-chi-postgres` | `.spec-snapshot.json` | `migrations/001_initial_schema.up.sql` + `.down.sql` | `migrations/NNN_schema_update.up.sql` + `.down.sql` (raw Postgres DDL) |
+| `go-chi-postgres` | `.spec-snapshot.json` | `migrations/001_initial_schema.up.sql` + `.down.sql` | `migrations/NNN_schema_update.up.sql` + `.down.sql` (raw SQL DDL, Postgres/SQLite/MySQL dialect) |
 | `ts-express-postgres` | `.spec-snapshot.json` | `prisma/migrations/001_initial_schema/migration.sql` (+ advisory `down.sql`) + `prisma/migrations/migration_lock.toml` | `prisma/migrations/NNN_schema_update/migration.sql` (+ advisory `down.sql`) |
 
 Revision numbering is 3-digit zero-padded across all three targets (`001`, `002`, …). Prisma's lexicographic ordering is satisfied; Alembic and golang-migrate both accept arbitrary tokens as long as they are unique.

--- a/docs/content/docs/targets/go/chi/meta.json
+++ b/docs/content/docs/targets/go/chi/meta.json
@@ -1,6 +1,8 @@
 {
   "title": "chi",
   "pages": [
-    "postgres"
+    "postgres",
+    "sqlite",
+    "mysql"
   ]
 }

--- a/docs/content/docs/targets/go/chi/mysql.mdx
+++ b/docs/content/docs/targets/go/chi/mysql.mdx
@@ -1,0 +1,58 @@
+---
+title: MySQL
+description: Reference for the go-chi-mysql deployment target
+---
+
+This page documents only how the `go-chi-mysql` target **differs** from
+[`go-chi-postgres`](/targets/go/chi/postgres). Everything not listed here — file
+tree, naming conventions, HTTP contract, OpenAPI, the chi app, Dafny
+integration, extension points — is identical; read the
+[PostgreSQL page](/targets/go/chi/postgres) for the full reference.
+
+The database axis is a pluggable `Dialect` strategy
+(`modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala`) plus
+the Go-side `GoDbView` in `EmitGo.scala`; together they decide the Bun dialect
+and driver, the raw-SQL column types, the connection wiring, and the
+`docker-compose` / generated-CI database service. Selecting MySQL is one flag —
+no emitter or template changes.
+
+```bash
+sbt "cli/run compile --framework chi --db mysql --ignore-verify --out /tmp/out fixtures/spec/url_shortener.spec"
+```
+
+## Deltas from PostgreSQL
+
+| Aspect              | PostgreSQL                                  | MySQL                                          |
+| ------------------- | ------------------------------------------- | ---------------------------------------------- |
+| Bun dialect         | `pgdialect`                                 | `mysqldialect`                                 |
+| Driver              | `bun/driver/pgdriver`                       | `go-sql-driver/mysql` (blank import)           |
+| App DSN             | `postgres://…@localhost:5432/…?sslmode=disable` | `<svc>:<svc>@tcp(localhost:3306)/<svc>?parseTime=true` |
+| `golang-migrate` URL | `postgres://…?sslmode=disable`             | `mysql://<svc>:<svc>@tcp(localhost:3306)/<svc>` |
+| Database service    | `postgres:16-alpine` in compose / CI        | `mysql:8.4` in compose / CI                    |
+| Migration tx wrap   | `BEGIN; … COMMIT;`                          | none (MySQL auto-commits DDL)                  |
+| Unbounded strings   | `TEXT`                                       | `VARCHAR(255)`                                 |
+
+- **Compose / CI service.** The emitted `docker-compose.yml` and
+  `.github/workflows/ci.yml` provision a `mysql:8.4` service (replacing the
+  Postgres one). `internal/database/database.go` opens it with
+  `sql.Open("mysql", dsn)` (driver registered via the
+  `_ "github.com/go-sql-driver/mysql"` blank import) and wraps it in
+  `bun.NewDB(sqldb, mysqldialect.New())`.
+- **No transaction wrapper.** MySQL implicitly commits DDL, so the emitted
+  `migrations/*.sql` omit the explicit `BEGIN;`/`COMMIT;` the Postgres target
+  uses.
+- **Column types.** `String→VARCHAR(255)`, `Int→BIGINT`, `Float→DOUBLE`,
+  `Bool→TINYINT(1)`, `DateTime→DATETIME`, `Date→DATE`, `UUID→CHAR(36)`,
+  `Decimal→DECIMAL`, `Bytes→LONGBLOB`, `Set/Seq→JSON`. A 32-bit `SERIAL` PK
+  stays `INT AUTO_INCREMENT` (not widened to `BIGINT`). The emitter is
+  canonical.
+
+## CI gate
+
+`.github/workflows/go-build.yml` runs the `mysql` matrix leg: `go build` plus a
+`golang-migrate` `up → down -all → up` round-trip against a real `mysql:8.4`
+service, so the emitted `migrations/*.sql` is proven to apply and reverse on
+MySQL.
+
+If this page and the emitted output disagree, the emitter wins — file an issue
+or PR to correct the doc.

--- a/docs/content/docs/targets/go/chi/postgres.mdx
+++ b/docs/content/docs/targets/go/chi/postgres.mdx
@@ -28,7 +28,7 @@ the output for `url_shortener.spec` is checked in under
 | --------------- | ---------------------------------------------------------------- |
 | Language        | Go 1.22                                                          |
 | Framework       | chi v5 (`net/http`)                                              |
-| Driver          | `pgx` v5 + `pgxpool`                                             |
+| ORM / driver    | Bun (`uptrace/bun`) + `bun/driver/pgdriver`                       |
 | Migration tool  | `golang-migrate` (raw SQL under `migrations/`)                  |
 | Database        | PostgreSQL 16+                                                   |
 | Validation      | `go-playground/validator/v10` struct tags                        |
@@ -44,14 +44,14 @@ the output for `url_shortener.spec` is checked in under
 ├── cmd/server/main.go              # entrypoint, chi router wiring
 ├── internal/
 │   ├── config/config.go            # env-driven Config struct
-│   ├── database/database.go        # pgxpool connect + ping
+│   ├── database/database.go        # bun.NewDB connect + ping
 │   ├── models/{entity}.go          # struct + create/read DTOs + ErrorResponse
 │   ├── handlers/
 │   │   ├── common.go               # writeJSON / writeError helpers
 │   │   └── {entity_plural}.go      # chi handler funcs (1 per operation)
 │   └── services/
 │       ├── common.go               # ErrNotFound sentinel
-│       └── {entity}.go             # pgx-backed business logic
+│       └── {entity}.go             # Bun query-builder business logic
 ├── migrations/
 │   ├── 001_initial_schema.up.sql
 │   └── 001_initial_schema.down.sql
@@ -105,14 +105,15 @@ verified-body cache is populated, the compiler:
 3. Emits operation bindings of the form `dafnykernel.{OperationName}`.
 
 The kernel is only emitted when at least one operation is classified as
-`LLM_SYNTHESIS`; otherwise the Go project is purely CRUD/`pgx`.
+`LLM_SYNTHESIS`; otherwise the Go project is purely CRUD/Bun.
 
 ## CI gate
 
-`.github/workflows/go-build.yml` re-runs `compile --framework chi --db postgres` on
+`.github/workflows/go-build.yml` is a `{postgres, sqlite, mysql}` matrix. On
 every PR that touches the Go templates, profile, emitter, or the shared
-migration renderer, then runs `go mod tidy && go vet && go build` against the
-emitted project **and** a `golang-migrate` round-trip
-(`up → down -all → up`) against a real `postgres:17` service — so the emitted
-`migrations/*.sql` is proven to apply and reverse, not just that the Go code
-compiles.
+migration renderer it re-runs `compile --framework chi --db <dialect>`, then
+`go mod tidy && go vet && go build` against the emitted project **and** a
+`golang-migrate` round-trip (`up → down -all → up`) against a real
+`postgres:17` / `mysql:8.4` service (SQLite uses a file) — so the emitted
+`migrations/*.sql` is proven to apply and reverse on every supported dialect,
+not just that the Go code compiles.

--- a/docs/content/docs/targets/go/chi/sqlite.mdx
+++ b/docs/content/docs/targets/go/chi/sqlite.mdx
@@ -1,0 +1,57 @@
+---
+title: SQLite
+description: Reference for the go-chi-sqlite deployment target
+---
+
+This page documents only how the `go-chi-sqlite` target **differs** from
+[`go-chi-postgres`](/targets/go/chi/postgres). Everything not listed here — file
+tree, naming conventions, HTTP contract, OpenAPI, the chi app, Dafny
+integration, extension points — is identical; read the
+[PostgreSQL page](/targets/go/chi/postgres) for the full reference.
+
+The database axis is a pluggable `Dialect` strategy
+(`modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala`) plus
+the Go-side `GoDbView` in `EmitGo.scala`; together they decide the Bun dialect
+and driver, the raw-SQL column types, the connection wiring, and the
+`docker-compose` / generated-CI database service. Selecting SQLite is one flag —
+no emitter or template changes.
+
+```bash
+sbt "cli/run compile --framework chi --db sqlite --ignore-verify --out /tmp/out fixtures/spec/url_shortener.spec"
+```
+
+## Deltas from PostgreSQL
+
+| Aspect              | PostgreSQL                                  | SQLite                                              |
+| ------------------- | ------------------------------------------- | --------------------------------------------------- |
+| Bun dialect         | `pgdialect`                                 | `sqlitedialect`                                     |
+| Driver              | `bun/driver/pgdriver`                       | `bun/driver/sqliteshim` (pure-Go modernc, no CGO)   |
+| App DSN             | `postgres://…@localhost:5432/…?sslmode=disable` | `file:<svc>.db?cache=shared&_pragma=foreign_keys(1)` |
+| `golang-migrate` URL | `postgres://…?sslmode=disable`             | `sqlite://<svc>.db`                                 |
+| Database service    | `postgres:16-alpine` in compose / CI        | **none** — file-backed, no compose/CI DB service    |
+| Migration tx wrap   | `BEGIN; … COMMIT;`                          | none (golang-migrate wraps each migration itself)   |
+| Auto-increment PK   | `BIGSERIAL` + separate `CONSTRAINT pk_…`    | inline `INTEGER PRIMARY KEY AUTOINCREMENT`          |
+
+- **File-backed, no service.** The emitted `docker-compose.yml` and
+  `.github/workflows/ci.yml` have no database container; the database is a local
+  file. `internal/database/database.go` opens it with
+  `sql.Open(sqliteshim.ShimName, dsn)` and wraps it in
+  `bun.NewDB(sqldb, sqlitedialect.New())`.
+- **No transaction wrapper.** golang-migrate's SQLite driver runs each migration
+  in its own transaction, so the emitted `migrations/*.sql` omit the explicit
+  `BEGIN;`/`COMMIT;` the Postgres target uses (a nested transaction would
+  error).
+- **Auto-increment PK.** SQLite only auto-increments the `INTEGER PRIMARY KEY`
+  rowid alias, so the PK is declared inline (no separate `CONSTRAINT pk_…`).
+- **Column types.** `String→TEXT`, `Int→INTEGER`, `Float→REAL`,
+  `Bool→BOOLEAN`, `DateTime→DATETIME`, `Date→DATE`, `UUID→TEXT`,
+  `Decimal→NUMERIC`, `Bytes→BLOB`, `Set/Seq→TEXT`. The emitter is canonical.
+
+## CI gate
+
+`.github/workflows/go-build.yml` runs the `sqlite` matrix leg: `go build` plus a
+`golang-migrate` `up → down -all → up` round-trip against a file database, so the
+emitted `migrations/*.sql` is proven to apply and reverse on SQLite.
+
+If this page and the emitted output disagree, the emitter wins — file an issue
+or PR to correct the doc.

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.dockerignore
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+*.md
+tests
+.env
+.env.*
+*.env

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.env.example
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=url_shortener:url_shortener@tcp(localhost:3306)/url_shortener?parseTime=true
+BASE_URL=http://localhost:8080
+PORT=8080
+LOG_LEVEL=info

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      BASE_URL: http://localhost:8080
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - run: go mod tidy
+      - run: go vet ./...
+      - run: go test ./...

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
@@ -13,18 +13,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
-      postgres:
-        image: postgres:16-alpine
+      db:
+        image: mysql:8.4
         env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
+          MYSQL_USER: url_shortener
+          MYSQL_PASSWORD: url_shortener
+          MYSQL_DATABASE: url_shortener
+          MYSQL_ROOT_PASSWORD: url_shortener_root
         ports:
-          - 5432:5432
+          - "3306:3306"
         options: >-
-          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -u url_shortener -purl_shortener --silent" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
-      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      DATABASE_URL: url_shortener:url_shortener@tcp(localhost:3306)/url_shortener?parseTime=true
       BASE_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.gitignore
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.gitignore
@@ -1,0 +1,9 @@
+/server
+/bin/
+/dist/
+/vendor/
+*.test
+*.out
+.env
+.idea/
+.vscode/

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.spec-snapshot.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion" : 2,
+  "schema" : {
+    "tables" : [
+      {
+        "name" : "url_mappings",
+        "entityName" : "UrlMapping",
+        "columns" : [
+          {
+            "name" : "id",
+            "sqlType" : "BIGSERIAL",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "code",
+            "sqlType" : "TEXT",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "url",
+            "sqlType" : "TEXT",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "created_at",
+            "sqlType" : "TIMESTAMPTZ",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "click_count",
+            "sqlType" : "INTEGER",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "updated_at",
+            "sqlType" : "TIMESTAMPTZ",
+            "nullable" : false,
+            "defaultValue" : "NOW()"
+          }
+        ],
+        "primaryKey" : "id",
+        "foreignKeys" : [
+        ],
+        "checks" : [
+          "click_count >= 0"
+        ],
+        "indexes" : [
+        ]
+      }
+    ],
+    "triggers" : [
+    ]
+  }
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/Dockerfile
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /src
+COPY go.mod ./
+COPY go.su[m] ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/server ./cmd/server
+
+FROM alpine:3.20
+RUN apk add --no-cache wget && adduser -D -u 10001 app
+USER app
+COPY --from=builder /out/server /usr/local/bin/server
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+	CMD wget -qO- http://localhost:8080/health || exit 1
+ENTRYPOINT ["/usr/local/bin/server"]

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/Makefile
@@ -1,0 +1,29 @@
+.PHONY: build run test fmt vet tidy migrate-up migrate-down
+
+MIGRATE_DSN ?= mysql://url_shortener:url_shortener@tcp(localhost:3306)/url_shortener
+
+build:
+	go build ./...
+
+run:
+	go run ./cmd/server
+
+test:
+	go test ./...
+
+fmt:
+	gofmt -s -w .
+
+vet:
+	go vet ./...
+
+tidy:
+	go mod tidy
+
+migrate-up:
+	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
+	migrate -path migrations -database "$(MIGRATE_DSN)" up
+
+migrate-down:
+	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
+	migrate -path migrations -database "$(MIGRATE_DSN)" down

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/Makefile
@@ -1,7 +1,5 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
-MIGRATE_DSN ?= mysql://url_shortener:url_shortener@tcp(localhost:3306)/url_shortener
-
 build:
 	go build ./...
 
@@ -22,8 +20,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" up
+	migrate -path migrations -database "$${MIGRATE_DSN:-mysql://url_shortener:url_shortener@tcp(localhost:3306)/url_shortener}" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" down
+	migrate -path migrations -database "$${MIGRATE_DSN:-mysql://url_shortener:url_shortener@tcp(localhost:3306)/url_shortener}" down

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/README.md
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/README.md
@@ -1,0 +1,18 @@
+# UrlShortener
+
+Generated Go service (Go + chi + MySQL).
+
+## Quick start
+
+```bash
+docker compose up --build
+curl http://localhost:8080/health
+```
+
+## Local dev
+
+```bash
+go mod tidy
+go test ./...
+DATABASE_URL=postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable go run ./cmd/server
+```

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/README.md
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/README.md
@@ -14,5 +14,5 @@ curl http://localhost:8080/health
 ```bash
 go mod tidy
 go test ./...
-DATABASE_URL=postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable go run ./cmd/server
+DATABASE_URL='url_shortener:url_shortener@tcp(localhost:3306)/url_shortener?parseTime=true' go run ./cmd/server
 ```

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
@@ -36,10 +36,8 @@ func main() {
 	}
 	defer func() { _ = db.Close() }()
 
-
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -53,17 +51,10 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-
-
 	r.Post("/shorten", urlMappingHandler.Shorten)
-
 	r.Get("/urls", urlMappingHandler.ListAll)
-
 	r.Get("/{code}", urlMappingHandler.Resolve)
-
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/generated/url-shortener/internal/config"
+	"github.com/generated/url-shortener/internal/database"
+	"github.com/generated/url-shortener/internal/handlers"
+	"github.com/generated/url-shortener/internal/services"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	db, err := database.Connect(context.Background(), cfg.DatabaseURL)
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer func() { _ = db.Close() }()
+
+
+	urlMappingSvc := services.NewUrlMappingService(db, cfg)
+	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
+
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.Timeout(30 * time.Second))
+
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+
+
+	r.Post("/shorten", urlMappingHandler.Shorten)
+
+	r.Get("/urls", urlMappingHandler.ListAll)
+
+	r.Get("/{code}", urlMappingHandler.Resolve)
+
+	r.Delete("/{code}", urlMappingHandler.Delete)
+
+
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Port),
+		Handler:      r,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("starting server", "port", cfg.Port)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-done
+	slog.Info("shutting down")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = server.Shutdown(ctx)
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/docker-compose.yml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  app:
+    build: .
+    environment:
+      DATABASE_URL: url_shortener:url_shortener@tcp(db:3306)/url_shortener?parseTime=true
+      BASE_URL: http://localhost:8080
+      PORT: 8080
+    ports:
+      - "8080:8080"
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:8.4
+    environment:
+      MYSQL_USER: url_shortener
+      MYSQL_PASSWORD: url_shortener
+      MYSQL_DATABASE: url_shortener
+      MYSQL_ROOT_PASSWORD: url_shortener_root
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u url_shortener -purl_shortener --silent"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    volumes:
+      - dbdata:/var/lib/mysql
+
+volumes:
+  dbdata:

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/go.mod
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/go.mod
@@ -3,19 +3,11 @@ module github.com/generated/url-shortener
 go 1.22
 
 require (
-
 	github.com/go-chi/chi/v5 v5.1.0
-
 	github.com/uptrace/bun v1.2.18
-
 	github.com/go-sql-driver/mysql v1.10.0
-
 	github.com/google/uuid v1.6.0
-
 	github.com/shopspring/decimal v1.4.0
-
 	github.com/caarlos0/env/v11 v11.2.0
-
 	github.com/go-playground/validator/v10 v10.22.1
-
 )

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/go.mod
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/go.mod
@@ -1,0 +1,21 @@
+module github.com/generated/url-shortener
+
+go 1.22
+
+require (
+
+	github.com/go-chi/chi/v5 v5.1.0
+
+	github.com/uptrace/bun v1.2.18
+
+	github.com/go-sql-driver/mysql v1.10.0
+
+	github.com/google/uuid v1.6.0
+
+	github.com/shopspring/decimal v1.4.0
+
+	github.com/caarlos0/env/v11 v11.2.0
+
+	github.com/go-playground/validator/v10 v10.22.1
+
+)

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/config/config.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+import "github.com/caarlos0/env/v11"
+
+type Config struct {
+	DatabaseURL string `env:"DATABASE_URL" envDefault:"url_shortener:url_shortener@tcp(localhost:3306)/url_shortener?parseTime=true"`
+	BaseURL     string `env:"BASE_URL"     envDefault:"http://localhost:8080"`
+	Port        int    `env:"PORT"         envDefault:"8080"`
+	LogLevel    string `env:"LOG_LEVEL"    envDefault:"info"`
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{}
+	if err := env.Parse(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/database/database.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/database/database.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/mysqldialect"
+)
+
+func Connect(ctx context.Context, dsn string) (*bun.DB, error) {
+	sqldb, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db := bun.NewDB(sqldb, mysqldialect.New())
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/common.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/common.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/generated/url-shortener/internal/models"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, models.ErrorResponse{Detail: detail})
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/generated/url-shortener/internal/models"
+	"github.com/generated/url-shortener/internal/services"
+)
+
+type UrlMappingHandler struct {
+	svc *services.UrlMappingService
+}
+
+func NewUrlMappingHandler(svc *services.UrlMappingService) *UrlMappingHandler {
+	return &UrlMappingHandler{svc: svc}
+}
+
+
+func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
+
+
+	var body models.ShortenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+
+
+
+
+
+
+	if err := h.svc.Shorten(r.Context(), body); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(201)
+
+}
+
+
+func (h *UrlMappingHandler) ListAll(w http.ResponseWriter, r *http.Request) {
+
+
+
+
+
+	result, err := h.svc.ListAll(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, 200, result)
+
+
+
+
+}
+
+
+func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
+
+	code := chi.URLParam(r, "code")
+
+
+
+
+
+
+
+	result, err := h.svc.Resolve(r.Context(), code)
+	if err != nil {
+		if errors.Is(err, services.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	http.Redirect(w, r, result.URL, 302)
+
+
+
+}
+
+
+func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
+
+	code := chi.URLParam(r, "code")
+
+
+
+
+
+
+	ok, err := h.svc.Delete(r.Context(), code)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	w.WriteHeader(204)
+
+
+
+}
+
+

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
@@ -19,60 +19,30 @@ func NewUrlMappingHandler(svc *services.UrlMappingService) *UrlMappingHandler {
 	return &UrlMappingHandler{svc: svc}
 }
 
-
 func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
-
-
 	var body models.ShortenRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-
-
-
-
-
-
-
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	w.WriteHeader(201)
-
 }
 
-
 func (h *UrlMappingHandler) ListAll(w http.ResponseWriter, r *http.Request) {
-
-
-
-
-
 	result, err := h.svc.ListAll(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, 200, result)
-
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
-
 	result, err := h.svc.Resolve(r.Context(), code)
 	if err != nil {
 		if errors.Is(err, services.ErrNotFound) {
@@ -82,23 +52,11 @@ func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-
 	http.Redirect(w, r, result.URL, 302)
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
 	ok, err := h.svc.Delete(r.Context(), code)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -109,9 +67,4 @@ func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(204)
-
-
-
 }
-
-

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -8,38 +8,23 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-
 	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-
 	Code string `bun:"code,notnull" json:"code"`
-
 	URL string `bun:"url,notnull" json:"url"`
-
 	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-
 	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
-
 }
 
 type UrlMappingCreate struct {
-
 	Code string `json:"code" validate:"required"`
-
 	URL string `json:"url" validate:"required"`
-
 	CreatedAt time.Time `json:"created_at" validate:"required"`
-
 	ClickCount int64 `json:"click_count" validate:"required"`
-
 }
-
 
 type ShortenRequest struct {
-
 	URL string `json:"url" validate:"required"`
-
 }
-
 
 type ErrorResponse struct {
 	Detail string `json:"detail"`

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type UrlMapping struct {
+	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
+
+	ID int64 `bun:"id,pk,autoincrement" json:"id"`
+
+	Code string `bun:"code,notnull" json:"code"`
+
+	URL string `bun:"url,notnull" json:"url"`
+
+	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
+
+	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
+
+}
+
+type UrlMappingCreate struct {
+
+	Code string `json:"code" validate:"required"`
+
+	URL string `json:"url" validate:"required"`
+
+	CreatedAt time.Time `json:"created_at" validate:"required"`
+
+	ClickCount int64 `json:"click_count" validate:"required"`
+
+}
+
+
+type ShortenRequest struct {
+
+	URL string `json:"url" validate:"required"`
+
+}
+
+
+type ErrorResponse struct {
+	Detail string `json:"detail"`
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/common.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/common.go
@@ -1,0 +1,5 @@
+package services
+
+import "errors"
+
+var ErrNotFound = errors.New("not found")

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/uptrace/bun"
+
+	"github.com/generated/url-shortener/internal/config"
+	"github.com/generated/url-shortener/internal/models"
+)
+
+type UrlMappingService struct {
+	db  *bun.DB
+	cfg *config.Config
+}
+
+func NewUrlMappingService(db *bun.DB, cfg *config.Config) *UrlMappingService {
+	return &UrlMappingService{db: db, cfg: cfg}
+}
+
+
+
+
+
+
+
+
+// TODO: implement Shorten; the convention engine could not derive a
+// CRUD shape for this operation, so the stub returns an explicit error to
+// avoid silently reporting success.
+func (s *UrlMappingService) Shorten(ctx context.Context, body models.ShortenRequest) error {
+	_ = ctx
+	_ = s
+	return errors.New("Shorten not implemented")
+}
+
+
+
+
+
+
+func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, error) {
+	items := make([]models.UrlMapping, 0)
+	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+
+
+
+
+
+
+
+
+
+
+func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
+	m := new(models.UrlMapping)
+	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("code"), code).Limit(1).Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+
+
+
+
+
+
+
+func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {
+	res, err := s.db.NewDelete().Model((*models.UrlMapping)(nil)).Where("? = ?", bun.Ident("code"), code).Exec(ctx)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+
+
+
+

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
@@ -20,13 +20,6 @@ func NewUrlMappingService(db *bun.DB, cfg *config.Config) *UrlMappingService {
 	return &UrlMappingService{db: db, cfg: cfg}
 }
 
-
-
-
-
-
-
-
 // TODO: implement Shorten; the convention engine could not derive a
 // CRUD shape for this operation, so the stub returns an explicit error to
 // avoid silently reporting success.
@@ -36,11 +29,6 @@ func (s *UrlMappingService) Shorten(ctx context.Context, body models.ShortenRequ
 	return errors.New("Shorten not implemented")
 }
 
-
-
-
-
-
 func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, error) {
 	items := make([]models.UrlMapping, 0)
 	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
@@ -48,16 +36,6 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	}
 	return items, nil
 }
-
-
-
-
-
-
-
-
-
-
 
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
 	m := new(models.UrlMapping)
@@ -71,13 +49,6 @@ func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.U
 	return m, nil
 }
 
-
-
-
-
-
-
-
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {
 	res, err := s.db.NewDelete().Model((*models.UrlMapping)(nil)).Where("? = ?", bun.Ident("code"), code).Exec(ctx)
 	if err != nil {
@@ -89,8 +60,3 @@ func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, erro
 	}
 	return n > 0, nil
 }
-
-
-
-
-

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.down.sql
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.down.sql
@@ -1,0 +1,7 @@
+
+
+
+DROP TABLE url_mappings;
+
+
+

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
@@ -1,0 +1,16 @@
+
+
+
+CREATE TABLE url_mappings (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    code VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL,
+    click_count INT NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT pk_url_mappings PRIMARY KEY (id),
+    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+);
+
+
+

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/openapi.yaml
@@ -1,0 +1,245 @@
+openapi: 3.1.0
+info:
+  title: UrlShortener
+  version: 0.1.0
+  description: API for UrlShortener. Generated from formal specification.
+servers:
+- url: http://localhost:8000
+  description: Local development
+paths:
+  /shorten:
+    post:
+      operationId: shorten
+      summary: Shorten
+      tags:
+      - url_mapping
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UrlMappingCreate'
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UrlMappingRead'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /{code}:
+    get:
+      operationId: resolve
+      summary: Resolve
+      tags:
+      - url_mapping
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+      responses:
+        '302':
+          description: Redirect
+          headers:
+            Location:
+              description: Target URL
+              schema:
+                type:
+                - string
+                format: uri
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      operationId: delete
+      summary: Delete
+      tags:
+      - url_mapping
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /urls:
+    get:
+      operationId: list_all
+      summary: ListAll
+      tags:
+      - url_mapping
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type:
+                - array
+                items:
+                  $ref: '#/components/schemas/UrlMappingRead'
+  /health:
+    get:
+      operationId: health_check
+      summary: Health check
+      description: Returns 200 if the service is running.
+      tags:
+      - infrastructure
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type:
+                - object
+                required:
+                - status
+                properties:
+                  status:
+                    type:
+                    - string
+                    enum:
+                    - ok
+components:
+  schemas:
+    ErrorResponse:
+      type:
+      - object
+      required:
+      - detail
+      properties:
+        detail:
+          type:
+          - string
+          description: Human-readable error description
+      description: Standard error response body
+    UrlMappingCreate:
+      type:
+      - object
+      required:
+      - code
+      - url
+      - created_at
+      - click_count
+      properties:
+        code:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+        url:
+          type:
+          - string
+          minLength: 1
+        created_at:
+          type:
+          - string
+          format: date-time
+        click_count:
+          type:
+          - integer
+          minimum: 0.0
+      description: Create payload for UrlMapping
+    UrlMappingRead:
+      type:
+      - object
+      required:
+      - id
+      - code
+      - url
+      - created_at
+      - click_count
+      properties:
+        url:
+          type:
+          - string
+          minLength: 1
+        code:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+        created_at:
+          type:
+          - string
+          format: date-time
+        click_count:
+          type:
+          - integer
+          minimum: 0.0
+        id:
+          type:
+          - integer
+      description: Read view for UrlMapping
+    UrlMappingUpdate:
+      type:
+      - object
+      properties:
+        code:
+          type:
+          - string
+          - 'null'
+          minLength: 6
+          maxLength: 10
+        url:
+          type:
+          - string
+          - 'null'
+          minLength: 1
+        created_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        click_count:
+          type:
+          - integer
+          - 'null'
+          minimum: 0.0
+      description: Update payload for UrlMapping
+tags:
+- name: url_mapping
+  description: UrlMapping operations
+- name: infrastructure
+  description: Health and metrics endpoints
+x-invariant:
+  allURLsValid: (all c in store | isValidURI(store[c]))
+  metadataConsistent: (dom(store) = dom(metadata))
+  clickCountNonNegative: (all c in metadata | (metadata[c].click_count >= 0))

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/tests/health_test.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/tests/health_test.go
@@ -1,0 +1,7 @@
+package tests
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	t.Skip("TODO: replace with a real test exercising the generated handlers")
+}

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
@@ -13,18 +13,18 @@ jobs:
   test:
     runs-on: ubuntu-latest
     services:
-      postgres:
+      db:
         image: postgres:16-alpine
         env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
+          POSTGRES_USER: url_shortener
+          POSTGRES_PASSWORD: url_shortener
+          POSTGRES_DB: url_shortener
         ports:
-          - 5432:5432
+          - "5432:5432"
         options: >-
-          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+          --health-cmd "pg_isready -U url_shortener" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
-      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      DATABASE_URL: postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable
       BASE_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
+MIGRATE_DSN ?= postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable
+
 build:
 	go build ./...
 
@@ -20,8 +22,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$$DATABASE_URL" up
+	migrate -path migrations -database "$(MIGRATE_DSN)" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$$DATABASE_URL" down
+	migrate -path migrations -database "$(MIGRATE_DSN)" down

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/Makefile
@@ -1,7 +1,5 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
-MIGRATE_DSN ?= postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable
-
 build:
 	go build ./...
 
@@ -22,8 +20,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" up
+	migrate -path migrations -database "$${MIGRATE_DSN:-postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable}" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" down
+	migrate -path migrations -database "$${MIGRATE_DSN:-postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable}" down

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/README.md
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/README.md
@@ -14,5 +14,5 @@ curl http://localhost:8080/health
 ```bash
 go mod tidy
 go test ./...
-DATABASE_URL=postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable go run ./cmd/server
+DATABASE_URL='postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable' go run ./cmd/server
 ```

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
@@ -36,10 +36,8 @@ func main() {
 	}
 	defer func() { _ = db.Close() }()
 
-
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -53,17 +51,10 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-
-
 	r.Post("/shorten", urlMappingHandler.Shorten)
-
 	r.Get("/urls", urlMappingHandler.ListAll)
-
 	r.Get("/{code}", urlMappingHandler.Resolve)
-
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/go.mod
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/go.mod
@@ -3,19 +3,11 @@ module github.com/generated/url-shortener
 go 1.22
 
 require (
-
 	github.com/go-chi/chi/v5 v5.1.0
-
 	github.com/uptrace/bun v1.2.18
-
 	github.com/uptrace/bun/driver/pgdriver v1.2.18
-
 	github.com/google/uuid v1.6.0
-
 	github.com/shopspring/decimal v1.4.0
-
 	github.com/caarlos0/env/v11 v11.2.0
-
 	github.com/go-playground/validator/v10 v10.22.1
-
 )

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
@@ -19,60 +19,30 @@ func NewUrlMappingHandler(svc *services.UrlMappingService) *UrlMappingHandler {
 	return &UrlMappingHandler{svc: svc}
 }
 
-
 func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
-
-
 	var body models.ShortenRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-
-
-
-
-
-
-
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	w.WriteHeader(201)
-
 }
 
-
 func (h *UrlMappingHandler) ListAll(w http.ResponseWriter, r *http.Request) {
-
-
-
-
-
 	result, err := h.svc.ListAll(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, 200, result)
-
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
-
 	result, err := h.svc.Resolve(r.Context(), code)
 	if err != nil {
 		if errors.Is(err, services.ErrNotFound) {
@@ -82,23 +52,11 @@ func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-
 	http.Redirect(w, r, result.URL, 302)
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
 	ok, err := h.svc.Delete(r.Context(), code)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -109,9 +67,4 @@ func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(204)
-
-
-
 }
-
-

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
@@ -8,38 +8,23 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-
 	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-
 	Code string `bun:"code,notnull" json:"code"`
-
 	URL string `bun:"url,notnull" json:"url"`
-
 	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-
 	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
-
 }
 
 type UrlMappingCreate struct {
-
 	Code string `json:"code" validate:"required"`
-
 	URL string `json:"url" validate:"required"`
-
 	CreatedAt time.Time `json:"created_at" validate:"required"`
-
 	ClickCount int64 `json:"click_count" validate:"required"`
-
 }
-
 
 type ShortenRequest struct {
-
 	URL string `json:"url" validate:"required"`
-
 }
-
 
 type ErrorResponse struct {
 	Detail string `json:"detail"`

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
@@ -20,13 +20,6 @@ func NewUrlMappingService(db *bun.DB, cfg *config.Config) *UrlMappingService {
 	return &UrlMappingService{db: db, cfg: cfg}
 }
 
-
-
-
-
-
-
-
 // TODO: implement Shorten; the convention engine could not derive a
 // CRUD shape for this operation, so the stub returns an explicit error to
 // avoid silently reporting success.
@@ -36,11 +29,6 @@ func (s *UrlMappingService) Shorten(ctx context.Context, body models.ShortenRequ
 	return errors.New("Shorten not implemented")
 }
 
-
-
-
-
-
 func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, error) {
 	items := make([]models.UrlMapping, 0)
 	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
@@ -48,16 +36,6 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	}
 	return items, nil
 }
-
-
-
-
-
-
-
-
-
-
 
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
 	m := new(models.UrlMapping)
@@ -71,13 +49,6 @@ func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.U
 	return m, nil
 }
 
-
-
-
-
-
-
-
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {
 	res, err := s.db.NewDelete().Model((*models.UrlMapping)(nil)).Where("? = ?", bun.Ident("code"), code).Exec(ctx)
 	if err != nil {
@@ -89,8 +60,3 @@ func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, erro
 	}
 	return n > 0, nil
 }
-
-
-
-
-

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.dockerignore
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+*.md
+tests
+.env
+.env.*
+*.env

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.env.example
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=file:url_shortener.db?cache=shared&_pragma=foreign_keys(1)
+BASE_URL=http://localhost:8080
+PORT=8080
+LOG_LEVEL=info

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -12,19 +12,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
     env:
-      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      DATABASE_URL: file:url_shortener.db?cache=shared&_pragma=foreign_keys(1)
       BASE_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+      BASE_URL: http://localhost:8080
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - run: go mod tidy
+      - run: go vet ./...
+      - run: go test ./...

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.gitignore
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.gitignore
@@ -1,0 +1,9 @@
+/server
+/bin/
+/dist/
+/vendor/
+*.test
+*.out
+.env
+.idea/
+.vscode/

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.spec-snapshot.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion" : 2,
+  "schema" : {
+    "tables" : [
+      {
+        "name" : "url_mappings",
+        "entityName" : "UrlMapping",
+        "columns" : [
+          {
+            "name" : "id",
+            "sqlType" : "BIGSERIAL",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "code",
+            "sqlType" : "TEXT",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "url",
+            "sqlType" : "TEXT",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "created_at",
+            "sqlType" : "TIMESTAMPTZ",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "click_count",
+            "sqlType" : "INTEGER",
+            "nullable" : false,
+            "defaultValue" : null
+          },
+          {
+            "name" : "updated_at",
+            "sqlType" : "TIMESTAMPTZ",
+            "nullable" : false,
+            "defaultValue" : "NOW()"
+          }
+        ],
+        "primaryKey" : "id",
+        "foreignKeys" : [
+        ],
+        "checks" : [
+          "click_count >= 0"
+        ],
+        "indexes" : [
+        ]
+      }
+    ],
+    "triggers" : [
+    ]
+  }
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Dockerfile
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /src
+COPY go.mod ./
+COPY go.su[m] ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/server ./cmd/server
+
+FROM alpine:3.20
+RUN apk add --no-cache wget && adduser -D -u 10001 app
+USER app
+COPY --from=builder /out/server /usr/local/bin/server
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+	CMD wget -qO- http://localhost:8080/health || exit 1
+ENTRYPOINT ["/usr/local/bin/server"]

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Makefile
@@ -1,7 +1,5 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
-MIGRATE_DSN ?= sqlite://url_shortener.db
-
 build:
 	go build ./...
 
@@ -22,8 +20,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" up
+	migrate -path migrations -database "$${MIGRATE_DSN:-sqlite://url_shortener.db}" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" down
+	migrate -path migrations -database "$${MIGRATE_DSN:-sqlite://url_shortener.db}" down

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Makefile
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/Makefile
@@ -1,0 +1,29 @@
+.PHONY: build run test fmt vet tidy migrate-up migrate-down
+
+MIGRATE_DSN ?= sqlite://url_shortener.db
+
+build:
+	go build ./...
+
+run:
+	go run ./cmd/server
+
+test:
+	go test ./...
+
+fmt:
+	gofmt -s -w .
+
+vet:
+	go vet ./...
+
+tidy:
+	go mod tidy
+
+migrate-up:
+	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
+	migrate -path migrations -database "$(MIGRATE_DSN)" up
+
+migrate-down:
+	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
+	migrate -path migrations -database "$(MIGRATE_DSN)" down

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/README.md
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/README.md
@@ -1,0 +1,18 @@
+# UrlShortener
+
+Generated Go service (Go + chi + SQLite).
+
+## Quick start
+
+```bash
+docker compose up --build
+curl http://localhost:8080/health
+```
+
+## Local dev
+
+```bash
+go mod tidy
+go test ./...
+DATABASE_URL=postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable go run ./cmd/server
+```

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/README.md
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/README.md
@@ -14,5 +14,5 @@ curl http://localhost:8080/health
 ```bash
 go mod tidy
 go test ./...
-DATABASE_URL=postgres://url_shortener:url_shortener@localhost:5432/url_shortener?sslmode=disable go run ./cmd/server
+DATABASE_URL='file:url_shortener.db?cache=shared&_pragma=foreign_keys(1)' go run ./cmd/server
 ```

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
@@ -36,10 +36,8 @@ func main() {
 	}
 	defer func() { _ = db.Close() }()
 
-
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
@@ -53,17 +51,10 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-
-
 	r.Post("/shorten", urlMappingHandler.Shorten)
-
 	r.Get("/urls", urlMappingHandler.ListAll)
-
 	r.Get("/{code}", urlMappingHandler.Resolve)
-
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/generated/url-shortener/internal/config"
+	"github.com/generated/url-shortener/internal/database"
+	"github.com/generated/url-shortener/internal/handlers"
+	"github.com/generated/url-shortener/internal/services"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("failed to load config", "error", err)
+		os.Exit(1)
+	}
+
+	db, err := database.Connect(context.Background(), cfg.DatabaseURL)
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+	defer func() { _ = db.Close() }()
+
+
+	urlMappingSvc := services.NewUrlMappingService(db, cfg)
+	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
+
+
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.Timeout(30 * time.Second))
+
+	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+
+
+	r.Post("/shorten", urlMappingHandler.Shorten)
+
+	r.Get("/urls", urlMappingHandler.ListAll)
+
+	r.Get("/{code}", urlMappingHandler.Resolve)
+
+	r.Delete("/{code}", urlMappingHandler.Delete)
+
+
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Port),
+		Handler:      r,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	done := make(chan os.Signal, 1)
+	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("starting server", "port", cfg.Port)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-done
+	slog.Info("shutting down")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = server.Shutdown(ctx)
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/docker-compose.yml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build: .
+    environment:
+      DATABASE_URL: file:url_shortener.db?cache=shared&_pragma=foreign_keys(1)
+      BASE_URL: http://localhost:8080
+      PORT: 8080
+    ports:
+      - "8080:8080"

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/go.mod
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/go.mod
@@ -1,0 +1,21 @@
+module github.com/generated/url-shortener
+
+go 1.22
+
+require (
+
+	github.com/go-chi/chi/v5 v5.1.0
+
+	github.com/uptrace/bun v1.2.18
+
+	github.com/uptrace/bun/driver/sqliteshim v1.2.18
+
+	github.com/google/uuid v1.6.0
+
+	github.com/shopspring/decimal v1.4.0
+
+	github.com/caarlos0/env/v11 v11.2.0
+
+	github.com/go-playground/validator/v10 v10.22.1
+
+)

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/go.mod
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/go.mod
@@ -3,19 +3,11 @@ module github.com/generated/url-shortener
 go 1.22
 
 require (
-
 	github.com/go-chi/chi/v5 v5.1.0
-
 	github.com/uptrace/bun v1.2.18
-
 	github.com/uptrace/bun/driver/sqliteshim v1.2.18
-
 	github.com/google/uuid v1.6.0
-
 	github.com/shopspring/decimal v1.4.0
-
 	github.com/caarlos0/env/v11 v11.2.0
-
 	github.com/go-playground/validator/v10 v10.22.1
-
 )

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/config/config.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+import "github.com/caarlos0/env/v11"
+
+type Config struct {
+	DatabaseURL string `env:"DATABASE_URL" envDefault:"file:url_shortener.db?cache=shared&_pragma=foreign_keys(1)"`
+	BaseURL     string `env:"BASE_URL"     envDefault:"http://localhost:8080"`
+	Port        int    `env:"PORT"         envDefault:"8080"`
+	LogLevel    string `env:"LOG_LEVEL"    envDefault:"info"`
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{}
+	if err := env.Parse(cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/database/database.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/database/database.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/sqlitedialect"
+	"github.com/uptrace/bun/driver/sqliteshim"
+)
+
+func Connect(ctx context.Context, dsn string) (*bun.DB, error) {
+	sqldb, err := sql.Open(sqliteshim.ShimName, dsn)
+	if err != nil {
+		return nil, err
+	}
+	db := bun.NewDB(sqldb, sqlitedialect.New())
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/common.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/common.go
@@ -1,0 +1,18 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/generated/url-shortener/internal/models"
+)
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, detail string) {
+	writeJSON(w, status, models.ErrorResponse{Detail: detail})
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/generated/url-shortener/internal/models"
+	"github.com/generated/url-shortener/internal/services"
+)
+
+type UrlMappingHandler struct {
+	svc *services.UrlMappingService
+}
+
+func NewUrlMappingHandler(svc *services.UrlMappingService) *UrlMappingHandler {
+	return &UrlMappingHandler{svc: svc}
+}
+
+
+func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
+
+
+	var body models.ShortenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+
+
+
+
+
+
+	if err := h.svc.Shorten(r.Context(), body); err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	w.WriteHeader(201)
+
+}
+
+
+func (h *UrlMappingHandler) ListAll(w http.ResponseWriter, r *http.Request) {
+
+
+
+
+
+	result, err := h.svc.ListAll(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, 200, result)
+
+
+
+
+}
+
+
+func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
+
+	code := chi.URLParam(r, "code")
+
+
+
+
+
+
+
+	result, err := h.svc.Resolve(r.Context(), code)
+	if err != nil {
+		if errors.Is(err, services.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	http.Redirect(w, r, result.URL, 302)
+
+
+
+}
+
+
+func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
+
+	code := chi.URLParam(r, "code")
+
+
+
+
+
+
+	ok, err := h.svc.Delete(r.Context(), code)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if !ok {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+	w.WriteHeader(204)
+
+
+
+}
+
+

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
@@ -19,60 +19,30 @@ func NewUrlMappingHandler(svc *services.UrlMappingService) *UrlMappingHandler {
 	return &UrlMappingHandler{svc: svc}
 }
 
-
 func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
-
-
 	var body models.ShortenRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-
-
-
-
-
-
-
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	w.WriteHeader(201)
-
 }
 
-
 func (h *UrlMappingHandler) ListAll(w http.ResponseWriter, r *http.Request) {
-
-
-
-
-
 	result, err := h.svc.ListAll(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, 200, result)
-
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
-
 	result, err := h.svc.Resolve(r.Context(), code)
 	if err != nil {
 		if errors.Is(err, services.ErrNotFound) {
@@ -82,23 +52,11 @@ func (h *UrlMappingHandler) Resolve(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-
 	http.Redirect(w, r, result.URL, 302)
-
-
-
 }
 
-
 func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
-
 	code := chi.URLParam(r, "code")
-
-
-
-
-
-
 	ok, err := h.svc.Delete(r.Context(), code)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
@@ -109,9 +67,4 @@ func (h *UrlMappingHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(204)
-
-
-
 }
-
-

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -8,38 +8,23 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-
 	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-
 	Code string `bun:"code,notnull" json:"code"`
-
 	URL string `bun:"url,notnull" json:"url"`
-
 	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-
 	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
-
 }
 
 type UrlMappingCreate struct {
-
 	Code string `json:"code" validate:"required"`
-
 	URL string `json:"url" validate:"required"`
-
 	CreatedAt time.Time `json:"created_at" validate:"required"`
-
 	ClickCount int64 `json:"click_count" validate:"required"`
-
 }
-
 
 type ShortenRequest struct {
-
 	URL string `json:"url" validate:"required"`
-
 }
-
 
 type ErrorResponse struct {
 	Detail string `json:"detail"`

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"time"
+
+	"github.com/uptrace/bun"
+)
+
+type UrlMapping struct {
+	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
+
+	ID int64 `bun:"id,pk,autoincrement" json:"id"`
+
+	Code string `bun:"code,notnull" json:"code"`
+
+	URL string `bun:"url,notnull" json:"url"`
+
+	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
+
+	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
+
+}
+
+type UrlMappingCreate struct {
+
+	Code string `json:"code" validate:"required"`
+
+	URL string `json:"url" validate:"required"`
+
+	CreatedAt time.Time `json:"created_at" validate:"required"`
+
+	ClickCount int64 `json:"click_count" validate:"required"`
+
+}
+
+
+type ShortenRequest struct {
+
+	URL string `json:"url" validate:"required"`
+
+}
+
+
+type ErrorResponse struct {
+	Detail string `json:"detail"`
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/common.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/common.go
@@ -1,0 +1,5 @@
+package services
+
+import "errors"
+
+var ErrNotFound = errors.New("not found")

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
@@ -1,0 +1,96 @@
+package services
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/uptrace/bun"
+
+	"github.com/generated/url-shortener/internal/config"
+	"github.com/generated/url-shortener/internal/models"
+)
+
+type UrlMappingService struct {
+	db  *bun.DB
+	cfg *config.Config
+}
+
+func NewUrlMappingService(db *bun.DB, cfg *config.Config) *UrlMappingService {
+	return &UrlMappingService{db: db, cfg: cfg}
+}
+
+
+
+
+
+
+
+
+// TODO: implement Shorten; the convention engine could not derive a
+// CRUD shape for this operation, so the stub returns an explicit error to
+// avoid silently reporting success.
+func (s *UrlMappingService) Shorten(ctx context.Context, body models.ShortenRequest) error {
+	_ = ctx
+	_ = s
+	return errors.New("Shorten not implemented")
+}
+
+
+
+
+
+
+func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, error) {
+	items := make([]models.UrlMapping, 0)
+	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+
+
+
+
+
+
+
+
+
+
+func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
+	m := new(models.UrlMapping)
+	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("code"), code).Limit(1).Scan(ctx)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+
+
+
+
+
+
+
+func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {
+	res, err := s.db.NewDelete().Model((*models.UrlMapping)(nil)).Where("? = ?", bun.Ident("code"), code).Exec(ctx)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+
+
+
+

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
@@ -20,13 +20,6 @@ func NewUrlMappingService(db *bun.DB, cfg *config.Config) *UrlMappingService {
 	return &UrlMappingService{db: db, cfg: cfg}
 }
 
-
-
-
-
-
-
-
 // TODO: implement Shorten; the convention engine could not derive a
 // CRUD shape for this operation, so the stub returns an explicit error to
 // avoid silently reporting success.
@@ -36,11 +29,6 @@ func (s *UrlMappingService) Shorten(ctx context.Context, body models.ShortenRequ
 	return errors.New("Shorten not implemented")
 }
 
-
-
-
-
-
 func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, error) {
 	items := make([]models.UrlMapping, 0)
 	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
@@ -48,16 +36,6 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	}
 	return items, nil
 }
-
-
-
-
-
-
-
-
-
-
 
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
 	m := new(models.UrlMapping)
@@ -71,13 +49,6 @@ func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.U
 	return m, nil
 }
 
-
-
-
-
-
-
-
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {
 	res, err := s.db.NewDelete().Model((*models.UrlMapping)(nil)).Where("? = ?", bun.Ident("code"), code).Exec(ctx)
 	if err != nil {
@@ -89,8 +60,3 @@ func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, erro
 	}
 	return n > 0, nil
 }
-
-
-
-
-

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.down.sql
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.down.sql
@@ -1,0 +1,7 @@
+
+
+
+DROP TABLE url_mappings;
+
+
+

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
@@ -1,0 +1,15 @@
+
+
+
+CREATE TABLE url_mappings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    code TEXT NOT NULL,
+    url TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    click_count INTEGER NOT NULL,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+);
+
+
+

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/openapi.yaml
@@ -1,0 +1,245 @@
+openapi: 3.1.0
+info:
+  title: UrlShortener
+  version: 0.1.0
+  description: API for UrlShortener. Generated from formal specification.
+servers:
+- url: http://localhost:8000
+  description: Local development
+paths:
+  /shorten:
+    post:
+      operationId: shorten
+      summary: Shorten
+      tags:
+      - url_mapping
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UrlMappingCreate'
+      responses:
+        '201':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UrlMappingRead'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /{code}:
+    get:
+      operationId: resolve
+      summary: Resolve
+      tags:
+      - url_mapping
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+      responses:
+        '302':
+          description: Redirect
+          headers:
+            Location:
+              description: Target URL
+              schema:
+                type:
+                - string
+                format: uri
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      operationId: delete
+      summary: Delete
+      tags:
+      - url_mapping
+      parameters:
+      - name: code
+        in: path
+        required: true
+        schema:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+      responses:
+        '204':
+          description: No content
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /urls:
+    get:
+      operationId: list_all
+      summary: ListAll
+      tags:
+      - url_mapping
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type:
+                - array
+                items:
+                  $ref: '#/components/schemas/UrlMappingRead'
+  /health:
+    get:
+      operationId: health_check
+      summary: Health check
+      description: Returns 200 if the service is running.
+      tags:
+      - infrastructure
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type:
+                - object
+                required:
+                - status
+                properties:
+                  status:
+                    type:
+                    - string
+                    enum:
+                    - ok
+components:
+  schemas:
+    ErrorResponse:
+      type:
+      - object
+      required:
+      - detail
+      properties:
+        detail:
+          type:
+          - string
+          description: Human-readable error description
+      description: Standard error response body
+    UrlMappingCreate:
+      type:
+      - object
+      required:
+      - code
+      - url
+      - created_at
+      - click_count
+      properties:
+        code:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+        url:
+          type:
+          - string
+          minLength: 1
+        created_at:
+          type:
+          - string
+          format: date-time
+        click_count:
+          type:
+          - integer
+          minimum: 0.0
+      description: Create payload for UrlMapping
+    UrlMappingRead:
+      type:
+      - object
+      required:
+      - id
+      - code
+      - url
+      - created_at
+      - click_count
+      properties:
+        url:
+          type:
+          - string
+          minLength: 1
+        code:
+          type:
+          - string
+          minLength: 6
+          maxLength: 10
+        created_at:
+          type:
+          - string
+          format: date-time
+        click_count:
+          type:
+          - integer
+          minimum: 0.0
+        id:
+          type:
+          - integer
+      description: Read view for UrlMapping
+    UrlMappingUpdate:
+      type:
+      - object
+      properties:
+        code:
+          type:
+          - string
+          - 'null'
+          minLength: 6
+          maxLength: 10
+        url:
+          type:
+          - string
+          - 'null'
+          minLength: 1
+        created_at:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        click_count:
+          type:
+          - integer
+          - 'null'
+          minimum: 0.0
+      description: Update payload for UrlMapping
+tags:
+- name: url_mapping
+  description: UrlMapping operations
+- name: infrastructure
+  description: Health and metrics endpoints
+x-invariant:
+  allURLsValid: (all c in store | isValidURI(store[c]))
+  metadataConsistent: (dom(store) = dom(metadata))
+  clickCountNonNegative: (all c in metadata | (metadata[c].click_count >= 0))

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/tests/health_test.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/tests/health_test.go
@@ -1,0 +1,7 @@
+package tests
+
+import "testing"
+
+func TestPlaceholder(t *testing.T) {
+	t.Skip("TODO: replace with a real test exercising the generated handlers")
+}

--- a/modules/codegen/src/main/resources/templates/go/chi/Makefile.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/Makefile.hbs
@@ -1,7 +1,5 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
-MIGRATE_DSN ?= {{db.migrateUrl}}
-
 build:
 	go build ./...
 
@@ -22,8 +20,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" up
+	migrate -path migrations -database "$${MIGRATE_DSN:-{{db.migrateUrl}}{{! }}}" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$(MIGRATE_DSN)" down
+	migrate -path migrations -database "$${MIGRATE_DSN:-{{db.migrateUrl}}{{! }}}" down

--- a/modules/codegen/src/main/resources/templates/go/chi/Makefile.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/Makefile.hbs
@@ -1,5 +1,7 @@
 .PHONY: build run test fmt vet tidy migrate-up migrate-down
 
+MIGRATE_DSN ?= {{db.migrateUrl}}
+
 build:
 	go build ./...
 
@@ -20,8 +22,8 @@ tidy:
 
 migrate-up:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$$DATABASE_URL" up
+	migrate -path migrations -database "$(MIGRATE_DSN)" up
 
 migrate-down:
 	@command -v migrate >/dev/null 2>&1 || { echo >&2 "install golang-migrate first"; exit 1; }
-	migrate -path migrations -database "$$DATABASE_URL" down
+	migrate -path migrations -database "$(MIGRATE_DSN)" down

--- a/modules/codegen/src/main/resources/templates/go/chi/README.md.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/README.md.hbs
@@ -14,5 +14,5 @@ curl http://localhost:8080/health
 ```bash
 go mod tidy
 go test ./...
-DATABASE_URL=postgres://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}?sslmode=disable go run ./cmd/server
+DATABASE_URL='{{db.appDsn}}' go run ./cmd/server
 ```

--- a/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
@@ -36,11 +36,9 @@ func main() {
 	}
 	defer func() { _ = db.Close() }()
 
-{{#each entities}}
-	{{entityCamel}}Svc := services.New{{entity.modelClassName}}Service(db, cfg)
+{{#each entities}}	{{entityCamel}}Svc := services.New{{entity.modelClassName}}Service(db, cfg)
 	{{entityCamel}}Handler := handlers.New{{entity.modelClassName}}Handler({{entityCamel}}Svc)
 {{/each}}
-
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -53,12 +51,8 @@ func main() {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
-{{#each entities}}
-{{#each operations}}
-	r.{{pascal_case method}}("{{chiPath}}", {{../entityCamel}}Handler.{{handlerName}})
-{{/each}}
-{{/each}}
-
+{{#each entities}}{{#each operations}}	r.{{pascal_case method}}("{{chiPath}}", {{../entityCamel}}Handler.{{handlerName}})
+{{/each}}{{/each}}
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/modules/codegen/src/main/resources/templates/go/chi/docker-compose.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/docker-compose.yml.hbs
@@ -2,28 +2,27 @@ services:
   app:
     build: .
     environment:
-      DATABASE_URL: postgres://{{service.snakeName}}:{{service.snakeName}}@db:5432/{{service.snakeName}}?sslmode=disable
+      DATABASE_URL: {{db.appDsnCompose}}
       BASE_URL: http://localhost:8080
       PORT: 8080
     ports:
       - "8080:8080"
-    depends_on:
+{{#if db.hasDbService}}    depends_on:
       db:
         condition: service_healthy
 
   db:
-    image: postgres:16-alpine
+    image: {{db.dbImage}}
     environment:
-      POSTGRES_USER: {{service.snakeName}}
-      POSTGRES_PASSWORD: {{service.snakeName}}
-      POSTGRES_DB: {{service.snakeName}}
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U {{service.snakeName}}"]
+{{#each db.composeEnv}}      {{this.key}}: {{this.value}}
+{{/each}}    healthcheck:
+      test: ["CMD-SHELL", "{{db.dbHealthCmd}}"]
       interval: 5s
       timeout: 3s
       retries: 10
     volumes:
-      - dbdata:/var/lib/postgresql/data
+      - dbdata:{{db.dbVolumePath}}
 
 volumes:
   dbdata:
+{{/if~}}

--- a/modules/codegen/src/main/resources/templates/go/chi/env.example.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/env.example.hbs
@@ -1,4 +1,4 @@
-DATABASE_URL=postgres://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}?sslmode=disable
+DATABASE_URL={{db.appDsn}}
 BASE_URL=http://localhost:8080
 PORT=8080
 LOG_LEVEL=info

--- a/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
@@ -12,19 +12,17 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:16-alpine
+{{#if db.hasDbService}}    services:
+      db:
+        image: {{db.dbImage}}
         env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: test
-        ports:
-          - 5432:5432
+{{#each db.composeEnv}}          {{this.key}}: {{this.value}}
+{{/each}}        ports:
+          - "{{db.dbPort}}:{{db.dbPort}}"
         options: >-
-          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
-    env:
-      DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+          --health-cmd "{{db.dbHealthCmd}}" --health-interval 5s --health-timeout 3s --health-retries 10
+{{/if}}    env:
+      DATABASE_URL: {{db.appDsn}}
       BASE_URL: http://localhost:8080
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/modules/codegen/src/main/resources/templates/go/chi/go.mod.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/go.mod.hbs
@@ -3,7 +3,5 @@ module {{module}}
 go 1.22
 
 require (
-{{#each profile.dependencies}}
-	{{this.name}} {{this.version}}
-{{/each}}
-)
+{{#each profile.dependencies}}	{{this.name}} {{this.version}}
+{{/each}})

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/config/config.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/config/config.go.hbs
@@ -3,7 +3,7 @@ package config
 import "github.com/caarlos0/env/v11"
 
 type Config struct {
-	DatabaseURL string `env:"DATABASE_URL" envDefault:"postgres://{{service.snakeName}}:{{service.snakeName}}@localhost:5432/{{service.snakeName}}?sslmode=disable"`
+	DatabaseURL string `env:"DATABASE_URL" envDefault:"{{db.appDsn}}"`
 	BaseURL     string `env:"BASE_URL"     envDefault:"http://localhost:8080"`
 	Port        int    `env:"PORT"         envDefault:"8080"`
 	LogLevel    string `env:"LOG_LEVEL"    envDefault:"info"`

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/database/database.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/database/database.go.hbs
@@ -3,15 +3,12 @@ package database
 import (
 	"context"
 	"database/sql"
-
-	"github.com/uptrace/bun"
-	"github.com/uptrace/bun/dialect/pgdialect"
-	"github.com/uptrace/bun/driver/pgdriver"
+{{db.databaseImports}}
 )
 
 func Connect(ctx context.Context, dsn string) (*bun.DB, error) {
-	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
-	db := bun.NewDB(sqldb, pgdialect.New())
+	{{db.openStmt}}
+	db := bun.NewDB(sqldb, {{db.bunNew}})
 	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return nil, err

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
@@ -18,29 +18,21 @@ type {{entity.entity.modelClassName}}Handler struct {
 func New{{entity.entity.modelClassName}}Handler(svc *services.{{entity.entity.modelClassName}}Service) *{{entity.entity.modelClassName}}Handler {
 	return &{{entity.entity.modelClassName}}Handler{svc: svc}
 }
-
 {{#each entity.operations}}
 func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.ResponseWriter, r *http.Request) {
-{{#each pathParams}}
-	{{goName}} := chi.URLParam(r, "{{name}}")
-{{/each}}
-{{#if hasRequestBody}}
-	var body models.{{requestBodyType}}
+{{#each pathParams}}	{{goName}} := chi.URLParam(r, "{{name}}")
+{{/each}}{{#if hasRequestBody}}	var body models.{{requestBodyType}}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-{{/if}}
-{{#if (eq routeKind "create")}}
-	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{/if}}{{#if (eq routeKind "create")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, {{successStatus}}, result)
-{{/if}}
-{{#if (eq routeKind "read")}}
-	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{/if}}{{#if (eq routeKind "read")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		if errors.Is(err, services.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not found")
@@ -50,17 +42,13 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		return
 	}
 	writeJSON(w, {{successStatus}}, result)
-{{/if}}
-{{#if (eq routeKind "list")}}
-	result, err := h.svc.{{serviceMethod}}(r.Context())
+{{/if}}{{#if (eq routeKind "list")}}	result, err := h.svc.{{serviceMethod}}(r.Context())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, {{successStatus}}, result)
-{{/if}}
-{{#if (eq routeKind "delete")}}
-	ok, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{/if}}{{#if (eq routeKind "delete")}}	ok, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -70,9 +58,7 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		return
 	}
 	w.WriteHeader({{successStatus}})
-{{/if}}
-{{#if (eq routeKind "redirect")}}
-	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{/if}}{{#if (eq routeKind "redirect")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		if errors.Is(err, services.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "not found")
@@ -81,21 +67,14 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-{{#if redirectField}}
-	http.Redirect(w, r, result.{{redirectField}}, {{successStatus}})
-{{else}}
-	writeError(w, http.StatusInternalServerError, "{{operationName}}: no redirect target field on {{../entity.entity.modelClassName}}")
+{{#if redirectField}}	http.Redirect(w, r, result.{{redirectField}}, {{successStatus}})
+{{else}}	writeError(w, http.StatusInternalServerError, "{{operationName}}: no redirect target field on {{../entity.entity.modelClassName}}")
 	_ = result
 	return
-{{/if}}
-{{/if}}
-{{#if (eq routeKind "other")}}
-	if err := h.svc.{{serviceMethod}}(r.Context(){{#if serviceCallArgs}}, {{serviceCallArgs}}{{/if}}); err != nil {
+{{/if}}{{/if}}{{#if (eq routeKind "other")}}	if err := h.svc.{{serviceMethod}}(r.Context(){{#if serviceCallArgs}}, {{serviceCallArgs}}{{/if}}); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	w.WriteHeader({{successStatus}})
-{{/if}}
-}
-
-{{/each}}
+{{/if}}{{! }}}
+{{/each~}}

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
@@ -10,24 +10,16 @@ import (
 
 type {{entity.entity.modelClassName}} struct {
 	bun.BaseModel `bun:"table:{{entity.entity.tableName}},alias:{{entity.entity.tableName}}"`
-{{#each entity.fields}}
-	{{this.goField}} {{this.domainType}} `bun:"{{this.bunTag}}" json:"{{this.jsonTag}}"`
-{{/each}}
-}
+{{#each entity.fields}}	{{this.goField}} {{this.domainType}} `bun:"{{this.bunTag}}" json:"{{this.jsonTag}}"`
+{{/each}}{{! }}}
 
 type {{entity.entity.createSchemaName}} struct {
-{{#each entity.nonIdFields}}
-	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
-{{/each}}
-}
-
+{{#each entity.nonIdFields}}	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
+{{/each}}{{! }}}
 {{#each entity.customSchemas}}
 type {{this.name}} struct {
-{{#each this.fields}}
-	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
-{{/each}}
-}
-
+{{#each this.fields}}	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
+{{/each}}{{! }}}
 {{/each}}
 type ErrorResponse struct {
 	Detail string `json:"detail"`

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
@@ -19,10 +19,8 @@ type {{entity.entity.modelClassName}}Service struct {
 func New{{entity.entity.modelClassName}}Service(db *bun.DB, cfg *config.Config) *{{entity.entity.modelClassName}}Service {
 	return &{{entity.entity.modelClassName}}Service{db: db, cfg: cfg}
 }
-
 {{#each entity.operations}}
-{{#if (eq routeKind "create")}}
-func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, body models.{{requestBodyType}}) (*models.{{../entity.entity.modelClassName}}, error) {
+{{#if (eq routeKind "create")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, body models.{{requestBodyType}}) (*models.{{../entity.entity.modelClassName}}, error) {
 	m := &models.{{../entity.entity.modelClassName}}{
 {{#each createAssigns}}		{{this}},
 {{/each}}	}
@@ -31,10 +29,7 @@ func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx conte
 	}
 	return m, nil
 }
-
-{{/if}}
-{{#if (eq routeKind "read")}}
-func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
+{{/if}}{{#if (eq routeKind "read")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
 	m := new(models.{{../entity.entity.modelClassName}})
 	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("{{lookupColumn}}"), {{serviceCallArgs}}).Limit(1).Scan(ctx)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -45,20 +40,14 @@ func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx conte
 	}
 	return m, nil
 }
-
-{{/if}}
-{{#if (eq routeKind "list")}}
-func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context) ([]models.{{../entity.entity.modelClassName}}, error) {
+{{/if}}{{#if (eq routeKind "list")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context) ([]models.{{../entity.entity.modelClassName}}, error) {
 	items := make([]models.{{../entity.entity.modelClassName}}, 0)
 	if err := s.db.NewSelect().Model(&items).Order("id").Scan(ctx); err != nil {
 		return nil, err
 	}
 	return items, nil
 }
-
-{{/if}}
-{{#if (eq routeKind "delete")}}
-func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (bool, error) {
+{{/if}}{{#if (eq routeKind "delete")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (bool, error) {
 	res, err := s.db.NewDelete().Model((*models.{{../entity.entity.modelClassName}})(nil)).Where("? = ?", bun.Ident("{{lookupColumn}}"), {{serviceCallArgs}}).Exec(ctx)
 	if err != nil {
 		return false, err
@@ -69,10 +58,7 @@ func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx conte
 	}
 	return n > 0, nil
 }
-
-{{/if}}
-{{#if (eq routeKind "redirect")}}
-func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
+{{/if}}{{#if (eq routeKind "redirect")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
 	m := new(models.{{../entity.entity.modelClassName}})
 	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("{{lookupColumn}}"), {{serviceCallArgs}}).Limit(1).Scan(ctx)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -83,10 +69,7 @@ func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx conte
 	}
 	return m, nil
 }
-
-{{/if}}
-{{#if (eq routeKind "other")}}
-// TODO: implement {{serviceMethod}}; the convention engine could not derive a
+{{/if}}{{#if (eq routeKind "other")}}// TODO: implement {{serviceMethod}}; the convention engine could not derive a
 // CRUD shape for this operation, so the stub returns an explicit error to
 // avoid silently reporting success.
 func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context{{#if serviceSignatureArgs}}, {{serviceSignatureArgs}}{{/if}}) error {
@@ -94,6 +77,4 @@ func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx conte
 	_ = s
 	return errors.New("{{serviceMethod}} not implemented")
 }
-
-{{/if}}
-{{/each}}
+{{/if}}{{/each~}}

--- a/modules/codegen/src/main/resources/templates/go/chi/migrations/migration.down.sql.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/migrations/migration.down.sql.hbs
@@ -1,7 +1,7 @@
-BEGIN;
+{{txBegin}}
 
 {{#each migration.downgradeStatements}}
 {{{this}}}
 
 {{/each}}
-COMMIT;
+{{txCommit}}

--- a/modules/codegen/src/main/resources/templates/go/chi/migrations/migration.up.sql.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/migrations/migration.up.sql.hbs
@@ -1,7 +1,7 @@
-BEGIN;
+{{txBegin}}
 
 {{#each migration.upgradeStatements}}
 {{{this}}}
 
 {{/each}}
-COMMIT;
+{{txCommit}}

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -99,6 +99,7 @@ final private case class GoDbView(
     txCommit: String,
     hasDbService: Boolean,
     dbImage: String,
+    dbPort: String,
     dbVolumePath: String,
     dbHealthCmd: String,
     composeEnv: List[GoComposeEnv]
@@ -235,6 +236,7 @@ object EmitGo:
         txCommit = "COMMIT;",
         hasDbService = true,
         dbImage = "postgres:16-alpine",
+        dbPort = "5432",
         dbVolumePath = "/var/lib/postgresql/data",
         dbHealthCmd = s"pg_isready -U $snake",
         composeEnv = List(
@@ -262,6 +264,7 @@ object EmitGo:
         txCommit = "",
         hasDbService = false,
         dbImage = "",
+        dbPort = "",
         dbVolumePath = "",
         dbHealthCmd = "",
         composeEnv = Nil
@@ -285,6 +288,7 @@ object EmitGo:
         txCommit = "",
         hasDbService = true,
         dbImage = "mysql:8.4",
+        dbPort = "3306",
         dbVolumePath = "/var/lib/mysql",
         dbHealthCmd = s"mysqladmin ping -h 127.0.0.1 -u $snake -p$snake --silent",
         composeEnv = List(

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -85,6 +85,25 @@ final private case class GoEntityCtx(
 
 final private case class GoServiceNames(name: String, snakeName: String, kebabName: String)
 
+final private case class GoComposeEnv(key: String, value: String)
+
+final private case class GoDbView(
+    id: String,
+    databaseImports: String,
+    openStmt: String,
+    bunNew: String,
+    appDsn: String,
+    appDsnCompose: String,
+    migrateUrl: String,
+    txBegin: String,
+    txCommit: String,
+    hasDbService: Boolean,
+    dbImage: String,
+    dbVolumePath: String,
+    dbHealthCmd: String,
+    composeEnv: List[GoComposeEnv]
+)
+
 final private case class GoProjectCtx(
     service: GoServiceNames,
     module: String,
@@ -92,6 +111,7 @@ final private case class GoProjectCtx(
     needsTime: Boolean,
     needsUuid: Boolean,
     needsDecimal: Boolean,
+    db: GoDbView,
     dafnyKernel: Option[DafnyKernel]
 )
 
@@ -129,6 +149,7 @@ object EmitGo:
       needsTime = needsTime,
       needsUuid = needsUuid,
       needsDecimal = needsDecimal,
+      db = goDbView(profiled.profile.database, service.snakeName),
       dafnyKernel = opts.dafnyKernel
     )
 
@@ -171,7 +192,7 @@ object EmitGo:
         engine.renderAny(templates.serviceEntity, perEntity)
       )
 
-    emitMigrationFiles(profiled, opts, templates, engine, files)
+    emitMigrationFiles(profiled, opts, templates, engine, projectCtx.db, files)
 
     files += EmittedFile(
       "openapi.yaml",
@@ -188,14 +209,106 @@ object EmitGo:
   private def goModuleName(serviceKebab: String): String =
     s"github.com/generated/$serviceKebab"
 
+  private def importBlock(lines: List[String]): String =
+    "\n" + lines.map(l => s"\t$l").mkString("\n")
+
+  private val sqlOpenWithErr: String =
+    "\n\tif err != nil {\n\t\treturn nil, err\n\t}"
+
+  private def goDbView(database: String, snake: String): GoDbView = database match
+    case "postgres" =>
+      GoDbView(
+        id = "postgres",
+        databaseImports = importBlock(
+          List(
+            "\"github.com/uptrace/bun\"",
+            "\"github.com/uptrace/bun/dialect/pgdialect\"",
+            "\"github.com/uptrace/bun/driver/pgdriver\""
+          )
+        ),
+        openStmt = "sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))",
+        bunNew = "pgdialect.New()",
+        appDsn = s"postgres://$snake:$snake@localhost:5432/$snake?sslmode=disable",
+        appDsnCompose = s"postgres://$snake:$snake@db:5432/$snake?sslmode=disable",
+        migrateUrl = s"postgres://$snake:$snake@localhost:5432/$snake?sslmode=disable",
+        txBegin = "BEGIN;",
+        txCommit = "COMMIT;",
+        hasDbService = true,
+        dbImage = "postgres:16-alpine",
+        dbVolumePath = "/var/lib/postgresql/data",
+        dbHealthCmd = s"pg_isready -U $snake",
+        composeEnv = List(
+          GoComposeEnv("POSTGRES_USER", snake),
+          GoComposeEnv("POSTGRES_PASSWORD", snake),
+          GoComposeEnv("POSTGRES_DB", snake)
+        )
+      )
+    case "sqlite" =>
+      GoDbView(
+        id = "sqlite",
+        databaseImports = importBlock(
+          List(
+            "\"github.com/uptrace/bun\"",
+            "\"github.com/uptrace/bun/dialect/sqlitedialect\"",
+            "\"github.com/uptrace/bun/driver/sqliteshim\""
+          )
+        ),
+        openStmt = s"sqldb, err := sql.Open(sqliteshim.ShimName, dsn)$sqlOpenWithErr",
+        bunNew = "sqlitedialect.New()",
+        appDsn = s"file:$snake.db?cache=shared&_pragma=foreign_keys(1)",
+        appDsnCompose = s"file:$snake.db?cache=shared&_pragma=foreign_keys(1)",
+        migrateUrl = s"sqlite://$snake.db",
+        txBegin = "",
+        txCommit = "",
+        hasDbService = false,
+        dbImage = "",
+        dbVolumePath = "",
+        dbHealthCmd = "",
+        composeEnv = Nil
+      )
+    case "mysql" =>
+      GoDbView(
+        id = "mysql",
+        databaseImports = importBlock(
+          List(
+            "_ \"github.com/go-sql-driver/mysql\"",
+            "\"github.com/uptrace/bun\"",
+            "\"github.com/uptrace/bun/dialect/mysqldialect\""
+          )
+        ),
+        openStmt = s"""sqldb, err := sql.Open("mysql", dsn)$sqlOpenWithErr""",
+        bunNew = "mysqldialect.New()",
+        appDsn = s"$snake:$snake@tcp(localhost:3306)/$snake?parseTime=true",
+        appDsnCompose = s"$snake:$snake@tcp(db:3306)/$snake?parseTime=true",
+        migrateUrl = s"mysql://$snake:$snake@tcp(localhost:3306)/$snake",
+        txBegin = "",
+        txCommit = "",
+        hasDbService = true,
+        dbImage = "mysql:8.4",
+        dbVolumePath = "/var/lib/mysql",
+        dbHealthCmd = s"mysqladmin ping -h 127.0.0.1 -u $snake -p$snake --silent",
+        composeEnv = List(
+          GoComposeEnv("MYSQL_USER", snake),
+          GoComposeEnv("MYSQL_PASSWORD", snake),
+          GoComposeEnv("MYSQL_DATABASE", snake),
+          GoComposeEnv("MYSQL_ROOT_PASSWORD", s"${snake}_root")
+        )
+      )
+    case other =>
+      throw new RuntimeException(
+        s"No Go database view for '$other' (known: postgres, sqlite, mysql)"
+      )
+
   private def emitMigrationFiles(
       profiled: ProfiledService,
       opts: EmitOptions,
       templates: specrest.codegen.GoChiPostgresTemplates,
       engine: TemplateEngine,
+      db: GoDbView,
       files: scala.collection.mutable.Builder[EmittedFile, List[EmittedFile]]
   ): Unit =
-    val schema = profiled.schema
+    val schema  = profiled.schema
+    val dialect = specrest.codegen.migration.Dialect.forDatabase(profiled.profile.database)
     files += EmittedFile(
       ".spec-snapshot.json",
       SchemaCodec.encode(SchemaSnapshot.of(schema))
@@ -206,10 +319,14 @@ object EmitGo:
       val triggerOps = schema.triggers.map(MigrationOp.AddTrigger.apply)
       val ops        = tableOps ++ triggerOps
       val view = SqlMigrationView(
-        upgradeStatements = SqlRenderer.upgrade(ops),
-        downgradeStatements = SqlRenderer.downgrade(ops)
+        upgradeStatements = SqlRenderer.upgrade(ops, dialect),
+        downgradeStatements = SqlRenderer.downgrade(ops, dialect)
       )
-      val scope = Map[String, Any]("migration" -> view)
+      val scope = Map[String, Any](
+        "migration" -> view,
+        "txBegin"   -> db.txBegin,
+        "txCommit"  -> db.txCommit
+      )
       files += EmittedFile(
         "migrations/001_initial_schema.up.sql",
         engine.renderAny(templates.migrationUp, scope)
@@ -227,10 +344,14 @@ object EmitGo:
         if ops.nonEmpty then
           val nextRev = Revision.next(opts.existingRevisions)
           val view = SqlMigrationView(
-            upgradeStatements = SqlRenderer.upgrade(ops),
-            downgradeStatements = SqlRenderer.downgrade(ops)
+            upgradeStatements = SqlRenderer.upgrade(ops, dialect),
+            downgradeStatements = SqlRenderer.downgrade(ops, dialect)
           )
-          val scope = Map[String, Any]("migration" -> view)
+          val scope = Map[String, Any](
+            "migration" -> view,
+            "txBegin"   -> db.txBegin,
+            "txCommit"  -> db.txCommit
+          )
           files += EmittedFile(
             s"migrations/${nextRev}_schema_update.up.sql",
             engine.renderAny(templates.migrationUp, scope)
@@ -258,6 +379,7 @@ object EmitGo:
       "needsTime"    -> proj.needsTime,
       "needsUuid"    -> proj.needsUuid,
       "needsDecimal" -> proj.needsDecimal,
+      "db"           -> proj.db,
       "hasDafny"     -> proj.dafnyKernel.isDefined
     )
     currentEntity match

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -50,6 +50,17 @@ trait Dialect:
     */
   def deployment(snake: String): DialectView
 
+  /** Raw-SQL DDL facet, used by the golang-migrate / Prisma `migration.sql` path (`SqlRenderer`).
+    * Postgres returns the schema's column type verbatim so the existing postgres goldens are
+    * byte-identical; sqlite/mysql remap via `CanonicalType`. `serialColumnDef` renders the
+    * auto-increment primary key column inline; `serialUsesSeparatePk` is false where the dialect
+    * requires the pk declared on the column itself (SQLite rowid alias).
+    */
+  def sqlColumnType(sqlType: String): String
+  def sqlServerDefault(expr: String): String
+  def serialColumnDef(name: String): String
+  def serialUsesSeparatePk: Boolean
+
   def schemaDiagnostics(schema: DatabaseSchema): List[ConventionDiagnostic] =
     schema.tables.flatMap(_.indexes).flatMap(ix => partialIndex(ix).diagnostics)
 
@@ -102,6 +113,47 @@ object Dialect:
       upgrade = triggers.map((_, sql) => s"op.execute(${AlembicSyntax.tripleQuoted(sql)})"),
       downgrade = triggers.map((name, _) => s"""op.execute("DROP TRIGGER IF EXISTS $name;")""")
     )
+
+  private[migration] def normalizeNow(expr: String): String =
+    if expr.trim.equalsIgnoreCase("NOW()") then "CURRENT_TIMESTAMP" else expr
+
+  private[migration] def sqliteType(sqlType: String): String =
+    CanonicalType.parse(sqlType) match
+      case Some(CanonicalType.Text)                => "TEXT"
+      case Some(CanonicalType.Varchar(_))          => "TEXT"
+      case Some(CanonicalType.Int4)                => "INTEGER"
+      case Some(CanonicalType.Serial4)             => "INTEGER"
+      case Some(CanonicalType.Int8)                => "INTEGER"
+      case Some(CanonicalType.Serial8)             => "INTEGER"
+      case Some(CanonicalType.Float8)              => "REAL"
+      case Some(CanonicalType.Bool)                => "BOOLEAN"
+      case Some(CanonicalType.Timestamptz)         => "DATETIME"
+      case Some(CanonicalType.DateOnly)            => "DATE"
+      case Some(CanonicalType.Uuid)                => "TEXT"
+      case Some(CanonicalType.Numeric(p, Some(s))) => s"NUMERIC($p, $s)"
+      case Some(CanonicalType.Numeric(p, None))    => s"NUMERIC($p)"
+      case Some(CanonicalType.Bytes)               => "BLOB"
+      case Some(CanonicalType.Json)                => "TEXT"
+      case None                                    => sqlType
+
+  private[migration] def mysqlType(sqlType: String): String =
+    CanonicalType.parse(sqlType) match
+      case Some(CanonicalType.Text)                => "VARCHAR(255)"
+      case Some(CanonicalType.Varchar(n))          => s"VARCHAR($n)"
+      case Some(CanonicalType.Int4)                => "INT"
+      case Some(CanonicalType.Serial4)             => "INT"
+      case Some(CanonicalType.Int8)                => "BIGINT"
+      case Some(CanonicalType.Serial8)             => "BIGINT"
+      case Some(CanonicalType.Float8)              => "DOUBLE"
+      case Some(CanonicalType.Bool)                => "TINYINT(1)"
+      case Some(CanonicalType.Timestamptz)         => "DATETIME"
+      case Some(CanonicalType.DateOnly)            => "DATE"
+      case Some(CanonicalType.Uuid)                => "CHAR(36)"
+      case Some(CanonicalType.Numeric(p, Some(s))) => s"DECIMAL($p, $s)"
+      case Some(CanonicalType.Numeric(p, None))    => s"DECIMAL($p)"
+      case Some(CanonicalType.Bytes)               => "LONGBLOB"
+      case Some(CanonicalType.Json)                => "JSON"
+      case None                                    => sqlType
 
 object Postgres extends Dialect:
   val id = "postgres"
@@ -166,6 +218,11 @@ object Postgres extends Dialect:
     )
   )
 
+  def sqlColumnType(sqlType: String): String = sqlType
+  def sqlServerDefault(expr: String): String = expr
+  def serialColumnDef(name: String): String  = s"$name BIGSERIAL NOT NULL"
+  def serialUsesSeparatePk: Boolean          = true
+
 object Sqlite extends Dialect:
   val id = "sqlite"
 
@@ -216,6 +273,11 @@ object Sqlite extends Dialect:
     engineArgs = """    connect_args={"check_same_thread": False},""",
     composeEnv = Nil
   )
+
+  def sqlColumnType(sqlType: String): String = Dialect.sqliteType(sqlType)
+  def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
+  def serialColumnDef(name: String): String  = s"$name INTEGER PRIMARY KEY AUTOINCREMENT"
+  def serialUsesSeparatePk: Boolean          = false
 
 object Mysql extends Dialect:
   val id = "mysql"
@@ -284,3 +346,8 @@ object Mysql extends Dialect:
       ComposeEnv("MYSQL_ROOT_PASSWORD", s"${snake}_root")
     )
   )
+
+  def sqlColumnType(sqlType: String): String = Dialect.mysqlType(sqlType)
+  def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
+  def serialColumnDef(name: String): String  = s"$name BIGINT NOT NULL AUTO_INCREMENT"
+  def serialUsesSeparatePk: Boolean          = true

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -53,12 +53,13 @@ trait Dialect:
   /** Raw-SQL DDL facet, used by the golang-migrate / Prisma `migration.sql` path (`SqlRenderer`).
     * Postgres returns the schema's column type verbatim so the existing postgres goldens are
     * byte-identical; sqlite/mysql remap via `CanonicalType`. `serialColumnDef` renders the
-    * auto-increment primary key column inline; `serialUsesSeparatePk` is false where the dialect
-    * requires the pk declared on the column itself (SQLite rowid alias).
+    * auto-increment primary key column inline; `sqlType` carries the source width (`SERIAL` vs
+    * `BIGSERIAL`) so 32-bit serials are not silently widened to 64-bit. `serialUsesSeparatePk` is
+    * false where the dialect requires the pk declared on the column itself (SQLite rowid alias).
     */
   def sqlColumnType(sqlType: String): String
   def sqlServerDefault(expr: String): String
-  def serialColumnDef(name: String): String
+  def serialColumnDef(name: String, sqlType: String): String
   def serialUsesSeparatePk: Boolean
 
   def schemaDiagnostics(schema: DatabaseSchema): List[ConventionDiagnostic] =
@@ -116,6 +117,11 @@ object Dialect:
 
   private[migration] def normalizeNow(expr: String): String =
     if expr.trim.equalsIgnoreCase("NOW()") then "CURRENT_TIMESTAMP" else expr
+
+  private[migration] def isSerial4(sqlType: String): Boolean =
+    CanonicalType.parse(sqlType) match
+      case Some(CanonicalType.Serial4) => true
+      case _                           => false
 
   private[migration] def sqliteType(sqlType: String): String =
     CanonicalType.parse(sqlType) match
@@ -220,8 +226,9 @@ object Postgres extends Dialect:
 
   def sqlColumnType(sqlType: String): String = sqlType
   def sqlServerDefault(expr: String): String = expr
-  def serialColumnDef(name: String): String  = s"$name BIGSERIAL NOT NULL"
-  def serialUsesSeparatePk: Boolean          = true
+  def serialColumnDef(name: String, sqlType: String): String =
+    if Dialect.isSerial4(sqlType) then s"$name SERIAL NOT NULL" else s"$name BIGSERIAL NOT NULL"
+  def serialUsesSeparatePk: Boolean = true
 
 object Sqlite extends Dialect:
   val id = "sqlite"
@@ -276,8 +283,9 @@ object Sqlite extends Dialect:
 
   def sqlColumnType(sqlType: String): String = Dialect.sqliteType(sqlType)
   def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
-  def serialColumnDef(name: String): String  = s"$name INTEGER PRIMARY KEY AUTOINCREMENT"
-  def serialUsesSeparatePk: Boolean          = false
+  def serialColumnDef(name: String, @scala.annotation.unused sqlType: String): String =
+    s"$name INTEGER PRIMARY KEY AUTOINCREMENT"
+  def serialUsesSeparatePk: Boolean = false
 
 object Mysql extends Dialect:
   val id = "mysql"
@@ -349,5 +357,7 @@ object Mysql extends Dialect:
 
   def sqlColumnType(sqlType: String): String = Dialect.mysqlType(sqlType)
   def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
-  def serialColumnDef(name: String): String  = s"$name BIGINT NOT NULL AUTO_INCREMENT"
-  def serialUsesSeparatePk: Boolean          = true
+  def serialColumnDef(name: String, sqlType: String): String =
+    if Dialect.isSerial4(sqlType) then s"$name INT NOT NULL AUTO_INCREMENT"
+    else s"$name BIGINT NOT NULL AUTO_INCREMENT"
+  def serialUsesSeparatePk: Boolean = true

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -144,7 +144,7 @@ object Renderers:
     createStmt :: indexStmts
 
   private def sqlColumnDef(c: ColumnSpec, dialect: Dialect): String =
-    if isSerial(c.sqlType) then dialect.serialColumnDef(c.name)
+    if isSerial(c.sqlType) then dialect.serialColumnDef(c.name, c.sqlType)
     else
       val parts = scala.collection.mutable.ListBuffer.empty[String]
       parts += c.name

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -17,7 +17,10 @@ object Renderers:
 
   def render(op: MigrationOp, dialect: Dialect = Postgres): Rendered = op match
     case CreateTable(t) =>
-      Rendered(sql = () => sqlCreateTable(t), alembic = () => alembicCreateTable(t, dialect))
+      Rendered(
+        sql = () => sqlCreateTable(t, dialect),
+        alembic = () => alembicCreateTable(t, dialect)
+      )
 
     case DropTable(t) =>
       Rendered(
@@ -28,7 +31,7 @@ object Renderers:
     case AddColumn(tbl, c) =>
       val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
       Rendered(
-        sql = () => List(s"ALTER TABLE $tbl ADD COLUMN ${sqlColumnDef(c)};"),
+        sql = () => List(s"ALTER TABLE $tbl ADD COLUMN ${sqlColumnDef(c, dialect)};"),
         alembic = () =>
           List(s"""op.add_column("$tbl", ${alembicColumn(
               c,
@@ -120,25 +123,35 @@ object Renderers:
         alembic = () => dialect.renderTrigger(t).downgrade
       )
 
-  private def sqlCreateTable(t: TableSpec): List[String] =
-    val columnLines = t.columns.map(c => "    " + sqlColumnDef(c))
-    val pkLine      = s"    CONSTRAINT pk_${t.name} PRIMARY KEY (${t.primaryKey})"
+  private def isSerial(sqlType: String): Boolean =
+    CanonicalType.parse(sqlType) match
+      case Some(CanonicalType.Serial4) | Some(CanonicalType.Serial8) => true
+      case _                                                         => false
+
+  private def sqlCreateTable(t: TableSpec, dialect: Dialect): List[String] =
+    val columnLines = t.columns.map(c => "    " + sqlColumnDef(c, dialect))
+    val pkIsSerial  = t.columns.find(_.name == t.primaryKey).exists(c => isSerial(c.sqlType))
+    val pkLines =
+      if pkIsSerial && !dialect.serialUsesSeparatePk then Nil
+      else List(s"    CONSTRAINT pk_${t.name} PRIMARY KEY (${t.primaryKey})")
     val fkLines = t.foreignKeys.map: fk =>
       "    " + sqlForeignKeyInline(t.name, fk)
     val checkLines = namedChecks(t).map: (name, sql) =>
       s"    CONSTRAINT $name CHECK ($sql)"
-    val bodyLines  = (columnLines ++ List(pkLine) ++ fkLines ++ checkLines).mkString(",\n")
+    val bodyLines  = (columnLines ++ pkLines ++ fkLines ++ checkLines).mkString(",\n")
     val createStmt = s"CREATE TABLE ${t.name} (\n$bodyLines\n);"
     val indexStmts = t.indexes.map(ix => sqlCreateIndex(t.name, ix))
     createStmt :: indexStmts
 
-  private def sqlColumnDef(c: ColumnSpec): String =
-    val parts = scala.collection.mutable.ListBuffer.empty[String]
-    parts += c.name
-    parts += c.sqlType
-    c.defaultValue.foreach(d => parts += s"DEFAULT $d")
-    parts += (if c.nullable then "NULL" else "NOT NULL")
-    parts.mkString(" ")
+  private def sqlColumnDef(c: ColumnSpec, dialect: Dialect): String =
+    if isSerial(c.sqlType) then dialect.serialColumnDef(c.name)
+    else
+      val parts = scala.collection.mutable.ListBuffer.empty[String]
+      parts += c.name
+      parts += dialect.sqlColumnType(c.sqlType)
+      c.defaultValue.foreach(d => parts += s"DEFAULT ${dialect.sqlServerDefault(d)}")
+      parts += (if c.nullable then "NULL" else "NOT NULL")
+      parts.mkString(" ")
 
   private def sqlForeignKeyInline(tableName: String, fk: ForeignKeySpec): String =
     s"CONSTRAINT ${fkName(tableName, fk)} FOREIGN KEY (${fk.column}) " +

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SqlRenderer.scala
@@ -2,8 +2,8 @@ package specrest.codegen.migration
 
 object SqlRenderer:
 
-  def upgrade(ops: List[MigrationOp]): List[String] =
-    ops.flatMap(op => Renderers.render(op).sql())
+  def upgrade(ops: List[MigrationOp], dialect: Dialect = Postgres): List[String] =
+    ops.flatMap(op => Renderers.render(op, dialect).sql())
 
-  def downgrade(ops: List[MigrationOp]): List[String] =
-    ops.reverse.flatMap(op => Renderers.render(op.inverse).sql())
+  def downgrade(ops: List[MigrationOp], dialect: Dialect = Postgres): List[String] =
+    ops.reverse.flatMap(op => Renderers.render(op.inverse, dialect).sql())

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
@@ -8,16 +8,14 @@ import specrest.profile.LanguageId
 import specrest.profile.TargetKey
 
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
 class EmitGoTest extends CatsEffectSuite:
 
-  private val GoldenRoot =
+  private def goldenRoot(db: DatabaseId): Path =
     Paths
-      .get(
-        "fixtures/golden/codegen",
-        TargetKey(LanguageId.Go, Chi.id, DatabaseId.Postgres).segments*
-      )
+      .get("fixtures/golden/codegen", TargetKey(LanguageId.Go, Chi.id, db).segments*)
       .resolve("url_shortener")
 
   test("emitProject for go-chi-postgres produces a valid Go project layout for url_shortener"):
@@ -105,35 +103,43 @@ class EmitGoTest extends CatsEffectSuite:
       assert(snapshot.contains("\"schemaVersion\""), snapshot)
       assert(snapshot.contains("url_mappings"), snapshot)
 
-  test("emitProject for go-chi-postgres matches the checked-in url_shortener golden"):
-    SpecFixtures.loadProfiled("url_shortener", "go-chi-postgres").map: profiled =>
-      val files           = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
-      val expected        = walkGolden()
-      val missingInOutput = expected.keySet.diff(files.keySet)
-      val extraInOutput   = files.keySet.diff(expected.keySet)
-      assert(
-        missingInOutput.isEmpty,
-        s"emitter dropped golden files: ${missingInOutput.toList.sorted.mkString(", ")}"
-      )
-      assert(
-        extraInOutput.isEmpty,
-        s"emitter produced files not in golden: ${extraInOutput.toList.sorted.mkString(", ")}"
-      )
-      expected.toList.sortBy(_._1).foreach: (rel, want) =>
-        val got = files(rel)
-        if got != want then
-          fail(
-            s"$rel diverges from golden\n--- expected ---\n$want\n--- got ---\n$got\n--- end ---"
-          )
+  private val dialectCases = List(
+    DatabaseId.Postgres -> "go-chi-postgres",
+    DatabaseId.Sqlite   -> "go-chi-sqlite",
+    DatabaseId.Mysql    -> "go-chi-mysql"
+  )
 
-  private def walkGolden(): Map[String, String] =
-    if !Files.isDirectory(GoldenRoot) then Map.empty
+  dialectCases.foreach: (db, target) =>
+    test(s"emitProject for $target matches the checked-in url_shortener golden"):
+      SpecFixtures.loadProfiled("url_shortener", target).map: profiled =>
+        val files           = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+        val expected        = walkGolden(goldenRoot(db))
+        val missingInOutput = expected.keySet.diff(files.keySet)
+        val extraInOutput   = files.keySet.diff(expected.keySet)
+        assert(expected.nonEmpty, s"no golden tree at ${goldenRoot(db)}")
+        assert(
+          missingInOutput.isEmpty,
+          s"emitter dropped golden files: ${missingInOutput.toList.sorted.mkString(", ")}"
+        )
+        assert(
+          extraInOutput.isEmpty,
+          s"emitter produced files not in golden: ${extraInOutput.toList.sorted.mkString(", ")}"
+        )
+        expected.toList.sortBy(_._1).foreach: (rel, want) =>
+          val got = files(rel)
+          if got != want then
+            fail(
+              s"$rel diverges from golden\n--- expected ---\n$want\n--- got ---\n$got\n--- end ---"
+            )
+
+  private def walkGolden(root: Path): Map[String, String] =
+    if !Files.isDirectory(root) then Map.empty
     else
-      val stream = Files.walk(GoldenRoot)
+      val stream = Files.walk(root)
       try
         import scala.jdk.CollectionConverters.*
         stream.iterator.asScala
           .filter(Files.isRegularFile(_))
-          .map(p => GoldenRoot.relativize(p).toString.replace('\\', '/') -> Files.readString(p))
+          .map(p => root.relativize(p).toString.replace('\\', '/') -> Files.readString(p))
           .toMap
       finally stream.close()

--- a/modules/profile/src/main/scala/specrest/profile/Targets.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Targets.scala
@@ -113,7 +113,16 @@ object Fastapi extends Framework:
 object Chi extends Framework:
   val id                                  = "chi"
   val supportedLanguages: Set[LanguageId] = Set(LanguageId.Go)
-  val supportedDialects: Set[DatabaseId]  = Set(DatabaseId.Postgres)
+  val supportedDialects: Set[DatabaseId] =
+    Set(DatabaseId.Postgres, DatabaseId.Sqlite, DatabaseId.Mysql)
+
+  private def driverDep(database: DatabaseId): DependencySpec = database match
+    case DatabaseId.Postgres =>
+      DependencySpec("github.com/uptrace/bun/driver/pgdriver", "v1.2.18")
+    case DatabaseId.Sqlite =>
+      DependencySpec("github.com/uptrace/bun/driver/sqliteshim", "v1.2.18")
+    case DatabaseId.Mysql =>
+      DependencySpec("github.com/go-sql-driver/mysql", "v1.10.0")
 
   def profile(language: LanguageId, database: DatabaseId): DeploymentProfile =
     DeploymentProfile(
@@ -136,7 +145,7 @@ object Chi extends Framework:
       dependencies = List(
         DependencySpec("github.com/go-chi/chi/v5", "v5.1.0"),
         DependencySpec("github.com/uptrace/bun", "v1.2.18"),
-        DependencySpec("github.com/uptrace/bun/driver/pgdriver", "v1.2.18"),
+        driverDep(database),
         DependencySpec("github.com/google/uuid", "v1.6.0"),
         DependencySpec("github.com/shopspring/decimal", "v1.4.0"),
         DependencySpec("github.com/caarlos0/env/v11", "v11.2.0"),

--- a/modules/profile/src/test/scala/specrest/profile/TargetCompositionTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/TargetCompositionTest.scala
@@ -52,6 +52,8 @@ class TargetCompositionTest extends CatsEffectSuite:
     ("python-fastapi-sqlite", "aiosqlite"),
     ("python-fastapi-mysql", "aiomysql"),
     ("go-chi-postgres", "bun"),
+    ("go-chi-sqlite", "bun"),
+    ("go-chi-mysql", "bun"),
     ("ts-express-postgres", "@prisma/client")
   ).foreach: (slug, wantDriver) =>
     test(s"Registry.resolveSlug('$slug') yields the expected profile"):
@@ -64,7 +66,7 @@ class TargetCompositionTest extends CatsEffectSuite:
   List(
     ("python-chi-postgres", "language"),
     ("go-fastapi-postgres", "language"),
-    ("go-chi-sqlite", "database"),
+    ("ts-express-sqlite", "database"),
     ("ts-express-mysql", "database"),
     ("python-rails-postgres", "framework")
   ).foreach: (slug, axis) =>
@@ -77,7 +79,9 @@ class TargetCompositionTest extends CatsEffectSuite:
     assertEquals(
       Registry.listProfiles,
       List(
+        "go-chi-mysql",
         "go-chi-postgres",
+        "go-chi-sqlite",
         "python-fastapi-mysql",
         "python-fastapi-postgres",
         "python-fastapi-sqlite",


### PR DESCRIPTION
## Summary
- chi now supports **postgres + sqlite + mysql**, matching the fastapi capability set. Selection is a Bun dialect/driver switch — no new framework.
- New `GoDbView` (`EmitGo.scala`) centralises per-dialect wiring: bun `dialect.New()` + driver import, `sql.OpenDB` (pgdriver) vs `sql.Open` (sqliteshim / go-sql-driver), app DSN, golang-migrate URL, and the docker-compose db service (none for sqlite).
- DDL renderer is now dialect-aware (`Dialect`/`Renderers`/`SqlRenderer`): **Postgres = identity**, so the postgres golden migration SQL is byte-identical (only its `Makefile` changed: `$DATABASE_URL` → `MIGRATE_DSN`). sqlite/mysql remap column types via `CanonicalType` (`INTEGER PRIMARY KEY AUTOINCREMENT`, `BIGINT AUTO_INCREMENT`, `VARCHAR(255)`, …) and drop the postgres `BEGIN;/COMMIT;` wrapper (nested-tx conflict on golang-migrate sqlite; single-statement requirement on mysql).
- `Targets.scala`: `Chi.supportedDialects` = {postgres, sqlite, mysql}; per-dialect driver dep (pgdriver / sqliteshim / go-sql-driver/mysql).
- New golden trees `fixtures/golden/codegen/go/chi/{sqlite,mysql}/url_shortener`; `EmitGoTest` parametrised over the three dialects; `TargetCompositionTest` registry expectations updated.
- `go-build.yml` is now a `{postgres, sqlite, mysql}` matrix running `go build` + `migrate up/down/up` against real Postgres/MySQL service containers (sqlite = file).

## Test plan
- [x] `go build` + golang-migrate `up → down -all → up` round-trip verified locally against real DBs for **all three dialects** (sqlite file, Dockerised postgres:17 / mysql:8.4); postgres regression clean.
- [x] `sbt profile/test codegen/test cli/test testgen/test` — all green (EmitGoTest 4/4, TargetCompositionTest 27/27).
- [x] Postgres golden migration SQL byte-identical (`git diff` on the postgres golden is `Makefile`-only).
- [ ] CI: go-build matrix green for postgres/sqlite/mysql.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQLite and MySQL support to the Go `chi` generator via a Bun dialect switch, with per‑dialect DB wiring, migrations, and CI. Also fixes generated CI/README to match the chosen dialect, preserves `SERIAL` width, and makes migrate DSNs shell‑safe.

- New Features
  - `--db {postgres|sqlite|mysql}` selects the dialect; generated code wires the correct Bun dialect/driver, DSNs, and compose/CI DB service (none for SQLite).
  - Dialect-aware migrations: Postgres untouched; SQLite/MySQL remap types and normalize `NOW()`; tx wrappers only on Postgres. `go-build.yml` runs `go build` + `golang-migrate` round-trip in a `{postgres, sqlite, mysql}` matrix.
  - Docs: added `go/chi/{sqlite,mysql}` delta pages and updated the Postgres page to Bun.

- Bug Fixes
  - Generated project CI and README are dialect-aware (SQLite uses file DSN and no DB service; MySQL uses `mysql:8.4` and `tcp()` DSN).
  - `SERIAL` width preserved in SQL: 32-bit stays `SERIAL`/`INT`, not widened to `BIGSERIAL`/`BIGINT`.
  - `Makefile` migration targets use `${MIGRATE_DSN:-<default>}` per dialect to avoid Make mangling and allow shell-safe overrides.

<sup>Written for commit f3325c9c69bd02ae7223c46310d85c7eca068bb6. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/261?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-database support: generated Go (chi) projects now target Postgres, SQLite, and MySQL with corresponding fixtures and snapshots.

* **Infrastructure**
  * CI now runs a dialect matrix to build and migrate against each SQL dialect; per-dialect DB services and compose configs are emitted.
  * Migrations and runtime DB URLs are database-aware and generated per dialect.

* **Chores**
  * Tests and docs expanded to validate codegen across all supported databases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->