### PR TITLE
fix: flatten `entity extends` inheritance into the IR

### DIFF
--- a/fixtures/golden/ir/edge_cases.json
+++ b/fixtures/golden/ir/edge_cases.json
@@ -97,6 +97,77 @@
       "fields" : [
         {
           "kind" : "Field",
+          "name" : "id",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 8,
+              "endLine" : 8,
+              "endCol" : 11
+            }
+          },
+          "constraint" : {
+            "kind" : "BinaryOp",
+            "op" : ">",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "value",
+              "span" : {
+                "startLine" : 8,
+                "startCol" : 18,
+                "endLine" : 8,
+                "endCol" : 23
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 0,
+              "span" : {
+                "startLine" : 8,
+                "startCol" : 26,
+                "endLine" : 8,
+                "endCol" : 27
+              }
+            },
+            "span" : {
+              "startLine" : 8,
+              "startCol" : 18,
+              "endLine" : 8,
+              "endCol" : 27
+            }
+          },
+          "span" : {
+            "startLine" : 8,
+            "startCol" : 4,
+            "endLine" : 8,
+            "endCol" : 27
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "created_at",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "DateTime",
+            "span" : {
+              "startLine" : 9,
+              "startCol" : 16,
+              "endLine" : 9,
+              "endCol" : 24
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 9,
+            "startCol" : 4,
+            "endLine" : 9,
+            "endCol" : 24
+          }
+        },
+        {
+          "kind" : "Field",
           "name" : "name",
           "typeExpr" : {
             "kind" : "NamedType",

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -349,3 +349,24 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(pgUp.contains("""CHECK (code ~ '^[a-zA-Z0-9]+$')"""), pgUp)
       assert(sqUp.contains("CHECK (length(code) >= 6)"), sqUp)
       assert(!sqUp.contains("code ~"), sqUp)
+
+  // O: `entity Child extends Base` was not flattened — Child's table dropped every inherited
+  // column and its `where` refinement, and (because the parent declared `id`) fell through to a
+  // synthesized BIGSERIAL id with no `id > 0` CHECK. Inheritance is now resolved in the IR, so
+  // Child inherits Base's typed `id` (+ `id > 0`) and declared `created_at` across all dialects.
+  test("entity `extends` flattens parent fields + refinements into the child table"):
+    for
+      pg     <- fileMapOf("edge_cases", "go-chi-postgres")
+      sqlite <- fileMapOf("edge_cases", "go-chi-sqlite")
+      mysql  <- fileMapOf("edge_cases", "go-chi-mysql")
+    yield
+      def children(files: Map[String, String]): String =
+        val up = files("migrations/001_initial_schema.up.sql")
+        up.linesIterator.dropWhile(!_.contains("CREATE TABLE children"))
+          .takeWhile(!_.trim.startsWith(");"))
+          .mkString("\n")
+      for ch <- List(children(pg), children(sqlite), children(mysql)) do
+        assert(ch.contains("CONSTRAINT ck_children_0 CHECK (id > 0)"), ch)
+        assert(ch.contains("CONSTRAINT pk_children PRIMARY KEY (id)"), ch)
+        assert(ch.contains("created_at"), ch)
+        assert(!ch.contains("BIGSERIAL"), ch)

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -74,8 +74,9 @@ object Builder:
   // attached to the child anywhere downstream (schema derivation, model emitters, Alloy/Dafny all
   // read only the entity's own members). Resolve the inheritance chain here so every consumer sees
   // a single flattened entity. Order is root-first then own; a same-named child field shadows the
-  // inherited one in the parent's position. The visited-set makes a malformed `extends` cycle
-  // terminate instead of looping (no throw — a structural guard, mirroring alias resolution).
+  // inherited one in the parent's position. The visited-set is seeded with the entity itself, so
+  // a malformed `extends` cycle (including the self-referential `entity A extends A`) collapses to
+  // no inheritance instead of looping (no throw — a structural guard, mirroring alias resolution).
   private def flattenInheritance(ir: ServiceIRFull): ServiceIRFull =
     val byName = ir.c.collect { case e: EntityDeclFull => e.a -> e }.toMap
 
@@ -89,7 +90,7 @@ object Builder:
 
     val flattened = ir.c.map:
       case e: EntityDeclFull if e.b.isDefined =>
-        val ancestry = chain(e.a, Set.empty).dropRight(1)
+        val ancestry = chain(e.a, Set(e.a)).dropRight(1)
         if ancestry.isEmpty then e
         else
           val fields = scala.collection.mutable.LinkedHashMap.empty[String, field_decl_full]

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -64,8 +64,41 @@ object Builder:
       mergePreamble: Boolean
   ): Either[VerifyError.Build, ServiceIRFull] =
     val imports = tree.importDecl.asScala.map(imp => unquote(imp.STRING_LIT.getText)).toList
-    val raw     = new IRBuilder().buildService(tree.serviceDecl).map(_.copy(b = imports))
+    val raw =
+      new IRBuilder().buildService(tree.serviceDecl).map(_.copy(b = imports)).map(
+        flattenInheritance
+      )
     if mergePreamble then raw.map(mergeWithPreamble) else raw
+
+  // `entity Child extends Base` is parsed but the parent's fields and entity invariants are not
+  // attached to the child anywhere downstream (schema derivation, model emitters, Alloy/Dafny all
+  // read only the entity's own members). Resolve the inheritance chain here so every consumer sees
+  // a single flattened entity. Order is root-first then own; a same-named child field shadows the
+  // inherited one in the parent's position. The visited-set makes a malformed `extends` cycle
+  // terminate instead of looping (no throw — a structural guard, mirroring alias resolution).
+  private def flattenInheritance(ir: ServiceIRFull): ServiceIRFull =
+    val byName = ir.c.collect { case e: EntityDeclFull => e.a -> e }.toMap
+
+    def chain(name: String, seen: Set[String]): List[EntityDeclFull] =
+      byName.get(name) match
+        case None => Nil
+        case Some(e) =>
+          e.b match
+            case Some(parent) if !seen(parent) => chain(parent, seen + name) :+ e
+            case _                             => List(e)
+
+    val flattened = ir.c.map:
+      case e: EntityDeclFull if e.b.isDefined =>
+        val ancestry = chain(e.a, Set.empty).dropRight(1)
+        if ancestry.isEmpty then e
+        else
+          val fields = scala.collection.mutable.LinkedHashMap.empty[String, field_decl_full]
+          for a <- ancestry; f <- a.c.collect { case fd: FieldDeclFull => fd } do fields(f.a) = f
+          for f <- e.c.collect { case fd: FieldDeclFull => fd } do fields(f.a) = f
+          e.copy(c = fields.values.toList, d = ancestry.flatMap(_.d) ::: e.d)
+      case other => other
+
+    ir.copy(c = flattened)
 
   private def mergeWithPreamble(ir: ServiceIRFull): ServiceIRFull =
     val userNames = ir.m.map { case PredicateDeclFull(n, _, _, _) => n }.toSet


### PR DESCRIPTION
## Summary

Continues the fixture cascade. `edge_cases.spec` (the next uncovered spec) exposed **Defect O**: `entity Child extends Base` is parsed and stored in the IR but **never resolved** — `Schema.deriveTable`, the python/go/ts model emitters, and the Alloy/Dafny translators all read only an entity's *own* members (`EntityDeclFull.c`), never the `extends_` parent. The only consumer of `extends_` was `lint/UnusedEntity`.

Consequence (confirmed across fastapi/alembic, go/SQL, ts/prisma, all three dialects): the child table silently **dropped every inherited column and its `where` refinement**, and — because the parent declared `id` — fell through to a synthesized `BIGSERIAL` id of a *different type* with **no `id > 0` CHECK**. Builds passed; the data model was silently wrong.

## Fix

A single inheritance-flatten pass in `Builder.buildIRCore`, so every downstream consumer (codegen **and** verification) sees one flattened entity:

- Resolves the `extends` chain **root-first**, then the entity's own fields.
- A same-named child field **shadows** the inherited one, keeping the parent's column position (deterministic via `LinkedHashMap`).
- Parent entity-invariants are merged too (parent-first).
- A visited-set makes a malformed `extends` cycle **terminate** rather than loop (structural guard, no throw — mirrors the alias-resolver cycle guard from #269).
- `extends_` is left populated (lint still works; idempotent).

After the fix `children` correctly inherits Base's `id INTEGER` PK + `CHECK (id > 0)` and the declared `created_at`, then its own `name`/`score`, then the auto `updated_at` — consistent across postgres/sqlite/mysql (mysql's SQLAlchemy path still drops the auto-inc-PK check per the existing #270 M-rule; go-chi raw SQL keeps it, as designed).

## Scope

- **Only `edge_cases.spec` uses `extends`** among all fixtures, so no existing CI fixture / golden output changes (verified: EmitGo/EmitTs/EmitPython goldens unchanged, Postgres byte-identical).
- `fixtures/golden/ir/edge_cases.json` regenerated to carry the merged fields — the CI `ParseBuildGoldenTest — edge_cases` now guards flattening end-to-end.
- New `DialectProfileEmitTest` case asserts the child inherits the typed `id` + `id > 0` + `created_at` across all three dialects (runs in CI `build-and-test`/`coverage`).
- `edge_cases.spec` is **not** promoted to the build+migrate matrix: it is a grammar/parser stress fixture (lambdas, set-comprehensions, the-expr, constructors), not a deployable app, and it fails verification (`FloatLit` unsupported). Forcing it through `go build`/`tsc`/`alembic` would explode scope far beyond this defect; the deterministic regression + regenerated IR golden cover it instead.

## Test plan

- [x] `parser/test` (incl. regenerated `ParseBuildGoldenTest — edge_cases`)
- [x] `convention/test` (66), `codegen/test` (218, incl. new `extends` case)
- [x] `ir/test` (43), `lint/test` (31), `cli/test` (56), `profile/test` (46), `testgen/test` (233)
- [x] `verify/test` (163) — IR flatten doesn't perturb verification
- [x] `scalafixAll --check` clean; scalafmt clean
- [ ] CI matrix green (4 unchanged fixtures × 3 dialects × 3 targets)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattened `entity extends` inheritance into the IR so children include all inherited fields and invariants. Fixes silent drops of parent columns/constraints that caused wrong PKs across codegen and translators.

- Bug Fixes
  - Resolve `extends` chains root-first in `Builder`, merging parent fields and entity invariants into the child; same-name child fields shadow; column order is preserved.
  - Guard cycles with a visited set seeded with the entity, so `entity A extends A` does not self-merge or duplicate invariants; keep `extends_` populated for linting.
  - Verified across Postgres/SQLite/MySQL: children inherit the typed `id` with `CHECK (id > 0)` and `created_at`, with no `BIGSERIAL` fallback; updated `edge_cases` IR golden and added a dialect test; no other goldens change.

<sup>Written for commit ba4721f279c5ec2c9414708198e05b581388455f. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/271?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity inheritance is now automatically flattened during code generation, enabling child entities to inherit fields and constraints from parent entities in generated database schemas.

* **Tests**
  * Added comprehensive test coverage validating entity inheritance flattening across multiple database backends (Postgres, SQLite, MySQL), ensuring inherited fields and constraints are properly included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->