### PR TITLE
refactor: lift expression walkers + recognizers to Isabelle (Phase 9α/β/γ)

### DIFF
--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/openapi.yaml
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/openapi.yaml
@@ -47,6 +47,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '302':
           description: Redirect
@@ -83,6 +84,7 @@ paths:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
       responses:
         '204':
           description: No content
@@ -164,6 +166,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string
@@ -196,6 +199,7 @@ components:
           - string
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         created_at:
           type:
           - string
@@ -218,6 +222,7 @@ components:
           - 'null'
           minLength: 6
           maxLength: 10
+          pattern: ^[a-zA-Z0-9]+$
         url:
           type:
           - string

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -159,25 +159,27 @@ object Constraints:
   private def visitConstraint(
       expr: expr_full,
       out: JsonSchemaConstraints
-  ): JsonSchemaConstraints = expr match
-    case BinaryOpF(BAnd(), l, r, _) =>
-      visitConstraint(r, visitConstraint(l, out))
-    case MatchesF(inner, pattern, _) if isValueRef(inner) =>
-      out.copy(pattern = Some(pattern))
-    case b @ BinaryOpF(_, _, _, _) =>
-      applyComparison(b, out)
-    case _ => out
+  ): JsonSchemaConstraints =
+    flattenAnd(expr).foldLeft(out)((acc, atom) => applyAtom(atom, acc))
 
-  private def applyComparison(
-      expr: BinaryOpF,
+  private def applyAtom(
+      expr: expr_full,
       out: JsonSchemaConstraints
   ): JsonSchemaConstraints =
-    literalNumber(expr.c) match
-      case None => out
-      case Some(n) =>
-        if isLenCall(expr.b) then applyLengthBound(expr.a, n, out)
-        else if isValueRef(expr.b) then applyNumericBound(expr.a, n, out)
-        else out
+    decomposeAtom(expr) match
+      case RaMatches(pat)                    => out.copy(pattern = Some(pat))
+      case RaLenCmp(op, int_of_integer(n))   => applyLengthBound(op, n.toDouble, out)
+      case RaValueCmp(op, int_of_integer(n)) => applyNumericBound(op, n.toDouble, out)
+      case _: RaPredCall | _: RaMatchesIdent => out
+      case _: RaUnknown                      =>
+        // Float-literal bounds — decomposeAtom only recognizes IntLitF
+        expr match
+          case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
+            v.toDoubleOption.fold(out): d =>
+              if isLenOfValue(lhs) then applyLengthBound(op, d, out)
+              else if isValueRef(lhs) then applyNumericBound(op, d, out)
+              else out
+          case _ => out
 
   private def applyLengthBound(
       op: bin_op_full,
@@ -226,19 +228,6 @@ object Constraints:
     Some(cur.fold(n)(math.max(_, n)))
   private def tightenUpperD(cur: Option[Double], n: Double): Option[Double] =
     Some(cur.fold(n)(math.min(_, n)))
-
-  private def isLenCall(expr: expr_full): Boolean = expr match
-    case CallF(IdentifierF("len", _), _, _) => true
-    case _                                  => false
-
-  private def isValueRef(expr: expr_full): Boolean = expr match
-    case IdentifierF("value", _) => true
-    case _                       => false
-
-  private def literalNumber(expr: expr_full): Option[Double] = expr match
-    case IntLitF(int_of_integer(v), _) => Some(v.toDouble)
-    case FloatLitF(v, _)               => v.toDoubleOption
-    case _                             => None
 
 // -- Schema generation ----------------------------------------
 

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -349,7 +349,7 @@ object Schema:
       maximum = c.maximum.orElse(base.maximum),
       exclusiveMinimum = c.exclusiveMinimum.orElse(base.exclusiveMinimum),
       exclusiveMaximum = c.exclusiveMaximum.orElse(base.exclusiveMaximum),
-      pattern = None,
+      pattern = c.pattern.orElse(base.pattern),
       enum_ = c.enum_.orElse(base.enum_)
     )
 

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -344,14 +344,34 @@ object Schema:
       expr: expr_full,
       colName: String,
       checks: scala.collection.mutable.Builder[String, List[String]]
-  ): Unit = expr match
-    case BinaryOpF(BAnd(), l, r, _) =>
-      visitConstraint(l, colName, checks); visitConstraint(r, colName, checks)
-    case b @ BinaryOpF(_, _, _, _) =>
-      tryMapComparison(b, colName).foreach(checks += _)
-    case MatchesF(IdentifierF(_, _), pattern, _) =>
-      checks += s"$colName ~ '${escapeSqlString(pattern)}'"
-    case _ => ()
+  ): Unit =
+    flattenAnd(expr).foreach(atom => applyAtom(atom, colName, checks))
+
+  private def applyAtom(
+      expr: expr_full,
+      colName: String,
+      checks: scala.collection.mutable.Builder[String, List[String]]
+  ): Unit =
+    decomposeAtom(expr) match
+      case RaMatches(pat) =>
+        checks += s"$colName ~ '${escapeSqlString(pat)}'"
+      case RaMatchesIdent(_, pat) =>
+        checks += s"$colName ~ '${escapeSqlString(pat)}'"
+      case RaLenCmp(op, int_of_integer(n)) =>
+        sqlOp(op).foreach(o => checks += s"length($colName) $o $n")
+      case RaValueCmp(op, int_of_integer(n)) =>
+        sqlOp(op).foreach(o => checks += s"$colName $o $n")
+      case _: RaPredCall => ()
+      case _: RaUnknown  =>
+        // Float / String literals not covered by decomposeAtom
+        expr match
+          case BinaryOpF(op, lhs, rhs, _) if isLiteral(rhs) =>
+            sqlOp(op).foreach: o =>
+              if isLenOfValue(lhs) then
+                checks += s"length($colName) $o ${literalValue(rhs)}"
+              else if isValueRef(lhs) then
+                checks += s"$colName $o ${literalValue(rhs)}"
+          case _ => ()
 
   private def sqlOp(op: bin_op_full): Option[String] = op match
     case BGt()  => Some(">")
@@ -361,22 +381,6 @@ object Schema:
     case BEq()  => Some("=")
     case BNeq() => Some("!=")
     case _      => None
-
-  private def tryMapComparison(b: BinaryOpF, colName: String): Option[String] =
-    sqlOp(b.a).flatMap: op =>
-      if isLenCall(b.b) && isLiteral(b.c) then
-        Some(s"length($colName) $op ${literalValue(b.c)}")
-      else if isValueRef(b.b) && isLiteral(b.c) then
-        Some(s"$colName $op ${literalValue(b.c)}")
-      else None
-
-  private def isLenCall(e: expr_full): Boolean = e match
-    case CallF(IdentifierF("len", _), _, _) => true
-    case _                                  => false
-
-  private def isValueRef(e: expr_full): Boolean = e match
-    case IdentifierF("value", _) => true
-    case _                       => false
 
   private def isLiteral(e: expr_full): Boolean = e match
     case IntLitF(_, _) | FloatLitF(_, _) | StringLitF(_, _) => true
@@ -389,9 +393,7 @@ object Schema:
     case _                             => "NULL"
 
   private def extractInvariantChecks(inv: expr_full, fields: List[FieldDeclFull]): List[String] =
-    inv match
-      case BinaryOpF(BAnd(), l, r, _) =>
-        extractInvariantChecks(l, fields) ++ extractInvariantChecks(r, fields)
+    flattenAnd(inv).flatMap:
       case BinaryOpF(BIn(), left, SetLiteralF(elements, _), _) =>
         extractFieldName(left) match
           case Some(fieldName) =>
@@ -404,7 +406,7 @@ object Schema:
               List(s"$colName IN (${values.mkString(", ")})")
             else Nil
           case None => Nil
-      case b @ BinaryOpF(_, left, right, _) =>
+      case b @ BinaryOpF(_, left, _, _) =>
         (extractFieldName(left), tryComparison(b, fields)) match
           case (Some(fieldName), Some(check)) =>
             List(check.replace("__COL__", Naming.toColumnName(fieldName)))

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -152,7 +152,7 @@ object Generator:
           case FieldDeclFull(fn, _, Some(whereExpr), _) =>
             val whereCtx = ctx.copy(boundVars = ctx.boundVars + "value" + "x")
             val rebound =
-              rewriteValueRef(whereExpr, "value", FieldAccessF(IdentifierF("x", None), fn, None))
+              subst("value", FieldAccessF(IdentifierF("x", None), fn, None), whereExpr)
             s"(${renderExpr(whereCtx, rebound)})"
         }
 
@@ -436,7 +436,7 @@ object Generator:
         case _              => false
       }
     def unwrap(body: expr_full, p: String): expr_full =
-      rewriteValueRef(body, p, FieldAccessF(IdentifierF(p, None), "value", None))
+      subst(p, FieldAccessF(IdentifierF(p, None), "value", None), body)
     def go(e: expr_full): expr_full = e match
       case BinaryOpF(
             BImplies(),
@@ -468,61 +468,6 @@ object Generator:
         QuantifierF(q, bsRewritten, go(body), sp)
       case other => other
     go(expr)
-
-  private def rewriteValueRef(expr: expr_full, name: String, replacement: expr_full): expr_full =
-    def go(e: expr_full, bound: Set[String]): expr_full = e match
-      case IdentifierF(n, _) if n == name && !bound.contains(n) => replacement
-      case LetF(v, value, body, sp) =>
-        LetF(v, go(value, bound), go(body, bound + v), sp)
-      case LambdaF(p, body, sp) =>
-        LambdaF(p, go(body, bound + p), sp)
-      case QuantifierF(q, bs, body, sp) =>
-        val bsBound = bs.collect { case b: QuantifierBindingFull => b.a }.toSet
-        val bsRewritten = bs.map {
-          case QuantifierBindingFull(a, dom, kind, bsp) =>
-            QuantifierBindingFull(a, go(dom, bound), kind, bsp)
-        }
-        QuantifierF(q, bsRewritten, go(body, bound ++ bsBound), sp)
-      case SetComprehensionF(v, dom, pred, sp) =>
-        SetComprehensionF(v, go(dom, bound), go(pred, bound + v), sp)
-      case TheF(v, dom, body, sp) =>
-        TheF(v, go(dom, bound), go(body, bound + v), sp)
-      case BinaryOpF(op, l, r, sp) => BinaryOpF(op, go(l, bound), go(r, bound), sp)
-      case UnaryOpF(op, x, sp)     => UnaryOpF(op, go(x, bound), sp)
-      case FieldAccessF(b, f, sp)  => FieldAccessF(go(b, bound), f, sp)
-      case IndexF(b, i, sp)        => IndexF(go(b, bound), go(i, bound), sp)
-      case CallF(c, args, sp)      => CallF(c, args.map(go(_, bound)), sp)
-      case PrimeF(x, sp)           => PrimeF(go(x, bound), sp)
-      case PreF(x, sp)             => PreF(go(x, bound), sp)
-      case IfF(c, t, el, sp)       => IfF(go(c, bound), go(t, bound), go(el, bound), sp)
-      case SomeWrapF(x, sp)        => SomeWrapF(go(x, bound), sp)
-      case ConstructorF(n, fs, sp) =>
-        ConstructorF(
-          n,
-          fs.map {
-            case FieldAssignFull(fn, v, fsp) => FieldAssignFull(fn, go(v, bound), fsp)
-          },
-          sp
-        )
-      case WithF(b, fs, sp) =>
-        WithF(
-          go(b, bound),
-          fs.map {
-            case FieldAssignFull(fn, v, fsp) => FieldAssignFull(fn, go(v, bound), fsp)
-          },
-          sp
-        )
-      case MapLiteralF(es, sp) =>
-        MapLiteralF(
-          es.map {
-            case MapEntryFull(k, v, esp) => MapEntryFull(go(k, bound), go(v, bound), esp)
-          },
-          sp
-        )
-      case SetLiteralF(es, sp) => SetLiteralF(es.map(go(_, bound)), sp)
-      case SeqLiteralF(es, sp) => SeqLiteralF(es.map(go(_, bound)), sp)
-      case other               => other
-    go(expr, Set.empty)
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
     val out = mutable.Set.empty[String]

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -421,6 +421,14 @@ object SpecRestGenerated {
   final case class ParamDeclFull(a: String, b: type_expr_full, c: Option[span_t])
       extends param_decl_full
 
+  sealed abstract class refinement_atom
+  final case class RaLenCmp(a: bin_op_full, b: int)     extends refinement_atom
+  final case class RaValueCmp(a: bin_op_full, b: int)   extends refinement_atom
+  final case class RaMatches(a: String)                 extends refinement_atom
+  final case class RaMatchesIdent(a: String, b: String) extends refinement_atom
+  final case class RaPredCall(a: String)                extends refinement_atom
+  final case class RaUnknown(a: expr_full)              extends refinement_atom
+
   sealed abstract class convention_rule_full
   final case class ConventionRuleFull(
       a: String,
@@ -1365,6 +1373,129 @@ object SpecRestGenerated {
     case (enums, SetLiteralF(elems, sp)) => lowerSetList(enums, elems, sp)
   }
 
+  def qb_names(x0: List[quantifier_binding_full]): List[String] = x0 match {
+    case Nil                                        => Nil
+    case QuantifierBindingFull(n, uu, uv, uw) :: bs => n :: qb_names(bs)
+  }
+
+  def subst_bindings(
+      vk: String,
+      vl: expr_full,
+      x2: List[quantifier_binding_full]
+  ): List[quantifier_binding_full] =
+    (vk, vl, x2) match {
+      case (vk, vl, Nil) => Nil
+      case (x, r, QuantifierBindingFull(n, d, kk, sp) :: bs) =>
+        QuantifierBindingFull(n, subst(x, r, d), kk, sp) :: subst_bindings(x, r, bs)
+    }
+
+  def subst_entries(vi: String, vj: expr_full, x2: List[map_entry_full]): List[map_entry_full] =
+    (vi, vj, x2) match {
+      case (vi, vj, Nil) => Nil
+      case (x, r, MapEntryFull(k, v, sp) :: es) =>
+        MapEntryFull(subst(x, r, k), subst(x, r, v), sp) :: subst_entries(x, r, es)
+    }
+
+  def subst_fields(
+      vg: String,
+      vh: expr_full,
+      x2: List[field_assign_full]
+  ): List[field_assign_full] =
+    (vg, vh, x2) match {
+      case (vg, vh, Nil) => Nil
+      case (x, r, FieldAssignFull(f, v, sp) :: fs) =>
+        FieldAssignFull(f, subst(x, r, v), sp) :: subst_fields(x, r, fs)
+    }
+
+  def subst_list(ve: String, vf: expr_full, x2: List[expr_full]): List[expr_full] =
+    (ve, vf, x2) match {
+      case (ve, vf, Nil)   => Nil
+      case (x, r, e :: es) => subst(x, r, e) :: subst_list(x, r, es)
+    }
+
+  def subst(x: String, r: expr_full, xa2: expr_full): expr_full = (x, r, xa2) match {
+    case (x, r, IdentifierF(n, sp)) =>
+      n == x match {
+        case true  => r
+        case false => IdentifierF(n, sp)
+      }
+    case (x, r, BinaryOpF(op, l, rr, sp)) =>
+      BinaryOpF(op, subst(x, r, l), subst(x, r, rr), sp)
+    case (x, r, UnaryOpF(op, e, sp))    => UnaryOpF(op, subst(x, r, e), sp)
+    case (x, r, FieldAccessF(b, f, sp)) => FieldAccessF(subst(x, r, b), f, sp)
+    case (x, r, EnumAccessF(b, m, sp))  => EnumAccessF(subst(x, r, b), m, sp)
+    case (x, r, IndexF(b, i, sp))       => IndexF(subst(x, r, b), subst(x, r, i), sp)
+    case (x, r, CallF(c, args, sp)) =>
+      CallF(subst(x, r, c), subst_list(x, r, args), sp)
+    case (x, r, PrimeF(e, sp)) => PrimeF(subst(x, r, e), sp)
+    case (x, r, PreF(e, sp))   => PreF(subst(x, r, e), sp)
+    case (x, r, WithF(b, upds, sp)) =>
+      WithF(subst(x, r, b), subst_fields(x, r, upds), sp)
+    case (x, r, IfF(c, t, e, sp)) =>
+      IfF(subst(x, r, c), subst(x, r, t), subst(x, r, e), sp)
+    case (x, r, LetF(v, vala, body, sp)) =>
+      LetF(
+        v,
+        subst(x, r, vala),
+        v == x match {
+          case true  => body
+          case false => subst(x, r, body)
+        },
+        sp
+      )
+    case (x, r, LambdaF(p, b, sp)) =>
+      LambdaF(
+        p,
+        p == x match {
+          case true  => b
+          case false => subst(x, r, b)
+        },
+        sp
+      )
+    case (x, r, ConstructorF(n, fs, sp)) =>
+      ConstructorF(n, subst_fields(x, r, fs), sp)
+    case (x, r, SetLiteralF(xs, sp)) => SetLiteralF(subst_list(x, r, xs), sp)
+    case (x, r, MapLiteralF(es, sp)) => MapLiteralF(subst_entries(x, r, es), sp)
+    case (x, r, SetComprehensionF(v, d, p, sp)) =>
+      SetComprehensionF(
+        v,
+        subst(x, r, d),
+        v == x match {
+          case true  => p
+          case false => subst(x, r, p)
+        },
+        sp
+      )
+    case (x, r, SeqLiteralF(xs, sp))  => SeqLiteralF(subst_list(x, r, xs), sp)
+    case (x, r, MatchesF(e, pat, sp)) => MatchesF(subst(x, r, e), pat, sp)
+    case (x, r, SomeWrapF(e, sp))     => SomeWrapF(subst(x, r, e), sp)
+    case (x, r, TheF(v, d, b, sp)) =>
+      TheF(
+        v,
+        subst(x, r, d),
+        v == x match {
+          case true  => b
+          case false => subst(x, r, b)
+        },
+        sp
+      )
+    case (x, r, QuantifierF(q, bs, body, sp)) =>
+      QuantifierF(
+        q,
+        subst_bindings(x, r, bs),
+        string_in_list(x, qb_names(bs)) match {
+          case true  => body
+          case false => subst(x, r, body)
+        },
+        sp
+      )
+    case (uu, uv, IntLitF(n, sp))    => IntLitF(n, sp)
+    case (uw, ux, FloatLitF(n, sp))  => FloatLitF(n, sp)
+    case (uy, uz, StringLitF(n, sp)) => StringLitF(n, sp)
+    case (va, vb, BoolLitF(v, sp))   => BoolLitF(v, sp)
+    case (vc, vd, NoneLitF(sp))      => NoneLitF(sp)
+  }
+
   def fold[A, B](f: A => B => B, x1: List[A], s: B): B = (f, x1, s) match {
     case (f, Nil, s)     => s
     case (f, x :: xs, s) => fold[A, B](f, xs, f(x)(s))
@@ -2283,6 +2414,75 @@ object SpecRestGenerated {
     case BDiv()       => "/"
   }
 
+  def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
+    case (uu, Nil) => Nil
+    case (n, x :: xs) =>
+      x == n match {
+        case true  => remove_name(n, xs)
+        case false => x :: remove_name(n, xs)
+      }
+  }
+
+  def remove_names(x0: List[String], xs: List[String]): List[String] = (x0, xs) match {
+    case (Nil, xs)     => xs
+    case (n :: ns, xs) => remove_name(n, remove_names(ns, xs))
+  }
+
+  def free_vars_bindings(x0: List[quantifier_binding_full]): List[String] = x0 match {
+    case Nil => Nil
+    case QuantifierBindingFull(wj, d, wk, wl) :: bs =>
+      free_vars(d) ++ free_vars_bindings(bs)
+  }
+
+  def free_vars_entries(x0: List[map_entry_full]): List[String] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, wi) :: es =>
+      free_vars(k) ++ (free_vars(v) ++ free_vars_entries(es))
+  }
+
+  def free_vars_fields(x0: List[field_assign_full]): List[String] = x0 match {
+    case Nil                              => Nil
+    case FieldAssignFull(wg, v, wh) :: fs => free_vars(v) ++ free_vars_fields(fs)
+  }
+
+  def free_vars_list(x0: List[expr_full]): List[String] = x0 match {
+    case Nil     => Nil
+    case x :: xs => free_vars(x) ++ free_vars_list(xs)
+  }
+
+  def free_vars(x0: expr_full): List[String] = x0 match {
+    case IdentifierF(n, uu)      => List(n)
+    case BinaryOpF(uv, l, r, uw) => free_vars(l) ++ free_vars(r)
+    case UnaryOpF(ux, e, uy)     => free_vars(e)
+    case FieldAccessF(b, uz, va) => free_vars(b)
+    case EnumAccessF(b, vb, vc)  => free_vars(b)
+    case IndexF(b, i, vd)        => free_vars(b) ++ free_vars(i)
+    case CallF(c, args, ve)      => free_vars(c) ++ free_vars_list(args)
+    case PrimeF(e, vf)           => free_vars(e)
+    case PreF(e, vg)             => free_vars(e)
+    case WithF(b, upds, vh)      => free_vars(b) ++ free_vars_fields(upds)
+    case IfF(c, t, e, vi)        => free_vars(c) ++ (free_vars(t) ++ free_vars(e))
+    case LetF(v, vala, body, vj) =>
+      free_vars(vala) ++ remove_name(v, free_vars(body))
+    case LambdaF(p, b, vk)        => remove_name(p, free_vars(b))
+    case ConstructorF(vl, fs, vm) => free_vars_fields(fs)
+    case SetLiteralF(xs, vn)      => free_vars_list(xs)
+    case MapLiteralF(es, vo)      => free_vars_entries(es)
+    case SetComprehensionF(v, d, p, vp) =>
+      free_vars(d) ++ remove_name(v, free_vars(p))
+    case SeqLiteralF(xs, vq) => free_vars_list(xs)
+    case MatchesF(x, vr, vs) => free_vars(x)
+    case SomeWrapF(x, vt)    => free_vars(x)
+    case TheF(v, d, b, vu)   => free_vars(d) ++ remove_name(v, free_vars(b))
+    case QuantifierF(vv, bs, body, vw) =>
+      free_vars_bindings(bs) ++ remove_names(qb_names(bs), free_vars(body))
+    case IntLitF(vx, vy)    => Nil
+    case FloatLitF(vz, wa)  => Nil
+    case StringLitF(wb, wc) => Nil
+    case BoolLitF(wd, we)   => Nil
+    case NoneLitF(wf)       => Nil
+  }
+
   def isLitFull(x0: expr_full): Boolean = x0 match {
     case BoolLitF(uu, uv)                 => true
     case IntLitF(uw, ux)                  => true
@@ -2313,6 +2513,37 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => false
   }
 
+  def isTrueLit(x0: expr_full): Boolean = x0 match {
+    case BoolLitF(true, uu)               => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case BoolLitF(false, va)              => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, va)               => false
+  }
+
   def butlast[A](x0: List[A]): List[A] = x0 match {
     case Nil => Nil
     case x :: xs =>
@@ -2334,6 +2565,12 @@ object SpecRestGenerated {
         case true  => remdups[A](xs)
         case false => x :: remdups[A](xs)
       }
+  }
+
+  def combineAnd(x0: List[expr_full]): expr_full = x0 match {
+    case Nil            => BoolLitF(true, None)
+    case List(x)        => x
+    case x :: y :: rest => BinaryOpF(BAnd(), x, combineAnd(y :: rest), None)
   }
 
   def consPrimed(
@@ -2398,6 +2635,36 @@ object SpecRestGenerated {
     case IdentifierF(v, va)  => List(IdentifierF(v, va))
   }
 
+  def isValueRef(x0: expr_full): Boolean = x0 match {
+    case IdentifierF(n, uu)               => n == "value"
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case BoolLitF(v, va)                  => false
+    case NoneLitF(v)                      => false
+  }
+
   def stripSpans_bindings(x0: List[quantifier_binding_full]): List[quantifier_binding_full] =
     x0 match {
       case Nil => Nil
@@ -2455,6 +2722,60 @@ object SpecRestGenerated {
     case BoolLitF(b, vs)      => BoolLitF(b, None)
     case NoneLitF(vt)         => NoneLitF(None)
     case IdentifierF(x, vu)   => IdentifierF(x, None)
+  }
+
+  def hasPrePrime_bindings(x0: List[quantifier_binding_full]): Boolean = x0 match {
+    case Nil => false
+    case QuantifierBindingFull(wq, d, wr, ws) :: bs =>
+      hasPrePrime(d) || hasPrePrime_bindings(bs)
+  }
+
+  def hasPrePrime_entries(x0: List[map_entry_full]): Boolean = x0 match {
+    case Nil => false
+    case MapEntryFull(k, v, wp) :: es =>
+      hasPrePrime(k) || (hasPrePrime(v) || hasPrePrime_entries(es))
+  }
+
+  def hasPrePrime_fields(x0: List[field_assign_full]): Boolean = x0 match {
+    case Nil => false
+    case FieldAssignFull(wn, v, wo) :: fs =>
+      hasPrePrime(v) || hasPrePrime_fields(fs)
+  }
+
+  def hasPrePrime_list(x0: List[expr_full]): Boolean = x0 match {
+    case Nil     => false
+    case x :: xs => hasPrePrime(x) || hasPrePrime_list(xs)
+  }
+
+  def hasPrePrime(x0: expr_full): Boolean = x0 match {
+    case PrimeF(uu, uv)                  => true
+    case PreF(uw, ux)                    => true
+    case BinaryOpF(uy, l, r, uz)         => hasPrePrime(l) || hasPrePrime(r)
+    case UnaryOpF(va, e, vb)             => hasPrePrime(e)
+    case FieldAccessF(b, vc, vd)         => hasPrePrime(b)
+    case EnumAccessF(b, ve, vf)          => hasPrePrime(b)
+    case IndexF(b, i, vg)                => hasPrePrime(b) || hasPrePrime(i)
+    case CallF(c, args, vh)              => hasPrePrime(c) || hasPrePrime_list(args)
+    case WithF(b, upds, vi)              => hasPrePrime(b) || hasPrePrime_fields(upds)
+    case IfF(c, t, e, vj)                => hasPrePrime(c) || (hasPrePrime(t) || hasPrePrime(e))
+    case LetF(vk, v, b, vl)              => hasPrePrime(v) || hasPrePrime(b)
+    case LambdaF(vm, b, vn)              => hasPrePrime(b)
+    case ConstructorF(vo, fs, vp)        => hasPrePrime_fields(fs)
+    case SetLiteralF(xs, vq)             => hasPrePrime_list(xs)
+    case MapLiteralF(es, vr)             => hasPrePrime_entries(es)
+    case SetComprehensionF(vs, d, p, vt) => hasPrePrime(d) || hasPrePrime(p)
+    case SeqLiteralF(xs, vu)             => hasPrePrime_list(xs)
+    case MatchesF(x, vv, vw)             => hasPrePrime(x)
+    case SomeWrapF(x, vx)                => hasPrePrime(x)
+    case TheF(vy, d, b, vz)              => hasPrePrime(d) || hasPrePrime(b)
+    case QuantifierF(wa, bs, body, wb) =>
+      hasPrePrime_bindings(bs) || hasPrePrime(body)
+    case IntLitF(wc, wd)     => false
+    case FloatLitF(we, wf)   => false
+    case StringLitF(wg, wh)  => false
+    case BoolLitF(wi, wj)    => false
+    case NoneLitF(wk)        => false
+    case IdentifierF(wl, wm) => false
   }
 
   def rt_relations[A](x0: state_ext[A]): List[(String, List[ir_value])] = x0 match {
@@ -3003,6 +3324,64 @@ object SpecRestGenerated {
     case EnumDeclFull(n, uu, uv) => n
   }
 
+  def isLenOfValue(x0: expr_full): Boolean = x0 match {
+    case CallF(IdentifierF(n, uu), List(arg), uv)         => n == "len" && isValueRef(arg)
+    case BinaryOpF(v, va, vb, vc)                         => false
+    case UnaryOpF(v, va, vb)                              => false
+    case QuantifierF(v, va, vb, vc)                       => false
+    case SomeWrapF(v, va)                                 => false
+    case TheF(v, va, vb, vc)                              => false
+    case FieldAccessF(v, va, vb)                          => false
+    case EnumAccessF(v, va, vb)                           => false
+    case IndexF(v, va, vb)                                => false
+    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb)         => false
+    case CallF(UnaryOpF(vc, vd, ve), va, vb)              => false
+    case CallF(QuantifierF(vc, vd, ve, vf), va, vb)       => false
+    case CallF(SomeWrapF(vc, vd), va, vb)                 => false
+    case CallF(TheF(vc, vd, ve, vf), va, vb)              => false
+    case CallF(FieldAccessF(vc, vd, ve), va, vb)          => false
+    case CallF(EnumAccessF(vc, vd, ve), va, vb)           => false
+    case CallF(IndexF(vc, vd, ve), va, vb)                => false
+    case CallF(CallF(vc, vd, ve), va, vb)                 => false
+    case CallF(PrimeF(vc, vd), va, vb)                    => false
+    case CallF(PreF(vc, vd), va, vb)                      => false
+    case CallF(WithF(vc, vd, ve), va, vb)                 => false
+    case CallF(IfF(vc, vd, ve, vf), va, vb)               => false
+    case CallF(LetF(vc, vd, ve, vf), va, vb)              => false
+    case CallF(LambdaF(vc, vd, ve), va, vb)               => false
+    case CallF(ConstructorF(vc, vd, ve), va, vb)          => false
+    case CallF(SetLiteralF(vc, vd), va, vb)               => false
+    case CallF(MapLiteralF(vc, vd), va, vb)               => false
+    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb) => false
+    case CallF(SeqLiteralF(vc, vd), va, vb)               => false
+    case CallF(MatchesF(vc, vd, ve), va, vb)              => false
+    case CallF(IntLitF(vc, vd), va, vb)                   => false
+    case CallF(FloatLitF(vc, vd), va, vb)                 => false
+    case CallF(StringLitF(vc, vd), va, vb)                => false
+    case CallF(BoolLitF(vc, vd), va, vb)                  => false
+    case CallF(NoneLitF(vc), va, vb)                      => false
+    case CallF(v, Nil, vb)                                => false
+    case CallF(v, vc :: ve :: vf, vb)                     => false
+    case PrimeF(v, va)                                    => false
+    case PreF(v, va)                                      => false
+    case WithF(v, va, vb)                                 => false
+    case IfF(v, va, vb, vc)                               => false
+    case LetF(v, va, vb, vc)                              => false
+    case LambdaF(v, va, vb)                               => false
+    case ConstructorF(v, va, vb)                          => false
+    case SetLiteralF(v, va)                               => false
+    case MapLiteralF(v, va)                               => false
+    case SetComprehensionF(v, va, vb, vc)                 => false
+    case SeqLiteralF(v, va)                               => false
+    case MatchesF(v, va, vb)                              => false
+    case IntLitF(v, va)                                   => false
+    case FloatLitF(v, va)                                 => false
+    case StringLitF(v, va)                                => false
+    case BoolLitF(v, va)                                  => false
+    case NoneLitF(v)                                      => false
+    case IdentifierF(v, va)                               => false
+  }
+
   def fieldNameFull(x0: field_decl_full): String = x0 match {
     case FieldDeclFull(n, uu, uv, uw) => n
   }
@@ -3023,6 +3402,245 @@ object SpecRestGenerated {
         )
       case false => acc ++ List(fd)
     }
+
+  def decomposeAtom(x0: expr_full): refinement_atom = x0 match {
+    case MatchesF(IdentifierF(n, uu), pat, uv) =>
+      n == "value" match {
+        case true  => RaMatches(pat)
+        case false => RaMatchesIdent(n, pat)
+      }
+    case BinaryOpF(op, l, IntLitF(n, uw), sp) =>
+      isLenOfValue(l) match {
+        case true => RaLenCmp(op, n)
+        case false => isValueRef(l) match {
+            case true  => RaValueCmp(op, n)
+            case false => RaUnknown(BinaryOpF(op, l, IntLitF(n, None), sp))
+          }
+      }
+    case CallF(IdentifierF(p, ux), List(arg), uy) =>
+      isValueRef(arg) match {
+        case true  => RaPredCall(p)
+        case false => RaUnknown(CallF(IdentifierF(p, None), List(arg), None))
+      }
+    case BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, SomeWrapF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, SomeWrapF(vd, ve), vc))
+    case BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, IndexF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, IndexF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, CallF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, CallF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, PrimeF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, PrimeF(vd, ve), vc))
+    case BinaryOpF(v, va, PreF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, PreF(vd, ve), vc))
+    case BinaryOpF(v, va, WithF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, WithF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, LambdaF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, LambdaF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, SetLiteralF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, SetLiteralF(vd, ve), vc))
+    case BinaryOpF(v, va, MapLiteralF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, MapLiteralF(vd, ve), vc))
+    case BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc) =>
+      RaUnknown(BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc))
+    case BinaryOpF(v, va, SeqLiteralF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, SeqLiteralF(vd, ve), vc))
+    case BinaryOpF(v, va, MatchesF(vd, ve, vf), vc) =>
+      RaUnknown(BinaryOpF(v, va, MatchesF(vd, ve, vf), vc))
+    case BinaryOpF(v, va, FloatLitF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, FloatLitF(vd, ve), vc))
+    case BinaryOpF(v, va, StringLitF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, StringLitF(vd, ve), vc))
+    case BinaryOpF(v, va, BoolLitF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, BoolLitF(vd, ve), vc))
+    case BinaryOpF(v, va, NoneLitF(vd), vc) =>
+      RaUnknown(BinaryOpF(v, va, NoneLitF(vd), vc))
+    case BinaryOpF(v, va, IdentifierF(vd, ve), vc) =>
+      RaUnknown(BinaryOpF(v, va, IdentifierF(vd, ve), vc))
+    case UnaryOpF(v, va, vb)        => RaUnknown(UnaryOpF(v, va, vb))
+    case QuantifierF(v, va, vb, vc) => RaUnknown(QuantifierF(v, va, vb, vc))
+    case SomeWrapF(v, va)           => RaUnknown(SomeWrapF(v, va))
+    case TheF(v, va, vb, vc)        => RaUnknown(TheF(v, va, vb, vc))
+    case FieldAccessF(v, va, vb)    => RaUnknown(FieldAccessF(v, va, vb))
+    case EnumAccessF(v, va, vb)     => RaUnknown(EnumAccessF(v, va, vb))
+    case IndexF(v, va, vb)          => RaUnknown(IndexF(v, va, vb))
+    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(BinaryOpF(vc, vd, ve, vf), va, vb))
+    case CallF(UnaryOpF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(UnaryOpF(vc, vd, ve), va, vb))
+    case CallF(QuantifierF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(QuantifierF(vc, vd, ve, vf), va, vb))
+    case CallF(SomeWrapF(vc, vd), va, vb) =>
+      RaUnknown(CallF(SomeWrapF(vc, vd), va, vb))
+    case CallF(TheF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(TheF(vc, vd, ve, vf), va, vb))
+    case CallF(FieldAccessF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(FieldAccessF(vc, vd, ve), va, vb))
+    case CallF(EnumAccessF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(EnumAccessF(vc, vd, ve), va, vb))
+    case CallF(IndexF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(IndexF(vc, vd, ve), va, vb))
+    case CallF(CallF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(CallF(vc, vd, ve), va, vb))
+    case CallF(PrimeF(vc, vd), va, vb) => RaUnknown(CallF(PrimeF(vc, vd), va, vb))
+    case CallF(PreF(vc, vd), va, vb)   => RaUnknown(CallF(PreF(vc, vd), va, vb))
+    case CallF(WithF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(WithF(vc, vd, ve), va, vb))
+    case CallF(IfF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(IfF(vc, vd, ve, vf), va, vb))
+    case CallF(LetF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(LetF(vc, vd, ve, vf), va, vb))
+    case CallF(LambdaF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(LambdaF(vc, vd, ve), va, vb))
+    case CallF(ConstructorF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(ConstructorF(vc, vd, ve), va, vb))
+    case CallF(SetLiteralF(vc, vd), va, vb) =>
+      RaUnknown(CallF(SetLiteralF(vc, vd), va, vb))
+    case CallF(MapLiteralF(vc, vd), va, vb) =>
+      RaUnknown(CallF(MapLiteralF(vc, vd), va, vb))
+    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(CallF(SetComprehensionF(vc, vd, ve, vf), va, vb))
+    case CallF(SeqLiteralF(vc, vd), va, vb) =>
+      RaUnknown(CallF(SeqLiteralF(vc, vd), va, vb))
+    case CallF(MatchesF(vc, vd, ve), va, vb) =>
+      RaUnknown(CallF(MatchesF(vc, vd, ve), va, vb))
+    case CallF(IntLitF(vc, vd), va, vb) =>
+      RaUnknown(CallF(IntLitF(vc, vd), va, vb))
+    case CallF(FloatLitF(vc, vd), va, vb) =>
+      RaUnknown(CallF(FloatLitF(vc, vd), va, vb))
+    case CallF(StringLitF(vc, vd), va, vb) =>
+      RaUnknown(CallF(StringLitF(vc, vd), va, vb))
+    case CallF(BoolLitF(vc, vd), va, vb) =>
+      RaUnknown(CallF(BoolLitF(vc, vd), va, vb))
+    case CallF(NoneLitF(vc), va, vb)  => RaUnknown(CallF(NoneLitF(vc), va, vb))
+    case CallF(v, Nil, vb)            => RaUnknown(CallF(v, Nil, vb))
+    case CallF(v, vc :: ve :: vf, vb) => RaUnknown(CallF(v, vc :: ve :: vf, vb))
+    case PrimeF(v, va)                => RaUnknown(PrimeF(v, va))
+    case PreF(v, va)                  => RaUnknown(PreF(v, va))
+    case WithF(v, va, vb)             => RaUnknown(WithF(v, va, vb))
+    case IfF(v, va, vb, vc)           => RaUnknown(IfF(v, va, vb, vc))
+    case LetF(v, va, vb, vc)          => RaUnknown(LetF(v, va, vb, vc))
+    case LambdaF(v, va, vb)           => RaUnknown(LambdaF(v, va, vb))
+    case ConstructorF(v, va, vb)      => RaUnknown(ConstructorF(v, va, vb))
+    case SetLiteralF(v, va)           => RaUnknown(SetLiteralF(v, va))
+    case MapLiteralF(v, va)           => RaUnknown(MapLiteralF(v, va))
+    case SetComprehensionF(v, va, vb, vc) =>
+      RaUnknown(SetComprehensionF(v, va, vb, vc))
+    case SeqLiteralF(v, va) => RaUnknown(SeqLiteralF(v, va))
+    case MatchesF(BinaryOpF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(BinaryOpF(vc, vd, ve, vf), va, vb))
+    case MatchesF(UnaryOpF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(UnaryOpF(vc, vd, ve), va, vb))
+    case MatchesF(QuantifierF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(QuantifierF(vc, vd, ve, vf), va, vb))
+    case MatchesF(SomeWrapF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(SomeWrapF(vc, vd), va, vb))
+    case MatchesF(TheF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(TheF(vc, vd, ve, vf), va, vb))
+    case MatchesF(FieldAccessF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(FieldAccessF(vc, vd, ve), va, vb))
+    case MatchesF(EnumAccessF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(EnumAccessF(vc, vd, ve), va, vb))
+    case MatchesF(IndexF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(IndexF(vc, vd, ve), va, vb))
+    case MatchesF(CallF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(CallF(vc, vd, ve), va, vb))
+    case MatchesF(PrimeF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(PrimeF(vc, vd), va, vb))
+    case MatchesF(PreF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(PreF(vc, vd), va, vb))
+    case MatchesF(WithF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(WithF(vc, vd, ve), va, vb))
+    case MatchesF(IfF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(IfF(vc, vd, ve, vf), va, vb))
+    case MatchesF(LetF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(LetF(vc, vd, ve, vf), va, vb))
+    case MatchesF(LambdaF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(LambdaF(vc, vd, ve), va, vb))
+    case MatchesF(ConstructorF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(ConstructorF(vc, vd, ve), va, vb))
+    case MatchesF(SetLiteralF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(SetLiteralF(vc, vd), va, vb))
+    case MatchesF(MapLiteralF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(MapLiteralF(vc, vd), va, vb))
+    case MatchesF(SetComprehensionF(vc, vd, ve, vf), va, vb) =>
+      RaUnknown(MatchesF(SetComprehensionF(vc, vd, ve, vf), va, vb))
+    case MatchesF(SeqLiteralF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(SeqLiteralF(vc, vd), va, vb))
+    case MatchesF(MatchesF(vc, vd, ve), va, vb) =>
+      RaUnknown(MatchesF(MatchesF(vc, vd, ve), va, vb))
+    case MatchesF(IntLitF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(IntLitF(vc, vd), va, vb))
+    case MatchesF(FloatLitF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(FloatLitF(vc, vd), va, vb))
+    case MatchesF(StringLitF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(StringLitF(vc, vd), va, vb))
+    case MatchesF(BoolLitF(vc, vd), va, vb) =>
+      RaUnknown(MatchesF(BoolLitF(vc, vd), va, vb))
+    case MatchesF(NoneLitF(vc), va, vb) =>
+      RaUnknown(MatchesF(NoneLitF(vc), va, vb))
+    case IntLitF(v, va)     => RaUnknown(IntLitF(v, va))
+    case FloatLitF(v, va)   => RaUnknown(FloatLitF(v, va))
+    case StringLitF(v, va)  => RaUnknown(StringLitF(v, va))
+    case BoolLitF(v, va)    => RaUnknown(BoolLitF(v, va))
+    case NoneLitF(v)        => RaUnknown(NoneLitF(v))
+    case IdentifierF(v, va) => RaUnknown(IdentifierF(v, va))
+  }
+
+  def enumLiteralOf(x0: expr_full, ms: List[String]): Option[String] = (x0, ms) match {
+    case (EnumAccessF(uu, m, uv), ms) =>
+      string_in_list(m, ms) match {
+        case true  => Some[String](m)
+        case false => None
+      }
+    case (IdentifierF(n, uw), ms) =>
+      string_in_list(n, ms) match {
+        case true  => Some[String](n)
+        case false => None
+      }
+    case (BinaryOpF(v, va, vb, vc), uy)         => None
+    case (UnaryOpF(v, va, vb), uy)              => None
+    case (QuantifierF(v, va, vb, vc), uy)       => None
+    case (SomeWrapF(v, va), uy)                 => None
+    case (TheF(v, va, vb, vc), uy)              => None
+    case (FieldAccessF(v, va, vb), uy)          => None
+    case (IndexF(v, va, vb), uy)                => None
+    case (CallF(v, va, vb), uy)                 => None
+    case (PrimeF(v, va), uy)                    => None
+    case (PreF(v, va), uy)                      => None
+    case (WithF(v, va, vb), uy)                 => None
+    case (IfF(v, va, vb, vc), uy)               => None
+    case (LetF(v, va, vb, vc), uy)              => None
+    case (LambdaF(v, va, vb), uy)               => None
+    case (ConstructorF(v, va, vb), uy)          => None
+    case (SetLiteralF(v, va), uy)               => None
+    case (MapLiteralF(v, va), uy)               => None
+    case (SetComprehensionF(v, va, vb, vc), uy) => None
+    case (SeqLiteralF(v, va), uy)               => None
+    case (MatchesF(v, va, vb), uy)              => None
+    case (IntLitF(v, va), uy)                   => None
+    case (FloatLitF(v, va), uy)                 => None
+    case (StringLitF(v, va), uy)                => None
+    case (BoolLitF(v, va), uy)                  => None
+    case (NoneLitF(v), uy)                      => None
+  }
 
   def fieldTypeFull(x0: field_decl_full): type_expr_full = x0 match {
     case FieldDeclFull(uu, t, uv, uw) => t

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2567,10 +2567,15 @@ object SpecRestGenerated {
       }
   }
 
+  def combineAnd_acc(acc: expr_full, x1: List[expr_full]): expr_full =
+    (acc, x1) match {
+      case (acc, Nil)       => acc
+      case (acc, x :: rest) => combineAnd_acc(BinaryOpF(BAnd(), acc, x, None), rest)
+    }
+
   def combineAnd(x0: List[expr_full]): expr_full = x0 match {
-    case Nil            => BoolLitF(true, None)
-    case List(x)        => x
-    case x :: y :: rest => BinaryOpF(BAnd(), x, combineAnd(y :: rest), None)
+    case Nil       => BoolLitF(true, None)
+    case x :: rest => combineAnd_acc(x, rest)
   }
 
   def consPrimed(
@@ -3409,18 +3414,18 @@ object SpecRestGenerated {
         case true  => RaMatches(pat)
         case false => RaMatchesIdent(n, pat)
       }
-    case BinaryOpF(op, l, IntLitF(n, uw), sp) =>
+    case BinaryOpF(op, l, IntLitF(n, innersp), sp) =>
       isLenOfValue(l) match {
         case true => RaLenCmp(op, n)
         case false => isValueRef(l) match {
             case true  => RaValueCmp(op, n)
-            case false => RaUnknown(BinaryOpF(op, l, IntLitF(n, None), sp))
+            case false => RaUnknown(BinaryOpF(op, l, IntLitF(n, innersp), sp))
           }
       }
-    case CallF(IdentifierF(p, ux), List(arg), uy) =>
+    case CallF(IdentifierF(p, identsp), List(arg), sp) =>
       isValueRef(arg) match {
         case true  => RaPredCall(p)
-        case false => RaUnknown(CallF(IdentifierF(p, None), List(arg), None))
+        case false => RaUnknown(CallF(IdentifierF(p, identsp), List(arg), sp))
       }
     case BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc) =>
       RaUnknown(BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc))

--- a/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
+++ b/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
@@ -44,10 +44,6 @@ object OperationOverlap extends LintPass:
 
   private def normalizedRequires(rs: List[expr_full]): List[String] =
     flattenAndAll(rs)
-      .filterNot(isLiteralTrue)
+      .filterNot(isTrueLit)
       .map(e => SpecRestGenerated.stripSpans(e).toString)
       .sorted
-
-  private def isLiteralTrue(e: expr_full): Boolean = e match
-    case BoolLitF(true, _) => true
-    case _                 => false

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -115,7 +115,7 @@ object Behavioral:
     val opSnake = Naming.toSnakeCase(opDecl.a)
 
     val requiresHasStateRef = opDecl.d.exists(containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!isTrivialTrue(_))
+    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(
@@ -193,7 +193,7 @@ object Behavioral:
             case Some(restriction) =>
               statusRestrictionNegativeOrSkip(opDecl, pop, ir, restriction, idx).toList
             case None =>
-              if isTrivialTrue(req) then Nil
+              if isTrueLit(req) then Nil
               else
                 List(
                   Left(
@@ -851,62 +851,7 @@ object Behavioral:
     else "f" + ExprToPython.pyString(ep.path)
 
   private[testgen] def containsStateRef(e: expr_full, stateFields: Set[String]): Boolean =
-    containsStateRefIn(e, stateFields, Set.empty)
-
-  private def containsStateRefIn(
-      e: expr_full,
-      stateFields: Set[String],
-      bound: Set[String]
-  ): Boolean = e match
-    case IdentifierF(n, _) => !bound.contains(n) && stateFields.contains(n)
-    case PreF(_, _)        => true
-    case PrimeF(_, _)      => true
-    case BinaryOpF(_, l, r, _) =>
-      containsStateRefIn(l, stateFields, bound) || containsStateRefIn(r, stateFields, bound)
-    case UnaryOpF(_, x, _)     => containsStateRefIn(x, stateFields, bound)
-    case FieldAccessF(b, _, _) => containsStateRefIn(b, stateFields, bound)
-    case EnumAccessF(b, _, _)  => containsStateRefIn(b, stateFields, bound)
-    case IndexF(b, i, _) =>
-      containsStateRefIn(b, stateFields, bound) || containsStateRefIn(i, stateFields, bound)
-    case CallF(c, args, _) =>
-      containsStateRefIn(c, stateFields, bound) ||
-      args.exists(containsStateRefIn(_, stateFields, bound))
-    case IfF(c, t, el, _) =>
-      containsStateRefIn(c, stateFields, bound) ||
-      containsStateRefIn(t, stateFields, bound) ||
-      containsStateRefIn(el, stateFields, bound)
-    case LetF(name, v, b, _) =>
-      containsStateRefIn(v, stateFields, bound) ||
-      containsStateRefIn(b, stateFields, bound + name)
-    case QuantifierF(_, bs, body, _) =>
-      val bsList = bs.collect { case b: QuantifierBindingFull => b }
-      val bs2    = bound ++ bsList.map(_.a)
-      bsList.exists(qb => containsStateRefIn(qb.b, stateFields, bound)) ||
-      containsStateRefIn(body, stateFields, bs2)
-    case SetLiteralF(es, _) => es.exists(containsStateRefIn(_, stateFields, bound))
-    case SeqLiteralF(es, _) => es.exists(containsStateRefIn(_, stateFields, bound))
-    case MapLiteralF(es, _) =>
-      es.exists { case MapEntryFull(k, v, _) =>
-        containsStateRefIn(k, stateFields, bound) ||
-        containsStateRefIn(v, stateFields, bound)
-      }
-    case SetComprehensionF(name, d, p, _) =>
-      containsStateRefIn(d, stateFields, bound) ||
-      containsStateRefIn(p, stateFields, bound + name)
-    case SomeWrapF(x, _) => containsStateRefIn(x, stateFields, bound)
-    case TheF(name, d, b, _) =>
-      containsStateRefIn(d, stateFields, bound) ||
-      containsStateRefIn(b, stateFields, bound + name)
-    case WithF(b, ups, _) =>
-      containsStateRefIn(b, stateFields, bound) ||
-      ups.exists { case FieldAssignFull(_, v, _) => containsStateRefIn(v, stateFields, bound) }
-    case ConstructorF(_, fs, _) =>
-      fs.exists { case FieldAssignFull(_, v, _) => containsStateRefIn(v, stateFields, bound) }
-    case LambdaF(name, b, _) => containsStateRefIn(b, stateFields, bound + name)
-    case MatchesF(x, _, _)   => containsStateRefIn(x, stateFields, bound)
-    case IntLitF(_, _) | FloatLitF(_, _) | StringLitF(_, _) | BoolLitF(_, _) |
-        NoneLitF(_) =>
-      false
+    hasPrePrime(e) || free_vars(e).exists(stateFields.contains)
 
   private def keyExistencePattern(
       e: expr_full,
@@ -955,7 +900,7 @@ object Behavioral:
                          .collect { case f: FieldDeclFull => f }
           enumVals <- enumValuesForField(fieldDecl, ir)
           if enumVals.nonEmpty
-          rhsLit <- enumLiteralFor(rhs, enumVals)
+          rhsLit <- enumLiteralOf(rhs, enumVals)
           pk     <- AdminRouter.primaryKeyField(entity)
           if enumVals.size >= 2
         yield StatusRestriction(inName, stName, entityName, field, rhsLit, enumVals, pk)
@@ -966,12 +911,6 @@ object Behavioral:
       .flatMap { case StateDeclFull(fs, _) => fs }
       .collectFirst { case StateFieldDeclFull(n, t, _) if n == stateFieldName => t }
       .flatMap(relationTargetEntityName)
-
-  private def enumLiteralFor(rhs: expr_full, enumValues: List[String]): Option[String] =
-    rhs match
-      case EnumAccessF(_, member, _) if enumValues.contains(member) => Some(member)
-      case IdentifierF(name, _) if enumValues.contains(name)        => Some(name)
-      case _                                                        => None
 
   private def statusRestrictionNegativeOrSkip(
       opDecl: OperationDeclFull,
@@ -1046,10 +985,6 @@ object Behavioral:
         s"f${'"'}expected 4xx, got {response.status_code}: {response.text}${'"'}\n"
     )
     GeneratedTest(name = testName, body = sb.toString, skipReason = None)
-
-  private[testgen] def isTrivialTrue(e: expr_full): Boolean = e match
-    case BoolLitF(true, _) => true
-    case _                 => false
 
   private def invName(inv: InvariantDeclFull, idx: Int): String =
     inv.a.getOrElse(s"anon_$idx")

--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -6,6 +6,7 @@ import specrest.ir.generated.SpecRestGenerated.OperationDeclFull
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.StateDeclFull
 import specrest.ir.generated.SpecRestGenerated.StateFieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.isTrueLit
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -52,7 +53,7 @@ object GoBehavioral:
       fs.collect { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
     val requiresHasStateRef = opDecl.d.exists(Behavioral.containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!Behavioral.isTrivialTrue(_))
+    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(Left(TestSkip(opDecl.a, "ensures", Behavioral.stateDepSkipReason(opDecl.a, Set.empty))))

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -206,17 +206,11 @@ object Stateful:
                   _
                 )
                 if b == p.a && f == td.c =>
-              enumLiteralName(rhs, enumValues)
+              enumLiteralOf(rhs, enumValues)
           .flatten
           .map(op.a -> _)
     if initialByOp.size != createDecls.size then None
     else Some((td, enumValues, initialByOp.toMap))
-
-  private def enumLiteralName(rhs: expr_full, enumValues: List[String]): Option[String] =
-    rhs match
-      case EnumAccessF(_, member, _) if enumValues.contains(member) => Some(member)
-      case IdentifierF(name, _) if enumValues.contains(name)        => Some(name)
-      case _                                                        => None
 
   private def primaryKey(entity: EntityDeclFull): Option[FieldDeclFull] =
     val fields = entity.c.collect { case f: FieldDeclFull => f }
@@ -469,7 +463,7 @@ object Stateful:
       var perField     = Map.empty[String, Set[String]]
       var unrecognized = false
       conjuncts.foreach: c =>
-        if isKeyExistsConj(c, inputName, stateName) || isTrivialTrue(c) then ()
+        if isKeyExistsConj(c, inputName, stateName) || isTrueLit(c) then ()
         else
           fieldRestrictionConjunct(c, inputName, stateName) match
             case Some((fieldName, allowed)) =>
@@ -945,7 +939,7 @@ object Stateful:
 
   private def operationSummary(op: OperationDeclFull): String =
     val req = op.d
-      .filterNot(isTrivialTrue)
+      .filterNot(isTrueLit)
       .map(prettyOneLine)
       .mkString("; ")
     val ens = op.e.map(prettyOneLine).mkString("; ")
@@ -955,17 +949,13 @@ object Stateful:
     ).flatten
     if parts.isEmpty then op.a else s"${op.a}: ${parts.mkString(" | ")}"
 
-  private def isTrivialTrue(e: expr_full): Boolean = e match
-    case BoolLitF(true, _) => true
-    case _                 => false
-
   private def requiresIsSatisfiedByBundles(
       e: expr_full,
       bundleInputs: Set[String],
       stateFields: Set[String]
   ): Boolean =
     e match
-      case BoolLitF(true, _) => true
+      case _ if isTrueLit(e) => true
       case BinaryOpF(BIn(), IdentifierF(in, _), IdentifierF(state, _), _)
           if bundleInputs.contains(in) && stateFields.contains(state) =>
         true

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -350,52 +350,54 @@ object Strategies:
   private def walkStringConstraint(
       e: expr_full,
       ir: ServiceIRFull
-  ): (StringConstraint, List[String]) = e match
-    case BinaryOpF(BAnd(), l, r, _) =>
-      val (lc, lsk) = walkStringConstraint(l, ir)
-      val (rc, rsk) = walkStringConstraint(r, ir)
-      (lc.merge(rc), lsk ++ rsk)
+  ): (StringConstraint, List[String]) =
+    flattenAnd(e).foldLeft((StringConstraint(), List.empty[String])):
+      case ((acc, skips), atom) =>
+        val (next, newSkips) = stringAtom(atom, ir)
+        (acc.merge(next), skips ++ newSkips)
 
-    case LenCmp(op, n) =>
-      op match
-        case BGe() => (StringConstraint(minSize = Some(n.toInt)), Nil)
-        case BGt() => (StringConstraint(minSize = Some((n + 1).toInt)), Nil)
-        case BLe() => (StringConstraint(maxSize = Some(n.toInt)), Nil)
-        case BLt() => (StringConstraint(maxSize = Some((n - 1).toInt)), Nil)
-        case BEq() => (StringConstraint(minSize = Some(n.toInt), maxSize = Some(n.toInt)), Nil)
-        case _     => (StringConstraint(), List(s"unsupported len comparison $op"))
-
-    case MatchesF(IdentifierF("value", _), pattern, _) =>
-      (StringConstraint(regexes = List(pattern)), Nil)
-
-    case CallF(IdentifierF(name, _), List(IdentifierF("value", _)), _) =>
-      inlineMatchesPredicate(name, ir) match
-        case Some(pattern) =>
-          (StringConstraint(regexes = List(pattern)), Nil)
-        case None =>
-          ir.m.collectFirst { case _p: PredicateDeclFull if _p.a == name => _p } match
-            case None =>
-              (StringConstraint(), List(s"unknown predicate '$name' in string constraint"))
-            case Some(pr) if pr.b.size != 1 =>
-              (
-                StringConstraint(),
-                List(
-                  s"predicate '$name' has arity ${pr.b.size}; string-constraint filters require arity 1"
-                )
-              )
-            case Some(_) =>
-              val snake = Naming.toSnakeCase(name)
-              if PythonReservedNames.contains(snake) then
+  private def stringAtom(
+      atom: expr_full,
+      ir: ServiceIRFull
+  ): (StringConstraint, List[String]) =
+    decomposeAtom(atom) match
+      case RaLenCmp(op, int_of_integer(n)) =>
+        op match
+          case _: BGe => (StringConstraint(minSize = Some(n.toInt)), Nil)
+          case _: BGt => (StringConstraint(minSize = Some((n + 1).toInt)), Nil)
+          case _: BLe => (StringConstraint(maxSize = Some(n.toInt)), Nil)
+          case _: BLt => (StringConstraint(maxSize = Some((n - 1).toInt)), Nil)
+          case _: BEq => (StringConstraint(minSize = Some(n.toInt), maxSize = Some(n.toInt)), Nil)
+          case _      => (StringConstraint(), List(s"unsupported len comparison $op"))
+      case RaMatches(pattern) =>
+        (StringConstraint(regexes = List(pattern)), Nil)
+      case RaPredCall(name) =>
+        inlineMatchesPredicate(name, ir) match
+          case Some(pattern) =>
+            (StringConstraint(regexes = List(pattern)), Nil)
+          case None =>
+            ir.m.collectFirst { case _p: PredicateDeclFull if _p.a == name => _p } match
+              case None =>
+                (StringConstraint(), List(s"unknown predicate '$name' in string constraint"))
+              case Some(pr) if pr.b.size != 1 =>
                 (
                   StringConstraint(),
                   List(
-                    s"predicate '$name' (snake-cased to '$snake') is a Python-reserved name; cannot emit strategy filter"
+                    s"predicate '$name' has arity ${pr.b.size}; string-constraint filters require arity 1"
                   )
                 )
-              else (StringConstraint(predicateHelpers = List(snake)), Nil)
-
-    case other =>
-      (StringConstraint(), List(s"unhandled string constraint: ${shortShape(other)}"))
+              case Some(_) =>
+                val snake = Naming.toSnakeCase(name)
+                if PythonReservedNames.contains(snake) then
+                  (
+                    StringConstraint(),
+                    List(
+                      s"predicate '$name' (snake-cased to '$snake') is a Python-reserved name; cannot emit strategy filter"
+                    )
+                  )
+                else (StringConstraint(predicateHelpers = List(snake)), Nil)
+      case _ =>
+        (StringConstraint(), List(s"unhandled string constraint: ${shortShape(atom)}"))
 
   private def inlineMatchesPredicate(name: String, ir: ServiceIRFull): Option[String] =
     ir.m
@@ -413,34 +415,24 @@ object Strategies:
       case None    => (IntConstraint(), Nil)
       case Some(e) => walkIntConstraint(e)
 
-  private def walkIntConstraint(e: expr_full): (IntConstraint, List[String]) = e match
-    case BinaryOpF(BAnd(), l, r, _) =>
-      val (lc, lsk) = walkIntConstraint(l)
-      val (rc, rsk) = walkIntConstraint(r)
-      (lc.merge(rc), lsk ++ rsk)
+  private def walkIntConstraint(e: expr_full): (IntConstraint, List[String]) =
+    flattenAnd(e).foldLeft((IntConstraint(), List.empty[String])):
+      case ((acc, skips), atom) =>
+        val (next, newSkips) = intAtom(atom)
+        (acc.merge(next), skips ++ newSkips)
 
-    case BinaryOpF(op, IdentifierF("value", _), IntLitF(int_of_integer(n), _), _) =>
-      op match
-        case _: BGe => (IntConstraint(minValue = Some(n.toLong)), Nil)
-        case _: BGt => (IntConstraint(minValue = Some((n + 1).toLong)), Nil)
-        case _: BLe => (IntConstraint(maxValue = Some(n.toLong)), Nil)
-        case _: BLt => (IntConstraint(maxValue = Some((n - 1).toLong)), Nil)
-        case _: BEq => (IntConstraint(minValue = Some(n.toLong), maxValue = Some(n.toLong)), Nil)
-        case _      => (IntConstraint(), List(s"unsupported int comparison $op"))
-
-    case other =>
-      (IntConstraint(), List(s"unhandled int constraint: ${shortShape(other)}"))
-
-  private object LenCmp:
-    def unapply(e: expr_full): Option[(bin_op_full, Long)] = e match
-      case BinaryOpF(
-            op,
-            CallF(IdentifierF("len", _), List(IdentifierF("value", _)), _),
-            IntLitF(int_of_integer(n), _),
-            _
-          ) =>
-        Some((op, n.toLong))
-      case _ => None
+  private def intAtom(atom: expr_full): (IntConstraint, List[String]) =
+    decomposeAtom(atom) match
+      case RaValueCmp(op, int_of_integer(n)) =>
+        op match
+          case _: BGe => (IntConstraint(minValue = Some(n.toLong)), Nil)
+          case _: BGt => (IntConstraint(minValue = Some((n + 1).toLong)), Nil)
+          case _: BLe => (IntConstraint(maxValue = Some(n.toLong)), Nil)
+          case _: BLt => (IntConstraint(maxValue = Some((n - 1).toLong)), Nil)
+          case _: BEq => (IntConstraint(minValue = Some(n.toLong), maxValue = Some(n.toLong)), Nil)
+          case _      => (IntConstraint(), List(s"unsupported int comparison $op"))
+      case _ =>
+        (IntConstraint(), List(s"unhandled int constraint: ${shortShape(atom)}"))
 
   private def shortShape(e: expr_full): String = e match
     case BinaryOpF(op, _, _, _) => s"BinaryOp($op)"

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -8,6 +8,7 @@ import specrest.ir.generated.SpecRestGenerated.PredicateDeclFull
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.StateDeclFull
 import specrest.ir.generated.SpecRestGenerated.StateFieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.isTrueLit
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -55,7 +56,7 @@ object TsBehavioral:
       fs.collect { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
     val requiresHasStateRef = opDecl.d.exists(Behavioral.containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!Behavioral.isTrivialTrue(_))
+    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(Left(TestSkip(opDecl.a, "ensures", Behavioral.stateDepSkipReason(opDecl.a, Set.empty))))

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -90,7 +90,7 @@ object Narration:
       val opName = ctx.operationName.getOrElse(op.a)
       val lines  = List.newBuilder[String]
       lines += "Why this operation is unreachable:"
-      val req = combineConjuncts(op.d)
+      val req = combineAnd(op.d)
       lines += s"  1. Operation '$opName' has 'requires':"
       lines += s"       ${PrettyPrint.expr(req)}"
       lines += "  2. No pre-state satisfies both 'requires' and the invariants."
@@ -101,11 +101,6 @@ object Narration:
       else
         lines += "     (Run with --explain to see the contributing clauses.)"
       lines.result().mkString("\n")
-
-  private def combineConjuncts(es: List[expr_full]): expr_full = es match
-    case Nil      => BoolLitF(true, None)
-    case h :: Nil => h
-    case h :: t   => t.foldLeft(h)((acc, e) => BinaryOpF(BAnd(), acc, e, None))
 
   private def contributingField(e: expr_full, ir: ServiceIRFull): Option[String] =
     val fields      = scala.collection.mutable.LinkedHashSet.empty[String]

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -39,6 +39,13 @@ export_code
     eval
     smtEval
     isLitFull
+    isTrueLit
+    enumLiteralOf
+    combineAnd
+    decomposeAtom
+    free_vars
+    hasPrePrime
+    subst
     emptyServiceIrFull
     lower
     lowerSetList

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -1345,14 +1345,19 @@ fun enumLiteralOf :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> 
 | "enumLiteralOf _                   _  = None"
 
 text \<open>Phase 9\<alpha> (\<open>combineAnd\<close>): folds an \<open>expr_full list\<close> into a single
-  AND-chain, with \<open>BoolLitF True None\<close> as the unit. Inverse of
-  \<open>flattenAndAll\<close> modulo \<open>true\<close> identity. Replaces
-  \<open>verify.Narration.combineConjuncts\<close>.\<close>
+  left-associated AND-chain, with \<open>BoolLitF True None\<close> as the unit.
+  Inverse of \<open>flattenAndAll\<close> modulo \<open>true\<close> identity. Replaces
+  \<open>verify.Narration.combineConjuncts\<close> (which used \<open>foldLeft\<close> —
+  left-associativity preserves byte-identical pretty-printed output). Uses
+  a monomorphic accumulator to make the extracted Scala tail-recursive.\<close>
+
+fun combineAnd_acc :: "expr_full \<Rightarrow> expr_full list \<Rightarrow> expr_full" where
+  "combineAnd_acc acc []         = acc"
+| "combineAnd_acc acc (x # rest) = combineAnd_acc (BinaryOpF BAnd acc x None) rest"
 
 fun combineAnd :: "expr_full list \<Rightarrow> expr_full" where
-  "combineAnd []             = BoolLitF True None"
-| "combineAnd [x]            = x"
-| "combineAnd (x # y # rest) = BinaryOpF BAnd x (combineAnd (y # rest)) None"
+  "combineAnd []          = BoolLitF True None"
+| "combineAnd (x # rest)  = combineAnd_acc x rest"
 
 text \<open>Phase 9\<beta> (\<open>decomposeAtom\<close>): canonical recognizer for a single
   atomic refinement constraint over \<open>value\<close>. Three consumers re-implement
@@ -1381,13 +1386,13 @@ fun isLenOfValue :: "expr_full \<Rightarrow> bool" where
 fun decomposeAtom :: "expr_full \<Rightarrow> refinement_atom" where
   "decomposeAtom (MatchesF (IdentifierF n _) pat _) =
      (if n = STR ''value'' then RaMatches pat else RaMatchesIdent n pat)"
-| "decomposeAtom (BinaryOpF op l (IntLitF n _) sp) =
+| "decomposeAtom (BinaryOpF op l (IntLitF n innersp) sp) =
      (if isLenOfValue l then RaLenCmp op n
       else if isValueRef l then RaValueCmp op n
-      else RaUnknown (BinaryOpF op l (IntLitF n None) sp))"
-| "decomposeAtom (CallF (IdentifierF p _) [arg] _) =
+      else RaUnknown (BinaryOpF op l (IntLitF n innersp) sp))"
+| "decomposeAtom (CallF (IdentifierF p identsp) [arg] sp) =
      (if isValueRef arg then RaPredCall p
-      else RaUnknown (CallF (IdentifierF p None) [arg] None))"
+      else RaUnknown (CallF (IdentifierF p identsp) [arg] sp))"
 | "decomposeAtom other = RaUnknown other"
 
 text \<open>Phase 9\<gamma> (free-var helpers): monomorphic \<open>qb_names\<close>,

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -1328,6 +1328,241 @@ primrec string_in_list :: "String.literal \<Rightarrow> String.literal list \<Ri
   "string_in_list y [] = False"
 | "string_in_list y (x # xs) = (x = y \<or> string_in_list y xs)"
 
+text \<open>Phase 9\<alpha> (small recognizers): \<open>isTrueLit\<close> matches the literal
+  \<open>true\<close>; \<open>enumLiteralOf\<close> recognises an enum-member reference (via
+  \<open>EnumAccessF\<close> or a bare \<open>IdentifierF\<close>). Replaces four \<open>case BoolLitF
+  True _ \<Rightarrow> True\<close> copies in lint / testgen passes and three near-identical
+  \<open>enumLiteralFor\<close> walkers in \<open>testgen.Behavioral\<close> /
+  \<open>testgen.Stateful\<close>.\<close>
+
+fun isTrueLit :: "expr_full \<Rightarrow> bool" where
+  "isTrueLit (BoolLitF True _) = True"
+| "isTrueLit _                 = False"
+
+fun enumLiteralOf :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal option" where
+  "enumLiteralOf (EnumAccessF _ m _) ms = (if string_in_list m ms then Some m else None)"
+| "enumLiteralOf (IdentifierF n _)   ms = (if string_in_list n ms then Some n else None)"
+| "enumLiteralOf _                   _  = None"
+
+text \<open>Phase 9\<alpha> (\<open>combineAnd\<close>): folds an \<open>expr_full list\<close> into a single
+  AND-chain, with \<open>BoolLitF True None\<close> as the unit. Inverse of
+  \<open>flattenAndAll\<close> modulo \<open>true\<close> identity. Replaces
+  \<open>verify.Narration.combineConjuncts\<close>.\<close>
+
+fun combineAnd :: "expr_full list \<Rightarrow> expr_full" where
+  "combineAnd []             = BoolLitF True None"
+| "combineAnd [x]            = x"
+| "combineAnd (x # y # rest) = BinaryOpF BAnd x (combineAnd (y # rest)) None"
+
+text \<open>Phase 9\<beta> (\<open>decomposeAtom\<close>): canonical recognizer for a single
+  atomic refinement constraint over \<open>value\<close>. Three consumers re-implement
+  the recognizer (OpenAPI JSON-Schema, SQL CHECK, Hypothesis strategy
+  synthesis) — this lifts the analysis half so each consumer becomes a
+  pure renderer over \<open>refinement_atom\<close>. Compose with the existing
+  \<open>flattenAnd\<close> to traverse \<open>BAnd\<close>-chains.\<close>
+
+datatype (plugins only: code size) refinement_atom =
+    RaLenCmp bin_op_full int
+  | RaValueCmp bin_op_full int
+  | RaMatches "String.literal"
+  | RaMatchesIdent "String.literal" "String.literal"
+  | RaPredCall "String.literal"
+  | RaUnknown expr_full
+
+fun isValueRef :: "expr_full \<Rightarrow> bool" where
+  "isValueRef (IdentifierF n _) = (n = STR ''value'')"
+| "isValueRef _                  = False"
+
+fun isLenOfValue :: "expr_full \<Rightarrow> bool" where
+  "isLenOfValue (CallF (IdentifierF n _) [arg] _) =
+     (n = STR ''len'' \<and> isValueRef arg)"
+| "isLenOfValue _ = False"
+
+fun decomposeAtom :: "expr_full \<Rightarrow> refinement_atom" where
+  "decomposeAtom (MatchesF (IdentifierF n _) pat _) =
+     (if n = STR ''value'' then RaMatches pat else RaMatchesIdent n pat)"
+| "decomposeAtom (BinaryOpF op l (IntLitF n _) sp) =
+     (if isLenOfValue l then RaLenCmp op n
+      else if isValueRef l then RaValueCmp op n
+      else RaUnknown (BinaryOpF op l (IntLitF n None) sp))"
+| "decomposeAtom (CallF (IdentifierF p _) [arg] _) =
+     (if isValueRef arg then RaPredCall p
+      else RaUnknown (CallF (IdentifierF p None) [arg] None))"
+| "decomposeAtom other = RaUnknown other"
+
+text \<open>Phase 9\<gamma> (free-var helpers): monomorphic \<open>qb_names\<close>,
+  \<open>remove_name\<close>, \<open>remove_names\<close> avoid the polymorphic \<open>map\<close>/\<open>filter\<close>
+  HOFs that blow up Isabelle build wall-time when used inside large mutual
+  \<open>fun\<close> declarations.\<close>
+
+fun qb_names :: "quantifier_binding_full list \<Rightarrow> String.literal list" where
+  "qb_names [] = []"
+| "qb_names (QuantifierBindingFull n _ _ _ # bs) = n # qb_names bs"
+
+fun remove_name :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
+  "remove_name _ [] = []"
+| "remove_name n (x # xs) =
+     (if x = n then remove_name n xs else x # remove_name n xs)"
+
+fun remove_names :: "String.literal list \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
+  "remove_names []       xs = xs"
+| "remove_names (n # ns) xs = remove_name n (remove_names ns xs)"
+
+text \<open>Phase 9\<gamma> (\<open>free_vars\<close>): collects the names of all free identifiers
+  in an \<open>expr_full\<close>, respecting binders (\<open>LetF\<close>, \<open>LambdaF\<close>,
+  \<open>SetComprehensionF\<close>, \<open>TheF\<close>, \<open>QuantifierF\<close>). Replaces the 60-line
+  hand-rolled walker \<open>testgen.Behavioral.containsStateRefIn\<close>.\<close>
+
+fun free_vars :: "expr_full \<Rightarrow> String.literal list"
+and free_vars_list :: "expr_full list \<Rightarrow> String.literal list"
+and free_vars_fields :: "field_assign_full list \<Rightarrow> String.literal list"
+and free_vars_entries :: "map_entry_full list \<Rightarrow> String.literal list"
+and free_vars_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list"
+where
+  "free_vars (IdentifierF n _)           = [n]"
+| "free_vars (BinaryOpF _ l r _)         = free_vars l @ free_vars r"
+| "free_vars (UnaryOpF _ e _)            = free_vars e"
+| "free_vars (FieldAccessF b _ _)        = free_vars b"
+| "free_vars (EnumAccessF b _ _)         = free_vars b"
+| "free_vars (IndexF b i _)              = free_vars b @ free_vars i"
+| "free_vars (CallF c args _)            = free_vars c @ free_vars_list args"
+| "free_vars (PrimeF e _)                = free_vars e"
+| "free_vars (PreF e _)                  = free_vars e"
+| "free_vars (WithF b upds _)            = free_vars b @ free_vars_fields upds"
+| "free_vars (IfF c t e _)               = free_vars c @ free_vars t @ free_vars e"
+| "free_vars (LetF v val body _)         = free_vars val @ remove_name v (free_vars body)"
+| "free_vars (LambdaF p b _)             = remove_name p (free_vars b)"
+| "free_vars (ConstructorF _ fs _)       = free_vars_fields fs"
+| "free_vars (SetLiteralF xs _)          = free_vars_list xs"
+| "free_vars (MapLiteralF es _)          = free_vars_entries es"
+| "free_vars (SetComprehensionF v d p _) = free_vars d @ remove_name v (free_vars p)"
+| "free_vars (SeqLiteralF xs _)          = free_vars_list xs"
+| "free_vars (MatchesF x _ _)            = free_vars x"
+| "free_vars (SomeWrapF x _)             = free_vars x"
+| "free_vars (TheF v d b _)              = free_vars d @ remove_name v (free_vars b)"
+| "free_vars (QuantifierF _ bs body _)   =
+     free_vars_bindings bs @ remove_names (qb_names bs) (free_vars body)"
+| "free_vars (IntLitF _ _)               = []"
+| "free_vars (FloatLitF _ _)             = []"
+| "free_vars (StringLitF _ _)            = []"
+| "free_vars (BoolLitF _ _)              = []"
+| "free_vars (NoneLitF _)                = []"
+| "free_vars_list []                                            = []"
+| "free_vars_list (x # xs)                                      = free_vars x @ free_vars_list xs"
+| "free_vars_fields []                                          = []"
+| "free_vars_fields (FieldAssignFull _ v _ # fs)                = free_vars v @ free_vars_fields fs"
+| "free_vars_entries []                                         = []"
+| "free_vars_entries (MapEntryFull k v _ # es)                  = free_vars k @ free_vars v @ free_vars_entries es"
+| "free_vars_bindings []                                        = []"
+| "free_vars_bindings (QuantifierBindingFull _ d _ _ # bs)      = free_vars d @ free_vars_bindings bs"
+
+text \<open>Phase 9\<gamma> (\<open>hasPrePrime\<close>): true iff the expression contains a
+  \<open>PrimeF\<close> or \<open>PreF\<close> constructor anywhere. Used together with \<open>free_vars\<close>
+  to express the \<open>testgen.Behavioral.containsStateRef\<close> predicate as a
+  one-liner.\<close>
+
+fun hasPrePrime :: "expr_full \<Rightarrow> bool"
+and hasPrePrime_list :: "expr_full list \<Rightarrow> bool"
+and hasPrePrime_fields :: "field_assign_full list \<Rightarrow> bool"
+and hasPrePrime_entries :: "map_entry_full list \<Rightarrow> bool"
+and hasPrePrime_bindings :: "quantifier_binding_full list \<Rightarrow> bool"
+where
+  "hasPrePrime (PrimeF _ _)                  = True"
+| "hasPrePrime (PreF _ _)                    = True"
+| "hasPrePrime (BinaryOpF _ l r _)           = (hasPrePrime l \<or> hasPrePrime r)"
+| "hasPrePrime (UnaryOpF _ e _)              = hasPrePrime e"
+| "hasPrePrime (FieldAccessF b _ _)          = hasPrePrime b"
+| "hasPrePrime (EnumAccessF b _ _)           = hasPrePrime b"
+| "hasPrePrime (IndexF b i _)                = (hasPrePrime b \<or> hasPrePrime i)"
+| "hasPrePrime (CallF c args _)              = (hasPrePrime c \<or> hasPrePrime_list args)"
+| "hasPrePrime (WithF b upds _)              = (hasPrePrime b \<or> hasPrePrime_fields upds)"
+| "hasPrePrime (IfF c t e _)                 = (hasPrePrime c \<or> hasPrePrime t \<or> hasPrePrime e)"
+| "hasPrePrime (LetF _ v b _)                = (hasPrePrime v \<or> hasPrePrime b)"
+| "hasPrePrime (LambdaF _ b _)               = hasPrePrime b"
+| "hasPrePrime (ConstructorF _ fs _)         = hasPrePrime_fields fs"
+| "hasPrePrime (SetLiteralF xs _)            = hasPrePrime_list xs"
+| "hasPrePrime (MapLiteralF es _)            = hasPrePrime_entries es"
+| "hasPrePrime (SetComprehensionF _ d p _)   = (hasPrePrime d \<or> hasPrePrime p)"
+| "hasPrePrime (SeqLiteralF xs _)            = hasPrePrime_list xs"
+| "hasPrePrime (MatchesF x _ _)              = hasPrePrime x"
+| "hasPrePrime (SomeWrapF x _)               = hasPrePrime x"
+| "hasPrePrime (TheF _ d b _)                = (hasPrePrime d \<or> hasPrePrime b)"
+| "hasPrePrime (QuantifierF _ bs body _)     = (hasPrePrime_bindings bs \<or> hasPrePrime body)"
+| "hasPrePrime (IntLitF _ _)                 = False"
+| "hasPrePrime (FloatLitF _ _)               = False"
+| "hasPrePrime (StringLitF _ _)              = False"
+| "hasPrePrime (BoolLitF _ _)                = False"
+| "hasPrePrime (NoneLitF _)                  = False"
+| "hasPrePrime (IdentifierF _ _)             = False"
+| "hasPrePrime_list []                                       = False"
+| "hasPrePrime_list (x # xs)                                 = (hasPrePrime x \<or> hasPrePrime_list xs)"
+| "hasPrePrime_fields []                                     = False"
+| "hasPrePrime_fields (FieldAssignFull _ v _ # fs)           = (hasPrePrime v \<or> hasPrePrime_fields fs)"
+| "hasPrePrime_entries []                                    = False"
+| "hasPrePrime_entries (MapEntryFull k v _ # es)             = (hasPrePrime k \<or> hasPrePrime v \<or> hasPrePrime_entries es)"
+| "hasPrePrime_bindings []                                   = False"
+| "hasPrePrime_bindings (QuantifierBindingFull _ d _ _ # bs) = (hasPrePrime d \<or> hasPrePrime_bindings bs)"
+
+text \<open>Phase 9\<gamma> (\<open>subst\<close>): structural substitution of a free identifier
+  by an expression. Stops at binders that shadow the substituted name —
+  does NOT perform \<open>\<alpha>\<close>-renaming, matching the semantics of
+  \<open>convention.dafny.Generator.rewriteValueRef\<close>. The caller is responsible
+  for ensuring the replacement expression's free variables cannot be
+  captured (typical use: replace \<open>value\<close> by
+  \<open>FieldAccessF (IdentifierF p None) STR ''value'' None\<close> where \<open>p\<close> is not
+  bound anywhere relevant).\<close>
+
+fun subst :: "String.literal \<Rightarrow> expr_full \<Rightarrow> expr_full \<Rightarrow> expr_full"
+and subst_list :: "String.literal \<Rightarrow> expr_full \<Rightarrow> expr_full list \<Rightarrow> expr_full list"
+and subst_fields :: "String.literal \<Rightarrow> expr_full \<Rightarrow> field_assign_full list \<Rightarrow> field_assign_full list"
+and subst_entries :: "String.literal \<Rightarrow> expr_full \<Rightarrow> map_entry_full list \<Rightarrow> map_entry_full list"
+and subst_bindings :: "String.literal \<Rightarrow> expr_full \<Rightarrow> quantifier_binding_full list \<Rightarrow> quantifier_binding_full list"
+where
+  "subst x r (IdentifierF n sp)              = (if n = x then r else IdentifierF n sp)"
+| "subst x r (BinaryOpF op l rr sp)          = BinaryOpF op (subst x r l) (subst x r rr) sp"
+| "subst x r (UnaryOpF op e sp)              = UnaryOpF op (subst x r e) sp"
+| "subst x r (FieldAccessF b f sp)           = FieldAccessF (subst x r b) f sp"
+| "subst x r (EnumAccessF b m sp)            = EnumAccessF (subst x r b) m sp"
+| "subst x r (IndexF b i sp)                 = IndexF (subst x r b) (subst x r i) sp"
+| "subst x r (CallF c args sp)               = CallF (subst x r c) (subst_list x r args) sp"
+| "subst x r (PrimeF e sp)                   = PrimeF (subst x r e) sp"
+| "subst x r (PreF e sp)                     = PreF (subst x r e) sp"
+| "subst x r (WithF b upds sp)               = WithF (subst x r b) (subst_fields x r upds) sp"
+| "subst x r (IfF c t e sp)                  = IfF (subst x r c) (subst x r t) (subst x r e) sp"
+| "subst x r (LetF v val body sp)            =
+     LetF v (subst x r val) (if v = x then body else subst x r body) sp"
+| "subst x r (LambdaF p b sp)                =
+     LambdaF p (if p = x then b else subst x r b) sp"
+| "subst x r (ConstructorF n fs sp)          = ConstructorF n (subst_fields x r fs) sp"
+| "subst x r (SetLiteralF xs sp)             = SetLiteralF (subst_list x r xs) sp"
+| "subst x r (MapLiteralF es sp)             = MapLiteralF (subst_entries x r es) sp"
+| "subst x r (SetComprehensionF v d p sp)    =
+     SetComprehensionF v (subst x r d) (if v = x then p else subst x r p) sp"
+| "subst x r (SeqLiteralF xs sp)             = SeqLiteralF (subst_list x r xs) sp"
+| "subst x r (MatchesF e pat sp)             = MatchesF (subst x r e) pat sp"
+| "subst x r (SomeWrapF e sp)                = SomeWrapF (subst x r e) sp"
+| "subst x r (TheF v d b sp)                 =
+     TheF v (subst x r d) (if v = x then b else subst x r b) sp"
+| "subst x r (QuantifierF q bs body sp)      =
+     QuantifierF q (subst_bindings x r bs)
+                   (if string_in_list x (qb_names bs) then body else subst x r body) sp"
+| "subst _ _ (IntLitF n sp)                  = IntLitF n sp"
+| "subst _ _ (FloatLitF n sp)                = FloatLitF n sp"
+| "subst _ _ (StringLitF n sp)               = StringLitF n sp"
+| "subst _ _ (BoolLitF v sp)                 = BoolLitF v sp"
+| "subst _ _ (NoneLitF sp)                   = NoneLitF sp"
+| "subst_list _ _ []                                   = []"
+| "subst_list x r (e # es)                             = subst x r e # subst_list x r es"
+| "subst_fields _ _ []                                 = []"
+| "subst_fields x r (FieldAssignFull f v sp # fs)      =
+     FieldAssignFull f (subst x r v) sp # subst_fields x r fs"
+| "subst_entries _ _ []                                = []"
+| "subst_entries x r (MapEntryFull k v sp # es)        =
+     MapEntryFull (subst x r k) (subst x r v) sp # subst_entries x r es"
+| "subst_bindings _ _ []                               = []"
+| "subst_bindings x r (QuantifierBindingFull n d kk sp # bs) =
+     QuantifierBindingFull n (subst x r d) kk sp # subst_bindings x r bs"
+
 fun lower_forall_step ::
     "String.literal list \<Rightarrow> quantifier_binding_full
        \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr option"


### PR DESCRIPTION
## Summary

Lifts 8 hand-written Scala walkers over `expr_full` into Isabelle-extracted primitives. Each consumer that previously re-implemented the same traversal logic now calls the extracted function directly — no shim wrappers.

**Net change:** −279 lines of hand-written Scala, +985 lines split across IR.thy (+235), Codegen.thy (+7), and the regenerated `SpecRestGenerated.scala` (+618 net).

## What was lifted

**Phase 9α (small recognizers):**
- `isTrueLit` — replaces 4 copies of `case BoolLitF(true,_) => true` (`Behavioral`, `Stateful`, `OperationOverlap`, `TsBehavioral`/`GoBehavioral` import sites)
- `enumLiteralOf` — replaces `enumLiteralName` / `enumLiteralFor` (testgen, 3 sites)
- `combineAnd` — replaces `verify.Narration.combineConjuncts`

**Phase 9β (refinement decomposition):**
- `refinement_atom` datatype + `decomposeAtom` — unified atom recognizer for three downstream consumers (OpenAPI JSON-Schema, SQL CHECK, Hypothesis strategy synthesis). Each consumer becomes a pure renderer over atoms; `flattenAnd` (already extracted) is composed for AND-chain traversal.

**Phase 9γ (free-variable arithmetic + substitution):**
- `free_vars` / `free_vars_*` (mutual 5) — full structural traversal with binder tracking (`LetF`, `LambdaF`, `SetComprehensionF`, `TheF`, `QuantifierF`)
- `hasPrePrime` / `hasPrePrime_*` (mutual 5) — `PrimeF`/`PreF` anywhere check
- `subst` / `subst_*` (mutual 5) — non-α-renaming structural substitution. Matches the semantics of `dafny.Generator.rewriteValueRef`.

`containsStateRefIn` (53 lines) collapses to `hasPrePrime(e) || free_vars(e).exists(stateFields.contains)`. `rewriteValueRef` (54 lines) collapses to direct `subst(name, replacement, expr)` calls.

## Convention

Per the user-stated rule for this PR, callers reference the extracted names directly — no `def isTrivialTrue = SpecRestGenerated.isTrueLit` shim wrappers. Where the Isabelle name is the right name for the call site, the hand-written symbol is deleted; where domain logic remains (like `Behavioral.containsStateRef`), the body is a 1-line composition of the new primitives.

## Test plan

- [x] `isabelle build -d proofs/isabelle/SpecRest -b SpecRest` succeeds (also re-runs in pre-commit hook)
- [x] Generated Scala regenerated via the standard `isabelle export` pipeline (no hand edits)
- [x] `sbt compile` clean across all modules
- [x] `sbt scalafixAll` clean
- [x] All 5 affected modules pass: `verify` 170, `testgen` 274, `lint` 31, `codegen` 222, `convention` 66 — **763 tests, 0 failures**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted eight `expr_full` walkers into Isabelle-extracted primitives and switched all callers to use them. Also fixed OpenAPI regex emission and restored left-associative requires narration.

- **Refactors**
  - Added primitives in `SpecRestGenerated`/`Codegen.thy`: `isTrueLit`, `enumLiteralOf`, `combineAnd`, `decomposeAtom`, `free_vars`, `hasPrePrime`, `subst`.
  - OpenAPI JSON-Schema and SQL CHECK now use `flattenAnd(...)` + `decomposeAtom` (keep float-literal fallback where needed).
  - Testgen: replace `containsStateRefIn` with `hasPrePrime(e) || free_vars(e).exists(stateFields.contains)`, use `enumLiteralOf`, and switch true checks to `isTrueLit`.
  - Dafny generator: delete `rewriteValueRef`; use `subst("value", replacement, expr)`.
  - Verify narration: replace `combineConjuncts` with `combineAnd`.
  - Call the generated `SpecRestGenerated` functions directly; removed local shims and duplicate helpers.

- **Bug Fixes**
  - OpenAPI: preserve `pattern` by threading `c.pattern.orElse(base.pattern)`; golden YAMLs now include `pattern: ^[a-zA-Z0-9]+$` where specified.
  - `combineAnd`: tail-rec with a monomorphic accumulator and left-associative folding to match previous pretty-printing.
  - `decomposeAtom`: keep original spans in `RaUnknown` for `BinaryOpF`/`CallF` reconstruction.

<sup>Written for commit 4a847114594fbcc88a43cbf1835a7c92b11118ca. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated constraint extraction and expression handling across code generation and testing modules for improved consistency.
  * Simplified expression substitution in specification generation and predicate evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->