### PR TITLE
fix: redirect ops with spec side-effects are fail-loud stubs (go/ts)

### DIFF
--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 
 	"github.com/uptrace/bun"
@@ -37,16 +36,13 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	return items, nil
 }
 
+// TODO: implement Resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub returns an
+// explicit error to avoid silently reporting success — matching the fastapi target.
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
-	m := new(models.UrlMapping)
-	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("code"), code).Limit(1).Scan(ctx)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+	_ = ctx
+	_ = s
+	return nil, errors.New("Resolve not implemented")
 }
 
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 
 	"github.com/uptrace/bun"
@@ -37,16 +36,13 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	return items, nil
 }
 
+// TODO: implement Resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub returns an
+// explicit error to avoid silently reporting success — matching the fastapi target.
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
-	m := new(models.UrlMapping)
-	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("code"), code).Limit(1).Scan(ctx)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+	_ = ctx
+	_ = s
+	return nil, errors.New("Resolve not implemented")
 }
 
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 
 	"github.com/uptrace/bun"
@@ -37,16 +36,13 @@ func (s *UrlMappingService) ListAll(ctx context.Context) ([]models.UrlMapping, e
 	return items, nil
 }
 
+// TODO: implement Resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub returns an
+// explicit error to avoid silently reporting success — matching the fastapi target.
 func (s *UrlMappingService) Resolve(ctx context.Context, code string) (*models.UrlMapping, error) {
-	m := new(models.UrlMapping)
-	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("code"), code).Limit(1).Scan(ctx)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+	_ = ctx
+	_ = s
+	return nil, errors.New("Resolve not implemented")
 }
 
 func (s *UrlMappingService) Delete(ctx context.Context, code string) (bool, error) {

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
@@ -55,10 +55,11 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 
 
 
+// TODO: implement resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub throws to
+// avoid silently reporting success — matching the fastapi target.
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
-  return prisma.urlMapping.findFirst({
-    where: { code: code },
-  }) as unknown as Promise<UrlMappingRead | null>;
+  throw new Error('resolve not implemented');
 };
 
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
@@ -55,10 +55,11 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 
 
 
+// TODO: implement resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub throws to
+// avoid silently reporting success — matching the fastapi target.
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
-  return prisma.urlMapping.findFirst({
-    where: { code: code },
-  }) as unknown as Promise<UrlMappingRead | null>;
+  throw new Error('resolve not implemented');
 };
 
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
@@ -55,10 +55,11 @@ export const listAll = async (): Promise<UrlMappingRead[]> => {
 
 
 
+// TODO: implement resolve; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub throws to
+// avoid silently reporting success — matching the fastapi target.
 export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
-  return prisma.urlMapping.findFirst({
-    where: { code: code },
-  }) as unknown as Promise<UrlMappingRead | null>;
+  throw new Error('resolve not implemented');
 };
 
 

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
@@ -2,7 +2,7 @@ package services
 
 import (
 {{#if entity.hasOperations}}	"context"
-{{/if}}{{#if entity.usesNotFound}}	"database/sql"
+{{/if}}{{#if entity.usesSqlNoRows}}	"database/sql"
 {{/if}}{{#if entity.usesErrors}}	"errors"
 {{/if}}
 	"github.com/uptrace/bun"
@@ -58,16 +58,13 @@ func New{{entity.entity.modelClassName}}Service(db *bun.DB, cfg *config.Config) 
 	}
 	return n > 0, nil
 }
-{{/if}}{{#if (eq routeKind "redirect")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
-	m := new(models.{{../entity.entity.modelClassName}})
-	err := s.db.NewSelect().Model(m).Where("? = ?", bun.Ident("{{lookupColumn}}"), {{serviceCallArgs}}).Limit(1).Scan(ctx)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
+{{/if}}{{#if (eq routeKind "redirect")}}// TODO: implement {{serviceMethod}}; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub returns an
+// explicit error to avoid silently reporting success — matching the fastapi target.
+func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, {{serviceSignatureArgs}}) (*models.{{../entity.entity.modelClassName}}, error) {
+	_ = ctx
+	_ = s
+	return nil, errors.New("{{serviceMethod}} not implemented")
 }
 {{/if}}{{#if (eq routeKind "other")}}// TODO: implement {{serviceMethod}}; the convention engine could not derive a
 // CRUD shape for this operation, so the stub returns an explicit error to

--- a/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
@@ -66,10 +66,11 @@ export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturn
 
 {{/if}}
 {{#if (eq routeKind "redirect")}}
+// TODO: implement {{handlerName}}; a redirect operation carries spec side-effects the
+// convention engine cannot derive (e.g. click-count increment), so the stub throws to
+// avoid silently reporting success — matching the fastapi target.
 export const {{handlerName}} = async ({{serviceSignatureArgs}}): {{serviceReturnType}} => {
-  return prisma.{{../entity.entityCamel}}.{{prismaCall}}({
-    where: { {{prismaWhere}} },
-  }){{#if ../entity.needsResultCast}} as unknown as {{serviceReturnType}}{{/if}};
+  throw new Error('{{handlerName}} not implemented');
 };
 
 {{/if}}

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -89,6 +89,7 @@ final private case class GoEntityCtx(
     usesPathParams: Boolean,
     usesNotFound: Boolean,
     usesErrors: Boolean,
+    usesSqlNoRows: Boolean,
     customSchemas: List[GoCustomSchema]
 )
 
@@ -451,9 +452,14 @@ object EmitGo:
     val needsDecimal = nonIdFields.exists: f =>
       f.domainType.contains("decimal.Decimal")
 
+    // The handler's `errors` import covers `errors.Is(ErrNotFound)` in the read AND redirect
+    // routes (the redirect route still maps a not-found error to 404). The service's
+    // `database/sql` import is needed only by the `read` branch's `sql.ErrNoRows` — a redirect
+    // op is now a fail-loud stub that does no row lookup, so it must not pull in `database/sql`.
     val usesNotFound = operations.exists: o =>
       o.routeKind == "read" || o.routeKind == "redirect"
     val usesErrors      = usesNotFound || operations.exists(_.routeKind == "other")
+    val usesSqlNoRows   = operations.exists(_.routeKind == "read")
     val usesRequestBody = operations.exists(_.hasRequestBody)
     val usesPathParams  = operations.exists(_.pathParams.nonEmpty)
 
@@ -483,6 +489,7 @@ object EmitGo:
       usesPathParams = usesPathParams,
       usesNotFound = usesNotFound,
       usesErrors = usesErrors,
+      usesSqlNoRows = usesSqlNoRows,
       customSchemas = customSchemas
     )
 

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -270,6 +270,27 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val tsUrlSvc = tsUrl("src/services/urlMapping.ts")
       assert(tsUrlSvc.contains("prisma.urlMapping.findMany("), tsUrlSvc)
 
+  // S: url_shortener.Resolve has a state-mutating side-effect (click_count++) the engine can't
+  // derive, so all three targets must fail loud — not silently look up and redirect while
+  // dropping the increment. fastapi already stubbed it; go/ts must now match.
+  test("redirect op with a side-effect is a fail-loud stub across all three targets"):
+    for
+      ts <- fileMapOf("url_shortener", "ts-express-postgres")
+      go <- fileMapOf("url_shortener", "go-chi-postgres")
+      fa <- fileMapOf("url_shortener", "python-fastapi-postgres")
+    yield
+      val tsSvc = ts("src/services/urlMapping.ts")
+      val goSvc = go("internal/services/url_mapping.go")
+      val faSvc = fa("app/services/url_mapping.py")
+      assert(tsSvc.contains("throw new Error('resolve not implemented')"), tsSvc)
+      assert(!tsSvc.contains("prisma.urlMapping.findFirst"), tsSvc)
+      assert(goSvc.contains("errors.New(\"Resolve not implemented\")"), goSvc)
+      assert(!goSvc.contains("database/sql"), goSvc)
+      assert(faSvc.contains("def resolve") && faSvc.contains("NotImplementedError"), faSvc)
+      // the 302 redirect ROUTE is preserved in all three (spec-faithful API surface)
+      assert(go("internal/handlers/url_mappings.go").contains("http.Redirect"), "go route")
+      assert(ts("src/routes/urlMappings.ts").contains("res.redirect(302"), "ts route")
+
   // Q: a synthesized PK is BIGSERIAL (64-bit) in every migration. ts-express must declare it as
   // Prisma `BigInt` so the generated client matches its own migration.sql; an explicit `id: Int`
   // stays Prisma `Int`. (fastapi/go are already consistently 64-bit / 32-bit respectively.)

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
@@ -92,7 +92,9 @@ class EmitGoTest extends CatsEffectSuite:
         svc
       )
       assert(svc.contains("bun.Ident(\"code\")"), svc)
-      assert(svc.contains("ErrNotFound"), svc)
+      // Resolve carries a spec side-effect (click_count++) the engine can't derive, so it is a
+      // fail-loud stub — not a silent findFirst that drops the increment (matches fastapi).
+      assert(svc.contains("errors.New(\"Resolve not implemented\")"), svc)
 
       val migUp = files("migrations/001_initial_schema.up.sql")
       assert(migUp.contains("CREATE TABLE url_mappings"), migUp)

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTsTest.scala
@@ -84,7 +84,9 @@ class EmitTsTest extends CatsEffectSuite:
       assert(routes.contains("res.redirect(302, result.url)"), routes)
 
       val service = files("src/services/urlMapping.ts")
-      assert(service.contains("prisma.urlMapping.findFirst"), service)
+      // Resolve carries a spec side-effect (click_count++) the engine can't derive, so it is a
+      // fail-loud stub — not a silent findFirst that drops the increment (matches fastapi).
+      assert(service.contains("throw new Error('resolve not implemented')"), service)
       assert(service.contains("prisma.urlMapping.deleteMany"), service)
       assert(service.contains("prisma.urlMapping.findMany"), service)
 


### PR DESCRIPTION
## Summary

Continues the cascade. **Defect S**: `url_shortener.Resolve` ensures `metadata'[code].click_count = pre(metadata)[code].click_count + 1` — a state-mutating side-effect the convention engine can't derive (LLM_SYNTHESIS). The three targets diverged:

| Target | `Resolve` service |
|---|---|
| fastapi | `raise NotImplementedError("PartialUpdate operation 'Resolve' …")` — fail-loud ✅ |
| go-chi | `s.db.NewSelect()…Where(code)…Scan` + redirect — **silently no click_count++** ❌ |
| ts-express | `prisma.urlMapping.findFirst({where:{code}})` + redirect — **silently no click_count++** ❌ |

Same spec op → honest 500 under fastapi, silently-wrong 302 under go/ts. Cross-renderer divergence + the same silent-wrong-impl class as Defect R, here for the Redirect shape.

## Fix

The divergence was in the **service templates**, not `RouteKind` (all three get `RouteKind.Redirect` from the shared classifier). The python service template's `redirect` branch already stubs; the go/ts ones did a real lookup. Aligned the go/ts service-template `redirect` branches with python's fail-loud stub, **keeping the 302 redirect ROUTE in all three** (spec-faithful API surface — better than discarding it). `EmitPython` untouched → fastapi byte-identical.

**Go import follow-through:** a stubbed redirect no longer does a row lookup, so the service must not import `database/sql`/`sql.ErrNoRows`. The single `usesNotFound` flag conflated two needs; split into `usesNotFound` (handler `errors.Is` for read **and** redirect routes) and `usesSqlNoRows` (service `database/sql` for `read` only). Verified imports-vs-usage by inspection across all 3 dialects (no read op in url_shortener → `database/sql` correctly absent; handler `errors` retained).

## Scope / invariants

- **fastapi byte-identical** (python template untouched) — EmitPythonTest 3/3 green.
- Only go/ts `url_shortener` service goldens change (Resolve → stub; go drops `database/sql`). 6 files, route/handler unchanged.
- Obsolete Resolve-lookup assertions (`ErrNotFound` in go, `findFirst` in ts) updated to assert the corrected stub; added a cross-renderer Defect-S regression (all 3 fail-loud; 302 route preserved).

## Test plan

- [x] codegen 222 (EmitGo/Ts/Python + DialectProfileEmit 32), convention 66, parser 30, ir 43, lint 31, cli 56, profile 46, testgen 233, verify 163 — all green; scalafix clean
- [x] python goldens byte-identical; go imports verified vs usage all dialects
- [ ] CI go-build (`go build` — definitively validates the import split) + ts-build (`tsc`) matrices; fastapi unaffected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirect operations with spec-defined side effects now fail loud in Go and TS services, matching FastAPI, to prevent silent state skips. 302 redirect routes are preserved; only the service implementations change.

- **Bug Fixes**
  - Go/TS service templates for redirect now return explicit "not implemented" errors instead of doing a DB lookup; routes still issue 302 redirects.
  - Updated `url_shortener` goldens (Resolve) for Go/TS; FastAPI remains unchanged.

- **Refactors**
  - Split Go import flags: `usesNotFound` (handler `errors.Is` for read/redirect) vs `usesSqlNoRows` (service `database/sql` for read only). Redirect services no longer import `database/sql`/`sql.ErrNoRows`.
  - Added regression tests to enforce fail-loud redirect stubs and keep the 302 route across targets.

<sup>Written for commit a1bc616c4a04d511ebeb0b6118fd5ec8cab815f1. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/275?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

