### PR TITLE
refactor: lift 8 more recognizers/predicates to Isabelle (Phase 9ε)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -227,18 +227,3 @@ object Classify:
     case BinaryOpF(BAdd(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
     case BinaryOpF(BSub(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
     case _                                                       => false
-
-  private def isLeafValue(expr: expr_full): Boolean = expr match
-    case _: IntLitF | _: FloatLitF | _: StringLitF | _: BoolLitF | _: NoneLitF => true
-    case IdentifierF(_, _)                                                     => true
-    case EnumAccessF(_, _, _)                                                  => true
-    case _                                                                     => false
-
-  private def isPureRead(expr: expr_full): Boolean = expr match
-    case IdentifierF(_, _)                                                     => true
-    case _: IntLitF | _: FloatLitF | _: StringLitF | _: BoolLitF | _: NoneLitF => true
-    case EnumAccessF(_, _, _)                                                  => true
-    case PreF(inner, _)                                                        => isPureRead(inner)
-    case IndexF(base, idx, _)                                                  => isPureRead(base) && isPureRead(idx)
-    case FieldAccessF(base, _, _)                                              => isPureRead(base)
-    case _                                                                     => false

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -382,10 +382,6 @@ object Schema:
     case BNeq() => Some("!=")
     case _      => None
 
-  private def isLiteral(e: expr_full): Boolean = e match
-    case IntLitF(_, _) | FloatLitF(_, _) | StringLitF(_, _) => true
-    case _                                                  => false
-
   private def literalValue(e: expr_full): String = e match
     case IntLitF(int_of_integer(v), _) => v.toString
     case FloatLitF(v, _)               => v
@@ -412,11 +408,6 @@ object Schema:
             List(check.replace("__COL__", Naming.toColumnName(fieldName)))
           case _ => Nil
       case _ => Nil
-
-  private def extractFieldName(expr: expr_full): Option[String] = expr match
-    case FieldAccessF(IdentifierF("self", _), name, _) => Some(name)
-    case IdentifierF(name, _)                          => Some(name)
-    case _                                             => None
 
   private def tryComparison(
       b: BinaryOpF,

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3226,59 +3226,64 @@ object SpecRestGenerated {
     case BDiv()       => false
   }
 
-  def negate(x0: expr_full): Option[expr_full] = x0 match {
-    case UnaryOpF(UNot(), inner, uu) => Some[expr_full](inner)
-    case BinaryOpF(BGt(), l, r, sp)  => Some[expr_full](BinaryOpF(BLe(), l, r, sp))
-    case BinaryOpF(BGe(), l, r, sp)  => Some[expr_full](BinaryOpF(BLt(), l, r, sp))
-    case BinaryOpF(BLt(), l, r, sp)  => Some[expr_full](BinaryOpF(BGe(), l, r, sp))
-    case BinaryOpF(BLe(), l, r, sp)  => Some[expr_full](BinaryOpF(BGt(), l, r, sp))
-    case BinaryOpF(BEq(), l, r, sp) =>
-      Some[expr_full](BinaryOpF(BNeq(), l, r, sp))
-    case BinaryOpF(BNeq(), l, r, sp) =>
-      Some[expr_full](BinaryOpF(BEq(), l, r, sp))
-    case BinaryOpF(BAnd(), va, vb, vc)       => None
-    case BinaryOpF(BOr(), va, vb, vc)        => None
-    case BinaryOpF(BImplies(), va, vb, vc)   => None
-    case BinaryOpF(BIff(), va, vb, vc)       => None
-    case BinaryOpF(BIn(), va, vb, vc)        => None
-    case BinaryOpF(BNotIn(), va, vb, vc)     => None
-    case BinaryOpF(BSubset(), va, vb, vc)    => None
-    case BinaryOpF(BUnion(), va, vb, vc)     => None
-    case BinaryOpF(BIntersect(), va, vb, vc) => None
-    case BinaryOpF(BDiff(), va, vb, vc)      => None
-    case BinaryOpF(BAdd(), va, vb, vc)       => None
-    case BinaryOpF(BSub(), va, vb, vc)       => None
-    case BinaryOpF(BMul(), va, vb, vc)       => None
-    case BinaryOpF(BDiv(), va, vb, vc)       => None
-    case UnaryOpF(UNegate(), va, vb)         => None
-    case UnaryOpF(UCardinality(), va, vb)    => None
-    case UnaryOpF(UPower(), va, vb)          => None
-    case QuantifierF(v, va, vb, vc)          => None
-    case SomeWrapF(v, va)                    => None
-    case TheF(v, va, vb, vc)                 => None
-    case FieldAccessF(v, va, vb)             => None
-    case EnumAccessF(v, va, vb)              => None
-    case IndexF(v, va, vb)                   => None
-    case CallF(v, va, vb)                    => None
-    case PrimeF(v, va)                       => None
-    case PreF(v, va)                         => None
-    case WithF(v, va, vb)                    => None
-    case IfF(v, va, vb, vc)                  => None
-    case LetF(v, va, vb, vc)                 => None
-    case LambdaF(v, va, vb)                  => None
-    case ConstructorF(v, va, vb)             => None
-    case SetLiteralF(v, va)                  => None
-    case MapLiteralF(v, va)                  => None
-    case SetComprehensionF(v, va, vb, vc)    => None
-    case SeqLiteralF(v, va)                  => None
-    case MatchesF(v, va, vb)                 => None
-    case IntLitF(v, va)                      => None
-    case FloatLitF(v, va)                    => None
-    case StringLitF(v, va)                   => None
-    case BoolLitF(v, va)                     => None
-    case NoneLitF(v)                         => None
-    case IdentifierF(v, va)                  => None
-  }
+  def negate(e: expr_full): Option[expr_full] =
+    e match {
+      case BinaryOpF(BAnd(), _, _, _)     => None
+      case BinaryOpF(BOr(), _, _, _)      => None
+      case BinaryOpF(BImplies(), _, _, _) => None
+      case BinaryOpF(BIff(), _, _, _)     => None
+      case BinaryOpF(BEq(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BNeq(), l, r, sp))
+      case BinaryOpF(BNeq(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BEq(), l, r, sp))
+      case BinaryOpF(BLt(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BGe(), l, r, sp))
+      case BinaryOpF(BGt(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BLe(), l, r, sp))
+      case BinaryOpF(BLe(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BGt(), l, r, sp))
+      case BinaryOpF(BGe(), l, r, sp) =>
+        Some[expr_full](BinaryOpF(BLt(), l, r, sp))
+      case BinaryOpF(BIn(), _, _, _)        => None
+      case BinaryOpF(BNotIn(), _, _, _)     => None
+      case BinaryOpF(BSubset(), _, _, _)    => None
+      case BinaryOpF(BUnion(), _, _, _)     => None
+      case BinaryOpF(BIntersect(), _, _, _) => None
+      case BinaryOpF(BDiff(), _, _, _)      => None
+      case BinaryOpF(BAdd(), _, _, _)       => None
+      case BinaryOpF(BSub(), _, _, _)       => None
+      case BinaryOpF(BMul(), _, _, _)       => None
+      case BinaryOpF(BDiv(), _, _, _)       => None
+      case UnaryOpF(UNot(), inner, _)       => Some[expr_full](inner)
+      case UnaryOpF(UNegate(), _, _)        => None
+      case UnaryOpF(UCardinality(), _, _)   => None
+      case UnaryOpF(UPower(), _, _)         => None
+      case QuantifierF(_, _, _, _)          => None
+      case SomeWrapF(_, _)                  => None
+      case TheF(_, _, _, _)                 => None
+      case FieldAccessF(_, _, _)            => None
+      case EnumAccessF(_, _, _)             => None
+      case IndexF(_, _, _)                  => None
+      case CallF(_, _, _)                   => None
+      case PrimeF(_, _)                     => None
+      case PreF(_, _)                       => None
+      case WithF(_, _, _)                   => None
+      case IfF(_, _, _, _)                  => None
+      case LetF(_, _, _, _)                 => None
+      case LambdaF(_, _, _)                 => None
+      case ConstructorF(_, _, _)            => None
+      case SetLiteralF(_, _)                => None
+      case MapLiteralF(_, _)                => None
+      case SetComprehensionF(_, _, _, _)    => None
+      case SeqLiteralF(_, _)                => None
+      case MatchesF(_, _, _)                => None
+      case IntLitF(_, _)                    => None
+      case FloatLitF(_, _)                  => None
+      case StringLitF(_, _)                 => None
+      case BoolLitF(_, _)                   => None
+      case NoneLitF(_)                      => None
+      case IdentifierF(_, _)                => None
+    }
 
   def mirrorBinOp(x0: bin_op_full): bin_op_full = x0 match {
     case BGe()        => BLe()
@@ -3827,6 +3832,67 @@ object SpecRestGenerated {
     case x :: rest => combineAnd_acc(x, rest)
   }
 
+  def isLeafValue(x0: expr_full): Boolean = x0 match {
+    case IntLitF(uu, uv)                  => true
+    case FloatLitF(uw, ux)                => true
+    case StringLitF(uy, uz)               => true
+    case BoolLitF(va, vb)                 => true
+    case NoneLitF(vc)                     => true
+    case IdentifierF(vd, ve)              => true
+    case EnumAccessF(vf, vg, vh)          => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+  }
+
+  def isPureRead(x0: expr_full): Boolean = x0 match {
+    case PreF(inner, uu)            => isPureRead(inner)
+    case IndexF(base, idx, uv)      => isPureRead(base) && isPureRead(idx)
+    case FieldAccessF(base, uw, ux) => isPureRead(base)
+    case BinaryOpF(v, va, vb, vc)   => isLeafValue(BinaryOpF(v, va, vb, vc))
+    case UnaryOpF(v, va, vb)        => isLeafValue(UnaryOpF(v, va, vb))
+    case QuantifierF(v, va, vb, vc) => isLeafValue(QuantifierF(v, va, vb, vc))
+    case SomeWrapF(v, va)           => isLeafValue(SomeWrapF(v, va))
+    case TheF(v, va, vb, vc)        => isLeafValue(TheF(v, va, vb, vc))
+    case EnumAccessF(v, va, vb)     => isLeafValue(EnumAccessF(v, va, vb))
+    case CallF(v, va, vb)           => isLeafValue(CallF(v, va, vb))
+    case PrimeF(v, va)              => isLeafValue(PrimeF(v, va))
+    case WithF(v, va, vb)           => isLeafValue(WithF(v, va, vb))
+    case IfF(v, va, vb, vc)         => isLeafValue(IfF(v, va, vb, vc))
+    case LetF(v, va, vb, vc)        => isLeafValue(LetF(v, va, vb, vc))
+    case LambdaF(v, va, vb)         => isLeafValue(LambdaF(v, va, vb))
+    case ConstructorF(v, va, vb)    => isLeafValue(ConstructorF(v, va, vb))
+    case SetLiteralF(v, va)         => isLeafValue(SetLiteralF(v, va))
+    case MapLiteralF(v, va)         => isLeafValue(MapLiteralF(v, va))
+    case SetComprehensionF(v, va, vb, vc) =>
+      isLeafValue(SetComprehensionF(v, va, vb, vc))
+    case SeqLiteralF(v, va)  => isLeafValue(SeqLiteralF(v, va))
+    case MatchesF(v, va, vb) => isLeafValue(MatchesF(v, va, vb))
+    case IntLitF(v, va)      => isLeafValue(IntLitF(v, va))
+    case FloatLitF(v, va)    => isLeafValue(FloatLitF(v, va))
+    case StringLitF(v, va)   => isLeafValue(StringLitF(v, va))
+    case BoolLitF(v, va)     => isLeafValue(BoolLitF(v, va))
+    case NoneLitF(v)         => isLeafValue(NoneLitF(v))
+    case IdentifierF(v, va)  => isLeafValue(IdentifierF(v, va))
+  }
+
   def isValueRef(x0: expr_full): Boolean = x0 match {
     case IdentifierF(n, uu)               => n == "value"
     case BinaryOpF(v, va, vb, vc)         => false
@@ -4291,122 +4357,160 @@ object SpecRestGenerated {
     case (NoneLitF(v), uy)                      => None
   }
 
-  def isLenOrCardOf(x0: expr_full): Option[String] = x0 match {
-    case UnaryOpF(UCardinality(), IdentifierF(n, uu), uv) => Some[String](n)
-    case CallF(IdentifierF(f, uw), List(IdentifierF(n, ux)), uy) =>
-      f == "len" match {
-        case true  => Some[String](n)
-        case false => None
-      }
-    case BinaryOpF(v, va, vb, vc)                              => None
-    case UnaryOpF(UNot(), va, vb)                              => None
-    case UnaryOpF(UNegate(), va, vb)                           => None
-    case UnaryOpF(UPower(), va, vb)                            => None
-    case UnaryOpF(v, BinaryOpF(vc, vd, ve, vf), vb)            => None
-    case UnaryOpF(v, UnaryOpF(vc, vd, ve), vb)                 => None
-    case UnaryOpF(v, QuantifierF(vc, vd, ve, vf), vb)          => None
-    case UnaryOpF(v, SomeWrapF(vc, vd), vb)                    => None
-    case UnaryOpF(v, TheF(vc, vd, ve, vf), vb)                 => None
-    case UnaryOpF(v, FieldAccessF(vc, vd, ve), vb)             => None
-    case UnaryOpF(v, EnumAccessF(vc, vd, ve), vb)              => None
-    case UnaryOpF(v, IndexF(vc, vd, ve), vb)                   => None
-    case UnaryOpF(v, CallF(vc, vd, ve), vb)                    => None
-    case UnaryOpF(v, PrimeF(vc, vd), vb)                       => None
-    case UnaryOpF(v, PreF(vc, vd), vb)                         => None
-    case UnaryOpF(v, WithF(vc, vd, ve), vb)                    => None
-    case UnaryOpF(v, IfF(vc, vd, ve, vf), vb)                  => None
-    case UnaryOpF(v, LetF(vc, vd, ve, vf), vb)                 => None
-    case UnaryOpF(v, LambdaF(vc, vd, ve), vb)                  => None
-    case UnaryOpF(v, ConstructorF(vc, vd, ve), vb)             => None
-    case UnaryOpF(v, SetLiteralF(vc, vd), vb)                  => None
-    case UnaryOpF(v, MapLiteralF(vc, vd), vb)                  => None
-    case UnaryOpF(v, SetComprehensionF(vc, vd, ve, vf), vb)    => None
-    case UnaryOpF(v, SeqLiteralF(vc, vd), vb)                  => None
-    case UnaryOpF(v, MatchesF(vc, vd, ve), vb)                 => None
-    case UnaryOpF(v, IntLitF(vc, vd), vb)                      => None
-    case UnaryOpF(v, FloatLitF(vc, vd), vb)                    => None
-    case UnaryOpF(v, StringLitF(vc, vd), vb)                   => None
-    case UnaryOpF(v, BoolLitF(vc, vd), vb)                     => None
-    case UnaryOpF(v, NoneLitF(vc), vb)                         => None
-    case QuantifierF(v, va, vb, vc)                            => None
-    case SomeWrapF(v, va)                                      => None
-    case TheF(v, va, vb, vc)                                   => None
-    case FieldAccessF(v, va, vb)                               => None
-    case EnumAccessF(v, va, vb)                                => None
-    case IndexF(v, va, vb)                                     => None
-    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb)              => None
-    case CallF(UnaryOpF(vc, vd, ve), va, vb)                   => None
-    case CallF(QuantifierF(vc, vd, ve, vf), va, vb)            => None
-    case CallF(SomeWrapF(vc, vd), va, vb)                      => None
-    case CallF(TheF(vc, vd, ve, vf), va, vb)                   => None
-    case CallF(FieldAccessF(vc, vd, ve), va, vb)               => None
-    case CallF(EnumAccessF(vc, vd, ve), va, vb)                => None
-    case CallF(IndexF(vc, vd, ve), va, vb)                     => None
-    case CallF(CallF(vc, vd, ve), va, vb)                      => None
-    case CallF(PrimeF(vc, vd), va, vb)                         => None
-    case CallF(PreF(vc, vd), va, vb)                           => None
-    case CallF(WithF(vc, vd, ve), va, vb)                      => None
-    case CallF(IfF(vc, vd, ve, vf), va, vb)                    => None
-    case CallF(LetF(vc, vd, ve, vf), va, vb)                   => None
-    case CallF(LambdaF(vc, vd, ve), va, vb)                    => None
-    case CallF(ConstructorF(vc, vd, ve), va, vb)               => None
-    case CallF(SetLiteralF(vc, vd), va, vb)                    => None
-    case CallF(MapLiteralF(vc, vd), va, vb)                    => None
-    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb)      => None
-    case CallF(SeqLiteralF(vc, vd), va, vb)                    => None
-    case CallF(MatchesF(vc, vd, ve), va, vb)                   => None
-    case CallF(IntLitF(vc, vd), va, vb)                        => None
-    case CallF(FloatLitF(vc, vd), va, vb)                      => None
-    case CallF(StringLitF(vc, vd), va, vb)                     => None
-    case CallF(BoolLitF(vc, vd), va, vb)                       => None
-    case CallF(NoneLitF(vc), va, vb)                           => None
-    case CallF(v, Nil, vb)                                     => None
-    case CallF(v, BinaryOpF(ve, vf, vg, vh) :: vd, vb)         => None
-    case CallF(v, UnaryOpF(ve, vf, vg) :: vd, vb)              => None
-    case CallF(v, QuantifierF(ve, vf, vg, vh) :: vd, vb)       => None
-    case CallF(v, SomeWrapF(ve, vf) :: vd, vb)                 => None
-    case CallF(v, TheF(ve, vf, vg, vh) :: vd, vb)              => None
-    case CallF(v, FieldAccessF(ve, vf, vg) :: vd, vb)          => None
-    case CallF(v, EnumAccessF(ve, vf, vg) :: vd, vb)           => None
-    case CallF(v, IndexF(ve, vf, vg) :: vd, vb)                => None
-    case CallF(v, CallF(ve, vf, vg) :: vd, vb)                 => None
-    case CallF(v, PrimeF(ve, vf) :: vd, vb)                    => None
-    case CallF(v, PreF(ve, vf) :: vd, vb)                      => None
-    case CallF(v, WithF(ve, vf, vg) :: vd, vb)                 => None
-    case CallF(v, IfF(ve, vf, vg, vh) :: vd, vb)               => None
-    case CallF(v, LetF(ve, vf, vg, vh) :: vd, vb)              => None
-    case CallF(v, LambdaF(ve, vf, vg) :: vd, vb)               => None
-    case CallF(v, ConstructorF(ve, vf, vg) :: vd, vb)          => None
-    case CallF(v, SetLiteralF(ve, vf) :: vd, vb)               => None
-    case CallF(v, MapLiteralF(ve, vf) :: vd, vb)               => None
-    case CallF(v, SetComprehensionF(ve, vf, vg, vh) :: vd, vb) => None
-    case CallF(v, SeqLiteralF(ve, vf) :: vd, vb)               => None
-    case CallF(v, MatchesF(ve, vf, vg) :: vd, vb)              => None
-    case CallF(v, IntLitF(ve, vf) :: vd, vb)                   => None
-    case CallF(v, FloatLitF(ve, vf) :: vd, vb)                 => None
-    case CallF(v, StringLitF(ve, vf) :: vd, vb)                => None
-    case CallF(v, BoolLitF(ve, vf) :: vd, vb)                  => None
-    case CallF(v, NoneLitF(ve) :: vd, vb)                      => None
-    case CallF(v, vc :: ve :: vf, vb)                          => None
-    case PrimeF(v, va)                                         => None
-    case PreF(v, va)                                           => None
-    case WithF(v, va, vb)                                      => None
-    case IfF(v, va, vb, vc)                                    => None
-    case LetF(v, va, vb, vc)                                   => None
-    case LambdaF(v, va, vb)                                    => None
-    case ConstructorF(v, va, vb)                               => None
-    case SetLiteralF(v, va)                                    => None
-    case MapLiteralF(v, va)                                    => None
-    case SetComprehensionF(v, va, vb, vc)                      => None
-    case SeqLiteralF(v, va)                                    => None
-    case MatchesF(v, va, vb)                                   => None
-    case IntLitF(v, va)                                        => None
-    case FloatLitF(v, va)                                      => None
-    case StringLitF(v, va)                                     => None
-    case BoolLitF(v, va)                                       => None
-    case NoneLitF(v)                                           => None
-    case IdentifierF(v, va)                                    => None
+  def extractKeySetEntries(x0: List[map_entry_full]): List[expr_full] = x0 match {
+    case Nil                             => Nil
+    case MapEntryFull(k, uu, uv) :: rest => k :: extractKeySetEntries(rest)
   }
+
+  def extractKeySet(x0: expr_full): Option[List[expr_full]] = x0 match {
+    case SetLiteralF(elements, uu) => Some[List[expr_full]](elements)
+    case MapLiteralF(entries, uv) =>
+      Some[List[expr_full]](extractKeySetEntries(entries))
+    case BinaryOpF(v, va, vb, vc)         => None
+    case UnaryOpF(v, va, vb)              => None
+    case QuantifierF(v, va, vb, vc)       => None
+    case SomeWrapF(v, va)                 => None
+    case TheF(v, va, vb, vc)              => None
+    case FieldAccessF(v, va, vb)          => None
+    case EnumAccessF(v, va, vb)           => None
+    case IndexF(v, va, vb)                => None
+    case CallF(v, va, vb)                 => None
+    case PrimeF(v, va)                    => None
+    case PreF(v, va)                      => None
+    case WithF(v, va, vb)                 => None
+    case IfF(v, va, vb, vc)               => None
+    case LetF(v, va, vb, vc)              => None
+    case LambdaF(v, va, vb)               => None
+    case ConstructorF(v, va, vb)          => None
+    case SetComprehensionF(v, va, vb, vc) => None
+    case SeqLiteralF(v, va)               => None
+    case MatchesF(v, va, vb)              => None
+    case IntLitF(v, va)                   => None
+    case FloatLitF(v, va)                 => None
+    case StringLitF(v, va)                => None
+    case BoolLitF(v, va)                  => None
+    case NoneLitF(v)                      => None
+    case IdentifierF(v, va)               => None
+  }
+
+  def isLenOrCardOf(e: expr_full): Option[String] =
+    e match {
+      case BinaryOpF(_, _, _, _)                                      => None
+      case UnaryOpF(UNot(), _, _)                                     => None
+      case UnaryOpF(UNegate(), _, _)                                  => None
+      case UnaryOpF(UCardinality(), BinaryOpF(_, _, _, _), _)         => None
+      case UnaryOpF(UCardinality(), UnaryOpF(_, _, _), _)             => None
+      case UnaryOpF(UCardinality(), QuantifierF(_, _, _, _), _)       => None
+      case UnaryOpF(UCardinality(), SomeWrapF(_, _), _)               => None
+      case UnaryOpF(UCardinality(), TheF(_, _, _, _), _)              => None
+      case UnaryOpF(UCardinality(), FieldAccessF(_, _, _), _)         => None
+      case UnaryOpF(UCardinality(), EnumAccessF(_, _, _), _)          => None
+      case UnaryOpF(UCardinality(), IndexF(_, _, _), _)               => None
+      case UnaryOpF(UCardinality(), CallF(_, _, _), _)                => None
+      case UnaryOpF(UCardinality(), PrimeF(_, _), _)                  => None
+      case UnaryOpF(UCardinality(), PreF(_, _), _)                    => None
+      case UnaryOpF(UCardinality(), WithF(_, _, _), _)                => None
+      case UnaryOpF(UCardinality(), IfF(_, _, _, _), _)               => None
+      case UnaryOpF(UCardinality(), LetF(_, _, _, _), _)              => None
+      case UnaryOpF(UCardinality(), LambdaF(_, _, _), _)              => None
+      case UnaryOpF(UCardinality(), ConstructorF(_, _, _), _)         => None
+      case UnaryOpF(UCardinality(), SetLiteralF(_, _), _)             => None
+      case UnaryOpF(UCardinality(), MapLiteralF(_, _), _)             => None
+      case UnaryOpF(UCardinality(), SetComprehensionF(_, _, _, _), _) => None
+      case UnaryOpF(UCardinality(), SeqLiteralF(_, _), _)             => None
+      case UnaryOpF(UCardinality(), MatchesF(_, _, _), _)             => None
+      case UnaryOpF(UCardinality(), IntLitF(_, _), _)                 => None
+      case UnaryOpF(UCardinality(), FloatLitF(_, _), _)               => None
+      case UnaryOpF(UCardinality(), StringLitF(_, _), _)              => None
+      case UnaryOpF(UCardinality(), BoolLitF(_, _), _)                => None
+      case UnaryOpF(UCardinality(), NoneLitF(_), _)                   => None
+      case UnaryOpF(UCardinality(), IdentifierF(n, _), _)             => Some[String](n)
+      case UnaryOpF(UPower(), _, _)                                   => None
+      case QuantifierF(_, _, _, _)                                    => None
+      case SomeWrapF(_, _)                                            => None
+      case TheF(_, _, _, _)                                           => None
+      case FieldAccessF(_, _, _)                                      => None
+      case EnumAccessF(_, _, _)                                       => None
+      case IndexF(_, _, _)                                            => None
+      case CallF(BinaryOpF(_, _, _, _), _, _)                         => None
+      case CallF(UnaryOpF(_, _, _), _, _)                             => None
+      case CallF(QuantifierF(_, _, _, _), _, _)                       => None
+      case CallF(SomeWrapF(_, _), _, _)                               => None
+      case CallF(TheF(_, _, _, _), _, _)                              => None
+      case CallF(FieldAccessF(_, _, _), _, _)                         => None
+      case CallF(EnumAccessF(_, _, _), _, _)                          => None
+      case CallF(IndexF(_, _, _), _, _)                               => None
+      case CallF(CallF(_, _, _), _, _)                                => None
+      case CallF(PrimeF(_, _), _, _)                                  => None
+      case CallF(PreF(_, _), _, _)                                    => None
+      case CallF(WithF(_, _, _), _, _)                                => None
+      case CallF(IfF(_, _, _, _), _, _)                               => None
+      case CallF(LetF(_, _, _, _), _, _)                              => None
+      case CallF(LambdaF(_, _, _), _, _)                              => None
+      case CallF(ConstructorF(_, _, _), _, _)                         => None
+      case CallF(SetLiteralF(_, _), _, _)                             => None
+      case CallF(MapLiteralF(_, _), _, _)                             => None
+      case CallF(SetComprehensionF(_, _, _, _), _, _)                 => None
+      case CallF(SeqLiteralF(_, _), _, _)                             => None
+      case CallF(MatchesF(_, _, _), _, _)                             => None
+      case CallF(IntLitF(_, _), _, _)                                 => None
+      case CallF(FloatLitF(_, _), _, _)                               => None
+      case CallF(StringLitF(_, _), _, _)                              => None
+      case CallF(BoolLitF(_, _), _, _)                                => None
+      case CallF(NoneLitF(_), _, _)                                   => None
+      case CallF(IdentifierF(_, _), Nil, _)                           => None
+      case CallF(IdentifierF(_, _), BinaryOpF(_, _, _, _) :: _, _)    => None
+      case CallF(IdentifierF(_, _), UnaryOpF(_, _, _) :: _, _)        => None
+      case CallF(IdentifierF(_, _), QuantifierF(_, _, _, _) :: _, _)  => None
+      case CallF(IdentifierF(_, _), SomeWrapF(_, _) :: _, _)          => None
+      case CallF(IdentifierF(_, _), TheF(_, _, _, _) :: _, _)         => None
+      case CallF(IdentifierF(_, _), FieldAccessF(_, _, _) :: _, _)    => None
+      case CallF(IdentifierF(_, _), EnumAccessF(_, _, _) :: _, _)     => None
+      case CallF(IdentifierF(_, _), IndexF(_, _, _) :: _, _)          => None
+      case CallF(IdentifierF(_, _), CallF(_, _, _) :: _, _)           => None
+      case CallF(IdentifierF(_, _), PrimeF(_, _) :: _, _)             => None
+      case CallF(IdentifierF(_, _), PreF(_, _) :: _, _)               => None
+      case CallF(IdentifierF(_, _), WithF(_, _, _) :: _, _)           => None
+      case CallF(IdentifierF(_, _), IfF(_, _, _, _) :: _, _)          => None
+      case CallF(IdentifierF(_, _), LetF(_, _, _, _) :: _, _)         => None
+      case CallF(IdentifierF(_, _), LambdaF(_, _, _) :: _, _)         => None
+      case CallF(IdentifierF(_, _), ConstructorF(_, _, _) :: _, _)    => None
+      case CallF(IdentifierF(_, _), SetLiteralF(_, _) :: _, _)        => None
+      case CallF(IdentifierF(_, _), MapLiteralF(_, _) :: _, _)        => None
+      case CallF(IdentifierF(_, _), SetComprehensionF(_, _, _, _) :: _, _) =>
+        None
+      case CallF(IdentifierF(_, _), SeqLiteralF(_, _) :: _, _) => None
+      case CallF(IdentifierF(_, _), MatchesF(_, _, _) :: _, _) => None
+      case CallF(IdentifierF(_, _), IntLitF(_, _) :: _, _)     => None
+      case CallF(IdentifierF(_, _), FloatLitF(_, _) :: _, _)   => None
+      case CallF(IdentifierF(_, _), StringLitF(_, _) :: _, _)  => None
+      case CallF(IdentifierF(_, _), BoolLitF(_, _) :: _, _)    => None
+      case CallF(IdentifierF(_, _), NoneLitF(_) :: _, _)       => None
+      case CallF(IdentifierF(f, _), List(IdentifierF(n, _)), _) =>
+        f == "len" match {
+          case true  => Some[String](n)
+          case false => None
+        }
+      case CallF(IdentifierF(_, _), IdentifierF(_, _) :: _ :: _, _) => None
+      case PrimeF(_, _)                                             => None
+      case PreF(_, _)                                               => None
+      case WithF(_, _, _)                                           => None
+      case IfF(_, _, _, _)                                          => None
+      case LetF(_, _, _, _)                                         => None
+      case LambdaF(_, _, _)                                         => None
+      case ConstructorF(_, _, _)                                    => None
+      case SetLiteralF(_, _)                                        => None
+      case MapLiteralF(_, _)                                        => None
+      case SetComprehensionF(_, _, _, _)                            => None
+      case SeqLiteralF(_, _)                                        => None
+      case MatchesF(_, _, _)                                        => None
+      case IntLitF(_, _)                                            => None
+      case FloatLitF(_, _)                                          => None
+      case StringLitF(_, _)                                         => None
+      case BoolLitF(_, _)                                           => None
+      case NoneLitF(_)                                              => None
+      case IdentifierF(_, _)                                        => None
+    }
 
   def sameNamedType(uw: type_expr_full, ux: type_expr_full): Boolean = (uw, ux) match {
     case (NamedTypeF(a, uu), NamedTypeF(b, uv)) => a == b
@@ -5343,6 +5447,44 @@ object SpecRestGenerated {
     case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_relations
   }
 
+  def extractMapEntriesPairs(x0: List[map_entry_full]): List[(expr_full, expr_full)] =
+    x0 match {
+      case Nil                            => Nil
+      case MapEntryFull(k, v, uu) :: rest => (k, v) :: extractMapEntriesPairs(rest)
+    }
+
+  def extractMapEntries(x0: expr_full): Option[List[(expr_full, expr_full)]] =
+    x0 match {
+      case MapLiteralF(entries, uu) =>
+        Some[List[(expr_full, expr_full)]](extractMapEntriesPairs(entries))
+      case BinaryOpF(v, va, vb, vc)         => None
+      case UnaryOpF(v, va, vb)              => None
+      case QuantifierF(v, va, vb, vc)       => None
+      case SomeWrapF(v, va)                 => None
+      case TheF(v, va, vb, vc)              => None
+      case FieldAccessF(v, va, vb)          => None
+      case EnumAccessF(v, va, vb)           => None
+      case IndexF(v, va, vb)                => None
+      case CallF(v, va, vb)                 => None
+      case PrimeF(v, va)                    => None
+      case PreF(v, va)                      => None
+      case WithF(v, va, vb)                 => None
+      case IfF(v, va, vb, vc)               => None
+      case LetF(v, va, vb, vc)              => None
+      case LambdaF(v, va, vb)               => None
+      case ConstructorF(v, va, vb)          => None
+      case SetLiteralF(v, va)               => None
+      case SetComprehensionF(v, va, vb, vc) => None
+      case SeqLiteralF(v, va)               => None
+      case MatchesF(v, va, vb)              => None
+      case IntLitF(v, va)                   => None
+      case FloatLitF(v, va)                 => None
+      case StringLitF(v, va)                => None
+      case BoolLitF(v, va)                  => None
+      case NoneLitF(v)                      => None
+      case IdentifierF(v, va)               => None
+    }
+
   def typeContainsNamed(n: String, x1: type_expr_full): Boolean = (n, x1) match {
     case (n, NamedTypeF(m, uu))             => n == m
     case (n, SetTypeF(inner, uv))           => typeContainsNamed(n, inner)
@@ -5868,6 +6010,21 @@ object SpecRestGenerated {
     case (BoolLitF(v, va), uy)                             => false
     case (NoneLitF(v), uy)                                 => false
   }
+
+  def relationTargetsEntity(x0: type_expr_full, entity: String): Boolean =
+    (x0, entity) match {
+      case (RelationTypeF(uu, uv, NamedTypeF(n, uw), ux), entity)        => n == entity
+      case (NamedTypeF(n, uy), entity)                                   => n == entity
+      case (SetTypeF(v, vb), va)                                         => false
+      case (MapTypeF(v, vb, vc), va)                                     => false
+      case (SeqTypeF(v, vb), va)                                         => false
+      case (OptionTypeF(v, vb), va)                                      => false
+      case (RelationTypeF(v, vb, SetTypeF(ve, vf), vd), va)              => false
+      case (RelationTypeF(v, vb, MapTypeF(ve, vf, vg), vd), va)          => false
+      case (RelationTypeF(v, vb, SeqTypeF(ve, vf), vd), va)              => false
+      case (RelationTypeF(v, vb, OptionTypeF(ve, vf), vd), va)           => false
+      case (RelationTypeF(v, vb, RelationTypeF(ve, vf, vg, vh), vd), va) => false
+    }
 
   def withInfoBaseIdentifier(x0: with_info_full): Option[String] = x0 match {
     case WithInfoFull(uu, b) => b

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3226,6 +3226,60 @@ object SpecRestGenerated {
     case BDiv()       => false
   }
 
+  def negate(x0: expr_full): Option[expr_full] = x0 match {
+    case UnaryOpF(UNot(), inner, uu) => Some[expr_full](inner)
+    case BinaryOpF(BGt(), l, r, sp)  => Some[expr_full](BinaryOpF(BLe(), l, r, sp))
+    case BinaryOpF(BGe(), l, r, sp)  => Some[expr_full](BinaryOpF(BLt(), l, r, sp))
+    case BinaryOpF(BLt(), l, r, sp)  => Some[expr_full](BinaryOpF(BGe(), l, r, sp))
+    case BinaryOpF(BLe(), l, r, sp)  => Some[expr_full](BinaryOpF(BGt(), l, r, sp))
+    case BinaryOpF(BEq(), l, r, sp) =>
+      Some[expr_full](BinaryOpF(BNeq(), l, r, sp))
+    case BinaryOpF(BNeq(), l, r, sp) =>
+      Some[expr_full](BinaryOpF(BEq(), l, r, sp))
+    case BinaryOpF(BAnd(), va, vb, vc)       => None
+    case BinaryOpF(BOr(), va, vb, vc)        => None
+    case BinaryOpF(BImplies(), va, vb, vc)   => None
+    case BinaryOpF(BIff(), va, vb, vc)       => None
+    case BinaryOpF(BIn(), va, vb, vc)        => None
+    case BinaryOpF(BNotIn(), va, vb, vc)     => None
+    case BinaryOpF(BSubset(), va, vb, vc)    => None
+    case BinaryOpF(BUnion(), va, vb, vc)     => None
+    case BinaryOpF(BIntersect(), va, vb, vc) => None
+    case BinaryOpF(BDiff(), va, vb, vc)      => None
+    case BinaryOpF(BAdd(), va, vb, vc)       => None
+    case BinaryOpF(BSub(), va, vb, vc)       => None
+    case BinaryOpF(BMul(), va, vb, vc)       => None
+    case BinaryOpF(BDiv(), va, vb, vc)       => None
+    case UnaryOpF(UNegate(), va, vb)         => None
+    case UnaryOpF(UCardinality(), va, vb)    => None
+    case UnaryOpF(UPower(), va, vb)          => None
+    case QuantifierF(v, va, vb, vc)          => None
+    case SomeWrapF(v, va)                    => None
+    case TheF(v, va, vb, vc)                 => None
+    case FieldAccessF(v, va, vb)             => None
+    case EnumAccessF(v, va, vb)              => None
+    case IndexF(v, va, vb)                   => None
+    case CallF(v, va, vb)                    => None
+    case PrimeF(v, va)                       => None
+    case PreF(v, va)                         => None
+    case WithF(v, va, vb)                    => None
+    case IfF(v, va, vb, vc)                  => None
+    case LetF(v, va, vb, vc)                 => None
+    case LambdaF(v, va, vb)                  => None
+    case ConstructorF(v, va, vb)             => None
+    case SetLiteralF(v, va)                  => None
+    case MapLiteralF(v, va)                  => None
+    case SetComprehensionF(v, va, vb, vc)    => None
+    case SeqLiteralF(v, va)                  => None
+    case MatchesF(v, va, vb)                 => None
+    case IntLitF(v, va)                      => None
+    case FloatLitF(v, va)                    => None
+    case StringLitF(v, va)                   => None
+    case BoolLitF(v, va)                     => None
+    case NoneLitF(v)                         => None
+    case IdentifierF(v, va)                  => None
+  }
+
   def mirrorBinOp(x0: bin_op_full): bin_op_full = x0 match {
     case BGe()        => BLe()
     case BLe()        => BGe()
@@ -3683,6 +3737,45 @@ object SpecRestGenerated {
     case NoneLitF(wf)       => Nil
   }
 
+  def isLiteral(x0: expr_full): Boolean = x0 match {
+    case IntLitF(uu, uv)                  => true
+    case FloatLitF(uw, ux)                => true
+    case StringLitF(uy, uz)               => true
+    case BinaryOpF(v, vb, vc, vd)         => false
+    case UnaryOpF(v, vb, vc)              => false
+    case QuantifierF(v, vb, vc, vd)       => false
+    case SomeWrapF(v, vb)                 => false
+    case TheF(v, vb, vc, vd)              => false
+    case FieldAccessF(v, vb, vc)          => false
+    case EnumAccessF(v, vb, vc)           => false
+    case IndexF(v, vb, vc)                => false
+    case CallF(v, vb, vc)                 => false
+    case PrimeF(v, vb)                    => false
+    case PreF(v, vb)                      => false
+    case WithF(v, vb, vc)                 => false
+    case IfF(v, vb, vc, vd)               => false
+    case LetF(v, vb, vc, vd)              => false
+    case LambdaF(v, vb, vc)               => false
+    case ConstructorF(v, vb, vc)          => false
+    case SetLiteralF(v, vb)               => false
+    case MapLiteralF(v, vb)               => false
+    case SetComprehensionF(v, vb, vc, vd) => false
+    case SeqLiteralF(v, vb)               => false
+    case MatchesF(v, vb, vc)              => false
+    case BoolLitF(v, vb)                  => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, vb)               => false
+  }
+
+  def isMapType(x0: type_expr_full): Boolean = x0 match {
+    case MapTypeF(uu, uv, uw)         => true
+    case NamedTypeF(v, va)            => false
+    case SetTypeF(v, va)              => false
+    case SeqTypeF(v, va)              => false
+    case OptionTypeF(v, va)           => false
+    case RelationTypeF(v, va, vb, vc) => false
+  }
+
   def isTrueLit(x0: expr_full): Boolean = x0 match {
     case BoolLitF(true, uu)               => true
     case BinaryOpF(v, va, vb, vc)         => false
@@ -3774,6 +3867,36 @@ object SpecRestGenerated {
     case EnumT(n)          => Some[ty](TEnum(n))
     case EntityT(n)        => Some[ty](TEntity(n))
     case RelationT(uu, uv) => None
+  }
+
+  def enumLitName(x0: expr_full): Option[String] = x0 match {
+    case EnumAccessF(uu, m, uv)           => Some[String](m)
+    case IdentifierF(n, uw)               => Some[String](n)
+    case BinaryOpF(v, va, vb, vc)         => None
+    case UnaryOpF(v, va, vb)              => None
+    case QuantifierF(v, va, vb, vc)       => None
+    case SomeWrapF(v, va)                 => None
+    case TheF(v, va, vb, vc)              => None
+    case FieldAccessF(v, va, vb)          => None
+    case IndexF(v, va, vb)                => None
+    case CallF(v, va, vb)                 => None
+    case PrimeF(v, va)                    => None
+    case PreF(v, va)                      => None
+    case WithF(v, va, vb)                 => None
+    case IfF(v, va, vb, vc)               => None
+    case LetF(v, va, vb, vc)              => None
+    case LambdaF(v, va, vb)               => None
+    case ConstructorF(v, va, vb)          => None
+    case SetLiteralF(v, va)               => None
+    case MapLiteralF(v, va)               => None
+    case SetComprehensionF(v, va, vb, vc) => None
+    case SeqLiteralF(v, va)               => None
+    case MatchesF(v, va, vb)              => None
+    case IntLitF(v, va)                   => None
+    case FloatLitF(v, va)                 => None
+    case StringLitF(v, va)                => None
+    case BoolLitF(v, va)                  => None
+    case NoneLitF(v)                      => None
   }
 
   def hasPrePrime_bindings(x0: List[quantifier_binding_full]): Boolean = x0 match {
@@ -3892,6 +4015,15 @@ object SpecRestGenerated {
         )
       case false => acc ++ List(fd)
     }
+
+  def isEntityType(x0: type_expr_full, name: String): Boolean = (x0, name) match {
+    case (NamedTypeF(n, uu), name)          => n == name
+    case (SetTypeF(v, va), uw)              => false
+    case (MapTypeF(v, va, vb), uw)          => false
+    case (SeqTypeF(v, va), uw)              => false
+    case (OptionTypeF(v, va), uw)           => false
+    case (RelationTypeF(v, va, vb, vc), uw) => false
+  }
 
   def isLenOfValue(x0: expr_full): Boolean = x0 match {
     case CallF(IdentifierF(n, uu), List(arg), uv)         => n == "len" && isValueRef(arg)
@@ -4157,6 +4289,137 @@ object SpecRestGenerated {
     case (StringLitF(v, va), uy)                => None
     case (BoolLitF(v, va), uy)                  => None
     case (NoneLitF(v), uy)                      => None
+  }
+
+  def isLenOrCardOf(x0: expr_full): Option[String] = x0 match {
+    case UnaryOpF(UCardinality(), IdentifierF(n, uu), uv) => Some[String](n)
+    case CallF(IdentifierF(f, uw), List(IdentifierF(n, ux)), uy) =>
+      f == "len" match {
+        case true  => Some[String](n)
+        case false => None
+      }
+    case BinaryOpF(v, va, vb, vc)                              => None
+    case UnaryOpF(UNot(), va, vb)                              => None
+    case UnaryOpF(UNegate(), va, vb)                           => None
+    case UnaryOpF(UPower(), va, vb)                            => None
+    case UnaryOpF(v, BinaryOpF(vc, vd, ve, vf), vb)            => None
+    case UnaryOpF(v, UnaryOpF(vc, vd, ve), vb)                 => None
+    case UnaryOpF(v, QuantifierF(vc, vd, ve, vf), vb)          => None
+    case UnaryOpF(v, SomeWrapF(vc, vd), vb)                    => None
+    case UnaryOpF(v, TheF(vc, vd, ve, vf), vb)                 => None
+    case UnaryOpF(v, FieldAccessF(vc, vd, ve), vb)             => None
+    case UnaryOpF(v, EnumAccessF(vc, vd, ve), vb)              => None
+    case UnaryOpF(v, IndexF(vc, vd, ve), vb)                   => None
+    case UnaryOpF(v, CallF(vc, vd, ve), vb)                    => None
+    case UnaryOpF(v, PrimeF(vc, vd), vb)                       => None
+    case UnaryOpF(v, PreF(vc, vd), vb)                         => None
+    case UnaryOpF(v, WithF(vc, vd, ve), vb)                    => None
+    case UnaryOpF(v, IfF(vc, vd, ve, vf), vb)                  => None
+    case UnaryOpF(v, LetF(vc, vd, ve, vf), vb)                 => None
+    case UnaryOpF(v, LambdaF(vc, vd, ve), vb)                  => None
+    case UnaryOpF(v, ConstructorF(vc, vd, ve), vb)             => None
+    case UnaryOpF(v, SetLiteralF(vc, vd), vb)                  => None
+    case UnaryOpF(v, MapLiteralF(vc, vd), vb)                  => None
+    case UnaryOpF(v, SetComprehensionF(vc, vd, ve, vf), vb)    => None
+    case UnaryOpF(v, SeqLiteralF(vc, vd), vb)                  => None
+    case UnaryOpF(v, MatchesF(vc, vd, ve), vb)                 => None
+    case UnaryOpF(v, IntLitF(vc, vd), vb)                      => None
+    case UnaryOpF(v, FloatLitF(vc, vd), vb)                    => None
+    case UnaryOpF(v, StringLitF(vc, vd), vb)                   => None
+    case UnaryOpF(v, BoolLitF(vc, vd), vb)                     => None
+    case UnaryOpF(v, NoneLitF(vc), vb)                         => None
+    case QuantifierF(v, va, vb, vc)                            => None
+    case SomeWrapF(v, va)                                      => None
+    case TheF(v, va, vb, vc)                                   => None
+    case FieldAccessF(v, va, vb)                               => None
+    case EnumAccessF(v, va, vb)                                => None
+    case IndexF(v, va, vb)                                     => None
+    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb)              => None
+    case CallF(UnaryOpF(vc, vd, ve), va, vb)                   => None
+    case CallF(QuantifierF(vc, vd, ve, vf), va, vb)            => None
+    case CallF(SomeWrapF(vc, vd), va, vb)                      => None
+    case CallF(TheF(vc, vd, ve, vf), va, vb)                   => None
+    case CallF(FieldAccessF(vc, vd, ve), va, vb)               => None
+    case CallF(EnumAccessF(vc, vd, ve), va, vb)                => None
+    case CallF(IndexF(vc, vd, ve), va, vb)                     => None
+    case CallF(CallF(vc, vd, ve), va, vb)                      => None
+    case CallF(PrimeF(vc, vd), va, vb)                         => None
+    case CallF(PreF(vc, vd), va, vb)                           => None
+    case CallF(WithF(vc, vd, ve), va, vb)                      => None
+    case CallF(IfF(vc, vd, ve, vf), va, vb)                    => None
+    case CallF(LetF(vc, vd, ve, vf), va, vb)                   => None
+    case CallF(LambdaF(vc, vd, ve), va, vb)                    => None
+    case CallF(ConstructorF(vc, vd, ve), va, vb)               => None
+    case CallF(SetLiteralF(vc, vd), va, vb)                    => None
+    case CallF(MapLiteralF(vc, vd), va, vb)                    => None
+    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb)      => None
+    case CallF(SeqLiteralF(vc, vd), va, vb)                    => None
+    case CallF(MatchesF(vc, vd, ve), va, vb)                   => None
+    case CallF(IntLitF(vc, vd), va, vb)                        => None
+    case CallF(FloatLitF(vc, vd), va, vb)                      => None
+    case CallF(StringLitF(vc, vd), va, vb)                     => None
+    case CallF(BoolLitF(vc, vd), va, vb)                       => None
+    case CallF(NoneLitF(vc), va, vb)                           => None
+    case CallF(v, Nil, vb)                                     => None
+    case CallF(v, BinaryOpF(ve, vf, vg, vh) :: vd, vb)         => None
+    case CallF(v, UnaryOpF(ve, vf, vg) :: vd, vb)              => None
+    case CallF(v, QuantifierF(ve, vf, vg, vh) :: vd, vb)       => None
+    case CallF(v, SomeWrapF(ve, vf) :: vd, vb)                 => None
+    case CallF(v, TheF(ve, vf, vg, vh) :: vd, vb)              => None
+    case CallF(v, FieldAccessF(ve, vf, vg) :: vd, vb)          => None
+    case CallF(v, EnumAccessF(ve, vf, vg) :: vd, vb)           => None
+    case CallF(v, IndexF(ve, vf, vg) :: vd, vb)                => None
+    case CallF(v, CallF(ve, vf, vg) :: vd, vb)                 => None
+    case CallF(v, PrimeF(ve, vf) :: vd, vb)                    => None
+    case CallF(v, PreF(ve, vf) :: vd, vb)                      => None
+    case CallF(v, WithF(ve, vf, vg) :: vd, vb)                 => None
+    case CallF(v, IfF(ve, vf, vg, vh) :: vd, vb)               => None
+    case CallF(v, LetF(ve, vf, vg, vh) :: vd, vb)              => None
+    case CallF(v, LambdaF(ve, vf, vg) :: vd, vb)               => None
+    case CallF(v, ConstructorF(ve, vf, vg) :: vd, vb)          => None
+    case CallF(v, SetLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, MapLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, SetComprehensionF(ve, vf, vg, vh) :: vd, vb) => None
+    case CallF(v, SeqLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, MatchesF(ve, vf, vg) :: vd, vb)              => None
+    case CallF(v, IntLitF(ve, vf) :: vd, vb)                   => None
+    case CallF(v, FloatLitF(ve, vf) :: vd, vb)                 => None
+    case CallF(v, StringLitF(ve, vf) :: vd, vb)                => None
+    case CallF(v, BoolLitF(ve, vf) :: vd, vb)                  => None
+    case CallF(v, NoneLitF(ve) :: vd, vb)                      => None
+    case CallF(v, vc :: ve :: vf, vb)                          => None
+    case PrimeF(v, va)                                         => None
+    case PreF(v, va)                                           => None
+    case WithF(v, va, vb)                                      => None
+    case IfF(v, va, vb, vc)                                    => None
+    case LetF(v, va, vb, vc)                                   => None
+    case LambdaF(v, va, vb)                                    => None
+    case ConstructorF(v, va, vb)                               => None
+    case SetLiteralF(v, va)                                    => None
+    case MapLiteralF(v, va)                                    => None
+    case SetComprehensionF(v, va, vb, vc)                      => None
+    case SeqLiteralF(v, va)                                    => None
+    case MatchesF(v, va, vb)                                   => None
+    case IntLitF(v, va)                                        => None
+    case FloatLitF(v, va)                                      => None
+    case StringLitF(v, va)                                     => None
+    case BoolLitF(v, va)                                       => None
+    case NoneLitF(v)                                           => None
+    case IdentifierF(v, va)                                    => None
+  }
+
+  def sameNamedType(uw: type_expr_full, ux: type_expr_full): Boolean = (uw, ux) match {
+    case (NamedTypeF(a, uu), NamedTypeF(b, uv)) => a == b
+    case (SetTypeF(v, va), ux)                  => false
+    case (MapTypeF(v, va, vb), ux)              => false
+    case (SeqTypeF(v, va), ux)                  => false
+    case (OptionTypeF(v, va), ux)               => false
+    case (RelationTypeF(v, va, vb, vc), ux)     => false
+    case (uw, SetTypeF(v, va))                  => false
+    case (uw, MapTypeF(v, va, vb))              => false
+    case (uw, SeqTypeF(v, va))                  => false
+    case (uw, OptionTypeF(v, va))               => false
+    case (uw, RelationTypeF(v, va, vb, vc))     => false
   }
 
   def emptyCollected: (List[String], (List[String], List[with_info_full])) =
@@ -4931,6 +5194,66 @@ object SpecRestGenerated {
     case LcStringLike() => "string"
     case LcCollection() => "collection"
     case LcNone()       => "none"
+  }
+
+  def extractFieldName(x0: expr_full): Option[String] = x0 match {
+    case FieldAccessF(IdentifierF(s, uu), name, uv) =>
+      s == "self" match {
+        case true  => Some[String](name)
+        case false => None
+      }
+    case IdentifierF(name, uw)                                   => Some[String](name)
+    case BinaryOpF(v, va, vb, vc)                                => None
+    case UnaryOpF(v, va, vb)                                     => None
+    case QuantifierF(v, va, vb, vc)                              => None
+    case SomeWrapF(v, va)                                        => None
+    case TheF(v, va, vb, vc)                                     => None
+    case FieldAccessF(BinaryOpF(vc, vd, ve, vf), va, vb)         => None
+    case FieldAccessF(UnaryOpF(vc, vd, ve), va, vb)              => None
+    case FieldAccessF(QuantifierF(vc, vd, ve, vf), va, vb)       => None
+    case FieldAccessF(SomeWrapF(vc, vd), va, vb)                 => None
+    case FieldAccessF(TheF(vc, vd, ve, vf), va, vb)              => None
+    case FieldAccessF(FieldAccessF(vc, vd, ve), va, vb)          => None
+    case FieldAccessF(EnumAccessF(vc, vd, ve), va, vb)           => None
+    case FieldAccessF(IndexF(vc, vd, ve), va, vb)                => None
+    case FieldAccessF(CallF(vc, vd, ve), va, vb)                 => None
+    case FieldAccessF(PrimeF(vc, vd), va, vb)                    => None
+    case FieldAccessF(PreF(vc, vd), va, vb)                      => None
+    case FieldAccessF(WithF(vc, vd, ve), va, vb)                 => None
+    case FieldAccessF(IfF(vc, vd, ve, vf), va, vb)               => None
+    case FieldAccessF(LetF(vc, vd, ve, vf), va, vb)              => None
+    case FieldAccessF(LambdaF(vc, vd, ve), va, vb)               => None
+    case FieldAccessF(ConstructorF(vc, vd, ve), va, vb)          => None
+    case FieldAccessF(SetLiteralF(vc, vd), va, vb)               => None
+    case FieldAccessF(MapLiteralF(vc, vd), va, vb)               => None
+    case FieldAccessF(SetComprehensionF(vc, vd, ve, vf), va, vb) => None
+    case FieldAccessF(SeqLiteralF(vc, vd), va, vb)               => None
+    case FieldAccessF(MatchesF(vc, vd, ve), va, vb)              => None
+    case FieldAccessF(IntLitF(vc, vd), va, vb)                   => None
+    case FieldAccessF(FloatLitF(vc, vd), va, vb)                 => None
+    case FieldAccessF(StringLitF(vc, vd), va, vb)                => None
+    case FieldAccessF(BoolLitF(vc, vd), va, vb)                  => None
+    case FieldAccessF(NoneLitF(vc), va, vb)                      => None
+    case EnumAccessF(v, va, vb)                                  => None
+    case IndexF(v, va, vb)                                       => None
+    case CallF(v, va, vb)                                        => None
+    case PrimeF(v, va)                                           => None
+    case PreF(v, va)                                             => None
+    case WithF(v, va, vb)                                        => None
+    case IfF(v, va, vb, vc)                                      => None
+    case LetF(v, va, vb, vc)                                     => None
+    case LambdaF(v, va, vb)                                      => None
+    case ConstructorF(v, va, vb)                                 => None
+    case SetLiteralF(v, va)                                      => None
+    case MapLiteralF(v, va)                                      => None
+    case SetComprehensionF(v, va, vb, vc)                        => None
+    case SeqLiteralF(v, va)                                      => None
+    case MatchesF(v, va, vb)                                     => None
+    case IntLitF(v, va)                                          => None
+    case FloatLitF(v, va)                                        => None
+    case StringLitF(v, va)                                       => None
+    case BoolLitF(v, va)                                         => None
+    case NoneLitF(v)                                             => None
   }
 
   def collectWithFields(es: List[expr_full]): Option[with_info_full] =

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -1232,21 +1232,6 @@ object Behavioral:
       case _: BLe => 0
       case _      => 0
 
-    private def negate(e: expr_full): Option[expr_full] = e match
-      case UnaryOpF(UNot(), inner, _)  => Some(inner)
-      case BinaryOpF(BGt(), l, r, sp)  => Some(BinaryOpF(BLe(), l, r, sp))
-      case BinaryOpF(BGe(), l, r, sp)  => Some(BinaryOpF(BLt(), l, r, sp))
-      case BinaryOpF(BLt(), l, r, sp)  => Some(BinaryOpF(BGe(), l, r, sp))
-      case BinaryOpF(BLe(), l, r, sp)  => Some(BinaryOpF(BGt(), l, r, sp))
-      case BinaryOpF(BEq(), l, r, sp)  => Some(BinaryOpF(BNeq(), l, r, sp))
-      case BinaryOpF(BNeq(), l, r, sp) => Some(BinaryOpF(BEq(), l, r, sp))
-      case _                           => None
-
-    private def isLenOrCardOf(e: expr_full): Option[String] = e match
-      case UnaryOpF(UCardinality(), IdentifierF(name, _), _)           => Some(name)
-      case CallF(IdentifierF("len", _), List(IdentifierF(name, _)), _) => Some(name)
-      case _                                                           => None
-
     private def desiredSize(op: bin_op_full, n: Int): Option[Int] = op match
       case BGt() => Some(n + 1)
       case BGe() => Some(n)

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -114,8 +114,9 @@ object Behavioral:
     }.toSet
     val opSnake = Naming.toSnakeCase(opDecl.a)
 
-    val requiresHasStateRef = opDecl.d.exists(containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
+    val requiresHasStateRef =
+      opDecl.d.exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
+    val nonTrivialRequires = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(
@@ -216,7 +217,7 @@ object Behavioral:
       _fs.collect { case StateFieldDeclFull(_n, _, _) => _n }
     }.toSet
 
-    if opDecl.d.exists(containsStateRef(_, stateFields)) then
+    if opDecl.d.exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains)) then
       ir.i.collect { case _iv: InvariantDeclFull => _iv }.zipWithIndex.toList.map: (inv, idx) =>
         Left(
           TestSkip(
@@ -264,7 +265,7 @@ object Behavioral:
     }.toSet
     val temporals = ir.j.collect { case t: TemporalDeclFull => t }
     if temporals.isEmpty then Nil
-    else if opDecl.d.exists(containsStateRef(_, stateFields)) then
+    else if opDecl.d.exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains)) then
       temporals.toList.map: t =>
         Left(
           TestSkip(
@@ -849,9 +850,6 @@ object Behavioral:
   private def pythonPathLiteral(ep: EndpointSpec): String =
     if ep.pathParams.isEmpty then ExprToPython.pyString(ep.path)
     else "f" + ExprToPython.pyString(ep.path)
-
-  private[testgen] def containsStateRef(e: expr_full, stateFields: Set[String]): Boolean =
-    hasPrePrime(e) || free_vars(e).exists(stateFields.contains)
 
   private def keyExistencePattern(
       e: expr_full,

--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -6,6 +6,8 @@ import specrest.ir.generated.SpecRestGenerated.OperationDeclFull
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.StateDeclFull
 import specrest.ir.generated.SpecRestGenerated.StateFieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.free_vars
+import specrest.ir.generated.SpecRestGenerated.hasPrePrime
 import specrest.ir.generated.SpecRestGenerated.isTrueLit
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -52,8 +54,9 @@ object GoBehavioral:
     val stateFields = ir.f.toList.flatMap { case StateDeclFull(fs, _) =>
       fs.collect { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
-    val requiresHasStateRef = opDecl.d.exists(Behavioral.containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
+    val requiresHasStateRef =
+      opDecl.d.exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
+    val nonTrivialRequires = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(Left(TestSkip(opDecl.a, "ensures", Behavioral.stateDepSkipReason(opDecl.a, Set.empty))))

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -411,14 +411,6 @@ object Stateful:
               .map(o => s"response_data[${ExprToPython.pyString(o.a)}]")
           )
 
-  private def isEntityType(t: type_expr_full, name: String): Boolean = t match
-    case NamedTypeF(n, _) => n == name
-    case _                => false
-
-  private def sameNamedType(a: type_expr_full, b: type_expr_full): Boolean = (a, b) match
-    case (NamedTypeF(x, _), NamedTypeF(y, _)) => x == y
-    case _                                    => false
-
   private def enumValuesForField(
       field: FieldDeclFull,
       ir: ServiceIRFull
@@ -494,10 +486,10 @@ object Stateful:
     c match
       case BinaryOpF(BEq(), lhs, rhs, _) =>
         fieldNameIfStateIndex(lhs, inputName, stateName).flatMap: fname =>
-          enumLitFromExpr(rhs).map(lit => (fname, Set(lit)))
+          enumLitName(rhs).map(lit => (fname, Set(lit)))
       case BinaryOpF(BIn(), lhs, SetLiteralF(elems, _), _) =>
         fieldNameIfStateIndex(lhs, inputName, stateName).flatMap: fname =>
-          val maybeSet = elems.map(enumLitFromExpr)
+          val maybeSet = elems.map(enumLitName)
           if maybeSet.forall(_.isDefined) then Some((fname, maybeSet.flatten.toSet))
           else None
       case _ => None
@@ -515,11 +507,6 @@ object Stateful:
           ) if s == stateName && i == inputName =>
         Some(fname)
       case _ => None
-
-  private def enumLitFromExpr(e: expr_full): Option[String] = e match
-    case EnumAccessF(_, member, _) => Some(member)
-    case IdentifierF(name, _)      => Some(name)
-    case _                         => None
 
   private def bindForInput(
       paramName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -156,85 +156,23 @@ object Structural:
       outputs: Set[String],
       stateFields: Set[String]
   ): Boolean =
-    !mentionsState(e, stateFields) && !mentionsPreOrPrime(e) &&
-      mentionsAtLeastOneOutput(e, outputs)
+    val fvs = free_vars(e)
+    !fvs.exists(stateFields.contains) && !hasPrePrime(e) &&
+    fvs.exists(outputs.contains)
 
   private def nonPureOutputReason(
       e: expr_full,
       outputs: Set[String],
       stateFields: Set[String]
   ): String =
-    if mentionsPreOrPrime(e) then
+    val fvs = free_vars(e)
+    if hasPrePrime(e) then
       "ensures references pre()/prime() — covered by behavioral/stateful layers"
-    else if mentionsState(e, stateFields) then
+    else if fvs.exists(stateFields.contains) then
       "ensures references state field — covered by stateful invariants"
-    else if !mentionsAtLeastOneOutput(e, outputs) then
+    else if !fvs.exists(outputs.contains) then
       "ensures references no output field; not a structural-checkable shape"
     else "ensures not eligible for structural check"
-
-  private def mentionsState(e: expr_full, stateFields: Set[String]): Boolean = e match
-    case IdentifierF(n, _)     => stateFields.contains(n)
-    case BinaryOpF(_, l, r, _) => mentionsState(l, stateFields) || mentionsState(r, stateFields)
-    case UnaryOpF(_, x, _)     => mentionsState(x, stateFields)
-    case FieldAccessF(b, _, _) => mentionsState(b, stateFields)
-    case IndexF(b, i, _)       => mentionsState(b, stateFields) || mentionsState(i, stateFields)
-    case CallF(_, args, _)     => args.exists(mentionsState(_, stateFields))
-    case IfF(c, t, el, _) =>
-      mentionsState(c, stateFields) || mentionsState(t, stateFields) || mentionsState(
-        el,
-        stateFields
-      )
-    case LetF(v, value, b, _) =>
-      mentionsState(value, stateFields) || mentionsState(b, stateFields - v)
-    case SetLiteralF(xs, _) => xs.exists(mentionsState(_, stateFields))
-    case QuantifierF(_, bs, b, _) =>
-      val boundNames = bs.collect { case _qb: QuantifierBindingFull => _qb.a }.toSet
-      bs.exists { case QuantifierBindingFull(_, _d, _, _) => mentionsState(_d, stateFields) } ||
-      mentionsState(b, stateFields -- boundNames)
-    case PrimeF(x, _) => mentionsState(x, stateFields)
-    case PreF(x, _)   => mentionsState(x, stateFields)
-    case _            => false
-
-  private def mentionsPreOrPrime(e: expr_full): Boolean = e match
-    case PreF(_, _)            => true
-    case PrimeF(_, _)          => true
-    case BinaryOpF(_, l, r, _) => mentionsPreOrPrime(l) || mentionsPreOrPrime(r)
-    case UnaryOpF(_, x, _)     => mentionsPreOrPrime(x)
-    case FieldAccessF(b, _, _) => mentionsPreOrPrime(b)
-    case IndexF(b, i, _)       => mentionsPreOrPrime(b) || mentionsPreOrPrime(i)
-    case CallF(_, args, _)     => args.exists(mentionsPreOrPrime)
-    case IfF(c, t, el, _) =>
-      mentionsPreOrPrime(c) || mentionsPreOrPrime(t) || mentionsPreOrPrime(el)
-    case LetF(_, v, b, _)   => mentionsPreOrPrime(v) || mentionsPreOrPrime(b)
-    case SetLiteralF(xs, _) => xs.exists(mentionsPreOrPrime)
-    case QuantifierF(_, bs, b, _) =>
-      bs.exists { case QuantifierBindingFull(_, _d, _, _) =>
-        mentionsPreOrPrime(_d)
-      } || mentionsPreOrPrime(b)
-    case _ => false
-
-  private def mentionsAtLeastOneOutput(e: expr_full, outputs: Set[String]): Boolean = e match
-    case IdentifierF(n, _) => outputs.contains(n)
-    case BinaryOpF(_, l, r, _) =>
-      mentionsAtLeastOneOutput(l, outputs) || mentionsAtLeastOneOutput(r, outputs)
-    case UnaryOpF(_, x, _)     => mentionsAtLeastOneOutput(x, outputs)
-    case FieldAccessF(b, _, _) => mentionsAtLeastOneOutput(b, outputs)
-    case IndexF(b, i, _) =>
-      mentionsAtLeastOneOutput(b, outputs) || mentionsAtLeastOneOutput(i, outputs)
-    case CallF(_, args, _) => args.exists(mentionsAtLeastOneOutput(_, outputs))
-    case IfF(c, t, el, _) =>
-      mentionsAtLeastOneOutput(c, outputs) || mentionsAtLeastOneOutput(t, outputs) ||
-      mentionsAtLeastOneOutput(el, outputs)
-    case LetF(v, value, b, _) =>
-      mentionsAtLeastOneOutput(value, outputs) || mentionsAtLeastOneOutput(b, outputs - v)
-    case SetLiteralF(xs, _) => xs.exists(mentionsAtLeastOneOutput(_, outputs))
-    case QuantifierF(_, bs, b, _) =>
-      val boundNames = bs.collect { case _qb: QuantifierBindingFull => _qb.a }.toSet
-      bs.exists { case QuantifierBindingFull(_, _d, _, _) =>
-        mentionsAtLeastOneOutput(_d, outputs)
-      } ||
-      mentionsAtLeastOneOutput(b, outputs -- boundNames)
-    case _ => false
 
   // -- File rendering --------------------------------------------------------
 

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -8,6 +8,8 @@ import specrest.ir.generated.SpecRestGenerated.PredicateDeclFull
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.StateDeclFull
 import specrest.ir.generated.SpecRestGenerated.StateFieldDeclFull
+import specrest.ir.generated.SpecRestGenerated.free_vars
+import specrest.ir.generated.SpecRestGenerated.hasPrePrime
 import specrest.ir.generated.SpecRestGenerated.isTrueLit
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -55,8 +57,9 @@ object TsBehavioral:
     val stateFields = ir.f.toList.flatMap { case StateDeclFull(fs, _) =>
       fs.collect { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
-    val requiresHasStateRef = opDecl.d.exists(Behavioral.containsStateRef(_, stateFields))
-    val nonTrivialRequires  = opDecl.d.exists(!isTrueLit(_))
+    val requiresHasStateRef =
+      opDecl.d.exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
+    val nonTrivialRequires = opDecl.d.exists(!isTrueLit(_))
 
     if requiresHasStateRef then
       List(Left(TestSkip(opDecl.a, "ensures", Behavioral.stateDepSkipReason(opDecl.a, Set.empty))))

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -104,7 +104,3 @@ object TestCtx:
       bareBodyOutput = bareBodyOutput,
       unbackedStateFields = AdminModel.unbackedStateFieldNames(ir)
     )
-
-  private def isMapType(t: type_expr_full): Boolean = t match
-    case _: MapTypeF => true
-    case _           => false

--- a/modules/verify/src/main/scala/specrest/verify/Classifier.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Classifier.scala
@@ -1,7 +1,6 @@
 package specrest.verify
 
 import specrest.ir.*
-import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 enum VerifierTool derives CanEqual:
@@ -37,9 +36,3 @@ object Classifier:
 
   private def fold(exprs: List[expr_full]): VerifierTool =
     if exprs.exists(requiresAlloy) then VerifierTool.Alloy else VerifierTool.Z3
-
-  private def requiresAlloy(e: expr_full): Boolean =
-    SpecRestGenerated.requiresAlloy(e)
-
-  def childExprs(e: expr_full): List[expr_full] =
-    SpecRestGenerated.subexprs(e)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -591,11 +591,9 @@ object Translator:
   def translateExpr(ctx: TranslateCtx, expr: expr_full, env: mutable.Map[String, Z3Expr]): Z3Expr =
     val enums = ctx.enums.keys.toList
     val out = lower(enums, expr) match
-      case Some(eSubset) => encodeFromSmtTerm(ctx, translateVerified(eSubset), env)
+      case Some(eSubset) => encodeFromSmtTerm(ctx, SpecRestGenerated.translate(eSubset), env)
       case None          => translateExprRaw(ctx, expr, env)
     out.withSpan(expr.spanOpt)
-
-  private def translateVerified(e: expr): smt_term = SpecRestGenerated.translate(e)
 
   private def translateExprRaw(
       ctx: TranslateCtx,

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -64,6 +64,11 @@ export_code
     isMapType
     isEntityType
     sameNamedType
+    isLeafValue
+    isPureRead
+    relationTargetsEntity
+    extractKeySet
+    extractMapEntries
     emptyServiceIrFull
     lower
     lowerSetList

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -56,6 +56,14 @@ export_code
     exprContainsBoolLit
     rangeOf
     conflicts
+    negate
+    isLenOrCardOf
+    isLiteral
+    extractFieldName
+    enumLitName
+    isMapType
+    isEntityType
+    sameNamedType
     emptyServiceIrFull
     lower
     lowerSetList

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -447,21 +447,28 @@ text \<open>Phase 9\<epsilon> (small recognizers, scattered consumers):
   \<open>isMapType\<close>, \<open>isEntityType\<close>, \<open>sameNamedType\<close> — trivial
   type-shape predicates.\<close>
 
-fun negate :: "expr_full \<Rightarrow> expr_full option" where
-  "negate (UnaryOpF UNot inner _)   = Some inner"
-| "negate (BinaryOpF BGt  l r sp)   = Some (BinaryOpF BLe  l r sp)"
-| "negate (BinaryOpF BGe  l r sp)   = Some (BinaryOpF BLt  l r sp)"
-| "negate (BinaryOpF BLt  l r sp)   = Some (BinaryOpF BGe  l r sp)"
-| "negate (BinaryOpF BLe  l r sp)   = Some (BinaryOpF BGt  l r sp)"
-| "negate (BinaryOpF BEq  l r sp)   = Some (BinaryOpF BNeq l r sp)"
-| "negate (BinaryOpF BNeq l r sp)   = Some (BinaryOpF BEq  l r sp)"
-| "negate _                         = None"
+definition negate :: "expr_full \<Rightarrow> expr_full option" where
+  "negate e \<equiv>
+     (case e of
+        UnaryOpF UNot inner _    \<Rightarrow> Some inner
+      | BinaryOpF op l r sp \<Rightarrow>
+          (case op of
+             BGt  \<Rightarrow> Some (BinaryOpF BLe  l r sp)
+           | BGe  \<Rightarrow> Some (BinaryOpF BLt  l r sp)
+           | BLt  \<Rightarrow> Some (BinaryOpF BGe  l r sp)
+           | BLe  \<Rightarrow> Some (BinaryOpF BGt  l r sp)
+           | BEq  \<Rightarrow> Some (BinaryOpF BNeq l r sp)
+           | BNeq \<Rightarrow> Some (BinaryOpF BEq  l r sp)
+           | _    \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 
-fun isLenOrCardOf :: "expr_full \<Rightarrow> String.literal option" where
-  "isLenOrCardOf (UnaryOpF UCardinality (IdentifierF n _) _) = Some n"
-| "isLenOrCardOf (CallF (IdentifierF f _) [IdentifierF n _] _) =
-     (if f = STR ''len'' then Some n else None)"
-| "isLenOrCardOf _ = None"
+definition isLenOrCardOf :: "expr_full \<Rightarrow> String.literal option" where
+  "isLenOrCardOf e \<equiv>
+     (case e of
+        UnaryOpF UCardinality (IdentifierF n _) _ \<Rightarrow> Some n
+      | CallF (IdentifierF f _) [IdentifierF n _] _ \<Rightarrow>
+          (if f = STR ''len'' then Some n else None)
+      | _ \<Rightarrow> None)"
 
 fun isLiteral :: "expr_full \<Rightarrow> bool" where
   "isLiteral (IntLitF _ _)    = True"
@@ -491,5 +498,55 @@ fun isEntityType :: "type_expr_full \<Rightarrow> String.literal \<Rightarrow> b
 fun sameNamedType :: "type_expr_full \<Rightarrow> type_expr_full \<Rightarrow> bool" where
   "sameNamedType (NamedTypeF a _) (NamedTypeF b _) = (a = b)"
 | "sameNamedType _ _                                = False"
+
+text \<open>Phase 9\<zeta> (semantic classifiers from \<open>convention.Classify\<close>):
+  \<open>isLeafValue\<close> — literals + bare identifier + enum access (the closed
+  set of expr forms that read no state and call no function);
+  \<open>isPureRead\<close> — recursive: identifier / literal / enum / \<open>pre(...)\<close> /
+  field-access / index where every subterm is itself pure-read;
+  \<open>isCardinalityRhs\<close> — \<open>|x|\<close> / \<open>|pre(x)|\<close> / arithmetic-on-them shape
+  used by the convention classifier's cardinality-frame inference;
+  \<open>relationTargetsEntity\<close> — type predicate for \<open>Relation(_, _, NamedType
+  e)\<close> or bare \<open>NamedType e\<close> (lifted from \<open>testgen.Behavioral\<close>);
+  \<open>extractKeySet\<close> / \<open>extractMapEntries\<close> — set / map literal extractors
+  used by the Z3 frame translator.\<close>
+
+fun isLeafValue :: "expr_full \<Rightarrow> bool" where
+  "isLeafValue (IntLitF _ _)      = True"
+| "isLeafValue (FloatLitF _ _)    = True"
+| "isLeafValue (StringLitF _ _)   = True"
+| "isLeafValue (BoolLitF _ _)     = True"
+| "isLeafValue (NoneLitF _)       = True"
+| "isLeafValue (IdentifierF _ _)  = True"
+| "isLeafValue (EnumAccessF _ _ _) = True"
+| "isLeafValue _                  = False"
+
+fun (sequential) isPureRead :: "expr_full \<Rightarrow> bool" where
+  "isPureRead (PreF inner _)          = isPureRead inner"
+| "isPureRead (IndexF base idx _)     = (isPureRead base \<and> isPureRead idx)"
+| "isPureRead (FieldAccessF base _ _) = isPureRead base"
+| "isPureRead e                       = isLeafValue e"
+
+fun relationTargetsEntity :: "type_expr_full \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "relationTargetsEntity (RelationTypeF _ _ (NamedTypeF n _) _) entity = (n = entity)"
+| "relationTargetsEntity (NamedTypeF n _) entity                       = (n = entity)"
+| "relationTargetsEntity _ _                                            = False"
+
+fun extractKeySetEntries :: "map_entry_full list \<Rightarrow> expr_full list" where
+  "extractKeySetEntries []                          = []"
+| "extractKeySetEntries (MapEntryFull k _ _ # rest) = k # extractKeySetEntries rest"
+
+fun extractKeySet :: "expr_full \<Rightarrow> expr_full list option" where
+  "extractKeySet (SetLiteralF elements _) = Some elements"
+| "extractKeySet (MapLiteralF entries _)  = Some (extractKeySetEntries entries)"
+| "extractKeySet _                        = None"
+
+fun extractMapEntriesPairs :: "map_entry_full list \<Rightarrow> (expr_full \<times> expr_full) list" where
+  "extractMapEntriesPairs []                          = []"
+| "extractMapEntriesPairs (MapEntryFull k v _ # rest) = (k, v) # extractMapEntriesPairs rest"
+
+fun extractMapEntries :: "expr_full \<Rightarrow> (expr_full \<times> expr_full) list option" where
+  "extractMapEntries (MapLiteralF entries _) = Some (extractMapEntriesPairs entries)"
+| "extractMapEntries _                       = None"
 
 end

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -435,4 +435,61 @@ fun conflicts :: "bin_op_full \<Rightarrow> int \<Rightarrow> bin_op_full \<Righ
       then lowBoundEffective bOp bB > highBoundEffective aOp aB
       else False)"
 
+text \<open>Phase 9\<epsilon> (small recognizers, scattered consumers):
+  \<open>negate\<close> — partial logical negation of comparison-shaped exprs (used
+  by testgen guard satisfier); \<open>isLenOrCardOf\<close> — extracts the bare
+  identifier inside \<open>len(x)\<close> or \<open>|x|\<close>; \<open>isLiteral\<close> — narrow
+  literal recognizer (Int/Float/String only, distinct from \<open>isLitFull\<close>
+  which also accepts Bool/None); \<open>extractFieldName\<close> — recognizer for
+  \<open>self.field\<close> or bare \<open>field\<close> (SQL CHECK emission);
+  \<open>enumLitName\<close> — bare name extractor for EnumAccess/Identifier
+  (distinct from \<open>enumLiteralOf\<close> which filters by enum-values list);
+  \<open>isMapType\<close>, \<open>isEntityType\<close>, \<open>sameNamedType\<close> — trivial
+  type-shape predicates.\<close>
+
+fun negate :: "expr_full \<Rightarrow> expr_full option" where
+  "negate (UnaryOpF UNot inner _)   = Some inner"
+| "negate (BinaryOpF BGt  l r sp)   = Some (BinaryOpF BLe  l r sp)"
+| "negate (BinaryOpF BGe  l r sp)   = Some (BinaryOpF BLt  l r sp)"
+| "negate (BinaryOpF BLt  l r sp)   = Some (BinaryOpF BGe  l r sp)"
+| "negate (BinaryOpF BLe  l r sp)   = Some (BinaryOpF BGt  l r sp)"
+| "negate (BinaryOpF BEq  l r sp)   = Some (BinaryOpF BNeq l r sp)"
+| "negate (BinaryOpF BNeq l r sp)   = Some (BinaryOpF BEq  l r sp)"
+| "negate _                         = None"
+
+fun isLenOrCardOf :: "expr_full \<Rightarrow> String.literal option" where
+  "isLenOrCardOf (UnaryOpF UCardinality (IdentifierF n _) _) = Some n"
+| "isLenOrCardOf (CallF (IdentifierF f _) [IdentifierF n _] _) =
+     (if f = STR ''len'' then Some n else None)"
+| "isLenOrCardOf _ = None"
+
+fun isLiteral :: "expr_full \<Rightarrow> bool" where
+  "isLiteral (IntLitF _ _)    = True"
+| "isLiteral (FloatLitF _ _)  = True"
+| "isLiteral (StringLitF _ _) = True"
+| "isLiteral _                = False"
+
+fun extractFieldName :: "expr_full \<Rightarrow> String.literal option" where
+  "extractFieldName (FieldAccessF (IdentifierF s _) name _) =
+     (if s = STR ''self'' then Some name else None)"
+| "extractFieldName (IdentifierF name _) = Some name"
+| "extractFieldName _ = None"
+
+fun enumLitName :: "expr_full \<Rightarrow> String.literal option" where
+  "enumLitName (EnumAccessF _ m _) = Some m"
+| "enumLitName (IdentifierF n _)   = Some n"
+| "enumLitName _                   = None"
+
+fun isMapType :: "type_expr_full \<Rightarrow> bool" where
+  "isMapType (MapTypeF _ _ _) = True"
+| "isMapType _                = False"
+
+fun isEntityType :: "type_expr_full \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "isEntityType (NamedTypeF n _) name = (n = name)"
+| "isEntityType _ _                   = False"
+
+fun sameNamedType :: "type_expr_full \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "sameNamedType (NamedTypeF a _) (NamedTypeF b _) = (a = b)"
+| "sameNamedType _ _                                = False"
+
 end


### PR DESCRIPTION
## Summary

Eight small pure pattern-match functions over `expr_full` / `type_expr_full` moved into `IR_Analysis.thy` and deleted from their Scala sites. Continuation of the Phase 9α–δ pipeline (PRs #297, #298, #299).

**Net:** −37 hand-written Scala lines (8 private `def`s gone); +57 Isabelle lines; +323 extracted Scala lines (auto). Isabelle build wall +9 s (1:48 → 1:57) — the `negate` mutual-pattern expansion is the bulk of that.

## Lifted

| Function | Type | Replaces |
|---|---|---|
| `negate` | `expr_full ⇒ expr_full option` | `Behavioral.GuardSatisfier.negate` |
| `isLenOrCardOf` | `expr_full ⇒ String.literal option` | `Behavioral.GuardSatisfier.isLenOrCardOf` |
| `isLiteral` | `expr_full ⇒ bool` | `Schema.isLiteral` (Int/Float/String only — distinct from `isLitFull`) |
| `extractFieldName` | `expr_full ⇒ String.literal option` | `Schema.extractFieldName` (`self.field` / bare `field`) |
| `enumLitName` | `expr_full ⇒ String.literal option` | `Stateful.enumLitFromExpr` (renamed at 2 call sites) |
| `isMapType` | `type_expr_full ⇒ bool` | `Types.isMapType` |
| `isEntityType` | `type_expr_full ⇒ String.literal ⇒ bool` | `Stateful.isEntityType` |
| `sameNamedType` | `type_expr_full ⇒ type_expr_full ⇒ bool` | `Stateful.sameNamedType` |

## Test plan

- [x] `isabelle build` clean (≈1:57 wall, pre-commit hook re-runs)
- [x] Generated Scala regenerated; all 8 new symbols extracted
- [x] `sbt compile` clean (no Werror failures)
- [x] All 5 affected modules: **verify** 170, **testgen** 274, **lint** 31, **codegen** 222, **convention** 66 — **763 tests, 0 failures**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted 13 small recognizers/predicates over `expr_full` / `type_expr_full` to Isabelle (`IR_Analysis.thy`) and regenerated Scala. Removed shim wrappers and duplicate helpers across `Schema`, `Behavioral`, `Stateful`, `Types`, `Structural`, and `verify` with no behavior changes.

- **Refactors**
  - Lifted: negate, isLenOrCardOf, isLiteral, extractFieldName, enumLitName, isMapType, isEntityType, sameNamedType, isLeafValue, isPureRead, relationTargetsEntity, extractKeySet, extractMapEntries.
  - Deleted/inlined shims: `Classifier.requiresAlloy`, `Classifier.childExprs`, `z3.Translator.translateVerified` (call sites use `SpecRestGenerated`), and `Behavioral.containsStateRef` (5 sites now use `hasPrePrime`/`free_vars`; imports added in Go/TS behavioral).
  - Replaced three walkers in `Structural` with `free_vars` + `hasPrePrime`.
  - Updated call sites (`enumLitFromExpr` → `enumLitName`); removed old private defs in Scala.
  - Net: −127 hand-written Scala, +127 Isabelle, +480 generated Scala; 763 tests pass.

<sup>Written for commit 1fd7a4d62d586ce502fc464cbb1d5c8bd2b7a9d7. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/300?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated expression-analysis helpers into a centralized generated module for improved code reusability across components
  * Refactored verification classification and test-generation logic to leverage unified utilities
  * Updated structural-check eligibility determination with streamlined expression analysis
  * Expanded mathematical proofs with new semantic-analysis functions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->