### PR TITLE
feat(proofs): lift Path's HTTP-method/status decisions into Isabelle

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -1,6 +1,7 @@
 package specrest.convention
 
 import specrest.ir.*
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 object Path:
@@ -42,9 +43,7 @@ object Path:
             case _              => true
         other += ParamSpec(name, ty, required)
 
-    val isGet = method match
-      case _: GET => true
-      case _      => false
+    val isGet = isGetMethod(method)
     EndpointSpec(
       operationName = classificationOperationName(classification),
       method = method,
@@ -59,9 +58,9 @@ object Path:
       c: operation_classification,
       conv: Option[conventions_decl_full]
   ): http_method =
-    getConvention(conv, classificationOperationName(c), "http_method")
+    val override_ = getConvention(conv, classificationOperationName(c), "http_method")
       .flatMap(parseHttpMethod)
-      .getOrElse(classificationMethod(c))
+    SpecRestGenerated.resolveMethod(override_, classificationMethod(c))
 
   private def resolvePath(
       c: operation_classification,
@@ -139,18 +138,8 @@ object Path:
       conv: Option[conventions_decl_full],
       effective: http_method
   ): Int =
-    getConvention(conv, classificationOperationName(c), "http_status_success") match
-      case Some(s) => s.toInt
-      case None =>
-        val isDelete = effective match
-          case _: DELETE => true
-          case _         => false
-        if isDelete then 204
-        else
-          classificationKind(c) match
-            case _: Create | _: CreateChild => 201
-            case _: Deletea                 => 204
-            case _                          => 200
+    val overrideStr = getConvention(conv, classificationOperationName(c), "http_status_success")
+    SpecRestGenerated.resolveStatus(overrideStr, effective, classificationKind(c)).toInt
 
   def getConvention(
       conv: Option[conventions_decl_full],

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3598,45 +3598,6 @@ object SpecRestGenerated {
     case (p, x :: xs) => p(x) && list_all[A](p, xs)
   }
 
-  def equal_route_kind(x0: route_kind, x1: route_kind): Boolean = (x0, x1) match {
-    case (RkRedirect(), RkOther())    => false
-    case (RkOther(), RkRedirect())    => false
-    case (RkDelete(), RkOther())      => false
-    case (RkOther(), RkDelete())      => false
-    case (RkDelete(), RkRedirect())   => false
-    case (RkRedirect(), RkDelete())   => false
-    case (RkList(), RkOther())        => false
-    case (RkOther(), RkList())        => false
-    case (RkList(), RkRedirect())     => false
-    case (RkRedirect(), RkList())     => false
-    case (RkList(), RkDelete())       => false
-    case (RkDelete(), RkList())       => false
-    case (RkRead(), RkOther())        => false
-    case (RkOther(), RkRead())        => false
-    case (RkRead(), RkRedirect())     => false
-    case (RkRedirect(), RkRead())     => false
-    case (RkRead(), RkDelete())       => false
-    case (RkDelete(), RkRead())       => false
-    case (RkRead(), RkList())         => false
-    case (RkList(), RkRead())         => false
-    case (RkCreate(), RkOther())      => false
-    case (RkOther(), RkCreate())      => false
-    case (RkCreate(), RkRedirect())   => false
-    case (RkRedirect(), RkCreate())   => false
-    case (RkCreate(), RkDelete())     => false
-    case (RkDelete(), RkCreate())     => false
-    case (RkCreate(), RkList())       => false
-    case (RkList(), RkCreate())       => false
-    case (RkCreate(), RkRead())       => false
-    case (RkRead(), RkCreate())       => false
-    case (RkOther(), RkOther())       => true
-    case (RkRedirect(), RkRedirect()) => true
-    case (RkDelete(), RkDelete())     => true
-    case (RkList(), RkList())         => true
-    case (RkRead(), RkRead())         => true
-    case (RkCreate(), RkCreate())     => true
-  }
-
   def equal_nat(m: nat, n: nat): Boolean =
     integer_of_nat(m) == integer_of_nat(n)
 
@@ -3750,6 +3711,15 @@ object SpecRestGenerated {
         }
     }
 
+  def isRkList(x0: route_kind): Boolean = x0 match {
+    case RkList()     => true
+    case RkCreate()   => false
+    case RkRead()     => false
+    case RkDelete()   => false
+    case RkRedirect() => false
+    case RkOther()    => false
+  }
+
   def classify(
       method: http_method,
       status: int,
@@ -3759,7 +3729,7 @@ object SpecRestGenerated {
   ): route_kind = {
     val shape =
       classifyShape(method, status, pathParamCount, kind): route_kind;
-    equal_route_kind(shape, RkList()) && hasFilterInputs match {
+    isRkList(shape) && hasFilterInputs match {
       case true  => RkOther()
       case false => shape
     }
@@ -4313,35 +4283,13 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, vb, vc) => None
   }
 
-  def equal_http_method(x0: http_method, x1: http_method): Boolean = (x0, x1) match {
-    case (PATCH(), DELETE())  => false
-    case (DELETE(), PATCH())  => false
-    case (PUT(), DELETE())    => false
-    case (DELETE(), PUT())    => false
-    case (PUT(), PATCH())     => false
-    case (PATCH(), PUT())     => false
-    case (POST(), DELETE())   => false
-    case (DELETE(), POST())   => false
-    case (POST(), PATCH())    => false
-    case (PATCH(), POST())    => false
-    case (POST(), PUT())      => false
-    case (PUT(), POST())      => false
-    case (GET(), DELETE())    => false
-    case (DELETE(), GET())    => false
-    case (GET(), PATCH())     => false
-    case (PATCH(), GET())     => false
-    case (GET(), PUT())       => false
-    case (PUT(), GET())       => false
-    case (GET(), POST())      => false
-    case (POST(), GET())      => false
-    case (DELETE(), DELETE()) => true
-    case (PATCH(), PATCH())   => true
-    case (PUT(), PUT())       => true
-    case (POST(), POST())     => true
-    case (GET(), GET())       => true
+  def isGetMethod(x0: http_method): Boolean = x0 match {
+    case GET()    => true
+    case POST()   => false
+    case PUT()    => false
+    case PATCH()  => false
+    case DELETE() => false
   }
-
-  def isGetMethod(m: http_method): Boolean = equal_http_method(m, GET())
 
   def indexColumns(x0: index_spec): List[String] = x0 match {
     case IndexSpec(uu, cs, uv, uw) => cs
@@ -4436,112 +4384,27 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => None
   }
 
-  def equal_operation_kind(x0: operation_kind, x1: operation_kind): Boolean =
-    (x0, x1) match {
-      case (BatchMutation(), Transition())    => false
-      case (Transition(), BatchMutation())    => false
-      case (SideEffect(), Transition())       => false
-      case (Transition(), SideEffect())       => false
-      case (SideEffect(), BatchMutation())    => false
-      case (BatchMutation(), SideEffect())    => false
-      case (FilteredRead(), Transition())     => false
-      case (Transition(), FilteredRead())     => false
-      case (FilteredRead(), BatchMutation())  => false
-      case (BatchMutation(), FilteredRead())  => false
-      case (FilteredRead(), SideEffect())     => false
-      case (SideEffect(), FilteredRead())     => false
-      case (CreateChild(), Transition())      => false
-      case (Transition(), CreateChild())      => false
-      case (CreateChild(), BatchMutation())   => false
-      case (BatchMutation(), CreateChild())   => false
-      case (CreateChild(), SideEffect())      => false
-      case (SideEffect(), CreateChild())      => false
-      case (CreateChild(), FilteredRead())    => false
-      case (FilteredRead(), CreateChild())    => false
-      case (Deletea(), Transition())          => false
-      case (Transition(), Deletea())          => false
-      case (Deletea(), BatchMutation())       => false
-      case (BatchMutation(), Deletea())       => false
-      case (Deletea(), SideEffect())          => false
-      case (SideEffect(), Deletea())          => false
-      case (Deletea(), FilteredRead())        => false
-      case (FilteredRead(), Deletea())        => false
-      case (Deletea(), CreateChild())         => false
-      case (CreateChild(), Deletea())         => false
-      case (PartialUpdate(), Transition())    => false
-      case (Transition(), PartialUpdate())    => false
-      case (PartialUpdate(), BatchMutation()) => false
-      case (BatchMutation(), PartialUpdate()) => false
-      case (PartialUpdate(), SideEffect())    => false
-      case (SideEffect(), PartialUpdate())    => false
-      case (PartialUpdate(), FilteredRead())  => false
-      case (FilteredRead(), PartialUpdate())  => false
-      case (PartialUpdate(), CreateChild())   => false
-      case (CreateChild(), PartialUpdate())   => false
-      case (PartialUpdate(), Deletea())       => false
-      case (Deletea(), PartialUpdate())       => false
-      case (Replace(), Transition())          => false
-      case (Transition(), Replace())          => false
-      case (Replace(), BatchMutation())       => false
-      case (BatchMutation(), Replace())       => false
-      case (Replace(), SideEffect())          => false
-      case (SideEffect(), Replace())          => false
-      case (Replace(), FilteredRead())        => false
-      case (FilteredRead(), Replace())        => false
-      case (Replace(), CreateChild())         => false
-      case (CreateChild(), Replace())         => false
-      case (Replace(), Deletea())             => false
-      case (Deletea(), Replace())             => false
-      case (Replace(), PartialUpdate())       => false
-      case (PartialUpdate(), Replace())       => false
-      case (Read(), Transition())             => false
-      case (Transition(), Read())             => false
-      case (Read(), BatchMutation())          => false
-      case (BatchMutation(), Read())          => false
-      case (Read(), SideEffect())             => false
-      case (SideEffect(), Read())             => false
-      case (Read(), FilteredRead())           => false
-      case (FilteredRead(), Read())           => false
-      case (Read(), CreateChild())            => false
-      case (CreateChild(), Read())            => false
-      case (Read(), Deletea())                => false
-      case (Deletea(), Read())                => false
-      case (Read(), PartialUpdate())          => false
-      case (PartialUpdate(), Read())          => false
-      case (Read(), Replace())                => false
-      case (Replace(), Read())                => false
-      case (Create(), Transition())           => false
-      case (Transition(), Create())           => false
-      case (Create(), BatchMutation())        => false
-      case (BatchMutation(), Create())        => false
-      case (Create(), SideEffect())           => false
-      case (SideEffect(), Create())           => false
-      case (Create(), FilteredRead())         => false
-      case (FilteredRead(), Create())         => false
-      case (Create(), CreateChild())          => false
-      case (CreateChild(), Create())          => false
-      case (Create(), Deletea())              => false
-      case (Deletea(), Create())              => false
-      case (Create(), PartialUpdate())        => false
-      case (PartialUpdate(), Create())        => false
-      case (Create(), Replace())              => false
-      case (Replace(), Create())              => false
-      case (Create(), Read())                 => false
-      case (Read(), Create())                 => false
-      case (Transition(), Transition())       => true
-      case (BatchMutation(), BatchMutation()) => true
-      case (SideEffect(), SideEffect())       => true
-      case (FilteredRead(), FilteredRead())   => true
-      case (CreateChild(), CreateChild())     => true
-      case (Deletea(), Deletea())             => true
-      case (PartialUpdate(), PartialUpdate()) => true
-      case (Replace(), Replace())             => true
-      case (Read(), Read())                   => true
-      case (Create(), Create())               => true
-    }
+  def isDeleteKind(x0: operation_kind): Boolean = x0 match {
+    case Deletea()       => true
+    case Create()        => false
+    case Read()          => false
+    case Replace()       => false
+    case PartialUpdate() => false
+    case CreateChild()   => false
+    case FilteredRead()  => false
+    case SideEffect()    => false
+    case BatchMutation() => false
+    case Transition()    => false
+  }
 
-  def isDeleteKind(k: operation_kind): Boolean =
-    equal_operation_kind(k, Deletea())
+  def isRkCreate(x0: route_kind): Boolean = x0 match {
+    case RkCreate()   => true
+    case RkRead()     => false
+    case RkList()     => false
+    case RkDelete()   => false
+    case RkRedirect() => false
+    case RkOther()    => false
+  }
 
   def columnSqlType(x0: column_spec): String = x0 match {
     case ColumnSpec(uu, t, uv, uw) => t
@@ -4872,10 +4735,26 @@ object SpecRestGenerated {
       case (Some(n), (p, (f, w))) => (n :: p, (f, w))
     }
 
-  def isCreateLikeKind(k: operation_kind): Boolean =
-    equal_operation_kind(k, Create()) || equal_operation_kind(k, CreateChild())
+  def isCreateLikeKind(x0: operation_kind): Boolean = x0 match {
+    case Create()        => true
+    case CreateChild()   => true
+    case Read()          => false
+    case Replace()       => false
+    case PartialUpdate() => false
+    case Deletea()       => false
+    case FilteredRead()  => false
+    case SideEffect()    => false
+    case BatchMutation() => false
+    case Transition()    => false
+  }
 
-  def isDeleteMethod(m: http_method): Boolean = equal_http_method(m, DELETE())
+  def isDeleteMethod(x0: http_method): Boolean = x0 match {
+    case DELETE() => true
+    case GET()    => false
+    case POST()   => false
+    case PUT()    => false
+    case PATCH()  => false
+  }
 
   def defaultStatus(mth: http_method, knd: operation_kind): String =
     isDeleteMethod(mth) match {
@@ -4924,6 +4803,15 @@ object SpecRestGenerated {
 
   def downList(ops: List[migration_op]): List[migration_op] =
     rev[migration_op](map[migration_op, migration_op]((a: migration_op) => inverseOp(a), ops))
+
+  def isStubShape(x0: route_kind): Boolean = x0 match {
+    case RkRedirect() => true
+    case RkOther()    => true
+    case RkCreate()   => false
+    case RkRead()     => false
+    case RkList()     => false
+    case RkDelete()   => false
+  }
 
   def columnNullable(x0: column_spec): Boolean = x0 match {
     case ColumnSpec(uu, uv, n, uw) => n
@@ -5583,9 +5471,7 @@ object SpecRestGenerated {
   }
 
   def isFailLoudStub(hasDafnyMethod: Boolean, effectiveKind: route_kind): Boolean =
-    !hasDafnyMethod &&
-      (equal_route_kind(effectiveKind, RkRedirect()) ||
-        equal_route_kind(effectiveKind, RkOther()))
+    !hasDafnyMethod && isStubShape(effectiveKind)
 
   def indexFilterClause(x0: index_spec): Option[String] = x0 match {
     case IndexSpec(uu, uv, uw, f) => f
@@ -8014,7 +7900,7 @@ object SpecRestGenerated {
   }
 
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
-    equal_route_kind(initial, RkCreate()) && !matchesCreateShape match {
+    isRkCreate(initial) && !matchesCreateShape match {
       case true  => RkOther()
       case false => initial
     }
@@ -8033,7 +7919,7 @@ object SpecRestGenerated {
       bodyParamNames: List[String],
       entityNonIdColumns: List[String]
   ): Boolean =
-    equal_route_kind(classification, RkCreate()) &&
+    isRkCreate(classification) &&
       (distinct[String](bodyParamNames) &&
         equal_set[String](seta[String](bodyParamNames), seta[String](entityNonIdColumns)))
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4313,6 +4313,36 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, vb, vc) => None
   }
 
+  def equal_http_method(x0: http_method, x1: http_method): Boolean = (x0, x1) match {
+    case (PATCH(), DELETE())  => false
+    case (DELETE(), PATCH())  => false
+    case (PUT(), DELETE())    => false
+    case (DELETE(), PUT())    => false
+    case (PUT(), PATCH())     => false
+    case (PATCH(), PUT())     => false
+    case (POST(), DELETE())   => false
+    case (DELETE(), POST())   => false
+    case (POST(), PATCH())    => false
+    case (PATCH(), POST())    => false
+    case (POST(), PUT())      => false
+    case (PUT(), POST())      => false
+    case (GET(), DELETE())    => false
+    case (DELETE(), GET())    => false
+    case (GET(), PATCH())     => false
+    case (PATCH(), GET())     => false
+    case (GET(), PUT())       => false
+    case (PUT(), GET())       => false
+    case (GET(), POST())      => false
+    case (POST(), GET())      => false
+    case (DELETE(), DELETE()) => true
+    case (PATCH(), PATCH())   => true
+    case (PUT(), PUT())       => true
+    case (POST(), POST())     => true
+    case (GET(), GET())       => true
+  }
+
+  def isGetMethod(m: http_method): Boolean = equal_http_method(m, GET())
+
   def indexColumns(x0: index_spec): List[String] = x0 match {
     case IndexSpec(uu, cs, uv, uw) => cs
   }
@@ -4405,6 +4435,113 @@ object SpecRestGenerated {
     case MatchesF(v, va, vb)              => None
     case IdentifierF(v, va)               => None
   }
+
+  def equal_operation_kind(x0: operation_kind, x1: operation_kind): Boolean =
+    (x0, x1) match {
+      case (BatchMutation(), Transition())    => false
+      case (Transition(), BatchMutation())    => false
+      case (SideEffect(), Transition())       => false
+      case (Transition(), SideEffect())       => false
+      case (SideEffect(), BatchMutation())    => false
+      case (BatchMutation(), SideEffect())    => false
+      case (FilteredRead(), Transition())     => false
+      case (Transition(), FilteredRead())     => false
+      case (FilteredRead(), BatchMutation())  => false
+      case (BatchMutation(), FilteredRead())  => false
+      case (FilteredRead(), SideEffect())     => false
+      case (SideEffect(), FilteredRead())     => false
+      case (CreateChild(), Transition())      => false
+      case (Transition(), CreateChild())      => false
+      case (CreateChild(), BatchMutation())   => false
+      case (BatchMutation(), CreateChild())   => false
+      case (CreateChild(), SideEffect())      => false
+      case (SideEffect(), CreateChild())      => false
+      case (CreateChild(), FilteredRead())    => false
+      case (FilteredRead(), CreateChild())    => false
+      case (Deletea(), Transition())          => false
+      case (Transition(), Deletea())          => false
+      case (Deletea(), BatchMutation())       => false
+      case (BatchMutation(), Deletea())       => false
+      case (Deletea(), SideEffect())          => false
+      case (SideEffect(), Deletea())          => false
+      case (Deletea(), FilteredRead())        => false
+      case (FilteredRead(), Deletea())        => false
+      case (Deletea(), CreateChild())         => false
+      case (CreateChild(), Deletea())         => false
+      case (PartialUpdate(), Transition())    => false
+      case (Transition(), PartialUpdate())    => false
+      case (PartialUpdate(), BatchMutation()) => false
+      case (BatchMutation(), PartialUpdate()) => false
+      case (PartialUpdate(), SideEffect())    => false
+      case (SideEffect(), PartialUpdate())    => false
+      case (PartialUpdate(), FilteredRead())  => false
+      case (FilteredRead(), PartialUpdate())  => false
+      case (PartialUpdate(), CreateChild())   => false
+      case (CreateChild(), PartialUpdate())   => false
+      case (PartialUpdate(), Deletea())       => false
+      case (Deletea(), PartialUpdate())       => false
+      case (Replace(), Transition())          => false
+      case (Transition(), Replace())          => false
+      case (Replace(), BatchMutation())       => false
+      case (BatchMutation(), Replace())       => false
+      case (Replace(), SideEffect())          => false
+      case (SideEffect(), Replace())          => false
+      case (Replace(), FilteredRead())        => false
+      case (FilteredRead(), Replace())        => false
+      case (Replace(), CreateChild())         => false
+      case (CreateChild(), Replace())         => false
+      case (Replace(), Deletea())             => false
+      case (Deletea(), Replace())             => false
+      case (Replace(), PartialUpdate())       => false
+      case (PartialUpdate(), Replace())       => false
+      case (Read(), Transition())             => false
+      case (Transition(), Read())             => false
+      case (Read(), BatchMutation())          => false
+      case (BatchMutation(), Read())          => false
+      case (Read(), SideEffect())             => false
+      case (SideEffect(), Read())             => false
+      case (Read(), FilteredRead())           => false
+      case (FilteredRead(), Read())           => false
+      case (Read(), CreateChild())            => false
+      case (CreateChild(), Read())            => false
+      case (Read(), Deletea())                => false
+      case (Deletea(), Read())                => false
+      case (Read(), PartialUpdate())          => false
+      case (PartialUpdate(), Read())          => false
+      case (Read(), Replace())                => false
+      case (Replace(), Read())                => false
+      case (Create(), Transition())           => false
+      case (Transition(), Create())           => false
+      case (Create(), BatchMutation())        => false
+      case (BatchMutation(), Create())        => false
+      case (Create(), SideEffect())           => false
+      case (SideEffect(), Create())           => false
+      case (Create(), FilteredRead())         => false
+      case (FilteredRead(), Create())         => false
+      case (Create(), CreateChild())          => false
+      case (CreateChild(), Create())          => false
+      case (Create(), Deletea())              => false
+      case (Deletea(), Create())              => false
+      case (Create(), PartialUpdate())        => false
+      case (PartialUpdate(), Create())        => false
+      case (Create(), Replace())              => false
+      case (Replace(), Create())              => false
+      case (Create(), Read())                 => false
+      case (Read(), Create())                 => false
+      case (Transition(), Transition())       => true
+      case (BatchMutation(), BatchMutation()) => true
+      case (SideEffect(), SideEffect())       => true
+      case (FilteredRead(), FilteredRead())   => true
+      case (CreateChild(), CreateChild())     => true
+      case (Deletea(), Deletea())             => true
+      case (PartialUpdate(), PartialUpdate()) => true
+      case (Replace(), Replace())             => true
+      case (Read(), Read())                   => true
+      case (Create(), Create())               => true
+    }
+
+  def isDeleteKind(k: operation_kind): Boolean =
+    equal_operation_kind(k, Deletea())
 
   def columnSqlType(x0: column_spec): String = x0 match {
     case ColumnSpec(uu, t, uv, uw) => t
@@ -4733,6 +4870,35 @@ object SpecRestGenerated {
     (x0, c) match {
       case (None, c)              => c
       case (Some(n), (p, (f, w))) => (n :: p, (f, w))
+    }
+
+  def isCreateLikeKind(k: operation_kind): Boolean =
+    equal_operation_kind(k, Create()) || equal_operation_kind(k, CreateChild())
+
+  def isDeleteMethod(m: http_method): Boolean = equal_http_method(m, DELETE())
+
+  def defaultStatus(mth: http_method, knd: operation_kind): String =
+    isDeleteMethod(mth) match {
+      case true => "204"
+      case false => isCreateLikeKind(knd) match {
+          case true => "201"
+          case false => isDeleteKind(knd) match {
+              case true  => "204"
+              case false => "200"
+            }
+        }
+    }
+
+  def resolveMethod(overridea: Option[http_method], fallback: http_method): http_method =
+    overridea match {
+      case None    => fallback
+      case Some(m) => m
+    }
+
+  def resolveStatus(overridea: Option[String], mth: http_method, knd: operation_kind): String =
+    overridea match {
+      case None    => defaultStatus(mth, knd)
+      case Some(s) => s
     }
 
   def inverseOp(x0: migration_op): migration_op = x0 match {

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -246,7 +246,6 @@ export_code
     defaultStatus
     resolveStatus
     resolveMethod
-    isGetMethod
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -239,6 +239,14 @@ export_code
     classificationTargetEntity
     classificationStrategy
     classificationSignals
+    isGetMethod
+    isDeleteMethod
+    isCreateLikeKind
+    isDeleteKind
+    defaultStatus
+    resolveStatus
+    resolveMethod
+    isGetMethod
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/Methods.thy
+++ b/proofs/isabelle/SpecRest/Methods.thy
@@ -23,6 +23,53 @@ definition parseHttpMethod :: "String.literal \<Rightarrow> http_method option" 
     else if s = STR ''DELETE'' then Some DELETE
     else None)"
 
-lemmas parseHttpMethod_code [code] = parseHttpMethod_def
+text \<open>HTTP-method / status / GET-classification decisions lifted from
+  \<open>specrest.convention.Path\<close>. Convention-rule lookups happen in Scala
+  (rules carry mixed-type literal values that don't fit cleanly in HOL);
+  the lifted decisions take the parsed override (\<open>Option\<close>) plus the
+  classification's fallback method and kind, and produce the effective
+  values used by codegen + testgen + openapi.
+
+  Status codes are returned as \<open>String.literal\<close> (Scala parses to Int at
+  the boundary) — sidesteps the polymorphic-numeral extraction issue
+  with HOL nat/int literals.\<close>
+
+definition isGetMethod :: "http_method \<Rightarrow> bool" where
+  "isGetMethod m = (m = GET)"
+
+definition isDeleteMethod :: "http_method \<Rightarrow> bool" where
+  "isDeleteMethod m = (m = DELETE)"
+
+definition isCreateLikeKind :: "operation_kind \<Rightarrow> bool" where
+  "isCreateLikeKind k = (k = Create \<or> k = CreateChild)"
+
+definition isDeleteKind :: "operation_kind \<Rightarrow> bool" where
+  "isDeleteKind k = (k = Delete)"
+
+definition defaultStatus :: "http_method \<Rightarrow> operation_kind \<Rightarrow> String.literal" where
+  "defaultStatus mth knd = (
+    if isDeleteMethod mth then STR ''204''
+    else if isCreateLikeKind knd then STR ''201''
+    else if isDeleteKind knd then STR ''204''
+    else STR ''200'')"
+
+definition resolveStatus ::
+  "String.literal option \<Rightarrow> http_method \<Rightarrow> operation_kind \<Rightarrow> String.literal"
+where
+  "resolveStatus override mth knd = (
+    case override of Some s \<Rightarrow> s | None \<Rightarrow> defaultStatus mth knd)"
+
+definition resolveMethod :: "http_method option \<Rightarrow> http_method \<Rightarrow> http_method" where
+  "resolveMethod override fallback = (
+    case override of Some m \<Rightarrow> m | None \<Rightarrow> fallback)"
+
+lemmas parseHttpMethod_code [code]    = parseHttpMethod_def
+lemmas isGetMethod_code [code]        = isGetMethod_def
+lemmas isDeleteMethod_code [code]     = isDeleteMethod_def
+lemmas isCreateLikeKind_code [code]   = isCreateLikeKind_def
+lemmas isDeleteKind_code [code]       = isDeleteKind_def
+lemmas defaultStatus_code [code]      = defaultStatus_def
+lemmas resolveStatus_code [code]      = resolveStatus_def
+lemmas resolveMethod_code [code]      = resolveMethod_def
 
 end

--- a/proofs/isabelle/SpecRest/Methods.thy
+++ b/proofs/isabelle/SpecRest/Methods.thy
@@ -34,17 +34,22 @@ text \<open>HTTP-method / status / GET-classification decisions lifted from
   the boundary) — sidesteps the polymorphic-numeral extraction issue
   with HOL nat/int literals.\<close>
 
-definition isGetMethod :: "http_method \<Rightarrow> bool" where
-  "isGetMethod m = (m = GET)"
+fun isGetMethod :: "http_method \<Rightarrow> bool" where
+  "isGetMethod GET = True"
+| "isGetMethod _   = False"
 
-definition isDeleteMethod :: "http_method \<Rightarrow> bool" where
-  "isDeleteMethod m = (m = DELETE)"
+fun isDeleteMethod :: "http_method \<Rightarrow> bool" where
+  "isDeleteMethod DELETE = True"
+| "isDeleteMethod _      = False"
 
-definition isCreateLikeKind :: "operation_kind \<Rightarrow> bool" where
-  "isCreateLikeKind k = (k = Create \<or> k = CreateChild)"
+fun isCreateLikeKind :: "operation_kind \<Rightarrow> bool" where
+  "isCreateLikeKind Create      = True"
+| "isCreateLikeKind CreateChild = True"
+| "isCreateLikeKind _           = False"
 
-definition isDeleteKind :: "operation_kind \<Rightarrow> bool" where
-  "isDeleteKind k = (k = Delete)"
+fun isDeleteKind :: "operation_kind \<Rightarrow> bool" where
+  "isDeleteKind Delete = True"
+| "isDeleteKind _      = False"
 
 definition defaultStatus :: "http_method \<Rightarrow> operation_kind \<Rightarrow> String.literal" where
   "defaultStatus mth knd = (
@@ -64,10 +69,10 @@ definition resolveMethod :: "http_method option \<Rightarrow> http_method \<Righ
     case override of Some m \<Rightarrow> m | None \<Rightarrow> fallback)"
 
 lemmas parseHttpMethod_code [code]    = parseHttpMethod_def
-lemmas isGetMethod_code [code]        = isGetMethod_def
-lemmas isDeleteMethod_code [code]     = isDeleteMethod_def
-lemmas isCreateLikeKind_code [code]   = isCreateLikeKind_def
-lemmas isDeleteKind_code [code]       = isDeleteKind_def
+lemmas isGetMethod_code [code]        = isGetMethod.simps
+lemmas isDeleteMethod_code [code]     = isDeleteMethod.simps
+lemmas isCreateLikeKind_code [code]   = isCreateLikeKind.simps
+lemmas isDeleteKind_code [code]       = isDeleteKind.simps
 lemmas defaultStatus_code [code]      = defaultStatus_def
 lemmas resolveStatus_code [code]      = resolveStatus_def
 lemmas resolveMethod_code [code]      = resolveMethod_def

--- a/proofs/isabelle/SpecRest/RouteKind.thy
+++ b/proofs/isabelle/SpecRest/RouteKind.thy
@@ -33,12 +33,25 @@ text \<open>The \<open>list\<close> route returns every row and takes no argumen
   filter input would be silently dropped. Downgrade to \<open>RkOther\<close> (the fail-loud
   stub) when the operation has body or query parameters.\<close>
 
+fun isRkList :: "route_kind \<Rightarrow> bool" where
+  "isRkList RkList = True"
+| "isRkList _      = False"
+
+fun isRkCreate :: "route_kind \<Rightarrow> bool" where
+  "isRkCreate RkCreate = True"
+| "isRkCreate _        = False"
+
+fun isStubShape :: "route_kind \<Rightarrow> bool" where
+  "isStubShape RkRedirect = True"
+| "isStubShape RkOther    = True"
+| "isStubShape _          = False"
+
 definition classify ::
   "http_method \<Rightarrow> int \<Rightarrow> nat \<Rightarrow> operation_kind \<Rightarrow> bool \<Rightarrow> route_kind"
 where
   "classify method status pathParamCount kind hasFilterInputs = (
     let shape = classifyShape method status pathParamCount kind in
-    if shape = RkList \<and> hasFilterInputs then RkOther else shape)"
+    if isRkList shape \<and> hasFilterInputs then RkOther else shape)"
 
 text \<open>The effective route kind: downgrades a \<open>RkCreate\<close> whose request body
   doesn't match the entity's non-id columns to the fail-loud stub.\<close>
@@ -47,12 +60,12 @@ definition effectiveRouteKind ::
   "route_kind \<Rightarrow> bool \<Rightarrow> route_kind"
 where
   "effectiveRouteKind initial matchesCreateShape = (
-    if initial = RkCreate \<and> \<not> matchesCreateShape then RkOther else initial)"
+    if isRkCreate initial \<and> \<not> matchesCreateShape then RkOther else initial)"
 
 text \<open>Predicate for matchesEntityCreateShape: the operation classifies as Create
-  and its body params exactly cover the entity's non-id columns.\<close>
+  and its body params exactly cover the entity's non-id columns.
 
-text \<open>Set-equality plus distinctness on the body-param side rules out the
+  Set-equality plus distinctness on the body-param side rules out the
   duplicate-name pathology where \<open>[a, a]\<close> would otherwise match \<open>[a, b]\<close>
   via length+forall (length 2, every element in \<open>{a,b\<close>}). The entity
   column list is derived from a \<open>Set.toList\<close> on the Scala side so it is
@@ -62,7 +75,7 @@ definition matchesCreateShape ::
   "route_kind \<Rightarrow> String.literal list \<Rightarrow> String.literal list \<Rightarrow> bool"
 where
   "matchesCreateShape classification bodyParamNames entityNonIdColumns = (
-    classification = RkCreate
+    isRkCreate classification
     \<and> distinct bodyParamNames
     \<and> set bodyParamNames = set entityNonIdColumns)"
 
@@ -75,9 +88,12 @@ definition isFailLoudStub ::
   "bool \<Rightarrow> route_kind \<Rightarrow> bool"
 where
   "isFailLoudStub hasDafnyMethod effectiveKind =
-    (\<not> hasDafnyMethod \<and> (effectiveKind = RkRedirect \<or> effectiveKind = RkOther))"
+    (\<not> hasDafnyMethod \<and> isStubShape effectiveKind)"
 
 lemmas isRedirectStatus_code [code]   = isRedirectStatus_def
+lemmas isRkList_code [code]           = isRkList.simps
+lemmas isRkCreate_code [code]         = isRkCreate.simps
+lemmas isStubShape_code [code]        = isStubShape.simps
 lemmas classifyShape_code [code]      = classifyShape_def
 lemmas classify_code [code]           = classify_def
 lemmas effectiveRouteKind_code [code] = effectiveRouteKind_def


### PR DESCRIPTION
## Summary

Lifts the HTTP-method, success-status, and GET-routing decisions from `specrest.convention.Path` into Isabelle proofs. The convention layer's routing intelligence now has the **same proven oracle for status codes and method overrides** that codegen + testgen + openapi can share.

Builds on PR #319 (Classify + HttpMethod + OperationKind lift) and PR #320 (camelCase function naming).

## What's now proven

Defined in `Methods.thy` (co-located with `http_method` / `operation_kind`):

- `isGetMethod(m) := m = GET`
- `isDeleteMethod(m) := m = DELETE`
- `isCreateLikeKind(k) := k = Create ∨ k = CreateChild`
- `isDeleteKind(k) := k = Delete`
- `defaultStatus(method, kind) : String.literal` — the M5/M1/etc. status table: DELETE → "204"; Create/CreateChild → "201"; Delete kind → "204"; else "200"
- `resolveStatus(override, method, kind) : String.literal` — convention override > default
- `resolveMethod(override, fallback) : http_method` — `parseHttpMethod`-parsed override > classification fallback

## Why status codes are String.literal

Tried `int` and `nat` returns first; Isabelle's code generator raises **"Illegal fixed variable 'a — defaultStatus"** for any int/nat literal in the body, even with explicit `:: nat` annotations and helper constants like `definition statusOk :: nat where "statusOk = 200"`. Diagnosed in 4 build cycles — the polymorphic-numeral inference defeats the export-time `'a` resolution check.

`String.literal` sidesteps it entirely: status codes flow as strings through the proven layer and Scala parses `.toInt` at the boundary. Behavior unchanged.

## Why everything is in Methods.thy (not a new Endpoints.thy)

Originally created `Endpoints.thy` (imports `Methods + Classify + RouteKind`). Even simple definitions like `isGetMethod m = (m = GET)` failed `export_code` with the same "Illegal fixed variable 'a" error there. Moved a single definition into `Methods.thy` directly — exported cleanly. Some interaction in `Endpoints.thy`'s transitive imports (via `Classify` → `IR_Analysis` → `IR_Lower`) pollutes the type-class resolution context. Co-locating with the source datatypes avoids it.

Saved as `feedback_isabelle_export_theory_pollution.md` for future lifts: define close to source datatypes, avoid deep-import-chain theories for code-generated functions.

## Path.scala wiring

The hand-written `Path.resolveMethod` / `resolveStatus` / `isGet`-pattern-match now delegate to the lifted versions; the convention-rule string lookup (which extracts raw String values from `ConventionRuleFull`) and URL templating (string interpolation) stay in Scala.

## Commit

- `9d0cf70` — feat(proofs): lift Path's HTTP-method/status decisions into Isabelle

## Test plan

- [x] `isabelle build` green (2m00s, well under cap)
- [x] No `sorry` / `oops`
- [x] `sbt clean; test` — 1,120 / 1,120 pass, 1 skipped (pre-existing)
- [x] Scalafix clean
- [x] No goldens needed regen (output is byte-identical — the status codes were always `200`/`201`/`204` and the convention override path is unchanged)

## What's still in Scala

These parts of Path.scala stay in Scala because they involve string manipulation that doesn't fit HOL cleanly:

- `autoDerivePath` — URL template assembly (heavy string interp)
- `extractActionVerb`, `extractPathParamNames` — string ops + regex
- `findIdParam` — uses `name.endsWith("_id")` which would need a helper
- `getConvention` + `exprToString` — `BigInt.toString` for IntLit conversion

A separate PR could lift these (the structural ones — `findIdParam` is small and doable with a `String.literal` suffix helper) but the value-per-effort is much lower than the routing decisions just lifted.

## After this PR

The full route-classification + endpoint-derivation pipeline is now from proofs:
```
op.endpoint.method : http_method          (extracted)
op.kind            : operation_kind       (extracted)
        ↓
classify → operation_classification       (extracted)
        ↓
resolveMethod / resolveStatus / isGet     (extracted, THIS PR)
        ↓
EndpointSpec
```

Three components (codegen, testgen, openapi) consume one proven oracle end-to-end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves HTTP method selection, success status resolution, and GET checks from `specrest.convention.Path` into Isabelle, and replaces `=` checks with pattern-matching predicates to slim generated code. Behavior is unchanged; codegen, testgen, and OpenAPI now share one verified oracle.

- **New Features**
  - Exported proven functions: `isGetMethod`, `isDeleteMethod`, `isCreateLikeKind`, `isDeleteKind`, `defaultStatus`, `resolveStatus`, `resolveMethod`.
  - Default status: DELETE → "204"; Create/CreateChild → "201"; Delete kind → "204"; else → "200".

- **Refactors**
  - `Path.scala` delegates to `SpecRestGenerated.resolveMethod`/`resolveStatus` and `isGetMethod`.
  - Status codes flow as `String.literal`; Scala parses to `Int`.
  - Replaced `=` comparisons with pattern-matching predicates and added `isRkList`/`isRkCreate`/`isStubShape`; removes generated `equal_*` tables and reduces `SpecRestGenerated.scala` size.
  - Removed duplicate `isGetMethod` from `export_code` list; no behavior change or generated diff.

<sup>Written for commit 1dca45841a711c994e7b9faddbddb1e2d777f0e5. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/321?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored HTTP method and status code resolution logic to centralize helper functions and improve code maintainability. These internal changes consolidate decision-making for HTTP method classification and default status code selection without affecting user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->