### PR TITLE
fix(cli): correct stale --help strings falsified by native multi-target conformance

### DIFF
--- a/modules/cli/src/main/scala/specrest/cli/Main.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Main.scala
@@ -199,7 +199,7 @@ object Main
     val withTests = Opts
       .flag(
         "with-tests",
-        "also emit Hypothesis property tests + admin router (python-fastapi-postgres only)"
+        "also emit the native conformance suite (behavioral/stateful/structural) in the target's own language + the gated test-admin router"
       )
       .orFalse
     val strictStrategies = Opts
@@ -479,7 +479,7 @@ object Main
       .withDefault("python3")
     Opts.subcommand(
       "test",
-      "Run the emitted conformance suite against a running service (python-fastapi-postgres only)"
+      "Run the emitted Python conformance runner against a running service (python-fastapi targets; ts/go use their native runner)"
     ):
       (outDir, profile, serverUrl, pythonBin, verbose, quiet, colorMode).mapN:
         (o, p, s, py, v, q, c) =>


### PR DESCRIPTION
The merged native-conformance cascade (#278 / #279 / #280, closing #265) left two `Main.scala` help strings factually wrong — the binary's own `--help` misreports its behavior:

- **`--with-tests`**: was "also emit Hypothesis property tests + admin router (python-fastapi-postgres only)". Now emits a native behavioral/stateful/structural conformance suite in the target's own language (pytest+Hypothesis+Schemathesis / Vitest+fast-check / `go test`+rapid) for **all** targets.
- **`test` subcommand header**: was "(python-fastapi-postgres only)". `spec-to-rest test` drives the Python `run_conformance.py` (python-fastapi, any dialect — not postgres-only); ts/go run their own native runners.

Found while cross-checking the docs CLI-flag tables (PR #281) against the actual `modules/cli` source. The full audit: exit-code table in `cli.mdx` verified accurate vs `ExitCodes.scala`; `verification.mdx` verify-flag reference accurate vs `Main.scala`; the only doc gap (`--synthesis-partial` missing from `cli.mdx`) is fixed in #281. These two were the only **code** violators.

Text-only change. cli compiles; `CliSmokeTest` 40/40.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect CLI help text to match native multi-target conformance. Updates the `--with-tests` flag and `test` subcommand descriptions; no behavior change.

- **Bug Fixes**
  - `--with-tests`: now states it emits the native conformance suite (behavioral/stateful/structural) in the target’s language plus the gated test-admin router.
  - `test` subcommand: now clarifies it runs the Python conformance runner for python-fastapi targets; TypeScript/Go use their native runners.

<sup>Written for commit ddf095856cf3f7788f4144c75ef4a4286a0703e8. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/282?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

