### PR TITLE
feat(testgen): close translation gap for auth_service (#149 phase 1)

### DIFF
--- a/docs/content/docs/pipelines/mutation-testing.mdx
+++ b/docs/content/docs/pipelines/mutation-testing.mdx
@@ -28,7 +28,11 @@ Each fixture gets a Postgres 17 service container with
 `POSTGRES_USER`/`PASSWORD`/`DB` all set to the fixture name; the jobs are
 independent (`fail-fast: false`).
 [`auth_service`](https://github.com/HardMax71/spec_to_rest/issues/149) is
-tracked for inclusion once its 15% testgen-translator skip rate closes.
+tracked for inclusion. Translation gap closed (skip rate now 4/40 = 10%,
+matching every other fixture's generic unbacked-scalar-state floor); remaining
+blocker is the synth-cache axis — every auth operation is `LLM_SYNTHESIS`, so
+mutation-testing needs `--with-synthesis` against a committed verified-body
+cache that CI can read without LLM API calls. See [#149](https://github.com/HardMax71/spec_to_rest/issues/149).
 
 ## How a single matrix entry works
 

--- a/fixtures/golden/dafny/safe_counter.dfy
+++ b/fixtures/golden/dafny/safe_counter.dfy
@@ -3,6 +3,14 @@
 
 datatype Option<T> = None | Some(value: T)
 
+ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+  requires exists k :: k in m && p(k)
+  requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
+  ensures TheBy(m, p) in m && p(TheBy(m, p))
+{
+  var k :| k in m && p(k); k
+}
+
 class ServiceState
 {
   var count: int

--- a/fixtures/golden/dafny/todo_list.dfy
+++ b/fixtures/golden/dafny/todo_list.dfy
@@ -3,6 +3,14 @@
 
 datatype Option<T> = None | Some(value: T)
 
+ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+  requires exists k :: k in m && p(k)
+  requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
+  ensures TheBy(m, p) in m && p(TheBy(m, p))
+{
+  var k :| k in m && p(k); k
+}
+
 datatype Status = TODO | IN_PROGRESS | DONE | ARCHIVED
 datatype Priority = LOW | MEDIUM | HIGH | URGENT
 

--- a/fixtures/golden/dafny/url_shortener.dfy
+++ b/fixtures/golden/dafny/url_shortener.dfy
@@ -3,6 +3,14 @@
 
 datatype Option<T> = None | Some(value: T)
 
+ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+  requires exists k :: k in m && p(k)
+  requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
+  ensures TheBy(m, p) in m && p(TheBy(m, p))
+{
+  var k :| k in m && p(k); k
+}
+
 type ShortCode = string
 predicate ShortCodeWhere(value: string)
 {

--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -5790,17 +5790,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 214,
+                "startLine" : 212,
                 "startCol" : 14,
-                "endLine" : 214,
+                "endLine" : 212,
                 "endCol" : 19
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 214,
+              "startLine" : 212,
               "startCol" : 8,
-              "endLine" : 214,
+              "endLine" : 212,
               "endCol" : 19
             }
           },
@@ -5810,17 +5810,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 214,
+                "startLine" : 212,
                 "startCol" : 27,
-                "endLine" : 214,
+                "endLine" : 212,
                 "endCol" : 32
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 214,
+              "startLine" : 212,
               "startCol" : 21,
-              "endLine" : 214,
+              "endLine" : 212,
               "endCol" : 32
             }
           }
@@ -5835,9 +5835,9 @@
               "kind" : "Identifier",
               "name" : "u1",
               "span" : {
-                "startLine" : 215,
+                "startLine" : 213,
                 "startCol" : 6,
-                "endLine" : 215,
+                "endLine" : 213,
                 "endCol" : 8
               }
             },
@@ -5845,16 +5845,16 @@
               "kind" : "Identifier",
               "name" : "u2",
               "span" : {
-                "startLine" : 215,
+                "startLine" : 213,
                 "startCol" : 12,
-                "endLine" : 215,
+                "endLine" : 213,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 215,
+              "startLine" : 213,
               "startCol" : 6,
-              "endLine" : 215,
+              "endLine" : 213,
               "endCol" : 14
             }
           },
@@ -5869,9 +5869,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 213,
                     "startCol" : 23,
-                    "endLine" : 215,
+                    "endLine" : 213,
                     "endCol" : 28
                   }
                 },
@@ -5879,24 +5879,24 @@
                   "kind" : "Identifier",
                   "name" : "u1",
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 213,
                     "startCol" : 29,
-                    "endLine" : 215,
+                    "endLine" : 213,
                     "endCol" : 31
                   }
                 },
                 "span" : {
-                  "startLine" : 215,
+                  "startLine" : 213,
                   "startCol" : 23,
-                  "endLine" : 215,
+                  "endLine" : 213,
                   "endCol" : 32
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 215,
+                "startLine" : 213,
                 "startCol" : 23,
-                "endLine" : 215,
+                "endLine" : 213,
                 "endCol" : 38
               }
             },
@@ -5908,9 +5908,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 213,
                     "startCol" : 42,
-                    "endLine" : 215,
+                    "endLine" : 213,
                     "endCol" : 47
                   }
                 },
@@ -5918,52 +5918,52 @@
                   "kind" : "Identifier",
                   "name" : "u2",
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 213,
                     "startCol" : 48,
-                    "endLine" : 215,
+                    "endLine" : 213,
                     "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 215,
+                  "startLine" : 213,
                   "startCol" : 42,
-                  "endLine" : 215,
+                  "endLine" : 213,
                   "endCol" : 51
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 215,
+                "startLine" : 213,
                 "startCol" : 42,
-                "endLine" : 215,
+                "endLine" : 213,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 215,
+              "startLine" : 213,
               "startCol" : 23,
-              "endLine" : 215,
+              "endLine" : 213,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 215,
+            "startLine" : 213,
             "startCol" : 6,
-            "endLine" : 215,
+            "endLine" : 213,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 214,
+          "startLine" : 212,
           "startCol" : 4,
-          "endLine" : 215,
+          "endLine" : 213,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 213,
+        "startLine" : 211,
         "startCol" : 2,
-        "endLine" : 215,
+        "endLine" : 213,
         "endCol" : 57
       }
     },
@@ -5980,17 +5980,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 218,
+                "startLine" : 216,
                 "startCol" : 17,
-                "endLine" : 218,
+                "endLine" : 216,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 218,
+              "startLine" : 216,
               "startCol" : 8,
-              "endLine" : 218,
+              "endLine" : 216,
               "endCol" : 30
             }
           }
@@ -6007,9 +6007,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 217,
                   "startCol" : 6,
-                  "endLine" : 219,
+                  "endLine" : 217,
                   "endCol" : 19
                 }
               },
@@ -6017,16 +6017,16 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 217,
                   "startCol" : 20,
-                  "endLine" : 219,
+                  "endLine" : 217,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 219,
+                "startLine" : 217,
                 "startCol" : 6,
-                "endLine" : 219,
+                "endLine" : 217,
                 "endCol" : 26
               }
             },
@@ -6036,9 +6036,9 @@
                 "kind" : "Identifier",
                 "name" : "ran",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 217,
                   "startCol" : 30,
-                  "endLine" : 219,
+                  "endLine" : 217,
                   "endCol" : 33
                 }
               },
@@ -6047,24 +6047,24 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 219,
+                    "startLine" : 217,
                     "startCol" : 34,
-                    "endLine" : 219,
+                    "endLine" : 217,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 219,
+                "startLine" : 217,
                 "startCol" : 30,
-                "endLine" : 219,
+                "endLine" : 217,
                 "endCol" : 40
               }
             },
             "span" : {
-              "startLine" : 219,
+              "startLine" : 217,
               "startCol" : 6,
-              "endLine" : 219,
+              "endLine" : 217,
               "endCol" : 40
             }
           },
@@ -6079,9 +6079,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 220,
+                    "startLine" : 218,
                     "startCol" : 10,
-                    "endLine" : 220,
+                    "endLine" : 218,
                     "endCol" : 23
                   }
                 },
@@ -6089,24 +6089,24 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 220,
+                    "startLine" : 218,
                     "startCol" : 24,
-                    "endLine" : 220,
+                    "endLine" : 218,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 220,
+                  "startLine" : 218,
                   "startCol" : 10,
-                  "endLine" : 220,
+                  "endLine" : 218,
                   "endCol" : 30
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 220,
+                "startLine" : 218,
                 "startCol" : 10,
-                "endLine" : 220,
+                "endLine" : 218,
                 "endCol" : 36
               }
             },
@@ -6114,37 +6114,37 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 220,
+                "startLine" : 218,
                 "startCol" : 39,
-                "endLine" : 220,
+                "endLine" : 218,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 220,
+              "startLine" : 218,
               "startCol" : 10,
-              "endLine" : 220,
+              "endLine" : 218,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 219,
+            "startLine" : 217,
             "startCol" : 6,
-            "endLine" : 220,
+            "endLine" : 218,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 218,
+          "startLine" : 216,
           "startCol" : 4,
-          "endLine" : 220,
+          "endLine" : 218,
           "endCol" : 44
         }
       },
       "span" : {
-        "startLine" : 217,
+        "startLine" : 215,
         "startCol" : 2,
-        "endLine" : 220,
+        "endLine" : 218,
         "endCol" : 44
       }
     },
@@ -6161,17 +6161,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 223,
+                "startLine" : 221,
                 "startCol" : 13,
-                "endLine" : 223,
+                "endLine" : 221,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 223,
+              "startLine" : 221,
               "startCol" : 8,
-              "endLine" : 223,
+              "endLine" : 221,
               "endCol" : 21
             }
           }
@@ -6187,9 +6187,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 222,
                   "startCol" : 6,
-                  "endLine" : 224,
+                  "endLine" : 222,
                   "endCol" : 14
                 }
               },
@@ -6197,24 +6197,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 222,
                   "startCol" : 15,
-                  "endLine" : 224,
+                  "endLine" : 222,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 224,
+                "startLine" : 222,
                 "startCol" : 6,
-                "endLine" : 224,
+                "endLine" : 222,
                 "endCol" : 17
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 224,
+              "startLine" : 222,
               "startCol" : 6,
-              "endLine" : 224,
+              "endLine" : 222,
               "endCol" : 25
             }
           },
@@ -6222,30 +6222,30 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 224,
+              "startLine" : 222,
               "startCol" : 29,
-              "endLine" : 224,
+              "endLine" : 222,
               "endCol" : 34
             }
           },
           "span" : {
-            "startLine" : 224,
+            "startLine" : 222,
             "startCol" : 6,
-            "endLine" : 224,
+            "endLine" : 222,
             "endCol" : 34
           }
         },
         "span" : {
-          "startLine" : 223,
+          "startLine" : 221,
           "startCol" : 4,
-          "endLine" : 224,
+          "endLine" : 222,
           "endCol" : 34
         }
       },
       "span" : {
-        "startLine" : 222,
+        "startLine" : 220,
         "startCol" : 2,
-        "endLine" : 224,
+        "endLine" : 222,
         "endCol" : 34
       }
     },
@@ -6262,17 +6262,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 227,
+                "startLine" : 225,
                 "startCol" : 13,
-                "endLine" : 227,
+                "endLine" : 225,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 227,
+              "startLine" : 225,
               "startCol" : 8,
-              "endLine" : 227,
+              "endLine" : 225,
               "endCol" : 21
             }
           }
@@ -6293,16 +6293,16 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 228,
+                      "startLine" : 226,
                       "startCol" : 10,
-                      "endLine" : 228,
+                      "endLine" : 226,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 226,
                     "startCol" : 6,
-                    "endLine" : 228,
+                    "endLine" : 226,
                     "endCol" : 19
                   }
                 },
@@ -6310,24 +6310,24 @@
                   "kind" : "Identifier",
                   "name" : "s",
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 226,
                     "startCol" : 20,
-                    "endLine" : 228,
+                    "endLine" : 226,
                     "endCol" : 21
                   }
                 },
                 "span" : {
-                  "startLine" : 228,
+                  "startLine" : 226,
                   "startCol" : 6,
-                  "endLine" : 228,
+                  "endLine" : 226,
                   "endCol" : 22
                 }
               },
               "field" : "is_revoked",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 226,
                 "startCol" : 6,
-                "endLine" : 228,
+                "endLine" : 226,
                 "endCol" : 33
               }
             },
@@ -6335,16 +6335,16 @@
               "kind" : "BoolLit",
               "value" : true,
               "span" : {
-                "startLine" : 228,
+                "startLine" : 226,
                 "startCol" : 36,
-                "endLine" : 228,
+                "endLine" : 226,
                 "endCol" : 40
               }
             },
             "span" : {
-              "startLine" : 228,
+              "startLine" : 226,
               "startCol" : 6,
-              "endLine" : 228,
+              "endLine" : 226,
               "endCol" : 40
             }
           },
@@ -6361,16 +6361,16 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 228,
+                      "startLine" : 226,
                       "startCol" : 49,
-                      "endLine" : 228,
+                      "endLine" : 226,
                       "endCol" : 57
                     }
                   },
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 226,
                     "startCol" : 49,
-                    "endLine" : 228,
+                    "endLine" : 226,
                     "endCol" : 58
                   }
                 },
@@ -6378,24 +6378,24 @@
                   "kind" : "Identifier",
                   "name" : "s",
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 226,
                     "startCol" : 59,
-                    "endLine" : 228,
+                    "endLine" : 226,
                     "endCol" : 60
                   }
                 },
                 "span" : {
-                  "startLine" : 228,
+                  "startLine" : 226,
                   "startCol" : 49,
-                  "endLine" : 228,
+                  "endLine" : 226,
                   "endCol" : 61
                 }
               },
               "field" : "is_revoked",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 226,
                 "startCol" : 49,
-                "endLine" : 228,
+                "endLine" : 226,
                 "endCol" : 72
               }
             },
@@ -6403,37 +6403,37 @@
               "kind" : "BoolLit",
               "value" : true,
               "span" : {
-                "startLine" : 228,
+                "startLine" : 226,
                 "startCol" : 75,
-                "endLine" : 228,
+                "endLine" : 226,
                 "endCol" : 79
               }
             },
             "span" : {
-              "startLine" : 228,
+              "startLine" : 226,
               "startCol" : 49,
-              "endLine" : 228,
+              "endLine" : 226,
               "endCol" : 79
             }
           },
           "span" : {
-            "startLine" : 228,
+            "startLine" : 226,
             "startCol" : 6,
-            "endLine" : 228,
+            "endLine" : 226,
             "endCol" : 79
           }
         },
         "span" : {
-          "startLine" : 227,
+          "startLine" : 225,
           "startCol" : 4,
-          "endLine" : 228,
+          "endLine" : 226,
           "endCol" : 79
         }
       },
       "span" : {
-        "startLine" : 226,
+        "startLine" : 224,
         "startCol" : 2,
-        "endLine" : 228,
+        "endLine" : 226,
         "endCol" : 79
       }
     },
@@ -6450,17 +6450,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 231,
+                "startLine" : 229,
                 "startCol" : 14,
-                "endLine" : 231,
+                "endLine" : 229,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 231,
+              "startLine" : 229,
               "startCol" : 8,
-              "endLine" : 231,
+              "endLine" : 229,
               "endCol" : 22
             }
           },
@@ -6470,17 +6470,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 231,
+                "startLine" : 229,
                 "startCol" : 30,
-                "endLine" : 231,
+                "endLine" : 229,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 231,
+              "startLine" : 229,
               "startCol" : 24,
-              "endLine" : 231,
+              "endLine" : 229,
               "endCol" : 38
             }
           }
@@ -6495,9 +6495,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 232,
+                "startLine" : 230,
                 "startCol" : 6,
-                "endLine" : 232,
+                "endLine" : 230,
                 "endCol" : 8
               }
             },
@@ -6505,16 +6505,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 232,
+                "startLine" : 230,
                 "startCol" : 12,
-                "endLine" : 232,
+                "endLine" : 230,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 232,
+              "startLine" : 230,
               "startCol" : 6,
-              "endLine" : 232,
+              "endLine" : 230,
               "endCol" : 14
             }
           },
@@ -6529,9 +6529,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 233,
+                    "startLine" : 231,
                     "startCol" : 8,
-                    "endLine" : 233,
+                    "endLine" : 231,
                     "endCol" : 16
                   }
                 },
@@ -6539,24 +6539,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 233,
+                    "startLine" : 231,
                     "startCol" : 17,
-                    "endLine" : 233,
+                    "endLine" : 231,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 233,
+                  "startLine" : 231,
                   "startCol" : 8,
-                  "endLine" : 233,
+                  "endLine" : 231,
                   "endCol" : 20
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 233,
+                "startLine" : 231,
                 "startCol" : 8,
-                "endLine" : 233,
+                "endLine" : 231,
                 "endCol" : 33
               }
             },
@@ -6568,9 +6568,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 233,
+                    "startLine" : 231,
                     "startCol" : 37,
-                    "endLine" : 233,
+                    "endLine" : 231,
                     "endCol" : 45
                   }
                 },
@@ -6578,52 +6578,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 233,
+                    "startLine" : 231,
                     "startCol" : 46,
-                    "endLine" : 233,
+                    "endLine" : 231,
                     "endCol" : 48
                   }
                 },
                 "span" : {
-                  "startLine" : 233,
+                  "startLine" : 231,
                   "startCol" : 37,
-                  "endLine" : 233,
+                  "endLine" : 231,
                   "endCol" : 49
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 233,
+                "startLine" : 231,
                 "startCol" : 37,
-                "endLine" : 233,
+                "endLine" : 231,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 233,
+              "startLine" : 231,
               "startCol" : 8,
-              "endLine" : 233,
+              "endLine" : 231,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 232,
+            "startLine" : 230,
             "startCol" : 6,
-            "endLine" : 233,
+            "endLine" : 231,
             "endCol" : 62
           }
         },
         "span" : {
-          "startLine" : 231,
+          "startLine" : 229,
           "startCol" : 4,
-          "endLine" : 233,
+          "endLine" : 231,
           "endCol" : 62
         }
       },
       "span" : {
-        "startLine" : 230,
+        "startLine" : 228,
         "startCol" : 2,
-        "endLine" : 233,
+        "endLine" : 231,
         "endCol" : 62
       }
     },
@@ -6640,17 +6640,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 236,
+                "startLine" : 234,
                 "startCol" : 17,
-                "endLine" : 236,
+                "endLine" : 234,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 236,
+              "startLine" : 234,
               "startCol" : 8,
-              "endLine" : 236,
+              "endLine" : 234,
               "endCol" : 30
             }
           }
@@ -6667,9 +6667,9 @@
                 "kind" : "Identifier",
                 "name" : "recentFailedAttempts",
                 "span" : {
-                  "startLine" : 237,
+                  "startLine" : 235,
                   "startCol" : 6,
-                  "endLine" : 237,
+                  "endLine" : 235,
                   "endCol" : 26
                 }
               },
@@ -6678,17 +6678,17 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 237,
+                    "startLine" : 235,
                     "startCol" : 27,
-                    "endLine" : 237,
+                    "endLine" : 235,
                     "endCol" : 32
                   }
                 }
               ],
               "span" : {
-                "startLine" : 237,
+                "startLine" : 235,
                 "startCol" : 6,
-                "endLine" : 237,
+                "endLine" : 235,
                 "endCol" : 33
               }
             },
@@ -6696,16 +6696,16 @@
               "kind" : "IntLit",
               "value" : 5,
               "span" : {
-                "startLine" : 237,
+                "startLine" : 235,
                 "startCol" : 36,
-                "endLine" : 237,
+                "endLine" : 235,
                 "endCol" : 37
               }
             },
             "span" : {
-              "startLine" : 237,
+              "startLine" : 235,
               "startCol" : 6,
-              "endLine" : 237,
+              "endLine" : 235,
               "endCol" : 37
             }
           },
@@ -6719,17 +6719,17 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 238,
+                    "startLine" : 236,
                     "startCol" : 18,
-                    "endLine" : 238,
+                    "endLine" : 236,
                     "endCol" : 26
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 238,
+                  "startLine" : 236,
                   "startCol" : 12,
-                  "endLine" : 238,
+                  "endLine" : 236,
                   "endCol" : 26
                 }
               }
@@ -6741,9 +6741,9 @@
                 "kind" : "Identifier",
                 "name" : "op",
                 "span" : {
-                  "startLine" : 238,
+                  "startLine" : 236,
                   "startCol" : 29,
-                  "endLine" : 238,
+                  "endLine" : 236,
                   "endCol" : 31
                 }
               },
@@ -6751,44 +6751,44 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 238,
+                  "startLine" : 236,
                   "startCol" : 34,
-                  "endLine" : 238,
+                  "endLine" : 236,
                   "endCol" : 39
                 }
               },
               "span" : {
-                "startLine" : 238,
+                "startLine" : 236,
                 "startCol" : 29,
-                "endLine" : 238,
+                "endLine" : 236,
                 "endCol" : 39
               }
             },
             "span" : {
-              "startLine" : 238,
+              "startLine" : 236,
               "startCol" : 9,
-              "endLine" : 238,
+              "endLine" : 236,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 237,
+            "startLine" : 235,
             "startCol" : 6,
-            "endLine" : 238,
+            "endLine" : 236,
             "endCol" : 40
           }
         },
         "span" : {
-          "startLine" : 236,
+          "startLine" : 234,
           "startCol" : 4,
-          "endLine" : 238,
+          "endLine" : 236,
           "endCol" : 40
         }
       },
       "span" : {
-        "startLine" : 235,
+        "startLine" : 233,
         "startCol" : 2,
-        "endLine" : 238,
+        "endLine" : 236,
         "endCol" : 40
       }
     }
@@ -6796,334 +6796,272 @@
   "temporals" : [
   ],
   "facts" : [
+  ],
+  "functions" : [
     {
-      "kind" : "Fact",
-      "name" : "recentFailedAttemptsDef",
-      "expr" : {
-        "kind" : "Quantifier",
-        "quantifier" : "all",
-        "bindings" : [
-          {
-            "variable" : "email",
-            "domain" : {
-              "kind" : "Call",
-              "callee" : {
-                "kind" : "Identifier",
-                "name" : "dom",
-                "span" : {
-                  "startLine" : 204,
-                  "startCol" : 17,
-                  "endLine" : 204,
-                  "endCol" : 20
-                }
-              },
-              "args" : [
-                {
-                  "kind" : "Identifier",
-                  "name" : "user_by_email",
-                  "span" : {
-                    "startLine" : 204,
-                    "startCol" : 21,
-                    "endLine" : 204,
-                    "endCol" : 34
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 204,
-                "startCol" : 17,
-                "endLine" : 204,
-                "endCol" : 35
-              }
-            },
-            "bindingKind" : "in",
+      "kind" : "Function",
+      "name" : "recentFailedAttempts",
+      "params" : [
+        {
+          "kind" : "Param",
+          "name" : "email",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Email",
             "span" : {
-              "startLine" : 204,
-              "startCol" : 8,
-              "endLine" : 204,
-              "endCol" : 35
-            }
-          }
-        ],
-        "body" : {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Call",
-            "callee" : {
-              "kind" : "Identifier",
-              "name" : "recentFailedAttempts",
-              "span" : {
-                "startLine" : 205,
-                "startCol" : 6,
-                "endLine" : 205,
-                "endCol" : 26
-              }
-            },
-            "args" : [
-              {
-                "kind" : "Identifier",
-                "name" : "email",
-                "span" : {
-                  "startLine" : 205,
-                  "startCol" : 27,
-                  "endLine" : 205,
-                  "endCol" : 32
-                }
-              }
-            ],
-            "span" : {
-              "startLine" : 205,
-              "startCol" : 6,
-              "endLine" : 205,
-              "endCol" : 33
+              "startLine" : 203,
+              "startCol" : 39,
+              "endLine" : 203,
+              "endCol" : 44
             }
           },
-          "right" : {
-            "kind" : "UnaryOp",
-            "op" : "cardinality",
-            "operand" : {
-              "kind" : "SetComprehension",
-              "variable" : "a",
-              "domain" : {
-                "kind" : "Identifier",
-                "name" : "login_attempts",
-                "span" : {
-                  "startLine" : 206,
-                  "startCol" : 16,
-                  "endLine" : 206,
-                  "endCol" : 30
-                }
-              },
-              "predicate" : {
+          "span" : {
+            "startLine" : 203,
+            "startCol" : 32,
+            "endLine" : 203,
+            "endCol" : 44
+          }
+        }
+      ],
+      "returnType" : {
+        "kind" : "NamedType",
+        "name" : "Int",
+        "span" : {
+          "startLine" : 203,
+          "startCol" : 47,
+          "endLine" : 203,
+          "endCol" : 50
+        }
+      },
+      "body" : {
+        "kind" : "UnaryOp",
+        "op" : "cardinality",
+        "operand" : {
+          "kind" : "SetComprehension",
+          "variable" : "a",
+          "domain" : {
+            "kind" : "Identifier",
+            "name" : "login_attempts",
+            "span" : {
+              "startLine" : 204,
+              "startCol" : 12,
+              "endLine" : 204,
+              "endCol" : 26
+            }
+          },
+          "predicate" : {
+            "kind" : "BinaryOp",
+            "op" : "and",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "and",
+              "left" : {
                 "kind" : "BinaryOp",
-                "op" : "and",
+                "op" : "=",
                 "left" : {
-                  "kind" : "BinaryOp",
-                  "op" : "and",
-                  "left" : {
-                    "kind" : "BinaryOp",
-                    "op" : "=",
-                    "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Identifier",
-                        "name" : "a",
-                        "span" : {
-                          "startLine" : 207,
-                          "startCol" : 11,
-                          "endLine" : 207,
-                          "endCol" : 12
-                        }
-                      },
-                      "field" : "email",
-                      "span" : {
-                        "startLine" : 207,
-                        "startCol" : 11,
-                        "endLine" : 207,
-                        "endCol" : 18
-                      }
-                    },
-                    "right" : {
-                      "kind" : "Identifier",
-                      "name" : "email",
-                      "span" : {
-                        "startLine" : 207,
-                        "startCol" : 21,
-                        "endLine" : 207,
-                        "endCol" : 26
-                      }
-                    },
+                  "kind" : "FieldAccess",
+                  "base" : {
+                    "kind" : "Identifier",
+                    "name" : "a",
                     "span" : {
-                      "startLine" : 207,
-                      "startCol" : 11,
-                      "endLine" : 207,
-                      "endCol" : 26
+                      "startLine" : 205,
+                      "startCol" : 7,
+                      "endLine" : 205,
+                      "endCol" : 8
                     }
                   },
-                  "right" : {
-                    "kind" : "BinaryOp",
-                    "op" : "=",
-                    "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Identifier",
-                        "name" : "a",
-                        "span" : {
-                          "startLine" : 208,
-                          "startCol" : 15,
-                          "endLine" : 208,
-                          "endCol" : 16
-                        }
-                      },
-                      "field" : "success",
-                      "span" : {
-                        "startLine" : 208,
-                        "startCol" : 15,
-                        "endLine" : 208,
-                        "endCol" : 24
-                      }
-                    },
-                    "right" : {
-                      "kind" : "BoolLit",
-                      "value" : false,
-                      "span" : {
-                        "startLine" : 208,
-                        "startCol" : 27,
-                        "endLine" : 208,
-                        "endCol" : 32
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 208,
-                      "startCol" : 15,
-                      "endLine" : 208,
-                      "endCol" : 32
-                    }
-                  },
+                  "field" : "email",
                   "span" : {
-                    "startLine" : 207,
-                    "startCol" : 11,
-                    "endLine" : 208,
-                    "endCol" : 32
+                    "startLine" : 205,
+                    "startCol" : 7,
+                    "endLine" : 205,
+                    "endCol" : 14
                   }
                 },
                 "right" : {
-                  "kind" : "BinaryOp",
-                  "op" : ">",
-                  "left" : {
-                    "kind" : "FieldAccess",
-                    "base" : {
-                      "kind" : "Identifier",
-                      "name" : "a",
-                      "span" : {
-                        "startLine" : 209,
-                        "startCol" : 15,
-                        "endLine" : 209,
-                        "endCol" : 16
-                      }
-                    },
-                    "field" : "timestamp",
-                    "span" : {
-                      "startLine" : 209,
-                      "startCol" : 15,
-                      "endLine" : 209,
-                      "endCol" : 26
-                    }
-                  },
-                  "right" : {
-                    "kind" : "BinaryOp",
-                    "op" : "-",
-                    "left" : {
-                      "kind" : "Call",
-                      "callee" : {
-                        "kind" : "Identifier",
-                        "name" : "now",
-                        "span" : {
-                          "startLine" : 209,
-                          "startCol" : 29,
-                          "endLine" : 209,
-                          "endCol" : 32
-                        }
-                      },
-                      "args" : [
-                      ],
-                      "span" : {
-                        "startLine" : 209,
-                        "startCol" : 29,
-                        "endLine" : 209,
-                        "endCol" : 34
-                      }
-                    },
-                    "right" : {
-                      "kind" : "Call",
-                      "callee" : {
-                        "kind" : "Identifier",
-                        "name" : "minutes",
-                        "span" : {
-                          "startLine" : 209,
-                          "startCol" : 37,
-                          "endLine" : 209,
-                          "endCol" : 44
-                        }
-                      },
-                      "args" : [
-                        {
-                          "kind" : "IntLit",
-                          "value" : 15,
-                          "span" : {
-                            "startLine" : 209,
-                            "startCol" : 45,
-                            "endLine" : 209,
-                            "endCol" : 47
-                          }
-                        }
-                      ],
-                      "span" : {
-                        "startLine" : 209,
-                        "startCol" : 37,
-                        "endLine" : 209,
-                        "endCol" : 48
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 209,
-                      "startCol" : 29,
-                      "endLine" : 209,
-                      "endCol" : 48
-                    }
-                  },
+                  "kind" : "Identifier",
+                  "name" : "email",
                   "span" : {
-                    "startLine" : 209,
-                    "startCol" : 15,
-                    "endLine" : 209,
-                    "endCol" : 48
+                    "startLine" : 205,
+                    "startCol" : 17,
+                    "endLine" : 205,
+                    "endCol" : 22
+                  }
+                },
+                "span" : {
+                  "startLine" : 205,
+                  "startCol" : 7,
+                  "endLine" : 205,
+                  "endCol" : 22
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "FieldAccess",
+                  "base" : {
+                    "kind" : "Identifier",
+                    "name" : "a",
+                    "span" : {
+                      "startLine" : 206,
+                      "startCol" : 11,
+                      "endLine" : 206,
+                      "endCol" : 12
+                    }
+                  },
+                  "field" : "success",
+                  "span" : {
+                    "startLine" : 206,
+                    "startCol" : 11,
+                    "endLine" : 206,
+                    "endCol" : 20
+                  }
+                },
+                "right" : {
+                  "kind" : "BoolLit",
+                  "value" : false,
+                  "span" : {
+                    "startLine" : 206,
+                    "startCol" : 23,
+                    "endLine" : 206,
+                    "endCol" : 28
+                  }
+                },
+                "span" : {
+                  "startLine" : 206,
+                  "startCol" : 11,
+                  "endLine" : 206,
+                  "endCol" : 28
+                }
+              },
+              "span" : {
+                "startLine" : 205,
+                "startCol" : 7,
+                "endLine" : 206,
+                "endCol" : 28
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : ">",
+              "left" : {
+                "kind" : "FieldAccess",
+                "base" : {
+                  "kind" : "Identifier",
+                  "name" : "a",
+                  "span" : {
+                    "startLine" : 207,
+                    "startCol" : 11,
+                    "endLine" : 207,
+                    "endCol" : 12
+                  }
+                },
+                "field" : "timestamp",
+                "span" : {
+                  "startLine" : 207,
+                  "startCol" : 11,
+                  "endLine" : 207,
+                  "endCol" : 22
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "-",
+                "left" : {
+                  "kind" : "Call",
+                  "callee" : {
+                    "kind" : "Identifier",
+                    "name" : "now",
+                    "span" : {
+                      "startLine" : 207,
+                      "startCol" : 25,
+                      "endLine" : 207,
+                      "endCol" : 28
+                    }
+                  },
+                  "args" : [
+                  ],
+                  "span" : {
+                    "startLine" : 207,
+                    "startCol" : 25,
+                    "endLine" : 207,
+                    "endCol" : 30
+                  }
+                },
+                "right" : {
+                  "kind" : "Call",
+                  "callee" : {
+                    "kind" : "Identifier",
+                    "name" : "minutes",
+                    "span" : {
+                      "startLine" : 207,
+                      "startCol" : 33,
+                      "endLine" : 207,
+                      "endCol" : 40
+                    }
+                  },
+                  "args" : [
+                    {
+                      "kind" : "IntLit",
+                      "value" : 15,
+                      "span" : {
+                        "startLine" : 207,
+                        "startCol" : 41,
+                        "endLine" : 207,
+                        "endCol" : 43
+                      }
+                    }
+                  ],
+                  "span" : {
+                    "startLine" : 207,
+                    "startCol" : 33,
+                    "endLine" : 207,
+                    "endCol" : 44
                   }
                 },
                 "span" : {
                   "startLine" : 207,
-                  "startCol" : 11,
-                  "endLine" : 209,
-                  "endCol" : 48
+                  "startCol" : 25,
+                  "endLine" : 207,
+                  "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 206,
-                "startCol" : 9,
-                "endLine" : 209,
-                "endCol" : 50
+                "startLine" : 207,
+                "startCol" : 11,
+                "endLine" : 207,
+                "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 206,
-              "startCol" : 8,
-              "endLine" : 209,
-              "endCol" : 50
+              "startLine" : 205,
+              "startCol" : 7,
+              "endLine" : 207,
+              "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 205,
-            "startCol" : 6,
-            "endLine" : 209,
-            "endCol" : 50
+            "startLine" : 204,
+            "startCol" : 5,
+            "endLine" : 207,
+            "endCol" : 46
           }
         },
         "span" : {
           "startLine" : 204,
           "startCol" : 4,
-          "endLine" : 209,
-          "endCol" : 50
+          "endLine" : 207,
+          "endCol" : 46
         }
       },
       "span" : {
         "startLine" : 203,
         "startCol" : 2,
-        "endLine" : 209,
-        "endCol" : 50
+        "endLine" : 207,
+        "endCol" : 46
       }
     }
-  ],
-  "functions" : [
   ],
   "predicates" : [
     {
@@ -7243,16 +7181,16 @@
           "kind" : "StringLit",
           "value" : "/auth/register",
           "span" : {
-            "startLine" : 243,
+            "startLine" : 241,
             "startCol" : 25,
-            "endLine" : 243,
+            "endLine" : 241,
             "endCol" : 41
           }
         },
         "span" : {
-          "startLine" : 243,
+          "startLine" : 241,
           "startCol" : 4,
-          "endLine" : 243,
+          "endLine" : 241,
           "endCol" : 41
         }
       },
@@ -7265,16 +7203,16 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 244,
+            "startLine" : 242,
             "startCol" : 35,
-            "endLine" : 244,
+            "endLine" : 242,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 244,
+          "startLine" : 242,
           "startCol" : 4,
-          "endLine" : 244,
+          "endLine" : 242,
           "endCol" : 38
         }
       },
@@ -7287,8 +7225,52 @@
           "kind" : "StringLit",
           "value" : "/auth/login",
           "span" : {
-            "startLine" : 246,
+            "startLine" : 244,
             "startCol" : 22,
+            "endLine" : 244,
+            "endCol" : 35
+          }
+        },
+        "span" : {
+          "startLine" : 244,
+          "startCol" : 4,
+          "endLine" : 244,
+          "endCol" : 35
+        }
+      },
+      {
+        "kind" : "ConventionRule",
+        "target" : "Login",
+        "property" : "http_method",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "StringLit",
+          "value" : "POST",
+          "span" : {
+            "startLine" : 245,
+            "startCol" : 24,
+            "endLine" : 245,
+            "endCol" : 30
+          }
+        },
+        "span" : {
+          "startLine" : 245,
+          "startCol" : 4,
+          "endLine" : 245,
+          "endCol" : 30
+        }
+      },
+      {
+        "kind" : "ConventionRule",
+        "target" : "Login",
+        "property" : "http_status_success",
+        "qualifier" : null,
+        "value" : {
+          "kind" : "IntLit",
+          "value" : 200,
+          "span" : {
+            "startLine" : 246,
+            "startCol" : 32,
             "endLine" : 246,
             "endCol" : 35
           }
@@ -7302,50 +7284,6 @@
       },
       {
         "kind" : "ConventionRule",
-        "target" : "Login",
-        "property" : "http_method",
-        "qualifier" : null,
-        "value" : {
-          "kind" : "StringLit",
-          "value" : "POST",
-          "span" : {
-            "startLine" : 247,
-            "startCol" : 24,
-            "endLine" : 247,
-            "endCol" : 30
-          }
-        },
-        "span" : {
-          "startLine" : 247,
-          "startCol" : 4,
-          "endLine" : 247,
-          "endCol" : 30
-        }
-      },
-      {
-        "kind" : "ConventionRule",
-        "target" : "Login",
-        "property" : "http_status_success",
-        "qualifier" : null,
-        "value" : {
-          "kind" : "IntLit",
-          "value" : 200,
-          "span" : {
-            "startLine" : 248,
-            "startCol" : 32,
-            "endLine" : 248,
-            "endCol" : 35
-          }
-        },
-        "span" : {
-          "startLine" : 248,
-          "startCol" : 4,
-          "endLine" : 248,
-          "endCol" : 35
-        }
-      },
-      {
-        "kind" : "ConventionRule",
         "target" : "RefreshToken",
         "property" : "http_path",
         "qualifier" : null,
@@ -7353,16 +7291,16 @@
           "kind" : "StringLit",
           "value" : "/auth/refresh",
           "span" : {
-            "startLine" : 250,
+            "startLine" : 248,
             "startCol" : 29,
-            "endLine" : 250,
+            "endLine" : 248,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 250,
+          "startLine" : 248,
           "startCol" : 4,
-          "endLine" : 250,
+          "endLine" : 248,
           "endCol" : 44
         }
       },
@@ -7375,16 +7313,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 251,
+            "startLine" : 249,
             "startCol" : 31,
-            "endLine" : 251,
+            "endLine" : 249,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 251,
+          "startLine" : 249,
           "startCol" : 4,
-          "endLine" : 251,
+          "endLine" : 249,
           "endCol" : 37
         }
       },
@@ -7397,16 +7335,16 @@
           "kind" : "StringLit",
           "value" : "/auth/password-reset",
           "span" : {
-            "startLine" : 253,
+            "startLine" : 251,
             "startCol" : 37,
-            "endLine" : 253,
+            "endLine" : 251,
             "endCol" : 59
           }
         },
         "span" : {
-          "startLine" : 253,
+          "startLine" : 251,
           "startCol" : 4,
-          "endLine" : 253,
+          "endLine" : 251,
           "endCol" : 59
         }
       },
@@ -7419,16 +7357,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 254,
+            "startLine" : 252,
             "startCol" : 39,
-            "endLine" : 254,
+            "endLine" : 252,
             "endCol" : 45
           }
         },
         "span" : {
-          "startLine" : 254,
+          "startLine" : 252,
           "startCol" : 4,
-          "endLine" : 254,
+          "endLine" : 252,
           "endCol" : 45
         }
       },
@@ -7441,16 +7379,16 @@
           "kind" : "StringLit",
           "value" : "/auth/password-reset/confirm",
           "span" : {
-            "startLine" : 256,
+            "startLine" : 254,
             "startCol" : 30,
-            "endLine" : 256,
+            "endLine" : 254,
             "endCol" : 60
           }
         },
         "span" : {
-          "startLine" : 256,
+          "startLine" : 254,
           "startCol" : 4,
-          "endLine" : 256,
+          "endLine" : 254,
           "endCol" : 60
         }
       },
@@ -7463,16 +7401,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 257,
+            "startLine" : 255,
             "startCol" : 32,
-            "endLine" : 257,
+            "endLine" : 255,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 257,
+          "startLine" : 255,
           "startCol" : 4,
-          "endLine" : 257,
+          "endLine" : 255,
           "endCol" : 38
         }
       },
@@ -7485,16 +7423,16 @@
           "kind" : "StringLit",
           "value" : "/auth/logout",
           "span" : {
-            "startLine" : 259,
+            "startLine" : 257,
             "startCol" : 23,
-            "endLine" : 259,
+            "endLine" : 257,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 259,
+          "startLine" : 257,
           "startCol" : 4,
-          "endLine" : 259,
+          "endLine" : 257,
           "endCol" : 37
         }
       },
@@ -7507,16 +7445,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 260,
+            "startLine" : 258,
             "startCol" : 25,
-            "endLine" : 260,
+            "endLine" : 258,
             "endCol" : 31
           }
         },
         "span" : {
-          "startLine" : 260,
+          "startLine" : 258,
           "startCol" : 4,
-          "endLine" : 260,
+          "endLine" : 258,
           "endCol" : 31
         }
       },
@@ -7529,31 +7467,31 @@
           "kind" : "IntLit",
           "value" : 204,
           "span" : {
-            "startLine" : 261,
+            "startLine" : 259,
             "startCol" : 33,
-            "endLine" : 261,
+            "endLine" : 259,
             "endCol" : 36
           }
         },
         "span" : {
-          "startLine" : 261,
+          "startLine" : 259,
           "startCol" : 4,
-          "endLine" : 261,
+          "endLine" : 259,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 242,
+      "startLine" : 240,
       "startCol" : 2,
-      "endLine" : 262,
+      "endLine" : 260,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 263,
+    "endLine" : 261,
     "endCol" : 1
   }
 }

--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -6629,6 +6629,196 @@
     },
     {
       "kind" : "Invariant",
+      "name" : "refreshTokensUnique",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "s1",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "sessions",
+              "span" : {
+                "startLine" : 234,
+                "startCol" : 14,
+                "endLine" : 234,
+                "endCol" : 22
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 234,
+              "startCol" : 8,
+              "endLine" : 234,
+              "endCol" : 22
+            }
+          },
+          {
+            "variable" : "s2",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "sessions",
+              "span" : {
+                "startLine" : 234,
+                "startCol" : 30,
+                "endLine" : 234,
+                "endCol" : 38
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 234,
+              "startCol" : 24,
+              "endLine" : 234,
+              "endCol" : 38
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "implies",
+          "left" : {
+            "kind" : "BinaryOp",
+            "op" : "!=",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "s1",
+              "span" : {
+                "startLine" : 235,
+                "startCol" : 6,
+                "endLine" : 235,
+                "endCol" : 8
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "s2",
+              "span" : {
+                "startLine" : 235,
+                "startCol" : 12,
+                "endLine" : 235,
+                "endCol" : 14
+              }
+            },
+            "span" : {
+              "startLine" : 235,
+              "startCol" : 6,
+              "endLine" : 235,
+              "endCol" : 14
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "!=",
+            "left" : {
+              "kind" : "FieldAccess",
+              "base" : {
+                "kind" : "Index",
+                "base" : {
+                  "kind" : "Identifier",
+                  "name" : "sessions",
+                  "span" : {
+                    "startLine" : 236,
+                    "startCol" : 8,
+                    "endLine" : 236,
+                    "endCol" : 16
+                  }
+                },
+                "index" : {
+                  "kind" : "Identifier",
+                  "name" : "s1",
+                  "span" : {
+                    "startLine" : 236,
+                    "startCol" : 17,
+                    "endLine" : 236,
+                    "endCol" : 19
+                  }
+                },
+                "span" : {
+                  "startLine" : 236,
+                  "startCol" : 8,
+                  "endLine" : 236,
+                  "endCol" : 20
+                }
+              },
+              "field" : "refresh_token",
+              "span" : {
+                "startLine" : 236,
+                "startCol" : 8,
+                "endLine" : 236,
+                "endCol" : 34
+              }
+            },
+            "right" : {
+              "kind" : "FieldAccess",
+              "base" : {
+                "kind" : "Index",
+                "base" : {
+                  "kind" : "Identifier",
+                  "name" : "sessions",
+                  "span" : {
+                    "startLine" : 236,
+                    "startCol" : 38,
+                    "endLine" : 236,
+                    "endCol" : 46
+                  }
+                },
+                "index" : {
+                  "kind" : "Identifier",
+                  "name" : "s2",
+                  "span" : {
+                    "startLine" : 236,
+                    "startCol" : 47,
+                    "endLine" : 236,
+                    "endCol" : 49
+                  }
+                },
+                "span" : {
+                  "startLine" : 236,
+                  "startCol" : 38,
+                  "endLine" : 236,
+                  "endCol" : 50
+                }
+              },
+              "field" : "refresh_token",
+              "span" : {
+                "startLine" : 236,
+                "startCol" : 38,
+                "endLine" : 236,
+                "endCol" : 64
+              }
+            },
+            "span" : {
+              "startLine" : 236,
+              "startCol" : 8,
+              "endLine" : 236,
+              "endCol" : 64
+            }
+          },
+          "span" : {
+            "startLine" : 235,
+            "startCol" : 6,
+            "endLine" : 236,
+            "endCol" : 64
+          }
+        },
+        "span" : {
+          "startLine" : 234,
+          "startCol" : 4,
+          "endLine" : 236,
+          "endCol" : 64
+        }
+      },
+      "span" : {
+        "startLine" : 233,
+        "startCol" : 2,
+        "endLine" : 236,
+        "endCol" : 64
+      }
+    },
+    {
+      "kind" : "Invariant",
       "name" : "rateLimitEnforced",
       "expr" : {
         "kind" : "Quantifier",
@@ -6640,17 +6830,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 234,
+                "startLine" : 239,
                 "startCol" : 17,
-                "endLine" : 234,
+                "endLine" : 239,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 234,
+              "startLine" : 239,
               "startCol" : 8,
-              "endLine" : 234,
+              "endLine" : 239,
               "endCol" : 30
             }
           }
@@ -6667,9 +6857,9 @@
                 "kind" : "Identifier",
                 "name" : "recentFailedAttempts",
                 "span" : {
-                  "startLine" : 235,
+                  "startLine" : 240,
                   "startCol" : 6,
-                  "endLine" : 235,
+                  "endLine" : 240,
                   "endCol" : 26
                 }
               },
@@ -6678,17 +6868,17 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 235,
+                    "startLine" : 240,
                     "startCol" : 27,
-                    "endLine" : 235,
+                    "endLine" : 240,
                     "endCol" : 32
                   }
                 }
               ],
               "span" : {
-                "startLine" : 235,
+                "startLine" : 240,
                 "startCol" : 6,
-                "endLine" : 235,
+                "endLine" : 240,
                 "endCol" : 33
               }
             },
@@ -6696,16 +6886,16 @@
               "kind" : "IntLit",
               "value" : 5,
               "span" : {
-                "startLine" : 235,
+                "startLine" : 240,
                 "startCol" : 36,
-                "endLine" : 235,
+                "endLine" : 240,
                 "endCol" : 37
               }
             },
             "span" : {
-              "startLine" : 235,
+              "startLine" : 240,
               "startCol" : 6,
-              "endLine" : 235,
+              "endLine" : 240,
               "endCol" : 37
             }
           },
@@ -6719,17 +6909,17 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 236,
+                    "startLine" : 241,
                     "startCol" : 18,
-                    "endLine" : 236,
+                    "endLine" : 241,
                     "endCol" : 26
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 236,
+                  "startLine" : 241,
                   "startCol" : 12,
-                  "endLine" : 236,
+                  "endLine" : 241,
                   "endCol" : 26
                 }
               }
@@ -6741,9 +6931,9 @@
                 "kind" : "Identifier",
                 "name" : "op",
                 "span" : {
-                  "startLine" : 236,
+                  "startLine" : 241,
                   "startCol" : 29,
-                  "endLine" : 236,
+                  "endLine" : 241,
                   "endCol" : 31
                 }
               },
@@ -6751,44 +6941,44 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 236,
+                  "startLine" : 241,
                   "startCol" : 34,
-                  "endLine" : 236,
+                  "endLine" : 241,
                   "endCol" : 39
                 }
               },
               "span" : {
-                "startLine" : 236,
+                "startLine" : 241,
                 "startCol" : 29,
-                "endLine" : 236,
+                "endLine" : 241,
                 "endCol" : 39
               }
             },
             "span" : {
-              "startLine" : 236,
+              "startLine" : 241,
               "startCol" : 9,
-              "endLine" : 236,
+              "endLine" : 241,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 235,
+            "startLine" : 240,
             "startCol" : 6,
-            "endLine" : 236,
+            "endLine" : 241,
             "endCol" : 40
           }
         },
         "span" : {
-          "startLine" : 234,
+          "startLine" : 239,
           "startCol" : 4,
-          "endLine" : 236,
+          "endLine" : 241,
           "endCol" : 40
         }
       },
       "span" : {
-        "startLine" : 233,
+        "startLine" : 238,
         "startCol" : 2,
-        "endLine" : 236,
+        "endLine" : 241,
         "endCol" : 40
       }
     }
@@ -7181,16 +7371,16 @@
           "kind" : "StringLit",
           "value" : "/auth/register",
           "span" : {
-            "startLine" : 241,
+            "startLine" : 246,
             "startCol" : 25,
-            "endLine" : 241,
+            "endLine" : 246,
             "endCol" : 41
           }
         },
         "span" : {
-          "startLine" : 241,
+          "startLine" : 246,
           "startCol" : 4,
-          "endLine" : 241,
+          "endLine" : 246,
           "endCol" : 41
         }
       },
@@ -7203,16 +7393,16 @@
           "kind" : "IntLit",
           "value" : 201,
           "span" : {
-            "startLine" : 242,
+            "startLine" : 247,
             "startCol" : 35,
-            "endLine" : 242,
+            "endLine" : 247,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 242,
+          "startLine" : 247,
           "startCol" : 4,
-          "endLine" : 242,
+          "endLine" : 247,
           "endCol" : 38
         }
       },
@@ -7225,16 +7415,16 @@
           "kind" : "StringLit",
           "value" : "/auth/login",
           "span" : {
-            "startLine" : 244,
+            "startLine" : 249,
             "startCol" : 22,
-            "endLine" : 244,
+            "endLine" : 249,
             "endCol" : 35
           }
         },
         "span" : {
-          "startLine" : 244,
+          "startLine" : 249,
           "startCol" : 4,
-          "endLine" : 244,
+          "endLine" : 249,
           "endCol" : 35
         }
       },
@@ -7247,16 +7437,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 245,
+            "startLine" : 250,
             "startCol" : 24,
-            "endLine" : 245,
+            "endLine" : 250,
             "endCol" : 30
           }
         },
         "span" : {
-          "startLine" : 245,
+          "startLine" : 250,
           "startCol" : 4,
-          "endLine" : 245,
+          "endLine" : 250,
           "endCol" : 30
         }
       },
@@ -7269,16 +7459,16 @@
           "kind" : "IntLit",
           "value" : 200,
           "span" : {
-            "startLine" : 246,
+            "startLine" : 251,
             "startCol" : 32,
-            "endLine" : 246,
+            "endLine" : 251,
             "endCol" : 35
           }
         },
         "span" : {
-          "startLine" : 246,
+          "startLine" : 251,
           "startCol" : 4,
-          "endLine" : 246,
+          "endLine" : 251,
           "endCol" : 35
         }
       },
@@ -7291,16 +7481,16 @@
           "kind" : "StringLit",
           "value" : "/auth/refresh",
           "span" : {
-            "startLine" : 248,
+            "startLine" : 253,
             "startCol" : 29,
-            "endLine" : 248,
+            "endLine" : 253,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 248,
+          "startLine" : 253,
           "startCol" : 4,
-          "endLine" : 248,
+          "endLine" : 253,
           "endCol" : 44
         }
       },
@@ -7313,16 +7503,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 249,
+            "startLine" : 254,
             "startCol" : 31,
-            "endLine" : 249,
+            "endLine" : 254,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 249,
+          "startLine" : 254,
           "startCol" : 4,
-          "endLine" : 249,
+          "endLine" : 254,
           "endCol" : 37
         }
       },
@@ -7335,16 +7525,16 @@
           "kind" : "StringLit",
           "value" : "/auth/password-reset",
           "span" : {
-            "startLine" : 251,
+            "startLine" : 256,
             "startCol" : 37,
-            "endLine" : 251,
+            "endLine" : 256,
             "endCol" : 59
           }
         },
         "span" : {
-          "startLine" : 251,
+          "startLine" : 256,
           "startCol" : 4,
-          "endLine" : 251,
+          "endLine" : 256,
           "endCol" : 59
         }
       },
@@ -7357,16 +7547,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 252,
+            "startLine" : 257,
             "startCol" : 39,
-            "endLine" : 252,
+            "endLine" : 257,
             "endCol" : 45
           }
         },
         "span" : {
-          "startLine" : 252,
+          "startLine" : 257,
           "startCol" : 4,
-          "endLine" : 252,
+          "endLine" : 257,
           "endCol" : 45
         }
       },
@@ -7379,16 +7569,16 @@
           "kind" : "StringLit",
           "value" : "/auth/password-reset/confirm",
           "span" : {
-            "startLine" : 254,
+            "startLine" : 259,
             "startCol" : 30,
-            "endLine" : 254,
+            "endLine" : 259,
             "endCol" : 60
           }
         },
         "span" : {
-          "startLine" : 254,
+          "startLine" : 259,
           "startCol" : 4,
-          "endLine" : 254,
+          "endLine" : 259,
           "endCol" : 60
         }
       },
@@ -7401,16 +7591,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 255,
+            "startLine" : 260,
             "startCol" : 32,
-            "endLine" : 255,
+            "endLine" : 260,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 255,
+          "startLine" : 260,
           "startCol" : 4,
-          "endLine" : 255,
+          "endLine" : 260,
           "endCol" : 38
         }
       },
@@ -7423,16 +7613,16 @@
           "kind" : "StringLit",
           "value" : "/auth/logout",
           "span" : {
-            "startLine" : 257,
+            "startLine" : 262,
             "startCol" : 23,
-            "endLine" : 257,
+            "endLine" : 262,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 257,
+          "startLine" : 262,
           "startCol" : 4,
-          "endLine" : 257,
+          "endLine" : 262,
           "endCol" : 37
         }
       },
@@ -7445,16 +7635,16 @@
           "kind" : "StringLit",
           "value" : "POST",
           "span" : {
-            "startLine" : 258,
+            "startLine" : 263,
             "startCol" : 25,
-            "endLine" : 258,
+            "endLine" : 263,
             "endCol" : 31
           }
         },
         "span" : {
-          "startLine" : 258,
+          "startLine" : 263,
           "startCol" : 4,
-          "endLine" : 258,
+          "endLine" : 263,
           "endCol" : 31
         }
       },
@@ -7467,31 +7657,31 @@
           "kind" : "IntLit",
           "value" : 204,
           "span" : {
-            "startLine" : 259,
+            "startLine" : 264,
             "startCol" : 33,
-            "endLine" : 259,
+            "endLine" : 264,
             "endCol" : 36
           }
         },
         "span" : {
-          "startLine" : 259,
+          "startLine" : 264,
           "startCol" : 4,
-          "endLine" : 259,
+          "endLine" : 264,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 240,
+      "startLine" : 245,
       "startCol" : 2,
-      "endLine" : 260,
+      "endLine" : 265,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 261,
+    "endLine" : 266,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/auth_service.spec
+++ b/fixtures/spec/auth_service.spec
@@ -200,13 +200,11 @@ service AuthService {
 
   // --- Helper Functions ---
 
-  fact recentFailedAttemptsDef:
-    all email in dom(user_by_email) |
-      recentFailedAttempts(email) =
-        #{ a in login_attempts |
-           a.email = email
-           and a.success = false
-           and a.timestamp > now() - minutes(15) }
+  function recentFailedAttempts(email: Email): Int =
+    #{ a in login_attempts |
+       a.email = email
+       and a.success = false
+       and a.timestamp > now() - minutes(15) }
 
   // --- Global Invariants ---
 

--- a/fixtures/spec/auth_service.spec
+++ b/fixtures/spec/auth_service.spec
@@ -230,6 +230,11 @@ service AuthService {
       s1 != s2 implies
         sessions[s1].access_token != sessions[s2].access_token
 
+  invariant refreshTokensUnique:
+    all s1 in sessions, s2 in sessions |
+      s1 != s2 implies
+        sessions[s1].refresh_token != sessions[s2].refresh_token
+
   invariant rateLimitEnforced:
     all email in user_by_email |
       recentFailedAttempts(email) < 5 or

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -95,11 +95,6 @@ class CliSmokeTest extends CatsEffectSuite:
   test("InspectFormat.parse accepts dafny"):
     assertEquals(InspectFormat.parse("dafny").toOption, Some(InspectFormat.Dafny))
 
-  test("inspect --format dafny exits with Translator on unsupported expression (#32)"):
-    Inspect
-      .run("fixtures/spec/edge_cases.spec", InspectFormat.Dafny, log)
-      .assertEquals(ExitCodes.Translator)
-
   test("InspectFormat.parse accepts dafny-prompt (#28)"):
     assertEquals(
       InspectFormat.parse("dafny-prompt").toOption,

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -70,6 +70,7 @@ object Generator:
 
       sb ++= header(ir.a)
       sb ++= optionDatatype()
+      sb ++= theByFunction()
 
       val enumDecls    = renderEnums(ir.d)
       val typeAliases  = renderTypeAliases(ctx, ir.e)
@@ -114,6 +115,22 @@ object Generator:
 
   private def optionDatatype(): String =
     "\ndatatype Option<T> = None | Some(value: T)\n"
+
+  // Deterministic spec-level "unique element of a map" used to lower `TheF` in a way
+  // Dafny can verify across ensures + body. Same call (same map, same predicate)
+  // yields the same key — so a method body that mutates `m[TheBy(m, p)]` discharges
+  // an ensures that references `m[TheBy(m, p)]`. The two preconditions force the
+  // caller to prove existence + uniqueness from spec invariants; without that, the
+  // call site fails to verify (which is the right outcome — `the X | P(X)` is
+  // undefined when P matches zero or many elements).
+  private def theByFunction(): String =
+    "\nghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K\n" +
+      "  requires exists k :: k in m && p(k)\n" +
+      "  requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2\n" +
+      "  ensures TheBy(m, p) in m && p(TheBy(m, p))\n" +
+      "{\n" +
+      "  var k :| k in m && p(k); k\n" +
+      "}\n"
 
   private def renderEnums(decls: List[enum_decl_full])(using DafnyLabel): String =
     val parts = decls.collect { case EnumDeclFull(name, vs, _) =>
@@ -586,15 +603,17 @@ object Generator:
         if isMapDomain(ctx, dom) then s"$domStr[$v]" else v
       s"(set $v | $v in $domStr && $predStr :: $projection)"
     case TheF(v, dom, body, _) =>
-      // `the v in dom | body` = the unique element of dom satisfying body. Lowered
-      // to Dafny's let-such-that: pick a witness satisfying the predicate, then
-      // yield it. Uniqueness is the spec contract's burden — the verifier rejects
-      // bodies where the witness isn't actually unique under the operation's
-      // requires/invariants.
+      // `the v in dom | body` = the unique element satisfying body. Lowered to a
+      // call to the deterministic spec-level helper TheBy so the SAME witness is
+      // referenced across ensures + body within one proof obligation. Inlining
+      // `var x :| ...` instead would give Dafny a fresh witness each occurrence
+      // and CEGIS cannot converge. Uniqueness + existence are the helper's
+      // preconditions, discharged from spec invariants at the call site.
       val innerCtx = ctx.copy(boundVars = ctx.boundVars + v)
       val domStr   = renderExpr(ctx, dom)
       val bodyStr  = renderExpr(innerCtx, body)
-      s"(var $v :| $v in $domStr && $bodyStr; $v)"
+      val keyType  = theByKeyType(ctx, dom)
+      s"TheBy($domStr, ($v: $keyType) => $bodyStr)"
     case WithF(base, fields, _) =>
       val parts = fields.map { case FieldAssignFull(n, v, _) =>
         s"$n := ${renderExpr(ctx, v)}"
@@ -609,6 +628,18 @@ object Generator:
 
   private def isMapDomain(ctx: Ctx, dom: expr_full): Boolean =
     peelRelationRefFull(dom).exists(isMapStateField(ctx, _))
+
+  // Extract the key type of the map/relation `dom` refers to, so the lambda passed
+  // to TheBy is fully type-annotated (Dafny cannot infer the parameter type through
+  // a generic call).
+  private def theByKeyType(ctx: Ctx, dom: expr_full)(using DafnyLabel): String =
+    peelRelationRefFull(dom).flatMap(ctx.stateFields.get) match
+      case Some(MapTypeF(k, _, _))            => renderType(ctx, k)
+      case Some(RelationTypeF(from, _, _, _)) => renderType(ctx, from)
+      case _ =>
+        failDafny(
+          s"TheBy: cannot infer key type — expected a map/relation state field, got ${dom.getClass.getSimpleName}"
+        )
 
   private def isMapStateField(ctx: Ctx, name: String): Boolean =
     ctx.stateFields.get(name).exists {

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -585,6 +585,16 @@ object Generator:
       val projection =
         if isMapDomain(ctx, dom) then s"$domStr[$v]" else v
       s"(set $v | $v in $domStr && $predStr :: $projection)"
+    case TheF(v, dom, body, _) =>
+      // `the v in dom | body` = the unique element of dom satisfying body. Lowered
+      // to Dafny's let-such-that: pick a witness satisfying the predicate, then
+      // yield it. Uniqueness is the spec contract's burden — the verifier rejects
+      // bodies where the witness isn't actually unique under the operation's
+      // requires/invariants.
+      val innerCtx = ctx.copy(boundVars = ctx.boundVars + v)
+      val domStr   = renderExpr(ctx, dom)
+      val bodyStr  = renderExpr(innerCtx, body)
+      s"(var $v :| $v in $domStr && $bodyStr; $v)"
     case WithF(base, fields, _) =>
       val parts = fields.map { case FieldAssignFull(n, v, _) =>
         s"$n := ${renderExpr(ctx, v)}"
@@ -596,8 +606,6 @@ object Generator:
     case LambdaF(p, body, _) =>
       val inner = ctx.copy(boundVars = ctx.boundVars + p)
       s"(($p: int) => ${renderExpr(inner, body)})"
-    case other =>
-      failDafny(s"unsupported expression in Dafny translation: ${other.getClass.getSimpleName}")
 
   private def isMapDomain(ctx: Ctx, dom: expr_full): Boolean =
     peelRelationRefFull(dom).exists(isMapStateField(ctx, _))

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -13,6 +13,8 @@
 package tests
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"regexp"
 	"sort"
@@ -535,4 +537,10 @@ func _call(f any, args ...any) any {
 
 func _now() any {
 	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func _sha256Hex(s any) any {
+	str, _ := s.(string)
+	sum := sha256.Sum256([]byte(str))
+	return hex.EncodeToString(sum[:])
 }

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -536,11 +536,14 @@ func _call(f any, args ...any) any {
 }
 
 func _now() any {
-	return time.Now().UTC().Format(time.RFC3339)
+	// Epoch seconds (float64) so `now() - minutes(15)` is numeric arithmetic.
+	// Aligns with _mul-based time-unit functions which return numeric seconds.
+	return float64(time.Now().UTC().Unix())
 }
 
 func _sha256Hex(s any) any {
-	str, _ := s.(string)
-	sum := sha256.Sum256([]byte(str))
+	// Coerce any value (numbers come from JSON as float64) to its canonical
+	// string form before hashing, mirroring Python's str(...) coercion.
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%v", s)))
 	return hex.EncodeToString(sum[:])
 }

--- a/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
+++ b/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
@@ -5,6 +5,8 @@
 // `len`, `|`/`&`/`-`, powerset). State read from /__test_admin__/state is a
 // plain JSON object; relation/map state fields project as `{ key: value }`.
 
+import { createHash } from "node:crypto";
+
 type Anything = unknown;
 
 function asArray(x: Anything): Anything[] {
@@ -88,4 +90,8 @@ export function _powerset(x: Anything): Set<Set<Anything>> {
     subsets.push(new Set(sub));
   }
   return new Set(subsets);
+}
+
+export function _sha256Hex(x: Anything): string {
+  return createHash("sha256").update(String(x)).digest("hex");
 }

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -238,10 +238,12 @@ object ExprToPython extends ExprBackend:
       case "min" if args.size == 1 =>
         lift1(translate(args.head, ctx))(a => ExprPy.Py(s"min($a)"))
       case "now" if args.isEmpty =>
-        ExprPy.Py("datetime.datetime.now(datetime.timezone.utc).isoformat()")
+        // Epoch seconds (float) so `now() - minutes(15)` is numeric arithmetic.
+        // Aligns with days/hours/minutes/seconds which all return numeric seconds.
+        ExprPy.Py("datetime.datetime.now(datetime.timezone.utc).timestamp()")
       case "hash" if args.size == 1 =>
         lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"hashlib.sha256(($a).encode()).hexdigest()")
+          ExprPy.Py(s"hashlib.sha256(str($a).encode()).hexdigest()")
         )
       case "days" if args.size == 1 =>
         lift1(translate(args.head, ctx))(a =>

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -239,9 +239,25 @@ object ExprToPython extends ExprBackend:
         lift1(translate(args.head, ctx))(a => ExprPy.Py(s"min($a)"))
       case "now" if args.isEmpty =>
         ExprPy.Py("datetime.datetime.now(datetime.timezone.utc).isoformat()")
+      case "hash" if args.size == 1 =>
+        lift1(translate(args.head, ctx))(a =>
+          ExprPy.Py(s"hashlib.sha256(($a).encode()).hexdigest()")
+        )
       case "days" if args.size == 1 =>
         lift1(translate(args.head, ctx))(a =>
           ExprPy.Py(s"datetime.timedelta(days=$a).total_seconds()")
+        )
+      case "hours" if args.size == 1 =>
+        lift1(translate(args.head, ctx))(a =>
+          ExprPy.Py(s"datetime.timedelta(hours=$a).total_seconds()")
+        )
+      case "minutes" if args.size == 1 =>
+        lift1(translate(args.head, ctx))(a =>
+          ExprPy.Py(s"datetime.timedelta(minutes=$a).total_seconds()")
+        )
+      case "seconds" if args.size == 1 =>
+        lift1(translate(args.head, ctx))(a =>
+          ExprPy.Py(s"datetime.timedelta(seconds=$a).total_seconds()")
         )
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx, span)

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -301,8 +301,16 @@ object GoExprBackend extends ExprBackend:
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_min($a)"))
       case "now" if args.isEmpty =>
         ExprPy.Py("_now()")
+      case "hash" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_sha256Hex($a)"))
       case "days" if args.size == 1 =>
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(86400))"))
+      case "hours" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(3600))"))
+      case "minutes" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(60))"))
+      case "seconds" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(1))"))
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx)
       case other =>

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -860,6 +860,7 @@ object Stateful:
         |See tests/_testgen_skips.json for clauses skipped during translation.
         |${TQ}
         |import datetime
+        |import hashlib
         |import re
         |
         |from hypothesis import HealthCheck, settings

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -240,6 +240,7 @@ object Structural:
         |during translation.
         |${TQ}
         |import datetime
+        |import hashlib
         |import os
         |import re
         |

--- a/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
@@ -19,6 +19,7 @@ object Templates:
 
   private val PredicatesHeader: String =
     """|import datetime
+       |import hashlib
        |import itertools
        |import re
        |

--- a/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestEmit.scala
@@ -99,7 +99,7 @@ object TestEmit:
     val usesRedact =
       bodies.contains("redact(") || specs.exists(_.body.contains("\"***REDACTED***\""))
     val rtHelpers =
-      List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_subset", "_union")
+      List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_sha256Hex", "_subset", "_union")
         .filter(h => bodies.contains(s"$h("))
     val userImports = specs
       .flatMap(_.imports)
@@ -222,6 +222,7 @@ object TestEmit:
          |for clauses that were not turned into tests.
          |\"\"\"
          |import datetime
+         |import hashlib
          |import re
          |
          |from hypothesis import HealthCheck, assume, given, settings

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -182,7 +182,7 @@ object TsBehavioral:
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim
 
   private val RuntimeHelpers =
-    List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_subset", "_union")
+    List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_sha256Hex", "_subset", "_union")
 
   // vitest fails a test file that contains zero tests (the same hazard as
   // pytest exit-5). When every behavioral op is a fail-loud stub / state-dep /

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -250,7 +250,9 @@ object TsExprBackend extends ExprBackend:
       case "min" if args.size == 1 =>
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"Math.min(...Array.from($a))"))
       case "now" if args.isEmpty =>
-        ExprPy.Py("new Date().toISOString()")
+        // Epoch seconds (number) so `now() - minutes(15)` is numeric arithmetic.
+        // Aligns with the seconds-valued time-unit functions below.
+        ExprPy.Py("(Date.now() / 1000)")
       case "hash" if args.size == 1 =>
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_sha256Hex($a)"))
       case "days" if args.size == 1 =>

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -251,8 +251,16 @@ object TsExprBackend extends ExprBackend:
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"Math.min(...Array.from($a))"))
       case "now" if args.isEmpty =>
         ExprPy.Py("new Date().toISOString()")
+      case "hash" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_sha256Hex($a)"))
       case "days" if args.size == 1 =>
         ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 86400)"))
+      case "hours" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 3600)"))
+      case "minutes" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 60)"))
+      case "seconds" if args.size == 1 =>
+        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"($a)"))
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx)
       case other =>

--- a/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
@@ -194,7 +194,7 @@ object TsStateful:
         |""".stripMargin
 
   private val RuntimeHelpers =
-    List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_subset", "_union")
+    List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_sha256Hex", "_subset", "_union")
 
   private def prettyOneLine(e: expr_full): String =
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -135,6 +135,45 @@ class BackendTest extends CatsEffectSuite:
     assert(pyText(e, c).contains("not backed by an entity table"), pyText(e, c))
     assert(tsText(e, c).contains("not backed by an entity table"), tsText(e, c))
 
+  test("hash/1 builtin lowers per-backend (#149 phase 1)"):
+    val c     = ctx(inputs = Set("x"))
+    val callE = CallF(IdentifierF("hash", None), List(IdentifierF("x", None)), None)
+    assertEquals(pyText(callE, c), "hashlib.sha256(str(x).encode()).hexdigest()")
+    assertEquals(tsText(callE, c), "_sha256Hex(x)")
+
+  test("now() + time-units lower to numeric seconds in both backends (#149 phase 1)"):
+    val c     = ctx()
+    val now   = CallF(IdentifierF("now", None), Nil, None)
+    val mins5 = CallF(IdentifierF("minutes", None), List(i1(5)), None)
+    val hrs2  = CallF(IdentifierF("hours", None), List(i1(2)), None)
+    val secs9 = CallF(IdentifierF("seconds", None), List(i1(9)), None)
+    val days1 = CallF(IdentifierF("days", None), List(i1(1)), None)
+    assertEquals(pyText(now, c), "datetime.datetime.now(datetime.timezone.utc).timestamp()")
+    assertEquals(pyText(mins5, c), "datetime.timedelta(minutes=5).total_seconds()")
+    assertEquals(pyText(hrs2, c), "datetime.timedelta(hours=2).total_seconds()")
+    assertEquals(pyText(secs9, c), "datetime.timedelta(seconds=9).total_seconds()")
+    assertEquals(pyText(days1, c), "datetime.timedelta(days=1).total_seconds()")
+    assertEquals(tsText(now, c), "(Date.now() / 1000)")
+    assertEquals(tsText(mins5, c), "((5) * 60)")
+    assertEquals(tsText(hrs2, c), "((2) * 3600)")
+    assertEquals(tsText(secs9, c), "(9)")
+    assertEquals(tsText(days1, c), "((1) * 86400)")
+
+  test("now() - minutes(15) is numeric arithmetic (no str/float mismatch — cubic P1)"):
+    val c = ctx()
+    val sub = BinaryOpF(
+      BSub(),
+      CallF(IdentifierF("now", None), Nil, None),
+      CallF(IdentifierF("minutes", None), List(i1(15)), None),
+      None
+    )
+    // Python: float - float; TS: number - number. Both well-typed.
+    assertEquals(
+      pyText(sub, c),
+      "((datetime.datetime.now(datetime.timezone.utc).timestamp()) - (datetime.timedelta(minutes=15).total_seconds()))"
+    )
+    assertEquals(tsText(sub, c), "(((Date.now() / 1000)) - (((15) * 60)))")
+
   // ---- TsVitestHarness: TS scaffold + the _runtime.ts contract ----
 
   private def loadIR(path: String) =
@@ -170,7 +209,17 @@ class BackendTest extends CatsEffectSuite:
         .find(_.path == "tests/_runtime.ts")
         .get
         .content
-      for h <- List("_len", "_in", "_eq", "_union", "_inter", "_diff", "_subset", "_powerset")
+      for h <- List(
+                 "_len",
+                 "_in",
+                 "_eq",
+                 "_union",
+                 "_inter",
+                 "_diff",
+                 "_subset",
+                 "_powerset",
+                 "_sha256Hex"
+               )
       do assert(rt.contains(s"export function $h"), s"missing $h in _runtime.ts")
 
   test("_predicates.ts imports _runtime and renders user predicates via TsExprBackend"):
@@ -281,6 +330,19 @@ class BackendTest extends CatsEffectSuite:
     assert(go.fixedDict(List(("name", "ARB"))).startsWith("genDict("), go.fixedDict(Nil))
     assertEquals(go.functionName("ShortCode"), "strategyShortCode")
 
+  test("GoExprBackend: hash + now() + time-units lower per-backend (#149 phase 1)"):
+    val c     = ctx(inputs = Set("x"))
+    val callE = CallF(IdentifierF("hash", None), List(IdentifierF("x", None)), None)
+    assertEquals(goText(callE, c), "_sha256Hex(x)")
+    val now = CallF(IdentifierF("now", None), Nil, None)
+    assertEquals(goText(now, c), "_now()")
+    val mins5 = CallF(IdentifierF("minutes", None), List(i1(5)), None)
+    assertEquals(goText(mins5, c), "_mul(int64(5), int64(60))")
+    val hrs2 = CallF(IdentifierF("hours", None), List(i1(2)), None)
+    assertEquals(goText(hrs2, c), "_mul(int64(2), int64(3600))")
+    val secs9 = CallF(IdentifierF("seconds", None), List(i1(9)), None)
+    assertEquals(goText(secs9, c), "_mul(int64(9), int64(1))")
+
   test("GoExprBackend: literals, equality/membership, cardinality, quantifier"):
     assertEquals(goText(BoolLitF(true, None), ctx()), "true")
     assertEquals(goText(NoneLitF(None), ctx()), "nil")
@@ -349,7 +411,8 @@ class BackendTest extends CatsEffectSuite:
                  "_powerset",
                  "_truthy",
                  "_field",
-                 "_set"
+                 "_set",
+                 "_sha256Hex"
                )
       do assert(rt.contains(s"func $h("), s"missing func $h in conf_runtime.go")
       assert(rt.contains("//go:build conformance"), rt.take(40))

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -139,7 +139,7 @@ class ExprToPythonTest extends CatsEffectSuite:
     val nowE = CallF(id("now"), Nil, None)
     assertEquals(
       py(ExprToPython.translate(nowE, ctx)),
-      "datetime.datetime.now(datetime.timezone.utc).isoformat()"
+      "datetime.datetime.now(datetime.timezone.utc).timestamp()"
     )
     val daysE = CallF(id("days"), List(i(30)), None)
     assertEquals(
@@ -175,12 +175,13 @@ class ExprToPythonTest extends CatsEffectSuite:
     val callE = CallF(id("noSuchBuiltin"), List(id("x")), None)
     assert(reason(ExprToPython.translate(callE, ctx)).contains("noSuchBuiltin/1"))
 
-  test("hash/1 is a builtin: emits hashlib.sha256(...).hexdigest()"):
+  test("hash/1 is a builtin: emits hashlib.sha256(str(...).encode()).hexdigest()"):
     // `url` is an `inputs` field in this test ctx, so the inner translation succeeds.
+    // str(...) coercion makes the call robust to non-string inputs (numbers, None).
     val callE = CallF(id("hash"), List(id("url")), None)
     assertEquals(
       py(ExprToPython.translate(callE, ctx)),
-      "hashlib.sha256((url).encode()).hexdigest()"
+      "hashlib.sha256(str(url).encode()).hexdigest()"
     )
 
   test("minutes/hours/seconds/days are builtins: emit timedelta total_seconds"):

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -172,8 +172,26 @@ class ExprToPythonTest extends CatsEffectSuite:
     assertEquals(py(ExprToPython.translate(callE, ctxWithFn)), "is_positive(5)")
 
   test("Unknown function (not built-in, not user-declared) skips"):
-    val callE = CallF(id("hash"), List(id("x")), None)
-    assert(reason(ExprToPython.translate(callE, ctx)).contains("hash/1"))
+    val callE = CallF(id("noSuchBuiltin"), List(id("x")), None)
+    assert(reason(ExprToPython.translate(callE, ctx)).contains("noSuchBuiltin/1"))
+
+  test("hash/1 is a builtin: emits hashlib.sha256(...).hexdigest()"):
+    // `url` is an `inputs` field in this test ctx, so the inner translation succeeds.
+    val callE = CallF(id("hash"), List(id("url")), None)
+    assertEquals(
+      py(ExprToPython.translate(callE, ctx)),
+      "hashlib.sha256((url).encode()).hexdigest()"
+    )
+
+  test("minutes/hours/seconds/days are builtins: emit timedelta total_seconds"):
+    List(
+      ("minutes", "datetime.timedelta(minutes=5).total_seconds()"),
+      ("hours", "datetime.timedelta(hours=5).total_seconds()"),
+      ("seconds", "datetime.timedelta(seconds=5).total_seconds()"),
+      ("days", "datetime.timedelta(days=5).total_seconds()")
+    ).foreach: (fname, expected) =>
+      val callE = CallF(id(fname), List(i(5)), None)
+      assertEquals(py(ExprToPython.translate(callE, ctx)), expected, s"$fname/1")
 
   test("User-defined call with wrong arity skips with arity-mismatch reason"):
     val fn = FunctionDeclFull(

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -72,7 +72,12 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ("todo_list", 50, 2, "next_id is unbacked scalar state"),
     ("ecommerce", 76, 5, "3 unbacked scalar-state ensures + 2 `removed` parser scope leak"),
     ("edge_cases", 29, 3, "plain is unbacked scalar state"),
-    ("auth_service", 40, 10, "4 unbacked scalar-state + 6 undeclared hash/recentFailedAttempts")
+    (
+      "auth_service",
+      40,
+      4,
+      "4 unbacked scalar-state (hash + minutes/hours/seconds + recentFailedAttempts function all now translated)"
+    )
   ).foreach: (name, expectedTotal, expectedSkipped, why) =>
     test(s"$name: $expectedTotal clauses, $expectedSkipped skips ($why)"):
       measure(s"fixtures/spec/$name.spec").map: (total, skipped, _) =>

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -74,9 +74,9 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ("edge_cases", 29, 3, "plain is unbacked scalar state"),
     (
       "auth_service",
-      40,
+      41,
       4,
-      "4 unbacked scalar-state (hash + minutes/hours/seconds + recentFailedAttempts function all now translated)"
+      "4 unbacked scalar-state (hash + minutes/hours/seconds + recentFailedAttempts function all now translated); 41 = 40 + 1 from the refreshTokensUnique invariant added for TheBy's uniqueness precondition"
     )
   ).foreach: (name, expectedTotal, expectedSkipped, why) =>
     test(s"$name: $expectedTotal clauses, $expectedSkipped skips ($why)"):


### PR DESCRIPTION
## Summary

Phase 1 of #149 — drops auth_service skip rate from **10/40 (25%) → 4/40 (10%)**, matching every other fixture's generic unbacked-scalar-state floor. The translation half of the issue is now done.

Phase 2 (matrix entry + synth-cache for handler synthesis) is **deferred** — it requires LLM API access for \`synth verify-all\` to populate a committable cache of verified Dafny bodies, which is out of reach from this session. Doing only the matrix entry without a cache would fail nightly CI on day 1 (every auth op is \`LLM_SYNTHESIS\`, so handlers raise \`NotImplementedError\` and pytest can't even reach the mutation step).

## What was missing

- \`hash/1\` was lint-allowlisted (\`UndefinedRef.scala:14\`) but **not translated** by any of the three \`ExprBackend\`s — fell through to "unknown function" Skip.
- \`minutes/hours/seconds\` were lint-allowlisted but only \`days\` was translated. Used by \`recentFailedAttempts\` which gates rate-limit invariants.
- \`recentFailedAttempts\` was defined via \`fact\`, but \`TestCtx.userFunctions\` only collects \`FunctionDeclFull\` — facts are invisible to testgen.

## What changed

| Layer | Change |
|---|---|
| \`ExprToPython\` | \`hash/1\` → \`hashlib.sha256(...).hexdigest()\`; \`minutes/hours/seconds/1\` → \`datetime.timedelta(...).total_seconds()\` |
| \`TsExprBackend\` | \`hash/1\` → \`_sha256Hex(...)\` (helper added to \`_runtime.ts\`); \`minutes/hours/seconds\` → integer-second arithmetic |
| \`GoExprBackend\` | \`hash/1\` → \`_sha256Hex(...)\` (helper added to \`conf_runtime.go\`); \`minutes/hours/seconds\` → \`_mul(x, int64(...))\` |
| Test-file headers | \`import hashlib\` added alongside \`import datetime\` in \`Templates\`, \`TestEmit\`, \`Structural\`, \`Stateful\` |
| TS \`_runtime.ts\` | \`import { createHash } from "node:crypto"\` + exported \`_sha256Hex\` |
| Go \`conf_runtime.go\` | \`crypto/sha256\` + \`encoding/hex\` imports + \`_sha256Hex\` helper |
| Runtime-helper import lists | \`TsBehavioral\`/\`TsStateful\`/\`TestEmit\`: added \`_sha256Hex\` (already filtered to actually-used helpers) |
| \`auth_service.spec\` | \`fact recentFailedAttemptsDef:\` → \`function recentFailedAttempts(email: Email): Int = #{...}\`. The RHS was already an executable set-cardinality expression — purely syntactic rewrite. |
| \`SkipRateProbeTest\` | auth_service expectation 10 → 4; reason updated |
| \`ExprToPythonTest\` | Replaced obsolete "hash is unknown" test with hash/minutes/hours/seconds/days positive cases + a new "unknown function" case using \`noSuchBuiltin\` |
| \`mutation-testing.mdx\` | Stale "15% testgen-translator skip rate" rewritten as "translation gap closed; remaining blocker is the synth-cache axis" |

## Test plan

- [x] \`sbt testgen/test\` — 276 / 276 pass (3 new ExprToPython cases, updated SkipRateProbe expectation)
- [x] \`sbt codegen/test\` — 227 / 227 pass
- [x] \`sbt cli/test\` — 60 / 60 pass
- [x] \`sbt scalafmtCheckAll\` clean
- [x] \`sbt scalafixAll\` clean
- [x] Pre-commit hooks pass
- [ ] CI green

## What's still needed to close #149

Acceptance criterion #4 — \`auth_service\` in mutation matrix with documented threshold — requires the synth-cache work, tracked separately. Sketch:

1. Run \`sbt cli/run synth verify-all fixtures/spec/auth_service.spec\` locally with \`ANTHROPIC_API_KEY\` set (~\$0.10–1 in API calls)
2. Commit the resulting \`.spec-to-rest/synth-cache/verified/auth_service/*.json\` files
3. Add \`setup-dafny\` step to \`mutation-testing.yml\`
4. Add \`auth_service\` to the \`fixture\` matrix with \`--with-synthesis --synthesis-cache-dir <committed-path>\`
5. Set a per-fixture \`MUTATION_THRESHOLD\` for auth_service (e.g. 80% to allow some headroom on the LLM-synthesized bodies), documented in the workflow comment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the auth_service translation gap and completes phase 1 of #149 by adding hash/time-unit support and numeric `now()` across Python/TS/Go, plus deterministic Dafny lowering for `the` via `TheBy` and a `refreshTokensUnique` invariant. Skip rate drops from 10/40 to 4/41; matrix entry stays deferred until a committed synth-cache is available.

- **New Features**
  - Translate `hash/1` in all backends; add `_sha256Hex` to TS/Go runtimes and use `hashlib.sha256(str(...).encode()).hexdigest()` in Python.
  - Make `now()` return epoch seconds in Python/TS/Go; translate `minutes`/`hours`/`seconds` (and `days`) to numeric seconds.
  - Rewrite `recentFailedAttempts` as a function so testgen can use it.
  - Dafny: emit ghost `TheBy` and lower `the v in dom | body` to `TheBy(...)` for deterministic witnesses; add `refreshTokensUnique` invariant; regenerate goldens; remove obsolete CLI test.
  - Update docs/tests to reflect the 4/41 skip rate and the synth-cache blocker; bump `SkipRateProbeTest` totals to 41.

<sup>Written for commit 487a6782b963bd5f0597c61717fc2b204176909e. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/307?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated mutation-testing docs with current status and synthesis-cache requirements.

* **New Features**
  * Added SHA-256 hashing support to generated test runtimes (Python, Go, TypeScript).
  * Added time-duration helpers (days, hours, minutes, seconds) and numeric epoch timestamps.

* **Tests**
  * Expanded coverage for hash/time conversions and runtime helper exports.

* **Improvements**
  * Improved auth failure counting and added refresh-token uniqueness invariant.
  * Added a deterministic helper for selecting unique map elements in generated Dafny skeletons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->