### PR TITLE
feat(proofs): lift validateIrContext (Validate.scala)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -213,35 +213,20 @@ object Validate:
       ir: ServiceIRFull,
       diagnostics: DiagBuilder
   ): Unit =
-    rule.b match
-      case "partial_index" =>
-        rule.c.foreach: field =>
-          val entityMatch = entityByName(ir.c, rule.a)
-          if entityMatch.isDefined && !entityHasField(ir.c, rule.a, field) then
-            err(
-              rule,
-              s"""${rule.a}.partial_index "$field" — no field named '$field' on entity '${rule.a}'""",
-              diagnostics
-            )
-      case "test_strategy" =>
-        rule.c.foreach: field =>
-          val opMatch     = ir.g.collectFirst { case o: OperationDeclFull if o.a == rule.a => o }
-          val entityMatch = entityByName(ir.c, rule.a)
-          val knownField =
-            opMatch.exists(_.b.exists { case ParamDeclFull(n, _, _) => n == field }) ||
-              entityHasField(ir.c, rule.a, field)
-          if !knownField then
-            val targetKind =
-              if opMatch.isDefined then "operation"
-              else if entityMatch.isDefined then "entity"
-              else "target"
-            err(
-              rule,
-              s"""${rule.a}.test_strategy "$field" — no field named '$field' on $targetKind '${rule
-                  .a}'""",
-              diagnostics
-            )
-      case _ => ()
+    val ops = ir.g.collect { case o: OperationDeclFull => o }
+    validateIrContextRule(rule, ir.c, ops).foreach:
+      case PartialIndexFieldMissing(target, field) =>
+        err(
+          rule,
+          s"""$target.partial_index "$field" — no field named '$field' on entity '$target'""",
+          diagnostics
+        )
+      case TestStrategyFieldMissing(target, field, kind) =>
+        err(
+          rule,
+          s"""$target.test_strategy "$field" — no field named '$field' on $kind '$target'""",
+          diagnostics
+        )
 
   private def detectEntityFieldCollisions(
       rules: List[convention_rule_full],

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -213,8 +213,7 @@ object Validate:
       ir: ServiceIRFull,
       diagnostics: DiagBuilder
   ): Unit =
-    val ops = ir.g.collect { case o: OperationDeclFull => o }
-    validateIrContextRule(rule, ir.c, ops).foreach:
+    validateIrContextRule(rule, ir.c, ir.g).foreach:
       case PartialIndexFieldMissing(target, field) =>
         err(
           rule,

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -982,6 +982,11 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
+  sealed abstract class convention_ir_diagnostic
+  final case class PartialIndexFieldMissing(a: String, b: String) extends convention_ir_diagnostic
+  final case class TestStrategyFieldMissing(a: String, b: String, c: String)
+      extends convention_ir_diagnostic
+
   def max[A: ord](a: A, b: A): A =
     less_eq[A](a, b) match {
       case true  => b
@@ -2822,6 +2827,11 @@ object SpecRestGenerated {
         case Some(basea) => lower_with_assigns(enums, updates, basea, sp)
       }
     case (enums, SetLiteralF(elems, sp)) => lowerSetList(enums, elems, sp)
+  }
+
+  def is_none[A](x0: Option[A]): Boolean = x0 match {
+    case None    => true
+    case Some(x) => false
   }
 
   def rt_relations[A](x0: state_ext[A]): List[(String, List[ir_value])] = x0 match {
@@ -10402,6 +10412,16 @@ object SpecRestGenerated {
   ): Option[List[String]] =
     findEnumValuesInTypeAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, em, Nil)
 
+  def paramListHasName(x0: List[param_decl_full], uu: String): Boolean =
+    (x0, uu) match {
+      case (Nil, uu) => false
+      case (ParamDeclFull(pn, uv, uw) :: rest, nm) =>
+        pn == nm match {
+          case true  => true
+          case false => paramListHasName(rest, nm)
+        }
+    }
+
   def buildOperationClassification(
       name: String,
       targetEntity: Option[String],
@@ -10541,6 +10561,16 @@ object SpecRestGenerated {
   def signalsTargetEntityFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
   }
+
+  def findOperationByName(x0: List[operation_decl_full], uu: String): Option[operation_decl_full] =
+    (x0, uu) match {
+      case (Nil, uu) => None
+      case (OperationDeclFull(n, a, b, c, d, e) :: rest, nm) =>
+        n == nm match {
+          case true  => Some[operation_decl_full](OperationDeclFull(n, a, b, c, d, e))
+          case false => findOperationByName(rest, nm)
+        }
+    }
 
   def parseTestStrategyPv(e: expr_full): convention_value =
     asStringLit(e) match {
@@ -10689,5 +10719,58 @@ object SpecRestGenerated {
       bounds,
       flattenAnd(e)
     )
+
+  def operationHasParamNamed(x0: operation_decl_full, nm: String): Boolean =
+    (x0, nm) match {
+      case (OperationDeclFull(uu, inputs, uv, uw, ux, uy), nm) =>
+        paramListHasName(inputs, nm)
+    }
+
+  def validateIrContextRule(
+      x0: convention_rule_full,
+      entities: List[entity_decl_full],
+      ops: List[operation_decl_full]
+  ): List[convention_ir_diagnostic] =
+    (x0, entities, ops) match {
+      case (ConventionRuleFull(target, prop, qualOpt, uu, uv), entities, ops) =>
+        qualOpt match {
+          case None => Nil
+          case Some(field) =>
+            prop == "partial_index" match {
+              case true => entityByName(entities, target) match {
+                  case None => Nil
+                  case Some(_) =>
+                    entityHasField(entities, target, field) match {
+                      case true  => Nil
+                      case false => List(PartialIndexFieldMissing(target, field))
+                    }
+                }
+              case false => prop == "test_strategy" match {
+                  case true =>
+                    val opMatch     = findOperationByName(ops, target): Option[operation_decl_full]
+                    val entityMatch = entityByName(entities, target): Option[entity_decl_full]
+                    val inParams =
+                      (opMatch match {
+                        case None     => false
+                        case Some(op) => operationHasParamNamed(op, field)
+                      }): Boolean
+                    val inEntity = entityHasField(entities, target, field): Boolean
+                    val targetKind =
+                      (!is_none[operation_decl_full](opMatch) match {
+                        case true => "operation"
+                        case false => !is_none[entity_decl_full](entityMatch) match {
+                            case true  => "entity"
+                            case false => "target"
+                          }
+                      }): String;
+                    inParams || inEntity match {
+                      case true  => Nil
+                      case false => List(TestStrategyFieldMissing(target, field, targetKind))
+                    }
+                  case false => Nil
+                }
+            }
+        }
+    }
 
 } /* object SpecRestGenerated */

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -257,6 +257,9 @@ export_code
     extractPartialIndexRules
     appendPartialIndexes
     parseConventionValue
+    findOperationByName
+    operationHasParamNamed
+    validateIrContextRule
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/ValidateConventions.thy
@@ -155,6 +155,72 @@ where
       else if prop = STR ''strategy''            then parseStrategyPv e
       else CvUnknown e)"
 
+text \<open>IR-context validation for individual convention rules. Two
+  diagnostics: partial_index references a non-existent entity field;
+  test_strategy references a non-existent operation-input / entity
+  field. The cross-cutting collection bookkeeping (rule iteration,
+  diagnostic span tracking) stays in Scala; this function takes one
+  rule + the IR-context lookups and emits the typed diagnostics for
+  Scala to format and accumulate.
+
+  Mirrors the legacy \<open>Validate.validateIrContext\<close> branch logic.\<close>
+
+datatype convention_ir_diagnostic =
+    PartialIndexFieldMissing "String.literal" "String.literal"
+      \<comment> \<open>target entity name, qualifier field name\<close>
+  | TestStrategyFieldMissing "String.literal" "String.literal" "String.literal"
+      \<comment> \<open>target name, qualifier field name, target-kind label
+          ("operation" / "entity" / "target")\<close>
+
+fun findOperationByName ::
+  "operation_decl_full list \<Rightarrow> String.literal \<Rightarrow> operation_decl_full option"
+where
+  "findOperationByName [] _ = None"
+| "findOperationByName (OperationDeclFull n a b c d e # rest) nm =
+     (if n = nm then Some (OperationDeclFull n a b c d e)
+      else findOperationByName rest nm)"
+
+fun paramListHasName ::
+  "param_decl_full list \<Rightarrow> String.literal \<Rightarrow> bool"
+where
+  "paramListHasName [] _ = False"
+| "paramListHasName (ParamDeclFull pn _ _ # rest) nm =
+     (if pn = nm then True else paramListHasName rest nm)"
+
+fun operationHasParamNamed ::
+  "operation_decl_full \<Rightarrow> String.literal \<Rightarrow> bool"
+where
+  "operationHasParamNamed (OperationDeclFull _ inputs _ _ _ _) nm =
+     paramListHasName inputs nm"
+
+fun validateIrContextRule ::
+  "convention_rule_full \<Rightarrow> entity_decl_full list \<Rightarrow>
+   operation_decl_full list \<Rightarrow> convention_ir_diagnostic list"
+where
+  "validateIrContextRule (ConventionRuleFull target prop qualOpt _ _) entities ops =
+     (case qualOpt of
+        None \<Rightarrow> []
+      | Some field \<Rightarrow>
+          if prop = STR ''partial_index'' then
+            (case entityByName entities target of
+               None \<Rightarrow> []
+             | Some _ \<Rightarrow>
+                 if entityHasField entities target field then []
+                 else [PartialIndexFieldMissing target field])
+          else if prop = STR ''test_strategy'' then
+            let opMatch     = findOperationByName ops target;
+                entityMatch = entityByName entities target;
+                inParams    = (case opMatch of
+                                 None    \<Rightarrow> False
+                               | Some op \<Rightarrow> operationHasParamNamed op field);
+                inEntity    = entityHasField entities target field;
+                targetKind  = (if opMatch \<noteq> None then STR ''operation''
+                               else if entityMatch \<noteq> None then STR ''entity''
+                               else STR ''target'')
+            in if inParams \<or> inEntity then []
+               else [TestStrategyFieldMissing target field targetKind]
+          else [])"
+
 lemmas literalIsEmpty_code [code] = literalIsEmpty_def
 lemmas asciiIsWhitespace_code [code] = asciiIsWhitespace.simps
 lemmas literalIsBlank_code [code] = literalIsBlank_def
@@ -174,5 +240,9 @@ lemmas parseBoolPv_code [code] = parseBoolPv_def
 lemmas parseTestStrategyPv_code [code] = parseTestStrategyPv_def
 lemmas parseStrategyPv_code [code] = parseStrategyPv_def
 lemmas parseConventionValue_code [code] = parseConventionValue_def
+lemmas findOperationByName_code [code] = findOperationByName.simps
+lemmas paramListHasName_code [code] = paramListHasName.simps
+lemmas operationHasParamNamed_code [code] = operationHasParamNamed.simps
+lemmas validateIrContextRule_code [code] = validateIrContextRule.simps
 
 end


### PR DESCRIPTION
## Summary

\`Validate.scala\`'s \`validateIrContext\` was the last per-rule decision logic in the convention validator after PR #329. It checks two diagnostics:

- \`partial_index "field"\` — entity exists ∧ field exists on that entity
- \`test_strategy "field"\` — field exists as operation input OR entity field; picks target-kind label (\`"operation"\` / \`"entity"\` / \`"target"\`)

This PR lifts the dispatch + existence checks into Isabelle with a typed-diagnostic return:

\`\`\`isabelle
datatype convention_ir_diagnostic =
    PartialIndexFieldMissing literal literal
  | TestStrategyFieldMissing literal literal literal

findOperationByName    : op list => literal => op option
paramListHasName       : param list => literal => bool
operationHasParamNamed : op => literal => bool
validateIrContextRule  : rule => entity list => op list
                      => convention_ir_diagnostic list
\`\`\`

Scala iterates rules, calls the lifted function once per rule, and maps each typed diagnostic to the existing string-formatted \`ConventionDiagnostic\`. The formatting (\`rule.a\` / \`.b\` interpolation, span threading) stays Scala-side; the structural decisions are now in HOL.

## Extraction note
All new helpers are written as top-level \`fun\` patterns (not \`definition\` + inner \`case\`) — single-constructor sealed datatypes extract as val-patterns from inner \`case\` blocks, which Scala 3 \`-Werror\` rejects with E197.

## After this PR
\`Validate.scala\` has no remaining single-rule decision logic; only cross-cutting bookkeeping (duplicate detection, target/property matrix, qualifier-required) and the \`detectEntityFieldCollisions\` cross-rule check remain.

## Test plan
- [x] \`isabelle build\` clean (1:51)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted per-rule IR-context validation into Isabelle with typed diagnostics for `partial_index` and `test_strategy`, removing the last rule-specific logic from `Validate.scala` while keeping error formatting in Scala. Also removed a redundant allocation in the Scala call site.

- **Refactors**
  - Added in `ValidateConventions.thy`: `convention_ir_diagnostic`, `findOperationByName`, `paramListHasName`, `operationHasParamNamed`, `validateIrContextRule`; exported via `Codegen.thy`.
  - Generated corresponding Scala in `SpecRestGenerated.scala`; updated `Validate.scala` to call `validateIrContextRule` and map diagnostics to existing `ConventionDiagnostic`.
  - Dropped a no-op `collect` on `ir.g`; pass ops directly to `validateIrContextRule` to avoid per-rule list allocation.
  - No behavior changes; tests pass; no golden diff.

<sup>Written for commit a73c026888c3072290d9358f429a04bea46890cf. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/334?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization of internal validation logic for convention rules, consolidating field-existence checks into a dedicated validation function.

* **Chores**
  * Extended formal verification infrastructure to support enhanced validation capabilities with additional helper functions and exports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->