### PR TITLE
feat(proofs): lift MissingEnsures + open LintAnalysis.thy

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -10461,6 +10461,11 @@ object SpecRestGenerated {
       flattenEnsures(requiresa)
     ))
 
+  def operationMissingEnsures(x0: operation_decl_full): Boolean = x0 match {
+    case OperationDeclFull(uu, uv, outputs, uw, ensures, ux) =>
+      !nulla[param_decl_full](outputs) && nulla[expr_full](ensures)
+  }
+
   def anonInvariantName(idx: nat): String = "anon_" + showNat(idx)
 
   def findEnumValuesInTypeAux(

--- a/modules/lint/src/main/scala/specrest/lint/MissingEnsures.scala
+++ b/modules/lint/src/main/scala/specrest/lint/MissingEnsures.scala
@@ -6,14 +6,14 @@ object MissingEnsures extends LintPass:
   val code = "L03"
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
-    ir.g.flatMap { case op @ OperationDeclFull(name, _, outputs, _, ensures, span) =>
-      if outputs.nonEmpty && ensures.isEmpty then
+    ir.g.flatMap { case op: OperationDeclFull =>
+      if operationMissingEnsures(op) then
         List(
           LintDiagnostic(
             code,
             LintLevel.Warning,
-            s"operation '$name' declares outputs but has no 'ensures' block — outputs will be unconstrained",
-            span
+            s"operation '${op.a}' declares outputs but has no 'ensures' block — outputs will be unconstrained",
+            op.f
           )
         )
       else Nil

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -18,6 +18,7 @@ theory Codegen
     ValidateConventions
     ParseTemporal
     ParsePath
+    LintAnalysis
     Classify
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
@@ -267,6 +268,7 @@ export_code
     validateIrContextRule
     extractTsTuples
     collisionsForRule
+    operationMissingEnsures
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -1,0 +1,22 @@
+theory LintAnalysis
+  imports IR
+begin
+
+text \<open>Pure decision predicates for the lint analyses in
+  \<open>modules/lint/\<close>. Scala iterates the IR slots, calls the lifted
+  predicate per declaration, and emits formatted diagnostics
+  Scala-side — same boundary established by \<open>validateIrContextRule\<close>
+  in \<open>ValidateConventions\<close>.
+
+  Starting tiny: \<open>operationMissingEnsures\<close> for \<open>L03\<close>. Subsequent
+  lint passes (\<open>UnusedEntity\<close> / \<open>UndefinedRef\<close> / \<open>TypeMismatch\<close>)
+  need IR walkers that respect or ignore binders and will land in
+  follow-up PRs.\<close>
+
+fun operationMissingEnsures :: "operation_decl_full \<Rightarrow> bool" where
+  "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _) =
+     (outputs \<noteq> [] \<and> ensures = [])"
+
+lemmas operationMissingEnsures_code [code] = operationMissingEnsures.simps
+
+end

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -27,5 +27,6 @@ session SpecRest = HOL +
     ValidateConventions
     ParseTemporal
     ParsePath
+    LintAnalysis
     Classify
     Codegen


### PR DESCRIPTION
## Summary

Opens the **lint-pass lift domain**. New theory \`LintAnalysis.thy\` will host the pure decision predicates for the rules in \`modules/lint/\`. Starting tiny with the simplest pass (\`L03 — MissingEnsures\`):

\`\`\`isabelle
operationMissingEnsures : op => bool
  -- outputs ≠ [] ∧ ensures = []
\`\`\`

Lifted via top-level \`fun\` head pattern to avoid the single-ctor val-pattern warning. \`MissingEnsures.scala\` iterates \`ir.g\`, calls the lifted predicate per op, formats the diagnostic. Same boundary established by \`validateIrContextRule\` in \`ValidateConventions\` (lift decides → Scala formats).

## Why so small

This is intentionally a foothold PR. Subsequent lint passes need substantial infrastructure:

- **UnusedEntity / UndefinedRef** — IR walkers collecting referenced names from type_expr_full + expr_full (with or without binder respect)
- **TypeMismatch** — type-checking walker
- **CircularPredicate** — graph cycle detection (needs termination proof in HOL)
- **OperationOverlap** — uses \`.toString\` of ADTs fragilely

Each warrants its own PR with attention. \`LintAnalysis.thy\` is the home they'll grow into.

## Test plan
- [x] \`isabelle build\` clean (1:49)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `LintAnalysis.thy` with the lifted L03 MissingEnsures predicate and exposes it via codegen; the Scala lint pass now calls this predicate to emit the warning. This opens the proofs-backed lint domain so future passes can reuse the same pattern.

- **New Features**
  - Added `LintAnalysis.thy` with `operationMissingEnsures : operation_decl_full => bool`.
  - Exported `operationMissingEnsures` from Isabelle and generated it in `SpecRestGenerated.scala`.
  - Updated `MissingEnsures.scala` to use the lifted predicate and format the diagnostic.

<sup>Written for commit 65c55ec074e6e71a7b78fc8b640cac5657c96645. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/339?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of operations with outputs that are missing required `ensures` clauses in specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->