### PR TITLE
fix(ci): add Cambridge mirror + force IPv4 + diagnose curl failures

### DIFF
--- a/.github/workflows/isabelle-build.yml
+++ b/.github/workflows/isabelle-build.yml
@@ -55,24 +55,30 @@ jobs:
           else
             echo "Tarball cache miss; trying download mirrors in order."
             tum="https://isabelle.in.tum.de/website-Isabelle${ISABELLE_VERSION}/dist/Isabelle${ISABELLE_VERSION}_linux.tar.gz"
+            cam="https://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/Isabelle${ISABELLE_VERSION}_linux.tar.gz"
             gh_release="https://github.com/${GITHUB_REPOSITORY}/releases/download/isabelle-${ISABELLE_VERSION}/Isabelle${ISABELLE_VERSION}_linux.tar.gz"
-            for url in "$tum" "$gh_release"; do
+            err="$(mktemp)"
+            for url in "$tum" "$cam" "$gh_release"; do
               echo "::group::Trying $url"
-              if curl --fail --location --show-error --silent \
-                      --connect-timeout 60 --max-time 600 \
-                      --retry 3 --retry-delay 15 --retry-connrefused \
-                      --user-agent "Mozilla/5.0 (isabelle-build-ci)" \
-                      --output "$tar.partial" "$url"; then
+              rc=0
+              curl -4 --fail --location --show-error \
+                   --connect-timeout 60 --max-time 1200 \
+                   --retry 3 --retry-delay 15 --retry-connrefused \
+                   --user-agent "Mozilla/5.0 (isabelle-build-ci)" \
+                   --output "$tar.partial" "$url" 2>"$err" || rc=$?
+              if [ "$rc" -eq 0 ] && [ -s "$tar.partial" ]; then
                 mv "$tar.partial" "$tar"
                 echo "Downloaded from $url ($(stat -c %s "$tar") bytes)"
                 echo "::endgroup::"
                 break
               fi
-              rc=$?
               rm -f "$tar.partial"
-              echo "Failed (curl exit $rc); trying next mirror."
+              echo "Failed (curl exit $rc); curl stderr (last 20 lines):"
+              tail -n 20 "$err" || true
+              echo "Trying next mirror."
               echo "::endgroup::"
             done
+            rm -f "$err"
             if [ ! -s "$tar" ]; then
               echo "::error::All Isabelle download mirrors failed."
               echo "::error::To enable the GitHub-release fallback, upload"


### PR DESCRIPTION
## Root cause(s)

Every recent cold-cache `Install Isabelle` failure (post-merge of #302 + several earlier) traces to TUM (`isabelle.in.tum.de`) being unreachable from this repo's runner network. Two distinct symptoms across environments:

| Environment | Default curl | `curl -4` | Cambridge mirror |
|---|---|---|---|
| Author's home Linux box | exit 35 RST | **HTTP/2 200** | works |
| GitHub-hosted ubuntu-latest runner | exit 35 RST | **still exit 35 RST** | **works (38 MB/s)** |

So `-4` is necessary but not sufficient — TUM is also blocking GH-runner IP space at the v4 layer. **Cambridge** (`www.cl.cam.ac.uk/research/hvg/Isabelle/`) is the actually-reliable mirror from CI.

The previous workflow only knew about TUM + a placeholder GH-release URL (which 404s because no asset was ever uploaded), so every cold-cache install died.

## What this PR changes

A single edit to the `Install Isabelle` step:

1. **Add the Cambridge mirror** (`cl.cam.ac.uk`) as a fallback between TUM and the GH-release placeholder. **This is the actual fix** — TUM stays first because when it works (cache pre-warming locally, etc.) it's the canonical source; Cambridge takes over when the runner can't reach TUM.
2. **`curl -4`** — defensive. Doesn't help in this incident but rules out v6 as a confound for future debugging.
3. **Capture curl's real exit code.** Previous `if curl; then; fi; rc=$?` always captured 0 (the `if` consumes the real code). Now `rc=0; curl ... || rc=$?` surfaces the real exit. Without this, the validation run on this branch would still have said "Failed (curl exit 0)" — useless. With it, the log now says "Failed (curl exit 35)" and prints curl's stderr.
4. **Capture curl stderr.** `--silent --show-error` can still print nothing on certain TLS-layer aborts. Redirect stderr to a temp file and `tail -n 20` it on failure.

## Validation

CI run [26309495702](https://github.com/HardMax71/spec_to_rest/actions/runs/26309495702) on this branch exercised the cold-cache install path end-to-end:

```text
Tarball cache miss; trying download mirrors in order.
##[group]Trying https://isabelle.in.tum.de/.../Isabelle2025-2_linux.tar.gz
Failed (curl exit 35); curl stderr (last 20 lines):
  curl: (35) Recv failure: Connection reset by peer
Trying next mirror.
##[group]Trying https://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/Isabelle2025-2_linux.tar.gz
Downloaded from https://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/Isabelle2025-2_linux.tar.gz (1228480874 bytes)
```

→ ✓ isabelle in 4m28s, all downstream steps green including `isabelle-timing-trace` artifact upload.

## What's next after merge

Main push will hit the same cold-cache install path (main has no isabelle cache after the #302 cache-scoping story documented in that PR). It should now pass via Cambridge → save the cache under `refs/heads/main` scope → future main runs hit cache → the chicken-and-egg is broken for good.

If TUM comes back later, no maintenance needed: the workflow will silently use TUM again (it's listed first).