### PR TITLE
fix: ts-express synthesized PK is Prisma BigInt (matches BIGSERIAL migration)

### DIFF
--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 
 model UrlMapping {
 
-  id Int @id @default(autoincrement())
+  id BigInt @id @default(autoincrement())
 
   code String
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
@@ -5,9 +5,17 @@ import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
 // Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
-// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract
+// (matching the fastapi/go targets). Fail loud rather than silently round an id past the
+// JS safe-integer range — realistic auto-increment ids never approach 2^53.
 (BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
-  return Number(this);
+  const n = Number(this);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(
+      `cannot serialize id ${this.toString()}: exceeds JS safe-integer range`,
+    );
+  }
+  return n;
 };
 
 export const app = express();

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
@@ -4,6 +4,12 @@ import type { Request, Response } from 'express';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
+// Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+(BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
+  return Number(this);
+};
+
 export const app = express();
 
 app.use(express.json({ limit: '1mb' }));

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
@@ -42,7 +42,7 @@ export const shorten = async (body: ShortenRequest): Promise<void> => {
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
-  });
+  }) as unknown as Promise<UrlMappingRead[]>;
 };
 
 
@@ -58,7 +58,7 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   return prisma.urlMapping.findFirst({
     where: { code: code },
-  });
+  }) as unknown as Promise<UrlMappingRead | null>;
 };
 
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 
 model UrlMapping {
 
-  id Int @id @default(autoincrement())
+  id BigInt @id @default(autoincrement()) @db.BigInt
 
   code String @db.Text
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
@@ -5,9 +5,17 @@ import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
 // Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
-// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract
+// (matching the fastapi/go targets). Fail loud rather than silently round an id past the
+// JS safe-integer range — realistic auto-increment ids never approach 2^53.
 (BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
-  return Number(this);
+  const n = Number(this);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(
+      `cannot serialize id ${this.toString()}: exceeds JS safe-integer range`,
+    );
+  }
+  return n;
 };
 
 export const app = express();

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
@@ -4,6 +4,12 @@ import type { Request, Response } from 'express';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
+// Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+(BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
+  return Number(this);
+};
+
 export const app = express();
 
 app.use(express.json({ limit: '1mb' }));

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
@@ -42,7 +42,7 @@ export const shorten = async (body: ShortenRequest): Promise<void> => {
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
-  });
+  }) as unknown as Promise<UrlMappingRead[]>;
 };
 
 
@@ -58,7 +58,7 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   return prisma.urlMapping.findFirst({
     where: { code: code },
-  });
+  }) as unknown as Promise<UrlMappingRead | null>;
 };
 
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
@@ -10,7 +10,7 @@ datasource db {
 
 model UrlMapping {
 
-  id Int @id @default(autoincrement())
+  id BigInt @id @default(autoincrement())
 
   code String
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
@@ -5,9 +5,17 @@ import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
 // Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
-// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract
+// (matching the fastapi/go targets). Fail loud rather than silently round an id past the
+// JS safe-integer range — realistic auto-increment ids never approach 2^53.
 (BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
-  return Number(this);
+  const n = Number(this);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(
+      `cannot serialize id ${this.toString()}: exceeds JS safe-integer range`,
+    );
+  }
+  return n;
 };
 
 export const app = express();

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
@@ -4,6 +4,12 @@ import type { Request, Response } from 'express';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
+// Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+(BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
+  return Number(this);
+};
+
 export const app = express();
 
 app.use(express.json({ limit: '1mb' }));

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
@@ -42,7 +42,7 @@ export const shorten = async (body: ShortenRequest): Promise<void> => {
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
-  });
+  }) as unknown as Promise<UrlMappingRead[]>;
 };
 
 
@@ -58,7 +58,7 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   return prisma.urlMapping.findFirst({
     where: { code: code },
-  });
+  }) as unknown as Promise<UrlMappingRead | null>;
 };
 
 

--- a/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
@@ -5,9 +5,17 @@ import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
 // Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
-// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract
+// (matching the fastapi/go targets). Fail loud rather than silently round an id past the
+// JS safe-integer range — realistic auto-increment ids never approach 2^53.
 (BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
-  return Number(this);
+  const n = Number(this);
+  if (!Number.isSafeInteger(n)) {
+    throw new Error(
+      `cannot serialize id ${this.toString()}: exceeds JS safe-integer range`,
+    );
+  }
+  return n;
 };
 
 export const app = express();

--- a/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
@@ -4,6 +4,12 @@ import type { Request, Response } from 'express';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
+// Prisma returns `bigint` for 64-bit auto-increment ids, which `JSON.stringify` cannot
+// serialize. Emit it as a JSON number so the wire stays the spec's integer contract.
+(BigInt.prototype as unknown as { toJSON: () => number }).toJSON = function (): number {
+  return Number(this);
+};
+
 export const app = express();
 
 app.use(express.json({ limit: '1mb' }));

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -431,13 +431,20 @@ object EmitTs:
           )
           (pk, entity.fields.filterNot(_.fieldName == "id").map(mkField))
         case None =>
+          // Synthesized PK is always BIGSERIAL (64-bit) — the Prisma type must match the
+          // migration's column (Prisma `BigInt`), not the legacy hardcoded `Int`, or the
+          // generated client is mistyped against its own migration. The DTO/zod stay `number`
+          // (the spec's `Int` wire contract); a bigint id is bridged by the result cast and
+          // the app-level BigInt JSON serializer.
+          val nativeAttr = if nativeAttrs then nativePrismaAttr("BIGSERIAL") else ""
           val pk = TsFieldView(
             tsField = "id",
             jsonName = "id",
             columnName = "id",
             domainType = "number",
-            prismaType = "Int",
-            prismaAttrs = s"@id $prismaAutoIncrement",
+            prismaType = prismaTypeFor("BIGSERIAL"),
+            prismaAttrs =
+              List(s"@id $prismaAutoIncrement", nativeAttr).filter(_.nonEmpty).mkString(" "),
             zodSchema = "z.number()",
             nullable = false,
             isPrimaryKey = true
@@ -449,7 +456,10 @@ object EmitTs:
     val needsBuffer  = nonIdFields.exists(f => f.domainType.contains("Buffer"))
     // Prisma types a Json column as JsonValue, which does not match the zod-derived
     // read DTO (e.g. string[]); the service must cast the row at the boundary.
-    val needsResultCast = allFields.exists(_.prismaType == "Json")
+    // A BigInt PK (synthesized BIGSERIAL) makes the Prisma row type diverge from the
+    // number-typed DTO; the cast keeps tsc happy and the app-level BigInt JSON serializer
+    // emits it as a number on the wire (the spec's `Int` contract).
+    val needsResultCast = allFields.exists(f => f.prismaType == "Json" || f.prismaType == "BigInt")
 
     val customSchemas = operations.flatMap: op =>
       op.customRequestSchemaName.map(name => TsCustomSchema(name, op.customRequestFields))
@@ -498,7 +508,9 @@ object EmitTs:
     "TEXT"             -> PrismaMapping("String", "@db.Text"),
     "VARCHAR"          -> PrismaMapping("String", "@db.VarChar"),
     "INTEGER"          -> PrismaMapping("Int", "@db.Integer"),
+    "SERIAL"           -> PrismaMapping("Int", "@db.Integer"),
     "BIGINT"           -> PrismaMapping("BigInt", "@db.BigInt"),
+    "BIGSERIAL"        -> PrismaMapping("BigInt", "@db.BigInt"),
     "SMALLINT"         -> PrismaMapping("Int", "@db.SmallInt"),
     "BOOLEAN"          -> PrismaMapping("Boolean", "@db.Boolean"),
     "DOUBLE PRECISION" -> PrismaMapping("Float", "@db.DoublePrecision"),
@@ -557,11 +569,30 @@ object EmitTs:
       nativeAttrs: Boolean
   ): TsOperation =
     val endpoint = op.endpoint
+    // The synthesized PK is BIGSERIAL -> Prisma `BigInt`, so a path param that resolves to the
+    // PK (`{id}`) must be coerced to `bigint` for the Prisma `where`. A param matching a
+    // non-id entity column (e.g. `{code}`) is a normal lookup and keeps its spec type.
+    val pkSqlType =
+      entity.fields.find(_.fieldName == "id").map(_.ormColumnType).getOrElse("BIGSERIAL")
+    val pkIsBigInt = prismaTypeFor(pkSqlType) == "BigInt"
+    val bigIntPkParam: Option[String] =
+      if !pkIsBigInt then None
+      else
+        endpoint.pathParams.headOption.collect:
+          case p if !entity.fields.exists(_.columnName == p.name) => p.name
     val pathParams = endpoint.pathParams.map: p =>
-      val tsType = tsTypeForParam(p.typeExpr, typeLookup)
-      val nm     = toCamelCase(p.name)
+      val isBigIntPk = bigIntPkParam.contains(p.name)
+      val tsType     = if isBigIntPk then "bigint" else tsTypeForParam(p.typeExpr, typeLookup)
+      val nm         = toCamelCase(p.name)
       val stmt =
-        if tsType == "number" then
+        if isBigIntPk then
+          s"""      let $nm: bigint;
+             |      try {
+             |        $nm = BigInt(req.params['${p.name}'] ?? '');
+             |      } catch {
+             |        throw NotFound();
+             |      }""".stripMargin
+        else if tsType == "number" then
           s"""      const $nm = Number(req.params['${p.name}']);
              |      if (!Number.isFinite($nm)) {
              |        throw NotFound();
@@ -615,7 +646,7 @@ object EmitTs:
 
     val whereExpr = pathParams.headOption match
       case Some(p) => s"$lookupField: ${p.tsName}"
-      case None    => "id: 0"
+      case None    => if pkIsBigInt then "id: 0n" else "id: 0"
 
     val lookupIsPk = lookupField == "id"
     val readCall   = if lookupIsPk then "findUnique" else "findFirst"

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -231,9 +231,10 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(!urlRoutes.contains("Number(req.params"), urlRoutes)
       assert(urlRoutes.contains("req.params['code'] ?? ''"), urlRoutes)
 
-  // Prisma types a Json column as JsonValue, so the service must cast the row to the
-  // read DTO. Entities without a Json field must NOT get the cast (zero golden churn).
-  test("ts-express: Json-bearing service casts result; plain entity untouched"):
+  // Prisma types a Json column as JsonValue and a synthesized BIGSERIAL PK as `bigint`; both
+  // diverge from the number-typed read DTO, so the service must cast the row. (The zero-churn
+  // guard for genuinely plain entities is the byte-exact EmitTsTest golden itself.)
+  test("ts-express: service casts Json-bearing and BigInt-PK rows"):
     for
       todo <- fileMapOf("todo_list", "ts-express-postgres")
       url  <- fileMapOf("url_shortener", "ts-express-postgres")
@@ -242,11 +243,26 @@ class DialectProfileEmitTest extends CatsEffectSuite:
         files.collect {
           case (p, c) if p.startsWith("src/services/") && p.endsWith(".ts") => c
         }.mkString
-      val todoSvc = services(todo)
-      val urlSvc  = services(url)
+      val todoSvc = services(todo) // Todo.tags: Set -> Json column
+      val urlSvc  = services(url)  // UrlMapping: synthesized BIGSERIAL PK -> bigint
       assert(todoSvc.contains("as unknown as Promise<TodoRead | null>"), todoSvc)
       assert(todoSvc.contains("as unknown as Promise<TodoRead[]>"), todoSvc)
-      assert(!urlSvc.contains("as unknown as"), urlSvc)
+      assert(urlSvc.contains("as unknown as Promise<UrlMappingRead[]>"), urlSvc)
+
+  // Q: a synthesized PK is BIGSERIAL (64-bit) in every migration. ts-express must declare it as
+  // Prisma `BigInt` so the generated client matches its own migration.sql; an explicit `id: Int`
+  // stays Prisma `Int`. (fastapi/go are already consistently 64-bit / 32-bit respectively.)
+  test("ts-express synthesized PK is Prisma BigInt; explicit integer PK stays Int"):
+    for
+      url  <- fileMapOf("url_shortener", "ts-express-postgres")
+      todo <- fileMapOf("todo_list", "ts-express-postgres")
+    yield
+      val urlPrisma  = url("prisma/schema.prisma")
+      val urlMig     = url("prisma/migrations/001_initial_schema/migration.sql")
+      val todoPrisma = todo("prisma/schema.prisma")
+      assert(urlMig.contains("id BIGSERIAL"), urlMig)
+      assert(urlPrisma.contains("id BigInt @id @default(autoincrement()) @db.BigInt"), urlPrisma)
+      assert(todoPrisma.contains("id Int @id") && !todoPrisma.contains("id BigInt"), todoPrisma)
 
   // F: ErrorResponse is a shared model type. Emitting it per-entity made any multi-entity
   // Go project fail to build ("ErrorResponse redeclared"). It must live once in common.go.


### PR DESCRIPTION
## Summary

Continues the PK-consistency cascade. **Defect Q**: a synthesized primary key is `BIGSERIAL` (64-bit) in every migration — fastapi (`sa.BigInteger`) and go-chi (`BIGSERIAL`) honour it, and so does ts-express's *own* raw `prisma/migrations/.../migration.sql`. But `prisma/schema.prisma` hardcoded `id Int @id @default(autoincrement())` (32-bit), so the generated Prisma Client was mistyped against the very migration it ships with — an internal schema/migration contradiction (ids > 2³¹ silently truncate in the TS client). Live in `url_shortener` (golden tree) + `ecommerce`/`auth_service` synthesized-PK entities.

## Fix (chosen design: widen Prisma to BigInt)

- `PrismaSqlTypes` gains `BIGSERIAL → BigInt/@db.BigInt` and `SERIAL → Int/@db.Integer`; the synthesized-PK branch derives the Prisma type from the canonical type instead of hardcoding `Int` — single source of truth, same philosophy as the Defect-P predicate.
- The read DTO/zod stay `number` (the spec's `Int` wire contract). The `bigint` row is bridged by: the existing `as unknown as` cast (`needsResultCast` now also triggers on a `BigInt` field) **and** a new app-level `BigInt.prototype.toJSON → Number(this)` so `res.json` emits the id as a JSON number.
- A path param that resolves to a `BigInt` PK is coerced via `BigInt(...)` (typed `bigint`) so the Prisma `where` type-checks; non-id lookups (`{code}`) and explicit `id: Int` PKs are unchanged.

## Scope / invariants

- **fastapi & go-chi output byte-identical** (Defect Q was ts-express-only). Postgres byte-identical there.
- Only ts-express synthesized-PK fixtures change. url_shortener ts golden regenerated — minimal diff: `schema.prisma` (1 line → `id BigInt … @db.BigInt`), `src/app.ts` (+6, the serializer), `src/services/urlMapping.ts` (4 lines, the casts). No route/types/zod churn (url_shortener looks up by `code`, not id).
- Obsolete "plain entity gets no cast" test rewritten (a BigInt-PK entity legitimately casts now); added a Defect-Q regression (synthesized PK ⇒ Prisma `BigInt` matching `BIGSERIAL`; explicit `id: Int` ⇒ stays `Int`).

## Test plan

- [x] codegen 220, convention 66, parser 30, ir 43, lint 31, cli 56, profile 46, testgen 233, verify 163 — all green; scalafix clean
- [x] url_shortener ts goldens regenerated & byte-match; fastapi/go goldens untouched
- [ ] **CI ts-express matrix** (`tsc + prisma + migrate`, 5 fixtures × 3 dialects) — the real type-correctness gate (cannot run tsc locally); go/fastapi matrices unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch ts-express synthesized primary keys to Prisma BigInt to match `BIGSERIAL` migrations and prevent ID truncation. Add guarded BigInt→JSON serialization so responses still return numbers without silent precision loss.

- **Bug Fixes**
  - Map `BIGSERIAL` → Prisma `BigInt/@db.BigInt` and `SERIAL` → `Int/@db.Integer`; synthesized PK now derives Prisma type from the canonical SQL type.
  - Cast Prisma results when rows contain `BigInt` or `Json` so they match read DTO types; default `where` uses `0n` for bigint PKs.
  - Add `BigInt.prototype.toJSON` with a safe-integer check to emit IDs as JSON numbers or throw if unsafe.
  - Coerce `{id}` path params to `bigint` for Prisma `where`; non-id lookups and explicit `id: Int` PKs are unchanged.
  - Scope: only ts-express synthesized-PK fixtures changed; fastapi/go outputs unchanged.

<sup>Written for commit a0ae734dea26b30fb850b3d3bdf3ed29a1d5e217. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/273?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for 64-bit auto-increment identifiers across MySQL, PostgreSQL, and SQLite databases, enabling larger ID values.

* **Bug Fixes**
  * Fixed JSON serialization of large numeric IDs to ensure proper data formatting in API responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->