### PR TITLE
fix(playground): use bare CLI framework IDs (chi / express / fastapi)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -1,10 +1,5 @@
 name: Site
 
-# CI + deploy for the docs site (which bundles the playground).
-# On PR / push: validate (check CLI snippets aren't stale, Next.js builds).
-# On push to main / release / workflow_dispatch: also deploy to Fly.
-# Release events rebuild the container image with the new CLI binary baked in.
-
 on:
   pull_request:
     paths:
@@ -59,11 +54,7 @@ jobs:
       - name: Compile CLI runtime classpath
         run: sbt --error 'set ThisBuild / showSuccess := false' "show cli/Runtime/fullClasspathAsJars"
 
-      # Use the runner's pre-installed Node (ubuntu-latest ships Node 20+
-      # which is what Next.js 16 needs). Dropping `actions/setup-node`
-      # avoids both the cache-poisoning class of zizmor findings and any
-      # implicit caching the action does. Print versions so a future
-      # incompatibility is obvious from the log.
+      # Runner's Node 20 is enough for Next.js 16; dropping setup-node avoids zizmor's cache-poisoning rule.
       - name: Verify pre-installed Node + npm
         run: |
           node --version
@@ -98,9 +89,7 @@ jobs:
 
       - name: Resolve CLI version to bake into the image
         id: ver
-        # All `${{ }}` expansions go through env vars so they can't break out
-        # of the shell quoting and inject arbitrary commands (zizmor / cubic /
-        # coderabbit each flagged this on the previous revision).
+        # All ${{ }} via env: (zizmor template-injection rule).
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
@@ -118,9 +107,7 @@ jobs:
           else
             tag=$(gh release view --repo "$REPO" --json tagName --jq .tagName)
           fi
-          # Tag must look like a Git ref / version string — defence in depth
-          # against a deploy actor smuggling a build arg through a malformed
-          # release name.
+          # Tag-shape check: defence against a malformed release name leaking into --build-arg.
           if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
             echo "::error::resolved tag $tag has unexpected characters; aborting" >&2
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,11 @@
 - **No inline comments that restate the code.** Only add a comment when the _why_ is non-obvious (a
   hidden invariant, a workaround for a specific library bug, a surprising constraint). If removing
   the comment would not confuse a future reader, do not write it.
+- **Short comments by default. Multi-line comments only when the reason for the code is outside the
+  code's fixable scope** — the solution is hacky because of a downstream constraint (library bug,
+  framework lifecycle quirk, security-tool false-positive forcing a workaround, external protocol
+  contract). If the _why_ fits in one sentence, the comment is one line. If it takes a paragraph to
+  explain a hack you can't fix in this repo, write the paragraph.
 
 ## Imports
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,15 +1,11 @@
 ARG SPEC_TO_REST_VERSION=latest
 
 FROM node:22-bookworm-slim AS web-build
-# Mirror the repo layout (docs/ + fixtures/spec/ siblings under the repo root)
-# so docs/scripts/run-cli-snippets.mjs's `REPO_ROOT = path.resolve(docs, "..")`
-# resolves correctly inside the build.
+# /repo layout mirrors the source tree so run-cli-snippets.mjs's `REPO_ROOT = path.resolve(docs, "..")` resolves.
 WORKDIR /repo
-# Cache the npm deps layer separately from source changes. --ignore-scripts
-# skips the package.json `postinstall: fumadocs-mdx` step, which would
-# otherwise fail here because content/ hasn't been COPY'd yet.
 COPY docs/package.json docs/package-lock.json ./docs/
 WORKDIR /repo/docs
+# --ignore-scripts: package.json's postinstall (fumadocs-mdx) needs content/ which isn't COPY'd yet.
 RUN npm ci --ignore-scripts
 
 WORKDIR /repo

--- a/docs/app/api/compile/route.ts
+++ b/docs/app/api/compile/route.ts
@@ -21,7 +21,11 @@ type FastTarget = "check" | "summary" | "ir" | "dafny";
 type SlowTarget = "verify" | "compile" | "synth";
 type Target = FastTarget | SlowTarget;
 
-const FRAMEWORKS = ["fastapi", "ts-express", "go-chi"] as const;
+// Bare framework IDs as the CLI's `--framework` expects (chi/express/fastapi).
+// The `<lang>-<framework>-<db>` slug naming (e.g. `go-chi-postgres`) is for
+// docs URLs only; CLI flags take the framework alone and infer `--lang` from
+// the framework's supportedLanguages when it's 1:1.
+const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
 const DBS = ["sqlite", "postgres", "mysql"] as const;
 type Framework = (typeof FRAMEWORKS)[number];
 type Db = (typeof DBS)[number];

--- a/docs/app/api/compile/route.ts
+++ b/docs/app/api/compile/route.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promise
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { NextResponse } from "next/server";
+import { loadTargets } from "@/lib/targets";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,14 +19,9 @@ type FastTarget = "check" | "summary" | "ir" | "dafny";
 type SlowTarget = "verify" | "compile" | "synth";
 type Target = FastTarget | SlowTarget;
 
-const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
-const DBS = ["sqlite", "postgres", "mysql"] as const;
-type Framework = (typeof FRAMEWORKS)[number];
-type Db = (typeof DBS)[number];
-
 interface CompileOpts {
-  framework: Framework;
-  db: Db;
+  framework: string;
+  db: string;
 }
 
 interface SynthOpts {
@@ -91,13 +87,6 @@ function isTarget(t: unknown): t is Target {
   return typeof t === "string" && TARGETS.has(t as Target);
 }
 
-function isFramework(s: unknown): s is Framework {
-  return typeof s === "string" && (FRAMEWORKS as readonly string[]).includes(s);
-}
-
-function isDb(s: unknown): s is Db {
-  return typeof s === "string" && (DBS as readonly string[]).includes(s);
-}
 
 export async function POST(req: Request) {
   let body: CompileRequest;
@@ -179,7 +168,7 @@ async function runVerify(specPath: string) {
 }
 
 async function runCompile(specPath: string, tmp: string, raw: unknown) {
-  const opts = parseCompileOpts(raw);
+  const opts = await parseCompileOpts(raw);
   if (typeof opts === "string") return jerr(400, opts);
   const outDir = join(tmp, "out");
   const r = await runBinary(
@@ -268,14 +257,17 @@ async function runSynth(specPath: string, raw: unknown, headers: Headers) {
   );
 }
 
-function parseCompileOpts(raw: unknown): CompileOpts | string {
-  if (raw === undefined || raw === null) return { framework: "fastapi", db: "sqlite" };
+async function parseCompileOpts(raw: unknown): Promise<CompileOpts | string> {
+  const { frameworks, dbs } = await loadTargets();
+  if (raw === undefined || raw === null)
+    return { framework: frameworks[0] ?? "fastapi", db: dbs[0] ?? "sqlite" };
   if (typeof raw !== "object")
     return "compile options must be an object: { framework, db }";
   const r = raw as Record<string, unknown>;
-  if (!isFramework(r.framework))
-    return `compile.framework must be one of: ${FRAMEWORKS.join(", ")}`;
-  if (!isDb(r.db)) return `compile.db must be one of: ${DBS.join(", ")}`;
+  if (typeof r.framework !== "string" || !frameworks.includes(r.framework))
+    return `compile.framework must be one of: ${frameworks.join(", ")}`;
+  if (typeof r.db !== "string" || !dbs.includes(r.db))
+    return `compile.db must be one of: ${dbs.join(", ")}`;
   return { framework: r.framework, db: r.db };
 }
 

--- a/docs/app/api/compile/route.ts
+++ b/docs/app/api/compile/route.ts
@@ -6,9 +6,6 @@ import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
-// Synth can take ~10 min; Next.js default route timeout is 60s on serverless
-// runtimes. We're on Fly (always-on Node), so this just bumps the perceived
-// limit for clients with patient retries.
 export const maxDuration = 660;
 
 const MAX_SPEC_BYTES = 50 * 1024;
@@ -21,10 +18,6 @@ type FastTarget = "check" | "summary" | "ir" | "dafny";
 type SlowTarget = "verify" | "compile" | "synth";
 type Target = FastTarget | SlowTarget;
 
-// Bare framework IDs as the CLI's `--framework` expects (chi/express/fastapi).
-// The `<lang>-<framework>-<db>` slug naming (e.g. `go-chi-postgres`) is for
-// docs URLs only; CLI flags take the framework alone and infer `--lang` from
-// the framework's supportedLanguages when it's 1:1.
 const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
 const DBS = ["sqlite", "postgres", "mysql"] as const;
 type Framework = (typeof FRAMEWORKS)[number];
@@ -74,8 +67,6 @@ interface CompileFailure {
 
 type CompileResponse = CompileSuccess | CompileFailure;
 
-// Per-target wall-clock cap. Synth gets generous budget; everything else stays
-// snappy so a single misbehaving request can't park a container slot.
 const TIMEOUTS_MS: Record<Target, number> = {
   check: 8_000,
   summary: 8_000,
@@ -301,8 +292,6 @@ function parseSynthOpts(raw: unknown): SynthOpts | string {
 }
 
 function pickProviderEnv(model: string, key: string): Record<string, string> {
-  // Forward the key to the env var the spec-to-rest CLI expects. Pattern lifted
-  // from modules/synth/.../OpenAIProvider.scala / AnthropicProvider.scala.
   if (model.toLowerCase().startsWith("gpt")) return { OPENAI_API_KEY: key };
   if (model.toLowerCase().startsWith("claude")) return { ANTHROPIC_API_KEY: key };
   // Unknown model prefix — set both, let the provider pick what it needs.
@@ -346,9 +335,6 @@ async function collectFiles(
       const buf = await readFile(full);
       const slice = buf.subarray(0, sliceBytes);
       const truncated = sliceBytes < st.size;
-      // Skip the BOM and decode binary-ish bytes lossily — emitted code is
-      // text, but compile may drop an .ico or .png; show a placeholder so the
-      // file picker still works.
       const looksBinary = slice.includes(0);
       out.push({
         path: rel,

--- a/docs/app/api/meta/route.ts
+++ b/docs/app/api/meta/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { loadTargets } from "@/lib/targets";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const t = await loadTargets();
+  return NextResponse.json(t, {
+    headers: { "cache-control": "public, s-maxage=300, stale-while-revalidate=86400" },
+  });
+}

--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -22,7 +22,15 @@ const TARGETS: { value: Target; label: string; description: string }[] = [
   { value: "synth", label: "Synth", description: "LLM CEGIS (BYO API key)" },
 ];
 
-const FRAMEWORKS = ["fastapi", "ts-express", "go-chi"] as const;
+// Bare framework IDs the CLI accepts (--framework chi|express|fastapi). The
+// CLI infers --lang from the framework when it supports one language (current
+// 1:1 mapping: chi → go, express → ts, fastapi → python).
+const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
+const FRAMEWORK_DISPLAY: Record<(typeof FRAMEWORKS)[number], string> = {
+  chi: "chi (Go)",
+  express: "express (TypeScript)",
+  fastapi: "fastapi (Python)",
+};
 const DBS = ["sqlite", "postgres", "mysql"] as const;
 type Framework = (typeof FRAMEWORKS)[number];
 type Db = (typeof DBS)[number];
@@ -266,7 +274,7 @@ function CompileOptsRow(props: {
         label="Framework"
         value={props.opts.framework}
         onChange={(v) => props.onChange({ ...props.opts, framework: v as Framework })}
-        options={FRAMEWORKS.map((f) => ({ value: f, label: f }))}
+        options={FRAMEWORKS.map((f) => ({ value: f, label: FRAMEWORK_DISPLAY[f] }))}
       />
       <Select
         label="DB"

--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -22,15 +22,26 @@ const TARGETS: { value: Target; label: string; description: string }[] = [
   { value: "synth", label: "Synth", description: "LLM CEGIS (BYO API key)" },
 ];
 
-const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
-const FRAMEWORK_DISPLAY: Record<(typeof FRAMEWORKS)[number], string> = {
+// Pretty display labels are still hardcoded — there's no "human name for a
+// framework ID" anywhere in the Scala source. If a fourth framework arrives,
+// add a row here OR fall back to the bare ID via FRAMEWORK_LABEL_FALLBACK.
+const FRAMEWORK_DISPLAY: Record<string, string> = {
   chi: "chi (Go)",
   express: "express (TypeScript)",
   fastapi: "fastapi (Python)",
 };
-const DBS = ["sqlite", "postgres", "mysql"] as const;
-type Framework = (typeof FRAMEWORKS)[number];
-type Db = (typeof DBS)[number];
+
+interface Targets {
+  frameworks: string[];
+  dbs: string[];
+  languages: string[];
+}
+
+const TARGETS_FALLBACK: Targets = {
+  frameworks: ["chi", "express", "fastapi"],
+  dbs: ["mysql", "postgres", "sqlite"],
+  languages: ["go", "python", "ts"],
+};
 
 const MODELS = [
   { value: "gpt-5-mini", label: "gpt-5-mini (OpenAI)" },
@@ -84,8 +95,8 @@ type RunState =
     };
 
 interface CompileOpts {
-  framework: Framework;
-  db: Db;
+  framework: string;
+  db: string;
 }
 
 interface SynthOpts {
@@ -110,7 +121,28 @@ export function Playground() {
     apiKey: "",
   });
   const [selectedFile, setSelectedFile] = useState<string>("");
+  const [targets, setTargets] = useState<Targets>(TARGETS_FALLBACK);
   const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/meta")
+      .then((r) => r.json() as Promise<Targets>)
+      .then((t) => {
+        if (cancelled) return;
+        setTargets(t);
+        setCompileOpts((co) => ({
+          framework: t.frameworks.includes(co.framework)
+            ? co.framework
+            : (t.frameworks[0] ?? co.framework),
+          db: t.dbs.includes(co.db) ? co.db : (t.dbs[0] ?? co.db),
+        }));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const submit = useCallback(async () => {
     abortRef.current?.abort();
@@ -192,7 +224,7 @@ export function Playground() {
         running={state.kind === "loading"}
       />
       {showCompileOpts && (
-        <CompileOptsRow opts={compileOpts} onChange={setCompileOpts} />
+        <CompileOptsRow opts={compileOpts} onChange={setCompileOpts} targets={targets} />
       )}
       {showSynthOpts && <SynthOptsRow opts={synthOpts} onChange={setSynthOpts} />}
       <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
@@ -263,6 +295,7 @@ function Toolbar(props: {
 function CompileOptsRow(props: {
   opts: CompileOpts;
   onChange: (o: CompileOpts) => void;
+  targets: Targets;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-md border border-fd-border bg-fd-card/60 p-2 text-sm">
@@ -270,14 +303,17 @@ function CompileOptsRow(props: {
       <Select
         label="Framework"
         value={props.opts.framework}
-        onChange={(v) => props.onChange({ ...props.opts, framework: v as Framework })}
-        options={FRAMEWORKS.map((f) => ({ value: f, label: FRAMEWORK_DISPLAY[f] }))}
+        onChange={(v) => props.onChange({ ...props.opts, framework: v })}
+        options={props.targets.frameworks.map((f) => ({
+          value: f,
+          label: FRAMEWORK_DISPLAY[f] ?? f,
+        }))}
       />
       <Select
         label="DB"
         value={props.opts.db}
-        onChange={(v) => props.onChange({ ...props.opts, db: v as Db })}
-        options={DBS.map((d) => ({ value: d, label: d }))}
+        onChange={(v) => props.onChange({ ...props.opts, db: v })}
+        options={props.targets.dbs.map((d) => ({ value: d, label: d }))}
       />
     </div>
   );

--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -22,9 +22,6 @@ const TARGETS: { value: Target; label: string; description: string }[] = [
   { value: "synth", label: "Synth", description: "LLM CEGIS (BYO API key)" },
 ];
 
-// Bare framework IDs the CLI accepts (--framework chi|express|fastapi). The
-// CLI infers --lang from the framework when it supports one language (current
-// 1:1 mapping: chi → go, express → ts, fastapi → python).
 const FRAMEWORKS = ["chi", "express", "fastapi"] as const;
 const FRAMEWORK_DISPLAY: Record<(typeof FRAMEWORKS)[number], string> = {
   chi: "chi (Go)",

--- a/docs/content/docs/playground.mdx
+++ b/docs/content/docs/playground.mdx
@@ -18,7 +18,7 @@ The editor below sends your spec to `spec-to-rest` running server-side on the sa
 
 ### What about compile / verify / synth?
 
-All three run in the playground too — they're already bundled in the same `spec-to-rest` binary that powers the inspect targets. `verify` does the Alloy / Z3 model check; `compile` emits the full per-framework + per-DB output (FastAPI / ts-express / go-chi × sqlite / postgres / mysql) which the UI renders as a file tree; `synth` invokes the LLM CEGIS loop and needs a key you provide (the playground never stores it; it's forwarded as a header for that single request and discarded).
+All three run in the playground too — they're already bundled in the same `spec-to-rest` binary that powers the inspect targets. `verify` does the Alloy / Z3 model check; `compile` emits the full per-framework + per-DB output (`fastapi` Python / `express` TypeScript / `chi` Go × `sqlite` / `postgres` / `mysql`) which the UI renders as a file tree; `synth` invokes the LLM CEGIS loop and needs a key you provide (the playground never stores it; it's forwarded as a header for that single request and discarded).
 
 For long-running work — `verify` on a complex spec or `synth` with multi-iteration repair — [installing the CLI](/install) is still faster (~50 ms cold start vs cold-VM boot, no spec-size cap, no per-request wall-clock limit).
 

--- a/docs/lib/targets.ts
+++ b/docs/lib/targets.ts
@@ -1,0 +1,61 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execP = promisify(exec);
+const BINARY = process.env.SPEC_TO_REST_BIN ?? "/usr/local/bin/spec-to-rest";
+
+export interface Targets {
+  frameworks: string[];
+  dbs: string[];
+  languages: string[];
+}
+
+const FALLBACK: Targets = {
+  frameworks: ["chi", "express", "fastapi"],
+  dbs: ["mysql", "postgres", "sqlite"],
+  languages: ["go", "python", "ts"],
+};
+
+let cached: Targets | null = null;
+let inflight: Promise<Targets> | null = null;
+
+export async function loadTargets(): Promise<Targets> {
+  if (cached) return cached;
+  if (inflight) return inflight;
+  inflight = (async () => {
+    try {
+      const { stdout } = await execP(`${BINARY} compile --help`, {
+        timeout: 5_000,
+        env: { ...process.env, NO_COLOR: "1" },
+      });
+      const parsed = parseHelp(stdout);
+      cached = parsed.frameworks.length && parsed.dbs.length && parsed.languages.length
+        ? parsed
+        : FALLBACK;
+      return cached;
+    } catch {
+      cached = FALLBACK;
+      return cached;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+export function parseHelp(text: string): Targets {
+  return {
+    frameworks: pickList(text, /framework:\s*([a-z][a-z0-9,\s]*)/i),
+    dbs: pickList(text, /database:\s*([a-z][a-z0-9,\s]*)/i),
+    languages: pickList(text, /language:\s*([a-z][a-z0-9,\s]*)/i),
+  };
+}
+
+function pickList(text: string, re: RegExp): string[] {
+  const m = text.match(re);
+  if (!m) return [];
+  return m[1]
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => /^[a-z][a-z0-9-]*$/.test(s));
+}

--- a/docs/lib/targets.ts
+++ b/docs/lib/targets.ts
@@ -1,7 +1,7 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-const execP = promisify(exec);
+const execFileP = promisify(execFile);
 const BINARY = process.env.SPEC_TO_REST_BIN ?? "/usr/local/bin/spec-to-rest";
 
 export interface Targets {
@@ -24,7 +24,7 @@ export async function loadTargets(): Promise<Targets> {
   if (inflight) return inflight;
   inflight = (async () => {
     try {
-      const { stdout } = await execP(`${BINARY} compile --help`, {
+      const { stdout } = await execFileP(BINARY, ["compile", "--help"], {
         timeout: 5_000,
         env: { ...process.env, NO_COLOR: "1" },
       });


### PR DESCRIPTION
## Bug

Playground rejected every non-Python framework with:

\`\`\`
unknown framework 'go-chi' (known: chi, express, fastapi)
\`\`\`

The compile target was sending the docs-slug naming (\`go-chi\`, \`ts-express\`) to \`--framework\`, but [\`modules/profile/.../Registry.scala\`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Registry.scala) keys the framework map on bare IDs only. The slug form \`<lang>-<framework>-<db>\` is for docs URLs and PR titles, not CLI flags.

## Fix

- \`docs/app/api/compile/route.ts\`: \`FRAMEWORKS\` allow-list is now \`["chi","express","fastapi"]\`. Rejects \`go-chi\` at the API boundary with the canonical list.
- \`docs/components/playground.tsx\`: same allow-list, plus a small \`FRAMEWORK_DISPLAY\` map so the dropdown shows \`chi (Go)\` / \`express (TypeScript)\` / \`fastapi (Python)\` instead of bare IDs.
- \`docs/content/docs/playground.mdx\`: normalised the prose to use the canonical names with consistent backticks.

CLI auto-infers \`--lang\` from \`--framework\` when the framework maps to one language (current 1:1: chi → go, express → ts, fastapi → python — see [\`Targets.scala\`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/profile/src/main/scala/specrest/profile/Targets.scala)). So the API doesn't need to pass \`--lang\` explicitly.

## Trace

Grepped all of \`docs/\`, \`modules/cli\`, \`.github/workflows/\` for \`go-chi\`/\`ts-express\`/\`python-fastapi\`. The slug naming appears in:

- \`docs/content/docs/targets/<lang>/<framework>/<db>.mdx\` — URL convention, correct
- \`docs/content/docs/roadmap.mdx\` — descriptive text, correct
- \`.github/workflows/{go,python,ts}-build.yml\` — job names, correct

The bug was confined to the two playground files. Everything else uses the slug convention correctly for docs URLs / human-facing labels but never passes it to the CLI.

## Test plan

End-to-end smoke on a fresh \`docker build -f deploy/Dockerfile .\`:

| framework | db | result |
|---|---|---|
| \`chi\` | sqlite | ✓ ok=true, 21 files |
| \`express\` | sqlite | ✓ ok=true, 24 files |
| \`fastapi\` | sqlite | ✓ ok=true, 27 files |
| \`go-chi\` (old wrong name) | sqlite | ✓ 400 \"compile.framework must be one of: chi, express, fastapi\" |

After merge the Site workflow auto-redeploys; live playground will accept all three frameworks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the playground to use bare CLI framework IDs (`chi`, `express`, `fastapi`) and loads framework/DB/language lists dynamically from the CLI, so compile works and future additions auto-populate.

- **Bug Fixes**
  - API (`docs/app/api/compile/route.ts`): Validates `framework`/`db` against live CLI lists and rejects slug values like `go-chi`.
  - UI (`docs/components/playground.tsx`): Sends bare IDs with `FRAMEWORK_DISPLAY`; options now come from `/api/meta`.
  - Docs (`docs/content/docs/playground.mdx`): Canonical backticked names.

- **Refactors**
  - `docs/lib/targets.ts`: Parses `spec-to-rest compile --help`, caches in-memory with fallback, and uses `execFile` (no shell) for safer shellouts.
  - API meta (`docs/app/api/meta/route.ts`): New endpoint exposing target lists (s-maxage 5m, SWR 1d).
  - Comments/CI: Added short-comment rule in `CLAUDE.md`; trimmed verbose comments in workflows and `deploy/Dockerfile` (no behavior changes).

<sup>Written for commit fb457305ed9d478c2c182df692c6307caab8d36a. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/313?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized framework naming conventions across the Playground and compile API to use consistent CLI-style identifiers.
  * Enhanced the framework dropdown with user-friendly display names for improved clarity.

* **Documentation**
  * Updated Playground documentation to reflect standardized framework naming conventions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->