### PR TITLE
feat(proofs): lift asStableMap name-disambiguation + showNat primitive

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -625,41 +625,22 @@ object OpenApi:
   private def buildXInvariant(profiled: ProfiledService): Option[Map[String, String]] =
     val pairs = profiled.ir.i.collect { case inv: InvariantDeclFull => inv }.zipWithIndex.map:
       case (inv, idx) =>
-        val name = inv.a.getOrElse(s"anon_$idx")
+        val name = inv.a.getOrElse(anonInvariantName(Nata(BigInt(idx))))
         name -> prettyOneLine(inv.b)
-    asStableMap(pairs)
+    toStableListMap(disambiguateKeys(pairs))
 
   private def buildXTemporal(profiled: ProfiledService): Option[Map[String, TemporalAnnotation]] =
     val pairs = profiled.ir.j.collect { case t: TemporalDeclFull => t }.flatMap: t =>
-      t.b match
-        case CallF(IdentifierF("always", _), arg :: Nil, _) =>
-          Some(t.a -> TemporalAnnotation("always", prettyOneLine(arg)))
-        case CallF(IdentifierF("eventually", _), arg :: Nil, _) =>
-          Some(t.a -> TemporalAnnotation("eventually", prettyOneLine(arg)))
-        case CallF(IdentifierF("fairness", _), arg :: Nil, _) =>
-          Some(t.a -> TemporalAnnotation("fairness", prettyOneLine(arg)))
-        case _ =>
-          None
-    asStableMap(pairs)
+      classifyTemporalCall(t.b).map: (kind, arg) =>
+        t.a -> TemporalAnnotation(kind, prettyOneLine(arg))
+    toStableListMap(disambiguateKeys(pairs))
 
-  // Disambiguate duplicate keys: the first occurrence keeps its bare name; each
-  // subsequent collision tries `<base>_0`, `<base>_1`, ... until an unused key
-  // is found. Robust against pathological inputs like `["foo", "foo_0", "foo"]`
-  // where a naive `<base>_<idx>` scheme would itself collide with an existing
-  // explicit name. ListMap preserves insertion order in YAML output.
-  private def asStableMap[V](pairs: List[(String, V)]): Option[Map[String, V]] =
+  // ListMap preserves insertion order; the lifted disambiguateKeys already
+  // returns a collision-free ordered list. Empty → None so the absent x-key
+  // is omitted from the emitted YAML.
+  private def toStableListMap[V](pairs: List[(String, V)]): Option[Map[String, V]] =
     if pairs.isEmpty then None
-    else
-      val (entriesRev, _) = pairs.foldLeft((List.empty[(String, V)], Set.empty[String])):
-        case ((acc, seen), (base, v)) =>
-          val key = if !seen.contains(base) then base else freshKey(base, seen)
-          ((key, v) :: acc, seen + key)
-      Some(scala.collection.immutable.ListMap.from(entriesRev.reverse))
-
-  @scala.annotation.tailrec
-  private def freshKey(base: String, seen: Set[String], i: Int = 0): String =
-    val candidate = s"${base}_$i"
-    if !seen.contains(candidate) then candidate else freshKey(base, seen, i + 1)
+    else Some(scala.collection.immutable.ListMap.from(pairs))
 
   private def prettyOneLine(e: expr_full): String =
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/DisambiguateKeysTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/DisambiguateKeysTest.scala
@@ -1,0 +1,87 @@
+package specrest.codegen.openapi
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+// Helpers in a companion object so the test-data-construction closures
+// (foreach over case-tables at class-init time) don't capture `this` and
+// trip Scala's safe-initialization checker.
+object DisambiguateKeysTest:
+  private def n(i: Int): nat                = Nata(BigInt(i))
+  private def ident(s: String): IdentifierF = IdentifierF(s, None)
+  private def call(name: String, arg: expr_full): CallF =
+    CallF(ident(name), List(arg), None)
+  private val dummyArg: expr_full = BoolLitF(true, None)
+
+class DisambiguateKeysTest extends CatsEffectSuite:
+
+  import DisambiguateKeysTest.*
+
+  // -- showNat --
+
+  List[(String, Int, String)](
+    ("zero", 0, "0"),
+    ("single-digit", 7, "7"),
+    ("two-digit", 42, "42"),
+    ("three-digit", 100, "100"),
+    ("large", 12345, "12345")
+  ).foreach: (name, input, expected) =>
+    test(s"showNat: $name"):
+      assertEquals(showNat(n(input)), expected)
+
+  // -- anonInvariantName --
+
+  List[(Int, String)](
+    (0, "anon_0"),
+    (1, "anon_1"),
+    (42, "anon_42")
+  ).foreach: (idx, expected) =>
+    test(s"anonInvariantName($idx) = $expected"):
+      assertEquals(anonInvariantName(n(idx)), expected)
+
+  // -- disambiguateKeys (no collisions) --
+
+  test("disambiguateKeys: empty input → empty output"):
+    assertEquals(disambiguateKeys[Int](Nil), Nil)
+
+  test("disambiguateKeys: unique names pass through unchanged, preserving order"):
+    val input = List("a" -> 1, "b" -> 2, "c" -> 3)
+    assertEquals(disambiguateKeys(input), input)
+
+  // -- disambiguateKeys (collisions) --
+
+  test("disambiguateKeys: duplicate name gets _0 suffix"):
+    val input = List("foo" -> 1, "foo" -> 2)
+    assertEquals(disambiguateKeys(input), List("foo" -> 1, "foo_0" -> 2))
+
+  test("disambiguateKeys: triple duplicate gets _0, _1"):
+    val input = List("foo" -> 1, "foo" -> 2, "foo" -> 3)
+    assertEquals(disambiguateKeys(input), List("foo" -> 1, "foo_0" -> 2, "foo_1" -> 3))
+
+  test("disambiguateKeys: existing _0 in input forces collision to skip to _1"):
+    // matches the pathological case the original Scala asStableMap was
+    // engineered to handle: ["foo", "foo_0", "foo"] should NOT collide
+    // foo (#3) with the explicit foo_0 (#2) — should advance to foo_1
+    val input = List("foo" -> 1, "foo_0" -> 2, "foo" -> 3)
+    assertEquals(disambiguateKeys(input), List("foo" -> 1, "foo_0" -> 2, "foo_1" -> 3))
+
+  test("disambiguateKeys: order preserved with mixed collisions"):
+    val input = List("a" -> 1, "b" -> 2, "a" -> 3, "b" -> 4, "c" -> 5)
+    assertEquals(
+      disambiguateKeys(input),
+      List("a" -> 1, "b" -> 2, "a_0" -> 3, "b_0" -> 4, "c" -> 5)
+    )
+
+  // -- classifyTemporalCall --
+
+  List[(String, expr_full, Option[(String, expr_full)])](
+    ("always", call("always", dummyArg), Some(("always", dummyArg))),
+    ("eventually", call("eventually", dummyArg), Some(("eventually", dummyArg))),
+    ("fairness", call("fairness", dummyArg), Some(("fairness", dummyArg))),
+    ("unknown call name", call("nope", dummyArg), None),
+    ("call with 0 args", CallF(ident("always"), Nil, None), None),
+    ("call with 2 args", CallF(ident("always"), List(dummyArg, dummyArg), None), None),
+    ("non-call expr", dummyArg, None)
+  ).foreach: (name, input, expected) =>
+    test(s"classifyTemporalCall: $name"):
+      assertEquals(classifyTemporalCall(input), expected)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -7648,6 +7648,29 @@ object SpecRestGenerated {
       case IdentifierF(_, _)                                        => Nil
     }
 
+  def modulo_integer(k: BigInt, l: BigInt): BigInt =
+    snd[BigInt, BigInt](divmod_integer(k, l))
+
+  def modulo_nat(m: nat, n: nat): nat =
+    Nata(modulo_integer(integer_of_nat(m), integer_of_nat(n)))
+
+  def divide_nat(m: nat, n: nat): nat =
+    Nata(divide_integer(integer_of_nat(m), integer_of_nat(n)))
+
+  def digitsRev(n: nat): List[nat] =
+    less_nat(n, nat_of_integer(BigInt(10))) match {
+      case true => List(n)
+      case false => modulo_nat(n, nat_of_integer(BigInt(10))) ::
+          digitsRev(divide_nat(n, nat_of_integer(BigInt(10))))
+    }
+
+  def showNat(n: nat): String =
+    Str_Literal.literalOfAsciis(rev[BigInt](map[nat, BigInt](
+      (d: nat) =>
+        integer_of_nat(plus_nat(nat_of_integer(BigInt(48)), d)),
+      digitsRev(n)
+    )))
+
   def triggerFunctionName(x0: trigger_spec): String = x0 match {
     case TriggerSpec(uu, fn, uv, uw, ux, uy, uz, va) => fn
   }
@@ -7851,6 +7874,20 @@ object SpecRestGenerated {
     case NamedTypeF(v, va)             => false
     case OptionTypeF(v, va)            => false
   }
+
+  def freshKeyAux(fuel: nat, base: String, uu: List[String], i: nat): String =
+    equal_nat(fuel, zero_nat) match {
+      case true => base + "_" + showNat(i)
+      case false =>
+        val candidate = base + "_" + showNat(i): String;
+        membera[String](uu, candidate) match {
+          case true  => freshKeyAux(minus_nat(fuel, one_nat), base, uu, Suc(i))
+          case false => candidate
+        }
+    }
+
+  def freshKey(base: String, seen: List[String]): String =
+    freshKeyAux(Suc(size_list[String](seen)), base, seen, zero_nat)
 
   def signalsHasCollectionInput(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, uz, va, vb, h) => h
@@ -9730,9 +9767,6 @@ object SpecRestGenerated {
         }
     }
 
-  def modulo_integer(k: BigInt, l: BigInt): BigInt =
-    snd[BigInt, BigInt](divmod_integer(k, l))
-
   def modulo_int(k: int, l: int): int =
     int_of_integer(modulo_integer(integer_of_int(k), integer_of_int(l)))
 
@@ -9837,6 +9871,25 @@ object SpecRestGenerated {
       case RaUnknown(_)         => applyFloatAtomOpenApi(atom, bounds)
     }
 
+  def disambiguateKeysAux[A](
+      x0: List[(String, A)],
+      uu: List[String],
+      acc: List[(String, A)]
+  ): List[(String, A)] =
+    (x0, uu, acc) match {
+      case (Nil, uu, acc) => rev[(String, A)](acc)
+      case ((base, v) :: rest, seen, acc) =>
+        val key =
+          (membera[String](seen, base) match {
+            case true  => freshKey(base, seen)
+            case false => base
+          }): String;
+        disambiguateKeysAux[A](rest, key :: seen, (key, v) :: acc)
+    }
+
+  def disambiguateKeys[A](pairs: List[(String, A)]): List[(String, A)] =
+    disambiguateKeysAux[A](pairs, Nil, Nil)
+
   def classificationOperationName(x0: operation_classification): String = x0 match {
     case OperationClassification(n, uu, uv, uw, ux, uy, uz) => n
   }
@@ -9857,6 +9910,8 @@ object SpecRestGenerated {
         keyExistsInRequiresOf(stateFields, a),
       flattenEnsures(requiresa)
     ))
+
+  def anonInvariantName(idx: nat): String = "anon_" + showNat(idx)
 
   def findEnumValuesInTypeAux(
       fuel: nat,
@@ -9979,6 +10034,75 @@ object SpecRestGenerated {
   def signalsTargetEntityFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
   }
+
+  def classifyTemporalCall(e: expr_full): Option[(String, expr_full)] =
+    e match {
+      case BinaryOpF(_, _, _, _)                      => None
+      case UnaryOpF(_, _, _)                          => None
+      case QuantifierF(_, _, _, _)                    => None
+      case SomeWrapF(_, _)                            => None
+      case TheF(_, _, _, _)                           => None
+      case FieldAccessF(_, _, _)                      => None
+      case EnumAccessF(_, _, _)                       => None
+      case IndexF(_, _, _)                            => None
+      case CallF(BinaryOpF(_, _, _, _), _, _)         => None
+      case CallF(UnaryOpF(_, _, _), _, _)             => None
+      case CallF(QuantifierF(_, _, _, _), _, _)       => None
+      case CallF(SomeWrapF(_, _), _, _)               => None
+      case CallF(TheF(_, _, _, _), _, _)              => None
+      case CallF(FieldAccessF(_, _, _), _, _)         => None
+      case CallF(EnumAccessF(_, _, _), _, _)          => None
+      case CallF(IndexF(_, _, _), _, _)               => None
+      case CallF(CallF(_, _, _), _, _)                => None
+      case CallF(PrimeF(_, _), _, _)                  => None
+      case CallF(PreF(_, _), _, _)                    => None
+      case CallF(WithF(_, _, _), _, _)                => None
+      case CallF(IfF(_, _, _, _), _, _)               => None
+      case CallF(LetF(_, _, _, _), _, _)              => None
+      case CallF(LambdaF(_, _, _), _, _)              => None
+      case CallF(ConstructorF(_, _, _), _, _)         => None
+      case CallF(SetLiteralF(_, _), _, _)             => None
+      case CallF(MapLiteralF(_, _), _, _)             => None
+      case CallF(SetComprehensionF(_, _, _, _), _, _) => None
+      case CallF(SeqLiteralF(_, _), _, _)             => None
+      case CallF(MatchesF(_, _, _), _, _)             => None
+      case CallF(IntLitF(_, _), _, _)                 => None
+      case CallF(FloatLitF(_, _), _, _)               => None
+      case CallF(StringLitF(_, _), _, _)              => None
+      case CallF(BoolLitF(_, _), _, _)                => None
+      case CallF(NoneLitF(_), _, _)                   => None
+      case CallF(IdentifierF(_, _), Nil, _)           => None
+      case CallF(IdentifierF(name, _), List(arg), _) =>
+        name == "always" match {
+          case true => Some[(String, expr_full)](("always", arg))
+          case false => name == "eventually" match {
+              case true => Some[(String, expr_full)](("eventually", arg))
+              case false => name == "fairness" match {
+                  case true  => Some[(String, expr_full)](("fairness", arg))
+                  case false => None
+                }
+            }
+        }
+      case CallF(IdentifierF(_, _), _ :: _ :: _, _) => None
+      case PrimeF(_, _)                             => None
+      case PreF(_, _)                               => None
+      case WithF(_, _, _)                           => None
+      case IfF(_, _, _, _)                          => None
+      case LetF(_, _, _, _)                         => None
+      case LambdaF(_, _, _)                         => None
+      case ConstructorF(_, _, _)                    => None
+      case SetLiteralF(_, _)                        => None
+      case MapLiteralF(_, _)                        => None
+      case SetComprehensionF(_, _, _, _)            => None
+      case SeqLiteralF(_, _)                        => None
+      case MatchesF(_, _, _)                        => None
+      case IntLitF(_, _)                            => None
+      case FloatLitF(_, _)                          => None
+      case StringLitF(_, _)                         => None
+      case BoolLitF(_, _)                           => None
+      case NoneLitF(_)                              => None
+      case IdentifierF(_, _)                        => None
+    }
 
   def collectionElementEntityName(ty: type_expr_full): Option[String] =
     ty match {

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -241,6 +241,10 @@ export_code
     visitConstraintOpenApi
     decimalToNonNegInt
     parseDecimalLit
+    showNat
+    disambiguateKeys
+    anonInvariantName
+    classifyTemporalCall
     primitiveTypeToSql
     classifyColumnType
     collectionElementEntityName

--- a/proofs/isabelle/SpecRest/OpenApiConstraints.thy
+++ b/proofs/isabelle/SpecRest/OpenApiConstraints.thy
@@ -265,7 +265,16 @@ text \<open>Name disambiguation: given an ordered list of \<open>(name, value)\<
   already-emitted (or natural) name. Output preserves input order;
   matches the existing Scala \<open>asStableMap\<close> behaviour and its robust
   handling of pathological inputs like \<open>["foo", "foo_0", "foo"]\<close>
-  (the second \<open>foo\<close> skips the explicit \<open>foo_0\<close> to land at \<open>foo_1\<close>).\<close>
+  (the second \<open>foo\<close> skips the explicit \<open>foo_0\<close> to land at \<open>foo_1\<close>).
+
+  Complexity: O(n^2) on n input pairs, plus O(n) per collision iteration
+  on the \<open>freshKey\<close> search (so O(n^3) worst-case on adversarial inputs
+  where every entry collides). Acceptable for the real usage — invariant
+  and temporal lists in spec files are bounded by a handful of entries.
+  Same list-based \<open>List.member\<close> pattern as \<open>aliasRefinements\<close> /
+  \<open>findEnumValuesInType\<close>; the planned \<open>HOL-Library.RBT_Mapping\<close>
+  swap (see \<open>docs/.../isabelle-proofs.mdx\<close> Layer 2) drops every lookup
+  to O(log n) without changing the call sites.\<close>
 
 fun freshKeyAux ::
   "nat \<Rightarrow> String.literal \<Rightarrow> String.literal list \<Rightarrow> nat \<Rightarrow> String.literal"
@@ -300,8 +309,8 @@ text \<open>Anonymous-invariant naming: produces \<open>anon_<i>\<close> for inv
 definition anonInvariantName :: "nat \<Rightarrow> String.literal" where
   "anonInvariantName idx = STR ''anon_'' + showNat idx"
 
-text \<open>Temporal-formula classifier: recognises the recognised three top-level
-  call shapes (\<open>always\<close>/\<open>eventually\<close>/\<open>fairness\<close>) and returns the matched
+text \<open>Temporal-formula classifier: recognises the three top-level call
+  shapes (\<open>always\<close>/\<open>eventually\<close>/\<open>fairness\<close>) and returns the matched
   keyword plus the argument. Other shapes return \<open>None\<close> (Scala caller
   filters them out). Used by \<open>OpenApi.buildXTemporal\<close>.\<close>
 

--- a/proofs/isabelle/SpecRest/OpenApiConstraints.thy
+++ b/proofs/isabelle/SpecRest/OpenApiConstraints.thy
@@ -246,4 +246,83 @@ lemmas applyFloatAtomOpenApi_code [code] = applyFloatAtomOpenApi_def
 lemmas applyAtomOpenApi_code [code] = applyAtomOpenApi_def
 lemmas visitConstraintOpenApi_code [code] = visitConstraintOpenApi_def
 
+text \<open>\<open>showNat\<close>: render a \<open>nat\<close> as a base-10 decimal \<open>String.literal\<close>
+  via ASCII octet construction. Reverse of \<open>parseDecimalLit\<close>'s digit
+  parsing. Foundational for any code-extracted formatter that needs
+  numeric→text (auto-numbered names, error messages, etc.).\<close>
+
+fun digitsRev :: "nat \<Rightarrow> nat list" where
+  "digitsRev n = (if n < 10 then [n]
+                  else (n mod 10) # digitsRev (n div 10))"
+
+definition showNat :: "nat \<Rightarrow> String.literal" where
+  "showNat n = String.literal_of_asciis
+                 (rev (map (\<lambda>d. integer_of_nat (48 + d)) (digitsRev n)))"
+
+text \<open>Name disambiguation: given an ordered list of \<open>(name, value)\<close>
+  pairs, replace each duplicate name with \<open>\<open>name\<close>_<i>\<close> where \<open>i\<close>
+  is the smallest non-negative index that doesn't collide with any
+  already-emitted (or natural) name. Output preserves input order;
+  matches the existing Scala \<open>asStableMap\<close> behaviour and its robust
+  handling of pathological inputs like \<open>["foo", "foo_0", "foo"]\<close>
+  (the second \<open>foo\<close> skips the explicit \<open>foo_0\<close> to land at \<open>foo_1\<close>).\<close>
+
+fun freshKeyAux ::
+  "nat \<Rightarrow> String.literal \<Rightarrow> String.literal list \<Rightarrow> nat \<Rightarrow> String.literal"
+where
+  "freshKeyAux 0 base _ i = base + STR ''_'' + showNat i"
+| "freshKeyAux (Suc fuel) base seen i =
+     (let candidate = base + STR ''_'' + showNat i
+      in if List.member seen candidate
+         then freshKeyAux fuel base seen (Suc i)
+         else candidate)"
+
+definition freshKey :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal" where
+  "freshKey base seen = freshKeyAux (Suc (length seen)) base seen 0"
+
+fun disambiguateKeysAux ::
+  "(String.literal \<times> 'a) list \<Rightarrow> String.literal list
+    \<Rightarrow> (String.literal \<times> 'a) list \<Rightarrow> (String.literal \<times> 'a) list"
+where
+  "disambiguateKeysAux [] _ acc = rev acc"
+| "disambiguateKeysAux ((base, v) # rest) seen acc =
+     (let key = (if List.member seen base then freshKey base seen else base)
+      in disambiguateKeysAux rest (key # seen) ((key, v) # acc))"
+
+definition disambiguateKeys ::
+  "(String.literal \<times> 'a) list \<Rightarrow> (String.literal \<times> 'a) list"
+where
+  "disambiguateKeys pairs = disambiguateKeysAux pairs [] []"
+
+text \<open>Anonymous-invariant naming: produces \<open>anon_<i>\<close> for invariants
+  without explicit names. Pure mirror of the Scala \<open>s"anon_$idx"\<close>.\<close>
+
+definition anonInvariantName :: "nat \<Rightarrow> String.literal" where
+  "anonInvariantName idx = STR ''anon_'' + showNat idx"
+
+text \<open>Temporal-formula classifier: recognises the recognised three top-level
+  call shapes (\<open>always\<close>/\<open>eventually\<close>/\<open>fairness\<close>) and returns the matched
+  keyword plus the argument. Other shapes return \<open>None\<close> (Scala caller
+  filters them out). Used by \<open>OpenApi.buildXTemporal\<close>.\<close>
+
+definition classifyTemporalCall ::
+  "expr_full \<Rightarrow> (String.literal \<times> expr_full) option"
+where
+  "classifyTemporalCall e = (case e of
+       CallF (IdentifierF name _) [arg] _ \<Rightarrow>
+         (if name = STR ''always''      then Some (STR ''always'', arg)
+          else if name = STR ''eventually'' then Some (STR ''eventually'', arg)
+          else if name = STR ''fairness''   then Some (STR ''fairness'', arg)
+          else None)
+     | _ \<Rightarrow> None)"
+
+lemmas digitsRev_code [code] = digitsRev.simps
+lemmas showNat_code [code] = showNat_def
+lemmas freshKeyAux_code [code] = freshKeyAux.simps
+lemmas freshKey_code [code] = freshKey_def
+lemmas disambiguateKeysAux_code [code] = disambiguateKeysAux.simps
+lemmas disambiguateKeys_code [code] = disambiguateKeys_def
+lemmas anonInvariantName_code [code] = anonInvariantName_def
+lemmas classifyTemporalCall_code [code] = classifyTemporalCall_def
+
 end


### PR DESCRIPTION
## Summary

Lifts the name-disambiguation algorithm that `OpenApi.buildXInvariant` / `buildXTemporal` used for handling duplicate invariant/temporal keys. Adds **`showNat`** as a foundational nat→string formatter (mirror of the `parseDecimalLit` parser from PR #326).

### New in `OpenApiConstraints.thy`

- **`digitsRev` / `showNat`** — nat → base-10 `String.literal` via `String.literal_of_asciis` on ASCII octets. Foundational for any future code-extracted formatter needing numeric→text.
- **`freshKey` / `freshKeyAux`** — fuel-bounded loop finding the smallest non-negative index n such that `base_n` is not in `seen`.
- **`disambiguateKeys`** (polymorphic in value type) — pure ordered walk that renames duplicate keys via `freshKey`. Preserves input order. Handles the pathological `["foo", "foo_0", "foo"]` case: the third `foo` correctly skips the explicit `foo_0` and lands at `foo_1`.
- **`anonInvariantName`** — `anon_<i>` formatter for unnamed invariants.
- **`classifyTemporalCall`** — recognises `always`/`eventually`/`fairness` `CallF` shapes, returns `(keyword, arg)` or `None`.

### Scala refactor (`OpenApi.scala`)

`asStableMap` and `freshKey` deleted. `buildXInvariant` uses `anonInvariantName` + `disambiguateKeys`; `buildXTemporal` uses `classifyTemporalCall` + `disambiguateKeys`. `PrettyPrint.expr` and `ListMap` wrapping stay in Scala (lifted algorithm returns a collision-free ordered list; Scala wraps for YAML output).

## Test plan

- [x] `isabelle build` — green (1:56 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `DisambiguateKeysTest` — 21 focused tests: `showNat` (zero / single-digit / two-digit / three-digit / large), `anonInvariantName`, `disambiguateKeys` (empty / unique / duplicate / triple / `foo_0` pathological / mixed), `classifyTemporalCall` (3 keywords / wrong name / 0 args / 2 args / non-call)
- [x] `sbt scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted duplicate-key disambiguation and temporal-call classification into Isabelle proofs, added a `showNat` formatter, and documented the algorithm’s O(n^2) complexity. `OpenApi` now uses the lifted functions for stable, collision-free YAML keys with unchanged behavior and better test coverage.

- **New Features**
  - `showNat`: nat → base-10 string.
  - `disambiguateKeys` + `freshKey`: ordered renaming that skips existing suffixes (e.g., ["foo", "foo_0", "foo"] → "foo_1").
  - `anonInvariantName`: `anon_<i>` for unnamed invariants.
  - `classifyTemporalCall`: detects `always`/`eventually`/`fairness` calls and extracts the arg.

- **Refactors**
  - `OpenApi.scala`: replaced `asStableMap`/`freshKey` with `disambiguateKeys`, `anonInvariantName`, and `classifyTemporalCall`; added `toStableListMap` to keep order and omit empty.
  - Added `DisambiguateKeysTest` covering number formatting, anon names, collision cases, and temporal classification.
  - Proofs/docs: comments in `OpenApiConstraints.thy` now note O(n^2) disambiguation complexity and worst-case behavior.

<sup>Written for commit 80f5f6b12f7d69caba80c6be8d07015dbf2340a2. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

