### PR TITLE
refactor: lift second wave of pattern matches to Isabelle (Phase 9δ)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ ThisBuild / coverageFailOnMinimum      := true
 ThisBuild / coverageHighlighting       := true
 ThisBuild / coverageExcludedPackages := List(
   "specrest\\.parser\\.generated\\..*",
+  "specrest\\.ir\\.generated\\..*",
   ".*\\.bench\\..*"
 ).mkString(";")
 

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -470,14 +470,7 @@ object Generator:
     go(expr)
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
-    val out = mutable.Set.empty[String]
-    def walk(e: expr_full, primed: Boolean): Unit = e match
-      case PrimeF(inner, _)  => walk(inner, primed = true)
-      case PreF(inner, _)    => walk(inner, primed = false)
-      case IdentifierF(n, _) => if primed then out += n
-      case _                 => SpecRestGenerated.subexprs(e).foreach(walk(_, primed))
-    ensures.foreach(walk(_, primed = false))
-    out.toSet
+    collectPrimedIdentifiers(ensures).toSet
 
   private def renderExterns(ctx: Ctx): String =
     val sb = new StringBuilder

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -331,6 +331,13 @@ object SpecRestGenerated {
   final case class NoneLitF(a: Option[span_t])                          extends expr_full
   final case class IdentifierF(a: String, b: Option[span_t])            extends expr_full
 
+  sealed abstract class lit_class
+  final case class LcNumeric()    extends lit_class
+  final case class LcBool()       extends lit_class
+  final case class LcStringLike() extends lit_class
+  final case class LcCollection() extends lit_class
+  final case class LcNone()       extends lit_class
+
   sealed abstract class type_expr
   final case class BoolT()                               extends type_expr
   final case class IntT()                                extends type_expr
@@ -1504,6 +1511,29 @@ object SpecRestGenerated {
   def rev[A](xs: List[A]): List[A] =
     fold[A, List[A]]((a: A) => (b: List[A]) => a :: b, xs, Nil)
 
+  def isComp(x0: bin_op_full): Boolean = x0 match {
+    case BGe()        => true
+    case BGt()        => true
+    case BLe()        => true
+    case BLt()        => true
+    case BAnd()       => false
+    case BOr()        => false
+    case BImplies()   => false
+    case BIff()       => false
+    case BEq()        => false
+    case BNeq()       => false
+    case BIn()        => false
+    case BNotIn()     => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+    case BAdd()       => false
+    case BSub()       => false
+    case BMul()       => false
+    case BDiv()       => false
+  }
+
   def spanOf(x0: expr_full): Option[span_t] = x0 match {
     case BinaryOpF(uu, uv, uw, sp)         => sp
     case UnaryOpF(ux, uy, sp)              => sp
@@ -1551,6 +1581,146 @@ object SpecRestGenerated {
   def nulla[A](x0: List[A]): Boolean = x0 match {
     case Nil     => true
     case x :: xs => false
+  }
+
+  def mirrorBinOp(x0: bin_op_full): bin_op_full = x0 match {
+    case BGe()        => BLe()
+    case BLe()        => BGe()
+    case BGt()        => BLt()
+    case BLt()        => BGt()
+    case BAnd()       => BAnd()
+    case BOr()        => BOr()
+    case BImplies()   => BImplies()
+    case BIff()       => BIff()
+    case BEq()        => BEq()
+    case BNeq()       => BNeq()
+    case BIn()        => BIn()
+    case BNotIn()     => BNotIn()
+    case BSubset()    => BSubset()
+    case BUnion()     => BUnion()
+    case BIntersect() => BIntersect()
+    case BDiff()      => BDiff()
+    case BAdd()       => BAdd()
+    case BSub()       => BSub()
+    case BMul()       => BMul()
+    case BDiv()       => BDiv()
+  }
+
+  def rangeOf(x0: expr_full): Option[(String, (bin_op_full, int))] = x0 match {
+    case BinaryOpF(op, IdentifierF(n, uu), IntLitF(v, uv), uw) =>
+      isComp(op) match {
+        case true  => Some[(String, (bin_op_full, int))]((n, (op, v)))
+        case false => None
+      }
+    case BinaryOpF(op, IntLitF(v, ux), IdentifierF(n, uy), uz) =>
+      isComp(op) match {
+        case true  => Some[(String, (bin_op_full, int))]((n, (mirrorBinOp(op), v)))
+        case false => None
+      }
+    case BinaryOpF(v, BinaryOpF(ve, vf, vg, vh), vc, vd)                => None
+    case BinaryOpF(v, UnaryOpF(ve, vf, vg), vc, vd)                     => None
+    case BinaryOpF(v, QuantifierF(ve, vf, vg, vh), vc, vd)              => None
+    case BinaryOpF(v, SomeWrapF(ve, vf), vc, vd)                        => None
+    case BinaryOpF(v, TheF(ve, vf, vg, vh), vc, vd)                     => None
+    case BinaryOpF(v, FieldAccessF(ve, vf, vg), vc, vd)                 => None
+    case BinaryOpF(v, EnumAccessF(ve, vf, vg), vc, vd)                  => None
+    case BinaryOpF(v, IndexF(ve, vf, vg), vc, vd)                       => None
+    case BinaryOpF(v, CallF(ve, vf, vg), vc, vd)                        => None
+    case BinaryOpF(v, PrimeF(ve, vf), vc, vd)                           => None
+    case BinaryOpF(v, PreF(ve, vf), vc, vd)                             => None
+    case BinaryOpF(v, WithF(ve, vf, vg), vc, vd)                        => None
+    case BinaryOpF(v, IfF(ve, vf, vg, vh), vc, vd)                      => None
+    case BinaryOpF(v, LetF(ve, vf, vg, vh), vc, vd)                     => None
+    case BinaryOpF(v, LambdaF(ve, vf, vg), vc, vd)                      => None
+    case BinaryOpF(v, ConstructorF(ve, vf, vg), vc, vd)                 => None
+    case BinaryOpF(v, SetLiteralF(ve, vf), vc, vd)                      => None
+    case BinaryOpF(v, MapLiteralF(ve, vf), vc, vd)                      => None
+    case BinaryOpF(v, SetComprehensionF(ve, vf, vg, vh), vc, vd)        => None
+    case BinaryOpF(v, SeqLiteralF(ve, vf), vc, vd)                      => None
+    case BinaryOpF(v, MatchesF(ve, vf, vg), vc, vd)                     => None
+    case BinaryOpF(v, IntLitF(ve, vf), BinaryOpF(va, vb, vg, vh), vd)   => None
+    case BinaryOpF(v, IntLitF(ve, vf), UnaryOpF(va, vb, vg), vd)        => None
+    case BinaryOpF(v, IntLitF(ve, vf), QuantifierF(va, vb, vg, vh), vd) => None
+    case BinaryOpF(v, IntLitF(ve, vf), SomeWrapF(va, vb), vd)           => None
+    case BinaryOpF(v, IntLitF(ve, vf), TheF(va, vb, vg, vh), vd)        => None
+    case BinaryOpF(v, IntLitF(ve, vf), FieldAccessF(va, vb, vg), vd)    => None
+    case BinaryOpF(v, IntLitF(ve, vf), EnumAccessF(va, vb, vg), vd)     => None
+    case BinaryOpF(v, IntLitF(ve, vf), IndexF(va, vb, vg), vd)          => None
+    case BinaryOpF(v, IntLitF(ve, vf), CallF(va, vb, vg), vd)           => None
+    case BinaryOpF(v, IntLitF(ve, vf), PrimeF(va, vb), vd)              => None
+    case BinaryOpF(v, IntLitF(ve, vf), PreF(va, vb), vd)                => None
+    case BinaryOpF(v, IntLitF(ve, vf), WithF(va, vb, vg), vd)           => None
+    case BinaryOpF(v, IntLitF(ve, vf), IfF(va, vb, vg, vh), vd)         => None
+    case BinaryOpF(v, IntLitF(ve, vf), LetF(va, vb, vg, vh), vd)        => None
+    case BinaryOpF(v, IntLitF(ve, vf), LambdaF(va, vb, vg), vd)         => None
+    case BinaryOpF(v, IntLitF(ve, vf), ConstructorF(va, vb, vg), vd)    => None
+    case BinaryOpF(v, IntLitF(ve, vf), SetLiteralF(va, vb), vd)         => None
+    case BinaryOpF(v, IntLitF(ve, vf), MapLiteralF(va, vb), vd)         => None
+    case BinaryOpF(v, IntLitF(ve, vf), SetComprehensionF(va, vb, vg, vh), vd) =>
+      None
+    case BinaryOpF(v, IntLitF(ve, vf), SeqLiteralF(va, vb), vd)     => None
+    case BinaryOpF(v, IntLitF(ve, vf), MatchesF(va, vb, vg), vd)    => None
+    case BinaryOpF(v, IntLitF(ve, vf), IntLitF(va, vb), vd)         => None
+    case BinaryOpF(v, IntLitF(ve, vf), FloatLitF(va, vb), vd)       => None
+    case BinaryOpF(v, IntLitF(ve, vf), StringLitF(va, vb), vd)      => None
+    case BinaryOpF(v, IntLitF(ve, vf), BoolLitF(va, vb), vd)        => None
+    case BinaryOpF(v, IntLitF(ve, vf), NoneLitF(va), vd)            => None
+    case BinaryOpF(v, FloatLitF(ve, vf), vc, vd)                    => None
+    case BinaryOpF(v, StringLitF(ve, vf), vc, vd)                   => None
+    case BinaryOpF(v, BoolLitF(ve, vf), vc, vd)                     => None
+    case BinaryOpF(v, NoneLitF(ve), vc, vd)                         => None
+    case BinaryOpF(v, vb, BinaryOpF(ve, vf, vg, vh), vd)            => None
+    case BinaryOpF(v, vb, UnaryOpF(ve, vf, vg), vd)                 => None
+    case BinaryOpF(v, vb, QuantifierF(ve, vf, vg, vh), vd)          => None
+    case BinaryOpF(v, vb, SomeWrapF(ve, vf), vd)                    => None
+    case BinaryOpF(v, vb, TheF(ve, vf, vg, vh), vd)                 => None
+    case BinaryOpF(v, vb, FieldAccessF(ve, vf, vg), vd)             => None
+    case BinaryOpF(v, vb, EnumAccessF(ve, vf, vg), vd)              => None
+    case BinaryOpF(v, vb, IndexF(ve, vf, vg), vd)                   => None
+    case BinaryOpF(v, vb, CallF(ve, vf, vg), vd)                    => None
+    case BinaryOpF(v, vb, PrimeF(ve, vf), vd)                       => None
+    case BinaryOpF(v, vb, PreF(ve, vf), vd)                         => None
+    case BinaryOpF(v, vb, WithF(ve, vf, vg), vd)                    => None
+    case BinaryOpF(v, vb, IfF(ve, vf, vg, vh), vd)                  => None
+    case BinaryOpF(v, vb, LetF(ve, vf, vg, vh), vd)                 => None
+    case BinaryOpF(v, vb, LambdaF(ve, vf, vg), vd)                  => None
+    case BinaryOpF(v, vb, ConstructorF(ve, vf, vg), vd)             => None
+    case BinaryOpF(v, vb, SetLiteralF(ve, vf), vd)                  => None
+    case BinaryOpF(v, vb, MapLiteralF(ve, vf), vd)                  => None
+    case BinaryOpF(v, vb, SetComprehensionF(ve, vf, vg, vh), vd)    => None
+    case BinaryOpF(v, vb, SeqLiteralF(ve, vf), vd)                  => None
+    case BinaryOpF(v, vb, MatchesF(ve, vf, vg), vd)                 => None
+    case BinaryOpF(v, vb, FloatLitF(ve, vf), vd)                    => None
+    case BinaryOpF(v, vb, StringLitF(ve, vf), vd)                   => None
+    case BinaryOpF(v, vb, BoolLitF(ve, vf), vd)                     => None
+    case BinaryOpF(v, vb, NoneLitF(ve), vd)                         => None
+    case BinaryOpF(v, IdentifierF(va, vc), IdentifierF(ve, vf), vd) => None
+    case UnaryOpF(v, vb, vc)                                        => None
+    case QuantifierF(v, vb, vc, vd)                                 => None
+    case SomeWrapF(v, vb)                                           => None
+    case TheF(v, vb, vc, vd)                                        => None
+    case FieldAccessF(v, vb, vc)                                    => None
+    case EnumAccessF(v, vb, vc)                                     => None
+    case IndexF(v, vb, vc)                                          => None
+    case CallF(v, vb, vc)                                           => None
+    case PrimeF(v, vb)                                              => None
+    case PreF(v, vb)                                                => None
+    case WithF(v, vb, vc)                                           => None
+    case IfF(v, vb, vc, vd)                                         => None
+    case LetF(v, vb, vc, vd)                                        => None
+    case LambdaF(v, vb, vc)                                         => None
+    case ConstructorF(v, vb, vc)                                    => None
+    case SetLiteralF(v, vb)                                         => None
+    case MapLiteralF(v, vb)                                         => None
+    case SetComprehensionF(v, vb, vc, vd)                           => None
+    case SeqLiteralF(v, vb)                                         => None
+    case MatchesF(v, vb, vc)                                        => None
+    case IntLitF(v, vb)                                             => None
+    case FloatLitF(v, vb)                                           => None
+    case StringLitF(v, vb)                                          => None
+    case BoolLitF(v, vb)                                            => None
+    case NoneLitF(v)                                                => None
+    case IdentifierF(v, vb)                                         => None
   }
 
   def foldl[A, B](f: A => B => A, a: A, x2: List[B]): A = (f, a, x2) match {
@@ -1631,6 +1801,36 @@ object SpecRestGenerated {
             }
         }
     }
+
+  def litClass(x0: expr_full): Option[lit_class] = x0 match {
+    case IntLitF(uu, uv)                  => Some[lit_class](LcNumeric())
+    case FloatLitF(uw, ux)                => Some[lit_class](LcNumeric())
+    case BoolLitF(uy, uz)                 => Some[lit_class](LcBool())
+    case StringLitF(va, vb)               => Some[lit_class](LcStringLike())
+    case SetLiteralF(vc, vd)              => Some[lit_class](LcCollection())
+    case MapLiteralF(ve, vf)              => Some[lit_class](LcCollection())
+    case SeqLiteralF(vg, vh)              => Some[lit_class](LcCollection())
+    case NoneLitF(vi)                     => Some[lit_class](LcNone())
+    case BinaryOpF(v, va, vb, vc)         => None
+    case UnaryOpF(v, va, vb)              => None
+    case QuantifierF(v, va, vb, vc)       => None
+    case SomeWrapF(v, va)                 => None
+    case TheF(v, va, vb, vc)              => None
+    case FieldAccessF(v, va, vb)          => None
+    case EnumAccessF(v, va, vb)           => None
+    case IndexF(v, va, vb)                => None
+    case CallF(v, va, vb)                 => None
+    case PrimeF(v, va)                    => None
+    case PreF(v, va)                      => None
+    case WithF(v, va, vb)                 => None
+    case IfF(v, va, vb, vc)               => None
+    case LetF(v, va, vb, vc)              => None
+    case LambdaF(v, va, vb)               => None
+    case ConstructorF(v, va, vb)          => None
+    case SetComprehensionF(v, va, vb, vc) => None
+    case MatchesF(v, va, vb)              => None
+    case IdentifierF(v, va)               => None
+  }
 
   def subexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] = x0 match {
     case Nil                                        => Nil
@@ -2391,6 +2591,29 @@ object SpecRestGenerated {
         }
     }
 
+  def binOpName(x0: bin_op_full): String = x0 match {
+    case BAdd()       => "+"
+    case BSub()       => "-"
+    case BMul()       => "*"
+    case BDiv()       => "/"
+    case BLt()        => "<"
+    case BGt()        => ">"
+    case BLe()        => "<="
+    case BGe()        => ">="
+    case BAnd()       => "and"
+    case BOr()        => "or"
+    case BImplies()   => "implies"
+    case BIff()       => "iff"
+    case BIn()        => "in"
+    case BNotIn()     => "not in"
+    case BEq()        => "="
+    case BNeq()       => "!="
+    case BSubset()    => "subset"
+    case BUnion()     => "++"
+    case BIntersect() => "&"
+    case BDiff()      => "--"
+  }
+
   def binOpToTs(x0: bin_op_full): String = x0 match {
     case BAnd()       => "and"
     case BOr()        => "or"
@@ -2412,6 +2635,74 @@ object SpecRestGenerated {
     case BSub()       => "-"
     case BMul()       => "*"
     case BDiv()       => "/"
+  }
+
+  def less_eq_int(k: int, l: int): Boolean =
+    integer_of_int(k) <= integer_of_int(l)
+
+  def isStrictBound(x0: bin_op_full): Boolean = x0 match {
+    case BGt()        => true
+    case BLt()        => true
+    case BAnd()       => false
+    case BOr()        => false
+    case BImplies()   => false
+    case BIff()       => false
+    case BEq()        => false
+    case BNeq()       => false
+    case BLe()        => false
+    case BGe()        => false
+    case BIn()        => false
+    case BNotIn()     => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+    case BAdd()       => false
+    case BSub()       => false
+    case BMul()       => false
+    case BDiv()       => false
+  }
+
+  def isLowBound(x0: bin_op_full): Boolean = x0 match {
+    case BGe()        => true
+    case BGt()        => true
+    case BAnd()       => false
+    case BOr()        => false
+    case BImplies()   => false
+    case BIff()       => false
+    case BEq()        => false
+    case BNeq()       => false
+    case BLt()        => false
+    case BLe()        => false
+    case BIn()        => false
+    case BNotIn()     => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+    case BAdd()       => false
+    case BSub()       => false
+    case BMul()       => false
+    case BDiv()       => false
+  }
+
+  def conflicts(aOp: bin_op_full, aB: int, bOp: bin_op_full, bB: int): Boolean = {
+    val aLow   = isLowBound(aOp): Boolean
+    val bLow   = isLowBound(bOp): Boolean
+    val strict = isStrictBound(aOp) || isStrictBound(bOp): Boolean;
+    aLow && !bLow match {
+      case true => strict match {
+          case true  => less_eq_int(bB, aB)
+          case false => less_int(bB, aB)
+        }
+      case false => !aLow && bLow match {
+          case true => strict match {
+              case true  => less_eq_int(aB, bB)
+              case false => less_int(aB, bB)
+            }
+          case false => false
+        }
+    }
   }
 
   def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
@@ -3009,9 +3300,6 @@ object SpecRestGenerated {
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
     map_of[String, ir_value](env, name)
-
-  def less_eq_int(k: int, l: int): Boolean =
-    integer_of_int(k) <= integer_of_int(l)
 
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
     (uu, uv, uw) match {
@@ -4455,6 +4743,14 @@ object SpecRestGenerated {
       case (uy, IdentifierF(v, va))                                                  => Nil
     }
 
+  def describeLitClass(x0: lit_class): String = x0 match {
+    case LcNumeric()    => "numeric"
+    case LcBool()       => "boolean"
+    case LcStringLike() => "string"
+    case LcCollection() => "collection"
+    case LcNone()       => "none"
+  }
+
   def entityFieldNames(es: List[entity_decl_full], ename: String): List[String] =
     entityByName(es, ename) match {
       case None => Nil
@@ -4549,6 +4845,15 @@ object SpecRestGenerated {
   def findFieldDeclFull(fs: List[field_decl_full], nm: String): Option[field_decl_full] =
     find[field_decl_full]((fd: field_decl_full) => fieldNameFull(fd) == nm, fs)
 
+  def typeContainsNamed(n: String, x1: type_expr_full): Boolean = (n, x1) match {
+    case (n, NamedTypeF(m, uu))             => n == m
+    case (n, SetTypeF(inner, uv))           => typeContainsNamed(n, inner)
+    case (n, OptionTypeF(inner, uw))        => typeContainsNamed(n, inner)
+    case (ux, MapTypeF(v, va, vb))          => false
+    case (ux, SeqTypeF(v, va))              => false
+    case (ux, RelationTypeF(v, va, vb, vc)) => false
+  }
+
   def tyctxEmpty: tyctx_ext[Unit] =
     tyctx_exta[Unit](Nil, state_schema_exta[Unit](Nil, ()), Nil, Nil, Nil, ())
 
@@ -4626,6 +4931,67 @@ object SpecRestGenerated {
       case Nil    => None
       case x :: _ => Some[String](x)
     }
+
+  def exprContainsBoolLit_bindings(x0: List[quantifier_binding_full]): Boolean =
+    x0 match {
+      case Nil => false
+      case QuantifierBindingFull(wo, d, wp, wq) :: bs =>
+        exprContainsBoolLit(d) || exprContainsBoolLit_bindings(bs)
+    }
+
+  def exprContainsBoolLit_entries(x0: List[map_entry_full]): Boolean = x0 match {
+    case Nil => false
+    case MapEntryFull(k, v, wn) :: es =>
+      exprContainsBoolLit(k) ||
+      (exprContainsBoolLit(v) || exprContainsBoolLit_entries(es))
+  }
+
+  def exprContainsBoolLit_fields(x0: List[field_assign_full]): Boolean = x0 match {
+    case Nil => false
+    case FieldAssignFull(wl, v, wm) :: fs =>
+      exprContainsBoolLit(v) || exprContainsBoolLit_fields(fs)
+  }
+
+  def exprContainsBoolLit_list(x0: List[expr_full]): Boolean = x0 match {
+    case Nil     => false
+    case x :: xs => exprContainsBoolLit(x) || exprContainsBoolLit_list(xs)
+  }
+
+  def exprContainsBoolLit(x0: expr_full): Boolean = x0 match {
+    case BoolLitF(uu, uv) => true
+    case BinaryOpF(uw, l, r, ux) =>
+      exprContainsBoolLit(l) || exprContainsBoolLit(r)
+    case UnaryOpF(uy, e, uz)     => exprContainsBoolLit(e)
+    case FieldAccessF(b, va, vb) => exprContainsBoolLit(b)
+    case EnumAccessF(b, vc, vd)  => exprContainsBoolLit(b)
+    case IndexF(b, i, ve)        => exprContainsBoolLit(b) || exprContainsBoolLit(i)
+    case CallF(c, args, vf) =>
+      exprContainsBoolLit(c) || exprContainsBoolLit_list(args)
+    case PrimeF(e, vg) => exprContainsBoolLit(e)
+    case PreF(e, vh)   => exprContainsBoolLit(e)
+    case WithF(b, upds, vi) =>
+      exprContainsBoolLit(b) || exprContainsBoolLit_fields(upds)
+    case IfF(c, t, e, vj) =>
+      exprContainsBoolLit(c) || (exprContainsBoolLit(t) || exprContainsBoolLit(e))
+    case LetF(vk, v, b, vl)       => exprContainsBoolLit(v) || exprContainsBoolLit(b)
+    case LambdaF(vm, b, vn)       => exprContainsBoolLit(b)
+    case ConstructorF(vo, fs, vp) => exprContainsBoolLit_fields(fs)
+    case SetLiteralF(xs, vq)      => exprContainsBoolLit_list(xs)
+    case MapLiteralF(es, vr)      => exprContainsBoolLit_entries(es)
+    case SetComprehensionF(vs, d, p, vt) =>
+      exprContainsBoolLit(d) || exprContainsBoolLit(p)
+    case SeqLiteralF(xs, vu) => exprContainsBoolLit_list(xs)
+    case MatchesF(x, vv, vw) => exprContainsBoolLit(x)
+    case SomeWrapF(x, vx)    => exprContainsBoolLit(x)
+    case TheF(vy, d, b, vz)  => exprContainsBoolLit(d) || exprContainsBoolLit(b)
+    case QuantifierF(wa, bs, body, wb) =>
+      exprContainsBoolLit_bindings(bs) || exprContainsBoolLit(body)
+    case IntLitF(wc, wd)     => false
+    case FloatLitF(we, wf)   => false
+    case StringLitF(wg, wh)  => false
+    case NoneLitF(wi)        => false
+    case IdentifierF(wj, wk) => false
+  }
 
   def preservedRelationOf(stateFields: List[String], x1: expr_full): List[String] =
     (stateFields, x1) match {

--- a/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
+++ b/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
@@ -6,19 +6,6 @@ import specrest.ir.generated.SpecRestGenerated.*
 object TypeMismatch extends LintPass:
   val code = "L01"
 
-  private enum LitClass derives CanEqual:
-    case Numeric, Bool, StringLike, Collection, NoneLit
-
-  private def litClass(e: expr_full): Option[LitClass] = e match
-    case _: IntLitF    => Some(LitClass.Numeric)
-    case _: FloatLitF  => Some(LitClass.Numeric)
-    case _: BoolLitF   => Some(LitClass.Bool)
-    case _: StringLitF => Some(LitClass.StringLike)
-    case _: SetLiteralF | _: MapLiteralF | _: SeqLiteralF =>
-      Some(LitClass.Collection)
-    case _: NoneLitF => Some(LitClass.NoneLit)
-    case _           => None
-
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
     val out = List.newBuilder[LintDiagnostic]
     val visit: expr_full => Unit =
@@ -26,21 +13,21 @@ object TypeMismatch extends LintPass:
         checkBinary(op, left, right, span, out)
       case UnaryOpF(UNot(), operand, span) =>
         litClass(operand) match
-          case Some(c) if c != LitClass.Bool =>
+          case Some(c) if !isBool(c) =>
             out += LintDiagnostic(
               code,
               LintLevel.Error,
-              s"logical 'not' applied to a ${describe(c)} literal",
+              s"logical 'not' applied to a ${describeLitClass(c)} literal",
               span
             )
           case _ => ()
       case UnaryOpF(UNegate(), operand, span) =>
         litClass(operand) match
-          case Some(c) if c != LitClass.Numeric =>
+          case Some(c) if !isNumeric(c) =>
             out += LintDiagnostic(
               code,
               LintLevel.Error,
-              s"arithmetic '-' applied to a ${describe(c)} literal",
+              s"arithmetic '-' applied to a ${describeLitClass(c)} literal",
               span
             )
           case _ => ()
@@ -64,6 +51,22 @@ object TypeMismatch extends LintPass:
 
     out.result()
 
+  private def isBool(c: lit_class): Boolean = c match
+    case LcBool() => true
+    case _        => false
+
+  private def isNumeric(c: lit_class): Boolean = c match
+    case LcNumeric() => true
+    case _           => false
+
+  private def isBoolOrNone(c: lit_class): Boolean = c match
+    case LcBool() | LcNone() => true
+    case _                   => false
+
+  private def isNonCollection(c: lit_class): Boolean = c match
+    case LcNumeric() | LcBool() | LcStringLike() | LcNone() => true
+    case _                                                  => false
+
   private def checkBinary(
       op: bin_op_full,
       left: expr_full,
@@ -78,72 +81,42 @@ object TypeMismatch extends LintPass:
         // `+` and `-` are overloaded for set/map union and diff in this DSL,
         // and `+` for string concatenation. Only flag when a literal is clearly
         // never a number (Bool or None) — those cases admit no overload.
-        val bad = lc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit) ||
-          rc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit)
+        val bad = lc.exists(isBoolOrNone) || rc.exists(isBoolOrNone)
         if bad then
           out += LintDiagnostic(
             code,
             LintLevel.Error,
-            s"arithmetic '${binOpName(op)}' has a ${describe((lc ++ rc).find(c => c == LitClass.Bool || c == LitClass.NoneLit).get)} literal operand",
+            s"arithmetic '${binOpName(op)}' has a ${describeLitClass((lc ++ rc).find(isBoolOrNone).get)} literal operand",
             span
           )
       case BLt() | BGt() | BLe() | BGe() =>
         // Comparisons can apply to numbers, strings (lexicographic), or sets
         // (subset/superset). Only flag on Bool/None literals (never ordered).
-        val bad = lc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit) ||
-          rc.exists(c => c == LitClass.Bool || c == LitClass.NoneLit)
+        val bad = lc.exists(isBoolOrNone) || rc.exists(isBoolOrNone)
         if bad then
           out += LintDiagnostic(
             code,
             LintLevel.Error,
-            s"comparison '${binOpName(op)}' has a ${describe((lc ++ rc).find(c => c == LitClass.Bool || c == LitClass.NoneLit).get)} literal operand",
+            s"comparison '${binOpName(op)}' has a ${describeLitClass((lc ++ rc).find(isBoolOrNone).get)} literal operand",
             span
           )
       case BAnd() | BOr() | BImplies() | BIff() =>
-        val bad = lc.exists(_ != LitClass.Bool) || rc.exists(_ != LitClass.Bool)
+        val bad = lc.exists(!isBool(_)) || rc.exists(!isBool(_))
         if bad then
-          val offender = (lc ++ rc).find(_ != LitClass.Bool).get
+          val offender = (lc ++ rc).find(!isBool(_)).get
           out += LintDiagnostic(
             code,
             LintLevel.Error,
-            s"logical '${binOpName(op)}' applied to a ${describe(offender)} literal",
+            s"logical '${binOpName(op)}' applied to a ${describeLitClass(offender)} literal",
             span
           )
       case BIn() | BNotIn() =>
-        val bad = rc.exists(c =>
-          c == LitClass.Numeric || c == LitClass.Bool || c == LitClass.StringLike || c == LitClass.NoneLit
-        )
+        val bad = rc.exists(isNonCollection)
         if bad then
           out += LintDiagnostic(
             code,
             LintLevel.Error,
-            s"'${binOpName(op)}' right operand is a ${describe(rc.get)} literal, not a collection",
+            s"'${binOpName(op)}' right operand is a ${describeLitClass(rc.get)} literal, not a collection",
             span
           )
       case _ => ()
-
-  private def describe(c: LitClass): String = c match
-    case LitClass.Numeric    => "numeric"
-    case LitClass.Bool       => "boolean"
-    case LitClass.StringLike => "string"
-    case LitClass.Collection => "collection"
-    case LitClass.NoneLit    => "none"
-
-  private def binOpName(op: bin_op_full): String = op match
-    case BAdd()     => "+"
-    case BSub()     => "-"
-    case BMul()     => "*"
-    case BDiv()     => "/"
-    case BLt()      => "<"
-    case BGt()      => ">"
-    case BLe()      => "<="
-    case BGe()      => ">="
-    case BAnd()     => "and"
-    case BOr()      => "or"
-    case BImplies() => "implies"
-    case BIff()     => "iff"
-    case BIn()      => "in"
-    case BNotIn()   => "not in"
-    case BEq()      => "="
-    case BNeq()     => "!="
-    case other      => other.toString

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -187,46 +187,11 @@ object Narration:
   private def rangePairConflict(invs: List[InvariantDeclFull]): Option[String] =
     val ranges = invs.flatMap { case d @ InvariantDeclFull(_, e, _) => rangeOf(e).map(r => (d, r)) }
     ranges.combinations(2).collectFirst:
-      case List((aDecl, (aIdent, aOp, aBound)), (bDecl, (bIdent, bOp, bBound)))
+      case List((aDecl, (aIdent, (aOp, aBound))), (bDecl, (bIdent, (bOp, bBound))))
           if aIdent == bIdent && conflicts(aOp, aBound, bOp, bBound) =>
         val aName = aDecl.a.getOrElse("invariant")
         val bName = bDecl.a.getOrElse("invariant")
         s"For example, '$aName' and '$bName' bound '$aIdent' to disjoint ranges."
-
-  private def rangeOf(e: expr_full): Option[(String, bin_op_full, Long)] = e match
-    case BinaryOpF(op, l, r, _) if isComp(op) =>
-      (l, r) match
-        case (IdentifierF(n, _), IntLitF(int_of_integer(v), _)) => Some((n, op, v.toLong))
-        case (IntLitF(int_of_integer(v), _), IdentifierF(n, _)) => Some((n, mirror(op), v.toLong))
-        case _                                                  => None
-    case _ => None
-
-  private def isComp(op: bin_op_full): Boolean = op match
-    case _: BGe | _: BGt | _: BLe | _: BLt => true
-    case _                                 => false
-
-  private def mirror(op: bin_op_full): bin_op_full = op match
-    case _: BGe => BLe()
-    case _: BLe => BGe()
-    case _: BGt => BLt()
-    case _: BLt => BGt()
-    case other  => other
-
-  private def conflicts(aOp: bin_op_full, aB: Long, bOp: bin_op_full, bB: Long): Boolean =
-    def isLow(o: bin_op_full): Boolean = o match
-      case _: BGe | _: BGt => true
-      case _               => false
-    def isStrict(o: bin_op_full): Boolean = o match
-      case _: BGt | _: BLt => true
-      case _               => false
-    val aLow    = isLow(aOp)
-    val bLow    = isLow(bOp)
-    val aStrict = isStrict(aOp)
-    val bStrict = isStrict(bOp)
-    val strict  = aStrict || bStrict
-    if aLow && !bLow then if strict then aB >= bB else aB > bB
-    else if !aLow && bLow then if strict then bB >= aB else bB > aB
-    else false
 
   private def cap(s: String): String =
     val lines = s.split("\n", -1).toList

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -3,7 +3,6 @@ package specrest.verify.alloy
 import cats.effect.IO
 import specrest.ir.*
 import specrest.ir.generated.SpecRestGenerated.*
-import specrest.verify.Classifier
 
 import scala.collection.mutable
 import scala.util.boundary
@@ -198,16 +197,7 @@ object Translator:
     else baseSigs
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
-    val mentioned = mutable.Set.empty[String]
-    def walk(e: expr_full, underPrime: Boolean): Unit = e match
-      case PrimeF(inner, _) => walk(inner, underPrime = true)
-      case PreF(inner, _)   => walk(inner, underPrime = false)
-      case IdentifierF(name, _) =>
-        if underPrime then mentioned += name
-      case _ =>
-        Classifier.childExprs(e).foreach(walk(_, underPrime))
-    ensures.foreach(walk(_, underPrime = false))
-    mentioned.toSet
+    collectPrimedIdentifiers(ensures).toSet
 
   private def buildCtx(ir: ServiceIRFull): Ctx =
     val stateFields = ir.f.toList.flatMap { case StateDeclFull(fs, _) => fs }
@@ -243,27 +233,20 @@ object Translator:
     sigs.toList
 
   private def needsBoolSig(ctx: Ctx): Boolean =
-    def typeUsesBool(t: type_expr_full): Boolean = t match
-      case NamedTypeF("Bool", _) => true
-      case SetTypeF(inner, _)    => typeUsesBool(inner)
-      case OptionTypeF(inner, _) => typeUsesBool(inner)
-      case _                     => false
-    def exprUsesBoolLit(e: expr_full): Boolean = e match
-      case BoolLitF(_, _) => true
-      case _              => Classifier.childExprs(e).exists(exprUsesBoolLit)
+    val containsBool: type_expr_full => Boolean = typeContainsNamed("Bool", _)
     val inFields =
       ctx.ir.c.exists {
         case EntityDeclFull(_, _, fs, _, _) =>
-          fs.exists { case FieldDeclFull(_, t, _, _) => typeUsesBool(t) }
+          fs.exists { case FieldDeclFull(_, t, _, _) => containsBool(t) }
       } ||
-        ctx.stateFields.values.exists(typeUsesBool) ||
-        ctx.inputFields.values.exists(typeUsesBool)
+        ctx.stateFields.values.exists(containsBool) ||
+        ctx.inputFields.values.exists(containsBool)
     val inExprs =
-      ctx.ir.i.exists { case InvariantDeclFull(_, e, _) => exprUsesBoolLit(e) } ||
-        ctx.ir.j.exists { case TemporalDeclFull(_, e, _) => exprUsesBoolLit(e) } ||
+      ctx.ir.i.exists { case InvariantDeclFull(_, e, _) => exprContainsBoolLit(e) } ||
+        ctx.ir.j.exists { case TemporalDeclFull(_, e, _) => exprContainsBoolLit(e) } ||
         ctx.ir.g.exists {
           case OperationDeclFull(_, _, _, requires, ensures, _) =>
-            requires.exists(exprUsesBoolLit) || ensures.exists(exprUsesBoolLit)
+            requires.exists(exprContainsBoolLit) || ensures.exists(exprContainsBoolLit)
         }
     inFields || inExprs
 

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -46,6 +46,13 @@ export_code
     free_vars
     hasPrePrime
     subst
+    litClass
+    describeLitClass
+    binOpName
+    typeContainsNamed
+    exprContainsBoolLit
+    rangeOf
+    conflicts
     emptyServiceIrFull
     lower
     lowerSetList

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -1568,6 +1568,161 @@ where
 | "subst_bindings x r (QuantifierBindingFull n d kk sp # bs) =
      QuantifierBindingFull n (subst x r d) kk sp # subst_bindings x r bs"
 
+text \<open>Phase 9\<delta> (lint TypeMismatch / L01): \<open>lit_class\<close> classifies an
+  expression literal into a small ADT; \<open>litClass\<close> recognises which class
+  (if any) an \<open>expr_full\<close> belongs to; \<open>binOpName\<close> renders a binary
+  operator's user-facing name (used in diagnostic messages).
+  \<open>describeLitClass\<close> renders the class as a noun for diagnostics.
+  Replaces \<open>lint.TypeMismatch.LitClass\<close>, \<open>litClass\<close>, \<open>describe\<close>, and
+  \<open>binOpName\<close> — the bulk of L01's pure analysis surface.\<close>
+
+datatype (plugins only: code size) lit_class =
+    LcNumeric | LcBool | LcStringLike | LcCollection | LcNone
+
+fun litClass :: "expr_full \<Rightarrow> lit_class option" where
+  "litClass (IntLitF _ _)     = Some LcNumeric"
+| "litClass (FloatLitF _ _)   = Some LcNumeric"
+| "litClass (BoolLitF _ _)    = Some LcBool"
+| "litClass (StringLitF _ _)  = Some LcStringLike"
+| "litClass (SetLiteralF _ _) = Some LcCollection"
+| "litClass (MapLiteralF _ _) = Some LcCollection"
+| "litClass (SeqLiteralF _ _) = Some LcCollection"
+| "litClass (NoneLitF _)      = Some LcNone"
+| "litClass _                 = None"
+
+fun describeLitClass :: "lit_class \<Rightarrow> String.literal" where
+  "describeLitClass LcNumeric    = STR ''numeric''"
+| "describeLitClass LcBool       = STR ''boolean''"
+| "describeLitClass LcStringLike = STR ''string''"
+| "describeLitClass LcCollection = STR ''collection''"
+| "describeLitClass LcNone       = STR ''none''"
+
+fun binOpName :: "bin_op_full \<Rightarrow> String.literal" where
+  "binOpName BAdd       = STR ''+''"
+| "binOpName BSub       = STR ''-''"
+| "binOpName BMul       = STR ''*''"
+| "binOpName BDiv       = STR ''/''"
+| "binOpName BLt        = STR ''<''"
+| "binOpName BGt        = STR ''>''"
+| "binOpName BLe        = STR ''<=''"
+| "binOpName BGe        = STR ''>=''"
+| "binOpName BAnd       = STR ''and''"
+| "binOpName BOr        = STR ''or''"
+| "binOpName BImplies   = STR ''implies''"
+| "binOpName BIff       = STR ''iff''"
+| "binOpName BIn        = STR ''in''"
+| "binOpName BNotIn     = STR ''not in''"
+| "binOpName BEq        = STR ''=''"
+| "binOpName BNeq       = STR ''!=''"
+| "binOpName BSubset    = STR ''subset''"
+| "binOpName BUnion     = STR ''++''"
+| "binOpName BIntersect = STR ''&''"
+| "binOpName BDiff      = STR ''--''"
+
+text \<open>Phase 9\<delta> (\<open>typeContainsNamed\<close>, \<open>exprContainsBoolLit\<close>): two
+  structural predicates lifted from \<open>verify.alloy.Translator\<close>. The first
+  asks whether a \<open>type_expr_full\<close> mentions a given named type anywhere
+  in its structural unfolding (only descending into \<open>SetTypeF\<close> and
+  \<open>OptionTypeF\<close>, matching the original walker's narrow scope). The
+  second is a structural fold returning \<open>True\<close> iff a \<open>BoolLitF\<close> appears
+  anywhere in the expression tree.\<close>
+
+fun typeContainsNamed :: "String.literal \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "typeContainsNamed n (NamedTypeF m _)      = (n = m)"
+| "typeContainsNamed n (SetTypeF inner _)    = typeContainsNamed n inner"
+| "typeContainsNamed n (OptionTypeF inner _) = typeContainsNamed n inner"
+| "typeContainsNamed _ _                     = False"
+
+fun exprContainsBoolLit :: "expr_full \<Rightarrow> bool"
+and exprContainsBoolLit_list :: "expr_full list \<Rightarrow> bool"
+and exprContainsBoolLit_fields :: "field_assign_full list \<Rightarrow> bool"
+and exprContainsBoolLit_entries :: "map_entry_full list \<Rightarrow> bool"
+and exprContainsBoolLit_bindings :: "quantifier_binding_full list \<Rightarrow> bool"
+where
+  "exprContainsBoolLit (BoolLitF _ _)              = True"
+| "exprContainsBoolLit (BinaryOpF _ l r _)         = (exprContainsBoolLit l \<or> exprContainsBoolLit r)"
+| "exprContainsBoolLit (UnaryOpF _ e _)            = exprContainsBoolLit e"
+| "exprContainsBoolLit (FieldAccessF b _ _)        = exprContainsBoolLit b"
+| "exprContainsBoolLit (EnumAccessF b _ _)         = exprContainsBoolLit b"
+| "exprContainsBoolLit (IndexF b i _)              = (exprContainsBoolLit b \<or> exprContainsBoolLit i)"
+| "exprContainsBoolLit (CallF c args _)            = (exprContainsBoolLit c \<or> exprContainsBoolLit_list args)"
+| "exprContainsBoolLit (PrimeF e _)                = exprContainsBoolLit e"
+| "exprContainsBoolLit (PreF e _)                  = exprContainsBoolLit e"
+| "exprContainsBoolLit (WithF b upds _)            = (exprContainsBoolLit b \<or> exprContainsBoolLit_fields upds)"
+| "exprContainsBoolLit (IfF c t e _)               = (exprContainsBoolLit c \<or> exprContainsBoolLit t \<or> exprContainsBoolLit e)"
+| "exprContainsBoolLit (LetF _ v b _)              = (exprContainsBoolLit v \<or> exprContainsBoolLit b)"
+| "exprContainsBoolLit (LambdaF _ b _)             = exprContainsBoolLit b"
+| "exprContainsBoolLit (ConstructorF _ fs _)       = exprContainsBoolLit_fields fs"
+| "exprContainsBoolLit (SetLiteralF xs _)          = exprContainsBoolLit_list xs"
+| "exprContainsBoolLit (MapLiteralF es _)          = exprContainsBoolLit_entries es"
+| "exprContainsBoolLit (SetComprehensionF _ d p _) = (exprContainsBoolLit d \<or> exprContainsBoolLit p)"
+| "exprContainsBoolLit (SeqLiteralF xs _)          = exprContainsBoolLit_list xs"
+| "exprContainsBoolLit (MatchesF x _ _)            = exprContainsBoolLit x"
+| "exprContainsBoolLit (SomeWrapF x _)             = exprContainsBoolLit x"
+| "exprContainsBoolLit (TheF _ d b _)              = (exprContainsBoolLit d \<or> exprContainsBoolLit b)"
+| "exprContainsBoolLit (QuantifierF _ bs body _)   = (exprContainsBoolLit_bindings bs \<or> exprContainsBoolLit body)"
+| "exprContainsBoolLit (IntLitF _ _)               = False"
+| "exprContainsBoolLit (FloatLitF _ _)             = False"
+| "exprContainsBoolLit (StringLitF _ _)            = False"
+| "exprContainsBoolLit (NoneLitF _)                = False"
+| "exprContainsBoolLit (IdentifierF _ _)           = False"
+| "exprContainsBoolLit_list []                                                  = False"
+| "exprContainsBoolLit_list (x # xs)                                            = (exprContainsBoolLit x \<or> exprContainsBoolLit_list xs)"
+| "exprContainsBoolLit_fields []                                                = False"
+| "exprContainsBoolLit_fields (FieldAssignFull _ v _ # fs)                      = (exprContainsBoolLit v \<or> exprContainsBoolLit_fields fs)"
+| "exprContainsBoolLit_entries []                                               = False"
+| "exprContainsBoolLit_entries (MapEntryFull k v _ # es)                        = (exprContainsBoolLit k \<or> exprContainsBoolLit v \<or> exprContainsBoolLit_entries es)"
+| "exprContainsBoolLit_bindings []                                              = False"
+| "exprContainsBoolLit_bindings (QuantifierBindingFull _ d _ _ # bs)            = (exprContainsBoolLit d \<or> exprContainsBoolLit_bindings bs)"
+
+text \<open>Phase 9\<delta> (Narration conflict helpers): pure pattern matches lifted
+  from \<open>verify.Narration\<close>. \<open>isComp\<close>/\<open>isLowBound\<close>/\<open>isStrictBound\<close> classify
+  a \<open>bin_op_full\<close>; \<open>mirrorBinOp\<close> swaps a comparison's direction (for the
+  \<open>IntLit cmp Identifier\<close> case); \<open>rangeOf\<close> extracts a
+  \<open>(name, op, bound)\<close> triple from a comparison-against-literal shape;
+  \<open>conflicts\<close> detects whether two bounds on the same identifier carve out
+  disjoint ranges. Used by the contradictory-invariants diagnostic.\<close>
+
+fun isComp :: "bin_op_full \<Rightarrow> bool" where
+  "isComp BGe = True"
+| "isComp BGt = True"
+| "isComp BLe = True"
+| "isComp BLt = True"
+| "isComp _   = False"
+
+fun isLowBound :: "bin_op_full \<Rightarrow> bool" where
+  "isLowBound BGe = True"
+| "isLowBound BGt = True"
+| "isLowBound _   = False"
+
+fun isStrictBound :: "bin_op_full \<Rightarrow> bool" where
+  "isStrictBound BGt = True"
+| "isStrictBound BLt = True"
+| "isStrictBound _   = False"
+
+fun mirrorBinOp :: "bin_op_full \<Rightarrow> bin_op_full" where
+  "mirrorBinOp BGe    = BLe"
+| "mirrorBinOp BLe    = BGe"
+| "mirrorBinOp BGt    = BLt"
+| "mirrorBinOp BLt    = BGt"
+| "mirrorBinOp other  = other"
+
+fun rangeOf :: "expr_full \<Rightarrow> (String.literal \<times> bin_op_full \<times> int) option" where
+  "rangeOf (BinaryOpF op (IdentifierF n _) (IntLitF v _) _) =
+     (if isComp op then Some (n, op, v) else None)"
+| "rangeOf (BinaryOpF op (IntLitF v _) (IdentifierF n _) _) =
+     (if isComp op then Some (n, mirrorBinOp op, v) else None)"
+| "rangeOf _ = None"
+
+fun conflicts :: "bin_op_full \<Rightarrow> int \<Rightarrow> bin_op_full \<Rightarrow> int \<Rightarrow> bool" where
+  "conflicts aOp aB bOp bB =
+     (let aLow    = isLowBound aOp;
+          bLow    = isLowBound bOp;
+          strict  = isStrictBound aOp \<or> isStrictBound bOp
+      in (if aLow \<and> \<not> bLow then (if strict then aB \<ge> bB else aB > bB)
+          else if \<not> aLow \<and> bLow then (if strict then bB \<ge> aB else bB > aB)
+          else False))"
+
 fun lower_forall_step ::
     "String.literal list \<Rightarrow> quantifier_binding_full
        \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr option"


### PR DESCRIPTION
## Summary

Follow-up to #297. Lifts four more hand-written pattern-match clusters into Isabelle-extracted primitives.

**Net:** −128 hand-written Scala lines, +155 IR.thy lines, +372 regenerated Scala lines.

## What was lifted

### Phase 9δ-1 — lint `TypeMismatch` (L01)
The bulk of L01's pure analysis surface moved into Isabelle:
- `lit_class` datatype (Numeric/Bool/StringLike/Collection/None)
- `litClass: expr_full ⇒ lit_class option` — 8-arm literal recognizer
- `describeLitClass: lit_class ⇒ String.literal` — diagnostic noun renderer
- `binOpName: bin_op_full ⇒ String.literal` — 20-arm user-facing operator name

The diagnostic combinator (`checkBinary` building `LintDiagnostic`s with line numbers) stays Scala-side; the per-call helpers `isBool`/`isNumeric`/`isBoolOrNone`/`isNonCollection` are tiny pattern-match wrappers around the extracted enum to keep `-language:strictEquality` happy (no `==` on extracted ADTs).

### Phase 9δ-2 — Alloy translator
- `typeContainsNamed: String.literal ⇒ type_expr_full ⇒ bool` — parameterised over the target type name, so reusable for future "type tree contains X" checks. Replaces inline `typeUsesBool`.
- `exprContainsBoolLit` (mutual 5 over expr_full + collectors) — full structural fold matching the `requiresAlloy` pattern. Replaces inline `exprUsesBoolLit`.

### Phase 9δ-3 — Narration conflict-detection helpers
- `rangeOf: expr_full ⇒ (String.literal × bin_op_full × int) option` — extracts the canonical triple from a `Identifier cmp IntLit` shape (or its mirror)
- `conflicts: bin_op_full × int × bin_op_full × int ⇒ bool` — pure disjoint-bound predicate
- Helpers: `isComp`, `isLowBound`, `isStrictBound`, `mirrorBinOp`

### Tier 1a — no Isabelle change, just dedup
Deleted `primedStateFields` from **both** `alloy.Translator` and `dafny.Generator` (identical 9-line walkers) and routed both to the existing extracted `collectPrimedIdentifiers(...).toSet`. I traced semantic equivalence on three witness cases:
- `Prime(s.f.g)` → both yield `["s"]`
- `Prime(s) + Pre(t)` → both yield `["s"]`
- `Prime(Pre(s))` → both yield `[]`

The only theoretical divergence is `Prime(f(args))` (Prime wrapping a function call), where the Scala walker over-collects function names while `rootIdentifier` correctly returns `None` — the parser never produces this shape, so no behavioural difference in practice.

## Deferred (Tier 3 — argued against in the analysis)

- **PrettyPrint.expr** — 100-line spec-syntax renderer with character-level string escaping. Lifting requires modelling string escapes via `char` pattern matching in Isabelle; verbose for marginal gain.
- **TypeMap.mapType** — pure structural recursion over `type_expr_full` but the result type (`MappedType`) is per-target-language string fragments. Would need a larger refactor splitting classification from rendering.
- **Z3 shape recognizers** (`matchesFullReplacement`, `matchNotInPrimed`, `matchFieldUpdatePrimed`, etc.) — each 3-5 lines, single Z3 consumer, no other use.
- **CounterExample.sortToTy** — IO/decoding glue; already uses extracted `tyctx` primitives.

## On the IO question

Isabelle/HOL is pure — no IO, no FFI, no concurrency. The existing layering ("Isabelle owns the pure middle, Scala owns the IO shell") is already maximal: `IO { readSpec } → parse → tyctxFromService → lower → translate → solve → IO { … }` has the pure section already lifted.

## Test plan

- [x] `isabelle build` succeeds (pre-commit hook + manual ≈ 6m41s)
- [x] Regen via `isabelle export` (no hand edits to generated)
- [x] `sbt compile` clean (Werror-clean after removing the now-unused `Classifier` import from `alloy.Translator`)
- [x] `sbt scalafixAll` clean
- [x] All affected modules pass: `verify` 170, `testgen` 274, `lint` 31, `codegen` 222, `convention` 66 — **763 tests, 0 failures**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted more pattern-match logic into Isabelle to centralize pure analysis for linting, Alloy translation, and narration. Also updated coverage to ignore generated IR code.

- **Refactors**
  - Lint L01: moved literal classification and op-name mapping to Isabelle (`lit_class`, `litClass`, `describeLitClass`, `binOpName`); Scala checks now use small match helpers for strict equality.
  - Alloy translator: replaced inline walkers with `typeContainsNamed` and `exprContainsBoolLit` to detect Bool usage in types/expressions.
  - Narration: lifted `rangeOf`, `conflicts`, and helpers (`isComp`, `isLowBound`, `isStrictBound`, `mirrorBinOp`).
  - Dedup: removed `primedStateFields` from Alloy and Dafny; both now use `collectPrimedIdentifiers(...).toSet`.
  - Codegen: exported new functions in `Codegen.thy`; regenerated `SpecRestGenerated`.
  - CI: exclude `specrest.ir.generated.*` from coverage to avoid counting generated code.

<sup>Written for commit 14015c0b9c8113d7514e615974202a1437cac15e. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/298?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type mismatch diagnostics with enhanced detection for invalid literal operands in unary and binary operations, providing clearer error messages.

* **Refactor**
  * Streamlined internal helper detection and expression analysis utilities across verification and lint modules to reduce code complexity and dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->