### PR TITLE
feat(proofs): lift classifyInvariantAtom (Schema.scala SQL CHECK derivation)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -329,33 +329,31 @@ object Schema:
     case StringLitF(v, _)              => s"'${escapeSqlString(v)}'"
     case _                             => "NULL"
 
-  private def extractInvariantChecks(inv: expr_full, fields: List[FieldDeclFull]): List[String] =
-    flattenAnd(inv).flatMap:
-      case BinaryOpF(BIn(), left, SetLiteralF(elements, _), _) =>
-        extractFieldName(left) match
-          case Some(fieldName) =>
-            val colName = Naming.toColumnName(fieldName)
-            val values = elements.collect {
-              case StringLitF(v, _)              => s"'${escapeSqlString(v)}'"
-              case IntLitF(int_of_integer(v), _) => v.toString
-            }
-            if values.length == elements.length && values.nonEmpty then
-              List(s"$colName IN (${values.mkString(", ")})")
-            else Nil
-          case None => Nil
-      case b @ BinaryOpF(_, left, _, _) =>
-        (extractFieldName(left), tryComparison(b, fields)) match
-          case (Some(fieldName), Some(check)) =>
-            List(check.replace("__COL__", Naming.toColumnName(fieldName)))
-          case _ => Nil
-      case _ => Nil
-
-  private def tryComparison(
-      b: BinaryOpF,
+  private def extractInvariantChecks(
+      inv: expr_full,
       @annotation.unused fields: List[FieldDeclFull]
-  ): Option[String] =
-    sqlOp(b.a).flatMap: op =>
-      if isLiteral(b.c) then Some(s"__COL__ $op ${literalValue(b.c)}") else None
+  ): List[String] =
+    flattenAnd(inv).flatMap: atom =>
+      classifyInvariantAtom(atom) match
+        case _: IcSkip => Nil
+        case IcInClause(fieldName, elements) =>
+          val colName = Naming.toColumnName(fieldName)
+          val values = elements.collect {
+            case StringLitF(v, _)              => s"'${escapeSqlString(v)}'"
+            case IntLitF(int_of_integer(v), _) => v.toString
+          }
+          // Lifted predicate already required all elements to be literals.
+          // The Scala collect narrows further to String/Int (Float / Bool /
+          // None aren't supported as IN-clause values), so an atom with a
+          // non-(String|Int) literal element is dropped here.
+          if values.length == elements.length && values.nonEmpty then
+            List(s"$colName IN (${values.mkString(", ")})")
+          else Nil
+        case IcCompare(fieldName, op, rhs) =>
+          val colName = Naming.toColumnName(fieldName)
+          // sqlOp is total on the operators the lifted classifier admits
+          // (Gt/Lt/Ge/Le/Eq/Neq) — see SchemaDerive.sqlOp_def.
+          sqlOp(op).toList.map(o => s"$colName $o ${literalValue(rhs)}")
 
   private def applyPartialIndexConventions(
       tables: List[table_spec],

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -972,6 +972,11 @@ object SpecRestGenerated {
       g: Option[String]
   ) extends openapi_bounds
 
+  sealed abstract class invariant_check_class
+  final case class IcSkip()                                           extends invariant_check_class
+  final case class IcInClause(a: String, b: List[expr_full])          extends invariant_check_class
+  final case class IcCompare(a: String, b: bin_op_full, c: expr_full) extends invariant_check_class
+
   sealed abstract class openapi_primitive_def
   final case class OpenApiPrimDef(a: List[String], b: Option[String]) extends openapi_primitive_def
 
@@ -10002,6 +10007,274 @@ object SpecRestGenerated {
         }
     }
   }
+
+  def classifyInvariantAtom(e: expr_full): invariant_check_class =
+    e match {
+      case BinaryOpF(op, left, rhs, _) =>
+        extractFieldName(left) match {
+          case None => IcSkip()
+          case Some(fn) =>
+            (op, rhs) match {
+              case (BAnd(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BOr(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BImplies(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIff(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BEq(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BNeq(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BLt(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BGt(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BLe(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BGe(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), BinaryOpF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), UnaryOpF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), QuantifierF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), SomeWrapF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), TheF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), FieldAccessF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), EnumAccessF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), IndexF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), CallF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), PrimeF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), PreF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), WithF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), IfF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), LetF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), LambdaF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), ConstructorF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), SetLiteralF(elements, _)) =>
+                !nulla[expr_full](elements) &&
+                  list_all[expr_full]((a: expr_full) => isLiteral(a), elements) match {
+                  case true  => IcInClause(fn, elements)
+                  case false => IcSkip()
+                }
+              case (BIn(), MapLiteralF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), SetComprehensionF(_, _, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), SeqLiteralF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), MatchesF(_, _, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), IntLitF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), FloatLitF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), StringLitF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), BoolLitF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), NoneLitF(_)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIn(), IdentifierF(_, _)) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BNotIn(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BSubset(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BUnion(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BIntersect(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BDiff(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BAdd(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BSub(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BMul(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+              case (BDiv(), _) =>
+                isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+                  case true  => IcCompare(fn, op, rhs)
+                  case false => IcSkip()
+                }
+            }
+        }
+      case UnaryOpF(_, _, _)             => IcSkip()
+      case QuantifierF(_, _, _, _)       => IcSkip()
+      case SomeWrapF(_, _)               => IcSkip()
+      case TheF(_, _, _, _)              => IcSkip()
+      case FieldAccessF(_, _, _)         => IcSkip()
+      case EnumAccessF(_, _, _)          => IcSkip()
+      case IndexF(_, _, _)               => IcSkip()
+      case CallF(_, _, _)                => IcSkip()
+      case PrimeF(_, _)                  => IcSkip()
+      case PreF(_, _)                    => IcSkip()
+      case WithF(_, _, _)                => IcSkip()
+      case IfF(_, _, _, _)               => IcSkip()
+      case LetF(_, _, _, _)              => IcSkip()
+      case LambdaF(_, _, _)              => IcSkip()
+      case ConstructorF(_, _, _)         => IcSkip()
+      case SetLiteralF(_, _)             => IcSkip()
+      case MapLiteralF(_, _)             => IcSkip()
+      case SetComprehensionF(_, _, _, _) => IcSkip()
+      case SeqLiteralF(_, _)             => IcSkip()
+      case MatchesF(_, _, _)             => IcSkip()
+      case IntLitF(_, _)                 => IcSkip()
+      case FloatLitF(_, _)               => IcSkip()
+      case StringLitF(_, _)              => IcSkip()
+      case BoolLitF(_, _)                => IcSkip()
+      case NoneLitF(_)                   => IcSkip()
+      case IdentifierF(_, _)             => IcSkip()
+    }
 
   def openapiPrimitiveOf(nm: String): Option[openapi_primitive_def] =
     nm == "String" match {

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -258,6 +258,7 @@ export_code
     validateTrigger
     extractPartialIndexRules
     appendPartialIndexes
+    classifyInvariantAtom
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -312,9 +312,49 @@ where
      TableSpec nm ent cols pk fks cks
        (ixs @ map (\<lambda>cf. case cf of (col, filt) \<Rightarrow> partialIndexSpec nm col filt) colFilters)"
 
+text \<open>Invariant-atom classifier for entity \<open>CHECK\<close> constraint derivation
+  in \<open>Schema.extractInvariantChecks\<close>. After flattening a conjunctive
+  invariant body via \<open>flattenAnd\<close>, each atom maps to one of three
+  templates:
+
+  \<^item> \<open>IcInClause field literals\<close>: \<open>field IN (\<dots>)\<close> — the atom was
+    \<open>BIn\<close> against a \<open>SetLiteralF\<close> whose elements are all literals
+    (Scala-side restriction to \<open>StringLitF\<close>/\<open>IntLitF\<close> happens at
+    emit time);
+  \<^item> \<open>IcCompare field op rhs\<close>: \<open>field <op> <literal>\<close> — the atom was a
+    binary comparison with an extractable field name on the left and a
+    literal-shaped RHS, and \<open>sqlOp op\<close> recognises the operator;
+  \<^item> \<open>IcSkip\<close>: nothing emitted — atom didn't fit any template.
+
+  Scala dispatches on the typed class and emits the SQL string from
+  the components (escape, format, interpolate).\<close>
+
+datatype invariant_check_class =
+    IcSkip
+  | IcInClause "String.literal" "expr_full list"
+  | IcCompare "String.literal" bin_op_full expr_full
+
+definition classifyInvariantAtom :: "expr_full \<Rightarrow> invariant_check_class" where
+  "classifyInvariantAtom e = (case e of
+      BinaryOpF op left rhs _ \<Rightarrow>
+        (case extractFieldName left of
+           None    \<Rightarrow> IcSkip
+         | Some fn \<Rightarrow>
+            (case (op, rhs) of
+               (BIn, SetLiteralF elements _) \<Rightarrow>
+                 (if elements \<noteq> [] \<and> list_all isLiteral elements
+                  then IcInClause fn elements
+                  else IcSkip)
+             | _ \<Rightarrow>
+                 (if isLiteral rhs \<and> sqlOp op \<noteq> None
+                  then IcCompare fn op rhs
+                  else IcSkip)))
+    | _ \<Rightarrow> IcSkip)"
+
 lemmas extractPartialIndexRuleOpt_code [code] = extractPartialIndexRuleOpt.simps
 lemmas extractPartialIndexRules_code [code] = extractPartialIndexRules_def
 lemmas partialIndexSpec_code [code] = partialIndexSpec_def
 lemmas appendPartialIndexes_code [code] = appendPartialIndexes.simps
+lemmas classifyInvariantAtom_code [code] = classifyInvariantAtom_def
 
 end


### PR DESCRIPTION
## Summary

\`Schema.extractInvariantChecks\` dispatched on the shape of each conjunct of a flattened invariant body:

- **IN-clause** if \`BIn\` against a pure-literal \`SetLiteralF\`
- **Comparison** if a recognized binop against a literal RHS (via \`isLiteral\` + \`sqlOp\`)
- **Skip** otherwise

The structural decision is liftable; SQL string emission stays Scala (depends on per-literal-type formatting + the \`escapeSqlString\` apostrophe-doubling).

## New typed sum in \`SchemaDerive.thy\`

\`\`\`isabelle
datatype invariant_check_class =
    IcSkip
  | IcInClause literal (expr_full list)
  | IcCompare literal bin_op_full expr_full

classifyInvariantAtom : expr_full => invariant_check_class
\`\`\`

All predicates the lifted dispatcher uses (\`extractFieldName\`, \`isLiteral\`, \`sqlOp\`) were already in \`IR_Helpers\` / \`IR_Analysis\` / \`SchemaDerive\` from earlier PRs — no new helpers needed.

## Scala-side

\`extractInvariantChecks\` now flatMaps over the lifted classes:

\`\`\`scala
IcSkip                 -> Nil
IcInClause(fn, elems)  -> Scala collects String/Int literals
                          (Float/Bool/None still dropped) and
                          interpolates the IN(...) clause
IcCompare(fn, op, rhs) -> sqlOp(op) + literalValue + interpolation
\`\`\`

Removes the inline shape-matching from Schema.scala (the \`BIn\` / \`BinaryOpF\` nested cases + \`tryComparison\` helper); the structural decision is now in HOL.

## Test plan
- [x] \`isabelle build\` clean (1:59)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff (SQL emission byte-identical)
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted invariant-atom classification into proofs and refactored Scala CHECK derivation to use it, removing inline AST matching. Emitted SQL is unchanged; tests pass.

- **Refactors**
  - Added `invariant_check_class` and `classifyInvariantAtom` in `SchemaDerive.thy`, exported via `Codegen` and surfaced in generated `SpecRestGenerated.scala`.
  - Switched `Schema.extractInvariantChecks` to the classifier: `IcSkip` -> skip, `IcInClause` -> emit IN(...), `IcCompare` -> emit comparison; removed `tryComparison` and nested pattern matches.
  - Kept SQL emission in Scala (escape/format), with IN values limited to String/Int literals.

<sup>Written for commit 9e77af84b08cd29b62695cecaac6655d6931a3b4. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/340?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

