### PR TITLE
feat(proofs): lift classifyColumnType (Schema.mapTypeToColumn kernel)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -6,20 +6,6 @@ import specrest.ir.idx
 
 object Schema:
 
-  private val PrimitiveTypeMap: Map[String, String] = Map(
-    "String"   -> "TEXT",
-    "Int"      -> "INTEGER",
-    "Float"    -> "DOUBLE PRECISION",
-    "Bool"     -> "BOOLEAN",
-    "Boolean"  -> "BOOLEAN",
-    "DateTime" -> "TIMESTAMPTZ",
-    "Date"     -> "DATE",
-    "UUID"     -> "UUID",
-    "Decimal"  -> "NUMERIC(19,4)",
-    "Bytes"    -> "BYTEA",
-    "Money"    -> "INTEGER"
-  )
-
   // An explicit integer `id` PK is widened to 64-bit. Spec integer semantics are
   // unbounded, so a 32-bit INTEGER overflows on ids >= 2^31 — surfacing as a 500
   // instead of a 4xx not-found — and it would also disagree with synthesized
@@ -261,78 +247,36 @@ object Schema:
       enumMap: Map[String, EnumDeclFull],
       aliasMap: Map[String, TypeAliasDeclFull]
   ): MappedField =
-    typeExpr match
-      case NamedTypeF(name, _) =>
-        PrimitiveTypeMap.get(name) match
-          case Some(sqlType) =>
-            MappedField(
-              ColumnSpec(colName, sqlType, false, None),
-              None,
-              None
-            )
-          case None =>
-            enumMap.get(name) match
-              case Some(EnumDeclFull(_, vs, _)) =>
-                val values = vs.map(v => s"'${escapeSqlString(v)}'").mkString(", ")
-                MappedField(
-                  ColumnSpec(colName, "TEXT", false, None),
-                  None,
-                  Some(s"$colName IN ($values)")
-                )
-              case None if entityNames.contains(name) =>
-                val refTable = Naming.toTableName(name)
-                MappedField(
-                  ColumnSpec(colName + "_id", "BIGINT", false, None),
-                  Some(ForeignKeySpec(colName + "_id", refTable, "id", "CASCADE")),
-                  None
-                )
-              case None =>
-                aliasMap.get(name) match
-                  case Some(TypeAliasDeclFull(_, t, _, _)) =>
-                    mapTypeToColumn(colName, t, entityNames, enumMap, aliasMap)
-                  case None =>
-                    MappedField(
-                      ColumnSpec(colName, "TEXT", false, None),
-                      None,
-                      None
-                    )
-      case OptionTypeF(inner, _) =>
-        val innerMapped = mapTypeToColumn(colName, inner, entityNames, enumMap, aliasMap)
-        val nullableCol = ColumnSpec(
-          columnName(innerMapped.column),
-          columnSqlType(innerMapped.column),
-          true,
-          columnDefaultValue(innerMapped.column)
-        )
+    val classified =
+      classifyColumnType(typeExpr, aliasMap.toList, enumMap.toList, entityNames.toList)
+    val (kind, nullable) = classified match
+      case ClassifiedColumn(k, n) => (k, n)
+    kind match
+      case CkPrim(sqlType) =>
+        MappedField(ColumnSpec(colName, sqlType, nullable, None), None, None)
+      case CkEnum(vs) =>
+        val values = vs.map(v => s"'${escapeSqlString(v)}'").mkString(", ")
         MappedField(
-          nullableCol,
-          innerMapped.foreignKey,
-          innerMapped.check
-        )
-      case SetTypeF(_, _) =>
-        MappedField(
-          ColumnSpec(colName, "JSONB", false, Some("'[]'::jsonb")),
+          ColumnSpec(colName, "TEXT", nullable, None),
           None,
+          Some(s"$colName IN ($values)")
+        )
+      case CkEntityRef(name) =>
+        val refTable = Naming.toTableName(name)
+        val fkCol    = colName + "_id"
+        MappedField(
+          ColumnSpec(fkCol, "BIGINT", nullable, None),
+          Some(ForeignKeySpec(fkCol, refTable, "id", "CASCADE")),
           None
         )
-      case SeqTypeF(_, _) =>
-        MappedField(
-          ColumnSpec(colName, "JSONB", false, Some("'[]'::jsonb")),
-          None,
-          None
-        )
-      case MapTypeF(_, _, _) =>
-        MappedField(
-          ColumnSpec(colName, "JSONB", false, Some("'{}'::jsonb")),
-          None,
-          None
-        )
-      case RelationTypeF(_, _, _, _) =>
-        MappedField(
-          ColumnSpec(colName, "BIGINT", false, None),
-          None,
-          None
-        )
+      case _: CkJsonArray =>
+        MappedField(ColumnSpec(colName, "JSONB", nullable, Some("'[]'::jsonb")), None, None)
+      case _: CkJsonObject =>
+        MappedField(ColumnSpec(colName, "JSONB", nullable, Some("'{}'::jsonb")), None, None)
+      case _: CkRelation =>
+        MappedField(ColumnSpec(colName, "BIGINT", nullable, None), None, None)
+      case _: CkUnknown =>
+        MappedField(ColumnSpec(colName, "TEXT", nullable, None), None, None)
 
   private def escapeSqlString(s: String): String = s.replace("'", "''")
 

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -22,17 +22,26 @@ object Schema:
       check: Option[String]
   )
 
+  final private case class ClassifierCtx(
+      aliasAList: List[(String, TypeAliasDeclFull)],
+      enumAList: List[(String, EnumDeclFull)],
+      entityNamesList: List[String]
+  )
+
   def deriveSchema(ir: ServiceIRFull): database_schema =
     val ix          = ir.idx
     val entities    = ix.entities
     val entityNames = ix.entityNames
-    val enumMap     = ix.enumByName
-    val aliasMap    = ix.aliasByName
-    val entityRefs  = buildEntityRefMap(ir, entityNames, enumMap, aliasMap)
+    val cctx = ClassifierCtx(
+      aliasAList = ix.aliasAList,
+      enumAList = ix.enumAList,
+      entityNamesList = ix.entityNamesList
+    )
+    val entityRefs = buildEntityRefMap(ir, cctx)
 
     val tables = List.newBuilder[table_spec]
     for entity <- entities do
-      tables += deriveTable(entity, ir, entityNames, enumMap, aliasMap, entityRefs)
+      tables += deriveTable(entity, ir, entityNames, cctx, entityRefs)
 
     ir.f match
       case Some(StateDeclFull(fs, _)) =>
@@ -50,9 +59,7 @@ object Schema:
 
   private def buildEntityRefMap(
       ir: ServiceIRFull,
-      entityNames: Set[String],
-      enumMap: Map[String, EnumDeclFull],
-      aliasMap: Map[String, TypeAliasDeclFull]
+      cctx: ClassifierCtx
   ): Map[String, EntityRef] =
     ir.idx.entities.map { entity =>
       val fields = entity.c.collect { case f: FieldDeclFull => f }
@@ -63,7 +70,7 @@ object Schema:
       val idFkSqlType = idField match
         case None => "BIGINT"
         case Some(f) =>
-          val mapped = mapTypeToColumn("id", f.b, entityNames, enumMap, aliasMap)
+          val mapped = mapTypeToColumn("id", f.b, cctx)
           // A FK referencing the PK must match its widened type.
           columnSqlType(mapped.column) match
             case "BIGSERIAL" => "BIGINT"
@@ -75,8 +82,7 @@ object Schema:
       entity: EntityDeclFull,
       ir: ServiceIRFull,
       entityNames: Set[String],
-      enumMap: Map[String, EnumDeclFull],
-      aliasMap: Map[String, TypeAliasDeclFull],
+      cctx: ClassifierCtx,
       entityRefs: Map[String, EntityRef]
   ): table_spec =
     val fields = entity.c.collect { case f: FieldDeclFull => f }
@@ -95,7 +101,7 @@ object Schema:
 
     for field <- fields do
       val colName    = Naming.toColumnName(field.a)
-      val mapped     = mapFieldToColumn(field, entityNames, enumMap, aliasMap, entityRefs)
+      val mapped     = mapFieldToColumn(field, cctx, entityRefs)
       val widenedSql = widenExplicitIdPkSqlType(field.a, columnSqlType(mapped.column))
       val column = ColumnSpec(
         columnName(mapped.column),
@@ -111,7 +117,7 @@ object Schema:
       mapped.check.foreach(checks += _)
       field.c.foreach: c =>
         checks ++= extractChecks(colName, c)
-      for refinement <- SpecRestGenerated.aliasRefinements(field.b, aliasMap.toList) do
+      for refinement <- SpecRestGenerated.aliasRefinements(field.b, cctx.aliasAList) do
         checks ++= extractChecks(colName, refinement)
 
     for inv <- entity.d do
@@ -214,16 +220,14 @@ object Schema:
 
   private def mapFieldToColumn(
       field: FieldDeclFull,
-      entityNames: Set[String],
-      enumMap: Map[String, EnumDeclFull],
-      aliasMap: Map[String, TypeAliasDeclFull],
+      cctx: ClassifierCtx,
       entityRefs: Map[String, EntityRef]
   ): MappedField =
     val colName = Naming.toColumnName(field.a)
-    val mapped  = mapTypeToColumn(colName, field.b, entityNames, enumMap, aliasMap)
+    val mapped  = mapTypeToColumn(colName, field.b, cctx)
     if mapped.foreignKey.isEmpty && colName.endsWith("_id") then
       val prefix       = colName.dropRight("_id".length)
-      val targetEntity = entityNames.find(n => Naming.toSnakeCase(n) == prefix)
+      val targetEntity = cctx.entityNamesList.find(n => Naming.toSnakeCase(n) == prefix)
       targetEntity.flatMap(entityRefs.get) match
         case Some(ref) =>
           val widened = ColumnSpec(
@@ -243,12 +247,10 @@ object Schema:
   private def mapTypeToColumn(
       colName: String,
       typeExpr: type_expr_full,
-      entityNames: Set[String],
-      enumMap: Map[String, EnumDeclFull],
-      aliasMap: Map[String, TypeAliasDeclFull]
+      cctx: ClassifierCtx
   ): MappedField =
     val classified =
-      classifyColumnType(typeExpr, aliasMap.toList, enumMap.toList, entityNames.toList)
+      classifyColumnType(typeExpr, cctx.aliasAList, cctx.enumAList, cctx.entityNamesList)
     val (kind, nullable) = classified match
       case ClassifiedColumn(k, n) => (k, n)
     kind match

--- a/modules/convention/src/test/scala/specrest/convention/ClassifyColumnTypeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ClassifyColumnTypeTest.scala
@@ -92,10 +92,10 @@ class ClassifyColumnTypeTest extends CatsEffectSuite:
     assertEquals(nullable, true)
 
   test("SetType and SeqType classify as CkJsonArray"):
-    val setRes = classify(SetTypeF(named("Int"), None))
-    assertEquals(setRes._1, CkJsonArray())
-    val seqRes = classify(SeqTypeF(named("String"), None))
-    assertEquals(seqRes._1, CkJsonArray())
+    val (setK, _) = classify(SetTypeF(named("Int"), None))
+    assertEquals(setK, CkJsonArray())
+    val (seqK, _) = classify(SeqTypeF(named("String"), None))
+    assertEquals(seqK, CkJsonArray())
 
   test("MapType classifies as CkJsonObject"):
     val (k, _) = classify(MapTypeF(named("String"), named("Int"), None))

--- a/modules/convention/src/test/scala/specrest/convention/ClassifyColumnTypeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ClassifyColumnTypeTest.scala
@@ -1,0 +1,117 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+class ClassifyColumnTypeTest extends CatsEffectSuite:
+
+  private def named(t: String): NamedTypeF = NamedTypeF(t, None)
+  private def alias(name: String, target: type_expr_full): TypeAliasDeclFull =
+    TypeAliasDeclFull(name, target, None, None)
+  private def enumD(name: String, values: List[String]): EnumDeclFull =
+    EnumDeclFull(name, values, None)
+
+  private def classify(
+      ty: type_expr_full,
+      aliases: List[(String, TypeAliasDeclFull)] = Nil,
+      enums: List[(String, EnumDeclFull)] = Nil,
+      entityNames: List[String] = Nil
+  ): (column_kind, Boolean) =
+    classifyColumnType(ty, aliases, enums, entityNames) match
+      case ClassifiedColumn(k, n) => (k, n)
+
+  test("primitives map through primitiveTypeToSql"):
+    val cases = List(
+      "String"   -> "TEXT",
+      "Int"      -> "INTEGER",
+      "Float"    -> "DOUBLE PRECISION",
+      "Bool"     -> "BOOLEAN",
+      "Boolean"  -> "BOOLEAN",
+      "DateTime" -> "TIMESTAMPTZ",
+      "Date"     -> "DATE",
+      "UUID"     -> "UUID",
+      "Decimal"  -> "NUMERIC(19,4)",
+      "Bytes"    -> "BYTEA",
+      "Money"    -> "INTEGER"
+    )
+    cases.foreach: (specType, sqlType) =>
+      val (k, nullable) = classify(named(specType))
+      assertEquals(k, CkPrim(sqlType), s"failed for $specType")
+      assertEquals(nullable, false)
+
+  test("OptionType sets nullable=true on the inner classification"):
+    val (k, nullable) = classify(OptionTypeF(named("Int"), None))
+    assertEquals(k, CkPrim("INTEGER"))
+    assertEquals(nullable, true)
+
+  test("nested Option layers collapse to a single nullable=true"):
+    val nested        = OptionTypeF(OptionTypeF(named("String"), None), None)
+    val (k, nullable) = classify(nested)
+    assertEquals(k, CkPrim("TEXT"))
+    assertEquals(nullable, true)
+
+  test("enum NamedType resolves to CkEnum carrying the values"):
+    val statusEnum    = enumD("Status", List("OPEN", "CLOSED"))
+    val (k, nullable) = classify(named("Status"), enums = List("Status" -> statusEnum))
+    assertEquals(k, CkEnum(List("OPEN", "CLOSED")))
+    assertEquals(nullable, false)
+
+  test("entity NamedType resolves to CkEntityRef carrying the entity name"):
+    val (k, nullable) = classify(named("User"), entityNames = List("User"))
+    assertEquals(k, CkEntityRef("User"))
+    assertEquals(nullable, false)
+
+  test("alias chain resolves to the leaf classification"):
+    val email    = alias("Email", named("String"))
+    val tier2    = alias("EmailAlias", named("Email"))
+    val aliases  = List("Email" -> email, "EmailAlias" -> tier2)
+    val (k1, n1) = classify(named("Email"), aliases = aliases)
+    assertEquals(k1, CkPrim("TEXT"))
+    assertEquals(n1, false)
+    val (k2, n2) = classify(named("EmailAlias"), aliases = aliases)
+    assertEquals(k2, CkPrim("TEXT"))
+    assertEquals(n2, false)
+
+  test("alias chain to enum resolves to CkEnum"):
+    val statusEnum  = enumD("Status", List("ON", "OFF"))
+    val statusAlias = alias("StatusAlias", named("Status"))
+    val (k, _) = classify(
+      named("StatusAlias"),
+      aliases = List("StatusAlias" -> statusAlias),
+      enums = List("Status" -> statusEnum)
+    )
+    assertEquals(k, CkEnum(List("ON", "OFF")))
+
+  test("Option of alias preserves nullable across the chain"):
+    val email = alias("Email", named("String"))
+    val (k, nullable) = classify(
+      OptionTypeF(named("Email"), None),
+      aliases = List("Email" -> email)
+    )
+    assertEquals(k, CkPrim("TEXT"))
+    assertEquals(nullable, true)
+
+  test("SetType and SeqType classify as CkJsonArray"):
+    val setRes = classify(SetTypeF(named("Int"), None))
+    assertEquals(setRes._1, CkJsonArray())
+    val seqRes = classify(SeqTypeF(named("String"), None))
+    assertEquals(seqRes._1, CkJsonArray())
+
+  test("MapType classifies as CkJsonObject"):
+    val (k, _) = classify(MapTypeF(named("String"), named("Int"), None))
+    assertEquals(k, CkJsonObject())
+
+  test("RelationType classifies as CkRelation"):
+    val rel    = RelationTypeF(named("User"), MultOne(), named("Order"), None)
+    val (k, _) = classify(rel)
+    assertEquals(k, CkRelation())
+
+  test("unresolved NamedType falls back to CkUnknown"):
+    val (k, _) = classify(named("NotARealType"))
+    assertEquals(k, CkUnknown())
+
+  test("cyclic alias chain bottoms out at CkUnknown instead of looping"):
+    val a      = alias("A", named("B"))
+    val b      = alias("B", named("A"))
+    val (k, _) = classify(named("A"), aliases = List("A" -> a, "B" -> b))
+    assertEquals(k, CkUnknown())

--- a/modules/ir/src/main/scala/specrest/ir/IrIndex.scala
+++ b/modules/ir/src/main/scala/specrest/ir/IrIndex.scala
@@ -15,6 +15,7 @@ final case class IrIndex(
 ):
   def aliasAList: List[(String, TypeAliasDeclFull)] = aliasByName.toList
   def enumAList: List[(String, EnumDeclFull)]       = enumByName.toList
+  def entityNamesList: List[String]                 = entities.map(_.a)
 
 object IrIndex:
   private val cache: java.util.Map[ServiceIRFull, IrIndex] =

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -36,11 +36,16 @@ object SpecRestGenerated {
 
   def less_int(k: int, l: int): Boolean = integer_of_int(k) < integer_of_int(l)
 
-  def equal_bool(p: Boolean, pa: Boolean): Boolean = (p, pa) match {
-    case (false, p) => !p
-    case (true, p)  => p
-    case (p, false) => !p
-    case (p, true)  => p
+  def equal_int(k: int, l: int): Boolean =
+    integer_of_int(k) == integer_of_int(l)
+
+  sealed abstract class span_t
+  final case class SpanT(a: int, b: int, c: int, d: int) extends span_t
+
+  def equal_span_ta(x0: span_t, x1: span_t): Boolean = (x0, x1) match {
+    case (SpanT(x1, x2, x3, x4), SpanT(y1, y2, y3, y4)) =>
+      equal_int(x1, y1) &&
+      (equal_int(x2, y2) && (equal_int(x3, y3) && equal_int(x4, y4)))
   }
 
   trait equal[A] {
@@ -79,6 +84,17 @@ object SpecRestGenerated {
       val `SpecRestGenerated.equal` = (a: smt_val, b: smt_val) =>
         equal_smt_vala(a, b)
     }
+    implicit def `SpecRestGenerated.equal_span_t`: equal[span_t] = new equal[span_t] {
+      val `SpecRestGenerated.equal` = (a: span_t, b: span_t) =>
+        equal_span_ta(a, b)
+    }
+  }
+
+  def equal_bool(p: Boolean, pa: Boolean): Boolean = (p, pa) match {
+    case (false, p) => !p
+    case (true, p)  => p
+    case (p, false) => !p
+    case (p, true)  => p
   }
 
   def eq[A: equal](a: A, b: A): Boolean = equal[A](a, b)
@@ -89,9 +105,6 @@ object SpecRestGenerated {
     case (x21 :: x22, y21 :: y22) => eq[A](x21, y21) && equal_list[A](x22, y22)
     case (Nil, Nil)               => true
   }
-
-  def equal_int(k: int, l: int): Boolean =
-    integer_of_int(k) == integer_of_int(l)
 
   sealed abstract class smt_val
   final case class SBool(a: Boolean)                              extends smt_val
@@ -287,9 +300,6 @@ object SpecRestGenerated {
   final case class SubOp() extends arith_op
   final case class MulOp() extends arith_op
   final case class DivOp() extends arith_op
-
-  sealed abstract class span_t
-  final case class SpanT(a: int, b: int, c: int, d: int) extends span_t
 
   sealed abstract class set_op
   final case class UnionOp()     extends set_op
@@ -699,6 +709,15 @@ object SpecRestGenerated {
   final case class DatabaseSchema(a: List[table_spec], b: List[trigger_spec])
       extends database_schema
 
+  sealed abstract class column_kind
+  final case class CkPrim(a: String)       extends column_kind
+  final case class CkEnum(a: List[String]) extends column_kind
+  final case class CkEntityRef(a: String)  extends column_kind
+  final case class CkJsonArray()           extends column_kind
+  final case class CkJsonObject()          extends column_kind
+  final case class CkRelation()            extends column_kind
+  final case class CkUnknown()             extends column_kind
+
   sealed abstract class analysis_signals
   final case class AnalysisSignals(
       a: List[String],
@@ -826,6 +845,9 @@ object SpecRestGenerated {
       c: String,
       d: analysis_signals
   ) extends classification_result
+
+  sealed abstract class classified_column
+  final case class ClassifiedColumn(a: column_kind, b: Boolean) extends classified_column
 
   sealed abstract class detected_aggregate
   final case class DetectedAggregate(a: String, b: String, c: trigger_aggregate, d: Option[String])
@@ -8526,6 +8548,188 @@ object SpecRestGenerated {
     case NoneLitF(wi)        => false
     case IdentifierF(wj, wk) => false
   }
+
+  def equal_multiplicity(x0: multiplicity, x1: multiplicity): Boolean =
+    (x0, x1) match {
+      case (MultSome(), MultSet())  => false
+      case (MultSet(), MultSome())  => false
+      case (MultLone(), MultSet())  => false
+      case (MultSet(), MultLone())  => false
+      case (MultLone(), MultSome()) => false
+      case (MultSome(), MultLone()) => false
+      case (MultOne(), MultSet())   => false
+      case (MultSet(), MultOne())   => false
+      case (MultOne(), MultSome())  => false
+      case (MultSome(), MultOne())  => false
+      case (MultOne(), MultLone())  => false
+      case (MultLone(), MultOne())  => false
+      case (MultSet(), MultSet())   => true
+      case (MultSome(), MultSome()) => true
+      case (MultLone(), MultLone()) => true
+      case (MultOne(), MultOne())   => true
+    }
+
+  def equal_type_expr_full(x0: type_expr_full, x1: type_expr_full): Boolean =
+    (x0, x1) match {
+      case (OptionTypeF(x51, x52), RelationTypeF(x61, x62, x63, x64))   => false
+      case (RelationTypeF(x61, x62, x63, x64), OptionTypeF(x51, x52))   => false
+      case (SeqTypeF(x41, x42), RelationTypeF(x61, x62, x63, x64))      => false
+      case (RelationTypeF(x61, x62, x63, x64), SeqTypeF(x41, x42))      => false
+      case (SeqTypeF(x41, x42), OptionTypeF(x51, x52))                  => false
+      case (OptionTypeF(x51, x52), SeqTypeF(x41, x42))                  => false
+      case (MapTypeF(x31, x32, x33), RelationTypeF(x61, x62, x63, x64)) => false
+      case (RelationTypeF(x61, x62, x63, x64), MapTypeF(x31, x32, x33)) => false
+      case (MapTypeF(x31, x32, x33), OptionTypeF(x51, x52))             => false
+      case (OptionTypeF(x51, x52), MapTypeF(x31, x32, x33))             => false
+      case (MapTypeF(x31, x32, x33), SeqTypeF(x41, x42))                => false
+      case (SeqTypeF(x41, x42), MapTypeF(x31, x32, x33))                => false
+      case (SetTypeF(x21, x22), RelationTypeF(x61, x62, x63, x64))      => false
+      case (RelationTypeF(x61, x62, x63, x64), SetTypeF(x21, x22))      => false
+      case (SetTypeF(x21, x22), OptionTypeF(x51, x52))                  => false
+      case (OptionTypeF(x51, x52), SetTypeF(x21, x22))                  => false
+      case (SetTypeF(x21, x22), SeqTypeF(x41, x42))                     => false
+      case (SeqTypeF(x41, x42), SetTypeF(x21, x22))                     => false
+      case (SetTypeF(x21, x22), MapTypeF(x31, x32, x33))                => false
+      case (MapTypeF(x31, x32, x33), SetTypeF(x21, x22))                => false
+      case (NamedTypeF(x11, x12), RelationTypeF(x61, x62, x63, x64))    => false
+      case (RelationTypeF(x61, x62, x63, x64), NamedTypeF(x11, x12))    => false
+      case (NamedTypeF(x11, x12), OptionTypeF(x51, x52))                => false
+      case (OptionTypeF(x51, x52), NamedTypeF(x11, x12))                => false
+      case (NamedTypeF(x11, x12), SeqTypeF(x41, x42))                   => false
+      case (SeqTypeF(x41, x42), NamedTypeF(x11, x12))                   => false
+      case (NamedTypeF(x11, x12), MapTypeF(x31, x32, x33))              => false
+      case (MapTypeF(x31, x32, x33), NamedTypeF(x11, x12))              => false
+      case (NamedTypeF(x11, x12), SetTypeF(x21, x22))                   => false
+      case (SetTypeF(x21, x22), NamedTypeF(x11, x12))                   => false
+      case (RelationTypeF(x61, x62, x63, x64), RelationTypeF(y61, y62, y63, y64)) =>
+        equal_type_expr_full(x61, y61) &&
+        (equal_multiplicity(x62, y62) &&
+          (equal_type_expr_full(x63, y63) && equal_option[span_t](x64, y64)))
+      case (OptionTypeF(x51, x52), OptionTypeF(y51, y52)) =>
+        equal_type_expr_full(x51, y51) && equal_option[span_t](x52, y52)
+      case (SeqTypeF(x41, x42), SeqTypeF(y41, y42)) =>
+        equal_type_expr_full(x41, y41) && equal_option[span_t](x42, y42)
+      case (MapTypeF(x31, x32, x33), MapTypeF(y31, y32, y33)) =>
+        equal_type_expr_full(x31, y31) &&
+        (equal_type_expr_full(x32, y32) && equal_option[span_t](x33, y33))
+      case (SetTypeF(x21, x22), SetTypeF(y21, y22)) =>
+        equal_type_expr_full(x21, y21) && equal_option[span_t](x22, y22)
+      case (NamedTypeF(x11, x12), NamedTypeF(y11, y12)) =>
+        x11 == y11 && equal_option[span_t](x12, y12)
+    }
+
+  def primitiveTypeToSql(nm: String): Option[String] =
+    nm == "String" match {
+      case true => Some[String]("TEXT")
+      case false => nm == "Int" match {
+          case true => Some[String]("INTEGER")
+          case false => nm == "Float" match {
+              case true => Some[String]("DOUBLE PRECISION")
+              case false => nm == "Bool" match {
+                  case true => Some[String]("BOOLEAN")
+                  case false => nm == "Boolean" match {
+                      case true => Some[String]("BOOLEAN")
+                      case false => nm == "DateTime" match {
+                          case true => Some[String]("TIMESTAMPTZ")
+                          case false => nm == "Date" match {
+                              case true => Some[String]("DATE")
+                              case false => nm == "UUID" match {
+                                  case true => Some[String]("UUID")
+                                  case false => nm == "Decimal" match {
+                                      case true => Some[String]("NUMERIC(19,4)")
+                                      case false => nm == "Bytes" match {
+                                          case true => Some[String]("BYTEA")
+                                          case false => nm == "Money" match {
+                                              case true  => Some[String]("INTEGER")
+                                              case false => None
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+  def classifyColumnTypeAux(
+      fuel: nat,
+      uu: type_expr_full,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[(String, enum_decl_full)],
+      ux: List[String],
+      uy: List[String],
+      nullable: Boolean
+  ): classified_column =
+    equal_nat(fuel, zero_nat) match {
+      case true => ClassifiedColumn(CkUnknown(), nullable)
+      case false =>
+        val stripped = stripOptions(uu): type_expr_full
+        val nullablea =
+          nullable ||
+            !equal_type_expr_full(stripped, uu): Boolean;
+        stripped match {
+          case NamedTypeF(name, _) =>
+            primitiveTypeToSql(name) match {
+              case None =>
+                map_of[String, enum_decl_full](uw, name) match {
+                  case None =>
+                    membera[String](ux, name) match {
+                      case true => ClassifiedColumn(CkEntityRef(name), nullablea)
+                      case false => membera[String](uy, name) match {
+                          case true => ClassifiedColumn(CkUnknown(), nullablea)
+                          case false => map_of[String, type_alias_decl_full](uv, name) match {
+                              case None =>
+                                ClassifiedColumn(CkUnknown(), nullablea)
+                              case Some(TypeAliasDeclFull(_, base, _, _)) =>
+                                classifyColumnTypeAux(
+                                  minus_nat(fuel, one_nat),
+                                  base,
+                                  uv,
+                                  uw,
+                                  ux,
+                                  name :: uy,
+                                  nullablea
+                                )
+                            }
+                        }
+                    }
+                  case Some(EnumDeclFull(_, vs, _)) =>
+                    ClassifiedColumn(CkEnum(vs), nullablea)
+                }
+              case Some(sqlType) =>
+                ClassifiedColumn(CkPrim(sqlType), nullablea)
+            }
+          case SetTypeF(_, _) =>
+            ClassifiedColumn(CkJsonArray(), nullablea)
+          case MapTypeF(_, _, _) =>
+            ClassifiedColumn(CkJsonObject(), nullablea)
+          case SeqTypeF(_, _) =>
+            ClassifiedColumn(CkJsonArray(), nullablea)
+          case OptionTypeF(_, _) =>
+            ClassifiedColumn(CkUnknown(), nullablea)
+          case RelationTypeF(_, _, _, _) =>
+            ClassifiedColumn(CkRelation(), nullablea)
+        }
+    }
+
+  def classifyColumnType(
+      ty: type_expr_full,
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)],
+      entityNames: List[String]
+  ): classified_column =
+    classifyColumnTypeAux(
+      Suc(size_list[(String, type_alias_decl_full)](am)),
+      ty,
+      am,
+      em,
+      entityNames,
+      Nil,
+      false
+    )
 
   def mergeStringConstraint(x0: string_constraint, x1: string_constraint): string_constraint =
     (x0, x1) match {

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -215,6 +215,8 @@ export_code
     isFailLoudStub
     aliasRefinements
     findEnumValuesInType
+    primitiveTypeToSql
+    classifyColumnType
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -178,6 +178,9 @@ where
        | SeqTypeF _ _      \<Rightarrow> ClassifiedColumn CkJsonArray nullable'
        | MapTypeF _ _ _    \<Rightarrow> ClassifiedColumn CkJsonObject nullable'
        | RelationTypeF _ _ _ _ \<Rightarrow> ClassifiedColumn CkRelation nullable'
+       \<comment> \<open>Unreachable: \<open>stripOptions\<close> peels all outer \<open>OptionTypeF\<close> layers, so
+         \<open>stripped\<close> is never \<open>OptionTypeF\<close>. Required for \<open>fun\<close> match completeness;
+         anyone weakening \<open>stripOptions\<close> would need to revisit this branch.\<close>
        | OptionTypeF _ _   \<Rightarrow> ClassifiedColumn CkUnknown nullable')"
 
 definition classifyColumnType ::

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -1,5 +1,5 @@
 theory SchemaDerive
-  imports Schema MigrationOps IR_Helpers IR_Analysis IR_Lower
+  imports Schema MigrationOps IR_Helpers IR_Analysis IR_Lower SchemaTraversal
 begin
 
 text \<open>Pure utility lifts from \<open>specrest.convention.Schema\<close>. The bulk of
@@ -99,6 +99,97 @@ definition detectAggregateInvariant :: "expr_full \<Rightarrow> detected_aggrega
                    (case ac of AggregateCall coll agg src \<Rightarrow>
                       Some (DetectedAggregate tgt coll agg src))))
      | _ \<Rightarrow> None)"
+
+text \<open>SQL type lookup for the 11 spec primitives understood by deriveSchema.
+  Lifted from \<open>specrest.convention.Schema.PrimitiveTypeMap\<close>. \<open>Money\<close> is an
+  INTEGER alias (cents-as-int convention); \<open>Boolean\<close> aliases \<open>Bool\<close>.\<close>
+
+definition primitiveTypeToSql :: "String.literal \<Rightarrow> String.literal option" where
+  "primitiveTypeToSql nm = (
+    if nm = STR ''String''   then Some (STR ''TEXT'')
+    else if nm = STR ''Int''      then Some (STR ''INTEGER'')
+    else if nm = STR ''Float''    then Some (STR ''DOUBLE PRECISION'')
+    else if nm = STR ''Bool''     then Some (STR ''BOOLEAN'')
+    else if nm = STR ''Boolean''  then Some (STR ''BOOLEAN'')
+    else if nm = STR ''DateTime'' then Some (STR ''TIMESTAMPTZ'')
+    else if nm = STR ''Date''     then Some (STR ''DATE'')
+    else if nm = STR ''UUID''     then Some (STR ''UUID'')
+    else if nm = STR ''Decimal''  then Some (STR ''NUMERIC(19,4)'')
+    else if nm = STR ''Bytes''    then Some (STR ''BYTEA'')
+    else if nm = STR ''Money''    then Some (STR ''INTEGER'')
+    else None)"
+
+text \<open>Column-kind classification for the deriveSchema field walker. Lifts the
+  pure recursive part of \<open>specrest.convention.Schema.mapTypeToColumn\<close>: peels
+  \<open>OptionTypeF\<close> wrappers tracking nullability, follows alias chains via
+  \<open>map_of am\<close>, and produces a flat \<open>column_kind\<close> tag the Scala caller
+  uses to build the final \<open>column_spec\<close> (FK col name, CHECK string,
+  default literals are all string-building post-steps that stay in Scala).
+
+  Alias-cycle protection: the same fuel-bounded visited-set pattern as
+  \<open>aliasRefinements\<close> / \<open>findEnumValuesInType\<close> in \<open>SchemaTraversal\<close>.\<close>
+
+datatype column_kind =
+    CkPrim "String.literal"        \<comment> \<open>sql type from primitiveTypeToSql\<close>
+  | CkEnum "String.literal list"   \<comment> \<open>enum value list (used to build IN-list CHECK)\<close>
+  | CkEntityRef "String.literal"   \<comment> \<open>target entity name (Scala builds FK + _id suffix)\<close>
+  | CkJsonArray                    \<comment> \<open>SetTypeF / SeqTypeF → JSONB with '[]'::jsonb default\<close>
+  | CkJsonObject                   \<comment> \<open>MapTypeF → JSONB with '{}'::jsonb default\<close>
+  | CkRelation                     \<comment> \<open>RelationTypeF → BIGINT\<close>
+  | CkUnknown                      \<comment> \<open>unresolved NamedTypeF → TEXT fallback\<close>
+
+datatype classified_column = ClassifiedColumn column_kind bool
+  \<comment> \<open>kind + nullable flag (true iff the type expression had an outer OptionTypeF
+      anywhere in the alias chain)\<close>
+
+text \<open>\<open>stripOptions\<close> (from SchemaTraversal) peels all outer \<open>OptionTypeF\<close>
+  layers; we use it before each alias-hop dispatch so fuel is only consumed on
+  alias chains, not on Option-nesting depth (which is structurally bounded by
+  the input type). The nullable flag is set whenever stripping changed the type
+  — at the top of the input or after following an alias whose body was an
+  \<open>OptionTypeF\<close>.\<close>
+
+fun classifyColumnTypeAux ::
+  "nat \<Rightarrow> type_expr_full \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list
+    \<Rightarrow> String.literal list \<Rightarrow> bool \<Rightarrow> classified_column"
+where
+  "classifyColumnTypeAux 0 _ _ _ _ _ nullable = ClassifiedColumn CkUnknown nullable"
+| "classifyColumnTypeAux (Suc fuel) ty am em entityNames seen nullable =
+     (let stripped = stripOptions ty;
+          nullable' = nullable \<or> stripped \<noteq> ty
+      in case stripped of
+         NamedTypeF name _ \<Rightarrow>
+           (case primitiveTypeToSql name of
+              Some sqlType \<Rightarrow> ClassifiedColumn (CkPrim sqlType) nullable'
+            | None \<Rightarrow>
+                (case map_of em name of
+                   Some (EnumDeclFull _ vs _) \<Rightarrow> ClassifiedColumn (CkEnum vs) nullable'
+                 | None \<Rightarrow>
+                     (if name \<in> set entityNames then
+                        ClassifiedColumn (CkEntityRef name) nullable'
+                      else if name \<in> set seen then
+                        ClassifiedColumn CkUnknown nullable'
+                      else case map_of am name of
+                             Some (TypeAliasDeclFull _ base _ _) \<Rightarrow>
+                               classifyColumnTypeAux fuel base am em entityNames
+                                 (name # seen) nullable'
+                           | None \<Rightarrow> ClassifiedColumn CkUnknown nullable')))
+       | SetTypeF _ _      \<Rightarrow> ClassifiedColumn CkJsonArray nullable'
+       | SeqTypeF _ _      \<Rightarrow> ClassifiedColumn CkJsonArray nullable'
+       | MapTypeF _ _ _    \<Rightarrow> ClassifiedColumn CkJsonObject nullable'
+       | RelationTypeF _ _ _ _ \<Rightarrow> ClassifiedColumn CkRelation nullable'
+       | OptionTypeF _ _   \<Rightarrow> ClassifiedColumn CkUnknown nullable')"
+
+definition classifyColumnType ::
+  "type_expr_full \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list
+    \<Rightarrow> classified_column"
+where
+  "classifyColumnType ty am em entityNames =
+     classifyColumnTypeAux (Suc (length am)) ty am em entityNames [] False"
+
+lemmas primitiveTypeToSql_code [code] = primitiveTypeToSql_def
+lemmas classifyColumnTypeAux_code [code] = classifyColumnTypeAux.simps
+lemmas classifyColumnType_code [code] = classifyColumnType_def
 
 lemmas widenExplicitIdPkSqlType_code [code] = widenExplicitIdPkSqlType_def
 lemmas sqlOp_code [code] = sqlOp_def


### PR DESCRIPTION
## Summary

Extracts the pure recursive type-classification kernel of `specrest.convention.Schema.mapTypeToColumn` into Isabelle. Continues the deriveSchema lift series with a tractable, self-contained chunk.

### What's lifted

- **`primitiveTypeToSql`** — mirror of `Schema.PrimitiveTypeMap` (the 11 spec primitives → SQL type table)
- **`classifyColumnType`** — recursive type-walker over `type_expr_full` + alias chain + entity/enum maps that produces a flat `column_kind` tag:

  - `CkPrim sql_type` — primitive (TEXT/INTEGER/...)
  - `CkEnum values` — enum: Scala builds the IN-list CHECK string
  - `CkEntityRef name` — entity: Scala appends `_id` and builds the FK
  - `CkJsonArray` — Set/Seq → JSONB with `'[]'::jsonb` default
  - `CkJsonObject` — Map → JSONB with `'{}'::jsonb` default
  - `CkRelation` — RelationType → BIGINT
  - `CkUnknown` — unresolved NamedType / cycle / fuel exhaustion

  Plus `nullable: Bool` tracked through Option layers (including Option-through-alias chains).

### Design notes

- Reuses the **fuel-bounded visited-set pattern** from `aliasRefinements` / `findEnumValuesInType` in `SchemaTraversal.thy`.
- **Option-nesting handled structurally via `stripOptions`** outside the fuel loop — only alias hops consume fuel. Initial design consumed fuel on Option peels, which broke `Option[Int]` with zero aliases. Fixed by checking `stripped != ty` to detect nullability without recursion.

### What stays in Scala

The string-formatting post-step (escapeSqlString, IN-list join, `_id` suffix, `Naming.toTableName`, JSONB defaults, FK construction). Char-level / regex / mutable-builder concerns that don't benefit from lifting.

### Code-shape impact

`Schema.mapTypeToColumn` shrinks from **72 lines to 28 lines** — pattern-matches the extracted classification and dispatches to formatters. `PrimitiveTypeMap` deleted from Scala (single source of truth now in `SchemaDerive.thy`).

## Test plan

- [x] `isabelle build` — green (1:58 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `ClassifyColumnTypeTest` — 13 focused tests
- [x] `sbt scalafixAll` run before push

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the pure column-type classifier from `specrest.convention.Schema.mapTypeToColumn` into Isabelle (`primitiveTypeToSql`, `classifyColumnType`) and reduced Scala to simple formatting. This shrinks the mapper, centralizes primitive mapping, and makes the recursion provable and reusable.

- **Refactors**
  - Centralized type classification in Isabelle; Scala now switches on `column_kind` + `nullable` to format enums, FKs (`_id`), JSONB defaults, and checks.
  - Added `column_kind`/`classifyColumnType` to `SpecRestGenerated.scala` via codegen and exported in `Codegen.thy`; removed `PrimitiveTypeMap` from Scala.
  - Introduced `ClassifierCtx` to pass alias/enum/entity lists once (no per-call `.toList`); added `IrIndex.entityNamesList` and threaded through schema derivation and `aliasRefinements`.
  - Added `ClassifyColumnTypeTest` (13 cases). All tests pass.

<sup>Written for commit 0c5be2e2989ec775ee60b68e1323b84c5d14dcb0. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/323?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal schema column type classification logic for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for column type classification including primitives, enums, entity references, and nested type handling.

* **Chores**
  * Updated formal verification artifacts to align with implementation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->