### PR TITLE
feat(proofs): lift derivePathPattern + pathWithIdSuffix

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -77,24 +77,10 @@ object Path:
   ): String =
     val entity  = classificationTargetEntity(c)
     val segment = entity.map(Naming.toPathSegment).getOrElse(Naming.toKebabCase(op.a))
-
-    def segOrIdPath: String =
-      findIdParam(op, ir) match
-        case Some(id) => s"/$segment/{$id}"
-        case None     => s"/$segment"
-
-    classificationKind(c) match
-      case _: Create => s"/$segment"
-      case _: Read | _: FilteredRead | _: Replace | _: PartialUpdate | _: Deletea =>
-        segOrIdPath
-      case _: Transition =>
-        val action = extractActionVerb(op.a, entity)
-        findIdParam(op, ir) match
-          case Some(id) => s"/$segment/{$id}/$action"
-          case None     => s"/$segment/$action"
-      case _: BatchMutation => s"/$segment/batch"
-      case _: SideEffect    => s"/${Naming.toKebabCase(op.a)}"
-      case _: CreateChild   => s"/$segment"
+    val opKebab = Naming.toKebabCase(op.a)
+    val action  = extractActionVerb(op.a, entity)
+    val idOpt   = findIdParam(op, ir)
+    SpecRestGenerated.derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)
 
   private def findIdParam(op: OperationDeclFull, ir: ServiceIRFull): Option[String] =
     ir.f match

--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -76,8 +76,8 @@ object Path:
       ir: ServiceIRFull
   ): String =
     val entity  = classificationTargetEntity(c)
-    val segment = entity.map(Naming.toPathSegment).getOrElse(Naming.toKebabCase(op.a))
     val opKebab = Naming.toKebabCase(op.a)
+    val segment = entity.map(Naming.toPathSegment).getOrElse(opKebab)
     val action  = extractActionVerb(op.a, entity)
     val idOpt   = findIdParam(op, ir)
     SpecRestGenerated.derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5615,6 +5615,12 @@ object SpecRestGenerated {
     case ParamDeclFull(uu, t, uv) => t
   }
 
+  def pathWithIdSuffix(segment: String, idParamOpt: Option[String]): String =
+    idParamOpt match {
+      case None       => "/" + segment
+      case Some(idNm) => "/" + segment + "/{" + idNm + "}"
+    }
+
   def isFailLoudStub(hasDafnyMethod: Boolean, effectiveKind: route_kind): Boolean =
     !hasDafnyMethod && isStubShape(effectiveKind)
 
@@ -7026,6 +7032,30 @@ object SpecRestGenerated {
                   sp
                 )
             }
+        }
+    }
+
+  def derivePathPattern(
+      knd: operation_kind,
+      segment: String,
+      idParamOpt: Option[String],
+      action: String,
+      opKebab: String
+  ): String =
+    knd match {
+      case Create()        => "/" + segment
+      case Read()          => pathWithIdSuffix(segment, idParamOpt)
+      case Replace()       => pathWithIdSuffix(segment, idParamOpt)
+      case PartialUpdate() => pathWithIdSuffix(segment, idParamOpt)
+      case Deletea()       => pathWithIdSuffix(segment, idParamOpt)
+      case CreateChild()   => "/" + segment
+      case FilteredRead()  => pathWithIdSuffix(segment, idParamOpt)
+      case SideEffect()    => "/" + opKebab
+      case BatchMutation() => "/" + segment + "/batch"
+      case Transition() =>
+        idParamOpt match {
+          case None       => "/" + segment + "/" + action
+          case Some(idNm) => "/" + segment + "/{" + idNm + "}/" + action
         }
     }
 

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -288,6 +288,8 @@ export_code
     defaultStatus
     resolveStatus
     resolveMethod
+    pathWithIdSuffix
+    derivePathPattern
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/Methods.thy
+++ b/proofs/isabelle/SpecRest/Methods.thy
@@ -68,6 +68,47 @@ definition resolveMethod :: "http_method option \<Rightarrow> http_method \<Righ
   "resolveMethod override fallback = (
     case override of Some m \<Rightarrow> m | None \<Rightarrow> fallback)"
 
+text \<open>URL-path template derivation. Mirrors \<open>Path.autoDerivePath\<close> when no
+  \<open>http_path\<close> convention override is set. Inputs come precomputed from
+  Scala because the segment / action / op-kebab values flow through
+  \<open>Naming.toKebabCase\<close>/\<open>toPathSegment\<close> (regex-driven, stays Scala-side):
+
+  \<^item> \<open>segment\<close>: entity kebab segment (or op kebab as fallback when no
+    target entity)
+  \<^item> \<open>idParamOpt\<close>: result of \<open>findIdParam\<close> — the URL-path placeholder
+    name for the resource id when one is required by the kind
+  \<^item> \<open>action\<close>: precomputed action verb (only consulted by Transition)
+  \<^item> \<open>opKebab\<close>: precomputed kebab-case op name (only consulted by
+    SideEffect)
+
+  The output is the URL-path template with \<open>{id}\<close>-style placeholders
+  inserted where the kind requires.\<close>
+
+definition pathWithIdSuffix ::
+  "String.literal \<Rightarrow> String.literal option \<Rightarrow> String.literal"
+where
+  "pathWithIdSuffix segment idParamOpt = (case idParamOpt of
+       None    \<Rightarrow> STR ''/'' + segment
+     | Some idNm \<Rightarrow> STR ''/'' + segment + STR ''/{'' + idNm + STR ''}'')"
+
+definition derivePathPattern ::
+  "operation_kind \<Rightarrow> String.literal \<Rightarrow> String.literal option \<Rightarrow>
+   String.literal \<Rightarrow> String.literal \<Rightarrow> String.literal"
+where
+  "derivePathPattern knd segment idParamOpt action opKebab = (case knd of
+       Create        \<Rightarrow> STR ''/'' + segment
+     | CreateChild   \<Rightarrow> STR ''/'' + segment
+     | BatchMutation \<Rightarrow> STR ''/'' + segment + STR ''/batch''
+     | SideEffect    \<Rightarrow> STR ''/'' + opKebab
+     | Transition    \<Rightarrow> (case idParamOpt of
+                           None    \<Rightarrow> STR ''/'' + segment + STR ''/'' + action
+                         | Some idNm \<Rightarrow> STR ''/'' + segment + STR ''/{'' + idNm + STR ''}/'' + action)
+     | Read          \<Rightarrow> pathWithIdSuffix segment idParamOpt
+     | FilteredRead  \<Rightarrow> pathWithIdSuffix segment idParamOpt
+     | Replace       \<Rightarrow> pathWithIdSuffix segment idParamOpt
+     | PartialUpdate \<Rightarrow> pathWithIdSuffix segment idParamOpt
+     | Delete        \<Rightarrow> pathWithIdSuffix segment idParamOpt)"
+
 lemmas parseHttpMethod_code [code]    = parseHttpMethod_def
 lemmas isGetMethod_code [code]        = isGetMethod.simps
 lemmas isDeleteMethod_code [code]     = isDeleteMethod.simps
@@ -76,5 +117,7 @@ lemmas isDeleteKind_code [code]       = isDeleteKind.simps
 lemmas defaultStatus_code [code]      = defaultStatus_def
 lemmas resolveStatus_code [code]      = resolveStatus_def
 lemmas resolveMethod_code [code]      = resolveMethod_def
+lemmas pathWithIdSuffix_code [code]   = pathWithIdSuffix_def
+lemmas derivePathPattern_code [code]  = derivePathPattern_def
 
 end


### PR DESCRIPTION
## Summary

\`Path.autoDerivePath\` is a 10-way decision over \`operation_kind\` that picks a URL-path template:
- \`Create\` / \`CreateChild\` → \`/segment\`
- \`Read\` / \`FilteredRead\` / \`Replace\` / \`PartialUpdate\` / \`Delete\` → \`/segment\` or \`/segment/{id}\` depending on \`findIdParam\`
- \`Transition\` → \`/segment/action\` or \`/segment/{id}/action\`
- \`BatchMutation\` → \`/segment/batch\`
- \`SideEffect\` → \`/op-kebab\`

The decision is pure shape selection over the kind; only the string inputs (\`segment\`, \`action\`, \`opKebab\`, \`idParam\`) need to be precomputed Scala-side because \`Naming.toKebabCase\` / \`toPathSegment\` are regex-driven.

This PR lifts the dispatcher into \`Methods.thy\` alongside the existing pattern-decisions (\`resolveStatus\`, \`resolveMethod\`, \`defaultStatus\`):

\`\`\`isabelle
pathWithIdSuffix  : literal => literal option => literal
derivePathPattern : operation_kind => literal => literal option
                 => literal => literal => literal
\`\`\`

\`Path.autoDerivePath\` precomputes the four string inputs and delegates to the lifted function. Drops ~22 lines of Scala-side match-case in favor of a single call.

## Test plan
- [x] \`isabelle build\` clean (~2 min)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff (output paths byte-identical)
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted URL path pattern derivation into the Isabelle layer and exported it to Scala, so `Path.autoDerivePath` now delegates to `SpecRestGenerated.derivePathPattern`. Also deduped `Naming.toKebabCase(op.a)` in `autoDerivePath` to avoid repeated work; behavior remains identical.

- **Refactors**
  - Added `derivePathPattern` and `pathWithIdSuffix` to `proofs/isabelle/SpecRest/Methods.thy`.
  - Exported both via `Codegen.thy` and generated implementations in `SpecRestGenerated.scala`.
  - Replaced ~22 lines of match-case in `specrest/convention/Path.scala` with a single call to `SpecRestGenerated.derivePathPattern`; kept `Naming.toKebabCase`/`toPathSegment` and `findIdParam` in Scala.
  - Deduped `Naming.toKebabCase(op.a)` by computing `opKebab` once and using it as the segment fallback.
  - No behavior change (paths are byte-identical).

<sup>Written for commit 8a8111872d01ac279fe9785a1daa9d119d93bf82. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/331?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved HTTP path pattern generation architecture for enhanced code maintainability and organization
  * Updated code generation capabilities to support improved path derivation functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->