### PR TITLE
fix(proof): parameterise value_has_ty by tyctx, tighten vt_entity_with (closes #285 review)

### DIFF
--- a/proofs/isabelle/STATUS.md
+++ b/proofs/isabelle/STATUS.md
@@ -113,7 +113,8 @@ not incremental PRs:
   theorem (`wf Γ e ⟹ ∃v. eval e env = Some v`), so nothing proves the compiler only ever feeds
   soundness a well-formed, in-subset expression. This is the missing front-half of the soundness
   story. _Phase H1 landed (`Semantics.thy` §Phase 9n):_ value-type ADT `ty`
-  (TBool/TInt/TEnum/TEntity/TSet) + inductive value typing `value_has_ty` (infix `::v`) +
+  (TBool/TInt/TEnum/TEntity/TSet) + inductive value typing `value_has_ty` (prefix
+  `value_has_ty Γ v t`; previously infix `::v` pre-Phase-9ww-followup, see below) +
   `eval_arith_preservation` + `eval_cmp_preservation`. _Phase H2 landed (Semantics.thy §Phase
   9o-9q + Soundness.thy §Phase 9r):_ lexical typing context `tyenv` + `env_agrees` predicate (9o);
   state-resident-scalar schema `state_schema` + `state_agrees_scalars` + joint `tyctx` +
@@ -209,11 +210,23 @@ not incremental PRs:
   `lower_with_assigns_eval_implies_base_eval` (the chain's outer eval succeeds ⟹ the base's eval
   also succeeds — used to discharge the IH(1) base-eval premise);
   `lower_with_assigns_preserves_entity` (the chain preserves `TEntity ename` — by structural
-  induction on updates, each `WithRec` wrap re-applies `vt_entity_with` to preserve the entity type,
-  with no per-override type constraint needed). The umbrella case applies the three helpers in
-  sequence and closes — _no use of the per-update IH_ — because `vt_entity_with` is the
-  unconditional preservation rule for entity-update wrappers (override types are constrained only
-  for the semantic invariant `entity_field_well_typed`, supplied via `agrees_strict`). _Phase 9ee
+  induction on updates, each `WithRec` wrap re-applies `vt_entity_with` to preserve the entity type;
+  post-Phase-9ww-followup the rule now requires the override be typed at the declared field type,
+  so the lemma takes a per-update `updates_typed` premise threaded from `T_With.IH(2)`). The
+  umbrella case composes the three helpers and closes via the tightened `vt_entity_with`.
+
+  _Phase 9ww-followup (PR #286):_ tightened `vt_entity_with` per the H3-blocker raised by
+  coderabbitai on PR #285. Old rule: `base ::v TEntity ename ⟹ VEntityWith base fld override ::v
+  TEntity ename` (override unconstrained), which let a derivation type any garbage value as an
+  entity field override and so `entity_field_well_typed Γ st` was unprovable for non-TInt schemas.
+  New rule: `value_has_ty Γ base (TEntity ename) ⟹ schemaFieldType Γ ename fld = Some ft ⟹
+  value_has_ty Γ override ft ⟹ value_has_ty Γ (VEntityWith base fld override) (TEntity ename)`.
+  Required parameterising `value_has_ty` by `tyctx` (the override-typing premise consults
+  `schemaFieldType Γ`), dropping the infix `::v`, and threading `Γ` through `env_agrees`,
+  `state_agrees_scalars`, `env_agrees_strict` and their tc_env-update simp companions.
+  `lower_with_assigns_preserves_entity` took the per-update typing premise (a universally
+  quantified IH-shaped predicate), and the H3 `T_With` case feeds it from `T_With.IH(2)`. ~100
+  references rewritten; Isabelle build 5:49 → 6:02, no Scala-side diff. _Phase 9ee
   extension:_ `T_Forall_QAll` (single-binding universal quantifier). The rule binds the body in a
   context extended by `(var, t_dom)` for any `t_dom` — the body must type at `TBool`, no constraint
   on whether `dnm` is an enum or relation at the typing level (lowering's `string_in_list dnm enums`

--- a/proofs/isabelle/SpecRest/Semantics.thy
+++ b/proofs/isabelle/SpecRest/Semantics.thy
@@ -154,59 +154,24 @@ datatype (plugins only: code size) ty =
   | TEntity "String.literal"
   | TSet ty
 
-inductive value_has_ty :: "ir_value \<Rightarrow> ty \<Rightarrow> bool" (infix "::v" 50) where
-  vt_bool:        "VBool b ::v TBool"
-| vt_int:         "VInt n ::v TInt"
-| vt_enum:        "VEnum ename ev ::v TEnum ename"
-| vt_entity:      "VEntity ename eid ::v TEntity ename"
-| vt_set:         "(\<forall>v \<in> set vs. v ::v t) \<Longrightarrow> VSet vs ::v TSet t"
-| vt_entity_with: "base ::v TEntity ename
-                     \<Longrightarrow> VEntityWith base fld override ::v TEntity ename"
+text \<open>The typing context \<open>tyctx\<close> and its sub-records are declared
+  here (before \<open>value_has_ty\<close>) because \<open>vt_entity_with\<close> needs to
+  consult \<open>schemaFieldType \<Gamma>\<close> when constraining the override.
+  Pre-\<open>value_has_ty\<close>-Γ this whole block lived ~200 lines below;
+  hoisting only the type / record / lookup declarations keeps the
+  proof-helper lemmas in their original location.\<close>
 
-inductive_cases value_has_ty_bool_cases [elim!]: "VBool b ::v t"
-inductive_cases value_has_ty_int_cases [elim!]: "VInt n ::v t"
-inductive_cases value_has_ty_enum_cases [elim!]: "VEnum ename ev ::v t"
-inductive_cases value_has_ty_entity_cases [elim!]: "VEntity ename eid ::v t"
-inductive_cases value_has_ty_set_cases [elim!]: "VSet vs ::v t"
-inductive_cases value_has_ty_entity_with_cases [elim!]:
-  "VEntityWith base fld override ::v t"
+type_synonym tyenv = "(String.literal \<times> ty) list"
 
-lemma value_has_ty_VBool_iff [simp]: "VBool b ::v t \<longleftrightarrow> t = TBool"
-  by (auto intro: vt_bool)
+record state_schema =
+  ss_scalars :: "(String.literal \<times> ty) list"
 
-lemma value_has_ty_VInt_iff [simp]: "VInt n ::v t \<longleftrightarrow> t = TInt"
-  by (auto intro: vt_int)
-
-lemma value_has_ty_VEnum_iff [simp]:
-  "VEnum ename ev ::v t \<longleftrightarrow> t = TEnum ename"
-  by (auto intro: vt_enum)
-
-lemma value_has_ty_VEntity_iff [simp]:
-  "VEntity ename eid ::v t \<longleftrightarrow> t = TEntity ename"
-  by (auto intro: vt_entity)
-
-text \<open>Phase H2b (schema typing). A partial translation from
-  spec-side \<open>type_expr\<close> (the declared form on fields / state
-  scalars / relation positions) to the value-side \<open>ty\<close> ADT used
-  by \<open>value_has_ty\<close>. Partial: \<open>RelationT\<close> has no direct \<open>ty\<close>
-  counterpart (relations are kept structurally separate in this
-  fragment); field declarations referring to it map to \<open>None\<close>
-  and the field is not typeable via the H3 chain.\<close>
-
-fun typeExprToTy :: "type_expr \<Rightarrow> ty option" where
-  "typeExprToTy BoolT           = Some TBool"
-| "typeExprToTy IntT            = Some TInt"
-| "typeExprToTy (EnumT n)       = Some (TEnum n)"
-| "typeExprToTy (EntityT n)     = Some (TEntity n)"
-| "typeExprToTy (RelationT _ _) = None"
-
-text \<open>The \<open>*Full\<close> analogue. \<open>type_expr_full\<close> uses a single
-  \<open>NamedTypeF\<close> constructor for both primitives (\<open>STR ''Bool''\<close>,
-  \<open>STR ''Int''\<close>, ...) and user-defined enum / entity names
-  (\<open>EnumName\<close>, \<open>EntityName\<close>) — disambiguation requires the enum
-  and entity name lists from context. Set wraps recursively; all
-  out-of-fragment shapes (Float / String / Option / Map / Seq /
-  Relation / DateTime / Duration / UUID) map to \<open>None\<close>.\<close>
+record tyctx =
+  tc_env       :: tyenv
+  tc_schema    :: state_schema
+  tc_entities  :: "entity_decl_full list"
+  tc_relations :: "state_field_decl_full list"
+  tc_enums     :: "String.literal list"
 
 fun typeExprFullToTy ::
   "String.literal list \<Rightarrow> String.literal list
@@ -220,110 +185,6 @@ fun typeExprFullToTy ::
 | "typeExprFullToTy enums entities (SetTypeF inner _) =
      map_option TSet (typeExprFullToTy enums entities inner)"
 | "typeExprFullToTy _ _ _ = None"
-
-text \<open>The spec-level analogue of \<open>peel_relation_ref :: expr \<Rightarrow>
-  String.literal option\<close>, lifted to \<open>expr_full\<close>. Recognises the
-  three syntactic shapes \<open>rel_ref_shape\<close> accepts (bare ident,
-  pre-ident, prime-ident) and extracts the relation name. Used
-  by \<open>T_Index\<close> to bind \<open>rel_name\<close> from the base subterm.\<close>
-
-fun peelRelationRefFull :: "expr_full \<Rightarrow> String.literal option" where
-  "peelRelationRefFull (IdentifierF rel _)              = Some rel"
-| "peelRelationRefFull (PreF (IdentifierF rel _) _)     = Some rel"
-| "peelRelationRefFull (PrimeF (IdentifierF rel _) _)   = Some rel"
-| "peelRelationRefFull _                                = None"
-
-lemma eval_arith_preservation:
-  assumes "eval_arith op x y = Some v"
-      and "\<And>a. x = Some a \<Longrightarrow> a ::v TInt"
-      and "\<And>b. y = Some b \<Longrightarrow> b ::v TInt"
-  shows "v ::v TInt"
-  using assms eval_arith_some_imp_int[OF assms(1)]
-  by (induction op x y rule: eval_arith.induct)
-     (auto split: if_splits intro: vt_int)
-
-lemma eval_cmp_preservation:
-  assumes "eval_cmp op x y = Some v"
-  shows "v ::v TBool"
-  using assms by (induction op x y rule: eval_cmp.induct) (auto intro: vt_bool)
-
-text \<open>Phase H2 (start) - typing context and environment agreement.
-  The H2 phase introduces a typing context \<open>tyenv\<close> for lexical
-  binders and the \<open>env_agrees\<close> predicate witnessing that the
-  runtime environment satisfies the context. This is the lexical
-  half of the typing context; state-schema typing (relations /
-  entity fields) is the next sub-phase. Together they will support
-  the typing relation \<open>Gamma |- e : t\<close> over \<open>expr_full\<close> and the
-  rule-induction type-safety theorem.\<close>
-
-type_synonym tyenv = "(String.literal \<times> ty) list"
-
-definition tyenv_lookup :: "tyenv \<Rightarrow> String.literal \<Rightarrow> ty option" where
-  "tyenv_lookup G x = map_of G x"
-
-definition env_agrees :: "env \<Rightarrow> tyenv \<Rightarrow> bool" where
-  "env_agrees env G =
-     (\<forall>x t. tyenv_lookup G x = Some t \<longrightarrow>
-            (\<exists>v. map_of env x = Some v \<and> v ::v t))"
-
-lemma env_agrees_lookup:
-  assumes "env_agrees env G" and "tyenv_lookup G x = Some t"
-  shows "\<exists>v. map_of env x = Some v \<and> v ::v t"
-  using assms by (simp add: env_agrees_def)
-
-lemma env_agrees_empty [simp]: "env_agrees env []"
-  by (simp add: env_agrees_def tyenv_lookup_def)
-
-lemma env_agrees_cons:
-  assumes "env_agrees env G" and "v ::v t"
-  shows "env_agrees ((x, v) # env) ((x, t) # G)"
-  using assms
-  by (auto simp: env_agrees_def tyenv_lookup_def split: if_splits)
-
-text \<open>Phase H2 (state schema). The companion to \<open>env_agrees\<close>:
-  \<open>state_schema\<close> assigns types to state-resident scalars, and
-  \<open>state_agrees_scalars\<close> witnesses that the runtime \<open>state\<close>
-  satisfies that typing. The false naive \<open>free_vars \<subseteq> dom env\<close>
-  scope lemma proved earlier showed Ident must read from state
-  too - this is the typed half of that reading. Relation /
-  entity-field schema typing extends this record in subsequent
-  sub-phases.\<close>
-
-record state_schema =
-  ss_scalars :: "(String.literal \<times> ty) list"
-
-definition state_agrees_scalars :: "state \<Rightarrow> state_schema \<Rightarrow> bool" where
-  "state_agrees_scalars st sch =
-     (\<forall>x t. map_of (ss_scalars sch) x = Some t \<longrightarrow>
-            (\<exists>v. state_lookup_scalar st x = Some v \<and> v ::v t))"
-
-lemma state_agrees_scalars_lookup:
-  assumes "state_agrees_scalars st sch"
-      and "map_of (ss_scalars sch) x = Some t"
-  shows "\<exists>v. state_lookup_scalar st x = Some v \<and> v ::v t"
-  using assms by (simp add: state_agrees_scalars_def)
-
-lemma state_agrees_scalars_empty [simp]:
-  "state_agrees_scalars st \<lparr> ss_scalars = [] \<rparr>"
-  by (simp add: state_agrees_scalars_def)
-
-text \<open>Phase H2 (joint context). \<open>tyctx\<close> bundles the lexical and
-  state-schema halves; \<open>agrees env st \<Gamma>\<close> is the predicate that
-  the H3 type-safety theorem will require on any well-typed
-  evaluation.\<close>
-
-record tyctx =
-  tc_env       :: tyenv
-  tc_schema    :: state_schema
-  tc_entities  :: "entity_decl_full list"
-  tc_relations :: "state_field_decl_full list"
-  tc_enums     :: "String.literal list"
-
-text \<open>The schema-side type lookups consume the \<open>*Full\<close> IR
-  (\<open>entity_decl_full\<close>, \<open>state_field_decl_full\<close>) that Scala
-  consumers actually have. \<open>tyctx\<close> is passed in directly so a
-  single argument carries the enum-name list, entity-decl list,
-  and state-field-decl list needed to disambiguate \<open>NamedTypeF\<close>.\<close>
 
 definition schemaFieldType ::
   "tyctx \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> ty option" where
@@ -340,6 +201,185 @@ definition schemaFieldType ::
                 (map entityNameFull (tc_entities \<Gamma>))
                 (fieldTypeFull fd))"
 
+text \<open>\<open>value_has_ty\<close> is parameterised by the typing context
+  \<open>\<Gamma>\<close> so the \<open>vt_entity_with\<close> rule can require its override to
+  have the field's declared type. Without \<open>\<Gamma>\<close> the rule was
+  \<open>base ::v TEntity ename \<Longrightarrow> VEntityWith base fld override ::v
+  TEntity ename\<close> for any \<open>override\<close>; a derivation could pick
+  \<open>override = VInt 0\<close> for an entity whose \<open>fld\<close> is declared
+  \<open>TBool\<close>, then \<open>entity_field_well_typed\<close> (universally
+  quantified over values) failed for any non-\<open>TInt\<close> schema —
+  blocking the H3 callers from discharging \<open>agrees_strict\<close>.
+  Flagged on PR #285 by cubic-dev-ai + coderabbitai; this is the
+  follow-up.
+
+  Notation: the old infix \<open>v ::v t\<close> would not extend to a third
+  argument without losing readability, so callers now write
+  \<open>value_has_ty \<Gamma> v t\<close>.\<close>
+
+inductive value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Rightarrow> bool" where
+  vt_bool:        "value_has_ty \<Gamma> (VBool b) TBool"
+| vt_int:         "value_has_ty \<Gamma> (VInt n) TInt"
+| vt_enum:        "value_has_ty \<Gamma> (VEnum ename ev) (TEnum ename)"
+| vt_entity:      "value_has_ty \<Gamma> (VEntity ename eid) (TEntity ename)"
+| vt_set:         "(\<forall>v \<in> set vs. value_has_ty \<Gamma> v t)
+                     \<Longrightarrow> value_has_ty \<Gamma> (VSet vs) (TSet t)"
+| vt_entity_with: "value_has_ty \<Gamma> base (TEntity ename)
+                     \<Longrightarrow> schemaFieldType \<Gamma> ename fld = Some ft
+                     \<Longrightarrow> value_has_ty \<Gamma> override ft
+                     \<Longrightarrow> value_has_ty \<Gamma> (VEntityWith base fld override)
+                                       (TEntity ename)"
+
+inductive_cases value_has_ty_bool_cases [elim!]: "value_has_ty \<Gamma> (VBool b) t"
+inductive_cases value_has_ty_int_cases [elim!]: "value_has_ty \<Gamma> (VInt n) t"
+inductive_cases value_has_ty_enum_cases [elim!]:
+  "value_has_ty \<Gamma> (VEnum ename ev) t"
+inductive_cases value_has_ty_entity_cases [elim!]:
+  "value_has_ty \<Gamma> (VEntity ename eid) t"
+inductive_cases value_has_ty_set_cases [elim!]: "value_has_ty \<Gamma> (VSet vs) t"
+inductive_cases value_has_ty_entity_with_cases [elim!]:
+  "value_has_ty \<Gamma> (VEntityWith base fld override) t"
+
+lemma value_has_ty_VBool_iff [simp]:
+  "value_has_ty \<Gamma> (VBool b) t \<longleftrightarrow> t = TBool"
+  by (auto intro: vt_bool)
+
+lemma value_has_ty_VInt_iff [simp]:
+  "value_has_ty \<Gamma> (VInt n) t \<longleftrightarrow> t = TInt"
+  by (auto intro: vt_int)
+
+lemma value_has_ty_VEnum_iff [simp]:
+  "value_has_ty \<Gamma> (VEnum ename ev) t \<longleftrightarrow> t = TEnum ename"
+  by (auto intro: vt_enum)
+
+lemma value_has_ty_VEntity_iff [simp]:
+  "value_has_ty \<Gamma> (VEntity ename eid) t \<longleftrightarrow> t = TEntity ename"
+  by (auto intro: vt_entity)
+
+lemma schemaFieldType_tc_env_update [simp]:
+  "schemaFieldType (\<Gamma>\<lparr>tc_env := xs\<rparr>) ename fname
+     = schemaFieldType \<Gamma> ename fname"
+  by (auto simp: schemaFieldType_def split: option.splits)
+
+text \<open>Invariance of \<open>value_has_ty\<close> under \<open>tc_env\<close> updates.
+  Required because the existing \<open>*_tc_env_update [simp]\<close> lemmas
+  for \<open>entity_field_well_typed\<close> and \<open>relation_value_well_typed\<close>
+  unfold to bodies that contain \<open>value_has_ty\<close> calls — and after
+  parameterisation those need to know the predicate doesn't read
+  \<open>tc_env\<close>. \<open>vt_entity_with\<close> consults \<open>schemaFieldType \<Gamma>\<close>
+  (which depends only on \<open>tc_entities\<close> and \<open>tc_enums\<close>) and not
+  \<open>tc_env\<close>, so the predicate is tc_env-invariant.\<close>
+
+lemma value_has_ty_tc_env_update [simp]:
+  "value_has_ty (\<Gamma>\<lparr>tc_env := xs\<rparr>) v t \<longleftrightarrow> value_has_ty \<Gamma> v t"
+proof
+  show "value_has_ty (\<Gamma>\<lparr>tc_env := xs\<rparr>) v t \<Longrightarrow> value_has_ty \<Gamma> v t"
+    by (induction "\<Gamma>\<lparr>tc_env := xs\<rparr>" v t rule: value_has_ty.induct)
+       (auto intro: value_has_ty.intros)
+  show "value_has_ty \<Gamma> v t \<Longrightarrow> value_has_ty (\<Gamma>\<lparr>tc_env := xs\<rparr>) v t"
+    by (induction \<Gamma> v t rule: value_has_ty.induct)
+       (auto intro: value_has_ty.intros)
+qed
+
+text \<open>Phase H2b (schema typing). A partial translation from
+  spec-side \<open>type_expr\<close> (the declared form on fields / state
+  scalars / relation positions) to the value-side \<open>ty\<close> ADT used
+  by \<open>value_has_ty\<close>. Partial: \<open>RelationT\<close> has no direct \<open>ty\<close>
+  counterpart (relations are kept structurally separate in this
+  fragment); field declarations referring to it map to \<open>None\<close>
+  and the field is not typeable via the H3 chain.\<close>
+
+fun typeExprToTy :: "type_expr \<Rightarrow> ty option" where
+  "typeExprToTy BoolT           = Some TBool"
+| "typeExprToTy IntT            = Some TInt"
+| "typeExprToTy (EnumT n)       = Some (TEnum n)"
+| "typeExprToTy (EntityT n)     = Some (TEntity n)"
+| "typeExprToTy (RelationT _ _) = None"
+
+text \<open>The spec-level analogue of \<open>peel_relation_ref :: expr \<Rightarrow>
+  String.literal option\<close>, lifted to \<open>expr_full\<close>. Recognises the
+  three syntactic shapes \<open>rel_ref_shape\<close> accepts (bare ident,
+  pre-ident, prime-ident) and extracts the relation name. Used
+  by \<open>T_Index\<close> to bind \<open>rel_name\<close> from the base subterm.
+
+  \<open>typeExprFullToTy\<close> hoisted up to the \<open>value_has_ty\<close> block since
+  \<open>schemaFieldType\<close> (referenced by \<open>vt_entity_with\<close>) depends on it.\<close>
+
+fun peelRelationRefFull :: "expr_full \<Rightarrow> String.literal option" where
+  "peelRelationRefFull (IdentifierF rel _)              = Some rel"
+| "peelRelationRefFull (PreF (IdentifierF rel _) _)     = Some rel"
+| "peelRelationRefFull (PrimeF (IdentifierF rel _) _)   = Some rel"
+| "peelRelationRefFull _                                = None"
+
+lemma eval_arith_preservation:
+  assumes "eval_arith op x y = Some v"
+      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
+      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b TInt"
+  shows "value_has_ty \<Gamma> v TInt"
+  using assms eval_arith_some_imp_int[OF assms(1)]
+  by (induction op x y rule: eval_arith.induct)
+     (auto split: if_splits intro: vt_int)
+
+lemma eval_cmp_preservation:
+  assumes "eval_cmp op x y = Some v"
+  shows "value_has_ty \<Gamma> v TBool"
+  using assms by (induction op x y rule: eval_cmp.induct) (auto intro: vt_bool)
+
+text \<open>Phase H2 (start) - typing context and environment agreement.
+  The H2 phase introduces a typing context \<open>tyenv\<close> for lexical
+  binders and the \<open>env_agrees\<close> predicate witnessing that the
+  runtime environment satisfies the context. This is the lexical
+  half of the typing context; state-schema typing (relations /
+  entity fields) is the next sub-phase. Together they will support
+  the typing relation \<open>Gamma |- e : t\<close> over \<open>expr_full\<close> and the
+  rule-induction type-safety theorem.\<close>
+
+definition tyenv_lookup :: "tyenv \<Rightarrow> String.literal \<Rightarrow> ty option" where
+  "tyenv_lookup G x = map_of G x"
+
+definition env_agrees :: "tyctx \<Rightarrow> env \<Rightarrow> tyenv \<Rightarrow> bool" where
+  "env_agrees \<Gamma> env G =
+     (\<forall>x t. tyenv_lookup G x = Some t \<longrightarrow>
+            (\<exists>v. map_of env x = Some v \<and> value_has_ty \<Gamma> v t))"
+
+lemma env_agrees_lookup:
+  assumes "env_agrees \<Gamma> env G" and "tyenv_lookup G x = Some t"
+  shows "\<exists>v. map_of env x = Some v \<and> value_has_ty \<Gamma> v t"
+  using assms by (simp add: env_agrees_def)
+
+lemma env_agrees_empty [simp]: "env_agrees \<Gamma> env []"
+  by (simp add: env_agrees_def tyenv_lookup_def)
+
+lemma env_agrees_cons:
+  assumes "env_agrees \<Gamma> env G" and "value_has_ty \<Gamma> v t"
+  shows "env_agrees \<Gamma> ((x, v) # env) ((x, t) # G)"
+  using assms
+  by (auto simp: env_agrees_def tyenv_lookup_def split: if_splits)
+
+text \<open>Phase H2 (state schema). The companion to \<open>env_agrees\<close>:
+  \<open>state_schema\<close> assigns types to state-resident scalars, and
+  \<open>state_agrees_scalars\<close> witnesses that the runtime \<open>state\<close>
+  satisfies that typing. The false naive \<open>free_vars \<subseteq> dom env\<close>
+  scope lemma proved earlier showed Ident must read from state
+  too - this is the typed half of that reading. Relation /
+  entity-field schema typing extends this record in subsequent
+  sub-phases.\<close>
+
+definition state_agrees_scalars :: "tyctx \<Rightarrow> state \<Rightarrow> state_schema \<Rightarrow> bool" where
+  "state_agrees_scalars \<Gamma> st sch =
+     (\<forall>x t. map_of (ss_scalars sch) x = Some t \<longrightarrow>
+            (\<exists>v. state_lookup_scalar st x = Some v \<and> value_has_ty \<Gamma> v t))"
+
+lemma state_agrees_scalars_lookup:
+  assumes "state_agrees_scalars \<Gamma> st sch"
+      and "map_of (ss_scalars sch) x = Some t"
+  shows "\<exists>v. state_lookup_scalar st x = Some v \<and> value_has_ty \<Gamma> v t"
+  using assms by (simp add: state_agrees_scalars_def)
+
+lemma state_agrees_scalars_empty [simp]:
+  "state_agrees_scalars \<Gamma> st \<lparr> ss_scalars = [] \<rparr>"
+  by (simp add: state_agrees_scalars_def)
+
 text \<open>The state-typing semantic invariant: any value typed at
   \<open>TEntity ename\<close>, when accessed via \<open>value_field_lookup\<close> for a
   field declared in the entity's schema, yields a value of the
@@ -352,17 +392,17 @@ definition entity_field_well_typed ::
   "tyctx \<Rightarrow> state \<Rightarrow> bool" where
   "entity_field_well_typed \<Gamma> st \<longleftrightarrow>
      (\<forall>v ename fname ft fv.
-        v ::v TEntity ename
+        value_has_ty \<Gamma> v (TEntity ename)
         \<and> schemaFieldType \<Gamma> ename fname = Some ft
         \<and> value_field_lookup st v fname = Some fv
-        \<longrightarrow> fv ::v ft)"
+        \<longrightarrow> value_has_ty \<Gamma> fv ft)"
 
 lemma entity_field_well_typed_lookup:
   assumes "entity_field_well_typed \<Gamma> st"
-      and "vb ::v TEntity ename"
+      and "value_has_ty \<Gamma> vb (TEntity ename)"
       and "schemaFieldType \<Gamma> ename fname = Some ft"
       and "value_field_lookup st vb fname = Some fv"
-  shows "fv ::v ft"
+  shows "value_has_ty \<Gamma> fv ft"
   using assms by (auto simp: entity_field_well_typed_def)
 
 text \<open>Relation-schema lookup + state-typing invariant. Mirrors
@@ -395,24 +435,22 @@ definition relation_value_well_typed ::
      (\<forall>rel_name tv k v.
         schemaRelationValueType \<Gamma> rel_name = Some tv
         \<and> state_lookup_key st rel_name k = Some v
-        \<longrightarrow> v ::v tv)"
+        \<longrightarrow> value_has_ty \<Gamma> v tv)"
 
 lemma relation_value_well_typed_lookup:
   assumes "relation_value_well_typed \<Gamma> st"
       and "schemaRelationValueType \<Gamma> rel_name = Some tv"
       and "state_lookup_key st rel_name k = Some v"
-  shows "v ::v tv"
+  shows "value_has_ty \<Gamma> v tv"
   using assms by (auto simp: relation_value_well_typed_def)
 
 text \<open>The schema-side predicates depend only on \<open>tc_entities\<close>,
   \<open>tc_relations\<close>, and \<open>tc_enums\<close> — not on \<open>tc_env\<close> — so they're
   invariant under \<open>tc_env\<close>-updates. These [simp] rules let the
-  \<open>T_Let\<close> cons step close automatically.\<close>
-
-lemma schemaFieldType_tc_env_update [simp]:
-  "schemaFieldType (\<Gamma>\<lparr>tc_env := xs\<rparr>) ename fname
-     = schemaFieldType \<Gamma> ename fname"
-  by (auto simp: schemaFieldType_def split: option.splits)
+  \<open>T_Let\<close> cons step close automatically.
+  (\<open>schemaFieldType_tc_env_update\<close> is hoisted up beside
+  \<open>value_has_ty_tc_env_update\<close>, since \<open>vt_entity_with\<close>'s
+  override-typing premise consults it.)\<close>
 
 lemma schemaRelationValueType_tc_env_update [simp]:
   "schemaRelationValueType (\<Gamma>\<lparr>tc_env := xs\<rparr>) rel_name
@@ -430,20 +468,36 @@ lemma relation_value_well_typed_tc_env_update [simp]:
      = relation_value_well_typed \<Gamma> st"
   by (simp add: relation_value_well_typed_def)
 
+text \<open>Companion invariance lemmas for the \<open>agrees\<close>-side
+  predicates: the lexical / scalar agreement bodies reference
+  \<open>value_has_ty \<Gamma> v t\<close> as their only \<open>\<Gamma>\<close>-dependent piece, and
+  \<open>value_has_ty_tc_env_update\<close> handles that, so the wrapper
+  predicates are also invariant. \<open>env_agrees_strict\<close>'s lemma is
+  declared after its definition further below.\<close>
+
+lemma env_agrees_tc_env_update [simp]:
+  "env_agrees (\<Gamma>\<lparr>tc_env := xs\<rparr>) env G = env_agrees \<Gamma> env G"
+  by (simp add: env_agrees_def)
+
+lemma state_agrees_scalars_tc_env_update [simp]:
+  "state_agrees_scalars (\<Gamma>\<lparr>tc_env := xs\<rparr>) st sch
+     = state_agrees_scalars \<Gamma> st sch"
+  by (simp add: state_agrees_scalars_def)
+
 definition agrees :: "env \<Rightarrow> state \<Rightarrow> tyctx \<Rightarrow> bool" where
   "agrees env st \<Gamma> \<longleftrightarrow>
-     env_agrees env (tc_env \<Gamma>) \<and> state_agrees_scalars st (tc_schema \<Gamma>)"
+     env_agrees \<Gamma> env (tc_env \<Gamma>) \<and> state_agrees_scalars \<Gamma> st (tc_schema \<Gamma>)"
 
 lemma agrees_env_lookup:
   assumes "agrees env st \<Gamma>"
       and "tyenv_lookup (tc_env \<Gamma>) x = Some t"
-  shows "\<exists>v. map_of env x = Some v \<and> v ::v t"
+  shows "\<exists>v. map_of env x = Some v \<and> value_has_ty \<Gamma> v t"
   using assms by (auto simp: agrees_def dest: env_agrees_lookup)
 
 lemma agrees_state_lookup:
   assumes "agrees env st \<Gamma>"
       and "map_of (ss_scalars (tc_schema \<Gamma>)) x = Some t"
-  shows "\<exists>v. state_lookup_scalar st x = Some v \<and> v ::v t"
+  shows "\<exists>v. state_lookup_scalar st x = Some v \<and> value_has_ty \<Gamma> v t"
   using assms by (auto simp: agrees_def dest: state_agrees_scalars_lookup)
 
 text \<open>Strict env agreement: every \<open>env\<close>-binding is also typed in \<open>tyenv\<close>
@@ -452,15 +506,19 @@ text \<open>Strict env agreement: every \<open>env\<close>-binding is also typed
   when \<open>x\<close> is NOT in \<open>tyenv\<close>, and strict agreement guarantees that means
   \<open>env_lookup x = None\<close> so eval's Ident arm falls through to the state.\<close>
 
-definition env_agrees_strict :: "env \<Rightarrow> tyenv \<Rightarrow> bool" where
-  "env_agrees_strict env G \<longleftrightarrow>
-     env_agrees env G \<and>
+definition env_agrees_strict :: "tyctx \<Rightarrow> env \<Rightarrow> tyenv \<Rightarrow> bool" where
+  "env_agrees_strict \<Gamma> env G \<longleftrightarrow>
+     env_agrees \<Gamma> env G \<and>
      (\<forall>x v. map_of env x = Some v \<longrightarrow> (\<exists>t. tyenv_lookup G x = Some t))"
+
+lemma env_agrees_strict_tc_env_update [simp]:
+  "env_agrees_strict (\<Gamma>\<lparr>tc_env := xs\<rparr>) env G = env_agrees_strict \<Gamma> env G"
+  by (simp add: env_agrees_strict_def)
 
 definition agrees_strict :: "env \<Rightarrow> state \<Rightarrow> tyctx \<Rightarrow> bool" where
   "agrees_strict env st \<Gamma> \<longleftrightarrow>
-     env_agrees_strict env (tc_env \<Gamma>) \<and>
-     state_agrees_scalars st (tc_schema \<Gamma>) \<and>
+     env_agrees_strict \<Gamma> env (tc_env \<Gamma>) \<and>
+     state_agrees_scalars \<Gamma> st (tc_schema \<Gamma>) \<and>
      entity_field_well_typed \<Gamma> st \<and>
      relation_value_well_typed \<Gamma> st"
 
@@ -469,18 +527,18 @@ lemma agrees_strict_imp_agrees:
   by (auto simp: agrees_strict_def agrees_def env_agrees_strict_def)
 
 lemma env_agrees_strict_lookup_none:
-  assumes "env_agrees_strict env G" and "tyenv_lookup G x = None"
+  assumes "env_agrees_strict \<Gamma> env G" and "tyenv_lookup G x = None"
   shows "map_of env x = None"
   using assms by (auto simp: env_agrees_strict_def)
 
 lemma env_agrees_strict_empty [simp]:
-  "env_agrees_strict [] []"
+  "env_agrees_strict \<Gamma> [] []"
   by (simp add: env_agrees_strict_def)
 
 lemma agrees_strict_env_lookup:
   assumes "agrees_strict env st \<Gamma>"
       and "tyenv_lookup (tc_env \<Gamma>) x = Some t"
-  shows "\<exists>v. map_of env x = Some v \<and> v ::v t"
+  shows "\<exists>v. map_of env x = Some v \<and> value_has_ty \<Gamma> v t"
   using assms agrees_strict_imp_agrees agrees_env_lookup by blast
 
 lemma agrees_strict_state_lookup:
@@ -488,38 +546,38 @@ lemma agrees_strict_state_lookup:
       and "tyenv_lookup (tc_env \<Gamma>) x = None"
       and "map_of (ss_scalars (tc_schema \<Gamma>)) x = Some t"
   shows "map_of env x = None
-         \<and> (\<exists>v. state_lookup_scalar st x = Some v \<and> v ::v t)"
+         \<and> (\<exists>v. state_lookup_scalar st x = Some v \<and> value_has_ty \<Gamma> v t)"
 proof -
-  have es: "env_agrees_strict env (tc_env \<Gamma>)"
+  have es: "env_agrees_strict \<Gamma> env (tc_env \<Gamma>)"
     using assms(1) by (simp add: agrees_strict_def)
-  have ss: "state_agrees_scalars st (tc_schema \<Gamma>)"
+  have ss: "state_agrees_scalars \<Gamma> st (tc_schema \<Gamma>)"
     using assms(1) by (simp add: agrees_strict_def)
   have "map_of env x = None"
     by (rule env_agrees_strict_lookup_none[OF es assms(2)])
-  moreover have "\<exists>v. state_lookup_scalar st x = Some v \<and> v ::v t"
+  moreover have "\<exists>v. state_lookup_scalar st x = Some v \<and> value_has_ty \<Gamma> v t"
     by (rule state_agrees_scalars_lookup[OF ss assms(3)])
   ultimately show ?thesis ..
 qed
 
 lemma env_agrees_strict_cons:
-  assumes "env_agrees_strict env G" and "v ::v t"
-  shows "env_agrees_strict ((x, v) # env) ((x, t) # G)"
+  assumes "env_agrees_strict \<Gamma> env G" and "value_has_ty \<Gamma> v t"
+  shows "env_agrees_strict \<Gamma> ((x, v) # env) ((x, t) # G)"
   using assms
   by (auto simp: env_agrees_strict_def env_agrees_def tyenv_lookup_def
            split: if_splits)
 
 lemma agrees_strict_cons:
-  assumes "agrees_strict env st \<Gamma>" and "v ::v t"
+  assumes "agrees_strict env st \<Gamma>" and "value_has_ty \<Gamma> v t"
   shows "agrees_strict ((x, v) # env) st
            (\<Gamma>\<lparr>tc_env := (x, t) # tc_env \<Gamma>\<rparr>)"
   using assms env_agrees_strict_cons by (auto simp: agrees_strict_def)
 
 lemma agrees_strict_field_lookup:
   assumes "agrees_strict env st \<Gamma>"
-      and "vb ::v TEntity ename"
+      and "value_has_ty \<Gamma> vb (TEntity ename)"
       and "schemaFieldType \<Gamma> ename fname = Some ft"
       and "value_field_lookup st vb fname = Some fv"
-  shows "fv ::v ft"
+  shows "value_has_ty \<Gamma> fv ft"
   using assms entity_field_well_typed_lookup
   by (auto simp: agrees_strict_def)
 
@@ -527,7 +585,7 @@ lemma agrees_strict_relation_lookup:
   assumes "agrees_strict env st \<Gamma>"
       and "schemaRelationValueType \<Gamma> rel_name = Some tv"
       and "state_lookup_key st rel_name k = Some v"
-  shows "v ::v tv"
+  shows "value_has_ty \<Gamma> v tv"
   using assms relation_value_well_typed_lookup
   by (auto simp: agrees_strict_def)
 
@@ -866,8 +924,8 @@ next
 qed
 
 lemma dedupe_values_preserves_value_ty:
-  assumes "\<forall>v \<in> set vs. v ::v t"
-  shows "\<forall>v \<in> set (dedupe_values vs). v ::v t"
+  assumes "\<forall>v \<in> set vs. value_has_ty \<Gamma> v t"
+  shows "\<forall>v \<in> set (dedupe_values vs). value_has_ty \<Gamma> v t"
   using assms set_dedupe_values_subset by blast
 
 definition set_union_values :: "ir_value list \<Rightarrow> ir_value list \<Rightarrow> ir_value list" where
@@ -880,22 +938,22 @@ definition set_diff_values :: "ir_value list \<Rightarrow> ir_value list \<Right
   "set_diff_values l r \<equiv> dedupe_values (filter (\<lambda>v. \<not> contains_value r v) l)"
 
 lemma set_union_values_preserves_value_ty:
-  assumes "\<forall>v \<in> set l. v ::v t" and "\<forall>v \<in> set r. v ::v t"
-  shows "\<forall>v \<in> set (set_union_values l r). v ::v t"
+  assumes "\<forall>v \<in> set l. value_has_ty \<Gamma> v t" and "\<forall>v \<in> set r. value_has_ty \<Gamma> v t"
+  shows "\<forall>v \<in> set (set_union_values l r). value_has_ty \<Gamma> v t"
   using assms set_dedupe_values_subset[of "l @ r"]
   unfolding set_union_values_def
   by auto
 
 lemma set_intersect_values_preserves_value_ty:
-  assumes "\<forall>v \<in> set l. v ::v t"
-  shows "\<forall>v \<in> set (set_intersect_values l r). v ::v t"
+  assumes "\<forall>v \<in> set l. value_has_ty \<Gamma> v t"
+  shows "\<forall>v \<in> set (set_intersect_values l r). value_has_ty \<Gamma> v t"
   using assms set_dedupe_values_subset[of "filter (\<lambda>v. contains_value r v) l"]
   unfolding set_intersect_values_def
   by auto
 
 lemma set_diff_values_preserves_value_ty:
-  assumes "\<forall>v \<in> set l. v ::v t"
-  shows "\<forall>v \<in> set (set_diff_values l r). v ::v t"
+  assumes "\<forall>v \<in> set l. value_has_ty \<Gamma> v t"
+  shows "\<forall>v \<in> set (set_diff_values l r). value_has_ty \<Gamma> v t"
   using assms set_dedupe_values_subset[of "filter (\<lambda>v. \<not> contains_value r v) l"]
   unfolding set_diff_values_def
   by auto

--- a/proofs/isabelle/SpecRest/Soundness.thy
+++ b/proofs/isabelle/SpecRest/Soundness.thy
@@ -2002,11 +2002,18 @@ next
 qed
 
 lemma lower_with_assigns_preserves_entity:
-  "lower_with_assigns enums updates be sp = Some e'
-     \<Longrightarrow> eval sch st env e' = Some v
-     \<Longrightarrow> eval sch st env be = Some bv
-     \<Longrightarrow> bv ::v TEntity ename
-     \<Longrightarrow> v ::v TEntity ename"
+  assumes "lower_with_assigns enums updates be sp = Some e'"
+      and "eval sch st env e' = Some v"
+      and "eval sch st env be = Some bv"
+      and "value_has_ty \<Gamma> bv (TEntity ename)"
+      and updates_typed:
+        "\<forall>fld vhd sphd. FieldAssignFull fld vhd sphd \<in> set updates
+            \<longrightarrow> (\<exists>ft. schemaFieldType \<Gamma> ename fld = Some ft
+                    \<and> (\<forall>vhd' vhd_val. lower enums vhd = Some vhd'
+                          \<longrightarrow> eval sch st env vhd' = Some vhd_val
+                          \<longrightarrow> value_has_ty \<Gamma> vhd_val ft))"
+  shows "value_has_ty \<Gamma> v (TEntity ename)"
+  using assms
 proof (induction updates arbitrary: be e' v bv)
   case Nil
   hence "e' = be" by simp
@@ -2026,10 +2033,28 @@ next
        new_bv_eq: "new_bv = VEntityWith bv fld vhd_val"
    and ev_vhd:   "eval sch st env vhd' = Some vhd_val"
     by (auto split: option.splits ir_value.splits)
-  have new_bv_ty: "new_bv ::v TEntity ename"
-    using new_bv_eq Cons.prems(4) vt_entity_with by simp
+  have hd_in: "FieldAssignFull fld vhd sphd \<in> set (hd # rest)"
+    using hd_eq by simp
+  from Cons.prems(5) hd_in obtain ft where
+       sft:        "schemaFieldType \<Gamma> ename fld = Some ft"
+   and vhd_typed: "\<forall>vhd' vhd_val. lower enums vhd = Some vhd'
+                       \<longrightarrow> eval sch st env vhd' = Some vhd_val
+                       \<longrightarrow> value_has_ty \<Gamma> vhd_val ft"
+    by blast
+  have vhd_val_ty: "value_has_ty \<Gamma> vhd_val ft"
+    using vhd_typed vhd_low ev_vhd by blast
+  have new_bv_ty: "value_has_ty \<Gamma> new_bv (TEntity ename)"
+    using new_bv_eq Cons.prems(4) sft vhd_val_ty
+    by (auto intro: vt_entity_with)
+  have rest_typed:
+    "\<forall>fld vhd sphd. FieldAssignFull fld vhd sphd \<in> set rest
+        \<longrightarrow> (\<exists>ft. schemaFieldType \<Gamma> ename fld = Some ft
+                \<and> (\<forall>vhd' vhd_val. lower enums vhd = Some vhd'
+                      \<longrightarrow> eval sch st env vhd' = Some vhd_val
+                      \<longrightarrow> value_has_ty \<Gamma> vhd_val ft))"
+    using Cons.prems(5) by auto
   show ?case
-    using Cons.IH[OF rest_low Cons.prems(2) new_bv_eval new_bv_ty] .
+    using Cons.IH[OF rest_low Cons.prems(2) new_bv_eval new_bv_ty rest_typed] .
 qed
 
 text \<open>Phase H2 -> 9j bridge. Every well-typed expression in the
@@ -2176,7 +2201,7 @@ text \<open>Phase H3 (preservation, leaves). Per-typing-rule preservation
 lemma h3_pres_BoolLit:
   assumes "lower enums (BoolLitF b sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TBool"
+  shows "value_has_ty \<Gamma> v TBool"
 proof -
   have "lower enums (BoolLitF b sp) = Some (BoolLit b sp)" by simp
   with assms(1) have "e' = BoolLit b sp" by simp
@@ -2186,7 +2211,7 @@ qed
 lemma h3_pres_IntLit:
   assumes "lower enums (IntLitF n sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TInt"
+  shows "value_has_ty \<Gamma> v TInt"
 proof -
   have "lower enums (IntLitF n sp) = Some (IntLit n sp)" by simp
   with assms(1) have "e' = IntLit n sp" by simp
@@ -2198,16 +2223,16 @@ lemma h3_pres_Ident_Lex:
       and "tyenv_lookup (tc_env \<Gamma>) x = Some t"
       and "lower enums (IdentifierF x sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v t"
+  shows "value_has_ty \<Gamma> v t"
 proof -
   have "lower enums (IdentifierF x sp) = Some (Ident x sp)" by simp
   with assms(3) have e_eq: "e' = Ident x sp" by simp
-  obtain w where ew: "map_of env x = Some w" and wt: "w ::v t"
+  obtain w where ew: "map_of env x = Some w" and wt: "value_has_ty \<Gamma> w t"
     using agrees_strict_env_lookup[OF assms(1,2)] by blast
   have "eval sch st env (Ident x sp) = Some w"
     using ew by (simp add: env_lookup_def)
   with assms(4) e_eq have "v = w" by simp
-  thus "v ::v t" using wt by simp
+  thus "value_has_ty \<Gamma> v t" using wt by simp
 qed
 
 lemma h3_pres_Ident_State:
@@ -2216,18 +2241,18 @@ lemma h3_pres_Ident_State:
       and "map_of (ss_scalars (tc_schema \<Gamma>)) x = Some t"
       and "lower enums (IdentifierF x sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v t"
+  shows "value_has_ty \<Gamma> v t"
 proof -
   have "lower enums (IdentifierF x sp) = Some (Ident x sp)" by simp
   with assms(4) have e_eq: "e' = Ident x sp" by simp
   from agrees_strict_state_lookup[OF assms(1,2,3)]
   obtain w where mn: "map_of env x = None"
              and sw: "state_lookup_scalar st x = Some w"
-             and wt: "w ::v t" by blast
+             and wt: "value_has_ty \<Gamma> w t" by blast
   have "eval sch st env (Ident x sp) = Some w"
     using mn sw by (simp add: env_lookup_def)
   with assms(5) e_eq have "v = w" by simp
-  thus "v ::v t" using wt by simp
+  thus "value_has_ty \<Gamma> v t" using wt by simp
 qed
 
 text \<open>Phase H3 (preservation, recursive cases). For the unary /
@@ -2238,7 +2263,7 @@ text \<open>Phase H3 (preservation, recursive cases). For the unary /
 lemma h3_pres_Not:
   assumes "lower enums (UnaryOpF UNot e sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TBool"
+  shows "value_has_ty \<Gamma> v TBool"
 proof -
   from assms(1) obtain e_sub where
        sub_low: "lower enums e = Some e_sub"
@@ -2249,13 +2274,13 @@ proof -
   then obtain b where "v = VBool (\<not> b)"
     by (cases "eval sch st env e_sub")
        (auto split: ir_value.splits)
-  thus "v ::v TBool" by simp
+  thus "value_has_ty \<Gamma> v TBool" by simp
 qed
 
 lemma h3_pres_Neg:
   assumes "lower enums (UnaryOpF UNegate e sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TInt"
+  shows "value_has_ty \<Gamma> v TInt"
 proof -
   from assms(1) obtain e_sub where
        sub_low: "lower enums e = Some e_sub"
@@ -2266,14 +2291,14 @@ proof -
   then obtain n where "v = VInt (- n)"
     by (cases "eval sch st env e_sub")
        (auto split: ir_value.splits)
-  thus "v ::v TInt" by simp
+  thus "value_has_ty \<Gamma> v TInt" by simp
 qed
 
 lemma h3_pres_Arith:
   assumes "op \<in> {BAdd, BSub, BMul, BDiv}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TInt"
+  shows "value_has_ty \<Gamma> v TInt"
 proof -
   from assms(1,2) obtain l' r' aop where
        l_low: "lower enums l = Some l'"
@@ -2287,15 +2312,15 @@ proof -
        el: "eval sch st env l' = Some (VInt a)"
    and er: "eval sch st env r' = Some (VInt b)"
     by blast
-  show "v ::v TInt"
+  show "value_has_ty \<Gamma> v TInt"
   proof (rule eval_arith_preservation[OF ev])
     fix a' assume "eval sch st env l' = Some a'"
     with el have "a' = VInt a" by simp
-    thus "a' ::v TInt" by simp
+    thus "value_has_ty \<Gamma> a' TInt" by simp
   next
     fix b' assume "eval sch st env r' = Some b'"
     with er have "b' = VInt b" by simp
-    thus "b' ::v TInt" by simp
+    thus "value_has_ty \<Gamma> b' TInt" by simp
   qed
 qed
 
@@ -2303,7 +2328,7 @@ lemma h3_pres_Cmp:
   assumes "op \<in> {BEq, BNeq, BLt, BLe, BGt, BGe}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TBool"
+  shows "value_has_ty \<Gamma> v TBool"
 proof -
   from assms(1,2) obtain l' r' cop where
        e_eq: "e' = Cmp cop l' r' sp"
@@ -2311,14 +2336,14 @@ proof -
   from assms(3) e_eq
   have ev: "eval_cmp cop (eval sch st env l') (eval sch st env r') = Some v"
     by simp
-  from eval_cmp_preservation[OF ev] show "v ::v TBool" .
+  from eval_cmp_preservation[OF ev] show "value_has_ty \<Gamma> v TBool" .
 qed
 
 lemma h3_pres_Bool_Bin:
   assumes "op \<in> {BAnd, BOr, BImplies, BIff}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
-  shows "v ::v TBool"
+  shows "value_has_ty \<Gamma> v TBool"
 proof -
   from assms(1,2) obtain l' r' bop where
        e_eq: "e' = BoolBin bop l' r' sp"
@@ -2329,7 +2354,7 @@ proof -
   then obtain a b where "v = VBool (eval_bool_bin bop a b)"
     by (cases "eval sch st env l'"; cases "eval sch st env r'")
        (auto split: ir_value.splits)
-  thus "v ::v TBool" by simp
+  thus "value_has_ty \<Gamma> v TBool" by simp
 qed
 
 text \<open>Phase H3 (umbrella). Composes the per-rule preservation
@@ -2342,7 +2367,7 @@ theorem h3_preservation:
       and "lower enums e = Some e'"
       and "eval sch st env e' = Some v"
       and "tc_enums \<Gamma> = enums"
-  shows "v ::v t"
+  shows "value_has_ty \<Gamma> v t"
   using assms
 proof (induction arbitrary: e' v env rule: expr_has_ty.induct)
   case (T_BoolLit \<Gamma> b sp)
@@ -2385,7 +2410,7 @@ next
        ev_v: "eval sch st env v' = Some va"
    and ev_body: "eval sch st ((x, va) # env) body' = Some v"
     by (auto split: option.splits)
-  have va_ty: "va ::v t1"
+  have va_ty: "value_has_ty \<Gamma> va t1"
     using T_Let.IH(1)[OF T_Let.prems(1) v_low ev_v T_Let.prems(4)] .
   hence agr_ext: "agrees_strict ((x, va) # env) st
                     (\<Gamma>\<lparr>tc_env := (x, t1) # tc_env \<Gamma>\<rparr>)"
@@ -2393,7 +2418,7 @@ next
   have enums_ext: "tc_enums (\<Gamma>\<lparr>tc_env := (x, t1) # tc_env \<Gamma>\<rparr>) = enums"
     using T_Let.prems(4) by simp
   show ?case
-    using T_Let.IH(2)[OF agr_ext body_low ev_body enums_ext] .
+    using T_Let.IH(2)[OF agr_ext body_low ev_body enums_ext] by simp
 next
   case (T_Prime \<Gamma> e t sp)
   from T_Prime.prems(2) obtain ei where
@@ -2484,17 +2509,17 @@ next
    and ev_sl:   "eval sch st env sL = Some (VSet rest_vs)"
    and v_eq:   "v = VSet (dedupe_values (va # rest_vs))"
     by (auto split: option.splits ir_value.splits)
-  have va_ty: "va ::v t"
+  have va_ty: "value_has_ty \<Gamma> va t"
     using T_SetLit_Cons.IH(1)[OF T_SetLit_Cons.prems(1) e_low ev_e
                                   T_SetLit_Cons.prems(4)] .
-  have rest_ty: "VSet rest_vs ::v TSet t"
+  have rest_ty: "value_has_ty \<Gamma> (VSet rest_vs) (TSet t)"
     using T_SetLit_Cons.IH(2)[OF T_SetLit_Cons.prems(1) rest_low ev_sl
                                   T_SetLit_Cons.prems(4)] .
-  hence rest_all: "\<forall>v \<in> set rest_vs. v ::v t"
+  hence rest_all: "\<forall>v \<in> set rest_vs. value_has_ty \<Gamma> v t"
     by (auto elim: value_has_ty_set_cases)
-  have all_ty: "\<forall>v \<in> set (va # rest_vs). v ::v t"
+  have all_ty: "\<forall>v \<in> set (va # rest_vs). value_has_ty \<Gamma> v t"
     using va_ty rest_all by simp
-  hence "\<forall>v \<in> set (dedupe_values (va # rest_vs)). v ::v t"
+  hence "\<forall>v \<in> set (dedupe_values (va # rest_vs)). value_has_ty \<Gamma> v t"
     by (rule dedupe_values_preserves_value_ty)
   thus ?case
     by (simp add: v_eq vt_set)
@@ -2513,13 +2538,13 @@ next
     by blast
   have v_eq: "v = VSet (set_union_values lv rv)"
     using h ev_l ev_r by simp
-  have l_all: "\<forall>v \<in> set lv. v ::v t"
+  have l_all: "\<forall>v \<in> set lv. value_has_ty \<Gamma> v t"
     using T_BUnion.IH(1)[OF T_BUnion.prems(1) l_low ev_l T_BUnion.prems(4)]
     by (auto elim: value_has_ty_set_cases)
-  have r_all: "\<forall>v \<in> set rv. v ::v t"
+  have r_all: "\<forall>v \<in> set rv. value_has_ty \<Gamma> v t"
     using T_BUnion.IH(2)[OF T_BUnion.prems(1) r_low ev_r T_BUnion.prems(4)]
     by (auto elim: value_has_ty_set_cases)
-  have "\<forall>v \<in> set (set_union_values lv rv). v ::v t"
+  have "\<forall>v \<in> set (set_union_values lv rv). value_has_ty \<Gamma> v t"
     by (rule set_union_values_preserves_value_ty[OF l_all r_all])
   thus ?case
     by (simp add: v_eq vt_set)
@@ -2538,11 +2563,11 @@ next
     by blast
   have v_eq: "v = VSet (set_intersect_values lv rv)"
     using h ev_l ev_r by simp
-  have l_all: "\<forall>v \<in> set lv. v ::v t"
+  have l_all: "\<forall>v \<in> set lv. value_has_ty \<Gamma> v t"
     using T_BIntersect.IH(1)[OF T_BIntersect.prems(1) l_low ev_l
                                  T_BIntersect.prems(4)]
     by (auto elim: value_has_ty_set_cases)
-  hence "\<forall>v \<in> set (set_intersect_values lv rv). v ::v t"
+  hence "\<forall>v \<in> set (set_intersect_values lv rv). value_has_ty \<Gamma> v t"
     by (rule set_intersect_values_preserves_value_ty)
   thus ?case
     by (simp add: v_eq vt_set)
@@ -2561,10 +2586,10 @@ next
     by blast
   have v_eq: "v = VSet (set_diff_values lv rv)"
     using h ev_l ev_r by simp
-  have l_all: "\<forall>v \<in> set lv. v ::v t"
+  have l_all: "\<forall>v \<in> set lv. value_has_ty \<Gamma> v t"
     using T_BDiff.IH(1)[OF T_BDiff.prems(1) l_low ev_l T_BDiff.prems(4)]
     by (auto elim: value_has_ty_set_cases)
-  hence "\<forall>v \<in> set (set_diff_values lv rv). v ::v t"
+  hence "\<forall>v \<in> set (set_diff_values lv rv). value_has_ty \<Gamma> v t"
     by (rule set_diff_values_preserves_value_ty)
   thus ?case
     by (simp add: v_eq vt_set)
@@ -2608,7 +2633,7 @@ next
        ev_base: "eval sch st env b' = Some vb"
    and v_eq:   "value_field_lookup st vb fname = Some v"
     by (auto split: option.splits)
-  have vb_ty: "vb ::v TEntity ename"
+  have vb_ty: "value_has_ty \<Gamma> vb (TEntity ename)"
     using T_FieldAccess.IH[OF T_FieldAccess.prems(1) base_low ev_base
                               T_FieldAccess.prems(4)] .
   show ?case
@@ -2638,11 +2663,19 @@ next
     by (auto split: option.splits)
   from lower_with_assigns_eval_implies_base_eval[OF lwa T_With.prems(3)]
   obtain bv where ev_base: "eval sch st env base' = Some bv" by blast
-  have bv_ty: "bv ::v TEntity ename"
+  have bv_ty: "value_has_ty \<Gamma> bv (TEntity ename)"
     using T_With.IH(1)[OF T_With.prems(1) base_low ev_base T_With.prems(4)] .
+  have updates_typed:
+    "\<forall>fld vhd sphd. FieldAssignFull fld vhd sphd \<in> set updates
+        \<longrightarrow> (\<exists>ft. schemaFieldType \<Gamma> ename fld = Some ft
+                \<and> (\<forall>vhd' vhd_val. lower enums vhd = Some vhd'
+                      \<longrightarrow> eval sch st env vhd' = Some vhd_val
+                      \<longrightarrow> value_has_ty \<Gamma> vhd_val ft))"
+    using T_With.IH(2) T_With.prems(1) T_With.prems(4)
+    by blast
   show ?case
     using lower_with_assigns_preserves_entity[OF lwa T_With.prems(3)
-                                                 ev_base bv_ty] .
+                                                 ev_base bv_ty updates_typed] .
 next
   case (T_Forall_QAll_Enum dnm \<Gamma> var body sp_id m sp_b sp)
   have in_enums: "string_in_list dnm enums"
@@ -2916,11 +2949,11 @@ theorem cat_h_progress_and_preservation:
       and "agrees_strict env st \<Gamma>"
       and "tc_enums \<Gamma> = enums"
   shows "\<exists>e'. lower enums e = Some e'
-              \<and> (\<forall>v. eval sch st env e' = Some v \<longrightarrow> v ::v t)"
+              \<and> (\<forall>v. eval sch st env e' = Some v \<longrightarrow> value_has_ty \<Gamma> v t)"
 proof -
   from well_typed_imp_lower_some[OF assms(1)]
   obtain e' where e'_eq: "lower enums e = Some e'" by blast
-  have "\<forall>v. eval sch st env e' = Some v \<longrightarrow> v ::v t"
+  have "\<forall>v. eval sch st env e' = Some v \<longrightarrow> value_has_ty \<Gamma> v t"
     using assms e'_eq h3_preservation by blast
   with e'_eq show ?thesis by blast
 qed


### PR DESCRIPTION
## Summary

Closes the last unresolved review thread from PR #285 (coderabbitai's `vt_entity_with` finding). One-commit branch (`753579c`) tightens the rule that lets `VEntityWith` values type as `TEntity ename` so the override is constrained to the field's declared schema type, parameterising `value_has_ty` by the typing context.

## The bug

Old rule:

```isabelle
vt_entity_with: "base ::v TEntity ename
                   ⟹ VEntityWith base fld override ::v TEntity ename"
```

`override` is unconstrained — a derivation could exhibit

```isabelle
VEntityWith (VEntity ename eid) fld (VInt 0)  ::v  TEntity ename
```

with the override being an `Int` for a field declared `Bool`. The universally quantified

```isabelle
entity_field_well_typed Γ st ⟷
  (∀v ename fname ft fv.
     v ::v TEntity ename ∧ schemaFieldType Γ ename fname = Some ft
     ∧ value_field_lookup st v fname = Some fv ⟶ fv ::v ft)
```

then becomes unprovable in any tyctx with a non-`TInt` field, blocking every H3 caller from discharging `agrees_strict`.

## The fix

Parameterise `value_has_ty` by `tyctx` so the override-typing premise can reach `schemaFieldType Γ`:

```isabelle
inductive value_has_ty :: "tyctx ⇒ ir_value ⇒ ty ⇒ bool" where
  ...
| vt_entity_with: "value_has_ty Γ base (TEntity ename)
                     ⟹ schemaFieldType Γ ename fld = Some ft
                     ⟹ value_has_ty Γ override ft
                     ⟹ value_has_ty Γ (VEntityWith base fld override)
                                       (TEntity ename)"
```

## Cascade

| Layer | Change |
|---|---|
| `value_has_ty` | signature + 6 rules + 6 `inductive_cases` + 4 `_iff` simp lemmas; infix `::v` dropped — too dense as a 3-arg op |
| `tyenv`, `state_schema`, `tyctx`, `typeExprFullToTy`, `schemaFieldType` | hoisted above `value_has_ty` (its `vt_entity_with` consults `schemaFieldType`) |
| New simp lemmas | `value_has_ty_tc_env_update`, `env_agrees_tc_env_update`, `env_agrees_strict_tc_env_update`, `state_agrees_scalars_tc_env_update` — the `T_Let` cons step needs them to reduce body-typing-in-extended-Γ back to plain Γ |
| `env_agrees`, `state_agrees_scalars`, `env_agrees_strict` | gain `tyctx` first arg; `agrees` / `agrees_strict` / lookup / cons / empty / state-lookup / field-lookup lemmas thread it through |
| `lower_with_assigns_preserves_entity` | takes a new `updates_typed` premise (universally quantified per-update guarantee that lowering+evaluating yields a value typed at `schemaFieldType Γ ename fld`). Proof uses it to discharge `vt_entity_with`'s new premises when constructing `VEntityWith` |
| H3 `T_With` case | feeds `updates_typed` from `T_With.IH(2)` — exactly the H3 IH the typing rule's universally quantified second premise produces |
| H3 `T_Let` case | final step picks up `by simp` (IH now lands the body-typing in `Γ⦇tc_env := …⦈`, simp reduces via `value_has_ty_tc_env_update`) |
| ~100 `::v` sites | mechanically rewritten to `value_has_ty Γ` via a Python pass that protected `\<open>...\<close>` text blocks; the old infix is preserved in docstrings as historical reference |

## Build / test

- Isabelle: green at **6:02** wall (pre-change main was 5:49 — the new tc_env-invariance proofs add ~10s).
- Re-extracted `SpecRestGenerated.scala`: **byte-identical** — `value_has_ty` is a proof-only inductive predicate, never extracted.
- sbt compile: clean.
- sbt test: **1044 / 1045** (1 skipped, 0 failed) — identical to pre-change.

## Trail

- coderabbitai's original analysis: https://github.com/HardMax71/spec_to_rest/pull/285#discussion_r3281515260
- Deferral + acknowledgement: same thread
- Implementation: this PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened entity update typing so `VEntityWith` overrides must match the field’s schema type. Parameterised `value_has_ty` by the typing context to enable this and unblock H3 `agrees_strict` proofs.

- **Bug Fixes**
  - Constrain `vt_entity_with` with `schemaFieldType Γ`; the override must type-check at the field’s declared type.
  - Restores `entity_field_well_typed Γ st` and fixes the H3 blocker noted in #285’s review.

- **Refactors**
  - Parameterised `value_has_ty` to `value_has_ty Γ v t` and dropped the `::v` infix.
  - Threaded `Γ` through `env_agrees`, `state_agrees_scalars`, and `env_agrees_strict`; added tc_env-invariance simp lemmas.
  - Hoisted `tyenv`, `state_schema`, `tyctx`, `typeExprFullToTy`, and `schemaFieldType` above `value_has_ty`.
  - Strengthened `lower_with_assigns_preserves_entity` with an `updates_typed` premise and adjusted H3 `T_With`/`T_Let`. No extraction changes; Scala build/tests unchanged.

<sup>Written for commit 753579cc4ad0db92d35dd97b91e365b71195888b. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/286?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored type system predicates to use consistent parameterization throughout the formal specification.
  * Updated proof infrastructure for type preservation and agreement predicates to ensure uniform typing representations.
  * Enhanced entity field typing rules with explicit context parameterization for improved type safety guarantees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->