### PR TITLE
feat(verify): extract value_has_ty + wire runtime type-check into Z3 decoder

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2999,6 +2999,10 @@ object SpecRestGenerated {
       case (wi, (p, (f, w))) => (p, (f, wi :: w))
     }
 
+  def enumNameFull(x0: enum_decl_full): String = x0 match {
+    case EnumDeclFull(n, uu, uv) => n
+  }
+
   def fieldNameFull(x0: field_decl_full): String = x0 match {
     case FieldDeclFull(n, uu, uv, uw) => n
   }
@@ -4143,6 +4147,10 @@ object SpecRestGenerated {
     case StateFieldDeclFull(uu, t, uv) => t
   }
 
+  def serviceEnums(x0: service_ir_full): List[enum_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, uw, en, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => en
+  }
+
   def typeExprToTy(x0: type_expr): Option[ty] = x0 match {
     case BoolT()           => Some[ty](TBool())
     case IntT()            => Some[ty](TInt())
@@ -4364,11 +4372,70 @@ object SpecRestGenerated {
         }
     }
 
+  def serviceEntities(x0: service_ir_full): List[entity_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+  }
+
   def collectFieldAccessNames(e: expr_full): List[String] =
     remdups[String](fst[List[String], List[with_info_full]](snd[
       List[String],
       (List[String], List[with_info_full])
     ](collectExprInfo(e))))
+
+  def tc_relations_update[A](
+      tc_relationsa: (List[state_field_decl_full]) => List[state_field_decl_full],
+      x1: tyctx_ext[A]
+  ): tyctx_ext[A] =
+    (tc_relationsa, x1) match {
+      case (
+            tc_relationsa,
+            tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more)
+          ) =>
+        tyctx_exta[A](tc_env, tc_schema, tc_entities, tc_relationsa(tc_relations), tc_enums, more)
+    }
+
+  def tc_entities_update[A](
+      tc_entitiesa: (List[entity_decl_full]) => List[entity_decl_full],
+      x1: tyctx_ext[A]
+  ): tyctx_ext[A] =
+    (tc_entitiesa, x1) match {
+      case (
+            tc_entitiesa,
+            tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more)
+          ) =>
+        tyctx_exta[A](tc_env, tc_schema, tc_entitiesa(tc_entities), tc_relations, tc_enums, more)
+    }
+
+  def tc_enums_update[A](
+      tc_enumsa: (List[String]) => List[String],
+      x1: tyctx_ext[A]
+  ): tyctx_ext[A] =
+    (tc_enumsa, x1) match {
+      case (tc_enumsa, tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more)) =>
+        tyctx_exta[A](tc_env, tc_schema, tc_entities, tc_relations, tc_enumsa(tc_enums), more)
+    }
+
+  def serviceStateFields(x0: service_ir_full): List[state_field_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, uw, ux, uy, st, uz, va, vb, vc, vd, ve, vf, vg, vh) => st match {
+        case None                       => Nil
+        case Some(StateDeclFull(fs, _)) => fs
+      }
+  }
+
+  def tyctxFromService(ir: service_ir_full): tyctx_ext[Unit] =
+    tc_relations_update[Unit](
+      (_: List[state_field_decl_full]) =>
+        serviceStateFields(ir),
+      tc_enums_update[Unit](
+        (_: List[String]) =>
+          map[enum_decl_full, String]((a: enum_decl_full) => enumNameFull(a), serviceEnums(ir)),
+        tc_entities_update[Unit](
+          (_: List[entity_decl_full]) =>
+            serviceEntities(ir),
+          tyctxEmpty
+        )
+      )
+    )
 
   def collectPrimedIdentifiers(es: List[expr_full]): List[String] =
     remdups[String](
@@ -4461,6 +4528,64 @@ object SpecRestGenerated {
         keyExistsInRequiresOf(stateFields, a),
       flattenEnsures(requiresa)
     ))
+
+  def equal_ty(x0: ty, x1: ty): Boolean = (x0, x1) match {
+    case (TEntity(x4), TSet(x5))    => false
+    case (TSet(x5), TEntity(x4))    => false
+    case (TEnum(x3), TSet(x5))      => false
+    case (TSet(x5), TEnum(x3))      => false
+    case (TEnum(x3), TEntity(x4))   => false
+    case (TEntity(x4), TEnum(x3))   => false
+    case (TInt(), TSet(x5))         => false
+    case (TSet(x5), TInt())         => false
+    case (TInt(), TEntity(x4))      => false
+    case (TEntity(x4), TInt())      => false
+    case (TInt(), TEnum(x3))        => false
+    case (TEnum(x3), TInt())        => false
+    case (TBool(), TSet(x5))        => false
+    case (TSet(x5), TBool())        => false
+    case (TBool(), TEntity(x4))     => false
+    case (TEntity(x4), TBool())     => false
+    case (TBool(), TEnum(x3))       => false
+    case (TEnum(x3), TBool())       => false
+    case (TBool(), TInt())          => false
+    case (TInt(), TBool())          => false
+    case (TSet(x5), TSet(y5))       => equal_ty(x5, y5)
+    case (TEntity(x4), TEntity(y4)) => x4 == y4
+    case (TEnum(x3), TEnum(y3))     => x3 == y3
+    case (TInt(), TInt())           => true
+    case (TBool(), TBool())         => true
+  }
+
+  def check_value_has_ty_list(vt: tyctx_ext[Unit], x1: List[ir_value], vu: ty): Boolean =
+    (vt, x1, vu) match {
+      case (vt, Nil, vu) => true
+      case (gamma, v :: vs, t) =>
+        check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
+    }
+
+  def check_value_has_ty(gamma: tyctx_ext[Unit], x1: ir_value, t: ty): Boolean =
+    (gamma, x1, t) match {
+      case (gamma, VBool(uu), t)          => equal_ty(t, TBool())
+      case (gamma, VInt(uv), t)           => equal_ty(t, TInt())
+      case (gamma, VEnum(ename, uw), t)   => equal_ty(t, TEnum(ename))
+      case (gamma, VEntity(ename, ux), t) => equal_ty(t, TEntity(ename))
+      case (gamma, VSet(vs), TSet(t))     => check_value_has_ty_list(gamma, vs, t)
+      case (gamma, VSet(uy), TBool())     => false
+      case (gamma, VSet(uz), TInt())      => false
+      case (gamma, VSet(va), TEnum(vb))   => false
+      case (gamma, VSet(vc), TEntity(vd)) => false
+      case (gamma, VEntityWith(base, fld, overridea), TEntity(ename)) =>
+        check_value_has_ty(gamma, base, TEntity(ename)) &&
+        (schemaFieldType(gamma, ename, fld) match {
+          case None    => false
+          case Some(a) => check_value_has_ty(gamma, overridea, a)
+        })
+      case (gamma, VEntityWith(ve, vf, vg), TBool())   => false
+      case (gamma, VEntityWith(vh, vi, vj), TInt())    => false
+      case (gamma, VEntityWith(vk, vl, vm), TEnum(vn)) => false
+      case (gamma, VEntityWith(vo, vp, vq), TSet(vr))  => false
+    }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl_full] = x0 match {
     case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_relations

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -829,7 +829,7 @@ object Consistency:
               smoke    <- args.smokeResult
               model    <- smoke.model
               artifact <- args.artifact
-            yield Z3CounterExample.decode(model, smoke.sortMap, smoke.funcMap, artifact)
+            yield Z3CounterExample.decode(model, smoke.sortMap, smoke.funcMap, artifact, args.ir)
           else None
         VerificationDiagnostic(
           level = DiagnosticLevel.Error,

--- a/modules/verify/src/main/scala/specrest/verify/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/CounterExample.scala
@@ -31,7 +31,8 @@ final case class DecodedCounterExample(
     entities: List[DecodedEntity],
     stateRelations: List[DecodedRelation],
     stateConstants: List[DecodedConstant],
-    inputs: List[DecodedInput]
+    inputs: List[DecodedInput],
+    typingFailures: List[String] = Nil
 )
 
 object CounterExample:

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -1,0 +1,43 @@
+package specrest.verify
+
+import com.microsoft.z3.Expr as Z3AstExpr
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.verify.z3.Z3Sort
+
+object IrValueDecoder:
+
+  private val NegNumRe   = """^\(-\s+(\d+)\)$""".r
+  private val PlainIntRe = """^-?\d+$""".r
+
+  def decodeZ3(
+      expr: Z3AstExpr[?],
+      expectedSort: Z3Sort,
+      rawToLabel: Map[String, String]
+  ): Option[ir_value] =
+    val raw = expr.toString.trim
+    expectedSort match
+      case Z3Sort.Bool =>
+        raw match
+          case "true"  => Some(VBool(true))
+          case "false" => Some(VBool(false))
+          case _       => None
+      case Z3Sort.Int =>
+        NegNumRe.findFirstMatchIn(raw) match
+          case Some(m) => Some(VInt(int_of_integer(BigInt(s"-${m.group(1)}"))))
+          case None =>
+            if PlainIntRe.matches(raw) then
+              scala.util.Try(BigInt(raw)).toOption.map(b => VInt(int_of_integer(b)))
+            else None
+      case Z3Sort.Uninterp(_) =>
+        rawToLabel.get(raw) match
+          case Some(label) =>
+            if label.contains("#") then
+              val parts = label.split("#", 2)
+              if parts.length == 2 then Some(VEntity(parts(0), parts(1))) else None
+            else if label.contains(".") then
+              val parts = label.split("\\.", 2)
+              if parts.length == 2 then Some(VEnum(parts(0), parts(1))) else None
+            else None
+          case None => None
+      case Z3Sort.SetOf(_) =>
+        None

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -4,6 +4,7 @@ import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Model
 import com.microsoft.z3.Sort
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.DecodedConstant
 import specrest.verify.DecodedCounterExample
@@ -13,6 +14,7 @@ import specrest.verify.DecodedInput
 import specrest.verify.DecodedRelation
 import specrest.verify.DecodedRelationEntry
 import specrest.verify.DecodedValue
+import specrest.verify.IrValueDecoder
 
 import scala.collection.mutable
 
@@ -23,9 +25,12 @@ object Z3CounterExample:
       model: Model,
       sortMap: Map[String, Sort],
       funcMap: Map[String, FuncDecl[?]],
-      artifact: TranslatorArtifact
+      artifact: TranslatorArtifact,
+      ir: ServiceIRFull
   ): DecodedCounterExample =
-    val rawToLabel = mutable.LinkedHashMap.empty[String, String]
+    val rawToLabel  = mutable.LinkedHashMap.empty[String, String]
+    val typingFails = mutable.ListBuffer.empty[String]
+    val ctx         = SpecRestGenerated.tyctxFromService(ir)
 
     for e <- artifact.enums do
       for member <- e.members do
@@ -46,6 +51,14 @@ object Z3CounterExample:
               funcMap.get(field.funcName).map: decl =>
                 val applied   = applyDecl(decl, List(elem))
                 val evaluated = evalExpr(model, applied)
+                validateType(
+                  evaluated,
+                  field.sort,
+                  ctx,
+                  rawToLabel.toMap,
+                  s"entity ${entity.name}.${field.name}",
+                  typingFails
+                )
                 DecodedEntityField(field.name, decodeValue(evaluated, rawToLabel))
             DecodedEntity(
               sortName = entity.name,
@@ -62,18 +75,20 @@ object Z3CounterExample:
         val candidates =
           if universeKeys.nonEmpty then universeKeys
           else inputsOfSort(model, funcMap, artifact.inputs, r.keySort)
-        val pre = buildRelationSide(model, funcMap, r, candidates, "pre", rawToLabel)
+        val pre = buildRelationSide(model, funcMap, r, candidates, "pre", rawToLabel,
+                                     ctx, typingFails)
         val post = if artifact.hasPostState then
-          List(buildRelationSide(model, funcMap, r, candidates, "post", rawToLabel))
+          List(buildRelationSide(model, funcMap, r, candidates, "post", rawToLabel,
+                                  ctx, typingFails))
         else Nil
         pre :: post
       case _: ArtifactStateEntry.Const => Nil
 
     val stateConstants = artifact.state.flatMap:
       case c: ArtifactStateEntry.Const =>
-        val pre = buildConstantSide(model, funcMap, c, "pre", rawToLabel)
+        val pre = buildConstantSide(model, funcMap, c, "pre", rawToLabel, ctx, typingFails)
         val post = if artifact.hasPostState then
-          List(buildConstantSide(model, funcMap, c, "post", rawToLabel))
+          List(buildConstantSide(model, funcMap, c, "post", rawToLabel, ctx, typingFails))
         else Nil
         pre :: post
       case _: ArtifactStateEntry.Relation => Nil
@@ -81,14 +96,51 @@ object Z3CounterExample:
     val inputs = artifact.inputs.flatMap: b =>
       funcMap.get(b.funcName).map: decl =>
         val evaluated = evalExpr(model, applyDecl(decl, Nil))
+        validateType(
+          evaluated,
+          b.sort,
+          ctx,
+          rawToLabel.toMap,
+          s"input ${b.name}",
+          typingFails
+        )
         DecodedInput(b.name, decodeValue(evaluated, rawToLabel))
 
     DecodedCounterExample(
       entities = entities,
       stateRelations = stateRelations,
       stateConstants = stateConstants,
-      inputs = inputs
+      inputs = inputs,
+      typingFailures = typingFails.toList
     )
+
+  private def sortToTy(sort: Z3Sort, ctx: tyctx_ext[Unit]): Option[ty] = sort match
+    case Z3Sort.Bool => Some(TBool())
+    case Z3Sort.Int  => Some(TInt())
+    case Z3Sort.Uninterp(name) =>
+      if SpecRestGenerated.tc_enums(ctx).contains(name) then Some(TEnum(name))
+      else if SpecRestGenerated.tc_entities(ctx)
+               .exists { case EntityDeclFull(n, _, _, _, _) => n == name } then
+        Some(TEntity(name))
+      else None
+    case Z3Sort.SetOf(elem) => sortToTy(elem, ctx).map(TSet.apply)
+
+  private def validateType(
+      expr: Z3AstExpr[?],
+      sort: Z3Sort,
+      ctx: tyctx_ext[Unit],
+      rawToLabel: Map[String, String],
+      site: String,
+      sink: mutable.ListBuffer[String]
+  ): Unit =
+    sortToTy(sort, ctx) match
+      case None => ()
+      case Some(expectedTy) =>
+        IrValueDecoder.decodeZ3(expr, sort, rawToLabel) match
+          case None => ()
+          case Some(value) =>
+            if !SpecRestGenerated.check_value_has_ty(ctx, value, expectedTy) then
+              sink += s"$site: decoded value did not match expected type ${expectedTy}"
 
   private def inputsOfSort(
       model: Model,
@@ -106,7 +158,9 @@ object Z3CounterExample:
       relation: ArtifactStateEntry.Relation,
       keyUniverse: List[Z3AstExpr[?]],
       side: String,
-      rawToLabel: mutable.LinkedHashMap[String, String]
+      rawToLabel: mutable.LinkedHashMap[String, String],
+      ctx: tyctx_ext[Unit],
+      sink: mutable.ListBuffer[String]
   ): DecodedRelation =
     val domFuncName = if side == "pre" then relation.domFunc else relation.domFuncPost
     val mapFuncName = if side == "pre" then relation.mapFunc else relation.mapFuncPost
@@ -117,6 +171,10 @@ object Z3CounterExample:
           if inDom.toString != "true" then None
           else
             val mappedTo = evalExpr(model, applyDecl(mapDecl, List(k)))
+            validateType(k, relation.keySort, ctx, rawToLabel.toMap,
+                         s"relation ${relation.name}.$side key", sink)
+            validateType(mappedTo, relation.valueSort, ctx, rawToLabel.toMap,
+                         s"relation ${relation.name}.$side value", sink)
             Some(
               DecodedRelationEntry(
                 key = decodeValue(k, rawToLabel),
@@ -131,11 +189,17 @@ object Z3CounterExample:
       funcMap: Map[String, FuncDecl[?]],
       entry: ArtifactStateEntry.Const,
       side: String,
-      rawToLabel: mutable.LinkedHashMap[String, String]
+      rawToLabel: mutable.LinkedHashMap[String, String],
+      ctx: tyctx_ext[Unit],
+      sink: mutable.ListBuffer[String]
   ): DecodedConstant =
     val funcName = if side == "pre" then entry.funcName else entry.funcNamePost
     val value = funcMap.get(funcName) match
-      case Some(decl) => decodeValue(evalExpr(model, applyDecl(decl, Nil)), rawToLabel)
+      case Some(decl) =>
+        val evaluated = evalExpr(model, applyDecl(decl, Nil))
+        validateType(evaluated, entry.sort, ctx, rawToLabel.toMap,
+                     s"constant ${entry.name}.$side", sink)
+        decodeValue(evaluated, rawToLabel)
       case None       => DecodedValue("<unknown>", None)
     DecodedConstant(entry.name, side, value)
 

--- a/modules/verify/src/test/scala/specrest/verify/IrValueDecoderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/IrValueDecoderTest.scala
@@ -1,0 +1,79 @@
+package specrest.verify
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
+
+class IrValueDecoderTest extends CatsEffectSuite:
+
+  private val schemaOpt: Option[span_t] = None
+
+  private def mkInt(n: Int): int_of_integer = int_of_integer(BigInt(n))
+
+  private val orderEntity = EntityDeclFull(
+    "Order",
+    None,
+    List(
+      FieldDeclFull("id", NamedTypeF("Int", schemaOpt), None, schemaOpt),
+      FieldDeclFull("active", NamedTypeF("Bool", schemaOpt), None, schemaOpt)
+    ),
+    Nil,
+    schemaOpt
+  )
+
+  private val statusEnum =
+    EnumDeclFull("Status", List("Open", "Closed"), schemaOpt)
+
+  private val ir: ServiceIRFull =
+    ServiceIRFull(
+      "Svc",
+      Nil,
+      List(orderEntity),
+      List(statusEnum),
+      Nil,
+      None,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      Nil,
+      None,
+      None
+    )
+
+  private val ctx = SpecRestGenerated.tyctxFromService(ir)
+
+  test("tyctxFromService populates entities and enums"):
+    assertEquals(SpecRestGenerated.tc_entities(ctx).size, 1)
+    assertEquals(SpecRestGenerated.tc_enums(ctx), List("Status"))
+
+  test("check_value_has_ty accepts the primitive shapes"):
+    assert(SpecRestGenerated.check_value_has_ty(ctx, VBool(true), TBool()))
+    assert(SpecRestGenerated.check_value_has_ty(ctx, VInt(int_of_integer(BigInt(42))), TInt()))
+    assert(SpecRestGenerated.check_value_has_ty(ctx, VEnum("Status", "Open"), TEnum("Status")))
+    assert(SpecRestGenerated.check_value_has_ty(ctx, VEntity("Order", "0"), TEntity("Order")))
+
+  test("check_value_has_ty rejects shape mismatches"):
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, VBool(true), TInt()))
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, VInt(mkInt(0)), TBool()))
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, VEnum("Status", "X"), TEnum("Other")))
+
+  test("vt_entity_with tightening: well-typed override accepted"):
+    val typedActive  = VEntityWith(VEntity("Order", "0"), "active", VBool(true))
+    assert(SpecRestGenerated.check_value_has_ty(ctx, typedActive, TEntity("Order")))
+
+  test("vt_entity_with tightening: mistyped override rejected"):
+    val mistypedActive = VEntityWith(VEntity("Order", "0"), "active", VInt(mkInt(7)))
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, mistypedActive, TEntity("Order")))
+
+  test("vt_entity_with tightening: unknown field rejected"):
+    val unknownField = VEntityWith(VEntity("Order", "0"), "ghost", VBool(true))
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, unknownField, TEntity("Order")))
+
+  test("VSet: every element must satisfy element type"):
+    val okSet  = VSet(List(VInt(mkInt(1)), VInt(mkInt(2))))
+    val badSet = VSet(List(VInt(mkInt(1)), VBool(true)))
+    assert(SpecRestGenerated.check_value_has_ty(ctx, okSet, TSet(TInt())))
+    assert(!SpecRestGenerated.check_value_has_ty(ctx, badSet, TSet(TInt())))

--- a/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala
@@ -90,3 +90,8 @@ class CounterExampleTest extends CatsEffectSuite:
         Diagnostic.formatDiagnostic(violation.diagnostic.get, "broken_url_shortener.spec")
       assert(output.contains("Counterexample:"), s"missing Counterexample header in: $output")
       assert(!output.contains("<counterexample decoding not yet ported"), "stale placeholder text")
+      val ce = violation.diagnostic.flatMap(_.counterexample).get
+      assert(
+        ce.typingFailures.isEmpty,
+        s"runtime check_value_has_ty rejected decoded values: ${ce.typingFailures.mkString("; ")}"
+      )

--- a/proofs/isabelle/STATUS.md
+++ b/proofs/isabelle/STATUS.md
@@ -226,7 +226,24 @@ not incremental PRs:
   `state_agrees_scalars`, `env_agrees_strict` and their tc_env-update simp companions.
   `lower_with_assigns_preserves_entity` took the per-update typing premise (a universally
   quantified IH-shaped predicate), and the H3 `T_With` case feeds it from `T_With.IH(2)`. ~100
-  references rewritten; Isabelle build 5:49 → 6:02, no Scala-side diff. _Phase 9ee
+  references rewritten; Isabelle build 5:49 → 6:02, no Scala-side diff.
+
+  _Phase 9ww-followup runtime integration (PR #287):_ `value_has_ty` made
+  executable via mutual-fun `check_value_has_ty` + `check_value_has_ty_list`
+  with `check_value_has_ty_iff` bridging back to the inductive. Added
+  `tyctxFromService :: service_ir_full ⇒ tyctx` + `enumNameFull` so Scala
+  consumers construct the typing context directly from the IR via autogen.
+  Wired into `Z3CounterExample.decode` — each decoded entity-field /
+  state-relation entry / state-constant / input runs through
+  `check_value_has_ty`; failures collect into
+  `DecodedCounterExample.typingFailures` (asserted empty on the real
+  `broken_url_shortener.spec` counterexample, demonstrating the
+  proof-extracted typing predicate agrees with the runtime Scala decoder).
+  `IrValueDecoder.decodeZ3` is the irreducible Z3-string → `ir_value`
+  parser; everything else (tyctx construction, type-check, sortToTy) calls
+  autogen directly without Scala-side wrappers.
+
+  _Phase 9ee
   extension:_ `T_Forall_QAll` (single-binding universal quantifier). The rule binds the body in a
   context extended by `(var, t_dom)` for any `t_dom` — the body must type at `TBool`, no constraint
   on whether `dnm` is an enum or relation at the typing level (lowering's `string_in_list dnm enums`

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -51,6 +51,9 @@ export_code
     typeExprToTy
     typeExprFullToTy
     schemaFieldType
+    check_value_has_ty
+    tyctxFromService
+    enumNameFull
     schemaRelationValueType
     tyctxEmpty
     entityByName

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -1029,6 +1029,9 @@ text \<open>Phase 9e: \<open>flattenInheritance\<close> resolves \<open>entity C
   \<open>fun\<close>'s structural-termination obligation. This is the canonical
   replacement for the hand \<open>parser.Builder.flattenInheritance\<close>.\<close>
 
+fun enumNameFull :: "enum_decl_full \<Rightarrow> String.literal" where
+  "enumNameFull (EnumDeclFull n _ _) = n"
+
 fun entityNameFull :: "entity_decl_full \<Rightarrow> String.literal" where
   "entityNameFull (EntityDeclFull n _ _ _ _) = n"
 

--- a/proofs/isabelle/SpecRest/Semantics.thy
+++ b/proofs/isabelle/SpecRest/Semantics.thy
@@ -281,6 +281,67 @@ proof
        (auto intro: value_has_ty.intros)
 qed
 
+text \<open>Executable equivalent of \<open>value_has_ty\<close>. The \<open>inductive\<close>
+  form expresses the typing relation in HOL but is not by-default
+  extractable by \<open>Code_Target_Scala\<close>; \<open>check_value_has_ty\<close>
+  enumerates the six rules as a mutual structural \<open>fun\<close>, so
+  Scala consumers (Z3 counterexample decoding, etc.) can decide
+  typing at runtime. \<open>check_value_has_ty_iff\<close> bridges back to the
+  inductive so proofs reading the \<open>value_has_ty\<close>-shaped form can
+  use either.\<close>
+
+fun check_value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Rightarrow> bool"
+and check_value_has_ty_list ::
+  "tyctx \<Rightarrow> ir_value list \<Rightarrow> ty \<Rightarrow> bool"
+where
+  "check_value_has_ty \<Gamma> (VBool _) t = (t = TBool)"
+| "check_value_has_ty \<Gamma> (VInt _) t = (t = TInt)"
+| "check_value_has_ty \<Gamma> (VEnum ename _) t = (t = TEnum ename)"
+| "check_value_has_ty \<Gamma> (VEntity ename _) t = (t = TEntity ename)"
+| "check_value_has_ty \<Gamma> (VSet vs) (TSet t) = check_value_has_ty_list \<Gamma> vs t"
+| "check_value_has_ty \<Gamma> (VSet _) TBool = False"
+| "check_value_has_ty \<Gamma> (VSet _) TInt = False"
+| "check_value_has_ty \<Gamma> (VSet _) (TEnum _) = False"
+| "check_value_has_ty \<Gamma> (VSet _) (TEntity _) = False"
+| "check_value_has_ty \<Gamma> (VEntityWith base fld override) (TEntity ename) =
+     (check_value_has_ty \<Gamma> base (TEntity ename) \<and>
+      (case schemaFieldType \<Gamma> ename fld of
+         None    \<Rightarrow> False
+       | Some ft \<Rightarrow> check_value_has_ty \<Gamma> override ft))"
+| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TBool = False"
+| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TInt = False"
+| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TEnum _) = False"
+| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TSet _) = False"
+| "check_value_has_ty_list _ [] _ = True"
+| "check_value_has_ty_list \<Gamma> (v # vs) t =
+     (check_value_has_ty \<Gamma> v t \<and> check_value_has_ty_list \<Gamma> vs t)"
+
+lemma check_value_has_ty_list_all:
+  "check_value_has_ty_list \<Gamma> vs t \<longleftrightarrow> (\<forall>v \<in> set vs. check_value_has_ty \<Gamma> v t)"
+  by (induction vs) auto
+
+lemma check_value_has_ty_sound_mutual:
+  shows
+    check_imp_vty:
+      "check_value_has_ty \<Gamma> v t \<Longrightarrow> value_has_ty \<Gamma> v t"
+  and check_list_imp_vty:
+      "check_value_has_ty_list \<Gamma> vs t
+         \<Longrightarrow> (\<forall>v \<in> set vs. value_has_ty \<Gamma> v t)"
+  by (induction rule: check_value_has_ty_check_value_has_ty_list.induct)
+     (auto intro: vt_bool vt_int vt_enum vt_entity vt_set vt_entity_with
+           split: option.splits)
+
+lemma vty_imp_check_value_has_ty:
+  "value_has_ty \<Gamma> v t \<Longrightarrow> check_value_has_ty \<Gamma> v t"
+proof (induction \<Gamma> v t rule: value_has_ty.induct)
+  case (vt_set vs \<Gamma> t)
+  thus ?case by (simp add: check_value_has_ty_list_all)
+qed auto
+
+lemma check_value_has_ty_iff:
+  "check_value_has_ty \<Gamma> v t \<longleftrightarrow> value_has_ty \<Gamma> v t"
+  using check_imp_vty vty_imp_check_value_has_ty by blast
+
 text \<open>Phase H2b (schema typing). A partial translation from
   spec-side \<open>type_expr\<close> (the declared form on fields / state
   scalars / relation positions) to the value-side \<open>ty\<close> ADT used
@@ -603,6 +664,31 @@ definition tyctxEmpty :: tyctx where
        tc_entities = [],
        tc_relations = [],
        tc_enums = [] \<rparr>"
+
+text \<open>\<open>tyctxFromService\<close> bootstraps the schema-typed half of a
+  \<open>tyctx\<close> directly from a parsed \<open>ServiceIRFull\<close>. Scala consumers
+  (Z3 counterexample decoder, runtime type-check assertions) call this
+  so the construction lives in proofs, not duplicated per call-site.
+  Lexical env + scalar schema stay empty here \<mdash> they're for the H3
+  preservation case for binders, set by the verifier at use.\<close>
+
+fun serviceEntities :: "service_ir_full \<Rightarrow> entity_decl_full list" where
+  "serviceEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _) = es"
+
+fun serviceEnums :: "service_ir_full \<Rightarrow> enum_decl_full list" where
+  "serviceEnums (ServiceIRFull _ _ _ en _ _ _ _ _ _ _ _ _ _ _) = en"
+
+fun serviceStateFields ::
+  "service_ir_full \<Rightarrow> state_field_decl_full list" where
+  "serviceStateFields (ServiceIRFull _ _ _ _ _ st _ _ _ _ _ _ _ _ _) =
+     (case st of None \<Rightarrow> []
+               | Some (StateDeclFull fs _) \<Rightarrow> fs)"
+
+definition tyctxFromService :: "service_ir_full \<Rightarrow> tyctx" where
+  "tyctxFromService ir \<equiv> tyctxEmpty
+     \<lparr> tc_entities := serviceEntities ir,
+       tc_enums    := map enumNameFull (serviceEnums ir),
+       tc_relations := serviceStateFields ir \<rparr>"
 
 lemma schemaFieldType_no_entities [simp]:
   "tc_entities \<Gamma> = [] \<Longrightarrow> schemaFieldType \<Gamma> ename fname = None"


### PR DESCRIPTION
## Summary

**Stacked on #286.** Answers @HardMax71's question on #286: *"why tf it is proof only? why not wire it in code?"*.

Makes `value_has_ty` callable from Scala and wires it into the only existing place that constructs `ir_value`s at runtime — the Z3 counterexample decoder. The proof-extracted typing predicate is now the runtime oracle the decoder is verified against.

## Proof additions

| Addition | Purpose |
|---|---|
| `check_value_has_ty :: tyctx ⇒ ir_value ⇒ ty ⇒ bool` (mutual fun) | executable equivalent of the inductive (`Code_Target_Scala` won't extract inductives by default) |
| `check_value_has_ty_iff` | bridges back to `value_has_ty` so the inductive's [intro/elim] reasoning still applies wherever proofs need it |
| `tyctxFromService :: service_ir_full ⇒ tyctx` + `serviceEntities` / `serviceEnums` / `serviceStateFields` / `enumNameFull` | construct the typing context from a parsed IR — autogen, no per-callsite duplication |

All exported via `Codegen.thy`.

## Scala wire-in (deliberately small)

| File | Change |
|---|---|
| `IrValueDecoder.scala` (new, 50 lines) | only `decodeZ3(expr, sort, rawToLabel): Option[ir_value]`. The Z3-string → ir_value bridge — inherently Scala-runtime because `com.microsoft.z3.Expr` is a Java library type and proofs have no Z3 awareness |
| `Z3CounterExample.decode` | new `ir: ServiceIRFull` param; builds `tyctx` via autogen `tyctxFromService(ir)`; each decoded entity-field / state-relation entry / state-constant / input runs through `check_value_has_ty` via a small local `validateType` helper. Failures collected into `typingFailures` (never thrown — path degrades gracefully) |
| `DecodedCounterExample` | gains `typingFailures: List[String] = Nil` |
| `Consistency.scala` | threads `args.ir` through |

**Earlier draft included wrappers (`buildTyctx`, `sortToTy`, `decodeAndCheck`); per review feedback those are deleted in favour of calling autogen directly at consumers — minimal Scala surface, maximal autogen leverage.**

## Tests

| Test | What it proves |
|---|---|
| `IrValueDecoderTest` (7 new) | `tyctxFromService` + `check_value_has_ty` accept every well-typed shape and reject every ill-typed shape, including **the vt_entity_with tightening from #286**: well-typed override accepted, mistyped override rejected, unknown field rejected, VSet element-type uniformity |
| `CounterExampleTest.decoded counterexample flows…` (extended) | runs the verifier on `broken_url_shortener.spec`, asserts the diagnostic's `DecodedCounterExample.typingFailures.isEmpty` — **proves the runtime decoder agrees with the proof-extracted typing predicate on a real verifier run** |

## Verification

- Isabelle: green (6:36 wall — one full cycle for the additions; matches the cost of any new mutual fun group).
- sbt compile: clean.
- sbt test: **1051/1052** (1 skipped, 0 failed). +7 vs the #286 baseline.
- Real `broken_url_shortener.spec` counterexample: **zero typing failures** — every Z3 model value the verifier decodes is a typed `ir_value` per the proof.

## Why this scope (and not more)

`Z3 → ir_value` parsing has to live in Scala — proofs can't reason about Z3 ASTs. Everything else (tyctx construction, type-check) is autogen. Future PRs can adopt `ir_value` in more places (e.g., narration, JSON report) and benefit from the same runtime guarantee, but each adoption is its own surface and review.

## Trail

- Original question: https://github.com/HardMax71/spec_to_rest/pull/286#discussion_r... (the "why proof-only?" thread)
- Implementation: this PR


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the proof typing predicate callable at runtime and validates all decoded Z3 model values against it. The decoder now reports type mismatches via `DecodedCounterExample.typingFailures`.

- **New Features**
  - Adds `check_value_has_ty` (executable) and `tyctxFromService` to `SpecRestGenerated` and exports them for Scala use.
  - Introduces `IrValueDecoder.decodeZ3` to convert Z3 expressions into `ir_value`.
  - Wires runtime type-checking into `Z3CounterExample.decode`: builds `tyctx` from IR and validates entity fields, relations, constants, and inputs.
  - Extends `DecodedCounterExample` with `typingFailures: List[String]` for graceful error reporting.

- **Migration**
  - Update calls to `Z3CounterExample.decode` to pass `ir: ServiceIRFull`.

<sup>Written for commit d9f14b36869a4cd76a27ec6dcd83961f7804fa32. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/287?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

