### PR TITLE
feat(proofs): lift classifyOpenApiNamedType (OpenApi.namedTypeSchema kernel)

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -102,7 +102,6 @@ final case class OpenApiDocument(
 final case class BuildContext(
     aliasMap: Map[String, TypeAliasDeclFull],
     enumMap: Map[String, EnumDeclFull],
-    entityNames: Set[String],
     entityDecls: Map[String, EntityDeclFull],
     aliasAList: List[(String, TypeAliasDeclFull)],
     enumAList: List[(String, EnumDeclFull)],
@@ -648,7 +647,6 @@ object OpenApi:
     val ctx = BuildContext(
       aliasMap = idx.aliasByName,
       enumMap = idx.enumByName,
-      entityNames = profiled.entities.map(_.entityName).toSet,
       entityDecls = idx.entityByName,
       aliasAList = idx.aliasAList,
       enumAList = idx.enumAList,

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -105,7 +105,8 @@ final case class BuildContext(
     entityNames: Set[String],
     entityDecls: Map[String, EntityDeclFull],
     aliasAList: List[(String, TypeAliasDeclFull)],
-    enumAList: List[(String, EnumDeclFull)]
+    enumAList: List[(String, EnumDeclFull)],
+    entityNamesList: List[String]
 )
 
 // -- Constraints extraction ------------------------------------
@@ -219,19 +220,9 @@ final case class FieldSchema(schema: SchemaObject, nullable: Boolean)
 
 object Schema:
 
-  private val PrimitiveSchemas: Map[String, SchemaObject] = Map(
-    "String"   -> SchemaObject(`type` = Some(List("string"))),
-    "Int"      -> SchemaObject(`type` = Some(List("integer"))),
-    "Float"    -> SchemaObject(`type` = Some(List("number"))),
-    "Bool"     -> SchemaObject(`type` = Some(List("boolean"))),
-    "Boolean"  -> SchemaObject(`type` = Some(List("boolean"))),
-    "DateTime" -> SchemaObject(`type` = Some(List("string")), format = Some("date-time")),
-    "Date"     -> SchemaObject(`type` = Some(List("string")), format = Some("date")),
-    "UUID"     -> SchemaObject(`type` = Some(List("string")), format = Some("uuid")),
-    "Decimal"  -> SchemaObject(`type` = Some(List("string")), format = Some("decimal")),
-    "Bytes"    -> SchemaObject(`type` = Some(List("string")), format = Some("byte")),
-    "Money"    -> SchemaObject(`type` = Some(List("integer")))
-  )
+  private def primitiveDefToSchema(p: openapi_primitive_def): SchemaObject =
+    p match
+      case OpenApiPrimDef(types, fmt) => SchemaObject(`type` = Some(types), format = fmt)
 
   def fieldToSchema(
       typeExpr: type_expr_full,
@@ -287,21 +278,17 @@ object Schema:
       c: JsonSchemaConstraints,
       ctx: BuildContext
   ): SchemaObject =
-    PrimitiveSchemas.get(name) match
-      case Some(p) => mergeConstraints(p, c)
-      case None =>
-        ctx.enumMap.get(name) match
-          case Some(e) =>
-            SchemaObject(`type` = Some(List("string")), enum_ = Some(e.b))
-          case None =>
-            if ctx.entityNames.contains(name) then
-              SchemaObject(ref = Some(s"#/components/schemas/${name}Read"))
-            else
-              ctx.aliasMap.get(name) match
-                case Some(alias) =>
-                  typeExprToSchema(alias.b, c, ctx)
-                case None =>
-                  mergeConstraints(SchemaObject(`type` = Some(List("string"))), c)
+    classifyOpenApiNamedType(name, ctx.aliasAList, ctx.enumAList, ctx.entityNamesList) match
+      case OntPrimitive(p) =>
+        mergeConstraints(primitiveDefToSchema(p), c)
+      case OntEnum(values) =>
+        SchemaObject(`type` = Some(List("string")), enum_ = Some(values))
+      case OntEntityRef(n) =>
+        SchemaObject(ref = Some(s"#/components/schemas/${n}Read"))
+      case OntAliasToType(base) =>
+        typeExprToSchema(base, c, ctx)
+      case _: OntUnknown =>
+        mergeConstraints(SchemaObject(`type` = Some(List("string"))), c)
 
   private def buildArraySchema(
       inner: type_expr_full,
@@ -664,7 +651,8 @@ object OpenApi:
       entityNames = profiled.entities.map(_.entityName).toSet,
       entityDecls = idx.entityByName,
       aliasAList = idx.aliasAList,
-      enumAList = idx.enumAList
+      enumAList = idx.enumAList,
+      entityNamesList = idx.entityNamesList
     )
 
     OpenApiDocument(

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/ClassifyOpenApiNamedTypeTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/ClassifyOpenApiNamedTypeTest.scala
@@ -1,0 +1,102 @@
+package specrest.codegen.openapi
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+class ClassifyOpenApiNamedTypeTest extends CatsEffectSuite:
+
+  private def named(t: String): NamedTypeF = NamedTypeF(t, None)
+  private def alias(name: String, target: type_expr_full): TypeAliasDeclFull =
+    TypeAliasDeclFull(name, target, None, None)
+  private def enumD(name: String, values: List[String]): EnumDeclFull =
+    EnumDeclFull(name, values, None)
+
+  private def classify(
+      name: String,
+      aliases: List[(String, TypeAliasDeclFull)] = Nil,
+      enums: List[(String, EnumDeclFull)] = Nil,
+      entityNames: List[String] = Nil
+  ): openapi_named_kind =
+    classifyOpenApiNamedType(name, aliases, enums, entityNames)
+
+  test("openapiPrimitiveOf maps the 11 spec primitives correctly"):
+    val cases = List(
+      "String"   -> OpenApiPrimDef(List("string"), None),
+      "Int"      -> OpenApiPrimDef(List("integer"), None),
+      "Float"    -> OpenApiPrimDef(List("number"), None),
+      "Bool"     -> OpenApiPrimDef(List("boolean"), None),
+      "Boolean"  -> OpenApiPrimDef(List("boolean"), None),
+      "DateTime" -> OpenApiPrimDef(List("string"), Some("date-time")),
+      "Date"     -> OpenApiPrimDef(List("string"), Some("date")),
+      "UUID"     -> OpenApiPrimDef(List("string"), Some("uuid")),
+      "Decimal"  -> OpenApiPrimDef(List("string"), Some("decimal")),
+      "Bytes"    -> OpenApiPrimDef(List("string"), Some("byte")),
+      "Money"    -> OpenApiPrimDef(List("integer"), None)
+    )
+    cases.foreach: (specType, expected) =>
+      assertEquals(openapiPrimitiveOf(specType), Some(expected), s"failed for $specType")
+    assertEquals(openapiPrimitiveOf("NotAType"), None)
+
+  test("classifies primitives directly"):
+    assertEquals(classify("Int"), OntPrimitive(OpenApiPrimDef(List("integer"), None)))
+    assertEquals(
+      classify("DateTime"),
+      OntPrimitive(OpenApiPrimDef(List("string"), Some("date-time")))
+    )
+
+  test("classifies enum NamedType"):
+    val statusEnum = enumD("Status", List("OPEN", "CLOSED"))
+    val result     = classify("Status", enums = List("Status" -> statusEnum))
+    assertEquals(result, OntEnum(List("OPEN", "CLOSED")))
+
+  test("classifies entity NamedType as entity-ref"):
+    assertEquals(classify("User", entityNames = List("User")), OntEntityRef("User"))
+
+  test("alias chain resolves through to leaf primitive"):
+    val email   = alias("Email", named("String"))
+    val tier2   = alias("EmailAlias", named("Email"))
+    val aliases = List("Email" -> email, "EmailAlias" -> tier2)
+    assertEquals(
+      classify("EmailAlias", aliases = aliases),
+      OntPrimitive(OpenApiPrimDef(List("string"), None))
+    )
+
+  test("alias chain to enum resolves to OntEnum"):
+    val statusEnum  = enumD("Status", List("ON", "OFF"))
+    val statusAlias = alias("StatusAlias", named("Status"))
+    val result = classify(
+      "StatusAlias",
+      aliases = List("StatusAlias" -> statusAlias),
+      enums = List("Status" -> statusEnum)
+    )
+    assertEquals(result, OntEnum(List("ON", "OFF")))
+
+  test("alias chain to entity resolves to OntEntityRef"):
+    val userAlias = alias("UserAlias", named("User"))
+    val result = classify(
+      "UserAlias",
+      aliases = List("UserAlias" -> userAlias),
+      entityNames = List("User")
+    )
+    assertEquals(result, OntEntityRef("User"))
+
+  test("alias whose body is a structural type returns OntAliasToType"):
+    val intSetAlias = alias("IntSet", SetTypeF(named("Int"), None))
+    val result      = classify("IntSet", aliases = List("IntSet" -> intSetAlias))
+    assertEquals(result, OntAliasToType(SetTypeF(named("Int"), None)))
+
+  test("alias whose body is an Option returns OntAliasToType"):
+    val optStr = alias("OptStr", OptionTypeF(named("String"), None))
+    val result = classify("OptStr", aliases = List("OptStr" -> optStr))
+    assertEquals(result, OntAliasToType(OptionTypeF(named("String"), None)))
+
+  test("unknown name falls back to OntUnknown"):
+    assertEquals(classify("NotARealThing"), OntUnknown())
+
+  test("cyclic alias chain bottoms out at OntUnknown instead of looping"):
+    val a = alias("A", named("B"))
+    val b = alias("B", named("A"))
+    assertEquals(
+      classify("A", aliases = List("A" -> a, "B" -> b)),
+      OntUnknown()
+    )

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -874,6 +874,16 @@ object SpecRestGenerated {
       g: analysis_signals
   ) extends operation_classification
 
+  sealed abstract class openapi_primitive_def
+  final case class OpenApiPrimDef(a: List[String], b: Option[String]) extends openapi_primitive_def
+
+  sealed abstract class openapi_named_kind
+  final case class OntPrimitive(a: openapi_primitive_def) extends openapi_named_kind
+  final case class OntEnum(a: List[String])               extends openapi_named_kind
+  final case class OntEntityRef(a: String)                extends openapi_named_kind
+  final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
+  final case class OntUnknown()                           extends openapi_named_kind
+
   def integer_of_nat(x0: nat): BigInt = x0 match {
     case Nata(x) => x
   }
@@ -9263,6 +9273,62 @@ object SpecRestGenerated {
       (List[String], List[with_info_full])
     ](collectExprInfo(e))))
 
+  def openapiPrimitiveOf(nm: String): Option[openapi_primitive_def] =
+    nm == "String" match {
+      case true => Some[openapi_primitive_def](OpenApiPrimDef(List("string"), None))
+      case false => nm == "Int" match {
+          case true => Some[openapi_primitive_def](OpenApiPrimDef(List("integer"), None))
+          case false => nm == "Float" match {
+              case true => Some[openapi_primitive_def](OpenApiPrimDef(List("number"), None))
+              case false => nm == "Bool" match {
+                  case true => Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
+                  case false => nm == "Boolean" match {
+                      case true =>
+                        Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
+                      case false => nm == "DateTime" match {
+                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                              List("string"),
+                              Some[String]("date-time")
+                            ))
+                          case false => nm == "Date" match {
+                              case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                  List("string"),
+                                  Some[String]("date")
+                                ))
+                              case false => nm == "UUID" match {
+                                  case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                      List("string"),
+                                      Some[String]("uuid")
+                                    ))
+                                  case false => nm == "Decimal" match {
+                                      case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                          List("string"),
+                                          Some[String]("decimal")
+                                        ))
+                                      case false => nm == "Bytes" match {
+                                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                              List("string"),
+                                              Some[String]("byte")
+                                            ))
+                                          case false => nm == "Money" match {
+                                              case true =>
+                                                Some[openapi_primitive_def](OpenApiPrimDef(
+                                                  List("integer"),
+                                                  None
+                                                ))
+                                              case false => None
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
   def classificationTargetEntity(x0: operation_classification): Option[String] =
     x0 match {
       case OperationClassification(uu, uv, uw, ux, t, uy, uz) => t
@@ -9501,5 +9567,67 @@ object SpecRestGenerated {
       case OptionTypeF(_, _)                      => None
       case RelationTypeF(_, _, _, _)              => None
     }
+
+  def classifyOpenApiNamedTypeAux(
+      fuel: nat,
+      uu: String,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[(String, enum_decl_full)],
+      ux: List[String],
+      uy: List[String]
+  ): openapi_named_kind =
+    equal_nat(fuel, zero_nat) match {
+      case true => OntUnknown()
+      case false => openapiPrimitiveOf(uu) match {
+          case None =>
+            map_of[String, enum_decl_full](uw, uu) match {
+              case None =>
+                membera[String](ux, uu) match {
+                  case true => OntEntityRef(uu)
+                  case false => membera[String](uy, uu) match {
+                      case true => OntUnknown()
+                      case false => map_of[String, type_alias_decl_full](uv, uu) match {
+                          case None => OntUnknown()
+                          case Some(TypeAliasDeclFull(_, base, _, _)) =>
+                            base match {
+                              case NamedTypeF(n, _) =>
+                                classifyOpenApiNamedTypeAux(
+                                  minus_nat(fuel, one_nat),
+                                  n,
+                                  uv,
+                                  uw,
+                                  ux,
+                                  uu :: uy
+                                )
+                              case SetTypeF(_, _)    => OntAliasToType(base)
+                              case MapTypeF(_, _, _) => OntAliasToType(base)
+                              case SeqTypeF(_, _)    => OntAliasToType(base)
+                              case OptionTypeF(_, _) => OntAliasToType(base)
+                              case RelationTypeF(_, _, _, _) =>
+                                OntAliasToType(base)
+                            }
+                        }
+                    }
+                }
+              case Some(EnumDeclFull(_, vs, _)) => OntEnum(vs)
+            }
+          case Some(a) => OntPrimitive(a)
+        }
+    }
+
+  def classifyOpenApiNamedType(
+      name: String,
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)],
+      entityNames: List[String]
+  ): openapi_named_kind =
+    classifyOpenApiNamedTypeAux(
+      Suc(size_list[(String, type_alias_decl_full)](am)),
+      name,
+      am,
+      em,
+      entityNames,
+      Nil
+    )
 
 } /* object SpecRestGenerated */

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -215,6 +215,8 @@ export_code
     isFailLoudStub
     aliasRefinements
     findEnumValuesInType
+    openapiPrimitiveOf
+    classifyOpenApiNamedType
     primitiveTypeToSql
     classifyColumnType
     collectionElementEntityName

--- a/proofs/isabelle/SpecRest/SchemaTraversal.thy
+++ b/proofs/isabelle/SpecRest/SchemaTraversal.thy
@@ -82,10 +82,89 @@ where
   "findEnumValuesInType ty am em =
      findEnumValuesInTypeAux (Suc (length am)) ty am em []"
 
+text \<open>OpenAPI primitive type table — lifted from
+  \<open>specrest.codegen.openapi.OpenApi.Schema.PrimitiveSchemas\<close>. Each spec
+  primitive maps to an OpenAPI \<open>type\<close> list and an optional \<open>format\<close>
+  string. The Scala caller wraps this into \<open>SchemaObject\<close>.\<close>
+
+datatype openapi_primitive_def = OpenApiPrimDef
+  "String.literal list"      \<comment> \<open>type list, e.g. ["string"] or ["integer"]\<close>
+  "String.literal option"    \<comment> \<open>format, e.g. Some "date-time"\<close>
+
+definition openapiPrimitiveOf ::
+  "String.literal \<Rightarrow> openapi_primitive_def option"
+where
+  "openapiPrimitiveOf nm = (
+    if nm = STR ''String''   then Some (OpenApiPrimDef [STR ''string''] None)
+    else if nm = STR ''Int''      then Some (OpenApiPrimDef [STR ''integer''] None)
+    else if nm = STR ''Float''    then Some (OpenApiPrimDef [STR ''number''] None)
+    else if nm = STR ''Bool''     then Some (OpenApiPrimDef [STR ''boolean''] None)
+    else if nm = STR ''Boolean''  then Some (OpenApiPrimDef [STR ''boolean''] None)
+    else if nm = STR ''DateTime'' then Some (OpenApiPrimDef [STR ''string''] (Some (STR ''date-time'')))
+    else if nm = STR ''Date''     then Some (OpenApiPrimDef [STR ''string''] (Some (STR ''date'')))
+    else if nm = STR ''UUID''     then Some (OpenApiPrimDef [STR ''string''] (Some (STR ''uuid'')))
+    else if nm = STR ''Decimal''  then Some (OpenApiPrimDef [STR ''string''] (Some (STR ''decimal'')))
+    else if nm = STR ''Bytes''    then Some (OpenApiPrimDef [STR ''string''] (Some (STR ''byte'')))
+    else if nm = STR ''Money''    then Some (OpenApiPrimDef [STR ''integer''] None)
+    else None)"
+
+text \<open>OpenAPI named-type classifier — mirrors \<open>classifyColumnType\<close> in
+  \<open>SchemaDerive\<close> but produces an OpenAPI-shaped kind. Walks the alias chain
+  using the same fuel-bounded visited-set pattern as the rest of this theory.
+  Used by \<open>OpenApi.Schema.namedTypeSchema\<close> to dispatch on what a name
+  resolves to without the Scala caller re-implementing the alias walk.
+
+  When an alias chain lands on a non-NamedType structural type (\<open>Set\<close>,
+  \<open>Seq\<close>, \<open>Map\<close>, \<open>Relation\<close>, \<open>Option\<close>) we return that type via
+  \<open>OntAliasToType\<close> and let the Scala caller dispatch through its existing
+  \<open>typeExprToSchema\<close> — keeps the OpenAPI-specific structural rendering
+  (array \<open>items\<close>, object \<open>additionalProperties\<close>, etc.) in Scala where it
+  builds the recursive \<open>SchemaObject\<close>.\<close>
+
+datatype openapi_named_kind =
+    OntPrimitive openapi_primitive_def
+  | OntEnum "String.literal list"
+  | OntEntityRef String.literal
+  | OntAliasToType type_expr_full
+  | OntUnknown
+
+fun classifyOpenApiNamedTypeAux ::
+  "nat \<Rightarrow> String.literal \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list
+    \<Rightarrow> String.literal list \<Rightarrow> openapi_named_kind"
+where
+  "classifyOpenApiNamedTypeAux 0 _ _ _ _ _ = OntUnknown"
+| "classifyOpenApiNamedTypeAux (Suc fuel) name am em entityNames seen = (
+     case openapiPrimitiveOf name of
+       Some p \<Rightarrow> OntPrimitive p
+     | None \<Rightarrow>
+         (case map_of em name of
+            Some (EnumDeclFull _ vs _) \<Rightarrow> OntEnum vs
+          | None \<Rightarrow>
+              (if name \<in> set entityNames then OntEntityRef name
+               else if name \<in> set seen then OntUnknown
+               else case map_of am name of
+                      None \<Rightarrow> OntUnknown
+                    | Some (TypeAliasDeclFull _ base _ _) \<Rightarrow>
+                        (case base of
+                           NamedTypeF n' _ \<Rightarrow>
+                             classifyOpenApiNamedTypeAux fuel n' am em entityNames
+                               (name # seen)
+                         | _ \<Rightarrow> OntAliasToType base))))"
+
+definition classifyOpenApiNamedType ::
+  "String.literal \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list
+    \<Rightarrow> openapi_named_kind"
+where
+  "classifyOpenApiNamedType name am em entityNames =
+     classifyOpenApiNamedTypeAux (Suc (length am)) name am em entityNames []"
+
 lemmas stripOptions_code [code] = stripOptions.simps
 lemmas aliasRefinementsAux_code [code] = aliasRefinementsAux.simps
 lemmas aliasRefinements_code [code] = aliasRefinements_def
 lemmas findEnumValuesInTypeAux_code [code] = findEnumValuesInTypeAux.simps
 lemmas findEnumValuesInType_code [code] = findEnumValuesInType_def
+lemmas openapiPrimitiveOf_code [code] = openapiPrimitiveOf_def
+lemmas classifyOpenApiNamedTypeAux_code [code] = classifyOpenApiNamedTypeAux.simps
+lemmas classifyOpenApiNamedType_code [code] = classifyOpenApiNamedType_def
 
 end


### PR DESCRIPTION
## Summary

Mirrors the `classifyColumnType` pattern (#323) for OpenAPI schema emission. Lifts the alias-chain-aware NamedType classifier that `OpenApi.Schema.namedTypeSchema` used to implement inline.

### What's lifted (in `SchemaTraversal.thy`)

- **`openapi_primitive_def`** — type list + optional format (mirror of `OpenApi.PrimitiveSchemas`)
- **`openapiPrimitiveOf`** — the 11-entry primitive lookup table
- **`openapi_named_kind`** ADT with five variants:
  - `OntPrimitive openapi_primitive_def` — primitive type + format
  - `OntEnum String.literal list` — enum
  - `OntEntityRef String.literal` — entity → `#/components` ref
  - `OntAliasToType type_expr_full` — alias chain landed on a structural type (`Set`/`Seq`/`Map`/`Relation`/`Option`); Scala dispatches via existing `typeExprToSchema`
  - `OntUnknown` — unresolved fallback (string)
- **`classifyOpenApiNamedType`** — fuel-bounded alias chain walker reusing the visited-set pattern from `aliasRefinements` / `findEnumValuesInType` / `classifyColumnType`

### Refactor

`OpenApi.Schema.namedTypeSchema` now pattern-matches the extracted tag and dispatches. `PrimitiveSchemas` deleted from Scala — single source of truth in `SchemaTraversal.thy`. `BuildContext` gains an `entityNamesList` field (built once from `ir.idx.entityNamesList`) to feed the lifted classifier.

### Why a side ADT instead of inlining alias resolution everywhere

Alias chains can land on structural types (`Set[Bar]`, `Map[K, V]`, etc.) that OpenAPI renders recursively. The classifier resolves the NamedType part of the chain and returns `OntAliasToType` for "go handle this structural thing"; Scala's existing `typeExprToSchema` does the recursive build. Keeps OpenAPI-specific structural rendering in Scala where it belongs.

## Test plan

- [x] `isabelle build` — green (2:00 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `ClassifyOpenApiNamedTypeTest` — 11 focused tests: all primitives, single-name enum/entity-ref, alias chain to primitive/enum/entity, alias landing on SetType/OptionType, unresolved name, cyclic alias guard
- [x] `sbt scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the OpenAPI NamedType classifier into proofs and wired Scala to use it. This centralizes classification, handles alias chains (including structural types), and simplifies `OpenApi.Schema.namedTypeSchema`.

- **Refactors**
  - In `SchemaTraversal.thy`: `openapi_primitive_def`, `openapiPrimitiveOf`, `openapi_named_kind`, and `classifyOpenApiNamedType` (fuel-bounded).
  - `specrest.codegen.openapi.OpenApi.Schema.namedTypeSchema` now dispatches via `classifyOpenApiNamedType`; uses `primitiveDefToSchema`; removed `PrimitiveSchemas`.
  - Build context: added `entityNamesList` (from `ir.idx.entityNamesList`) and removed redundant `entityNames` Set.
  - Exported `openapiPrimitiveOf` and `classifyOpenApiNamedType` via `Codegen.thy`.

- **Tests**
  - Added focused tests for primitives, enums, entity refs, alias chains (including structural), unknowns, and cycles.

<sup>Written for commit 140ede1eabf70e353f7047d5ba158452a23690d6. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved OpenAPI schema generation with enhanced classification of primitive types, enums, and entity references.
  * Strengthened alias chain resolution with improved cyclic reference handling.

* **Tests**
  * Added comprehensive test coverage for type classification logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->