### PR TITLE
feat(proofs): lift synthTemporalExpr + prove parseTemporalBody round-trip

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/Serialize.scala
+++ b/modules/ir/src/main/scala/specrest/ir/Serialize.scala
@@ -625,7 +625,7 @@ object Serialize:
 
   given temporalDeclEnc: Encoder[temporal_decl_full] = Encoder.AsObject.instance:
     case TemporalDeclFull(n, b, sp) =>
-      kindObj("Temporal", "name" -> n.asJson, "expr" -> temporalBodyAsExpr(b).asJson).addSpan(sp)
+      kindObj("Temporal", "name" -> n.asJson, "expr" -> synthTemporalExpr(b).asJson).addSpan(sp)
 
   given temporalDeclDec: Decoder[temporal_decl_full] = Decoder.instance: c =>
     for
@@ -633,12 +633,6 @@ object Serialize:
       e  <- c.get[expr_full]("expr")
       sp <- c.getOrElse[Option[span_t]]("span")(None)
     yield TemporalDeclFull(n, parseTemporalBody(e), sp)
-
-  private def temporalBodyAsExpr(b: temporal_body): expr_full = b match
-    case TbAlways(arg)     => CallF(IdentifierF("always", None), arg :: Nil, None)
-    case TbEventually(arg) => CallF(IdentifierF("eventually", None), arg :: Nil, None)
-    case TbFairness(arg)   => CallF(IdentifierF("fairness", None), arg :: Nil, None)
-    case TbInvalid(raw)    => raw
 
   given factDeclEnc: Encoder[fact_decl_full] = Encoder.AsObject.instance:
     case FactDeclFull(n, e, sp) =>

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -9129,6 +9129,16 @@ object SpecRestGenerated {
       case IdentifierF(_, _)                        => TbInvalid(e)
     }
 
+  def synthTemporalExpr(b: temporal_body): expr_full =
+    b match {
+      case TbAlways(arg) => CallF(IdentifierF("always", None), List(arg), None)
+      case TbEventually(arg) =>
+        CallF(IdentifierF("eventually", None), List(arg), None)
+      case TbFairness(arg) =>
+        CallF(IdentifierF("fairness", None), List(arg), None)
+      case TbInvalid(raw) => raw
+    }
+
   def equal_multiplicity(x0: multiplicity, x1: multiplicity): Boolean =
     (x0, x1) match {
       case (MultSome(), MultSet())  => false

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -249,6 +249,7 @@ export_code
     anonInvariantName
     parseTemporalBody
     temporalArg
+    synthTemporalExpr
     primitiveTypeToSql
     classifyColumnType
     collectionElementEntityName

--- a/proofs/isabelle/SpecRest/ParseTemporal.thy
+++ b/proofs/isabelle/SpecRest/ParseTemporal.thy
@@ -30,7 +30,73 @@ fun temporalArg :: "temporal_body \<Rightarrow> expr_full" where
 | "temporalArg (TbFairness e) = e"
 | "temporalArg (TbInvalid e) = e"
 
+text \<open>Inverse direction: re-synthesise the original \<open>expr_full\<close> shape
+  from a typed body. Used by Scala's \<open>Serialize\<close> to round-trip
+  \<open>temporal_decl_full\<close> through JSON without expanding the wire format.
+  The synthesised \<open>CallF\<close>s carry no spans — span information is
+  preserved on the outer \<open>TemporalDeclFull\<close> wrapper, not on the
+  re-emitted call wrapper.\<close>
+
+definition synthTemporalExpr :: "temporal_body \<Rightarrow> expr_full" where
+  "synthTemporalExpr b = (case b of
+       TbAlways arg     \<Rightarrow> CallF (IdentifierF (STR ''always'') None) [arg] None
+     | TbEventually arg \<Rightarrow> CallF (IdentifierF (STR ''eventually'') None) [arg] None
+     | TbFairness arg   \<Rightarrow> CallF (IdentifierF (STR ''fairness'') None) [arg] None
+     | TbInvalid raw    \<Rightarrow> raw)"
+
+text \<open>Round-trip laws. For the three wellformed body shapes, the
+  synthesiser and parser are inverses by construction. The
+  \<open>TbInvalid\<close> case requires the invariant that the carried raw
+  expression doesn't match a wellformed shape — captured by the
+  conditional lemma below — and the unconditional idempotence
+  corollary follows from case analysis on \<open>parseTemporalBody e\<close>.
+
+  These prove that the Scala wire format chosen in PR #330
+  (encode \<open>synthTemporalExpr b\<close>, decode with \<open>parseTemporalBody\<close>)
+  is sound: every typed body that originally came from the parser
+  round-trips faithfully.\<close>
+
+lemma parseTemporalBody_synth_always:
+  "parseTemporalBody (synthTemporalExpr (TbAlways e)) = TbAlways e"
+  by (simp add: synthTemporalExpr_def parseTemporalBody_def)
+
+lemma parseTemporalBody_synth_eventually:
+  "parseTemporalBody (synthTemporalExpr (TbEventually e)) = TbEventually e"
+  by (simp add: synthTemporalExpr_def parseTemporalBody_def)
+
+lemma parseTemporalBody_synth_fairness:
+  "parseTemporalBody (synthTemporalExpr (TbFairness e)) = TbFairness e"
+  by (simp add: synthTemporalExpr_def parseTemporalBody_def)
+
+lemma parseTemporalBody_TbInvalid_raw_eq:
+  "parseTemporalBody e = TbInvalid raw \<Longrightarrow> raw = e"
+  by (auto simp: parseTemporalBody_def
+           split: expr_full.splits list.splits if_splits)
+
+lemma parseTemporalBody_synth_invalid:
+  assumes "parseTemporalBody e = TbInvalid e"
+  shows   "parseTemporalBody (synthTemporalExpr (TbInvalid e)) = TbInvalid e"
+  using assms by (simp add: synthTemporalExpr_def)
+
+theorem parseTemporalBody_idempotent:
+  "parseTemporalBody (synthTemporalExpr (parseTemporalBody e)) = parseTemporalBody e"
+proof (cases "parseTemporalBody e")
+  case (TbAlways arg)
+  then show ?thesis using parseTemporalBody_synth_always by simp
+next
+  case (TbEventually arg)
+  then show ?thesis using parseTemporalBody_synth_eventually by simp
+next
+  case (TbFairness arg)
+  then show ?thesis using parseTemporalBody_synth_fairness by simp
+next
+  case (TbInvalid raw)
+  hence "raw = e" using parseTemporalBody_TbInvalid_raw_eq by blast
+  thus ?thesis using TbInvalid by (simp add: synthTemporalExpr_def)
+qed
+
 lemmas parseTemporalBody_code [code] = parseTemporalBody_def
 lemmas temporalArg_code [code] = temporalArg.simps
+lemmas synthTemporalExpr_code [code] = synthTemporalExpr_def
 
 end


### PR DESCRIPTION
## Summary

**First proof-bearing PR this session.** PR #330 set up the typed \`temporal_body\` ADT with \`parseTemporalBody\` (recognise) and a Scala-side \`Serialize.temporalBodyAsExpr\` (synthesise) for JSON round-tripping. This PR lifts the synthesiser into Isabelle and adds the theorems that justify the wire-format design.

### Proofs added (in \`ParseTemporal.thy\`)

\`\`\`isabelle
parseTemporalBody_synth_always      : parse (synth (TbAlways e))     = TbAlways e
parseTemporalBody_synth_eventually  : parse (synth (TbEventually e)) = TbEventually e
parseTemporalBody_synth_fairness    : parse (synth (TbFairness e))   = TbFairness e
parseTemporalBody_TbInvalid_raw_eq  : parse e = TbInvalid raw ⇒ raw = e
parseTemporalBody_synth_invalid     : parse e = TbInvalid e ⇒
                                       parse (synth (TbInvalid e)) = TbInvalid e
parseTemporalBody_idempotent        : parse (synth (parse e)) = parse e
\`\`\`

The **idempotence theorem** is the soundness law that PR #330's wire format relies on — Scala JSON encodes via \`synthTemporalExpr\`, decodes via \`parseTemporalBody\`, and this proves the round-trip is stable on every input the parser ever produces.

### Code unification

\`Serialize.scala\`'s hand-rolled \`temporalBodyAsExpr\` (5 lines) is removed in favour of the lifted \`synthTemporalExpr\`. The helper now lives once in Isabelle alongside its inverse and its correctness proof.

## Test plan
- [x] \`isabelle build\` clean — all proofs go through (1:54)
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts `synthTemporalExpr` into Isabelle and proves its round‑trip with `parseTemporalBody`, ensuring the temporal JSON wire format is stable. Replaces the Scala helper with the generated encoder.

- **New Features**
  - Add `synthTemporalExpr` to `ParseTemporal.thy` and export via codegen.
  - Prove `parseTemporalBody (synthTemporalExpr b) = b` for `TbAlways`, `TbEventually`, `TbFairness`, plus idempotence `parseTemporalBody (synthTemporalExpr (parseTemporalBody e)) = parseTemporalBody e`.

- **Refactors**
  - Remove `temporalBodyAsExpr` from `Serialize.scala`; use `synthTemporalExpr`.
  - Update `SpecRestGenerated` and export list to include `synthTemporalExpr`.

<sup>Written for commit 56bd2c3ac0c906d5244bce1e89d3393a849d233d. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/336?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Internal Updates**
  * Updated temporal expression serialization mechanisms for improved consistency in declaration handling
  * Extended code generation infrastructure to support enhanced temporal synthesis capabilities
  * Added mathematical verification for round-trip correctness of temporal expression processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->