### PR TITLE
feat(proofs): lift applyPartialIndexConventions kernel

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -362,22 +362,17 @@ object Schema:
       entities: List[EntityDeclFull],
       conv: Option[conventions_decl_full]
   ): List[table_spec] =
-    val rules = conv.toList.flatMap { case ConventionsDeclFull(rs, _) =>
-      rs.collect {
-        case ConventionRuleFull(target, "partial_index", Some(col), StringLitF(filt, _), _) =>
-          (target, col, filt)
-      }
-    }
+    val rules = extractPartialIndexRules(conv)
     if rules.isEmpty then tables
     else
       val entityByName = entities.map(e => e.a -> e).toMap
+      // Resolve target entity name → table name (regex + convention lookup, stays in Scala).
       val rulesByTable: Map[String, List[(String, String)]] = rules
-        .flatMap { (target, col, filt) =>
+        .flatMap { case (target, (col, filt)) =>
           entityByName.get(target).map: e =>
-            val tableName =
+            val tableNm =
               Path.getConvention(conv, e.a, "db_table").getOrElse(Naming.toTableName(e.a))
-            val colName = Naming.toColumnName(col)
-            (tableName, colName, filt)
+            (tableNm, Naming.toColumnName(col), filt)
         }
         .groupBy(_._1)
         .view
@@ -385,24 +380,8 @@ object Schema:
         .toMap
       tables.map: t =>
         rulesByTable.get(tableName(t)) match
-          case None => t
-          case Some(colFilters) =>
-            val partials = colFilters.map: (col, filt) =>
-              IndexSpec(
-                s"idx_${tableName(t)}_${col}_partial",
-                List(col),
-                false,
-                Some(filt)
-              )
-            TableSpec(
-              tableName(t),
-              tableEntityName(t),
-              tableColumns(t),
-              tablePrimaryKey(t),
-              tableForeignKeys(t),
-              tableChecks(t),
-              tableIndexes(t) ++ partials
-            )
+          case None             => t
+          case Some(colFilters) => appendPartialIndexes(t, colFilters)
 
   private def detectAggregateTriggers(
       entities: List[EntityDeclFull],

--- a/modules/convention/src/test/scala/specrest/convention/PartialIndexConventionsTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/PartialIndexConventionsTest.scala
@@ -1,0 +1,117 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+
+object PartialIndexConventionsTest:
+  private def rule(
+      target: String,
+      prop: String,
+      col: Option[String],
+      v: expr_full
+  ): ConventionRuleFull =
+    ConventionRuleFull(target, prop, col, v, None)
+  private def stringL(s: String): StringLitF = StringLitF(s, None)
+  private def intL(n: Int): IntLitF          = IntLitF(int_of_integer(BigInt(n)), None)
+  private def conv(rs: List[convention_rule_full]): conventions_decl_full =
+    ConventionsDeclFull(rs, None)
+
+  // Minimal TableSpec for index-append tests.
+  private def table(name: String, indexes: List[index_spec] = Nil): TableSpec =
+    TableSpec(name, name + "_entity", Nil, "id", Nil, Nil, indexes)
+
+class PartialIndexConventionsTest extends CatsEffectSuite:
+
+  import PartialIndexConventionsTest.*
+
+  // -- extractPartialIndexRules --
+
+  test("None convention block → empty rules"):
+    assertEquals(extractPartialIndexRules(None), Nil)
+
+  test("empty rule list → empty"):
+    assertEquals(extractPartialIndexRules(Some(conv(Nil))), Nil)
+
+  test("non-partial_index rules are skipped"):
+    val rs = List(
+      rule("Order", "db_table", None, stringL("orders")),
+      rule("User", "http_path", None, stringL("/users"))
+    )
+    assertEquals(extractPartialIndexRules(Some(conv(rs))), Nil)
+
+  test("partial_index with String filter is captured"):
+    val rs = List(rule("Order", "partial_index", Some("status"), stringL("status = 'active'")))
+    assertEquals(
+      extractPartialIndexRules(Some(conv(rs))),
+      List(("Order", ("status", "status = 'active'")))
+    )
+
+  test("partial_index without column is dropped"):
+    val rs = List(rule("Order", "partial_index", None, stringL("status = 'active'")))
+    assertEquals(extractPartialIndexRules(Some(conv(rs))), Nil)
+
+  test("partial_index with non-String filter is dropped"):
+    val rs = List(rule("Order", "partial_index", Some("status"), intL(1)))
+    assertEquals(extractPartialIndexRules(Some(conv(rs))), Nil)
+
+  test("multiple partial_index rules preserved in order, interleaved with others"):
+    val rs = List(
+      rule("Order", "partial_index", Some("status"), stringL("p1")),
+      rule("Order", "db_table", None, stringL("orders")),
+      rule("Order", "partial_index", Some("priority"), stringL("p2")),
+      rule("User", "partial_index", Some("active"), stringL("p3"))
+    )
+    assertEquals(
+      extractPartialIndexRules(Some(conv(rs))),
+      List(
+        ("Order", ("status", "p1")),
+        ("Order", ("priority", "p2")),
+        ("User", ("active", "p3"))
+      )
+    )
+
+  // -- appendPartialIndexes --
+
+  test("empty colFilters leaves the table indexes unchanged"):
+    val t = table("orders")
+    assertEquals(appendPartialIndexes(t, Nil), t)
+
+  test("one (col, filter) appends one IndexSpec with canonical name"):
+    val t      = table("orders")
+    val result = appendPartialIndexes(t, List(("status", "status = 'open'")))
+    val expected =
+      IndexSpec("idx_orders_status_partial", List("status"), false, Some("status = 'open'"))
+    assertEquals(tableIndexes(result), List(expected))
+
+  test("multiple (col, filter) entries append multiple indexes in order"):
+    val t      = table("orders")
+    val result = appendPartialIndexes(t, List(("status", "f1"), ("priority", "f2")))
+    assertEquals(
+      tableIndexes(result),
+      List(
+        IndexSpec("idx_orders_status_partial", List("status"), false, Some("f1")),
+        IndexSpec("idx_orders_priority_partial", List("priority"), false, Some("f2"))
+      )
+    )
+
+  test("existing indexes preserved with partials appended after"):
+    val existing = IndexSpec("idx_orders_id", List("id"), true, None)
+    val t        = table("orders", indexes = List(existing))
+    val result   = appendPartialIndexes(t, List(("status", "f")))
+    assertEquals(
+      tableIndexes(result),
+      List(
+        existing,
+        IndexSpec("idx_orders_status_partial", List("status"), false, Some("f"))
+      )
+    )
+
+  test("appendPartialIndexes preserves entity/PK/FK/checks fields"):
+    val t      = table("orders")
+    val result = appendPartialIndexes(t, List(("status", "f")))
+    assertEquals(tableName(result), tableName(t))
+    assertEquals(tableEntityName(result), tableEntityName(t))
+    assertEquals(tablePrimaryKey(result), tablePrimaryKey(t))
+    assertEquals(tableColumns(result), tableColumns(t))
+    assertEquals(tableForeignKeys(result), tableForeignKeys(t))
+    assertEquals(tableChecks(result), tableChecks(t))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8433,6 +8433,9 @@ object SpecRestGenerated {
       case IdentifierF(_, _)                                 => None
     }
 
+  def partialIndexSpec(tableNm: String, col: String, filt: String): index_spec =
+    IndexSpec("idx_" + tableNm + "_" + col + "_partial", List(col), false, Some[String](filt))
+
   def peelRelationRefFull(x0: expr_full): Option[String] = x0 match {
     case IdentifierF(rel, uu)                          => Some[String](rel)
     case PreF(IdentifierF(rel, uv), uw)                => Some[String](rel)
@@ -9441,6 +9444,27 @@ object SpecRestGenerated {
     case WithInfoFull(uu, b) => b
   }
 
+  def appendPartialIndexes(x0: table_spec, colFilters: List[(String, String)]): table_spec =
+    (x0, colFilters) match {
+      case (TableSpec(nm, ent, cols, pk, fks, cks, ixs), colFilters) =>
+        TableSpec(
+          nm,
+          ent,
+          cols,
+          pk,
+          fks,
+          cks,
+          ixs ++
+            map[(String, String), index_spec](
+              (a: (String, String)) => {
+                val (aa, b) = a: ((String, String));
+                partialIndexSpec(nm, aa, b)
+              },
+              colFilters
+            )
+        )
+    }
+
   def schemaRelationValueType(gamma: tyctx_ext[Unit], rel_name: String): Option[ty] =
     find[state_field_decl_full](
       (sf: state_field_decl_full) =>
@@ -10023,6 +10047,57 @@ object SpecRestGenerated {
       case BoolLitF(_, _)                   => None
       case NoneLitF(_)                      => None
       case IdentifierF(_, _)                => None
+    }
+
+  def extractPartialIndexRuleOpt(x0: convention_rule_full): Option[(String, (String, String))] =
+    x0 match {
+      case ConventionRuleFull(target, prop, colOpt, vala, uu) =>
+        prop == "partial_index" match {
+          case true => (colOpt, vala) match {
+              case (None, _)                                => None
+              case (Some(_), BinaryOpF(_, _, _, _))         => None
+              case (Some(_), UnaryOpF(_, _, _))             => None
+              case (Some(_), QuantifierF(_, _, _, _))       => None
+              case (Some(_), SomeWrapF(_, _))               => None
+              case (Some(_), TheF(_, _, _, _))              => None
+              case (Some(_), FieldAccessF(_, _, _))         => None
+              case (Some(_), EnumAccessF(_, _, _))          => None
+              case (Some(_), IndexF(_, _, _))               => None
+              case (Some(_), CallF(_, _, _))                => None
+              case (Some(_), PrimeF(_, _))                  => None
+              case (Some(_), PreF(_, _))                    => None
+              case (Some(_), WithF(_, _, _))                => None
+              case (Some(_), IfF(_, _, _, _))               => None
+              case (Some(_), LetF(_, _, _, _))              => None
+              case (Some(_), LambdaF(_, _, _))              => None
+              case (Some(_), ConstructorF(_, _, _))         => None
+              case (Some(_), SetLiteralF(_, _))             => None
+              case (Some(_), MapLiteralF(_, _))             => None
+              case (Some(_), SetComprehensionF(_, _, _, _)) => None
+              case (Some(_), SeqLiteralF(_, _))             => None
+              case (Some(_), MatchesF(_, _, _))             => None
+              case (Some(_), IntLitF(_, _))                 => None
+              case (Some(_), FloatLitF(_, _))               => None
+              case (Some(col), StringLitF(filt, _)) =>
+                Some[(String, (String, String))]((target, (col, filt)))
+              case (Some(_), BoolLitF(_, _))    => None
+              case (Some(_), NoneLitF(_))       => None
+              case (Some(_), IdentifierF(_, _)) => None
+            }
+          case false => None
+        }
+    }
+
+  def extractPartialIndexRules(conv: Option[conventions_decl_full])
+      : List[(String, (String, String))] =
+    conv match {
+      case None => Nil
+      case Some(ConventionsDeclFull(rs, _)) =>
+        map_filter[convention_rule_full, (String, (String, String))](
+          (a: convention_rule_full) =>
+            extractPartialIndexRuleOpt(a),
+          rs
+        )
     }
 
   def widenExplicitIdPkSqlType(field_name: String, sql_type: String): String =

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -250,6 +250,8 @@ export_code
     collectionElementEntityName
     uniqueBackFkColumn
     validateTrigger
+    extractPartialIndexRules
+    appendPartialIndexes
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -266,4 +266,55 @@ lemmas lambdaProjection_code [code] = lambdaProjection_def
 lemmas decodeAggregateCall_code [code] = decodeAggregateCall_def
 lemmas detectAggregateInvariant_code [code] = detectAggregateInvariant_def
 
+text \<open>Partial-index convention extraction. Lifts the pure parts of
+  \<open>specrest.convention.Schema.applyPartialIndexConventions\<close>:
+
+  \<^item> \<open>extractPartialIndexRules\<close>: scans the convention block for
+    \<open>partial_index\<close> rules with a String-literal filter clause, returning
+    a list of \<open>(target_entity, column, filter)\<close> triples. The Scala caller
+    then resolves \<open>target_entity\<close> to a table name (uses \<open>Path.getConvention\<close>
+    + \<open>Naming.toTableName\<close>, both regex/lookup-bound and staying in Scala).
+
+  \<^item> \<open>partialIndexSpec\<close>: builds the partial \<open>index_spec\<close> with the
+    canonical \<open>idx_<table>_<col>_partial\<close> identifier.
+
+  \<^item> \<open>appendPartialIndexes\<close>: appends a list of \<open>(col, filter)\<close>
+    derived indexes onto a \<open>table_spec\<close>, preserving the other fields.\<close>
+
+primrec extractPartialIndexRuleOpt ::
+  "convention_rule_full \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) option"
+where
+  "extractPartialIndexRuleOpt (ConventionRuleFull target prop colOpt val _) =
+     (if prop = STR ''partial_index''
+      then (case (colOpt, val) of
+              (Some col, StringLitF filt _) \<Rightarrow> Some (target, col, filt)
+            | _ \<Rightarrow> None)
+      else None)"
+
+definition extractPartialIndexRules ::
+  "conventions_decl_full option \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list"
+where
+  "extractPartialIndexRules conv = (case conv of
+       None \<Rightarrow> []
+     | Some (ConventionsDeclFull rs _) \<Rightarrow> List.map_filter extractPartialIndexRuleOpt rs)"
+
+definition partialIndexSpec ::
+  "String.literal \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> index_spec"
+where
+  "partialIndexSpec tableNm col filt =
+     IndexSpec (STR ''idx_'' + tableNm + STR ''_'' + col + STR ''_partial'')
+               [col] False (Some filt)"
+
+primrec appendPartialIndexes ::
+  "table_spec \<Rightarrow> (String.literal \<times> String.literal) list \<Rightarrow> table_spec"
+where
+  "appendPartialIndexes (TableSpec nm ent cols pk fks cks ixs) colFilters =
+     TableSpec nm ent cols pk fks cks
+       (ixs @ map (\<lambda>cf. case cf of (col, filt) \<Rightarrow> partialIndexSpec nm col filt) colFilters)"
+
+lemmas extractPartialIndexRuleOpt_code [code] = extractPartialIndexRuleOpt.simps
+lemmas extractPartialIndexRules_code [code] = extractPartialIndexRules_def
+lemmas partialIndexSpec_code [code] = partialIndexSpec_def
+lemmas appendPartialIndexes_code [code] = appendPartialIndexes.simps
+
 end


### PR DESCRIPTION
## Summary

Completes the `Schema.deriveSchema` lift series — the last remaining sub-routine with pure-decision logic worth lifting: partial-index convention-rule extraction + index-spec append.

### Lifted (in `SchemaDerive.thy`)

- **`extractPartialIndexRuleOpt`** — pattern-matches a single `ConventionRuleFull`, returns `Some(target, col, filt)` for `partial_index` rules with a column qualifier and a String-literal filter; `None` otherwise.
- **`extractPartialIndexRules`** — convention-block walker returning the ordered list of `(target, col, filt)` triples.
- **`partialIndexSpec`** — builds the canonical `idx_<table>_<col>_partial` `IndexSpec` from name + column + filter (uses `String.literal +`).
- **`appendPartialIndexes`** — appends a list of `(col, filter)` entries as `IndexSpec`s to a `table_spec`, preserving all other fields.

### Scala refactor (`Schema.applyPartialIndexConventions`)

The rule-extraction case-pattern and the `IndexSpec`-construction + table-rebuild loop are gone. Remaining Scala work: the naming-resolution step (target entity → table name via `Path.getConvention` + `Naming.toTableName`, regex-bound) and the group-by-table folding. Function shrinks from **45 lines → 17**.

## Test plan

- [x] `isabelle build` — green (2:00 elapsed)
- [x] `sbt test` — all 1,120 tests pass
- [x] `PartialIndexConventionsTest` — 12 focused tests: rule-extraction edge cases (None / empty / non-`partial_index` / missing column / non-String filter / interleaved), `appendPartialIndexes` correctness (empty / single / multiple / preserves existing indexes / preserves other table fields)
- [x] `sbt scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts the partial-index convention kernel into verified helpers and refactors `Schema.applyPartialIndexConventions` to use them. This simplifies the function and centralizes rule parsing and index construction.

- **Refactors**
  - `Schema.applyPartialIndexConventions` now delegates rule extraction and index creation to generated helpers; only table-name resolution and per-table folding stay in Scala.
  - Removes manual case matching and table rebuild loop; function shrinks from 45 to 17 lines.

- **New Features**
  - Adds `extractPartialIndexRules`, `partialIndexSpec`, and `appendPartialIndexes` in `SchemaDerive.thy`, exported via codegen (`SpecRestGenerated.scala`).
  - `extractPartialIndexRules` returns ordered `(target, (col, filter))` for `partial_index` rules with a column and String filter.
  - `appendPartialIndexes` appends canonical `idx_<table>_<col>_partial` specs to a `table_spec` without touching other fields.

<sup>Written for commit 978254d635b47b4cfd189603529ab4ce9e630fef. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/328?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved partial index convention handling with modular helper functions, replacing inline pattern matching for better code organization.

* **Tests**
  * Added comprehensive test coverage for partial index rule extraction and application, including edge cases and rule ordering validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->