### PR TITLE
fix(migration): reject AlterColumnType across auto-increment identity (#249)

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -118,9 +118,17 @@ object SchemaDiff:
     next.columns.flatMap: nc =>
       prevByName.get(nc.name).toList.flatMap: pc =>
         val typeChange =
-          if pc.sqlType != nc.sqlType then
-            List(MigrationOp.AlterColumnType(next.name, nc.name, pc.sqlType, nc.sqlType))
-          else Nil
+          if pc.sqlType == nc.sqlType then Nil
+          else if CanonicalType.isAutoIncrementType(pc.sqlType) ||
+            CanonicalType.isAutoIncrementType(nc.sqlType)
+          then
+            throw new RuntimeException(
+              s"Cannot ALTER ${next.name}.${nc.name} from ${pc.sqlType} to ${nc.sqlType}: " +
+                "auto-increment identity supply (SERIAL/BIGSERIAL) cannot be added or removed " +
+                "in place. The transition changes default-value generation, sequence ownership, " +
+                "and FK semantics; perform a manual data-preserving migration."
+            )
+          else List(MigrationOp.AlterColumnType(next.name, nc.name, pc.sqlType, nc.sqlType))
         val nullableChange =
           if pc.nullable != nc.nullable then
             List(MigrationOp.AlterColumnNullable(next.name, nc.name, pc.nullable, nc.nullable))

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/SchemaDiffTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/SchemaDiffTest.scala
@@ -77,6 +77,32 @@ class SchemaDiffTest extends CatsEffectSuite:
     val ops    = SchemaDiff.compute(before, after)
     assertEquals(ops, List(AlterColumnType("users", "email", "TEXT", "VARCHAR(255)")))
 
+  // Adding or removing an explicit `id: Int` PK toggles between BIGINT (application-supplied,
+  // see Schema.widenExplicitIdPkSqlType) and BIGSERIAL (synthesized). The transition cannot be
+  // expressed as an in-place ALTER on any supported dialect — SQLite has no answer at all — and
+  // a silent rewrite would orphan FKs that target the PK. So the diff layer rejects it loud and
+  // requires the user to perform a manual data-preserving migration.
+  private def autoIncRejectionCases: List[(String, String)] = List(
+    "BIGINT"    -> "BIGSERIAL",
+    "BIGSERIAL" -> "BIGINT",
+    "INTEGER"   -> "SERIAL",
+    "SERIAL"    -> "INTEGER",
+    "BIGINT"    -> "SERIAL",
+    "BIGSERIAL" -> "INTEGER"
+  )
+
+  autoIncRejectionCases.foreach: (oldT, newT) =>
+    test(s"AlterColumnType from $oldT to $newT is rejected at the diff layer"):
+      val before = DatabaseSchema(
+        List(table("users", cols = List(ColumnSpec("id", oldT, nullable = false, None))))
+      )
+      val after = DatabaseSchema(
+        List(table("users", cols = List(ColumnSpec("id", newT, nullable = false, None))))
+      )
+      val ex = intercept[RuntimeException](SchemaDiff.compute(before, after))
+      assert(ex.getMessage.contains("auto-increment identity supply"), ex.getMessage)
+      assert(ex.getMessage.contains("users.id"), ex.getMessage)
+
   test("nullability change produces AlterColumnNullable"):
     val cols0 = List(ColumnSpec("email", "TEXT", nullable = false, None))
     val cols1 = List(ColumnSpec("email", "TEXT", nullable = true, None))

--- a/modules/codegen/src/test/scala/specrest/codegen/migration/SqlRendererTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/migration/SqlRendererTest.scala
@@ -51,12 +51,6 @@ class SqlRendererTest extends CatsEffectSuite:
       List("ALTER TABLE posts DROP COLUMN legacy;")
     )
 
-  test("AlterColumnType strips BIGSERIAL to BIGINT"):
-    assertEquals(
-      SqlRenderer.upgrade(List(AlterColumnType("posts", "id", "INTEGER", "BIGSERIAL"))),
-      List("ALTER TABLE posts ALTER COLUMN id TYPE BIGINT;")
-    )
-
   test("AlterColumnNullable emits SET/DROP NOT NULL"):
     val toNullable = SqlRenderer.upgrade(
       List(AlterColumnNullable("posts", "title", oldNullable = false, newNullable = true))


### PR DESCRIPTION
## Summary

Closes #249.

The `AlterColumnType` renderer arm silently stripped `SERIAL`/`BIGSERIAL` to `INTEGER`/`BIGINT`, losing default-value generation and sequence ownership. Contrary to the issue's "effectively dead" framing, the path is reachable today: toggling an explicit `id: Int` field on/off flips the column's `sqlType` between `BIGINT` (per `Schema.widenExplicitIdPkSqlType`) and `BIGSERIAL` (synthesized), and the resulting `ALTER COLUMN id TYPE BIGINT;` executes silently on Postgres while dropping the sequence.

**Option A** chosen (reject at the diff layer) over Option B (emit dialect-aware sequence DDL):
- Postgres rejects `ALTER COLUMN ... TYPE BIGSERIAL`; SQLite cannot add `AUTOINCREMENT` via `ALTER` at all; MySQL needs a different statement shape — multi-dialect emission is fragile.
- A silent `Drop+Add` on a PK would orphan every foreign key targeting it.
- The transition is a structural change to identity-supply mode that deserves a loud signal, not a rewrite.

The throw matches the existing structural-rejection precedent in `SchemaDiff.topoSort` (FK-cycle detection at `SchemaDiff.scala:177`) and names the table.column, from→to types, and the cause (default-value generation, sequence ownership, FK semantics).

## Changes

- `SchemaDiff.scala` — `intraTableAlters` rejects with a precise message when either side of a type change parses to `CanonicalType.isAutoIncrement`.
- `SchemaDiffTest.scala` — 6 parametrized rejection tests (`BIGINT⇄BIGSERIAL`, `INTEGER⇄SERIAL`, `BIGINT→SERIAL`, `BIGSERIAL→INTEGER`).
- `SqlRendererTest.scala` — delete the obsolete `"AlterColumnType strips BIGSERIAL to BIGINT"` test that locked in the wrong behavior on an input the diff layer now rejects.

Net: +37 / −9.

## Test plan

- [x] `sbt codegen/test` — 227 / 227 pass (24 SchemaDiff tests, including 6 new rejection cases)
- [x] `sbt codegen/scalafixAll` clean
- [x] Pre-commit hooks pass (scalafmt, ??? guard, EOL, trailing whitespace)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject altering column types across auto-increment identity (`SERIAL`/`BIGSERIAL`) to prevent sequence loss and FK breakage. The diff now throws instead of emitting coerced SQL, fixing cases triggered by toggling an explicit `id: Int`.

- **Bug Fixes**
  - Block `AlterColumnType` when old or new type is auto-increment; error names `table.column` and from/to types.
  - Added six rejection tests; removed the renderer test that expected coercion.

- **Migration**
  - To change identity supply, do a manual migration: add a new column with the desired type/identity, backfill, swap PK and update FKs, then drop the old column.

<sup>Written for commit 3d3859ba0098acf851cb87fd4f7d5573452550b2. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/304?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safety validation to prevent automatic type conversions for auto-increment columns. Manual migrations are now required when changing between auto-increment and standard column types (e.g., BIGINT↔BIGSERIAL, SERIAL↔INTEGER) to ensure data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->