### PR TITLE
refactor(testgen): Builtins registry — single source of truth across Py/TS/Go backends + lint

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val convention = (project in file("modules/convention"))
 
 lazy val lint = (project in file("modules/lint"))
   .settings(noTestWarts *)
-  .dependsOn(ir, parser % Test)
+  .dependsOn(ir, convention, parser % Test)
   .settings(
     name := "spec-lint",
     libraryDependencies ++= commonMainDeps ++ commonTestDeps

--- a/docs/content/docs/design/architecture.mdx
+++ b/docs/content/docs/design/architecture.mdx
@@ -124,11 +124,11 @@ modules/
 ├── ir/         # IR ADT (Isabelle-extracted SpecRestGenerated.scala), circe Serialize, PrettyPrint, VerifyError
 ├── parser/     # ANTLR4 grammar, Parse, Builder, Preamble injection
 ├── lint/       # Structural lints L01-L06
-├── convention/ # M1-M10 classifier, naming, path, schema, validate
+├── convention/ # M1-M10 classifier, naming, path, schema, validate, Builtins registry (single source of truth for spec-language builtin functions)
 ├── profile/    # Deployment profiles, type mapping, annotation
 ├── verify/     # Z3 + Alloy translators, backends, Consistency, Diagnostic, Narration
 ├── codegen/    # Engine (handlebars.java), Emit, OpenAPI, Alembic
-├── testgen/    # Backend seam (ExprBackend/StrategyBackend/HarnessTemplates), Strategies, Stateful/Structural/Behavioral + Ts*/Go* emitters
+├── testgen/    # Backend seam (ExprBackend/StrategyBackend/HarnessTemplates), Strategies, Stateful/Structural/Behavioral + Ts*/Go* emitters; dispatches builtin calls through convention.Builtins
 ├── synth/      # LLM integration, PromptBuilder, DiffChecker, DafnyVerifier, CegisLoop, Cache, Tracker
 ├── cli/        # decline-effect CommandIOApp: check / inspect / verify / compile / synth try / synth verify
 └── bench/      # JMH benchmarks (ParallelVerifyBench, parallel verify CSV golden)

--- a/docs/content/docs/pipelines/test-generation.mdx
+++ b/docs/content/docs/pipelines/test-generation.mdx
@@ -52,7 +52,14 @@ language-agnostic. Only the leaf rendering varies, behind the `Backend.scala` se
 `modules/testgen`:
 
 - **`ExprBackend`** — translates an IR expression to the target language
-  (`ExprToPython` / `TsExprBackend` / `GoExprBackend`).
+  (`ExprToPython` / `TsExprBackend` / `GoExprBackend`). Each backend returns
+  the shared `Translated.Emit(text) | Translated.Skip(reason, span)` ADT — a
+  language-agnostic result, despite the historical `ExprPy` name (renamed in #308).
+- **`Builtins`** (in `modules/convention`) — the single registry of spec-language
+  builtin functions (`len`, `dom`, `now`, `hash`, `minutes`/`hours`/`seconds`,
+  `abs`, `sum`, ...). Each entry carries per-backend emit lambdas plus import
+  metadata. Adding a new builtin is one struct entry, automatically picked up by
+  all three backends and the lint allowlist via `Builtins.names`.
 - **`StrategyBackend`** — renders a spec type into a generator
   (`PythonHypothesisStrategy` `st.*` / `TsFastCheckStrategy` `fc.*` /
   `GoRapidStrategy` `rapid`).
@@ -833,20 +840,23 @@ a length/regex.
 ## Coverage on canonical fixtures
 
 `ExprToPython` covers every `Expr` constructor in the IR, no translator coverage gaps
-remain. The remaining `ExprPy.Skip` outputs split into (i) user errors in the spec
-(unbound identifier, undeclared function, wrong arity, reserved-name binding), (ii) typed
-`Quantifier` bindings, and (iii) parser-side gaps (currently the multi-clause `let ... in`
+remain. The remaining `Translated.Skip` outputs split into (i) **unbacked-scalar-state
+floor** — state fields not backed by an entity table get projected as `null` by the
+test-admin `/state` endpoint, so they can't be asserted black-box (`safe_counter.count`,
+`url_shortener.base_url`, `todo_list.next_id`, `edge_cases.plain`, `auth_service.next_*_id`),
+(ii) user errors in the spec (unbound identifier, undeclared function, wrong arity,
+reserved-name binding), and (iii) parser-side gaps (currently the multi-clause `let ... in`
 body in ecommerce). These numbers are locked in `SkipRateProbeTest.scala`; CI fails if
 they regress.
 
 | Fixture | Total clauses | Translated | Skipped | Skip rate | Remaining-skip reason |
 |---|---|---|---|---|---|
-| `safe_counter.spec` | 5 | 5 | 0 | **0.0%** |, |
-| `url_shortener.spec` | 21 | 21 | 0 | **0.0%** |, |
-| `todo_list.spec` | 50 | 50 | 0 | **0.0%** |, |
-| `edge_cases.spec` | 29 | 29 | 0 | **0.0%** |, |
-| `ecommerce.spec` | 76 | 74 | 2 | **2.6%** | parser scope leak, multi-clause `let ... in` body, follow-up |
-| `auth_service.spec` | 40 | 34 | 6 | **15.0%** | spec calls `hash()` and `recentFailedAttempts()` without declaring them as `function`/`predicate`; treated as user errors |
+| `safe_counter.spec` | 5 | 2 | 3 | **60.0%** | `count` is unbacked scalar state |
+| `url_shortener.spec` | 21 | 20 | 1 | **4.8%** | `base_url` is unbacked scalar state |
+| `todo_list.spec` | 50 | 48 | 2 | **4.0%** | `next_id` is unbacked scalar state |
+| `edge_cases.spec` | 29 | 26 | 3 | **10.3%** | `plain` is unbacked scalar state |
+| `ecommerce.spec` | 76 | 71 | 5 | **6.6%** | 3 unbacked scalar-state + 2 `removed` parser scope leak |
+| `auth_service.spec` | 41 | 37 | 4 | **9.8%** | 4 unbacked scalar-state (`hash`, `minutes`/`hours`/`seconds`, and `recentFailedAttempts` function all translate as of #307) |
 
 ## What `_testgen_skips.json` looks like
 

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -191,9 +191,11 @@ the generated tests rather than emitted as `pytest.skip` notes.
 
 Empirical skip rates on the canonical fixtures (locked in
 [`SkipRateProbeTest`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala)):
-`safe_counter`, `url_shortener`, `todo_list`, `edge_cases` all 0.0%; `ecommerce` 2.6%
-(2 / 76, parser scope leak in multi-clause `let ... in` body); `auth_service` 15.0%
-(6 / 40, undeclared `hash` / `recentFailedAttempts` calls). See
+`safe_counter` 60.0% (3 / 5), `url_shortener` 4.8% (1 / 21), `todo_list` 4.0% (2 / 50),
+`edge_cases` 10.3% (3 / 29) — all from unbacked scalar state the admin `/state`
+endpoint projects as null; `ecommerce` 6.6% (5 / 76, mostly unbacked-scalar + 2 from
+a parser scope leak); `auth_service` 9.8% (4 / 41, all unbacked scalar-state — `hash`,
+time-unit, and `recentFailedAttempts` builtins translate as of #307). See
 [Test Generation pipeline](/pipelines/test-generation) for the full surface.
 
 ## Convention overrides

--- a/fixtures/golden/dafny/safe_counter.dfy
+++ b/fixtures/golden/dafny/safe_counter.dfy
@@ -3,7 +3,7 @@
 
 datatype Option<T> = None | Some(value: T)
 
-ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+ghost function TheBy<K, V>(m: map<K, V>, p: K -> bool): K
   requires exists k :: k in m && p(k)
   requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
   ensures TheBy(m, p) in m && p(TheBy(m, p))

--- a/fixtures/golden/dafny/todo_list.dfy
+++ b/fixtures/golden/dafny/todo_list.dfy
@@ -3,7 +3,7 @@
 
 datatype Option<T> = None | Some(value: T)
 
-ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+ghost function TheBy<K, V>(m: map<K, V>, p: K -> bool): K
   requires exists k :: k in m && p(k)
   requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
   ensures TheBy(m, p) in m && p(TheBy(m, p))

--- a/fixtures/golden/dafny/url_shortener.dfy
+++ b/fixtures/golden/dafny/url_shortener.dfy
@@ -3,7 +3,7 @@
 
 datatype Option<T> = None | Some(value: T)
 
-ghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K
+ghost function TheBy<K, V>(m: map<K, V>, p: K -> bool): K
   requires exists k :: k in m && p(k)
   requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2
   ensures TheBy(m, p) in m && p(TheBy(m, p))

--- a/modules/convention/src/main/scala/specrest/convention/Builtins.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Builtins.scala
@@ -163,17 +163,20 @@ object Builtins:
     description = "absolute value of a numeric expression"
   )
 
-  // Higher-order: second arg is a function/lambda applied per element. The
-  // backends render LambdaF as their native lambda form (Python `(lambda x:
-  // ...)`, TS `(x) => ...`, Go `func(x any) any { return ... }`), so we just
-  // compose an opaque call here. Use `_x` as the iteration variable to avoid
-  // collision with the spec's lambda param name (lambda's param shadows
-  // anyway, but `_x` makes intent obvious to a reader).
+  // Higher-order: second arg is a function/lambda applied per element. Both args
+  // are pre-rendered; we never introduce a new binding name so a spec like
+  // `let _x = V in sum(coll, i => i + _x)` doesn't see its free `_x` shadowed
+  // by an iteration variable. The lambda is passed AS A VALUE to a function
+  // that consumes a sequence:
+  //   Python: `sum(map(lambda, coll))` — map iterates, no inner binding
+  //   TS: `coll.map(lambda).reduce(...)` — lambda runs before reduce's callback
+  //                                         introduces its own `v`
+  //   Go: `_sum(coll, lambda)` — runtime helper invokes per element
   val Sum: BuiltinSpec = BuiltinSpec(
     name = "sum",
     arity = 2,
-    py = a => s"sum((${a(1)})(_x) for _x in (${a(0)}))",
-    ts = a => s"Array.from(${a(0)}).reduce((acc, _x) => acc + Number((${a(1)})(_x)), 0)",
+    py = a => s"sum(map(${a(1)}, ${a(0)}))",
+    ts = a => s"Array.from(${a(0)}).map(${a(1)}).reduce((acc, v) => acc + Number(v), 0)",
     go = a => s"_sum(${a(0)}, ${a(1)})",
     description = "sum of `fn(elem)` over a collection"
   )

--- a/modules/convention/src/main/scala/specrest/convention/Builtins.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Builtins.scala
@@ -152,9 +152,35 @@ object Builtins:
     description = "SHA-256 hex digest of the (coerced-to-string) argument"
   )
 
+  // Absolute value. All three backends accept the arg pre-rendered; Go uses the
+  // `_abs` runtime helper to handle the `any` payload uniformly.
+  val Abs: BuiltinSpec = BuiltinSpec(
+    name = "abs",
+    arity = 1,
+    py = a => s"abs(${a(0)})",
+    ts = a => s"Math.abs(Number(${a(0)}))",
+    go = a => s"_abs(${a(0)})",
+    description = "absolute value of a numeric expression"
+  )
+
+  // Higher-order: second arg is a function/lambda applied per element. The
+  // backends render LambdaF as their native lambda form (Python `(lambda x:
+  // ...)`, TS `(x) => ...`, Go `func(x any) any { return ... }`), so we just
+  // compose an opaque call here. Use `_x` as the iteration variable to avoid
+  // collision with the spec's lambda param name (lambda's param shadows
+  // anyway, but `_x` makes intent obvious to a reader).
+  val Sum: BuiltinSpec = BuiltinSpec(
+    name = "sum",
+    arity = 2,
+    py = a => s"sum((${a(1)})(_x) for _x in (${a(0)}))",
+    ts = a => s"Array.from(${a(0)}).reduce((acc, _x) => acc + Number((${a(1)})(_x)), 0)",
+    go = a => s"_sum(${a(0)}, ${a(1)})",
+    description = "sum of `fn(elem)` over a collection"
+  )
+
   // The canonical list. Order is documentational; lookups go through `byName`.
   val all: List[BuiltinSpec] =
-    List(Len, Dom, Ran, Max, Min, Now, Days, Hours, Minutes, Seconds, Hash)
+    List(Len, Dom, Ran, Max, Min, Abs, Now, Days, Hours, Minutes, Seconds, Hash, Sum)
 
   val byName: Map[String, BuiltinSpec] = all.map(b => b.name -> b).toMap
 

--- a/modules/convention/src/main/scala/specrest/convention/Builtins.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Builtins.scala
@@ -1,0 +1,161 @@
+package specrest.convention
+
+object Builtins:
+
+  // One spec per spec-language builtin function. Each backend's expression
+  // translator dispatches via `Builtins.byName` instead of carrying its own
+  // case-list, so adding a builtin is a single edit here (was 4+ files: the
+  // three ExprBackends plus the lint allowlist plus runtime-template imports).
+  //
+  // The emit fields are intentionally per-backend lambdas: emitting
+  // `hashlib.sha256(...)` vs `_sha256Hex(...)` vs `crypto/sha256.Sum256(...)`
+  // is irreducible per-language work, but bundling those three together makes
+  // the symmetry visible and makes it impossible to forget one.
+  //
+  // Higher-order builtins (currently just `sum`, which takes a lambda) are NOT
+  // here — they keep their per-backend special-case because the lambda
+  // unpacking pattern needs to access ctx.boundVars, which would require
+  // threading a ctx-aware closure type through the registry.
+  final case class BuiltinSpec(
+      name: String,
+      arity: Int,
+      py: List[String] => String,
+      ts: List[String] => String,
+      go: List[String] => String,
+      pyImports: List[String] = Nil,
+      tsImports: List[BuiltinSpec.TsImport] = Nil,
+      goImports: List[String] = Nil,
+      description: String
+  )
+
+  object BuiltinSpec:
+    // ("node:crypto", "createHash") → `import { createHash } from "node:crypto"`.
+    final case class TsImport(module: String, symbol: String) derives CanEqual
+
+  // --- set/map operations ---
+
+  val Len: BuiltinSpec = BuiltinSpec(
+    name = "len",
+    arity = 1,
+    py = a => s"len(${a(0)})",
+    ts = a => s"_len(${a(0)})",
+    go = a => s"_len(${a(0)})",
+    description = "cardinality of a collection"
+  )
+
+  val Dom: BuiltinSpec = BuiltinSpec(
+    name = "dom",
+    arity = 1,
+    py = a => s"set(${a(0)}.keys())",
+    ts = a => s"new Set(Object.keys(${a(0)}))",
+    go = a => s"_keys(${a(0)})",
+    description = "key-set of a map"
+  )
+
+  val Ran: BuiltinSpec = BuiltinSpec(
+    name = "ran",
+    arity = 1,
+    py = a => s"set(${a(0)}.values())",
+    ts = a => s"new Set(Object.values(${a(0)}))",
+    go = a => s"_values(${a(0)})",
+    description = "value-set of a map"
+  )
+
+  val Max: BuiltinSpec = BuiltinSpec(
+    name = "max",
+    arity = 1,
+    py = a => s"max(${a(0)})",
+    ts = a => s"Math.max(...Array.from(${a(0)}))",
+    go = a => s"_max(${a(0)})",
+    description = "maximum of a non-empty collection"
+  )
+
+  val Min: BuiltinSpec = BuiltinSpec(
+    name = "min",
+    arity = 1,
+    py = a => s"min(${a(0)})",
+    ts = a => s"Math.min(...Array.from(${a(0)}))",
+    go = a => s"_min(${a(0)})",
+    description = "minimum of a non-empty collection"
+  )
+
+  // --- time ---
+
+  // `now()` returns epoch seconds (float/number) so `now() - minutes(15)` is
+  // well-typed numeric arithmetic across all backends. Comparing the result
+  // against an ISO-string DateTime field is a separate concern (type-aware
+  // field-access lowering — not solved here, deferred).
+  val Now: BuiltinSpec = BuiltinSpec(
+    name = "now",
+    arity = 0,
+    py = _ => "datetime.datetime.now(datetime.timezone.utc).timestamp()",
+    ts = _ => "(Date.now() / 1000)",
+    go = _ => "_now()",
+    pyImports = List("datetime"),
+    description = "current UTC time as epoch seconds (numeric, not ISO string)"
+  )
+
+  val Days: BuiltinSpec = BuiltinSpec(
+    name = "days",
+    arity = 1,
+    py = a => s"datetime.timedelta(days=${a(0)}).total_seconds()",
+    ts = a => s"((${a(0)}) * 86400)",
+    go = a => s"_mul(${a(0)}, int64(86400))",
+    pyImports = List("datetime"),
+    description = "n days expressed as epoch seconds"
+  )
+
+  val Hours: BuiltinSpec = BuiltinSpec(
+    name = "hours",
+    arity = 1,
+    py = a => s"datetime.timedelta(hours=${a(0)}).total_seconds()",
+    ts = a => s"((${a(0)}) * 3600)",
+    go = a => s"_mul(${a(0)}, int64(3600))",
+    pyImports = List("datetime"),
+    description = "n hours expressed as epoch seconds"
+  )
+
+  val Minutes: BuiltinSpec = BuiltinSpec(
+    name = "minutes",
+    arity = 1,
+    py = a => s"datetime.timedelta(minutes=${a(0)}).total_seconds()",
+    ts = a => s"((${a(0)}) * 60)",
+    go = a => s"_mul(${a(0)}, int64(60))",
+    pyImports = List("datetime"),
+    description = "n minutes expressed as epoch seconds"
+  )
+
+  val Seconds: BuiltinSpec = BuiltinSpec(
+    name = "seconds",
+    arity = 1,
+    py = a => s"datetime.timedelta(seconds=${a(0)}).total_seconds()",
+    ts = a => s"(${a(0)})",
+    go = a => s"_mul(${a(0)}, int64(1))",
+    pyImports = List("datetime"),
+    description = "n seconds expressed as epoch seconds"
+  )
+
+  // --- hashing ---
+
+  // SHA-256 hex digest. Argument is coerced to string in every backend (Python
+  // `str(...)`, Go `fmt.Sprintf("%v", ...)`, TS `String(...)`) so non-string
+  // inputs (numbers from JSON, None/null) don't blow up at runtime.
+  val Hash: BuiltinSpec = BuiltinSpec(
+    name = "hash",
+    arity = 1,
+    py = a => s"hashlib.sha256(str(${a(0)}).encode()).hexdigest()",
+    ts = a => s"_sha256Hex(${a(0)})",
+    go = a => s"_sha256Hex(${a(0)})",
+    pyImports = List("hashlib"),
+    tsImports = List(BuiltinSpec.TsImport("node:crypto", "createHash")),
+    goImports = List("crypto/sha256", "encoding/hex"),
+    description = "SHA-256 hex digest of the (coerced-to-string) argument"
+  )
+
+  // The canonical list. Order is documentational; lookups go through `byName`.
+  val all: List[BuiltinSpec] =
+    List(Len, Dom, Ran, Max, Min, Now, Days, Hours, Minutes, Seconds, Hash)
+
+  val byName: Map[String, BuiltinSpec] = all.map(b => b.name -> b).toMap
+
+  val names: Set[String] = byName.keySet

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -124,7 +124,7 @@ object Generator:
   // call site fails to verify (which is the right outcome — `the X | P(X)` is
   // undefined when P matches zero or many elements).
   private def theByFunction(): String =
-    "\nghost function TheBy<K(==), V>(m: map<K, V>, p: K -> bool): K\n" +
+    "\nghost function TheBy<K, V>(m: map<K, V>, p: K -> bool): K\n" +
       "  requires exists k :: k in m && p(k)\n" +
       "  requires forall k1, k2 :: k1 in m && k2 in m && p(k1) && p(k2) ==> k1 == k2\n" +
       "  ensures TheBy(m, p) in m && p(TheBy(m, p))\n" +

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -1,24 +1,11 @@
 package specrest.lint
 
+import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 object UndefinedRef extends LintPass:
   val code = "L02"
-
-  private val builtins: Set[String] = Set(
-    "len",
-    "dom",
-    "ran",
-    "abs",
-    "hash",
-    "now",
-    "sum",
-    "minutes",
-    "hours",
-    "days",
-    "seconds"
-  )
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
     val out = List.newBuilder[LintDiagnostic]
@@ -34,7 +21,7 @@ object UndefinedRef extends LintPass:
     val factImplicit = ir.k.flatMap { case FactDeclFull(_, e, _) => collectCallees(e) }.toSet
     val global =
       stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++
-        predicates ++ functions ++ builtins ++ factImplicit
+        predicates ++ functions ++ Builtins.names ++ factImplicit
 
     def check(expr: expr_full, scope: Set[String]): Unit =
       walk(expr, scope, out)

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -16,6 +16,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strings"
@@ -533,6 +534,20 @@ func _call(f any, args ...any) any {
 		}
 	}
 	return nil
+}
+
+func _abs(x any) any {
+	// JSON-decoded numbers come in as float64; spec ints survive as int64.
+	// Coerce to float64 and delegate to math.Abs, mirroring TS's Math.abs(Number(x)).
+	switch v := x.(type) {
+	case float64:
+		return math.Abs(v)
+	case int64:
+		return math.Abs(float64(v))
+	case int:
+		return math.Abs(float64(v))
+	}
+	return math.NaN()
 }
 
 func _now() any {

--- a/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
@@ -8,10 +8,10 @@ import specrest.profile.ProfiledService
 
 // Translates an IR expression to a target-language expression. Each backend owns
 // its own recursion — Python comprehensions/quantifiers do not leaf-swap to TS
-// `.every`/`.map` or Go loops — over the shared ExprPy result ADT and TestCtx.
+// `.every`/`.map` or Go loops — over the shared Translated result ADT and TestCtx.
 // `stringLiteral` renders a Scala string as a target string literal.
 trait ExprBackend:
-  def translate(expr: expr_full, ctx: TestCtx): ExprPy
+  def translate(expr: expr_full, ctx: TestCtx): Translated
   def stringLiteral(s: String): String
 
 // The language-specific scaffold + path layout. `scaffoldFiles` returns the
@@ -139,38 +139,38 @@ object PythonHypothesisStrategy extends StrategyBackend:
   def functionName(typeName: String): String =
     s"strategy_${specrest.convention.Naming.toSnakeCase(typeName)}"
 
-// Skip-propagation algebra over ExprPy — pure, language-neutral. Shared by every
+// Skip-propagation algebra over Translated — pure, language-neutral. Shared by every
 // ExprBackend so the recursion's short-circuit-on-Skip behaviour is identical
 // across target languages; only the rendered tokens differ.
 object ExprLift:
-  def lift1(a: ExprPy)(f: String => ExprPy): ExprPy = a match
-    case ExprPy.Py(x)          => f(x)
-    case s @ ExprPy.Skip(_, _) => s
+  def lift1(a: Translated)(f: String => Translated): Translated = a match
+    case Translated.Emit(x)        => f(x)
+    case s @ Translated.Skip(_, _) => s
 
-  def lift2(a: ExprPy, b: ExprPy)(f: (String, String) => ExprPy): ExprPy =
+  def lift2(a: Translated, b: Translated)(f: (String, String) => Translated): Translated =
     (a, b) match
-      case (ExprPy.Py(x), ExprPy.Py(y)) => f(x, y)
-      case (s @ ExprPy.Skip(_, _), _)   => s
-      case (_, s @ ExprPy.Skip(_, _))   => s
+      case (Translated.Emit(x), Translated.Emit(y)) => f(x, y)
+      case (s @ Translated.Skip(_, _), _)           => s
+      case (_, s @ Translated.Skip(_, _))           => s
 
-  def lift3(a: ExprPy, b: ExprPy, c: ExprPy)(
-      f: (String, String, String) => ExprPy
-  ): ExprPy =
+  def lift3(a: Translated, b: Translated, c: Translated)(
+      f: (String, String, String) => Translated
+  ): Translated =
     (a, b, c) match
-      case (ExprPy.Py(x), ExprPy.Py(y), ExprPy.Py(z)) => f(x, y, z)
-      case (s @ ExprPy.Skip(_, _), _, _)              => s
-      case (_, s @ ExprPy.Skip(_, _), _)              => s
-      case (_, _, s @ ExprPy.Skip(_, _))              => s
+      case (Translated.Emit(x), Translated.Emit(y), Translated.Emit(z)) => f(x, y, z)
+      case (s @ Translated.Skip(_, _), _, _)                            => s
+      case (_, s @ Translated.Skip(_, _), _)                            => s
+      case (_, _, s @ Translated.Skip(_, _))                            => s
 
-  def liftAll(parts: List[ExprPy], span: Option[span_t])(
-      f: List[String] => ExprPy
-  ): ExprPy =
-    parts.collectFirst { case s @ ExprPy.Skip(_, _) => s } match
+  def liftAll(parts: List[Translated], span: Option[span_t])(
+      f: List[String] => Translated
+  ): Translated =
+    parts.collectFirst { case s @ Translated.Skip(_, _) => s } match
       case Some(s) => s
       case None =>
-        val texts = parts.collect { case ExprPy.Py(t) => t }
+        val texts = parts.collect { case Translated.Emit(t) => t }
         if texts.size == parts.size then f(texts)
-        else ExprPy.Skip("internal: lift mismatch", span)
+        else Translated.Skip("internal: lift mismatch", span)
 
 object TsLit:
   def str(s: String): String =

--- a/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
@@ -172,6 +172,27 @@ object ExprLift:
         if texts.size == parts.size then f(texts)
         else Translated.Skip("internal: lift mismatch", span)
 
+  // Shared dispatcher for `Builtins.byName` lookups. Each backend supplies only
+  // `pickEmit` (e.g. `_.py` for Python, `_.ts` for TypeScript) — the arity check,
+  // the unknown-name skip message, and the lift-from-translated-args plumbing
+  // live here exactly once.
+  def dispatchBuiltin(
+      fname: String,
+      args: List[Translated],
+      span: Option[span_t],
+      pickEmit: specrest.convention.Builtins.BuiltinSpec => List[String] => String
+  ): Translated =
+    specrest.convention.Builtins.byName.get(fname) match
+      case Some(spec) if spec.arity == args.size =>
+        liftAll(args, span)(rendered => Translated.Emit(pickEmit(spec)(rendered)))
+      case Some(spec) =>
+        Translated.Skip(
+          s"$fname expects ${spec.arity} arg(s), got ${args.size}",
+          span
+        )
+      case None =>
+        Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
+
 object TsLit:
   def str(s: String): String =
     val escaped = s

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -146,9 +146,9 @@ object Behavioral:
               Left(TestSkip(opDecl.a, s"ensures[$idx]", aggregateEqualitySkipReason))
             else
               ExprToPython.translate(clause, ctx) match
-                case ExprPy.Skip(reason, _) =>
+                case Translated.Skip(reason, _) =>
                   Left(TestSkip(opDecl.a, s"ensures[$idx]", reason))
-                case ExprPy.Py(text) =>
+                case Translated.Emit(text) =>
                   Right(
                     buildPositiveTest(
                       name = s"test_${opSnake}_ensures_$idx",
@@ -240,9 +240,9 @@ object Behavioral:
         case Right(strategySig) =>
           ir.i.collect { case _iv: InvariantDeclFull => _iv }.zipWithIndex.toList.map: (inv, idx) =>
             ExprToPython.translate(inv.b, ctx) match
-              case ExprPy.Skip(reason, _) =>
+              case Translated.Skip(reason, _) =>
                 Left(TestSkip(opDecl.a, s"invariant[${invName(inv, idx)}]", reason))
-              case ExprPy.Py(text) =>
+              case Translated.Emit(text) =>
                 Right(
                   buildInvariantTest(
                     name = s"test_${opSnake}_invariant_${Naming.toSnakeCase(invName(inv, idx))}",
@@ -290,9 +290,9 @@ object Behavioral:
             TemporalShape.of(t) match
               case TemporalShape.Always(arg) =>
                 ExprToPython.translate(arg, ctx) match
-                  case ExprPy.Skip(reason, _) =>
+                  case Translated.Skip(reason, _) =>
                     List(Left(TestSkip(opDecl.a, s"temporal[${t.a}]", reason)))
-                  case ExprPy.Py(text) =>
+                  case Translated.Emit(text) =>
                     List(
                       Right(
                         buildInvariantTest(

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.Builtins
 import specrest.convention.Naming
 import specrest.ir.generated.SpecRestGenerated.*
 
@@ -48,12 +49,12 @@ object ExprToPython extends ExprBackend:
 
   def stringLiteral(s: String): String = pyString(s)
 
-  def translate(expr: expr_full, ctx: TestCtx): ExprPy = expr match
-    case BoolLitF(v, _)   => ExprPy.Py(if v then "True" else "False")
-    case IntLitF(n, _)    => ExprPy.Py(integer_of_int(n).toString)
-    case FloatLitF(d, _)  => ExprPy.Py(d.toString)
-    case StringLitF(s, _) => ExprPy.Py(pyString(s))
-    case NoneLitF(_)      => ExprPy.Py("None")
+  def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
+    case BoolLitF(v, _)   => Translated.Emit(if v then "True" else "False")
+    case IntLitF(n, _)    => Translated.Emit(integer_of_int(n).toString)
+    case FloatLitF(d, _)  => Translated.Emit(d.toString)
+    case StringLitF(s, _) => Translated.Emit(pyString(s))
+    case NoneLitF(_)      => Translated.Emit("None")
 
     case IdentifierF(name, span) => resolveIdent(name, ctx, span)
 
@@ -62,7 +63,9 @@ object ExprToPython extends ExprBackend:
 
     case BinaryOpF(BAdd(), l, r, _)
         if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
-      lift2(translate(l, ctx), translate(r, ctx))((lp, rp) => ExprPy.Py(s"{**($lp), **($rp)}"))
+      lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
+        Translated.Emit(s"{**($lp), **($rp)}")
+      )
 
     case BinaryOpF(op, l, r, _) =>
       lift2(translate(l, ctx), translate(r, ctx))(binOpText(op, _, _))
@@ -71,33 +74,33 @@ object ExprToPython extends ExprBackend:
       lift1(translate(x, ctx))(unOpText(op, _))
 
     case FieldAccessF(base, field, _) =>
-      lift1(translate(base, ctx))(b => ExprPy.Py(s"$b[${pyString(field)}]"))
+      lift1(translate(base, ctx))(b => Translated.Emit(s"$b[${pyString(field)}]"))
 
-    case EnumAccessF(_, member, _) => ExprPy.Py(pyString(member))
+    case EnumAccessF(_, member, _) => Translated.Emit(pyString(member))
 
     case IndexF(base, idx, _) =>
-      lift2(translate(base, ctx), translate(idx, ctx))((b, i) => ExprPy.Py(s"$b[$i]"))
+      lift2(translate(base, ctx), translate(idx, ctx))((b, i) => Translated.Emit(s"$b[$i]"))
 
     case CallF(callee, args, span) => callExpr(callee, args, ctx, span)
 
     case IfF(c, t, e, _) =>
       lift3(translate(c, ctx), translate(t, ctx), translate(e, ctx))((cp, tp, ep) =>
-        ExprPy.Py(s"(($tp) if ($cp) else ($ep))")
+        Translated.Emit(s"(($tp) if ($cp) else ($ep))")
       )
 
     case LetF(v, value, body, span) =>
       if PythonReservedNames.contains(v) then
-        ExprPy.Skip(s"Let with Python-reserved binding name '$v'", span)
+        Translated.Skip(s"Let with Python-reserved binding name '$v'", span)
       else
         lift2(translate(value, ctx), translate(body, ctx.withBound(List(v))))((vp, bp) =>
-          ExprPy.Py(s"((lambda $v=($vp): ($bp))())")
+          Translated.Emit(s"((lambda $v=($vp): ($bp))())")
         )
 
     case SetLiteralF(elements, span) =>
-      if elements.isEmpty then ExprPy.Py("set()")
+      if elements.isEmpty then Translated.Emit("set()")
       else
         val parts = elements.map(translate(_, ctx))
-        liftAll(parts, span)(ps => ExprPy.Py(s"{${ps.mkString(", ")}}"))
+        liftAll(parts, span)(ps => Translated.Emit(s"{${ps.mkString(", ")}}"))
 
     case QuantifierF(kind, bindings, body, span) =>
       quantifier(kind, bindings, body, ctx, span)
@@ -113,42 +116,42 @@ object ExprToPython extends ExprBackend:
 
     case SeqLiteralF(elements, span) =>
       val parts = elements.map(translate(_, ctx))
-      liftAll(parts, span)(ps => ExprPy.Py(s"[${ps.mkString(", ")}]"))
+      liftAll(parts, span)(ps => Translated.Emit(s"[${ps.mkString(", ")}]"))
 
     case MatchesF(e, pattern, span) =>
       lift1(translate(e, ctx))(t =>
-        ExprPy.Py(s"(re.fullmatch(${pyString(pattern)}, $t) is not None)")
+        Translated.Emit(s"(re.fullmatch(${pyString(pattern)}, $t) is not None)")
       )
 
     case TheF(v, dom, body, span) =>
       if PythonReservedNames.contains(v) then
-        ExprPy.Skip(s"The with Python-reserved binding name '$v'", span)
+        Translated.Skip(s"The with Python-reserved binding name '$v'", span)
       else
         val innerCtx = ctx.withBound(List(v))
         lift2(translate(dom, ctx), translate(body, innerCtx))((dp, bp) =>
-          ExprPy.Py(s"next(($v for $v in ($dp) if ($bp)), None)")
+          Translated.Emit(s"next(($v for $v in ($dp) if ($bp)), None)")
         )
 
     case LambdaF(param, body, span) =>
       if PythonReservedNames.contains(param) then
-        ExprPy.Skip(s"Lambda with Python-reserved param name '$param'", span)
+        Translated.Skip(s"Lambda with Python-reserved param name '$param'", span)
       else
         val innerCtx = ctx.withBound(List(param))
-        lift1(translate(body, innerCtx))(b => ExprPy.Py(s"(lambda $param: ($b))"))
+        lift1(translate(body, innerCtx))(b => Translated.Emit(s"(lambda $param: ($b))"))
 
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
-  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): ExprPy =
+  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
     if PythonReservedNames.contains(name) &&
       (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then ExprPy.Skip(s"identifier '$name' is a Python-reserved name", span)
-    else if ctx.boundVars.contains(name) then ExprPy.Py(name)
-    else if ctx.bareBodyOutput.contains(name) then ExprPy.Py("response_data")
-    else if ctx.outputs.contains(name) then ExprPy.Py(s"response_data[${pyString(name)}]")
-    else if ctx.inputs.contains(name) then ExprPy.Py(name)
+    then Translated.Skip(s"identifier '$name' is a Python-reserved name", span)
+    else if ctx.boundVars.contains(name) then Translated.Emit(name)
+    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("response_data")
+    else if ctx.outputs.contains(name) then Translated.Emit(s"response_data[${pyString(name)}]")
+    else if ctx.inputs.contains(name) then Translated.Emit(name)
     else if ctx.stateFields.contains(name) then
       if ctx.unbackedStateFields.contains(name) then
-        ExprPy.Skip(
+        Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
@@ -157,130 +160,111 @@ object ExprToPython extends ExprBackend:
         val dict = ctx.capture match
           case CaptureMode.PostState => "post_state"
           case CaptureMode.PreState  => "pre_state"
-        ExprPy.Py(s"$dict[${pyString(name)}]")
-    else if ctx.enumValues.contains(name) then ExprPy.Skip(s"enum-type identifier '$name'", span)
+        Translated.Emit(s"$dict[${pyString(name)}]")
+    else if ctx.enumValues.contains(name) then
+      Translated.Skip(s"enum-type identifier '$name'", span)
     else
       ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => ExprPy.Py(pyString(name))
-        case None    => ExprPy.Skip(s"unbound identifier '$name'", span)
+        case Some(_) => Translated.Emit(pyString(name))
+        case None    => Translated.Skip(s"unbound identifier '$name'", span)
 
-  private def binOpText(op: bin_op_full, l: String, r: String): ExprPy =
+  private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match
-      case BAnd()       => ExprPy.Py(s"(($l) and ($r))")
-      case BOr()        => ExprPy.Py(s"(($l) or ($r))")
-      case BImplies()   => ExprPy.Py(s"((not ($l)) or ($r))")
-      case BIff()       => ExprPy.Py(s"(($l) == ($r))")
-      case BEq()        => ExprPy.Py(s"(($l) == ($r))")
-      case BNeq()       => ExprPy.Py(s"(($l) != ($r))")
-      case BLt()        => ExprPy.Py(s"(($l) < ($r))")
-      case BGt()        => ExprPy.Py(s"(($l) > ($r))")
-      case BLe()        => ExprPy.Py(s"(($l) <= ($r))")
-      case BGe()        => ExprPy.Py(s"(($l) >= ($r))")
-      case BIn()        => ExprPy.Py(s"(($l) in ($r))")
-      case BNotIn()     => ExprPy.Py(s"(($l) not in ($r))")
-      case BAdd()       => ExprPy.Py(s"(($l) + ($r))")
-      case BSub()       => ExprPy.Py(s"(($l) - ($r))")
-      case BMul()       => ExprPy.Py(s"(($l) * ($r))")
-      case BDiv()       => ExprPy.Py(s"(($l) / ($r))")
-      case BUnion()     => ExprPy.Py(s"(($l) | ($r))")
-      case BIntersect() => ExprPy.Py(s"(($l) & ($r))")
-      case BDiff()      => ExprPy.Py(s"(($l) - ($r))")
-      case BSubset()    => ExprPy.Py(s"(($l) <= ($r))")
+      case BAnd()       => Translated.Emit(s"(($l) and ($r))")
+      case BOr()        => Translated.Emit(s"(($l) or ($r))")
+      case BImplies()   => Translated.Emit(s"((not ($l)) or ($r))")
+      case BIff()       => Translated.Emit(s"(($l) == ($r))")
+      case BEq()        => Translated.Emit(s"(($l) == ($r))")
+      case BNeq()       => Translated.Emit(s"(($l) != ($r))")
+      case BLt()        => Translated.Emit(s"(($l) < ($r))")
+      case BGt()        => Translated.Emit(s"(($l) > ($r))")
+      case BLe()        => Translated.Emit(s"(($l) <= ($r))")
+      case BGe()        => Translated.Emit(s"(($l) >= ($r))")
+      case BIn()        => Translated.Emit(s"(($l) in ($r))")
+      case BNotIn()     => Translated.Emit(s"(($l) not in ($r))")
+      case BAdd()       => Translated.Emit(s"(($l) + ($r))")
+      case BSub()       => Translated.Emit(s"(($l) - ($r))")
+      case BMul()       => Translated.Emit(s"(($l) * ($r))")
+      case BDiv()       => Translated.Emit(s"(($l) / ($r))")
+      case BUnion()     => Translated.Emit(s"(($l) | ($r))")
+      case BIntersect() => Translated.Emit(s"(($l) & ($r))")
+      case BDiff()      => Translated.Emit(s"(($l) - ($r))")
+      case BSubset()    => Translated.Emit(s"(($l) <= ($r))")
 
-  private def unOpText(op: un_op_full, x: String): ExprPy = op match
-    case UNot()         => ExprPy.Py(s"(not ($x))")
-    case UNegate()      => ExprPy.Py(s"(-($x))")
-    case UCardinality() => ExprPy.Py(s"len($x)")
-    case UPower()       => ExprPy.Py(s"_powerset($x)")
+  private def unOpText(op: un_op_full, x: String): Translated = op match
+    case UNot()         => Translated.Emit(s"(not ($x))")
+    case UNegate()      => Translated.Emit(s"(-($x))")
+    case UCardinality() => Translated.Emit(s"len($x)")
+    case UPower()       => Translated.Emit(s"_powerset($x)")
 
   private def callExpr(
       callee: expr_full,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     callee match
       case IdentifierF(name, _) => identifierCall(name, args, ctx, span)
       case _ =>
         val parts = args.map(translate(_, ctx))
         lift1(translate(callee, ctx)): cp =>
-          liftAll(parts, span)(ps => ExprPy.Py(s"($cp)(${ps.mkString(", ")})"))
+          liftAll(parts, span)(ps => Translated.Emit(s"($cp)(${ps.mkString(", ")})"))
 
   private def identifierCall(
       fname: String,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     recognizedCall(fname, args, ctx, span) match
-      case ExprPy.Py(text) => ExprPy.Py(text)
-      case ExprPy.Skip(_, _) =>
+      case Translated.Emit(text) => Translated.Emit(text)
+      case Translated.Skip(_, _) =>
         userDefinedCall(fname, args, ctx, span) match
-          case ExprPy.Py(text) => ExprPy.Py(text)
-          case ExprPy.Skip(reason, _) =>
-            ExprPy.Skip(reason, span)
+          case Translated.Emit(text) => Translated.Emit(text)
+          case Translated.Skip(reason, _) =>
+            Translated.Skip(reason, span)
 
   private def recognizedCall(
       fname: String,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     fname match
-      case "len" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a => ExprPy.Py(s"len($a)"))
-      case "dom" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a => ExprPy.Py(s"set($a.keys())"))
-      case "ran" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a => ExprPy.Py(s"set($a.values())"))
-      case "max" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a => ExprPy.Py(s"max($a)"))
-      case "min" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a => ExprPy.Py(s"min($a)"))
-      case "now" if args.isEmpty =>
-        // Epoch seconds (float) so `now() - minutes(15)` is numeric arithmetic.
-        // Aligns with days/hours/minutes/seconds which all return numeric seconds.
-        ExprPy.Py("datetime.datetime.now(datetime.timezone.utc).timestamp()")
-      case "hash" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"hashlib.sha256(str($a).encode()).hexdigest()")
-        )
-      case "days" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"datetime.timedelta(days=$a).total_seconds()")
-        )
-      case "hours" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"datetime.timedelta(hours=$a).total_seconds()")
-        )
-      case "minutes" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"datetime.timedelta(minutes=$a).total_seconds()")
-        )
-      case "seconds" if args.size == 1 =>
-        lift1(translate(args.head, ctx))(a =>
-          ExprPy.Py(s"datetime.timedelta(seconds=$a).total_seconds()")
-        )
+      // Higher-order builtin: `sum(coll, x => expr)` — kept as a per-backend
+      // special because the lambda body needs ctx.boundVars threading. Every
+      // other builtin is data-driven via the shared Builtins registry below.
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx, span)
-      case other =>
-        ExprPy.Skip(s"unknown function '$other/${args.size}' (see #138)", span)
+      case _ =>
+        Builtins.byName.get(fname) match
+          case Some(spec) if spec.arity == args.size =>
+            liftAll(args.map(translate(_, ctx)), span)(rendered =>
+              Translated.Emit(spec.py(rendered))
+            )
+          case Some(spec) =>
+            Translated.Skip(
+              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
+              span
+            )
+          case None =>
+            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
 
   private def sumCall(
       coll: expr_full,
       fn: expr_full,
       ctx: TestCtx,
       @scala.annotation.unused span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     fn match
       case LambdaF(param, body, _) if !PythonReservedNames.contains(param) =>
         val innerCtx = ctx.withBound(List(param))
         lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          ExprPy.Py(s"sum(($b) for $param in ($c))")
+          Translated.Emit(s"sum(($b) for $param in ($c))")
         )
       case _ =>
         lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          ExprPy.Py(s"sum(($f)(_x) for _x in ($c))")
+          Translated.Emit(s"sum(($f)(_x) for _x in ($c))")
         )
 
   private def userDefinedCall(
@@ -288,60 +272,60 @@ object ExprToPython extends ExprBackend:
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val expectedArity = ctx.userFunctions
       .get(fname)
       .map(_.b.size)
       .orElse(ctx.userPredicates.get(fname).map(_.b.size))
     expectedArity match
       case None =>
-        ExprPy.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
+        Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
       case Some(n) if n != args.size =>
-        ExprPy.Skip(
+        Translated.Skip(
           s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
           span
         )
       case Some(_) =>
         val parts  = args.map(translate(_, ctx))
         val pyName = Naming.toSnakeCase(fname)
-        liftAll(parts, span)(ps => ExprPy.Py(s"$pyName(${ps.mkString(", ")})"))
+        liftAll(parts, span)(ps => Translated.Emit(s"$pyName(${ps.mkString(", ")})"))
 
   private def mapLiteral(
       entries: List[map_entry_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if entries.isEmpty then ExprPy.Py("{}")
+  ): Translated =
+    if entries.isEmpty then Translated.Emit("{}")
     else
       val pairs = entries.collect { case MapEntryFull(k, v, _) =>
-        lift2(translate(k, ctx), translate(v, ctx))((kx, vx) => ExprPy.Py(s"$kx: $vx"))
+        lift2(translate(k, ctx), translate(v, ctx))((kx, vx) => Translated.Emit(s"$kx: $vx"))
       }
-      liftAll(pairs, span)(ps => ExprPy.Py(s"{${ps.mkString(", ")}}"))
+      liftAll(pairs, span)(ps => Translated.Emit(s"{${ps.mkString(", ")}}"))
 
   private def constructorLiteral(
       fields: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if fields.isEmpty then ExprPy.Py("{}")
+  ): Translated =
+    if fields.isEmpty then Translated.Emit("{}")
     else
       val pairs = fields.collect { case FieldAssignFull(n, v, _) =>
-        lift1(translate(v, ctx))(vx => ExprPy.Py(s"${pyString(n)}: $vx"))
+        lift1(translate(v, ctx))(vx => Translated.Emit(s"${pyString(n)}: $vx"))
       }
-      liftAll(pairs, span)(ps => ExprPy.Py(s"{${ps.mkString(", ")}}"))
+      liftAll(pairs, span)(ps => Translated.Emit(s"{${ps.mkString(", ")}}"))
 
   private def withUpdate(
       base: expr_full,
       updates: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val basePy = translate(base, ctx)
     val pairs = updates.collect { case FieldAssignFull(n, v, _) =>
-      lift1(translate(v, ctx))(vx => ExprPy.Py(s"${pyString(n)}: $vx"))
+      lift1(translate(v, ctx))(vx => Translated.Emit(s"${pyString(n)}: $vx"))
     }
     lift1(basePy): bp =>
-      liftAll(pairs, span)(ps => ExprPy.Py(s"{**($bp), ${ps.mkString(", ")}}"))
+      liftAll(pairs, span)(ps => Translated.Emit(s"{**($bp), ${ps.mkString(", ")}}"))
 
   private def setComprehension(
       v: String,
@@ -349,9 +333,9 @@ object ExprToPython extends ExprBackend:
       pred: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     if PythonReservedNames.contains(v) then
-      ExprPy.Skip(s"SetComprehension with Python-reserved binding name '$v'", span)
+      Translated.Skip(s"SetComprehension with Python-reserved binding name '$v'", span)
     else
       val innerCtx    = ctx.withBound(List(v))
       val domPy       = translate(dom, ctx)
@@ -359,7 +343,7 @@ object ExprToPython extends ExprBackend:
       val isMapDomain = peelRelationRefFull(dom).exists(ctx.mapStateFields.contains)
       lift2(domPy, predPy): (d, p) =>
         val iter = if isMapDomain then s"($d).values()" else s"($d)"
-        ExprPy.Py(s"{$v for $v in $iter if ($p)}")
+        Translated.Emit(s"{$v for $v in $iter if ($p)}")
 
   private def quantifier(
       kind: quant_kind_full,
@@ -367,11 +351,11 @@ object ExprToPython extends ExprBackend:
       body: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val isAllIn = bindings.forall:
       case QuantifierBindingFull(_, _, BkIn(), _) => true
       case _                                      => false
-    if !isAllIn then ExprPy.Skip("quantifier with non-`in` binding", span)
+    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       val domains    = bindings.collect { case QuantifierBindingFull(_, d, _, _) => translate(d, ctx) }
@@ -384,9 +368,9 @@ object ExprToPython extends ExprBackend:
         val genFor  = s"for $pairs"
         val genExpr = s"($bp $genFor)"
         kind match
-          case QAll()              => ExprPy.Py(s"all$genExpr")
-          case QSome() | QExists() => ExprPy.Py(s"any$genExpr")
-          case QNo()               => ExprPy.Py(s"(not any$genExpr)")
+          case QAll()              => Translated.Emit(s"all$genExpr")
+          case QSome() | QExists() => Translated.Emit(s"any$genExpr")
+          case QNo()               => Translated.Emit(s"(not any$genExpr)")
 
   private[testgen] def pyString(s: String): String =
     val escaped = s
@@ -397,16 +381,16 @@ object ExprToPython extends ExprBackend:
       .replace("\t", "\\t")
     s"\"$escaped\""
 
-  private def lift1(a: ExprPy)(f: String => ExprPy): ExprPy = ExprLift.lift1(a)(f)
+  private def lift1(a: Translated)(f: String => Translated): Translated = ExprLift.lift1(a)(f)
 
-  private def lift2(a: ExprPy, b: ExprPy)(f: (String, String) => ExprPy): ExprPy =
+  private def lift2(a: Translated, b: Translated)(f: (String, String) => Translated): Translated =
     ExprLift.lift2(a, b)(f)
 
-  private def lift3(a: ExprPy, b: ExprPy, c: ExprPy)(
-      f: (String, String, String) => ExprPy
-  ): ExprPy = ExprLift.lift3(a, b, c)(f)
+  private def lift3(a: Translated, b: Translated, c: Translated)(
+      f: (String, String, String) => Translated
+  ): Translated = ExprLift.lift3(a, b, c)(f)
 
   private def liftAll(
-      parts: List[ExprPy],
+      parts: List[Translated],
       span: Option[span_t]
-  )(f: List[String] => ExprPy): ExprPy = ExprLift.liftAll(parts, span)(f)
+  )(f: List[String] => Translated): Translated = ExprLift.liftAll(parts, span)(f)

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -1,6 +1,5 @@
 package specrest.testgen
 
-import specrest.convention.Builtins
 import specrest.convention.Naming
 import specrest.ir.generated.SpecRestGenerated.*
 
@@ -230,42 +229,7 @@ object ExprToPython extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    fname match
-      // Higher-order builtin: `sum(coll, x => expr)` — kept as a per-backend
-      // special because the lambda body needs ctx.boundVars threading. Every
-      // other builtin is data-driven via the shared Builtins registry below.
-      case "sum" if args.size == 2 =>
-        sumCall(args(0), args(1), ctx, span)
-      case _ =>
-        Builtins.byName.get(fname) match
-          case Some(spec) if spec.arity == args.size =>
-            liftAll(args.map(translate(_, ctx)), span)(rendered =>
-              Translated.Emit(spec.py(rendered))
-            )
-          case Some(spec) =>
-            Translated.Skip(
-              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
-              span
-            )
-          case None =>
-            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-
-  private def sumCall(
-      coll: expr_full,
-      fn: expr_full,
-      ctx: TestCtx,
-      @scala.annotation.unused span: Option[span_t]
-  ): Translated =
-    fn match
-      case LambdaF(param, body, _) if !PythonReservedNames.contains(param) =>
-        val innerCtx = ctx.withBound(List(param))
-        lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          Translated.Emit(s"sum(($b) for $param in ($c))")
-        )
-      case _ =>
-        lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          Translated.Emit(s"sum(($f)(_x) for _x in ($c))")
-        )
+    ExprLift.dispatchBuiltin(fname, args.map(translate(_, ctx)), span, _.py)
 
   private def userDefinedCall(
       fname: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -75,9 +75,9 @@ object GoBehavioral:
               Left(TestSkip(opDecl.a, s"ensures[$idx]", Behavioral.aggregateEqualitySkipReason))
             else
               GoExprBackend.translate(clause, ctx) match
-                case ExprPy.Skip(reason, _) =>
+                case Translated.Skip(reason, _) =>
                   Left(TestSkip(opDecl.a, s"ensures[$idx]", reason))
-                case ExprPy.Py(text) =>
+                case Translated.Emit(text) =>
                   Right(
                     buildPositiveTest(
                       name = s"Test_${opSnake}_ensures_$idx",

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -1,6 +1,5 @@
 package specrest.testgen
 
-import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated.*
 
 private[testgen] val GoReservedNames: Set[String] = Set(
@@ -291,35 +290,7 @@ object GoExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    fname match
-      // Higher-order builtin: lambda body needs ctx.boundVars threading.
-      case "sum" if args.size == 2 =>
-        sumCall(args(0), args(1), ctx)
-      case _ =>
-        Builtins.byName.get(fname) match
-          case Some(spec) if spec.arity == args.size =>
-            ExprLift.liftAll(args.map(translate(_, ctx)), span)(rendered =>
-              Translated.Emit(spec.go(rendered))
-            )
-          case Some(spec) =>
-            Translated.Skip(
-              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
-              span
-            )
-          case None =>
-            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-
-  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): Translated =
-    fn match
-      case LambdaF(param, body, _) if !GoReservedNames.contains(param) =>
-        val innerCtx = ctx.withBound(List(param))
-        ExprLift.lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          Translated.Emit(s"_sum($c, func($param any) any { return $b })")
-        )
-      case _ =>
-        ExprLift.lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          Translated.Emit(s"_sum($c, func(_x any) any { return _call($f, _x) })")
-        )
+    ExprLift.dispatchBuiltin(fname, args.map(translate(_, ctx)), span, _.go)
 
   private def userDefinedCall(
       fname: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated.*
 
 private[testgen] val GoReservedNames: Set[String] = Set(
@@ -103,12 +104,12 @@ object GoExprBackend extends ExprBackend:
 
   def stringLiteral(s: String): String = GoLit.str(s)
 
-  def translate(expr: expr_full, ctx: TestCtx): ExprPy = expr match
-    case BoolLitF(v, _)   => ExprPy.Py(if v then "true" else "false")
-    case IntLitF(n, _)    => ExprPy.Py(s"int64(${integer_of_int(n).toString})")
-    case FloatLitF(d, _)  => ExprPy.Py(d.toString)
-    case StringLitF(s, _) => ExprPy.Py(GoLit.str(s))
-    case NoneLitF(_)      => ExprPy.Py("nil")
+  def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
+    case BoolLitF(v, _)   => Translated.Emit(if v then "true" else "false")
+    case IntLitF(n, _)    => Translated.Emit(s"int64(${integer_of_int(n).toString})")
+    case FloatLitF(d, _)  => Translated.Emit(d.toString)
+    case StringLitF(s, _) => Translated.Emit(GoLit.str(s))
+    case NoneLitF(_)      => Translated.Emit("nil")
 
     case IdentifierF(name, span) => resolveIdent(name, ctx, span)
 
@@ -118,7 +119,7 @@ object GoExprBackend extends ExprBackend:
     case BinaryOpF(BAdd(), l, r, _)
         if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
       ExprLift.lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
-        ExprPy.Py(s"_merge($lp, $rp)")
+        Translated.Emit(s"_merge($lp, $rp)")
       )
 
     case BinaryOpF(op, l, r, _) =>
@@ -128,35 +129,35 @@ object GoExprBackend extends ExprBackend:
       ExprLift.lift1(translate(x, ctx))(unOpText(op, _))
 
     case FieldAccessF(base, field, _) =>
-      ExprLift.lift1(translate(base, ctx))(b => ExprPy.Py(s"_field($b, ${GoLit.str(field)})"))
+      ExprLift.lift1(translate(base, ctx))(b => Translated.Emit(s"_field($b, ${GoLit.str(field)})"))
 
-    case EnumAccessF(_, member, _) => ExprPy.Py(GoLit.str(member))
+    case EnumAccessF(_, member, _) => Translated.Emit(GoLit.str(member))
 
     case IndexF(base, idx, _) =>
       ExprLift.lift2(translate(base, ctx), translate(idx, ctx))((b, i) =>
-        ExprPy.Py(s"_index($b, $i)")
+        Translated.Emit(s"_index($b, $i)")
       )
 
     case CallF(callee, args, span) => callExpr(callee, args, ctx, span)
 
     case IfF(c, t, e, _) =>
       ExprLift.lift3(translate(c, ctx), translate(t, ctx), translate(e, ctx))((cp, tp, ep) =>
-        ExprPy.Py(s"func() any { if _truthy($cp) { return $tp }; return $ep }()")
+        Translated.Emit(s"func() any { if _truthy($cp) { return $tp }; return $ep }()")
       )
 
     case LetF(v, value, body, span) =>
       if GoReservedNames.contains(v) then
-        ExprPy.Skip(s"Let with Go-reserved binding name '$v'", span)
+        Translated.Skip(s"Let with Go-reserved binding name '$v'", span)
       else
         ExprLift.lift2(translate(value, ctx), translate(body, ctx.withBound(List(v))))((vp, bp) =>
-          ExprPy.Py(s"func($v any) any { return $bp }($vp)")
+          Translated.Emit(s"func($v any) any { return $bp }($vp)")
         )
 
     case SetLiteralF(elements, span) =>
-      if elements.isEmpty then ExprPy.Py("_set()")
+      if elements.isEmpty then Translated.Emit("_set()")
       else
         val parts = elements.map(translate(_, ctx))
-        ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"_set(${ps.mkString(", ")})"))
+        ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"_set(${ps.mkString(", ")})"))
 
     case QuantifierF(kind, bindings, body, span) =>
       quantifier(kind, bindings, body, ctx, span)
@@ -172,44 +173,45 @@ object GoExprBackend extends ExprBackend:
 
     case SeqLiteralF(elements, span) =>
       val parts = elements.map(translate(_, ctx))
-      ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"[]any{${ps.mkString(", ")}}"))
+      ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"[]any{${ps.mkString(", ")}}"))
 
     case MatchesF(e, pattern, _) =>
       ExprLift.lift1(translate(e, ctx))(t =>
-        ExprPy.Py(s"_matches($t, ${GoLit.str(s"^(?:$pattern)$$")})")
+        Translated.Emit(s"_matches($t, ${GoLit.str(s"^(?:$pattern)$$")})")
       )
 
     case TheF(v, dom, body, span) =>
       if GoReservedNames.contains(v) then
-        ExprPy.Skip(s"The with Go-reserved binding name '$v'", span)
+        Translated.Skip(s"The with Go-reserved binding name '$v'", span)
       else
         val innerCtx = ctx.withBound(List(v))
         ExprLift.lift2(translate(dom, ctx), translate(body, innerCtx))((dp, bp) =>
-          ExprPy.Py(s"_find($dp, func($v any) bool { return _truthy($bp) })")
+          Translated.Emit(s"_find($dp, func($v any) bool { return _truthy($bp) })")
         )
 
     case LambdaF(param, body, span) =>
       if GoReservedNames.contains(param) then
-        ExprPy.Skip(s"Lambda with Go-reserved param name '$param'", span)
+        Translated.Skip(s"Lambda with Go-reserved param name '$param'", span)
       else
         val innerCtx = ctx.withBound(List(param))
         ExprLift.lift1(translate(body, innerCtx))(b =>
-          ExprPy.Py(s"func($param any) any { return $b }")
+          Translated.Emit(s"func($param any) any { return $b }")
         )
 
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
-  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): ExprPy =
+  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
     if GoReservedNames.contains(name) &&
       (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then ExprPy.Skip(s"identifier '$name' is a Go-reserved name", span)
-    else if ctx.boundVars.contains(name) then ExprPy.Py(name)
-    else if ctx.bareBodyOutput.contains(name) then ExprPy.Py("responseData")
-    else if ctx.outputs.contains(name) then ExprPy.Py(s"_field(responseData, ${GoLit.str(name)})")
-    else if ctx.inputs.contains(name) then ExprPy.Py(name)
+    then Translated.Skip(s"identifier '$name' is a Go-reserved name", span)
+    else if ctx.boundVars.contains(name) then Translated.Emit(name)
+    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("responseData")
+    else if ctx.outputs.contains(name) then
+      Translated.Emit(s"_field(responseData, ${GoLit.str(name)})")
+    else if ctx.inputs.contains(name) then Translated.Emit(name)
     else if ctx.stateFields.contains(name) then
       if ctx.unbackedStateFields.contains(name) then
-        ExprPy.Skip(
+        Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
@@ -218,55 +220,56 @@ object GoExprBackend extends ExprBackend:
         val obj = ctx.capture match
           case CaptureMode.PostState => "postState"
           case CaptureMode.PreState  => "preState"
-        ExprPy.Py(s"_field($obj, ${GoLit.str(name)})")
-    else if ctx.enumValues.contains(name) then ExprPy.Skip(s"enum-type identifier '$name'", span)
+        Translated.Emit(s"_field($obj, ${GoLit.str(name)})")
+    else if ctx.enumValues.contains(name) then
+      Translated.Skip(s"enum-type identifier '$name'", span)
     else
       ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => ExprPy.Py(GoLit.str(name))
-        case None    => ExprPy.Skip(s"unbound identifier '$name'", span)
+        case Some(_) => Translated.Emit(GoLit.str(name))
+        case None    => Translated.Skip(s"unbound identifier '$name'", span)
 
-  private def binOpText(op: bin_op_full, l: String, r: String): ExprPy =
+  private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match
-      case BAnd()       => ExprPy.Py(s"(_truthy($l) && _truthy($r))")
-      case BOr()        => ExprPy.Py(s"(_truthy($l) || _truthy($r))")
-      case BImplies()   => ExprPy.Py(s"(!_truthy($l) || _truthy($r))")
-      case BIff()       => ExprPy.Py(s"_eq($l, $r)")
-      case BEq()        => ExprPy.Py(s"_eq($l, $r)")
-      case BNeq()       => ExprPy.Py(s"(!_eq($l, $r))")
-      case BLt()        => ExprPy.Py(s"_lt($l, $r)")
-      case BGt()        => ExprPy.Py(s"_gt($l, $r)")
-      case BLe()        => ExprPy.Py(s"_le($l, $r)")
-      case BGe()        => ExprPy.Py(s"_ge($l, $r)")
-      case BIn()        => ExprPy.Py(s"_in($l, $r)")
-      case BNotIn()     => ExprPy.Py(s"(!_in($l, $r))")
-      case BAdd()       => ExprPy.Py(s"_add($l, $r)")
-      case BSub()       => ExprPy.Py(s"_sub($l, $r)")
-      case BMul()       => ExprPy.Py(s"_mul($l, $r)")
-      case BDiv()       => ExprPy.Py(s"_div($l, $r)")
-      case BUnion()     => ExprPy.Py(s"_union($l, $r)")
-      case BIntersect() => ExprPy.Py(s"_inter($l, $r)")
-      case BDiff()      => ExprPy.Py(s"_diff($l, $r)")
-      case BSubset()    => ExprPy.Py(s"_subset($l, $r)")
+      case BAnd()       => Translated.Emit(s"(_truthy($l) && _truthy($r))")
+      case BOr()        => Translated.Emit(s"(_truthy($l) || _truthy($r))")
+      case BImplies()   => Translated.Emit(s"(!_truthy($l) || _truthy($r))")
+      case BIff()       => Translated.Emit(s"_eq($l, $r)")
+      case BEq()        => Translated.Emit(s"_eq($l, $r)")
+      case BNeq()       => Translated.Emit(s"(!_eq($l, $r))")
+      case BLt()        => Translated.Emit(s"_lt($l, $r)")
+      case BGt()        => Translated.Emit(s"_gt($l, $r)")
+      case BLe()        => Translated.Emit(s"_le($l, $r)")
+      case BGe()        => Translated.Emit(s"_ge($l, $r)")
+      case BIn()        => Translated.Emit(s"_in($l, $r)")
+      case BNotIn()     => Translated.Emit(s"(!_in($l, $r))")
+      case BAdd()       => Translated.Emit(s"_add($l, $r)")
+      case BSub()       => Translated.Emit(s"_sub($l, $r)")
+      case BMul()       => Translated.Emit(s"_mul($l, $r)")
+      case BDiv()       => Translated.Emit(s"_div($l, $r)")
+      case BUnion()     => Translated.Emit(s"_union($l, $r)")
+      case BIntersect() => Translated.Emit(s"_inter($l, $r)")
+      case BDiff()      => Translated.Emit(s"_diff($l, $r)")
+      case BSubset()    => Translated.Emit(s"_subset($l, $r)")
 
-  private def unOpText(op: un_op_full, x: String): ExprPy = op match
-    case UNot()         => ExprPy.Py(s"(!_truthy($x))")
-    case UNegate()      => ExprPy.Py(s"_neg($x)")
-    case UCardinality() => ExprPy.Py(s"_len($x)")
-    case UPower()       => ExprPy.Py(s"_powerset($x)")
+  private def unOpText(op: un_op_full, x: String): Translated = op match
+    case UNot()         => Translated.Emit(s"(!_truthy($x))")
+    case UNegate()      => Translated.Emit(s"_neg($x)")
+    case UCardinality() => Translated.Emit(s"_len($x)")
+    case UPower()       => Translated.Emit(s"_powerset($x)")
 
   private def callExpr(
       callee: expr_full,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     callee match
       case IdentifierF(name, _) => identifierCall(name, args, ctx, span)
       case _ =>
         val parts = args.map(translate(_, ctx))
         ExprLift.lift1(translate(callee, ctx)): cp =>
           ExprLift.liftAll(parts, span)(ps =>
-            ExprPy.Py(s"_call($cp${if ps.isEmpty then "" else ", " + ps.mkString(", ")})")
+            Translated.Emit(s"_call($cp${if ps.isEmpty then "" else ", " + ps.mkString(", ")})")
           )
 
   private def identifierCall(
@@ -274,58 +277,48 @@ object GoExprBackend extends ExprBackend:
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     recognizedCall(fname, args, ctx, span) match
-      case ExprPy.Py(text) => ExprPy.Py(text)
-      case ExprPy.Skip(_, _) =>
+      case Translated.Emit(text) => Translated.Emit(text)
+      case Translated.Skip(_, _) =>
         userDefinedCall(fname, args, ctx, span) match
-          case ExprPy.Py(text)        => ExprPy.Py(text)
-          case ExprPy.Skip(reason, _) => ExprPy.Skip(reason, span)
+          case Translated.Emit(text)      => Translated.Emit(text)
+          case Translated.Skip(reason, _) => Translated.Skip(reason, span)
 
   private def recognizedCall(
       fname: String,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     fname match
-      case "len" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_len($a)"))
-      case "dom" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_keys($a)"))
-      case "ran" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_values($a)"))
-      case "max" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_max($a)"))
-      case "min" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_min($a)"))
-      case "now" if args.isEmpty =>
-        ExprPy.Py("_now()")
-      case "hash" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_sha256Hex($a)"))
-      case "days" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(86400))"))
-      case "hours" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(3600))"))
-      case "minutes" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(60))"))
-      case "seconds" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_mul($a, int64(1))"))
+      // Higher-order builtin: lambda body needs ctx.boundVars threading.
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx)
-      case other =>
-        ExprPy.Skip(s"unknown function '$other/${args.size}' (see #138)", span)
+      case _ =>
+        Builtins.byName.get(fname) match
+          case Some(spec) if spec.arity == args.size =>
+            ExprLift.liftAll(args.map(translate(_, ctx)), span)(rendered =>
+              Translated.Emit(spec.go(rendered))
+            )
+          case Some(spec) =>
+            Translated.Skip(
+              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
+              span
+            )
+          case None =>
+            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
 
-  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): ExprPy =
+  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): Translated =
     fn match
       case LambdaF(param, body, _) if !GoReservedNames.contains(param) =>
         val innerCtx = ctx.withBound(List(param))
         ExprLift.lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          ExprPy.Py(s"_sum($c, func($param any) any { return $b })")
+          Translated.Emit(s"_sum($c, func($param any) any { return $b })")
         )
       case _ =>
         ExprLift.lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          ExprPy.Py(s"_sum($c, func(_x any) any { return _call($f, _x) })")
+          Translated.Emit(s"_sum($c, func(_x any) any { return _call($f, _x) })")
         )
 
   private def userDefinedCall(
@@ -333,63 +326,63 @@ object GoExprBackend extends ExprBackend:
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val expectedArity = ctx.userFunctions
       .get(fname)
       .map(_.b.size)
       .orElse(ctx.userPredicates.get(fname).map(_.b.size))
     expectedArity match
       case None =>
-        ExprPy.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
+        Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
       case Some(n) if n != args.size =>
-        ExprPy.Skip(
+        Translated.Skip(
           s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
           span
         )
       case Some(_) if GoReservedNames.contains(fname) =>
-        ExprPy.Skip(s"user-defined call '$fname' is a Go-reserved name", span)
+        Translated.Skip(s"user-defined call '$fname' is a Go-reserved name", span)
       case Some(_) =>
         val parts = args.map(translate(_, ctx))
-        ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"$fname(${ps.mkString(", ")})"))
+        ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"$fname(${ps.mkString(", ")})"))
 
   private def mapLiteral(
       entries: List[map_entry_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if entries.isEmpty then ExprPy.Py("map[string]any{}")
+  ): Translated =
+    if entries.isEmpty then Translated.Emit("map[string]any{}")
     else
       val pairs = entries.collect { case MapEntryFull(k, v, _) =>
         ExprLift.lift2(translate(k, ctx), translate(v, ctx))((kx, vx) =>
-          ExprPy.Py(s"$kx, $vx")
+          Translated.Emit(s"$kx, $vx")
         )
       }
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"_mapOf(${ps.mkString(", ")})"))
+      ExprLift.liftAll(pairs, span)(ps => Translated.Emit(s"_mapOf(${ps.mkString(", ")})"))
 
   private def constructorLiteral(
       fields: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if fields.isEmpty then ExprPy.Py("map[string]any{}")
+  ): Translated =
+    if fields.isEmpty then Translated.Emit("map[string]any{}")
     else
       val pairs = fields.collect { case FieldAssignFull(n, v, _) =>
-        ExprLift.lift1(translate(v, ctx))(vx => ExprPy.Py(s"${GoLit.str(n)}, $vx"))
+        ExprLift.lift1(translate(v, ctx))(vx => Translated.Emit(s"${GoLit.str(n)}, $vx"))
       }
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"_mapOf(${ps.mkString(", ")})"))
+      ExprLift.liftAll(pairs, span)(ps => Translated.Emit(s"_mapOf(${ps.mkString(", ")})"))
 
   private def withUpdate(
       base: expr_full,
       updates: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val basePy = translate(base, ctx)
     val pairs = updates.collect { case FieldAssignFull(n, v, _) =>
-      ExprLift.lift1(translate(v, ctx))(vx => ExprPy.Py(s"${GoLit.str(n)}, $vx"))
+      ExprLift.lift1(translate(v, ctx))(vx => Translated.Emit(s"${GoLit.str(n)}, $vx"))
     }
     ExprLift.lift1(basePy): bp =>
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"_with($bp, ${ps.mkString(", ")})"))
+      ExprLift.liftAll(pairs, span)(ps => Translated.Emit(s"_with($bp, ${ps.mkString(", ")})"))
 
   private def setComprehension(
       v: String,
@@ -397,15 +390,15 @@ object GoExprBackend extends ExprBackend:
       pred: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     if GoReservedNames.contains(v) then
-      ExprPy.Skip(s"SetComprehension with Go-reserved binding name '$v'", span)
+      Translated.Skip(s"SetComprehension with Go-reserved binding name '$v'", span)
     else
       val innerCtx = ctx.withBound(List(v))
       val domPy    = translate(dom, ctx)
       val predPy   = translate(pred, innerCtx)
       ExprLift.lift2(domPy, predPy): (d, p) =>
-        ExprPy.Py(s"_setFilter($d, func($v any) bool { return _truthy($p) })")
+        Translated.Emit(s"_setFilter($d, func($v any) bool { return _truthy($p) })")
 
   private def quantifier(
       kind: quant_kind_full,
@@ -413,15 +406,15 @@ object GoExprBackend extends ExprBackend:
       body: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val isAllIn = bindings.forall:
       case QuantifierBindingFull(_, _, BkIn(), _) => true
       case _                                      => false
-    if !isAllIn then ExprPy.Skip("quantifier with non-`in` binding", span)
+    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       if boundNames.exists(GoReservedNames.contains) then
-        ExprPy.Skip("quantifier with Go-reserved binding name", span)
+        Translated.Skip("quantifier with Go-reserved binding name", span)
       else
         val domains = bindings.collect { case QuantifierBindingFull(_, d, _, _) =>
           translate(d, ctx)
@@ -438,6 +431,6 @@ object GoExprBackend extends ExprBackend:
             val (v, d) = pair
             s"$helper($d, func($v any) bool { return $acc })"
           kind match
-            case QAll()              => ExprPy.Py(nested)
-            case QSome() | QExists() => ExprPy.Py(nested)
-            case QNo()               => ExprPy.Py(s"(!($nested))")
+            case QAll()              => Translated.Emit(nested)
+            case QSome() | QExists() => Translated.Emit(nested)
+            case QNo()               => Translated.Emit(s"(!($nested))")

--- a/modules/testgen/src/main/scala/specrest/testgen/GoStateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoStateful.scala
@@ -42,10 +42,10 @@ object GoStateful:
       ir.i.collect { case inv: InvariantDeclFull => inv }.zipWithIndex.flatMap: (inv, idx) =>
         val name = inv.a.getOrElse(s"anon_$idx")
         GoExprBackend.translate(inv.b, invCtx) match
-          case ExprPy.Skip(reason, _) =>
+          case Translated.Skip(reason, _) =>
             skips += TestSkip("<invariants>", s"stateful_invariant[$name]", reason)
             None
-          case ExprPy.Py(text) =>
+          case Translated.Emit(text) =>
             Some((name, prettyOneLine(inv.b), text))
 
     if ir.j.nonEmpty || ir.h.nonEmpty then

--- a/modules/testgen/src/main/scala/specrest/testgen/GoTestHarness.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoTestHarness.scala
@@ -95,9 +95,9 @@ object GoTestHarness extends HarnessTemplates:
         case None =>
           val ctx = predicateBodyCtx(paramNames.toSet, ir)
           GoExprBackend.translate(body, ctx) match
-            case ExprPy.Py(text) =>
+            case Translated.Emit(text) =>
               s"func $specName($sigParams) any {\n\treturn $text\n}\n\n"
-            case ExprPy.Skip(reason, _) =>
+            case Translated.Skip(reason, _) =>
               stub(s"testgen: cannot translate body of '$specName': $reason")
 
   private def predicateBodyCtx(params: Set[String], ir: ServiceIRFull): TestCtx =

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -648,10 +648,10 @@ object Stateful:
     val name       = inv.a.getOrElse(s"anon_$idx")
     val methodName = Naming.toSnakeCase(name)
     ExprToPython.translate(inv.b, ctx) match
-      case ExprPy.Skip(reason, _) =>
+      case Translated.Skip(reason, _) =>
         val skip = TestSkip("<invariants>", s"stateful_invariant[$name]", reason)
         (None, Some(skip))
-      case ExprPy.Py(text) =>
+      case Translated.Emit(text) =>
         val sb = new StringBuilder
         sb.append("    @invariant()\n")
         sb.append(s"    def invariant_$methodName(self):\n")
@@ -672,11 +672,11 @@ object Stateful:
     TemporalShape.of(decl) match
       case TemporalShape.Always(arg) =>
         ExprToPython.translate(arg, ctx) match
-          case ExprPy.Skip(reason, _) =>
+          case Translated.Skip(reason, _) =>
             TemporalEmission.Skip(
               TestSkip("<temporals>", s"stateful_temporal_always[${decl.a}]", reason)
             )
-          case ExprPy.Py(text) =>
+          case Translated.Emit(text) =>
             val methodName = Naming.toSnakeCase(decl.a)
             val sb         = new StringBuilder
             sb.append("    @invariant()\n")
@@ -691,11 +691,11 @@ object Stateful:
             TemporalEmission.AlwaysBlock(sb.toString)
       case TemporalShape.Eventually(arg) =>
         ExprToPython.translate(arg, ctx) match
-          case ExprPy.Skip(reason, _) =>
+          case Translated.Skip(reason, _) =>
             TemporalEmission.Skip(
               TestSkip("<temporals>", s"stateful_temporal_eventually[${decl.a}]", reason)
             )
-          case ExprPy.Py(text) =>
+          case Translated.Emit(text) =>
             val methodName = Naming.toSnakeCase(decl.a)
             val flagName   = s"_eventually_seen_$methodName"
             val sb         = new StringBuilder

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -61,8 +61,8 @@ object Structural:
   ): Option[StructuralCheck] =
     val ctx = invariantCtx(ir)
     ExprToPython.translate(inv.b, ctx) match
-      case ExprPy.Skip(_, _) => None
-      case ExprPy.Py(text) =>
+      case Translated.Skip(_, _) => None
+      case Translated.Emit(text) =>
         val name       = inv.a.getOrElse(s"anon_$idx")
         val methodName = Naming.toSnakeCase(name)
         val sb         = new StringBuilder
@@ -86,7 +86,7 @@ object Structural:
     val ctx  = invariantCtx(ir)
     val name = inv.a.getOrElse(s"anon_$idx")
     ExprToPython.translate(inv.b, ctx) match
-      case ExprPy.Skip(reason, _) =>
+      case Translated.Skip(reason, _) =>
         Some(TestSkip("<invariants>", s"structural_invariant[$name]", reason))
       case _ => None
 
@@ -129,9 +129,9 @@ object Structural:
         else
           val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
           ExprToPython.translate(clause, ctx) match
-            case ExprPy.Skip(reason, _) =>
+            case Translated.Skip(reason, _) =>
               List(Left(TestSkip(opDecl.a, s"structural_ensures[$idx]", reason)))
-            case ExprPy.Py(text) =>
+            case Translated.Emit(text) =>
               val checkName  = s"_check_${opSnake}_ensures_$idx"
               val pathLit    = ExprToPython.pyString(pop.endpoint.path)
               val methodLit  = ExprToPython.pyString(pop.endpoint.method.toString.toUpperCase)

--- a/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Templates.scala
@@ -72,9 +72,9 @@ object Templates:
         case None =>
           val ctx = predicateBodyCtx(paramNames.toSet, ir)
           ExprToPython.translate(body, ctx) match
-            case ExprPy.Py(text) =>
+            case Translated.Emit(text) =>
               s"def $safePyName($sigParams):\n    return $text\n\n"
-            case ExprPy.Skip(reason, _) =>
+            case Translated.Skip(reason, _) =>
               s"def $safePyName($sigParams):\n" +
                 s"    raise NotImplementedError(${ExprToPython.pyString(s"testgen: cannot translate body of '$specName': $reason")})\n\n"
 

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -78,9 +78,9 @@ object TsBehavioral:
               Left(TestSkip(opDecl.a, s"ensures[$idx]", Behavioral.aggregateEqualitySkipReason))
             else
               TsExprBackend.translate(clause, ctx) match
-                case ExprPy.Skip(reason, _) =>
+                case Translated.Skip(reason, _) =>
                   Left(TestSkip(opDecl.a, s"ensures[$idx]", reason))
-                case ExprPy.Py(text) =>
+                case Translated.Emit(text) =>
                   Right(
                     buildPositiveTest(
                       name = s"test_${opSnake}_ensures_$idx",

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -1,6 +1,5 @@
 package specrest.testgen
 
-import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated.*
 
 private[testgen] val TsReservedNames: Set[String] = Set(
@@ -242,35 +241,7 @@ object TsExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    fname match
-      // Higher-order builtin: lambda body needs ctx.boundVars threading.
-      case "sum" if args.size == 2 =>
-        sumCall(args(0), args(1), ctx)
-      case _ =>
-        Builtins.byName.get(fname) match
-          case Some(spec) if spec.arity == args.size =>
-            ExprLift.liftAll(args.map(translate(_, ctx)), span)(rendered =>
-              Translated.Emit(spec.ts(rendered))
-            )
-          case Some(spec) =>
-            Translated.Skip(
-              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
-              span
-            )
-          case None =>
-            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-
-  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): Translated =
-    fn match
-      case LambdaF(param, body, _) if !TsReservedNames.contains(param) =>
-        val innerCtx = ctx.withBound(List(param))
-        ExprLift.lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          Translated.Emit(s"Array.from($c).reduce((_acc, $param) => _acc + ($b), 0)")
-        )
-      case _ =>
-        ExprLift.lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          Translated.Emit(s"Array.from($c).reduce((_acc, _x) => _acc + ($f)(_x), 0)")
-        )
+    ExprLift.dispatchBuiltin(fname, args.map(translate(_, ctx)), span, _.ts)
 
   private def userDefinedCall(
       fname: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated.*
 
 private[testgen] val TsReservedNames: Set[String] = Set(
@@ -59,12 +60,12 @@ object TsExprBackend extends ExprBackend:
 
   def stringLiteral(s: String): String = TsLit.str(s)
 
-  def translate(expr: expr_full, ctx: TestCtx): ExprPy = expr match
-    case BoolLitF(v, _)   => ExprPy.Py(if v then "true" else "false")
-    case IntLitF(n, _)    => ExprPy.Py(integer_of_int(n).toString)
-    case FloatLitF(d, _)  => ExprPy.Py(d.toString)
-    case StringLitF(s, _) => ExprPy.Py(TsLit.str(s))
-    case NoneLitF(_)      => ExprPy.Py("null")
+  def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
+    case BoolLitF(v, _)   => Translated.Emit(if v then "true" else "false")
+    case IntLitF(n, _)    => Translated.Emit(integer_of_int(n).toString)
+    case FloatLitF(d, _)  => Translated.Emit(d.toString)
+    case StringLitF(s, _) => Translated.Emit(TsLit.str(s))
+    case NoneLitF(_)      => Translated.Emit("null")
 
     case IdentifierF(name, span) => resolveIdent(name, ctx, span)
 
@@ -74,7 +75,7 @@ object TsExprBackend extends ExprBackend:
     case BinaryOpF(BAdd(), l, r, _)
         if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
       ExprLift.lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
-        ExprPy.Py(s"{ ...($lp), ...($rp) }")
+        Translated.Emit(s"{ ...($lp), ...($rp) }")
       )
 
     case BinaryOpF(op, l, r, _) =>
@@ -84,33 +85,35 @@ object TsExprBackend extends ExprBackend:
       ExprLift.lift1(translate(x, ctx))(unOpText(op, _))
 
     case FieldAccessF(base, field, _) =>
-      ExprLift.lift1(translate(base, ctx))(b => ExprPy.Py(s"$b[${TsLit.str(field)}]"))
+      ExprLift.lift1(translate(base, ctx))(b => Translated.Emit(s"$b[${TsLit.str(field)}]"))
 
-    case EnumAccessF(_, member, _) => ExprPy.Py(TsLit.str(member))
+    case EnumAccessF(_, member, _) => Translated.Emit(TsLit.str(member))
 
     case IndexF(base, idx, _) =>
-      ExprLift.lift2(translate(base, ctx), translate(idx, ctx))((b, i) => ExprPy.Py(s"$b[$i]"))
+      ExprLift.lift2(translate(base, ctx), translate(idx, ctx))((b, i) =>
+        Translated.Emit(s"$b[$i]")
+      )
 
     case CallF(callee, args, span) => callExpr(callee, args, ctx, span)
 
     case IfF(c, t, e, _) =>
       ExprLift.lift3(translate(c, ctx), translate(t, ctx), translate(e, ctx))((cp, tp, ep) =>
-        ExprPy.Py(s"(($cp) ? ($tp) : ($ep))")
+        Translated.Emit(s"(($cp) ? ($tp) : ($ep))")
       )
 
     case LetF(v, value, body, span) =>
       if TsReservedNames.contains(v) then
-        ExprPy.Skip(s"Let with TypeScript-reserved binding name '$v'", span)
+        Translated.Skip(s"Let with TypeScript-reserved binding name '$v'", span)
       else
         ExprLift.lift2(translate(value, ctx), translate(body, ctx.withBound(List(v))))((vp, bp) =>
-          ExprPy.Py(s"(($v) => ($bp))($vp)")
+          Translated.Emit(s"(($v) => ($bp))($vp)")
         )
 
     case SetLiteralF(elements, span) =>
-      if elements.isEmpty then ExprPy.Py("new Set()")
+      if elements.isEmpty then Translated.Emit("new Set()")
       else
         val parts = elements.map(translate(_, ctx))
-        ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"new Set([${ps.mkString(", ")}])"))
+        ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"new Set([${ps.mkString(", ")}])"))
 
     case QuantifierF(kind, bindings, body, span) =>
       quantifier(kind, bindings, body, ctx, span)
@@ -126,42 +129,42 @@ object TsExprBackend extends ExprBackend:
 
     case SeqLiteralF(elements, span) =>
       val parts = elements.map(translate(_, ctx))
-      ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"[${ps.mkString(", ")}]"))
+      ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"[${ps.mkString(", ")}]"))
 
     case MatchesF(e, pattern, _) =>
       ExprLift.lift1(translate(e, ctx))(t =>
-        ExprPy.Py(s"(new RegExp(${TsLit.str(s"^(?:$pattern)$$")}).test($t))")
+        Translated.Emit(s"(new RegExp(${TsLit.str(s"^(?:$pattern)$$")}).test($t))")
       )
 
     case TheF(v, dom, body, span) =>
       if TsReservedNames.contains(v) then
-        ExprPy.Skip(s"The with TypeScript-reserved binding name '$v'", span)
+        Translated.Skip(s"The with TypeScript-reserved binding name '$v'", span)
       else
         val innerCtx = ctx.withBound(List(v))
         ExprLift.lift2(translate(dom, ctx), translate(body, innerCtx))((dp, bp) =>
-          ExprPy.Py(s"(Array.from($dp).find(($v) => ($bp)) ?? null)")
+          Translated.Emit(s"(Array.from($dp).find(($v) => ($bp)) ?? null)")
         )
 
     case LambdaF(param, body, span) =>
       if TsReservedNames.contains(param) then
-        ExprPy.Skip(s"Lambda with TypeScript-reserved param name '$param'", span)
+        Translated.Skip(s"Lambda with TypeScript-reserved param name '$param'", span)
       else
         val innerCtx = ctx.withBound(List(param))
-        ExprLift.lift1(translate(body, innerCtx))(b => ExprPy.Py(s"(($param) => ($b))"))
+        ExprLift.lift1(translate(body, innerCtx))(b => Translated.Emit(s"(($param) => ($b))"))
 
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
-  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): ExprPy =
+  private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
     if TsReservedNames.contains(name) &&
       (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then ExprPy.Skip(s"identifier '$name' is a TypeScript-reserved name", span)
-    else if ctx.boundVars.contains(name) then ExprPy.Py(name)
-    else if ctx.bareBodyOutput.contains(name) then ExprPy.Py("responseData")
-    else if ctx.outputs.contains(name) then ExprPy.Py(s"responseData[${TsLit.str(name)}]")
-    else if ctx.inputs.contains(name) then ExprPy.Py(name)
+    then Translated.Skip(s"identifier '$name' is a TypeScript-reserved name", span)
+    else if ctx.boundVars.contains(name) then Translated.Emit(name)
+    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("responseData")
+    else if ctx.outputs.contains(name) then Translated.Emit(s"responseData[${TsLit.str(name)}]")
+    else if ctx.inputs.contains(name) then Translated.Emit(name)
     else if ctx.stateFields.contains(name) then
       if ctx.unbackedStateFields.contains(name) then
-        ExprPy.Skip(
+        Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
@@ -170,114 +173,103 @@ object TsExprBackend extends ExprBackend:
         val obj = ctx.capture match
           case CaptureMode.PostState => "postState"
           case CaptureMode.PreState  => "preState"
-        ExprPy.Py(s"$obj[${TsLit.str(name)}]")
-    else if ctx.enumValues.contains(name) then ExprPy.Skip(s"enum-type identifier '$name'", span)
+        Translated.Emit(s"$obj[${TsLit.str(name)}]")
+    else if ctx.enumValues.contains(name) then
+      Translated.Skip(s"enum-type identifier '$name'", span)
     else
       ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => ExprPy.Py(TsLit.str(name))
-        case None    => ExprPy.Skip(s"unbound identifier '$name'", span)
+        case Some(_) => Translated.Emit(TsLit.str(name))
+        case None    => Translated.Skip(s"unbound identifier '$name'", span)
 
-  private def binOpText(op: bin_op_full, l: String, r: String): ExprPy =
+  private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match
-      case BAnd()       => ExprPy.Py(s"(($l) && ($r))")
-      case BOr()        => ExprPy.Py(s"(($l) || ($r))")
-      case BImplies()   => ExprPy.Py(s"((!($l)) || ($r))")
-      case BIff()       => ExprPy.Py(s"_eq(($l), ($r))")
-      case BEq()        => ExprPy.Py(s"_eq(($l), ($r))")
-      case BNeq()       => ExprPy.Py(s"(!_eq(($l), ($r)))")
-      case BLt()        => ExprPy.Py(s"(($l) < ($r))")
-      case BGt()        => ExprPy.Py(s"(($l) > ($r))")
-      case BLe()        => ExprPy.Py(s"(($l) <= ($r))")
-      case BGe()        => ExprPy.Py(s"(($l) >= ($r))")
-      case BIn()        => ExprPy.Py(s"_in(($l), ($r))")
-      case BNotIn()     => ExprPy.Py(s"(!_in(($l), ($r)))")
-      case BAdd()       => ExprPy.Py(s"(($l) + ($r))")
-      case BSub()       => ExprPy.Py(s"(($l) - ($r))")
-      case BMul()       => ExprPy.Py(s"(($l) * ($r))")
-      case BDiv()       => ExprPy.Py(s"(($l) / ($r))")
-      case BUnion()     => ExprPy.Py(s"_union(($l), ($r))")
-      case BIntersect() => ExprPy.Py(s"_inter(($l), ($r))")
-      case BDiff()      => ExprPy.Py(s"_diff(($l), ($r))")
-      case BSubset()    => ExprPy.Py(s"_subset(($l), ($r))")
+      case BAnd()       => Translated.Emit(s"(($l) && ($r))")
+      case BOr()        => Translated.Emit(s"(($l) || ($r))")
+      case BImplies()   => Translated.Emit(s"((!($l)) || ($r))")
+      case BIff()       => Translated.Emit(s"_eq(($l), ($r))")
+      case BEq()        => Translated.Emit(s"_eq(($l), ($r))")
+      case BNeq()       => Translated.Emit(s"(!_eq(($l), ($r)))")
+      case BLt()        => Translated.Emit(s"(($l) < ($r))")
+      case BGt()        => Translated.Emit(s"(($l) > ($r))")
+      case BLe()        => Translated.Emit(s"(($l) <= ($r))")
+      case BGe()        => Translated.Emit(s"(($l) >= ($r))")
+      case BIn()        => Translated.Emit(s"_in(($l), ($r))")
+      case BNotIn()     => Translated.Emit(s"(!_in(($l), ($r)))")
+      case BAdd()       => Translated.Emit(s"(($l) + ($r))")
+      case BSub()       => Translated.Emit(s"(($l) - ($r))")
+      case BMul()       => Translated.Emit(s"(($l) * ($r))")
+      case BDiv()       => Translated.Emit(s"(($l) / ($r))")
+      case BUnion()     => Translated.Emit(s"_union(($l), ($r))")
+      case BIntersect() => Translated.Emit(s"_inter(($l), ($r))")
+      case BDiff()      => Translated.Emit(s"_diff(($l), ($r))")
+      case BSubset()    => Translated.Emit(s"_subset(($l), ($r))")
 
-  private def unOpText(op: un_op_full, x: String): ExprPy = op match
-    case UNot()         => ExprPy.Py(s"(!($x))")
-    case UNegate()      => ExprPy.Py(s"(-($x))")
-    case UCardinality() => ExprPy.Py(s"_len($x)")
-    case UPower()       => ExprPy.Py(s"_powerset($x)")
+  private def unOpText(op: un_op_full, x: String): Translated = op match
+    case UNot()         => Translated.Emit(s"(!($x))")
+    case UNegate()      => Translated.Emit(s"(-($x))")
+    case UCardinality() => Translated.Emit(s"_len($x)")
+    case UPower()       => Translated.Emit(s"_powerset($x)")
 
   private def callExpr(
       callee: expr_full,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     callee match
       case IdentifierF(name, _) => identifierCall(name, args, ctx, span)
       case _ =>
         val parts = args.map(translate(_, ctx))
         ExprLift.lift1(translate(callee, ctx)): cp =>
-          ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"($cp)(${ps.mkString(", ")})"))
+          ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"($cp)(${ps.mkString(", ")})"))
 
   private def identifierCall(
       fname: String,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     recognizedCall(fname, args, ctx, span) match
-      case ExprPy.Py(text) => ExprPy.Py(text)
-      case ExprPy.Skip(_, _) =>
+      case Translated.Emit(text) => Translated.Emit(text)
+      case Translated.Skip(_, _) =>
         userDefinedCall(fname, args, ctx, span) match
-          case ExprPy.Py(text)        => ExprPy.Py(text)
-          case ExprPy.Skip(reason, _) => ExprPy.Skip(reason, span)
+          case Translated.Emit(text)      => Translated.Emit(text)
+          case Translated.Skip(reason, _) => Translated.Skip(reason, span)
 
   private def recognizedCall(
       fname: String,
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     fname match
-      case "len" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_len($a)"))
-      case "dom" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"new Set(Object.keys($a))"))
-      case "ran" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"new Set(Object.values($a))"))
-      case "max" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"Math.max(...Array.from($a))"))
-      case "min" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"Math.min(...Array.from($a))"))
-      case "now" if args.isEmpty =>
-        // Epoch seconds (number) so `now() - minutes(15)` is numeric arithmetic.
-        // Aligns with the seconds-valued time-unit functions below.
-        ExprPy.Py("(Date.now() / 1000)")
-      case "hash" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"_sha256Hex($a)"))
-      case "days" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 86400)"))
-      case "hours" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 3600)"))
-      case "minutes" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"(($a) * 60)"))
-      case "seconds" if args.size == 1 =>
-        ExprLift.lift1(translate(args.head, ctx))(a => ExprPy.Py(s"($a)"))
+      // Higher-order builtin: lambda body needs ctx.boundVars threading.
       case "sum" if args.size == 2 =>
         sumCall(args(0), args(1), ctx)
-      case other =>
-        ExprPy.Skip(s"unknown function '$other/${args.size}' (see #138)", span)
+      case _ =>
+        Builtins.byName.get(fname) match
+          case Some(spec) if spec.arity == args.size =>
+            ExprLift.liftAll(args.map(translate(_, ctx)), span)(rendered =>
+              Translated.Emit(spec.ts(rendered))
+            )
+          case Some(spec) =>
+            Translated.Skip(
+              s"$fname expects ${spec.arity} arg(s), got ${args.size}",
+              span
+            )
+          case None =>
+            Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
 
-  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): ExprPy =
+  private def sumCall(coll: expr_full, fn: expr_full, ctx: TestCtx): Translated =
     fn match
       case LambdaF(param, body, _) if !TsReservedNames.contains(param) =>
         val innerCtx = ctx.withBound(List(param))
         ExprLift.lift2(translate(coll, ctx), translate(body, innerCtx))((c, b) =>
-          ExprPy.Py(s"Array.from($c).reduce((_acc, $param) => _acc + ($b), 0)")
+          Translated.Emit(s"Array.from($c).reduce((_acc, $param) => _acc + ($b), 0)")
         )
       case _ =>
         ExprLift.lift2(translate(coll, ctx), translate(fn, ctx))((c, f) =>
-          ExprPy.Py(s"Array.from($c).reduce((_acc, _x) => _acc + ($f)(_x), 0)")
+          Translated.Emit(s"Array.from($c).reduce((_acc, _x) => _acc + ($f)(_x), 0)")
         )
 
   private def userDefinedCall(
@@ -285,63 +277,65 @@ object TsExprBackend extends ExprBackend:
       args: List[expr_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val expectedArity = ctx.userFunctions
       .get(fname)
       .map(_.b.size)
       .orElse(ctx.userPredicates.get(fname).map(_.b.size))
     expectedArity match
       case None =>
-        ExprPy.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
+        Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
       case Some(n) if n != args.size =>
-        ExprPy.Skip(
+        Translated.Skip(
           s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
           span
         )
       case Some(_) if TsReservedNames.contains(fname) =>
-        ExprPy.Skip(s"user-defined call '$fname' is a TypeScript-reserved name", span)
+        Translated.Skip(s"user-defined call '$fname' is a TypeScript-reserved name", span)
       case Some(_) =>
         val parts = args.map(translate(_, ctx))
-        ExprLift.liftAll(parts, span)(ps => ExprPy.Py(s"$fname(${ps.mkString(", ")})"))
+        ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"$fname(${ps.mkString(", ")})"))
 
   private def mapLiteral(
       entries: List[map_entry_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if entries.isEmpty then ExprPy.Py("{}")
+  ): Translated =
+    if entries.isEmpty then Translated.Emit("{}")
     else
       val pairs = entries.collect { case MapEntryFull(k, v, _) =>
         ExprLift.lift2(translate(k, ctx), translate(v, ctx))((kx, vx) =>
-          ExprPy.Py(s"[$kx, $vx]")
+          Translated.Emit(s"[$kx, $vx]")
         )
       }
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"Object.fromEntries([${ps.mkString(", ")}])"))
+      ExprLift.liftAll(pairs, span)(ps =>
+        Translated.Emit(s"Object.fromEntries([${ps.mkString(", ")}])")
+      )
 
   private def constructorLiteral(
       fields: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
-    if fields.isEmpty then ExprPy.Py("{}")
+  ): Translated =
+    if fields.isEmpty then Translated.Emit("{}")
     else
       val pairs = fields.collect { case FieldAssignFull(n, v, _) =>
-        ExprLift.lift1(translate(v, ctx))(vx => ExprPy.Py(s"${TsLit.str(n)}: $vx"))
+        ExprLift.lift1(translate(v, ctx))(vx => Translated.Emit(s"${TsLit.str(n)}: $vx"))
       }
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"{ ${ps.mkString(", ")} }"))
+      ExprLift.liftAll(pairs, span)(ps => Translated.Emit(s"{ ${ps.mkString(", ")} }"))
 
   private def withUpdate(
       base: expr_full,
       updates: List[field_assign_full],
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val basePy = translate(base, ctx)
     val pairs = updates.collect { case FieldAssignFull(n, v, _) =>
-      ExprLift.lift1(translate(v, ctx))(vx => ExprPy.Py(s"${TsLit.str(n)}: $vx"))
+      ExprLift.lift1(translate(v, ctx))(vx => Translated.Emit(s"${TsLit.str(n)}: $vx"))
     }
     ExprLift.lift1(basePy): bp =>
-      ExprLift.liftAll(pairs, span)(ps => ExprPy.Py(s"{ ...($bp), ${ps.mkString(", ")} }"))
+      ExprLift.liftAll(pairs, span)(ps => Translated.Emit(s"{ ...($bp), ${ps.mkString(", ")} }"))
 
   private def setComprehension(
       v: String,
@@ -349,9 +343,9 @@ object TsExprBackend extends ExprBackend:
       pred: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     if TsReservedNames.contains(v) then
-      ExprPy.Skip(s"SetComprehension with TypeScript-reserved binding name '$v'", span)
+      Translated.Skip(s"SetComprehension with TypeScript-reserved binding name '$v'", span)
     else
       val innerCtx    = ctx.withBound(List(v))
       val domPy       = translate(dom, ctx)
@@ -359,7 +353,7 @@ object TsExprBackend extends ExprBackend:
       val isMapDomain = peelRelationRefFull(dom).exists(ctx.mapStateFields.contains)
       ExprLift.lift2(domPy, predPy): (d, p) =>
         val iter = if isMapDomain then s"Object.values($d)" else s"$d"
-        ExprPy.Py(s"new Set(Array.from($iter).filter(($v) => ($p)))")
+        Translated.Emit(s"new Set(Array.from($iter).filter(($v) => ($p)))")
 
   private def quantifier(
       kind: quant_kind_full,
@@ -367,11 +361,11 @@ object TsExprBackend extends ExprBackend:
       body: expr_full,
       ctx: TestCtx,
       span: Option[span_t]
-  ): ExprPy =
+  ): Translated =
     val isAllIn = bindings.forall:
       case QuantifierBindingFull(_, _, BkIn(), _) => true
       case _                                      => false
-    if !isAllIn then ExprPy.Skip("quantifier with non-`in` binding", span)
+    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       val domains    = bindings.collect { case QuantifierBindingFull(_, d, _, _) => translate(d, ctx) }
@@ -387,6 +381,6 @@ object TsExprBackend extends ExprBackend:
           val (v, d) = pair
           s"Array.from($d).$method(($v) => ($acc))"
         kind match
-          case QAll()              => ExprPy.Py(nested)
-          case QSome() | QExists() => ExprPy.Py(nested)
-          case QNo()               => ExprPy.Py(s"(!($nested))")
+          case QAll()              => Translated.Emit(nested)
+          case QSome() | QExists() => Translated.Emit(nested)
+          case QNo()               => Translated.Emit(s"(!($nested))")

--- a/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
@@ -44,10 +44,10 @@ object TsStateful:
       ir.i.collect { case inv: InvariantDeclFull => inv }.zipWithIndex.flatMap: (inv, idx) =>
         val name = inv.a.getOrElse(s"anon_$idx")
         TsExprBackend.translate(inv.b, invCtx) match
-          case ExprPy.Skip(reason, _) =>
+          case Translated.Skip(reason, _) =>
             skips += TestSkip("<invariants>", s"stateful_invariant[$name]", reason)
             None
-          case ExprPy.Py(text) =>
+          case Translated.Emit(text) =>
             Some((name, prettyOneLine(inv.b), text))
 
     if ir.j.nonEmpty || ir.h.nonEmpty then

--- a/modules/testgen/src/main/scala/specrest/testgen/TsVitestHarness.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsVitestHarness.scala
@@ -100,9 +100,9 @@ object TsVitestHarness extends HarnessTemplates:
         case None =>
           val ctx = predicateBodyCtx(paramNames.toSet, ir)
           TsExprBackend.translate(body, ctx) match
-            case ExprPy.Py(text) =>
+            case Translated.Emit(text) =>
               s"export function $specName($sigParams): any {\n  return $text;\n}\n\n"
-            case ExprPy.Skip(reason, _) =>
+            case Translated.Skip(reason, _) =>
               stub(s"testgen: cannot translate body of '$specName': $reason")
 
   private def predicateBodyCtx(params: Set[String], ir: ServiceIRFull): TestCtx =

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -46,8 +46,13 @@ object SupportedTargets:
       .sorted
       .mkString(", ")
 
-enum ExprPy derives CanEqual:
-  case Py(text: String)
+// Result type for any expression-translation backend. The payload is an opaque
+// target-language string (Python, TS, Go, …); the type itself is language-
+// agnostic, despite its old name `Translated.Emit` which leaked the Python-was-first
+// history. Renamed Translated/Emit so a `TsExprBackend.translate(...)` call no
+// longer reads as "TS backend returns Python".
+enum Translated derives CanEqual:
+  case Emit(text: String)
   case Skip(reason: String, span: Option[span_t])
 
 enum CaptureMode derives CanEqual:

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -48,9 +48,9 @@ object SupportedTargets:
 
 // Result type for any expression-translation backend. The payload is an opaque
 // target-language string (Python, TS, Go, …); the type itself is language-
-// agnostic, despite its old name `Translated.Emit` which leaked the Python-was-first
-// history. Renamed Translated/Emit so a `TsExprBackend.translate(...)` call no
-// longer reads as "TS backend returns Python".
+// agnostic, despite its old name `ExprPy.Py` which leaked the Python-was-first
+// history. Renamed to Translated.Emit so a `TsExprBackend.translate(...)` call
+// no longer reads as "TS backend returns Python".
 enum Translated derives CanEqual:
   case Emit(text: String)
   case Skip(reason: String, span: Option[span_t])

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -135,6 +135,36 @@ class BackendTest extends CatsEffectSuite:
     assert(pyText(e, c).contains("not backed by an entity table"), pyText(e, c))
     assert(tsText(e, c).contains("not backed by an entity table"), tsText(e, c))
 
+  // Single source-of-truth matrix: for every registered builtin, all three
+  // backends must produce a non-empty, non-skip emission given dummy args. The
+  // existence of this loop means a future builtin entry instantly gains
+  // three-backend coverage (or the test fails with a clear missing-emit).
+  test("every Builtins.all entry has a non-empty emission in every backend"):
+    val c = ctx(inputs = Set("arg0", "arg1"))
+    specrest.convention.Builtins.all.foreach: spec =>
+      val argIds = (0 until spec.arity).map(i => IdentifierF(s"arg$i", None): expr_full).toList
+      val callE  = CallF(IdentifierF(spec.name, None), argIds, None)
+      // sum/2 needs a LambdaF (not a bare identifier) as its second arg — fix it up.
+      val effective =
+        if spec.name == "sum" then
+          CallF(
+            IdentifierF("sum", None),
+            List(
+              IdentifierF("arg0", None),
+              LambdaF("_x", IdentifierF("_x", None), None)
+            ),
+            None
+          )
+        else callE
+      for (label, text) <- List(
+                             "python" -> pyText(effective, c),
+                             "ts"     -> tsText(effective, c),
+                             "go"     -> goText(effective, c)
+                           )
+      do
+        assert(!text.startsWith("<skip:"), s"${spec.name}/${spec.arity} skipped in $label: $text")
+        assert(text.nonEmpty, s"${spec.name}/${spec.arity} emitted empty $label")
+
   test("hash/1 builtin lowers per-backend (#149 phase 1)"):
     val c     = ctx(inputs = Set("x"))
     val callE = CallF(IdentifierF("hash", None), List(IdentifierF("x", None)), None)

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -88,11 +88,11 @@ class BackendTest extends CatsEffectSuite:
 
   private def i1(n: Int): expr_full = IntLitF(int_of_integer(BigInt(n)), None)
   private def pyText(e: expr_full, c: TestCtx): String = ExprToPython.translate(e, c) match
-    case ExprPy.Py(t)      => t
-    case ExprPy.Skip(r, _) => s"<skip:$r>"
+    case Translated.Emit(t)    => t
+    case Translated.Skip(r, _) => s"<skip:$r>"
   private def tsText(e: expr_full, c: TestCtx): String = TsExprBackend.translate(e, c) match
-    case ExprPy.Py(t)      => t
-    case ExprPy.Skip(r, _) => s"<skip:$r>"
+    case Translated.Emit(t)    => t
+    case Translated.Skip(r, _) => s"<skip:$r>"
 
   List(
     ("bool", (BoolLitF(true, None): expr_full), "True", "true"),
@@ -310,8 +310,8 @@ class BackendTest extends CatsEffectSuite:
   // ---- Go (go test + rapid) backend: same seam, third language ----
 
   private def goText(e: expr_full, c: TestCtx): String = GoExprBackend.translate(e, c) match
-    case ExprPy.Py(t)      => t
-    case ExprPy.Skip(r, _) => s"<skip:$r>"
+    case Translated.Emit(t)    => t
+    case Translated.Skip(r, _) => s"<skip:$r>"
 
   test("GoRapidStrategy renders core builders + constraints"):
     assertEquals(go.string, "genString()")

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -154,9 +154,15 @@ class ExprToPythonTest extends CatsEffectSuite:
       ),
       None
     )
+    // After the Builtins-registry refactor, `sum` lowers as an opaque
+    // function-call composition: the lambda renders as `(lambda i: ...)` via
+    // the standard LambdaF translator, and the registry's `sum` emit wraps
+    // it as `sum((lambda)(_x) for _x in coll)`. Same semantics, slightly less
+    // tight than the prior inline-body form — but per-backend special-casing
+    // is gone and adding new builtins is now a single registry entry.
     assertEquals(
       py(ExprToPython.translate(sumE, ctx)),
-      "sum((i[\"line_total\"]) for i in (post_state[\"store\"]))"
+      "sum(((lambda i: (i[\"line_total\"])))(_x) for _x in (post_state[\"store\"]))"
     )
 
   test("User-defined function call resolves via TestCtx.userFunctions"):

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -33,13 +33,13 @@ class ExprToPythonTest extends CatsEffectSuite:
     capture = CaptureMode.PostState
   )
 
-  private def py(e: ExprPy): String = e match
-    case ExprPy.Py(t)      => t
-    case ExprPy.Skip(r, _) => fail(s"expected Py, got Skip($r)")
+  private def py(e: Translated): String = e match
+    case Translated.Emit(t)    => t
+    case Translated.Skip(r, _) => fail(s"expected Py, got Skip($r)")
 
-  private def reason(e: ExprPy): String = e match
-    case ExprPy.Skip(r, _) => r
-    case ExprPy.Py(t)      => fail(s"expected Skip, got Py($t)")
+  private def reason(e: Translated): String = e match
+    case Translated.Skip(r, _) => r
+    case Translated.Emit(t)    => fail(s"expected Skip, got Py($t)")
 
   test("literals translate directly"):
     assertEquals(py(ExprToPython.translate(i(42), ctx)), "42")
@@ -515,13 +515,13 @@ class ExprToPythonTest extends CatsEffectSuite:
   test("Python-reserved input names are skipped (would otherwise emit invalid Python)"):
     val ctxKw = ctx.copy(inputs = ctx.inputs ++ Set("class", "lambda"))
     val r1    = ExprToPython.translate(id("class"), ctxKw)
-    assert(r1.isInstanceOf[ExprPy.Skip], s"got $r1")
+    assert(r1.isInstanceOf[Translated.Skip], s"got $r1")
     val r2 = ExprToPython.translate(id("lambda"), ctxKw)
-    assert(r2.isInstanceOf[ExprPy.Skip], s"got $r2")
+    assert(r2.isInstanceOf[Translated.Skip], s"got $r2")
 
   test("Let with Python-reserved binding name is skipped"):
     val e = LetF("class", i(1), id("class"), None)
     val r = ExprToPython.translate(e, ctx)
     r match
-      case ExprPy.Skip(reason, _) => assert(reason.contains("Python-reserved"))
-      case other                  => fail(s"expected Skip, got $other")
+      case Translated.Skip(reason, _) => assert(reason.contains("Python-reserved"))
+      case other                      => fail(s"expected Skip, got $other")

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -154,16 +154,35 @@ class ExprToPythonTest extends CatsEffectSuite:
       ),
       None
     )
-    // After the Builtins-registry refactor, `sum` lowers as an opaque
-    // function-call composition: the lambda renders as `(lambda i: ...)` via
-    // the standard LambdaF translator, and the registry's `sum` emit wraps
-    // it as `sum((lambda)(_x) for _x in coll)`. Same semantics, slightly less
-    // tight than the prior inline-body form — but per-backend special-casing
-    // is gone and adding new builtins is now a single registry entry.
+    // `sum(coll, fn)` lowers as `sum(map(lambda, coll))` — the `map` form
+    // introduces NO new binding name, so a spec like `let _x = V in sum(coll,
+    // i => i + _x)` keeps `_x` resolving to the outer let-binding (the prior
+    // `sum((lambda)(_x) for _x in coll)` form leaked `_x` as a generator var
+    // and shadowed the outer scope — cubic P2 on PR #308).
     assertEquals(
       py(ExprToPython.translate(sumE, ctx)),
-      "sum(((lambda i: (i[\"line_total\"])))(_x) for _x in (post_state[\"store\"]))"
+      "sum(map((lambda i: (i[\"line_total\"])), post_state[\"store\"]))"
     )
+
+  // Regression for the cubic P2 finding on PR #308: with the prior
+  // `sum((lambda)(_x) for _x in coll)` form, a spec that already had `_x` in
+  // scope (e.g. via a `let _x = V in ...` binding) would see the inner
+  // lambda's free `_x` reference resolve to the generator-introduced `_x`
+  // instead of the outer V. Using `sum(map(lambda, coll))` introduces no new
+  // binding name. This test pins that the emission contains `map(` (and
+  // therefore the `for _x in` pattern is gone).
+  test("sum/2 lowers as map(lambda, coll) — no inner binding (cubic P2 / #308)"):
+    val sumE = CallF(
+      id("sum"),
+      List(
+        id("store"),
+        LambdaF("i", FieldAccessF(id("i"), "line_total", None), None)
+      ),
+      None
+    )
+    val out = py(ExprToPython.translate(sumE, ctx))
+    assert(out.contains("sum(map("), s"expected sum(map(...)) form, got: $out")
+    assert(!out.contains("for _x in"), s"must not introduce a generator var, got: $out")
 
   test("User-defined function call resolves via TestCtx.userFunctions"):
     val fn = FunctionDeclFull(

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -27,17 +27,17 @@ class SkipRateProbeTest extends CatsEffectSuite:
         op.d.foreach: e =>
           total += 1
           ExprToPython.translate(e, reqCtx) match
-            case ExprPy.Skip(r, _) => skipped += 1; skipReasons += s"${op.a}.requires: $r"
-            case _                 => ()
+            case Translated.Skip(r, _) => skipped += 1; skipReasons += s"${op.a}.requires: $r"
+            case _                     => ()
         op.e.foreach: e =>
           total += 1
           ExprToPython.translate(e, ensCtx) match
-            case ExprPy.Skip(r, _) => skipped += 1; skipReasons += s"${op.a}.ensures: $r"
-            case _                 => ()
+            case Translated.Skip(r, _) => skipped += 1; skipReasons += s"${op.a}.ensures: $r"
+            case _                     => ()
       ir.i.collect { case inv: InvariantDeclFull => inv }.foreach: inv =>
         total += 1
         ExprToPython.translate(inv.b, baseCtx(ir)) match
-          case ExprPy.Skip(r, _) =>
+          case Translated.Skip(r, _) =>
             skipped += 1
             skipReasons += s"invariant ${inv.a.getOrElse("<anon>")}: $r"
           case _ => ()

--- a/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
@@ -42,7 +42,7 @@ class TestCtxTest extends CatsEffectSuite:
         val ensCtx = TestCtx.fromOperation(op, ir, CaptureMode.PostState)
         op.d.map(e => s"${op.a}.requires" -> ExprToPython.translate(e, reqCtx)) ++
           op.e.map(e => s"${op.a}.ensures" -> ExprToPython.translate(e, ensCtx))
-      val skips = results.collect { case (n, ExprPy.Skip(r, _)) => n -> r }
+      val skips = results.collect { case (n, Translated.Skip(r, _)) => n -> r }
       // `count` is the only state and it is unbacked; every clause that references it
       // must honest-skip rather than emit a `None`-comparison that crashes at runtime.
       assert(skips.nonEmpty, s"expected unbacked-state skips; got $results")
@@ -52,6 +52,8 @@ class TestCtxTest extends CatsEffectSuite:
       )
       // `Increment.requires` is the literal `true` — no state reference, stays translatable.
       assert(
-        results.exists { case (n, r) => n == "Increment.requires" && r.isInstanceOf[ExprPy.Py] },
+        results.exists { case (n, r) =>
+          n == "Increment.requires" && r.isInstanceOf[Translated.Emit]
+        },
         s"Increment.requires (`true`) must still translate; got $results"
       )


### PR DESCRIPTION
## Summary

Architectural cleanup: the spec-language builtin functions (\`hash\`, \`now\`, \`minutes\`, \`len\`, \`sum\`, \`abs\`, ...) are now defined in **one** place — \`modules/convention/src/main/scala/specrest/convention/Builtins.scala\` — and every consumer (the three ExprBackends + lint allowlist + future Dafny / runtime-import deriviation) reads from that single registry.

Motivation: adding a new builtin used to require edits to 8+ files (three ExprBackends + lint allowlist + runtime-template headers + tests). After this PR it's **one entry** in \`Builtins.scala\`.

## Three commits

1. \`2e3c310\` — **Add Builtins registry, migrate three ExprBackends to dispatch via it.** ~150 LoC registry + −50 LoC of duplicated per-backend cases.
2. \`01441a0\` — **Rename \`ExprPy\` → \`Translated\` (\`Py\` → \`Emit\`).** Pure rename across 19 files. The old name was Python-was-first archaeology; \`TsExprBackend.translate(...)\` returning an \`ExprPy.Py(...)\` literally read as "TS returns Python." Translated/Emit is language-agnostic.
3. \`34a07a7\` — **One-line dispatch + first-class abs/sum + lint derived.** Extracted \`ExprLift.dispatchBuiltin\` (kills the duplicate dispatch in three backends), moved \`abs\` and \`sum\` into the registry as first-class entries (they were the last per-backend special-cases), dropped the \`builtins\` private val in lint in favor of \`Builtins.names\` inline.

## Adding a new builtin: before vs after

| Step | Before | After |
|---|---|---|
| Translation | edit ExprToPython.scala + TsExprBackend.scala + GoExprBackend.scala | edit \`Builtins.scala\` (one struct entry with 3 emit lambdas) |
| Lint allowlist | edit \`UndefinedRef.builtins\` | automatic via \`Builtins.names\` |
| Test coverage | write 3 per-backend tests | covered by the registry-matrix loop in \`BackendTest\` |
| Runtime imports (e.g. \`hashlib\`) | edit Templates.scala, Stateful.scala, Structural.scala, TestEmit.scala, _runtime.ts header, conf_runtime.go header | already declared in the registry (pyImports, tsImports, goImports); future PR plumbs these through |

## What ships in this PR

- **\`Builtins.scala\`** — 13 entries (Len, Dom, Ran, Max, Min, Abs, Now, Days, Hours, Minutes, Seconds, Hash, Sum) with per-backend emit lambdas + import metadata + descriptions.
- **\`ExprLift.dispatchBuiltin\`** — shared dispatcher; each backend's recognizedCall is one line.
- **\`Translated\` ADT** (renamed from \`ExprPy\`) — language-agnostic result type.
- **\`_abs\`** Go runtime helper using \`math.Abs\` (mirrors TS \`Math.abs\`, py builtin).
- **Cross-backend matrix test**: loops the registry × {py, ts, go} asserting every entry has a non-skip emission. A future builtin added without all three emit fields breaks this with the missing name.
- **lint module** gains a \`convention\` dependency in \`build.sbt\` (was \`(ir, parser % Test)\`; now \`(ir, convention, parser % Test)\`).

## What's deliberately NOT in this PR (follow-ups)

- **Dafny preamble derivation** from \`Builtins\` (the externs walk in \`Generator.scala\` could be data-driven; current implementation works but isn't registry-aware).
- **Runtime-import derivation** for Python/TS/Go template headers (the metadata is in the registry already; threading it through the template emitters is a separate PR).
- **Isabelle extraction** of the registry — defer to the broader Phase 9 / Codegen.thy work.

## Test plan

- [x] \`sbt testgen/test\` — 281 / 281 (includes new matrix test)
- [x] \`sbt cli/test\` — 60 / 60
- [x] \`sbt lint/test\` — 12 / 12 (allowlist now \`Builtins.names\`)
- [x] \`sbt convention/test\` — 66 / 66
- [x] \`sbt scalafmtCheckAll\` clean
- [x] Pre-commit hooks pass
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes spec builtins in a single `Builtins` registry used by Python, TypeScript, Go backends and lint, reducing duplicate logic. Also fixes `sum/2` emission to avoid variable shadowing and updates docs to the `Translated` rename.

- **Refactors**
  - Added `modules/convention/.../Builtins.scala` with 13 builtins and per-backend emit lambdas; all backends dispatch via one registry.
  - Extracted `ExprLift.dispatchBuiltin(...)` so backends share arity checks and skip messages.
  - Renamed `ExprPy` to `Translated` (`Py` → `Emit`) for a language-agnostic result type.
  - Made `abs/1` first-class; added Go `_abs` helper.
  - Lint `UndefinedRef` now uses `Builtins.names`.
  - Added a cross-backend matrix test to ensure every builtin emits in all backends.
  - Docs updated (architecture/pipeline) to reference `Builtins` and `Translated`; skip-rate tables refreshed; Dafny `TheBy` signature simplified (`<K, V>`).
  - `lint` now depends on `convention` in `build.sbt`.

- **Bug Fixes**
  - `sum/2` now applies the lambda as a value to avoid generator-var shadowing:
    - Python: `sum(map(lambda, coll))`
    - TypeScript: `coll.map(lambda).reduce((acc, v) => acc + Number(v), 0)`
    - Go: unchanged (`_sum(coll, lambda)`)
  - Added a regression test pinning the new `sum/2` lowering.
  - Fixed a stale doc comment in `Types.scala` referencing the pre-rename name.

<sup>Written for commit 32687243481323ba394cbf5352a1b7c20ddf1d24. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/308?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

