### PR TITLE
feat(proofs): lift parsedValueToString + showInt/showBool helpers

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -112,13 +112,3 @@ object Path:
           parsedValueToString(pv)
       }.flatten
     }
-
-  // Render the canonical string form of a parsed_value for legacy string-keyed
-  // convention lookups. 5 cases — far fewer than a per-property variant scheme
-  // (12+) would generate.
-  private def parsedValueToString(pv: parsed_value): Option[String] = pv match
-    case PvString(s)              => Some(s)
-    case PvInt(int_of_integer(n)) => Some(n.toString)
-    case PvBool(b)                => Some(b.toString)
-    case PvStrPair(a, b)          => Some(s"$a:$b")
-    case _: PvExpr                => None // runtime-evaluated; not a literal

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8080,6 +8080,12 @@ object SpecRestGenerated {
     equal_list[BigInt](take[BigInt](size_list[BigInt](ys), xs), ys)
   }
 
+  def showInt(n: int): String =
+    less_int(n, zero_int) match {
+      case true  => "-" + showNat(nat.apply(uminus_int(n)))
+      case false => showNat(nat.apply(n))
+    }
+
   def signalsHasCollectionInput(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, uz, va, vb, h) => h
   }
@@ -8458,6 +8464,11 @@ object SpecRestGenerated {
     case BoolLitF(v, va)                  => None
     case NoneLitF(v)                      => None
     case IdentifierF(v, va)               => None
+  }
+
+  def showBool(x0: Boolean): String = x0 match {
+    case true  => "true"
+    case false => "false"
   }
 
   def valuesOf(x0: List[(String, (String, String))]): List[String] = x0 match {
@@ -10691,6 +10702,15 @@ object SpecRestGenerated {
               case false => CvBad(BadTestStrategy(v), e)
             }
         }
+    }
+
+  def parsedValueToString(pv: parsed_value): Option[String] =
+    pv match {
+      case PvString(a)     => Some[String](a)
+      case PvInt(n)        => Some[String](showInt(n))
+      case PvBool(b)       => Some[String](showBool(b))
+      case PvStrPair(a, b) => Some[String](a + ":" + b)
+      case PvExpr(_)       => None
     }
 
   def collectionElementEntityName(ty: type_expr_full): Option[String] =

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -259,6 +259,9 @@ export_code
     appendPartialIndexes
     parseConventionValue
     synthConventionValue
+    showBool
+    showInt
+    parsedValueToString
     findOperationByName
     operationHasParamNamed
     validateIrContextRule

--- a/proofs/isabelle/SpecRest/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/ValidateConventions.thy
@@ -424,7 +424,38 @@ proof -
   thus ?thesis using assms by (simp add: synthConventionValue_def)
 qed
 
+text \<open>Render a typed \<open>parsed_value\<close> back to the canonical string form
+  used by legacy string-keyed convention lookups (\<open>Path.getConvention\<close>).
+  The four primitive shapes have canonical renderings; \<open>PvExpr\<close> has no
+  meaningful string form (it carries a runtime-evaluated expression
+  like \<open>output.url\<close>) and returns \<open>None\<close>.
+
+  Mirrors the Scala \<open>parsedValueToString\<close> previously in \<open>Path\<close>; the
+  numeric / boolean conversions use the lifted \<open>showInt\<close> / \<open>showBool\<close>
+  helpers so the on-the-wire form is identical to \<open>BigInt.toString\<close>
+  / \<open>Boolean.toString\<close>.\<close>
+
+fun showBool :: "bool \<Rightarrow> String.literal" where
+  "showBool True  = STR ''true''"
+| "showBool False = STR ''false''"
+
+definition showInt :: "int \<Rightarrow> String.literal" where
+  "showInt n = (if n < 0
+                then STR ''-'' + showNat (nat (-n))
+                else showNat (nat n))"
+
+definition parsedValueToString :: "parsed_value \<Rightarrow> String.literal option" where
+  "parsedValueToString pv = (case pv of
+       PvString s    \<Rightarrow> Some s
+     | PvInt n       \<Rightarrow> Some (showInt n)
+     | PvBool b      \<Rightarrow> Some (showBool b)
+     | PvStrPair a b \<Rightarrow> Some (a + STR '':'' + b)
+     | PvExpr _      \<Rightarrow> None)"
+
 lemmas collisionsForRule_code [code] = collisionsForRule_def
 lemmas synthConventionValue_code [code] = synthConventionValue_def
+lemmas showBool_code [code] = showBool.simps
+lemmas showInt_code [code] = showInt_def
+lemmas parsedValueToString_code [code] = parsedValueToString_def
 
 end


### PR DESCRIPTION
## Summary

Lifts the typed-sum → string decoder that \`Path.getConvention\` uses for legacy string-keyed convention lookups. The 5-case \`parsed_value\` renderer:

\`\`\`isabelle
PvString s     -> Some s
PvInt n        -> Some (showInt n)
PvBool b       -> Some (showBool b)
PvStrPair a b  -> Some (a + ":" + b)
PvExpr _       -> None    -- runtime-evaluated, no literal form
\`\`\`

## New helpers (\`ValidateConventions.thy\`)

\`\`\`isabelle
showBool : bool => literal              (* "true" / "false", matches Boolean.toString *)
showInt  : int  => literal              (* delegates to showNat with sign handling *)
parsedValueToString : parsed_value => literal option
\`\`\`

\`showInt n = if n < 0 then "-" + showNat (nat (-n)) else showNat (nat n)\` — matches \`BigInt.toString\` on the wire.

## Code unification

Path.scala's hand-rolled \`parsedValueToString\` (7 lines including comment) is removed in favour of the lifted version.

**After this PR, Path.scala has no remaining hand-written decision or formatting logic in Scala.** \`getConvention\` delegates lookup to a list-collect + the lifted \`parsedValueToString\`; \`resolveMethod\` / \`resolveStatus\` / \`derivePathPattern\` / \`findIdParam\` / \`extractActionVerb\` all already delegate to lifted functions.

## Test plan
- [x] \`isabelle build\` clean (1:54)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the `parsed_value`→string renderer into proofs/codegen and wired `Path.getConvention` to use it, removing the custom Scala helper. This standardizes int/bool rendering and unifies legacy convention lookups.

- **New Features**
  - Added `showInt`, `showBool`, and `parsedValueToString` in `ValidateConventions.thy`, exported to `SpecRestGenerated.scala`.
  - `parsedValueToString`: renders string/int/bool/str-pair; returns `None` for expressions.

- **Refactors**
  - Removed the hand-rolled `parsedValueToString` from `Path.scala`; `getConvention` now delegates to the generated function.
  - `Path` has no remaining custom decision/formatting logic in Scala.

<sup>Written for commit ade0b82bcfe1dd1def22b73da95c9dba0c47f1ea. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/338?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

