### PR TITLE
fix: explicit integer PK is application-supplied, not auto-increment

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -1,6 +1,7 @@
 package specrest.codegen.alembic
 
 import specrest.codegen.migration.AlembicSyntax
+import specrest.codegen.migration.CanonicalType
 import specrest.codegen.migration.Dialect
 import specrest.codegen.migration.Postgres
 import specrest.codegen.migration.SchemaDiff
@@ -137,8 +138,8 @@ object Migration:
         onDelete = fk.onDelete
       )
     val checks =
-      SchemaDiff.namedChecks(t, dialect, SchemaDiff.sqlalchemyAutoIncrementPk(t)).map:
-        (name, sql) => AlembicCheck(name = name, sql = sql)
+      SchemaDiff.namedChecks(t, dialect, SchemaDiff.autoIncrementPk(t)).map: (name, sql) =>
+        AlembicCheck(name = name, sql = sql)
     val indexes = t.indexes.map: ix =>
       // Mirror sqlCreateIndex: when a partial index degrades on a dialect without partial-index
       // support, drop UNIQUE too (a full unique index over-enforces). Keeps the Alembic and raw
@@ -167,7 +168,7 @@ object Migration:
 
   private def buildColumn(c: ColumnSpec, t: TableSpec, dialect: Dialect): AlembicColumn =
     val isPk     = c.name == t.primaryKey
-    val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
+    val isSerial = CanonicalType.isAutoIncrementType(c.sqlType)
     AlembicColumn(
       name = c.name,
       saType = AlembicSyntax.mapSqlTypeToSa(c.sqlType, dialect),
@@ -183,7 +184,12 @@ object Migration:
     parts += s""""${c.name}""""
     parts += c.saType
     if c.primaryKey then parts += "primary_key=True"
-    if c.autoincrement then parts += "autoincrement=True"
+    // An explicit integer PK is application-supplied (spec `next_id`), not DB-generated. SQLAlchemy
+    // defaults a lone integer PK to `autoincrement="auto"` (-> SERIAL/AUTO_INCREMENT), so the
+    // non-serial PK must pin `autoincrement=False` to stay consistent with the raw-SQL/Prisma
+    // renderers and the spec. Synthesized serial PKs keep `autoincrement=True`.
+    if c.primaryKey then parts += s"autoincrement=${if c.autoincrement then "True" else "False"}"
+    else if c.autoincrement then parts += "autoincrement=True"
     c.serverDefault.foreach(d => parts += s"server_default=$d")
     parts += s"nullable=${if c.nullable then "True" else "False"}"
     s"sa.Column(${parts.result().mkString(", ")})"

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/CanonicalType.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/CanonicalType.scala
@@ -16,7 +16,19 @@ enum CanonicalType derives CanEqual:
   case Bytes
   case Json
 
+  // The single source of truth for "is this column a DB-generated surrogate key" — true only for
+  // the synthesized serial PKs, false for an explicitly-declared `id: Int` (application-supplied,
+  // tracked in the spec's `next_id` state). Every renderer (raw SQL / Alembic / Prisma) and the
+  // MySQL-3818 CHECK filter must derive auto-increment from this, never from an ad-hoc type-string
+  // test, so the three targets cannot diverge and a new dialect needs no renderer changes.
+  def isAutoIncrement: Boolean = this match
+    case Serial4 | Serial8 => true
+    case _                 => false
+
 object CanonicalType:
+
+  def isAutoIncrementType(sqlType: String): Boolean =
+    parse(sqlType).exists(_.isAutoIncrement)
 
   private val NumericWithScalePattern = """^NUMERIC\((\d+)\s*,\s*(\d+)\)$""".r
   private val NumericNoScalePattern   = """^NUMERIC\((\d+)\)$""".r

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -52,6 +52,13 @@ trait Dialect:
   def regexCheck(column: String, pattern: String): Option[String]
   def partialIndex(ix: IndexSpec): FeatureEmission[String]
 
+  /** Prisma attribute that makes a primary key DB-generated, emitted by the ts-express schema only
+    * for an auto-increment PK (`CanonicalType.isAutoIncrement`). Connector-agnostic for
+    * postgres/mysql/sqlite/sqlserver, so the default fits every dialect added so far; a future
+    * CockroachDB dialect overrides it (that connector needs `@default(sequence())` + `BigInt`).
+    */
+  def prismaAutoIncrement: String = "@default(autoincrement())"
+
   /** Service-name-parameterised deployment facts (connection URLs, docker-compose db service,
     * FK-pragma need). The single source of truth for the database axis — `DialectView.of`-style
     * enumeration must not be duplicated elsewhere; resolve via `Dialect.forDatabase` and call this.

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Renderers.scala
@@ -30,7 +30,7 @@ object Renderers:
       )
 
     case AddColumn(tbl, c) =>
-      val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
+      val isSerial = CanonicalType.isAutoIncrementType(c.sqlType)
       Rendered(
         sql = () => List(s"ALTER TABLE $tbl ADD COLUMN ${sqlColumnDef(c, dialect)};"),
         alembic = () =>
@@ -132,9 +132,7 @@ object Renderers:
       )
 
   private def isSerial(sqlType: String): Boolean =
-    CanonicalType.parse(sqlType) match
-      case Some(CanonicalType.Serial4) | Some(CanonicalType.Serial8) => true
-      case _                                                         => false
+    CanonicalType.isAutoIncrementType(sqlType)
 
   private def sqlCreateTable(t: TableSpec, dialect: Dialect): List[String] =
     val columnLines = t.columns.map(c => "    " + sqlColumnDef(c, dialect))
@@ -144,8 +142,7 @@ object Renderers:
       else List(s"    CONSTRAINT pk_${t.name} PRIMARY KEY (${t.primaryKey})")
     val fkLines = t.foreignKeys.map: fk =>
       "    " + sqlForeignKeyInline(t.name, fk)
-    val rawAutoIncPk = if pkIsSerial then Some(t.primaryKey) else None
-    val checkLines = namedChecks(t, dialect, rawAutoIncPk).map: (name, sql) =>
+    val checkLines = namedChecks(t, dialect, SchemaDiff.autoIncrementPk(t)).map: (name, sql) =>
       s"    CONSTRAINT $name CHECK ($sql)"
     val bodyLines  = (columnLines ++ pkLines ++ fkLines ++ checkLines).mkString(",\n")
     val createStmt = s"CREATE TABLE ${t.name} (\n$bodyLines\n);"
@@ -192,8 +189,8 @@ object Renderers:
       val isSerial = c.sqlType == "BIGSERIAL" || c.sqlType == "SERIAL"
       alembicColumn(c, primaryKey = isPk, autoincrement = isSerial, dialect = dialect)
     val fkArgs = t.foreignKeys.map(fk => alembicForeignKeyConstraint(t.name, fk))
-    val checkArgs = namedChecks(t, dialect, SchemaDiff.sqlalchemyAutoIncrementPk(t)).map:
-      (name, sql) => s"""sa.CheckConstraint(${pythonStringLiteral(sql)}, name="$name")"""
+    val checkArgs = namedChecks(t, dialect, SchemaDiff.autoIncrementPk(t)).map: (name, sql) =>
+      s"""sa.CheckConstraint(${pythonStringLiteral(sql)}, name="$name")"""
     val allArgs = (columnArgs ++ fkArgs ++ checkArgs).map(a => s"    $a,").mkString("\n")
     val createStmt =
       s"""op.create_table(
@@ -213,7 +210,10 @@ object Renderers:
     parts += s""""${c.name}""""
     parts += mapSqlTypeToSa(c.sqlType, dialect)
     if primaryKey then parts += "primary_key=True"
-    if autoincrement then parts += "autoincrement=True"
+    // See Migration.renderColumnCall: pin a non-serial PK to autoincrement=False so SQLAlchemy's
+    // default "auto" cannot turn an application-supplied integer PK into SERIAL/AUTO_INCREMENT.
+    if primaryKey then parts += s"autoincrement=${if autoincrement then "True" else "False"}"
+    else if autoincrement then parts += "autoincrement=True"
     mapServerDefault(c.defaultValue.map(dialect.alembicServerDefault))
       .foreach(d => parts += s"server_default=$d")
     parts += s"nullable=${if c.nullable then "True" else "False"}"

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -53,11 +53,11 @@ object SchemaDiff:
   def fkName(tableName: String, fk: ForeignKeySpec): String =
     s"fk_${tableName}_${fk.column}"
 
-  // `autoIncrementPk` is the PK column the *calling renderer* will emit as auto-increment in
-  // its own output (raw SQL: SERIAL only; SQLAlchemy: any integer PK — see helpers below). It
-  // is the caller's responsibility because the same schema is auto-increment under SQLAlchemy
-  // but not in raw `id INT` DDL. When set and the dialect forbids it, a CHECK referencing that
-  // column is dropped (MySQL error 3818).
+  // `autoIncrementPk` is the PK column the renderers emit as DB-generated — now a single notion
+  // across raw SQL and SQLAlchemy (`autoIncrementPk` below), since Alembic pins an explicit
+  // integer PK to `autoincrement=False`. When set and the dialect forbids it, a CHECK referencing
+  // that column is dropped (MySQL error 3818 — only synthesized serial PKs are affected; an
+  // explicit `id: Int` keeps its `id > 0` CHECK on every dialect).
   def namedChecks(
       t: TableSpec,
       dialect: Dialect = Postgres,
@@ -78,18 +78,14 @@ object SchemaDiff:
     case regexCheckPattern(col, pat) => dialect.regexCheck(col, pat)
     case _                           => Some(sql)
 
-  // SQLAlchemy's default autoincrement="auto" turns any single integer PRIMARY KEY into
-  // MySQL AUTO_INCREMENT (not just SERIAL), so its checks must be filtered on that basis.
-  def sqlalchemyAutoIncrementPk(t: TableSpec): Option[String] =
-    t.columns.find(c => c.name == t.primaryKey && isMysqlAutoIncrement(c.sqlType)).map(_.name)
-
-  private def isMysqlAutoIncrement(sqlType: String): Boolean =
-    CanonicalType.parse(sqlType) match
-      case Some(
-            CanonicalType.Int4 | CanonicalType.Int8 | CanonicalType.Serial4 | CanonicalType.Serial8
-          ) =>
-        true
-      case _ => false
+  // The PK column that the renderers emit as DB-generated, i.e. only a synthesized serial PK.
+  // Derived from the one canonical predicate so raw SQL, Alembic and Prisma cannot disagree:
+  // an explicitly-declared `id: Int` is application-supplied (Alembic pins autoincrement=False),
+  // so it is *not* returned here and its CHECK is kept on MySQL.
+  def autoIncrementPk(t: TableSpec): Option[String] =
+    t.columns
+      .find(c => c.name == t.primaryKey && CanonicalType.isAutoIncrementType(c.sqlType))
+      .map(_.name)
 
   private def referencesColumn(sql: String, column: String): Boolean =
     ("\\b" + java.util.regex.Pattern.quote(column) + "\\b").r.findFirstIn(sql).isDefined

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -157,6 +157,8 @@ object EmitTs:
         .toMap
 
     val db = tsDbView(profiled.profile.database, service.snakeName)
+    val prismaAutoIncrement =
+      specrest.codegen.migration.Dialect.forDatabase(profiled.profile.database).prismaAutoIncrement
 
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
@@ -164,7 +166,14 @@ object EmitTs:
         .map(op => enrichOperation(op, entity, typeLookup, db.nativeAttrs))
         .sortWith(byPathSpecificity)
       val maintained = triggerMaintainedByTable.getOrElse(entity.tableName, Set.empty)
-      buildEntityCtx(packageName, entity, entityOps, maintained, db.nativeAttrs)
+      buildEntityCtx(
+        packageName,
+        entity,
+        entityOps,
+        maintained,
+        db.nativeAttrs,
+        prismaAutoIncrement
+      )
 
     val needsDecimal = entities.exists(_.needsDecimal)
     val needsBuffer  = entities.exists(_.needsBuffer)
@@ -384,7 +393,8 @@ object EmitTs:
       entity: ProfiledEntity,
       operations: List[TsOperation],
       triggerMaintainedColumns: Set[String],
-      nativeAttrs: Boolean
+      nativeAttrs: Boolean,
+      prismaAutoIncrement: String
   ): TsEntityCtx =
     val entityCamel       = toCamelCase(entity.entityName)
     val entityPascal      = toPascalCase(entity.entityName)
@@ -408,11 +418,15 @@ object EmitTs:
     val (primaryKey, nonIdFields) =
       entity.fields.find(_.fieldName == "id") match
         case Some(idField) =>
+          // An explicitly-declared `id: Int` PK is application-supplied (spec `next_id`), so it
+          // must NOT carry the Prisma auto-increment default — only a synthesized serial PK does.
+          val auto =
+            specrest.codegen.migration.CanonicalType.isAutoIncrementType(idField.ormColumnType)
           val pk = toTsField(idField, nativeAttrs).copy(
             tsField = "id",
             jsonName = "id",
             columnName = "id",
-            prismaAttrs = "@id @default(autoincrement())",
+            prismaAttrs = if auto then s"@id $prismaAutoIncrement" else "@id",
             isPrimaryKey = true
           )
           (pk, entity.fields.filterNot(_.fieldName == "id").map(mkField))
@@ -423,7 +437,7 @@ object EmitTs:
             columnName = "id",
             domainType = "number",
             prismaType = "Int",
-            prismaAttrs = "@id @default(autoincrement())",
+            prismaAttrs = s"@id $prismaAutoIncrement",
             zodSchema = "z.number()",
             nullable = false,
             isPrimaryKey = true

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -131,11 +131,11 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(!tsSql.contains("::jsonb"), tsSql)
       assert(tsSql.contains("DEFAULT '[]'"), tsSql)
 
-  // todo_list `id: Int where value > 0` is a non-serial integer PK. SQLAlchemy's default
-  // autoincrement="auto" makes any single integer PK AUTO_INCREMENT on MySQL, which then
-  // rejects a CHECK referencing it (error 3818). Postgres/SQLite allow it, so `id > 0`
-  // must stay there and only be dropped for the MySQL Alembic schema.
-  test("python-fastapi-mysql: CHECK on auto-increment id is dropped (MySQL 3818)"):
+  // P: todo_list `id: Int where value > 0` is an application-supplied (non-serial) integer PK.
+  // Alembic now pins it to `autoincrement=False`, so SQLAlchemy does NOT make it MySQL
+  // AUTO_INCREMENT — the `id > 0` CHECK is therefore valid and retained on *every* dialect,
+  // matching the raw-SQL renderer. (The MySQL-3818 drop only applies to synthesized serial PKs.)
+  test("explicit integer PK CHECK is retained across all dialects (no MySQL-3818 drop)"):
     for
       pg     <- fileMapOf("todo_list", "python-fastapi-postgres")
       sqlite <- fileMapOf("todo_list", "python-fastapi-sqlite")
@@ -144,12 +144,12 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val pgMig = pg("alembic/versions/001_initial_schema.py")
       val sqMig = sqlite("alembic/versions/001_initial_schema.py")
       val myMig = mysql("alembic/versions/001_initial_schema.py")
-      assert(pgMig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), pgMig)
-      assert(sqMig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), sqMig)
-      assert(!myMig.contains("id > 0"), myMig)
-      assert(!myMig.contains("ck_todos_0"), myMig)
-      // surviving checks keep their original (stable) indices, not renumbered
-      assert(myMig.contains("""name="ck_todos_1""""), myMig)
+      for mig <- List(pgMig, sqMig, myMig) do
+        assert(mig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), mig)
+        assert(
+          mig.contains("""sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False"""),
+          mig
+        )
 
   // Raw go-chi/ts SQL uses a bare `id INT` PK (no AUTO_INCREMENT keyword), so the CHECK
   // is valid on MySQL there and must be retained.
@@ -157,6 +157,33 @@ class DialectProfileEmitTest extends CatsEffectSuite:
     fileMapOf("todo_list", "go-chi-mysql").map: files =>
       val up = files("migrations/001_initial_schema.up.sql")
       assert(up.contains("CHECK (id > 0)"), up)
+
+  // P: the auto-increment decision is one canonical predicate honoured identically by all three
+  // renderers. todo_list (single entity, explicit `id: Int`) is app-supplied -> no autoincrement
+  // anywhere; url_shortener (single entity, synthesized BIGSERIAL) is DB-generated -> everywhere.
+  test("explicit vs synthesized PK auto-increment is consistent across raw/alembic/prisma"):
+    for
+      tdAl <- fileMapOf("todo_list", "python-fastapi-postgres")
+      tdGo <- fileMapOf("todo_list", "go-chi-postgres")
+      tdTs <- fileMapOf("todo_list", "ts-express-postgres")
+      usAl <- fileMapOf("url_shortener", "python-fastapi-postgres")
+      usTs <- fileMapOf("url_shortener", "ts-express-postgres")
+    yield
+      val tdAlMig  = tdAl("alembic/versions/001_initial_schema.py")
+      val tdGoSql  = tdGo("migrations/001_initial_schema.up.sql")
+      val tdPrisma = tdTs("prisma/schema.prisma")
+      // explicit Todo.id (Int where value > 0): application-supplied on every renderer
+      assert(
+        tdAlMig.contains("""sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False"""),
+        tdAlMig
+      )
+      assert(tdGoSql.contains("id INTEGER NOT NULL") && !tdGoSql.contains("SERIAL"), tdGoSql)
+      assert(tdPrisma.contains("id Int @id") && !tdPrisma.contains("autoincrement"), tdPrisma)
+      // synthesized url_shortener.UrlMapping.id (BIGSERIAL): DB-generated everywhere (unchanged)
+      val usAlMig  = usAl("alembic/versions/001_initial_schema.py")
+      val usPrisma = usTs("prisma/schema.prisma")
+      assert(usAlMig.contains("autoincrement=True"), usAlMig)
+      assert(usPrisma.contains("@id @default(autoincrement())"), usPrisma)
 
   // The schema.prisma template owns nullability ({{#if nullable}}?{{/if}}); a second `?`
   // from prismaAttrs produced `String? ?` -> Prisma validation error P1012.


### PR DESCRIPTION
## Summary

Continues the cascade. **Defect P**: an explicitly-declared integer primary key (`id: Int`, or an alias over `Int` like `UserId`/`OrderId`) is *application-assigned* in the spec — every app fixture tracks it via `next_id` state and `id = pre(next_id)` — not DB-generated. The three renderers disagreed:

| Renderer | explicit `id: Int` PK |
|---|---|
| raw SQL (go-chi / ts-migrate) | `id INTEGER` — app-supplied ✅ |
| Alembic | `sa.Column(sa.Integer(), primary_key=True)` → SQLAlchemy `autoincrement="auto"` silently makes it SERIAL/AUTO_INCREMENT ❌ |
| Prisma | hardcoded `@id @default(autoincrement())` ❌ |

3 of 4 CI fixtures (todo_list, ecommerce, auth_service) hit this. The #270 MySQL-3818 CHECK-drop was a *workaround* for this very leak (SQLAlchemy auto-incrementing the PK → MySQL rejects `CHECK (id > 0)`).

## Root-cause + extensibility-first fix

Researched SQLAlchemy/Prisma/cross-DB identity semantics first (the autoincrement decision is dialect-independent at the ORM layer; only raw-SQL and Prisma-CockroachDB need per-dialect surface).

- **One predicate**: `CanonicalType.isAutoIncrement` (Serial4/8 only) — the single source of truth. Every renderer + the MySQL-3818 filter derive from it; no ad-hoc `sqlType == "BIGSERIAL"` string tests remain.
- **Alembic**: pins a non-serial PK to `autoincrement=False` (dialect-independent — SQLAlchemy handles all backends). Both the initial-schema and incremental renderers.
- **Prisma**: new `Dialect.prismaAutoIncrement` hook (default `@default(autoincrement())`); emitted only for an auto-increment PK. A future **CockroachDB** dialect overrides the hook (needs `@default(sequence())`+`BigInt`) — **zero EmitTs change**.
- **N+M unification**: `SchemaDiff.autoIncrementPk` replaces the two parallel raw/SQLAlchemy notions with the one predicate. An explicit `id: Int` now **keeps its `id > 0` CHECK on MySQL** across all renderers (root-causes #270's workaround).
- **Extensibility contract**: adding a DB stays "implement `Dialect` (incl. `serialColumnDef`/`prismaAutoIncrement` if non-standard) + register in `Dialect.forDatabase` + `DatabaseId`" — no renderer/`SchemaDiff` edits.

## Scope / invariants

- **Synthesized `BIGSERIAL` PKs unchanged** → url_shortener Emit{Go,Ts,Python} goldens **byte-identical** (verified); Postgres byte-identical.
- Only the explicit-integer-PK fixtures (todo_list/ecommerce/auth_service) change: Alembic `autoincrement=False`, Prisma `@id` (no default), MySQL retains `id > 0`.
- The #270 todo_list MySQL-3818 test is **inverted** to the corrected invariant (CHECK now retained on every dialect); added a cross-renderer Defect-P regression.

## Test plan

- [x] `codegen` 219, `convention` 66, `parser` 30, `ir` 43, `lint` 31, `cli` 56, `profile` 46, `testgen` 233, `verify` 163 — all green
- [x] url_shortener goldens byte-identical; scalafix/scalafmt clean
- [ ] CI build matrices: real-DB `alembic up/down/up`, `go migrate`, `prisma migrate`, and **fastapi `--with-tests` conformance** for todo_list/ecommerce/auth_service with application-supplied ids (the real end-to-end check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes explicit integer primary keys (`id: Int` or aliases) to be application-assigned, not auto-incremented by the database. Aligns raw SQL, Alembic, and Prisma outputs and keeps `id > 0` CHECKs on MySQL for explicit PKs.

- **Bug Fixes**
  - Added a single predicate `CanonicalType.isAutoIncrement` (Serial4/8 only) used by all renderers.
  - Alembic: pinned non-serial PKs to `autoincrement=False` in initial and incremental migrations.
  - Prisma: emits `@id` without `autoincrement()` for explicit integer PKs; introduced `Dialect.prismaAutoIncrement` for DB-specific defaults.
  - Replaced parallel notions with `SchemaDiff.autoIncrementPk`; MySQL now retains `id > 0` for explicit PKs.
  - No changes to synthesized serial PKs; updated tests and inverted the MySQL-3818 case to the corrected behavior.

<sup>Written for commit 22732302cb276246dfb0971b9918875599f7105b. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/272?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

