### PR TITLE
fix: enforce type-alias refinements as dialect-aware CHECKs; auth_service CI

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -17,6 +17,7 @@ on:
       - "fixtures/spec/url_shortener.spec"
       - "fixtures/spec/todo_list.spec"
       - "fixtures/spec/ecommerce.spec"
+      - "fixtures/spec/auth_service.spec"
   push:
     branches: [main]
     paths:
@@ -67,6 +68,15 @@ jobs:
             dialect: sqlite
             migrate_url: sqlite://app.db
           - fixture: ecommerce
+            dialect: mysql
+            migrate_url: mysql://app:app@tcp(127.0.0.1:3306)/app
+          - fixture: auth_service
+            dialect: postgres
+            migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
+          - fixture: auth_service
+            dialect: sqlite
+            migrate_url: sqlite://app.db
+          - fixture: auth_service
             dialect: mysql
             migrate_url: mysql://app:app@tcp(127.0.0.1:3306)/app
     services:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -18,6 +18,7 @@ on:
       - "fixtures/spec/url_shortener.spec"
       - "fixtures/spec/todo_list.spec"
       - "fixtures/spec/ecommerce.spec"
+      - "fixtures/spec/auth_service.spec"
   push:
     branches: [main]
     paths:
@@ -70,6 +71,15 @@ jobs:
             dialect: sqlite
             db_url: sqlite+aiosqlite:///./test.db
           - fixture: ecommerce
+            dialect: mysql
+            db_url: mysql+aiomysql://app:app@127.0.0.1:3306/app
+          - fixture: auth_service
+            dialect: postgres
+            db_url: postgresql+asyncpg://app:app@localhost:5432/app
+          - fixture: auth_service
+            dialect: sqlite
+            db_url: sqlite+aiosqlite:///./test.db
+          - fixture: auth_service
             dialect: mysql
             db_url: mysql+aiomysql://app:app@127.0.0.1:3306/app
     services:

--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -17,6 +17,7 @@ on:
       - "fixtures/spec/url_shortener.spec"
       - "fixtures/spec/todo_list.spec"
       - "fixtures/spec/ecommerce.spec"
+      - "fixtures/spec/auth_service.spec"
   push:
     branches: [main]
     paths:
@@ -67,6 +68,15 @@ jobs:
             dialect: sqlite
             db_url: file:./app.db
           - fixture: ecommerce
+            dialect: mysql
+            db_url: mysql://app:app@127.0.0.1:3306/app
+          - fixture: auth_service
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: auth_service
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: auth_service
             dialect: mysql
             db_url: mysql://app:app@127.0.0.1:3306/app
     services:

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
@@ -9,7 +9,11 @@ CREATE TABLE url_mappings (
     click_count INT NOT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
     CONSTRAINT pk_url_mappings PRIMARY KEY (id),
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_2 CHECK (code REGEXP '^[a-zA-Z0-9]+$'),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.up.sql
@@ -9,7 +9,11 @@ CREATE TABLE url_mappings (
     click_count INTEGER NOT NULL,
     updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
     CONSTRAINT pk_url_mappings PRIMARY KEY (id),
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_2 CHECK (code ~ '^[a-zA-Z0-9]+$'),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
@@ -8,7 +8,10 @@ CREATE TABLE url_mappings (
     created_at DATETIME NOT NULL,
     click_count INTEGER NOT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-16
+Create Date: 2026-05-17
 """
 from collections.abc import Sequence
 
@@ -33,7 +33,15 @@ def upgrade() -> None:
 
         sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
 
-        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_0"),
+        sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
+
+        sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
+
+        sa.CheckConstraint("code REGEXP '^[a-zA-Z0-9]+$'", name="ck_url_mappings_2"),
+
+        sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
+
+        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
 
     )
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-16
+Create Date: 2026-05-17
 """
 from collections.abc import Sequence
 
@@ -33,7 +33,15 @@ def upgrade() -> None:
 
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
 
-        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_0"),
+        sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
+
+        sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
+
+        sa.CheckConstraint("code ~ '^[a-zA-Z0-9]+$'", name="ck_url_mappings_2"),
+
+        sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
+
+        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
 
     )
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-16
+Create Date: 2026-05-17
 """
 from collections.abc import Sequence
 
@@ -33,7 +33,13 @@ def upgrade() -> None:
 
         sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
 
-        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_0"),
+        sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
+
+        sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
+
+        sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
+
+        sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
 
     )
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -10,7 +10,11 @@ CREATE TABLE url_mappings (
     click_count INT NOT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
     CONSTRAINT pk_url_mappings PRIMARY KEY (id),
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_2 CHECK (code REGEXP '^[a-zA-Z0-9]+$'),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -10,7 +10,11 @@ CREATE TABLE url_mappings (
     click_count INTEGER NOT NULL,
     updated_at TIMESTAMPTZ DEFAULT NOW() NOT NULL,
     CONSTRAINT pk_url_mappings PRIMARY KEY (id),
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_2 CHECK (code ~ '^[a-zA-Z0-9]+$'),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.spec-snapshot.json
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.spec-snapshot.json
@@ -47,6 +47,10 @@
         "foreignKeys" : [
         ],
         "checks" : [
+          "length(code) >= 6",
+          "length(code) <= 10",
+          "code ~ '^[a-zA-Z0-9]+$'",
+          "length(url) > 0",
           "click_count >= 0"
         ],
         "indexes" : [

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -9,7 +9,10 @@ CREATE TABLE url_mappings (
     created_at DATETIME NOT NULL,
     click_count INTEGER NOT NULL,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    CONSTRAINT ck_url_mappings_0 CHECK (click_count >= 0)
+    CONSTRAINT ck_url_mappings_0 CHECK (length(code) >= 6),
+    CONSTRAINT ck_url_mappings_1 CHECK (length(code) <= 10),
+    CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
+    CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
 
 

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -44,6 +44,12 @@ trait Dialect:
   def saType(t: CanonicalType): SaType
   def renderTrigger(t: TriggerSpec): TriggerEmission
   def rawTrigger(t: TriggerSpec): TriggerEmission
+
+  /** SQL for a regex CHECK predicate. Postgres `~`, MySQL `REGEXP`; SQLite has no regex in a CHECK
+    * (no `~`/REGEXP, no loadable extension at migrate time) so it returns None — the check is
+    * dropped for SQLite (regex stays enforced via the other dialects / app layer).
+    */
+  def regexCheck(column: String, pattern: String): Option[String]
   def partialIndex(ix: IndexSpec): FeatureEmission[String]
 
   /** Service-name-parameterised deployment facts (connection URLs, docker-compose db service,
@@ -241,6 +247,9 @@ object Postgres extends Dialect:
       downgrade = TriggerSql.dropStatements(t)
     )
 
+  def regexCheck(column: String, pattern: String): Option[String] =
+    Some(s"$column ~ '$pattern'")
+
   def partialIndex(ix: IndexSpec): FeatureEmission[String] =
     ix.filterClause match
       case Some(f) =>
@@ -307,6 +316,8 @@ object Sqlite extends Dialect:
   def renderTrigger(t: TriggerSpec): TriggerEmission = Dialect.perEventTriggerEmission(t)
   def rawTrigger(t: TriggerSpec): TriggerEmission    = Dialect.perEventRawTrigger(t)
 
+  def regexCheck(column: String, pattern: String): Option[String] = None
+
   def partialIndex(ix: IndexSpec): FeatureEmission[String] =
     ix.filterClause match
       case Some(f) =>
@@ -367,6 +378,9 @@ object Mysql extends Dialect:
 
   def renderTrigger(t: TriggerSpec): TriggerEmission = Dialect.perEventTriggerEmission(t)
   def rawTrigger(t: TriggerSpec): TriggerEmission    = Dialect.perEventRawTrigger(t)
+
+  def regexCheck(column: String, pattern: String): Option[String] =
+    Some(s"$column REGEXP '$pattern'")
 
   def partialIndex(ix: IndexSpec): FeatureEmission[String] =
     ix.filterClause match

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -6,6 +6,7 @@ import specrest.codegen.migration.AlembicSyntax.pythonStringLiteral
 import specrest.codegen.migration.MigrationOp.*
 import specrest.codegen.migration.SchemaDiff.fkName
 import specrest.codegen.migration.SchemaDiff.namedChecks
+import specrest.codegen.migration.SchemaDiff.rewriteCheck
 import specrest.convention.ColumnSpec
 import specrest.convention.ForeignKeySpec
 import specrest.convention.IndexSpec
@@ -76,10 +77,15 @@ object Renderers:
       )
 
     case AddCheck(tbl, name, sql) =>
+      // Apply the same dialect-aware regex rewrite as the initial-schema path (namedChecks):
+      // Postgres `~`, MySQL `REGEXP`, SQLite -> None (the AddCheck becomes a no-op).
       Rendered(
-        sql = () => List(s"ALTER TABLE $tbl ADD CONSTRAINT $name CHECK ($sql);"),
+        sql = () =>
+          rewriteCheck(sql, dialect).toList
+            .map(s => s"ALTER TABLE $tbl ADD CONSTRAINT $name CHECK ($s);"),
         alembic = () =>
-          List(s"""op.create_check_constraint("$name", "$tbl", ${pythonStringLiteral(sql)})""")
+          rewriteCheck(sql, dialect).toList
+            .map(s => s"""op.create_check_constraint("$name", "$tbl", ${pythonStringLiteral(s)})""")
       )
 
     case DropCheck(tbl, name, _) =>

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -68,7 +68,15 @@ object SchemaDiff:
         autoIncrementPk.exists(col => referencesColumn(sql, col))
     t.checks.distinct.zipWithIndex
       .filterNot((sql, _) => dropsAutoIncCheck(sql))
-      .map((sql, i) => (s"ck_${t.name}_$i", sql))
+      .flatMap((sql, i) => rewriteCheck(sql, dialect).map(s => (s"ck_${t.name}_$i", s)))
+
+  // A `value matches /re/` refinement is emitted canonically as the Postgres `col ~ 'pat'`.
+  // Rewrite it per dialect (Postgres identity, MySQL REGEXP, SQLite -> dropped).
+  private val regexCheckPattern = """^(\w+) ~ '(.*)'$""".r
+
+  private def rewriteCheck(sql: String, dialect: Dialect): Option[String] = sql match
+    case regexCheckPattern(col, pat) => dialect.regexCheck(col, pat)
+    case _                           => Some(sql)
 
   // SQLAlchemy's default autoincrement="auto" turns any single integer PRIMARY KEY into
   // MySQL AUTO_INCREMENT (not just SERIAL), so its checks must be filtered on that basis.

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -74,7 +74,7 @@ object SchemaDiff:
   // Rewrite it per dialect (Postgres identity, MySQL REGEXP, SQLite -> dropped).
   private val regexCheckPattern = """^(\w+) ~ '(.*)'$""".r
 
-  private def rewriteCheck(sql: String, dialect: Dialect): Option[String] = sql match
+  private[migration] def rewriteCheck(sql: String, dialect: Dialect): Option[String] = sql match
     case regexCheckPattern(col, pat) => dialect.regexCheck(col, pat)
     case _                           => Some(sql)
 

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -315,3 +315,37 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val mig = files("alembic/versions/001_initial_schema.py")
       assert(!mig.contains("op.drop_index("), mig)
       assert(mig.contains("op.drop_table("), mig)
+
+  // N: a refined type alias (Email/Token/PasswordHash) must carry its `where` predicate as a
+  // column CHECK — previously dropped entirely (no DB enforcement). Length checks are portable;
+  // M makes the regex dialect-aware: Postgres `~`, MySQL `REGEXP`, SQLite drops it.
+  test("type-alias refinements -> dialect-aware CHECKs (auth_service)"):
+    for
+      pg     <- fileMapOf("auth_service", "go-chi-postgres")
+      sqlite <- fileMapOf("auth_service", "go-chi-sqlite")
+      mysql  <- fileMapOf("auth_service", "go-chi-mysql")
+    yield
+      val pgUp = pg("migrations/001_initial_schema.up.sql")
+      val sqUp = sqlite("migrations/001_initial_schema.up.sql")
+      val myUp = mysql("migrations/001_initial_schema.up.sql")
+      assert(pgUp.contains("""CHECK (email ~ '^[^@]+@[^@]+\.[^@]+$')"""), pgUp)
+      assert(myUp.contains("""CHECK (email REGEXP '^[^@]+@[^@]+\.[^@]+$')"""), myUp)
+      assert(!sqUp.contains("email ~"), sqUp)
+      assert(!sqUp.contains("email REGEXP"), sqUp)
+      // length refinement (Token=128 / PasswordHash=64) is portable -> present in every dialect
+      for up <- List(pgUp, sqUp, myUp) do
+        assert(up.contains("CHECK (length(password_hash) = 64)"), up)
+        assert(up.contains("CHECK (length(access_token) = 128)"), up)
+
+  // N: url_shortener's ShortCode alias (len + regex) previously produced no CHECK at all.
+  test("url_shortener ShortCode alias now yields length + regex CHECKs"):
+    for
+      pg     <- fileMapOf("url_shortener", "go-chi-postgres")
+      sqlite <- fileMapOf("url_shortener", "go-chi-sqlite")
+    yield
+      val pgUp = pg("migrations/001_initial_schema.up.sql")
+      val sqUp = sqlite("migrations/001_initial_schema.up.sql")
+      assert(pgUp.contains("CHECK (length(code) >= 6)"), pgUp)
+      assert(pgUp.contains("""CHECK (code ~ '^[a-zA-Z0-9]+$')"""), pgUp)
+      assert(sqUp.contains("CHECK (length(code) >= 6)"), sqUp)
+      assert(!sqUp.contains("code ~"), sqUp)

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitPythonTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitPythonTest.scala
@@ -40,9 +40,14 @@ class EmitPythonTest extends CatsEffectSuite:
           extraInOutput.isEmpty,
           s"emitter produced files not in golden: ${extraInOutput.toList.sorted.mkString(", ")}"
         )
+        // `Create Date:` in the Alembic migration is `LocalDate.now` at emit time — an
+        // inherently non-deterministic generated timestamp that must not be golden-compared
+        // (it would only ever match on the exact day the golden was regenerated).
+        def norm(s: String): String =
+          s.replaceAll("(?m)^Create Date: .*$", "Create Date: <date>")
         expected.toList.sortBy(_._1).foreach: (rel, want) =>
           val got = files(rel)
-          if got != want then
+          if norm(got) != norm(want) then
             fail(
               s"$rel diverges from golden\n--- expected ---\n$want\n--- got ---\n$got\n--- end ---"
             )

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -105,6 +105,8 @@ object Schema:
       mapped.check.foreach(checks += _)
       field.c.foreach: c =>
         checks ++= extractChecks(colName, c)
+      for refinement <- aliasRefinements(field.b, aliasMap) do
+        checks ++= extractChecks(colName, refinement)
 
     for inv <- entity.d do
       checks ++= extractInvariantChecks(inv, fields)
@@ -308,6 +310,22 @@ object Schema:
     val checks = List.newBuilder[String]
     visitConstraint(constraint, colName, checks)
     checks.result()
+
+  // A field typed by a refined alias (`type Email = String where value matches ...`) must carry
+  // that alias's `where` predicate as a column CHECK, exactly as an inline field refinement does.
+  // Walks the alias chain (and through Option), with a visited guard against cyclic aliases.
+  private def aliasRefinements(
+      typeExpr: type_expr_full,
+      aliasMap: Map[String, TypeAliasDeclFull],
+      seen: Set[String] = Set.empty
+  ): List[expr_full] = typeExpr match
+    case NamedTypeF(name, _) if !seen(name) =>
+      aliasMap.get(name) match
+        case Some(TypeAliasDeclFull(_, base, pred, _)) =>
+          pred.toList ::: aliasRefinements(base, aliasMap, seen + name)
+        case None => Nil
+    case OptionTypeF(inner, _) => aliasRefinements(inner, aliasMap, seen)
+    case _                     => Nil
 
   private def visitConstraint(
       expr: expr_full,


### PR DESCRIPTION
## Summary

Continues the cascade after #269: promotes **`auth_service`** (regex-refined `Email`; exact-length `Token`/`PasswordHash`; `UserId = Int where value > 0`; 3 entities) to a first-class CI fixture across the python/go/ts build matrices, and fixes the two coupled defects it exposed.

### Defect N — type-alias `where` refinements enforced *nowhere*
A field typed by a refined alias (`email: Email` where `type Email = String where value matches /…/`) silently dropped the alias's predicate — **no DB CHECK** and no app validation — while *inline* field refinements (`display_name: String where len(value) >= 1`) were enforced. `Schema.scala` now walks the field's alias chain (and through `Option`, with a cyclic-alias visited-guard) and feeds each alias refinement through the same `extractChecks` path. Refined aliases now produce column CHECKs.

### Defect M — regex CHECK not dialect-aware (coupled to N)
`value matches /re/` is emitted canonically as the Postgres `col ~ 'pat'`. New `Dialect.regexCheck` makes the rendered CHECK dialect-aware via the shared `SchemaDiff.namedChecks` chokepoint (raw SQL **and** Alembic): **Postgres `~`** (byte-identical), **MySQL `REGEXP`**, **SQLite drops** the regex check (SQLite has no regex in a CHECK — length/range checks are unaffected; check indices stay stable). Without M, fixing N would leak `~` into SQLite (`near "~"`) and MySQL (`~` = bitwise-NOT).

### Scope
DB-layer enforcement only. App-layer validation of alias refinements (zod/Pydantic/go-validator regex/length) is a distinct, non-CI-tested surface and is a deliberate **deferred follow-up**, not silently dropped.

## Test plan

- [x] `auth_service` `go build` / `tsc --noEmit` / `prisma generate` / fastapi import all clean (multi-entity + `UserId` alias — F/G/H/N hold)
- [x] Emitted CHECKs verified per dialect: pg `email ~ '…'`, mysql `email REGEXP '…'`, sqlite regex dropped + `length(...)` checks retained, stable indices
- [x] `url_shortener` goldens regenerated (ShortCode alias now yields `length(code)`+regex CHECKs — previously **unenforced**); the only golden churn (migration + `.spec-snapshot.json` ×9 trees), Postgres operator byte-identical
- [x] codegen 217 / testgen 233 / cli 56 / profile 46; +2 deterministic `DialectProfileEmitTest` cases
- [x] `auth_service × {postgres,sqlite,mysql}` added to all 3 build matrices + path triggers
- [ ] CI: new `auth_service` legs round-trip migrations on real DBs (validates pg `~` / mysql `REGEXP` / sqlite-dropped end-to-end)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces refined type aliases as DB CHECK constraints and makes regex checks dialect-aware across initial and incremental migrations (Postgres `~`, MySQL `REGEXP`, dropped on SQLite). Adds `auth_service` to CI across Go/Python/TS and stabilizes Alembic goldens by ignoring non-deterministic dates.

- **Bug Fixes**
  - Fields using refined type aliases now emit column CHECKs by walking alias chains (including `Option`) with cycle guards.
  - Regex checks are dialect-aware in both initial schema and `AddCheck` migrations; SQLite omits the regex check.
  - Regenerated `url_shortener` goldens: `ShortCode` now has length and regex checks; index ordering remains stable.
  - Alembic migration goldens are date-independent by normalizing the `Create Date` line in `EmitPythonTest`.

- **New Features**
  - Promoted `auth_service` (regex `Email`, exact-length `Token`/`PasswordHash`, positive `UserId`) to CI across Postgres/SQLite/MySQL for Go, Python, and TS.
  - Added tests for alias-enforced CHECKs and dialect-specific regex emission, including the incremental `AddCheck` path.

<sup>Written for commit 52a650f149a324b1e8d80280c1c0af2afc89e88c. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/270?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced database schema validation with dialect-specific constraints to enforce data integrity across code patterns, field lengths, and non-empty requirements.

* **Chores**
  * Extended CI/CD pipelines to test the `auth_service` fixture across PostgreSQL, SQLite, and MySQL.

* **Tests**
  * Added coverage for dialect-aware constraint generation in migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->