### PR TITLE
refactor: extract renderer-agnostic AdminModel (foundation for go/ts conformance)

### DIFF
--- a/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
@@ -1,0 +1,79 @@
+package specrest.testgen
+
+import specrest.ir.generated.SpecRestGenerated.*
+
+object AdminModel:
+
+  final case class Projection(
+      entityName: String,
+      keyFieldName: String,
+      valueShape: ProjectionValue
+  )
+
+  enum ProjectionValue derives CanEqual:
+    case PrimitiveField(fieldName: String)
+    case EntityRow
+
+  def projectionFor(f: StateFieldDeclFull, ir: ServiceIRFull): Option[Projection] =
+    f.b match
+      case RelationTypeF(k, _, v, _) =>
+        inferRelationProjection(k, v, ir)
+      case NamedTypeF(name, _) =>
+        ir.c.collect { case e: EntityDeclFull if e.a == name => e }.headOption
+          .flatMap(e =>
+            primaryKeyField(e).map(pk => Projection(name, pk, ProjectionValue.EntityRow))
+          )
+      case _ => None
+
+  private def inferRelationProjection(
+      k: type_expr_full,
+      v: type_expr_full,
+      ir: ServiceIRFull
+  ): Option[Projection] =
+    val kName      = typeName(k)
+    val vName      = typeName(v)
+    val entityList = ir.c.collect { case e: EntityDeclFull => e }
+    (kName, vName) match
+      case (Some(kn), Some(vn)) if entityList.exists(_.a == vn) =>
+        for
+          entity <- entityList.find(_.a == vn)
+          keyField <-
+            entity.c.collect { case f: FieldDeclFull => f }.find(f => typeName(f.b).contains(kn))
+        yield Projection(vn, keyField.a, ProjectionValue.EntityRow)
+      case (Some(kn), Some(vn)) =>
+        entityList
+          .find: e =>
+            val ef = e.c.collect { case f: FieldDeclFull => f }
+            ef.exists(f => typeName(f.b).contains(kn)) &&
+            ef.exists(f => typeName(f.b).contains(vn))
+          .flatMap: e =>
+            val ef = e.c.collect { case f: FieldDeclFull => f }
+            for
+              keyField <- ef.find(f => typeName(f.b).contains(kn))
+              valField <- ef.find(f =>
+                            typeName(f.b).contains(vn) && f.a != keyField.a
+                          )
+            yield Projection(e.a, keyField.a, ProjectionValue.PrimitiveField(valField.a))
+      case _ => None
+
+  def typeName(t: type_expr_full): Option[String] = t match
+    case NamedTypeF(n, _) => Some(n)
+    case _                => None
+
+  def primaryKeyField(e: EntityDeclFull): Option[String] =
+    val fs = e.c.collect { case f: FieldDeclFull => f }
+    fs.find(_.a == "id").map(_.a).orElse(fs.headOption.map(_.a))
+
+  def isDateTimeType(
+      t: type_expr_full,
+      ir: ServiceIRFull,
+      seen: Set[String]
+  ): Boolean =
+    t match
+      case NamedTypeF("DateTime", _) => true
+      case OptionTypeF(inner, _)     => isDateTimeType(inner, ir, seen)
+      case NamedTypeF(name, _) if !seen.contains(name) =>
+        ir.e.collect { case a: TypeAliasDeclFull => a }
+          .find(_.a == name)
+          .exists(alias => isDateTimeType(alias.b, ir, seen + name))
+      case _ => false

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -27,7 +27,7 @@ object AdminRouter:
     val stateProjections =
       if stateFieldsList.isEmpty then "    return {}"
       else
-        val needsRows = stateFieldsList.exists(f => projectionFor(f, ir).isDefined)
+        val needsRows = stateFieldsList.exists(f => AdminModel.projectionFor(f, ir).isDefined)
         val rowsLine =
           if entities.size == 1 && needsRows then
             val e = entities.head
@@ -98,11 +98,21 @@ object AdminRouter:
        |$stateProjections$seedSection
        |""".stripMargin
 
+  private[testgen] def primaryKeyField(e: EntityDeclFull): Option[String] =
+    AdminModel.primaryKeyField(e)
+
+  private[testgen] def isDateTimeType(
+      t: type_expr_full,
+      ir: ServiceIRFull,
+      seen: Set[String]
+  ): Boolean =
+    AdminModel.isDateTimeType(t, ir, seen)
+
   private def seedHandler(entity: EntityDeclFull, ir: ServiceIRFull): String =
     val snake  = Naming.toSnakeCase(entity.a)
-    val pkName = primaryKeyField(entity).getOrElse("id")
+    val pkName = AdminModel.primaryKeyField(entity).getOrElse("id")
     val dtFields = entity.c.collect:
-      case FieldDeclFull(n, t, _, _) if isDateTimeType(t, ir, Set.empty) => n
+      case FieldDeclFull(n, t, _, _) if AdminModel.isDateTimeType(t, ir, Set.empty) => n
     val coercion =
       if dtFields.isEmpty then ""
       else
@@ -123,20 +133,6 @@ object AdminRouter:
         |    await session.refresh(obj)
         |    return {"$pkName": obj.$pkName}
         |""".stripMargin
-
-  private[testgen] def isDateTimeType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Boolean =
-    t match
-      case NamedTypeF("DateTime", _) => true
-      case OptionTypeF(inner, _)     => isDateTimeType(inner, ir, seen)
-      case NamedTypeF(name, _) if !seen.contains(name) =>
-        ir.e.collect { case a: TypeAliasDeclFull => a }
-          .find(_.a == name)
-          .exists(alias => isDateTimeType(alias.b, ir, seen + name))
-      case _ => false
 
   private[testgen] def isNumericType(
       t: type_expr_full,
@@ -165,79 +161,19 @@ object AdminRouter:
           .exists(alias => isOptionalType(alias.b, ir, seen + name))
       case _ => false
 
-  final private case class Projection(
-      entityName: String,
-      keyFieldName: String,
-      valueShape: ProjectionValue
-  )
-
-  private enum ProjectionValue derives CanEqual:
-    case PrimitiveField(fieldName: String)
-    case EntityRow
-
-  private def projectionFor(f: StateFieldDeclFull, ir: ServiceIRFull): Option[Projection] =
-    f.b match
-      case RelationTypeF(k, _, v, _) =>
-        inferRelationProjection(k, v, ir)
-      case NamedTypeF(name, _) =>
-        ir.c.collect { case e: EntityDeclFull if e.a == name => e }.headOption
-          .flatMap(e =>
-            primaryKeyField(e).map(pk => Projection(name, pk, ProjectionValue.EntityRow))
-          )
-      case _ => None
-
-  private def inferRelationProjection(
-      k: type_expr_full,
-      v: type_expr_full,
-      ir: ServiceIRFull
-  ): Option[Projection] =
-    val kName      = typeName(k)
-    val vName      = typeName(v)
-    val entityList = ir.c.collect { case e: EntityDeclFull => e }
-    (kName, vName) match
-      case (Some(kn), Some(vn)) if entityList.exists(_.a == vn) =>
-        for
-          entity <- entityList.find(_.a == vn)
-          keyField <-
-            entity.c.collect { case f: FieldDeclFull => f }.find(f => typeName(f.b).contains(kn))
-        yield Projection(vn, keyField.a, ProjectionValue.EntityRow)
-      case (Some(kn), Some(vn)) =>
-        entityList
-          .find: e =>
-            val ef = e.c.collect { case f: FieldDeclFull => f }
-            ef.exists(f => typeName(f.b).contains(kn)) &&
-            ef.exists(f => typeName(f.b).contains(vn))
-          .flatMap: e =>
-            val ef = e.c.collect { case f: FieldDeclFull => f }
-            for
-              keyField <- ef.find(f => typeName(f.b).contains(kn))
-              valField <- ef.find(f =>
-                            typeName(f.b).contains(vn) && f.a != keyField.a
-                          )
-            yield Projection(e.a, keyField.a, ProjectionValue.PrimitiveField(valField.a))
-      case _ => None
-
-  private def typeName(t: type_expr_full): Option[String] = t match
-    case NamedTypeF(n, _) => Some(n)
-    case _                => None
-
-  private[testgen] def primaryKeyField(e: EntityDeclFull): Option[String] =
-    val fs = e.c.collect { case f: FieldDeclFull => f }
-    fs.find(_.a == "id").map(_.a).orElse(fs.headOption.map(_.a))
-
   private def projectionLine(
       f: StateFieldDeclFull,
       ir: ServiceIRFull,
       entities: List[EntityDeclFull]
   ): String =
-    projectionFor(f, ir) match
+    AdminModel.projectionFor(f, ir) match
       case Some(p) =>
         val rowsRef =
           if entities.size <= 1 then "rows"
           else s"rows_${Naming.toSnakeCase(p.entityName)}"
         val valueExpr = p.valueShape match
-          case ProjectionValue.PrimitiveField(name) => s"row.$name"
-          case ProjectionValue.EntityRow            => "_row_to_dict(row)"
+          case AdminModel.ProjectionValue.PrimitiveField(name) => s"row.$name"
+          case AdminModel.ProjectionValue.EntityRow            => "_row_to_dict(row)"
         val key = pyStringLit(f.a)
         s"        $key: {row.${p.keyFieldName}: $valueExpr for row in $rowsRef}"
       case None =>


### PR DESCRIPTION
## Context

This is the **foundational keystone of Option 1** — closing the systemic gap that has been the root cause of the entire O–S cascade: **only fastapi has behavioral conformance in CI** (`--with-tests` → spec-derived HTTP-black-box suite vs a real DB). go-chi/ts-express only get `build`/`tsc`/`migrate`, so every defect O→S (id-width, unfiltered list, dropped redirect side-effect, …) shipped CI-green and was caught only by manual inspection.

Investigation established the conformance suite (`run_conformance.py` + behavioral/stateful/structural) is **100% language-agnostic** — `conftest.py` falls back to `httpx.Client(base_url=…)` against any running server. The only language-specific artifact is the **test-admin router** (`/__test_admin__/reset|state|seed`), today Python/SQLAlchemy-only.

## This PR (no behavior change)

Extracts the test-admin router's **spec-derived, language-agnostic logic** — state-field → `{pk: row}` projection inference, PK resolution, datetime-field detection — into a new `AdminModel` object. `AdminRouter` now consumes it and renders the **identical** Python/FastAPI output.

- **fastapi byte-identical** — `EmitPythonTest` 3/3; `testgen` 233, `codegen` 222 green; scalafix clean.
- `AdminRouter` keeps thin `private[testgen]` forwarders → `Behavioral.scala` callers untouched.
- `supportsTestgen` **unchanged** (ts/go still correctly rejected) — flipping it without the renderer would emit a Python router into a TS project, so that lands atomically with the TS renderer in the follow-up.

## Why split here

Option 1 = (a) this renderer-agnostic model [here], (b) a TS/Prisma `AdminModel` renderer + env-gated mount + `supportsTestgen(Express)` + ts-build CI running the conformance bundle, then fixing the ts behavioral divergences conformance surfaces; (c) the same for go-chi. (b)/(c) are inherently **CI-iteration-driven** (the conformance loop is the validator; there's no ts/go runtime locally) and must each land as their own green PR. This PR is the safe, verified foundation both build on.

## Test plan
- [x] `testgen` 233, `codegen` 222 (incl. EmitPythonTest 3/3 — fastapi byte-identical), scalafix clean
- [ ] CI: build-and-test + cross-checks (pure refactor — expect green everywhere)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a renderer-agnostic `AdminModel` for the test-admin router logic and switched `AdminRouter` to use it. Behavior is unchanged and FastAPI output remains byte-identical; this sets the base for CI conformance in `ts-express` and `go-chi`.

- **Refactors**
  - Moved projection inference, primary-key resolution, and DateTime detection into `AdminModel`.
  - Updated `AdminRouter` to delegate to `AdminModel`; added thin `private[testgen]` forwarders to keep existing callers unchanged.
  - Left `supportsTestgen` unchanged; TS/Go remain gated until their renderer lands.
  - Tests stay green, with FastAPI goldens unchanged.

<sup>Written for commit 7737eeafb8e7742396c2251b86fb4edc9821f6d6. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/276?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

