### PR TITLE
fix: filtered-list ops are fail-loud stubs, not silent unfiltered lists

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/RouteKind.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/RouteKind.scala
@@ -11,6 +11,18 @@ object RouteKind:
   private val RedirectStatuses: Set[Int] = Set(301, 302, 303, 307, 308)
 
   def classify(op: ProfiledOperation): RouteKind =
+    val shape = classifyShape(op)
+    // The `list` template returns every row and takes no arguments, so any declared filter
+    // input would be silently dropped — an unfiltered result returned with a 200. Emit the
+    // fail-loud stub (Other) instead, exactly as a Create whose shape doesn't match the
+    // entity is downgraded. A genuine list-all (no inputs) is unaffected; real filtering is
+    // the synthesis pass's job, not a silently-wrong direct emit.
+    if shape == List && hasFilterInputs(op) then Other else shape
+
+  private def hasFilterInputs(op: ProfiledOperation): Boolean =
+    op.endpoint.queryParams.nonEmpty || op.endpoint.bodyParams.nonEmpty
+
+  private def classifyShape(op: ProfiledOperation): RouteKind =
     val method          = op.endpoint.method
     val status          = op.endpoint.successStatus
     val pathParamCount  = op.endpoint.pathParams.length

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -243,11 +243,32 @@ class DialectProfileEmitTest extends CatsEffectSuite:
         files.collect {
           case (p, c) if p.startsWith("src/services/") && p.endsWith(".ts") => c
         }.mkString
-      val todoSvc = services(todo) // Todo.tags: Set -> Json column
-      val urlSvc  = services(url)  // UrlMapping: synthesized BIGSERIAL PK -> bigint
+      val todoSvc = services(todo) // Todo.tags: Set -> Json column (getTodo read cast)
+      val urlSvc  = services(url)  // UrlMapping: synthesized BIGSERIAL PK -> bigint (listAll cast)
       assert(todoSvc.contains("as unknown as Promise<TodoRead | null>"), todoSvc)
-      assert(todoSvc.contains("as unknown as Promise<TodoRead[]>"), todoSvc)
       assert(urlSvc.contains("as unknown as Promise<UrlMappingRead[]>"), urlSvc)
+
+  // R: a list op that declares filter inputs cannot be the plain list-all template (which
+  // ignores all inputs and would return every row with a 200). It must be the fail-loud stub,
+  // consistent with the other synthesis ops. A genuine input-less list-all is unaffected.
+  test("filtered list op is a fail-loud stub, not a silent unfiltered list-all"):
+    for
+      tsTodo <- fileMapOf("todo_list", "ts-express-postgres")
+      goTodo <- fileMapOf("todo_list", "go-chi-postgres")
+      faTodo <- fileMapOf("todo_list", "python-fastapi-postgres")
+      tsUrl  <- fileMapOf("url_shortener", "ts-express-postgres")
+    yield
+      val tsSvc = tsTodo("src/services/todo.ts")
+      val goSvc = goTodo("internal/services/todo.go")
+      val faSvc = faTodo("app/services/todo.py")
+      // ListTodos (status_filter/priority_filter/tag_filter) -> stub, never an unfiltered list
+      assert(tsSvc.contains("throw new Error('listTodos not implemented')"), tsSvc)
+      assert(!tsSvc.contains("listTodos = async (): Promise<TodoRead[]>"), tsSvc)
+      assert(goSvc.contains("\"ListTodos not implemented\""), goSvc)
+      assert(faSvc.contains("def list_todos") && faSvc.contains("NotImplementedError"), faSvc)
+      // url_shortener ListAll has no filter inputs -> genuine list-all, still emitted
+      val tsUrlSvc = tsUrl("src/services/urlMapping.ts")
+      assert(tsUrlSvc.contains("prisma.urlMapping.findMany("), tsUrlSvc)
 
   // Q: a synthesized PK is BIGSERIAL (64-bit) in every migration. ts-express must declare it as
   // Prisma `BigInt` so the generated client matches its own migration.sql; an explicit `id: Int`


### PR DESCRIPTION
## Summary

Continues the cascade. **Defect R**: a list operation that declares filter inputs was emitted as the plain list-all template, silently dropping the filters.

`todo_list.ListTodos`:
```text
input:  status_filter: Option[Status], priority_filter: Option[Priority], tag_filter: Option[String]
ensures: all t in results | t in ran(todos)
           and (status_filter = none or t.status = status_filter) and ...
```
Generated (all three targets): `prisma.todo.findMany({orderBy:{id:'asc'}})` / `db.NewSelect().Model(&items)` / `select(Todo)` — **no WHERE, no filter args**. `GET /todos?status_filter=DONE` silently returned **every** row with a 200. The declared params were absent from the service signature and route entirely.

This contradicts the codebase's own principle: `CreateTodo` (also LLM_SYNTHESIS) correctly emits `throw … "stub throws to avoid silently reporting success"`, while `ListTodos` did the opposite.

## Root cause + fix (chosen: R-A — fail-loud stub)

`RouteKind.classify` collapsed any input-bearing list op to `RouteKind.List`, and the list template ignores all inputs. The convention layer only marks `FilteredRead` when `filterParamCount > 3` (`Classify.scala:26`), so `ListTodos` (3 filters) fell through to plain `Read` → `List`.

Single shared rule in `RouteKind.classify` (consumed by **all three emitters**): a `List` shape with any query/body input → `Other` (the existing fail-loud stub), exactly mirroring `Create && !matchesEntityCreateShape => Other`. `ListTodos` now emits the same throw-stub as `CreateTodo` in ts/go/fastapi; real filtering remains the synthesis pass's job.

## Scope / invariants

- A genuine input-less list-all (`url_shortener.ListAll`) is **unaffected** → **EmitGo/EmitTs/EmitPython goldens byte-identical** (verified), Postgres byte-identical.
- Only the filtered-list ops change (`todo_list.ListTodos`, `ecommerce.ListOrders`) — build-matrix fixtures, no goldens.
- `testgen` 233 green locally → the conformance generator skips the `Other`-kind stub (same as `CreateTodo`), so fastapi `--with-tests` stays green.
- Obsolete cast-test assertion (the old wrong `TodoRead[]` list-all cast) updated; added a Defect-R regression (filtered list ⇒ stub in ts/go/fastapi; input-less list-all still emitted).

## Test plan

- [x] codegen 221, convention/parser/ir, lint 31, cli 56, profile 46, testgen 233, verify 163 — all green; scalafix clean
- [x] url_shortener goldens byte-identical across all 3 targets
- [ ] CI: `build-and-test` + any triggered matrices; fastapi `--with-tests` conformance stays green (ListTodos skipped as a stub)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where filtered list endpoints were emitted as unfiltered list-all handlers, dropping all filters and returning every row. Now these endpoints fail loudly with a stub; true list-all (no inputs) is unchanged.

- Bug Fixes
  - In `RouteKind.classify`, downgrade `List` ops with any query/body inputs to `Other` (fail-loud stub), mirroring the create mismatch rule.
  - Added `hasFilterInputs` and split shape logic into `classifyShape`.
  - Tests: assert stub for `todo_list.ListTodos` across TS/Go/FastAPI; keep `url_shortener.ListAll` as real list-all; removed obsolete cast check. Goldens unchanged.

<sup>Written for commit adb719baa4913d5d2ae85ffc7d689d40b99396c4. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/274?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation to prevent silently incorrect emission of unfiltered list operations when filter inputs are declared.

* **Tests**
  * Added tests validating that filtered list operations emit errors instead of silent incorrect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->