### PR TITLE
test(cli): explicit v1→v2 snapshot lift smoke test (closes #243)

### DIFF
--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -264,6 +264,57 @@ class CliSmokeTest extends CatsEffectSuite:
         assert(java.nio.file.Files.exists(outDir.resolve("Dockerfile")))
         assert(java.nio.file.Files.exists(outDir.resolve("openapi.yaml")))
 
+  test("v1 snapshot lifts transparently on re-compile: re-emits v2, no phantom 002 (#243)"):
+    tempOutPath.use: outDir =>
+      val snapPath      = outDir.resolve(".spec-snapshot.json")
+      val migrationsDir = outDir.resolve("alembic/versions")
+      val initialPath   = migrationsDir.resolve("001_initial_schema.py")
+      val opts = CompileOptions(
+        "python-fastapi-postgres",
+        outDir.toString,
+        ignoreVerify = true,
+        withTests = false
+      )
+      for
+        first <- Compile.run("fixtures/spec/url_shortener.spec", opts, log)
+        _ <- IO.blocking {
+               // Downgrade the freshly-written v2 snapshot to v1 by hand: set schemaVersion=1
+               // and drop the `triggers` field from `schema`. This simulates a snapshot left
+               // on disk by spec-to-rest <= the M7.6 release (before triggers existed).
+               val parsed     = io.circe.parser.parse(java.nio.file.Files.readString(snapPath))
+               val schemaJson = parsed.toOption.get.hcursor.downField("schema").focus.get
+               val schemaV1   = schemaJson.mapObject(_.remove("triggers"))
+               val v1Snapshot = io.circe.Json.obj(
+                 "schemaVersion" -> io.circe.Json.fromInt(1),
+                 "schema"        -> schemaV1
+               )
+               java.nio.file.Files.writeString(snapPath, v1Snapshot.spaces2)
+             }
+        v1OnDisk           <- IO.blocking(java.nio.file.Files.readString(snapPath))
+        initialBytesBefore <- IO.blocking(java.nio.file.Files.readAllBytes(initialPath))
+        second             <- Compile.run("fixtures/spec/url_shortener.spec", opts, log)
+        v2OnDisk           <- IO.blocking(java.nio.file.Files.readString(snapPath))
+        initialBytesAfter  <- IO.blocking(java.nio.file.Files.readAllBytes(initialPath))
+      yield
+        assertEquals(first, ExitCodes.Ok)
+        assertEquals(second, ExitCodes.Ok)
+        assert(
+          v1OnDisk.contains("\"schemaVersion\" : 1") && !v1OnDisk.contains("triggers"),
+          s"test setup: downgrade should produce a v1 snapshot with no triggers field; got:\n$v1OnDisk"
+        )
+        assert(
+          v2OnDisk.contains("\"schemaVersion\" : 2") && v2OnDisk.contains("\"triggers\""),
+          s"re-compile should re-emit a v2 snapshot with the triggers field present; got:\n$v2OnDisk"
+        )
+        assert(
+          !java.nio.file.Files.exists(migrationsDir.resolve("002_schema_update.py")),
+          "v1->v2 lift must be a no-op diff — no 002_schema_update.py should be produced"
+        )
+        assert(
+          java.util.Arrays.equals(initialBytesBefore, initialBytesAfter),
+          "001_initial_schema.py should be byte-stable across the v1->v2 lift"
+        )
+
   test("compile twice on the same spec is incremental: 001 stays put, snapshot stable, no 002"):
     tempOutPath.use: outDir =>
       val initialPath  = outDir.resolve("alembic/versions/001_initial_schema.py")


### PR DESCRIPTION
## Summary

Closes #243.

Belt-and-suspenders CLI-level test for the `SchemaCodec` v1→v2 lift that already shipped in #244 (M7.6, merged 2026-05-13). The lift itself is in `main` and verified at the codec level by `SchemaCodecTest:65-89`; this PR pins the property at the CLI end too, per the explicit ask in #243's acceptance criteria.

The composed proof already held:
- `SchemaCodecTest:65-89` — v1 JSON decodes to a v2-shaped value
- `CliSmokeTest:267-294` — empty diff → no new migration

But #243 explicitly asked for *"compile against v1 snapshot, compile again against v2 snapshot just written → zero new migration files"*. This commit makes that exact path a single named test rather than something a reader has to compose mentally.

## Test mechanism

1. Compile `url_shortener` → v2 snapshot + `001_initial_schema.py` on disk
2. **In-place downgrade**: hand-rewrite the snapshot via circe — set `schemaVersion: 1`, drop the `schema.triggers` field (didn't exist pre-M7.6)
3. Compile again
4. Assert:
   - both compiles exit `Ok`
   - snapshot is back to v2 after the second compile (silent forward-emission)
   - **no** `002_schema_update.py` was produced
   - `001_initial_schema.py` is byte-stable across the lift

## Crosswalk against #243 acceptance criteria

| Criterion | Where |
|---|---|
| `SchemaSnapshot.CurrentVersion = 2` | `SchemaCodec.scala:21` (shipped #244) |
| v1 JSON lifts to v2 with new fields at empty defaults | `SchemaCodec.scala:66-68` + `:50` (triggers Option, Nil default) + `IndexSpec.filterClause: Option[String] = None` |
| Round-trip: `encode(decode(v1_json))` | `SchemaCodecTest:65-89` |
| CLI smoke: v1 input → v2 re-emit, no phantom 002 | **This PR** (`CliSmokeTest`) |
| Clear error on unknown future version | `SchemaCodec.scala:69-71` + `SchemaCodecTest:91-93` |

## Test plan

- [x] New test passes locally (`sbt cli/testOnly specrest.cli.CliSmokeTest -- --tests=.*#243.*`)
- [x] `sbt cli/test` — 60 / 60 pass
- [x] `sbt cli/scalafixAll` clean
- [x] `sbt scalafmtCheckAll` clean
- [x] Pre-commit hooks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI smoke test for the v1→v2 `SchemaCodec` snapshot lift. It compiles, downgrades the snapshot to v1, recompiles, and confirms v2 is re-emitted with no `002_schema_update.py` and a byte-stable `001_initial_schema.py`, satisfying #243.

<sup>Written for commit adc211e678f0c46a4498c8bda77b97a122a48bb0. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/306?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

