### PR TITLE
refactor: lift isCardinalityRhs + isKeyExistsConj to Isabelle (Phase 9η)

### DIFF
--- a/docs/content/docs/design/isabelle-proofs.mdx
+++ b/docs/content/docs/design/isabelle-proofs.mdx
@@ -308,6 +308,56 @@ If your edit moves a definition between theory files, grep for
 `<name>.simps` / `<name>.induct` / `<name>_def` across `Soundness.thy`,
 `Semantics.thy`, `Translate.thy` before committing.
 
+### 9. Beware deep nested patterns — they extract to cross-product Scala
+
+`Code_Target_Scala` compiles each `case` arm into an exhaustive `match`
+over the matched type's constructors. A pattern that nests three or
+four constructor levels expands as the **cross product** of those
+constructors. For `expr_full` (28 constructors), one nested pattern
+quickly becomes 100–200 generated arms even when the Isabelle source
+is two lines.
+
+PR #301 review caught two cases of this:
+
+- `BinaryOpF BIn (IdentifierF i _) (IdentifierF s _) _` — naive
+  formulation extracted to a **200+-arm cross product** (op ×
+  left-shape × right-shape).
+- `fun stripAddSubIntLit e = e` recursive identity fallback — unfolds
+  to per-constructor identity reconstruction (~80 arms each
+  reconstructing the same `BinaryOpF(BAnd(), va, vb, vc) ⇒
+  BinaryOpF(BAnd(), va, vb, vc)` shape).
+
+For the BIn shape, switch to a **shallow split-case** + `\<and>` (each
+inner `case` is one constructor level deep and short-circuits on the
+first miss):
+
+```text
+(* DON'T — cross product *)
+case c of
+  BinaryOpF BIn (IdentifierF i _) (IdentifierF s _) _ ⇒
+    i = inputName ∧ s = stateName
+| _ ⇒ False
+
+(* DO — shallow split-case *)
+case c of
+  BinaryOpF op l r _ ⇒
+    (case op of BIn ⇒ True | _ ⇒ False) ∧
+    (case l of IdentifierF i _ ⇒ i = inputName | _ ⇒ False) ∧
+    (case r of IdentifierF s _ ⇒ s = stateName | _ ⇒ False)
+| _ ⇒ False
+```
+
+For the recursive identity-fallback (the `stripAddSubIntLit` shape),
+there's no compact extraction unless you avoid the recursion entirely.
+If the function has a single Scala consumer, **don't lift it** — the
+extracted bloat dominates the lift's value.
+
+**Rule of thumb:** before committing a lift, run the regen pipeline
+and `wc -l` the new `def`. If it's > 80 lines for a function that was
+< 10 in hand-written Scala, the lift is paying for itself in
+maintainability but not in line-count; reconsider whether single
+source of truth is worth the generated bloat at this site.
+
 ## Profiling: finding the next bottleneck
 
 `isabelle build -v -c` emits two kinds of timing line:

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -220,3 +220,10 @@ object Classify:
     case BinaryOpF(BEq(), IdentifierF(name, _), rhs, _) if outputNames.contains(name) =>
       isPureRead(rhs)
     case _ => false
+
+  private def isCardinalityRhs(rhs: expr_full, n: String): Boolean = rhs match
+    case UnaryOpF(UCardinality(), PreF(IdentifierF(m, _), _), _) => m == n
+    case UnaryOpF(UCardinality(), IdentifierF(m, _), _)          => m == n
+    case BinaryOpF(BAdd(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
+    case BinaryOpF(BSub(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
+    case _                                                       => false

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -220,10 +220,3 @@ object Classify:
     case BinaryOpF(BEq(), IdentifierF(name, _), rhs, _) if outputNames.contains(name) =>
       isPureRead(rhs)
     case _ => false
-
-  private def isCardinalityRhs(rhs: expr_full, n: String): Boolean = rhs match
-    case UnaryOpF(UCardinality(), PreF(IdentifierF(m, _), _), _) => m == n
-    case UnaryOpF(UCardinality(), IdentifierF(m, _), _)          => m == n
-    case BinaryOpF(BAdd(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
-    case BinaryOpF(BSub(), inner, IntLitF(_, _), _)              => isCardinalityRhs(inner, n)
-    case _                                                       => false

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5272,106 +5272,113 @@ object SpecRestGenerated {
 
   def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
     c match {
-      case BinaryOpF(BAnd(), _, _, _)                                    => false
-      case BinaryOpF(BOr(), _, _, _)                                     => false
-      case BinaryOpF(BImplies(), _, _, _)                                => false
-      case BinaryOpF(BIff(), _, _, _)                                    => false
-      case BinaryOpF(BEq(), _, _, _)                                     => false
-      case BinaryOpF(BNeq(), _, _, _)                                    => false
-      case BinaryOpF(BLt(), _, _, _)                                     => false
-      case BinaryOpF(BGt(), _, _, _)                                     => false
-      case BinaryOpF(BLe(), _, _, _)                                     => false
-      case BinaryOpF(BGe(), _, _, _)                                     => false
-      case BinaryOpF(BIn(), BinaryOpF(_, _, _, _), _, _)                 => false
-      case BinaryOpF(BIn(), UnaryOpF(_, _, _), _, _)                     => false
-      case BinaryOpF(BIn(), QuantifierF(_, _, _, _), _, _)               => false
-      case BinaryOpF(BIn(), SomeWrapF(_, _), _, _)                       => false
-      case BinaryOpF(BIn(), TheF(_, _, _, _), _, _)                      => false
-      case BinaryOpF(BIn(), FieldAccessF(_, _, _), _, _)                 => false
-      case BinaryOpF(BIn(), EnumAccessF(_, _, _), _, _)                  => false
-      case BinaryOpF(BIn(), IndexF(_, _, _), _, _)                       => false
-      case BinaryOpF(BIn(), CallF(_, _, _), _, _)                        => false
-      case BinaryOpF(BIn(), PrimeF(_, _), _, _)                          => false
-      case BinaryOpF(BIn(), PreF(_, _), _, _)                            => false
-      case BinaryOpF(BIn(), WithF(_, _, _), _, _)                        => false
-      case BinaryOpF(BIn(), IfF(_, _, _, _), _, _)                       => false
-      case BinaryOpF(BIn(), LetF(_, _, _, _), _, _)                      => false
-      case BinaryOpF(BIn(), LambdaF(_, _, _), _, _)                      => false
-      case BinaryOpF(BIn(), ConstructorF(_, _, _), _, _)                 => false
-      case BinaryOpF(BIn(), SetLiteralF(_, _), _, _)                     => false
-      case BinaryOpF(BIn(), MapLiteralF(_, _), _, _)                     => false
-      case BinaryOpF(BIn(), SetComprehensionF(_, _, _, _), _, _)         => false
-      case BinaryOpF(BIn(), SeqLiteralF(_, _), _, _)                     => false
-      case BinaryOpF(BIn(), MatchesF(_, _, _), _, _)                     => false
-      case BinaryOpF(BIn(), IntLitF(_, _), _, _)                         => false
-      case BinaryOpF(BIn(), FloatLitF(_, _), _, _)                       => false
-      case BinaryOpF(BIn(), StringLitF(_, _), _, _)                      => false
-      case BinaryOpF(BIn(), BoolLitF(_, _), _, _)                        => false
-      case BinaryOpF(BIn(), NoneLitF(_), _, _)                           => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), BinaryOpF(_, _, _, _), _) => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), UnaryOpF(_, _, _), _)     => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), QuantifierF(_, _, _, _), _) =>
-        false
-      case BinaryOpF(BIn(), IdentifierF(_, _), SomeWrapF(_, _), _)               => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), TheF(_, _, _, _), _)              => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), FieldAccessF(_, _, _), _)         => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), EnumAccessF(_, _, _), _)          => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), IndexF(_, _, _), _)               => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), CallF(_, _, _), _)                => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), PrimeF(_, _), _)                  => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), PreF(_, _), _)                    => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), WithF(_, _, _), _)                => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), IfF(_, _, _, _), _)               => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), LetF(_, _, _, _), _)              => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), LambdaF(_, _, _), _)              => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), ConstructorF(_, _, _), _)         => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), SetLiteralF(_, _), _)             => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), MapLiteralF(_, _), _)             => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), SetComprehensionF(_, _, _, _), _) => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), SeqLiteralF(_, _), _)             => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), MatchesF(_, _, _), _)             => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), IntLitF(_, _), _)                 => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), FloatLitF(_, _), _)               => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), StringLitF(_, _), _)              => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), BoolLitF(_, _), _)                => false
-      case BinaryOpF(BIn(), IdentifierF(_, _), NoneLitF(_), _)                   => false
-      case BinaryOpF(BIn(), IdentifierF(i, _), IdentifierF(s, _), _) =>
-        i == inputName && s == stateName
-      case BinaryOpF(BNotIn(), _, _, _)     => false
-      case BinaryOpF(BSubset(), _, _, _)    => false
-      case BinaryOpF(BUnion(), _, _, _)     => false
-      case BinaryOpF(BIntersect(), _, _, _) => false
-      case BinaryOpF(BDiff(), _, _, _)      => false
-      case BinaryOpF(BAdd(), _, _, _)       => false
-      case BinaryOpF(BSub(), _, _, _)       => false
-      case BinaryOpF(BMul(), _, _, _)       => false
-      case BinaryOpF(BDiv(), _, _, _)       => false
-      case UnaryOpF(_, _, _)                => false
-      case QuantifierF(_, _, _, _)          => false
-      case SomeWrapF(_, _)                  => false
-      case TheF(_, _, _, _)                 => false
-      case FieldAccessF(_, _, _)            => false
-      case EnumAccessF(_, _, _)             => false
-      case IndexF(_, _, _)                  => false
-      case CallF(_, _, _)                   => false
-      case PrimeF(_, _)                     => false
-      case PreF(_, _)                       => false
-      case WithF(_, _, _)                   => false
-      case IfF(_, _, _, _)                  => false
-      case LetF(_, _, _, _)                 => false
-      case LambdaF(_, _, _)                 => false
-      case ConstructorF(_, _, _)            => false
-      case SetLiteralF(_, _)                => false
-      case MapLiteralF(_, _)                => false
-      case SetComprehensionF(_, _, _, _)    => false
-      case SeqLiteralF(_, _)                => false
-      case MatchesF(_, _, _)                => false
-      case IntLitF(_, _)                    => false
-      case FloatLitF(_, _)                  => false
-      case StringLitF(_, _)                 => false
-      case BoolLitF(_, _)                   => false
-      case NoneLitF(_)                      => false
-      case IdentifierF(_, _)                => false
+      case BinaryOpF(op, l, r, _) =>
+        (op match {
+          case BAnd()       => false
+          case BOr()        => false
+          case BImplies()   => false
+          case BIff()       => false
+          case BEq()        => false
+          case BNeq()       => false
+          case BLt()        => false
+          case BGt()        => false
+          case BLe()        => false
+          case BGe()        => false
+          case BIn()        => true
+          case BNotIn()     => false
+          case BSubset()    => false
+          case BUnion()     => false
+          case BIntersect() => false
+          case BDiff()      => false
+          case BAdd()       => false
+          case BSub()       => false
+          case BMul()       => false
+          case BDiv()       => false
+        }) &&
+        ((l match {
+          case BinaryOpF(_, _, _, _)         => false
+          case UnaryOpF(_, _, _)             => false
+          case QuantifierF(_, _, _, _)       => false
+          case SomeWrapF(_, _)               => false
+          case TheF(_, _, _, _)              => false
+          case FieldAccessF(_, _, _)         => false
+          case EnumAccessF(_, _, _)          => false
+          case IndexF(_, _, _)               => false
+          case CallF(_, _, _)                => false
+          case PrimeF(_, _)                  => false
+          case PreF(_, _)                    => false
+          case WithF(_, _, _)                => false
+          case IfF(_, _, _, _)               => false
+          case LetF(_, _, _, _)              => false
+          case LambdaF(_, _, _)              => false
+          case ConstructorF(_, _, _)         => false
+          case SetLiteralF(_, _)             => false
+          case MapLiteralF(_, _)             => false
+          case SetComprehensionF(_, _, _, _) => false
+          case SeqLiteralF(_, _)             => false
+          case MatchesF(_, _, _)             => false
+          case IntLitF(_, _)                 => false
+          case FloatLitF(_, _)               => false
+          case StringLitF(_, _)              => false
+          case BoolLitF(_, _)                => false
+          case NoneLitF(_)                   => false
+          case IdentifierF(i, _)             => i == inputName
+        }) &&
+          (r match {
+            case BinaryOpF(_, _, _, _)         => false
+            case UnaryOpF(_, _, _)             => false
+            case QuantifierF(_, _, _, _)       => false
+            case SomeWrapF(_, _)               => false
+            case TheF(_, _, _, _)              => false
+            case FieldAccessF(_, _, _)         => false
+            case EnumAccessF(_, _, _)          => false
+            case IndexF(_, _, _)               => false
+            case CallF(_, _, _)                => false
+            case PrimeF(_, _)                  => false
+            case PreF(_, _)                    => false
+            case WithF(_, _, _)                => false
+            case IfF(_, _, _, _)               => false
+            case LetF(_, _, _, _)              => false
+            case LambdaF(_, _, _)              => false
+            case ConstructorF(_, _, _)         => false
+            case SetLiteralF(_, _)             => false
+            case MapLiteralF(_, _)             => false
+            case SetComprehensionF(_, _, _, _) => false
+            case SeqLiteralF(_, _)             => false
+            case MatchesF(_, _, _)             => false
+            case IntLitF(_, _)                 => false
+            case FloatLitF(_, _)               => false
+            case StringLitF(_, _)              => false
+            case BoolLitF(_, _)                => false
+            case NoneLitF(_)                   => false
+            case IdentifierF(s, _)             => s == stateName
+          }))
+      case UnaryOpF(_, _, _)             => false
+      case QuantifierF(_, _, _, _)       => false
+      case SomeWrapF(_, _)               => false
+      case TheF(_, _, _, _)              => false
+      case FieldAccessF(_, _, _)         => false
+      case EnumAccessF(_, _, _)          => false
+      case IndexF(_, _, _)               => false
+      case CallF(_, _, _)                => false
+      case PrimeF(_, _)                  => false
+      case PreF(_, _)                    => false
+      case WithF(_, _, _)                => false
+      case IfF(_, _, _, _)               => false
+      case LetF(_, _, _, _)              => false
+      case LambdaF(_, _, _)              => false
+      case ConstructorF(_, _, _)         => false
+      case SetLiteralF(_, _)             => false
+      case MapLiteralF(_, _)             => false
+      case SetComprehensionF(_, _, _, _) => false
+      case SeqLiteralF(_, _)             => false
+      case MatchesF(_, _, _)             => false
+      case IntLitF(_, _)                 => false
+      case FloatLitF(_, _)               => false
+      case StringLitF(_, _)              => false
+      case BoolLitF(_, _)                => false
+      case NoneLitF(_)                   => false
+      case IdentifierF(_, _)             => false
     }
 
   def entityFieldNames(es: List[entity_decl_full], ename: String): List[String] =
@@ -5463,245 +5470,6 @@ object SpecRestGenerated {
     case BoolLitF(v, va)                                         => None
     case NoneLitF(v)                                             => None
   }
-
-  def stripAddSubIntLit(x0: expr_full): expr_full = x0 match {
-    case BinaryOpF(BAdd(), inner, IntLitF(uu, uv), uw) => stripAddSubIntLit(inner)
-    case BinaryOpF(BSub(), inner, IntLitF(ux, uy), uz) => stripAddSubIntLit(inner)
-    case BinaryOpF(BAnd(), va, vb, vc)                 => BinaryOpF(BAnd(), va, vb, vc)
-    case BinaryOpF(BOr(), va, vb, vc)                  => BinaryOpF(BOr(), va, vb, vc)
-    case BinaryOpF(BImplies(), va, vb, vc)             => BinaryOpF(BImplies(), va, vb, vc)
-    case BinaryOpF(BIff(), va, vb, vc)                 => BinaryOpF(BIff(), va, vb, vc)
-    case BinaryOpF(BEq(), va, vb, vc)                  => BinaryOpF(BEq(), va, vb, vc)
-    case BinaryOpF(BNeq(), va, vb, vc)                 => BinaryOpF(BNeq(), va, vb, vc)
-    case BinaryOpF(BLt(), va, vb, vc)                  => BinaryOpF(BLt(), va, vb, vc)
-    case BinaryOpF(BGt(), va, vb, vc)                  => BinaryOpF(BGt(), va, vb, vc)
-    case BinaryOpF(BLe(), va, vb, vc)                  => BinaryOpF(BLe(), va, vb, vc)
-    case BinaryOpF(BGe(), va, vb, vc)                  => BinaryOpF(BGe(), va, vb, vc)
-    case BinaryOpF(BIn(), va, vb, vc)                  => BinaryOpF(BIn(), va, vb, vc)
-    case BinaryOpF(BNotIn(), va, vb, vc)               => BinaryOpF(BNotIn(), va, vb, vc)
-    case BinaryOpF(BSubset(), va, vb, vc)              => BinaryOpF(BSubset(), va, vb, vc)
-    case BinaryOpF(BUnion(), va, vb, vc)               => BinaryOpF(BUnion(), va, vb, vc)
-    case BinaryOpF(BIntersect(), va, vb, vc) =>
-      BinaryOpF(BIntersect(), va, vb, vc)
-    case BinaryOpF(BDiff(), va, vb, vc) => BinaryOpF(BDiff(), va, vb, vc)
-    case BinaryOpF(BSub(), va, BinaryOpF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, BinaryOpF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, UnaryOpF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, UnaryOpF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, QuantifierF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, QuantifierF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, SomeWrapF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, SomeWrapF(v, vd), vc)
-    case BinaryOpF(BSub(), va, TheF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, TheF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, FieldAccessF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, FieldAccessF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, EnumAccessF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, EnumAccessF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, IndexF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, IndexF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, CallF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, CallF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, PrimeF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, PrimeF(v, vd), vc)
-    case BinaryOpF(BSub(), va, PreF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, PreF(v, vd), vc)
-    case BinaryOpF(BSub(), va, WithF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, WithF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, IfF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, IfF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, LetF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, LetF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, LambdaF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, LambdaF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, ConstructorF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, ConstructorF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, SetLiteralF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, SetLiteralF(v, vd), vc)
-    case BinaryOpF(BSub(), va, MapLiteralF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, MapLiteralF(v, vd), vc)
-    case BinaryOpF(BSub(), va, SetComprehensionF(v, vd, ve, vf), vc) =>
-      BinaryOpF(BSub(), va, SetComprehensionF(v, vd, ve, vf), vc)
-    case BinaryOpF(BSub(), va, SeqLiteralF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, SeqLiteralF(v, vd), vc)
-    case BinaryOpF(BSub(), va, MatchesF(v, vd, ve), vc) =>
-      BinaryOpF(BSub(), va, MatchesF(v, vd, ve), vc)
-    case BinaryOpF(BSub(), va, FloatLitF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, FloatLitF(v, vd), vc)
-    case BinaryOpF(BSub(), va, StringLitF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, StringLitF(v, vd), vc)
-    case BinaryOpF(BSub(), va, BoolLitF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, BoolLitF(v, vd), vc)
-    case BinaryOpF(BSub(), va, NoneLitF(v), vc) =>
-      BinaryOpF(BSub(), va, NoneLitF(v), vc)
-    case BinaryOpF(BSub(), va, IdentifierF(v, vd), vc) =>
-      BinaryOpF(BSub(), va, IdentifierF(v, vd), vc)
-    case BinaryOpF(BMul(), va, vb, vc) => BinaryOpF(BMul(), va, vb, vc)
-    case BinaryOpF(BDiv(), va, vb, vc) => BinaryOpF(BDiv(), va, vb, vc)
-    case BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, SomeWrapF(vd, ve), vc) =>
-      BinaryOpF(v, va, SomeWrapF(vd, ve), vc)
-    case BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, IndexF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, IndexF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, CallF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, CallF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, PrimeF(vd, ve), vc) =>
-      BinaryOpF(v, va, PrimeF(vd, ve), vc)
-    case BinaryOpF(v, va, PreF(vd, ve), vc) => BinaryOpF(v, va, PreF(vd, ve), vc)
-    case BinaryOpF(v, va, WithF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, WithF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, LambdaF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, LambdaF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, SetLiteralF(vd, ve), vc) =>
-      BinaryOpF(v, va, SetLiteralF(vd, ve), vc)
-    case BinaryOpF(v, va, MapLiteralF(vd, ve), vc) =>
-      BinaryOpF(v, va, MapLiteralF(vd, ve), vc)
-    case BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc) =>
-      BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc)
-    case BinaryOpF(v, va, SeqLiteralF(vd, ve), vc) =>
-      BinaryOpF(v, va, SeqLiteralF(vd, ve), vc)
-    case BinaryOpF(v, va, MatchesF(vd, ve, vf), vc) =>
-      BinaryOpF(v, va, MatchesF(vd, ve, vf), vc)
-    case BinaryOpF(v, va, FloatLitF(vd, ve), vc) =>
-      BinaryOpF(v, va, FloatLitF(vd, ve), vc)
-    case BinaryOpF(v, va, StringLitF(vd, ve), vc) =>
-      BinaryOpF(v, va, StringLitF(vd, ve), vc)
-    case BinaryOpF(v, va, BoolLitF(vd, ve), vc) =>
-      BinaryOpF(v, va, BoolLitF(vd, ve), vc)
-    case BinaryOpF(v, va, NoneLitF(vd), vc) => BinaryOpF(v, va, NoneLitF(vd), vc)
-    case BinaryOpF(v, va, IdentifierF(vd, ve), vc) =>
-      BinaryOpF(v, va, IdentifierF(vd, ve), vc)
-    case UnaryOpF(v, va, vb)              => UnaryOpF(v, va, vb)
-    case QuantifierF(v, va, vb, vc)       => QuantifierF(v, va, vb, vc)
-    case SomeWrapF(v, va)                 => SomeWrapF(v, va)
-    case TheF(v, va, vb, vc)              => TheF(v, va, vb, vc)
-    case FieldAccessF(v, va, vb)          => FieldAccessF(v, va, vb)
-    case EnumAccessF(v, va, vb)           => EnumAccessF(v, va, vb)
-    case IndexF(v, va, vb)                => IndexF(v, va, vb)
-    case CallF(v, va, vb)                 => CallF(v, va, vb)
-    case PrimeF(v, va)                    => PrimeF(v, va)
-    case PreF(v, va)                      => PreF(v, va)
-    case WithF(v, va, vb)                 => WithF(v, va, vb)
-    case IfF(v, va, vb, vc)               => IfF(v, va, vb, vc)
-    case LetF(v, va, vb, vc)              => LetF(v, va, vb, vc)
-    case LambdaF(v, va, vb)               => LambdaF(v, va, vb)
-    case ConstructorF(v, va, vb)          => ConstructorF(v, va, vb)
-    case SetLiteralF(v, va)               => SetLiteralF(v, va)
-    case MapLiteralF(v, va)               => MapLiteralF(v, va)
-    case SetComprehensionF(v, va, vb, vc) => SetComprehensionF(v, va, vb, vc)
-    case SeqLiteralF(v, va)               => SeqLiteralF(v, va)
-    case MatchesF(v, va, vb)              => MatchesF(v, va, vb)
-    case IntLitF(v, va)                   => IntLitF(v, va)
-    case FloatLitF(v, va)                 => FloatLitF(v, va)
-    case StringLitF(v, va)                => StringLitF(v, va)
-    case BoolLitF(v, va)                  => BoolLitF(v, va)
-    case NoneLitF(v)                      => NoneLitF(v)
-    case IdentifierF(v, va)               => IdentifierF(v, va)
-  }
-
-  def isCardinalityRhs(e: expr_full, n: String): Boolean =
-    stripAddSubIntLit(e) match {
-      case BinaryOpF(_, _, _, _)                                         => false
-      case UnaryOpF(UNot(), _, _)                                        => false
-      case UnaryOpF(UNegate(), _, _)                                     => false
-      case UnaryOpF(UCardinality(), BinaryOpF(_, _, _, _), _)            => false
-      case UnaryOpF(UCardinality(), UnaryOpF(_, _, _), _)                => false
-      case UnaryOpF(UCardinality(), QuantifierF(_, _, _, _), _)          => false
-      case UnaryOpF(UCardinality(), SomeWrapF(_, _), _)                  => false
-      case UnaryOpF(UCardinality(), TheF(_, _, _, _), _)                 => false
-      case UnaryOpF(UCardinality(), FieldAccessF(_, _, _), _)            => false
-      case UnaryOpF(UCardinality(), EnumAccessF(_, _, _), _)             => false
-      case UnaryOpF(UCardinality(), IndexF(_, _, _), _)                  => false
-      case UnaryOpF(UCardinality(), CallF(_, _, _), _)                   => false
-      case UnaryOpF(UCardinality(), PrimeF(_, _), _)                     => false
-      case UnaryOpF(UCardinality(), PreF(BinaryOpF(_, _, _, _), _), _)   => false
-      case UnaryOpF(UCardinality(), PreF(UnaryOpF(_, _, _), _), _)       => false
-      case UnaryOpF(UCardinality(), PreF(QuantifierF(_, _, _, _), _), _) => false
-      case UnaryOpF(UCardinality(), PreF(SomeWrapF(_, _), _), _)         => false
-      case UnaryOpF(UCardinality(), PreF(TheF(_, _, _, _), _), _)        => false
-      case UnaryOpF(UCardinality(), PreF(FieldAccessF(_, _, _), _), _)   => false
-      case UnaryOpF(UCardinality(), PreF(EnumAccessF(_, _, _), _), _)    => false
-      case UnaryOpF(UCardinality(), PreF(IndexF(_, _, _), _), _)         => false
-      case UnaryOpF(UCardinality(), PreF(CallF(_, _, _), _), _)          => false
-      case UnaryOpF(UCardinality(), PreF(PrimeF(_, _), _), _)            => false
-      case UnaryOpF(UCardinality(), PreF(PreF(_, _), _), _)              => false
-      case UnaryOpF(UCardinality(), PreF(WithF(_, _, _), _), _)          => false
-      case UnaryOpF(UCardinality(), PreF(IfF(_, _, _, _), _), _)         => false
-      case UnaryOpF(UCardinality(), PreF(LetF(_, _, _, _), _), _)        => false
-      case UnaryOpF(UCardinality(), PreF(LambdaF(_, _, _), _), _)        => false
-      case UnaryOpF(UCardinality(), PreF(ConstructorF(_, _, _), _), _)   => false
-      case UnaryOpF(UCardinality(), PreF(SetLiteralF(_, _), _), _)       => false
-      case UnaryOpF(UCardinality(), PreF(MapLiteralF(_, _), _), _)       => false
-      case UnaryOpF(UCardinality(), PreF(SetComprehensionF(_, _, _, _), _), _) =>
-        false
-      case UnaryOpF(UCardinality(), PreF(SeqLiteralF(_, _), _), _)    => false
-      case UnaryOpF(UCardinality(), PreF(MatchesF(_, _, _), _), _)    => false
-      case UnaryOpF(UCardinality(), PreF(IntLitF(_, _), _), _)        => false
-      case UnaryOpF(UCardinality(), PreF(FloatLitF(_, _), _), _)      => false
-      case UnaryOpF(UCardinality(), PreF(StringLitF(_, _), _), _)     => false
-      case UnaryOpF(UCardinality(), PreF(BoolLitF(_, _), _), _)       => false
-      case UnaryOpF(UCardinality(), PreF(NoneLitF(_), _), _)          => false
-      case UnaryOpF(UCardinality(), PreF(IdentifierF(m, _), _), _)    => m == n
-      case UnaryOpF(UCardinality(), WithF(_, _, _), _)                => false
-      case UnaryOpF(UCardinality(), IfF(_, _, _, _), _)               => false
-      case UnaryOpF(UCardinality(), LetF(_, _, _, _), _)              => false
-      case UnaryOpF(UCardinality(), LambdaF(_, _, _), _)              => false
-      case UnaryOpF(UCardinality(), ConstructorF(_, _, _), _)         => false
-      case UnaryOpF(UCardinality(), SetLiteralF(_, _), _)             => false
-      case UnaryOpF(UCardinality(), MapLiteralF(_, _), _)             => false
-      case UnaryOpF(UCardinality(), SetComprehensionF(_, _, _, _), _) => false
-      case UnaryOpF(UCardinality(), SeqLiteralF(_, _), _)             => false
-      case UnaryOpF(UCardinality(), MatchesF(_, _, _), _)             => false
-      case UnaryOpF(UCardinality(), IntLitF(_, _), _)                 => false
-      case UnaryOpF(UCardinality(), FloatLitF(_, _), _)               => false
-      case UnaryOpF(UCardinality(), StringLitF(_, _), _)              => false
-      case UnaryOpF(UCardinality(), BoolLitF(_, _), _)                => false
-      case UnaryOpF(UCardinality(), NoneLitF(_), _)                   => false
-      case UnaryOpF(UCardinality(), IdentifierF(m, _), _)             => m == n
-      case UnaryOpF(UPower(), _, _)                                   => false
-      case QuantifierF(_, _, _, _)                                    => false
-      case SomeWrapF(_, _)                                            => false
-      case TheF(_, _, _, _)                                           => false
-      case FieldAccessF(_, _, _)                                      => false
-      case EnumAccessF(_, _, _)                                       => false
-      case IndexF(_, _, _)                                            => false
-      case CallF(_, _, _)                                             => false
-      case PrimeF(_, _)                                               => false
-      case PreF(_, _)                                                 => false
-      case WithF(_, _, _)                                             => false
-      case IfF(_, _, _, _)                                            => false
-      case LetF(_, _, _, _)                                           => false
-      case LambdaF(_, _, _)                                           => false
-      case ConstructorF(_, _, _)                                      => false
-      case SetLiteralF(_, _)                                          => false
-      case MapLiteralF(_, _)                                          => false
-      case SetComprehensionF(_, _, _, _)                              => false
-      case SeqLiteralF(_, _)                                          => false
-      case MatchesF(_, _, _)                                          => false
-      case IntLitF(_, _)                                              => false
-      case FloatLitF(_, _)                                            => false
-      case StringLitF(_, _)                                           => false
-      case BoolLitF(_, _)                                             => false
-      case NoneLitF(_)                                                => false
-      case IdentifierF(_, _)                                          => false
-    }
 
   def collectWithFields(es: List[expr_full]): Option[with_info_full] =
     snd[List[String], List[with_info_full]](

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5270,6 +5270,110 @@ object SpecRestGenerated {
       )
     )
 
+  def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
+    c match {
+      case BinaryOpF(BAnd(), _, _, _)                                    => false
+      case BinaryOpF(BOr(), _, _, _)                                     => false
+      case BinaryOpF(BImplies(), _, _, _)                                => false
+      case BinaryOpF(BIff(), _, _, _)                                    => false
+      case BinaryOpF(BEq(), _, _, _)                                     => false
+      case BinaryOpF(BNeq(), _, _, _)                                    => false
+      case BinaryOpF(BLt(), _, _, _)                                     => false
+      case BinaryOpF(BGt(), _, _, _)                                     => false
+      case BinaryOpF(BLe(), _, _, _)                                     => false
+      case BinaryOpF(BGe(), _, _, _)                                     => false
+      case BinaryOpF(BIn(), BinaryOpF(_, _, _, _), _, _)                 => false
+      case BinaryOpF(BIn(), UnaryOpF(_, _, _), _, _)                     => false
+      case BinaryOpF(BIn(), QuantifierF(_, _, _, _), _, _)               => false
+      case BinaryOpF(BIn(), SomeWrapF(_, _), _, _)                       => false
+      case BinaryOpF(BIn(), TheF(_, _, _, _), _, _)                      => false
+      case BinaryOpF(BIn(), FieldAccessF(_, _, _), _, _)                 => false
+      case BinaryOpF(BIn(), EnumAccessF(_, _, _), _, _)                  => false
+      case BinaryOpF(BIn(), IndexF(_, _, _), _, _)                       => false
+      case BinaryOpF(BIn(), CallF(_, _, _), _, _)                        => false
+      case BinaryOpF(BIn(), PrimeF(_, _), _, _)                          => false
+      case BinaryOpF(BIn(), PreF(_, _), _, _)                            => false
+      case BinaryOpF(BIn(), WithF(_, _, _), _, _)                        => false
+      case BinaryOpF(BIn(), IfF(_, _, _, _), _, _)                       => false
+      case BinaryOpF(BIn(), LetF(_, _, _, _), _, _)                      => false
+      case BinaryOpF(BIn(), LambdaF(_, _, _), _, _)                      => false
+      case BinaryOpF(BIn(), ConstructorF(_, _, _), _, _)                 => false
+      case BinaryOpF(BIn(), SetLiteralF(_, _), _, _)                     => false
+      case BinaryOpF(BIn(), MapLiteralF(_, _), _, _)                     => false
+      case BinaryOpF(BIn(), SetComprehensionF(_, _, _, _), _, _)         => false
+      case BinaryOpF(BIn(), SeqLiteralF(_, _), _, _)                     => false
+      case BinaryOpF(BIn(), MatchesF(_, _, _), _, _)                     => false
+      case BinaryOpF(BIn(), IntLitF(_, _), _, _)                         => false
+      case BinaryOpF(BIn(), FloatLitF(_, _), _, _)                       => false
+      case BinaryOpF(BIn(), StringLitF(_, _), _, _)                      => false
+      case BinaryOpF(BIn(), BoolLitF(_, _), _, _)                        => false
+      case BinaryOpF(BIn(), NoneLitF(_), _, _)                           => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), BinaryOpF(_, _, _, _), _) => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), UnaryOpF(_, _, _), _)     => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), QuantifierF(_, _, _, _), _) =>
+        false
+      case BinaryOpF(BIn(), IdentifierF(_, _), SomeWrapF(_, _), _)               => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), TheF(_, _, _, _), _)              => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), FieldAccessF(_, _, _), _)         => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), EnumAccessF(_, _, _), _)          => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), IndexF(_, _, _), _)               => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), CallF(_, _, _), _)                => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), PrimeF(_, _), _)                  => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), PreF(_, _), _)                    => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), WithF(_, _, _), _)                => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), IfF(_, _, _, _), _)               => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), LetF(_, _, _, _), _)              => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), LambdaF(_, _, _), _)              => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), ConstructorF(_, _, _), _)         => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), SetLiteralF(_, _), _)             => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), MapLiteralF(_, _), _)             => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), SetComprehensionF(_, _, _, _), _) => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), SeqLiteralF(_, _), _)             => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), MatchesF(_, _, _), _)             => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), IntLitF(_, _), _)                 => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), FloatLitF(_, _), _)               => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), StringLitF(_, _), _)              => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), BoolLitF(_, _), _)                => false
+      case BinaryOpF(BIn(), IdentifierF(_, _), NoneLitF(_), _)                   => false
+      case BinaryOpF(BIn(), IdentifierF(i, _), IdentifierF(s, _), _) =>
+        i == inputName && s == stateName
+      case BinaryOpF(BNotIn(), _, _, _)     => false
+      case BinaryOpF(BSubset(), _, _, _)    => false
+      case BinaryOpF(BUnion(), _, _, _)     => false
+      case BinaryOpF(BIntersect(), _, _, _) => false
+      case BinaryOpF(BDiff(), _, _, _)      => false
+      case BinaryOpF(BAdd(), _, _, _)       => false
+      case BinaryOpF(BSub(), _, _, _)       => false
+      case BinaryOpF(BMul(), _, _, _)       => false
+      case BinaryOpF(BDiv(), _, _, _)       => false
+      case UnaryOpF(_, _, _)                => false
+      case QuantifierF(_, _, _, _)          => false
+      case SomeWrapF(_, _)                  => false
+      case TheF(_, _, _, _)                 => false
+      case FieldAccessF(_, _, _)            => false
+      case EnumAccessF(_, _, _)             => false
+      case IndexF(_, _, _)                  => false
+      case CallF(_, _, _)                   => false
+      case PrimeF(_, _)                     => false
+      case PreF(_, _)                       => false
+      case WithF(_, _, _)                   => false
+      case IfF(_, _, _, _)                  => false
+      case LetF(_, _, _, _)                 => false
+      case LambdaF(_, _, _)                 => false
+      case ConstructorF(_, _, _)            => false
+      case SetLiteralF(_, _)                => false
+      case MapLiteralF(_, _)                => false
+      case SetComprehensionF(_, _, _, _)    => false
+      case SeqLiteralF(_, _)                => false
+      case MatchesF(_, _, _)                => false
+      case IntLitF(_, _)                    => false
+      case FloatLitF(_, _)                  => false
+      case StringLitF(_, _)                 => false
+      case BoolLitF(_, _)                   => false
+      case NoneLitF(_)                      => false
+      case IdentifierF(_, _)                => false
+    }
+
   def entityFieldNames(es: List[entity_decl_full], ename: String): List[String] =
     entityByName(es, ename) match {
       case None => Nil
@@ -5359,6 +5463,245 @@ object SpecRestGenerated {
     case BoolLitF(v, va)                                         => None
     case NoneLitF(v)                                             => None
   }
+
+  def stripAddSubIntLit(x0: expr_full): expr_full = x0 match {
+    case BinaryOpF(BAdd(), inner, IntLitF(uu, uv), uw) => stripAddSubIntLit(inner)
+    case BinaryOpF(BSub(), inner, IntLitF(ux, uy), uz) => stripAddSubIntLit(inner)
+    case BinaryOpF(BAnd(), va, vb, vc)                 => BinaryOpF(BAnd(), va, vb, vc)
+    case BinaryOpF(BOr(), va, vb, vc)                  => BinaryOpF(BOr(), va, vb, vc)
+    case BinaryOpF(BImplies(), va, vb, vc)             => BinaryOpF(BImplies(), va, vb, vc)
+    case BinaryOpF(BIff(), va, vb, vc)                 => BinaryOpF(BIff(), va, vb, vc)
+    case BinaryOpF(BEq(), va, vb, vc)                  => BinaryOpF(BEq(), va, vb, vc)
+    case BinaryOpF(BNeq(), va, vb, vc)                 => BinaryOpF(BNeq(), va, vb, vc)
+    case BinaryOpF(BLt(), va, vb, vc)                  => BinaryOpF(BLt(), va, vb, vc)
+    case BinaryOpF(BGt(), va, vb, vc)                  => BinaryOpF(BGt(), va, vb, vc)
+    case BinaryOpF(BLe(), va, vb, vc)                  => BinaryOpF(BLe(), va, vb, vc)
+    case BinaryOpF(BGe(), va, vb, vc)                  => BinaryOpF(BGe(), va, vb, vc)
+    case BinaryOpF(BIn(), va, vb, vc)                  => BinaryOpF(BIn(), va, vb, vc)
+    case BinaryOpF(BNotIn(), va, vb, vc)               => BinaryOpF(BNotIn(), va, vb, vc)
+    case BinaryOpF(BSubset(), va, vb, vc)              => BinaryOpF(BSubset(), va, vb, vc)
+    case BinaryOpF(BUnion(), va, vb, vc)               => BinaryOpF(BUnion(), va, vb, vc)
+    case BinaryOpF(BIntersect(), va, vb, vc) =>
+      BinaryOpF(BIntersect(), va, vb, vc)
+    case BinaryOpF(BDiff(), va, vb, vc) => BinaryOpF(BDiff(), va, vb, vc)
+    case BinaryOpF(BSub(), va, BinaryOpF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, BinaryOpF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, UnaryOpF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, UnaryOpF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, QuantifierF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, QuantifierF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, SomeWrapF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, SomeWrapF(v, vd), vc)
+    case BinaryOpF(BSub(), va, TheF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, TheF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, FieldAccessF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, FieldAccessF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, EnumAccessF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, EnumAccessF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, IndexF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, IndexF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, CallF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, CallF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, PrimeF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, PrimeF(v, vd), vc)
+    case BinaryOpF(BSub(), va, PreF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, PreF(v, vd), vc)
+    case BinaryOpF(BSub(), va, WithF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, WithF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, IfF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, IfF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, LetF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, LetF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, LambdaF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, LambdaF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, ConstructorF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, ConstructorF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, SetLiteralF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, SetLiteralF(v, vd), vc)
+    case BinaryOpF(BSub(), va, MapLiteralF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, MapLiteralF(v, vd), vc)
+    case BinaryOpF(BSub(), va, SetComprehensionF(v, vd, ve, vf), vc) =>
+      BinaryOpF(BSub(), va, SetComprehensionF(v, vd, ve, vf), vc)
+    case BinaryOpF(BSub(), va, SeqLiteralF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, SeqLiteralF(v, vd), vc)
+    case BinaryOpF(BSub(), va, MatchesF(v, vd, ve), vc) =>
+      BinaryOpF(BSub(), va, MatchesF(v, vd, ve), vc)
+    case BinaryOpF(BSub(), va, FloatLitF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, FloatLitF(v, vd), vc)
+    case BinaryOpF(BSub(), va, StringLitF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, StringLitF(v, vd), vc)
+    case BinaryOpF(BSub(), va, BoolLitF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, BoolLitF(v, vd), vc)
+    case BinaryOpF(BSub(), va, NoneLitF(v), vc) =>
+      BinaryOpF(BSub(), va, NoneLitF(v), vc)
+    case BinaryOpF(BSub(), va, IdentifierF(v, vd), vc) =>
+      BinaryOpF(BSub(), va, IdentifierF(v, vd), vc)
+    case BinaryOpF(BMul(), va, vb, vc) => BinaryOpF(BMul(), va, vb, vc)
+    case BinaryOpF(BDiv(), va, vb, vc) => BinaryOpF(BDiv(), va, vb, vc)
+    case BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, SomeWrapF(vd, ve), vc) =>
+      BinaryOpF(v, va, SomeWrapF(vd, ve), vc)
+    case BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, IndexF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, IndexF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, CallF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, CallF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, PrimeF(vd, ve), vc) =>
+      BinaryOpF(v, va, PrimeF(vd, ve), vc)
+    case BinaryOpF(v, va, PreF(vd, ve), vc) => BinaryOpF(v, va, PreF(vd, ve), vc)
+    case BinaryOpF(v, va, WithF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, WithF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, LambdaF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, LambdaF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, SetLiteralF(vd, ve), vc) =>
+      BinaryOpF(v, va, SetLiteralF(vd, ve), vc)
+    case BinaryOpF(v, va, MapLiteralF(vd, ve), vc) =>
+      BinaryOpF(v, va, MapLiteralF(vd, ve), vc)
+    case BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc) =>
+      BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc)
+    case BinaryOpF(v, va, SeqLiteralF(vd, ve), vc) =>
+      BinaryOpF(v, va, SeqLiteralF(vd, ve), vc)
+    case BinaryOpF(v, va, MatchesF(vd, ve, vf), vc) =>
+      BinaryOpF(v, va, MatchesF(vd, ve, vf), vc)
+    case BinaryOpF(v, va, FloatLitF(vd, ve), vc) =>
+      BinaryOpF(v, va, FloatLitF(vd, ve), vc)
+    case BinaryOpF(v, va, StringLitF(vd, ve), vc) =>
+      BinaryOpF(v, va, StringLitF(vd, ve), vc)
+    case BinaryOpF(v, va, BoolLitF(vd, ve), vc) =>
+      BinaryOpF(v, va, BoolLitF(vd, ve), vc)
+    case BinaryOpF(v, va, NoneLitF(vd), vc) => BinaryOpF(v, va, NoneLitF(vd), vc)
+    case BinaryOpF(v, va, IdentifierF(vd, ve), vc) =>
+      BinaryOpF(v, va, IdentifierF(vd, ve), vc)
+    case UnaryOpF(v, va, vb)              => UnaryOpF(v, va, vb)
+    case QuantifierF(v, va, vb, vc)       => QuantifierF(v, va, vb, vc)
+    case SomeWrapF(v, va)                 => SomeWrapF(v, va)
+    case TheF(v, va, vb, vc)              => TheF(v, va, vb, vc)
+    case FieldAccessF(v, va, vb)          => FieldAccessF(v, va, vb)
+    case EnumAccessF(v, va, vb)           => EnumAccessF(v, va, vb)
+    case IndexF(v, va, vb)                => IndexF(v, va, vb)
+    case CallF(v, va, vb)                 => CallF(v, va, vb)
+    case PrimeF(v, va)                    => PrimeF(v, va)
+    case PreF(v, va)                      => PreF(v, va)
+    case WithF(v, va, vb)                 => WithF(v, va, vb)
+    case IfF(v, va, vb, vc)               => IfF(v, va, vb, vc)
+    case LetF(v, va, vb, vc)              => LetF(v, va, vb, vc)
+    case LambdaF(v, va, vb)               => LambdaF(v, va, vb)
+    case ConstructorF(v, va, vb)          => ConstructorF(v, va, vb)
+    case SetLiteralF(v, va)               => SetLiteralF(v, va)
+    case MapLiteralF(v, va)               => MapLiteralF(v, va)
+    case SetComprehensionF(v, va, vb, vc) => SetComprehensionF(v, va, vb, vc)
+    case SeqLiteralF(v, va)               => SeqLiteralF(v, va)
+    case MatchesF(v, va, vb)              => MatchesF(v, va, vb)
+    case IntLitF(v, va)                   => IntLitF(v, va)
+    case FloatLitF(v, va)                 => FloatLitF(v, va)
+    case StringLitF(v, va)                => StringLitF(v, va)
+    case BoolLitF(v, va)                  => BoolLitF(v, va)
+    case NoneLitF(v)                      => NoneLitF(v)
+    case IdentifierF(v, va)               => IdentifierF(v, va)
+  }
+
+  def isCardinalityRhs(e: expr_full, n: String): Boolean =
+    stripAddSubIntLit(e) match {
+      case BinaryOpF(_, _, _, _)                                         => false
+      case UnaryOpF(UNot(), _, _)                                        => false
+      case UnaryOpF(UNegate(), _, _)                                     => false
+      case UnaryOpF(UCardinality(), BinaryOpF(_, _, _, _), _)            => false
+      case UnaryOpF(UCardinality(), UnaryOpF(_, _, _), _)                => false
+      case UnaryOpF(UCardinality(), QuantifierF(_, _, _, _), _)          => false
+      case UnaryOpF(UCardinality(), SomeWrapF(_, _), _)                  => false
+      case UnaryOpF(UCardinality(), TheF(_, _, _, _), _)                 => false
+      case UnaryOpF(UCardinality(), FieldAccessF(_, _, _), _)            => false
+      case UnaryOpF(UCardinality(), EnumAccessF(_, _, _), _)             => false
+      case UnaryOpF(UCardinality(), IndexF(_, _, _), _)                  => false
+      case UnaryOpF(UCardinality(), CallF(_, _, _), _)                   => false
+      case UnaryOpF(UCardinality(), PrimeF(_, _), _)                     => false
+      case UnaryOpF(UCardinality(), PreF(BinaryOpF(_, _, _, _), _), _)   => false
+      case UnaryOpF(UCardinality(), PreF(UnaryOpF(_, _, _), _), _)       => false
+      case UnaryOpF(UCardinality(), PreF(QuantifierF(_, _, _, _), _), _) => false
+      case UnaryOpF(UCardinality(), PreF(SomeWrapF(_, _), _), _)         => false
+      case UnaryOpF(UCardinality(), PreF(TheF(_, _, _, _), _), _)        => false
+      case UnaryOpF(UCardinality(), PreF(FieldAccessF(_, _, _), _), _)   => false
+      case UnaryOpF(UCardinality(), PreF(EnumAccessF(_, _, _), _), _)    => false
+      case UnaryOpF(UCardinality(), PreF(IndexF(_, _, _), _), _)         => false
+      case UnaryOpF(UCardinality(), PreF(CallF(_, _, _), _), _)          => false
+      case UnaryOpF(UCardinality(), PreF(PrimeF(_, _), _), _)            => false
+      case UnaryOpF(UCardinality(), PreF(PreF(_, _), _), _)              => false
+      case UnaryOpF(UCardinality(), PreF(WithF(_, _, _), _), _)          => false
+      case UnaryOpF(UCardinality(), PreF(IfF(_, _, _, _), _), _)         => false
+      case UnaryOpF(UCardinality(), PreF(LetF(_, _, _, _), _), _)        => false
+      case UnaryOpF(UCardinality(), PreF(LambdaF(_, _, _), _), _)        => false
+      case UnaryOpF(UCardinality(), PreF(ConstructorF(_, _, _), _), _)   => false
+      case UnaryOpF(UCardinality(), PreF(SetLiteralF(_, _), _), _)       => false
+      case UnaryOpF(UCardinality(), PreF(MapLiteralF(_, _), _), _)       => false
+      case UnaryOpF(UCardinality(), PreF(SetComprehensionF(_, _, _, _), _), _) =>
+        false
+      case UnaryOpF(UCardinality(), PreF(SeqLiteralF(_, _), _), _)    => false
+      case UnaryOpF(UCardinality(), PreF(MatchesF(_, _, _), _), _)    => false
+      case UnaryOpF(UCardinality(), PreF(IntLitF(_, _), _), _)        => false
+      case UnaryOpF(UCardinality(), PreF(FloatLitF(_, _), _), _)      => false
+      case UnaryOpF(UCardinality(), PreF(StringLitF(_, _), _), _)     => false
+      case UnaryOpF(UCardinality(), PreF(BoolLitF(_, _), _), _)       => false
+      case UnaryOpF(UCardinality(), PreF(NoneLitF(_), _), _)          => false
+      case UnaryOpF(UCardinality(), PreF(IdentifierF(m, _), _), _)    => m == n
+      case UnaryOpF(UCardinality(), WithF(_, _, _), _)                => false
+      case UnaryOpF(UCardinality(), IfF(_, _, _, _), _)               => false
+      case UnaryOpF(UCardinality(), LetF(_, _, _, _), _)              => false
+      case UnaryOpF(UCardinality(), LambdaF(_, _, _), _)              => false
+      case UnaryOpF(UCardinality(), ConstructorF(_, _, _), _)         => false
+      case UnaryOpF(UCardinality(), SetLiteralF(_, _), _)             => false
+      case UnaryOpF(UCardinality(), MapLiteralF(_, _), _)             => false
+      case UnaryOpF(UCardinality(), SetComprehensionF(_, _, _, _), _) => false
+      case UnaryOpF(UCardinality(), SeqLiteralF(_, _), _)             => false
+      case UnaryOpF(UCardinality(), MatchesF(_, _, _), _)             => false
+      case UnaryOpF(UCardinality(), IntLitF(_, _), _)                 => false
+      case UnaryOpF(UCardinality(), FloatLitF(_, _), _)               => false
+      case UnaryOpF(UCardinality(), StringLitF(_, _), _)              => false
+      case UnaryOpF(UCardinality(), BoolLitF(_, _), _)                => false
+      case UnaryOpF(UCardinality(), NoneLitF(_), _)                   => false
+      case UnaryOpF(UCardinality(), IdentifierF(m, _), _)             => m == n
+      case UnaryOpF(UPower(), _, _)                                   => false
+      case QuantifierF(_, _, _, _)                                    => false
+      case SomeWrapF(_, _)                                            => false
+      case TheF(_, _, _, _)                                           => false
+      case FieldAccessF(_, _, _)                                      => false
+      case EnumAccessF(_, _, _)                                       => false
+      case IndexF(_, _, _)                                            => false
+      case CallF(_, _, _)                                             => false
+      case PrimeF(_, _)                                               => false
+      case PreF(_, _)                                                 => false
+      case WithF(_, _, _)                                             => false
+      case IfF(_, _, _, _)                                            => false
+      case LetF(_, _, _, _)                                           => false
+      case LambdaF(_, _, _)                                           => false
+      case ConstructorF(_, _, _)                                      => false
+      case SetLiteralF(_, _)                                          => false
+      case MapLiteralF(_, _)                                          => false
+      case SetComprehensionF(_, _, _, _)                              => false
+      case SeqLiteralF(_, _)                                          => false
+      case MatchesF(_, _, _)                                          => false
+      case IntLitF(_, _)                                              => false
+      case FloatLitF(_, _)                                            => false
+      case StringLitF(_, _)                                           => false
+      case BoolLitF(_, _)                                             => false
+      case NoneLitF(_)                                                => false
+      case IdentifierF(_, _)                                          => false
+    }
 
   def collectWithFields(es: List[expr_full]): Option[with_info_full] =
     snd[List[String], List[with_info_full]](

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -98,16 +98,6 @@ object AdminRouter:
        |$stateProjections$seedSection
        |""".stripMargin
 
-  private[testgen] def primaryKeyField(e: EntityDeclFull): Option[String] =
-    AdminModel.primaryKeyField(e)
-
-  private[testgen] def isDateTimeType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Boolean =
-    AdminModel.isDateTimeType(t, ir, seen)
-
   private def seedHandler(entity: EntityDeclFull, ir: ServiceIRFull): String =
     val snake  = Naming.toSnakeCase(entity.a)
     val pkName = AdminModel.primaryKeyField(entity).getOrElse("id")

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -379,7 +379,7 @@ object Behavioral:
         ),
         Set.empty
       )
-    val pkOpt = AdminRouter.primaryKeyField(entity)
+    val pkOpt = AdminModel.primaryKeyField(entity)
     if pkOpt.isEmpty then
       return TransitionEmissionResult(
         List(
@@ -899,7 +899,7 @@ object Behavioral:
           enumVals <- enumValuesForField(fieldDecl, ir)
           if enumVals.nonEmpty
           rhsLit <- enumLiteralOf(rhs, enumVals)
-          pk     <- AdminRouter.primaryKeyField(entity)
+          pk     <- AdminModel.primaryKeyField(entity)
           if enumVals.size >= 2
         yield StatusRestriction(inName, stName, entityName, field, rhsLit, enumVals, pk)
       case _ => None
@@ -1152,8 +1152,8 @@ object Behavioral:
             fa <- findFieldDeclFull(entity.c, a).collect { case f: FieldDeclFull => f }
             fb <- findFieldDeclFull(entity.c, b).collect { case f: FieldDeclFull => f }
             kind <-
-              if AdminRouter.isDateTimeType(fa.b, ir, Set.empty) &&
-                AdminRouter.isDateTimeType(fb.b, ir, Set.empty)
+              if AdminModel.isDateTimeType(fa.b, ir, Set.empty) &&
+                AdminModel.isDateTimeType(fb.b, ir, Set.empty)
               then Some(DateTimeField)
               else if AdminRouter.isNumericType(fa.b, ir, Set.empty) &&
                 AdminRouter.isNumericType(fb.b, ir, Set.empty)
@@ -1319,7 +1319,7 @@ object Behavioral:
       val inner = f.b match
         case OptionTypeF(t, _) => t
         case t                 => t
-      if AdminRouter.isDateTimeType(inner, ir, Set.empty) then
+      if AdminModel.isDateTimeType(inner, ir, Set.empty) then
         Some("datetime.datetime(2024, 1, 1).isoformat()")
       else if AdminRouter.isNumericType(inner, ir, Set.empty) then Some("0")
       else

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -1223,21 +1223,6 @@ object Behavioral:
 
       case _ => None
 
-    private def orderedDelta(op: bin_op_full): Int = op match
-      case _: BGt => 1
-      case _: BGe => 0
-      case _: BLt => -1
-      case _: BLe => 0
-      case _      => 0
-
-    private def desiredSize(op: bin_op_full, n: Int): Option[Int] = op match
-      case BGt() => Some(n + 1)
-      case BGe() => Some(n)
-      case BEq() => Some(n).filter(_ >= 0)
-      case BLt() => Some(0).filter(_ < n)
-      case BLe() => Some(0).filter(_ <= n)
-      case _     => None
-
     private def collectionElementType(
         t: type_expr_full,
         ir: ServiceIRFull
@@ -1278,6 +1263,21 @@ object Behavioral:
                 Some(e.b.take(size).map(ExprToPython.pyString))
               case _ => None
           case _ => None
+
+    private def orderedDelta(op: bin_op_full): Int = op match
+      case _: BGt => 1
+      case _: BGe => 0
+      case _: BLt => -1
+      case _: BLe => 0
+      case _      => 0
+
+    private def desiredSize(op: bin_op_full, n: Int): Option[Int] = op match
+      case BGt() => Some(n + 1)
+      case BGe() => Some(n)
+      case BEq() => Some(n).filter(_ >= 0)
+      case BLt() => Some(0).filter(_ < n)
+      case BLe() => Some(0).filter(_ <= n)
+      case _     => None
 
     private def numericLiteralPy(e: expr_full): Option[String] = e match
       case IntLitF(int_of_integer(v), _) => Some(v.toString)

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -467,17 +467,6 @@ object Stateful:
       if unrecognized then None
       else Some(StatusRestriction(stateName, inputName, perField))
 
-  private def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
-    c match
-      case BinaryOpF(
-            BIn(),
-            IdentifierF(in, _),
-            IdentifierF(state, _),
-            _
-          ) =>
-        in == inputName && state == stateName
-      case _ => false
-
   private def fieldRestrictionConjunct(
       c: expr_full,
       inputName: String,

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -69,6 +69,8 @@ export_code
     relationTargetsEntity
     extractKeySet
     extractMapEntries
+    isCardinalityRhs
+    isKeyExistsConj
     emptyServiceIrFull
     lower
     lowerSetList

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -69,7 +69,6 @@ export_code
     relationTargetsEntity
     extractKeySet
     extractMapEntries
-    isCardinalityRhs
     isKeyExistsConj
     emptyServiceIrFull
     lower

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -549,4 +549,35 @@ fun extractMapEntries :: "expr_full \<Rightarrow> (expr_full \<times> expr_full)
   "extractMapEntries (MapLiteralF entries _) = Some (extractMapEntriesPairs entries)"
 | "extractMapEntries _                       = None"
 
+text \<open>Phase 9\<eta> (cardinality + key-existence recognizers):
+  \<open>isCardinalityRhs\<close> — \<open>|x|\<close>/\<open>|pre(x)|\<close> with optional \<open>± IntLit\<close>
+  peeling (uses a helper \<open>stripAddSubIntLit\<close> stripper + a leaf
+  \<open>case\<close>-based check to keep elaboration time bounded — the obvious
+  recursive \<open>fun\<close> formulation costs ~42 s of pattern overlap analysis);
+  \<open>isKeyExistsConj\<close> — recognizer for the \<open>input \<in> state\<close> shape used
+  by stateful test seeding.\<close>
+
+fun (sequential) stripAddSubIntLit :: "expr_full \<Rightarrow> expr_full" where
+  "stripAddSubIntLit (BinaryOpF BAdd inner (IntLitF _ _) _) = stripAddSubIntLit inner"
+| "stripAddSubIntLit (BinaryOpF BSub inner (IntLitF _ _) _) = stripAddSubIntLit inner"
+| "stripAddSubIntLit e = e"
+
+definition isCardinalityRhs :: "expr_full \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "isCardinalityRhs e n \<equiv>
+     (case stripAddSubIntLit e of
+        UnaryOpF UCardinality inner _ \<Rightarrow>
+          (case inner of
+             IdentifierF m _ \<Rightarrow> m = n
+           | PreF (IdentifierF m _) _ \<Rightarrow> m = n
+           | _ \<Rightarrow> False)
+      | _ \<Rightarrow> False)"
+
+definition isKeyExistsConj ::
+  "expr_full \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "isKeyExistsConj c inputName stateName \<equiv>
+     (case c of
+        BinaryOpF BIn (IdentifierF i _) (IdentifierF s _) _ \<Rightarrow>
+          i = inputName \<and> s = stateName
+      | _ \<Rightarrow> False)"
+
 end

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -549,35 +549,29 @@ fun extractMapEntries :: "expr_full \<Rightarrow> (expr_full \<times> expr_full)
   "extractMapEntries (MapLiteralF entries _) = Some (extractMapEntriesPairs entries)"
 | "extractMapEntries _                       = None"
 
-text \<open>Phase 9\<eta> (cardinality + key-existence recognizers):
-  \<open>isCardinalityRhs\<close> — \<open>|x|\<close>/\<open>|pre(x)|\<close> with optional \<open>± IntLit\<close>
-  peeling (uses a helper \<open>stripAddSubIntLit\<close> stripper + a leaf
-  \<open>case\<close>-based check to keep elaboration time bounded — the obvious
-  recursive \<open>fun\<close> formulation costs ~42 s of pattern overlap analysis);
-  \<open>isKeyExistsConj\<close> — recognizer for the \<open>input \<in> state\<close> shape used
-  by stateful test seeding.\<close>
+text \<open>Phase 9\<eta> (key-existence recognizer): \<open>isKeyExistsConj\<close> —
+  shallow split-case formulation: separate \<open>case\<close> on the binary
+  operator, on the left operand, and on the right operand, conjoined
+  via \<open>\<and>\<close>. The naive deep-nested pattern
+  \<open>BinaryOpF BIn (IdentifierF i _) (IdentifierF s _) _\<close> extracts to
+  a 200+-case cross-product match in Scala (op-vs-left-shape-vs-right-shape);
+  the split form generates three independent ~28-arm matches that
+  short-circuit on the first failure.
 
-fun (sequential) stripAddSubIntLit :: "expr_full \<Rightarrow> expr_full" where
-  "stripAddSubIntLit (BinaryOpF BAdd inner (IntLitF _ _) _) = stripAddSubIntLit inner"
-| "stripAddSubIntLit (BinaryOpF BSub inner (IntLitF _ _) _) = stripAddSubIntLit inner"
-| "stripAddSubIntLit e = e"
-
-definition isCardinalityRhs :: "expr_full \<Rightarrow> String.literal \<Rightarrow> bool" where
-  "isCardinalityRhs e n \<equiv>
-     (case stripAddSubIntLit e of
-        UnaryOpF UCardinality inner _ \<Rightarrow>
-          (case inner of
-             IdentifierF m _ \<Rightarrow> m = n
-           | PreF (IdentifierF m _) _ \<Rightarrow> m = n
-           | _ \<Rightarrow> False)
-      | _ \<Rightarrow> False)"
+  (\<open>isCardinalityRhs\<close> — the recursive cardinality-frame recognizer —
+  was attempted in this phase but reverted: the \<open>stripAddSubIntLit\<close>
+  helper extracts to a per-constructor identity fallback that bloats
+  the generated Scala unacceptably. Stays Scala-local in
+  \<open>convention.Classify\<close>.)\<close>
 
 definition isKeyExistsConj ::
   "expr_full \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> bool" where
   "isKeyExistsConj c inputName stateName \<equiv>
      (case c of
-        BinaryOpF BIn (IdentifierF i _) (IdentifierF s _) _ \<Rightarrow>
-          i = inputName \<and> s = stateName
+        BinaryOpF op l r _ \<Rightarrow>
+          (case op of BIn \<Rightarrow> True | _ \<Rightarrow> False) \<and>
+          (case l of IdentifierF i _ \<Rightarrow> i = inputName | _ \<Rightarrow> False) \<and>
+          (case r of IdentifierF s _ \<Rightarrow> s = stateName | _ \<Rightarrow> False)
       | _ \<Rightarrow> False)"
 
 end


### PR DESCRIPTION
## Summary

Two more pure recognizers moved to `IR_Analysis.thy`, deleted from `Convention.Classify` and `testgen.Stateful` respectively.

| Function | Type | Replaces |
|---|---|---|
| `isCardinalityRhs` | `expr_full ⇒ String.literal ⇒ bool` | `Classify.isCardinalityRhs` |
| `isKeyExistsConj` | `expr_full ⇒ String.literal ⇒ String.literal ⇒ bool` | `Stateful.isKeyExistsConj` |

## `isCardinalityRhs` implementation note

The straightforward 5-arm recursive `fun` formulation cost ~42 s of pattern overlap analysis on `expr_full`. Split into:

```text
fun (sequential) stripAddSubIntLit  -- peels BAdd/BSub with IntLit RHS
definition isCardinalityRhs         -- nested case on stripped expression
```

The recursive part uses `(sequential)` to skip exhaustiveness analysis; the leaf check uses `definition + case` to skip auto-derived simp/induct rules. Net: −20 s vs the naive formulation.

## Dropped this round (deferred):

- `orderedDelta` / `desiredSize` (Behavioral GuardSatisfier): bin_op_full → Int helpers. Returning Isabelle `int` (extracted as `int_of_integer(BigInt)`) forces ugly `case int_of_integer(b) => b.toInt` unpacking at every call site; not worth it for 2 use sites apiece.
- `numericLiteralStr`: Isabelle `show n` for `int` needs Show class machinery not in scope.

## Test plan

- [x] `isabelle build` succeeds (1:58 wall, within 2-min budget; main was 1:44)
- [x] Generated Scala regenerated cleanly
- [x] All 5 affected modules pass: **verify** 170, **testgen** 274, **lint** 31, **codegen** 222, **convention** 66 — **763 tests, 0 failures**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted `isKeyExistsConj` to Isabelle with a shallow split-case and removed the Scala helper; reverted the `isCardinalityRhs` lift. Also removed two `AdminRouter` shim wrappers and switched call sites to `AdminModel`. Build wall ~1:50; all 763 tests pass.

- **Refactors**
  - Added `isKeyExistsConj` in IR_Analysis.thy, exported via Codegen.thy, and generated into SpecRestGenerated.scala; documented the shallow split-case rule to avoid codegen blow-up; deleted the Scala helper in testgen.Stateful.
  - Reverted the lifted `isCardinalityRhs` and its `stripAddSubIntLit` helper; kept the Scala implementation.
  - Deleted `AdminRouter.primaryKeyField` and `AdminRouter.isDateTimeType` shims; updated Behavioral call sites to use `AdminModel` directly.

<sup>Written for commit d22e58c6dee46ece910cd74f2c58718d149aec4a. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Isabelle proof documentation with practical guidance on avoiding deeply nested patterns that impact code generation performance, including concrete examples and recommended optimization strategies.

* **Refactor**
  * Consolidated internal helper functions across the codebase and restructured module dependencies to improve code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->