### PR TITLE
fix: SQLite serial primary keys must map to INTEGER, not BIGINT

### DIFF
--- a/docs/content/docs/targets/python/fastapi/sqlite.mdx
+++ b/docs/content/docs/targets/python/fastapi/sqlite.mdx
@@ -37,16 +37,9 @@ sbt "cli/run compile --framework fastapi --db sqlite --ignore-verify --out /tmp/
 - **Test generation.** `--with-tests` (conformance / property suites) is Postgres-only by design;
   `python-fastapi-sqlite` emits only the smoke `tests/test_health.py` (plus
   `tests/test_log_redaction.py`).
-
-## Known limitation
-
-`Dialect.Sqlite.saType` maps serial primary keys to `sa.BigInteger()` → `BIGINT`. SQLite only
-auto-generates row ids for the exact `INTEGER PRIMARY KEY` type, so on SQLite an integer PK is
-**not** auto-incremented and inserts must supply the id explicitly. The Alembic migration is still
-valid DDL (the `up → down → up` round-trip is green — this is a runtime-insert behavior, not a
-migration failure), which is why it surfaces only when an app omits the PK on insert. Tracked
-separately from the matrix-drift work; the raw-SQL renderer (`go-chi` / `ts-express`) already
-special-cases this via `Dialect.Sqlite.serialColumnDef`.
+- **Serial primary keys.** A 64-bit serial PK maps to `sa.Integer()`, not `sa.BigInteger()`: SQLite
+  autoincrements only the `INTEGER PRIMARY KEY` rowid alias (itself 64-bit), so a `BIGINT` PK would
+  silently not autoincrement. This matches the raw-SQL renderer's `Dialect.Sqlite.serialColumnDef`.
 
 ## CI gate
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
@@ -21,7 +21,7 @@ def upgrade() -> None:
     op.create_table(
         "url_mappings",
 
-        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
 
         sa.Column("code", sa.Text(), nullable=False),
 

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -242,12 +242,14 @@ object Sqlite extends Dialect:
   )
 
   def saType(t: CanonicalType): SaType = t match
-    case CanonicalType.Text                => SaType("sa.Text()", None)
-    case CanonicalType.Varchar(n)          => SaType(s"sa.String(length=$n)", None)
-    case CanonicalType.Int4                => SaType("sa.Integer()", None)
-    case CanonicalType.Serial4             => SaType("sa.Integer()", None)
-    case CanonicalType.Int8                => SaType("sa.BigInteger()", None)
-    case CanonicalType.Serial8             => SaType("sa.BigInteger()", None)
+    case CanonicalType.Text       => SaType("sa.Text()", None)
+    case CanonicalType.Varchar(n) => SaType(s"sa.String(length=$n)", None)
+    case CanonicalType.Int4       => SaType("sa.Integer()", None)
+    case CanonicalType.Serial4    => SaType("sa.Integer()", None)
+    case CanonicalType.Int8       => SaType("sa.BigInteger()", None)
+    // SQLite autoincrements only the INTEGER PRIMARY KEY rowid alias; a BIGINT PK is
+    // not that alias, so a 64-bit serial must map to INTEGER (rowid is already 64-bit).
+    case CanonicalType.Serial8             => SaType("sa.Integer()", None)
     case CanonicalType.Float8              => SaType("sa.Float()", None)
     case CanonicalType.Bool                => SaType("sa.Boolean()", None)
     case CanonicalType.Timestamptz         => SaType("sa.DateTime()", None)

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -65,6 +65,14 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(!mig.contains("timezone=True"), mig)
       assert(!mig.contains("from sqlalchemy.dialects import postgresql"), mig)
       assert(mig.contains("sa.Text()"), mig)
+      // SQLite autoincrements only INTEGER PRIMARY KEY; a serial PK must not be BIGINT.
+      assert(!mig.contains("sa.BigInteger()"), mig)
+      assert(
+        mig.contains(
+          """sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True"""
+        ),
+        mig
+      )
       assert(files(".env.example").contains("sqlite+aiosqlite://"))
       assert(files("pyproject.toml").contains("aiosqlite"))
       assert(!files("pyproject.toml").contains("asyncpg"))


### PR DESCRIPTION
## Summary

Follow-up to #263 (which documented this as a known limitation). `Dialect.Sqlite.saType` mapped `Serial8` → `sa.BigInteger()` (→ `BIGINT`). **SQLite only autoincrements the `INTEGER PRIMARY KEY` rowid alias** — a `BIGINT` PK is not that alias, so `autoincrement=True` was a silent no-op: a generated `python-fastapi-sqlite` app that omits the PK on insert would fail to auto-generate ids.

It was latent because the Alembic DDL is still valid — the `up → down → up` CI round-trip is green (this is a runtime-insert behavior, not a migration failure).

**Fix:** `Serial8 → sa.Integer()` for the SQLite dialect only. SQLite's rowid alias is itself a 64-bit signed integer, so the mapping is lossless, and it now matches the raw-SQL renderer — `Dialect.Sqlite.serialColumnDef` already emits `INTEGER PRIMARY KEY AUTOINCREMENT` for `go-chi`/`ts-express`. Postgres/MySQL `saType` are untouched (`AlembicMigrationTest`'s Postgres path still asserts `sa.BigInteger()`).

Changes:
- `Dialect.Sqlite.saType`: `Serial8` → `sa.Integer()` (with a comment explaining the non-obvious SQLite rowid-alias constraint).
- `DialectProfileEmitTest` sqlite: assert the migration uses `sa.Integer()` for the autoincrement PK and contains **no** `sa.BigInteger()` — deterministic regression guard.
- Regenerated `python-fastapi-sqlite` golden — only `001_initial_schema.py`'s `id` column changes (`BigInteger` → `Integer`).
- `sqlite.mdx`: replaced the now-fixed "Known limitation" note with a "Serial primary keys" delta entry documenting the correct behavior.

## Test plan

- [x] `DialectProfileEmitTest` 9/9 (incl. new sqlite autoincrement assertion)
- [x] `EmitPythonTest` 3/3 (regenerated sqlite golden byte-exact)
- [x] `AlembicMigrationTest` 8/8 (Postgres path still `sa.BigInteger()` — unaffected)
- [x] `EmitTest` 21/21, `EmitGoTest`/`EmitTsTest` green
- [x] scalafmt / scalafix clean
- [ ] CI: python-build sqlite `alembic up/down/up` matrix leg green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SQLite serial primary key autoincrement by mapping `Serial8` to `sa.Integer()` instead of `sa.BigInteger()`. Generated `python-fastapi-sqlite` apps now auto-generate ids on insert, matching the raw-SQL renderers.

- **Bug Fixes**
  - Map `Dialect.Sqlite.saType` `Serial8` → `sa.Integer()` (with a clarifying comment).
  - Add a regression test to assert no `sa.BigInteger()` and a correct `INTEGER` PK in migrations.
  - Regenerate SQLite golden: `001_initial_schema.py` changes `BigInteger` → `Integer`.
  - Update `sqlite.mdx` docs to describe correct serial PK behavior.
  - Postgres/MySQL mappings remain unchanged.

<sup>Written for commit d8d7bf630004b10b5f51fad63bfafe7ca48b45a8. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/264?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

