### PR TITLE
fix: generated FastAPI app correctness (route-shadow, lint, redaction, Makefile)

### DIFF
--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/Makefile
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/Makefile
@@ -30,7 +30,11 @@ docker-down:             ## Stop all services and remove volumes
 	docker compose down -v
 
 test-conformance:        ## Run all 3 test layers against an already-running service (PROFILE=smoke|thorough|exhaustive)
-	uv run python tests/run_conformance.py $(PROFILE)
+	@if [ ! -f tests/run_conformance.py ]; then \
+		echo "tests/run_conformance.py not found — re-compile with --with-tests to generate the conformance suite. Skipping."; \
+	else \
+		uv run python tests/run_conformance.py $(PROFILE); \
+	fi
 
 test-conformance-docker: ## Boot service via docker compose, run conformance, tear down (PROFILE=...)
 	@set -e; \

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -36,19 +37,20 @@ app.add_middleware(
 )
 
 
-app.include_router(url_mappings.router)
-
-
-
-import os as _os
-if _os.environ.get("ENABLE_TEST_ADMIN") == "1":
-    try:
-        from app.routers import test_admin as _test_admin
-        app.include_router(_test_admin.router)
-    except ImportError:
-        pass
-
-
 @app.get("/health", tags=["infrastructure"])
 async def health_check() -> dict[str, str]:
     return {"status": "ok"}
+
+
+if os.environ.get("ENABLE_TEST_ADMIN") == "1":
+    try:
+        from app.routers import test_admin as _test_admin
+    except ModuleNotFoundError as exc:
+        if exc.name != "app.routers.test_admin":
+            raise
+    else:
+        app.include_router(_test_admin.router)
+
+
+app.include_router(url_mappings.router)
+

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/redaction.py
@@ -31,7 +31,8 @@ _REDACTED: str = "***REDACTED***"
 
 
 def is_sensitive(name: str) -> bool:
-    return name in _SENSITIVE_EXACT or name.endswith(_SENSITIVE_SUFFIXES)
+    n = name.lower()
+    return n in _SENSITIVE_EXACT or n.endswith(_SENSITIVE_SUFFIXES)
 
 
 def _redact_value(value: Any) -> Any:

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/tests/test_log_redaction.py
@@ -32,9 +32,22 @@ def test_is_sensitive_matches_exact_and_suffix():
     assert not is_sensitive("display_name")
 
 
+def test_is_sensitive_is_case_insensitive():
+    assert is_sensitive("Password")
+    assert is_sensitive("API_KEY")
+    assert is_sensitive("Session_Token")
+    assert is_sensitive("USER_PASSWORD")
+
+
 def test_processor_redacts_top_level_sensitive_keys():
     out = redact_sensitive(None, "info", {"event": "login", "password": "hunter2"})
     assert out == {"event": "login", "password": "***REDACTED***"}
+
+
+def test_processor_redacts_mixed_case_sensitive_keys():
+    out = redact_sensitive(None, "info", {"Password": "hunter2", "API_KEY": "k"})
+    assert out["Password"] == "***REDACTED***"
+    assert out["API_KEY"] == "***REDACTED***"
 
 
 def test_processor_recurses_into_nested_dicts():

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/tests/test_log_redaction.py
@@ -51,8 +51,11 @@ def test_processor_recurses_into_nested_dicts():
 
 def test_processor_pure_function_does_not_mask_non_sensitive():
     inp = {"email": "a@b.com", "user_id": 42}
+    before = dict(inp)
     out = redact_sensitive(None, "info", inp)
-    assert out == inp
+    assert inp == before, "processor mutated its input dict"
+    assert out == before
+    assert out is not inp, "processor must return a new dict, not the input"
 
 
 def test_processor_recurses_into_lists_of_dicts():

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/Makefile
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/Makefile
@@ -30,7 +30,11 @@ docker-down:             ## Stop all services and remove volumes
 	docker compose down -v
 
 test-conformance:        ## Run all 3 test layers against an already-running service (PROFILE=smoke|thorough|exhaustive)
-	uv run python tests/run_conformance.py $(PROFILE)
+	@if [ ! -f tests/run_conformance.py ]; then \
+		echo "tests/run_conformance.py not found — re-compile with --with-tests to generate the conformance suite. Skipping."; \
+	else \
+		uv run python tests/run_conformance.py $(PROFILE); \
+	fi
 
 test-conformance-docker: ## Boot service via docker compose, run conformance, tear down (PROFILE=...)
 	@set -e; \

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -36,19 +37,20 @@ app.add_middleware(
 )
 
 
-app.include_router(url_mappings.router)
-
-
-
-import os as _os
-if _os.environ.get("ENABLE_TEST_ADMIN") == "1":
-    try:
-        from app.routers import test_admin as _test_admin
-        app.include_router(_test_admin.router)
-    except ImportError:
-        pass
-
-
 @app.get("/health", tags=["infrastructure"])
 async def health_check() -> dict[str, str]:
     return {"status": "ok"}
+
+
+if os.environ.get("ENABLE_TEST_ADMIN") == "1":
+    try:
+        from app.routers import test_admin as _test_admin
+    except ModuleNotFoundError as exc:
+        if exc.name != "app.routers.test_admin":
+            raise
+    else:
+        app.include_router(_test_admin.router)
+
+
+app.include_router(url_mappings.router)
+

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/redaction.py
@@ -31,7 +31,8 @@ _REDACTED: str = "***REDACTED***"
 
 
 def is_sensitive(name: str) -> bool:
-    return name in _SENSITIVE_EXACT or name.endswith(_SENSITIVE_SUFFIXES)
+    n = name.lower()
+    return n in _SENSITIVE_EXACT or n.endswith(_SENSITIVE_SUFFIXES)
 
 
 def _redact_value(value: Any) -> Any:

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/tests/test_log_redaction.py
@@ -32,9 +32,22 @@ def test_is_sensitive_matches_exact_and_suffix():
     assert not is_sensitive("display_name")
 
 
+def test_is_sensitive_is_case_insensitive():
+    assert is_sensitive("Password")
+    assert is_sensitive("API_KEY")
+    assert is_sensitive("Session_Token")
+    assert is_sensitive("USER_PASSWORD")
+
+
 def test_processor_redacts_top_level_sensitive_keys():
     out = redact_sensitive(None, "info", {"event": "login", "password": "hunter2"})
     assert out == {"event": "login", "password": "***REDACTED***"}
+
+
+def test_processor_redacts_mixed_case_sensitive_keys():
+    out = redact_sensitive(None, "info", {"Password": "hunter2", "API_KEY": "k"})
+    assert out["Password"] == "***REDACTED***"
+    assert out["API_KEY"] == "***REDACTED***"
 
 
 def test_processor_recurses_into_nested_dicts():

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/tests/test_log_redaction.py
@@ -51,8 +51,11 @@ def test_processor_recurses_into_nested_dicts():
 
 def test_processor_pure_function_does_not_mask_non_sensitive():
     inp = {"email": "a@b.com", "user_id": 42}
+    before = dict(inp)
     out = redact_sensitive(None, "info", inp)
-    assert out == inp
+    assert inp == before, "processor mutated its input dict"
+    assert out == before
+    assert out is not inp, "processor must return a new dict, not the input"
 
 
 def test_processor_recurses_into_lists_of_dicts():

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/Makefile
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/Makefile
@@ -30,7 +30,11 @@ docker-down:             ## Stop all services and remove volumes
 	docker compose down -v
 
 test-conformance:        ## Run all 3 test layers against an already-running service (PROFILE=smoke|thorough|exhaustive)
-	uv run python tests/run_conformance.py $(PROFILE)
+	@if [ ! -f tests/run_conformance.py ]; then \
+		echo "tests/run_conformance.py not found — re-compile with --with-tests to generate the conformance suite. Skipping."; \
+	else \
+		uv run python tests/run_conformance.py $(PROFILE); \
+	fi
 
 test-conformance-docker: ## Boot service via docker compose, run conformance, tear down (PROFILE=...)
 	@set -e; \

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -36,19 +37,20 @@ app.add_middleware(
 )
 
 
-app.include_router(url_mappings.router)
-
-
-
-import os as _os
-if _os.environ.get("ENABLE_TEST_ADMIN") == "1":
-    try:
-        from app.routers import test_admin as _test_admin
-        app.include_router(_test_admin.router)
-    except ImportError:
-        pass
-
-
 @app.get("/health", tags=["infrastructure"])
 async def health_check() -> dict[str, str]:
     return {"status": "ok"}
+
+
+if os.environ.get("ENABLE_TEST_ADMIN") == "1":
+    try:
+        from app.routers import test_admin as _test_admin
+    except ModuleNotFoundError as exc:
+        if exc.name != "app.routers.test_admin":
+            raise
+    else:
+        app.include_router(_test_admin.router)
+
+
+app.include_router(url_mappings.router)
+

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/redaction.py
@@ -31,7 +31,8 @@ _REDACTED: str = "***REDACTED***"
 
 
 def is_sensitive(name: str) -> bool:
-    return name in _SENSITIVE_EXACT or name.endswith(_SENSITIVE_SUFFIXES)
+    n = name.lower()
+    return n in _SENSITIVE_EXACT or n.endswith(_SENSITIVE_SUFFIXES)
 
 
 def _redact_value(value: Any) -> Any:

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/tests/test_log_redaction.py
@@ -32,9 +32,22 @@ def test_is_sensitive_matches_exact_and_suffix():
     assert not is_sensitive("display_name")
 
 
+def test_is_sensitive_is_case_insensitive():
+    assert is_sensitive("Password")
+    assert is_sensitive("API_KEY")
+    assert is_sensitive("Session_Token")
+    assert is_sensitive("USER_PASSWORD")
+
+
 def test_processor_redacts_top_level_sensitive_keys():
     out = redact_sensitive(None, "info", {"event": "login", "password": "hunter2"})
     assert out == {"event": "login", "password": "***REDACTED***"}
+
+
+def test_processor_redacts_mixed_case_sensitive_keys():
+    out = redact_sensitive(None, "info", {"Password": "hunter2", "API_KEY": "k"})
+    assert out["Password"] == "***REDACTED***"
+    assert out["API_KEY"] == "***REDACTED***"
 
 
 def test_processor_recurses_into_nested_dicts():

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/tests/test_log_redaction.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/tests/test_log_redaction.py
@@ -51,8 +51,11 @@ def test_processor_recurses_into_nested_dicts():
 
 def test_processor_pure_function_does_not_mask_non_sensitive():
     inp = {"email": "a@b.com", "user_id": 42}
+    before = dict(inp)
     out = redact_sensitive(None, "info", inp)
-    assert out == inp
+    assert inp == before, "processor mutated its input dict"
+    assert out == before
+    assert out is not inp, "processor must return a new dict, not the input"
 
 
 def test_processor_recurses_into_lists_of_dicts():

--- a/modules/codegen/src/main/resources/templates/python/fastapi/Makefile.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/Makefile.hbs
@@ -30,7 +30,11 @@ docker-down:             ## Stop all services and remove volumes
 	docker compose down -v
 
 test-conformance:        ## Run all 3 test layers against an already-running service (PROFILE=smoke|thorough|exhaustive)
-	uv run python tests/run_conformance.py $(PROFILE)
+	@if [ ! -f tests/run_conformance.py ]; then \
+		echo "tests/run_conformance.py not found — re-compile with --with-tests to generate the conformance suite. Skipping."; \
+	else \
+		uv run python tests/run_conformance.py $(PROFILE); \
+	fi
 
 test-conformance-docker: ## Boot service via docker compose, run conformance, tear down (PROFILE=...)
 	@set -e; \

--- a/modules/codegen/src/main/resources/templates/python/fastapi/app/redaction.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/app/redaction.py.hbs
@@ -31,7 +31,8 @@ _REDACTED: str = "***REDACTED***"
 
 
 def is_sensitive(name: str) -> bool:
-    return name in _SENSITIVE_EXACT or name.endswith(_SENSITIVE_SUFFIXES)
+    n = name.lower()
+    return n in _SENSITIVE_EXACT or n.endswith(_SENSITIVE_SUFFIXES)
 
 
 def _redact_value(value: Any) -> Any:

--- a/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
@@ -1,5 +1,6 @@
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+import os
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -35,20 +36,21 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-{{#each entities}}
-app.include_router({{snake_case (pluralize this.entityName)}}.router)
-{{/each}}
-
-
-import os as _os
-if _os.environ.get("ENABLE_TEST_ADMIN") == "1":
-    try:
-        from app.routers import test_admin as _test_admin
-        app.include_router(_test_admin.router)
-    except ImportError:
-        pass
-
 
 @app.get("/health", tags=["infrastructure"])
 async def health_check() -> dict[str, str]:
     return {"status": "ok"}
+
+
+if os.environ.get("ENABLE_TEST_ADMIN") == "1":
+    try:
+        from app.routers import test_admin as _test_admin
+    except ModuleNotFoundError as exc:
+        if exc.name != "app.routers.test_admin":
+            raise
+    else:
+        app.include_router(_test_admin.router)
+
+{{#each entities}}
+app.include_router({{snake_case (pluralize this.entityName)}}.router)
+{{/each}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/tests/test_log_redaction.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/tests/test_log_redaction.py.hbs
@@ -32,9 +32,22 @@ def test_is_sensitive_matches_exact_and_suffix():
     assert not is_sensitive("display_name")
 
 
+def test_is_sensitive_is_case_insensitive():
+    assert is_sensitive("Password")
+    assert is_sensitive("API_KEY")
+    assert is_sensitive("Session_Token")
+    assert is_sensitive("USER_PASSWORD")
+
+
 def test_processor_redacts_top_level_sensitive_keys():
     out = redact_sensitive(None, "info", {"event": "login", "password": "hunter2"})
     assert out == {"event": "login", "password": "***REDACTED***"}
+
+
+def test_processor_redacts_mixed_case_sensitive_keys():
+    out = redact_sensitive(None, "info", {"Password": "hunter2", "API_KEY": "k"})
+    assert out["Password"] == "***REDACTED***"
+    assert out["API_KEY"] == "***REDACTED***"
 
 
 def test_processor_recurses_into_nested_dicts():

--- a/modules/codegen/src/main/resources/templates/python/fastapi/tests/test_log_redaction.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/tests/test_log_redaction.py.hbs
@@ -51,8 +51,11 @@ def test_processor_recurses_into_nested_dicts():
 
 def test_processor_pure_function_does_not_mask_non_sensitive():
     inp = {"email": "a@b.com", "user_id": 42}
+    before = dict(inp)
     out = redact_sensitive(None, "info", inp)
-    assert out == inp
+    assert inp == before, "processor mutated its input dict"
+    assert out == before
+    assert out is not inp, "processor must return a new dict, not the input"
 
 
 def test_processor_recurses_into_lists_of_dicts():


### PR DESCRIPTION
Fixes the genuine pre-existing bugs surfaced across the recent review cycles. All in the **python/fastapi** emitter — go-chi/ts-express verified unaffected.

## Fixes

| # | Severity | Issue | Fix |
|---|----------|-------|-----|
| 1 | **HIGH** | `/health` defined *after* entity routers in `main.py`; a root path-param GET (url_shortener's `Resolve` = `GET /{code}`) shadowed it under Starlette registration-order matching → `GET /health` hit the Resolve stub (500). | `/health` + test_admin router now register **before** entity routers. **Verified:** `GET /health → 200`, `/openapi.json → 200`, real `/{code}` still routes to Resolve. (ts-express already registers `/health` first; go-chi's radix router prefers static over `{param}` — both confirmed safe.) |
| 2 | MED | `main.py` Ruff **E402** (`import os` after executable code) + broad `except ImportError: pass` masking real errors in the test_admin import. | `import os` moved to top; narrowed to `except ModuleNotFoundError` guarded on the specific module name (`try/except/else`), so real errors inside test_admin still raise. |
| 3 | MED (sec) | `redaction.py` matched sensitive keys **case-sensitively** → `Password`, `API_KEY`, `Session_Token` leaked into logs. | Lowercase the key before exact/suffix checks. |
| 4 | LOW-MED | `make test-conformance` failed opaquely when emitted **without** `--with-tests` (`run_conformance.py` absent). | Guarded: clear message + graceful skip when the runner is absent. |
| 5 | NIT | `test_log_redaction` purity test only checked value equality. | Now asserts the input dict is unmutated **and** a new object is returned. |

## pyproject dependency-CVE finding — evaluated, dismissed

CodeRabbit (#263) flagged CVEs in generated deps. The cited versions/advisories (asyncpg 0.31.0, uvicorn 0.47.0, fastapi 0.136.1, SQLAlchemy `order_by` SQLi) **do not correspond to real releases or advisories** — verified via web research (May 2026). Generated deps use floor constraints on maintained majors; `uv` resolves patched releases at install. No change — acting on hallucinated CVEs would be wrong. (See PR discussion for sources.)

## Test plan

- [x] Route-shadow verified in-process: `GET /health → 200`, `/openapi.json → 200`
- [x] codegen 199/199 (incl. `EmitPythonTest` byte-exact vs regenerated goldens, `EmitGoTest`/`EmitTsTest` unchanged → confirms python-only)
- [x] testgen 233/233, cli 56/56
- [x] 12 python url_shortener goldens regenerated (only main.py / redaction.py / Makefile / test_log_redaction.py changed; go/ts untouched)
- [ ] CI: python-build + go/ts-build matrices green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness in generated `fastapi` apps: route order, case-insensitive log redaction, lint-safe imports, and Makefile behavior. Adds explicit tests to lock in the redaction logic; only the Python/FastAPI emitter changed (Go/TS unaffected).

- **Bug Fixes**
  - Register `/health` and optional `test_admin` before entity routers to prevent path-param routes from shadowing `/health`.
  - Move `import os` to the top and narrow `test_admin` import handling to `ModuleNotFoundError` so real errors surface.
  - Make redaction key checks case-insensitive and add regression tests for mixed-case keys; keep the processor pure (no mutation, returns a new dict).
  - Make `make test-conformance` skip with a clear message when `tests/run_conformance.py` is missing.

<sup>Written for commit 8da465035154843d117cb33743dedbe6d3696fe5. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/267?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sensitive data field detection now uses case-insensitive matching in redaction logic.
  * Optional test suite now gracefully handles missing test files instead of failing.

* **Tests**
  * Redaction processor tests strengthened to verify immutability and confirm new objects are returned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->