### PR TITLE
feat(proofs): lift extractVerbBeforeKebab + literal slice helpers

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -86,16 +86,7 @@ object Path:
     SpecRestGenerated.findIdParam(op.b, ir.f)
 
   private def extractActionVerb(opName: String, entityName: Option[String]): String =
-    entityName match
-      case None => Naming.toKebabCase(opName)
-      case Some(en) =>
-        if opName.endsWith(en) then
-          val verb = opName.dropRight(en.length)
-          if verb.nonEmpty then Naming.toKebabCase(verb) else Naming.toKebabCase(opName)
-        else if opName.startsWith(en) then
-          val verb = opName.drop(en.length)
-          if verb.nonEmpty then Naming.toKebabCase(verb) else Naming.toKebabCase(opName)
-        else Naming.toKebabCase(opName)
+    Naming.toKebabCase(SpecRestGenerated.extractVerbBeforeKebab(opName, entityName))
 
   private val PathParamRegex = """\{(\w+)\}""".r
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -1080,6 +1080,15 @@ object SpecRestGenerated {
     case x :: xs => false
   }
 
+  def take[A](n: nat, x1: List[A]): List[A] = (n, x1) match {
+    case (n, Nil) => Nil
+    case (n, x :: xs) =>
+      equal_nat(n, zero_nat) match {
+        case true  => Nil
+        case false => x :: take[A](minus_nat(n, one_nat), xs)
+      }
+  }
+
   def foldl[A, B](f: A => B => A, a: A, x2: List[B]): A = (f, a, x2) match {
     case (f, a, Nil)     => a
     case (f, a, x :: xs) => foldl[A, B](f, f(a)(x), xs)
@@ -5680,6 +5689,9 @@ object SpecRestGenerated {
         }
     }
 
+  def literalLength(s: String): nat =
+    size_list[BigInt](Str_Literal.asciisOfLiteral(s))
+
   def power[A: power](a: A, n: nat): A =
     equal_nat(n, zero_nat) match {
       case true  => one[A]
@@ -7149,6 +7161,9 @@ object SpecRestGenerated {
 
   def less_nat(m: nat, n: nat): Boolean = integer_of_nat(m) < integer_of_nat(n)
 
+  def literalDropLeft(n: nat, s: String): String =
+    Str_Literal.literalOfAsciis(drop[BigInt](n, Str_Literal.asciisOfLiteral(s)))
+
   def temporalArg(x0: temporal_body): expr_full = x0 match {
     case TbAlways(e)     => e
     case TbEventually(e) => e
@@ -7825,6 +7840,11 @@ object SpecRestGenerated {
       digitsRev(n)
     )))
 
+  def literalDropRight(n: nat, s: String): String = {
+    val xs = Str_Literal.asciisOfLiteral(s): List[BigInt];
+    Str_Literal.literalOfAsciis(take[BigInt](minus_nat(size_list[BigInt](xs), n), xs))
+  }
+
   def triggerFunctionName(x0: trigger_spec): String = x0 match {
     case TriggerSpec(uu, fn, uv, uw, ux, uy, uz, va) => fn
   }
@@ -8042,6 +8062,13 @@ object SpecRestGenerated {
 
   def freshKey(base: String, seen: List[String]): String =
     freshKeyAux(Suc(size_list[String](seen)), base, seen, zero_nat)
+
+  def literalStartsWith(pre: String, s: String): Boolean = {
+    val xs = Str_Literal.asciisOfLiteral(s): List[BigInt]
+    val ys = Str_Literal.asciisOfLiteral(pre): List[BigInt];
+    less_eq_nat(size_list[BigInt](ys), size_list[BigInt](xs)) &&
+    equal_list[BigInt](take[BigInt](size_list[BigInt](ys), xs), ys)
+  }
 
   def signalsHasCollectionInput(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, uz, va, vb, h) => h
@@ -9506,6 +9533,30 @@ object SpecRestGenerated {
     (v, x1) match {
       case (v, OpenApiBounds(uu, ml, mn, mx, emn, emx, p)) =>
         OpenApiBounds(v, ml, mn, mx, emn, emx, p)
+    }
+
+  def extractVerbBeforeKebab(opName: String, entityOpt: Option[String]): String =
+    entityOpt match {
+      case None => opName
+      case Some(en) =>
+        literalEndsWith(en, opName) match {
+          case true =>
+            val verb =
+              literalDropRight(literalLength(en), opName): String;
+            equal_nat(literalLength(verb), zero_nat) match {
+              case true  => opName
+              case false => verb
+            }
+          case false => literalStartsWith(en, opName) match {
+              case true =>
+                val verb = literalDropLeft(literalLength(en), opName): String;
+                equal_nat(literalLength(verb), zero_nat) match {
+                  case true  => opName
+                  case false => verb
+                }
+              case false => opName
+            }
+        }
     }
 
   def decodeAggregateCall(call: expr_full): Option[aggregate_call] =

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -296,6 +296,11 @@ export_code
     paramNameLooksLikeId
     stateRelationKeyTypeNames
     findIdParam
+    literalLength
+    literalStartsWith
+    literalDropLeft
+    literalDropRight
+    extractVerbBeforeKebab
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/ParsePath.thy
+++ b/proofs/isabelle/SpecRest/ParsePath.thy
@@ -105,7 +105,7 @@ definition literalDropRight :: "nat \<Rightarrow> String.literal \<Rightarrow> S
       in String.literal_of_asciis (take (length xs - n) xs))"
 
 text \<open>Extract the verb portion of an operation name before Scala feeds
-  it to \<open>Naming.toKebabCase\<close>. Three outcomes:
+  it to \<open>Naming.toKebabCase\<close>. Four outcomes:
 
   \<^enum> entity unknown \<Rightarrow> return the whole op name
   \<^enum> op name ends with entity name and the prefix verb is non-empty

--- a/proofs/isabelle/SpecRest/ParsePath.thy
+++ b/proofs/isabelle/SpecRest/ParsePath.thy
@@ -82,6 +82,56 @@ where
        None \<Rightarrow> None
      | Some _ \<Rightarrow> findIdParamAux (stateRelationKeyTypeNames stateOpt) params)"
 
+text \<open>General \<open>literalStartsWith\<close> / \<open>literalLength\<close> / \<open>literalDropLeft\<close>
+  / \<open>literalDropRight\<close>. Same shape as \<open>literalEndsWith\<close> above — operate
+  on the ASCII octet list. Used by \<open>extractVerbBeforeKebab\<close>; kept
+  general so other Path-related helpers can reuse them.\<close>
+
+definition literalLength :: "String.literal \<Rightarrow> nat" where
+  "literalLength s = length (String.asciis_of_literal s)"
+
+definition literalStartsWith :: "String.literal \<Rightarrow> String.literal \<Rightarrow> bool" where
+  "literalStartsWith pre s =
+     (let xs = String.asciis_of_literal s; ys = String.asciis_of_literal pre
+      in length ys \<le> length xs \<and> take (length ys) xs = ys)"
+
+definition literalDropLeft :: "nat \<Rightarrow> String.literal \<Rightarrow> String.literal" where
+  "literalDropLeft n s =
+     String.literal_of_asciis (drop n (String.asciis_of_literal s))"
+
+definition literalDropRight :: "nat \<Rightarrow> String.literal \<Rightarrow> String.literal" where
+  "literalDropRight n s =
+     (let xs = String.asciis_of_literal s
+      in String.literal_of_asciis (take (length xs - n) xs))"
+
+text \<open>Extract the verb portion of an operation name before Scala feeds
+  it to \<open>Naming.toKebabCase\<close>. Three outcomes:
+
+  \<^enum> entity unknown \<Rightarrow> return the whole op name
+  \<^enum> op name ends with entity name and the prefix verb is non-empty
+    \<Rightarrow> drop the suffix, return the prefix
+  \<^enum> op name starts with entity name and the trailing verb is non-empty
+    \<Rightarrow> drop the prefix, return the trailing verb
+  \<^enum> otherwise (no affix match, or the verb would collapse to empty)
+    \<Rightarrow> fall back to the whole op name
+
+  The Scala caller wraps the result in \<open>Naming.toKebabCase\<close>; the kebab
+  conversion itself is regex-driven and stays Scala-side.\<close>
+
+definition extractVerbBeforeKebab ::
+  "String.literal \<Rightarrow> String.literal option \<Rightarrow> String.literal"
+where
+  "extractVerbBeforeKebab opName entityOpt = (case entityOpt of
+       None    \<Rightarrow> opName
+     | Some en \<Rightarrow>
+         if literalEndsWith en opName then
+           let verb = literalDropRight (literalLength en) opName
+           in if literalLength verb = 0 then opName else verb
+         else if literalStartsWith en opName then
+           let verb = literalDropLeft (literalLength en) opName
+           in if literalLength verb = 0 then opName else verb
+         else opName)"
+
 lemmas literalEndsWith_code [code]            = literalEndsWith_def
 lemmas stateRelationKeyTypeNamesAux_code [code] = stateRelationKeyTypeNamesAux.simps
 lemmas stateRelationKeyTypeNames_code [code]  = stateRelationKeyTypeNames_def
@@ -89,5 +139,10 @@ lemmas paramTypeIsInt_code [code]             = paramTypeIsInt.simps
 lemmas paramNameLooksLikeId_code [code]       = paramNameLooksLikeId_def
 lemmas findIdParamAux_code [code]             = findIdParamAux.simps
 lemmas findIdParam_code [code]                = findIdParam_def
+lemmas literalLength_code [code]              = literalLength_def
+lemmas literalStartsWith_code [code]          = literalStartsWith_def
+lemmas literalDropLeft_code [code]            = literalDropLeft_def
+lemmas literalDropRight_code [code]           = literalDropRight_def
+lemmas extractVerbBeforeKebab_code [code]     = extractVerbBeforeKebab_def
 
 end


### PR DESCRIPTION
## Summary

\`Path.extractActionVerb\` does two things: it picks a "verb" substring out of the operation name (strip entity suffix or prefix where it matches, else use the whole name), then feeds the result to \`Naming.toKebabCase\`. The substring-selection is a pure 4-way decision over a string; the kebab-case step is regex-driven and stays Scala.

This PR lifts the selection into \`ParsePath.thy\`. Adds reusable literal-slice helpers (same \`asciis_of_literal\` pattern as the existing \`literalEndsWith\`):

\`\`\`isabelle
literalLength     : literal => nat
literalStartsWith : literal => literal => bool
literalDropLeft   : nat => literal => literal
literalDropRight  : nat => literal => literal

extractVerbBeforeKebab : literal => literal option => literal
  None                                            -> whole op name
  Some en, ends-with en + prefix non-empty        -> prefix
  Some en, starts-with en + trailing non-empty    -> trailing
  otherwise                                       -> whole op name
\`\`\`

\`Path.extractActionVerb\` shrinks from 9 lines of conditional kebab calls to one delegating call wrapped in \`Naming.toKebabCase\`.

## After this PR
Path.scala has no remaining **structural decisions** in Scala — every dispatch (HTTP method, status, URL template, id-param, action-verb extraction) goes through a lifted function. What's left is just the typed-sum decoder (\`getConvention\` / \`parsedValueToString\`) and light orchestration.

## Test plan
- [x] \`isabelle build\` clean (~1:50)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved action verb extraction into Isabelle to centralize path parsing and simplify Scala. Added literal slice helpers; `Path.extractActionVerb` now delegates to `SpecRestGenerated.extractVerbBeforeKebab` before `Naming.toKebabCase`.

- **Refactors**
  - Implemented `extractVerbBeforeKebab` in `ParsePath.thy` and exported via `SpecRestGenerated`.
  - Added helpers: `literalLength`, `literalStartsWith`, `literalDropLeft`, `literalDropRight`.
  - Replaced conditional logic in `Path.scala` with a single delegation + kebab-case.
  - Corrected `extractVerbBeforeKebab` docstring to list four outcomes.
  - `Path.scala` now has no structural decisions; all dispatch is lifted. No behavior change.

<sup>Written for commit e10fb08deee74d99db8ffecc196645d5658c0036. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

