### PR TITLE
fix(ci): always run actionlint + zizmor so required checks stop stalling

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -3,9 +3,8 @@ name: Workflow Lint
 on:
   push:
     branches: [main]
-    paths: [".github/workflows/**"]
   pull_request:
-    paths: [".github/workflows/**"]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Bug

PRs that don't touch \`.github/workflows/**\` sit indefinitely with a yellow pending circle. Cause:

- Branch protection on \`main\` lists \`actionlint\` and \`zizmor\` as **required** status checks.
- The only workflow that emits those check contexts (\`lint-workflows.yml\`) had \`paths: [\".github/workflows/**\"]\`.
- When a PR doesn't touch any workflow file, GitHub **skips** the workflow entirely — no run, no status reported, ever.
- Branch protection treats \"no status\" as \"still pending\" and the PR can never reach the all-green merge state.

## Fix

Drop the \`paths:\` filter. Both jobs combined take ~30 s (actionlint download + a few-second scan, zizmor scan via the official action). Cost of always running is trivial; the alternative is the persistent stall above.

## Why this is the standard pattern

GitHub's own [\"Skipping workflow runs\"](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs) docs explicitly warn that path-filtered required checks cause this exact deadlock. Two recommended solutions:

1. Remove the path filter — what this PR does. Simplest.
2. Add a \"fanout\" workflow that always runs and reports the same check name on no-op. Heavier infra.

(1) is what every Go / Rust / Node / Scala project at scale ends up doing for sub-minute linters. Saving 30 seconds per PR isn't worth the merge-queue paper cuts.

## Test plan

- [x] \`actionlint .github/workflows/lint-workflows.yml\` locally (the diff itself is valid YAML)
- [ ] On merge: next PR that doesn't touch workflows will see both \`actionlint\` and \`zizmor\` report instead of stall.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure required CI checks `actionlint` and `zizmor` always run. Removes path filters in `.github/workflows/lint-workflows.yml` to stop PRs getting stuck when no workflow files change.

- **Bug Fixes**
  - Removed `paths: [".github/workflows/**"]` from `push` and `pull_request` so the workflow runs on all PRs and pushes.
  - Added `workflow_dispatch` for manual runs.
  - Required checks now report on every PR; no more indefinite pending state.

<sup>Written for commit b3cd058d908928ef4015a5079d6573396de49211. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/315?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD automation to run linting checks on all pull requests and enabled manual trigger capability for added flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->