### PR TITLE
feat(proofs): lift visitConstraintOpenApi (OpenApi.Constraints Int subset)

### DIFF
--- a/.github/workflows/isabelle-build.yml
+++ b/.github/workflows/isabelle-build.yml
@@ -240,7 +240,7 @@ jobs:
           exported="$work/export/SpecRest.Codegen/code/SpecRestGenerated.scala"
           out="$work/SpecRestGenerated.scala"
           {
-            printf 'package specrest.ir.generated\n\nimport scala.annotation.nowarn\n\n@nowarn\n'
+            printf 'package specrest.ir.generated\n\n'
             cat "$exported"
           } > "$out"
           scalafmt --config .scalafmt.conf --non-interactive "$out" >/dev/null

--- a/docs/content/docs/design/isabelle-proofs.mdx
+++ b/docs/content/docs/design/isabelle-proofs.mdx
@@ -137,7 +137,7 @@ isabelle export -d proofs/isabelle/SpecRest -O "$work" \
   -x 'SpecRest.Codegen:code/*' SpecRest
 
 target="modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala"
-{ printf 'package specrest.ir.generated\n\nimport scala.annotation.nowarn\n\n@nowarn\n'
+{ printf 'package specrest.ir.generated\n\n'
   cat "$work/SpecRest.Codegen/code/SpecRestGenerated.scala"
 } > "$target"
 scalafmt --config .scalafmt.conf --non-interactive "$target"

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -137,35 +137,58 @@ object Constraints:
     for pred <- aliasRefinements(typeExpr, aliasAList) do
       out = visitConstraint(pred, out)
     constraint match
-      case Some(c) => visitConstraint(c, out)
-      case None    => out
+      case Some(c) => out = visitConstraint(c, out)
+      case None    => ()
+    out
 
   private def visitConstraint(
       expr: expr_full,
       out: JsonSchemaConstraints
   ): JsonSchemaConstraints =
-    flattenAnd(expr).foldLeft(out)((acc, atom) => applyAtom(atom, acc))
+    val intBounds = visitConstraintOpenApi(expr, emptyOpenApiIntBounds)
+    val withInt   = mergeIntBounds(out, intBounds)
+    flattenAnd(expr).foldLeft(withInt)((acc, atom) => applyFloatAtom(atom, acc))
 
-  private def applyAtom(
+  // Float-literal atoms aren't recognized by decomposeAtom (which only matches
+  // IntLitF). Walk the same atoms in Scala, contributing Double-valued bounds
+  // that the lifted Int walker couldn't see.
+  private def applyFloatAtom(
       expr: expr_full,
       out: JsonSchemaConstraints
   ): JsonSchemaConstraints =
     decomposeAtom(expr) match
-      case RaMatches(pat)                    => out.copy(pattern = Some(pat))
-      case RaLenCmp(op, int_of_integer(n))   => applyLengthBound(op, n.toDouble, out)
-      case RaValueCmp(op, int_of_integer(n)) => applyNumericBound(op, n.toDouble, out)
-      case _: RaPredCall | _: RaMatchesIdent => out
-      case _: RaUnknown                      =>
-        // Float-literal bounds — decomposeAtom only recognizes IntLitF
+      case _: (RaMatches | RaLenCmp | RaValueCmp | RaPredCall | RaMatchesIdent) => out
+      case _: RaUnknown =>
         expr match
           case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
             v.toDoubleOption.fold(out): d =>
-              if isLenOfValue(lhs) then applyLengthBound(op, d, out)
-              else if isValueRef(lhs) then applyNumericBound(op, d, out)
+              if isLenOfValue(lhs) then applyLengthBoundDouble(op, d, out)
+              else if isValueRef(lhs) then applyNumericBoundDouble(op, d, out)
               else out
           case _ => out
 
-  private def applyLengthBound(
+  private def mergeIntBounds(
+      out: JsonSchemaConstraints,
+      b: openapi_int_bounds
+  ): JsonSchemaConstraints =
+    b match
+      case OpenApiIntBounds(nl, ml, mn, mx, emn, emx, pat) =>
+        out.copy(
+          minLength = nl.map(asInt).orElse(out.minLength),
+          maxLength = ml.map(asInt).orElse(out.maxLength),
+          minimum = mn.map(asDouble).orElse(out.minimum),
+          maximum = mx.map(asDouble).orElse(out.maximum),
+          exclusiveMinimum = emn.map(asDouble).orElse(out.exclusiveMinimum),
+          exclusiveMaximum = emx.map(asDouble).orElse(out.exclusiveMaximum),
+          pattern = pat.orElse(out.pattern)
+        )
+
+  private def asInt(i: int): Int = i match
+    case int_of_integer(v) => v.toInt
+  private def asDouble(i: int): Double = i match
+    case int_of_integer(v) => v.toDouble
+
+  private def applyLengthBoundDouble(
       op: bin_op_full,
       n: Double,
       out: JsonSchemaConstraints
@@ -187,7 +210,7 @@ object Constraints:
           )
         case _ => out
 
-  private def applyNumericBound(
+  private def applyNumericBoundDouble(
       op: bin_op_full,
       n: Double,
       out: JsonSchemaConstraints

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -130,111 +130,40 @@ object Constraints:
       aliasAList: List[(String, TypeAliasDeclFull)],
       enumAList: List[(String, EnumDeclFull)]
   ): JsonSchemaConstraints =
-    var out = JsonSchemaConstraints()
-    findEnumValuesInType(typeExpr, aliasAList, enumAList) match
-      case Some(vs) => out = out.copy(enum_ = Some(vs))
-      case None     => ()
+    var bounds = emptyOpenApiBounds
     for pred <- aliasRefinements(typeExpr, aliasAList) do
-      out = visitConstraint(pred, out)
+      bounds = visitConstraintOpenApi(pred, bounds)
     constraint match
-      case Some(c) => out = visitConstraint(c, out)
+      case Some(c) => bounds = visitConstraintOpenApi(c, bounds)
       case None    => ()
-    out
+    val enum_ = findEnumValuesInType(typeExpr, aliasAList, enumAList)
+    boundsToConstraints(bounds, enum_)
 
-  private def visitConstraint(
-      expr: expr_full,
-      out: JsonSchemaConstraints
-  ): JsonSchemaConstraints =
-    val intBounds = visitConstraintOpenApi(expr, emptyOpenApiIntBounds)
-    val withInt   = mergeIntBounds(out, intBounds)
-    flattenAnd(expr).foldLeft(withInt)((acc, atom) => applyFloatAtom(atom, acc))
-
-  // Float-literal atoms aren't recognized by decomposeAtom (which only matches
-  // IntLitF). Walk the same atoms in Scala, contributing Double-valued bounds
-  // that the lifted Int walker couldn't see.
-  private def applyFloatAtom(
-      expr: expr_full,
-      out: JsonSchemaConstraints
-  ): JsonSchemaConstraints =
-    decomposeAtom(expr) match
-      case _: (RaMatches | RaLenCmp | RaValueCmp | RaPredCall | RaMatchesIdent) => out
-      case _: RaUnknown =>
-        expr match
-          case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
-            v.toDoubleOption.fold(out): d =>
-              if isLenOfValue(lhs) then applyLengthBoundDouble(op, d, out)
-              else if isValueRef(lhs) then applyNumericBoundDouble(op, d, out)
-              else out
-          case _ => out
-
-  private def mergeIntBounds(
-      out: JsonSchemaConstraints,
-      b: openapi_int_bounds
+  private def boundsToConstraints(
+      b: openapi_bounds,
+      enum_ : Option[List[String]]
   ): JsonSchemaConstraints =
     b match
-      case OpenApiIntBounds(nl, ml, mn, mx, emn, emx, pat) =>
-        out.copy(
-          minLength = nl.map(asInt).orElse(out.minLength),
-          maxLength = ml.map(asInt).orElse(out.maxLength),
-          minimum = mn.map(asDouble).orElse(out.minimum),
-          maximum = mx.map(asDouble).orElse(out.maximum),
-          exclusiveMinimum = emn.map(asDouble).orElse(out.exclusiveMinimum),
-          exclusiveMaximum = emx.map(asDouble).orElse(out.exclusiveMaximum),
-          pattern = pat.orElse(out.pattern)
+      case OpenApiBounds(nl, ml, mn, mx, emn, emx, pat) =>
+        JsonSchemaConstraints(
+          minLength = nl.map(asInt),
+          maxLength = ml.map(asInt),
+          minimum = mn.map(decimalToDouble),
+          maximum = mx.map(decimalToDouble),
+          exclusiveMinimum = emn.map(decimalToDouble),
+          exclusiveMaximum = emx.map(decimalToDouble),
+          pattern = pat,
+          enum_ = enum_
         )
 
   private def asInt(i: int): Int = i match
     case int_of_integer(v) => v.toInt
-  private def asDouble(i: int): Double = i match
-    case int_of_integer(v) => v.toDouble
 
-  private def applyLengthBoundDouble(
-      op: bin_op_full,
-      n: Double,
-      out: JsonSchemaConstraints
-  ): JsonSchemaConstraints =
-    if n != n.toInt.toDouble || n < 0 then out
-    else
-      val ni = n.toInt
-      op match
-        case _: BGe => out.copy(minLength = tightenLower(out.minLength, ni))
-        case _: BLe => out.copy(maxLength = tightenUpper(out.maxLength, ni))
-        case _: BGt => out.copy(minLength = tightenLower(out.minLength, ni + 1))
-        case _: BLt =>
-          if ni - 1 < 0 then out
-          else out.copy(maxLength = tightenUpper(out.maxLength, ni - 1))
-        case _: BEq =>
-          out.copy(
-            minLength = tightenLower(out.minLength, ni),
-            maxLength = tightenUpper(out.maxLength, ni)
-          )
-        case _ => out
-
-  private def applyNumericBoundDouble(
-      op: bin_op_full,
-      n: Double,
-      out: JsonSchemaConstraints
-  ): JsonSchemaConstraints =
-    op match
-      case _: BGe => out.copy(minimum = tightenLowerD(out.minimum, n))
-      case _: BLe => out.copy(maximum = tightenUpperD(out.maximum, n))
-      case _: BGt => out.copy(exclusiveMinimum = tightenLowerD(out.exclusiveMinimum, n))
-      case _: BLt => out.copy(exclusiveMaximum = tightenUpperD(out.exclusiveMaximum, n))
-      case _: BEq =>
-        out.copy(
-          minimum = tightenLowerD(out.minimum, n),
-          maximum = tightenUpperD(out.maximum, n)
-        )
-      case _ => out
-
-  private def tightenLower(cur: Option[Int], n: Int): Option[Int] =
-    Some(cur.fold(n)(math.max(_, n)))
-  private def tightenUpper(cur: Option[Int], n: Int): Option[Int] =
-    Some(cur.fold(n)(math.min(_, n)))
-  private def tightenLowerD(cur: Option[Double], n: Double): Option[Double] =
-    Some(cur.fold(n)(math.max(_, n)))
-  private def tightenUpperD(cur: Option[Double], n: Double): Option[Double] =
-    Some(cur.fold(n)(math.min(_, n)))
+  // decimal_lit DecimalLit(mantissa, exponent) represents mantissa * 10^exponent.
+  // BigDecimal handles arbitrary precision; .doubleValue trims to IEEE 754.
+  private def decimalToDouble(d: decimal_lit): Double = d match
+    case DecimalLit(int_of_integer(m), int_of_integer(e)) =>
+      BigDecimal(m.bigInteger, -e.toInt).doubleValue
 
 // -- Schema generation ----------------------------------------
 

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -1,0 +1,107 @@
+package specrest.codegen.openapi
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+class OpenApiConstraintsTest extends CatsEffectSuite:
+
+  private def ident(n: String): IdentifierF = IdentifierF(n, None)
+  private def intL(n: Int): IntLitF         = IntLitF(int_of_integer(BigInt(n)), None)
+  private def valueRef: IdentifierF         = ident("value")
+  private def lenOfValue: expr_full         = CallF(ident("len"), List(valueRef), None)
+
+  private def binOp(op: bin_op_full, l: expr_full, r: expr_full): BinaryOpF =
+    BinaryOpF(op, l, r, None)
+
+  private def walk(e: expr_full): openapi_int_bounds =
+    visitConstraintOpenApi(e, emptyOpenApiIntBounds)
+
+  private def fields(b: openapi_int_bounds) = b match
+    case OpenApiIntBounds(ml, mxl, mn, mx, emn, emx, p) =>
+      (ml, mxl, mn, mx, emn, emx, p)
+
+  test("emptyOpenApiIntBounds is all None"):
+    val (ml, mxl, mn, mx, emn, emx, p) = fields(emptyOpenApiIntBounds)
+    assertEquals((ml, mxl, mn, mx, emn, emx, p), (None, None, None, None, None, None, None))
+
+  test("RaValueCmp BGe sets inclusive minimum"):
+    val res = walk(binOp(BGe(), valueRef, intL(10)))
+    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
+    assertEquals(fields(res)._5, None) // exclusiveMinimum untouched
+
+  test("RaValueCmp BGt sets exclusive minimum (preserved, not +1)"):
+    val res = walk(binOp(BGt(), valueRef, intL(10)))
+    assertEquals(fields(res)._3, None) // inclusive minimum untouched
+    assertEquals(fields(res)._5, Some(int_of_integer(BigInt(10))))
+
+  test("RaValueCmp BLe sets inclusive maximum"):
+    val res = walk(binOp(BLe(), valueRef, intL(100)))
+    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(100))))
+
+  test("RaValueCmp BLt sets exclusive maximum"):
+    val res = walk(binOp(BLt(), valueRef, intL(100)))
+    assertEquals(fields(res)._6, Some(int_of_integer(BigInt(100))))
+
+  test("RaValueCmp BEq pins both bounds inclusive"):
+    val res = walk(binOp(BEq(), valueRef, intL(42)))
+    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(42))))
+    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(42))))
+
+  test("RaLenCmp BGe sets minLength"):
+    val res = walk(binOp(BGe(), lenOfValue, intL(3)))
+    assertEquals(fields(res)._1, Some(int_of_integer(BigInt(3))))
+
+  test("RaLenCmp BGt collapses to +1 (length is integer-bound)"):
+    val res = walk(binOp(BGt(), lenOfValue, intL(3)))
+    assertEquals(fields(res)._1, Some(int_of_integer(BigInt(4))))
+
+  test("RaLenCmp BLt skipped when n-1 would be negative"):
+    val res = walk(binOp(BLt(), lenOfValue, intL(0)))
+    assertEquals(fields(res)._2, None)
+
+  test("negative length bound is rejected silently"):
+    val res = walk(binOp(BGe(), lenOfValue, intL(-5)))
+    assertEquals(fields(res)._1, None)
+
+  test("MatchesF on value sets pattern via RaMatches"):
+    val matches = MatchesF(valueRef, "^foo$", None)
+    val r       = walk(matches)
+    assertEquals(fields(r)._7, Some("^foo$"))
+
+  test("AND-chain accumulates tighter bounds"):
+    val e = binOp(
+      BAnd(),
+      binOp(BGe(), valueRef, intL(10)),
+      binOp(BLe(), valueRef, intL(100))
+    )
+    val res = walk(e)
+    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
+    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(100))))
+
+  test("conflicting min picks the tighter (higher) bound"):
+    val e = binOp(
+      BAnd(),
+      binOp(BGe(), valueRef, intL(5)),
+      binOp(BGe(), valueRef, intL(20))
+    )
+    val res = walk(e)
+    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(20))))
+
+  test("conflicting max picks the tighter (lower) bound"):
+    val e = binOp(
+      BAnd(),
+      binOp(BLe(), valueRef, intL(100)),
+      binOp(BLe(), valueRef, intL(50))
+    )
+    val res = walk(e)
+    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(50))))
+
+  test("inclusive and exclusive minimum tracked independently"):
+    val e = binOp(
+      BAnd(),
+      binOp(BGe(), valueRef, intL(10)),
+      binOp(BGt(), valueRef, intL(20))
+    )
+    val res = walk(e)
+    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
+    assertEquals(fields(res)._5, Some(int_of_integer(BigInt(20))))

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -7,101 +7,170 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
 
   private def ident(n: String): IdentifierF = IdentifierF(n, None)
   private def intL(n: Int): IntLitF         = IntLitF(int_of_integer(BigInt(n)), None)
-  private def valueRef: IdentifierF         = ident("value")
-  private def lenOfValue: expr_full         = CallF(ident("len"), List(valueRef), None)
+  private def floatL(v: String): FloatLitF  = FloatLitF(v, None)
+  private val valueRef: IdentifierF         = ident("value")
+  private val lenOfValue: expr_full         = CallF(ident("len"), List(valueRef), None)
 
   private def binOp(op: bin_op_full, l: expr_full, r: expr_full): BinaryOpF =
     BinaryOpF(op, l, r, None)
 
-  private def walk(e: expr_full): openapi_int_bounds =
-    visitConstraintOpenApi(e, emptyOpenApiIntBounds)
+  private def walk(e: expr_full): openapi_bounds =
+    visitConstraintOpenApi(e, emptyOpenApiBounds)
 
-  private def fields(b: openapi_int_bounds) = b match
-    case OpenApiIntBounds(ml, mxl, mn, mx, emn, emx, p) =>
-      (ml, mxl, mn, mx, emn, emx, p)
+  private def i(n: Int): int                   = int_of_integer(BigInt(n))
+  private def dec(m: Int, e: Int): decimal_lit = DecimalLit(i(m), i(e))
 
-  test("emptyOpenApiIntBounds is all None"):
-    val (ml, mxl, mn, mx, emn, emx, p) = fields(emptyOpenApiIntBounds)
-    assertEquals((ml, mxl, mn, mx, emn, emx, p), (None, None, None, None, None, None, None))
+  // Named accessors over the positional Isabelle-extracted case class.
+  extension (b: openapi_bounds)
+    private def minLength: Option[int] = b match
+      case OpenApiBounds(v, _, _, _, _, _, _) => v
+    private def maxLength: Option[int] = b match
+      case OpenApiBounds(_, v, _, _, _, _, _) => v
+    private def minimum: Option[decimal_lit] = b match
+      case OpenApiBounds(_, _, v, _, _, _, _) => v
+    private def maximum: Option[decimal_lit] = b match
+      case OpenApiBounds(_, _, _, v, _, _, _) => v
+    private def exclusiveMinimum: Option[decimal_lit] = b match
+      case OpenApiBounds(_, _, _, _, v, _, _) => v
+    private def exclusiveMaximum: Option[decimal_lit] = b match
+      case OpenApiBounds(_, _, _, _, _, v, _) => v
+    private def pattern: Option[String] = b match
+      case OpenApiBounds(_, _, _, _, _, _, v) => v
 
-  test("RaValueCmp BGe sets inclusive minimum"):
-    val res = walk(binOp(BGe(), valueRef, intL(10)))
-    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
-    assertEquals(fields(res)._5, None) // exclusiveMinimum untouched
+  test("emptyOpenApiBounds is all None"):
+    val b = emptyOpenApiBounds
+    assertEquals(b.minLength, None)
+    assertEquals(b.maxLength, None)
+    assertEquals(b.minimum, None)
+    assertEquals(b.maximum, None)
+    assertEquals(b.exclusiveMinimum, None)
+    assertEquals(b.exclusiveMaximum, None)
+    assertEquals(b.pattern, None)
 
-  test("RaValueCmp BGt sets exclusive minimum (preserved, not +1)"):
-    val res = walk(binOp(BGt(), valueRef, intL(10)))
-    assertEquals(fields(res)._3, None) // inclusive minimum untouched
-    assertEquals(fields(res)._5, Some(int_of_integer(BigInt(10))))
+  // -- parseDecimalLit ----------------------------------------------------
 
-  test("RaValueCmp BLe sets inclusive maximum"):
-    val res = walk(binOp(BLe(), valueRef, intL(100)))
-    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(100))))
+  List[(String, String, Option[decimal_lit])](
+    ("integer", "5", Some(dec(5, 0))),
+    ("integer-large", "100", Some(dec(100, 0))),
+    ("zero", "0", Some(dec(0, 0))),
+    ("fractional", "3.14", Some(dec(314, -2))),
+    ("fractional-leading-zero", "0.5", Some(dec(5, -1))),
+    ("fractional-trailing-zero", "1.0", Some(dec(10, -1))),
+    ("negative-integer", "-5", Some(dec(-5, 0))),
+    ("negative-fractional", "-3.14", Some(dec(-314, -2))),
+    ("empty", "", None),
+    ("non-numeric", "abc", None),
+    ("scientific-rejected", "1.5e2", None),
+    ("trailing-dot", "1.", None),
+    ("leading-dot", ".5", None),
+    ("sign-only", "-", None),
+    ("internal-letter", "1a", None)
+  ).foreach: (name, input, expected) =>
+    test(s"parseDecimalLit: $name"):
+      assertEquals(parseDecimalLit(input), expected)
 
-  test("RaValueCmp BLt sets exclusive maximum"):
-    val res = walk(binOp(BLt(), valueRef, intL(100)))
-    assertEquals(fields(res)._6, Some(int_of_integer(BigInt(100))))
+  // -- decimalToNonNegInt -------------------------------------------------
 
-  test("RaValueCmp BEq pins both bounds inclusive"):
+  List[(String, decimal_lit, Option[int])](
+    ("plain integer", dec(5, 0), Some(i(5))),
+    ("zero", dec(0, 0), Some(i(0))),
+    ("trailing-zero-fractional", dec(10, -1), Some(i(1))), // 1.0
+    ("multiple-trailing-zeros", dec(100, -2), Some(i(1))), // 1.00
+    ("non-exact-fractional", dec(15, -1), None),           // 1.5
+    ("pi-fractional", dec(314, -2), None),                 // 3.14
+    ("negative-integer", dec(-5, 0), None),
+    ("positive-exponent", dec(3, 2), Some(i(300))) // 3e2 = 300
+  ).foreach: (name, input, expected) =>
+    test(s"decimalToNonNegInt: $name"):
+      assertEquals(decimalToNonNegInt(input), expected)
+
+  // -- RaValueCmp (Int path) ----------------------------------------------
+
+  List[(String, bin_op_full, Int, openapi_bounds => Option[decimal_lit], decimal_lit)](
+    ("BGe → inclusive min", BGe(), 10, _.minimum, dec(10, 0)),
+    ("BGt → exclusive min (NOT +1)", BGt(), 10, _.exclusiveMinimum, dec(10, 0)),
+    ("BLe → inclusive max", BLe(), 100, _.maximum, dec(100, 0)),
+    ("BLt → exclusive max", BLt(), 100, _.exclusiveMaximum, dec(100, 0))
+  ).foreach: (name, op, n, field, expected) =>
+    test(s"RaValueCmp: $name"):
+      assertEquals(field(walk(binOp(op, valueRef, intL(n)))), Some(expected))
+
+  test("RaValueCmp BEq pins both inclusive bounds"):
     val res = walk(binOp(BEq(), valueRef, intL(42)))
-    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(42))))
-    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(42))))
+    assertEquals(res.minimum, Some(dec(42, 0)))
+    assertEquals(res.maximum, Some(dec(42, 0)))
 
-  test("RaLenCmp BGe sets minLength"):
-    val res = walk(binOp(BGe(), lenOfValue, intL(3)))
-    assertEquals(fields(res)._1, Some(int_of_integer(BigInt(3))))
+  // -- RaLenCmp (Int path) ------------------------------------------------
 
-  test("RaLenCmp BGt collapses to +1 (length is integer-bound)"):
-    val res = walk(binOp(BGt(), lenOfValue, intL(3)))
-    assertEquals(fields(res)._1, Some(int_of_integer(BigInt(4))))
+  List[(String, bin_op_full, Int, openapi_bounds => Option[int], Int)](
+    ("BGe → minLength", BGe(), 3, _.minLength, 3),
+    ("BGt → minLength +1 (length is integer-valued)", BGt(), 3, _.minLength, 4),
+    ("BLe → maxLength", BLe(), 10, _.maxLength, 10),
+    ("BLt → maxLength -1", BLt(), 10, _.maxLength, 9)
+  ).foreach: (name, op, n, field, expected) =>
+    test(s"RaLenCmp: $name"):
+      assertEquals(field(walk(binOp(op, lenOfValue, intL(n)))), Some(i(expected)))
 
-  test("RaLenCmp BLt skipped when n-1 would be negative"):
-    val res = walk(binOp(BLt(), lenOfValue, intL(0)))
-    assertEquals(fields(res)._2, None)
+  test("RaLenCmp BLt n=0 dropped (would go negative)"):
+    assertEquals(walk(binOp(BLt(), lenOfValue, intL(0))).maxLength, None)
 
-  test("negative length bound is rejected silently"):
-    val res = walk(binOp(BGe(), lenOfValue, intL(-5)))
-    assertEquals(fields(res)._1, None)
+  test("RaLenCmp negative literal silently dropped"):
+    assertEquals(walk(binOp(BGe(), lenOfValue, intL(-5))).minLength, None)
 
-  test("MatchesF on value sets pattern via RaMatches"):
-    val matches = MatchesF(valueRef, "^foo$", None)
-    val r       = walk(matches)
-    assertEquals(fields(r)._7, Some("^foo$"))
+  // -- Float literal numeric bounds --------------------------------------
 
-  test("AND-chain accumulates tighter bounds"):
+  List[(String, bin_op_full, String, openapi_bounds => Option[decimal_lit], decimal_lit)](
+    ("BGe → minimum", BGe(), "1.5", _.minimum, dec(15, -1)),
+    ("BGt → exclusiveMinimum", BGt(), "3.14", _.exclusiveMinimum, dec(314, -2)),
+    ("BLe → maximum", BLe(), "100.5", _.maximum, dec(1005, -1)),
+    ("BLt → exclusiveMaximum", BLt(), "99.9", _.exclusiveMaximum, dec(999, -1))
+  ).foreach: (name, op, v, field, expected) =>
+    test(s"Float-literal numeric: $name"):
+      assertEquals(field(walk(binOp(op, valueRef, floatL(v)))), Some(expected))
+
+  // -- Float literal length bounds (integer-coerce or drop) --------------
+
+  List[(String, String, Option[Int])](
+    ("integer-valued .0 accepted", "3.0", Some(3)),
+    ("multiple zeros accepted", "5.00", Some(5)),
+    ("fractional rejected", "3.5", None),
+    ("negative rejected", "-1.0", None)
+  ).foreach: (name, v, expected) =>
+    test(s"Float-literal length: $name"):
+      val got = walk(binOp(BGe(), lenOfValue, floatL(v))).minLength
+      assertEquals(got, expected.map(i))
+
+  // -- Pattern -----------------------------------------------------------
+
+  test("MatchesF on value sets pattern"):
+    val res = walk(MatchesF(valueRef, "^foo$", None))
+    assertEquals(res.pattern, Some("^foo$"))
+
+  // -- AND-chain accumulation --------------------------------------------
+
+  test("AND-chain: int + float tighter inclusive minimum wins"):
     val e = binOp(
       BAnd(),
-      binOp(BGe(), valueRef, intL(10)),
-      binOp(BLe(), valueRef, intL(100))
+      binOp(BGe(), valueRef, intL(2)),
+      binOp(BGe(), valueRef, floatL("3.5"))
     )
-    val res = walk(e)
-    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
-    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(100))))
+    // 3.5 > 2, so 3.5 wins
+    assertEquals(walk(e).minimum, Some(dec(35, -1)))
 
-  test("conflicting min picks the tighter (higher) bound"):
+  test("AND-chain: two float bounds, tighter (lower) max wins"):
     val e = binOp(
       BAnd(),
-      binOp(BGe(), valueRef, intL(5)),
-      binOp(BGe(), valueRef, intL(20))
+      binOp(BLe(), valueRef, floatL("100.0")),
+      binOp(BLe(), valueRef, floatL("50.5"))
     )
-    val res = walk(e)
-    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(20))))
+    assertEquals(walk(e).maximum, Some(dec(505, -1)))
 
-  test("conflicting max picks the tighter (lower) bound"):
+  test("AND-chain: inclusive and exclusive minima tracked independently"):
     val e = binOp(
       BAnd(),
-      binOp(BLe(), valueRef, intL(100)),
-      binOp(BLe(), valueRef, intL(50))
-    )
-    val res = walk(e)
-    assertEquals(fields(res)._4, Some(int_of_integer(BigInt(50))))
-
-  test("inclusive and exclusive minimum tracked independently"):
-    val e = binOp(
-      BAnd(),
-      binOp(BGe(), valueRef, intL(10)),
+      binOp(BGe(), valueRef, floatL("1.5")),
       binOp(BGt(), valueRef, intL(20))
     )
     val res = walk(e)
-    assertEquals(fields(res)._3, Some(int_of_integer(BigInt(10))))
-    assertEquals(fields(res)._5, Some(int_of_integer(BigInt(20))))
+    assertEquals(res.minimum, Some(dec(15, -1)))
+    assertEquals(res.exclusiveMinimum, Some(dec(20, 0)))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -884,6 +884,17 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
+  sealed abstract class openapi_int_bounds
+  final case class OpenApiIntBounds(
+      a: Option[int],
+      b: Option[int],
+      c: Option[int],
+      d: Option[int],
+      e: Option[int],
+      f: Option[int],
+      g: Option[String]
+  ) extends openapi_int_bounds
+
   def integer_of_nat(x0: nat): BigInt = x0 match {
     case Nata(x) => x
   }
@@ -7941,6 +7952,14 @@ object SpecRestGenerated {
     case DropTrigger(wb)                     => false
   }
 
+  def maximumOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(uu, uv, uw, mx, ux, uy, uz) => mx
+  }
+
+  def minimumOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(uu, uv, mn, uw, ux, uy, uz) => mn
+  }
+
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
     isRkCreate(initial) && !matchesCreateShape match {
       case true  => RkOther()
@@ -8547,6 +8566,32 @@ object SpecRestGenerated {
     case StateFieldDeclFull(uu, t, uv) => t
   }
 
+  def maxLengthOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(uu, ml, uv, uw, ux, uy, uz) => ml
+  }
+
+  def minLengthOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(nl, uu, uv, uw, ux, uy, uz) => nl
+  }
+
+  def withMaximum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, ml, mn, uu, emn, emx, p)) =>
+        OpenApiIntBounds(nl, ml, mn, v, emn, emx, p)
+    }
+
+  def withMinimum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, ml, uu, mx, emn, emx, p)) =>
+        OpenApiIntBounds(nl, ml, v, mx, emn, emx, p)
+    }
+
+  def withPattern(v: Option[String], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, ml, mn, mx, emn, emx, uu)) =>
+        OpenApiIntBounds(nl, ml, mn, mx, emn, emx, v)
+    }
+
   def triggerSourceForeignKey(x0: trigger_spec): String = x0 match {
     case TriggerSpec(uu, uv, uw, ux, uy, sfk, uz, va) => sfk
   }
@@ -8976,6 +9021,30 @@ object SpecRestGenerated {
     case (BoolLitF(v, va), uy)                             => false
     case (NoneLitF(v), uy)                                 => false
   }
+
+  def tightenIntMax(cur: Option[int], n: int): Option[int] =
+    cur match {
+      case None    => Some[int](n)
+      case Some(x) => Some[int](min[int](x, n))
+    }
+
+  def tightenIntMin(cur: Option[int], n: int): Option[int] =
+    cur match {
+      case None    => Some[int](n)
+      case Some(x) => Some[int](max[int](x, n))
+    }
+
+  def withMaxLength(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, uu, mn, mx, emn, emx, p)) =>
+        OpenApiIntBounds(nl, v, mn, mx, emn, emx, p)
+    }
+
+  def withMinLength(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(uu, ml, mn, mx, emn, emx, p)) =>
+        OpenApiIntBounds(v, ml, mn, mx, emn, emx, p)
+    }
 
   def decodeAggregateCall(call: expr_full): Option[aggregate_call] =
     call match {
@@ -9409,6 +9478,113 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, RelationTypeF(vd, ve, vf, vg), vc) => None
   }
 
+  def withExclusiveMinimum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, ml, mn, mx, uu, emx, p)) =>
+        OpenApiIntBounds(nl, ml, mn, mx, v, emx, p)
+    }
+
+  def withExclusiveMaximum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+    (v, x1) match {
+      case (v, OpenApiIntBounds(nl, ml, mn, mx, emn, uu, p)) =>
+        OpenApiIntBounds(nl, ml, mn, mx, emn, v, p)
+    }
+
+  def exclusiveMinimumOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(uu, uv, uw, ux, emn, uy, uz) => emn
+  }
+
+  def exclusiveMaximumOf(x0: openapi_int_bounds): Option[int] = x0 match {
+    case OpenApiIntBounds(uu, uv, uw, ux, uy, emx, uz) => emx
+  }
+
+  def applyNumericBoundOpenApi(
+      op: bin_op_full,
+      n: int,
+      bounds: openapi_int_bounds
+  ): openapi_int_bounds =
+    op match {
+      case BAnd()     => bounds
+      case BOr()      => bounds
+      case BImplies() => bounds
+      case BIff()     => bounds
+      case BEq() =>
+        withMaximum(
+          tightenIntMax(maximumOf(bounds), n),
+          withMinimum(tightenIntMin(minimumOf(bounds), n), bounds)
+        )
+      case BNeq() => bounds
+      case BLt() =>
+        withExclusiveMaximum(tightenIntMax(exclusiveMaximumOf(bounds), n), bounds)
+      case BGt() =>
+        withExclusiveMinimum(tightenIntMin(exclusiveMinimumOf(bounds), n), bounds)
+      case BLe()        => withMaximum(tightenIntMax(maximumOf(bounds), n), bounds)
+      case BGe()        => withMinimum(tightenIntMin(minimumOf(bounds), n), bounds)
+      case BIn()        => bounds
+      case BNotIn()     => bounds
+      case BSubset()    => bounds
+      case BUnion()     => bounds
+      case BIntersect() => bounds
+      case BDiff()      => bounds
+      case BAdd()       => bounds
+      case BSub()       => bounds
+      case BMul()       => bounds
+      case BDiv()       => bounds
+    }
+
+  def applyLengthBoundOpenApi(
+      op: bin_op_full,
+      n: int,
+      bounds: openapi_int_bounds
+  ): openapi_int_bounds =
+    less_int(n, zero_int) match {
+      case true => bounds
+      case false => op match {
+          case BAnd()     => bounds
+          case BOr()      => bounds
+          case BImplies() => bounds
+          case BIff()     => bounds
+          case BEq() =>
+            withMaxLength(
+              tightenIntMax(maxLengthOf(bounds), n),
+              withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
+            )
+          case BNeq() => bounds
+          case BLt() =>
+            less_int(minus_int(n, one_int), zero_int) match {
+              case true => bounds
+              case false =>
+                withMaxLength(tightenIntMax(maxLengthOf(bounds), minus_int(n, one_int)), bounds)
+            }
+          case BGt() =>
+            withMinLength(tightenIntMin(minLengthOf(bounds), plus_int(n, one_int)), bounds)
+          case BLe() =>
+            withMaxLength(tightenIntMax(maxLengthOf(bounds), n), bounds)
+          case BGe() =>
+            withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
+          case BIn()        => bounds
+          case BNotIn()     => bounds
+          case BSubset()    => bounds
+          case BUnion()     => bounds
+          case BIntersect() => bounds
+          case BDiff()      => bounds
+          case BAdd()       => bounds
+          case BSub()       => bounds
+          case BMul()       => bounds
+          case BDiv()       => bounds
+        }
+    }
+
+  def applyAtomOpenApi(atom: expr_full, bounds: openapi_int_bounds): openapi_int_bounds =
+    decomposeAtom(atom) match {
+      case RaLenCmp(op, n)      => applyLengthBoundOpenApi(op, n, bounds)
+      case RaValueCmp(op, n)    => applyNumericBoundOpenApi(op, n, bounds)
+      case RaMatches(pat)       => withPattern(Some[String](pat), bounds)
+      case RaMatchesIdent(_, _) => bounds
+      case RaPredCall(_)        => bounds
+      case RaUnknown(_)         => bounds
+    }
+
   def classificationOperationName(x0: operation_classification): String = x0 match {
     case OperationClassification(n, uu, uv, uw, ux, uy, uz) => n
   }
@@ -9548,6 +9724,9 @@ object SpecRestGenerated {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
   }
 
+  def emptyOpenApiIntBounds: openapi_int_bounds =
+    OpenApiIntBounds(None, None, None, None, None, None, None)
+
   def collectionElementEntityName(ty: type_expr_full): Option[String] =
     ty match {
       case NamedTypeF(_, _)                       => None
@@ -9628,6 +9807,15 @@ object SpecRestGenerated {
       em,
       entityNames,
       Nil
+    )
+
+  def visitConstraintOpenApi(e: expr_full, bounds: openapi_int_bounds): openapi_int_bounds =
+    foldl[openapi_int_bounds, expr_full](
+      (acc: openapi_int_bounds) =>
+        (atom: expr_full) =>
+          applyAtomOpenApi(atom, acc),
+      bounds,
+      flattenAnd(e)
     )
 
 } /* object SpecRestGenerated */

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -1,15 +1,73 @@
 package specrest.ir.generated
 
-import scala.annotation.nowarn
+object Str_Literal {
 
-@nowarn
+  private def checkAscii(k: Int): Int =
+    0 <= k && k < 128 match {
+      case true  => k
+      case false => sys.error("Non-ASCII character in literal")
+    }
+
+  private def charOfAscii(k: BigInt): Char =
+    (k % 128).charValue
+
+  private def asciiOfChar(c: Char): BigInt =
+    BigInt(checkAscii(c.toInt))
+
+  def literalOfAsciis(ks: List[BigInt]): String =
+    ks.map(charOfAscii).mkString
+
+  def asciisOfLiteral(s: String): List[BigInt] =
+    s.toList.map(asciiOfChar)
+
+}
+
 object SpecRestGenerated {
 
   sealed abstract class int
   final case class int_of_integer(a: BigInt) extends int
 
+  sealed abstract class num
+  final case class Onea()       extends num
+  final case class Bit0(a: num) extends num
+  final case class Bit1(a: num) extends num
+
+  def one_inta: int = int_of_integer(BigInt(1))
+
+  trait one[A] {
+    val `SpecRestGenerated.one`: A
+  }
+  def one[A](implicit A: one[A]): A = A.`SpecRestGenerated.one`
+  object one {
+    implicit def `SpecRestGenerated.one_int`: one[int] = new one[int] {
+      val `SpecRestGenerated.one` = one_inta
+    }
+  }
+
   def integer_of_int(x0: int): BigInt = x0 match {
     case int_of_integer(k) => k
+  }
+
+  def times_inta(k: int, l: int): int =
+    int_of_integer(integer_of_int(k) * integer_of_int(l))
+
+  trait times[A] {
+    val `SpecRestGenerated.times`: (A, A) => A
+  }
+  def times[A](a: A, b: A)(implicit A: times[A]): A =
+    A.`SpecRestGenerated.times`(a, b)
+  object times {
+    implicit def `SpecRestGenerated.times_int`: times[int] = new times[int] {
+      val `SpecRestGenerated.times` = (a: int, b: int) => times_inta(a, b)
+    }
+  }
+
+  trait power[A] extends one[A] with times[A] {}
+  object power {
+    implicit def `SpecRestGenerated.power_int`: power[int] = new power[int] {
+      val `SpecRestGenerated.times` = (a: int, b: int) => times_inta(a, b)
+      val `SpecRestGenerated.one`   = one_inta
+    }
   }
 
   def less_eq_int(k: int, l: int): Boolean =
@@ -90,12 +148,11 @@ object SpecRestGenerated {
     }
   }
 
-  def equal_bool(p: Boolean, pa: Boolean): Boolean = (p, pa) match {
-    case (false, p) => !p
-    case (true, p)  => p
-    case (p, false) => !p
-    case (p, true)  => p
-  }
+  def equal_bool(p: Boolean, q: Boolean): Boolean =
+    p match {
+      case true  => q
+      case false => !q
+    }
 
   def eq[A: equal](a: A, b: A): Boolean = equal[A](a, b)
 
@@ -348,11 +405,6 @@ object SpecRestGenerated {
 
   sealed abstract class nat
   final case class Nata(a: BigInt) extends nat
-
-  sealed abstract class num
-  final case class One()        extends num
-  final case class Bit0(a: num) extends num
-  final case class Bit1(a: num) extends num
 
   sealed abstract class set[A]
   final case class seta[A](a: List[A])  extends set[A]
@@ -846,6 +898,9 @@ object SpecRestGenerated {
       d: analysis_signals
   ) extends classification_result
 
+  sealed abstract class decimal_lit
+  final case class DecimalLit(a: int, b: int) extends decimal_lit
+
   sealed abstract class classified_column
   final case class ClassifiedColumn(a: column_kind, b: Boolean) extends classified_column
 
@@ -874,6 +929,17 @@ object SpecRestGenerated {
       g: analysis_signals
   ) extends operation_classification
 
+  sealed abstract class openapi_bounds
+  final case class OpenApiBounds(
+      a: Option[int],
+      b: Option[int],
+      c: Option[decimal_lit],
+      d: Option[decimal_lit],
+      e: Option[decimal_lit],
+      f: Option[decimal_lit],
+      g: Option[String]
+  ) extends openapi_bounds
+
   sealed abstract class openapi_primitive_def
   final case class OpenApiPrimDef(a: List[String], b: Option[String]) extends openapi_primitive_def
 
@@ -884,16 +950,18 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
-  sealed abstract class openapi_int_bounds
-  final case class OpenApiIntBounds(
-      a: Option[int],
-      b: Option[int],
-      c: Option[int],
-      d: Option[int],
-      e: Option[int],
-      f: Option[int],
-      g: Option[String]
-  ) extends openapi_int_bounds
+  def max[A: ord](a: A, b: A): A =
+    less_eq[A](a, b) match {
+      case true  => b
+      case false => a
+    }
+
+  def nat_of_integer(k: BigInt): nat = Nata(max[BigInt](BigInt(0), k))
+
+  def comp[A, B, C](f: A => B, g: C => A): C => B = (x: C) => f(g(x))
+
+  def nat: int => nat =
+    comp[BigInt, nat, int]((a: BigInt) => nat_of_integer(a), (a: int) => integer_of_int(a))
 
   def integer_of_nat(x0: nat): BigInt = x0 match {
     case Nata(x) => x
@@ -1136,9 +1204,6 @@ object SpecRestGenerated {
   }
 
   def size_list[A](xs: List[A]): nat = length_tailrec[A](xs, zero_nat)
-
-  def times_int(k: int, l: int): int =
-    int_of_integer(integer_of_int(k) * integer_of_int(l))
 
   def minus_int(k: int, l: int): int =
     int_of_integer(integer_of_int(k) - integer_of_int(l))
@@ -1585,7 +1650,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), None)           => None
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
-            Some[smt_val](SInt(times_int(a, b)))
+            Some[smt_val](SInt(times_inta(a, b)))
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
@@ -2871,7 +2936,7 @@ object SpecRestGenerated {
       case (SubOp(), Some(VInt(a)), Some(VInt(b))) =>
         Some[ir_value](VInt(minus_int(a, b)))
       case (MulOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VInt(times_int(a, b)))
+        Some[ir_value](VInt(times_inta(a, b)))
       case (DivOp(), Some(VInt(a)), Some(VInt(b))) =>
         equal_int(b, zero_int) match {
           case true  => None
@@ -4076,8 +4141,6 @@ object SpecRestGenerated {
       case IdentifierF(_, _) => RaUnknown(e)
     }
 
-  def one_int: int = int_of_integer(BigInt(1))
-
   def intAtom(atom: expr_full): (int_constraint, List[String]) =
     decomposeAtom(atom) match {
       case RaLenCmp(_, _) =>
@@ -4095,9 +4158,9 @@ object SpecRestGenerated {
       case RaValueCmp(BNeq(), _) =>
         (emptyIntConstraint, List("unsupported int comparison"))
       case RaValueCmp(BLt(), n) =>
-        (IntConstraint(None, Some[int](minus_int(n, one_int)), Nil), Nil)
+        (IntConstraint(None, Some[int](minus_int(n, one_inta)), Nil), Nil)
       case RaValueCmp(BGt(), n) =>
-        (IntConstraint(Some[int](plus_int(n, one_int)), None, Nil), Nil)
+        (IntConstraint(Some[int](plus_int(n, one_inta)), None, Nil), Nil)
       case RaValueCmp(BLe(), n) => (IntConstraint(None, Some[int](n), Nil), Nil)
       case RaValueCmp(BGe(), n) => (IntConstraint(Some[int](n), None, Nil), Nil)
       case RaValueCmp(BIn(), _) =>
@@ -4275,12 +4338,6 @@ object SpecRestGenerated {
       case BoolLitF(_, _)                => None
       case NoneLitF(_)                   => None
       case IdentifierF(_, _)             => None
-    }
-
-  def max[A: ord](a: A, b: A): A =
-    less_eq[A](a, b) match {
-      case true  => b
-      case false => a
     }
 
   def minus_nat(m: nat, n: nat): nat =
@@ -4563,7 +4620,7 @@ object SpecRestGenerated {
   }
 
   def highBoundEffective(x0: bin_op_full, n: int): int = (x0, n) match {
-    case (BLt(), n)        => minus_int(n, one_int)
+    case (BLt(), n)        => minus_int(n, one_inta)
     case (BAnd(), n)       => n
     case (BOr(), n)        => n
     case (BImplies(), n)   => n
@@ -4586,7 +4643,7 @@ object SpecRestGenerated {
   }
 
   def lowBoundEffective(x0: bin_op_full, n: int): int = (x0, n) match {
-    case (BGt(), n)        => plus_int(n, one_int)
+    case (BGt(), n)        => plus_int(n, one_inta)
     case (BAnd(), n)       => n
     case (BOr(), n)        => n
     case (BImplies(), n)   => n
@@ -4944,9 +5001,9 @@ object SpecRestGenerated {
       case RaLenCmp(BNeq(), _) =>
         (emptyStringConstraint, List("unsupported len comparison"))
       case RaLenCmp(BLt(), n) =>
-        (StringConstraint(None, Some[int](minus_int(n, one_int)), Nil, Nil, Nil), Nil)
+        (StringConstraint(None, Some[int](minus_int(n, one_inta)), Nil, Nil, Nil), Nil)
       case RaLenCmp(BGt(), n) =>
-        (StringConstraint(Some[int](plus_int(n, one_int)), None, Nil, Nil, Nil), Nil)
+        (StringConstraint(Some[int](plus_int(n, one_inta)), None, Nil, Nil, Nil), Nil)
       case RaLenCmp(BLe(), n) =>
         (StringConstraint(None, Some[int](n), Nil, Nil, Nil), Nil)
       case RaLenCmp(BGe(), n) =>
@@ -5506,6 +5563,12 @@ object SpecRestGenerated {
         }
     }
 
+  def power[A: power](a: A, n: nat): A =
+    equal_nat(n, zero_nat) match {
+      case true  => one[A]
+      case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
+    }
+
   def isEntityType(x0: type_expr_full, name: String): Boolean = (x0, name) match {
     case (NamedTypeF(n, uu), name)          => n == name
     case (SetTypeF(v, va), uw)              => false
@@ -5532,6 +5595,10 @@ object SpecRestGenerated {
 
   def tc_enums[A](x0: tyctx_ext[A]): List[String] = x0 match {
     case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_enums
+  }
+
+  def mapEntryIsLeafLeaf(x0: map_entry_full): Boolean = x0 match {
+    case MapEntryFull(k, v, uu) => isLeafValue(k) && isLeafValue(v)
   }
 
   def innerIsTargetCard(x0: expr_full, n: String): Boolean = (x0, n) match {
@@ -6337,10 +6404,8 @@ object SpecRestGenerated {
           ) => l == r &&
         (membera[String](stateFieldNames, l) &&
           list_all[map_entry_full](
-            (a: map_entry_full) => {
-              val MapEntryFull(k, v, _) = a: map_entry_full;
-              isLeafValue(k) && isLeafValue(v)
-            },
+            (a: map_entry_full) =>
+              mapEntryIsLeafLeaf(a),
             entries
           ))
       case BinaryOpF(
@@ -7654,8 +7719,6 @@ object SpecRestGenerated {
     case OperationClassification(uu, k, uv, uw, ux, uy, uz) => k
   }
 
-  def nat_of_integer(k: BigInt): nat = Nata(max[BigInt](BigInt(0), k))
-
   def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
     c match {
       case BinaryOpF(op, l, r, _) =>
@@ -7952,12 +8015,26 @@ object SpecRestGenerated {
     case DropTrigger(wb)                     => false
   }
 
-  def maximumOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(uu, uv, uw, mx, ux, uy, uz) => mx
+  def decimalGt(x0: decimal_lit, x1: decimal_lit): Boolean = (x0, x1) match {
+    case (DecimalLit(m1, e1), DecimalLit(m2, e2)) =>
+      less_eq_int(e1, e2) match {
+        case true => less_int(
+            times_inta(m2, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e2, e1)))),
+            m1
+          )
+        case false => less_int(
+            m2,
+            times_inta(m1, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e1, e2))))
+          )
+      }
   }
 
-  def minimumOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(uu, uv, mn, uw, ux, uy, uz) => mn
+  def maximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, mx, ux, uy, uz) => mx
+  }
+
+  def minimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, mn, uw, ux, uy, uz) => mn
   }
 
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
@@ -7966,15 +8043,6 @@ object SpecRestGenerated {
       case false => initial
     }
 
-  def less_eq_set[A: equal](a: set[A], b: set[A]): Boolean = (a, b) match {
-    case (seta(xs), b)           => list_all[A]((x: A) => member[A](x, b), xs)
-    case (a, coset(ys))          => list_all[A]((y: A) => !member[A](y, a), ys)
-    case (coset(Nil), seta(Nil)) => false
-  }
-
-  def equal_set[A: equal](a: set[A], b: set[A]): Boolean =
-    less_eq_set[A](a, b) && less_eq_set[A](b, a)
-
   def matchesCreateShape(
       classification: route_kind,
       bodyParamNames: List[String],
@@ -7982,7 +8050,12 @@ object SpecRestGenerated {
   ): Boolean =
     isRkCreate(classification) &&
       (distinct[String](bodyParamNames) &&
-        equal_set[String](seta[String](bodyParamNames), seta[String](entityNonIdColumns)))
+        (list_all[String](
+          (a: String) =>
+            membera[String](entityNonIdColumns, a),
+          bodyParamNames
+        ) &&
+          list_all[String]((a: String) => membera[String](bodyParamNames, a), entityNonIdColumns)))
 
   def uniqueBackFkColumn(fks: List[foreign_key_spec], parentTable: String): Option[String] =
     filter[foreign_key_spec](
@@ -8236,6 +8309,20 @@ object SpecRestGenerated {
   def withInfoFieldNames(x0: with_info_full): List[String] = x0 match {
     case WithInfoFull(fs, uu) => fs
   }
+
+  def digitValue(c: BigInt): int = int_of_integer(c - BigInt(48))
+
+  def maxDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
+    decimalGt(a, b) match {
+      case true  => a
+      case false => b
+    }
+
+  def minDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
+    decimalGt(a, b) match {
+      case true  => b
+      case false => a
+    }
 
   def aggregateForName(name: String): Option[trigger_aggregate] =
     name == "sum" match {
@@ -8566,30 +8653,30 @@ object SpecRestGenerated {
     case StateFieldDeclFull(uu, t, uv) => t
   }
 
-  def maxLengthOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(uu, ml, uv, uw, ux, uy, uz) => ml
+  def maxLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(uu, ml, uv, uw, ux, uy, uz) => ml
   }
 
-  def minLengthOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(nl, uu, uv, uw, ux, uy, uz) => nl
+  def minLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(nl, uu, uv, uw, ux, uy, uz) => nl
   }
 
-  def withMaximum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, ml, mn, uu, emn, emx, p)) =>
-        OpenApiIntBounds(nl, ml, mn, v, emn, emx, p)
+      case (v, OpenApiBounds(nl, ml, mn, uu, emn, emx, p)) =>
+        OpenApiBounds(nl, ml, mn, v, emn, emx, p)
     }
 
-  def withMinimum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, ml, uu, mx, emn, emx, p)) =>
-        OpenApiIntBounds(nl, ml, v, mx, emn, emx, p)
+      case (v, OpenApiBounds(nl, ml, uu, mx, emn, emx, p)) =>
+        OpenApiBounds(nl, ml, v, mx, emn, emx, p)
     }
 
-  def withPattern(v: Option[String], x1: openapi_int_bounds): openapi_int_bounds =
+  def withPattern(v: Option[String], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, ml, mn, mx, emn, emx, uu)) =>
-        OpenApiIntBounds(nl, ml, mn, mx, emn, emx, v)
+      case (v, OpenApiBounds(nl, ml, mn, mx, emn, emx, uu)) =>
+        OpenApiBounds(nl, ml, mn, mx, emn, emx, v)
     }
 
   def triggerSourceForeignKey(x0: trigger_spec): String = x0 match {
@@ -8667,6 +8754,10 @@ object SpecRestGenerated {
     case NoneLitF(wi)        => false
     case IdentifierF(wj, wk) => false
   }
+
+  def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
+
+  def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
 
   def equal_multiplicity(x0: multiplicity, x1: multiplicity): Boolean =
     (x0, x1) match {
@@ -9022,6 +9113,18 @@ object SpecRestGenerated {
     case (NoneLitF(v), uy)                                 => false
   }
 
+  def tightenDecMax(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
+    cur match {
+      case None    => Some[decimal_lit](d)
+      case Some(x) => Some[decimal_lit](minDecimal(x, d))
+    }
+
+  def tightenDecMin(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
+    cur match {
+      case None    => Some[decimal_lit](d)
+      case Some(x) => Some[decimal_lit](maxDecimal(x, d))
+    }
+
   def tightenIntMax(cur: Option[int], n: int): Option[int] =
     cur match {
       case None    => Some[int](n)
@@ -9034,16 +9137,16 @@ object SpecRestGenerated {
       case Some(x) => Some[int](max[int](x, n))
     }
 
-  def withMaxLength(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withMaxLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, uu, mn, mx, emn, emx, p)) =>
-        OpenApiIntBounds(nl, v, mn, mx, emn, emx, p)
+      case (v, OpenApiBounds(nl, uu, mn, mx, emn, emx, p)) =>
+        OpenApiBounds(nl, v, mn, mx, emn, emx, p)
     }
 
-  def withMinLength(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withMinLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(uu, ml, mn, mx, emn, emx, p)) =>
-        OpenApiIntBounds(v, ml, mn, mx, emn, emx, p)
+      case (v, OpenApiBounds(uu, ml, mn, mx, emn, emx, p)) =>
+        OpenApiBounds(v, ml, mn, mx, emn, emx, p)
     }
 
   def decodeAggregateCall(call: expr_full): Option[aggregate_call] =
@@ -9342,6 +9445,62 @@ object SpecRestGenerated {
       (List[String], List[with_info_full])
     ](collectExprInfo(e))))
 
+  def consumeDigitsAux(x0: List[BigInt], acc: int, count: nat): (int, (nat, List[BigInt])) =
+    (x0, acc, count) match {
+      case (Nil, acc, count) => (acc, (count, Nil))
+      case (c :: cs, acc, count) =>
+        isDigitAscii(c) match {
+          case true => consumeDigitsAux(
+              cs,
+              plus_int(times_inta(acc, int_of_integer(BigInt(10))), digitValue(c)),
+              plus_nat(count, one_nat)
+            )
+          case false => (acc, (count, c :: cs))
+        }
+    }
+
+  def parseDecimalLit(s: String): Option[decimal_lit] = {
+    val cs0 = Str_Literal.asciisOfLiteral(s): List[BigInt]
+    val (sign, cs1) =
+      (cs0 match {
+        case Nil => (one_inta, cs0)
+        case c :: rs =>
+          c == BigInt(45) match {
+            case true  => (uminus_int(one_inta), rs)
+            case false => (one_inta, cs0)
+          }
+      }): ((int, List[BigInt]));
+    consumeDigitsAux(cs1, zero_int, zero_nat) match {
+      case (intPart, (intLen, Nil)) =>
+        equal_nat(intLen, zero_nat) match {
+          case true  => None
+          case false => Some[decimal_lit](DecimalLit(times_inta(sign, intPart), zero_int))
+        }
+      case (intPart, (intLen, c :: rs)) =>
+        c == BigInt(46) match {
+          case true =>
+            val (fracPart, (fracLen, rest2)) =
+              consumeDigitsAux(rs, zero_int, zero_nat): ((int, (nat, List[BigInt])));
+            nulla[BigInt](rest2) &&
+              (less_nat(zero_nat, intLen) &&
+                less_nat(zero_nat, fracLen)) match {
+              case true => Some[decimal_lit](DecimalLit(
+                  times_inta(
+                    sign,
+                    plus_int(
+                      times_inta(intPart, power[int](int_of_integer(BigInt(10)), fracLen)),
+                      fracPart
+                    )
+                  ),
+                  uminus_int(int_of_nat(fracLen))
+                ))
+              case false => None
+            }
+          case false => None
+        }
+    }
+  }
+
   def openapiPrimitiveOf(nm: String): Option[openapi_primitive_def] =
     nm == "String" match {
       case true => Some[openapi_primitive_def](OpenApiPrimDef(List("string"), None))
@@ -9478,31 +9637,31 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, RelationTypeF(vd, ve, vf, vg), vc) => None
   }
 
-  def withExclusiveMinimum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withExclusiveMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, ml, mn, mx, uu, emx, p)) =>
-        OpenApiIntBounds(nl, ml, mn, mx, v, emx, p)
+      case (v, OpenApiBounds(nl, ml, mn, mx, uu, emx, p)) =>
+        OpenApiBounds(nl, ml, mn, mx, v, emx, p)
     }
 
-  def withExclusiveMaximum(v: Option[int], x1: openapi_int_bounds): openapi_int_bounds =
+  def withExclusiveMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
-      case (v, OpenApiIntBounds(nl, ml, mn, mx, emn, uu, p)) =>
-        OpenApiIntBounds(nl, ml, mn, mx, emn, v, p)
+      case (v, OpenApiBounds(nl, ml, mn, mx, emn, uu, p)) =>
+        OpenApiBounds(nl, ml, mn, mx, emn, v, p)
     }
 
-  def exclusiveMinimumOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(uu, uv, uw, ux, emn, uy, uz) => emn
+  def exclusiveMinimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, ux, emn, uy, uz) => emn
   }
 
-  def exclusiveMaximumOf(x0: openapi_int_bounds): Option[int] = x0 match {
-    case OpenApiIntBounds(uu, uv, uw, ux, uy, emx, uz) => emx
+  def exclusiveMaximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, ux, uy, emx, uz) => emx
   }
 
   def applyNumericBoundOpenApi(
       op: bin_op_full,
-      n: int,
-      bounds: openapi_int_bounds
-  ): openapi_int_bounds =
+      d: decimal_lit,
+      bounds: openapi_bounds
+  ): openapi_bounds =
     op match {
       case BAnd()     => bounds
       case BOr()      => bounds
@@ -9510,16 +9669,16 @@ object SpecRestGenerated {
       case BIff()     => bounds
       case BEq() =>
         withMaximum(
-          tightenIntMax(maximumOf(bounds), n),
-          withMinimum(tightenIntMin(minimumOf(bounds), n), bounds)
+          tightenDecMax(maximumOf(bounds), d),
+          withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
         )
       case BNeq() => bounds
       case BLt() =>
-        withExclusiveMaximum(tightenIntMax(exclusiveMaximumOf(bounds), n), bounds)
+        withExclusiveMaximum(tightenDecMax(exclusiveMaximumOf(bounds), d), bounds)
       case BGt() =>
-        withExclusiveMinimum(tightenIntMin(exclusiveMinimumOf(bounds), n), bounds)
-      case BLe()        => withMaximum(tightenIntMax(maximumOf(bounds), n), bounds)
-      case BGe()        => withMinimum(tightenIntMin(minimumOf(bounds), n), bounds)
+        withExclusiveMinimum(tightenDecMin(exclusiveMinimumOf(bounds), d), bounds)
+      case BLe()        => withMaximum(tightenDecMax(maximumOf(bounds), d), bounds)
+      case BGe()        => withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
       case BIn()        => bounds
       case BNotIn()     => bounds
       case BSubset()    => bounds
@@ -9532,11 +9691,7 @@ object SpecRestGenerated {
       case BDiv()       => bounds
     }
 
-  def applyLengthBoundOpenApi(
-      op: bin_op_full,
-      n: int,
-      bounds: openapi_int_bounds
-  ): openapi_int_bounds =
+  def applyLengthBoundOpenApi(op: bin_op_full, n: int, bounds: openapi_bounds): openapi_bounds =
     less_int(n, zero_int) match {
       case true => bounds
       case false => op match {
@@ -9551,13 +9706,13 @@ object SpecRestGenerated {
             )
           case BNeq() => bounds
           case BLt() =>
-            less_int(minus_int(n, one_int), zero_int) match {
+            less_int(minus_int(n, one_inta), zero_int) match {
               case true => bounds
               case false =>
-                withMaxLength(tightenIntMax(maxLengthOf(bounds), minus_int(n, one_int)), bounds)
+                withMaxLength(tightenIntMax(maxLengthOf(bounds), minus_int(n, one_inta)), bounds)
             }
           case BGt() =>
-            withMinLength(tightenIntMin(minLengthOf(bounds), plus_int(n, one_int)), bounds)
+            withMinLength(tightenIntMin(minLengthOf(bounds), plus_int(n, one_inta)), bounds)
           case BLe() =>
             withMaxLength(tightenIntMax(maxLengthOf(bounds), n), bounds)
           case BGe() =>
@@ -9575,14 +9730,111 @@ object SpecRestGenerated {
         }
     }
 
-  def applyAtomOpenApi(atom: expr_full, bounds: openapi_int_bounds): openapi_int_bounds =
+  def modulo_integer(k: BigInt, l: BigInt): BigInt =
+    snd[BigInt, BigInt](divmod_integer(k, l))
+
+  def modulo_int(k: int, l: int): int =
+    int_of_integer(modulo_integer(integer_of_int(k), integer_of_int(l)))
+
+  def decimalToNonNegInt(x0: decimal_lit): Option[int] = x0 match {
+    case DecimalLit(m, e) =>
+      less_int(m, zero_int) match {
+        case true => None
+        case false => less_eq_int(zero_int, e) match {
+            case true =>
+              Some[int](times_inta(m, power[int](int_of_integer(BigInt(10)), nat.apply(e))))
+            case false =>
+              val p =
+                power[int](int_of_integer(BigInt(10)), nat.apply(uminus_int(e))): int;
+              equal_int(modulo_int(m, p), zero_int) match {
+                case true  => Some[int](divide_int(m, p))
+                case false => None
+              }
+          }
+      }
+  }
+
+  def applyFloatAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
+    atom match {
+      case BinaryOpF(_, _, BinaryOpF(_, _, _, _), _)         => bounds
+      case BinaryOpF(_, _, UnaryOpF(_, _, _), _)             => bounds
+      case BinaryOpF(_, _, QuantifierF(_, _, _, _), _)       => bounds
+      case BinaryOpF(_, _, SomeWrapF(_, _), _)               => bounds
+      case BinaryOpF(_, _, TheF(_, _, _, _), _)              => bounds
+      case BinaryOpF(_, _, FieldAccessF(_, _, _), _)         => bounds
+      case BinaryOpF(_, _, EnumAccessF(_, _, _), _)          => bounds
+      case BinaryOpF(_, _, IndexF(_, _, _), _)               => bounds
+      case BinaryOpF(_, _, CallF(_, _, _), _)                => bounds
+      case BinaryOpF(_, _, PrimeF(_, _), _)                  => bounds
+      case BinaryOpF(_, _, PreF(_, _), _)                    => bounds
+      case BinaryOpF(_, _, WithF(_, _, _), _)                => bounds
+      case BinaryOpF(_, _, IfF(_, _, _, _), _)               => bounds
+      case BinaryOpF(_, _, LetF(_, _, _, _), _)              => bounds
+      case BinaryOpF(_, _, LambdaF(_, _, _), _)              => bounds
+      case BinaryOpF(_, _, ConstructorF(_, _, _), _)         => bounds
+      case BinaryOpF(_, _, SetLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, MapLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, SetComprehensionF(_, _, _, _), _) => bounds
+      case BinaryOpF(_, _, SeqLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, MatchesF(_, _, _), _)             => bounds
+      case BinaryOpF(_, _, IntLitF(_, _), _)                 => bounds
+      case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
+        parseDecimalLit(v) match {
+          case None => bounds
+          case Some(d) =>
+            isLenOfValue(lhs) match {
+              case true => decimalToNonNegInt(d) match {
+                  case None => bounds
+                  case Some(ni) =>
+                    applyLengthBoundOpenApi(op, ni, bounds)
+                }
+              case false => isValueRef(lhs) match {
+                  case true  => applyNumericBoundOpenApi(op, d, bounds)
+                  case false => bounds
+                }
+            }
+        }
+      case BinaryOpF(_, _, StringLitF(_, _), _)  => bounds
+      case BinaryOpF(_, _, BoolLitF(_, _), _)    => bounds
+      case BinaryOpF(_, _, NoneLitF(_), _)       => bounds
+      case BinaryOpF(_, _, IdentifierF(_, _), _) => bounds
+      case UnaryOpF(_, _, _)                     => bounds
+      case QuantifierF(_, _, _, _)               => bounds
+      case SomeWrapF(_, _)                       => bounds
+      case TheF(_, _, _, _)                      => bounds
+      case FieldAccessF(_, _, _)                 => bounds
+      case EnumAccessF(_, _, _)                  => bounds
+      case IndexF(_, _, _)                       => bounds
+      case CallF(_, _, _)                        => bounds
+      case PrimeF(_, _)                          => bounds
+      case PreF(_, _)                            => bounds
+      case WithF(_, _, _)                        => bounds
+      case IfF(_, _, _, _)                       => bounds
+      case LetF(_, _, _, _)                      => bounds
+      case LambdaF(_, _, _)                      => bounds
+      case ConstructorF(_, _, _)                 => bounds
+      case SetLiteralF(_, _)                     => bounds
+      case MapLiteralF(_, _)                     => bounds
+      case SetComprehensionF(_, _, _, _)         => bounds
+      case SeqLiteralF(_, _)                     => bounds
+      case MatchesF(_, _, _)                     => bounds
+      case IntLitF(_, _)                         => bounds
+      case FloatLitF(_, _)                       => bounds
+      case StringLitF(_, _)                      => bounds
+      case BoolLitF(_, _)                        => bounds
+      case NoneLitF(_)                           => bounds
+      case IdentifierF(_, _)                     => bounds
+    }
+
+  def applyAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
     decomposeAtom(atom) match {
-      case RaLenCmp(op, n)      => applyLengthBoundOpenApi(op, n, bounds)
-      case RaValueCmp(op, n)    => applyNumericBoundOpenApi(op, n, bounds)
+      case RaLenCmp(op, n) => applyLengthBoundOpenApi(op, n, bounds)
+      case RaValueCmp(op, n) =>
+        applyNumericBoundOpenApi(op, decimalOfInt(n), bounds)
       case RaMatches(pat)       => withPattern(Some[String](pat), bounds)
-      case RaMatchesIdent(_, _) => bounds
-      case RaPredCall(_)        => bounds
-      case RaUnknown(_)         => bounds
+      case RaMatchesIdent(_, _) => applyFloatAtomOpenApi(atom, bounds)
+      case RaPredCall(_)        => applyFloatAtomOpenApi(atom, bounds)
+      case RaUnknown(_)         => applyFloatAtomOpenApi(atom, bounds)
     }
 
   def classificationOperationName(x0: operation_classification): String = x0 match {
@@ -9649,11 +9901,15 @@ object SpecRestGenerated {
       name: String,
       targetEntity: Option[String],
       strategy: synthesis_strategy,
-      res: classification_result
-  ): operation_classification = {
-    val ClassificationResult(k, m, rule, a) = res: classification_result;
-    OperationClassification(name, k, m, rule, targetEntity, strategy, a)
-  }
+      x3: classification_result
+  ): operation_classification =
+    (name, targetEntity, strategy, x3) match {
+      case (name, targetEntity, strategy, ClassificationResult(k, m, rule, sig)) =>
+        OperationClassification(name, k, m, rule, targetEntity, strategy, sig)
+    }
+
+  def emptyOpenApiBounds: openapi_bounds =
+    OpenApiBounds(None, None, None, None, None, None, None)
 
   def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
     invExpr match {
@@ -9723,9 +9979,6 @@ object SpecRestGenerated {
   def signalsTargetEntityFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
   }
-
-  def emptyOpenApiIntBounds: openapi_int_bounds =
-    OpenApiIntBounds(None, None, None, None, None, None, None)
 
   def collectionElementEntityName(ty: type_expr_full): Option[String] =
     ty match {
@@ -9809,9 +10062,9 @@ object SpecRestGenerated {
       Nil
     )
 
-  def visitConstraintOpenApi(e: expr_full, bounds: openapi_int_bounds): openapi_int_bounds =
-    foldl[openapi_int_bounds, expr_full](
-      (acc: openapi_int_bounds) =>
+  def visitConstraintOpenApi(e: expr_full, bounds: openapi_bounds): openapi_bounds =
+    foldl[openapi_bounds, expr_full](
+      (acc: openapi_bounds) =>
         (atom: expr_full) =>
           applyAtomOpenApi(atom, acc),
       bounds,

--- a/proofs/isabelle/README.md
+++ b/proofs/isabelle/README.md
@@ -47,7 +47,7 @@ isabelle export -d proofs/isabelle/SpecRest -O "$work" \
 
 target="modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala"
 {
-  printf 'package specrest.ir.generated\n\nimport scala.annotation.nowarn\n\n@nowarn\n'
+  printf 'package specrest.ir.generated\n\n'
   cat "$work/SpecRest.Codegen/code/SpecRestGenerated.scala"
 } > "$target"
 scalafmt --config .scalafmt.conf --non-interactive "$target"

--- a/proofs/isabelle/SpecRest/Classify.thy
+++ b/proofs/isabelle/SpecRest/Classify.thy
@@ -84,15 +84,14 @@ text \<open>Combines a routing decision with the operation name, target entity,
   computes name/targetEntity/strategy at the data-extraction boundary and
   passes them in.\<close>
 
-definition buildOperationClassification ::
+fun buildOperationClassification ::
   "String.literal \<Rightarrow> String.literal option \<Rightarrow> synthesis_strategy \<Rightarrow>
    classification_result \<Rightarrow> operation_classification"
 where
-  "buildOperationClassification name targetEntity strategy res = (
-    case res of ClassificationResult k m rule sig \<Rightarrow>
-      OperationClassification name k m rule targetEntity strategy sig)"
+  "buildOperationClassification name targetEntity strategy (ClassificationResult k m rule sig) =
+     OperationClassification name k m rule targetEntity strategy sig"
 
-lemmas buildOperationClassification_code [code] = buildOperationClassification_def
+lemmas buildOperationClassification_code [code] = buildOperationClassification.simps
 
 text \<open>The M3/M4 PUT-vs-PATCH refinement: replace if the with-clause covers
   every entity field; partial-update otherwise. Updates the signals record
@@ -167,6 +166,13 @@ fun isCardinalityRhs :: "expr_full \<Rightarrow> String.literal \<Rightarrow> bo
       \<and> isIntLit rhs \<and> isCardinalityRhs inner n)"
 | "isCardinalityRhs _ _ = False"
 
+text \<open>Top-level \<open>fun\<close> pattern instead of an inline \<open>case\<close>: avoids the
+  Scala 3 type-narrowing warning the code generator otherwise emits for
+  single-constructor destructuring inside a lambda.\<close>
+
+fun mapEntryIsLeafLeaf :: "map_entry_full \<Rightarrow> bool" where
+  "mapEntryIsLeafLeaf (MapEntryFull k v _) = (isLeafValue k \<and> isLeafValue v)"
+
 text \<open>\<open>isDirectEmitShape\<close>: a single ensures-clause is direct-emit-able when its
   shape matches one of the recognised verified-subset patterns (preserve a
   state field, append-disjoint, cardinality-preserving, single-index update,
@@ -186,7 +192,7 @@ where
          (PrimeF (IdentifierF l _) _)
          (BinaryOpF BAdd (PreF (IdentifierF r _) _) (MapLiteralF entries _) _) _ \<Rightarrow>
          l = r \<and> l \<in> set stateFieldNames \<and>
-         list_all (\<lambda>e. case e of MapEntryFull k v _ \<Rightarrow> isLeafValue k \<and> isLeafValue v) entries
+         list_all mapEntryIsLeafLeaf entries
      | BinaryOpF BEq (IndexF (PrimeF (IdentifierF n _) _) idx _) rhs _ \<Rightarrow>
          n \<in> set stateFieldNames \<and> isLeafValue idx \<and> isLeafValue rhs
      | BinaryOpF BEq

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -14,6 +14,7 @@ theory Codegen
     Methods
     RouteKind
     SchemaTraversal
+    OpenApiConstraints
     Classify
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
@@ -217,6 +218,8 @@ export_code
     findEnumValuesInType
     openapiPrimitiveOf
     classifyOpenApiNamedType
+    emptyOpenApiIntBounds
+    visitConstraintOpenApi
     primitiveTypeToSql
     classifyColumnType
     collectionElementEntityName

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -37,6 +37,15 @@ declare state_pair.defs[code]
 declare smt_model.defs[code]
 declare smt_model_pair.defs[code]
 
+text \<open>Override HOL's default \<open>equal\<close> equation on \<open>bool\<close>. The standard
+  typeclass derivation extracts as a 4-arm \<open>(p, pa) match\<close> where the last
+  two arms are subsumed by the first two — Scala 3 flags them as unreachable.
+  The direct \<open>iff\<close> form extracts to \<open>p == pa\<close> with no match at all.\<close>
+
+lemma equal_bool_direct [code]:
+  "HOL.equal (p::bool) q = (if p then q else \<not> q)"
+  by (cases p; cases q; simp add: equal_bool_def)
+
 text \<open>Rename Code_Target_Nat's \<open>Nat\<close> constructor to \<open>Nata\<close> in Scala output:
   the generated module also defines \<open>sealed abstract class nat\<close>, and on
   case-insensitive filesystems (macOS APFS, Windows NTFS) the class files
@@ -58,6 +67,16 @@ text \<open>\<open>Methods.Delete\<close> (operation_kind) renamed to \<open>Del
 code_identifier
   constant Methods.Delete \<rightharpoonup>
     (Scala) "SpecRestGenerated.Deletea"
+
+text \<open>\<open>Num.One\<close> constructor renamed to \<open>Onea\<close> for the same case-collision
+  reason: the extracted module references \<open>one_class.one\<close> (lowercase) via
+  the numeral machinery the decimal-literal parser pulls in, and on
+  case-insensitive filesystems (macOS APFS, Windows NTFS) the class files
+  \<open>SpecRestGenerated$One.class\<close> and \<open>SpecRestGenerated$one.class\<close>
+  collide.\<close>
+code_identifier
+  constant Num.One \<rightharpoonup>
+    (Scala) "SpecRestGenerated.Onea"
 
 text \<open>Type and constructor names follow Isabelle convention: lowercase \<open>snake_case\<close>
   for types, PascalCase for constructors. Consumers that need to coexist with
@@ -218,8 +237,10 @@ export_code
     findEnumValuesInType
     openapiPrimitiveOf
     classifyOpenApiNamedType
-    emptyOpenApiIntBounds
+    emptyOpenApiBounds
     visitConstraintOpenApi
+    decimalToNonNegInt
+    parseDecimalLit
     primitiveTypeToSql
     classifyColumnType
     collectionElementEntityName

--- a/proofs/isabelle/SpecRest/OpenApiConstraints.thy
+++ b/proofs/isabelle/SpecRest/OpenApiConstraints.thy
@@ -1,0 +1,124 @@
+theory OpenApiConstraints
+  imports IR_Helpers IR_Analysis
+begin
+
+text \<open>Constraint-bounds walker for OpenAPI schema emission. Lifts the Int
+  subset of \<open>specrest.codegen.openapi.OpenApi.Constraints.applyAtom\<close>: walks
+  the refinement-atoms recognised by \<open>decomposeAtom\<close> and accumulates
+  JSON-Schema-style bounds (length, numeric, pattern).
+
+  OpenAPI distinguishes inclusive vs exclusive bounds (\<open>minimum\<close> vs
+  \<open>exclusiveMinimum\<close>) — the strategy walker in \<open>Strategies.thy\<close> just
+  collapses BGt to +1 because it only cares about generator value ranges,
+  but OpenAPI emits the exclusive form to JSON output. We track both
+  separately here.
+
+  Float-literal atoms (the \<open>RaUnknown\<close> fallback in the Scala original)
+  stay in Scala — Isabelle handles the Int subset cleanly, the Scala
+  caller overlays Double-typed bounds after.\<close>
+
+datatype openapi_int_bounds = OpenApiIntBounds
+  "int option"               \<comment> \<open>min_length (inclusive)\<close>
+  "int option"               \<comment> \<open>max_length (inclusive)\<close>
+  "int option"               \<comment> \<open>minimum (inclusive)\<close>
+  "int option"               \<comment> \<open>maximum (inclusive)\<close>
+  "int option"               \<comment> \<open>exclusive_minimum\<close>
+  "int option"               \<comment> \<open>exclusive_maximum\<close>
+  "String.literal option"    \<comment> \<open>pattern\<close>
+
+definition emptyOpenApiIntBounds :: openapi_int_bounds where
+  "emptyOpenApiIntBounds = OpenApiIntBounds None None None None None None None"
+
+definition tightenIntMin :: "int option \<Rightarrow> int \<Rightarrow> int option" where
+  "tightenIntMin cur n = (case cur of None \<Rightarrow> Some n | Some x \<Rightarrow> Some (max x n))"
+
+definition tightenIntMax :: "int option \<Rightarrow> int \<Rightarrow> int option" where
+  "tightenIntMax cur n = (case cur of None \<Rightarrow> Some n | Some x \<Rightarrow> Some (min x n))"
+
+primrec withMinLength :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withMinLength v (OpenApiIntBounds _ ml mn mx emn emx p) = OpenApiIntBounds v ml mn mx emn emx p"
+primrec withMaxLength :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withMaxLength v (OpenApiIntBounds nl _ mn mx emn emx p) = OpenApiIntBounds nl v mn mx emn emx p"
+primrec withMinimum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withMinimum v (OpenApiIntBounds nl ml _ mx emn emx p) = OpenApiIntBounds nl ml v mx emn emx p"
+primrec withMaximum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withMaximum v (OpenApiIntBounds nl ml mn _ emn emx p) = OpenApiIntBounds nl ml mn v emn emx p"
+primrec withExclusiveMinimum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withExclusiveMinimum v (OpenApiIntBounds nl ml mn mx _ emx p) = OpenApiIntBounds nl ml mn mx v emx p"
+primrec withExclusiveMaximum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withExclusiveMaximum v (OpenApiIntBounds nl ml mn mx emn _ p) = OpenApiIntBounds nl ml mn mx emn v p"
+primrec withPattern :: "String.literal option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
+  "withPattern v (OpenApiIntBounds nl ml mn mx emn emx _) = OpenApiIntBounds nl ml mn mx emn emx v"
+
+primrec minLengthOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "minLengthOf (OpenApiIntBounds nl _ _ _ _ _ _) = nl"
+primrec maxLengthOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "maxLengthOf (OpenApiIntBounds _ ml _ _ _ _ _) = ml"
+primrec minimumOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "minimumOf (OpenApiIntBounds _ _ mn _ _ _ _) = mn"
+primrec maximumOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "maximumOf (OpenApiIntBounds _ _ _ mx _ _ _) = mx"
+primrec exclusiveMinimumOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "exclusiveMinimumOf (OpenApiIntBounds _ _ _ _ emn _ _) = emn"
+primrec exclusiveMaximumOf :: "openapi_int_bounds \<Rightarrow> int option" where
+  "exclusiveMaximumOf (OpenApiIntBounds _ _ _ _ _ emx _) = emx"
+primrec patternOf :: "openapi_int_bounds \<Rightarrow> String.literal option" where
+  "patternOf (OpenApiIntBounds _ _ _ _ _ _ p) = p"
+
+text \<open>Length bounds are non-negative integers — collapsing strict to non-strict
+  by \<open>\<plusminus>1\<close>. \<open>BLt 0\<close> yields no bound (we'd get a negative max length).\<close>
+
+definition applyLengthBoundOpenApi ::
+  "bin_op_full \<Rightarrow> int \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+where
+  "applyLengthBoundOpenApi op n bounds = (
+    if n < 0 then bounds
+    else case op of
+       BGe \<Rightarrow> withMinLength (tightenIntMin (minLengthOf bounds) n) bounds
+     | BLe \<Rightarrow> withMaxLength (tightenIntMax (maxLengthOf bounds) n) bounds
+     | BGt \<Rightarrow> withMinLength (tightenIntMin (minLengthOf bounds) (n + 1)) bounds
+     | BLt \<Rightarrow> (if n - 1 < 0 then bounds
+               else withMaxLength (tightenIntMax (maxLengthOf bounds) (n - 1)) bounds)
+     | BEq \<Rightarrow> withMaxLength (tightenIntMax (maxLengthOf bounds) n)
+              (withMinLength (tightenIntMin (minLengthOf bounds) n) bounds)
+     | _ \<Rightarrow> bounds)"
+
+text \<open>Numeric bounds preserve the inclusive/exclusive distinction — JSON Schema
+  treats \<open>minimum\<close> and \<open>exclusiveMinimum\<close> as distinct annotations.\<close>
+
+definition applyNumericBoundOpenApi ::
+  "bin_op_full \<Rightarrow> int \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+where
+  "applyNumericBoundOpenApi op n bounds = (case op of
+       BGe \<Rightarrow> withMinimum (tightenIntMin (minimumOf bounds) n) bounds
+     | BLe \<Rightarrow> withMaximum (tightenIntMax (maximumOf bounds) n) bounds
+     | BGt \<Rightarrow> withExclusiveMinimum (tightenIntMin (exclusiveMinimumOf bounds) n) bounds
+     | BLt \<Rightarrow> withExclusiveMaximum (tightenIntMax (exclusiveMaximumOf bounds) n) bounds
+     | BEq \<Rightarrow> withMaximum (tightenIntMax (maximumOf bounds) n)
+              (withMinimum (tightenIntMin (minimumOf bounds) n) bounds)
+     | _ \<Rightarrow> bounds)"
+
+definition applyAtomOpenApi ::
+  "expr_full \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+where
+  "applyAtomOpenApi atom bounds = (case decomposeAtom atom of
+       RaMatches pat \<Rightarrow> withPattern (Some pat) bounds
+     | RaLenCmp op n \<Rightarrow> applyLengthBoundOpenApi op n bounds
+     | RaValueCmp op n \<Rightarrow> applyNumericBoundOpenApi op n bounds
+     | _ \<Rightarrow> bounds)"
+
+definition visitConstraintOpenApi ::
+  "expr_full \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+where
+  "visitConstraintOpenApi e bounds =
+     foldl (\<lambda>acc atom. applyAtomOpenApi atom acc) bounds (flattenAnd e)"
+
+lemmas emptyOpenApiIntBounds_code [code] = emptyOpenApiIntBounds_def
+lemmas tightenIntMin_code [code] = tightenIntMin_def
+lemmas tightenIntMax_code [code] = tightenIntMax_def
+lemmas applyLengthBoundOpenApi_code [code] = applyLengthBoundOpenApi_def
+lemmas applyNumericBoundOpenApi_code [code] = applyNumericBoundOpenApi_def
+lemmas applyAtomOpenApi_code [code] = applyAtomOpenApi_def
+lemmas visitConstraintOpenApi_code [code] = visitConstraintOpenApi_def
+
+end

--- a/proofs/isabelle/SpecRest/OpenApiConstraints.thy
+++ b/proofs/isabelle/SpecRest/OpenApiConstraints.thy
@@ -2,32 +2,117 @@ theory OpenApiConstraints
   imports IR_Helpers IR_Analysis
 begin
 
-text \<open>Constraint-bounds walker for OpenAPI schema emission. Lifts the Int
-  subset of \<open>specrest.codegen.openapi.OpenApi.Constraints.applyAtom\<close>: walks
-  the refinement-atoms recognised by \<open>decomposeAtom\<close> and accumulates
-  JSON-Schema-style bounds (length, numeric, pattern).
+text \<open>Constraint-bounds walker for OpenAPI schema emission. Lifts
+  \<open>specrest.codegen.openapi.OpenApi.Constraints.applyAtom\<close> in full —
+  both the Int subset (\<open>RaValueCmp\<close> / \<open>RaLenCmp\<close> / \<open>RaMatches\<close>) and
+  the Float-literal fallback (\<open>BinaryOpF\<close> + \<open>FloatLitF\<close>) the original
+  walker handled inline.
 
-  OpenAPI distinguishes inclusive vs exclusive bounds (\<open>minimum\<close> vs
-  \<open>exclusiveMinimum\<close>) — the strategy walker in \<open>Strategies.thy\<close> just
-  collapses BGt to +1 because it only cares about generator value ranges,
-  but OpenAPI emits the exclusive form to JSON output. We track both
-  separately here.
+  Float-literal values arrive as text payloads on \<open>FloatLitF\<close>. We
+  parse them in Isabelle (\<open>parseDecimalLit\<close>) so there is no Scala-side
+  Double parsing — the Scala caller only converts the final lifted
+  \<open>decimal_lit\<close> to its target numeric type at the API boundary.
 
-  Float-literal atoms (the \<open>RaUnknown\<close> fallback in the Scala original)
-  stay in Scala — Isabelle handles the Int subset cleanly, the Scala
-  caller overlays Double-typed bounds after.\<close>
+  Numeric bounds are stored as \<open>decimal_lit\<close> = \<open>mantissa * 10\<^bsup>exponent\<^esup>\<close>
+  to preserve the user's input form exactly. Length bounds remain
+  \<open>int\<close> because lengths can't be fractional.\<close>
 
-datatype openapi_int_bounds = OpenApiIntBounds
+datatype decimal_lit = DecimalLit int int
+  \<comment> \<open>\<open>DecimalLit m e\<close> represents \<open>m * 10\<^sup>e\<close>.
+       Examples: "3.14" \<rightharpoonup> DecimalLit 314 (-2), "5" \<rightharpoonup> DecimalLit 5 0,
+                 "0.5" \<rightharpoonup> DecimalLit 5 (-1)\<close>
+
+text \<open>Comparison: align exponents to the smaller, scale the larger-exponent
+  mantissa up by the difference, then compare mantissas. Result holds for
+  arbitrary integer mantissas and exponents (positive or negative).\<close>
+
+fun decimalGt :: "decimal_lit \<Rightarrow> decimal_lit \<Rightarrow> bool" where
+  "decimalGt (DecimalLit m1 e1) (DecimalLit m2 e2) =
+     (if e1 \<le> e2
+      then m1 > m2 * (10 ^ nat (e2 - e1))
+      else m1 * (10 ^ nat (e1 - e2)) > m2)"
+
+definition maxDecimal :: "decimal_lit \<Rightarrow> decimal_lit \<Rightarrow> decimal_lit" where
+  "maxDecimal a b = (if decimalGt a b then a else b)"
+
+definition minDecimal :: "decimal_lit \<Rightarrow> decimal_lit \<Rightarrow> decimal_lit" where
+  "minDecimal a b = (if decimalGt a b then b else a)"
+
+definition decimalOfInt :: "int \<Rightarrow> decimal_lit" where
+  "decimalOfInt n = DecimalLit n 0"
+
+text \<open>Coerce a \<open>decimal_lit\<close> to \<open>int\<close> if it represents a non-negative
+  integer; \<open>None\<close> otherwise. Used to feed Float-literal length bounds
+  through the integer-only length path (the Scala original silently
+  rejected fractional length bounds with the same check).\<close>
+
+fun decimalToNonNegInt :: "decimal_lit \<Rightarrow> int option" where
+  "decimalToNonNegInt (DecimalLit m e) =
+     (if m < 0 then None
+      else if e \<ge> 0 then Some (m * (10 ^ nat e))
+      else (let p = 10 ^ nat (- e)
+            in if m mod p = 0 then Some (m div p) else None))"
+
+text \<open>Decimal-literal parser: \<open>String.literal \<Rightarrow> decimal_lit option\<close>.
+  Accepts an optional leading \<open>-\<close>, an integer part, and an optional
+  fractional part (\<open>.\<close> followed by digits). Rejects scientific notation
+  (\<open>e\<close>/\<open>E\<close> exponent) and any other trailing characters — spec refinements
+  use plain decimals in practice.
+
+  Implementation walks the ASCII octet list returned by
+  \<open>String.asciis_of_literal\<close>. ASCII codes: \<open>'0'..'9' = 48..57\<close>,
+  \<open>'-' = 45\<close>, \<open>'.' = 46\<close>.\<close>
+
+definition isDigitAscii :: "integer \<Rightarrow> bool" where
+  "isDigitAscii c = (48 \<le> c \<and> c \<le> 57)"
+
+definition digitValue :: "integer \<Rightarrow> int" where
+  "digitValue c = int_of_integer (c - 48)"
+
+fun consumeDigitsAux ::
+  "integer list \<Rightarrow> int \<Rightarrow> nat \<Rightarrow> (int \<times> nat \<times> integer list)"
+where
+  "consumeDigitsAux [] acc count = (acc, count, [])"
+| "consumeDigitsAux (c # cs) acc count =
+     (if isDigitAscii c
+      then consumeDigitsAux cs (acc * 10 + digitValue c) (count + 1)
+      else (acc, count, c # cs))"
+
+definition parseDecimalLit :: "String.literal \<Rightarrow> decimal_lit option" where
+  "parseDecimalLit s = (
+    let cs0 = String.asciis_of_literal s;
+        (sign, cs1) = (case cs0 of
+                         []     \<Rightarrow> (1::int, cs0)
+                       | c # rs \<Rightarrow> (if c = 45 then (-1::int, rs)
+                                    else (1::int, cs0)));
+        (intPart, intLen, rest1) = consumeDigitsAux cs1 0 0
+    in case rest1 of
+         [] \<Rightarrow> (if intLen = 0 then None
+                else Some (DecimalLit (sign * intPart) 0))
+       | (c # rs) \<Rightarrow>
+           (if c = 46 \<comment> \<open>'.'\<close>
+            then let (fracPart, fracLen, rest2) = consumeDigitsAux rs 0 0
+                 in (if rest2 = [] \<and> intLen > 0 \<and> fracLen > 0
+                     then Some (DecimalLit
+                                  (sign * (intPart * (10 ^ fracLen) + fracPart))
+                                  (- int fracLen))
+                     else None)
+            else None))"
+
+text \<open>Bounds record. Length bounds stay \<open>int option\<close> (lengths can't be
+  fractional); numeric bounds are \<open>decimal_lit option\<close>.\<close>
+
+datatype openapi_bounds = OpenApiBounds
   "int option"               \<comment> \<open>min_length (inclusive)\<close>
   "int option"               \<comment> \<open>max_length (inclusive)\<close>
-  "int option"               \<comment> \<open>minimum (inclusive)\<close>
-  "int option"               \<comment> \<open>maximum (inclusive)\<close>
-  "int option"               \<comment> \<open>exclusive_minimum\<close>
-  "int option"               \<comment> \<open>exclusive_maximum\<close>
+  "decimal_lit option"       \<comment> \<open>minimum (inclusive)\<close>
+  "decimal_lit option"       \<comment> \<open>maximum (inclusive)\<close>
+  "decimal_lit option"       \<comment> \<open>exclusive_minimum\<close>
+  "decimal_lit option"       \<comment> \<open>exclusive_maximum\<close>
   "String.literal option"    \<comment> \<open>pattern\<close>
 
-definition emptyOpenApiIntBounds :: openapi_int_bounds where
-  "emptyOpenApiIntBounds = OpenApiIntBounds None None None None None None None"
+definition emptyOpenApiBounds :: openapi_bounds where
+  "emptyOpenApiBounds = OpenApiBounds None None None None None None None"
 
 definition tightenIntMin :: "int option \<Rightarrow> int \<Rightarrow> int option" where
   "tightenIntMin cur n = (case cur of None \<Rightarrow> Some n | Some x \<Rightarrow> Some (max x n))"
@@ -35,41 +120,47 @@ definition tightenIntMin :: "int option \<Rightarrow> int \<Rightarrow> int opti
 definition tightenIntMax :: "int option \<Rightarrow> int \<Rightarrow> int option" where
   "tightenIntMax cur n = (case cur of None \<Rightarrow> Some n | Some x \<Rightarrow> Some (min x n))"
 
-primrec withMinLength :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withMinLength v (OpenApiIntBounds _ ml mn mx emn emx p) = OpenApiIntBounds v ml mn mx emn emx p"
-primrec withMaxLength :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withMaxLength v (OpenApiIntBounds nl _ mn mx emn emx p) = OpenApiIntBounds nl v mn mx emn emx p"
-primrec withMinimum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withMinimum v (OpenApiIntBounds nl ml _ mx emn emx p) = OpenApiIntBounds nl ml v mx emn emx p"
-primrec withMaximum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withMaximum v (OpenApiIntBounds nl ml mn _ emn emx p) = OpenApiIntBounds nl ml mn v emn emx p"
-primrec withExclusiveMinimum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withExclusiveMinimum v (OpenApiIntBounds nl ml mn mx _ emx p) = OpenApiIntBounds nl ml mn mx v emx p"
-primrec withExclusiveMaximum :: "int option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withExclusiveMaximum v (OpenApiIntBounds nl ml mn mx emn _ p) = OpenApiIntBounds nl ml mn mx emn v p"
-primrec withPattern :: "String.literal option \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds" where
-  "withPattern v (OpenApiIntBounds nl ml mn mx emn emx _) = OpenApiIntBounds nl ml mn mx emn emx v"
+definition tightenDecMin :: "decimal_lit option \<Rightarrow> decimal_lit \<Rightarrow> decimal_lit option" where
+  "tightenDecMin cur d = (case cur of None \<Rightarrow> Some d | Some x \<Rightarrow> Some (maxDecimal x d))"
 
-primrec minLengthOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "minLengthOf (OpenApiIntBounds nl _ _ _ _ _ _) = nl"
-primrec maxLengthOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "maxLengthOf (OpenApiIntBounds _ ml _ _ _ _ _) = ml"
-primrec minimumOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "minimumOf (OpenApiIntBounds _ _ mn _ _ _ _) = mn"
-primrec maximumOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "maximumOf (OpenApiIntBounds _ _ _ mx _ _ _) = mx"
-primrec exclusiveMinimumOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "exclusiveMinimumOf (OpenApiIntBounds _ _ _ _ emn _ _) = emn"
-primrec exclusiveMaximumOf :: "openapi_int_bounds \<Rightarrow> int option" where
-  "exclusiveMaximumOf (OpenApiIntBounds _ _ _ _ _ emx _) = emx"
-primrec patternOf :: "openapi_int_bounds \<Rightarrow> String.literal option" where
-  "patternOf (OpenApiIntBounds _ _ _ _ _ _ p) = p"
+definition tightenDecMax :: "decimal_lit option \<Rightarrow> decimal_lit \<Rightarrow> decimal_lit option" where
+  "tightenDecMax cur d = (case cur of None \<Rightarrow> Some d | Some x \<Rightarrow> Some (minDecimal x d))"
 
-text \<open>Length bounds are non-negative integers — collapsing strict to non-strict
-  by \<open>\<plusminus>1\<close>. \<open>BLt 0\<close> yields no bound (we'd get a negative max length).\<close>
+primrec withMinLength :: "int option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withMinLength v (OpenApiBounds _ ml mn mx emn emx p) = OpenApiBounds v ml mn mx emn emx p"
+primrec withMaxLength :: "int option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withMaxLength v (OpenApiBounds nl _ mn mx emn emx p) = OpenApiBounds nl v mn mx emn emx p"
+primrec withMinimum :: "decimal_lit option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withMinimum v (OpenApiBounds nl ml _ mx emn emx p) = OpenApiBounds nl ml v mx emn emx p"
+primrec withMaximum :: "decimal_lit option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withMaximum v (OpenApiBounds nl ml mn _ emn emx p) = OpenApiBounds nl ml mn v emn emx p"
+primrec withExclusiveMinimum :: "decimal_lit option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withExclusiveMinimum v (OpenApiBounds nl ml mn mx _ emx p) = OpenApiBounds nl ml mn mx v emx p"
+primrec withExclusiveMaximum :: "decimal_lit option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withExclusiveMaximum v (OpenApiBounds nl ml mn mx emn _ p) = OpenApiBounds nl ml mn mx emn v p"
+primrec withPattern :: "String.literal option \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds" where
+  "withPattern v (OpenApiBounds nl ml mn mx emn emx _) = OpenApiBounds nl ml mn mx emn emx v"
+
+primrec minLengthOf :: "openapi_bounds \<Rightarrow> int option" where
+  "minLengthOf (OpenApiBounds nl _ _ _ _ _ _) = nl"
+primrec maxLengthOf :: "openapi_bounds \<Rightarrow> int option" where
+  "maxLengthOf (OpenApiBounds _ ml _ _ _ _ _) = ml"
+primrec minimumOf :: "openapi_bounds \<Rightarrow> decimal_lit option" where
+  "minimumOf (OpenApiBounds _ _ mn _ _ _ _) = mn"
+primrec maximumOf :: "openapi_bounds \<Rightarrow> decimal_lit option" where
+  "maximumOf (OpenApiBounds _ _ _ mx _ _ _) = mx"
+primrec exclusiveMinimumOf :: "openapi_bounds \<Rightarrow> decimal_lit option" where
+  "exclusiveMinimumOf (OpenApiBounds _ _ _ _ emn _ _) = emn"
+primrec exclusiveMaximumOf :: "openapi_bounds \<Rightarrow> decimal_lit option" where
+  "exclusiveMaximumOf (OpenApiBounds _ _ _ _ _ emx _) = emx"
+primrec patternOf :: "openapi_bounds \<Rightarrow> String.literal option" where
+  "patternOf (OpenApiBounds _ _ _ _ _ _ p) = p"
+
+text \<open>Length bounds are non-negative integers — \<open>BGt\<close> collapses to \<open>+1\<close>
+  (length is always integer-valued), \<open>BLt 0\<close> yields no bound.\<close>
 
 definition applyLengthBoundOpenApi ::
-  "bin_op_full \<Rightarrow> int \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+  "bin_op_full \<Rightarrow> int \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds"
 where
   "applyLengthBoundOpenApi op n bounds = (
     if n < 0 then bounds
@@ -87,37 +178,71 @@ text \<open>Numeric bounds preserve the inclusive/exclusive distinction — JSON
   treats \<open>minimum\<close> and \<open>exclusiveMinimum\<close> as distinct annotations.\<close>
 
 definition applyNumericBoundOpenApi ::
-  "bin_op_full \<Rightarrow> int \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+  "bin_op_full \<Rightarrow> decimal_lit \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds"
 where
-  "applyNumericBoundOpenApi op n bounds = (case op of
-       BGe \<Rightarrow> withMinimum (tightenIntMin (minimumOf bounds) n) bounds
-     | BLe \<Rightarrow> withMaximum (tightenIntMax (maximumOf bounds) n) bounds
-     | BGt \<Rightarrow> withExclusiveMinimum (tightenIntMin (exclusiveMinimumOf bounds) n) bounds
-     | BLt \<Rightarrow> withExclusiveMaximum (tightenIntMax (exclusiveMaximumOf bounds) n) bounds
-     | BEq \<Rightarrow> withMaximum (tightenIntMax (maximumOf bounds) n)
-              (withMinimum (tightenIntMin (minimumOf bounds) n) bounds)
+  "applyNumericBoundOpenApi op d bounds = (case op of
+       BGe \<Rightarrow> withMinimum (tightenDecMin (minimumOf bounds) d) bounds
+     | BLe \<Rightarrow> withMaximum (tightenDecMax (maximumOf bounds) d) bounds
+     | BGt \<Rightarrow> withExclusiveMinimum (tightenDecMin (exclusiveMinimumOf bounds) d) bounds
+     | BLt \<Rightarrow> withExclusiveMaximum (tightenDecMax (exclusiveMaximumOf bounds) d) bounds
+     | BEq \<Rightarrow> withMaximum (tightenDecMax (maximumOf bounds) d)
+              (withMinimum (tightenDecMin (minimumOf bounds) d) bounds)
+     | _ \<Rightarrow> bounds)"
+
+text \<open>Atom dispatch. The \<open>decomposeAtom\<close> recognizer covers integer literals
+  and \<open>matches\<close> calls; the \<open>RaUnknown\<close> fallback for \<open>BinaryOpF op lhs
+  (FloatLitF v _) _\<close> dispatches to the decimal-literal walker (length or
+  numeric depending on whether the LHS is a length-of-value expression).\<close>
+
+definition applyFloatAtomOpenApi ::
+  "expr_full \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds"
+where
+  "applyFloatAtomOpenApi atom bounds = (case atom of
+       BinaryOpF op lhs (FloatLitF v _) _ \<Rightarrow>
+         (case parseDecimalLit v of
+            None \<Rightarrow> bounds
+          | Some d \<Rightarrow>
+              if isLenOfValue lhs
+              then (case decimalToNonNegInt d of
+                      None \<Rightarrow> bounds
+                    | Some ni \<Rightarrow> applyLengthBoundOpenApi op ni bounds)
+              else if isValueRef lhs
+              then applyNumericBoundOpenApi op d bounds
+              else bounds)
      | _ \<Rightarrow> bounds)"
 
 definition applyAtomOpenApi ::
-  "expr_full \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+  "expr_full \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds"
 where
   "applyAtomOpenApi atom bounds = (case decomposeAtom atom of
        RaMatches pat \<Rightarrow> withPattern (Some pat) bounds
      | RaLenCmp op n \<Rightarrow> applyLengthBoundOpenApi op n bounds
-     | RaValueCmp op n \<Rightarrow> applyNumericBoundOpenApi op n bounds
-     | _ \<Rightarrow> bounds)"
+     | RaValueCmp op n \<Rightarrow> applyNumericBoundOpenApi op (decimalOfInt n) bounds
+     | _ \<Rightarrow> applyFloatAtomOpenApi atom bounds)"
 
 definition visitConstraintOpenApi ::
-  "expr_full \<Rightarrow> openapi_int_bounds \<Rightarrow> openapi_int_bounds"
+  "expr_full \<Rightarrow> openapi_bounds \<Rightarrow> openapi_bounds"
 where
   "visitConstraintOpenApi e bounds =
      foldl (\<lambda>acc atom. applyAtomOpenApi atom acc) bounds (flattenAnd e)"
 
-lemmas emptyOpenApiIntBounds_code [code] = emptyOpenApiIntBounds_def
+lemmas decimalGt_code [code] = decimalGt.simps
+lemmas maxDecimal_code [code] = maxDecimal_def
+lemmas minDecimal_code [code] = minDecimal_def
+lemmas decimalOfInt_code [code] = decimalOfInt_def
+lemmas decimalToNonNegInt_code [code] = decimalToNonNegInt.simps
+lemmas isDigitAscii_code [code] = isDigitAscii_def
+lemmas digitValue_code [code] = digitValue_def
+lemmas consumeDigitsAux_code [code] = consumeDigitsAux.simps
+lemmas parseDecimalLit_code [code] = parseDecimalLit_def
+lemmas emptyOpenApiBounds_code [code] = emptyOpenApiBounds_def
 lemmas tightenIntMin_code [code] = tightenIntMin_def
 lemmas tightenIntMax_code [code] = tightenIntMax_def
+lemmas tightenDecMin_code [code] = tightenDecMin_def
+lemmas tightenDecMax_code [code] = tightenDecMax_def
 lemmas applyLengthBoundOpenApi_code [code] = applyLengthBoundOpenApi_def
 lemmas applyNumericBoundOpenApi_code [code] = applyNumericBoundOpenApi_def
+lemmas applyFloatAtomOpenApi_code [code] = applyFloatAtomOpenApi_def
 lemmas applyAtomOpenApi_code [code] = applyAtomOpenApi_def
 lemmas visitConstraintOpenApi_code [code] = visitConstraintOpenApi_def
 

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -23,5 +23,6 @@ session SpecRest = HOL +
     Methods
     RouteKind
     SchemaTraversal
+    OpenApiConstraints
     Classify
     Codegen

--- a/proofs/isabelle/SpecRest/RouteKind.thy
+++ b/proofs/isabelle/SpecRest/RouteKind.thy
@@ -77,7 +77,8 @@ where
   "matchesCreateShape classification bodyParamNames entityNonIdColumns = (
     isRkCreate classification
     \<and> distinct bodyParamNames
-    \<and> set bodyParamNames = set entityNonIdColumns)"
+    \<and> list_all (\<lambda>x. List.member entityNonIdColumns x) bodyParamNames
+    \<and> list_all (\<lambda>y. List.member bodyParamNames y) entityNonIdColumns)"
 
 text \<open>A handler is a fail-loud stub when the synthesis pass produced no kernel
   method and the effective shape is one the convention engine cannot derive


### PR DESCRIPTION
## Summary

Completes the `OpenApi.Constraints` lift series. PR #322 lifted the type-walk (alias chain → enum/refinement extraction); this lifts the **constraint-walk for Int-valued bounds** (length / numeric / pattern).

### New theory `OpenApiConstraints.thy`

- **`openapi_int_bounds`** ADT — 6 `int option` fields + `String.literal option` pattern: min/max length, minimum (incl), maximum (incl), exclusiveMinimum, exclusiveMaximum, pattern
- **`applyLengthBoundOpenApi`** — non-negative Int length bounds; `BGt` collapses to `+1` (no fractional length exists); `BLt` skipped when `n-1` would be negative
- **`applyNumericBoundOpenApi`** — preserves inclusive/exclusive distinction (`BGe` → `minimum`, `BGt` → `exclusiveMinimum`). **Key difference** from `Strategies.walkIntConstraint` which collapses `BGt` to `+1` (because Strategies only cares about generator value ranges, not JSON-Schema-emitted bounds)
- **`applyAtomOpenApi`** — dispatches on `decomposeAtom` recognition
- **`visitConstraintOpenApi`** — flattens AND-chains and folds applyAtomOpenApi

### Scala refactor (`OpenApi.Constraints.visitConstraint`)

1. Calls extracted `visitConstraintOpenApi` for Int atoms
2. Merges Int-bound result into `JsonSchemaConstraints` (Int → Double promotion at the boundary)
3. Walks atoms again to layer Float-literal-derived bounds (the only case the lifted walker can't see — `decomposeAtom` only recognises `IntLitF`)

The old `applyLengthBound`/`applyNumericBound` functions retained as `*Double` variants for Float-literal handling. All Int-subset logic — which is the vast majority of real specs — flows through extracted code.

### Why a separate theory + ADT instead of reusing `Strategies.int_constraint`

`Strategies.walkIntConstraint` collapses `BGt n` to `min_value = Some (n+1)` because it produces value generators where the inclusive lower bound is all that matters. OpenAPI distinguishes `minimum` from `exclusiveMinimum` because JSON Schema does — they're emitted separately. Different output semantics → different bounds shape.

## Test plan

- [x] `isabelle build` — green (2:05 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `OpenApiConstraintsTest` — 15 focused tests: empty bounds, each comparison op (`BGe`/`BGt`/`BLe`/`BLt`/`BEq`) for both length and numeric, inclusive/exclusive tracked independently, AND-chain accumulation, conflicting-bounds tightening, negative-length rejection, `BLt n=0` skip edge, `MatchesF` pattern extraction
- [x] `sbt scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the OpenAPI constraint walker into Isabelle for both Int and float literals, emitting exact JSON Schema bounds and patterns. Scala now only converts `decimal_lit` to `Double` and assembles `JsonSchemaConstraints`; generated code builds cleanly with no `@nowarn`.

- **New Features**
  - Added `OpenApiConstraints.thy` with `openapi_bounds`, `decimal_lit`, `parseDecimalLit`, and `visitConstraintOpenApi`.
  - Numeric bounds use decimals; length stays `int`. Inclusive/exclusive preserved; AND chains flattened. Lengths are non‑negative; `BGt` → `+1`; skip `BLt 0`. Extracts `pattern` from `MatchesF`.
  - New `OpenApiConstraintsTest` covering decimal parsing, float/int bounds, AND accumulation, conflicts, and patterns.

- **Refactors**
  - `OpenApi.Constraints` delegates to `visitConstraintOpenApi`; converts `decimal_lit` → `Double`; old Scala walkers removed.
  - Codegen: override `equal_bool`; replace set equality with list membership in `matchesCreateShape`; add `mapEntryIsLeafLeaf`; rename `Num.One` → `Onea`; small helpers to avoid narrowing warnings.
  - Regen snippets no longer insert `@nowarn` (docs README and CI workflow updated).

<sup>Written for commit 6229ba6ff7df9ec612585a3922031fce5af4b2ba. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Isabelle proof documentation references

* **Tests**
  * Added new test suite for OpenAPI constraint extraction validation

* **Refactor**
  * Improved constraint handling and OpenAPI bounds computation in the code generator
  * Enhanced Isabelle proof theories to optimize code generation output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->