### PR TITLE
feat(playground): in-browser CLI playground

### DIFF
--- a/docs/components/mdx.tsx
+++ b/docs/components/mdx.tsx
@@ -4,6 +4,7 @@ import type { MDXComponents } from "mdx/types";
 import { CliRun, CliRunInline } from "@/components/mdx/cli-run";
 import { Collapsible } from "@/components/mdx/collapsible";
 import { Mermaid } from "@/components/mdx/mermaid";
+import { Playground } from "@/components/playground";
 import { RailroadDiagram } from "@/components/mdx/railroad-diagram";
 import {
   FileTree,
@@ -19,6 +20,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
     CliRunInline,
     Collapsible,
     Mermaid,
+    Playground,
     RailroadDiagram,
     TypeTable,
     FileTree,

--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import Editor, { type OnMount } from "@monaco-editor/react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "fumadocs-ui/components/tabs";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_PLAYGROUND_API ?? "";
+
+type Target = "check" | "summary" | "ir" | "dafny";
+
+const TARGETS: { value: Target; label: string; lang: string; description: string }[] = [
+  { value: "check", label: "Check", lang: "plaintext", description: "Parse + lint" },
+  { value: "summary", label: "Summary", lang: "plaintext", description: "Operations + classifications" },
+  { value: "ir", label: "IR", lang: "scala", description: "Internal representation (Scala case classes)" },
+  { value: "dafny", label: "Dafny", lang: "scala", description: "Generated Dafny verification kernel" },
+];
+
+const EXAMPLES: { name: string; spec: string }[] = [
+  {
+    name: "safe_counter",
+    spec: `service SafeCounter {
+
+  state {
+    count: Int where value >= 0
+  }
+
+  operation Increment {
+    requires: count < 100
+    ensures:  count' = pre(count) + 1
+  }
+
+  operation Decrement {
+    requires: count > 0
+    ensures:  count' = pre(count) - 1
+  }
+
+  invariant countBounded: count >= 0 and count <= 100
+}
+`,
+  },
+  {
+    name: "url_shortener",
+    spec: `service UrlShortener {
+
+  type Code = String where len(value) >= 4 and len(value) <= 12
+
+  entity UrlMapping {
+    code: Code
+    url: String
+    click_count: Int where value >= 0
+  }
+
+  state {
+    store: Code -> lone String
+    metadata: Code -> lone UrlMapping
+  }
+
+  operation Shorten {
+    input:  code: Code, url: String
+    requires:
+      code not in store
+      len(url) >= 1
+    ensures:
+      store' = pre(store) + {code -> url}
+      metadata' = pre(metadata) + {code -> UrlMapping { code = code, url = url, click_count = 0 }}
+  }
+
+  operation Resolve {
+    input:  code: Code
+    output: url: String
+    requires: code in store
+    ensures:  url = pre(store)[code]
+  }
+
+  invariant codeIndexConsistent:
+    all c in store | c in metadata
+}
+`,
+  },
+  {
+    name: "todo_list",
+    spec: `service TodoList {
+
+  entity Todo {
+    id: Int where value > 0
+    title: String where len(value) >= 1
+    done: Bool
+  }
+
+  state {
+    todos: Int -> lone Todo
+    next_id: Int where value > 0
+  }
+
+  operation Add {
+    input:  title: String
+    output: todo: Todo
+    requires: len(title) >= 1
+    ensures:
+      todo.id = pre(next_id)
+      todo.title = title
+      todo.done = false
+      todos' = pre(todos) + {todo.id -> todo}
+      next_id' = pre(next_id) + 1
+  }
+
+  operation Complete {
+    input: id: Int
+    requires: id in todos
+    ensures:
+      todos'[id].done = true
+      todos'[id].id = pre(todos)[id].id
+      todos'[id].title = pre(todos)[id].title
+  }
+}
+`,
+  },
+];
+
+type ApiResponse =
+  | { ok: true; stdout: string; stderr: string }
+  | { ok: false; stdout: string; stderr: string; error: string };
+
+type RunState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ok"; stdout: string; stderr: string }
+  | { kind: "error"; message: string; stderr?: string };
+
+export function Playground() {
+  const [spec, setSpec] = useState<string>(EXAMPLES[0].spec);
+  const [target, setTarget] = useState<Target>("ir");
+  const [state, setState] = useState<RunState>({ kind: "idle" });
+  const abortRef = useRef<AbortController | null>(null);
+
+  const targetMeta = useMemo(() => TARGETS.find((t) => t.value === target)!, [target]);
+
+  const submit = useCallback(async () => {
+    if (!API_URL) {
+      setState({
+        kind: "error",
+        message:
+          "Playground backend not configured. Set NEXT_PUBLIC_PLAYGROUND_API at build time. See playground/README.md.",
+      });
+      return;
+    }
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    setState({ kind: "loading" });
+    try {
+      const res = await fetch(`${API_URL.replace(/\/$/, "")}/api/compile`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ spec, target }),
+        signal: ctrl.signal,
+      });
+      const data = (await res.json()) as ApiResponse;
+      if (data.ok) {
+        setState({ kind: "ok", stdout: data.stdout, stderr: data.stderr });
+      } else {
+        setState({
+          kind: "error",
+          message: data.error || `Backend returned ${res.status}`,
+          stderr: data.stderr,
+        });
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return;
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : "network error",
+      });
+    }
+  }, [spec, target]);
+
+  const onMount: OnMount = useCallback(
+    (editor, monaco) => {
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+        void submit();
+      });
+    },
+    [submit],
+  );
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return (
+    <div className="not-prose flex flex-col gap-3">
+      <Toolbar
+        target={target}
+        onTarget={setTarget}
+        onExample={(s) => setSpec(s)}
+        onSubmit={submit}
+        running={state.kind === "loading"}
+      />
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <EditorPane spec={spec} onChange={setSpec} onMount={onMount} />
+        <OutputPane state={state} targetLang={targetMeta.lang} />
+      </div>
+      {!API_URL && (
+        <p className="text-xs text-fd-muted-foreground">
+          <strong>Backend not configured.</strong> Set <code>NEXT_PUBLIC_PLAYGROUND_API</code> in the docs
+          build env. See <a href="https://github.com/HardMax71/spec_to_rest/tree/main/playground"><code>playground/README.md</code></a>.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Toolbar(props: {
+  target: Target;
+  onTarget: (t: Target) => void;
+  onExample: (spec: string) => void;
+  onSubmit: () => void;
+  running: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-md border border-fd-border bg-fd-card p-3">
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-fd-muted-foreground">Example</span>
+        <select
+          className="rounded border border-fd-border bg-fd-background px-2 py-1 text-sm"
+          defaultValue={EXAMPLES[0].name}
+          onChange={(e) => {
+            const ex = EXAMPLES.find((x) => x.name === e.target.value);
+            if (ex) props.onExample(ex.spec);
+          }}
+        >
+          {EXAMPLES.map((ex) => (
+            <option key={ex.name} value={ex.name}>
+              {ex.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <span className="text-fd-muted-foreground">Target</span>
+        <select
+          className="rounded border border-fd-border bg-fd-background px-2 py-1 text-sm"
+          value={props.target}
+          onChange={(e) => props.onTarget(e.target.value as Target)}
+        >
+          {TARGETS.map((t) => (
+            <option key={t.value} value={t.value} title={t.description}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        onClick={props.onSubmit}
+        disabled={props.running}
+        className="ml-auto rounded bg-fd-primary px-3 py-1.5 text-sm font-medium text-fd-primary-foreground disabled:opacity-50"
+      >
+        {props.running ? "Running…" : "Run (⌘/Ctrl+Enter)"}
+      </button>
+    </div>
+  );
+}
+
+function EditorPane(props: {
+  spec: string;
+  onChange: (s: string) => void;
+  onMount: OnMount;
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border border-fd-border">
+      <Editor
+        height="500px"
+        defaultLanguage="plaintext"
+        theme="vs-dark"
+        value={props.spec}
+        onChange={(v) => props.onChange(v ?? "")}
+        onMount={props.onMount}
+        options={{
+          minimap: { enabled: false },
+          fontSize: 13,
+          scrollBeyondLastLine: false,
+          tabSize: 2,
+          wordWrap: "on",
+        }}
+      />
+    </div>
+  );
+}
+
+function OutputPane(props: { state: RunState; targetLang: string }) {
+  const items = ["stdout", "stderr"];
+  return (
+    <div className="overflow-hidden rounded-md border border-fd-border">
+      <Tabs items={items} defaultIndex={0}>
+        <TabsContent value="stdout">
+          <ReadOnlyView
+            text={renderStdout(props.state)}
+            language={props.state.kind === "ok" ? props.targetLang : "plaintext"}
+          />
+        </TabsContent>
+        <TabsContent value="stderr">
+          <ReadOnlyView text={renderStderr(props.state)} language="plaintext" />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function ReadOnlyView(props: { text: string; language: string }) {
+  return (
+    <Editor
+      height="500px"
+      theme="vs-dark"
+      language={props.language}
+      value={props.text}
+      options={{
+        readOnly: true,
+        minimap: { enabled: false },
+        fontSize: 12,
+        scrollBeyondLastLine: false,
+        wordWrap: "on",
+      }}
+    />
+  );
+}
+
+function renderStdout(s: RunState): string {
+  switch (s.kind) {
+    case "idle":
+      return "// Click Run to compile the spec.\n";
+    case "loading":
+      return "// Running…\n";
+    case "ok":
+      return s.stdout || "// (no stdout — the subcommand produced no output)\n";
+    case "error":
+      return `// ERROR: ${s.message}\n`;
+  }
+}
+
+function renderStderr(s: RunState): string {
+  switch (s.kind) {
+    case "idle":
+    case "loading":
+      return "";
+    case "ok":
+      return s.stderr || "(empty)";
+    case "error":
+      return s.stderr || s.message;
+  }
+}

--- a/docs/content/docs/install.mdx
+++ b/docs/content/docs/install.mdx
@@ -6,6 +6,8 @@ description: Native binary, Docker image, GitHub Action, or from source
 `spec-to-rest` ships as a self-contained GraalVM native-image binary. Pick the
 form that fits your workflow.
 
+> **Just want to try a spec?** Skip the install — the [playground](/playground) runs the same binary in your browser (parse + IR + Dafny kernel only; up to 50 KB / 8 s per request).
+
 ## Native binary (recommended)
 
 Each tagged release publishes a per-platform archive. Download from

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
     "index",
     "spec-language",
     "install",
+    "playground",
     "cli",
     "roadmap",
     "---Deployment Targets---",

--- a/docs/content/docs/playground.mdx
+++ b/docs/content/docs/playground.mdx
@@ -1,0 +1,31 @@
+---
+title: Playground
+description: Type a spec, see its IR and Dafny kernel without installing the CLI
+---
+
+import { Playground } from "@/components/playground";
+
+The playground runs the same `spec-to-rest` binary as the [install](/install) page — just hosted behind a thin HTTP wrapper so you don't have to download anything to try a spec.
+
+<Playground />
+
+## Targets
+
+| Target | What it runs | What you see |
+| --- | --- | --- |
+| **Check** | `spec-to-rest check` | Empty stdout on success; error pointer on parse / lint failure |
+| **Summary** | `spec-to-rest inspect --format summary` | Entity / op / invariant counts and classifications |
+| **IR** | `spec-to-rest inspect --format ir` | The internal representation as Scala case-class text |
+| **Dafny** | `spec-to-rest inspect --format dafny` | The verification kernel — datatypes, `ServiceStateInv`, per-op method headers with their `requires` / `ensures` / `modifies` clauses |
+
+## Limits
+
+The playground caps spec size at **50 KB** and execution at **8 seconds**. For anything larger — including `compile` (multi-file generation), `verify` (Alloy / Z3 model checking), and `synth` (LLM-driven CEGIS) — [install the CLI](/install). The native binary boots in ~50 ms and has no caps.
+
+## What's *not* in the playground (deliberately)
+
+- **`compile`** — would need to return tens of files and a directory tree; for v1, single-text targets only.
+- **`verify`** — pulls in Alloy (~80 MB) and Z3; doubles the backend container image.
+- **`synth`** — runs LLM API calls, which would mean either bringing your own key or putting a paid endpoint behind the playground. Out of scope for a free toy.
+
+See [the playground README](https://github.com/HardMax71/spec_to_rest/tree/main/playground) for the backend's source, deployment recipe, and limits.

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@orama/orama": "^3.1.8",
         "@shikijs/transformers": "^4.0.2",
         "beautiful-mermaid": "^1.1.3",
@@ -1121,6 +1122,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -2313,6 +2337,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2329,6 +2354,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2345,6 +2371,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,6 +2388,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2377,6 +2405,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2393,6 +2422,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,6 +2439,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,6 +2456,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,6 +2473,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,6 +2498,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2481,6 +2515,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.10.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2491,6 +2526,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2500,6 +2536,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2509,6 +2546,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2526,6 +2564,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2535,6 +2574,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
       "version": "2.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "0BSD",
       "optional": true
@@ -2546,6 +2586,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2562,6 +2603,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2674,6 +2716,14 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3003,6 +3053,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/elkjs": {
@@ -4302,6 +4362,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -5344,6 +5417,17 @@
       ],
       "license": "MIT"
     },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
     "node_modules/motion": {
       "version": "12.38.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
@@ -6157,6 +6241,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
     "postinstall": "fumadocs-mdx"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@orama/orama": "^3.1.8",
     "@shikijs/transformers": "^4.0.2",
     "beautiful-mermaid": "^1.1.3",

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,0 +1,38 @@
+ARG SPEC_TO_REST_VERSION=v2.1.0
+
+FROM golang:1.23-alpine AS wrapper-build
+WORKDIR /src
+COPY go.mod ./
+COPY server.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/playground .
+
+FROM debian:bookworm-slim AS cli-fetch
+ARG SPEC_TO_REST_VERSION
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl tar \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /opt/spec-to-rest \
+ && curl -fL "https://github.com/HardMax71/spec_to_rest/releases/download/${SPEC_TO_REST_VERSION}/spec-to-rest-linux-amd64.tar.gz" \
+    | tar -xz -C /opt/spec-to-rest \
+ && chmod +x /opt/spec-to-rest/spec-to-rest
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates libstdc++6 zlib1g tini \
+ && rm -rf /var/lib/apt/lists/* \
+ && groupadd --system --gid 65532 nonroot \
+ && useradd  --system --uid 65532 --gid nonroot --home /tmp --shell /sbin/nologin nonroot
+
+COPY --from=cli-fetch    /opt/spec-to-rest/spec-to-rest /usr/local/bin/spec-to-rest
+COPY --from=wrapper-build /out/playground               /usr/local/bin/playground
+
+ENV PORT=8080 \
+    SPEC_TO_REST_BIN=/usr/local/bin/spec-to-rest \
+    NO_COLOR=1
+
+EXPOSE 8080
+USER nonroot
+WORKDIR /tmp
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/usr/local/bin/playground"]

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,101 @@
+# spec-to-rest playground backend
+
+Thin Go HTTP wrapper around the `spec-to-rest` CLI for the docs-site `/playground` page. Deploys as
+a container; tested on Google Cloud Run.
+
+## What it does
+
+Single endpoint, `POST /api/compile`, takes a spec body + target, writes the spec to a temp file,
+runs the CLI binary with a hard timeout, returns stdout/stderr as JSON. No state, no auth, no LLM
+calls. Rate-limit at the platform layer (Cloud Run max-instances / concurrency, or a Cloudflare
+in-front).
+
+```json
+POST /api/compile
+{"spec": "service ...", "target": "ir"}
+
+→ {"ok": true, "stdout": "...", "stderr": "..."}
+```
+
+Allowed `target` values: `check`, `summary`, `ir`, `dafny`. (Multi-file `compile` and Alloy-backed
+`verify` deferred to v2 — they need a bigger image and per-output marshalling.)
+
+## Limits
+
+| Knob              | Default                       | Where to change               |
+| ----------------- | ----------------------------- | ----------------------------- |
+| Max spec size     | 50 KB                         | `maxSpecBytes` in `server.go` |
+| Execution timeout | 8 s                           | `execTimeout` in `server.go`  |
+| CORS origin       | `*`                           | `CORS_ALLOW_ORIGIN` env var   |
+| CLI binary path   | `/usr/local/bin/spec-to-rest` | `SPEC_TO_REST_BIN` env var    |
+| Listen port       | 8080                          | `PORT` env var                |
+
+## Build
+
+```bash
+docker build -t spec-to-rest-playground:dev .
+# Build a different CLI release:
+docker build --build-arg SPEC_TO_REST_VERSION=v2.0.0 -t spec-to-rest-playground:v2.0.0 .
+```
+
+## Run locally
+
+```bash
+docker run --rm -p 8080:8080 spec-to-rest-playground:dev
+
+# Smoke test:
+curl -s localhost:8080/healthz
+curl -s -X POST localhost:8080/api/compile \
+  -H 'content-type: application/json' \
+  -d '{"spec":"service Demo { state { count: Int } }","target":"ir"}'
+```
+
+## Deploy to Cloud Run
+
+```bash
+PROJECT=your-gcp-project
+REGION=us-central1
+IMAGE=us-central1-docker.pkg.dev/$PROJECT/playground/spec-to-rest-playground:v2.1.0
+
+# Push image (Artifact Registry must already exist):
+docker tag spec-to-rest-playground:dev "$IMAGE"
+docker push "$IMAGE"
+
+# Deploy:
+gcloud run deploy spec-to-rest-playground \
+  --image="$IMAGE" \
+  --region="$REGION" \
+  --allow-unauthenticated \
+  --memory=256Mi \
+  --cpu=1 \
+  --max-instances=10 \
+  --concurrency=5 \
+  --timeout=15s \
+  --set-env-vars=CORS_ALLOW_ORIGIN=https://hardmax71.github.io
+```
+
+The deploy command above caps blast radius at ~50 concurrent requests (10 instances × 5 concurrency)
+— well within the free tier for typical docs-site traffic, and well below any plausible LLM-style
+cost spike (which this image cannot trigger; no LLM calls happen here).
+
+Set the playground URL in the docs build:
+
+```bash
+# In docs/.env.local or as a CI env var:
+NEXT_PUBLIC_PLAYGROUND_API=https://spec-to-rest-playground-<hash>-uc.a.run.app
+```
+
+The docs `/playground` page reads `NEXT_PUBLIC_PLAYGROUND_API` at build time; if unset, the page
+renders a "Backend not configured" notice and links back to the install instructions.
+
+## Updating the CLI version
+
+Bump `SPEC_TO_REST_VERSION` in the `docker build` invocation (or in the deploy workflow), rebuild,
+push, redeploy. The Dockerfile pins to a tagged release; never tracks `latest` so deploys are
+reproducible.
+
+## Why Go for the wrapper?
+
+100 LOC, no deps, ~6 MB static binary, no runtime needed beyond glibc (which the CLI already needs).
+Python+FastAPI would add 50-80 MB of interpreter + deps and a slower cold start; Node would be in
+the same ballpark. The wrapper does nothing that warrants more than this.

--- a/playground/go.mod
+++ b/playground/go.mod
@@ -1,0 +1,3 @@
+module github.com/HardMax71/spec_to_rest/playground
+
+go 1.23

--- a/playground/server.go
+++ b/playground/server.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	maxSpecBytes    = 50 * 1024
+	execTimeout     = 8 * time.Second
+	defaultPort     = "8080"
+	binaryEnv       = "SPEC_TO_REST_BIN"
+	defaultBinPath  = "/usr/local/bin/spec-to-rest"
+	corsAllowOrigin = "CORS_ALLOW_ORIGIN"
+)
+
+type compileRequest struct {
+	Spec   string `json:"spec"`
+	Target string `json:"target"`
+}
+
+type compileResponse struct {
+	OK     bool   `json:"ok"`
+	Stdout string `json:"stdout"`
+	Stderr string `json:"stderr"`
+	Error  string `json:"error,omitempty"`
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = defaultPort
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/api/compile", handleCompile)
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           withCORS(mux),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+
+	log.Printf("playground server listening on :%s", port)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("server: %v", err)
+	}
+}
+
+func withCORS(next http.Handler) http.Handler {
+	allow := os.Getenv(corsAllowOrigin)
+	if allow == "" {
+		allow = "*"
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", allow)
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Max-Age", "600")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func handleCompile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxSpecBytes+2048)
+	var req compileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, compileResponse{Error: "invalid JSON body: " + err.Error()})
+		return
+	}
+	if len(req.Spec) == 0 {
+		writeJSON(w, http.StatusBadRequest, compileResponse{Error: "empty spec"})
+		return
+	}
+	if len(req.Spec) > maxSpecBytes {
+		writeJSON(w, http.StatusRequestEntityTooLarge,
+			compileResponse{Error: fmt.Sprintf("spec exceeds %d bytes", maxSpecBytes)})
+		return
+	}
+
+	args, err := argsFor(req.Target)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, compileResponse{Error: err.Error()})
+		return
+	}
+
+	tmpDir, err := os.MkdirTemp("", "spec-")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, compileResponse{Error: "tmp: " + err.Error()})
+		return
+	}
+	defer os.RemoveAll(tmpDir)
+
+	specPath := filepath.Join(tmpDir, "playground.spec")
+	if err := os.WriteFile(specPath, []byte(req.Spec), 0o600); err != nil {
+		writeJSON(w, http.StatusInternalServerError, compileResponse{Error: "write: " + err.Error()})
+		return
+	}
+
+	stdout, stderr, runErr := runBinary(append(args, specPath))
+	resp := compileResponse{
+		OK:     runErr == nil,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+	if runErr != nil {
+		resp.Error = runErr.Error()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func argsFor(target string) ([]string, error) {
+	switch target {
+	case "check":
+		return []string{"check", "--quiet"}, nil
+	case "summary":
+		return []string{"inspect", "--format", "summary", "--quiet"}, nil
+	case "ir":
+		return []string{"inspect", "--format", "ir", "--quiet"}, nil
+	case "dafny":
+		return []string{"inspect", "--format", "dafny", "--quiet"}, nil
+	default:
+		return nil, fmt.Errorf("unsupported target %q; allowed: check, summary, ir, dafny", target)
+	}
+}
+
+func runBinary(args []string) (string, string, error) {
+	bin := os.Getenv(binaryEnv)
+	if bin == "" {
+		bin = defaultBinPath
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = []string{"HOME=/tmp", "PATH=/usr/local/bin:/usr/bin:/bin", "NO_COLOR=1"}
+
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	if ctx.Err() == context.DeadlineExceeded {
+		return outBuf.String(), errBuf.String(), fmt.Errorf("execution timed out after %s", execTimeout)
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return outBuf.String(), errBuf.String(),
+				fmt.Errorf("spec-to-rest exited with code %d", exitErr.ExitCode())
+		}
+		return outBuf.String(), errBuf.String(), err
+	}
+	return outBuf.String(), errBuf.String(), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, body compileResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}


### PR DESCRIPTION
## Summary

- New \`/playground\` page in the docs that lets visitors type a spec and see its IR / Dafny kernel without installing the CLI.
- Thin Go HTTP wrapper (\`playground/\`) around the existing \`spec-to-rest\` native binary, deployable to Cloud Run / any container host.
- v1 scope: \`check\`, \`summary\`, \`ir\`, \`dafny\` (single-text outputs). \`compile\` / \`verify\` / \`synth\` deferred.

## Architecture

```
Browser → docs site (/playground)
            │ Monaco editor + tabs (client-side)
            │ fetch POST → NEXT_PUBLIC_PLAYGROUND_API
            ▼
        Cloud Run container
            │ Go HTTP wrapper (~150 LOC, stdlib only)
            │ writes spec to /tmp, exec spec-to-rest with 8s timeout
            ▼
        JSON {ok, stdout, stderr}
```

The docs site stays a static export (\`output: "export"\`). Only the playground page makes a single network call; everything else (nav, layout, search, MDX rendering) is unchanged.

## Backend (\`playground/\`)

- \`server.go\` — \`POST /api/compile\`, \`GET /healthz\`. Max spec size 50 KB, exec timeout 8 s, configurable CORS via \`CORS_ALLOW_ORIGIN\`.
- \`Dockerfile\` — multi-stage: Go build → \`debian:bookworm-slim\` runtime with the CLI tarball pulled from GitHub Releases (pin via \`SPEC_TO_REST_VERSION\` build arg). Runs as nonroot, tini for signal handling.
- \`README.md\` — Cloud Run deploy recipe, knob inventory, rationale.

Smoke tested end-to-end against a local JAR shim:

| Target | stdout (response) |
|---|---|
| \`check\` | \`{ok: true, stdout: \"\"}\` (silent success) |
| \`summary\` | Service / op / invariant overview |
| \`ir\` | ~4 KB Scala case-class dump |
| \`dafny\` | ~40-line verification kernel |
| \`evil\` (unsupported) | \`400 unsupported target\` |
| \`{}\` (empty) | \`400 empty spec\` |
| 100 KB spec | \`413 spec exceeds 51200 bytes\` |
| OPTIONS preflight | \`204\` with CORS headers |

## Frontend (\`docs/components/playground.tsx\` + \`docs/content/docs/playground.mdx\`)

- Monaco editor (\`@monaco-editor/react\`, new dep)
- Three seeded examples (\`safe_counter\`, \`url_shortener\`, \`todo_list\`)
- Target dropdown, ⌘/Ctrl+Enter to run, abort-in-flight on retry
- Tabbed stdout/stderr output (Fumadocs UI Tabs)
- Reads \`NEXT_PUBLIC_PLAYGROUND_API\` at build time. If unset, renders a "Backend not configured" notice with a link to the README — verified by building with the env var empty.

## Cost / ops

| Traffic | Cloud Run cost |
|---|---|
| Low (≤10k req/mo, typical docs visitors) | $0 (free tier covers it) |
| Moderate (100k req/mo) | <$1/mo |
| HN spike (1M req/wk) | $5-15 one-off |
| Hard cap via \`--max-instances=10 --concurrency=5\` | ~50 concurrent requests max |

No LLM calls happen in the playground (\`synth\` is excluded), so there's no cost cliff from a viral spike beyond the platform's per-request fee.

## Test plan

- [x] \`go build playground/server.go\` succeeds
- [x] End-to-end smoke test (Bash + curl) hits all four targets + edge cases (bad target, empty body, oversize spec, CORS preflight)
- [x] \`docs/\` build passes (\`npm run build\` → 46 static pages generated, link check passes)
- [x] Playground page renders the "Backend not configured" placeholder when env var is unset

## Not in this PR (follow-ups)

- Multi-file \`compile\` output (would need a tar/JSON serialisation step + a file-tree viewer)
- \`verify\` (needs Alloy + Z3 in the container image → ~3× size)
- \`synth\` (LLM calls, cost considerations)
- GitHub Action to auto-build + push the playground image on release (the user runs \`docker build/push\` and \`gcloud run deploy\` themselves per the README)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-browser playground at /playground that runs the `spec-to-rest` CLI so users can type a spec and see IR/Dafny without installing anything. Includes a lightweight Go backend deployable to Cloud Run.

- **New Features**
  - Docs page `/playground` with Monaco editor (`@monaco-editor/react`), seeded examples, target picker, and stdout/stderr tabs; Cmd/Ctrl+Enter to run.
  - Supported targets: `check`, `summary`, `ir`, `dafny` (single-text outputs only).
  - Backend: `POST /api/compile` and `GET /healthz`; 50 KB spec limit, 8 s exec timeout, configurable CORS.
  - Dockerfile: multi-stage build, pinned `spec-to-rest` release, runs as nonroot with `tini`. Nav updated and Install page links to the playground.

- **Migration**
  - Deploy the backend container (e.g., Cloud Run). Set `NEXT_PUBLIC_PLAYGROUND_API` to its base URL for the docs build.
  - Optionally set `CORS_ALLOW_ORIGIN` on the backend.
  - If `NEXT_PUBLIC_PLAYGROUND_API` is unset, the page renders a “Backend not configured” notice.

<sup>Written for commit 5c3a6b90389e3266b77bbb97770e11221992a6d2. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/310?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive web-based Playground in the documentation where users can test specifications directly in their browser without local installation. Supports Check, Summary, IR, and Dafny targets with 50 KB spec size and 8-second execution limits.

* **Documentation**
  * Added comprehensive Playground documentation with usage instructions and operational limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->