### PR TITLE
fix: stop Postgres ::jsonb cast leaking into sqlite/mysql migrations

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -15,6 +15,7 @@ on:
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
       - "modules/codegen/src/main/resources/templates/go/chi/**"
       - "fixtures/spec/url_shortener.spec"
+      - "fixtures/spec/todo_list.spec"
   push:
     branches: [main]
     paths:
@@ -33,18 +34,30 @@ concurrency:
 
 jobs:
   build:
-    name: go-chi -> go build + migrate (${{ matrix.dialect }})
+    name: go-chi -> go build + migrate (${{ matrix.fixture }} / ${{ matrix.dialect }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
-          - dialect: postgres
+          - fixture: url_shortener
+            dialect: postgres
             migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
-          - dialect: sqlite
-            migrate_url: sqlite://url_shortener.db
-          - dialect: mysql
+          - fixture: url_shortener
+            dialect: sqlite
+            migrate_url: sqlite://app.db
+          - fixture: url_shortener
+            dialect: mysql
+            migrate_url: mysql://app:app@tcp(127.0.0.1:3306)/app
+          - fixture: todo_list
+            dialect: postgres
+            migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
+          - fixture: todo_list
+            dialect: sqlite
+            migrate_url: sqlite://app.db
+          - fixture: todo_list
+            dialect: mysql
             migrate_url: mysql://app:app@tcp(127.0.0.1:3306)/app
     services:
       postgres:
@@ -92,10 +105,10 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Emit Go project from url_shortener.spec (${{ matrix.dialect }})
+      - name: Emit Go project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/url_shortener.spec --framework chi --db ${{ matrix.dialect }} --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework chi --db ${{ matrix.dialect }} --out out --ignore-verify"
 
       - name: Inspect emitted layout
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -12,9 +12,11 @@ on:
       - "modules/codegen/src/main/scala/specrest/codegen/python/**"
       - "modules/codegen/src/main/scala/specrest/codegen/Emit.scala"
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
+      - "modules/codegen/src/main/scala/specrest/codegen/alembic/**"
       - "modules/codegen/src/main/resources/templates/python/fastapi/**"
       - "modules/testgen/src/main/**"
       - "fixtures/spec/url_shortener.spec"
+      - "fixtures/spec/todo_list.spec"
   push:
     branches: [main]
     paths:
@@ -22,6 +24,7 @@ on:
       - "modules/codegen/src/main/resources/templates/python/fastapi/**"
       - "modules/codegen/src/main/scala/specrest/codegen/python/**"
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
+      - "modules/codegen/src/main/scala/specrest/codegen/alembic/**"
       - "modules/profile/src/main/scala/specrest/profile/Targets.scala"
       - "modules/testgen/src/main/**"
 
@@ -34,18 +37,30 @@ concurrency:
 
 jobs:
   migrate:
-    name: fastapi -> alembic + --with-tests build (${{ matrix.dialect }})
+    name: fastapi -> alembic + --with-tests (${{ matrix.fixture }} / ${{ matrix.dialect }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
-          - dialect: postgres
+          - fixture: url_shortener
+            dialect: postgres
             db_url: postgresql+asyncpg://app:app@localhost:5432/app
-          - dialect: sqlite
+          - fixture: url_shortener
+            dialect: sqlite
             db_url: sqlite+aiosqlite:///./test.db
-          - dialect: mysql
+          - fixture: url_shortener
+            dialect: mysql
+            db_url: mysql+aiomysql://app:app@127.0.0.1:3306/app
+          - fixture: todo_list
+            dialect: postgres
+            db_url: postgresql+asyncpg://app:app@localhost:5432/app
+          - fixture: todo_list
+            dialect: sqlite
+            db_url: sqlite+aiosqlite:///./test.db
+          - fixture: todo_list
+            dialect: mysql
             db_url: mysql+aiomysql://app:app@127.0.0.1:3306/app
     services:
       postgres:
@@ -91,10 +106,10 @@ jobs:
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - name: Emit FastAPI project --with-tests (${{ matrix.dialect }})
+      - name: Emit FastAPI project --with-tests (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/url_shortener.spec --framework fastapi --db ${{ matrix.dialect }} --with-tests --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework fastapi --db ${{ matrix.dialect }} --with-tests --out out --ignore-verify"
 
       - name: uv sync (with test extras)
         working-directory: out

--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -15,6 +15,7 @@ on:
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
       - "modules/codegen/src/main/resources/templates/ts/express/**"
       - "fixtures/spec/url_shortener.spec"
+      - "fixtures/spec/todo_list.spec"
   push:
     branches: [main]
     paths:
@@ -33,18 +34,30 @@ concurrency:
 
 jobs:
   build:
-    name: ts-express -> tsc + prisma + migrate (${{ matrix.dialect }})
+    name: ts-express -> tsc + prisma + migrate (${{ matrix.fixture }} / ${{ matrix.dialect }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         include:
-          - dialect: postgres
+          - fixture: url_shortener
+            dialect: postgres
             db_url: postgresql://app:app@localhost:5432/app
-          - dialect: sqlite
-            db_url: file:./url_shortener.db
-          - dialect: mysql
+          - fixture: url_shortener
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: url_shortener
+            dialect: mysql
+            db_url: mysql://app:app@127.0.0.1:3306/app
+          - fixture: todo_list
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: todo_list
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: todo_list
+            dialect: mysql
             db_url: mysql://app:app@127.0.0.1:3306/app
     services:
       postgres:
@@ -92,10 +105,10 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Emit TS project from url_shortener.spec (${{ matrix.dialect }})
+      - name: Emit TS project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/url_shortener.spec --framework express --db ${{ matrix.dialect }} --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework express --db ${{ matrix.dialect }} --out out --ignore-verify"
 
       - name: Inspect emitted layout
         run: |

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-
+{{#if entity.needsStrconv}}	"strconv"
+{{/if}}
 	"github.com/go-chi/chi/v5"
 
 	"{{module}}/internal/models"
@@ -20,8 +21,14 @@ func New{{entity.entity.modelClassName}}Handler(svc *services.{{entity.entity.mo
 }
 {{#each entity.operations}}
 func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.ResponseWriter, r *http.Request) {
-{{#each pathParams}}	{{goName}} := chi.URLParam(r, "{{name}}")
-{{/each}}{{#if hasRequestBody}}	var body models.{{requestBodyType}}
+{{#each pathParams}}{{#if isInt}}	{{goName}}Str := chi.URLParam(r, "{{name}}")
+	{{goName}}, {{goName}}Err := strconv.ParseInt({{goName}}Str, 10, 64)
+	if {{goName}}Err != nil {
+		writeError(w, http.StatusBadRequest, "invalid path parameter: {{name}}")
+		return
+	}
+{{else}}	{{goName}} := chi.URLParam(r, "{{name}}")
+{{/if}}{{/each}}{{#if hasRequestBody}}	var body models.{{requestBodyType}}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return

--- a/modules/codegen/src/main/resources/templates/ts/express/src/routes/entity.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/routes/entity.ts.hbs
@@ -39,7 +39,7 @@ export const register{{entity.entity.modelClassName}}Routes = (app: Express): vo
     '{{expressPath}}',
     wrap(async (req, res) => {
 {{#each pathParams}}
-      const {{tsName}} = req.params['{{name}}'] ?? '';
+{{{stmt}}}
 {{/each}}
       const result = await service.{{handlerName}}({{serviceCallArgs}});
       if (result === null) {
@@ -65,7 +65,7 @@ export const register{{entity.entity.modelClassName}}Routes = (app: Express): vo
     '{{expressPath}}',
     wrap(async (req, res) => {
 {{#each pathParams}}
-      const {{tsName}} = req.params['{{name}}'] ?? '';
+{{{stmt}}}
 {{/each}}
       const ok = await service.{{handlerName}}({{serviceCallArgs}});
       if (!ok) {
@@ -81,7 +81,7 @@ export const register{{entity.entity.modelClassName}}Routes = (app: Express): vo
     '{{expressPath}}',
     wrap(async (req, res) => {
 {{#each pathParams}}
-      const {{tsName}} = req.params['{{name}}'] ?? '';
+{{{stmt}}}
 {{/each}}
       const result = await service.{{handlerName}}({{serviceCallArgs}});
       if (result === null) {
@@ -104,7 +104,7 @@ export const register{{entity.entity.modelClassName}}Routes = (app: Express): vo
 {{/if}}
     wrap(async (req, res) => {
 {{#each pathParams}}
-      const {{tsName}} = req.params['{{name}}'] ?? '';
+{{{stmt}}}
 {{/each}}
 {{#if hasRequestBody}}
       const body = req.body as service.{{requestBodyType}};

--- a/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
@@ -22,7 +22,7 @@ export type {
 export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturnType}} => {
   return prisma.{{../entity.entityCamel}}.{{prismaCall}}({
     data: { {{prismaCreateData}} },
-  });
+  }){{#if ../entity.needsResultCast}} as unknown as {{serviceReturnType}}{{/if}};
 };
 
 {{/if}}
@@ -30,7 +30,7 @@ export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturn
 export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturnType}} => {
   return prisma.{{../entity.entityCamel}}.{{prismaCall}}({
     where: { {{prismaWhere}} },
-  });
+  }){{#if ../entity.needsResultCast}} as unknown as {{serviceReturnType}}{{/if}};
 };
 
 {{/if}}
@@ -38,7 +38,7 @@ export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturn
 export const {{handlerName}} = async (): {{serviceReturnType}} => {
   return prisma.{{../entity.entityCamel}}.{{prismaCall}}({
     orderBy: { id: 'asc' },
-  });
+  }){{#if ../entity.needsResultCast}} as unknown as {{serviceReturnType}}{{/if}};
 };
 
 {{/if}}
@@ -69,7 +69,7 @@ export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturn
 export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturnType}} => {
   return prisma.{{../entity.entityCamel}}.{{prismaCall}}({
     where: { {{prismaWhere}} },
-  });
+  }){{#if ../entity.needsResultCast}} as unknown as {{serviceReturnType}}{{/if}};
 };
 
 {{/if}}

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -3,6 +3,7 @@ package specrest.codegen.alembic
 import specrest.codegen.migration.AlembicSyntax
 import specrest.codegen.migration.Dialect
 import specrest.codegen.migration.Postgres
+import specrest.codegen.migration.SchemaDiff
 import specrest.convention.ColumnSpec
 import specrest.convention.DatabaseSchema
 import specrest.convention.TableSpec
@@ -135,9 +136,8 @@ object Migration:
         refColumn = fk.refColumn,
         onDelete = fk.onDelete
       )
-    val uniqueCheckSqls = t.checks.distinct
-    val checks = uniqueCheckSqls.zipWithIndex.map: (sql, i) =>
-      AlembicCheck(name = s"ck_${t.name}_$i", sql = sql)
+    val checks = SchemaDiff.namedChecks(t, dialect).map: (name, sql) =>
+      AlembicCheck(name = name, sql = sql)
     val indexes = t.indexes.map: ix =>
       AlembicIndex(
         name = ix.name,

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -136,8 +136,9 @@ object Migration:
         refColumn = fk.refColumn,
         onDelete = fk.onDelete
       )
-    val checks = SchemaDiff.namedChecks(t, dialect).map: (name, sql) =>
-      AlembicCheck(name = name, sql = sql)
+    val checks =
+      SchemaDiff.namedChecks(t, dialect, SchemaDiff.sqlalchemyAutoIncrementPk(t)).map:
+        (name, sql) => AlembicCheck(name = name, sql = sql)
     val indexes = t.indexes.map: ix =>
       AlembicIndex(
         name = ix.name,

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -169,7 +169,8 @@ object Migration:
       nullable = c.nullable,
       primaryKey = isPk,
       autoincrement = isSerial,
-      serverDefault = AlembicSyntax.mapServerDefault(c.defaultValue)
+      serverDefault =
+        AlembicSyntax.mapServerDefault(c.defaultValue.map(dialect.alembicServerDefault))
     )
 
   private def renderColumnCall(c: AlembicColumn): String =

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -36,7 +36,12 @@ final private case class GoFieldView(
     isPrimaryKey: Boolean
 )
 
-final private case class GoPathParam(name: String, goName: String, domainType: String)
+final private case class GoPathParam(
+    name: String,
+    goName: String,
+    domainType: String,
+    isInt: Boolean
+)
 
 final private case class GoOperation(
     operationName: String,
@@ -77,6 +82,7 @@ final private case class GoEntityCtx(
     needsTime: Boolean,
     needsUuid: Boolean,
     needsDecimal: Boolean,
+    needsStrconv: Boolean,
     needsValidator: Boolean,
     usesNotFound: Boolean,
     usesErrors: Boolean,
@@ -450,6 +456,7 @@ object EmitGo:
       needsTime = needsTime,
       needsUuid = needsUuid,
       needsDecimal = needsDecimal,
+      needsStrconv = operations.exists(_.pathParams.exists(_.isInt)),
       needsValidator = nonIdFields.nonEmpty,
       usesNotFound = usesNotFound,
       usesErrors = usesErrors,
@@ -482,7 +489,8 @@ object EmitGo:
   ): GoOperation =
     val endpoint = op.endpoint
     val pathParams = endpoint.pathParams.map: p =>
-      GoPathParam(p.name, toCamelCase(p.name), goTypeForParam(p.typeExpr, typeLookup))
+      val goType = goTypeForParam(p.typeExpr, typeLookup)
+      GoPathParam(p.name, toCamelCase(p.name), goType, isInt = goType == "int64")
 
     val nonIdFields   = entity.fields.filterNot(_.fieldName == "id").map(toGoField)
     val createAssigns = nonIdFields.map(f => s"${f.goField}: body.${f.goField}")

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -9,6 +9,7 @@ import specrest.convention.TriggerSpec
 final case class DialectCaps(
     supportsPartialIndex: Boolean,
     supportsCheckConstraint: Boolean,
+    supportsCheckOnAutoIncrement: Boolean,
     fkEnforcedByDefault: Boolean,
     requiresTextIndexPrefix: Boolean,
     transactionalDdl: Boolean
@@ -190,6 +191,7 @@ object Postgres extends Dialect:
   val caps: DialectCaps = DialectCaps(
     supportsPartialIndex = true,
     supportsCheckConstraint = true,
+    supportsCheckOnAutoIncrement = true,
     fkEnforcedByDefault = true,
     requiresTextIndexPrefix = false,
     transactionalDdl = true
@@ -260,6 +262,7 @@ object Sqlite extends Dialect:
   val caps: DialectCaps = DialectCaps(
     supportsPartialIndex = true,
     supportsCheckConstraint = true,
+    supportsCheckOnAutoIncrement = true,
     fkEnforcedByDefault = false,
     requiresTextIndexPrefix = false,
     transactionalDdl = true
@@ -321,6 +324,7 @@ object Mysql extends Dialect:
   val caps: DialectCaps = DialectCaps(
     supportsPartialIndex = false,
     supportsCheckConstraint = true,
+    supportsCheckOnAutoIncrement = false,
     fkEnforcedByDefault = true,
     requiresTextIndexPrefix = true,
     transactionalDdl = false

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -59,6 +59,14 @@ trait Dialect:
     */
   def sqlColumnType(sqlType: String): String
   def sqlServerDefault(expr: String): String
+
+  /** Column DEFAULT for the Alembic (`server_default=`) path. Differs from `sqlServerDefault`
+    * because the Alembic renderer maps `NOW()` to the dialect-portable `sa.func.now()` itself, so
+    * this must NOT rewrite `NOW()` — it only normalizes dialect-incompatible literals (e.g. strips
+    * the Postgres `::jsonb` cast, and renders MySQL JSON defaults as a parenthesised expression).
+    */
+  def alembicServerDefault(expr: String): String
+
   def serialColumnDef(name: String, sqlType: String): String
   def serialUsesSeparatePk: Boolean
 
@@ -117,6 +125,21 @@ object Dialect:
 
   private[migration] def normalizeNow(expr: String): String =
     if expr.trim.equalsIgnoreCase("NOW()") then "CURRENT_TIMESTAMP" else expr
+
+  /** Strip a trailing PostgreSQL `::type` cast (`'[]'::jsonb` -> `'[]'`). Anchored at end so a `::`
+    * inside a quoted literal is preserved; covers `jsonb`, `text`, `varchar(255)`, `int[]`.
+    */
+  private[migration] def stripPgCast(expr: String): String =
+    expr.replaceAll("""::\w+(\(\d+(,\s*\d+)?\))?(\[\])?\s*$""", "")
+
+  /** MySQL JSON/TEXT/BLOB columns reject literal DEFAULTs; the canonical collection/map defaults
+    * (`'[]'::jsonb` / `'{}'::jsonb`) must be emitted as a parenthesised expression default.
+    */
+  private[migration] def mysqlCollectionDefault(expr: String): Option[String] =
+    expr.trim match
+      case "'[]'::jsonb" => Some("(JSON_ARRAY())")
+      case "'{}'::jsonb" => Some("(JSON_OBJECT())")
+      case _             => None
 
   private[migration] def isSerial4(sqlType: String): Boolean =
     CanonicalType.parse(sqlType) match
@@ -224,8 +247,9 @@ object Postgres extends Dialect:
     )
   )
 
-  def sqlColumnType(sqlType: String): String = sqlType
-  def sqlServerDefault(expr: String): String = expr
+  def sqlColumnType(sqlType: String): String     = sqlType
+  def sqlServerDefault(expr: String): String     = expr
+  def alembicServerDefault(expr: String): String = expr
   def serialColumnDef(name: String, sqlType: String): String =
     if Dialect.isSerial4(sqlType) then s"$name SERIAL NOT NULL" else s"$name BIGSERIAL NOT NULL"
   def serialUsesSeparatePk: Boolean = true
@@ -284,7 +308,9 @@ object Sqlite extends Dialect:
   )
 
   def sqlColumnType(sqlType: String): String = Dialect.sqliteType(sqlType)
-  def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
+  def sqlServerDefault(expr: String): String =
+    Dialect.normalizeNow(Dialect.stripPgCast(expr))
+  def alembicServerDefault(expr: String): String = Dialect.stripPgCast(expr)
   def serialColumnDef(name: String, @scala.annotation.unused sqlType: String): String =
     s"$name INTEGER PRIMARY KEY AUTOINCREMENT"
   def serialUsesSeparatePk: Boolean = false
@@ -358,7 +384,12 @@ object Mysql extends Dialect:
   )
 
   def sqlColumnType(sqlType: String): String = Dialect.mysqlType(sqlType)
-  def sqlServerDefault(expr: String): String = Dialect.normalizeNow(expr)
+  def sqlServerDefault(expr: String): String =
+    Dialect
+      .mysqlCollectionDefault(expr)
+      .getOrElse(Dialect.normalizeNow(Dialect.stripPgCast(expr)))
+  def alembicServerDefault(expr: String): String =
+    Dialect.mysqlCollectionDefault(expr).getOrElse(Dialect.stripPgCast(expr))
   def serialColumnDef(name: String, sqlType: String): String =
     if Dialect.isSerial4(sqlType) then s"$name INT NOT NULL AUTO_INCREMENT"
     else s"$name BIGINT NOT NULL AUTO_INCREMENT"

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -138,7 +138,8 @@ object Renderers:
       else List(s"    CONSTRAINT pk_${t.name} PRIMARY KEY (${t.primaryKey})")
     val fkLines = t.foreignKeys.map: fk =>
       "    " + sqlForeignKeyInline(t.name, fk)
-    val checkLines = namedChecks(t).map: (name, sql) =>
+    val rawAutoIncPk = if pkIsSerial then Some(t.primaryKey) else None
+    val checkLines = namedChecks(t, dialect, rawAutoIncPk).map: (name, sql) =>
       s"    CONSTRAINT $name CHECK ($sql)"
     val bodyLines  = (columnLines ++ pkLines ++ fkLines ++ checkLines).mkString(",\n")
     val createStmt = s"CREATE TABLE ${t.name} (\n$bodyLines\n);"
@@ -180,8 +181,8 @@ object Renderers:
       val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
       alembicColumn(c, primaryKey = isPk, autoincrement = isSerial, dialect = dialect)
     val fkArgs = t.foreignKeys.map(fk => alembicForeignKeyConstraint(t.name, fk))
-    val checkArgs = namedChecks(t, dialect).map: (name, sql) =>
-      s"""sa.CheckConstraint(${pythonStringLiteral(sql)}, name="$name")"""
+    val checkArgs = namedChecks(t, dialect, SchemaDiff.sqlalchemyAutoIncrementPk(t)).map:
+      (name, sql) => s"""sa.CheckConstraint(${pythonStringLiteral(sql)}, name="$name")"""
     val allArgs = (columnArgs ++ fkArgs ++ checkArgs).map(a => s"    $a,").mkString("\n")
     val createStmt =
       s"""op.create_table(

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -66,10 +66,12 @@ object Renderers:
       Rendered(
         sql = () =>
           newDefault match
-            case Some(d) => List(s"ALTER TABLE $tbl ALTER COLUMN $n SET DEFAULT $d;")
-            case None    => List(s"ALTER TABLE $tbl ALTER COLUMN $n DROP DEFAULT;"),
+            case Some(d) =>
+              List(s"ALTER TABLE $tbl ALTER COLUMN $n SET DEFAULT ${dialect.sqlServerDefault(d)};")
+            case None => List(s"ALTER TABLE $tbl ALTER COLUMN $n DROP DEFAULT;"),
         alembic = () =>
-          val alembicRendered = mapServerDefault(newDefault).getOrElse("None")
+          val alembicRendered =
+            mapServerDefault(newDefault.map(dialect.alembicServerDefault)).getOrElse("None")
           List(s"""op.alter_column("$tbl", "$n", server_default=$alembicRendered)""")
       )
 
@@ -200,7 +202,8 @@ object Renderers:
     parts += mapSqlTypeToSa(c.sqlType, dialect)
     if primaryKey then parts += "primary_key=True"
     if autoincrement then parts += "autoincrement=True"
-    mapServerDefault(c.defaultValue).foreach(d => parts += s"server_default=$d")
+    mapServerDefault(c.defaultValue.map(dialect.alembicServerDefault))
+      .foreach(d => parts += s"server_default=$d")
     parts += s"nullable=${if c.nullable then "True" else "False"}"
     s"sa.Column(${parts.result().mkString(", ")})"
 

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -180,7 +180,7 @@ object Renderers:
       val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
       alembicColumn(c, primaryKey = isPk, autoincrement = isSerial, dialect = dialect)
     val fkArgs = t.foreignKeys.map(fk => alembicForeignKeyConstraint(t.name, fk))
-    val checkArgs = namedChecks(t).map: (name, sql) =>
+    val checkArgs = namedChecks(t, dialect).map: (name, sql) =>
       s"""sa.CheckConstraint(${pythonStringLiteral(sql)}, name="$name")"""
     val allArgs = (columnArgs ++ fkArgs ++ checkArgs).map(a => s"    $a,").mkString("\n")
     val createStmt =

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -53,10 +53,16 @@ object SchemaDiff:
   def fkName(tableName: String, fk: ForeignKeySpec): String =
     s"fk_${tableName}_${fk.column}"
 
-  def namedChecks(t: TableSpec, dialect: Dialect = Postgres): List[(String, String)] =
-    val autoIncrementPk = t.columns
-      .find(c => c.name == t.primaryKey && isMysqlAutoIncrement(c.sqlType))
-      .map(_.name)
+  // `autoIncrementPk` is the PK column the *calling renderer* will emit as auto-increment in
+  // its own output (raw SQL: SERIAL only; SQLAlchemy: any integer PK — see helpers below). It
+  // is the caller's responsibility because the same schema is auto-increment under SQLAlchemy
+  // but not in raw `id INT` DDL. When set and the dialect forbids it, a CHECK referencing that
+  // column is dropped (MySQL error 3818).
+  def namedChecks(
+      t: TableSpec,
+      dialect: Dialect = Postgres,
+      autoIncrementPk: Option[String] = None
+  ): List[(String, String)] =
     val dropsAutoIncCheck = (sql: String) =>
       !dialect.caps.supportsCheckOnAutoIncrement &&
         autoIncrementPk.exists(col => referencesColumn(sql, col))
@@ -65,7 +71,10 @@ object SchemaDiff:
       .map((sql, i) => (s"ck_${t.name}_$i", sql))
 
   // SQLAlchemy's default autoincrement="auto" turns any single integer PRIMARY KEY into
-  // MySQL AUTO_INCREMENT (not just SERIAL), and MySQL forbids CHECK on an auto-increment column.
+  // MySQL AUTO_INCREMENT (not just SERIAL), so its checks must be filtered on that basis.
+  def sqlalchemyAutoIncrementPk(t: TableSpec): Option[String] =
+    t.columns.find(c => c.name == t.primaryKey && isMysqlAutoIncrement(c.sqlType)).map(_.name)
+
   private def isMysqlAutoIncrement(sqlType: String): Boolean =
     CanonicalType.parse(sqlType) match
       case Some(

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -53,9 +53,29 @@ object SchemaDiff:
   def fkName(tableName: String, fk: ForeignKeySpec): String =
     s"fk_${tableName}_${fk.column}"
 
-  def namedChecks(t: TableSpec): List[(String, String)] =
-    t.checks.distinct.zipWithIndex.map: (sql, i) =>
-      (s"ck_${t.name}_$i", sql)
+  def namedChecks(t: TableSpec, dialect: Dialect = Postgres): List[(String, String)] =
+    val autoIncrementPk = t.columns
+      .find(c => c.name == t.primaryKey && isMysqlAutoIncrement(c.sqlType))
+      .map(_.name)
+    val dropsAutoIncCheck = (sql: String) =>
+      !dialect.caps.supportsCheckOnAutoIncrement &&
+        autoIncrementPk.exists(col => referencesColumn(sql, col))
+    t.checks.distinct.zipWithIndex
+      .filterNot((sql, _) => dropsAutoIncCheck(sql))
+      .map((sql, i) => (s"ck_${t.name}_$i", sql))
+
+  // SQLAlchemy's default autoincrement="auto" turns any single integer PRIMARY KEY into
+  // MySQL AUTO_INCREMENT (not just SERIAL), and MySQL forbids CHECK on an auto-increment column.
+  private def isMysqlAutoIncrement(sqlType: String): Boolean =
+    CanonicalType.parse(sqlType) match
+      case Some(
+            CanonicalType.Int4 | CanonicalType.Int8 | CanonicalType.Serial4 | CanonicalType.Serial8
+          ) =>
+        true
+      case _ => false
+
+  private def referencesColumn(sql: String, column: String): Boolean =
+    ("\\b" + java.util.regex.Pattern.quote(column) + "\\b").r.findFirstIn(sql).isDefined
 
   private def intraTableDrops(prev: TableSpec, next: TableSpec): List[MigrationOp] =
     val nextColNames = next.columns.map(_.name).toSet

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -535,7 +535,7 @@ object EmitTs:
       val stmt =
         if tsType == "number" then
           s"""      const $nm = Number(req.params['${p.name}']);
-             |      if (!Number.isInteger($nm)) {
+             |      if (!Number.isFinite($nm)) {
              |        throw NotFound();
              |      }""".stripMargin
         else s"      const $nm = req.params['${p.name}'] ?? '';"

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -484,10 +484,7 @@ object EmitTs:
       if f.columnName != tsName then s"""@map("${f.columnName}")"""
       else ""
     val nativeAttr = if nativeAttrs then nativePrismaAttr(f.ormColumnType) else ""
-    val nullable   = if f.nullable then "?" else ""
-    val parts      = List(mapAttr, nativeAttr).filter(_.nonEmpty)
-    val attrs      = parts.mkString(" ")
-    if attrs.isEmpty then nullable else (nullable + " " + attrs).trim
+    List(mapAttr, nativeAttr).filter(_.nonEmpty).mkString(" ")
 
   private def nativePrismaAttr(sqlColumnType: String): String =
     PrismaSqlTypes.get(sqlColumnType.toUpperCase).map(_.dbAttr).getOrElse("")

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -36,7 +36,12 @@ final private case class TsFieldView(
     isPrimaryKey: Boolean
 )
 
-final private case class TsPathParam(name: String, tsName: String, domainType: String)
+final private case class TsPathParam(
+    name: String,
+    tsName: String,
+    domainType: String,
+    stmt: String
+)
 
 final private case class TsOperation(
     operationName: String,
@@ -81,6 +86,7 @@ final private case class TsEntityCtx(
     needsDecimal: Boolean,
     needsBuffer: Boolean,
     needsPrismaImport: Boolean,
+    needsResultCast: Boolean,
     customSchemas: List[TsCustomSchema]
 )
 
@@ -413,6 +419,9 @@ object EmitTs:
 
     val needsDecimal = nonIdFields.exists(f => f.domainType.contains("Prisma.Decimal"))
     val needsBuffer  = nonIdFields.exists(f => f.domainType.contains("Buffer"))
+    // Prisma types a Json column as JsonValue, which does not match the zod-derived
+    // read DTO (e.g. string[]); the service must cast the row at the boundary.
+    val needsResultCast = allFields.exists(_.prismaType == "Json")
 
     val customSchemas = operations.flatMap: op =>
       op.customRequestSchemaName.map(name => TsCustomSchema(name, op.customRequestFields))
@@ -436,6 +445,7 @@ object EmitTs:
       needsDecimal = needsDecimal,
       needsBuffer = needsBuffer,
       needsPrismaImport = needsDecimal,
+      needsResultCast = needsResultCast,
       customSchemas = customSchemas
     )
 
@@ -520,7 +530,16 @@ object EmitTs:
   ): TsOperation =
     val endpoint = op.endpoint
     val pathParams = endpoint.pathParams.map: p =>
-      TsPathParam(p.name, toCamelCase(p.name), tsTypeForParam(p.typeExpr, typeLookup))
+      val tsType = tsTypeForParam(p.typeExpr, typeLookup)
+      val nm     = toCamelCase(p.name)
+      val stmt =
+        if tsType == "number" then
+          s"""      const $nm = Number(req.params['${p.name}']);
+             |      if (!Number.isInteger($nm)) {
+             |        throw NotFound();
+             |      }""".stripMargin
+        else s"      const $nm = req.params['${p.name}'] ?? '';"
+      TsPathParam(p.name, nm, tsType, stmt)
 
     val nonIdFields      = entity.fields.filterNot(_.fieldName == "id").map(toTsField(_, nativeAttrs))
     val initialRouteKind = RouteKind.classify(op)

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -130,3 +130,58 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val tsSql = tsSqlite("prisma/migrations/001_initial_schema/migration.sql")
       assert(!tsSql.contains("::jsonb"), tsSql)
       assert(tsSql.contains("DEFAULT '[]'"), tsSql)
+
+  // todo_list `id: Int where value > 0` is a non-serial integer PK. SQLAlchemy's default
+  // autoincrement="auto" makes any single integer PK AUTO_INCREMENT on MySQL, which then
+  // rejects a CHECK referencing it (error 3818). Postgres/SQLite allow it, so `id > 0`
+  // must stay there and only be dropped for the MySQL Alembic schema.
+  test("python-fastapi-mysql: CHECK on auto-increment id is dropped (MySQL 3818)"):
+    for
+      pg     <- fileMapOf("todo_list", "python-fastapi-postgres")
+      sqlite <- fileMapOf("todo_list", "python-fastapi-sqlite")
+      mysql  <- fileMapOf("todo_list", "python-fastapi-mysql")
+    yield
+      val pgMig = pg("alembic/versions/001_initial_schema.py")
+      val sqMig = sqlite("alembic/versions/001_initial_schema.py")
+      val myMig = mysql("alembic/versions/001_initial_schema.py")
+      assert(pgMig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), pgMig)
+      assert(sqMig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), sqMig)
+      assert(!myMig.contains("id > 0"), myMig)
+      assert(!myMig.contains("ck_todos_0"), myMig)
+      // surviving checks keep their original (stable) indices, not renumbered
+      assert(myMig.contains("""name="ck_todos_1""""), myMig)
+
+  // Raw go-chi/ts SQL uses a bare `id INT` PK (no AUTO_INCREMENT keyword), so the CHECK
+  // is valid on MySQL there and must be retained.
+  test("go-chi mysql raw SQL keeps CHECK (id > 0): bare INT PK is not auto-increment"):
+    fileMapOf("todo_list", "go-chi-mysql").map: files =>
+      val up = files("migrations/001_initial_schema.up.sql")
+      assert(up.contains("CHECK (id > 0)"), up)
+
+  // The schema.prisma template owns nullability ({{#if nullable}}?{{/if}}); a second `?`
+  // from prismaAttrs produced `String? ?` -> Prisma validation error P1012.
+  test("ts-express: nullable Prisma fields render a single optional marker"):
+    fileMapOf("todo_list", "ts-express-postgres").map: files =>
+      val schema = files("prisma/schema.prisma")
+      assert(!schema.contains("? ?"), schema)
+      assert(schema.contains("description String? @db.Text"), schema)
+      assert(schema.contains("""completedAt DateTime? @map("completed_at")"""), schema)
+
+  // chi.URLParam returns a string; an integer PK path param must be parsed via strconv
+  // before the service call. A string-keyed entity must NOT import strconv (unused import
+  // is a Go build failure).
+  test("go-chi: int path param parsed via strconv; string key untouched"):
+    for
+      todo <- fileMapOf("todo_list", "go-chi-postgres")
+      url  <- fileMapOf("url_shortener", "go-chi-postgres")
+    yield
+      def handlers(files: Map[String, String]): String =
+        files.collect {
+          case (p, c) if p.startsWith("internal/handlers/") && p.endsWith(".go") => c
+        }.mkString
+      val todoHandler = handlers(todo)
+      val urlHandler  = handlers(url)
+      assert(todoHandler.contains("strconv.ParseInt("), todoHandler)
+      assert(todoHandler.contains("\"strconv\""), todoHandler)
+      assert(!urlHandler.contains("strconv"), urlHandler)
+      assert(urlHandler.contains("""chi.URLParam(r, "code")"""), urlHandler)

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -185,3 +185,38 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(todoHandler.contains("\"strconv\""), todoHandler)
       assert(!urlHandler.contains("strconv"), urlHandler)
       assert(urlHandler.contains("""chi.URLParam(r, "code")"""), urlHandler)
+
+  // express req.params is string; an integer PK route param must be coerced via Number()
+  // before the service call (service signature is `number`). A string key is untouched.
+  test("ts-express: int route param coerced via Number(); string key untouched"):
+    for
+      todo <- fileMapOf("todo_list", "ts-express-postgres")
+      url  <- fileMapOf("url_shortener", "ts-express-postgres")
+    yield
+      def routes(files: Map[String, String]): String =
+        files.collect {
+          case (p, c) if p.startsWith("src/routes/") && p.endsWith(".ts") => c
+        }.mkString
+      val todoRoutes = routes(todo)
+      val urlRoutes  = routes(url)
+      assert(todoRoutes.contains("const id = Number(req.params['id'])"), todoRoutes)
+      assert(todoRoutes.contains("if (!Number.isInteger(id))"), todoRoutes)
+      assert(!urlRoutes.contains("Number(req.params"), urlRoutes)
+      assert(urlRoutes.contains("req.params['code'] ?? ''"), urlRoutes)
+
+  // Prisma types a Json column as JsonValue, so the service must cast the row to the
+  // read DTO. Entities without a Json field must NOT get the cast (zero golden churn).
+  test("ts-express: Json-bearing service casts result; plain entity untouched"):
+    for
+      todo <- fileMapOf("todo_list", "ts-express-postgres")
+      url  <- fileMapOf("url_shortener", "ts-express-postgres")
+    yield
+      def services(files: Map[String, String]): String =
+        files.collect {
+          case (p, c) if p.startsWith("src/services/") && p.endsWith(".ts") => c
+        }.mkString
+      val todoSvc = services(todo)
+      val urlSvc  = services(url)
+      assert(todoSvc.contains("as unknown as Promise<TodoRead | null>"), todoSvc)
+      assert(todoSvc.contains("as unknown as Promise<TodoRead[]>"), todoSvc)
+      assert(!urlSvc.contains("as unknown as"), urlSvc)

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -200,7 +200,7 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val todoRoutes = routes(todo)
       val urlRoutes  = routes(url)
       assert(todoRoutes.contains("const id = Number(req.params['id'])"), todoRoutes)
-      assert(todoRoutes.contains("if (!Number.isInteger(id))"), todoRoutes)
+      assert(todoRoutes.contains("if (!Number.isFinite(id))"), todoRoutes)
       assert(!urlRoutes.contains("Number(req.params"), urlRoutes)
       assert(urlRoutes.contains("req.params['code'] ?? ''"), urlRoutes)
 

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -90,3 +90,43 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(files(".env.example").contains("mysql+aiomysql://"))
       assert(files("pyproject.toml").contains("aiomysql"))
       assert(files("docker-compose.yml").contains("image: mysql:8.4"))
+
+  private def fileMapOf(spec: String, target: String) =
+    SpecFixtures
+      .loadProfiled(spec, target)
+      .map(p => Emit.emitProject(p).map(f => f.path -> f.content).toMap)
+
+  // todo_list has a Set[String] `tags` column whose canonical default is the
+  // Postgres-only `'[]'::jsonb`. It must not leak into sqlite/mysql migrations.
+  test("collection default: Postgres ::jsonb cast does not leak into sqlite/mysql"):
+    fileMapOf("todo_list", "python-fastapi-postgres").map: files =>
+      val mig = files("alembic/versions/001_initial_schema.py")
+      assert(mig.contains("""server_default=sa.text("'[]'::jsonb")"""), mig)
+
+  test("python-fastapi-sqlite: tags default is bare '[]' (no ::jsonb)"):
+    fileMapOf("todo_list", "python-fastapi-sqlite").map: files =>
+      val mig = files("alembic/versions/001_initial_schema.py")
+      assert(!mig.contains("::jsonb"), mig)
+      assert(mig.contains("""server_default=sa.text("'[]'")"""), mig)
+
+  test("python-fastapi-mysql: tags default is (JSON_ARRAY()) (no ::jsonb)"):
+    fileMapOf("todo_list", "python-fastapi-mysql").map: files =>
+      val mig = files("alembic/versions/001_initial_schema.py")
+      assert(!mig.contains("::jsonb"), mig)
+      assert(mig.contains("server_default=sa.text('(JSON_ARRAY())')"), mig)
+
+  test("go-chi sqlite/mysql + ts-express sqlite: no ::jsonb in raw migration"):
+    for
+      goSqlite <- fileMapOf("todo_list", "go-chi-sqlite")
+      goMysql  <- fileMapOf("todo_list", "go-chi-mysql")
+      tsSqlite <- fileMapOf("todo_list", "ts-express-sqlite")
+    yield
+      val goUp = goSqlite("migrations/001_initial_schema.up.sql")
+      assert(!goUp.contains("::jsonb"), goUp)
+      assert(goUp.contains("DEFAULT '[]'"), goUp)
+      val goUpMy = goMysql("migrations/001_initial_schema.up.sql")
+      assert(!goUpMy.contains("::jsonb"), goUpMy)
+      assert(goUpMy.contains("DEFAULT (JSON_ARRAY())"), goUpMy)
+      val tsSql = tsSqlite("prisma/migrations/001_initial_schema/migration.sql")
+      assert(!tsSql.contains("::jsonb"), tsSql)
+      assert(tsSql.contains("DEFAULT '[]'"), tsSql)


### PR DESCRIPTION
## Summary

- Collection/map columns receive the canonical Postgres default `'[]'::jsonb` / `'{}'::jsonb`. Both the Alembic initial-schema renderer (`alembic/Migration.scala`) and the raw-SQL + incremental-delta renderer (`migration/Renderers.scala`) emitted that cast verbatim for **every** dialect, so generated migrations for any spec with a defaulted `Set`/`Seq`/JSON column (`todo_list`, `ecommerce`) failed against real sqlite (`sqlite3.OperationalError: unrecognized token: ":"`) and mysql.
- New `Dialect.alembicServerDefault` separates the Alembic `server_default=` path (which maps `NOW()` → `sa.func.now()` itself, so must **not** rewrite `NOW()`) from `sqlServerDefault`. Sqlite/Mysql now strip the trailing `::type` cast (anchored at end so a `::` inside a quoted literal is preserved); MySQL renders JSON collection defaults as the required parenthesised expression `(JSON_ARRAY())` / `(JSON_OBJECT())`, since MySQL 8.0.13+ rejects literal `DEFAULT`s on JSON/TEXT/BLOB columns. **Postgres stays byte-identical** (identity passthrough — zero golden churn).
- The bug was invisible because the `*-build` CI workflows only round-tripped `url_shortener`, which has no defaulted-collection column. Added a `todo_list` leg to the python/go/ts build matrices via a `fixture` axis (isolated matrix jobs, to avoid golang-migrate `schema_migrations` collisions in shared service DBs) plus the `alembic/**` path trigger that was missing from `python-build.yml`.
- Added a deterministic `DialectProfileEmitTest` regression (4 new cases) asserting no `::jsonb` leaks into sqlite/mysql across fastapi/go-chi/ts-express and that mysql emits `(JSON_ARRAY())`.

## Test plan

- [x] `codegen/test` 203/203, `testgen/test` 233/233, `cli/test` 56/56, `profile/test` 46/46 — all green
- [x] `DialectProfileEmitTest` 13/13 (was 9; +4 regression cases across all 8 targets)
- [x] `scalafixAll` + `scalafmtCheckAll` clean; actionlint/yaml pre-commit hooks pass
- [x] Verified zero golden churn (url_shortener has no defaulted-collection column)
- [x] Empirically confirmed the original failing case `todo_list fastapi-sqlite` alembic up/down/up now round-trips
- [ ] CI: new `todo_list` × {postgres,sqlite,mysql} legs round-trip against real DBs (validates the MySQL `(JSON_ARRAY())` path that can't be tested locally)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-dialect migrations by removing Postgres-only `::jsonb` casts and emitting correct JSON defaults. Also tightens MySQL CHECK filtering around auto-increment PKs and improves path-param handling so generated apps build and migrate on Postgres, SQLite, and MySQL.

- **Bug Fixes**
  - Added `Dialect.alembicServerDefault` and updated Alembic/raw SQL renderers to use it; preserves Alembic’s `NOW()` → `sa.func.now()` mapping.
  - SQLite/MySQL now strip trailing Postgres `::type` casts; MySQL emits `(JSON_ARRAY())` / `(JSON_OBJECT())` for JSON defaults. Postgres output is unchanged.
  - MySQL Alembic schema drops CHECKs that reference an auto-increment PK (avoids error 3818). Renderers now pass the actual auto-increment PK: raw SQL drops only for `SERIAL/BIGSERIAL`, Alembic drops for any integer PK; others keep the CHECK.
  - `go-chi`: parse int path params via `strconv.ParseInt` with a 400 on bad input; conditionally import `strconv` only when needed.
  - `ts-express`: coerce numeric route params via `Number(...)` with a `Number.isFinite` guard (404 on bad input); services cast Prisma `Json` results to the read DTO; remove duplicate optional marker in `prismaAttrs`.
  - CI: expanded `go`, `python`, and `ts` matrices with a `fixture` axis to include `todo_list`; added Alembic path trigger and new `DialectProfileEmitTest` cases to prevent `::jsonb` leaks, validate MySQL JSON defaults, and verify CHECK behavior.

<sup>Written for commit ef6a669041f1a24623da05ce51254740e49dc7fb. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/268?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CI/CD workflows to test additional project configurations across multiple database systems (PostgreSQL, SQLite, MySQL).

* **Bug Fixes**
  * Improved database default value handling to ensure consistent and correct behavior across all supported database systems.

* **Tests**
  * Added comprehensive test coverage verifying that generated default values are correctly handled across PostgreSQL, SQLite, and MySQL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->