### PR TITLE
feat: ts-express conformance — TS/Prisma test-admin router + CI gate

### DIFF
--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -14,6 +14,7 @@ on:
       - "modules/codegen/src/main/scala/specrest/codegen/Emit.scala"
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
       - "modules/codegen/src/main/resources/templates/ts/express/**"
+      - "modules/testgen/src/main/**"
       - "fixtures/spec/url_shortener.spec"
       - "fixtures/spec/todo_list.spec"
       - "fixtures/spec/ecommerce.spec"
@@ -26,6 +27,7 @@ on:
       - "modules/codegen/src/main/scala/specrest/codegen/ts/**"
       - "modules/codegen/src/main/scala/specrest/codegen/migration/**"
       - "modules/profile/src/main/scala/specrest/profile/Targets.scala"
+      - "modules/testgen/src/main/**"
 
 permissions:
   contents: read
@@ -170,3 +172,142 @@ jobs:
           npx prisma migrate deploy
           npx prisma migrate reset --force --skip-seed --skip-generate
           npx prisma migrate deploy
+
+  conformance:
+    name: ts-express -> conformance suite (${{ matrix.fixture }} / ${{ matrix.dialect }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - fixture: url_shortener
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: url_shortener
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: todo_list
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: todo_list
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: ecommerce
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: ecommerce
+            dialect: sqlite
+            db_url: file:./app.db
+          - fixture: auth_service
+            dialect: postgres
+            db_url: postgresql://app:app@localhost:5432/app
+          - fixture: auth_service
+            dialect: sqlite
+            db_url: file:./app.db
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: app
+          POSTGRES_PASSWORD: app
+          POSTGRES_DB: app
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U app"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+
+      - uses: sbt/setup-sbt@93e926cbdb4a428e41b4ef754124ec82925ffdc2 # v1.1.23
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Emit TS project --with-tests (${{ matrix.fixture }} / ${{ matrix.dialect }})
+        run: |
+          mkdir -p out
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework express --db ${{ matrix.dialect }} --with-tests --out out --ignore-verify"
+
+      - name: npm install
+        working-directory: out
+        run: npm install --no-audit --no-fund
+
+      - name: prisma generate
+        working-directory: out
+        run: npx prisma generate
+
+      - name: tsc --noEmit
+        working-directory: out
+        run: npx tsc --noEmit
+
+      - name: build dist
+        working-directory: out
+        run: npm run build
+
+      - name: Prisma migrate deploy
+        working-directory: out
+        env:
+          DATABASE_URL: ${{ matrix.db_url }}
+        run: npx prisma migrate deploy
+
+      - name: Boot ts-express server (ENABLE_TEST_ADMIN=1)
+        working-directory: out
+        env:
+          DATABASE_URL: ${{ matrix.db_url }}
+          ENABLE_TEST_ADMIN: "1"
+          PORT: "8080"
+        run: |
+          nohup node dist/index.js > server.log 2>&1 &
+          echo $! > server.pid
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
+              echo "server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server failed to become healthy" >&2
+          cat server.log >&2
+          exit 1
+
+      - name: Run conformance suite (smoke profile)
+        working-directory: out
+        env:
+          SPEC_TEST_BASE_URL: http://localhost:8080
+        run: |
+          uv run --python 3.13 \
+            --with 'pytest>=8.0' \
+            --with 'httpx>=0.28' \
+            --with hypothesis \
+            --with 'schemathesis>=4.16,<5' \
+            python tests/run_conformance.py smoke
+
+      - name: Server log (on failure)
+        if: failure()
+        working-directory: out
+        run: |
+          echo "::group::server.log"
+          cat server.log || true
+          echo "::endgroup::"
+
+      - name: Stop server
+        if: always()
+        working-directory: out
+        run: |
+          if [ -f server.pid ]; then kill "$(cat server.pid)" 2>/dev/null || true; fi

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/index.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/index.ts
@@ -2,6 +2,21 @@ import { app } from './app.js';
 import { config } from './config.js';
 import { prisma } from './prisma.js';
 
+if (process.env.ENABLE_TEST_ADMIN === '1') {
+  try {
+    const adminModulePath: string = './routes/testAdmin.js';
+    const mod = (await import(adminModulePath)) as {
+      registerTestAdminRoutes: (a: typeof app) => void;
+    };
+    mod.registerTestAdminRoutes(app);
+    console.log(JSON.stringify({ level: 'info', msg: 'test admin routes mounted' }));
+  } catch (e) {
+    console.log(
+      JSON.stringify({ level: 'warn', msg: 'test admin module unavailable', error: String(e) }),
+    );
+  }
+}
+
 const server = app.listen(config.port, () => {
   console.log(JSON.stringify({ level: 'info', msg: 'server started', port: config.port }));
 });

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/index.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/index.ts
@@ -2,6 +2,21 @@ import { app } from './app.js';
 import { config } from './config.js';
 import { prisma } from './prisma.js';
 
+if (process.env.ENABLE_TEST_ADMIN === '1') {
+  try {
+    const adminModulePath: string = './routes/testAdmin.js';
+    const mod = (await import(adminModulePath)) as {
+      registerTestAdminRoutes: (a: typeof app) => void;
+    };
+    mod.registerTestAdminRoutes(app);
+    console.log(JSON.stringify({ level: 'info', msg: 'test admin routes mounted' }));
+  } catch (e) {
+    console.log(
+      JSON.stringify({ level: 'warn', msg: 'test admin module unavailable', error: String(e) }),
+    );
+  }
+}
+
 const server = app.listen(config.port, () => {
   console.log(JSON.stringify({ level: 'info', msg: 'server started', port: config.port }));
 });

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/index.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/index.ts
@@ -2,6 +2,21 @@ import { app } from './app.js';
 import { config } from './config.js';
 import { prisma } from './prisma.js';
 
+if (process.env.ENABLE_TEST_ADMIN === '1') {
+  try {
+    const adminModulePath: string = './routes/testAdmin.js';
+    const mod = (await import(adminModulePath)) as {
+      registerTestAdminRoutes: (a: typeof app) => void;
+    };
+    mod.registerTestAdminRoutes(app);
+    console.log(JSON.stringify({ level: 'info', msg: 'test admin routes mounted' }));
+  } catch (e) {
+    console.log(
+      JSON.stringify({ level: 'warn', msg: 'test admin module unavailable', error: String(e) }),
+    );
+  }
+}
+
 const server = app.listen(config.port, () => {
   console.log(JSON.stringify({ level: 'info', msg: 'server started', port: config.port }));
 });

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -51,6 +51,7 @@ final case class CompileOptions(
     dafnyBin: Option[String] = None,
     dafnyTranslateTimeoutSec: Int = 60,
     allowSkeletons: Boolean = false,
+    synthesisPartial: Boolean = false,
     dryRun: Boolean = false
 )
 
@@ -213,8 +214,14 @@ object Compile:
             opts.synthesisCacheDir.map(Paths.get(_)).getOrElse(Cache.defaultRoot(Paths.get("")))
           val verifiedRoot = cacheRoot.resolve("verified")
           loadVerifiedBodies(specFile, synthOps, dafny.methods, verifiedRoot, opts, log).flatMap:
-            case Left(code) => IO.pure(Left(code))
+            case Left(code)    => IO.pure(Left(code))
             case Right(bodies) =>
+              // --synthesis-partial: only ops that actually got a verified body are bound to
+              // the kernel; the rest were spliced as skeletons / left unbound, so they must
+              // NOT be routed to the kernel — codegen emits the fail-loud stub and testgen
+              // (Finding 1) skips them. Binding off `synthOps` instead would call kernel
+              // methods backed by unverified placeholder bodies.
+              val boundOps = synthOps.filter(c => bodies.contains(c.operationName))
               FileAssembly.spliceAll(dafny.text, bodies) match
                 case Left(failure) =>
                   IO.delay(log.error(s"$specFile: splice failed: ${failure.message}"))
@@ -224,19 +231,19 @@ object Compile:
                     r.map: translated =>
                       val bindings = TargetLanguage.forCompileTarget(opts.target) match
                         case TargetLanguage.Go =>
-                          synthOps
+                          boundOps
                             .map(c =>
                               c.operationName -> s"dafnykernel.${c.operationName}"
                             )
                             .toMap
                         case TargetLanguage.JavaScript =>
-                          synthOps
+                          boundOps
                             .map(c =>
                               c.operationName -> s"dafnyKernel.${c.operationName}"
                             )
                             .toMap
                         case TargetLanguage.Python =>
-                          synthOps
+                          boundOps
                             .map(c => c.operationName -> dafnyCallable(c.operationName))
                             .toMap
                       val (packagePath, files) = TargetLanguage.forCompileTarget(opts.target) match
@@ -333,8 +340,9 @@ object Compile:
                   opts,
                   log
                 ).map:
-                  case Right(body) => Right(acc + (c.operationName -> body))
-                  case Left(code)  => Left(code)
+                  case Right(Some(body)) => Right(acc + (c.operationName -> body))
+                  case Right(None)       => Right(acc)
+                  case Left(code)        => Left(code)
 
   private def lookupOpBody(
       specFile: String,
@@ -344,17 +352,26 @@ object Compile:
       skeletonCache: Option[Cache],
       opts: CompileOptions,
       log: Logger
-  ): IO[Either[ExitCode, String]] =
+  ): IO[Either[ExitCode, Option[String]]] =
     val verifiedLookup = verifiedCache match
       case Some(c) => c.lookup(key)
       case None    => IO.pure(None)
+    def partialOrError: IO[Either[ExitCode, Option[String]]] =
+      if opts.synthesisPartial then
+        IO.delay(
+          log.warn(
+            s"$specFile: '$opName' has no verified body (--synthesis-partial); emitting a " +
+              "fail-loud stub — testgen records it in _testgen_skips.json and asserts no behavior"
+          )
+        ).as(Right(None))
+      else
+        IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
+          .as(Left(ExitCodes.Violations))
     verifiedLookup.flatMap:
       case Some(entry) if entry.outcome == specrest.synth.CacheOutcome.Verified =>
-        IO.pure(Right(entry.body))
+        IO.pure(Right(Some(entry.body)))
       case _ =>
-        if !opts.allowSkeletons then
-          IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
-            .as(Left(ExitCodes.Violations))
+        if !opts.allowSkeletons then partialOrError
         else
           val skeletonLookup = skeletonCache match
             case Some(c) => c.lookup(key)
@@ -367,10 +384,8 @@ object Compile:
                     "(--allow-skeletons set); the generated handler will halt at runtime " +
                     "with a Dafny HaltException when invoked"
                 )
-              ).as(Right(entry.body))
-            case None =>
-              IO.delay(missingVerifiedBodyError(specFile, opName, opts, log))
-                .as(Left(ExitCodes.Violations))
+              ).as(Right(Some(entry.body)))
+            case None => partialOrError
 
   private def missingVerifiedBodyError(
       specFile: String,

--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -247,6 +247,12 @@ object Main
         "fall back to unverified skeleton bodies (from `synth verify --fallback`) when the verified cache misses; the generated handler halts at runtime when invoked"
       )
       .orFalse
+    val synthesisPartial = Opts
+      .flag(
+        "synthesis-partial",
+        "use verified bodies where cached; emit a fail-loud stub (skipped by testgen) for LLM_SYNTHESIS ops with no verified body, instead of failing the build"
+      )
+      .orFalse
     val dryRun = Opts
       .flag(
         "dry-run",
@@ -268,11 +274,12 @@ object Main
         compileDafnyBin,
         compileTranslateTimeout,
         allowSkeletons,
+        synthesisPartial,
         dryRun,
         verbose,
         quiet,
         colorMode
-      ).mapN: (spec, t, o, iv, wt, ss, ws, sm, stp, scd, db, dtt, ask, dr, v, q, c) =>
+      ).mapN: (spec, t, o, iv, wt, ss, ws, sm, stp, scd, db, dtt, ask, sp, dr, v, q, c) =>
         Compile.run(
           spec,
           CompileOptions(
@@ -288,6 +295,7 @@ object Main
             dafnyBin = db,
             dafnyTranslateTimeoutSec = dtt,
             allowSkeletons = ask,
+            synthesisPartial = sp,
             dryRun = dr
           ),
           Logger.fromFlags(verbose = v, quiet = q, color = c)
@@ -303,7 +311,9 @@ object Main
       .withDefault(1.0)
     val maxTokens = Opts
       .option[Int]("max-tokens", "max output tokens")
-      .withDefault(2048)
+      // 2048 truncates a full Dafny body (and any reasoning-model preamble) before the
+      // closing code fence, yielding "no fenced code block found" and a wasted LLM call.
+      .withDefault(16384)
       .mapValidated: n =>
         if n > 0 then cats.data.Validated.valid(n)
         else cats.data.Validated.invalidNel(s"--max-tokens must be > 0 (got $n)")

--- a/modules/cli/src/main/scala/specrest/cli/TestCmd.scala
+++ b/modules/cli/src/main/scala/specrest/cli/TestCmd.scala
@@ -2,6 +2,7 @@ package specrest.cli
 
 import cats.effect.ExitCode
 import cats.effect.IO
+import specrest.testgen.SupportedTargets
 
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -28,9 +29,8 @@ object TestCmd:
       IO.delay(
         log.error(
           s"$ConformanceRunner not found under ${opts.outDir}; " +
-            "the conformance runner is emitted only for fastapi targets built with " +
-            "--with-tests. Re-compile with --framework fastapi --db <postgres|sqlite|mysql> " +
-            "--with-tests."
+            "the conformance runner is emitted only for targets built with --with-tests. " +
+            s"Re-compile a supported target (${SupportedTargets.describe}) with --with-tests."
         )
       ).as(ExitCodes.Translator)
     else invokeRunner(outRoot, opts, log)

--- a/modules/codegen/src/main/resources/templates/ts/express/src/index.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/index.ts.hbs
@@ -2,6 +2,21 @@ import { app } from './app.js';
 import { config } from './config.js';
 import { prisma } from './prisma.js';
 
+if (process.env.ENABLE_TEST_ADMIN === '1') {
+  try {
+    const adminModulePath: string = './routes/testAdmin.js';
+    const mod = (await import(adminModulePath)) as {
+      registerTestAdminRoutes: (a: typeof app) => void;
+    };
+    mod.registerTestAdminRoutes(app);
+    console.log(JSON.stringify({ level: 'info', msg: 'test admin routes mounted' }));
+  } catch (e) {
+    console.log(
+      JSON.stringify({ level: 'warn', msg: 'test admin module unavailable', error: String(e) }),
+    );
+  }
+}
+
 const server = app.listen(config.port, () => {
   console.log(JSON.stringify({ level: 'info', msg: 'server started', port: config.port }));
 });

--- a/modules/codegen/src/main/scala/specrest/codegen/RouteKind.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/RouteKind.scala
@@ -19,6 +19,32 @@ object RouteKind:
     // the synthesis pass's job, not a silently-wrong direct emit.
     if shape == List && hasFilterInputs(op) then Other else shape
 
+  // The effective route kind the service template actually emits: a Create whose request
+  // body does not match the entity's non-id columns cannot be a direct CRUD insert, so it
+  // is downgraded to the fail-loud stub (Other). This downgrade was duplicated verbatim in
+  // EmitTs/EmitPython/EmitGo — a single source here keeps codegen and testgen from drifting
+  // on which operations are real vs stubbed.
+  def effective(op: ProfiledOperation, entityNonIdColumns: Set[String]): RouteKind =
+    val initial = classify(op)
+    if initial == Create && !matchesEntityCreateShape(op, entityNonIdColumns) then Other
+    else initial
+
+  def matchesEntityCreateShape(op: ProfiledOperation, entityNonIdColumns: Set[String]): Boolean =
+    val bodyParamNames = op.endpoint.bodyParams.map(_.name)
+    classify(op) == Create &&
+    bodyParamNames.sizeIs == entityNonIdColumns.size &&
+    bodyParamNames.forall(entityNonIdColumns.contains)
+
+  // A handler is a fail-loud stub (throws `NotImplementedError` / `throw new Error`) when the
+  // synthesis pass produced no kernel method AND the effective shape is one the convention
+  // engine cannot derive a body for (Redirect carries spec side-effects; Other is the
+  // non-CRUD / shape-mismatch fallback). testgen must not assert behavior for these.
+  def isFailLoudStub(op: ProfiledOperation, entityNonIdColumns: Set[String]): Boolean =
+    op.dafnyMethod.isEmpty && (effective(op, entityNonIdColumns) match
+      case Redirect | Other => true
+      case _                => false
+    )
+
   private def hasFilterInputs(op: ProfiledOperation): Boolean =
     op.endpoint.queryParams.nonEmpty || op.endpoint.bodyParams.nonEmpty
 

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -534,11 +534,8 @@ object EmitGo:
 
     val entityNonIdColumnNames =
       entity.fields.filterNot(_.fieldName == "id").map(_.columnName).toSet
-    val bodyParamNames = endpoint.bodyParams.map(_.name)
     val matchesEntityCreateShape =
-      initialRouteKind == RouteKind.Create &&
-        bodyParamNames.size == entityNonIdColumnNames.size &&
-        bodyParamNames.forall(entityNonIdColumnNames.contains)
+      RouteKind.matchesEntityCreateShape(op, entityNonIdColumnNames)
 
     val hasRequestBody = initialRouteKind == RouteKind.Create || endpoint.bodyParams.nonEmpty
 
@@ -555,9 +552,7 @@ object EmitGo:
           .map(toGoField)
         (name, Some(name), fields)
 
-    val routeKind =
-      if initialRouteKind == RouteKind.Create && !matchesEntityCreateShape then RouteKind.Other
-      else initialRouteKind
+    val routeKind = RouteKind.effective(op, entityNonIdColumnNames)
 
     val pathParamCallArgs  = pathParams.map(_.goName).mkString(", ")
     val pathParamSignature = pathParams.map(p => s"${p.goName} ${p.domainType}").mkString(", ")

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -477,11 +477,8 @@ object EmitPython:
 
     val entityNonIdColumnNames =
       entity.fields.filterNot(_.fieldName == "id").map(_.columnName).toSet
-    val bodyParamNames = endpoint.bodyParams.map(_.name)
     val matchesEntityCreateShape =
-      initialRouteKind == RouteKind.Create &&
-        bodyParamNames.size == entityNonIdColumnNames.size &&
-        bodyParamNames.forall(entityNonIdColumnNames.contains)
+      RouteKind.matchesEntityCreateShape(op, entityNonIdColumnNames)
 
     var customRequestSchema: Option[CustomRequestSchema] = None
     var requestBodyType                                  = ""
@@ -497,10 +494,7 @@ object EmitPython:
         customRequestSchema =
           Some(CustomRequestSchema(requestBodyType, fields.map(schemaInputField)))
 
-    val routeKind =
-      if initialRouteKind == RouteKind.Create && !matchesEntityCreateShape then
-        RouteKind.Other
-      else initialRouteKind
+    val routeKind = RouteKind.effective(op, entityNonIdColumnNames)
 
     val (
       responseAnnotation,

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -607,11 +607,8 @@ object EmitTs:
 
     val entityNonIdColumnNames =
       entity.fields.filterNot(_.fieldName == "id").map(_.columnName).toSet
-    val bodyParamNames = endpoint.bodyParams.map(_.name)
     val matchesEntityCreateShape =
-      initialRouteKind == RouteKind.Create &&
-        bodyParamNames.size == entityNonIdColumnNames.size &&
-        bodyParamNames.forall(entityNonIdColumnNames.contains)
+      RouteKind.matchesEntityCreateShape(op, entityNonIdColumnNames)
 
     val hasRequestBody = initialRouteKind == RouteKind.Create || endpoint.bodyParams.nonEmpty
 
@@ -628,9 +625,7 @@ object EmitTs:
           .map(toTsField(_, nativeAttrs))
         (name, Some(name), fields)
 
-    val routeKind =
-      if initialRouteKind == RouteKind.Create && !matchesEntityCreateShape then RouteKind.Other
-      else initialRouteKind
+    val routeKind = RouteKind.effective(op, entityNonIdColumnNames)
 
     val readSchemaName = entity.readSchemaName
     val pathArgsCsv    = pathParams.map(_.tsName).mkString(", ")

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -131,10 +131,11 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(!tsSql.contains("::jsonb"), tsSql)
       assert(tsSql.contains("DEFAULT '[]'"), tsSql)
 
-  // P: todo_list `id: Int where value > 0` is an application-supplied (non-serial) integer PK.
-  // Alembic now pins it to `autoincrement=False`, so SQLAlchemy does NOT make it MySQL
-  // AUTO_INCREMENT — the `id > 0` CHECK is therefore valid and retained on *every* dialect,
-  // matching the raw-SQL renderer. (The MySQL-3818 drop only applies to synthesized serial PKs.)
+  // P: todo_list `id: Int where value > 0` is an application-supplied (non-serial) integer PK,
+  // widened to 64-bit (sa.BigInteger) per the spec's unbounded integer semantics. Alembic pins
+  // it to `autoincrement=False`, so SQLAlchemy does NOT make it MySQL AUTO_INCREMENT — the
+  // `id > 0` CHECK is therefore valid and retained on *every* dialect, matching the raw-SQL
+  // renderer. (The MySQL-3818 drop only applies to synthesized serial PKs.)
   test("explicit integer PK CHECK is retained across all dialects (no MySQL-3818 drop)"):
     for
       pg     <- fileMapOf("todo_list", "python-fastapi-postgres")
@@ -147,7 +148,9 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       for mig <- List(pgMig, sqMig, myMig) do
         assert(mig.contains("""sa.CheckConstraint('id > 0', name="ck_todos_0")"""), mig)
         assert(
-          mig.contains("""sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False"""),
+          mig.contains(
+            """sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=False"""
+          ),
           mig
         )
 
@@ -160,7 +163,8 @@ class DialectProfileEmitTest extends CatsEffectSuite:
 
   // P: the auto-increment decision is one canonical predicate honoured identically by all three
   // renderers. todo_list (single entity, explicit `id: Int`) is app-supplied -> no autoincrement
-  // anywhere; url_shortener (single entity, synthesized BIGSERIAL) is DB-generated -> everywhere.
+  // anywhere, and 64-bit-widened (BigInteger / BIGINT / Prisma BigInt) so the generated client
+  // matches its own migration; url_shortener (synthesized BIGSERIAL) is DB-generated everywhere.
   test("explicit vs synthesized PK auto-increment is consistent across raw/alembic/prisma"):
     for
       tdAl <- fileMapOf("todo_list", "python-fastapi-postgres")
@@ -172,13 +176,15 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val tdAlMig  = tdAl("alembic/versions/001_initial_schema.py")
       val tdGoSql  = tdGo("migrations/001_initial_schema.up.sql")
       val tdPrisma = tdTs("prisma/schema.prisma")
-      // explicit Todo.id (Int where value > 0): application-supplied on every renderer
+      // explicit Todo.id (Int where value > 0): application-supplied, 64-bit on every renderer
       assert(
-        tdAlMig.contains("""sa.Column("id", sa.Integer(), primary_key=True, autoincrement=False"""),
+        tdAlMig.contains(
+          """sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=False"""
+        ),
         tdAlMig
       )
-      assert(tdGoSql.contains("id INTEGER NOT NULL") && !tdGoSql.contains("SERIAL"), tdGoSql)
-      assert(tdPrisma.contains("id Int @id") && !tdPrisma.contains("autoincrement"), tdPrisma)
+      assert(tdGoSql.contains("id BIGINT NOT NULL") && !tdGoSql.contains("SERIAL"), tdGoSql)
+      assert(tdPrisma.contains("id BigInt @id") && !tdPrisma.contains("autoincrement"), tdPrisma)
       // synthesized url_shortener.UrlMapping.id (BIGSERIAL): DB-generated everywhere (unchanged)
       val usAlMig  = usAl("alembic/versions/001_initial_schema.py")
       val usPrisma = usTs("prisma/schema.prisma")
@@ -291,10 +297,11 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(go("internal/handlers/url_mappings.go").contains("http.Redirect"), "go route")
       assert(ts("src/routes/urlMappings.ts").contains("res.redirect(302"), "ts route")
 
-  // Q: a synthesized PK is BIGSERIAL (64-bit) in every migration. ts-express must declare it as
-  // Prisma `BigInt` so the generated client matches its own migration.sql; an explicit `id: Int`
-  // stays Prisma `Int`. (fastapi/go are already consistently 64-bit / 32-bit respectively.)
-  test("ts-express synthesized PK is Prisma BigInt; explicit integer PK stays Int"):
+  // Q: every PK is 64-bit in the migration — synthesized as BIGSERIAL, explicit `id: Int`
+  // widened to BIGINT. ts-express must declare both as Prisma `BigInt` so the generated client
+  // matches its own migration.sql; the synthesized one alone is DB-generated
+  // (`@default(autoincrement())`), the explicit one is application-supplied (bare `@id`).
+  test("ts-express PK is Prisma BigInt; synthesized auto-increments, explicit does not"):
     for
       url  <- fileMapOf("url_shortener", "ts-express-postgres")
       todo <- fileMapOf("todo_list", "ts-express-postgres")
@@ -304,7 +311,10 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       val todoPrisma = todo("prisma/schema.prisma")
       assert(urlMig.contains("id BIGSERIAL"), urlMig)
       assert(urlPrisma.contains("id BigInt @id @default(autoincrement()) @db.BigInt"), urlPrisma)
-      assert(todoPrisma.contains("id Int @id") && !todoPrisma.contains("id BigInt"), todoPrisma)
+      assert(
+        todoPrisma.contains("id BigInt @id") && !todoPrisma.contains("id BigInt @id @default"),
+        todoPrisma
+      )
 
   // F: ErrorResponse is a shared model type. Emitting it per-entity made any multi-entity
   // Go project fail to build ("ErrorResponse redeclared"). It must live once in common.go.
@@ -321,15 +331,17 @@ class DialectProfileEmitTest extends CatsEffectSuite:
       assert(entityModels.size >= 4, files.keys.toList.sorted.toString)
       entityModels.foreach(m => assert(!m.contains("type ErrorResponse struct"), m))
 
-  // G: type aliases over Int (OrderId/CustomerId = Int) used as params must resolve to the
-  // numeric type, not the `string` fallback (Prisma id is number; Go service wants int64).
+  // G: type aliases over Int (OrderId/CustomerId = Int) used as params must resolve to a
+  // numeric type, not the `string` fallback. `orderId` resolves to the Order PK, which is a
+  // 64-bit-widened BigInt, so the ts service coerces it to `bigint` for the Prisma `where`
+  // (the #273 bridge); Go wants int64.
   test("alias-over-Int params resolve to numeric in ts + go"):
     for
       ts <- fileMapOf("ecommerce", "ts-express-postgres")
       go <- fileMapOf("ecommerce", "go-chi-postgres")
     yield
       val orderSvc = ts("src/services/order.ts")
-      assert(orderSvc.contains("orderId: number"), orderSvc)
+      assert(orderSvc.contains("orderId: bigint"), orderSvc)
       assert(!orderSvc.contains("orderId: string"), orderSvc)
       val orderHandler = go.collect {
         case (p, c) if p.startsWith("internal/handlers/order") && p.endsWith(".go") => c

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -18,6 +18,16 @@ object Schema:
     "Money"    -> "INTEGER"
   )
 
+  // An explicit integer `id` PK is widened to 64-bit. Spec integer semantics are
+  // unbounded, so a 32-bit INTEGER overflows on ids >= 2^31 — surfacing as a 500
+  // instead of a 4xx not-found — and it would also disagree with synthesized
+  // BIGSERIAL PKs and BIGINT FKs. This is the single source of truth: both the
+  // migration DDL (deriveTable) and the codegen renderer types (profile.Annotate,
+  // which drives Prisma/SQLAlchemy/Go) must apply the *same* rule or the generated
+  // client is mistyped against its own migration.
+  def widenExplicitIdPkSqlType(fieldName: String, sqlType: String): String =
+    if fieldName == "id" && sqlType == "INTEGER" then "BIGINT" else sqlType
+
   final private case class EntityRef(tableName: String, idFkSqlType: String)
 
   final private case class MappedField(
@@ -69,7 +79,10 @@ object Schema:
         case None => "BIGINT"
         case Some(f) =>
           val mapped = mapTypeToColumn("id", f.b, entityNames, enumMap, aliasMap)
-          if mapped.column.sqlType == "BIGSERIAL" then "BIGINT" else mapped.column.sqlType
+          // A FK referencing the PK must match its widened type.
+          mapped.column.sqlType match
+            case "BIGSERIAL" => "BIGINT"
+            case other       => widenExplicitIdPkSqlType("id", other)
       entity.a -> EntityRef(tableName, idFkSqlType)
     }.toMap
 
@@ -98,7 +111,11 @@ object Schema:
     for field <- fields do
       val colName = Naming.toColumnName(field.a)
       val mapped  = mapFieldToColumn(field, entityNames, enumMap, aliasMap, entityRefs)
-      columns += mapped.column
+      val column =
+        mapped.column.copy(
+          sqlType = widenExplicitIdPkSqlType(field.a, mapped.column.sqlType)
+        )
+      columns += column
       mapped.foreignKey.foreach: fk =>
         foreignKeys += fk
         indexes += IndexSpec(s"idx_${tableName}_$colName", List(colName), unique = false)

--- a/modules/profile/src/main/scala/specrest/profile/Annotate.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Annotate.scala
@@ -96,11 +96,12 @@ object Annotate:
       profile: DeploymentProfile,
       ctx: TypeContext
   ): ProfiledField =
-    val mapped     = TypeMap.mapType(typeExpr, profile, ctx)
-    val colName    = Naming.toColumnName(fieldName)
-    val resolved   = TypeMap.resolveTypeExpr(typeExpr, ctx.aliasMap)
-    val nullable   = resolved.isInstanceOf[OptionTypeF]
-    val columnType = resolveColumnType(typeExpr, profile, ctx)
+    val mapped   = TypeMap.mapType(typeExpr, profile, ctx)
+    val colName  = Naming.toColumnName(fieldName)
+    val resolved = TypeMap.resolveTypeExpr(typeExpr, ctx.aliasMap)
+    val nullable = resolved.isInstanceOf[OptionTypeF]
+    val columnType =
+      Schema.widenExplicitIdPkSqlType(fieldName, resolveColumnType(typeExpr, profile, ctx))
     ProfiledField(
       fieldName = fieldName,
       columnName = colName,

--- a/modules/profile/src/main/scala/specrest/profile/Targets.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Targets.scala
@@ -177,6 +177,8 @@ object Express extends Framework:
   val supportedDialects: Set[DatabaseId] =
     Set(DatabaseId.Postgres, DatabaseId.Sqlite, DatabaseId.Mysql)
 
+  override def supportsTestgen(database: DatabaseId): Boolean = true
+
   def profile(language: LanguageId, database: DatabaseId): DeploymentProfile =
     DeploymentProfile(
       name = TargetKey(language, id, database).slug,

--- a/modules/profile/src/test/scala/specrest/profile/TargetCompositionTest.scala
+++ b/modules/profile/src/test/scala/specrest/profile/TargetCompositionTest.scala
@@ -98,8 +98,8 @@ class TargetCompositionTest extends CatsEffectSuite:
     intercept[RuntimeException]:
       Registry.getProfile("rust-actix-sqlite")
 
-  test("supportsTestgen covers every fastapi dialect and is false for chi/express"):
+  test("supportsTestgen covers every fastapi and express dialect and is false for chi"):
     List(DatabaseId.Postgres, DatabaseId.Sqlite, DatabaseId.Mysql).foreach: d =>
       assert(Fastapi.supportsTestgen(d), s"fastapi/$d")
+      assert(Express.supportsTestgen(d), s"express/$d")
       assert(!Chi.supportsTestgen(d), s"chi/$d")
-      assert(!Express.supportsTestgen(d), s"express/$d")

--- a/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
+++ b/modules/synth/src/main/scala/specrest/synth/CegisLoop.scala
@@ -154,7 +154,12 @@ final class CegisLoop(
       body: String,
       cost: Double
   ): IO[CegisOutcome] =
-    FileAssembly.splice(req.skeleton, req.classification.operationName, body) match
+    FileAssembly.splice(
+      req.skeleton,
+      req.classification.operationName,
+      body,
+      ResponseParser.helperSection(block, req.classification.operationName)
+    ) match
       case Left(failure) =>
         abort(AbortReason.SpliceFailed(failure.message, i), history)
       case Right(fullDfy) =>

--- a/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FileAssembly.scala
@@ -19,26 +19,37 @@ object FileAssembly:
   def splice(
       skeleton: String,
       methodName: String,
-      body: String
+      body: String,
+      helpers: String = ""
   ): Either[SpliceFailure, String] =
     val anchor = methodAnchor(methodName)
     anchor.findFirstMatchIn(skeleton) match
       case None =>
         Left(SpliceFailure(s"method '$methodName' not found in skeleton"))
-      case Some(m) =>
-        val nextMethodAt = NextMethodAnchor.findFirstMatchIn(skeleton.substring(m.end)) match
-          case Some(nm) => m.end + nm.start
-          case None     => skeleton.length
-        val placeholderAt = skeleton.indexOf(Placeholder, m.end)
-        if placeholderAt < 0 || placeholderAt >= nextMethodAt then
-          Left(SpliceFailure(s"placeholder not found within method '$methodName'"))
-        else
-          val before = skeleton.substring(0, placeholderAt)
-          val after  = skeleton.substring(placeholderAt + Placeholder.length)
-          val indented = body.linesIterator
-            .map(line => if line.isEmpty then line else s"  $line")
-            .mkString("\n")
-          Right(before + indented + (if indented.endsWith("\n") then "" else "\n") + after)
+      case Some(m0) =>
+        // The model emits helper functions/lemmas before the method declaration; inject
+        // them at module scope just before the method so the spliced body can call them.
+        val src =
+          if helpers.trim.isEmpty then skeleton
+          else
+            skeleton.substring(0, m0.start) + helpers.trim + "\n\n" + skeleton.substring(m0.start)
+        anchor.findFirstMatchIn(src) match
+          case None =>
+            Left(SpliceFailure(s"method '$methodName' not found in skeleton"))
+          case Some(m) =>
+            val nextMethodAt = NextMethodAnchor.findFirstMatchIn(src.substring(m.end)) match
+              case Some(nm) => m.end + nm.start
+              case None     => src.length
+            val placeholderAt = src.indexOf(Placeholder, m.end)
+            if placeholderAt < 0 || placeholderAt >= nextMethodAt then
+              Left(SpliceFailure(s"placeholder not found within method '$methodName'"))
+            else
+              val before = src.substring(0, placeholderAt)
+              val after  = src.substring(placeholderAt + Placeholder.length)
+              val indented = body.linesIterator
+                .map(line => if line.isEmpty then line else s"  $line")
+                .mkString("\n")
+              Right(before + indented + (if indented.endsWith("\n") then "" else "\n") + after)
 
   private def methodAnchor(name: String): Regex =
     s"""\\bmethod\\s+${Regex.quote(name)}(?=[\\s(<])""".r

--- a/modules/synth/src/main/scala/specrest/synth/Pricing.scala
+++ b/modules/synth/src/main/scala/specrest/synth/Pricing.scala
@@ -17,7 +17,14 @@ object Pricing:
     ModelPricing("claude-haiku-4-5", 0.80, 4.00, "anthropic"),
     ModelPricing("gpt-4o", 2.50, 10.00, "openai"),
     ModelPricing("gpt-4o-mini", 0.15, 0.60, "openai"),
-    ModelPricing("gpt-4-turbo", 10.00, 30.00, "openai")
+    ModelPricing("gpt-4-turbo", 10.00, 30.00, "openai"),
+    ModelPricing("gpt-4.1", 2.00, 8.00, "openai"),
+    ModelPricing("gpt-4.1-mini", 0.40, 1.60, "openai"),
+    // gpt-5 figures are deliberately conservative (high) estimates so an unpriced
+    // frontier model can never silently disable the --cost-cap-usd guard; the cap is
+    // meant to fail safe (abort early) rather than overspend on a missing price row.
+    ModelPricing("gpt-5", 2.50, 20.00, "openai"),
+    ModelPricing("gpt-5-mini", 0.50, 4.00, "openai")
   )
 
   def forModel(model: String): Option[ModelPricing] =

--- a/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ResponseParser.scala
@@ -18,6 +18,14 @@ object ResponseParser:
         if end < 0 then Left(ParseError(s"unterminated fenced block (opened with $tag)"))
         else Right(response.substring(start, end).stripPrefix("\n").stripSuffix("\n"))
 
+  // The prompt asks the model to put helper functions/lemmas BEFORE the method
+  // declaration. extractMethodBody returns only the in-brace body, so those helpers
+  // would be discarded and the spliced body would reference undefined symbols. This
+  // returns that pre-method helper section so the splicer can inject it at module scope.
+  def helperSection(code: String, methodName: String): String =
+    val idx = code.indexOf(s"method $methodName")
+    if idx <= 0 then "" else code.substring(0, idx).trim
+
   def extractMethodBody(code: String, methodName: String): Either[ParseError, String] =
     val needle = s"method $methodName"
     val idx    = code.indexOf(needle)

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
@@ -14,6 +14,11 @@ object AdminModel:
     case PrimitiveField(fieldName: String)
     case EntityRow
 
+  def unbackedStateFieldNames(ir: ServiceIRFull): Set[String] =
+    ir.f.toList.flatMap {
+      case StateDeclFull(fs, _) => fs.collect { case f: StateFieldDeclFull => f }
+    }.filter(f => projectionFor(f, ir).isEmpty).map(_.a).toSet
+
   def projectionFor(f: StateFieldDeclFull, ir: ServiceIRFull): Option[Projection] =
     f.b match
       case RelationTypeF(k, _, v, _) =>

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -30,7 +30,7 @@ object AdminRouterTs:
           .map: c =>
             val v =
               if c.isDate then
-                s"r.${c.tsField} == null ? null : new Date(r.${c.tsField}).toISOString()"
+                s"r.${c.tsField} == null ? null : new Date(r.${c.tsField} as string | Date).toISOString()"
               else s"r.${c.tsField}"
             s"""    ${tsKey(c.columnName)}: $v,"""
           .mkString("\n")
@@ -45,7 +45,7 @@ object AdminRouterTs:
       if entities.isEmpty then "      // no entities"
       else
         entities.reverse
-          .map(e => s"      await (prisma as AnyPrisma).${accessor(e)}.deleteMany();")
+          .map(e => s"      await (prisma as unknown as AnyPrisma).${accessor(e)}.deleteMany();")
           .mkString("\n")
 
     val stateFields = ir.f.toList.flatMap {
@@ -57,7 +57,7 @@ object AdminRouterTs:
     val rowsDecls = neededEntities
       .flatMap(en => entities.find(_.a == en))
       .map: e =>
-        s"      const rows_${e.a} = await (prisma as AnyPrisma).${accessor(e)}.findMany();"
+        s"      const rows_${e.a} = await (prisma as unknown as AnyPrisma).${accessor(e)}.findMany();"
       .mkString("\n")
     val stateProps = stateFields
       .map: f =>
@@ -103,7 +103,7 @@ object AdminRouterTs:
            |    }
            |    void (async () => {
            |      const body = req.body as Record<string, unknown>;
-           |      const created = await (prisma as AnyPrisma).${accessor(e)}.create({
+           |      const created = await (prisma as unknown as AnyPrisma).${accessor(e)}.create({
            |        data: {
            |$dataPairs
            |        },

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -1,7 +1,11 @@
 package specrest.testgen
 
 import specrest.convention.Naming
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.SpecRestGenerated.EntityDeclFull
+import specrest.ir.generated.SpecRestGenerated.FieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.StateDeclFull
+import specrest.ir.generated.SpecRestGenerated.StateFieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.TransitionDeclFull
 import specrest.profile.ProfiledService
 
 object AdminRouterTs:

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -1,0 +1,173 @@
+package specrest.testgen
+
+import specrest.convention.Naming
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.profile.ProfiledService
+
+object AdminRouterTs:
+
+  final private case class Col(tsField: String, columnName: String, isDate: Boolean)
+
+  def emit(profiled: ProfiledService): String =
+    val ir       = profiled.ir
+    val entities = ir.c.collect { case e: EntityDeclFull => e }
+
+    def colsOf(e: EntityDeclFull): List[Col] =
+      val fields = e.c.collect { case f: FieldDeclFull => f }
+      fields.map: f =>
+        Col(
+          tsField = Naming.toCamelCase(f.a),
+          columnName = Naming.toColumnName(f.a),
+          isDate = AdminModel.isDateTimeType(f.b, ir, Set.empty)
+        )
+
+    def accessor(e: EntityDeclFull): String = Naming.toCamelCase(e.a)
+
+    val rowToDictFns = entities
+      .map: e =>
+        val cols = colsOf(e)
+        val pairs = cols
+          .map: c =>
+            val v =
+              if c.isDate then
+                s"r.${c.tsField} == null ? null : new Date(r.${c.tsField}).toISOString()"
+              else s"r.${c.tsField}"
+            s"""    ${tsKey(c.columnName)}: $v,"""
+          .mkString("\n")
+        s"""function rowToDict_${e.a}(r: Record<string, unknown>): Record<string, unknown> {
+           |  return {
+           |$pairs
+           |  };
+           |}""".stripMargin
+      .mkString("\n\n")
+
+    val resetStmts =
+      if entities.isEmpty then "      // no entities"
+      else
+        entities.reverse
+          .map(e => s"      await (prisma as AnyPrisma).${accessor(e)}.deleteMany();")
+          .mkString("\n")
+
+    val stateFields = ir.f.toList.flatMap {
+      case StateDeclFull(fs, _) => fs.collect { case sf: StateFieldDeclFull => sf }
+    }
+    val neededEntities = stateFields
+      .flatMap(f => AdminModel.projectionFor(f, ir).map(_.entityName))
+      .distinct
+    val rowsDecls = neededEntities
+      .flatMap(en => entities.find(_.a == en))
+      .map: e =>
+        s"      const rows_${e.a} = await (prisma as AnyPrisma).${accessor(e)}.findMany();"
+      .mkString("\n")
+    val stateProps = stateFields
+      .map: f =>
+        AdminModel.projectionFor(f, ir) match
+          case Some(p) =>
+            val keyTs = Naming.toCamelCase(p.keyFieldName)
+            val value = p.valueShape match
+              case AdminModel.ProjectionValue.EntityRow =>
+                s"rowToDict_${p.entityName}(r)"
+              case AdminModel.ProjectionValue.PrimitiveField(name) =>
+                s"r.${Naming.toCamelCase(name)}"
+            s"""        ${tsKey(f.a)}: Object.fromEntries(
+               |          rows_${p.entityName}.map((r: Record<string, unknown>) => [
+               |            String(r.$keyTs), $value,
+               |          ]),
+               |        ),""".stripMargin
+          case None =>
+            s"        ${tsKey(f.a)}: null,"
+      .mkString("\n")
+
+    val seedEntities = ir.h.collect { case TransitionDeclFull(_, en, _, _, _) => en }.toSet
+    val seedTargets  = entities.filter(e => seedEntities.contains(e.a))
+    val seedHandlers = seedTargets
+      .map: e =>
+        val snake = Naming.toSnakeCase(e.a)
+        val pk    = AdminModel.primaryKeyField(e).getOrElse("id")
+        val pkTs  = Naming.toCamelCase(pk)
+        val cols  = colsOf(e)
+        val dataPairs = cols
+          .map: c =>
+            val src =
+              if c.isDate then
+                s"""body[${jsStr(c.columnName)}] == null ? undefined : new Date(body[${jsStr(
+                    c.columnName
+                  )}] as string)"""
+              else s"""body[${jsStr(c.columnName)}]"""
+            s"""          ${c.tsField}: $src,"""
+          .mkString("\n")
+        s"""  app.post('/__test_admin__/seed/$snake', (req: Request, res: Response): void => {
+           |    if (!enabled()) {
+           |      res.status(403).json({ detail: 'test admin disabled' });
+           |      return;
+           |    }
+           |    void (async () => {
+           |      const body = req.body as Record<string, unknown>;
+           |      const created = await (prisma as AnyPrisma).${accessor(e)}.create({
+           |        data: {
+           |$dataPairs
+           |        },
+           |      });
+           |      res.status(201).json({ ${tsKey(pk)}: created.$pkTs });
+           |    })().catch((e: unknown) => {
+           |      res.status(500).json({ detail: String(e) });
+           |    });
+           |  });""".stripMargin
+      .mkString("\n\n")
+    val seedSection =
+      if seedTargets.isEmpty then "" else "\n" + seedHandlers + "\n"
+
+    s"""import type { Express, Request, Response } from 'express';
+
+import { prisma } from '../prisma.js';
+
+// The conformance suite (tests/) is the spec-derived, language-agnostic HTTP black-box
+// driver shared with the fastapi target; this router exposes the identical test-admin
+// contract (reset / state / seed) so the same suite can run against ts-express.
+
+type AnyPrisma = Record<string, {
+  deleteMany: () => Promise<unknown>;
+  findMany: () => Promise<Array<Record<string, unknown>>>;
+  create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+}>;
+
+const enabled = (): boolean => process.env.ENABLE_TEST_ADMIN === '1';
+
+$rowToDictFns
+
+export const registerTestAdminRoutes = (app: Express): void => {
+  app.post('/__test_admin__/reset', (_req: Request, res: Response): void => {
+    if (!enabled()) {
+      res.status(403).json({ detail: 'test admin disabled' });
+      return;
+    }
+    void (async () => {
+$resetStmts
+      res.status(204).end();
+    })().catch((e: unknown) => {
+      res.status(500).json({ detail: String(e) });
+    });
+  });
+
+  app.get('/__test_admin__/state', (_req: Request, res: Response): void => {
+    if (!enabled()) {
+      res.status(403).json({ detail: 'test admin disabled' });
+      return;
+    }
+    void (async () => {
+$rowsDecls
+      res.status(200).json({
+$stateProps
+      });
+    })().catch((e: unknown) => {
+      res.status(500).json({ detail: String(e) });
+    });
+  });
+$seedSection};
+""".stripMargin
+
+  private def tsKey(s: String): String =
+    if s.matches("[A-Za-z_][A-Za-z0-9_]*") then s else jsStr(s)
+
+  private def jsStr(s: String): String =
+    "'" + s.replace("\\", "\\\\").replace("'", "\\'") + "'"

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -28,9 +28,12 @@ object Behavioral:
     val transition       = transitionEmission(profiled, ir)
     val coveredByTransit = transition.coveredOps
     val perOp = profiled.operations.flatMap: pop =>
-      ir.g.collectFirst { case o: OperationDeclFull if o.a == pop.operationName => o } match
-        case Some(opDecl) => testsForOperation(pop, opDecl, ir, coveredByTransit)
-        case None         => Nil
+      if StubOps.isStub(profiled, pop) then
+        List(Left(TestSkip(pop.operationName, "operation", StubOps.skipReason(pop))))
+      else
+        ir.g.collectFirst { case o: OperationDeclFull if o.a == pop.operationName => o } match
+          case Some(opDecl) => testsForOperation(pop, opDecl, ir, coveredByTransit)
+          case None         => Nil
     val collected = perOp ++ transition.results
     val tests     = collected.collect { case Right(t) => t }
     val skips     = collected.collect { case Left(s) => s }
@@ -53,6 +56,41 @@ object Behavioral:
       "state-dependent precondition; covered by transition tests (M5.9)"
     else
       "state-dependent precondition; positive ensures/invariant tests are covered by stateful tests (M5.2) for ops bundled into the state machine; the single-shot behavioral test would need explicit pre-seeding"
+
+  private val aggregateEqualitySkipReason: String =
+    "ensures equates a collection output to a set-builder over state; the HTTP black-box " +
+      "cannot faithfully assert aggregate equality (set vs list ordering, admin-state " +
+      "row shape vs read-schema shape, unhashable row dicts). Aggregate behavior is " +
+      "covered by the stateful and structural layers."
+
+  private def isCollectionType(t: type_expr_full): Boolean = t match
+    case _: SetTypeF | _: SeqTypeF | _: MapTypeF | _: RelationTypeF => true
+    case _                                                          => false
+
+  // `<collectionOutput> = { x in dom | pred }` (either orientation) cannot be checked by
+  // comparing the JSON response to a Python set built from the admin-state projection —
+  // the element shapes and container types differ irreconcilably black-box. Skip honestly
+  // rather than emit an assertion that can never hold.
+  private def isAggregateEqualityOverState(
+      clause: expr_full,
+      opDecl: OperationDeclFull
+  ): Boolean =
+    val collOutputs = opDecl.c.collect {
+      case ParamDeclFull(n, t, _) if isCollectionType(t) => n
+    }.toSet
+    def refsCollOutput(e: expr_full): Boolean = e match
+      case IdentifierF(n, _) => collOutputs.contains(n)
+      case PrimeF(inner, _)  => refsCollOutput(inner)
+      case PreF(inner, _)    => refsCollOutput(inner)
+      case _                 => false
+    def isComprehension(e: expr_full): Boolean = e match
+      case _: SetComprehensionF => true
+      case _                    => false
+    clause match
+      case BinaryOpF(BEq(), l, r, _) =>
+        (refsCollOutput(l) && isComprehension(r)) ||
+        (refsCollOutput(r) && isComprehension(l))
+      case _ => false
 
   final private case class TransitionEmissionResult(
       results: List[Either[TestSkip, GeneratedTest]],
@@ -99,22 +137,31 @@ object Behavioral:
         case Left(reason) =>
           List(Left(TestSkip(opDecl.a, "ensures", reason)))
         case Right(strategySig) =>
-          val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PreState)
+          val ctx =
+            TestCtx.fromOperation(
+              opDecl,
+              ir,
+              CaptureMode.PreState,
+              StubOps.bareBodyOutput(pop, opDecl)
+            )
           opDecl.e.zipWithIndex.map: (clause, idx) =>
-            ExprToPython.translate(clause, ctx) match
-              case ExprPy.Skip(reason, _) =>
-                Left(TestSkip(opDecl.a, s"ensures[$idx]", reason))
-              case ExprPy.Py(text) =>
-                Right(
-                  buildPositiveTest(
-                    name = s"test_${opSnake}_ensures_$idx",
-                    docstring = s"ensures: ${prettyOneLine(clause)}",
-                    inputArgs = strategySig,
-                    pop = pop,
-                    assertion = text,
-                    nonTrivialRequires = nonTrivialRequires
+            if isAggregateEqualityOverState(clause, opDecl) then
+              Left(TestSkip(opDecl.a, s"ensures[$idx]", aggregateEqualitySkipReason))
+            else
+              ExprToPython.translate(clause, ctx) match
+                case ExprPy.Skip(reason, _) =>
+                  Left(TestSkip(opDecl.a, s"ensures[$idx]", reason))
+                case ExprPy.Py(text) =>
+                  Right(
+                    buildPositiveTest(
+                      name = s"test_${opSnake}_ensures_$idx",
+                      docstring = s"ensures: ${prettyOneLine(clause)}",
+                      inputArgs = strategySig,
+                      pop = pop,
+                      assertion = text,
+                      nonTrivialRequires = nonTrivialRequires
+                    )
                   )
-                )
 
   private def negativeTests(
       pop: ProfiledOperation,
@@ -183,7 +230,13 @@ object Behavioral:
           )
         )
     else
-      val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
+      val ctx =
+        TestCtx.fromOperation(
+          opDecl,
+          ir,
+          CaptureMode.PostState,
+          StubOps.bareBodyOutput(pop, opDecl)
+        )
       inputArgList(pop, ir) match
         case Left(reason) =>
           List(Left(TestSkip(opDecl.a, "invariant_inputs", reason)))
@@ -225,7 +278,13 @@ object Behavioral:
           )
         )
     else
-      val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
+      val ctx =
+        TestCtx.fromOperation(
+          opDecl,
+          ir,
+          CaptureMode.PostState,
+          StubOps.bareBodyOutput(pop, opDecl)
+        )
       inputArgList(pop, ir) match
         case Left(reason) =>
           List(Left(TestSkip(opDecl.a, "temporal_inputs", reason)))
@@ -343,6 +402,11 @@ object Behavioral:
       val opDeclOpt        = ir.g.collectFirst { case _o: OperationDeclFull if _o.a == viaName => _o }
       val popOpt           = profiled.operations.find(_.operationName == viaName)
       val per: TransitionEmissionResult = (opDeclOpt, popOpt) match
+        case (Some(_), Some(pop)) if StubOps.isStub(profiled, pop) =>
+          TransitionEmissionResult(
+            List(Left(TestSkip(viaName, s"transition[$viaName]", StubOps.skipReason(pop)))),
+            Set.empty
+          )
         case (Some(_), Some(pop)) if pop.endpoint.pathParams.size != 1 =>
           TransitionEmissionResult(
             List(

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -141,6 +141,7 @@ object ExprToPython:
       (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
     then ExprPy.Skip(s"identifier '$name' is a Python-reserved name", span)
     else if ctx.boundVars.contains(name) then ExprPy.Py(name)
+    else if ctx.bareBodyOutput.contains(name) then ExprPy.Py("response_data")
     else if ctx.outputs.contains(name) then ExprPy.Py(s"response_data[${pyString(name)}]")
     else if ctx.inputs.contains(name) then ExprPy.Py(name)
     else if ctx.stateFields.contains(name) then

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -145,10 +145,17 @@ object ExprToPython:
     else if ctx.outputs.contains(name) then ExprPy.Py(s"response_data[${pyString(name)}]")
     else if ctx.inputs.contains(name) then ExprPy.Py(name)
     else if ctx.stateFields.contains(name) then
-      val dict = ctx.capture match
-        case CaptureMode.PostState => "post_state"
-        case CaptureMode.PreState  => "pre_state"
-      ExprPy.Py(s"$dict[${pyString(name)}]")
+      if ctx.unbackedStateFields.contains(name) then
+        ExprPy.Skip(
+          s"state field '$name' is not backed by an entity table; the test-admin " +
+            "/state endpoint projects it as null, so it cannot be asserted black-box",
+          span
+        )
+      else
+        val dict = ctx.capture match
+          case CaptureMode.PostState => "post_state"
+          case CaptureMode.PreState  => "pre_state"
+        ExprPy.Py(s"$dict[${pyString(name)}]")
     else if ctx.enumValues.contains(name) then ExprPy.Skip(s"enum-type identifier '$name'", span)
     else
       ctx.enumValues.find { case (_, vs) => vs.contains(name) } match

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -76,9 +76,17 @@ object Stateful:
 
     val opsConcrete = ir.g.collect { case op: OperationDeclFull => op }
     val rulesAndSkips = profiled.operations.flatMap: pop =>
-      opsConcrete.find(_.a == pop.operationName) match
-        case Some(opDecl) => emitRules(pop, opDecl, ir, entityBundles)
-        case None         => Nil
+      if StubOps.isStub(profiled, pop) then
+        List(
+          (
+            Left(()),
+            List(TestSkip(pop.operationName, "stateful_rule", StubOps.skipReason(pop)))
+          )
+        )
+      else
+        opsConcrete.find(_.a == pop.operationName) match
+          case Some(opDecl) => emitRules(pop, opDecl, ir, entityBundles)
+          case None         => Nil
     val ruleBlocks = rulesAndSkips.flatMap(_._1.toOption.toList.flatten)
     val ruleSkips  = rulesAndSkips.flatMap(_._2)
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -783,7 +783,8 @@ object Stateful:
       userFunctions = ir.l.collect { case f: FunctionDeclFull => f.a -> f }.toMap,
       userPredicates = ir.m.collect { case p: PredicateDeclFull => p.a -> p }.toMap,
       boundVars = Set.empty,
-      capture = CaptureMode.PostState
+      capture = CaptureMode.PostState,
+      unbackedStateFields = AdminModel.unbackedStateFieldNames(ir)
     )
 
   private def renderFile(
@@ -898,7 +899,11 @@ object Stateful:
         |    max_examples=25,
         |    stateful_step_count=20,
         |    deadline=None,
-        |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+        |    suppress_health_check=[
+        |        HealthCheck.too_slow,
+        |        HealthCheck.function_scoped_fixture,
+        |        HealthCheck.filter_too_much,
+        |    ],
         |)
         |$testName = $machineName.TestCase
         |""".stripMargin

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -105,15 +105,21 @@ object Stateful:
     val temporalSkips = temporalEmissions.collect:
       case TemporalEmission.Skip(skip) => skip
 
-    val py = renderFile(
-      ir = ir,
-      machineName = machName,
-      testName = testName,
-      bundles = bundles,
-      ruleBlocks = ruleBlocks,
-      invariantBlocks = invariantBlocks ++ temporalAlwaysBlocks,
-      eventuallySpecs = temporalEventuallySpecs
-    )
+    // A RuleBasedStateMachine with zero @rule methods is invalid — Hypothesis raises
+    // InvalidDefinition at runtime. When every operation is a fail-loud stub or
+    // untranslatable, emit one explicit skip instead; reasons are in _testgen_skips.json.
+    val py =
+      if ruleBlocks.isEmpty then statefulSkipPlaceholder(ir)
+      else
+        renderFile(
+          ir = ir,
+          machineName = machName,
+          testName = testName,
+          bundles = bundles,
+          ruleBlocks = ruleBlocks,
+          invariantBlocks = invariantBlocks ++ temporalAlwaysBlocks,
+          eventuallySpecs = temporalEventuallySpecs
+        )
 
     StatefulOutput(file = py, skips = ruleSkips ++ invariantSkips ++ temporalSkips)
 
@@ -787,6 +793,24 @@ object Stateful:
       unbackedStateFields = AdminModel.unbackedStateFieldNames(ir)
     )
 
+  private def statefulSkipPlaceholder(ir: ServiceIRFull): String =
+    s"""|${TQ}Auto-generated stateful tests for ${ir.a}.
+        |
+        |No Hypothesis RuleBasedStateMachine could be built: every operation is a
+        |fail-loud stub or references constructs that cannot be turned into a
+        |@rule, and a state machine with zero rules is invalid. This phase is
+        |skipped; see tests/_testgen_skips.json for the per-clause reasons.
+        |${TQ}
+        |import pytest
+        |
+        |
+        |def test_stateful_all_skipped():
+        |    pytest.skip(
+        |        "no stateful rules generated: every operation is a fail-loud "
+        |        "stub or untranslatable (see tests/_testgen_skips.json)"
+        |    )
+        |""".stripMargin
+
   private def renderFile(
       ir: ServiceIRFull,
       machineName: String,
@@ -861,9 +885,7 @@ object Stateful:
     val eventuallyObserverBlocks = eventuallySpecs.map(_.observer)
     val allInvariantBlocks       = invariantBlocks ++ eventuallyObserverBlocks
 
-    val ruleSection =
-      if ruleBlocks.isEmpty then "    # No rules generated; see _testgen_skips.json.\n    pass\n"
-      else ruleBlocks.mkString("\n")
+    val ruleSection = ruleBlocks.mkString("\n")
 
     val invariantSection =
       if allInvariantBlocks.isEmpty then ""

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -282,7 +282,7 @@ object Structural:
             |
             |
             |@schemathesis.hook
-            |def before_call(context, case):
+            |def before_call(context, case, kwargs):
             |    body = getattr(case, "body", None)
             |    if isinstance(body, dict):
             |        for _k, _v in list(body.items()):

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -66,7 +66,7 @@ object Structural:
         val name       = inv.a.getOrElse(s"anon_$idx")
         val methodName = Naming.toSnakeCase(name)
         val sb         = new StringBuilder
-        sb.append(s"def _check_invariant_$methodName(response, case):\n")
+        sb.append(s"def _check_invariant_$methodName(ctx, response, case):\n")
         sb.append(
           s"    ${TQ}invariant $name: ${escapeDocstring(prettyOneLine(inv.b))}$TQ\n"
         )
@@ -136,7 +136,7 @@ object Structural:
               val methodLit  = ExprToPython.pyString(pop.endpoint.method.toString.toUpperCase)
               val successLit = pop.endpoint.successStatus.toString
               val sb         = new StringBuilder
-              sb.append(s"def $checkName(response, case):\n")
+              sb.append(s"def $checkName(ctx, response, case):\n")
               sb.append(
                 s"    ${TQ}ensures: ${escapeDocstring(prettyOneLine(clause))}$TQ\n"
               )
@@ -242,9 +242,7 @@ object Structural:
       profiled: ProfiledService,
       checks: List[StructuralCheck]
   ): String =
-    val machineName = s"${ir.a}LinksStateMachine"
-    val testName    = s"TestStructuralLinks${ir.a}"
-    val checkDefs   = checks.map(_.pyFunctionBody).mkString("\n")
+    val checkDefs = checks.map(_.pyFunctionBody).mkString("\n")
     val checkTuple =
       if checks.isEmpty then "()"
       else "(\n" + checks.map(c => s"    ${c.pyFunctionName},").mkString("\n") + "\n)"
@@ -261,20 +259,9 @@ object Structural:
           "# them keeps schemathesis from asserting a 5xx stub against the documented schema.\n" +
           stubExcludeLines.mkString("\n")
 
-    val emitsLinks = profiled.operations.exists(_.targetEntity.isDefined)
-    val linksBlock =
-      if !emitsLinks then ""
-      else
-        s"""|
-            |$machineName = schema.as_state_machine()
-            |$machineName.TestCase.settings = settings(
-            |    max_examples=_PROFILE["max_examples"],
-            |    stateful_step_count=_PROFILE["stateful_step_count"],
-            |    deadline=None,
-            |    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
-            |)
-            |$testName = $machineName.TestCase
-            |""".stripMargin
+    // No schemathesis link-based state machine: the spec-derived OpenAPI document never
+    // emits `links`, so `schema.as_state_machine()` raises NoLinksFound on schemathesis
+    // 4.x. Stateful coverage is the dedicated Hypothesis `test_stateful_*` suite.
 
     val sensitiveFieldNames: List[String] =
       ir.g
@@ -369,7 +356,7 @@ object Structural:
         |        case.validate_response(response, checks=_ALL_CHECKS)
         |    else:
         |        case.validate_response(response)
-        |${linksBlock}""".stripMargin
+        |""".stripMargin
 
   private def prettyOneLine(e: expr_full): String =
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -104,7 +104,8 @@ object Structural:
       userFunctions = ir.l.collect { case f: FunctionDeclFull => f.a -> f }.toMap,
       userPredicates = ir.m.collect { case p: PredicateDeclFull => p.a -> p }.toMap,
       boundVars = Set.empty,
-      capture = CaptureMode.PostState
+      capture = CaptureMode.PostState,
+      unbackedStateFields = AdminModel.unbackedStateFieldNames(ir)
     )
 
   // -- Pure-output ensures (Create operations) -------------------------------

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -41,8 +41,13 @@ object Structural:
     val ensuresChecks = ensuresPairs.collect { case Right(c) => c }
     val ensuresSkips  = ensuresPairs.collect { case Left(s) => s }
 
+    val stubSkips =
+      profiled.operations
+        .filter(StubOps.isStub(profiled, _))
+        .map(op => TestSkip(op.operationName, "structural", StubOps.skipReason(op)))
+
     val checks = invChecks ++ ensuresChecks
-    val skips  = invSkips ++ ensuresSkips
+    val skips  = invSkips ++ ensuresSkips ++ stubSkips
 
     val py = renderFile(ir, profiled, checks)
     StructuralOutput(file = py, skips = skips)
@@ -243,6 +248,19 @@ object Structural:
     val checkTuple =
       if checks.isEmpty then "()"
       else "(\n" + checks.map(c => s"    ${c.pyFunctionName},").mkString("\n") + "\n)"
+    val stubExcludeLines =
+      profiled.operations
+        .filter(StubOps.isStub(profiled, _))
+        .map(op =>
+          s"""schema = schema.exclude(method="${op.endpoint.method}", path="${op.endpoint.path}")"""
+        )
+    val stubExcludes =
+      if stubExcludeLines.isEmpty then ""
+      else
+        "\n# Operations the convention engine stubs fail-loud (NotImplementedError); excluding\n" +
+          "# them keeps schemathesis from asserting a 5xx stub against the documented schema.\n" +
+          stubExcludeLines.mkString("\n")
+
     val emitsLinks = profiled.operations.exists(_.targetEntity.isDefined)
     val linksBlock =
       if !emitsLinks then ""
@@ -320,7 +338,7 @@ object Structural:
         |    )
         |_PROFILE = PROFILES[PROFILE]
         |
-        |schema = schemathesis.openapi.from_path("openapi.yaml")
+        |schema = schemathesis.openapi.from_path("openapi.yaml")$stubExcludes
         |
         |
         |def _path_matches(case, expected_template, expected_method):

--- a/modules/testgen/src/main/scala/specrest/testgen/StubOps.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/StubOps.scala
@@ -1,0 +1,33 @@
+package specrest.testgen
+
+import specrest.codegen.RouteKind
+import specrest.ir.generated.SpecRestGenerated.OperationDeclFull
+import specrest.ir.generated.SpecRestGenerated.ParamDeclFull
+import specrest.profile.ProfiledOperation
+import specrest.profile.ProfiledService
+
+object StubOps:
+
+  def isStub(profiled: ProfiledService, op: ProfiledOperation): Boolean =
+    RouteKind.isFailLoudStub(op, entityNonIdColumns(profiled, op))
+
+  // A `list` route returns the array as the bare response body, so its single declared
+  // output is the whole body — `response_data`, not `response_data["<name>"]`.
+  def bareBodyOutput(op: ProfiledOperation, opDecl: OperationDeclFull): Option[String] =
+    val outs = opDecl.c.collect { case ParamDeclFull(n, _, _) => n }
+    if RouteKind.classify(op) == RouteKind.List && outs.sizeIs == 1 then outs.headOption
+    else None
+
+  def skipReason(op: ProfiledOperation): String =
+    s"operation '${op.operationName}' is a fail-loud stub: the convention engine cannot " +
+      "derive a body and synthesis produced no kernel method, so the generated handler " +
+      "raises NotImplementedError. There is no behavior to assert against."
+
+  private def entityNonIdColumns(
+      profiled: ProfiledService,
+      op: ProfiledOperation
+  ): Set[String] =
+    op.targetEntity
+      .flatMap(en => profiled.entities.find(_.entityName == en))
+      .map(_.fields.filterNot(_.fieldName == "id").map(_.columnName).toSet)
+      .getOrElse(Set.empty)

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -7,15 +7,21 @@ import specrest.profile.ProfiledService
 object TestEmit:
 
   def emit(profiled: ProfiledService): List[EmittedFile] =
-    val ir             = profiled.ir
-    val serviceSnake   = Naming.toSnakeCase(ir.a)
-    val strategySpecs  = Strategies.forIR(ir)
-    val behavioralOut  = Behavioral.emitFor(profiled)
-    val statefulOut    = Stateful.emitFor(profiled)
-    val structuralOut  = Structural.emitFor(profiled)
-    val adminRouterSrc = AdminRouter.emit(profiled)
-    val strategiesPy   = renderStrategiesFile(strategySpecs)
-    val behavioralPy   = renderBehavioralFile(behavioralOut.tests, ir.a, strategySpecs)
+    val ir            = profiled.ir
+    val serviceSnake  = Naming.toSnakeCase(ir.a)
+    val strategySpecs = Strategies.forIR(ir)
+    val behavioralOut = Behavioral.emitFor(profiled)
+    val statefulOut   = Stateful.emitFor(profiled)
+    val structuralOut = Structural.emitFor(profiled)
+    // The conformance bundle (conftest/run_conformance/behavioral/stateful/structural) is the
+    // spec-derived, language-agnostic HTTP black-box suite — emitted identically for every
+    // target. Only the test-admin router is language-specific.
+    val (adminRouterFile, adminRouterSrc) =
+      if profiled.profile.framework == "express" then
+        (FilePaths.AdminRouterFileTs, AdminRouterTs.emit(profiled))
+      else (FilePaths.AdminRouterFile, AdminRouter.emit(profiled))
+    val strategiesPy = renderStrategiesFile(strategySpecs)
+    val behavioralPy = renderBehavioralFile(behavioralOut.tests, ir.a, strategySpecs)
     val skipsJson =
       renderSkipsJson(
         ir.a,
@@ -25,7 +31,7 @@ object TestEmit:
       )
 
     List(
-      EmittedFile(FilePaths.AdminRouterFile, adminRouterSrc),
+      EmittedFile(adminRouterFile, adminRouterSrc),
       EmittedFile(FilePaths.TestsInitFile, ""),
       EmittedFile(FilePaths.ConftestFile, Templates.conftest),
       EmittedFile(FilePaths.PredicatesFile, Templates.predicates(ir)),

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -117,9 +117,27 @@ object TestEmit:
          |
          |""".stripMargin.replace("\\\"", "\"")
 
-    val combined = header + strategyImport
-    if tests.isEmpty then combined + "# No tests generated; see _testgen_skips.json.\n"
-    else combined + tests.map(_.body).mkString("\n\n")
+    // A module with zero tests makes pytest exit 5 ("no tests collected") — a hard
+    // failure. When every operation is a fail-loud stub or untranslatable, emit one
+    // explicit skip so the phase passes honestly; reasons live in _testgen_skips.json.
+    if tests.isEmpty then
+      s"""|\"\"\"Auto-generated behavioral tests for $serviceName.
+          |
+          |No behavioral property tests could be generated: every operation is a
+          |fail-loud stub or references constructs that cannot be asserted
+          |black-box. See tests/_testgen_skips.json for the per-clause reasons.
+          |\"\"\"
+          |import pytest
+          |
+          |
+          |def test_behavioral_all_skipped():
+          |    pytest.skip(
+          |        "no behavioral tests generated: every operation is a fail-loud "
+          |        "stub or references untranslatable constructs "
+          |        "(see tests/_testgen_skips.json)"
+          |    )
+          |""".stripMargin.replace("\\\"", "\"")
+    else header + strategyImport + tests.map(_.body).mkString("\n\n")
 
   private def renderSkipsJson(
       serviceName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -62,13 +62,22 @@ final case class TestCtx(
     userFunctions: Map[String, FunctionDeclFull],
     userPredicates: Map[String, PredicateDeclFull],
     boundVars: Set[String],
-    capture: CaptureMode
+    capture: CaptureMode,
+    // The single output an endpoint returns as the bare response body (e.g. a `list`
+    // route returns the array itself, not `{"<name>": [...]}`). Such an output must
+    // translate to `response_data`, not `response_data["<name>"]`.
+    bareBodyOutput: Option[String] = None
 ):
   def withCapture(c: CaptureMode): TestCtx        = copy(capture = c)
   def withBound(names: Iterable[String]): TestCtx = copy(boundVars = boundVars ++ names)
 
 object TestCtx:
-  def fromOperation(op: OperationDeclFull, ir: ServiceIRFull, capture: CaptureMode): TestCtx =
+  def fromOperation(
+      op: OperationDeclFull,
+      ir: ServiceIRFull,
+      capture: CaptureMode,
+      bareBodyOutput: Option[String] = None
+  ): TestCtx =
     val stateNames = ir.f.toList.flatMap {
       case StateDeclFull(fs, _) => fs.collect { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
@@ -86,7 +95,8 @@ object TestCtx:
       userFunctions = ir.l.collect { case f: FunctionDeclFull => f.a -> f }.toMap,
       userPredicates = ir.m.collect { case p: PredicateDeclFull => p.a -> p }.toMap,
       boundVars = Set.empty,
-      capture = capture
+      capture = capture,
+      bareBodyOutput = bareBodyOutput
     )
 
   private def isMapType(t: type_expr_full): Boolean = t match

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -66,7 +66,11 @@ final case class TestCtx(
     // The single output an endpoint returns as the bare response body (e.g. a `list`
     // route returns the array itself, not `{"<name>": [...]}`). Such an output must
     // translate to `response_data`, not `response_data["<name>"]`.
-    bareBodyOutput: Option[String] = None
+    bareBodyOutput: Option[String] = None,
+    // State fields the test-admin `/state` endpoint cannot project (no backing entity
+    // table) — it emits them as `null`, so any assertion referencing them would compare
+    // against `None` and crash. Such expressions are honest-skipped, not emitted.
+    unbackedStateFields: Set[String] = Set.empty
 ):
   def withCapture(c: CaptureMode): TestCtx        = copy(capture = c)
   def withBound(names: Iterable[String]): TestCtx = copy(boundVars = boundVars ++ names)
@@ -96,7 +100,8 @@ object TestCtx:
       userPredicates = ir.m.collect { case p: PredicateDeclFull => p.a -> p }.toMap,
       boundVars = Set.empty,
       capture = capture,
-      bareBodyOutput = bareBodyOutput
+      bareBodyOutput = bareBodyOutput,
+      unbackedStateFields = AdminModel.unbackedStateFieldNames(ir)
     )
 
   private def isMapType(t: type_expr_full): Boolean = t match

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -13,6 +13,7 @@ object FilePaths:
   val PredicatesFile     = "tests/predicates.py"
   val SkipsFile          = "tests/_testgen_skips.json"
   val AdminRouterFile    = "app/routers/test_admin.py"
+  val AdminRouterFileTs  = "src/routes/testAdmin.ts"
   val PytestIniFile      = "pytest.ini"
   val RunConformanceFile = "tests/run_conformance.py"
 

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -5,15 +5,46 @@ import specrest.ir.generated.SpecRestGenerated.*
 import specrest.parser.Builder
 import specrest.parser.Parse
 import specrest.profile.Annotate
+import specrest.profile.ProfiledService
 
 class BehavioralTest extends CatsEffectSuite:
+
+  // These tests exercise the spec->test emission/translation logic, which only applies to
+  // *implemented* operations. The orthogonal "skip fail-loud stubs" gate (StubOps/Finding 1)
+  // is covered by its own focused test below; here every op that would otherwise be a
+  // fail-loud stub is marked synthesized so Finding 1 is transparent and the translation
+  // logic under test actually runs.
+  private def asSynthesized(profiled: ProfiledService): ProfiledService =
+    SynthFixture.asSynthesized(profiled)
 
   private def loadProfiled(path: String) =
     val src = scala.io.Source.fromFile(path).getLines.mkString("\n")
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
-          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Right(ir) =>
+            asSynthesized(Annotate.buildProfiledService(ir, "python-fastapi-postgres"))
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("Finding 1: a fail-loud stub op (no synthesized body) is skipped and recorded"):
+    val src = scala.io.Source.fromFile("fixtures/spec/url_shortener.spec").getLines.mkString("\n")
+    Parse.parseSpec(src).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val raw = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out = Behavioral.emitFor(raw)
+            assert(
+              out.skips.exists(s =>
+                s.operation == "Shorten" && s.reason.contains("fail-loud stub")
+              ),
+              s"expected Shorten stub-skip; skips=${out.skips}"
+            )
+            assert(
+              !out.tests.exists(_.name.contains("shorten")),
+              s"stub op must not emit positive tests; tests=${out.tests.map(_.name)}"
+            )
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
@@ -150,7 +181,8 @@ class BehavioralTest extends CatsEffectSuite:
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
-          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Right(ir) =>
+            asSynthesized(Annotate.buildProfiledService(ir, "python-fastapi-postgres"))
           case Left(err) => fail(s"build error for $label: $err")
       case Left(err) => fail(s"parse error for $label: $err")
 
@@ -484,7 +516,8 @@ class BehavioralTest extends CatsEffectSuite:
     Parse.parseSpec(spec).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
-          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Right(ir) =>
+            asSynthesized(Annotate.buildProfiledService(ir, "python-fastapi-postgres"))
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -48,27 +48,37 @@ class BehavioralTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("safe_counter: Increment positive ensures test, Decrement skipped"):
+  test("safe_counter: Increment ensures honest-skipped (unbacked count), Decrement state-dep"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
-      val out      = Behavioral.emitFor(profiled)
-      val incTests = out.tests.filter(_.name.contains("increment"))
-      assert(incTests.exists(_.name == "test_increment_ensures_0"), out.tests.map(_.name).toString)
+      val out = Behavioral.emitFor(profiled)
+      // `count` is pure scalar state with no backing table; asserting `count' = count + 1`
+      // black-box would compare `None`, so the ensures must honest-skip, not emit.
+      assert(
+        !out.tests.exists(_.name.startsWith("test_increment_ensures")),
+        s"Increment.ensures touches unbacked `count`; must not emit: ${out.tests.map(_.name)}"
+      )
+      assert(
+        out.skips.exists(s =>
+          s.operation == "Increment" && s.reason.contains("not backed by an entity table")
+        ),
+        s"expected Increment unbacked-state skip; got ${out.skips}"
+      )
       val decSkips = out.skips.filter(_.operation == "Decrement")
       assert(
         decSkips.exists(_.reason.contains("state-dependent precondition")),
         decSkips.toString
       )
 
-  test("Increment ensures body has expected structure"):
-    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
-      val out  = Behavioral.emitFor(profiled)
-      val test = out.tests.find(_.name == "test_increment_ensures_0").getOrElse(fail("missing"))
+  test("ensures body has expected admin-reset / state-capture / request structure"):
+    loadProfiled("fixtures/spec/edge_cases.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val test = out.tests
+        .find(_.name == "test_no_input_ensures_0")
+        .getOrElse(fail(s"missing test_no_input_ensures_0; got ${out.tests.map(_.name)}"))
       assert(test.body.contains("client.post(\"/__test_admin__/reset\")"))
       assert(test.body.contains("pre_state = client.get(\"/__test_admin__/state\")"))
       assert(test.body.contains("post_state = client.get(\"/__test_admin__/state\")"))
       assert(test.body.contains("response = client."), s"body=${test.body}")
-      assert(test.body.contains("post_state[\"count\"]"))
-      assert(test.body.contains("pre_state[\"count\"]"))
 
   test("url_shortener: Shorten ensures generated, Resolve+Delete state-dep skipped"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
@@ -112,12 +122,14 @@ class BehavioralTest extends CatsEffectSuite:
       assert(resolveNeg.body.contains("client.get(f\"/{code}\")"), resolveNeg.body)
 
   test("Operation with no inputs has no @given decorator"):
-    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
-      val out  = Behavioral.emitFor(profiled)
-      val test = out.tests.find(_.name == "test_increment_ensures_0").getOrElse(fail("missing"))
+    loadProfiled("fixtures/spec/edge_cases.spec").map: profiled =>
+      val out = Behavioral.emitFor(profiled)
+      val test = out.tests
+        .find(_.name == "test_no_input_ensures_0")
+        .getOrElse(fail(s"missing test_no_input_ensures_0; got ${out.tests.map(_.name)}"))
       assert(
         !test.body.contains("@given("),
-        s"Increment has no inputs; should not have @given:\n${test.body}"
+        s"NoInput has no inputs; should not have @given:\n${test.body}"
       )
 
   test("invariant test captures post_state via a separate /state call after the op"):

--- a/modules/testgen/src/test/scala/specrest/testgen/FilePathsTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/FilePathsTest.scala
@@ -16,19 +16,24 @@ class FilePathsTest extends CatsEffectSuite:
     assertEquals(FilePaths.PredicatesFile, "tests/predicates.py")
     assertEquals(FilePaths.SkipsFile, "tests/_testgen_skips.json")
     assertEquals(FilePaths.AdminRouterFile, "app/routers/test_admin.py")
+    assertEquals(FilePaths.AdminRouterFileTs, "src/routes/testAdmin.ts")
 
-  test("testgen supports every fastapi dialect; go/ts have no test emitter"):
+  test("testgen supports every fastapi and ts-express dialect; go-chi has no test emitter"):
     List(
       "python-fastapi-postgres",
       "python-fastapi-sqlite",
-      "python-fastapi-mysql"
+      "python-fastapi-mysql",
+      "ts-express-postgres",
+      "ts-express-sqlite",
+      "ts-express-mysql"
     ).foreach(t => assert(SupportedTargets.supports(t), t))
-    List("go-chi-postgres", "ts-express-postgres").foreach(t =>
+    List("go-chi-postgres", "go-chi-sqlite", "go-chi-mysql").foreach(t =>
       assert(!SupportedTargets.supports(t), t)
     )
     assertEquals(
       SupportedTargets.describe,
-      "python-fastapi-mysql, python-fastapi-postgres, python-fastapi-sqlite"
+      "python-fastapi-mysql, python-fastapi-postgres, python-fastapi-sqlite, " +
+        "ts-express-mysql, ts-express-postgres, ts-express-sqlite"
     )
 
   test("supports rejects parseable-but-invalid axis combinations"):

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -66,32 +66,15 @@ class SkipRateProbeTest extends CatsEffectSuite:
       capture = CaptureMode.PostState
     )
 
-  test("safe_counter: 5 clauses, 0 skips"):
-    measure("fixtures/spec/safe_counter.spec").map: (total, skipped, _) =>
-      assertEquals(total, 5)
-      assertEquals(skipped, 0)
-
-  test("url_shortener: 21 clauses, 0 skips"):
-    measure("fixtures/spec/url_shortener.spec").map: (total, skipped, _) =>
-      assertEquals(total, 21)
-      assertEquals(skipped, 0)
-
-  test("todo_list: 50 clauses, 0 skips"):
-    measure("fixtures/spec/todo_list.spec").map: (total, skipped, _) =>
-      assertEquals(total, 50)
-      assertEquals(skipped, 0)
-
-  test("ecommerce: 76 clauses, exactly 2 skips (multi-clause `let ... in` parser scope leak)"):
-    measure("fixtures/spec/ecommerce.spec").map: (total, skipped, _) =>
-      assertEquals(total, 76)
-      assertEquals(skipped, 2)
-
-  test("edge_cases: 29 clauses, 0 skips"):
-    measure("fixtures/spec/edge_cases.spec").map: (total, skipped, _) =>
-      assertEquals(total, 29)
-      assertEquals(skipped, 0)
-
-  test("auth_service: 40 clauses, exactly 6 skips (undeclared hash/recentFailedAttempts)"):
-    measure("fixtures/spec/auth_service.spec").map: (total, skipped, _) =>
-      assertEquals(total, 40)
-      assertEquals(skipped, 6)
+  List(
+    ("safe_counter", 5, 3, "count is unbacked scalar state (admin /state projects null)"),
+    ("url_shortener", 21, 1, "base_url is unbacked scalar state"),
+    ("todo_list", 50, 2, "next_id is unbacked scalar state"),
+    ("ecommerce", 76, 5, "3 unbacked scalar-state ensures + 2 `removed` parser scope leak"),
+    ("edge_cases", 29, 3, "plain is unbacked scalar state"),
+    ("auth_service", 40, 10, "4 unbacked scalar-state + 6 undeclared hash/recentFailedAttempts")
+  ).foreach: (name, expectedTotal, expectedSkipped, why) =>
+    test(s"$name: $expectedTotal clauses, $expectedSkipped skips ($why)"):
+      measure(s"fixtures/spec/$name.spec").map: (total, skipped, _) =>
+        assertEquals(total, expectedTotal)
+        assertEquals(skipped, expectedSkipped)

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -14,7 +14,31 @@ class StatefulTest extends CatsEffectSuite:
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
-          case Right(ir) => Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+          case Right(ir) =>
+            SynthFixture.asSynthesized(Annotate.buildProfiledService(ir, "python-fastapi-postgres"))
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  test("Finding 1: an unsynthesized fail-loud stub op is skipped from the state machine"):
+    val src =
+      scala.util.Using.resource(scala.io.Source.fromFile("fixtures/spec/url_shortener.spec")): s =>
+        s.getLines.mkString("\n")
+    Parse.parseSpec(src).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) =>
+            val raw = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+            val out = Stateful.emitFor(raw)
+            assert(
+              out.skips.exists(s =>
+                s.operation == "Shorten" && s.reason.contains("fail-loud stub")
+              ),
+              s"expected Shorten stub-skip; skips=${out.skips}"
+            )
+            assert(
+              !out.file.contains("def shorten(self"),
+              s"stub op must not become a state-machine rule; file=${out.file}"
+            )
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
@@ -277,8 +301,11 @@ class StatefulTest extends CatsEffectSuite:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) =>
-            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-            val out      = Stateful.emitFor(profiled)
+            val profiled = SynthFixture.asSynthesized(Annotate.buildProfiledService(
+              ir,
+              "python-fastapi-postgres"
+            ))
+            val out = Stateful.emitFor(profiled)
             assert(out.file.contains("foo_ids = Bundle(\"foo_ids\")"), out.file)
             assert(
               !out.file.contains("foo_active_ids = Bundle"),
@@ -340,8 +367,11 @@ class StatefulTest extends CatsEffectSuite:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) =>
-            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-            val out      = Stateful.emitFor(profiled)
+            val profiled = SynthFixture.asSynthesized(Annotate.buildProfiledService(
+              ir,
+              "python-fastapi-postgres"
+            ))
+            val out = Stateful.emitFor(profiled)
             // bundles for both status enum values exist
             assert(out.file.contains("foo_active_ids = Bundle(\"foo_active_ids\")"), out.file)
             assert(out.file.contains("foo_archived_ids = Bundle(\"foo_archived_ids\")"), out.file)
@@ -405,8 +435,11 @@ class StatefulTest extends CatsEffectSuite:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) =>
-            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-            val out      = Stateful.emitFor(profiled)
+            val profiled = SynthFixture.asSynthesized(Annotate.buildProfiledService(
+              ir,
+              "python-fastapi-postgres"
+            ))
+            val out = Stateful.emitFor(profiled)
             assert(out.file.contains("def move_from_a_to_b(self, id):"), out.file)
             assert(out.file.contains("def move_from_a_to_c(self, id):"), out.file)
           case Left(err) => fail(s"build error: $err")
@@ -465,8 +498,11 @@ class StatefulTest extends CatsEffectSuite:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) =>
-            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-            val out      = Stateful.emitFor(profiled)
+            val profiled = SynthFixture.asSynthesized(Annotate.buildProfiledService(
+              ir,
+              "python-fastapi-postgres"
+            ))
+            val out = Stateful.emitFor(profiled)
             // intersection of {ACTIVE, ARCHIVED} ∩ {ACTIVE} = {ACTIVE} → single bundle
             assert(
               out.file.contains("@rule(id=foo_active_ids)"),
@@ -515,8 +551,11 @@ class StatefulTest extends CatsEffectSuite:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) =>
-            val profiled = Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-            val out      = Stateful.emitFor(profiled)
+            val profiled = SynthFixture.asSynthesized(Annotate.buildProfiledService(
+              ir,
+              "python-fastapi-postgres"
+            ))
+            val out = Stateful.emitFor(profiled)
             // No transition → legacy single bundle. requires `foos[id].locked = false`
             // uses bool literal — not enum, so recognizer marks it unrecognized.
             // strictByConstruction = false → must NOT consume.
@@ -638,7 +677,10 @@ class StatefulTest extends CatsEffectSuite:
       n = None,
       o = None
     )
-    val profile  = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+    val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
+      ir,
+      "python-fastapi-postgres"
+    ))
     val out      = Stateful.emitFor(profile)
     val invSkips = out.skips.filter(_.kind.startsWith("stateful_invariant"))
     assert(invSkips.nonEmpty, s"expected at least one invariant skip; got ${out.skips}")
@@ -690,8 +732,11 @@ class StatefulTest extends CatsEffectSuite:
     val ir = serviceWithTemporals(
       List(TemporalDeclFull("counterStaysPositive", alwaysCall(arg), None))
     )
-    val profile = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-    val out     = Stateful.emitFor(profile)
+    val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
+      ir,
+      "python-fastapi-postgres"
+    ))
+    val out = Stateful.emitFor(profile)
     assert(
       out.file.contains("def temporal_always_counter_stays_positive(self):"),
       s"missing temporal_always_ block:\n${out.file}"
@@ -711,8 +756,11 @@ class StatefulTest extends CatsEffectSuite:
     val ir = serviceWithTemporals(
       List(TemporalDeclFull("counterReachesTen", eventuallyCall(arg), None))
     )
-    val profile = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-    val out     = Stateful.emitFor(profile)
+    val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
+      ir,
+      "python-fastapi-postgres"
+    ))
+    val out = Stateful.emitFor(profile)
     assert(
       out.file.contains("self._eventually_seen_counter_reaches_ten = False"),
       s"missing eventually flag init in _reset:\n${out.file}"
@@ -749,7 +797,10 @@ class StatefulTest extends CatsEffectSuite:
     val ir = serviceWithTemporals(
       List(TemporalDeclFull("fairStep", fairnessCall(arg), None))
     )
-    val profile   = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
+    val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
+      ir,
+      "python-fastapi-postgres"
+    ))
     val out       = Stateful.emitFor(profile)
     val fairSkips = out.skips.filter(_.kind.startsWith("stateful_temporal_fairness"))
     assertEquals(fairSkips.size, 1, s"expected exactly one fairness skip; got ${out.skips}")
@@ -760,9 +811,12 @@ class StatefulTest extends CatsEffectSuite:
     )
 
   test("no temporals → no teardown method"):
-    val ir      = serviceWithTemporals(Nil)
-    val profile = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
-    val out     = Stateful.emitFor(profile)
+    val ir = serviceWithTemporals(Nil)
+    val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
+      ir,
+      "python-fastapi-postgres"
+    ))
+    val out = Stateful.emitFor(profile)
     assert(
       !out.file.contains("def teardown(self):"),
       s"no eventually temporals → no teardown:\n${out.file}"

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -710,7 +710,10 @@ class StatefulTest extends CatsEffectSuite:
           None
         )
       ),
-      g = Nil,
+      // A valid Hypothesis state machine needs >= 1 @rule; without an operation the
+      // machine (even with temporals/invariants) is rejected at runtime, so the
+      // temporal-emission path is only reachable when at least one rule exists.
+      g = List(OperationDeclFull("Tick", Nil, Nil, List(BoolLitF(true, None)), Nil, None)),
       h = Nil,
       i = Nil,
       j = temporals,

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -693,12 +693,20 @@ class StatefulTest extends CatsEffectSuite:
     ServiceIRFull(
       a = "TempSvc",
       b = Nil,
-      c = Nil,
+      c = List(
+        EntityDeclFull(
+          "CounterRow",
+          None,
+          List(FieldDeclFull("id", NamedTypeF("Int", None), None, None)),
+          Nil,
+          None
+        )
+      ),
       d = Nil,
       e = Nil,
       f = Some(
         StateDeclFull(
-          List(StateFieldDeclFull("counter", NamedTypeF("Int", None), None)),
+          List(StateFieldDeclFull("counter", NamedTypeF("CounterRow", None), None)),
           None
         )
       ),

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -216,7 +216,7 @@ class StructuralTest extends CatsEffectSuite:
         s"missing schemathesis hook decorator:\n${out.file}"
       )
       assert(
-        out.file.contains("def before_call(context, case):"),
+        out.file.contains("def before_call(context, case, kwargs):"),
         s"missing before_call hook:\n${out.file}"
       )
 

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -114,7 +114,20 @@ class StructuralTest extends CatsEffectSuite:
       val out = Structural.emitFor(profiled)
       assert(!out.file.contains("schema.as_state_machine()"))
       assert(out.file.contains("def test_api_structural(case):"))
-      assert(out.file.contains("def _check_invariant_count_non_negative(ctx, response, case):"))
+      // `countNonNegative` reads unbacked scalar `count`; the admin /state projects it
+      // as null, so the global-invariant check must honest-skip rather than emit a
+      // `None >= 0` crash.
+      assert(
+        !out.file.contains("def _check_invariant_count_non_negative(ctx, response, case):"),
+        s"unbacked-state invariant check must not be emitted:\n${out.file}"
+      )
+      assert(
+        out.skips.exists(s =>
+          s.kind.startsWith("structural_invariant") &&
+            s.reason.contains("not backed by an entity table")
+        ),
+        s"expected recorded structural_invariant skip for countNonNegative; got ${out.skips}"
+      )
 
   test("invariant skips use <invariants> sentinel, not <service>"):
     val ir = ServiceIRFull(

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -49,9 +49,11 @@ class StructuralTest extends CatsEffectSuite:
   test("url_shortener: emits one global-invariant check per translatable invariant"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
       val out = Structural.emitFor(profiled)
-      assert(out.file.contains("def _check_invariant_all_ur_ls_valid(response, case):"))
-      assert(out.file.contains("def _check_invariant_metadata_consistent(response, case):"))
-      assert(out.file.contains("def _check_invariant_click_count_non_negative(response, case):"))
+      assert(out.file.contains("def _check_invariant_all_ur_ls_valid(ctx, response, case):"))
+      assert(out.file.contains("def _check_invariant_metadata_consistent(ctx, response, case):"))
+      assert(
+        out.file.contains("def _check_invariant_click_count_non_negative(ctx, response, case):")
+      )
       assert(out.file.contains("post_state = client.get(\"/__test_admin__/state\").json()"))
 
   test("url_shortener: invariant checks gated by status < 500"):
@@ -98,21 +100,21 @@ class StructuralTest extends CatsEffectSuite:
         s"at least one Shorten skip should cite pre()/prime():\n$shortenSkips"
       )
 
-  test("url_shortener: emits an as_state_machine() Links class"):
+  test("no schemathesis links state machine (spec-derived OpenAPI has no links)"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>
-      val out = Structural.emitFor(profiled)
-      assert(out.file.contains("schema.as_state_machine()"))
-      assert(out.file.contains("TestStructuralLinksUrlShortener = "))
-
-  test("safe_counter: no entities → no Links state machine emitted, but file is valid"):
-    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val out = Structural.emitFor(profiled)
       assert(
         !out.file.contains("schema.as_state_machine()"),
-        s"safe_counter has no entities; should not emit a Links state machine:\n${out.file}"
+        s"as_state_machine() raises NoLinksFound on schemathesis 4.x; must not be emitted:\n${out.file}"
       )
+      assert(!out.file.contains("TestStructuralLinks"))
+
+  test("safe_counter: structural file is valid, schemathesis-4.x check signature"):
+    loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
+      val out = Structural.emitFor(profiled)
+      assert(!out.file.contains("schema.as_state_machine()"))
       assert(out.file.contains("def test_api_structural(case):"))
-      assert(out.file.contains("def _check_invariant_count_non_negative(response, case):"))
+      assert(out.file.contains("def _check_invariant_count_non_negative(ctx, response, case):"))
 
   test("invariant skips use <invariants> sentinel, not <service>"):
     val ir = ServiceIRFull(

--- a/modules/testgen/src/test/scala/specrest/testgen/SynthFixture.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SynthFixture.scala
@@ -1,0 +1,24 @@
+package specrest.testgen
+
+import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
+import specrest.profile.Annotate
+import specrest.profile.ProfiledService
+
+// Emission/translation unit tests exercise logic that only applies to *implemented*
+// operations. The orthogonal "skip fail-loud stubs" gate (StubOps / Finding 1) is
+// covered by its own focused tests; everywhere else, ops that would otherwise be
+// fail-loud stubs are marked synthesized so Finding 1 is transparent and the logic
+// under test actually runs.
+object SynthFixture:
+
+  def asSynthesized(profiled: ProfiledService): ProfiledService =
+    Annotate.attachDafnyMethods(
+      profiled,
+      profiled.operations
+        .filter(op => StubOps.isStub(profiled, op))
+        .map(op => op.operationName -> s"_dafny_kernel.${op.operationName}")
+        .toMap
+    )
+
+  def profiled(ir: ServiceIRFull, target: String = "python-fastapi-postgres"): ProfiledService =
+    asSynthesized(Annotate.buildProfiledService(ir, target))

--- a/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
@@ -31,24 +31,27 @@ class TestCtxTest extends CatsEffectSuite:
       assertEquals(ctx.outputs, Set.empty[String])
       assertEquals(ctx.capture, CaptureMode.PreState)
 
-  test("ExprToPython translates every safe_counter clause without Skip"):
+  test("ExprToPython honest-skips safe_counter clauses that touch unbacked scalar `count`"):
     val src = scala.io.Source
       .fromFile("fixtures/spec/safe_counter.spec")
       .getLines
       .mkString("\n")
     loadIR(src).map: ir =>
-      ir.g.collect { case o: OperationDeclFull => o }.foreach: op =>
+      val results = ir.g.collect { case o: OperationDeclFull => o }.flatMap: op =>
         val reqCtx = TestCtx.fromOperation(op, ir, CaptureMode.PreState)
         val ensCtx = TestCtx.fromOperation(op, ir, CaptureMode.PostState)
-        op.d.foreach: e =>
-          val r = ExprToPython.translate(e, reqCtx)
-          assert(
-            r.isInstanceOf[ExprPy.Py],
-            s"requires of ${op.a} skipped: ${r match { case ExprPy.Skip(s, _) => s; case _ => "?" }}"
-          )
-        op.e.foreach: e =>
-          val r = ExprToPython.translate(e, ensCtx)
-          assert(
-            r.isInstanceOf[ExprPy.Py],
-            s"ensures of ${op.a} skipped: ${r match { case ExprPy.Skip(s, _) => s; case _ => "?" }}"
-          )
+        op.d.map(e => s"${op.a}.requires" -> ExprToPython.translate(e, reqCtx)) ++
+          op.e.map(e => s"${op.a}.ensures" -> ExprToPython.translate(e, ensCtx))
+      val skips = results.collect { case (n, ExprPy.Skip(r, _)) => n -> r }
+      // `count` is the only state and it is unbacked; every clause that references it
+      // must honest-skip rather than emit a `None`-comparison that crashes at runtime.
+      assert(skips.nonEmpty, s"expected unbacked-state skips; got $results")
+      assert(
+        skips.forall(_._2.contains("not backed by an entity table")),
+        s"safe_counter clauses should only skip for the unbacked-state reason; got $skips"
+      )
+      // `Increment.requires` is the literal `true` — no state reference, stays translatable.
+      assert(
+        results.exists { case (n, r) => n == "Increment.requires" && r.isInstanceOf[ExprPy.Py] },
+        s"Increment.requires (`true`) must still translate; got $results"
+      )

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -80,12 +80,19 @@ class TestEmitTest extends CatsEffectSuite:
       assert(beh.contains("strategy_short_code"))
       assert(beh.contains("def test_shorten_ensures_"), s"no shorten ensures test:\n$beh")
 
-  test("behavioral file for safe_counter contains Increment ensures, no @given"):
+  test("safe_counter behavioral honest-skips Increment (unbacked count), recorded in skips json"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val beh   = files.find(_.path == "tests/test_behavioral_safe_counter.py").get.content
-      assert(beh.contains("def test_increment_ensures_0("))
-      assert(!beh.contains("@given("), "Increment has no inputs; should have no @given")
+      assert(
+        !beh.contains("def test_increment_ensures_0("),
+        s"Increment.ensures touches unbacked `count`; must not emit a crashing test:\n$beh"
+      )
+      val skips = files.find(_.path == "tests/_testgen_skips.json").get.content
+      assert(
+        skips.contains("not backed by an entity table"),
+        s"unbacked-state skip must be recorded in the skips manifest:\n$skips"
+      )
 
   test("_testgen_skips.json is well-formed and contains no ExprToPython coverage skips"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -14,7 +14,7 @@ class TestEmitTest extends CatsEffectSuite:
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
-          case Right(ir) => Annotate.buildProfiledService(ir, target)
+          case Right(ir) => SynthFixture.asSynthesized(Annotate.buildProfiledService(ir, target))
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 


### PR DESCRIPTION
## Why

The O–S codegen-defect cascade (redirect side-effect stubs, filtered-list stubs, synthesized-PK type drift) all shipped CI-green and were caught only by manual inspection: go-chi and ts-express have **no behavioral conformance in CI** — only fastapi runs `--with-tests`. This is the systemic root cause tracked in the cascade.

The conformance bundle (`conftest`/`run_conformance`/`behavioral`/`stateful`/`structural`) is a **spec-derived, language-agnostic HTTP black-box driver**. The only language-specific artifact is the test-admin router. Foundation PR #276 extracted the renderer-agnostic `AdminModel`. This PR is step (b): wire **ts-express** into the suite.

## What

- **`AdminRouterTs`** — TS/Prisma renderer over `AdminModel`. Emits the identical reset/state/seed HTTP/JSON contract as the fastapi `test_admin.py`: snake-keyed row dicts, ISO-8601 datetimes, env-gated on `ENABLE_TEST_ADMIN=1` (403 otherwise), FK-safe reverse-order `deleteMany`, entity-row vs primitive-field state projections, unbacked scalar state → `null`.
- **`TestEmit` / `FilePaths`** — target-aware admin-router selection: `express` → `src/routes/testAdmin.ts`, else `app/routers/test_admin.py`. The rest of the bundle is emitted **identically** for every target.
- **`supportsTestgen(Express)=true`** — `--with-tests` now accepted for ts-express; `SupportedTargets.describe` lists the ts-express slugs.
- **`index.ts.hbs`** — env-gated optional-import mount mirroring the fastapi `main.py` self-gating pattern. Non-literal specifier so production builds (no `--with-tests`) don't fail `tsc` on the absent module and the import is a clean no-op.
- **`ts-build.yml`** — new `conformance` job: emit `--with-tests` → npm/prisma/tsc/build → `prisma migrate deploy` → boot `node dist/index.js` with `ENABLE_TEST_ADMIN=1` → run `tests/run_conformance.py smoke` against the live server via `uv`. Matrix: 4 fixtures × {postgres, sqlite}.
- **`TestCmd`** — generalized the hardcoded fastapi-only "re-compile with --framework fastapi" message off `SupportedTargets.describe`.

## Validation

- fastapi output **byte-identical** — `EmitPythonTest` 3/3.
- `testgen` 233/233, `profile` 46/46 (incl. `TargetCompositionTest`), `cli` 40/40 (incl. `CliSmokeTest`).
- Inspected emitted `testAdmin.ts` for `url_shortener` (no transitions → clean empty seed section) and `ecommerce` (5 entities, seed handlers, entity-row + unbacked-scalar projections) — cleanly indented, contract-faithful.
- scalafmt/scalafix clean; ts-build.yml lints.

The ts-build conformance run is the validator for any real ts behavioral/JSON-shape divergences; expected to drive a short fix-forward loop. Part of the systemic fix (#171); go-chi conformance is the follow-up step (c).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TS/Prisma test-admin router for ts-express and wires it into the conformance suite and CI to enforce behavioral/JSON-shape parity. Also makes conformance honest (skip fail-loud stubs and unbacked-state assertions), adds explicit skip placeholders for empty suites, fixes `schemathesis` 4.x hooks, and aligns explicit integer PKs to 64-bit across migration and clients.

- New Features
  - TS/Prisma test-admin router with FastAPI-parity (snake_case, ISO datetimes), gated by ENABLE_TEST_ADMIN=1; `--with-tests` now supported for ts-express; `index.ts` optionally mounts admin routes.
  - CI conformance job: emit `--with-tests`, build, boot with ENABLE_TEST_ADMIN=1, then run the smoke profile across fixtures on Postgres/SQLite.
  - Honest conformance: single-source `RouteKind.effective`/`isFailLoudStub`; skip fail‑loud stubs across behavioral/stateful/structural; list routes use bare-body outputs; `--synthesis-partial` binds only verified bodies; pricing rows for `gpt-4.1`/`gpt-4.1-mini`/`gpt-5`/`gpt-5-mini`; default `--max-tokens` is 16384.

- Bug Fixes
  - Structural conformance for `schemathesis` 4.x: custom checks use `(ctx, response, case)`; `before_call(context, case, kwargs)` hook arity fixed; removed the dead links state machine.
  - Behavioral/stateful honesty: emit a single pytest.skip placeholder when a phase would otherwise be empty or ruleless; all reasons recorded in `tests/_testgen_skips.json`.
  - TS strictness: generated `testAdmin.ts` compiles cleanly under `tsc --noEmit` (prisma cast and Date overload fixes).
  - Consistent types and safe tests: explicit integer `id` PKs widened to 64-bit across migration and renderer types (Prisma `BigInt @id`); assertions over unbacked scalar state are honestly skipped and recorded; stateful tests suppress `HealthCheck.filter_too_much`.

<sup>Written for commit dfc41a076772f0b6ee5e69a130d747e4a7e154b7. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test generation and conformance testing added for TypeScript + Express apps; servers can optionally enable test-admin endpoints at startup.
  * Test generator now skips unimplementable/stubbed operations and excludes them from fuzzing; unbacked state fields are skipped in generated checks.
  * Some generated clients/migrations now use 64-bit IDs where explicit integer PKs were widened.

* **Chores**
  * CI now runs conformance builds/tests for TypeScript/Express.
  * CLI: added --synthesis-partial flag and increased default --max-tokens for synthesis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->