### PR TITLE
fix(docs): static search returned no results — basePath not prefixed onto api URL

### DIFF
--- a/docs/components/provider.tsx
+++ b/docs/components/provider.tsx
@@ -9,6 +9,7 @@ export function Provider({ children }: { children: ReactNode }) {
       search={{
         options: {
           type: "static",
+          api: "/spec_to_rest/api/search",
         },
       }}
     >


### PR DESCRIPTION
## Summary

Search dialog opens, typing produces no results — silent failure across local dev, `dev:static` preview, and the deployed GitHub Pages docs.

## Root cause

`RootProvider`'s static-mode Orama search client (`fumadocs-core/dist/search/client/orama-static.js:32`) defaults its fetch URL to `/api/search`. Next.js auto-prefixes `basePath` onto `<Link>` and `<Image>` URLs but does **not** touch arbitrary `fetch()` calls, so with `basePath: "/spec_to_rest"` the client GETs `/api/search` → 404. The `useDocsSearch` hook catches the error (`client.js:85`) and stores it in `error` state without touching `results`, so the dialog renders an empty list with no indication anything failed.

The built static index at `out/api/search` (a 14 MB file) was correct all along — only the client-side URL was wrong.

## Fix

Override `api` on `search.options` in `components/provider.tsx` to the basePath-prefixed URL. Spread chain: `SearchProvider` spreads `options` onto `DefaultSearchDialog` (`contexts/search.js:50-54`), which threads `api` to `useDocsSearch` as `from` in static mode (`search-default.js:9-20`).

```ts
search={{
  options: {
    type: "static",
    api: "/spec_to_rest/api/search",
  },
}}
```

One URL works in all three environments because `basePath: "/spec_to_rest"` is unconditional in `next.config.mjs`:

| Env | URL fetched | Served by |
|---|---|---|
| `npm run dev` | `/spec_to_rest/api/search` | Next.js dev server (dynamic route handler) |
| `npm run dev:static` | `/spec_to_rest/api/search` | `serve` over `.preview/spec_to_rest/api/search` (the file `cp -al`'d from `out/`) |
| GitHub Pages | `/spec_to_rest/api/search` | static file at `<pages-root>/spec_to_rest/api/search` |

## Test plan

- [ ] `cd docs && npm run dev` → open search, type a known term ("verify", "spec"), confirm results appear.
- [ ] `cd docs && npm run dev:static` → same.
- [ ] After deploy: same on `https://hardmax71.github.io/spec_to_rest/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes docs search returning no results by prefixing the static search API URL with the Next.js `basePath`. The client now fetches the built index at `/spec_to_rest/api/search` instead of hitting 404.

- **Bug Fixes**
  - Set `search.options.api` to `/spec_to_rest/api/search` in `docs/components/provider.tsx`.
  - Restores search in local dev, `dev:static`, and GitHub Pages.

<sup>Written for commit 46804c90f202e087ed6d731d8cd873862719263b. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/295?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

