### PR TITLE
feat(proofs): lift findIdParam + literalEndsWith

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -83,24 +83,7 @@ object Path:
     SpecRestGenerated.derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)
 
   private def findIdParam(op: OperationDeclFull, ir: ServiceIRFull): Option[String] =
-    ir.f match
-      case None => None
-      case Some(StateDeclFull(fs, _)) =>
-        val keyTypeNames = fs.iterator.collect {
-          case StateFieldDeclFull(_, RelationTypeF(from, _, _, _), _) => typeName(from)
-        }.flatten.toSet
-        op.b.iterator
-          .collect { case ParamDeclFull(name, ty, _) => (name, ty) }
-          .map { case (name, ty) =>
-            typeName(ty) match
-              case Some(n) if keyTypeNames.contains(n) => Some(name)
-              case _ =>
-                ty match
-                  case NamedTypeF("Int", _) if name == "id" || name.endsWith("_id") =>
-                    Some(name)
-                  case _ => None
-          }
-          .collectFirst { case Some(name) => name }
+    SpecRestGenerated.findIdParam(op.b, ir.f)
 
   private def extractActionVerb(opName: String, entityName: Option[String]): String =
     entityName match

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -117,6 +117,9 @@ object SpecRestGenerated {
         val `SpecRestGenerated.equal` =
           (a: foreign_key_spec, b: foreign_key_spec) => equal_foreign_key_speca(a, b)
       }
+    implicit def `SpecRestGenerated.equal_integer`: equal[BigInt] = new equal[BigInt] {
+      val `SpecRestGenerated.equal` = (a: BigInt, b: BigInt) => a == b
+    }
     implicit def `SpecRestGenerated.equal_trigger_spec`: equal[trigger_spec] =
       new equal[trigger_spec] {
         val `SpecRestGenerated.equal` = (a: trigger_spec, b: trigger_spec) =>
@@ -1041,6 +1044,23 @@ object SpecRestGenerated {
     case IdentifierF(wo, sp)               => sp
   }
 
+  def minus_nat(m: nat, n: nat): nat =
+    Nata(max[BigInt](BigInt(0), integer_of_nat(m) - integer_of_nat(n)))
+
+  def equal_nat(m: nat, n: nat): Boolean =
+    integer_of_nat(m) == integer_of_nat(n)
+
+  def zero_nat: nat = Nata(BigInt(0))
+
+  def drop[A](n: nat, x1: List[A]): List[A] = (n, x1) match {
+    case (n, Nil) => Nil
+    case (n, x :: xs) =>
+      equal_nat(n, zero_nat) match {
+        case true  => x :: xs
+        case false => drop[A](minus_nat(n, one_nat), xs)
+      }
+  }
+
   def find[A](uu: A => Boolean, x1: List[A]): Option[A] = (uu, x1) match {
     case (uu, Nil) => None
     case (p, x :: xs) =>
@@ -1224,8 +1244,6 @@ object SpecRestGenerated {
     map_of[String, List[String]](sm_sort_members[Unit](m), sort_name)
 
   def uminus_int(k: int): int = int_of_integer(-integer_of_int(k))
-
-  def zero_nat: nat = Nata(BigInt(0))
 
   def length_tailrec[A](x0: List[A], n: nat): nat = (x0, n) match {
     case (Nil, n)     => n
@@ -3745,9 +3763,6 @@ object SpecRestGenerated {
     case (p, x :: xs) => p(x) && list_all[A](p, xs)
   }
 
-  def equal_nat(m: nat, n: nat): Boolean =
-    integer_of_nat(m) == integer_of_nat(n)
-
   def isRedirectStatus(s: int): Boolean =
     equal_int(s, int_of_integer(BigInt(301))) ||
       (equal_int(s, int_of_integer(BigInt(302))) ||
@@ -4369,9 +4384,6 @@ object SpecRestGenerated {
       case IdentifierF(_, _)             => None
     }
 
-  def minus_nat(m: nat, n: nat): nat =
-    Nata(max[BigInt](BigInt(0), integer_of_nat(m) - integer_of_nat(n)))
-
   def entityParentFull(x0: entity_decl_full): Option[String] = x0 match {
     case EntityDeclFull(uu, p, uv, uw, ux) => p
   }
@@ -4943,6 +4955,82 @@ object SpecRestGenerated {
   def downList(ops: List[migration_op]): List[migration_op] =
     rev[migration_op](map[migration_op, migration_op]((a: migration_op) => inverseOp(a), ops))
 
+  def stateRelationKeyTypeNamesAux(x0: List[state_field_decl_full]): List[String] =
+    x0 match {
+      case Nil => Nil
+      case sf :: rest =>
+        sf match {
+          case StateFieldDeclFull(_, NamedTypeF(_, _), _) =>
+            stateRelationKeyTypeNamesAux(rest)
+          case StateFieldDeclFull(_, SetTypeF(_, _), _) =>
+            stateRelationKeyTypeNamesAux(rest)
+          case StateFieldDeclFull(_, MapTypeF(_, _, _), _) =>
+            stateRelationKeyTypeNamesAux(rest)
+          case StateFieldDeclFull(_, SeqTypeF(_, _), _) =>
+            stateRelationKeyTypeNamesAux(rest)
+          case StateFieldDeclFull(_, OptionTypeF(_, _), _) =>
+            stateRelationKeyTypeNamesAux(rest)
+          case StateFieldDeclFull(_, RelationTypeF(frm, _, _, _), _) =>
+            typeName(frm) match {
+              case None    => stateRelationKeyTypeNamesAux(rest)
+              case Some(n) => n :: stateRelationKeyTypeNamesAux(rest)
+            }
+        }
+    }
+
+  def stateRelationKeyTypeNames(stateOpt: Option[state_decl_full]): List[String] =
+    stateOpt match {
+      case None                       => Nil
+      case Some(StateDeclFull(fs, _)) => stateRelationKeyTypeNamesAux(fs)
+    }
+
+  def less_eq_nat(m: nat, n: nat): Boolean =
+    integer_of_nat(m) <= integer_of_nat(n)
+
+  def literalEndsWith(suf: String, s: String): Boolean = {
+    val xs = Str_Literal.asciisOfLiteral(s): List[BigInt]
+    val ys = Str_Literal.asciisOfLiteral(suf): List[BigInt];
+    less_eq_nat(size_list[BigInt](ys), size_list[BigInt](xs)) &&
+    equal_list[BigInt](
+      drop[BigInt](minus_nat(size_list[BigInt](xs), size_list[BigInt](ys)), xs),
+      ys
+    )
+  }
+
+  def paramNameLooksLikeId(name: String): Boolean =
+    name == "id" || literalEndsWith("_id", name)
+
+  def paramTypeIsInt(x0: type_expr_full): Boolean = x0 match {
+    case NamedTypeF(n, uu)            => n == "Int"
+    case SetTypeF(v, va)              => false
+    case MapTypeF(v, va, vb)          => false
+    case SeqTypeF(v, va)              => false
+    case OptionTypeF(v, va)           => false
+    case RelationTypeF(v, va, vb, vc) => false
+  }
+
+  def findIdParamAux(uu: List[String], x1: List[param_decl_full]): Option[String] =
+    (uu, x1) match {
+      case (uu, Nil) => None
+      case (keys, ParamDeclFull(name, ty, uv) :: rest) =>
+        val matchesKey = (typeName(ty) match {
+          case None    => false
+          case Some(a) => membera[String](keys, a)
+        }): Boolean
+        val matchesNameRule =
+          paramTypeIsInt(ty) && paramNameLooksLikeId(name): Boolean;
+        matchesKey || matchesNameRule match {
+          case true  => Some[String](name)
+          case false => findIdParamAux(keys, rest)
+        }
+    }
+
+  def findIdParam(
+      params: List[param_decl_full],
+      stateOpt: Option[state_decl_full]
+  ): Option[String] =
+    findIdParamAux(stateRelationKeyTypeNames(stateOpt), params)
+
   def isStubShape(x0: route_kind): Boolean = x0 match {
     case RkRedirect() => true
     case RkOther()    => true
@@ -5403,9 +5491,6 @@ object SpecRestGenerated {
   def signalsWithFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, w, uz, va, vb) => w
   }
-
-  def less_eq_nat(m: nat, n: nat): Boolean =
-    integer_of_nat(m) <= integer_of_nat(n)
 
   def decidePutPatch(
       signals: analysis_signals,

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5029,7 +5029,10 @@ object SpecRestGenerated {
       params: List[param_decl_full],
       stateOpt: Option[state_decl_full]
   ): Option[String] =
-    findIdParamAux(stateRelationKeyTypeNames(stateOpt), params)
+    stateOpt match {
+      case None    => None
+      case Some(_) => findIdParamAux(stateRelationKeyTypeNames(stateOpt), params)
+    }
 
   def isStubShape(x0: route_kind): Boolean = x0 match {
     case RkRedirect() => true

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -17,6 +17,7 @@ theory Codegen
     OpenApiConstraints
     ValidateConventions
     ParseTemporal
+    ParsePath
     Classify
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
@@ -290,6 +291,11 @@ export_code
     resolveMethod
     pathWithIdSuffix
     derivePathPattern
+    literalEndsWith
+    paramTypeIsInt
+    paramNameLooksLikeId
+    stateRelationKeyTypeNames
+    findIdParam
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/ParsePath.thy
+++ b/proofs/isabelle/SpecRest/ParsePath.thy
@@ -1,0 +1,83 @@
+theory ParsePath
+  imports IR_Helpers Methods
+begin
+
+text \<open>Pure path-derivation helpers used by \<open>Path.autoDerivePath\<close>:
+  picking the URL-path id parameter from an operation's inputs.
+
+  The path-segment composition itself is \<open>derivePathPattern\<close> in
+  \<open>Methods\<close>; this theory adds the input-list selection rule.\<close>
+
+text \<open>\<open>literalEndsWith suf s\<close>: \<open>True\<close> when \<open>suf\<close> is a (possibly equal,
+  possibly empty) tail of \<open>s\<close>. Mirrors Scala's \<open>String.endsWith\<close> on
+  ASCII strings.\<close>
+
+definition literalEndsWith :: "String.literal \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "literalEndsWith suf s =
+     (let xs = String.asciis_of_literal s; ys = String.asciis_of_literal suf
+      in length ys \<le> length xs \<and> drop (length xs - length ys) xs = ys)"
+
+text \<open>State-relation key types: the named types reachable by following
+  the \<open>from\<close> column of every \<open>RelationTypeF\<close> in the state fields.
+  Operation inputs whose declared type matches one of these names are
+  presumed to be primary-key references and become \<open>{id}\<close> placeholders
+  in the URL path.\<close>
+
+primrec stateRelationKeyTypeNamesAux ::
+  "state_field_decl_full list \<Rightarrow> String.literal list"
+where
+  "stateRelationKeyTypeNamesAux [] = []"
+| "stateRelationKeyTypeNamesAux (sf # rest) = (case sf of
+       StateFieldDeclFull _ (RelationTypeF frm _ _ _) _ \<Rightarrow>
+         (case typeName frm of
+            None   \<Rightarrow> stateRelationKeyTypeNamesAux rest
+          | Some n \<Rightarrow> n # stateRelationKeyTypeNamesAux rest)
+     | _ \<Rightarrow> stateRelationKeyTypeNamesAux rest)"
+
+definition stateRelationKeyTypeNames ::
+  "state_decl_full option \<Rightarrow> String.literal list"
+where
+  "stateRelationKeyTypeNames stateOpt = (case stateOpt of
+       None \<Rightarrow> []
+     | Some (StateDeclFull fs _) \<Rightarrow> stateRelationKeyTypeNamesAux fs)"
+
+text \<open>A parameter "looks like" an integer id when its type is the bare
+  \<open>NamedTypeF "Int"\<close> and its name is either exactly \<open>id\<close> or ends with
+  the \<open>_id\<close> suffix. Mirrors the legacy heuristic in \<open>Path.findIdParam\<close>
+  used as a fallback when no state relation type matches.\<close>
+
+fun paramTypeIsInt :: "type_expr_full \<Rightarrow> bool" where
+  "paramTypeIsInt (NamedTypeF n _) = (n = STR ''Int'')"
+| "paramTypeIsInt _ = False"
+
+definition paramNameLooksLikeId :: "String.literal \<Rightarrow> bool" where
+  "paramNameLooksLikeId name =
+     (name = STR ''id'' \<or> literalEndsWith (STR ''_id'') name)"
+
+fun findIdParamAux ::
+  "String.literal list \<Rightarrow> param_decl_full list \<Rightarrow> String.literal option"
+where
+  "findIdParamAux _ [] = None"
+| "findIdParamAux keys (ParamDeclFull name ty _ # rest) =
+     (let matchesKey = (case typeName ty of
+                          None \<Rightarrow> False
+                        | Some n \<Rightarrow> List.member keys n);
+          matchesNameRule = paramTypeIsInt ty \<and> paramNameLooksLikeId name
+      in if matchesKey \<or> matchesNameRule then Some name
+         else findIdParamAux keys rest)"
+
+definition findIdParam ::
+  "param_decl_full list \<Rightarrow> state_decl_full option \<Rightarrow> String.literal option"
+where
+  "findIdParam params stateOpt =
+     findIdParamAux (stateRelationKeyTypeNames stateOpt) params"
+
+lemmas literalEndsWith_code [code]            = literalEndsWith_def
+lemmas stateRelationKeyTypeNamesAux_code [code] = stateRelationKeyTypeNamesAux.simps
+lemmas stateRelationKeyTypeNames_code [code]  = stateRelationKeyTypeNames_def
+lemmas paramTypeIsInt_code [code]             = paramTypeIsInt.simps
+lemmas paramNameLooksLikeId_code [code]       = paramNameLooksLikeId_def
+lemmas findIdParamAux_code [code]             = findIdParamAux.simps
+lemmas findIdParam_code [code]                = findIdParam_def
+
+end

--- a/proofs/isabelle/SpecRest/ParsePath.thy
+++ b/proofs/isabelle/SpecRest/ParsePath.thy
@@ -43,8 +43,11 @@ where
 
 text \<open>A parameter "looks like" an integer id when its type is the bare
   \<open>NamedTypeF "Int"\<close> and its name is either exactly \<open>id\<close> or ends with
-  the \<open>_id\<close> suffix. Mirrors the legacy heuristic in \<open>Path.findIdParam\<close>
-  used as a fallback when no state relation type matches.\<close>
+  the \<open>_id\<close> suffix. Per-parameter OR with the state-relation-key check;
+  iteration order across the param list decides ties — first-match wins,
+  matching the legacy Scala iterator + \<open>collectFirst\<close> semantics. (So an
+  earlier param's \<open>Int id\<close> heuristic match can preempt a later param's
+  state-relation match — this is intentional, not a regression.)\<close>
 
 fun paramTypeIsInt :: "type_expr_full \<Rightarrow> bool" where
   "paramTypeIsInt (NamedTypeF n _) = (n = STR ''Int'')"
@@ -66,11 +69,18 @@ where
       in if matchesKey \<or> matchesNameRule then Some name
          else findIdParamAux keys rest)"
 
+text \<open>Operations with no \<open>state\<close> block declared can never have a
+  meaningful \<open>{id}\<close>-style URL placeholder — there's no entity to look
+  up. Short-circuit \<open>None\<close> at the state level so the \<open>id\<close>/\<open>_id\<close>
+  heuristic only fires when at least one state field exists. Mirrors
+  the original Scala's \<open>ir.f match \<dots> case None \<Rightarrow> None\<close>.\<close>
+
 definition findIdParam ::
   "param_decl_full list \<Rightarrow> state_decl_full option \<Rightarrow> String.literal option"
 where
-  "findIdParam params stateOpt =
-     findIdParamAux (stateRelationKeyTypeNames stateOpt) params"
+  "findIdParam params stateOpt = (case stateOpt of
+       None \<Rightarrow> None
+     | Some _ \<Rightarrow> findIdParamAux (stateRelationKeyTypeNames stateOpt) params)"
 
 lemmas literalEndsWith_code [code]            = literalEndsWith_def
 lemmas stateRelationKeyTypeNamesAux_code [code] = stateRelationKeyTypeNamesAux.simps

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -26,5 +26,6 @@ session SpecRest = HOL +
     OpenApiConstraints
     ValidateConventions
     ParseTemporal
+    ParsePath
     Classify
     Codegen


### PR DESCRIPTION
## Summary

\`Path.findIdParam\` is the IR-walking helper that picks which input parameter becomes the URL-path \`{id}\` placeholder for an operation. Two rules:

1. **State-relation match**: input type matches a state-relation key type — i.e. the entity referenced by some state field's \`RelationTypeF.from\`.
2. **Heuristic fallback**: type is the bare \`NamedTypeF("Int")\` AND name is either \`"id"\` or ends with \`"_id"\`.

19 lines of iterator-collect-flatmap-collectFirst. Pure IR walk, no effects.

This PR lifts it into a new theory \`ParsePath.thy\` (imports \`IR_Helpers\` + \`Methods\`), broken into reusable pieces:

\`\`\`isabelle
literalEndsWith            : literal => literal => bool
stateRelationKeyTypeNames  : state_decl_full option => literal list
paramTypeIsInt             : type_expr_full => bool
paramNameLooksLikeId       : literal => bool
findIdParam                : param_decl_full list
                          => state_decl_full option
                          => literal option
\`\`\`

\`literalEndsWith\` mirrors the existing \`literalStartsWithSlash\` predicate (\`asciis_of_literal\` + \`drop\`) — other Path-related lifts may want it.

\`Path.findIdParam\` shrinks from 19 lines to a one-line delegating call.

## Test plan
- [x] \`isabelle build\` clean (1:50)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff (output paths byte-identical)
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted URL-path id selection into a new proofs theory `ParsePath.thy` and generated reusable helpers, reducing `Path.findIdParam` to a single delegating call with no behavior changes. Also fixed a regression by short-circuiting when no state is declared, preserving stateless service paths.

- **New Features**
  - Added `ParsePath.thy` with `literalEndsWith`, `stateRelationKeyTypeNames`, `paramTypeIsInt`, `paramNameLooksLikeId`, and `findIdParam`.
  - Exported to Scala; available via `SpecRestGenerated.findIdParam` and helpers.

- **Bug Fixes**
  - Restored short-circuit in `findIdParam` when `stateOpt` is `None`, so the `Int` + `id`/`_id` heuristic only runs when a state block exists (prevents `/segment/{id}` on stateless services).
  - Clarified docs on first-match OR semantics to reflect legacy behavior.

<sup>Written for commit a0d9137b56a7f45198763aaadeb8e76f6660d3a0. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/332?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved URL path parameter detection for ID placeholders. The system now uses enhanced heuristics to better identify operation parameters that should map to `{id}` path segments by analyzing parameter types, names, and state relation information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->