### PR TITLE
feat(proofs): lift detectTriggerCandidate (Schema.detectAggregateTriggers kernel)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -408,53 +408,21 @@ object Schema:
       entities: List[EntityDeclFull],
       tables: List[table_spec]
   ): List[trigger_spec] =
-    val tablesByEntity = tables.map(t => tableEntityName(t) -> t).toMap
-    val entityByName   = entities.map(e => e.a -> e).toMap
-    val out            = List.newBuilder[trigger_spec]
-    for parent <- entities do
-      val parentTable  = tablesByEntity.get(parent.a)
-      val parentFields = parent.c.collect { case f: FieldDeclFull => f }
-      for inv <- parent.d do
-        detectAggregateInvariant(inv) match
-          case Some(DetectedAggregate(targetField, collectionFieldName, aggregate, sourceField)) =>
-            val parentFieldOk   = parentFields.exists(_.a == targetField)
-            val collectionField = parentFields.find(_.a == collectionFieldName)
-            val childEntityName: Option[String] = collectionField.flatMap: f =>
-              f.b match
-                case SetTypeF(NamedTypeF(n, _), _) => Some(n)
-                case SeqTypeF(NamedTypeF(n, _), _) => Some(n)
-                case _                             => None
-            // Find back-FK on child table to parent — must be unique (ambiguous
-            // FKs to the same parent table can't be resolved without further
-            // input; emit nothing rather than picking arbitrarily).
-            val triggerOpt =
-              for
-                _           <- if parentFieldOk then Some(()) else None
-                parentTbl   <- parentTable
-                childName   <- childEntityName
-                childEntity <- entityByName.get(childName)
-                childTable  <- tablesByEntity.get(childName)
-                matchingFks = tableForeignKeys(childTable).filter(fk =>
-                                fkRefTable(fk) == tableName(parentTbl)
-                              )
-                fk             <- if matchingFks.size == 1 then matchingFks.headOption else None
-                childFieldNames = childEntity.c.collect { case f: FieldDeclFull => f.a }.toSet
-                _ <- sourceField match
-                       case Some(sf) if !childFieldNames.contains(sf) => None
-                       case _                                         => Some(())
-              yield
-                val parentSnake = Naming.toSnakeCase(parent.a)
-                val funcName    = s"recalc_${parentSnake}_$targetField"
-                TriggerSpec(
-                  s"trg_$funcName",
-                  funcName,
-                  tableName(parentTbl),
-                  Naming.toColumnName(targetField),
-                  tableName(childTable),
-                  fkColumn(fk),
-                  aggregate,
-                  sourceField.map(Naming.toColumnName)
-                )
-            triggerOpt.foreach(out += _)
-          case None => ()
+    val out = List.newBuilder[trigger_spec]
+    for parent <- entities; inv <- parent.d do
+      detectTriggerCandidate(parent, inv, entities, tables) match
+        case Some(TriggerCandidate(parentTable, targetField, childTable, fkCol, agg, srcField)) =>
+          val parentSnake = Naming.toSnakeCase(parent.a)
+          val funcName    = s"recalc_${parentSnake}_$targetField"
+          out += TriggerSpec(
+            s"trg_$funcName",
+            funcName,
+            parentTable,
+            Naming.toColumnName(targetField),
+            childTable,
+            fkCol,
+            agg,
+            srcField.map(Naming.toColumnName)
+          )
+        case None => ()
     out.result()

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -408,21 +408,47 @@ object Schema:
       entities: List[EntityDeclFull],
       tables: List[table_spec]
   ): List[trigger_spec] =
-    val out = List.newBuilder[trigger_spec]
-    for parent <- entities; inv <- parent.d do
-      detectTriggerCandidate(parent, inv, entities, tables) match
-        case Some(TriggerCandidate(parentTable, targetField, childTable, fkCol, agg, srcField)) =>
-          val parentSnake = Naming.toSnakeCase(parent.a)
-          val funcName    = s"recalc_${parentSnake}_$targetField"
-          out += TriggerSpec(
-            s"trg_$funcName",
-            funcName,
-            parentTable,
-            Naming.toColumnName(targetField),
-            childTable,
-            fkCol,
-            agg,
-            srcField.map(Naming.toColumnName)
-          )
+    val tablesByEntity = tables.map(t => tableEntityName(t) -> t).toMap
+    val entitiesByName = entities.map(e => e.a -> e).toMap
+    val out            = List.newBuilder[trigger_spec]
+    for
+      parent    <- entities
+      parentTbl <- tablesByEntity.get(parent.a)
+      inv       <- parent.d
+    do
+      detectAggregateInvariant(inv) match
+        case Some(DetectedAggregate(targetField, collFieldName, agg, sourceField)) =>
+          val parentFields = parent.c.collect { case f: FieldDeclFull => f }
+          val triggerOpt: Option[trigger_candidate] =
+            for
+              collField   <- parentFields.find(_.a == collFieldName)
+              childName   <- collectionElementEntityName(collField.b)
+              childEntity <- entitiesByName.get(childName)
+              childTable  <- tablesByEntity.get(childName)
+              validated <- validateTrigger(
+                             parentTbl,
+                             parentFields,
+                             childTable,
+                             childEntity,
+                             targetField,
+                             agg,
+                             sourceField
+                           )
+            yield validated
+          triggerOpt match
+            case Some(TriggerCandidate(parentTable, _, childTable, fkCol, _, srcField)) =>
+              val parentSnake = Naming.toSnakeCase(parent.a)
+              val funcName    = s"recalc_${parentSnake}_$targetField"
+              out += TriggerSpec(
+                s"trg_$funcName",
+                funcName,
+                parentTable,
+                Naming.toColumnName(targetField),
+                childTable,
+                fkCol,
+                agg,
+                srcField.map(Naming.toColumnName)
+              )
+            case None => ()
         case None => ()
     out.result()

--- a/modules/convention/src/test/scala/specrest/convention/DetectTriggerCandidateTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/DetectTriggerCandidateTest.scala
@@ -1,0 +1,186 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+class DetectTriggerCandidateTest extends CatsEffectSuite:
+
+  private def named(t: String): NamedTypeF = NamedTypeF(t, None)
+
+  private def fieldD(name: String, ty: type_expr_full): FieldDeclFull =
+    FieldDeclFull(name, ty, None, None)
+
+  private def entityD(
+      name: String,
+      fields: List[field_decl_full],
+      invariants: List[expr_full] = Nil
+  ): EntityDeclFull =
+    EntityDeclFull(name, None, fields, invariants, None)
+
+  private def col(name: String, sqlType: String): ColumnSpec =
+    ColumnSpec(name, sqlType, false, None)
+
+  private def fk(col: String, refTable: String): ForeignKeySpec =
+    ForeignKeySpec(col, refTable, "id", "CASCADE")
+
+  private def table(
+      name: String,
+      entity: String,
+      cols: List[column_spec],
+      fks: List[foreign_key_spec] = Nil
+  ): TableSpec =
+    TableSpec(name, entity, cols, "id", fks, Nil, Nil)
+
+  // sum(items, lambda i: i.amount) where parent has `total: Int` and field `items: Set[Item]`.
+  private def sumInvariant(target: String, coll: String, src: String): expr_full =
+    BinaryOpF(
+      BEq(),
+      IdentifierF(target, None),
+      CallF(
+        IdentifierF("sum", None),
+        List(
+          IdentifierF(coll, None),
+          LambdaF("i", FieldAccessF(IdentifierF("i", None), src, None), None)
+        ),
+        None
+      ),
+      None
+    )
+
+  private val parent = entityD(
+    "Order",
+    fields = List(fieldD("total", named("Int")), fieldD("items", SetTypeF(named("Item"), None))),
+    invariants = List(sumInvariant("total", "items", "amount"))
+  )
+
+  private val child = entityD(
+    "Item",
+    fields = List(fieldD("order_id", named("Int")), fieldD("amount", named("Int")))
+  )
+
+  private val orderTable =
+    table("orders", "Order", List(col("id", "BIGSERIAL"), col("total", "INTEGER")))
+  private val itemTable = table(
+    "items",
+    "Item",
+    List(col("id", "BIGSERIAL"), col("order_id", "BIGINT"), col("amount", "INTEGER")),
+    fks = List(fk("order_id", "orders"))
+  )
+
+  test("happy path: parent + child + unique back-FK + valid source field → Some candidate"):
+    val result = detectTriggerCandidate(
+      parent,
+      parent.d.head,
+      List(parent, child),
+      List(orderTable, itemTable)
+    )
+    assertEquals(
+      result,
+      Some(TriggerCandidate("orders", "total", "items", "order_id", SumAgg(), Some("amount")))
+    )
+
+  test("returns None if invariant doesn't match aggregate shape"):
+    val nonAgg = BoolLitF(true, None)
+    val result = detectTriggerCandidate(
+      parent,
+      nonAgg,
+      List(parent, child),
+      List(orderTable, itemTable)
+    )
+    assertEquals(result, None)
+
+  test("returns None if parent table missing from schema"):
+    val result = detectTriggerCandidate(
+      parent,
+      parent.d.head,
+      List(parent, child),
+      List(itemTable)
+    )
+    assertEquals(result, None)
+
+  test("returns None if target field doesn't exist on parent"):
+    val badParent = entityD(
+      "Order",
+      fields = List(fieldD("items", SetTypeF(named("Item"), None))),
+      invariants = List(sumInvariant("total", "items", "amount"))
+    )
+    val result = detectTriggerCandidate(
+      badParent,
+      badParent.d.head,
+      List(badParent, child),
+      List(orderTable, itemTable)
+    )
+    assertEquals(result, None)
+
+  test("returns None if collection field's element type is not an entity"):
+    val flatColl = entityD(
+      "Order",
+      fields = List(fieldD("total", named("Int")), fieldD("items", SetTypeF(named("Int"), None))),
+      invariants = List(sumInvariant("total", "items", "amount"))
+    )
+    val intTable = table("orders", "Order", List(col("id", "BIGSERIAL")))
+    val result = detectTriggerCandidate(
+      flatColl,
+      flatColl.d.head,
+      List(flatColl),
+      List(intTable)
+    )
+    assertEquals(result, None)
+
+  test("returns None if child has multiple FKs to parent (ambiguous)"):
+    val multiFkChild = table(
+      "items",
+      "Item",
+      List(col("id", "BIGSERIAL"), col("order_id", "BIGINT"), col("alt_order_id", "BIGINT")),
+      fks = List(fk("order_id", "orders"), fk("alt_order_id", "orders"))
+    )
+    val result = detectTriggerCandidate(
+      parent,
+      parent.d.head,
+      List(parent, child),
+      List(orderTable, multiFkChild)
+    )
+    assertEquals(result, None)
+
+  test("returns None if source-projection field missing from child"):
+    val childMissingSrc = entityD(
+      "Item",
+      fields = List(fieldD("order_id", named("Int")))
+    )
+    val result = detectTriggerCandidate(
+      parent,
+      parent.d.head,
+      List(parent, childMissingSrc),
+      List(orderTable, itemTable)
+    )
+    assertEquals(result, None)
+
+  test("Seq element type also resolves (parallel to Set)"):
+    val seqParent = entityD(
+      "Order",
+      fields = List(fieldD("total", named("Int")), fieldD("items", SeqTypeF(named("Item"), None))),
+      invariants = List(sumInvariant("total", "items", "amount"))
+    )
+    val result = detectTriggerCandidate(
+      seqParent,
+      seqParent.d.head,
+      List(seqParent, child),
+      List(orderTable, itemTable)
+    )
+    assertEquals(
+      result,
+      Some(TriggerCandidate("orders", "total", "items", "order_id", SumAgg(), Some("amount")))
+    )
+
+  test("uniqueBackFkColumn returns the column when exactly one FK matches"):
+    val fks = List(fk("order_id", "orders"), fk("user_id", "users"))
+    assertEquals(uniqueBackFkColumn(fks, "orders"), Some("order_id"))
+    assertEquals(uniqueBackFkColumn(fks, "users"), Some("user_id"))
+    assertEquals(uniqueBackFkColumn(fks, "nonexistent"), None)
+    assertEquals(uniqueBackFkColumn(List(fk("a", "x"), fk("b", "x")), "x"), None)
+
+  test("collectionElementEntityName extracts the inner NamedType"):
+    assertEquals(collectionElementEntityName(SetTypeF(named("User"), None)), Some("User"))
+    assertEquals(collectionElementEntityName(SeqTypeF(named("Order"), None)), Some("Order"))
+    assertEquals(collectionElementEntityName(named("User")), None)
+    assertEquals(collectionElementEntityName(SetTypeF(SetTypeF(named("X"), None), None)), None)

--- a/modules/convention/src/test/scala/specrest/convention/DetectTriggerCandidateTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/DetectTriggerCandidateTest.scala
@@ -12,10 +12,9 @@ class DetectTriggerCandidateTest extends CatsEffectSuite:
 
   private def entityD(
       name: String,
-      fields: List[field_decl_full],
-      invariants: List[expr_full] = Nil
+      fields: List[field_decl_full]
   ): EntityDeclFull =
-    EntityDeclFull(name, None, fields, invariants, None)
+    EntityDeclFull(name, None, fields, Nil, None)
 
   private def col(name: String, sqlType: String): ColumnSpec =
     ColumnSpec(name, sqlType, false, None)
@@ -31,26 +30,9 @@ class DetectTriggerCandidateTest extends CatsEffectSuite:
   ): TableSpec =
     TableSpec(name, entity, cols, "id", fks, Nil, Nil)
 
-  // sum(items, lambda i: i.amount) where parent has `total: Int` and field `items: Set[Item]`.
-  private def sumInvariant(target: String, coll: String, src: String): expr_full =
-    BinaryOpF(
-      BEq(),
-      IdentifierF(target, None),
-      CallF(
-        IdentifierF("sum", None),
-        List(
-          IdentifierF(coll, None),
-          LambdaF("i", FieldAccessF(IdentifierF("i", None), src, None), None)
-        ),
-        None
-      ),
-      None
-    )
-
   private val parent = entityD(
     "Order",
-    fields = List(fieldD("total", named("Int")), fieldD("items", SetTypeF(named("Item"), None))),
-    invariants = List(sumInvariant("total", "items", "amount"))
+    fields = List(fieldD("total", named("Int")), fieldD("items", SetTypeF(named("Item"), None)))
   )
 
   private val child = entityD(
@@ -67,63 +49,48 @@ class DetectTriggerCandidateTest extends CatsEffectSuite:
     fks = List(fk("order_id", "orders"))
   )
 
-  test("happy path: parent + child + unique back-FK + valid source field → Some candidate"):
-    val result = detectTriggerCandidate(
-      parent,
-      parent.d.head,
-      List(parent, child),
-      List(orderTable, itemTable)
+  private val parentFields = parent.c.collect { case f: FieldDeclFull => f }
+
+  test("happy path: parent has target + child has unique back-FK + source field exists → Some"):
+    val result = validateTrigger(
+      orderTable,
+      parentFields,
+      itemTable,
+      child,
+      "total",
+      SumAgg(),
+      Some("amount")
     )
     assertEquals(
       result,
       Some(TriggerCandidate("orders", "total", "items", "order_id", SumAgg(), Some("amount")))
     )
 
-  test("returns None if invariant doesn't match aggregate shape"):
-    val nonAgg = BoolLitF(true, None)
-    val result = detectTriggerCandidate(
-      parent,
-      nonAgg,
-      List(parent, child),
-      List(orderTable, itemTable)
+  test("happy path with no source field (COUNT-style)"):
+    val result = validateTrigger(
+      orderTable,
+      parentFields,
+      itemTable,
+      child,
+      "total",
+      CountAgg(),
+      None
     )
-    assertEquals(result, None)
-
-  test("returns None if parent table missing from schema"):
-    val result = detectTriggerCandidate(
-      parent,
-      parent.d.head,
-      List(parent, child),
-      List(itemTable)
+    assertEquals(
+      result,
+      Some(TriggerCandidate("orders", "total", "items", "order_id", CountAgg(), None))
     )
-    assertEquals(result, None)
 
   test("returns None if target field doesn't exist on parent"):
-    val badParent = entityD(
-      "Order",
-      fields = List(fieldD("items", SetTypeF(named("Item"), None))),
-      invariants = List(sumInvariant("total", "items", "amount"))
-    )
-    val result = detectTriggerCandidate(
-      badParent,
-      badParent.d.head,
-      List(badParent, child),
-      List(orderTable, itemTable)
-    )
-    assertEquals(result, None)
-
-  test("returns None if collection field's element type is not an entity"):
-    val flatColl = entityD(
-      "Order",
-      fields = List(fieldD("total", named("Int")), fieldD("items", SetTypeF(named("Int"), None))),
-      invariants = List(sumInvariant("total", "items", "amount"))
-    )
-    val intTable = table("orders", "Order", List(col("id", "BIGSERIAL")))
-    val result = detectTriggerCandidate(
-      flatColl,
-      flatColl.d.head,
-      List(flatColl),
-      List(intTable)
+    val noTarget = List(fieldD("items", SetTypeF(named("Item"), None)))
+    val result = validateTrigger(
+      orderTable,
+      noTarget,
+      itemTable,
+      child,
+      "total",
+      SumAgg(),
+      Some("amount")
     )
     assertEquals(result, None)
 
@@ -134,43 +101,42 @@ class DetectTriggerCandidateTest extends CatsEffectSuite:
       List(col("id", "BIGSERIAL"), col("order_id", "BIGINT"), col("alt_order_id", "BIGINT")),
       fks = List(fk("order_id", "orders"), fk("alt_order_id", "orders"))
     )
-    val result = detectTriggerCandidate(
-      parent,
-      parent.d.head,
-      List(parent, child),
-      List(orderTable, multiFkChild)
+    val result = validateTrigger(
+      orderTable,
+      parentFields,
+      multiFkChild,
+      child,
+      "total",
+      SumAgg(),
+      Some("amount")
+    )
+    assertEquals(result, None)
+
+  test("returns None if child has no FK to parent"):
+    val noFkChild = table("items", "Item", List(col("id", "BIGSERIAL")), fks = Nil)
+    val result = validateTrigger(
+      orderTable,
+      parentFields,
+      noFkChild,
+      child,
+      "total",
+      SumAgg(),
+      Some("amount")
     )
     assertEquals(result, None)
 
   test("returns None if source-projection field missing from child"):
-    val childMissingSrc = entityD(
-      "Item",
-      fields = List(fieldD("order_id", named("Int")))
-    )
-    val result = detectTriggerCandidate(
-      parent,
-      parent.d.head,
-      List(parent, childMissingSrc),
-      List(orderTable, itemTable)
+    val childMissingSrc = entityD("Item", fields = List(fieldD("order_id", named("Int"))))
+    val result = validateTrigger(
+      orderTable,
+      parentFields,
+      itemTable,
+      childMissingSrc,
+      "total",
+      SumAgg(),
+      Some("amount")
     )
     assertEquals(result, None)
-
-  test("Seq element type also resolves (parallel to Set)"):
-    val seqParent = entityD(
-      "Order",
-      fields = List(fieldD("total", named("Int")), fieldD("items", SeqTypeF(named("Item"), None))),
-      invariants = List(sumInvariant("total", "items", "amount"))
-    )
-    val result = detectTriggerCandidate(
-      seqParent,
-      seqParent.d.head,
-      List(seqParent, child),
-      List(orderTable, itemTable)
-    )
-    assertEquals(
-      result,
-      Some(TriggerCandidate("orders", "total", "items", "order_id", SumAgg(), Some("amount")))
-    )
 
   test("uniqueBackFkColumn returns the column when exactly one FK matches"):
     val fks = List(fk("order_id", "orders"), fk("user_id", "users"))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -849,6 +849,16 @@ object SpecRestGenerated {
   sealed abstract class classified_column
   final case class ClassifiedColumn(a: column_kind, b: Boolean) extends classified_column
 
+  sealed abstract class trigger_candidate
+  final case class TriggerCandidate(
+      a: String,
+      b: String,
+      c: String,
+      d: String,
+      e: trigger_aggregate,
+      f: Option[String]
+  ) extends trigger_candidate
+
   sealed abstract class detected_aggregate
   final case class DetectedAggregate(a: String, b: String, c: trigger_aggregate, d: Option[String])
       extends detected_aggregate
@@ -7564,6 +7574,9 @@ object SpecRestGenerated {
     case TriggerSpec(uu, uv, uw, tc, ux, uy, uz, va) => tc
   }
 
+  def tableByEntity(ts: List[table_spec], nm: String): Option[table_spec] =
+    find[table_spec]((t: table_spec) => tableEntityName(t) == nm, ts)
+
   def tc_relations_update[A](
       tc_relationsa: (List[state_field_decl_full]) => List[state_field_decl_full],
       x1: tyctx_ext[A]
@@ -8159,6 +8172,9 @@ object SpecRestGenerated {
         }
     }
 
+  def entityFieldDecls(e: entity_decl_full): List[field_decl_full] =
+    entityFieldsFull(e)
+
   def lambdaProjection(body: expr_full): Option[String] =
     body match {
       case BinaryOpF(_, _, _, _)                             => None
@@ -8731,6 +8747,17 @@ object SpecRestGenerated {
       false
     )
 
+  def uniqueBackFkColumn(fks: List[foreign_key_spec], parentTable: String): Option[String] =
+    filter[foreign_key_spec](
+      (fk: foreign_key_spec) =>
+        fkRefTable(fk) == parentTable,
+      fks
+    ) match {
+      case Nil         => None
+      case List(fk)    => Some[String](fkColumn(fk))
+      case _ :: _ :: _ => None
+    }
+
   def mergeStringConstraint(x0: string_constraint, x1: string_constraint): string_constraint =
     (x0, x1) match {
       case (StringConstraint(amin, amax, ar, ap, af), StringConstraint(bmin, bmax, br, bp, bf)) =>
@@ -9279,6 +9306,158 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, RelationTypeF(vd, ve, vf, vg), vc) => None
   }
 
+  def collectionElementEntityName(ty: type_expr_full): Option[String] =
+    ty match {
+      case NamedTypeF(_, _)                       => None
+      case SetTypeF(NamedTypeF(n, _), _)          => Some[String](n)
+      case SetTypeF(SetTypeF(_, _), _)            => None
+      case SetTypeF(MapTypeF(_, _, _), _)         => None
+      case SetTypeF(SeqTypeF(_, _), _)            => None
+      case SetTypeF(OptionTypeF(_, _), _)         => None
+      case SetTypeF(RelationTypeF(_, _, _, _), _) => None
+      case MapTypeF(_, _, _)                      => None
+      case SeqTypeF(NamedTypeF(n, _), _)          => Some[String](n)
+      case SeqTypeF(SetTypeF(_, _), _)            => None
+      case SeqTypeF(MapTypeF(_, _, _), _)         => None
+      case SeqTypeF(SeqTypeF(_, _), _)            => None
+      case SeqTypeF(OptionTypeF(_, _), _)         => None
+      case SeqTypeF(RelationTypeF(_, _, _, _), _) => None
+      case OptionTypeF(_, _)                      => None
+      case RelationTypeF(_, _, _, _)              => None
+    }
+
+  def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
+    invExpr match {
+      case BinaryOpF(BAnd(), _, _, _)     => None
+      case BinaryOpF(BOr(), _, _, _)      => None
+      case BinaryOpF(BImplies(), _, _, _) => None
+      case BinaryOpF(BIff(), _, _, _)     => None
+      case BinaryOpF(BEq(), lhs, rhs, _) =>
+        extractFieldName(lhs) match {
+          case None => None
+          case Some(tgt) =>
+            decodeAggregateCall(rhs) match {
+              case None => None
+              case Some(AggregateCall(coll, agg, src)) =>
+                Some[detected_aggregate](DetectedAggregate(tgt, coll, agg, src))
+            }
+        }
+      case BinaryOpF(BNeq(), _, _, _)       => None
+      case BinaryOpF(BLt(), _, _, _)        => None
+      case BinaryOpF(BGt(), _, _, _)        => None
+      case BinaryOpF(BLe(), _, _, _)        => None
+      case BinaryOpF(BGe(), _, _, _)        => None
+      case BinaryOpF(BIn(), _, _, _)        => None
+      case BinaryOpF(BNotIn(), _, _, _)     => None
+      case BinaryOpF(BSubset(), _, _, _)    => None
+      case BinaryOpF(BUnion(), _, _, _)     => None
+      case BinaryOpF(BIntersect(), _, _, _) => None
+      case BinaryOpF(BDiff(), _, _, _)      => None
+      case BinaryOpF(BAdd(), _, _, _)       => None
+      case BinaryOpF(BSub(), _, _, _)       => None
+      case BinaryOpF(BMul(), _, _, _)       => None
+      case BinaryOpF(BDiv(), _, _, _)       => None
+      case UnaryOpF(_, _, _)                => None
+      case QuantifierF(_, _, _, _)          => None
+      case SomeWrapF(_, _)                  => None
+      case TheF(_, _, _, _)                 => None
+      case FieldAccessF(_, _, _)            => None
+      case EnumAccessF(_, _, _)             => None
+      case IndexF(_, _, _)                  => None
+      case CallF(_, _, _)                   => None
+      case PrimeF(_, _)                     => None
+      case PreF(_, _)                       => None
+      case WithF(_, _, _)                   => None
+      case IfF(_, _, _, _)                  => None
+      case LetF(_, _, _, _)                 => None
+      case LambdaF(_, _, _)                 => None
+      case ConstructorF(_, _, _)            => None
+      case SetLiteralF(_, _)                => None
+      case MapLiteralF(_, _)                => None
+      case SetComprehensionF(_, _, _, _)    => None
+      case SeqLiteralF(_, _)                => None
+      case MatchesF(_, _, _)                => None
+      case IntLitF(_, _)                    => None
+      case FloatLitF(_, _)                  => None
+      case StringLitF(_, _)                 => None
+      case BoolLitF(_, _)                   => None
+      case NoneLitF(_)                      => None
+      case IdentifierF(_, _)                => None
+    }
+
+  def detectTriggerCandidate(
+      parent: entity_decl_full,
+      invExpr: expr_full,
+      entities: List[entity_decl_full],
+      tables: List[table_spec]
+  ): Option[trigger_candidate] =
+    detectAggregateInvariant(invExpr) match {
+      case None => None
+      case Some(DetectedAggregate(targetField, collFieldName, agg, sourceField)) =>
+        tableByEntity(tables, entityNameFull(parent)) match {
+          case None => None
+          case Some(parentTbl) =>
+            val parentFields =
+              entityFieldDecls(parent): List[field_decl_full];
+            !list_ex[field_decl_full](
+              (f: field_decl_full) =>
+                fieldNameFull(f) == targetField,
+              parentFields
+            ) match {
+              case true => None
+              case false => find[field_decl_full](
+                  (f: field_decl_full) =>
+                    fieldNameFull(f) == collFieldName,
+                  parentFields
+                ) match {
+                  case None => None
+                  case Some(collField) =>
+                    collectionElementEntityName(fieldTypeFull(collField)) match {
+                      case None => None
+                      case Some(childName) =>
+                        entityByName(entities, childName) match {
+                          case None => None
+                          case Some(childEntity) =>
+                            tableByEntity(tables, childName) match {
+                              case None => None
+                              case Some(childTbl) =>
+                                uniqueBackFkColumn(
+                                  tableForeignKeys(childTbl),
+                                  tableName(parentTbl)
+                                ) match {
+                                  case None => None
+                                  case Some(fkCol) =>
+                                    val childFields =
+                                      entityFieldDecls(childEntity): List[field_decl_full];
+                                    (sourceField match {
+                                      case None => true
+                                      case Some(sf) =>
+                                        list_ex[field_decl_full](
+                                          (f: field_decl_full) =>
+                                            fieldNameFull(f) == sf,
+                                          childFields
+                                        )
+                                    }) match {
+                                      case true =>
+                                        Some[trigger_candidate](TriggerCandidate(
+                                          tableName(parentTbl),
+                                          targetField,
+                                          tableName(childTbl),
+                                          fkCol,
+                                          agg,
+                                          sourceField
+                                        ))
+                                      case false => None
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
   def classificationOperationName(x0: operation_classification): String = x0 match {
     case OperationClassification(n, uu, uv, uw, ux, uy, uz) => n
   }
@@ -9348,65 +9527,6 @@ object SpecRestGenerated {
     val ClassificationResult(k, m, rule, a) = res: classification_result;
     OperationClassification(name, k, m, rule, targetEntity, strategy, a)
   }
-
-  def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
-    invExpr match {
-      case BinaryOpF(BAnd(), _, _, _)     => None
-      case BinaryOpF(BOr(), _, _, _)      => None
-      case BinaryOpF(BImplies(), _, _, _) => None
-      case BinaryOpF(BIff(), _, _, _)     => None
-      case BinaryOpF(BEq(), lhs, rhs, _) =>
-        extractFieldName(lhs) match {
-          case None => None
-          case Some(tgt) =>
-            decodeAggregateCall(rhs) match {
-              case None => None
-              case Some(AggregateCall(coll, agg, src)) =>
-                Some[detected_aggregate](DetectedAggregate(tgt, coll, agg, src))
-            }
-        }
-      case BinaryOpF(BNeq(), _, _, _)       => None
-      case BinaryOpF(BLt(), _, _, _)        => None
-      case BinaryOpF(BGt(), _, _, _)        => None
-      case BinaryOpF(BLe(), _, _, _)        => None
-      case BinaryOpF(BGe(), _, _, _)        => None
-      case BinaryOpF(BIn(), _, _, _)        => None
-      case BinaryOpF(BNotIn(), _, _, _)     => None
-      case BinaryOpF(BSubset(), _, _, _)    => None
-      case BinaryOpF(BUnion(), _, _, _)     => None
-      case BinaryOpF(BIntersect(), _, _, _) => None
-      case BinaryOpF(BDiff(), _, _, _)      => None
-      case BinaryOpF(BAdd(), _, _, _)       => None
-      case BinaryOpF(BSub(), _, _, _)       => None
-      case BinaryOpF(BMul(), _, _, _)       => None
-      case BinaryOpF(BDiv(), _, _, _)       => None
-      case UnaryOpF(_, _, _)                => None
-      case QuantifierF(_, _, _, _)          => None
-      case SomeWrapF(_, _)                  => None
-      case TheF(_, _, _, _)                 => None
-      case FieldAccessF(_, _, _)            => None
-      case EnumAccessF(_, _, _)             => None
-      case IndexF(_, _, _)                  => None
-      case CallF(_, _, _)                   => None
-      case PrimeF(_, _)                     => None
-      case PreF(_, _)                       => None
-      case WithF(_, _, _)                   => None
-      case IfF(_, _, _, _)                  => None
-      case LetF(_, _, _, _)                 => None
-      case LambdaF(_, _, _)                 => None
-      case ConstructorF(_, _, _)            => None
-      case SetLiteralF(_, _)                => None
-      case MapLiteralF(_, _)                => None
-      case SetComprehensionF(_, _, _, _)    => None
-      case SeqLiteralF(_, _)                => None
-      case MatchesF(_, _, _)                => None
-      case IntLitF(_, _)                    => None
-      case FloatLitF(_, _)                  => None
-      case StringLitF(_, _)                 => None
-      case BoolLitF(_, _)                   => None
-      case NoneLitF(_)                      => None
-      case IdentifierF(_, _)                => None
-    }
 
   def widenExplicitIdPkSqlType(field_name: String, sql_type: String): String =
     field_name == "id" && sql_type == "INTEGER" match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -7574,9 +7574,6 @@ object SpecRestGenerated {
     case TriggerSpec(uu, uv, uw, tc, ux, uy, uz, va) => tc
   }
 
-  def tableByEntity(ts: List[table_spec], nm: String): Option[table_spec] =
-    find[table_spec]((t: table_spec) => tableEntityName(t) == nm, ts)
-
   def tc_relations_update[A](
       tc_relationsa: (List[state_field_decl_full]) => List[state_field_decl_full],
       x1: tyctx_ext[A]
@@ -7958,6 +7955,60 @@ object SpecRestGenerated {
       (distinct[String](bodyParamNames) &&
         equal_set[String](seta[String](bodyParamNames), seta[String](entityNonIdColumns)))
 
+  def uniqueBackFkColumn(fks: List[foreign_key_spec], parentTable: String): Option[String] =
+    filter[foreign_key_spec](
+      (fk: foreign_key_spec) =>
+        fkRefTable(fk) == parentTable,
+      fks
+    ) match {
+      case Nil         => None
+      case List(fk)    => Some[String](fkColumn(fk))
+      case _ :: _ :: _ => None
+    }
+
+  def validateTrigger(
+      parentTbl: table_spec,
+      parentFields: List[field_decl_full],
+      childTbl: table_spec,
+      childEntity: entity_decl_full,
+      tgt: String,
+      agg: trigger_aggregate,
+      src: Option[String]
+  ): Option[trigger_candidate] =
+    !list_ex[field_decl_full](
+      (f: field_decl_full) =>
+        fieldNameFull(f) == tgt,
+      parentFields
+    ) match {
+      case true => None
+      case false => uniqueBackFkColumn(tableForeignKeys(childTbl), tableName(parentTbl)) match {
+          case None => None
+          case Some(fkCol) =>
+            val childFields =
+              entityFieldsFull(childEntity): List[field_decl_full];
+            (src match {
+              case None => true
+              case Some(sf) =>
+                list_ex[field_decl_full](
+                  (f: field_decl_full) =>
+                    fieldNameFull(f) == sf,
+                  childFields
+                )
+            }) match {
+              case true =>
+                Some[trigger_candidate](TriggerCandidate(
+                  tableName(parentTbl),
+                  tgt,
+                  tableName(childTbl),
+                  fkCol,
+                  agg,
+                  src
+                ))
+              case false => None
+            }
+        }
+    }
+
   def stripOptions(x0: type_expr_full): type_expr_full = x0 match {
     case OptionTypeF(inner, uu)       => stripOptions(inner)
     case NamedTypeF(v, va)            => NamedTypeF(v, va)
@@ -8171,9 +8222,6 @@ object SpecRestGenerated {
             }
         }
     }
-
-  def entityFieldDecls(e: entity_decl_full): List[field_decl_full] =
-    entityFieldsFull(e)
 
   def lambdaProjection(body: expr_full): Option[String] =
     body match {
@@ -8747,17 +8795,6 @@ object SpecRestGenerated {
       false
     )
 
-  def uniqueBackFkColumn(fks: List[foreign_key_spec], parentTable: String): Option[String] =
-    filter[foreign_key_spec](
-      (fk: foreign_key_spec) =>
-        fkRefTable(fk) == parentTable,
-      fks
-    ) match {
-      case Nil         => None
-      case List(fk)    => Some[String](fkColumn(fk))
-      case _ :: _ :: _ => None
-    }
-
   def mergeStringConstraint(x0: string_constraint, x1: string_constraint): string_constraint =
     (x0, x1) match {
       case (StringConstraint(amin, amax, ar, ap, af), StringConstraint(bmin, bmax, br, bp, bf)) =>
@@ -9306,158 +9343,6 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, RelationTypeF(vd, ve, vf, vg), vc) => None
   }
 
-  def collectionElementEntityName(ty: type_expr_full): Option[String] =
-    ty match {
-      case NamedTypeF(_, _)                       => None
-      case SetTypeF(NamedTypeF(n, _), _)          => Some[String](n)
-      case SetTypeF(SetTypeF(_, _), _)            => None
-      case SetTypeF(MapTypeF(_, _, _), _)         => None
-      case SetTypeF(SeqTypeF(_, _), _)            => None
-      case SetTypeF(OptionTypeF(_, _), _)         => None
-      case SetTypeF(RelationTypeF(_, _, _, _), _) => None
-      case MapTypeF(_, _, _)                      => None
-      case SeqTypeF(NamedTypeF(n, _), _)          => Some[String](n)
-      case SeqTypeF(SetTypeF(_, _), _)            => None
-      case SeqTypeF(MapTypeF(_, _, _), _)         => None
-      case SeqTypeF(SeqTypeF(_, _), _)            => None
-      case SeqTypeF(OptionTypeF(_, _), _)         => None
-      case SeqTypeF(RelationTypeF(_, _, _, _), _) => None
-      case OptionTypeF(_, _)                      => None
-      case RelationTypeF(_, _, _, _)              => None
-    }
-
-  def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
-    invExpr match {
-      case BinaryOpF(BAnd(), _, _, _)     => None
-      case BinaryOpF(BOr(), _, _, _)      => None
-      case BinaryOpF(BImplies(), _, _, _) => None
-      case BinaryOpF(BIff(), _, _, _)     => None
-      case BinaryOpF(BEq(), lhs, rhs, _) =>
-        extractFieldName(lhs) match {
-          case None => None
-          case Some(tgt) =>
-            decodeAggregateCall(rhs) match {
-              case None => None
-              case Some(AggregateCall(coll, agg, src)) =>
-                Some[detected_aggregate](DetectedAggregate(tgt, coll, agg, src))
-            }
-        }
-      case BinaryOpF(BNeq(), _, _, _)       => None
-      case BinaryOpF(BLt(), _, _, _)        => None
-      case BinaryOpF(BGt(), _, _, _)        => None
-      case BinaryOpF(BLe(), _, _, _)        => None
-      case BinaryOpF(BGe(), _, _, _)        => None
-      case BinaryOpF(BIn(), _, _, _)        => None
-      case BinaryOpF(BNotIn(), _, _, _)     => None
-      case BinaryOpF(BSubset(), _, _, _)    => None
-      case BinaryOpF(BUnion(), _, _, _)     => None
-      case BinaryOpF(BIntersect(), _, _, _) => None
-      case BinaryOpF(BDiff(), _, _, _)      => None
-      case BinaryOpF(BAdd(), _, _, _)       => None
-      case BinaryOpF(BSub(), _, _, _)       => None
-      case BinaryOpF(BMul(), _, _, _)       => None
-      case BinaryOpF(BDiv(), _, _, _)       => None
-      case UnaryOpF(_, _, _)                => None
-      case QuantifierF(_, _, _, _)          => None
-      case SomeWrapF(_, _)                  => None
-      case TheF(_, _, _, _)                 => None
-      case FieldAccessF(_, _, _)            => None
-      case EnumAccessF(_, _, _)             => None
-      case IndexF(_, _, _)                  => None
-      case CallF(_, _, _)                   => None
-      case PrimeF(_, _)                     => None
-      case PreF(_, _)                       => None
-      case WithF(_, _, _)                   => None
-      case IfF(_, _, _, _)                  => None
-      case LetF(_, _, _, _)                 => None
-      case LambdaF(_, _, _)                 => None
-      case ConstructorF(_, _, _)            => None
-      case SetLiteralF(_, _)                => None
-      case MapLiteralF(_, _)                => None
-      case SetComprehensionF(_, _, _, _)    => None
-      case SeqLiteralF(_, _)                => None
-      case MatchesF(_, _, _)                => None
-      case IntLitF(_, _)                    => None
-      case FloatLitF(_, _)                  => None
-      case StringLitF(_, _)                 => None
-      case BoolLitF(_, _)                   => None
-      case NoneLitF(_)                      => None
-      case IdentifierF(_, _)                => None
-    }
-
-  def detectTriggerCandidate(
-      parent: entity_decl_full,
-      invExpr: expr_full,
-      entities: List[entity_decl_full],
-      tables: List[table_spec]
-  ): Option[trigger_candidate] =
-    detectAggregateInvariant(invExpr) match {
-      case None => None
-      case Some(DetectedAggregate(targetField, collFieldName, agg, sourceField)) =>
-        tableByEntity(tables, entityNameFull(parent)) match {
-          case None => None
-          case Some(parentTbl) =>
-            val parentFields =
-              entityFieldDecls(parent): List[field_decl_full];
-            !list_ex[field_decl_full](
-              (f: field_decl_full) =>
-                fieldNameFull(f) == targetField,
-              parentFields
-            ) match {
-              case true => None
-              case false => find[field_decl_full](
-                  (f: field_decl_full) =>
-                    fieldNameFull(f) == collFieldName,
-                  parentFields
-                ) match {
-                  case None => None
-                  case Some(collField) =>
-                    collectionElementEntityName(fieldTypeFull(collField)) match {
-                      case None => None
-                      case Some(childName) =>
-                        entityByName(entities, childName) match {
-                          case None => None
-                          case Some(childEntity) =>
-                            tableByEntity(tables, childName) match {
-                              case None => None
-                              case Some(childTbl) =>
-                                uniqueBackFkColumn(
-                                  tableForeignKeys(childTbl),
-                                  tableName(parentTbl)
-                                ) match {
-                                  case None => None
-                                  case Some(fkCol) =>
-                                    val childFields =
-                                      entityFieldDecls(childEntity): List[field_decl_full];
-                                    (sourceField match {
-                                      case None => true
-                                      case Some(sf) =>
-                                        list_ex[field_decl_full](
-                                          (f: field_decl_full) =>
-                                            fieldNameFull(f) == sf,
-                                          childFields
-                                        )
-                                    }) match {
-                                      case true =>
-                                        Some[trigger_candidate](TriggerCandidate(
-                                          tableName(parentTbl),
-                                          targetField,
-                                          tableName(childTbl),
-                                          fkCol,
-                                          agg,
-                                          sourceField
-                                        ))
-                                      case false => None
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
   def classificationOperationName(x0: operation_classification): String = x0 match {
     case OperationClassification(n, uu, uv, uw, ux, uy, uz) => n
   }
@@ -9528,6 +9413,65 @@ object SpecRestGenerated {
     OperationClassification(name, k, m, rule, targetEntity, strategy, a)
   }
 
+  def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
+    invExpr match {
+      case BinaryOpF(BAnd(), _, _, _)     => None
+      case BinaryOpF(BOr(), _, _, _)      => None
+      case BinaryOpF(BImplies(), _, _, _) => None
+      case BinaryOpF(BIff(), _, _, _)     => None
+      case BinaryOpF(BEq(), lhs, rhs, _) =>
+        extractFieldName(lhs) match {
+          case None => None
+          case Some(tgt) =>
+            decodeAggregateCall(rhs) match {
+              case None => None
+              case Some(AggregateCall(coll, agg, src)) =>
+                Some[detected_aggregate](DetectedAggregate(tgt, coll, agg, src))
+            }
+        }
+      case BinaryOpF(BNeq(), _, _, _)       => None
+      case BinaryOpF(BLt(), _, _, _)        => None
+      case BinaryOpF(BGt(), _, _, _)        => None
+      case BinaryOpF(BLe(), _, _, _)        => None
+      case BinaryOpF(BGe(), _, _, _)        => None
+      case BinaryOpF(BIn(), _, _, _)        => None
+      case BinaryOpF(BNotIn(), _, _, _)     => None
+      case BinaryOpF(BSubset(), _, _, _)    => None
+      case BinaryOpF(BUnion(), _, _, _)     => None
+      case BinaryOpF(BIntersect(), _, _, _) => None
+      case BinaryOpF(BDiff(), _, _, _)      => None
+      case BinaryOpF(BAdd(), _, _, _)       => None
+      case BinaryOpF(BSub(), _, _, _)       => None
+      case BinaryOpF(BMul(), _, _, _)       => None
+      case BinaryOpF(BDiv(), _, _, _)       => None
+      case UnaryOpF(_, _, _)                => None
+      case QuantifierF(_, _, _, _)          => None
+      case SomeWrapF(_, _)                  => None
+      case TheF(_, _, _, _)                 => None
+      case FieldAccessF(_, _, _)            => None
+      case EnumAccessF(_, _, _)             => None
+      case IndexF(_, _, _)                  => None
+      case CallF(_, _, _)                   => None
+      case PrimeF(_, _)                     => None
+      case PreF(_, _)                       => None
+      case WithF(_, _, _)                   => None
+      case IfF(_, _, _, _)                  => None
+      case LetF(_, _, _, _)                 => None
+      case LambdaF(_, _, _)                 => None
+      case ConstructorF(_, _, _)            => None
+      case SetLiteralF(_, _)                => None
+      case MapLiteralF(_, _)                => None
+      case SetComprehensionF(_, _, _, _)    => None
+      case SeqLiteralF(_, _)                => None
+      case MatchesF(_, _, _)                => None
+      case IntLitF(_, _)                    => None
+      case FloatLitF(_, _)                  => None
+      case StringLitF(_, _)                 => None
+      case BoolLitF(_, _)                   => None
+      case NoneLitF(_)                      => None
+      case IdentifierF(_, _)                => None
+    }
+
   def widenExplicitIdPkSqlType(field_name: String, sql_type: String): String =
     field_name == "id" && sql_type == "INTEGER" match {
       case true  => "BIGINT"
@@ -9537,5 +9481,25 @@ object SpecRestGenerated {
   def signalsTargetEntityFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
   }
+
+  def collectionElementEntityName(ty: type_expr_full): Option[String] =
+    ty match {
+      case NamedTypeF(_, _)                       => None
+      case SetTypeF(NamedTypeF(n, _), _)          => Some[String](n)
+      case SetTypeF(SetTypeF(_, _), _)            => None
+      case SetTypeF(MapTypeF(_, _, _), _)         => None
+      case SetTypeF(SeqTypeF(_, _), _)            => None
+      case SetTypeF(OptionTypeF(_, _), _)         => None
+      case SetTypeF(RelationTypeF(_, _, _, _), _) => None
+      case MapTypeF(_, _, _)                      => None
+      case SeqTypeF(NamedTypeF(n, _), _)          => Some[String](n)
+      case SeqTypeF(SetTypeF(_, _), _)            => None
+      case SeqTypeF(MapTypeF(_, _, _), _)         => None
+      case SeqTypeF(SeqTypeF(_, _), _)            => None
+      case SeqTypeF(OptionTypeF(_, _), _)         => None
+      case SeqTypeF(RelationTypeF(_, _, _, _), _) => None
+      case OptionTypeF(_, _)                      => None
+      case RelationTypeF(_, _, _, _)              => None
+    }
 
 } /* object SpecRestGenerated */

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -217,6 +217,10 @@ export_code
     findEnumValuesInType
     primitiveTypeToSql
     classifyColumnType
+    tableByEntity
+    collectionElementEntityName
+    uniqueBackFkColumn
+    detectTriggerCandidate
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -217,10 +217,9 @@ export_code
     findEnumValuesInType
     primitiveTypeToSql
     classifyColumnType
-    tableByEntity
     collectionElementEntityName
     uniqueBackFkColumn
-    detectTriggerCandidate
+    validateTrigger
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -194,21 +194,17 @@ lemmas primitiveTypeToSql_code [code] = primitiveTypeToSql_def
 lemmas classifyColumnTypeAux_code [code] = classifyColumnTypeAux.simps
 lemmas classifyColumnType_code [code] = classifyColumnType_def
 
-text \<open>Aggregate-trigger detection: the orchestration kernel of
-  \<open>specrest.convention.Schema.detectAggregateTriggers\<close>. Lifts the per-invariant
-  decision logic — does the parent's invariant declare a valid SUM/COUNT/MIN/MAX
-  over a child entity that we can synthesize a recompute trigger for? The result
-  carries the resolved table/column names; the Scala caller formats the
-  PostgreSQL function and trigger identifiers (\<open>recalc_X_Y\<close> / \<open>trg_X_Y\<close>),
-  which is char-level naming work that stays in Scala.
+text \<open>Aggregate-trigger validation: the pure validity-check kernel of
+  \<open>specrest.convention.Schema.detectAggregateTriggers\<close>. The Scala caller
+  handles orchestration (parent/child name → table/entity lookups via
+  \<open>Map.get\<close> in O(1)) so the lifted predicate operates on already-resolved
+  inputs and avoids the O(N) per-invariant list scans an orchestration-shaped
+  lift would force. The result carries the resolved table/column names; the
+  Scala caller formats the PostgreSQL function and trigger identifiers
+  (\<open>recalc_X_Y\<close> / \<open>trg_X_Y\<close>), which is regex/Naming work that stays in Scala.
 
   Validity checks (all must hold to emit a candidate):
-  \<^enum> \<open>detectAggregateInvariant\<close> recognises the invariant shape
-  \<^enum> the named target field exists on the parent entity
-  \<^enum> the named collection field exists on the parent and its element type is
-    a NamedTypeF pointing at an entity (\<open>Set[NamedTypeF n]\<close> or \<open>Seq[NamedTypeF n]\<close>)
-  \<^enum> both parent and child have table_specs in the input list (i.e. they were
-    derived)
+  \<^enum> the named target field exists on the parent
   \<^enum> the child table has exactly one foreign key back to the parent (ambiguous
     multi-FK setups produce no trigger rather than guessing)
   \<^enum> if the aggregate carries a source-projection name, the child entity has
@@ -221,11 +217,6 @@ datatype trigger_candidate = TriggerCandidate
   String.literal             \<comment> \<open>child_back_fk_column\<close>
   trigger_aggregate          \<comment> \<open>aggregate kind\<close>
   "String.literal option"    \<comment> \<open>source_field (Scala turns into column name)\<close>
-
-definition tableByEntity ::
-  "table_spec list \<Rightarrow> String.literal \<Rightarrow> table_spec option"
-where
-  "tableByEntity ts nm = List.find (\<lambda>t. tableEntityName t = nm) ts"
 
 definition collectionElementEntityName ::
   "type_expr_full \<Rightarrow> String.literal option"
@@ -242,61 +233,31 @@ where
     (let matching = filter (\<lambda>fk. fkRefTable fk = parentTable) fks
      in case matching of [fk] \<Rightarrow> Some (fkColumn fk) | _ \<Rightarrow> None)"
 
-text \<open>Pull the field declarations out of an entity. Mirrors
-  \<open>entity.c.collect { case f: FieldDeclFull => f }\<close> on the Scala side.\<close>
-
-definition entityFieldDecls :: "entity_decl_full \<Rightarrow> field_decl_full list" where
-  "entityFieldDecls e = entityFieldsFull e"
-
-definition detectTriggerCandidate ::
-  "entity_decl_full \<Rightarrow> expr_full \<Rightarrow>
-    entity_decl_full list \<Rightarrow> table_spec list \<Rightarrow> trigger_candidate option"
+definition validateTrigger ::
+  "table_spec \<Rightarrow> field_decl_full list \<Rightarrow>
+    table_spec \<Rightarrow> entity_decl_full \<Rightarrow>
+    String.literal \<Rightarrow> trigger_aggregate \<Rightarrow> String.literal option \<Rightarrow>
+    trigger_candidate option"
 where
-  "detectTriggerCandidate parent invExpr entities tables = (
-    case detectAggregateInvariant invExpr of
-      None \<Rightarrow> None
-    | Some (DetectedAggregate targetField collFieldName agg sourceField) \<Rightarrow>
-        (case tableByEntity tables (entityNameFull parent) of
-           None \<Rightarrow> None
-         | Some parentTbl \<Rightarrow>
-             let parentFields = entityFieldDecls parent in
-             if \<not> (\<exists>f \<in> set parentFields. fieldNameFull f = targetField) then None
-             else case List.find (\<lambda>f. fieldNameFull f = collFieldName) parentFields of
-                    None \<Rightarrow> None
-                  | Some collField \<Rightarrow>
-                      (case collectionElementEntityName (fieldTypeFull collField) of
-                         None \<Rightarrow> None
-                       | Some childName \<Rightarrow>
-                           (case entityByName entities childName of
-                              None \<Rightarrow> None
-                            | Some childEntity \<Rightarrow>
-                                (case tableByEntity tables childName of
-                                   None \<Rightarrow> None
-                                 | Some childTbl \<Rightarrow>
-                                     (case uniqueBackFkColumn
-                                             (tableForeignKeys childTbl)
-                                             (tableName parentTbl) of
-                                        None \<Rightarrow> None
-                                      | Some fkCol \<Rightarrow>
-                                          let childFields = entityFieldDecls childEntity;
-                                              srcOk = (case sourceField of
-                                                         None \<Rightarrow> True
-                                                       | Some sf \<Rightarrow>
-                                                           \<exists>f \<in> set childFields.
-                                                             fieldNameFull f = sf)
-                                          in if srcOk
-                                             then Some (TriggerCandidate
-                                                        (tableName parentTbl)
-                                                        targetField
-                                                        (tableName childTbl)
-                                                        fkCol agg sourceField)
-                                             else None))))))"
+  "validateTrigger parentTbl parentFields childTbl childEntity tgt agg src =
+    (if \<not> (\<exists>f \<in> set parentFields. fieldNameFull f = tgt) then None
+     else case uniqueBackFkColumn (tableForeignKeys childTbl) (tableName parentTbl) of
+            None \<Rightarrow> None
+          | Some fkCol \<Rightarrow>
+              let childFields = entityFieldsFull childEntity;
+                  srcOk = (case src of
+                             None \<Rightarrow> True
+                           | Some sf \<Rightarrow>
+                               \<exists>f \<in> set childFields. fieldNameFull f = sf)
+              in if srcOk
+                 then Some (TriggerCandidate
+                              (tableName parentTbl) tgt
+                              (tableName childTbl) fkCol agg src)
+                 else None)"
 
-lemmas tableByEntity_code [code] = tableByEntity_def
 lemmas collectionElementEntityName_code [code] = collectionElementEntityName_def
 lemmas uniqueBackFkColumn_code [code] = uniqueBackFkColumn_def
-lemmas entityFieldDecls_code [code] = entityFieldDecls_def
-lemmas detectTriggerCandidate_code [code] = detectTriggerCandidate_def
+lemmas validateTrigger_code [code] = validateTrigger_def
 
 lemmas widenExplicitIdPkSqlType_code [code] = widenExplicitIdPkSqlType_def
 lemmas sqlOp_code [code] = sqlOp_def

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -194,6 +194,110 @@ lemmas primitiveTypeToSql_code [code] = primitiveTypeToSql_def
 lemmas classifyColumnTypeAux_code [code] = classifyColumnTypeAux.simps
 lemmas classifyColumnType_code [code] = classifyColumnType_def
 
+text \<open>Aggregate-trigger detection: the orchestration kernel of
+  \<open>specrest.convention.Schema.detectAggregateTriggers\<close>. Lifts the per-invariant
+  decision logic — does the parent's invariant declare a valid SUM/COUNT/MIN/MAX
+  over a child entity that we can synthesize a recompute trigger for? The result
+  carries the resolved table/column names; the Scala caller formats the
+  PostgreSQL function and trigger identifiers (\<open>recalc_X_Y\<close> / \<open>trg_X_Y\<close>),
+  which is char-level naming work that stays in Scala.
+
+  Validity checks (all must hold to emit a candidate):
+  \<^enum> \<open>detectAggregateInvariant\<close> recognises the invariant shape
+  \<^enum> the named target field exists on the parent entity
+  \<^enum> the named collection field exists on the parent and its element type is
+    a NamedTypeF pointing at an entity (\<open>Set[NamedTypeF n]\<close> or \<open>Seq[NamedTypeF n]\<close>)
+  \<^enum> both parent and child have table_specs in the input list (i.e. they were
+    derived)
+  \<^enum> the child table has exactly one foreign key back to the parent (ambiguous
+    multi-FK setups produce no trigger rather than guessing)
+  \<^enum> if the aggregate carries a source-projection name, the child entity has
+    a field with that name\<close>
+
+datatype trigger_candidate = TriggerCandidate
+  String.literal             \<comment> \<open>parent_table\<close>
+  String.literal             \<comment> \<open>target_field (Scala turns into column name)\<close>
+  String.literal             \<comment> \<open>child_table\<close>
+  String.literal             \<comment> \<open>child_back_fk_column\<close>
+  trigger_aggregate          \<comment> \<open>aggregate kind\<close>
+  "String.literal option"    \<comment> \<open>source_field (Scala turns into column name)\<close>
+
+definition tableByEntity ::
+  "table_spec list \<Rightarrow> String.literal \<Rightarrow> table_spec option"
+where
+  "tableByEntity ts nm = List.find (\<lambda>t. tableEntityName t = nm) ts"
+
+definition collectionElementEntityName ::
+  "type_expr_full \<Rightarrow> String.literal option"
+where
+  "collectionElementEntityName ty = (case ty of
+       SetTypeF (NamedTypeF n _) _ \<Rightarrow> Some n
+     | SeqTypeF (NamedTypeF n _) _ \<Rightarrow> Some n
+     | _ \<Rightarrow> None)"
+
+definition uniqueBackFkColumn ::
+  "foreign_key_spec list \<Rightarrow> String.literal \<Rightarrow> String.literal option"
+where
+  "uniqueBackFkColumn fks parentTable =
+    (let matching = filter (\<lambda>fk. fkRefTable fk = parentTable) fks
+     in case matching of [fk] \<Rightarrow> Some (fkColumn fk) | _ \<Rightarrow> None)"
+
+text \<open>Pull the field declarations out of an entity. Mirrors
+  \<open>entity.c.collect { case f: FieldDeclFull => f }\<close> on the Scala side.\<close>
+
+definition entityFieldDecls :: "entity_decl_full \<Rightarrow> field_decl_full list" where
+  "entityFieldDecls e = entityFieldsFull e"
+
+definition detectTriggerCandidate ::
+  "entity_decl_full \<Rightarrow> expr_full \<Rightarrow>
+    entity_decl_full list \<Rightarrow> table_spec list \<Rightarrow> trigger_candidate option"
+where
+  "detectTriggerCandidate parent invExpr entities tables = (
+    case detectAggregateInvariant invExpr of
+      None \<Rightarrow> None
+    | Some (DetectedAggregate targetField collFieldName agg sourceField) \<Rightarrow>
+        (case tableByEntity tables (entityNameFull parent) of
+           None \<Rightarrow> None
+         | Some parentTbl \<Rightarrow>
+             let parentFields = entityFieldDecls parent in
+             if \<not> (\<exists>f \<in> set parentFields. fieldNameFull f = targetField) then None
+             else case List.find (\<lambda>f. fieldNameFull f = collFieldName) parentFields of
+                    None \<Rightarrow> None
+                  | Some collField \<Rightarrow>
+                      (case collectionElementEntityName (fieldTypeFull collField) of
+                         None \<Rightarrow> None
+                       | Some childName \<Rightarrow>
+                           (case entityByName entities childName of
+                              None \<Rightarrow> None
+                            | Some childEntity \<Rightarrow>
+                                (case tableByEntity tables childName of
+                                   None \<Rightarrow> None
+                                 | Some childTbl \<Rightarrow>
+                                     (case uniqueBackFkColumn
+                                             (tableForeignKeys childTbl)
+                                             (tableName parentTbl) of
+                                        None \<Rightarrow> None
+                                      | Some fkCol \<Rightarrow>
+                                          let childFields = entityFieldDecls childEntity;
+                                              srcOk = (case sourceField of
+                                                         None \<Rightarrow> True
+                                                       | Some sf \<Rightarrow>
+                                                           \<exists>f \<in> set childFields.
+                                                             fieldNameFull f = sf)
+                                          in if srcOk
+                                             then Some (TriggerCandidate
+                                                        (tableName parentTbl)
+                                                        targetField
+                                                        (tableName childTbl)
+                                                        fkCol agg sourceField)
+                                             else None))))))"
+
+lemmas tableByEntity_code [code] = tableByEntity_def
+lemmas collectionElementEntityName_code [code] = collectionElementEntityName_def
+lemmas uniqueBackFkColumn_code [code] = uniqueBackFkColumn_def
+lemmas entityFieldDecls_code [code] = entityFieldDecls_def
+lemmas detectTriggerCandidate_code [code] = detectTriggerCandidate_def
+
 lemmas widenExplicitIdPkSqlType_code [code] = widenExplicitIdPkSqlType_def
 lemmas sqlOp_code [code] = sqlOp_def
 lemmas aggregateForName_code [code] = aggregateForName_def


### PR DESCRIPTION
## Summary

Extracts the pure orchestration kernel of `specrest.convention.Schema.detectAggregateTriggers` into Isabelle. Continues the `deriveSchema` lift series — `detectAggregateInvariant` already recognized the SUM/COUNT/MIN/MAX shape; this lift adds the wider validity decision that turns a recognized invariant into an emittable trigger candidate.

### What's lifted

- `tableByEntity` — name lookup over `table_spec list`
- `collectionElementEntityName` — peels `Set`/`Seq` to find inner `NamedTypeF`
- `uniqueBackFkColumn` — returns `Some(fk_col)` iff exactly one FK matches the parent table (ambiguous multi-FK → None)
- `entityFieldDecls` — accessor wrapper
- `trigger_candidate` ADT carrying the resolved `(parent_table, target_field, child_table, child_back_fk_col, aggregate, source_field)`
- `detectTriggerCandidate` — the validity predicate combining all checks:
  1. `detectAggregateInvariant` recognizes the shape
  2. parent has the target field
  3. collection field's element type is an entity name
  4. both parent and child have `table_specs` (i.e. were derived)
  5. child has exactly one back-FK to parent (multi-FK → ambiguous → None)
  6. source-projection field exists on child (when present)

### What stays in Scala

The PostgreSQL identifier naming — `recalc_${parentSnake}_${target}` and `trg_${funcName}`. Uses `Naming.toSnakeCase` / `Naming.toColumnName` (regex-based, hard to lift).

### Code-shape impact

`Schema.detectAggregateTriggers` shrinks from **54 lines to 22 lines** and delegates the entire decision logic to the extracted predicate.

## Test plan

- [x] `isabelle build` — green (2:02 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `DetectTriggerCandidateTest` — 10 focused tests covering: happy path, non-aggregate invariant rejection, missing parent table, missing target field, non-entity collection element, multi-FK ambiguity, missing source field, Seq parallel to Set, plus unit tests for `uniqueBackFkColumn` and `collectionElementEntityName`
- [x] `sbt scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted aggregate-trigger validation into Isabelle as a pure `validateTrigger` kernel, while keeping O(1) entity/table lookups in Scala to preserve performance and simplify `Schema.detectAggregateTriggers`. Scala still only formats PostgreSQL identifiers; the validation runs in generated code (54 → 22 lines in `Schema.detectAggregateTriggers`).

- **Refactors**
  - Replaced `detectTriggerCandidate` with `validateTrigger(parent_table, parent_fields, child_table, child_entity, target, agg, source)` that checks: parent has target field, child has a unique back-FK, and optional source field exists.
  - Moved orchestration back to Scala: `specrest.convention.Schema.detectAggregateTriggers` builds `tablesByEntity`/`entitiesByName`, uses `detectAggregateInvariant` + `collectionElementEntityName`, then calls `validateTrigger`. Dropped exports of `tableByEntity` and `entityFieldDecls`.
  - Added `TriggerCandidate` ADT and exported `collectionElementEntityName`, `uniqueBackFkColumn`, and `validateTrigger` via Isabelle codegen. Tests updated in `DetectTriggerCandidateTest` to cover happy paths, missing target, ambiguous/no back-FK, missing source, plus helper unit tests.

<sup>Written for commit 7238b7ea8ce514a2c4076566b516b4e346ab1dab. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/324?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

