### PR TITLE
feat(proofs): lift findEnumValuesInType (OpenApi.Constraints type-walk)

### DIFF
--- a/docs/content/docs/design/isabelle-proofs.mdx
+++ b/docs/content/docs/design/isabelle-proofs.mdx
@@ -380,6 +380,76 @@ thereafter — that's how you spot the hotspot. A typical iteration loop:
 Cap the wait at 5–6 minutes per iteration — anything longer and you're
 optimizing the wrong thing.
 
+## Passing IR context across the Scala/Isabelle boundary
+
+Lifted IR walkers (`aliasRefinements`, `findEnumValuesInType`, future
+`resolveType`) take alias and enum declarations as association lists:
+
+```text
+type_synonym alias_map = "(String.literal × type_alias_decl_full) list"
+type_synonym enum_map  = "(String.literal × enum_decl_full) list"
+```
+
+This is **deliberate**, not lazy. Isabelle's only code-extractable
+finite-map type is the abstract `Mapping`, and we don't currently wire
+it up to `RBT_Mapping` (the O(log n) red-black tree backing). Until we
+do, the walker uses `map_of` on a list — O(n) per lookup. The Scala
+caller's job is to make sure that lookup happens against a **pre-built
+list, not a re-derived one**.
+
+That's what `specrest.ir.IrIndex` is for. Built once per
+`ServiceIRFull` and cached in a weak-keyed map, it carries:
+
+```scala
+final case class IrIndex(
+    entities: List[EntityDeclFull],
+    enums: List[EnumDeclFull],
+    aliases: List[TypeAliasDeclFull],
+    entityByName: Map[String, EntityDeclFull],
+    enumByName:   Map[String, EnumDeclFull],
+    aliasByName:  Map[String, TypeAliasDeclFull],
+    entityNames:  Set[String],
+    enumNames:    Set[String],
+    aliasNames:   Set[String]
+)
+```
+
+Every consumer that previously wrote
+
+```scala
+val entityNames = ir.c.collect { case e: EntityDeclFull => e.a }.toSet
+val aliasMap    = ir.e.collect { case a: TypeAliasDeclFull => a.a -> a }.toMap
+```
+
+now writes `ir.idx.entityNames` / `ir.idx.aliasByName`. Adopt the
+pattern for any new consumer. The boilerplate is centralised and the
+maps cost one build per IR even when threaded through dozens of helper
+calls.
+
+**Why we keep symbolic name refs at all.** MLIR keeps its
+`SymbolRefAttr` precisely because resolved pointers tie an IR to a
+particular notion of scope and dominance; refs survive serialisation
+and round-tripping. Our IR is similar — `NamedTypeF "Email"` is a
+deliberate reference, not a missed resolution. The lookup cost is the
+price of decoupling.
+
+**Future work** (in order of impact):
+
+1. **Switch walker signatures to `Mapping`** and `import HOL-Library.RBT_Mapping`
+   in `Codegen.thy` so extracted lookups are O(log n) without changing
+   call sites. ~30 lines in `SchemaTraversal.thy`, ~5 in `Codegen.thy`,
+   plus a `Mapping.of_alist` wrap at the Scala boundary.
+2. **Resolve the IR once into a `resolved_type` side ADT** — eliminates
+   `alias_map` / `enum_map` from walker signatures entirely; walkers
+   become trivial pattern matches on the resolved form. This is what
+   CompCert / CakeML do at their elaboration phase; it's a bigger
+   refactor (~6 file touches across walkers + their Scala callers).
+
+References worth keeping handy:
+[MLIR Symbol References](https://mlir.llvm.org/docs/SymbolsAndSymbolTables/),
+[Isabelle `RBT_Mapping`](https://www.cl.cam.ac.uk/research/hvg/Isabelle/dist/library/HOL/HOL-Library/RBT_Mapping.html),
+[CakeML ICFP'16](https://cakeml.org/icfp16.pdf).
+
 ## Adding new functions to `IR_*` theories
 
 Decision tree:

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -127,32 +127,17 @@ object Constraints:
       aliasMap: Map[String, TypeAliasDeclFull],
       enumMap: Map[String, EnumDeclFull]
   ): JsonSchemaConstraints =
-    var out = JsonSchemaConstraints()
-    out = collectFromType(typeExpr, aliasMap, enumMap, out)
+    val aliasList = aliasMap.toList
+    val enumList  = enumMap.toList
+    var out       = JsonSchemaConstraints()
+    findEnumValuesInType(typeExpr, aliasList, enumList) match
+      case Some(vs) => out = out.copy(enum_ = Some(vs))
+      case None     => ()
+    for pred <- aliasRefinements(typeExpr, aliasList) do
+      out = visitConstraint(pred, out)
     constraint match
       case Some(c) => visitConstraint(c, out)
       case None    => out
-
-  private def collectFromType(
-      typeExpr: type_expr_full,
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull],
-      out: JsonSchemaConstraints
-  ): JsonSchemaConstraints = typeExpr match
-    case OptionTypeF(inner, _) =>
-      collectFromType(inner, aliasMap, enumMap, out)
-    case NamedTypeF(name, _) =>
-      enumMap.get(name) match
-        case Some(e) => out.copy(enum_ = Some(e.b))
-        case None =>
-          aliasMap.get(name) match
-            case Some(alias) =>
-              val afterType = collectFromType(alias.b, aliasMap, enumMap, out)
-              alias.c match
-                case Some(c) => visitConstraint(c, afterType)
-                case None    => afterType
-            case None => out
-    case _ => out
 
   private def visitConstraint(
       expr: expr_full,

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -5,8 +5,8 @@ import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
 import specrest.convention.ParamSpec
 import specrest.ir.PrettyPrint
-import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.idx
 import specrest.profile.ProfiledEntity
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -5,6 +5,7 @@ import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
 import specrest.convention.ParamSpec
 import specrest.ir.PrettyPrint
+import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledEntity
 import specrest.profile.ProfiledOperation
@@ -102,7 +103,9 @@ final case class BuildContext(
     aliasMap: Map[String, TypeAliasDeclFull],
     enumMap: Map[String, EnumDeclFull],
     entityNames: Set[String],
-    entityDecls: Map[String, EntityDeclFull]
+    entityDecls: Map[String, EntityDeclFull],
+    aliasAList: List[(String, TypeAliasDeclFull)],
+    enumAList: List[(String, EnumDeclFull)]
 )
 
 // -- Constraints extraction ------------------------------------
@@ -124,16 +127,14 @@ object Constraints:
   def extractFieldConstraints(
       typeExpr: type_expr_full,
       constraint: Option[expr_full],
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull]
+      aliasAList: List[(String, TypeAliasDeclFull)],
+      enumAList: List[(String, EnumDeclFull)]
   ): JsonSchemaConstraints =
-    val aliasList = aliasMap.toList
-    val enumList  = enumMap.toList
-    var out       = JsonSchemaConstraints()
-    findEnumValuesInType(typeExpr, aliasList, enumList) match
+    var out = JsonSchemaConstraints()
+    findEnumValuesInType(typeExpr, aliasAList, enumAList) match
       case Some(vs) => out = out.copy(enum_ = Some(vs))
       case None     => ()
-    for pred <- aliasRefinements(typeExpr, aliasList) do
+    for pred <- aliasRefinements(typeExpr, aliasAList) do
       out = visitConstraint(pred, out)
     constraint match
       case Some(c) => visitConstraint(c, out)
@@ -235,9 +236,7 @@ object Schema:
   def fieldToSchema(
       typeExpr: type_expr_full,
       constraint: Option[expr_full],
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull],
-      entityNames: Set[String]
+      ctx: BuildContext
   ): FieldSchema =
     val nullable = typeExpr match
       case _: OptionTypeF => true
@@ -245,8 +244,9 @@ object Schema:
     val effective = typeExpr match
       case OptionTypeF(inner, _) => inner
       case t                     => t
-    val cs = Constraints.extractFieldConstraints(effective, constraint, aliasMap, enumMap)
-    FieldSchema(typeExprToSchema(effective, cs, aliasMap, enumMap, entityNames), nullable)
+    val cs =
+      Constraints.extractFieldConstraints(effective, constraint, ctx.aliasAList, ctx.enumAList)
+    FieldSchema(typeExprToSchema(effective, cs, ctx), nullable)
 
   def makeNullable(schema: SchemaObject): SchemaObject =
     if schema.ref.isDefined then
@@ -262,59 +262,53 @@ object Schema:
   private def typeExprToSchema(
       typeExpr: type_expr_full,
       constraints: JsonSchemaConstraints,
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull],
-      entityNames: Set[String]
+      ctx: BuildContext
   ): SchemaObject = typeExpr match
     case NamedTypeF(name, _) =>
-      namedTypeSchema(name, constraints, aliasMap, enumMap, entityNames)
+      namedTypeSchema(name, constraints, ctx)
     case SetTypeF(inner, _) =>
-      buildArraySchema(inner, constraints, aliasMap, enumMap, entityNames)
+      buildArraySchema(inner, constraints, ctx)
     case SeqTypeF(inner, _) =>
-      buildArraySchema(inner, constraints, aliasMap, enumMap, entityNames)
+      buildArraySchema(inner, constraints, ctx)
     case MapTypeF(_, v, _) =>
-      val value = fieldToSchema(v, None, aliasMap, enumMap, entityNames)
+      val value = fieldToSchema(v, None, ctx)
       val ap    = if value.nullable then makeNullable(value.schema) else value.schema
       SchemaObject(
         `type` = Some(List("object")),
         additionalProperties = Some(SOBSchema(ap))
       )
     case OptionTypeF(inner, _) =>
-      typeExprToSchema(inner, constraints, aliasMap, enumMap, entityNames)
+      typeExprToSchema(inner, constraints, ctx)
     case RelationTypeF(_, _, _, _) =>
       SchemaObject(`type` = Some(List("integer")))
 
   private def namedTypeSchema(
       name: String,
       c: JsonSchemaConstraints,
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull],
-      entityNames: Set[String]
+      ctx: BuildContext
   ): SchemaObject =
     PrimitiveSchemas.get(name) match
       case Some(p) => mergeConstraints(p, c)
       case None =>
-        enumMap.get(name) match
+        ctx.enumMap.get(name) match
           case Some(e) =>
             SchemaObject(`type` = Some(List("string")), enum_ = Some(e.b))
           case None =>
-            if entityNames.contains(name) then
+            if ctx.entityNames.contains(name) then
               SchemaObject(ref = Some(s"#/components/schemas/${name}Read"))
             else
-              aliasMap.get(name) match
+              ctx.aliasMap.get(name) match
                 case Some(alias) =>
-                  typeExprToSchema(alias.b, c, aliasMap, enumMap, entityNames)
+                  typeExprToSchema(alias.b, c, ctx)
                 case None =>
                   mergeConstraints(SchemaObject(`type` = Some(List("string"))), c)
 
   private def buildArraySchema(
       inner: type_expr_full,
       c: JsonSchemaConstraints,
-      aliasMap: Map[String, TypeAliasDeclFull],
-      enumMap: Map[String, EnumDeclFull],
-      entityNames: Set[String]
+      ctx: BuildContext
   ): SchemaObject =
-    val innerSchema = fieldToSchema(inner, None, aliasMap, enumMap, entityNames)
+    val innerSchema = fieldToSchema(inner, None, ctx)
     val items =
       if innerSchema.nullable then makeNullable(innerSchema.schema) else innerSchema.schema
     SchemaObject(
@@ -362,13 +356,7 @@ object Components:
     entity.fields.zipWithIndex.map: (profiledField, idx) =>
       irFields(idx) match
         case FieldDeclFull(_, irType, irConstraint, _) =>
-          val fs = Schema.fieldToSchema(
-            irType,
-            irConstraint,
-            ctx.aliasMap,
-            ctx.enumMap,
-            ctx.entityNames
-          )
+          val fs = Schema.fieldToSchema(irType, irConstraint, ctx)
           DecoratedField(profiledField.columnName, fs.schema, fs.nullable)
 
   private def nonIdFields(fs: List[DecoratedField]): List[DecoratedField] =
@@ -504,13 +492,7 @@ object Paths:
       op.endpoint.queryParams.map(p => paramObject(p, "query", ctx))
 
   private def paramObject(p: ParamSpec, location: String, ctx: BuildContext): ParameterObject =
-    val fs = Schema.fieldToSchema(
-      p match { case ParamSpec(_, t, _) => t },
-      None,
-      ctx.aliasMap,
-      ctx.enumMap,
-      ctx.entityNames
-    )
+    val fs = Schema.fieldToSchema(p match { case ParamSpec(_, t, _) => t }, None, ctx)
     ParameterObject(
       name = p match { case ParamSpec(n, _, _) => n },
       in = location,
@@ -570,13 +552,7 @@ object Paths:
       val properties = collection.mutable.LinkedHashMap.empty[String, SchemaObject]
       val required   = List.newBuilder[String]
       for p <- params do
-        val fs = Schema.fieldToSchema(
-          p match { case ParamSpec(_, t, _) => t },
-          None,
-          ctx.aliasMap,
-          ctx.enumMap,
-          ctx.entityNames
-        )
+        val fs = Schema.fieldToSchema(p match { case ParamSpec(_, t, _) => t }, None, ctx)
         properties(p match { case ParamSpec(n, _, _) => n }) =
           if fs.nullable then Schema.makeNullable(fs.schema) else fs.schema
         if p.required then required += (p match { case ParamSpec(n, _, _) => n })
@@ -681,11 +657,15 @@ object Paths:
 object OpenApi:
 
   def buildOpenApiDocument(profiled: ProfiledService): OpenApiDocument =
-    val aliasMap    = profiled.ir.e.collect { case a: TypeAliasDeclFull => a.a -> a }.toMap
-    val enumMap     = profiled.ir.d.collect { case e: EnumDeclFull => e.a -> e }.toMap
-    val entityDecls = profiled.ir.c.collect { case e: EntityDeclFull => e.a -> e }.toMap
-    val entityNames = profiled.entities.map(_.entityName).toSet
-    val ctx         = BuildContext(aliasMap, enumMap, entityNames, entityDecls)
+    val idx = profiled.ir.idx
+    val ctx = BuildContext(
+      aliasMap = idx.aliasByName,
+      enumMap = idx.enumByName,
+      entityNames = profiled.entities.map(_.entityName).toSet,
+      entityDecls = idx.entityByName,
+      aliasAList = idx.aliasAList,
+      enumAList = idx.enumAList
+    )
 
     OpenApiDocument(
       openapi = "3.1.0",

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/ConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/ConstraintsTest.scala
@@ -1,0 +1,47 @@
+package specrest.codegen.openapi
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+class ConstraintsTest extends CatsEffectSuite:
+
+  private def named(t: String): NamedTypeF = NamedTypeF(t, None)
+
+  private def alias(name: String, target: type_expr_full): TypeAliasDeclFull =
+    TypeAliasDeclFull(name, target, None, None)
+
+  private def enumD(name: String, values: List[String]): EnumDeclFull =
+    EnumDeclFull(name, values, None)
+
+  test("findEnumValuesInType resolves enum reached through an alias chain"):
+    val statusEnum = enumD("Status", List("OPEN", "CLOSED"))
+    val tier1      = alias("StatusAlias", named("Status"))
+    val tier2      = alias("StatusAliasAlias", named("StatusAlias"))
+    val aliasAList = List("StatusAlias" -> tier1, "StatusAliasAlias" -> tier2)
+    val enumAList  = List("Status" -> statusEnum)
+
+    val direct = findEnumValuesInType(named("Status"), aliasAList, enumAList)
+    assertEquals(direct, Some(List("OPEN", "CLOSED")))
+
+    val oneHop = findEnumValuesInType(named("StatusAlias"), aliasAList, enumAList)
+    assertEquals(oneHop, Some(List("OPEN", "CLOSED")))
+
+    val twoHop = findEnumValuesInType(named("StatusAliasAlias"), aliasAList, enumAList)
+    assertEquals(twoHop, Some(List("OPEN", "CLOSED")))
+
+  test("findEnumValuesInType strips Option wrappers before resolution"):
+    val statusEnum = enumD("Status", List("OPEN", "CLOSED"))
+    val nested     = OptionTypeF(OptionTypeF(named("Status"), None), None)
+    val res        = findEnumValuesInType(nested, Nil, List("Status" -> statusEnum))
+    assertEquals(res, Some(List("OPEN", "CLOSED")))
+
+  test("findEnumValuesInType returns None when alias chain bottoms out at primitive"):
+    val emailAlias = alias("Email", named("String"))
+    val res        = findEnumValuesInType(named("Email"), List("Email" -> emailAlias), Nil)
+    assertEquals(res, None)
+
+  test("findEnumValuesInType is cycle-safe (returns None instead of looping)"):
+    val a   = alias("A", named("B"))
+    val b   = alias("B", named("A"))
+    val res = findEnumValuesInType(named("A"), List("A" -> a, "B" -> b), Nil)
+    assertEquals(res, None)

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -1,7 +1,7 @@
 package specrest.convention
 
-import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.idx
 
 object Classify:
 

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -1,5 +1,6 @@
 package specrest.convention
 
+import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
 
 object Classify:
@@ -12,7 +13,7 @@ object Classify:
       case Some(StateDeclFull(fs, _)) => fs.collect { case StateFieldDeclFull(n, _, _) => n }.toSet
       case None                       => Set.empty[String]
     val signals      = analyze(op, ir, stateFieldNames)
-    val entityMap    = ir.c.collect { case e: EntityDeclFull => e.a -> e }.toMap
+    val entityMap    = ir.idx.entityByName
     val targetEntity = resolveTargetEntity(op, ir, entityMap)
     val outputNames  = op.c.collect { case ParamDeclFull(n, _, _) => n }
     val strategy     = classifyStrategy(op.e, stateFieldNames.toList, outputNames)

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -1,5 +1,6 @@
 package specrest.convention
 
+import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
@@ -36,12 +37,11 @@ object Schema:
   )
 
   def deriveSchema(ir: ServiceIRFull): database_schema =
-    val entities    = ir.c.collect { case e: EntityDeclFull => e }
-    val enums       = ir.d.collect { case e: EnumDeclFull => e }
-    val aliases     = ir.e.collect { case a: TypeAliasDeclFull => a }
-    val entityNames = entities.map(_.a).toSet
-    val enumMap     = enums.map(e => e.a -> e).toMap
-    val aliasMap    = aliases.map(a => a.a -> a).toMap
+    val ix          = ir.idx
+    val entities    = ix.entities
+    val entityNames = ix.entityNames
+    val enumMap     = ix.enumByName
+    val aliasMap    = ix.aliasByName
     val entityRefs  = buildEntityRefMap(ir, entityNames, enumMap, aliasMap)
 
     val tables = List.newBuilder[table_spec]
@@ -68,7 +68,7 @@ object Schema:
       enumMap: Map[String, EnumDeclFull],
       aliasMap: Map[String, TypeAliasDeclFull]
   ): Map[String, EntityRef] =
-    ir.c.collect { case entity: EntityDeclFull => entity }.map { entity =>
+    ir.idx.entities.map { entity =>
       val fields = entity.c.collect { case f: FieldDeclFull => f }
       val tableName = Path
         .getConvention(ir.n, entity.a, "db_table")

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -1,8 +1,8 @@
 package specrest.convention
 
-import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.idx
 
 object Schema:
 

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -111,10 +111,11 @@ object Validate:
     conventions match
       case None => Nil
       case Some(ConventionsDeclFull(rules, _)) =>
+        val ix          = ir.idx
         val opNames     = ir.g.collect { case OperationDeclFull(n, _, _, _, _, _) => n }.toSet
-        val entityNames = ir.c.collect { case EntityDeclFull(n, _, _, _, _) => n }.toSet
-        val aliasNames  = ir.e.collect { case TypeAliasDeclFull(n, _, _, _) => n }.toSet
-        val enumNames   = ir.d.collect { case EnumDeclFull(n, _, _) => n }.toSet
+        val entityNames = ix.entityNames
+        val aliasNames  = ix.aliasNames
+        val enumNames   = ix.enumNames
         val diagnostics = List.newBuilder[ConventionDiagnostic]
         val seen        = scala.collection.mutable.Map.empty[String, ConventionRuleFull]
 
@@ -208,7 +209,7 @@ object Validate:
       ir: ServiceIRFull,
       diagnostics: DiagBuilder
   ): Unit =
-    val entityNames = ir.c.collect { case EntityDeclFull(n, _, _, _, _) => n }.toSet
+    val entityNames = ir.idx.entityNames
     val grouped = rules
       .collect[(String, String, String, ConventionRuleFull)] {
         case r @ ConventionRuleFull(t, "test_strategy", Some(f), StringLitF(v, _), _)

--- a/modules/ir/src/main/scala/specrest/ir/IrIndex.scala
+++ b/modules/ir/src/main/scala/specrest/ir/IrIndex.scala
@@ -1,0 +1,47 @@
+package specrest.ir
+
+import specrest.ir.generated.SpecRestGenerated.*
+
+final case class IrIndex(
+    entities: List[EntityDeclFull],
+    enums: List[EnumDeclFull],
+    aliases: List[TypeAliasDeclFull],
+    entityByName: Map[String, EntityDeclFull],
+    enumByName: Map[String, EnumDeclFull],
+    aliasByName: Map[String, TypeAliasDeclFull],
+    entityNames: Set[String],
+    enumNames: Set[String],
+    aliasNames: Set[String]
+):
+  def aliasAList: List[(String, TypeAliasDeclFull)] = aliasByName.toList
+  def enumAList: List[(String, EnumDeclFull)]       = enumByName.toList
+
+object IrIndex:
+  private val cache: java.util.Map[ServiceIRFull, IrIndex] =
+    java.util.Collections.synchronizedMap(new java.util.WeakHashMap[ServiceIRFull, IrIndex]())
+
+  def of(ir: ServiceIRFull): IrIndex =
+    Option(cache.get(ir)) match
+      case Some(hit) => hit
+      case None =>
+        val fresh = build(ir)
+        cache.put(ir, fresh)
+        fresh
+
+  private def build(ir: ServiceIRFull): IrIndex =
+    val entities = ir.c.collect { case e: EntityDeclFull => e }
+    val enums    = ir.d.collect { case e: EnumDeclFull => e }
+    val aliases  = ir.e.collect { case a: TypeAliasDeclFull => a }
+    IrIndex(
+      entities = entities,
+      enums = enums,
+      aliases = aliases,
+      entityByName = entities.map(e => e.a -> e).toMap,
+      enumByName = enums.map(e => e.a -> e).toMap,
+      aliasByName = aliases.map(a => a.a -> a).toMap,
+      entityNames = entities.map(_.a).toSet,
+      enumNames = enums.map(_.a).toSet,
+      aliasNames = aliases.map(_.a).toSet
+    )
+
+extension (ir: ServiceIRFull) def idx: IrIndex = IrIndex.of(ir)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -9096,6 +9096,45 @@ object SpecRestGenerated {
       flattenEnsures(requiresa)
     ))
 
+  def findEnumValuesInTypeAux(
+      fuel: nat,
+      uu: type_expr_full,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[(String, enum_decl_full)],
+      ux: List[String]
+  ): Option[List[String]] =
+    equal_nat(fuel, zero_nat) match {
+      case true => None
+      case false => stripOptions(uu) match {
+          case NamedTypeF(name, _) =>
+            map_of[String, enum_decl_full](uw, name) match {
+              case None =>
+                membera[String](ux, name) match {
+                  case true => None
+                  case false => map_of[String, type_alias_decl_full](uv, name) match {
+                      case None => None
+                      case Some(TypeAliasDeclFull(_, base, _, _)) =>
+                        findEnumValuesInTypeAux(minus_nat(fuel, one_nat), base, uv, uw, name :: ux)
+                    }
+                }
+              case Some(EnumDeclFull(_, vs, _)) =>
+                Some[List[String]](vs)
+            }
+          case SetTypeF(_, _)            => None
+          case MapTypeF(_, _, _)         => None
+          case SeqTypeF(_, _)            => None
+          case OptionTypeF(_, _)         => None
+          case RelationTypeF(_, _, _, _) => None
+        }
+    }
+
+  def findEnumValuesInType(
+      ty: type_expr_full,
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)]
+  ): Option[List[String]] =
+    findEnumValuesInTypeAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, em, Nil)
+
   def buildOperationClassification(
       name: String,
       targetEntity: Option[String],

--- a/modules/profile/src/main/scala/specrest/profile/Annotate.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Annotate.scala
@@ -17,17 +17,18 @@ object Annotate:
     val endpoints       = Path.deriveEndpoints(classifications, ir)
     val schema          = Schema.deriveSchema(ir)
 
+    val ix = ir.idx
     val ctx = TypeContext(
-      entityNames = ir.c.collect { case e: EntityDeclFull => e.a }.toSet,
-      enumNames = ir.d.collect { case e: EnumDeclFull => e.a }.toSet,
-      aliasMap = ir.e.collect { case TypeAliasDeclFull(n, t, _, _) => n -> t }.toMap
+      entityNames = ix.entityNames,
+      enumNames = ix.enumNames,
+      aliasMap = ix.aliases.map { case TypeAliasDeclFull(n, t, _, _) => n -> t }.toMap
     )
 
     val classificationMap = classifications.map(c => classificationOperationName(c) -> c).toMap
     val endpointMap       = endpoints.map(e => e.operationName -> e).toMap
     val tableMap          = schemaTables(schema).map(t => tableEntityName(t) -> t).toMap
 
-    val entities = ir.c.collect { case entity: EntityDeclFull =>
+    val entities = ix.entities.map { entity =>
       val tableName = Path
         .getConvention(ir.n, entity.a, "db_table")
         .getOrElse(Naming.toTableName(entity.a))

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -2,6 +2,7 @@ package specrest.testgen
 
 import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
+import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
 
 final case class StrategyImport(module: String, symbol: String)
@@ -43,7 +44,7 @@ object TestStrategyOverrides:
           if v == "live" || v == "redacted" =>
         (target, field, v)
     val opNames     = ir.g.collect { case o: OperationDeclFull => o.a }.toSet
-    val entityNames = ir.c.collect { case e: EntityDeclFull => e.a }.toSet
+    val entityNames = ir.idx.entityNames
     val perOp = rules.collect:
       case (t, f, v) if opNames.contains(t) => (t, f) -> v
     val perField = rules.collect:
@@ -59,14 +60,13 @@ object Strategies:
       ir: ServiceIRFull,
       b: StrategyBackend = PythonHypothesisStrategy
   ): List[StrategySpec] =
-    val overrides = strategyOverrides(ir)
-    val aliasSpecs =
-      ir.e.collect { case a: TypeAliasDeclFull => specForAlias(a, ir, overrides, b) }
-    val enumSpecs     = ir.d.collect { case e: EnumDeclFull => specForEnum(e, overrides, b) }
+    val overrides     = strategyOverrides(ir)
+    val ix            = ir.idx
+    val aliasSpecs    = ix.aliases.map(a => specForAlias(a, ir, overrides, b))
+    val enumSpecs     = ix.enums.map(e => specForEnum(e, overrides, b))
     val transEntities = transitionEntityNames(ir)
-    val entitySpecs = ir.c
-      .collect { case e: EntityDeclFull if transEntities.contains(e.a) => e }
-      .map(e => specForEntity(e, ir, b))
+    val entitySpecs =
+      ix.entities.filter(e => transEntities.contains(e.a)).map(e => specForEntity(e, ir, b))
     aliasSpecs ++ enumSpecs ++ entitySpecs
 
   def transitionEntityNames(ir: ServiceIRFull): Set[String] =

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -2,8 +2,8 @@ package specrest.testgen
 
 import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
-import specrest.ir.idx
 import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.idx
 
 final case class StrategyImport(module: String, symbol: String)
 

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -214,6 +214,7 @@ export_code
     matchesCreateShape
     isFailLoudStub
     aliasRefinements
+    findEnumValuesInType
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/SchemaTraversal.thy
+++ b/proofs/isabelle/SpecRest/SchemaTraversal.thy
@@ -14,6 +14,7 @@ text \<open>Pure IR traversals lifted from \<open>specrest.convention.Schema\<cl
   boundary.\<close>
 
 type_synonym alias_map = "(String.literal \<times> type_alias_decl_full) list"
+type_synonym enum_map  = "(String.literal \<times> enum_decl_full) list"
 
 text \<open>Fuel-bounded traversal: the visited set monotonically grows by one
   on each \<open>NamedTypeF\<close> hop and bounds the recursion depth, so we cap by
@@ -46,8 +47,39 @@ where
 definition aliasRefinements :: "type_expr_full \<Rightarrow> alias_map \<Rightarrow> expr_full list" where
   "aliasRefinements ty am = aliasRefinementsAux (Suc (length am)) ty am []"
 
+text \<open>\<open>findEnumValuesInType\<close> walks the same alias chain as
+  \<open>aliasRefinements\<close>; if any hop lands on an \<open>enum_decl_full\<close> the
+  enum's value list is returned. Used by OpenAPI schema emission to attach
+  \<open>enum:\<close> annotations to fields whose effective type resolves to an enum
+  (directly or through aliases).\<close>
+
+fun findEnumValuesInTypeAux ::
+  "nat \<Rightarrow> type_expr_full \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list
+    \<Rightarrow> String.literal list option"
+where
+  "findEnumValuesInTypeAux 0 _ _ _ _ = None"
+| "findEnumValuesInTypeAux (Suc fuel) ty am em seen = (case stripOptions ty of
+       NamedTypeF name _ \<Rightarrow>
+         (case map_of em name of
+            Some (EnumDeclFull _ vs _) \<Rightarrow> Some vs
+          | None \<Rightarrow>
+              (if name \<in> set seen then None
+               else case map_of am name of
+                      None \<Rightarrow> None
+                    | Some (TypeAliasDeclFull _ base _ _) \<Rightarrow>
+                        findEnumValuesInTypeAux fuel base am em (name # seen)))
+     | _ \<Rightarrow> None)"
+
+definition findEnumValuesInType ::
+  "type_expr_full \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list option"
+where
+  "findEnumValuesInType ty am em =
+     findEnumValuesInTypeAux (Suc (length am)) ty am em []"
+
 lemmas stripOptions_code [code] = stripOptions.simps
 lemmas aliasRefinementsAux_code [code] = aliasRefinementsAux.simps
 lemmas aliasRefinements_code [code] = aliasRefinements_def
+lemmas findEnumValuesInTypeAux_code [code] = findEnumValuesInTypeAux.simps
+lemmas findEnumValuesInType_code [code] = findEnumValuesInType_def
 
 end

--- a/proofs/isabelle/SpecRest/SchemaTraversal.thy
+++ b/proofs/isabelle/SpecRest/SchemaTraversal.thy
@@ -8,10 +8,16 @@ text \<open>Pure IR traversals lifted from \<open>specrest.convention.Schema\<cl
   carried by each \<open>TypeAliasDeclFull\<close>; the traversal needs a visited-set
   guard against cyclic aliases.
 
-  Alias maps are passed as association lists because Isabelle's \<open>Map\<close> is
-  abstract; the Scala caller converts \<open>Map[String, TypeAliasDeclFull]\<close> to
-  the equivalent \<open>(String.literal \<times> type_alias_decl_full) list\<close> at the
-  boundary.\<close>
+  Alias and enum decls are passed as association lists because Isabelle's
+  abstract \<open>Mapping\<close> is the only finite-map type the code generator
+  exposes; the Scala caller converts \<open>Map[String, TypeAliasDeclFull]\<close>
+  / \<open>Map[String, EnumDeclFull]\<close> to the equivalent
+  \<open>(String.literal \<times> _) list\<close> at the boundary (cached in
+  \<open>specrest.ir.IrIndex\<close> so the conversion happens once per IR).
+
+  Follow-up perf opportunity: \<open>HOL-Library.RBT_Mapping\<close> would swap the
+  underlying lookup from O(n) \<open>map_of\<close> to O(log n) red-black tree, with
+  no change to the walker signatures.\<close>
 
 type_synonym alias_map = "(String.literal \<times> type_alias_decl_full) list"
 type_synonym enum_map  = "(String.literal \<times> enum_decl_full) list"


### PR DESCRIPTION
## Summary

`OpenApi.Constraints.collectFromType` was reimplementing the alias-chain walking already lifted in `SchemaTraversal.thy` (`aliasRefinements`). The only logic on top was: detect when the resolved (alias-followed) type is an enum and pull its value list.

This PR:

- **Lifts `findEnumValuesInType`** into `SchemaTraversal.thy`, reusing the same `stripOptions` + `map_of am` + visited-set fuel pattern as `aliasRefinements`.
- **Adds `enum_map` type synonym** alongside the existing `alias_map`.
- **Refactors `OpenApi.Constraints.extractFieldConstraints`** to delegate the type-walk to the extracted helpers:
  - `findEnumValuesInType` for the `enum_` field
  - `aliasRefinements` (already extracted) for alias-predicate iteration
  - the 30-line private `collectFromType` is deleted
- **Exports `findEnumValuesInType`** via `Codegen.thy`.

Numeric/length bound walking (Double-aware in Scala) stays in Scala. Only the type-walk piece — which had a direct duplicate in `SchemaTraversal.thy` — was extracted.

## Test plan

- [x] `isabelle build` — green (2:04 elapsed, 6:50 cpu)
- [x] `sbt test` — all suites pass (1,120 tests)
- [x] Generated `SpecRestGenerated.scala` regenerated and committed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts enum resolution through aliases into Isabelle and switches OpenAPI to a centralized IR index. This removes duplicate type-walking, avoids per-call map builds, and makes enum detection consistent and cycle-safe.

- **Refactors**
  - Adds `findEnumValuesInType` to `SchemaTraversal.thy`, introduces `enum_map`, exports via `Codegen.thy`; regenerates `SpecRestGenerated.scala`.
  - Refactors `OpenApi.Constraints.extractFieldConstraints` to use `findEnumValuesInType` (for `enum_`) and `aliasRefinements` (for predicates); deletes `collectFromType`. Updates call sites to pass `aliasAList`/`enumAList`, and `Schema.fieldToSchema`/type builders now take a `ctx`.
  - Introduces `specrest.ir.IrIndex` (lists, name maps/sets, plus `aliasAList`/`enumAList`) and threads it via `ir.idx` in `OpenApi`, `convention.{Schema,Classify,Validate}`, `profile.Annotate`, and `testgen.Strategies`.
  - Adds `ConstraintsTest` covering enum-through-alias (direct, 1–2 hop), `Option`-wrapped enums, primitive leaves, and cycles.
  - Documents the Scala/Isabelle boundary alist pattern and the planned `RBT_Mapping` follow-up.

<sup>Written for commit 0c09b1cb7c5938160655c726bf512b103d1873fa. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/322?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal constraint processing for type expression evaluation.

* **Chores**
  * Updated code generation infrastructure to support additional exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->