### PR TITLE
feat(codegen): extension files preserved across regeneration (closes #62)

### DIFF
--- a/docs/content/docs/targets/go/chi/postgres.mdx
+++ b/docs/content/docs/targets/go/chi/postgres.mdx
@@ -43,6 +43,7 @@ is checked in under `fixtures/golden/codegen/go/chi/postgres/url_shortener/` and
 ├── internal/
 │   ├── config/config.go            # env-driven Config struct
 │   ├── database/database.go        # bun.NewDB connect + ping
+│   ├── extensions/extensions.go    # user code; preserved across regeneration
 │   ├── models/{entity}.go          # struct + create/read DTOs + ErrorResponse
 │   ├── handlers/
 │   │   ├── common.go               # writeJSON / writeError helpers
@@ -104,6 +105,37 @@ is populated, the compiler:
 
 The kernel is only emitted when at least one operation is classified as `LLM_SYNTHESIS`; otherwise
 the Go project is purely CRUD/Bun.
+
+## Extension points
+
+`internal/extensions/extensions.go` is scaffolded on first compile and preserved on every
+subsequent compile. The generated `cmd/server/main.go` calls `extensions.Register(r, db)`
+once, after mounting all spec-derived handlers — use it for custom routes or middleware
+that should live next to the generated code but survive regeneration:
+
+```go
+package extensions
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+)
+
+func Register(r chi.Router, db *bun.DB) {
+	_ = db
+	r.Get("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+}
+```
+
+`spec-to-rest compile --dry-run` reports this file as `preserve` on every run after the
+first. Any other manual edit under `cmd/`, `internal/`, or `migrations/` is overwritten on
+the next compile. In-file protected-region markers are intentionally not provided — the
+sidecar package is the supported mechanism.
 
 ## CI gate
 

--- a/docs/content/docs/targets/go/chi/postgres.mdx
+++ b/docs/content/docs/targets/go/chi/postgres.mdx
@@ -113,9 +113,9 @@ subsequent compile. The generated `cmd/server/main.go` calls `extensions.Registe
 once, **before** wiring any spec-derived route. That ordering is mandatory: chi panics on
 `r.Use(...)` after a route has been registered (`chi: all middlewares must be defined
 before routes on a mux`). Middleware installed here therefore wraps every generated
-handler; routes added here take precedence on path collisions (chi panics on duplicate
-registrations, so deliberately shadowing a generated path is not supported). Use it for
-custom routes or middleware that should live next to the generated code but survive
+handler. Routes added here are overwritten by any generated route with the same
+method + path (chi v5 silently replaces a duplicate; the spec wins on collision). Use it
+for custom routes or middleware that should live next to the generated code but survive
 regeneration:
 
 ```go

--- a/docs/content/docs/targets/go/chi/postgres.mdx
+++ b/docs/content/docs/targets/go/chi/postgres.mdx
@@ -36,7 +36,7 @@ is checked in under `fixtures/golden/codegen/go/chi/postgres/url_shortener/` and
 
 ## Project layout
 
-```text
+```tree
 .
 ├── go.mod
 ├── cmd/server/main.go              # entrypoint, chi router wiring
@@ -110,8 +110,13 @@ the Go project is purely CRUD/Bun.
 
 `internal/extensions/extensions.go` is scaffolded on first compile and preserved on every
 subsequent compile. The generated `cmd/server/main.go` calls `extensions.Register(r, db)`
-once, after mounting all spec-derived handlers — use it for custom routes or middleware
-that should live next to the generated code but survive regeneration:
+once, **before** wiring any spec-derived route. That ordering is mandatory: chi panics on
+`r.Use(...)` after a route has been registered (`chi: all middlewares must be defined
+before routes on a mux`). Middleware installed here therefore wraps every generated
+handler; routes added here take precedence on path collisions (chi panics on duplicate
+registrations, so deliberately shadowing a generated path is not supported). Use it for
+custom routes or middleware that should live next to the generated code but survive
+regeneration:
 
 ```go
 package extensions

--- a/docs/content/docs/targets/python/fastapi/postgres.mdx
+++ b/docs/content/docs/targets/python/fastapi/postgres.mdx
@@ -82,6 +82,8 @@ url_shortener/                                 # emitted project root
 │   ├── db/                                    # SQLAlchemy declarative base
 │   │   ├── __init__.py
 │   │   └── base.py
+│   ├── extensions/                            # user code; preserved across regeneration
+│   │   └── __init__.py                        # register(app: FastAPI) — called by main.py
 │   ├── models/                                # ORM mapping (one per entity)
 │   │   ├── __init__.py
 │   │   └── url_mapping.py
@@ -327,12 +329,31 @@ A `Makefile` exposes `install`, `run`, `test`, `lint`, `typecheck`, `migrate`, `
 
 ## Extension points
 
-Regeneration today overwrites every file in the emitted tree. Manual edits to `app/*.py`,
-`alembic/*`, the infrastructure files, or `openapi.yaml` will be lost on the next compile;
-the generated `README.md` warns consumers of this.
+Regeneration overwrites every file in the emitted tree **except** a small set of
+user-owned files that the compiler scaffolds once and never touches again. The supported,
+lossless ways to influence the output are:
 
-The supported, lossless ways to influence the output are:
+- **`app/extensions/__init__.py`** — scaffolded on first compile, preserved on every
+  subsequent compile. The generated `app/main.py` calls `register(app)` from this module
+  once, after mounting all spec-derived routers. Use it for custom endpoints, lifecycle
+  hooks, or middleware that should live next to the generated code but survive
+  regeneration:
 
+  ```python
+  from fastapi import APIRouter, FastAPI
+
+  custom = APIRouter(prefix="/custom", tags=["custom"])
+
+  @custom.get("/ping")
+  async def ping() -> dict[str, str]:
+      return {"status": "ok"}
+
+  def register(app: FastAPI) -> None:
+      app.include_router(custom)
+  ```
+
+  `spec-to-rest compile --dry-run` reports this file as `preserve` on every run after the
+  first, distinguishing it from `create` / `update` / `unchanged`.
 - **Convention overrides** declared inside a service-level `conventions { ... }` block. Each
   rule is `Target.property = value`, with an optional quoted qualifier between the property and
   `=` for properties like `http_header` that address a named slot:
@@ -352,12 +373,13 @@ The supported, lossless ways to influence the output are:
   These live inside the spec and survive regeneration. Grammar rule:
   `conventionRule: UPPER_IDENT DOT lowerIdent STRING_LIT? EQ expr` in `modules/parser/src/main/antlr4/Spec.g4`.
   See [Convention Engine](/design/convention-engine) for the full property list.
-- **Profile selection.** Eventually switching targets (`python-fastapi-sqlite`,
-  `go-chi-postgres`) without editing emitted code.
+- **Profile selection.** Switching targets (`python-fastapi-sqlite`, `go-chi-postgres`,
+  `ts-express-mysql`, …) without editing emitted code.
 
-Protected-region markers and sidecar extension files (so hand-written logic can coexist with
-regeneration) are planned in
-[M7.8, Protected regions & extension files](https://github.com/HardMax71/spec_to_rest/issues/62).
+Manual edits to any file other than `app/extensions/__init__.py` will be lost on the next
+compile; the generated `README.md` warns consumers of this. In-file protected-region markers
+(fences that splice user code into otherwise-generated bodies) are intentionally not
+provided — sidecar extension files are the supported mechanism.
 
 ## CI gate
 

--- a/docs/content/docs/targets/python/fastapi/postgres.mdx
+++ b/docs/content/docs/targets/python/fastapi/postgres.mdx
@@ -335,9 +335,10 @@ lossless ways to influence the output are:
 
 - **`app/extensions/__init__.py`** — scaffolded on first compile, preserved on every
   subsequent compile. The generated `app/main.py` calls `register(app)` from this module
-  once, after mounting all spec-derived routers. Use it for custom endpoints, lifecycle
-  hooks, or middleware that should live next to the generated code but survive
-  regeneration:
+  once, **before** mounting any spec-derived router — so middleware added here wraps every
+  generated endpoint and routes declared here take precedence on path collisions. Use it
+  for custom endpoints, lifecycle hooks, or middleware that should live next to the
+  generated code but survive regeneration:
 
   ```python
   from fastapi import APIRouter, FastAPI

--- a/docs/content/docs/targets/ts/express/postgres.mdx
+++ b/docs/content/docs/targets/ts/express/postgres.mdx
@@ -37,7 +37,7 @@ is checked in under `fixtures/golden/codegen/ts/express/postgres/url_shortener/`
 
 ## Project layout
 
-```text
+```tree
 .
 ├── package.json
 ├── tsconfig.json
@@ -130,9 +130,11 @@ the TS project is purely CRUD/Prisma.
 ## Extension points
 
 `src/extensions/index.ts` is scaffolded on first compile and preserved on every subsequent
-compile. The generated `src/app.ts` calls `registerExtensions(app)` once, after mounting
-all spec-derived routes and before the error handler — use it for custom routes or middleware
-that should live next to the generated code but survive regeneration:
+compile. The generated `src/app.ts` calls `registerExtensions(app)` once, **before**
+mounting any spec-derived route. Express only applies `app.use(...)` to routes registered
+after the call, so middleware installed here wraps every generated endpoint; routes added
+here take precedence on path collisions. Use it for custom routes or middleware that
+should live next to the generated code but survive regeneration:
 
 ```typescript
 import type { Express, Request, Response } from 'express';

--- a/docs/content/docs/targets/ts/express/postgres.mdx
+++ b/docs/content/docs/targets/ts/express/postgres.mdx
@@ -48,6 +48,8 @@ is checked in under `fixtures/golden/codegen/ts/express/postgres/url_shortener/`
 │   ├── app.ts                          # express() + routes + error middleware
 │   ├── config.ts                       # zod-validated env config
 │   ├── prisma.ts                       # PrismaClient singleton
+│   ├── extensions/
+│   │   └── index.ts                    # user code; preserved across regeneration
 │   ├── middleware/
 │   │   ├── error.ts                    # HttpError + zod 422 + 500 fallback
 │   │   └── validate.ts                 # validateBody(schema)
@@ -124,6 +126,28 @@ cache is populated, the compiler:
 
 The kernel is only emitted when at least one operation is classified as `LLM_SYNTHESIS`; otherwise
 the TS project is purely CRUD/Prisma.
+
+## Extension points
+
+`src/extensions/index.ts` is scaffolded on first compile and preserved on every subsequent
+compile. The generated `src/app.ts` calls `registerExtensions(app)` once, after mounting
+all spec-derived routes and before the error handler — use it for custom routes or middleware
+that should live next to the generated code but survive regeneration:
+
+```typescript
+import type { Express, Request, Response } from 'express';
+
+export function registerExtensions(app: Express): void {
+  app.get('/custom/ping', (_req: Request, res: Response) => {
+    res.status(200).json({ status: 'ok' });
+  });
+}
+```
+
+`spec-to-rest compile --dry-run` reports this file as `preserve` on every run after the
+first. Any other manual edit under `src/`, `prisma/`, or the infrastructure files is
+overwritten on the next compile. In-file protected-region markers are intentionally not
+provided — the sidecar module is the supported mechanism.
 
 ## CI gate
 

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/generated/url-shortener/internal/config"
 	"github.com/generated/url-shortener/internal/database"
+	"github.com/generated/url-shortener/internal/extensions"
 	"github.com/generated/url-shortener/internal/handlers"
 	"github.com/generated/url-shortener/internal/services"
 	"github.com/generated/url-shortener/internal/testadmin"
@@ -58,6 +59,8 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
+
+	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
@@ -48,6 +48,11 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
+	// chi panics on r.Use(...) after routes are registered, so the user hook
+	// runs here — before any generated route wiring — and may install both
+	// middleware and additional routes.
+	extensions.Register(r, db)
+
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -59,8 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
@@ -9,12 +9,11 @@ import (
 // overwritten by `spec-to-rest compile`.
 //
 // The generated cmd/server/main.go calls Register BEFORE wiring any
-// spec-derived route — that ordering is mandatory because chi panics on
-// r.Use(...) after a route has been registered ("chi: all middlewares
-// must be defined before routes on a mux"). Middleware installed here
-// therefore wraps every generated handler, and routes added here take
-// precedence on path collisions (chi panics on duplicate registrations,
-// so deliberately shadowing a generated path is not supported).
+// spec-derived route — required because chi panics on r.Use(...) after
+// a route has been registered. Middleware installed here therefore
+// wraps every generated handler. Routes added here are overwritten by
+// any generated route with the same method+path (chi v5 silently
+// replaces a duplicate; the spec wins on collision).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+)
+
+// Register lets you mount custom routes and middleware on top of the
+// spec-derived ones. This file is never overwritten by `spec-to-rest
+// compile`; the generated cmd/server/main.go calls Register once after
+// mounting all spec-derived handlers.
+//
+// Example:
+//
+//	func Register(r chi.Router, db *bun.DB) {
+//		r.Get("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+//			_, _ = w.Write([]byte(`{"status":"ok"}`))
+//		})
+//	}
+func Register(r chi.Router, db *bun.DB) {
+	_ = r
+	_ = db
+}

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/extensions/extensions.go
@@ -5,10 +5,16 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Register lets you mount custom routes and middleware on top of the
-// spec-derived ones. This file is never overwritten by `spec-to-rest
-// compile`; the generated cmd/server/main.go calls Register once after
-// mounting all spec-derived handlers.
+// Register installs custom routes and middleware. This file is never
+// overwritten by `spec-to-rest compile`.
+//
+// The generated cmd/server/main.go calls Register BEFORE wiring any
+// spec-derived route — that ordering is mandatory because chi panics on
+// r.Use(...) after a route has been registered ("chi: all middlewares
+// must be defined before routes on a mux"). Middleware installed here
+// therefore wraps every generated handler, and routes added here take
+// precedence on path collisions (chi panics on duplicate registrations,
+// so deliberately shadowing a generated path is not supported).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/generated/url-shortener/internal/config"
 	"github.com/generated/url-shortener/internal/database"
+	"github.com/generated/url-shortener/internal/extensions"
 	"github.com/generated/url-shortener/internal/handlers"
 	"github.com/generated/url-shortener/internal/services"
 	"github.com/generated/url-shortener/internal/testadmin"
@@ -58,6 +59,8 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
+
+	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
@@ -48,6 +48,11 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
+	// chi panics on r.Use(...) after routes are registered, so the user hook
+	// runs here — before any generated route wiring — and may install both
+	// middleware and additional routes.
+	extensions.Register(r, db)
+
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -59,8 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
@@ -9,12 +9,11 @@ import (
 // overwritten by `spec-to-rest compile`.
 //
 // The generated cmd/server/main.go calls Register BEFORE wiring any
-// spec-derived route — that ordering is mandatory because chi panics on
-// r.Use(...) after a route has been registered ("chi: all middlewares
-// must be defined before routes on a mux"). Middleware installed here
-// therefore wraps every generated handler, and routes added here take
-// precedence on path collisions (chi panics on duplicate registrations,
-// so deliberately shadowing a generated path is not supported).
+// spec-derived route — required because chi panics on r.Use(...) after
+// a route has been registered. Middleware installed here therefore
+// wraps every generated handler. Routes added here are overwritten by
+// any generated route with the same method+path (chi v5 silently
+// replaces a duplicate; the spec wins on collision).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+)
+
+// Register lets you mount custom routes and middleware on top of the
+// spec-derived ones. This file is never overwritten by `spec-to-rest
+// compile`; the generated cmd/server/main.go calls Register once after
+// mounting all spec-derived handlers.
+//
+// Example:
+//
+//	func Register(r chi.Router, db *bun.DB) {
+//		r.Get("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+//			_, _ = w.Write([]byte(`{"status":"ok"}`))
+//		})
+//	}
+func Register(r chi.Router, db *bun.DB) {
+	_ = r
+	_ = db
+}

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/extensions/extensions.go
@@ -5,10 +5,16 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Register lets you mount custom routes and middleware on top of the
-// spec-derived ones. This file is never overwritten by `spec-to-rest
-// compile`; the generated cmd/server/main.go calls Register once after
-// mounting all spec-derived handlers.
+// Register installs custom routes and middleware. This file is never
+// overwritten by `spec-to-rest compile`.
+//
+// The generated cmd/server/main.go calls Register BEFORE wiring any
+// spec-derived route — that ordering is mandatory because chi panics on
+// r.Use(...) after a route has been registered ("chi: all middlewares
+// must be defined before routes on a mux"). Middleware installed here
+// therefore wraps every generated handler, and routes added here take
+// precedence on path collisions (chi panics on duplicate registrations,
+// so deliberately shadowing a generated path is not supported).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/generated/url-shortener/internal/config"
 	"github.com/generated/url-shortener/internal/database"
+	"github.com/generated/url-shortener/internal/extensions"
 	"github.com/generated/url-shortener/internal/handlers"
 	"github.com/generated/url-shortener/internal/services"
 	"github.com/generated/url-shortener/internal/testadmin"
@@ -58,6 +59,8 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
+
+	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
@@ -48,6 +48,11 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
+	// chi panics on r.Use(...) after routes are registered, so the user hook
+	// runs here — before any generated route wiring — and may install both
+	// middleware and additional routes.
+	extensions.Register(r, db)
+
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -59,8 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
-	extensions.Register(r, db)
 
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
@@ -9,12 +9,11 @@ import (
 // overwritten by `spec-to-rest compile`.
 //
 // The generated cmd/server/main.go calls Register BEFORE wiring any
-// spec-derived route — that ordering is mandatory because chi panics on
-// r.Use(...) after a route has been registered ("chi: all middlewares
-// must be defined before routes on a mux"). Middleware installed here
-// therefore wraps every generated handler, and routes added here take
-// precedence on path collisions (chi panics on duplicate registrations,
-// so deliberately shadowing a generated path is not supported).
+// spec-derived route — required because chi panics on r.Use(...) after
+// a route has been registered. Middleware installed here therefore
+// wraps every generated handler. Routes added here are overwritten by
+// any generated route with the same method+path (chi v5 silently
+// replaces a duplicate; the spec wins on collision).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
@@ -1,0 +1,23 @@
+package extensions
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/uptrace/bun"
+)
+
+// Register lets you mount custom routes and middleware on top of the
+// spec-derived ones. This file is never overwritten by `spec-to-rest
+// compile`; the generated cmd/server/main.go calls Register once after
+// mounting all spec-derived handlers.
+//
+// Example:
+//
+//	func Register(r chi.Router, db *bun.DB) {
+//		r.Get("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+//			_, _ = w.Write([]byte(`{"status":"ok"}`))
+//		})
+//	}
+func Register(r chi.Router, db *bun.DB) {
+	_ = r
+	_ = db
+}

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/extensions/extensions.go
@@ -5,10 +5,16 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Register lets you mount custom routes and middleware on top of the
-// spec-derived ones. This file is never overwritten by `spec-to-rest
-// compile`; the generated cmd/server/main.go calls Register once after
-// mounting all spec-derived handlers.
+// Register installs custom routes and middleware. This file is never
+// overwritten by `spec-to-rest compile`.
+//
+// The generated cmd/server/main.go calls Register BEFORE wiring any
+// spec-derived route — that ordering is mandatory because chi panics on
+// r.Use(...) after a route has been registered ("chi: all middlewares
+// must be defined before routes on a mux"). Middleware installed here
+// therefore wraps every generated handler, and routes added here take
+// precedence on path collisions (chi panics on duplicate registrations,
+// so deliberately shadowing a generated path is not supported).
 //
 // Example:
 //

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-17
+Create Date: 2026-05-24
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/extensions/__init__.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    '''Register custom routes, middleware, and lifecycle hooks.
+
+    This file is never overwritten by `spec-to-rest compile`. Add user-defined
+    endpoints, middleware, or startup/shutdown hooks here; the generated
+    `app/main.py` calls this once after mounting all spec-derived routers.
+
+    Example:
+
+        from fastapi import APIRouter
+
+        custom = APIRouter(prefix="/custom", tags=["custom"])
+
+        @custom.get("/ping")
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        def register(app: FastAPI) -> None:
+            app.include_router(custom)
+    '''
+    del app

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/extensions/__init__.py
@@ -4,9 +4,10 @@ from fastapi import FastAPI
 def register(app: FastAPI) -> None:
     '''Register custom routes, middleware, and lifecycle hooks.
 
-    This file is never overwritten by `spec-to-rest compile`. Add user-defined
-    endpoints, middleware, or startup/shutdown hooks here; the generated
-    `app/main.py` calls this once after mounting all spec-derived routers.
+    This file is never overwritten by `spec-to-rest compile`. The generated
+    `app/main.py` calls this once BEFORE mounting any spec-derived router,
+    so middleware added here wraps every generated endpoint and routes
+    declared here take precedence on path collisions.
 
     Example:
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine
+from app.extensions import register as register_extensions
 from app.redaction import configure_logging
 
 from app.routers import url_mappings
@@ -54,3 +55,5 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
+
+register_extensions(app)

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
@@ -43,6 +43,8 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok"}
 
 
+register_extensions(app)
+
 if os.environ.get("ENABLE_TEST_ADMIN") == "1":
     try:
         from app.routers import test_admin as _test_admin
@@ -55,5 +57,3 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
-
-register_extensions(app)

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-17
+Create Date: 2026-05-24
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/extensions/__init__.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    '''Register custom routes, middleware, and lifecycle hooks.
+
+    This file is never overwritten by `spec-to-rest compile`. Add user-defined
+    endpoints, middleware, or startup/shutdown hooks here; the generated
+    `app/main.py` calls this once after mounting all spec-derived routers.
+
+    Example:
+
+        from fastapi import APIRouter
+
+        custom = APIRouter(prefix="/custom", tags=["custom"])
+
+        @custom.get("/ping")
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        def register(app: FastAPI) -> None:
+            app.include_router(custom)
+    '''
+    del app

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/extensions/__init__.py
@@ -4,9 +4,10 @@ from fastapi import FastAPI
 def register(app: FastAPI) -> None:
     '''Register custom routes, middleware, and lifecycle hooks.
 
-    This file is never overwritten by `spec-to-rest compile`. Add user-defined
-    endpoints, middleware, or startup/shutdown hooks here; the generated
-    `app/main.py` calls this once after mounting all spec-derived routers.
+    This file is never overwritten by `spec-to-rest compile`. The generated
+    `app/main.py` calls this once BEFORE mounting any spec-derived router,
+    so middleware added here wraps every generated endpoint and routes
+    declared here take precedence on path collisions.
 
     Example:
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine
+from app.extensions import register as register_extensions
 from app.redaction import configure_logging
 
 from app.routers import url_mappings
@@ -54,3 +55,5 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
+
+register_extensions(app)

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
@@ -43,6 +43,8 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok"}
 
 
+register_extensions(app)
+
 if os.environ.get("ENABLE_TEST_ADMIN") == "1":
     try:
         from app.routers import test_admin as _test_admin
@@ -55,5 +57,3 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
-
-register_extensions(app)

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-05-17
+Create Date: 2026-05-24
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/extensions/__init__.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+
+
+def register(app: FastAPI) -> None:
+    '''Register custom routes, middleware, and lifecycle hooks.
+
+    This file is never overwritten by `spec-to-rest compile`. Add user-defined
+    endpoints, middleware, or startup/shutdown hooks here; the generated
+    `app/main.py` calls this once after mounting all spec-derived routers.
+
+    Example:
+
+        from fastapi import APIRouter
+
+        custom = APIRouter(prefix="/custom", tags=["custom"])
+
+        @custom.get("/ping")
+        async def ping() -> dict[str, str]:
+            return {"status": "ok"}
+
+        def register(app: FastAPI) -> None:
+            app.include_router(custom)
+    '''
+    del app

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/extensions/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/extensions/__init__.py
@@ -4,9 +4,10 @@ from fastapi import FastAPI
 def register(app: FastAPI) -> None:
     '''Register custom routes, middleware, and lifecycle hooks.
 
-    This file is never overwritten by `spec-to-rest compile`. Add user-defined
-    endpoints, middleware, or startup/shutdown hooks here; the generated
-    `app/main.py` calls this once after mounting all spec-derived routers.
+    This file is never overwritten by `spec-to-rest compile`. The generated
+    `app/main.py` calls this once BEFORE mounting any spec-derived router,
+    so middleware added here wraps every generated endpoint and routes
+    declared here take precedence on path collisions.
 
     Example:
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine
+from app.extensions import register as register_extensions
 from app.redaction import configure_logging
 
 from app.routers import url_mappings
@@ -54,3 +55,5 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
+
+register_extensions(app)

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
@@ -43,6 +43,8 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok"}
 
 
+register_extensions(app)
+
 if os.environ.get("ENABLE_TEST_ADMIN") == "1":
     try:
         from app.routers import test_admin as _test_admin
@@ -55,5 +57,3 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 app.include_router(url_mappings.router)
 
-
-register_extensions(app)

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 
+import { registerExtensions } from './extensions/index.js';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
@@ -28,5 +29,6 @@ app.get('/health', (_req: Request, res: Response) => {
 });
 
 mountRoutes(app);
+registerExtensions(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/app.ts
@@ -28,7 +28,12 @@ app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
 
-mountRoutes(app);
+// Express applies middleware only to routes registered after the
+// `app.use(...)` call, so the user hook runs before generated routes are
+// mounted — middleware installed inside `registerExtensions` wraps every
+// spec-derived endpoint, and any extra routes added here take precedence
+// on collision.
 registerExtensions(app);
+mountRoutes(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/extensions/index.ts
@@ -1,0 +1,15 @@
+import type { Express } from 'express';
+
+// Register custom routes and middleware on top of the spec-derived ones.
+// This file is never overwritten by `spec-to-rest compile`; the generated
+// src/app.ts calls registerExtensions once after mounting all spec-derived
+// routes.
+//
+// Example:
+//
+//   export function registerExtensions(app: Express): void {
+//     app.get('/custom/ping', (_req, res) => res.status(200).json({ status: 'ok' }));
+//   }
+export function registerExtensions(app: Express): void {
+  void app;
+}

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/extensions/index.ts
@@ -1,9 +1,13 @@
 import type { Express } from 'express';
 
-// Register custom routes and middleware on top of the spec-derived ones.
-// This file is never overwritten by `spec-to-rest compile`; the generated
-// src/app.ts calls registerExtensions once after mounting all spec-derived
-// routes.
+// registerExtensions installs custom routes and middleware. This file is
+// never overwritten by `spec-to-rest compile`.
+//
+// The generated src/app.ts calls registerExtensions BEFORE mounting any
+// spec-derived route, because Express only applies `app.use(...)` to
+// routes registered after the call. Middleware installed here therefore
+// wraps every generated endpoint, and any extra routes declared here
+// take precedence on path collisions.
 //
 // Example:
 //

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 
+import { registerExtensions } from './extensions/index.js';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
@@ -28,5 +29,6 @@ app.get('/health', (_req: Request, res: Response) => {
 });
 
 mountRoutes(app);
+registerExtensions(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/app.ts
@@ -28,7 +28,12 @@ app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
 
-mountRoutes(app);
+// Express applies middleware only to routes registered after the
+// `app.use(...)` call, so the user hook runs before generated routes are
+// mounted — middleware installed inside `registerExtensions` wraps every
+// spec-derived endpoint, and any extra routes added here take precedence
+// on collision.
 registerExtensions(app);
+mountRoutes(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/extensions/index.ts
@@ -1,0 +1,15 @@
+import type { Express } from 'express';
+
+// Register custom routes and middleware on top of the spec-derived ones.
+// This file is never overwritten by `spec-to-rest compile`; the generated
+// src/app.ts calls registerExtensions once after mounting all spec-derived
+// routes.
+//
+// Example:
+//
+//   export function registerExtensions(app: Express): void {
+//     app.get('/custom/ping', (_req, res) => res.status(200).json({ status: 'ok' }));
+//   }
+export function registerExtensions(app: Express): void {
+  void app;
+}

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/extensions/index.ts
@@ -1,9 +1,13 @@
 import type { Express } from 'express';
 
-// Register custom routes and middleware on top of the spec-derived ones.
-// This file is never overwritten by `spec-to-rest compile`; the generated
-// src/app.ts calls registerExtensions once after mounting all spec-derived
-// routes.
+// registerExtensions installs custom routes and middleware. This file is
+// never overwritten by `spec-to-rest compile`.
+//
+// The generated src/app.ts calls registerExtensions BEFORE mounting any
+// spec-derived route, because Express only applies `app.use(...)` to
+// routes registered after the call. Middleware installed here therefore
+// wraps every generated endpoint, and any extra routes declared here
+// take precedence on path collisions.
 //
 // Example:
 //

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 
+import { registerExtensions } from './extensions/index.js';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
@@ -28,5 +29,6 @@ app.get('/health', (_req: Request, res: Response) => {
 });
 
 mountRoutes(app);
+registerExtensions(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/app.ts
@@ -28,7 +28,12 @@ app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
 
-mountRoutes(app);
+// Express applies middleware only to routes registered after the
+// `app.use(...)` call, so the user hook runs before generated routes are
+// mounted — middleware installed inside `registerExtensions` wraps every
+// spec-derived endpoint, and any extra routes added here take precedence
+// on collision.
 registerExtensions(app);
+mountRoutes(app);
 
 app.use(errorHandler);

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/extensions/index.ts
@@ -1,0 +1,15 @@
+import type { Express } from 'express';
+
+// Register custom routes and middleware on top of the spec-derived ones.
+// This file is never overwritten by `spec-to-rest compile`; the generated
+// src/app.ts calls registerExtensions once after mounting all spec-derived
+// routes.
+//
+// Example:
+//
+//   export function registerExtensions(app: Express): void {
+//     app.get('/custom/ping', (_req, res) => res.status(200).json({ status: 'ok' }));
+//   }
+export function registerExtensions(app: Express): void {
+  void app;
+}

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/extensions/index.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/extensions/index.ts
@@ -1,9 +1,13 @@
 import type { Express } from 'express';
 
-// Register custom routes and middleware on top of the spec-derived ones.
-// This file is never overwritten by `spec-to-rest compile`; the generated
-// src/app.ts calls registerExtensions once after mounting all spec-derived
-// routes.
+// registerExtensions installs custom routes and middleware. This file is
+// never overwritten by `spec-to-rest compile`.
+//
+// The generated src/app.ts calls registerExtensions BEFORE mounting any
+// spec-derived route, because Express only applies `app.use(...)` to
+// routes registered after the call. Middleware installed here therefore
+// wraps every generated endpoint, and any extra routes declared here
+// take precedence on path collisions.
 //
 // Example:
 //

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -26,7 +26,6 @@ import specrest.synth.DafnyTranslateCli
 import specrest.synth.FileAssembly
 import specrest.synth.TargetLanguage
 import specrest.synth.TranslatedDafny
-import specrest.testgen.FilePaths
 import specrest.testgen.Strategies
 import specrest.testgen.SupportedTargets
 import specrest.testgen.TestEmit
@@ -170,8 +169,7 @@ object Compile:
             files.foreach: f =>
               val target = outRoot.resolve(f.path)
               Option(target.getParent).foreach(Files.createDirectories(_))
-              val isUserStrategies = f.path == FilePaths.StrategiesUserFile
-              if isUserStrategies && Files.exists(target) then ()
+              if f.preserve && Files.exists(target) then ()
               else
                 Files.writeString(
                   target,

--- a/modules/cli/src/main/scala/specrest/cli/Plan.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Plan.scala
@@ -1,7 +1,6 @@
 package specrest.cli
 
 import specrest.codegen.EmittedFile
-import specrest.testgen.FilePaths
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -15,10 +14,9 @@ final case class FilePlan(action: FileAction, path: String)
 object Plan:
   def classify(files: List[EmittedFile], outRoot: Path): List[FilePlan] =
     files.map: f =>
-      val abs              = outRoot.resolve(f.path)
-      val isUserStrategies = f.path == FilePaths.StrategiesUserFile
+      val abs = outRoot.resolve(f.path)
       if Files.exists(abs) then
-        if isUserStrategies then FilePlan(FileAction.Preserved, f.path)
+        if f.preserve then FilePlan(FileAction.Preserved, f.path)
         else
           val onDisk = Files.readAllBytes(abs)
           val want   = f.content.getBytes(StandardCharsets.UTF_8)

--- a/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/CliSmokeTest.scala
@@ -649,3 +649,40 @@ class CliSmokeTest extends CatsEffectSuite:
       Map.empty
     )
     assert(parsed.isLeft, s"--with-tests should be rejected after removal; got $parsed")
+
+  List(
+    ("python-fastapi-postgres", "app/extensions/__init__.py", "app/main.py"),
+    ("go-chi-postgres", "internal/extensions/extensions.go", "cmd/server/main.go"),
+    ("ts-express-postgres", "src/extensions/index.ts", "src/app.ts")
+  ).foreach: (target, extPath, regenPath) =>
+    test(s"compile $target preserves the extension file across regeneration"):
+      tempOutPath.use: outDir =>
+        val userMarker = "// USER EDIT — must survive regen\n"
+        for
+          exit1 <- Compile.run(
+                     "fixtures/spec/url_shortener.spec",
+                     CompileOptions(target, outDir.toString, ignoreVerify = true),
+                     log
+                   )
+          _ <- IO.blocking {
+                 val ext = outDir.resolve(extPath)
+                 assert(java.nio.file.Files.exists(ext), s"$extPath not emitted on first run")
+                 java.nio.file.Files.writeString(ext, userMarker)
+                 val regen = outDir.resolve(regenPath)
+                 java.nio.file.Files.writeString(regen, "garbage-to-be-overwritten")
+               }
+          exit2 <- Compile.run(
+                     "fixtures/spec/url_shortener.spec",
+                     CompileOptions(target, outDir.toString, ignoreVerify = true),
+                     log
+                   )
+          extAfter   <- IO.blocking(java.nio.file.Files.readString(outDir.resolve(extPath)))
+          regenAfter <- IO.blocking(java.nio.file.Files.readString(outDir.resolve(regenPath)))
+        yield
+          assertEquals(exit1, ExitCodes.Ok)
+          assertEquals(exit2, ExitCodes.Ok)
+          assertEquals(extAfter, userMarker, s"$extPath should not be overwritten")
+          assert(
+            regenAfter != "garbage-to-be-overwritten",
+            s"$regenPath should be regenerated, not preserved"
+          )

--- a/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
@@ -48,6 +48,11 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
+	// chi panics on r.Use(...) after routes are registered, so the user hook
+	// runs here — before any generated route wiring — and may install both
+	// middleware and additional routes.
+	extensions.Register(r, db)
+
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
@@ -57,8 +62,6 @@ func main() {
 
 {{#each entities}}{{#each operations}}	r.{{pascal_case method}}("{{chiPath}}", {{../entityCamel}}Handler.{{handlerName}})
 {{/each}}{{/each}}
-	extensions.Register(r, db)
-
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
@@ -15,6 +15,7 @@ import (
 
 	"{{module}}/internal/config"
 	"{{module}}/internal/database"
+	"{{module}}/internal/extensions"
 	"{{module}}/internal/handlers"
 	"{{module}}/internal/services"
 	"{{module}}/internal/testadmin"
@@ -56,6 +57,8 @@ func main() {
 
 {{#each entities}}{{#each operations}}	r.{{pascal_case method}}("{{chiPath}}", {{../entityCamel}}Handler.{{handlerName}})
 {{/each}}{{/each}}
+	extensions.Register(r, db)
+
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.database import engine
+from app.extensions import register as register_extensions
 from app.redaction import configure_logging
 {{#each entities}}
 from app.routers import {{snake_case (pluralize this.entityName)}}
@@ -54,3 +55,5 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 {{#each entities}}
 app.include_router({{snake_case (pluralize this.entityName)}}.router)
 {{/each}}
+
+register_extensions(app)

--- a/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
@@ -43,6 +43,8 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok"}
 
 
+register_extensions(app)
+
 if os.environ.get("ENABLE_TEST_ADMIN") == "1":
     try:
         from app.routers import test_admin as _test_admin
@@ -55,5 +57,3 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 {{#each entities}}
 app.include_router({{snake_case (pluralize this.entityName)}}.router)
 {{/each}}
-
-register_extensions(app)

--- a/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
@@ -1,6 +1,7 @@
 import express from 'express';
 import type { Request, Response } from 'express';
 
+import { registerExtensions } from './extensions/index.js';
 import { errorHandler } from './middleware/error.js';
 import { mountRoutes } from './routes/index.js';
 
@@ -28,5 +29,6 @@ app.get('/health', (_req: Request, res: Response) => {
 });
 
 mountRoutes(app);
+registerExtensions(app);
 
 app.use(errorHandler);

--- a/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/app.ts.hbs
@@ -28,7 +28,12 @@ app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });
 });
 
-mountRoutes(app);
+// Express applies middleware only to routes registered after the
+// `app.use(...)` call, so the user hook runs before generated routes are
+// mounted — middleware installed inside `registerExtensions` wraps every
+// spec-derived endpoint, and any extra routes added here take precedence
+// on collision.
 registerExtensions(app);
+mountRoutes(app);
 
 app.use(errorHandler);

--- a/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Emit.scala
@@ -3,7 +3,7 @@ package specrest.codegen
 import specrest.convention.DatabaseSchema
 import specrest.profile.ProfiledService
 
-final case class EmittedFile(path: String, content: String)
+final case class EmittedFile(path: String, content: String, preserve: Boolean = false)
 
 final case class EmitOptions(
     createdDate: Option[String] = None,

--- a/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
@@ -42,12 +42,11 @@ object ExtensionStub:
       |// overwritten by `spec-to-rest compile`.
       |//
       |// The generated cmd/server/main.go calls Register BEFORE wiring any
-      |// spec-derived route — that ordering is mandatory because chi panics on
-      |// r.Use(...) after a route has been registered ("chi: all middlewares
-      |// must be defined before routes on a mux"). Middleware installed here
-      |// therefore wraps every generated handler, and routes added here take
-      |// precedence on path collisions (chi panics on duplicate registrations,
-      |// so deliberately shadowing a generated path is not supported).
+      |// spec-derived route — required because chi panics on r.Use(...) after
+      |// a route has been registered. Middleware installed here therefore
+      |// wraps every generated handler. Routes added here are overwritten by
+      |// any generated route with the same method+path (chi v5 silently
+      |// replaces a duplicate; the spec wins on collision).
       |//
       |// Example:
       |//

--- a/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
@@ -1,0 +1,74 @@
+package specrest.codegen
+
+object ExtensionStub:
+
+  val python: String =
+    """from fastapi import FastAPI
+      |
+      |
+      |def register(app: FastAPI) -> None:
+      |    '''Register custom routes, middleware, and lifecycle hooks.
+      |
+      |    This file is never overwritten by `spec-to-rest compile`. Add user-defined
+      |    endpoints, middleware, or startup/shutdown hooks here; the generated
+      |    `app/main.py` calls this once after mounting all spec-derived routers.
+      |
+      |    Example:
+      |
+      |        from fastapi import APIRouter
+      |
+      |        custom = APIRouter(prefix="/custom", tags=["custom"])
+      |
+      |        @custom.get("/ping")
+      |        async def ping() -> dict[str, str]:
+      |            return {"status": "ok"}
+      |
+      |        def register(app: FastAPI) -> None:
+      |            app.include_router(custom)
+      |    '''
+      |    del app
+      |""".stripMargin
+
+  val go: String =
+    """package extensions
+      |
+      |import (
+      |	"github.com/go-chi/chi/v5"
+      |	"github.com/uptrace/bun"
+      |)
+      |
+      |// Register lets you mount custom routes and middleware on top of the
+      |// spec-derived ones. This file is never overwritten by `spec-to-rest
+      |// compile`; the generated cmd/server/main.go calls Register once after
+      |// mounting all spec-derived handlers.
+      |//
+      |// Example:
+      |//
+      |//	func Register(r chi.Router, db *bun.DB) {
+      |//		r.Get("/custom/ping", func(w http.ResponseWriter, _ *http.Request) {
+      |//			_, _ = w.Write([]byte(`{"status":"ok"}`))
+      |//		})
+      |//	}
+      |func Register(r chi.Router, db *bun.DB) {
+      |	_ = r
+      |	_ = db
+      |}
+      |""".stripMargin
+
+  val ts: String =
+    """import type { Express } from 'express';
+      |
+      |// Register custom routes and middleware on top of the spec-derived ones.
+      |// This file is never overwritten by `spec-to-rest compile`; the generated
+      |// src/app.ts calls registerExtensions once after mounting all spec-derived
+      |// routes.
+      |//
+      |// Example:
+      |//
+      |//   export function registerExtensions(app: Express): void {
+      |//     app.get('/custom/ping', (_req, res) => res.status(200).json({ status: 'ok' }));
+      |//   }
+      |export function registerExtensions(app: Express): void {
+      |  void app;
+      |}
+      |""".stripMargin

--- a/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ExtensionStub.scala
@@ -9,9 +9,10 @@ object ExtensionStub:
       |def register(app: FastAPI) -> None:
       |    '''Register custom routes, middleware, and lifecycle hooks.
       |
-      |    This file is never overwritten by `spec-to-rest compile`. Add user-defined
-      |    endpoints, middleware, or startup/shutdown hooks here; the generated
-      |    `app/main.py` calls this once after mounting all spec-derived routers.
+      |    This file is never overwritten by `spec-to-rest compile`. The generated
+      |    `app/main.py` calls this once BEFORE mounting any spec-derived router,
+      |    so middleware added here wraps every generated endpoint and routes
+      |    declared here take precedence on path collisions.
       |
       |    Example:
       |
@@ -37,10 +38,16 @@ object ExtensionStub:
       |	"github.com/uptrace/bun"
       |)
       |
-      |// Register lets you mount custom routes and middleware on top of the
-      |// spec-derived ones. This file is never overwritten by `spec-to-rest
-      |// compile`; the generated cmd/server/main.go calls Register once after
-      |// mounting all spec-derived handlers.
+      |// Register installs custom routes and middleware. This file is never
+      |// overwritten by `spec-to-rest compile`.
+      |//
+      |// The generated cmd/server/main.go calls Register BEFORE wiring any
+      |// spec-derived route — that ordering is mandatory because chi panics on
+      |// r.Use(...) after a route has been registered ("chi: all middlewares
+      |// must be defined before routes on a mux"). Middleware installed here
+      |// therefore wraps every generated handler, and routes added here take
+      |// precedence on path collisions (chi panics on duplicate registrations,
+      |// so deliberately shadowing a generated path is not supported).
       |//
       |// Example:
       |//
@@ -58,10 +65,14 @@ object ExtensionStub:
   val ts: String =
     """import type { Express } from 'express';
       |
-      |// Register custom routes and middleware on top of the spec-derived ones.
-      |// This file is never overwritten by `spec-to-rest compile`; the generated
-      |// src/app.ts calls registerExtensions once after mounting all spec-derived
-      |// routes.
+      |// registerExtensions installs custom routes and middleware. This file is
+      |// never overwritten by `spec-to-rest compile`.
+      |//
+      |// The generated src/app.ts calls registerExtensions BEFORE mounting any
+      |// spec-derived route, because Express only applies `app.use(...)` to
+      |// routes registered after the call. Middleware installed here therefore
+      |// wraps every generated endpoint, and any extra routes declared here
+      |// take precedence on path collisions.
       |//
       |// Example:
       |//

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -3,6 +3,7 @@ package specrest.codegen.go
 import specrest.codegen.DafnyKernel
 import specrest.codegen.EmitOptions
 import specrest.codegen.EmittedFile
+import specrest.codegen.ExtensionStub
 import specrest.codegen.GoTemplates
 import specrest.codegen.RenderContext
 import specrest.codegen.RouteKind
@@ -202,6 +203,12 @@ object EmitGo:
 
     projectFiles.foreach: (path, tpl) =>
       files += EmittedFile(path, engine.renderAny(tpl, projectScope))
+
+    files += EmittedFile(
+      "internal/extensions/extensions.go",
+      ExtensionStub.go,
+      preserve = true
+    )
 
     // Go links statically: main.go always calls testadmin.Register, so the
     // package must always exist. This is the `!conformance` no-op; testgen

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -2,6 +2,7 @@ package specrest.codegen.python
 
 import specrest.codegen.EmitOptions
 import specrest.codegen.EmittedFile
+import specrest.codegen.ExtensionStub
 import specrest.codegen.RenderContext
 import specrest.codegen.RenderProfile
 import specrest.codegen.RouteKind
@@ -209,6 +210,11 @@ object EmitPython:
     files += EmittedFile("app/schemas/__init__.py", engine.renderAny(templates.schemaInit, ctx))
     files += EmittedFile("app/routers/__init__.py", engine.renderAny(templates.routerInit, ctx))
     files += EmittedFile("app/services/__init__.py", engine.renderAny(templates.serviceInit, ctx))
+    files += EmittedFile(
+      "app/extensions/__init__.py",
+      ExtensionStub.python,
+      preserve = true
+    )
 
     for entity <- ctx.entities do
       val table = ctx.schema.tables.find(_.entityName == entity.entityName)

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -3,6 +3,7 @@ package specrest.codegen.ts
 import specrest.codegen.DafnyKernel
 import specrest.codegen.EmitOptions
 import specrest.codegen.EmittedFile
+import specrest.codegen.ExtensionStub
 import specrest.codegen.RenderContext
 import specrest.codegen.RouteKind
 import specrest.codegen.TemplateEngine
@@ -240,6 +241,12 @@ object EmitTs:
 
     projectTail.foreach: (path, tpl) =>
       files += EmittedFile(path, engine.renderAny(tpl, projectScope))
+
+    files += EmittedFile(
+      "src/extensions/index.ts",
+      ExtensionStub.ts,
+      preserve = true
+    )
 
     files += EmittedFile(
       "openapi.yaml",

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -191,6 +191,7 @@ class EmitTest extends CatsEffectSuite:
         "app/schemas/__init__.py",
         "app/routers/__init__.py",
         "app/services/__init__.py",
+        "app/extensions/__init__.py",
         "app/models/url_mapping.py",
         "app/schemas/url_mapping.py",
         "app/routers/url_mappings.py",

--- a/modules/codegen/src/test/scala/specrest/codegen/ExtensionEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/ExtensionEmitTest.scala
@@ -21,38 +21,55 @@ class ExtensionEmitTest extends CatsEffectSuite:
         assert(ext.preserve, s"$extPath must be marked preserve=true")
         assert(ext.content.nonEmpty, s"$extPath stub should be non-empty")
 
-  test("python main.py imports and calls register_extensions"):
-    SpecFixtures.loadProfiled("url_shortener", "python-fastapi-postgres").map: profiled =>
-      val main = Emit.emitProject(profiled).find(_.path == "app/main.py").get.content
+  private def emittedContent(target: String, path: String): cats.effect.IO[String] =
+    SpecFixtures.loadProfiled("url_shortener", target).map: profiled =>
+      Emit
+        .emitProject(profiled)
+        .find(_.path == path)
+        .map(_.content)
+        .getOrElse(fail(s"$target did not emit $path"))
+
+  test("python main.py imports register_extensions and calls it before include_router"):
+    emittedContent("python-fastapi-postgres", "app/main.py").map: main =>
       assert(
         main.contains("from app.extensions import register as register_extensions"),
         s"main.py must import extension register; got:\n$main"
       )
+      val registerIdx  = main.indexOf("register_extensions(app)")
+      val firstInclude = main.indexOf("app.include_router(")
+      assert(registerIdx >= 0, s"main.py must call register_extensions(app); got:\n$main")
+      assert(firstInclude >= 0, s"main.py must call include_router; got:\n$main")
       assert(
-        main.contains("register_extensions(app)"),
-        s"main.py must call register_extensions(app); got:\n$main"
+        registerIdx < firstInclude,
+        s"register_extensions must run BEFORE include_router (got register@$registerIdx vs include@$firstInclude):\n$main"
       )
 
-  test("go main.go imports extensions package and calls extensions.Register"):
-    SpecFixtures.loadProfiled("url_shortener", "go-chi-postgres").map: profiled =>
-      val main = Emit.emitProject(profiled).find(_.path == "cmd/server/main.go").get.content
+  test("go main.go calls extensions.Register before any spec-derived route registration"):
+    emittedContent("go-chi-postgres", "cmd/server/main.go").map: main =>
       assert(
         main.contains("/internal/extensions\""),
         s"main.go must import extensions package; got:\n$main"
       )
+      val registerIdx = main.indexOf("extensions.Register(r, db)")
+      val healthIdx   = main.indexOf("r.Get(\"/health\"")
+      assert(registerIdx >= 0, s"main.go must call extensions.Register; got:\n$main")
+      assert(healthIdx >= 0, s"main.go must register /health; got:\n$main")
       assert(
-        main.contains("extensions.Register(r, db)"),
-        s"main.go must call extensions.Register; got:\n$main"
+        registerIdx < healthIdx,
+        s"extensions.Register must run BEFORE any route — chi panics on late r.Use (got register@$registerIdx vs /health@$healthIdx):\n$main"
       )
 
-  test("ts app.ts imports and calls registerExtensions"):
-    SpecFixtures.loadProfiled("url_shortener", "ts-express-postgres").map: profiled =>
-      val app = Emit.emitProject(profiled).find(_.path == "src/app.ts").get.content
+  test("ts app.ts calls registerExtensions before mountRoutes"):
+    emittedContent("ts-express-postgres", "src/app.ts").map: app =>
       assert(
         app.contains("from './extensions/index.js'"),
         s"app.ts must import registerExtensions; got:\n$app"
       )
+      val registerIdx = app.indexOf("registerExtensions(app)")
+      val mountIdx    = app.indexOf("mountRoutes(app)")
+      assert(registerIdx >= 0, s"app.ts must call registerExtensions(app); got:\n$app")
+      assert(mountIdx >= 0, s"app.ts must call mountRoutes(app); got:\n$app")
       assert(
-        app.contains("registerExtensions(app)"),
-        s"app.ts must call registerExtensions(app); got:\n$app"
+        registerIdx < mountIdx,
+        s"registerExtensions must run BEFORE mountRoutes so user middleware wraps generated routes (got register@$registerIdx vs mount@$mountIdx):\n$app"
       )

--- a/modules/codegen/src/test/scala/specrest/codegen/ExtensionEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/ExtensionEmitTest.scala
@@ -1,0 +1,58 @@
+package specrest.codegen
+
+import munit.CatsEffectSuite
+import specrest.codegen.testutil.SpecFixtures
+
+class ExtensionEmitTest extends CatsEffectSuite:
+
+  private val cases = List(
+    ("python-fastapi-postgres", "app/extensions/__init__.py"),
+    ("go-chi-postgres", "internal/extensions/extensions.go"),
+    ("ts-express-postgres", "src/extensions/index.ts")
+  )
+
+  cases.foreach: (target, extPath) =>
+    test(s"$target emits the extension scaffold with preserve=true"):
+      SpecFixtures.loadProfiled("url_shortener", target).map: profiled =>
+        val files = Emit.emitProject(profiled)
+        val ext = files.find(_.path == extPath).getOrElse(
+          fail(s"$target did not emit $extPath; got: ${files.map(_.path).mkString(", ")}")
+        )
+        assert(ext.preserve, s"$extPath must be marked preserve=true")
+        assert(ext.content.nonEmpty, s"$extPath stub should be non-empty")
+
+  test("python main.py imports and calls register_extensions"):
+    SpecFixtures.loadProfiled("url_shortener", "python-fastapi-postgres").map: profiled =>
+      val main = Emit.emitProject(profiled).find(_.path == "app/main.py").get.content
+      assert(
+        main.contains("from app.extensions import register as register_extensions"),
+        s"main.py must import extension register; got:\n$main"
+      )
+      assert(
+        main.contains("register_extensions(app)"),
+        s"main.py must call register_extensions(app); got:\n$main"
+      )
+
+  test("go main.go imports extensions package and calls extensions.Register"):
+    SpecFixtures.loadProfiled("url_shortener", "go-chi-postgres").map: profiled =>
+      val main = Emit.emitProject(profiled).find(_.path == "cmd/server/main.go").get.content
+      assert(
+        main.contains("/internal/extensions\""),
+        s"main.go must import extensions package; got:\n$main"
+      )
+      assert(
+        main.contains("extensions.Register(r, db)"),
+        s"main.go must call extensions.Register; got:\n$main"
+      )
+
+  test("ts app.ts imports and calls registerExtensions"):
+    SpecFixtures.loadProfiled("url_shortener", "ts-express-postgres").map: profiled =>
+      val app = Emit.emitProject(profiled).find(_.path == "src/app.ts").get.content
+      assert(
+        app.contains("from './extensions/index.js'"),
+        s"app.ts must import registerExtensions; got:\n$app"
+      )
+      assert(
+        app.contains("registerExtensions(app)"),
+        s"app.ts must call registerExtensions(app); got:\n$app"
+      )

--- a/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
@@ -34,7 +34,7 @@ object PythonFastApiHarness extends HarnessTemplates:
       EmittedFile(FilePaths.PredicatesFile, Templates.predicates(ir)),
       EmittedFile(FilePaths.PytestIniFile, Templates.pytestIni),
       EmittedFile(FilePaths.RedactionFile, Templates.redaction),
-      EmittedFile(FilePaths.StrategiesUserFile, Templates.strategiesUser),
+      EmittedFile(FilePaths.StrategiesUserFile, Templates.strategiesUser, preserve = true),
       EmittedFile(FilePaths.RunConformanceFile, Templates.runConformance)
     )
 

--- a/modules/testgen/src/main/scala/specrest/testgen/GoTestHarness.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoTestHarness.scala
@@ -33,7 +33,7 @@ object GoTestHarness extends HarnessTemplates:
       EmittedFile(GenFile, loadResource(GenFile)),
       EmittedFile(ClientFile, loadResource(ClientFile)),
       EmittedFile(RedactionFile, loadResource(RedactionFile)),
-      EmittedFile(StrategiesUserFile, loadResource(StrategiesUserFile)),
+      EmittedFile(StrategiesUserFile, loadResource(StrategiesUserFile), preserve = true),
       EmittedFile(PredicatesFile, predicates(ir)),
       EmittedFile(MainTestFile, loadResource(MainTestFile)),
       EmittedFile(RunConformanceFile, loadResource(RunConformanceFile))

--- a/modules/testgen/src/main/scala/specrest/testgen/TsVitestHarness.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsVitestHarness.scala
@@ -29,7 +29,7 @@ object TsVitestHarness extends HarnessTemplates:
       EmittedFile(RuntimeFile, loadResource(RuntimeFile)),
       EmittedFile(ClientFile, loadResource(ClientFile)),
       EmittedFile(RedactionFile, loadResource(RedactionFile)),
-      EmittedFile(StrategiesUserFile, loadResource(StrategiesUserFile)),
+      EmittedFile(StrategiesUserFile, loadResource(StrategiesUserFile), preserve = true),
       EmittedFile(PredicatesFile, predicates(ir)),
       EmittedFile(VitestConfigFile, loadResource(VitestConfigFile)),
       EmittedFile(RunConformanceFile, loadResource(RunConformanceFile))


### PR DESCRIPTION
## Summary

Closes the **Strategy-2 half of #62**: every target now emits a single
user-owned extension file that is scaffolded on first `compile` and
preserved on every subsequent run.

| Target                  | File                                  | Hook called from         |
| ----------------------- | ------------------------------------- | ------------------------ |
| `python-fastapi-*`      | \`app/extensions/__init__.py\`        | \`app/main.py\`          |
| \`go-chi-*\`            | \`internal/extensions/extensions.go\` | \`cmd/server/main.go\`   |
| \`ts-express-*\`        | \`src/extensions/index.ts\`           | \`src/app.ts\`           |

\`spec-to-rest compile --dry-run\` reports the file as \`preserve\` on every
run after the first, distinguishing it from \`create\` / \`update\` /
\`unchanged\`.

## Mechanism

\`EmittedFile\` gains a \`preserve: Boolean = false\` field. \`Plan.classify\`
and \`Compile.scala\` consult that flag instead of pattern-matching a single
hardcoded path (\`FilePaths.StrategiesUserFile\`). The hardcoded skip is
removed; the testgen user-strategies files set \`preserve = true\` for the
same effect.

## Strategy-1 (protected regions) — wontfix

In-file \`# === USER CODE START ===\` fences with a splice/merge routine
are intentionally not provided. Rationale in the design discussion: at
9-target scale the maintenance cost compounds (3 comment syntaxes,
fence drift on rename, generator-version churn), and modern codegen tooling
(sqlc, ent, prisma, tRPC, AWS CDK) converged on pure-regeneration +
sidecar-extension namespaces. The sidecar extension file is the
supported mechanism going forward; the per-target docs say so.

## Test plan
- [x] \`sbt test\` — 1077 tests, 0 failures locally
- [x] New \`ExtensionEmitTest\` (6 cases) — extension file emitted with \`preserve=true\`, entrypoints wire the hook
- [x] New \`CliSmokeTest\` cases (3, parametrized over Python/Go/TS) — second \`compile\` invocation does not overwrite a mutated extension file but does overwrite an ordinary generated file
- [x] All 9 golden trees regenerated; existing strict-equality (Python) and subset (Go/TS) tests pass
- [x] \`sbt scalafixAll\` — clean
- [x] Per-target docs updated (Python rewrites the existing \"Extension points\" section that referenced #62; Go and TS get new sections)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds user-owned extension files for Python FastAPI, Go chi, and TS Express that are scaffolded once and preserved across regeneration. Entrypoints call the extension hook before any generated routes so middleware wraps endpoints; docs now clarify that in chi, generated routes overwrite extension routes on collisions.

- **New Features**
  - Added `EmittedFile.preserve` and updated `Plan`/`Compile` to skip overwriting preserved files and show `preserve` in `spec-to-rest compile --dry-run`.
  - Extension scaffolds:
    - Python: `app/extensions/__init__.py` (called from `app/main.py` via `register_extensions(app)`).
    - Go: `internal/extensions/extensions.go` (called from `cmd/server/main.go` via `extensions.Register(r, db)`).
    - TS: `src/extensions/index.ts` (called from `src/app.ts` via `registerExtensions(app)`).
  - Replaced the hardcoded skip for testgen `StrategiesUserFile` with `preserve=true`; docs and tests cover preservation and hook ordering.

- **Bug Fixes**
  - Fixed hook ordering: all entrypoints invoke the extension register function before any spec-derived routes, avoiding chi’s late `r.Use(...)` panic and ensuring middleware wraps generated endpoints.
  - Corrected chi behavior on route collisions: last registration wins, so generated routes overwrite extension routes; updated stubs and target docs.

<sup>Written for commit b5c4594174cb42ccaf0f5ea588c5f1757692f2e2. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/316?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extension points now available across all supported frameworks, enabling users to add custom routes and middleware while preserving changes across regeneration cycles.

* **Documentation**
  * Documented extension mechanisms for Go Chi, Python FastAPI, and TypeScript Express targets, including integration patterns and preservation behavior during recompilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->