### PR TITLE
feat(proofs): lift detectEntityFieldCollisions

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -233,18 +233,21 @@ object Validate:
       diagnostics: DiagBuilder
   ): Unit =
     val entityNames = ir.idx.entityNames.toList
-    for case rule: ConventionRuleFull <- rules do
-      val pairs = collisionsForRule(rule, rules, entityNames)
-      if pairs.nonEmpty then
-        val field  = rule.c.getOrElse("")
-        val others = pairs.map((t, v) => s"$t=$v").mkString(", ")
-        diagnostics += ConventionDiagnostic(
-          DiagnosticLevel.Error,
-          s"conflicting test_strategy for field '$field' across entities ($others); operation inputs named '$field' would resolve ambiguously",
-          rule.e,
-          rule.a,
-          "test_strategy"
-        )
+    val tuples      = extractTsTuples(rules, entityNames)
+    rules.foreach:
+      case rule @ ConventionRuleFull(_, "test_strategy", Some(field), CvOk(PvBool(_)), _)
+          if ir.idx.entityNames.contains(rule.a) =>
+        val pairs = collisionsForRule(rule, tuples, entityNames)
+        if pairs.nonEmpty then
+          val others = pairs.map((t, v) => s"$t=$v").mkString(", ")
+          diagnostics += ConventionDiagnostic(
+            DiagnosticLevel.Error,
+            s"conflicting test_strategy for field '$field' across entities ($others); operation inputs named '$field' would resolve ambiguously",
+            rule.e,
+            rule.a,
+            "test_strategy"
+          )
+      case _ => ()
 
   private def err(rule: ConventionRuleFull, msg: String, diagnostics: DiagBuilder): Unit =
     diagnostics += ConventionDiagnostic(

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -232,30 +232,19 @@ object Validate:
       ir: ServiceIRFull,
       diagnostics: DiagBuilder
   ): Unit =
-    val entityNames = ir.idx.entityNames
-    val grouped = rules
-      .collect[(String, String, String, ConventionRuleFull)] {
-        case r @ ConventionRuleFull(t, "test_strategy", Some(f), CvOk(PvBool(live)), _)
-            if entityNames.contains(t) =>
-          (f, t, if live then "live" else "redacted", r)
-      }
-      .groupBy { case (field, _, _, _) => field }
-    grouped.foreach: (field, entries) =>
-      val distinctEntities = entries.map((_, t, _, _) => t).distinct
-      val distinctValues   = entries.map((_, _, v, _) => v).distinct
-      if distinctEntities.size > 1 && distinctValues.size > 1 then
-        entries.foreach: (_, target, _, rule) =>
-          val others = entries
-            .collect { case (_, t, v, _) if t != target => s"$t=$v" }
-            .distinct
-            .mkString(", ")
-          diagnostics += ConventionDiagnostic(
-            DiagnosticLevel.Error,
-            s"conflicting test_strategy for field '$field' across entities ($others); operation inputs named '$field' would resolve ambiguously",
-            rule.e,
-            rule.a,
-            "test_strategy"
-          )
+    val entityNames = ir.idx.entityNames.toList
+    for case rule: ConventionRuleFull <- rules do
+      val pairs = collisionsForRule(rule, rules, entityNames)
+      if pairs.nonEmpty then
+        val field  = rule.c.getOrElse("")
+        val others = pairs.map((t, v) => s"$t=$v").mkString(", ")
+        diagnostics += ConventionDiagnostic(
+          DiagnosticLevel.Error,
+          s"conflicting test_strategy for field '$field' across entities ($others); operation inputs named '$field' would resolve ambiguously",
+          rule.e,
+          rule.a,
+          "test_strategy"
+        )
 
   private def err(rule: ConventionRuleFull, msg: String, diagnostics: DiagBuilder): Unit =
     diagnostics += ConventionDiagnostic(

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8460,6 +8460,12 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => None
   }
 
+  def valuesOf(x0: List[(String, (String, (String, convention_rule_full)))]): List[String] =
+    x0 match {
+      case Nil                         => Nil
+      case (uu, (uv, (v, uw))) :: rest => v :: valuesOf(rest)
+    }
+
   def classificationMethod(x0: operation_classification): http_method = x0 match {
     case OperationClassification(uu, uv, m, uw, ux, uy, uz) => m
   }
@@ -8768,6 +8774,12 @@ object SpecRestGenerated {
     case NoneLitF(v)                      => None
     case IdentifierF(v, va)               => None
   }
+
+  def targetsOf(x0: List[(String, (String, (String, convention_rule_full)))]): List[String] =
+    x0 match {
+      case Nil                         => Nil
+      case (uu, (t, (uv, uw))) :: rest => t :: targetsOf(rest)
+    }
 
   def classificationSignals(x0: operation_classification): analysis_signals = x0 match {
     case OperationClassification(uu, uv, uw, ux, uy, uz, sg) => sg
@@ -9356,6 +9368,19 @@ object SpecRestGenerated {
     case NoneLitF(v)                      => None
     case IdentifierF(v, va)               => None
   }
+
+  def fieldFilter(
+      uu: String,
+      x1: List[(String, (String, (String, convention_rule_full)))]
+  ): List[(String, (String, (String, convention_rule_full)))] =
+    (uu, x1) match {
+      case (uu, Nil) => Nil
+      case (field, (g, (t, (v, r))) :: rest) =>
+        field == g match {
+          case true  => (g, (t, (v, r))) :: fieldFilter(field, rest)
+          case false => fieldFilter(field, rest)
+        }
+    }
 
   def parseBoolPv(e: expr_full): convention_value =
     asBoolLit(e) match {
@@ -10015,6 +10040,43 @@ object SpecRestGenerated {
         }
     }
 
+  def extractTsTuple(
+      x0: convention_rule_full,
+      ens: List[String]
+  ): Option[(String, (String, (String, convention_rule_full)))] =
+    (x0, ens) match {
+      case (ConventionRuleFull(target, prop, qualOpt, vala, span), ens) =>
+        prop == "test_strategy" && membera[String](ens, target) match {
+          case true => qualOpt match {
+              case None => None
+              case Some(f) =>
+                vala match {
+                  case CvOk(PvString(_)) => None
+                  case CvOk(PvInt(_))    => None
+                  case CvOk(PvBool(live)) =>
+                    Some[(String, (String, (String, convention_rule_full)))]((
+                      f,
+                      (
+                        target,
+                        (
+                          (live match {
+                            case true  => "live"
+                            case false => "redacted"
+                          }),
+                          ConventionRuleFull(target, prop, qualOpt, vala, span)
+                        )
+                      )
+                    ))
+                  case CvOk(PvStrPair(_, _)) => None
+                  case CvOk(PvExpr(_))       => None
+                  case CvBad(_, _)           => None
+                  case CvUnknown(_)          => None
+                }
+            }
+          case false => None
+        }
+    }
+
   def asciiIsWhitespace(c: BigInt): Boolean =
     c == BigInt(32) || (c == BigInt(9) || (c == BigInt(10) || c == BigInt(13)))
 
@@ -10320,6 +10382,18 @@ object SpecRestGenerated {
   def disambiguateKeys[A](pairs: List[(String, A)]): List[(String, A)] =
     disambiguateKeysAux[A](pairs, Nil, Nil)
 
+  def extractTsTuples(
+      x0: List[convention_rule_full],
+      uu: List[String]
+  ): List[(String, (String, (String, convention_rule_full)))] =
+    (x0, uu) match {
+      case (Nil, uu) => Nil
+      case (r :: rest, ens) => extractTsTuple(r, ens) match {
+          case None    => extractTsTuples(rest, ens)
+          case Some(t) => t :: extractTsTuples(rest, ens)
+        }
+    }
+
   def literalStartsWithSlash(s: String): Boolean =
     Str_Literal.asciisOfLiteral(s) match {
       case Nil    => false
@@ -10530,6 +10604,43 @@ object SpecRestGenerated {
     field_name == "id" && sql_type == "INTEGER" match {
       case true  => "BIGINT"
       case false => sql_type
+    }
+
+  def otherPairsForField(
+      uu: String,
+      x1: List[(String, (String, (String, convention_rule_full)))]
+  ): List[(String, String)] =
+    (uu, x1) match {
+      case (uu, Nil) => Nil
+      case (curTarget, (uv, (t, (v, uw))) :: rest) =>
+        !(t == curTarget) match {
+          case true  => (t, v) :: otherPairsForField(curTarget, rest)
+          case false => otherPairsForField(curTarget, rest)
+        }
+    }
+
+  def collisionsForRule(
+      rule: convention_rule_full,
+      rules: List[convention_rule_full],
+      entityNames: List[String]
+  ): List[(String, String)] =
+    extractTsTuple(rule, entityNames) match {
+      case None => Nil
+      case Some((field, (target, (_, _)))) =>
+        val allTups =
+          extractTsTuples(rules, entityNames): List[(
+              String,
+              (String, (String, convention_rule_full))
+          )]
+        val sameField =
+          fieldFilter(field, allTups): List[(String, (String, (String, convention_rule_full)))]
+        val targets = remdups[String](targetsOf(sameField)): List[String]
+        val values  = remdups[String](valuesOf(sameField)): List[String];
+        less_nat(one_nat, size_list[String](targets)) &&
+          less_nat(one_nat, size_list[String](values)) match {
+          case true  => remdups[(String, String)](otherPairsForField(target, sameField))
+          case false => Nil
+        }
     }
 
   def parseHttpHeaderPv(e: expr_full): convention_value =

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8460,11 +8460,10 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => None
   }
 
-  def valuesOf(x0: List[(String, (String, (String, convention_rule_full)))]): List[String] =
-    x0 match {
-      case Nil                         => Nil
-      case (uu, (uv, (v, uw))) :: rest => v :: valuesOf(rest)
-    }
+  def valuesOf(x0: List[(String, (String, String))]): List[String] = x0 match {
+    case Nil                   => Nil
+    case (uu, (uv, v)) :: rest => v :: valuesOf(rest)
+  }
 
   def classificationMethod(x0: operation_classification): http_method = x0 match {
     case OperationClassification(uu, uv, m, uw, ux, uy, uz) => m
@@ -8775,11 +8774,10 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => None
   }
 
-  def targetsOf(x0: List[(String, (String, (String, convention_rule_full)))]): List[String] =
-    x0 match {
-      case Nil                         => Nil
-      case (uu, (t, (uv, uw))) :: rest => t :: targetsOf(rest)
-    }
+  def targetsOf(x0: List[(String, (String, String))]): List[String] = x0 match {
+    case Nil                   => Nil
+    case (uu, (t, uv)) :: rest => t :: targetsOf(rest)
+  }
 
   def classificationSignals(x0: operation_classification): analysis_signals = x0 match {
     case OperationClassification(uu, uv, uw, ux, uy, uz, sg) => sg
@@ -9371,13 +9369,13 @@ object SpecRestGenerated {
 
   def fieldFilter(
       uu: String,
-      x1: List[(String, (String, (String, convention_rule_full)))]
-  ): List[(String, (String, (String, convention_rule_full)))] =
+      x1: List[(String, (String, String))]
+  ): List[(String, (String, String))] =
     (uu, x1) match {
       case (uu, Nil) => Nil
-      case (field, (g, (t, (v, r))) :: rest) =>
+      case (field, (g, (t, v)) :: rest) =>
         field == g match {
-          case true  => (g, (t, (v, r))) :: fieldFilter(field, rest)
+          case true  => (g, (t, v)) :: fieldFilter(field, rest)
           case false => fieldFilter(field, rest)
         }
     }
@@ -10043,9 +10041,9 @@ object SpecRestGenerated {
   def extractTsTuple(
       x0: convention_rule_full,
       ens: List[String]
-  ): Option[(String, (String, (String, convention_rule_full)))] =
+  ): Option[(String, (String, String))] =
     (x0, ens) match {
-      case (ConventionRuleFull(target, prop, qualOpt, vala, span), ens) =>
+      case (ConventionRuleFull(target, prop, qualOpt, vala, uu), ens) =>
         prop == "test_strategy" && membera[String](ens, target) match {
           case true => qualOpt match {
               case None => None
@@ -10054,17 +10052,14 @@ object SpecRestGenerated {
                   case CvOk(PvString(_)) => None
                   case CvOk(PvInt(_))    => None
                   case CvOk(PvBool(live)) =>
-                    Some[(String, (String, (String, convention_rule_full)))]((
+                    Some[(String, (String, String))]((
                       f,
                       (
                         target,
-                        (
-                          (live match {
-                            case true  => "live"
-                            case false => "redacted"
-                          }),
-                          ConventionRuleFull(target, prop, qualOpt, vala, span)
-                        )
+                        (live match {
+                          case true  => "live"
+                          case false => "redacted"
+                        })
                       )
                     ))
                   case CvOk(PvStrPair(_, _)) => None
@@ -10385,7 +10380,7 @@ object SpecRestGenerated {
   def extractTsTuples(
       x0: List[convention_rule_full],
       uu: List[String]
-  ): List[(String, (String, (String, convention_rule_full)))] =
+  ): List[(String, (String, String))] =
     (x0, uu) match {
       case (Nil, uu) => Nil
       case (r :: rest, ens) => extractTsTuple(r, ens) match {
@@ -10606,13 +10601,10 @@ object SpecRestGenerated {
       case false => sql_type
     }
 
-  def otherPairsForField(
-      uu: String,
-      x1: List[(String, (String, (String, convention_rule_full)))]
-  ): List[(String, String)] =
+  def otherPairsForField(uu: String, x1: List[(String, (String, String))]): List[(String, String)] =
     (uu, x1) match {
       case (uu, Nil) => Nil
-      case (curTarget, (uv, (t, (v, uw))) :: rest) =>
+      case (curTarget, (uv, (t, v)) :: rest) =>
         !(t == curTarget) match {
           case true  => (t, v) :: otherPairsForField(curTarget, rest)
           case false => otherPairsForField(curTarget, rest)
@@ -10621,19 +10613,14 @@ object SpecRestGenerated {
 
   def collisionsForRule(
       rule: convention_rule_full,
-      rules: List[convention_rule_full],
+      tuples: List[(String, (String, String))],
       entityNames: List[String]
   ): List[(String, String)] =
     extractTsTuple(rule, entityNames) match {
       case None => Nil
-      case Some((field, (target, (_, _)))) =>
-        val allTups =
-          extractTsTuples(rules, entityNames): List[(
-              String,
-              (String, (String, convention_rule_full))
-          )]
+      case Some((field, (target, _))) =>
         val sameField =
-          fieldFilter(field, allTups): List[(String, (String, (String, convention_rule_full)))]
+          fieldFilter(field, tuples): List[(String, (String, String))]
         val targets = remdups[String](targetsOf(sameField)): List[String]
         val values  = remdups[String](valuesOf(sameField)): List[String];
         less_nat(one_nat, size_list[String](targets)) &&

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -260,6 +260,7 @@ export_code
     findOperationByName
     operationHasParamNamed
     validateIrContextRule
+    collisionsForRule
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -260,6 +260,7 @@ export_code
     findOperationByName
     operationHasParamNamed
     validateIrContextRule
+    extractTsTuples
     collisionsForRule
     parseHttpMethod
     decidePutPatch

--- a/proofs/isabelle/SpecRest/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/ValidateConventions.thy
@@ -249,12 +249,17 @@ text \<open>Cross-rule test_strategy collision detection. Two entity-targeted
   \<open>[]\<close> if there's no conflict. Scala iterates rules, formats the
   "others" string from the returned pairs, and emits the diagnostic.\<close>
 
+text \<open>Per-rule tuple is \<open>(field, target, value)\<close>. The original rule is
+  not threaded through — downstream helpers only inspect the three
+  string components, and Scala already has the rule in hand at the
+  call site. Carrying the full rule through every tuple inflated the
+  extracted Scala type for no consumer.\<close>
+
 fun extractTsTuple ::
   "convention_rule_full \<Rightarrow> String.literal list
-   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
-       convention_rule_full) option"
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) option"
 where
-  "extractTsTuple (ConventionRuleFull target prop qualOpt val span) ens =
+  "extractTsTuple (ConventionRuleFull target prop qualOpt val _) ens =
      (if prop = STR ''test_strategy'' \<and> List.member ens target then
         (case qualOpt of
            None   \<Rightarrow> None
@@ -262,15 +267,13 @@ where
             (case val of
                CvOk (PvBool live) \<Rightarrow>
                  Some (f, target,
-                       (if live then STR ''live'' else STR ''redacted''),
-                       ConventionRuleFull target prop qualOpt val span)
+                       (if live then STR ''live'' else STR ''redacted''))
              | _ \<Rightarrow> None))
       else None)"
 
 fun extractTsTuples ::
   "convention_rule_full list \<Rightarrow> String.literal list
-   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
-       convention_rule_full) list"
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list"
 where
   "extractTsTuples [] _ = []"
 | "extractTsTuples (r # rest) ens =
@@ -280,51 +283,53 @@ where
 
 fun fieldFilter ::
   "String.literal
-   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
-       convention_rule_full) list
-   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
-       convention_rule_full) list"
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list"
 where
   "fieldFilter _ [] = []"
-| "fieldFilter field ((g, t, v, r) # rest) =
-     (if field = g then (g, t, v, r) # fieldFilter field rest
+| "fieldFilter field ((g, t, v) # rest) =
+     (if field = g then (g, t, v) # fieldFilter field rest
       else fieldFilter field rest)"
 
 fun targetsOf ::
-  "(String.literal \<times> String.literal \<times> String.literal \<times>
-    convention_rule_full) list \<Rightarrow> String.literal list"
+  "(String.literal \<times> String.literal \<times> String.literal) list
+   \<Rightarrow> String.literal list"
 where
   "targetsOf [] = []"
-| "targetsOf ((_, t, _, _) # rest) = t # targetsOf rest"
+| "targetsOf ((_, t, _) # rest) = t # targetsOf rest"
 
 fun valuesOf ::
-  "(String.literal \<times> String.literal \<times> String.literal \<times>
-    convention_rule_full) list \<Rightarrow> String.literal list"
+  "(String.literal \<times> String.literal \<times> String.literal) list
+   \<Rightarrow> String.literal list"
 where
   "valuesOf [] = []"
-| "valuesOf ((_, _, v, _) # rest) = v # valuesOf rest"
+| "valuesOf ((_, _, v) # rest) = v # valuesOf rest"
 
 fun otherPairsForField ::
   "String.literal
-   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
-       convention_rule_full) list
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list
    \<Rightarrow> (String.literal \<times> String.literal) list"
 where
   "otherPairsForField _ [] = []"
-| "otherPairsForField curTarget ((_, t, v, _) # rest) =
+| "otherPairsForField curTarget ((_, t, v) # rest) =
      (if t \<noteq> curTarget then (t, v) # otherPairsForField curTarget rest
       else otherPairsForField curTarget rest)"
 
+text \<open>Takes precomputed tuples so Scala can call \<open>extractTsTuples\<close>
+  once at the top of the validator loop and reuse the result across
+  every rule — the old per-rule re-extraction was cubic worst-case in
+  the rule count.\<close>
+
 definition collisionsForRule ::
-  "convention_rule_full \<Rightarrow> convention_rule_full list \<Rightarrow>
-   String.literal list \<Rightarrow> (String.literal \<times> String.literal) list"
+  "convention_rule_full
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal) list
+   \<Rightarrow> String.literal list \<Rightarrow> (String.literal \<times> String.literal) list"
 where
-  "collisionsForRule rule rules entityNames =
+  "collisionsForRule rule tuples entityNames =
      (case extractTsTuple rule entityNames of
         None \<Rightarrow> []
-      | Some (field, target, _, _) \<Rightarrow>
-         let allTups   = extractTsTuples rules entityNames;
-             sameField = fieldFilter field allTups;
+      | Some (field, target, _) \<Rightarrow>
+         let sameField = fieldFilter field tuples;
              targets   = remdups (targetsOf sameField);
              values    = remdups (valuesOf sameField)
          in if length targets > 1 \<and> length values > 1

--- a/proofs/isabelle/SpecRest/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/ValidateConventions.thy
@@ -239,10 +239,109 @@ lemmas parseHttpHeaderPv_code [code] = parseHttpHeaderPv_def
 lemmas parseBoolPv_code [code] = parseBoolPv_def
 lemmas parseTestStrategyPv_code [code] = parseTestStrategyPv_def
 lemmas parseStrategyPv_code [code] = parseStrategyPv_def
+text \<open>Cross-rule test_strategy collision detection. Two entity-targeted
+  test_strategy rules conflict when they share a field-qualifier name
+  but specify different entities AND different live/redacted values
+  (operation inputs named that field would resolve ambiguously).
+
+  Per-rule entry point: \<open>collisionsForRule\<close> returns the distinct
+  \<open>(other_target, other_value)\<close> pairs in conflict with \<open>rule\<close>, or
+  \<open>[]\<close> if there's no conflict. Scala iterates rules, formats the
+  "others" string from the returned pairs, and emits the diagnostic.\<close>
+
+fun extractTsTuple ::
+  "convention_rule_full \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
+       convention_rule_full) option"
+where
+  "extractTsTuple (ConventionRuleFull target prop qualOpt val span) ens =
+     (if prop = STR ''test_strategy'' \<and> List.member ens target then
+        (case qualOpt of
+           None   \<Rightarrow> None
+         | Some f \<Rightarrow>
+            (case val of
+               CvOk (PvBool live) \<Rightarrow>
+                 Some (f, target,
+                       (if live then STR ''live'' else STR ''redacted''),
+                       ConventionRuleFull target prop qualOpt val span)
+             | _ \<Rightarrow> None))
+      else None)"
+
+fun extractTsTuples ::
+  "convention_rule_full list \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
+       convention_rule_full) list"
+where
+  "extractTsTuples [] _ = []"
+| "extractTsTuples (r # rest) ens =
+     (case extractTsTuple r ens of
+        None   \<Rightarrow> extractTsTuples rest ens
+      | Some t \<Rightarrow> t # extractTsTuples rest ens)"
+
+fun fieldFilter ::
+  "String.literal
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
+       convention_rule_full) list
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
+       convention_rule_full) list"
+where
+  "fieldFilter _ [] = []"
+| "fieldFilter field ((g, t, v, r) # rest) =
+     (if field = g then (g, t, v, r) # fieldFilter field rest
+      else fieldFilter field rest)"
+
+fun targetsOf ::
+  "(String.literal \<times> String.literal \<times> String.literal \<times>
+    convention_rule_full) list \<Rightarrow> String.literal list"
+where
+  "targetsOf [] = []"
+| "targetsOf ((_, t, _, _) # rest) = t # targetsOf rest"
+
+fun valuesOf ::
+  "(String.literal \<times> String.literal \<times> String.literal \<times>
+    convention_rule_full) list \<Rightarrow> String.literal list"
+where
+  "valuesOf [] = []"
+| "valuesOf ((_, _, v, _) # rest) = v # valuesOf rest"
+
+fun otherPairsForField ::
+  "String.literal
+   \<Rightarrow> (String.literal \<times> String.literal \<times> String.literal \<times>
+       convention_rule_full) list
+   \<Rightarrow> (String.literal \<times> String.literal) list"
+where
+  "otherPairsForField _ [] = []"
+| "otherPairsForField curTarget ((_, t, v, _) # rest) =
+     (if t \<noteq> curTarget then (t, v) # otherPairsForField curTarget rest
+      else otherPairsForField curTarget rest)"
+
+definition collisionsForRule ::
+  "convention_rule_full \<Rightarrow> convention_rule_full list \<Rightarrow>
+   String.literal list \<Rightarrow> (String.literal \<times> String.literal) list"
+where
+  "collisionsForRule rule rules entityNames =
+     (case extractTsTuple rule entityNames of
+        None \<Rightarrow> []
+      | Some (field, target, _, _) \<Rightarrow>
+         let allTups   = extractTsTuples rules entityNames;
+             sameField = fieldFilter field allTups;
+             targets   = remdups (targetsOf sameField);
+             values    = remdups (valuesOf sameField)
+         in if length targets > 1 \<and> length values > 1
+            then remdups (otherPairsForField target sameField)
+            else [])"
+
 lemmas parseConventionValue_code [code] = parseConventionValue_def
 lemmas findOperationByName_code [code] = findOperationByName.simps
 lemmas paramListHasName_code [code] = paramListHasName.simps
 lemmas operationHasParamNamed_code [code] = operationHasParamNamed.simps
 lemmas validateIrContextRule_code [code] = validateIrContextRule.simps
+lemmas extractTsTuple_code [code] = extractTsTuple.simps
+lemmas extractTsTuples_code [code] = extractTsTuples.simps
+lemmas fieldFilter_code [code] = fieldFilter.simps
+lemmas targetsOf_code [code] = targetsOf.simps
+lemmas valuesOf_code [code] = valuesOf.simps
+lemmas otherPairsForField_code [code] = otherPairsForField.simps
+lemmas collisionsForRule_code [code] = collisionsForRule_def
 
 end


### PR DESCRIPTION
## Summary

Completes the **Validate.scala lift trajectory**. After PR #334 (\`validateIrContext\`), the cross-rule \`test_strategy\` collision check was the last decision-shaped logic in Validate.scala:

Two entity-targeted \`test_strategy\` rules conflict when they share a field-qualifier name but specify different entities AND different live/redacted values (operation inputs named that field would resolve ambiguously across entities).

## Design

Per-rule entry point:

\`\`\`isabelle
collisionsForRule : rule => rules => entity_names => (literal × literal) list
\`\`\`

Returns the distinct \`(other_target, other_value)\` pairs in conflict with \`rule\`, or \`[]\` when no conflict. Helpers:

\`\`\`isabelle
extractTsTuple        : rule  => entity_names => tuple option
extractTsTuples       : rules => entity_names => tuple list
fieldFilter           : field => tuples => tuples
targetsOf / valuesOf  : tuples => literal list
otherPairsForField    : target => tuples => (target × value) pairs
\`\`\`

The collision predicate (≥ 2 distinct targets AND ≥ 2 distinct values) is checked inside the lifted function; Scala iterates rules, calls the lift, and formats the \`"\$t=\$v"\` "others" string only when \`pairs\` is non-empty.

## Extraction note

All new helpers use top-level \`fun\` head patterns to avoid the E197 val-pattern warnings flagged in #334 (single-ctor sealed datatypes need head matching, not inner \`case\`).

## After this PR

Validate.scala's \`detectEntityFieldCollisions\` shrinks from 26 lines of \`groupBy\`/\`distinct\`/\`collect\` ops to 11 lines of iteration + formatting.

**Validate.scala now has zero structural decision logic** — everything that remains is collection bookkeeping (Map/Set for duplicates) and diagnostic message formatting, irreducible Scala glue.

## Test plan
- [x] \`isabelle build\` clean (1:55)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted cross-entity test_strategy collision detection from Scala into the Isabelle proofs with a per-rule entry point, and updated Scala to precompute tuples once per run. Behavior is unchanged, but the validator no longer holds decision logic and avoids cubic rescans.

- **Refactors**
  - Added `extractTsTuples` and updated `collisionsForRule` to accept precomputed tuples; exported via codegen.
  - Scala now precomputes tuples once, iterates only `test_strategy` rules with `Some(field)` and `CvOk(PvBool _)`, pattern-matching to bind `field` (no `getOrElse`).
  - Simplified tuples to `(field, target, value)` and generated helpers (`targetsOf`, `valuesOf`, `fieldFilter`, `otherPairsForField`); wired into generated code.

<sup>Written for commit 7c4ccbf23d338597e72cf4a25e914b02d838ee54. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/335?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the validation logic for detecting conflicts in test strategy rules. The enhanced collision detection mechanism now identifies and reports conflicting configuration definitions more efficiently, providing better diagnostic feedback while maintaining comprehensive validation coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->