### PR TITLE
feat(proofs): lift UnusedEntity + UndefinedRef walkers

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5972,6 +5972,70 @@ object SpecRestGenerated {
     case ParamDeclFull(uu, t, uv) => t
   }
 
+  def allSubexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(n, d, a, sp) :: bs =>
+        allSubexprs(d) ++ allSubexprs_bindings(bs)
+    }
+
+  def allSubexprs_entries(x0: List[map_entry_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, sp) :: es =>
+      allSubexprs(k) ++ (allSubexprs(v) ++ allSubexprs_entries(es))
+  }
+
+  def allSubexprs_fields(x0: List[field_assign_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case FieldAssignFull(n, v, sp) :: fs =>
+      allSubexprs(v) ++ allSubexprs_fields(fs)
+  }
+
+  def allSubexprs_list(x0: List[expr_full]): List[expr_full] = x0 match {
+    case Nil     => Nil
+    case x :: xs => allSubexprs(x) ++ allSubexprs_list(xs)
+  }
+
+  def allSubexprs(x0: expr_full): List[expr_full] = x0 match {
+    case BinaryOpF(op, l, r, sp) =>
+      BinaryOpF(op, l, r, sp) :: allSubexprs(l) ++ allSubexprs(r)
+    case UnaryOpF(op, e, sp)    => UnaryOpF(op, e, sp) :: allSubexprs(e)
+    case FieldAccessF(b, f, sp) => FieldAccessF(b, f, sp) :: allSubexprs(b)
+    case EnumAccessF(b, e, sp)  => EnumAccessF(b, e, sp) :: allSubexprs(b)
+    case IndexF(b, i, sp)       => IndexF(b, i, sp) :: allSubexprs(b) ++ allSubexprs(i)
+    case CallF(c, args, sp) =>
+      CallF(c, args, sp) :: allSubexprs(c) ++ allSubexprs_list(args)
+    case PrimeF(e, sp) => PrimeF(e, sp) :: allSubexprs(e)
+    case PreF(e, sp)   => PreF(e, sp) :: allSubexprs(e)
+    case WithF(b, ups, sp) =>
+      WithF(b, ups, sp) :: allSubexprs(b) ++ allSubexprs_fields(ups)
+    case IfF(c, t, e, sp) =>
+      IfF(c, t, e, sp) :: allSubexprs(c) ++ (allSubexprs(t) ++ allSubexprs(e))
+    case LetF(v, vala, body, sp) =>
+      LetF(v, vala, body, sp) :: allSubexprs(vala) ++ allSubexprs(body)
+    case LambdaF(p, b, sp) => LambdaF(p, b, sp) :: allSubexprs(b)
+    case ConstructorF(n, fs, sp) =>
+      ConstructorF(n, fs, sp) :: allSubexprs_fields(fs)
+    case SetLiteralF(xs, sp) => SetLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MapLiteralF(es, sp) => MapLiteralF(es, sp) :: allSubexprs_entries(es)
+    case SetComprehensionF(v, d, p, sp) =>
+      SetComprehensionF(v, d, p, sp) :: allSubexprs(d) ++ allSubexprs(p)
+    case SeqLiteralF(xs, sp)  => SeqLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MatchesF(e, pat, sp) => MatchesF(e, pat, sp) :: allSubexprs(e)
+    case SomeWrapF(e, sp)     => SomeWrapF(e, sp) :: allSubexprs(e)
+    case TheF(v, d, b, sp) =>
+      TheF(v, d, b, sp) :: allSubexprs(d) ++ allSubexprs(b)
+    case QuantifierF(q, bs, body, sp) =>
+      QuantifierF(q, bs, body, sp) ::
+        allSubexprs_bindings(bs) ++ allSubexprs(body)
+    case IdentifierF(n, sp) => List(IdentifierF(n, sp))
+    case IntLitF(n, sp)     => List(IntLitF(n, sp))
+    case FloatLitF(v, sp)   => List(FloatLitF(v, sp))
+    case StringLitF(v, sp)  => List(StringLitF(v, sp))
+    case BoolLitF(b, sp)    => List(BoolLitF(b, sp))
+    case NoneLitF(sp)       => List(NoneLitF(sp))
+  }
+
   def pathWithIdSuffix(segment: String, idParamOpt: Option[String]): String =
     idParamOpt match {
       case None       => "/" + segment
@@ -8074,6 +8138,36 @@ object SpecRestGenerated {
       case IdentifierF(_, _)                                        => Nil
     }
 
+  def exprSelfNames(x0: expr_full): List[String] = x0 match {
+    case IdentifierF(n, uu)               => List(n)
+    case ConstructorF(n, uv, uw)          => List(n)
+    case BinaryOpF(v, va, vb, vc)         => Nil
+    case UnaryOpF(v, va, vb)              => Nil
+    case QuantifierF(v, va, vb, vc)       => Nil
+    case SomeWrapF(v, va)                 => Nil
+    case TheF(v, va, vb, vc)              => Nil
+    case FieldAccessF(v, va, vb)          => Nil
+    case EnumAccessF(v, va, vb)           => Nil
+    case IndexF(v, va, vb)                => Nil
+    case CallF(v, va, vb)                 => Nil
+    case PrimeF(v, va)                    => Nil
+    case PreF(v, va)                      => Nil
+    case WithF(v, va, vb)                 => Nil
+    case IfF(v, va, vb, vc)               => Nil
+    case LetF(v, va, vb, vc)              => Nil
+    case LambdaF(v, va, vb)               => Nil
+    case SetLiteralF(v, va)               => Nil
+    case MapLiteralF(v, va)               => Nil
+    case SetComprehensionF(v, va, vb, vc) => Nil
+    case SeqLiteralF(v, va)               => Nil
+    case MatchesF(v, va, vb)              => Nil
+    case IntLitF(v, va)                   => Nil
+    case FloatLitF(v, va)                 => Nil
+    case StringLitF(v, va)                => Nil
+    case BoolLitF(v, va)                  => Nil
+    case NoneLitF(v)                      => Nil
+  }
+
   def modulo_integer(k: BigInt, l: BigInt): BigInt =
     snd[BigInt, BigInt](divmod_integer(k, l))
 
@@ -8831,210 +8925,128 @@ object SpecRestGenerated {
     case WithInfoFull(fs, uu) => fs
   }
 
-  def collectCallNames_bindings(x0: List[quantifier_binding_full], wy: List[String]): List[String] =
-    (x0, wy) match {
-      case (Nil, wy) => Nil
-      case (QuantifierBindingFull(wz, d, xa, xb) :: bs, filt) =>
-        collectCallNames(d, filt) ++ collectCallNames_bindings(bs, filt)
-    }
+  def callSelfAllNames(x0: expr_full): List[String] = x0 match {
+    case CallF(IdentifierF(n, uu), uv, uw)                => List(n)
+    case BinaryOpF(v, va, vb, vc)                         => Nil
+    case UnaryOpF(v, va, vb)                              => Nil
+    case QuantifierF(v, va, vb, vc)                       => Nil
+    case SomeWrapF(v, va)                                 => Nil
+    case TheF(v, va, vb, vc)                              => Nil
+    case FieldAccessF(v, va, vb)                          => Nil
+    case EnumAccessF(v, va, vb)                           => Nil
+    case IndexF(v, va, vb)                                => Nil
+    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb)         => Nil
+    case CallF(UnaryOpF(vc, vd, ve), va, vb)              => Nil
+    case CallF(QuantifierF(vc, vd, ve, vf), va, vb)       => Nil
+    case CallF(SomeWrapF(vc, vd), va, vb)                 => Nil
+    case CallF(TheF(vc, vd, ve, vf), va, vb)              => Nil
+    case CallF(FieldAccessF(vc, vd, ve), va, vb)          => Nil
+    case CallF(EnumAccessF(vc, vd, ve), va, vb)           => Nil
+    case CallF(IndexF(vc, vd, ve), va, vb)                => Nil
+    case CallF(CallF(vc, vd, ve), va, vb)                 => Nil
+    case CallF(PrimeF(vc, vd), va, vb)                    => Nil
+    case CallF(PreF(vc, vd), va, vb)                      => Nil
+    case CallF(WithF(vc, vd, ve), va, vb)                 => Nil
+    case CallF(IfF(vc, vd, ve, vf), va, vb)               => Nil
+    case CallF(LetF(vc, vd, ve, vf), va, vb)              => Nil
+    case CallF(LambdaF(vc, vd, ve), va, vb)               => Nil
+    case CallF(ConstructorF(vc, vd, ve), va, vb)          => Nil
+    case CallF(SetLiteralF(vc, vd), va, vb)               => Nil
+    case CallF(MapLiteralF(vc, vd), va, vb)               => Nil
+    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb) => Nil
+    case CallF(SeqLiteralF(vc, vd), va, vb)               => Nil
+    case CallF(MatchesF(vc, vd, ve), va, vb)              => Nil
+    case CallF(IntLitF(vc, vd), va, vb)                   => Nil
+    case CallF(FloatLitF(vc, vd), va, vb)                 => Nil
+    case CallF(StringLitF(vc, vd), va, vb)                => Nil
+    case CallF(BoolLitF(vc, vd), va, vb)                  => Nil
+    case CallF(NoneLitF(vc), va, vb)                      => Nil
+    case PrimeF(v, va)                                    => Nil
+    case PreF(v, va)                                      => Nil
+    case WithF(v, va, vb)                                 => Nil
+    case IfF(v, va, vb, vc)                               => Nil
+    case LetF(v, va, vb, vc)                              => Nil
+    case LambdaF(v, va, vb)                               => Nil
+    case ConstructorF(v, va, vb)                          => Nil
+    case SetLiteralF(v, va)                               => Nil
+    case MapLiteralF(v, va)                               => Nil
+    case SetComprehensionF(v, va, vb, vc)                 => Nil
+    case SeqLiteralF(v, va)                               => Nil
+    case MatchesF(v, va, vb)                              => Nil
+    case IntLitF(v, va)                                   => Nil
+    case FloatLitF(v, va)                                 => Nil
+    case StringLitF(v, va)                                => Nil
+    case BoolLitF(v, va)                                  => Nil
+    case NoneLitF(v)                                      => Nil
+    case IdentifierF(v, va)                               => Nil
+  }
 
-  def collectCallNames_entries(x0: List[map_entry_full], ww: List[String]): List[String] =
-    (x0, ww) match {
-      case (Nil, ww) => Nil
-      case (MapEntryFull(k, v, wx) :: es, filt) =>
-        collectCallNames(k, filt) ++
-          (collectCallNames(v, filt) ++ collectCallNames_entries(es, filt))
-    }
-
-  def collectCallNames_fields(x0: List[field_assign_full], wt: List[String]): List[String] =
-    (x0, wt) match {
-      case (Nil, wt) => Nil
-      case (FieldAssignFull(wu, v, wv) :: fs, filt) =>
-        collectCallNames(v, filt) ++ collectCallNames_fields(fs, filt)
-    }
-
-  def collectCallNames_list(x0: List[expr_full], ws: List[String]): List[String] =
-    (x0, ws) match {
-      case (Nil, ws) => Nil
-      case (x :: xs, filt) =>
-        collectCallNames(x, filt) ++ collectCallNames_list(xs, filt)
-    }
-
-  def collectCallNames(x0: expr_full, filt: List[String]): List[String] =
-    (x0, filt) match {
-      case (CallF(IdentifierF(n, uu), args, sp), filt) =>
+  def callSelfFilteredNames(filt: List[String], x1: expr_full): List[String] =
+    (filt, x1) match {
+      case (filt, CallF(IdentifierF(n, uu), uv, uw)) =>
         membera[String](filt, n) match {
-          case true  => n :: collectCallNames_list(args, filt)
-          case false => collectCallNames_list(args, filt)
+          case true  => List(n)
+          case false => Nil
         }
-      case (CallF(BinaryOpF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(BinaryOpF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(UnaryOpF(v, va, vb), args, uv), filt) =>
-        collectCallNames(UnaryOpF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(QuantifierF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(QuantifierF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(SomeWrapF(v, va), args, uv), filt) =>
-        collectCallNames(SomeWrapF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(TheF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(TheF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(FieldAccessF(v, va, vb), args, uv), filt) =>
-        collectCallNames(FieldAccessF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(EnumAccessF(v, va, vb), args, uv), filt) =>
-        collectCallNames(EnumAccessF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(IndexF(v, va, vb), args, uv), filt) =>
-        collectCallNames(IndexF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(CallF(v, va, vb), args, uv), filt) =>
-        collectCallNames(CallF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(PrimeF(v, va), args, uv), filt) =>
-        collectCallNames(PrimeF(v, va), filt) ++ collectCallNames_list(args, filt)
-      case (CallF(PreF(v, va), args, uv), filt) =>
-        collectCallNames(PreF(v, va), filt) ++ collectCallNames_list(args, filt)
-      case (CallF(WithF(v, va, vb), args, uv), filt) =>
-        collectCallNames(WithF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(IfF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(IfF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(LetF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(LetF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(LambdaF(v, va, vb), args, uv), filt) =>
-        collectCallNames(LambdaF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(ConstructorF(v, va, vb), args, uv), filt) =>
-        collectCallNames(ConstructorF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(SetLiteralF(v, va), args, uv), filt) =>
-        collectCallNames(SetLiteralF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(MapLiteralF(v, va), args, uv), filt) =>
-        collectCallNames(MapLiteralF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(SetComprehensionF(v, va, vb, vc), args, uv), filt) =>
-        collectCallNames(SetComprehensionF(v, va, vb, vc), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(SeqLiteralF(v, va), args, uv), filt) =>
-        collectCallNames(SeqLiteralF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(MatchesF(v, va, vb), args, uv), filt) =>
-        collectCallNames(MatchesF(v, va, vb), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(IntLitF(v, va), args, uv), filt) =>
-        collectCallNames(IntLitF(v, va), filt) ++ collectCallNames_list(args, filt)
-      case (CallF(FloatLitF(v, va), args, uv), filt) =>
-        collectCallNames(FloatLitF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(StringLitF(v, va), args, uv), filt) =>
-        collectCallNames(StringLitF(v, va), filt) ++
-          collectCallNames_list(args, filt)
-      case (CallF(BoolLitF(v, va), args, uv), filt) =>
-        collectCallNames(BoolLitF(v, va), filt) ++ collectCallNames_list(args, filt)
-      case (CallF(NoneLitF(v), args, uv), filt) =>
-        collectCallNames(NoneLitF(v), filt) ++ collectCallNames_list(args, filt)
-      case (BinaryOpF(uw, l, r, ux), filt) =>
-        collectCallNames(l, filt) ++ collectCallNames(r, filt)
-      case (UnaryOpF(uy, e, uz), filt)     => collectCallNames(e, filt)
-      case (FieldAccessF(b, va, vb), filt) => collectCallNames(b, filt)
-      case (EnumAccessF(b, vc, vd), filt)  => collectCallNames(b, filt)
-      case (IndexF(b, i, ve), filt) =>
-        collectCallNames(b, filt) ++ collectCallNames(i, filt)
-      case (PrimeF(e, vf), filt) => collectCallNames(e, filt)
-      case (PreF(e, vg), filt)   => collectCallNames(e, filt)
-      case (WithF(b, upds, vh), filt) =>
-        collectCallNames(b, filt) ++ collectCallNames_fields(upds, filt)
-      case (IfF(c, t, e, vi), filt) =>
-        collectCallNames(c, filt) ++
-          (collectCallNames(t, filt) ++ collectCallNames(e, filt))
-      case (LetF(vj, vala, body, vk), filt) =>
-        collectCallNames(vala, filt) ++ collectCallNames(body, filt)
-      case (LambdaF(vl, b, vm), filt)       => collectCallNames(b, filt)
-      case (ConstructorF(vn, fs, vo), filt) => collectCallNames_fields(fs, filt)
-      case (SetLiteralF(xs, vp), filt)      => collectCallNames_list(xs, filt)
-      case (MapLiteralF(es, vq), filt)      => collectCallNames_entries(es, filt)
-      case (SetComprehensionF(vr, d, p, vs), filt) =>
-        collectCallNames(d, filt) ++ collectCallNames(p, filt)
-      case (SeqLiteralF(xs, vt), filt) => collectCallNames_list(xs, filt)
-      case (MatchesF(x, vu, vv), filt) => collectCallNames(x, filt)
-      case (SomeWrapF(x, vw), filt)    => collectCallNames(x, filt)
-      case (TheF(vx, d, b, vy), filt) =>
-        collectCallNames(d, filt) ++ collectCallNames(b, filt)
-      case (QuantifierF(vz, bs, body, wa), filt) =>
-        collectCallNames_bindings(bs, filt) ++ collectCallNames(body, filt)
-      case (IdentifierF(wb, wc), wd) => Nil
-      case (IntLitF(we, wf), wg)     => Nil
-      case (FloatLitF(wh, wi), wj)   => Nil
-      case (StringLitF(wk, wl), wm)  => Nil
-      case (BoolLitF(wn, wo), wp)    => Nil
-      case (NoneLitF(wq), wr)        => Nil
+      case (ux, BinaryOpF(v, va, vb, vc))                         => Nil
+      case (ux, UnaryOpF(v, va, vb))                              => Nil
+      case (ux, QuantifierF(v, va, vb, vc))                       => Nil
+      case (ux, SomeWrapF(v, va))                                 => Nil
+      case (ux, TheF(v, va, vb, vc))                              => Nil
+      case (ux, FieldAccessF(v, va, vb))                          => Nil
+      case (ux, EnumAccessF(v, va, vb))                           => Nil
+      case (ux, IndexF(v, va, vb))                                => Nil
+      case (ux, CallF(BinaryOpF(vc, vd, ve, vf), va, vb))         => Nil
+      case (ux, CallF(UnaryOpF(vc, vd, ve), va, vb))              => Nil
+      case (ux, CallF(QuantifierF(vc, vd, ve, vf), va, vb))       => Nil
+      case (ux, CallF(SomeWrapF(vc, vd), va, vb))                 => Nil
+      case (ux, CallF(TheF(vc, vd, ve, vf), va, vb))              => Nil
+      case (ux, CallF(FieldAccessF(vc, vd, ve), va, vb))          => Nil
+      case (ux, CallF(EnumAccessF(vc, vd, ve), va, vb))           => Nil
+      case (ux, CallF(IndexF(vc, vd, ve), va, vb))                => Nil
+      case (ux, CallF(CallF(vc, vd, ve), va, vb))                 => Nil
+      case (ux, CallF(PrimeF(vc, vd), va, vb))                    => Nil
+      case (ux, CallF(PreF(vc, vd), va, vb))                      => Nil
+      case (ux, CallF(WithF(vc, vd, ve), va, vb))                 => Nil
+      case (ux, CallF(IfF(vc, vd, ve, vf), va, vb))               => Nil
+      case (ux, CallF(LetF(vc, vd, ve, vf), va, vb))              => Nil
+      case (ux, CallF(LambdaF(vc, vd, ve), va, vb))               => Nil
+      case (ux, CallF(ConstructorF(vc, vd, ve), va, vb))          => Nil
+      case (ux, CallF(SetLiteralF(vc, vd), va, vb))               => Nil
+      case (ux, CallF(MapLiteralF(vc, vd), va, vb))               => Nil
+      case (ux, CallF(SetComprehensionF(vc, vd, ve, vf), va, vb)) => Nil
+      case (ux, CallF(SeqLiteralF(vc, vd), va, vb))               => Nil
+      case (ux, CallF(MatchesF(vc, vd, ve), va, vb))              => Nil
+      case (ux, CallF(IntLitF(vc, vd), va, vb))                   => Nil
+      case (ux, CallF(FloatLitF(vc, vd), va, vb))                 => Nil
+      case (ux, CallF(StringLitF(vc, vd), va, vb))                => Nil
+      case (ux, CallF(BoolLitF(vc, vd), va, vb))                  => Nil
+      case (ux, CallF(NoneLitF(vc), va, vb))                      => Nil
+      case (ux, PrimeF(v, va))                                    => Nil
+      case (ux, PreF(v, va))                                      => Nil
+      case (ux, WithF(v, va, vb))                                 => Nil
+      case (ux, IfF(v, va, vb, vc))                               => Nil
+      case (ux, LetF(v, va, vb, vc))                              => Nil
+      case (ux, LambdaF(v, va, vb))                               => Nil
+      case (ux, ConstructorF(v, va, vb))                          => Nil
+      case (ux, SetLiteralF(v, va))                               => Nil
+      case (ux, MapLiteralF(v, va))                               => Nil
+      case (ux, SetComprehensionF(v, va, vb, vc))                 => Nil
+      case (ux, SeqLiteralF(v, va))                               => Nil
+      case (ux, MatchesF(v, va, vb))                              => Nil
+      case (ux, IntLitF(v, va))                                   => Nil
+      case (ux, FloatLitF(v, va))                                 => Nil
+      case (ux, StringLitF(v, va))                                => Nil
+      case (ux, BoolLitF(v, va))                                  => Nil
+      case (ux, NoneLitF(v))                                      => Nil
+      case (ux, IdentifierF(v, va))                               => Nil
     }
 
-  def collectExprNames_bindings(x0: List[quantifier_binding_full]): List[String] =
-    x0 match {
-      case Nil => Nil
-      case QuantifierBindingFull(wm, d, wn, wo) :: bs =>
-        collectExprNames(d) ++ collectExprNames_bindings(bs)
-    }
+  def collectCallNames(e: expr_full, filt: List[String]): List[String] =
+    maps[expr_full, String]((a: expr_full) => callSelfFilteredNames(filt, a), allSubexprs(e))
 
-  def collectExprNames_entries(x0: List[map_entry_full]): List[String] = x0 match {
-    case Nil => Nil
-    case MapEntryFull(k, v, wl) :: es =>
-      collectExprNames(k) ++ (collectExprNames(v) ++ collectExprNames_entries(es))
-  }
-
-  def collectExprNames_fields(x0: List[field_assign_full]): List[String] = x0 match {
-    case Nil => Nil
-    case FieldAssignFull(wj, v, wk) :: fs =>
-      collectExprNames(v) ++ collectExprNames_fields(fs)
-  }
-
-  def collectExprNames_list(x0: List[expr_full]): List[String] = x0 match {
-    case Nil     => Nil
-    case x :: xs => collectExprNames(x) ++ collectExprNames_list(xs)
-  }
-
-  def collectExprNames(x0: expr_full): List[String] = x0 match {
-    case IdentifierF(n, uu)      => List(n)
-    case ConstructorF(n, fs, uv) => n :: collectExprNames_fields(fs)
-    case BinaryOpF(uw, l, r, ux) => collectExprNames(l) ++ collectExprNames(r)
-    case UnaryOpF(uy, e, uz)     => collectExprNames(e)
-    case FieldAccessF(b, va, vb) => collectExprNames(b)
-    case EnumAccessF(b, vc, vd)  => collectExprNames(b)
-    case IndexF(b, i, ve)        => collectExprNames(b) ++ collectExprNames(i)
-    case CallF(c, args, vf)      => collectExprNames(c) ++ collectExprNames_list(args)
-    case PrimeF(e, vg)           => collectExprNames(e)
-    case PreF(e, vh)             => collectExprNames(e)
-    case WithF(b, upds, vi) =>
-      collectExprNames(b) ++ collectExprNames_fields(upds)
-    case IfF(c, t, e, vj) =>
-      collectExprNames(c) ++ (collectExprNames(t) ++ collectExprNames(e))
-    case LetF(vk, vala, body, vl) =>
-      collectExprNames(vala) ++ collectExprNames(body)
-    case LambdaF(vm, b, vn)  => collectExprNames(b)
-    case SetLiteralF(xs, vo) => collectExprNames_list(xs)
-    case MapLiteralF(es, vp) => collectExprNames_entries(es)
-    case SetComprehensionF(vq, d, p, vr) =>
-      collectExprNames(d) ++ collectExprNames(p)
-    case SeqLiteralF(xs, vs) => collectExprNames_list(xs)
-    case MatchesF(x, vt, vu) => collectExprNames(x)
-    case SomeWrapF(x, vv)    => collectExprNames(x)
-    case TheF(vw, d, b, vx)  => collectExprNames(d) ++ collectExprNames(b)
-    case QuantifierF(vy, bs, body, vz) =>
-      collectExprNames_bindings(bs) ++ collectExprNames(body)
-    case IntLitF(wa, wb)    => Nil
-    case FloatLitF(wc, wd)  => Nil
-    case StringLitF(we, wf) => Nil
-    case BoolLitF(wg, wh)   => Nil
-    case NoneLitF(wi)       => Nil
-  }
+  def collectExprNames(e: expr_full): List[String] =
+    maps[expr_full, String]((a: expr_full) => exprSelfNames(a), allSubexprs(e))
 
   def collectTypeNames(x0: type_expr_full): List[String] = x0 match {
     case NamedTypeF(n, uu)           => List(n)
@@ -10109,125 +10121,8 @@ object SpecRestGenerated {
     case (NoneLitF(v), uy)                                 => false
   }
 
-  def collectAllCallNames_bindings(x0: List[quantifier_binding_full]): List[String] =
-    x0 match {
-      case Nil => Nil
-      case QuantifierBindingFull(wq, d, wr, ws) :: bs =>
-        collectAllCallNames(d) ++ collectAllCallNames_bindings(bs)
-    }
-
-  def collectAllCallNames_entries(x0: List[map_entry_full]): List[String] = x0 match {
-    case Nil => Nil
-    case MapEntryFull(k, v, wp) :: es =>
-      collectAllCallNames(k) ++
-        (collectAllCallNames(v) ++ collectAllCallNames_entries(es))
-  }
-
-  def collectAllCallNames_fields(x0: List[field_assign_full]): List[String] = x0 match {
-    case Nil => Nil
-    case FieldAssignFull(wn, v, wo) :: fs =>
-      collectAllCallNames(v) ++ collectAllCallNames_fields(fs)
-  }
-
-  def collectAllCallNames_list(x0: List[expr_full]): List[String] = x0 match {
-    case Nil     => Nil
-    case x :: xs => collectAllCallNames(x) ++ collectAllCallNames_list(xs)
-  }
-
-  def collectAllCallNames(x0: expr_full): List[String] = x0 match {
-    case CallF(IdentifierF(n, uu), args, uv) =>
-      n :: collectAllCallNames_list(args)
-    case CallF(BinaryOpF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(BinaryOpF(v, va, vb, vc)) ++
-        collectAllCallNames_list(args)
-    case CallF(UnaryOpF(v, va, vb), args, uw) =>
-      collectAllCallNames(UnaryOpF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(QuantifierF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(QuantifierF(v, va, vb, vc)) ++
-        collectAllCallNames_list(args)
-    case CallF(SomeWrapF(v, va), args, uw) =>
-      collectAllCallNames(SomeWrapF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(TheF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(TheF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
-    case CallF(FieldAccessF(v, va, vb), args, uw) =>
-      collectAllCallNames(FieldAccessF(v, va, vb)) ++
-        collectAllCallNames_list(args)
-    case CallF(EnumAccessF(v, va, vb), args, uw) =>
-      collectAllCallNames(EnumAccessF(v, va, vb)) ++
-        collectAllCallNames_list(args)
-    case CallF(IndexF(v, va, vb), args, uw) =>
-      collectAllCallNames(IndexF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(CallF(v, va, vb), args, uw) =>
-      collectAllCallNames(CallF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(PrimeF(v, va), args, uw) =>
-      collectAllCallNames(PrimeF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(PreF(v, va), args, uw) =>
-      collectAllCallNames(PreF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(WithF(v, va, vb), args, uw) =>
-      collectAllCallNames(WithF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(IfF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(IfF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
-    case CallF(LetF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(LetF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
-    case CallF(LambdaF(v, va, vb), args, uw) =>
-      collectAllCallNames(LambdaF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(ConstructorF(v, va, vb), args, uw) =>
-      collectAllCallNames(ConstructorF(v, va, vb)) ++
-        collectAllCallNames_list(args)
-    case CallF(SetLiteralF(v, va), args, uw) =>
-      collectAllCallNames(SetLiteralF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(MapLiteralF(v, va), args, uw) =>
-      collectAllCallNames(MapLiteralF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(SetComprehensionF(v, va, vb, vc), args, uw) =>
-      collectAllCallNames(SetComprehensionF(v, va, vb, vc)) ++
-        collectAllCallNames_list(args)
-    case CallF(SeqLiteralF(v, va), args, uw) =>
-      collectAllCallNames(SeqLiteralF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(MatchesF(v, va, vb), args, uw) =>
-      collectAllCallNames(MatchesF(v, va, vb)) ++ collectAllCallNames_list(args)
-    case CallF(IntLitF(v, va), args, uw) =>
-      collectAllCallNames(IntLitF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(FloatLitF(v, va), args, uw) =>
-      collectAllCallNames(FloatLitF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(StringLitF(v, va), args, uw) =>
-      collectAllCallNames(StringLitF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(BoolLitF(v, va), args, uw) =>
-      collectAllCallNames(BoolLitF(v, va)) ++ collectAllCallNames_list(args)
-    case CallF(NoneLitF(v), args, uw) =>
-      collectAllCallNames(NoneLitF(v)) ++ collectAllCallNames_list(args)
-    case BinaryOpF(ux, l, r, uy) =>
-      collectAllCallNames(l) ++ collectAllCallNames(r)
-    case UnaryOpF(uz, e, va)     => collectAllCallNames(e)
-    case FieldAccessF(b, vb, vc) => collectAllCallNames(b)
-    case EnumAccessF(b, vd, ve)  => collectAllCallNames(b)
-    case IndexF(b, i, vf)        => collectAllCallNames(b) ++ collectAllCallNames(i)
-    case PrimeF(e, vg)           => collectAllCallNames(e)
-    case PreF(e, vh)             => collectAllCallNames(e)
-    case WithF(b, upds, vi) =>
-      collectAllCallNames(b) ++ collectAllCallNames_fields(upds)
-    case IfF(c, t, e, vj) =>
-      collectAllCallNames(c) ++ (collectAllCallNames(t) ++ collectAllCallNames(e))
-    case LetF(vk, vala, body, vl) =>
-      collectAllCallNames(vala) ++ collectAllCallNames(body)
-    case LambdaF(vm, b, vn)       => collectAllCallNames(b)
-    case ConstructorF(vo, fs, vp) => collectAllCallNames_fields(fs)
-    case SetLiteralF(xs, vq)      => collectAllCallNames_list(xs)
-    case MapLiteralF(es, vr)      => collectAllCallNames_entries(es)
-    case SetComprehensionF(vs, d, p, vt) =>
-      collectAllCallNames(d) ++ collectAllCallNames(p)
-    case SeqLiteralF(xs, vu) => collectAllCallNames_list(xs)
-    case MatchesF(x, vv, vw) => collectAllCallNames(x)
-    case SomeWrapF(x, vx)    => collectAllCallNames(x)
-    case TheF(vy, d, b, vz)  => collectAllCallNames(d) ++ collectAllCallNames(b)
-    case QuantifierF(wa, bs, body, wb) =>
-      collectAllCallNames_bindings(bs) ++ collectAllCallNames(body)
-    case IdentifierF(wc, wd) => Nil
-    case IntLitF(we, wf)     => Nil
-    case FloatLitF(wg, wh)   => Nil
-    case StringLitF(wi, wj)  => Nil
-    case BoolLitF(wk, wl)    => Nil
-    case NoneLitF(wm)        => Nil
-  }
+  def collectAllCallNames(e: expr_full): List[String] =
+    maps[expr_full, String]((a: expr_full) => callSelfAllNames(a), allSubexprs(e))
 
   def tightenDecMax(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
     cur match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4967,15 +4967,6 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => false
   }
 
-  def consPrimed(
-      x0: Option[String],
-      c: (List[String], (List[String], List[with_info_full]))
-  ): (List[String], (List[String], List[with_info_full])) =
-    (x0, c) match {
-      case (None, c)              => c
-      case (Some(n), (p, (f, w))) => (n :: p, (f, w))
-    }
-
   def isCreateLikeKind(x0: operation_kind): Boolean = x0 match {
     case Create()        => true
     case CreateChild()   => true
@@ -5697,14 +5688,6 @@ object SpecRestGenerated {
     case (BoolLitF(v, vc), vb)                  => false
     case (NoneLitF(v), vb)                      => false
   }
-
-  def consWithInfo(
-      wi: with_info_full,
-      x1: (List[String], (List[String], List[with_info_full]))
-  ): (List[String], (List[String], List[with_info_full])) =
-    (wi, x1) match {
-      case (wi, (p, (f, w))) => (p, (f, wi :: w))
-    }
 
   def enumNameFull(x0: enum_decl_full): String = x0 match {
     case EnumDeclFull(n, uu, uv) => n
@@ -7368,9 +7351,6 @@ object SpecRestGenerated {
     case (uw, RelationTypeF(v, va, vb, vc))     => false
   }
 
-  def emptyCollected: (List[String], (List[String], List[with_info_full])) =
-    (Nil, (Nil, Nil))
-
   def entityFieldsFull(x0: entity_decl_full): List[field_decl_full] = x0 match {
     case EntityDeclFull(uu, uv, fs, uw, ux) => fs
   }
@@ -7427,128 +7407,38 @@ object SpecRestGenerated {
         }
     }
 
-  def derivePathPattern(
-      knd: operation_kind,
-      segment: String,
-      idParamOpt: Option[String],
-      action: String,
-      opKebab: String
-  ): String =
-    knd match {
-      case Create()        => "/" + segment
-      case Read()          => pathWithIdSuffix(segment, idParamOpt)
-      case Replace()       => pathWithIdSuffix(segment, idParamOpt)
-      case PartialUpdate() => pathWithIdSuffix(segment, idParamOpt)
-      case Deletea()       => pathWithIdSuffix(segment, idParamOpt)
-      case CreateChild()   => "/" + segment
-      case FilteredRead()  => pathWithIdSuffix(segment, idParamOpt)
-      case SideEffect()    => "/" + opKebab
-      case BatchMutation() => "/" + segment + "/batch"
-      case Transition() =>
-        idParamOpt match {
-          case None       => "/" + segment + "/" + action
-          case Some(idNm) => "/" + segment + "/{" + idNm + "}/" + action
-        }
-    }
-
-  def less_nat(m: nat, n: nat): Boolean = integer_of_nat(m) < integer_of_nat(n)
-
-  def literalDropLeft(n: nat, s: String): String =
-    Str_Literal.literalOfAsciis(drop[BigInt](n, Str_Literal.asciisOfLiteral(s)))
-
-  def temporalArg(x0: temporal_body): expr_full = x0 match {
-    case TbAlways(e)     => e
-    case TbEventually(e) => e
-    case TbFairness(e)   => e
-    case TbInvalid(e)    => e
+  def primedIdSelect(x0: expr_full): List[String] = x0 match {
+    case PrimeF(inner, uu) => rootIdentifier(inner) match {
+        case None    => Nil
+        case Some(n) => List(n)
+      }
+    case BinaryOpF(v, va, vb, vc)         => Nil
+    case UnaryOpF(v, va, vb)              => Nil
+    case QuantifierF(v, va, vb, vc)       => Nil
+    case SomeWrapF(v, va)                 => Nil
+    case TheF(v, va, vb, vc)              => Nil
+    case FieldAccessF(v, va, vb)          => Nil
+    case EnumAccessF(v, va, vb)           => Nil
+    case IndexF(v, va, vb)                => Nil
+    case CallF(v, va, vb)                 => Nil
+    case PreF(v, va)                      => Nil
+    case WithF(v, va, vb)                 => Nil
+    case IfF(v, va, vb, vc)               => Nil
+    case LetF(v, va, vb, vc)              => Nil
+    case LambdaF(v, va, vb)               => Nil
+    case ConstructorF(v, va, vb)          => Nil
+    case SetLiteralF(v, va)               => Nil
+    case MapLiteralF(v, va)               => Nil
+    case SetComprehensionF(v, va, vb, vc) => Nil
+    case SeqLiteralF(v, va)               => Nil
+    case MatchesF(v, va, vb)              => Nil
+    case IntLitF(v, va)                   => Nil
+    case FloatLitF(v, va)                 => Nil
+    case StringLitF(v, va)                => Nil
+    case BoolLitF(v, va)                  => Nil
+    case NoneLitF(v)                      => Nil
+    case IdentifierF(v, va)               => Nil
   }
-
-  def triggerAggregateOf(x0: trigger_spec): trigger_aggregate = x0 match {
-    case TriggerSpec(uu, uv, uw, ux, uy, uz, a, va) => a
-  }
-
-  def triggerSourceTable(x0: trigger_spec): String = x0 match {
-    case TriggerSpec(uu, uv, uw, ux, st, uy, uz, va) => st
-  }
-
-  def triggerTargetTable(x0: trigger_spec): String = x0 match {
-    case TriggerSpec(uu, uv, tt, uw, ux, uy, uz, va) => tt
-  }
-
-  def tc_entities[A](x0: tyctx_ext[A]): List[entity_decl_full] = x0 match {
-    case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_entities
-  }
-
-  def typeExprFullToTy(
-      enums: List[String],
-      entities: List[String],
-      x2: type_expr_full
-  ): Option[ty] =
-    (enums, entities, x2) match {
-      case (enums, entities, NamedTypeF(n, uu)) =>
-        n == "Bool" match {
-          case true => Some[ty](TBool())
-          case false => n == "Int" match {
-              case true => Some[ty](TInt())
-              case false => membera[String](enums, n) match {
-                  case true => Some[ty](TEnum(n))
-                  case false => membera[String](entities, n) match {
-                      case true  => Some[ty](TEntity(n))
-                      case false => None
-                    }
-                }
-            }
-        }
-      case (enums, entities, SetTypeF(inner, uv)) =>
-        map_option[ty, ty]((a: ty) => TSet(a), typeExprFullToTy(enums, entities, inner))
-      case (uw, ux, MapTypeF(v, va, vb))          => None
-      case (uw, ux, SeqTypeF(v, va))              => None
-      case (uw, ux, OptionTypeF(v, va))           => None
-      case (uw, ux, RelationTypeF(v, va, vb, vc)) => None
-    }
-
-  def schemaFieldType(gamma: tyctx_ext[Unit], ename: String, fname: String): Option[ty] =
-    find[entity_decl_full](
-      (ed: entity_decl_full) =>
-        entityNameFull(ed) == ename,
-      tc_entities[Unit](gamma)
-    ) match {
-      case None => None
-      case Some(ed) =>
-        find[field_decl_full](
-          (fd: field_decl_full) =>
-            fieldNameFull(fd) == fname,
-          entityFieldsFull(ed)
-        ) match {
-          case None => None
-          case Some(fd) =>
-            typeExprFullToTy(
-              tc_enums[Unit](gamma),
-              map[entity_decl_full, String](
-                (a: entity_decl_full) =>
-                  entityNameFull(a),
-                tc_entities[Unit](gamma)
-              ),
-              fieldTypeFull(fd)
-            )
-        }
-    }
-
-  def serviceEntities(x0: service_ir_full): List[entity_decl_full] = x0 match {
-    case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
-  }
-
-  def signalsDeletesKey(x0: analysis_signals): Boolean = x0 match {
-    case AnalysisSignals(uu, uv, uw, d, ux, uy, uz, va, vb) => d
-  }
-
-  def combineCollected(
-      x0: (List[String], (List[String], List[with_info_full])),
-      x1: (List[String], (List[String], List[with_info_full]))
-  ): (List[String], (List[String], List[with_info_full])) =
-    (x0, x1) match {
-      case ((p1, (f1, w1)), (p2, (f2, w2))) => (p1 ++ p2, (f1 ++ f2, w1 ++ w2))
-    }
 
   def resolveWithBase(x0: expr_full): Option[String] = x0 match {
     case IdentifierF(uu, uv)                          => None
@@ -7673,101 +7563,158 @@ object SpecRestGenerated {
     case FieldAssignFull(n, uu, uv) => n
   }
 
-  def consFieldAccess(
-      n: String,
-      x1: (List[String], (List[String], List[with_info_full]))
-  ): (List[String], (List[String], List[with_info_full])) =
-    (n, x1) match {
-      case (n, (p, (f, w))) => (p, (n :: f, w))
+  def withInfoSelect(x0: expr_full): List[with_info_full] = x0 match {
+    case WithF(base, ups, uu) =>
+      List(WithInfoFull(
+        map[field_assign_full, String](
+          (a: field_assign_full) =>
+            fieldAssignName(a),
+          ups
+        ),
+        resolveWithBase(base)
+      ))
+    case BinaryOpF(v, va, vb, vc)         => Nil
+    case UnaryOpF(v, va, vb)              => Nil
+    case QuantifierF(v, va, vb, vc)       => Nil
+    case SomeWrapF(v, va)                 => Nil
+    case TheF(v, va, vb, vc)              => Nil
+    case FieldAccessF(v, va, vb)          => Nil
+    case EnumAccessF(v, va, vb)           => Nil
+    case IndexF(v, va, vb)                => Nil
+    case CallF(v, va, vb)                 => Nil
+    case PrimeF(v, va)                    => Nil
+    case PreF(v, va)                      => Nil
+    case IfF(v, va, vb, vc)               => Nil
+    case LetF(v, va, vb, vc)              => Nil
+    case LambdaF(v, va, vb)               => Nil
+    case ConstructorF(v, va, vb)          => Nil
+    case SetLiteralF(v, va)               => Nil
+    case MapLiteralF(v, va)               => Nil
+    case SetComprehensionF(v, va, vb, vc) => Nil
+    case SeqLiteralF(v, va)               => Nil
+    case MatchesF(v, va, vb)              => Nil
+    case IntLitF(v, va)                   => Nil
+    case FloatLitF(v, va)                 => Nil
+    case StringLitF(v, va)                => Nil
+    case BoolLitF(v, va)                  => Nil
+    case NoneLitF(v)                      => Nil
+    case IdentifierF(v, va)               => Nil
+  }
+
+  def derivePathPattern(
+      knd: operation_kind,
+      segment: String,
+      idParamOpt: Option[String],
+      action: String,
+      opKebab: String
+  ): String =
+    knd match {
+      case Create()        => "/" + segment
+      case Read()          => pathWithIdSuffix(segment, idParamOpt)
+      case Replace()       => pathWithIdSuffix(segment, idParamOpt)
+      case PartialUpdate() => pathWithIdSuffix(segment, idParamOpt)
+      case Deletea()       => pathWithIdSuffix(segment, idParamOpt)
+      case CreateChild()   => "/" + segment
+      case FilteredRead()  => pathWithIdSuffix(segment, idParamOpt)
+      case SideEffect()    => "/" + opKebab
+      case BatchMutation() => "/" + segment + "/batch"
+      case Transition() =>
+        idParamOpt match {
+          case None       => "/" + segment + "/" + action
+          case Some(idNm) => "/" + segment + "/{" + idNm + "}/" + action
+        }
     }
 
-  def collectExprInfo_bindings(x0: List[quantifier_binding_full])
-      : (List[String], (List[String], List[with_info_full])) =
-    x0 match {
-      case Nil => emptyCollected
-      case QuantifierBindingFull(wn, d, wo, wp) :: bs =>
-        combineCollected(collectExprInfo(d), collectExprInfo_bindings(bs))
+  def less_nat(m: nat, n: nat): Boolean = integer_of_nat(m) < integer_of_nat(n)
+
+  def literalDropLeft(n: nat, s: String): String =
+    Str_Literal.literalOfAsciis(drop[BigInt](n, Str_Literal.asciisOfLiteral(s)))
+
+  def temporalArg(x0: temporal_body): expr_full = x0 match {
+    case TbAlways(e)     => e
+    case TbEventually(e) => e
+    case TbFairness(e)   => e
+    case TbInvalid(e)    => e
+  }
+
+  def triggerAggregateOf(x0: trigger_spec): trigger_aggregate = x0 match {
+    case TriggerSpec(uu, uv, uw, ux, uy, uz, a, va) => a
+  }
+
+  def triggerSourceTable(x0: trigger_spec): String = x0 match {
+    case TriggerSpec(uu, uv, uw, ux, st, uy, uz, va) => st
+  }
+
+  def triggerTargetTable(x0: trigger_spec): String = x0 match {
+    case TriggerSpec(uu, uv, tt, uw, ux, uy, uz, va) => tt
+  }
+
+  def tc_entities[A](x0: tyctx_ext[A]): List[entity_decl_full] = x0 match {
+    case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_entities
+  }
+
+  def typeExprFullToTy(
+      enums: List[String],
+      entities: List[String],
+      x2: type_expr_full
+  ): Option[ty] =
+    (enums, entities, x2) match {
+      case (enums, entities, NamedTypeF(n, uu)) =>
+        n == "Bool" match {
+          case true => Some[ty](TBool())
+          case false => n == "Int" match {
+              case true => Some[ty](TInt())
+              case false => membera[String](enums, n) match {
+                  case true => Some[ty](TEnum(n))
+                  case false => membera[String](entities, n) match {
+                      case true  => Some[ty](TEntity(n))
+                      case false => None
+                    }
+                }
+            }
+        }
+      case (enums, entities, SetTypeF(inner, uv)) =>
+        map_option[ty, ty]((a: ty) => TSet(a), typeExprFullToTy(enums, entities, inner))
+      case (uw, ux, MapTypeF(v, va, vb))          => None
+      case (uw, ux, SeqTypeF(v, va))              => None
+      case (uw, ux, OptionTypeF(v, va))           => None
+      case (uw, ux, RelationTypeF(v, va, vb, vc)) => None
     }
 
-  def collectExprInfo_entries(x0: List[map_entry_full])
-      : (List[String], (List[String], List[with_info_full])) =
-    x0 match {
-      case Nil => emptyCollected
-      case MapEntryFull(k, v, wm) :: es =>
-        combineCollected(
-          combineCollected(collectExprInfo(k), collectExprInfo(v)),
-          collectExprInfo_entries(es)
-        )
+  def schemaFieldType(gamma: tyctx_ext[Unit], ename: String, fname: String): Option[ty] =
+    find[entity_decl_full](
+      (ed: entity_decl_full) =>
+        entityNameFull(ed) == ename,
+      tc_entities[Unit](gamma)
+    ) match {
+      case None => None
+      case Some(ed) =>
+        find[field_decl_full](
+          (fd: field_decl_full) =>
+            fieldNameFull(fd) == fname,
+          entityFieldsFull(ed)
+        ) match {
+          case None => None
+          case Some(fd) =>
+            typeExprFullToTy(
+              tc_enums[Unit](gamma),
+              map[entity_decl_full, String](
+                (a: entity_decl_full) =>
+                  entityNameFull(a),
+                tc_entities[Unit](gamma)
+              ),
+              fieldTypeFull(fd)
+            )
+        }
     }
 
-  def collectExprInfo_fields(x0: List[field_assign_full])
-      : (List[String], (List[String], List[with_info_full])) =
-    x0 match {
-      case Nil => emptyCollected
-      case FieldAssignFull(wk, v, wl) :: fs =>
-        combineCollected(collectExprInfo(v), collectExprInfo_fields(fs))
-    }
+  def serviceEntities(x0: service_ir_full): List[entity_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+  }
 
-  def collectExprInfo_list(x0: List[expr_full])
-      : (List[String], (List[String], List[with_info_full])) =
-    x0 match {
-      case Nil     => emptyCollected
-      case x :: xs => combineCollected(collectExprInfo(x), collectExprInfo_list(xs))
-    }
-
-  def collectExprInfo(x0: expr_full): (List[String], (List[String], List[with_info_full])) =
-    x0 match {
-      case PrimeF(inner, uu) =>
-        consPrimed(rootIdentifier(inner), collectExprInfo(inner))
-      case FieldAccessF(base, n, uv) => consFieldAccess(n, collectExprInfo(base))
-      case WithF(base, ups, uw) =>
-        consWithInfo(
-          WithInfoFull(
-            map[field_assign_full, String](
-              (a: field_assign_full) =>
-                fieldAssignName(a),
-              ups
-            ),
-            resolveWithBase(base)
-          ),
-          combineCollected(collectExprInfo(base), collectExprInfo_fields(ups))
-        )
-      case BinaryOpF(ux, l, r, uy) =>
-        combineCollected(collectExprInfo(l), collectExprInfo(r))
-      case UnaryOpF(uz, e, va) => collectExprInfo(e)
-      case QuantifierF(vb, bs, body, vc) =>
-        combineCollected(collectExprInfo_bindings(bs), collectExprInfo(body))
-      case SomeWrapF(e, vd) => collectExprInfo(e)
-      case TheF(ve, d, b, vf) =>
-        combineCollected(collectExprInfo(d), collectExprInfo(b))
-      case EnumAccessF(base, vg, vh) => collectExprInfo(base)
-      case IndexF(b, i, vi) =>
-        combineCollected(collectExprInfo(b), collectExprInfo(i))
-      case CallF(c, args, vj) =>
-        combineCollected(collectExprInfo(c), collectExprInfo_list(args))
-      case PreF(e, vk) => collectExprInfo(e)
-      case IfF(c, t, el, vl) =>
-        combineCollected(
-          combineCollected(collectExprInfo(c), collectExprInfo(t)),
-          collectExprInfo(el)
-        )
-      case LetF(vm, v, b, vn) =>
-        combineCollected(collectExprInfo(v), collectExprInfo(b))
-      case LambdaF(vo, b, vp)       => collectExprInfo(b)
-      case ConstructorF(vq, fs, vr) => collectExprInfo_fields(fs)
-      case SetLiteralF(xs, vs)      => collectExprInfo_list(xs)
-      case MapLiteralF(es, vt)      => collectExprInfo_entries(es)
-      case SetComprehensionF(vu, d, p, vv) =>
-        combineCollected(collectExprInfo(d), collectExprInfo(p))
-      case SeqLiteralF(xs, vw) => collectExprInfo_list(xs)
-      case MatchesF(e, vx, vy) => collectExprInfo(e)
-      case IntLitF(vz, wa)     => emptyCollected
-      case FloatLitF(wb, wc)   => emptyCollected
-      case StringLitF(wd, we)  => emptyCollected
-      case BoolLitF(wf, wg)    => emptyCollected
-      case NoneLitF(wh)        => emptyCollected
-      case IdentifierF(wi, wj) => emptyCollected
-    }
+  def signalsDeletesKey(x0: analysis_signals): Boolean = x0 match {
+    case AnalysisSignals(uu, uv, uw, d, ux, uy, uz, va, vb) => d
+  }
 
   def containsPreInPlusChain(x0: expr_full, field: String): Boolean =
     (x0, field) match {
@@ -8519,8 +8466,14 @@ object SpecRestGenerated {
   }
 
   def collectWithFields(es: List[expr_full]): Option[with_info_full] =
-    snd[List[String], List[with_info_full]](
-      snd[List[String], (List[String], List[with_info_full])](collectExprInfo_list(es))
+    maps[expr_full, with_info_full](
+      (e: expr_full) =>
+        maps[expr_full, with_info_full](
+          (a: expr_full) =>
+            withInfoSelect(a),
+          allSubexprs(e)
+        ),
+      es
     ) match {
       case Nil    => None
       case x :: _ => Some[with_info_full](x)
@@ -9898,6 +9851,36 @@ object SpecRestGenerated {
       case Some(ed) => findFieldDeclFull(entityFieldsFull(ed), fname)
     }
 
+  def fieldAccessNameSelect(x0: expr_full): List[String] = x0 match {
+    case FieldAccessF(uu, n, uv)          => List(n)
+    case BinaryOpF(v, va, vb, vc)         => Nil
+    case UnaryOpF(v, va, vb)              => Nil
+    case QuantifierF(v, va, vb, vc)       => Nil
+    case SomeWrapF(v, va)                 => Nil
+    case TheF(v, va, vb, vc)              => Nil
+    case EnumAccessF(v, va, vb)           => Nil
+    case IndexF(v, va, vb)                => Nil
+    case CallF(v, va, vb)                 => Nil
+    case PrimeF(v, va)                    => Nil
+    case PreF(v, va)                      => Nil
+    case WithF(v, va, vb)                 => Nil
+    case IfF(v, va, vb, vc)               => Nil
+    case LetF(v, va, vb, vc)              => Nil
+    case LambdaF(v, va, vb)               => Nil
+    case ConstructorF(v, va, vb)          => Nil
+    case SetLiteralF(v, va)               => Nil
+    case MapLiteralF(v, va)               => Nil
+    case SetComprehensionF(v, va, vb, vc) => Nil
+    case SeqLiteralF(v, va)               => Nil
+    case MatchesF(v, va, vb)              => Nil
+    case IntLitF(v, va)                   => Nil
+    case FloatLitF(v, va)                 => Nil
+    case StringLitF(v, va)                => Nil
+    case BoolLitF(v, va)                  => Nil
+    case NoneLitF(v)                      => Nil
+    case IdentifierF(v, va)               => Nil
+  }
+
   def keyExistsInRequiresOf(stateFields: List[String], e: expr_full): List[String] =
     e match {
       case BinaryOpF(BAnd(), _, _, _)                            => Nil
@@ -10426,10 +10409,10 @@ object SpecRestGenerated {
   }
 
   def collectFieldAccessNames(e: expr_full): List[String] =
-    remdups[String](fst[List[String], List[with_info_full]](snd[
-      List[String],
-      (List[String], List[with_info_full])
-    ](collectExprInfo(e))))
+    remdups[String](maps[expr_full, String](
+      (a: expr_full) => fieldAccessNameSelect(a),
+      allSubexprs(e)
+    ))
 
   def consumeDigitsAux(x0: List[BigInt], acc: int, count: nat): (int, (nat, List[BigInt])) =
     (x0, acc, count) match {
@@ -10860,9 +10843,11 @@ object SpecRestGenerated {
     }
 
   def collectPrimedIdentifiers(es: List[expr_full]): List[String] =
-    remdups[String](
-      fst[List[String], (List[String], List[with_info_full])](collectExprInfo_list(es))
-    )
+    remdups[String](maps[expr_full, String](
+      (e: expr_full) =>
+        maps[expr_full, String]((a: expr_full) => primedIdSelect(a), allSubexprs(e)),
+      es
+    ))
 
   def referencesPrimedRelation(x0: expr_full, rel: String): Boolean = (x0, rel) match {
     case (PrimeF(IdentifierF(n, uu), uv), rel)               => n == rel

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -10109,6 +10109,126 @@ object SpecRestGenerated {
     case (NoneLitF(v), uy)                                 => false
   }
 
+  def collectAllCallNames_bindings(x0: List[quantifier_binding_full]): List[String] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(wq, d, wr, ws) :: bs =>
+        collectAllCallNames(d) ++ collectAllCallNames_bindings(bs)
+    }
+
+  def collectAllCallNames_entries(x0: List[map_entry_full]): List[String] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, wp) :: es =>
+      collectAllCallNames(k) ++
+        (collectAllCallNames(v) ++ collectAllCallNames_entries(es))
+  }
+
+  def collectAllCallNames_fields(x0: List[field_assign_full]): List[String] = x0 match {
+    case Nil => Nil
+    case FieldAssignFull(wn, v, wo) :: fs =>
+      collectAllCallNames(v) ++ collectAllCallNames_fields(fs)
+  }
+
+  def collectAllCallNames_list(x0: List[expr_full]): List[String] = x0 match {
+    case Nil     => Nil
+    case x :: xs => collectAllCallNames(x) ++ collectAllCallNames_list(xs)
+  }
+
+  def collectAllCallNames(x0: expr_full): List[String] = x0 match {
+    case CallF(IdentifierF(n, uu), args, uv) =>
+      n :: collectAllCallNames_list(args)
+    case CallF(BinaryOpF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(BinaryOpF(v, va, vb, vc)) ++
+        collectAllCallNames_list(args)
+    case CallF(UnaryOpF(v, va, vb), args, uw) =>
+      collectAllCallNames(UnaryOpF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(QuantifierF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(QuantifierF(v, va, vb, vc)) ++
+        collectAllCallNames_list(args)
+    case CallF(SomeWrapF(v, va), args, uw) =>
+      collectAllCallNames(SomeWrapF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(TheF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(TheF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
+    case CallF(FieldAccessF(v, va, vb), args, uw) =>
+      collectAllCallNames(FieldAccessF(v, va, vb)) ++
+        collectAllCallNames_list(args)
+    case CallF(EnumAccessF(v, va, vb), args, uw) =>
+      collectAllCallNames(EnumAccessF(v, va, vb)) ++
+        collectAllCallNames_list(args)
+    case CallF(IndexF(v, va, vb), args, uw) =>
+      collectAllCallNames(IndexF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(CallF(v, va, vb), args, uw) =>
+      collectAllCallNames(CallF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(PrimeF(v, va), args, uw) =>
+      collectAllCallNames(PrimeF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(PreF(v, va), args, uw) =>
+      collectAllCallNames(PreF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(WithF(v, va, vb), args, uw) =>
+      collectAllCallNames(WithF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(IfF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(IfF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
+    case CallF(LetF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(LetF(v, va, vb, vc)) ++ collectAllCallNames_list(args)
+    case CallF(LambdaF(v, va, vb), args, uw) =>
+      collectAllCallNames(LambdaF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(ConstructorF(v, va, vb), args, uw) =>
+      collectAllCallNames(ConstructorF(v, va, vb)) ++
+        collectAllCallNames_list(args)
+    case CallF(SetLiteralF(v, va), args, uw) =>
+      collectAllCallNames(SetLiteralF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(MapLiteralF(v, va), args, uw) =>
+      collectAllCallNames(MapLiteralF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(SetComprehensionF(v, va, vb, vc), args, uw) =>
+      collectAllCallNames(SetComprehensionF(v, va, vb, vc)) ++
+        collectAllCallNames_list(args)
+    case CallF(SeqLiteralF(v, va), args, uw) =>
+      collectAllCallNames(SeqLiteralF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(MatchesF(v, va, vb), args, uw) =>
+      collectAllCallNames(MatchesF(v, va, vb)) ++ collectAllCallNames_list(args)
+    case CallF(IntLitF(v, va), args, uw) =>
+      collectAllCallNames(IntLitF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(FloatLitF(v, va), args, uw) =>
+      collectAllCallNames(FloatLitF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(StringLitF(v, va), args, uw) =>
+      collectAllCallNames(StringLitF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(BoolLitF(v, va), args, uw) =>
+      collectAllCallNames(BoolLitF(v, va)) ++ collectAllCallNames_list(args)
+    case CallF(NoneLitF(v), args, uw) =>
+      collectAllCallNames(NoneLitF(v)) ++ collectAllCallNames_list(args)
+    case BinaryOpF(ux, l, r, uy) =>
+      collectAllCallNames(l) ++ collectAllCallNames(r)
+    case UnaryOpF(uz, e, va)     => collectAllCallNames(e)
+    case FieldAccessF(b, vb, vc) => collectAllCallNames(b)
+    case EnumAccessF(b, vd, ve)  => collectAllCallNames(b)
+    case IndexF(b, i, vf)        => collectAllCallNames(b) ++ collectAllCallNames(i)
+    case PrimeF(e, vg)           => collectAllCallNames(e)
+    case PreF(e, vh)             => collectAllCallNames(e)
+    case WithF(b, upds, vi) =>
+      collectAllCallNames(b) ++ collectAllCallNames_fields(upds)
+    case IfF(c, t, e, vj) =>
+      collectAllCallNames(c) ++ (collectAllCallNames(t) ++ collectAllCallNames(e))
+    case LetF(vk, vala, body, vl) =>
+      collectAllCallNames(vala) ++ collectAllCallNames(body)
+    case LambdaF(vm, b, vn)       => collectAllCallNames(b)
+    case ConstructorF(vo, fs, vp) => collectAllCallNames_fields(fs)
+    case SetLiteralF(xs, vq)      => collectAllCallNames_list(xs)
+    case MapLiteralF(es, vr)      => collectAllCallNames_entries(es)
+    case SetComprehensionF(vs, d, p, vt) =>
+      collectAllCallNames(d) ++ collectAllCallNames(p)
+    case SeqLiteralF(xs, vu) => collectAllCallNames_list(xs)
+    case MatchesF(x, vv, vw) => collectAllCallNames(x)
+    case SomeWrapF(x, vx)    => collectAllCallNames(x)
+    case TheF(vy, d, b, vz)  => collectAllCallNames(d) ++ collectAllCallNames(b)
+    case QuantifierF(wa, bs, body, wb) =>
+      collectAllCallNames_bindings(bs) ++ collectAllCallNames(body)
+    case IdentifierF(wc, wd) => Nil
+    case IntLitF(we, wf)     => Nil
+    case FloatLitF(wg, wh)   => Nil
+    case StringLitF(wi, wj)  => Nil
+    case BoolLitF(wk, wl)    => Nil
+    case NoneLitF(wm)        => Nil
+  }
+
   def tightenDecMax(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
     cur match {
       case None    => Some[decimal_lit](d)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2081,6 +2081,70 @@ object SpecRestGenerated {
     case (f, x21 :: x22) => f(x21) :: map[A, B](f, x22)
   }
 
+  def allSubexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(n, d, a, sp) :: bs =>
+        allSubexprs(d) ++ allSubexprs_bindings(bs)
+    }
+
+  def allSubexprs_entries(x0: List[map_entry_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, sp) :: es =>
+      allSubexprs(k) ++ (allSubexprs(v) ++ allSubexprs_entries(es))
+  }
+
+  def allSubexprs_fields(x0: List[field_assign_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case FieldAssignFull(n, v, sp) :: fs =>
+      allSubexprs(v) ++ allSubexprs_fields(fs)
+  }
+
+  def allSubexprs_list(x0: List[expr_full]): List[expr_full] = x0 match {
+    case Nil     => Nil
+    case x :: xs => allSubexprs(x) ++ allSubexprs_list(xs)
+  }
+
+  def allSubexprs(x0: expr_full): List[expr_full] = x0 match {
+    case BinaryOpF(op, l, r, sp) =>
+      BinaryOpF(op, l, r, sp) :: allSubexprs(l) ++ allSubexprs(r)
+    case UnaryOpF(op, e, sp)    => UnaryOpF(op, e, sp) :: allSubexprs(e)
+    case FieldAccessF(b, f, sp) => FieldAccessF(b, f, sp) :: allSubexprs(b)
+    case EnumAccessF(b, e, sp)  => EnumAccessF(b, e, sp) :: allSubexprs(b)
+    case IndexF(b, i, sp)       => IndexF(b, i, sp) :: allSubexprs(b) ++ allSubexprs(i)
+    case CallF(c, args, sp) =>
+      CallF(c, args, sp) :: allSubexprs(c) ++ allSubexprs_list(args)
+    case PrimeF(e, sp) => PrimeF(e, sp) :: allSubexprs(e)
+    case PreF(e, sp)   => PreF(e, sp) :: allSubexprs(e)
+    case WithF(b, ups, sp) =>
+      WithF(b, ups, sp) :: allSubexprs(b) ++ allSubexprs_fields(ups)
+    case IfF(c, t, e, sp) =>
+      IfF(c, t, e, sp) :: allSubexprs(c) ++ (allSubexprs(t) ++ allSubexprs(e))
+    case LetF(v, vala, body, sp) =>
+      LetF(v, vala, body, sp) :: allSubexprs(vala) ++ allSubexprs(body)
+    case LambdaF(p, b, sp) => LambdaF(p, b, sp) :: allSubexprs(b)
+    case ConstructorF(n, fs, sp) =>
+      ConstructorF(n, fs, sp) :: allSubexprs_fields(fs)
+    case SetLiteralF(xs, sp) => SetLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MapLiteralF(es, sp) => MapLiteralF(es, sp) :: allSubexprs_entries(es)
+    case SetComprehensionF(v, d, p, sp) =>
+      SetComprehensionF(v, d, p, sp) :: allSubexprs(d) ++ allSubexprs(p)
+    case SeqLiteralF(xs, sp)  => SeqLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MatchesF(e, pat, sp) => MatchesF(e, pat, sp) :: allSubexprs(e)
+    case SomeWrapF(e, sp)     => SomeWrapF(e, sp) :: allSubexprs(e)
+    case TheF(v, d, b, sp) =>
+      TheF(v, d, b, sp) :: allSubexprs(d) ++ allSubexprs(b)
+    case QuantifierF(q, bs, body, sp) =>
+      QuantifierF(q, bs, body, sp) ::
+        allSubexprs_bindings(bs) ++ allSubexprs(body)
+    case IdentifierF(n, sp) => List(IdentifierF(n, sp))
+    case IntLitF(n, sp)     => List(IntLitF(n, sp))
+    case FloatLitF(v, sp)   => List(FloatLitF(v, sp))
+    case StringLitF(v, sp)  => List(StringLitF(v, sp))
+    case BoolLitF(b, sp)    => List(BoolLitF(b, sp))
+    case NoneLitF(sp)       => List(NoneLitF(sp))
+  }
+
   def string_in_list(y: String, x1: List[String]): Boolean = (y, x1) match {
     case (y, Nil)     => false
     case (y, x :: xs) => x == y || string_in_list(y, xs)
@@ -5608,70 +5672,6 @@ object SpecRestGenerated {
             }
         }
     }
-
-  def allSubexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] =
-    x0 match {
-      case Nil => Nil
-      case QuantifierBindingFull(n, d, a, sp) :: bs =>
-        allSubexprs(d) ++ allSubexprs_bindings(bs)
-    }
-
-  def allSubexprs_entries(x0: List[map_entry_full]): List[expr_full] = x0 match {
-    case Nil => Nil
-    case MapEntryFull(k, v, sp) :: es =>
-      allSubexprs(k) ++ (allSubexprs(v) ++ allSubexprs_entries(es))
-  }
-
-  def allSubexprs_fields(x0: List[field_assign_full]): List[expr_full] = x0 match {
-    case Nil => Nil
-    case FieldAssignFull(n, v, sp) :: fs =>
-      allSubexprs(v) ++ allSubexprs_fields(fs)
-  }
-
-  def allSubexprs_list(x0: List[expr_full]): List[expr_full] = x0 match {
-    case Nil     => Nil
-    case x :: xs => allSubexprs(x) ++ allSubexprs_list(xs)
-  }
-
-  def allSubexprs(x0: expr_full): List[expr_full] = x0 match {
-    case BinaryOpF(op, l, r, sp) =>
-      BinaryOpF(op, l, r, sp) :: allSubexprs(l) ++ allSubexprs(r)
-    case UnaryOpF(op, e, sp)    => UnaryOpF(op, e, sp) :: allSubexprs(e)
-    case FieldAccessF(b, f, sp) => FieldAccessF(b, f, sp) :: allSubexprs(b)
-    case EnumAccessF(b, e, sp)  => EnumAccessF(b, e, sp) :: allSubexprs(b)
-    case IndexF(b, i, sp)       => IndexF(b, i, sp) :: allSubexprs(b) ++ allSubexprs(i)
-    case CallF(c, args, sp) =>
-      CallF(c, args, sp) :: allSubexprs(c) ++ allSubexprs_list(args)
-    case PrimeF(e, sp) => PrimeF(e, sp) :: allSubexprs(e)
-    case PreF(e, sp)   => PreF(e, sp) :: allSubexprs(e)
-    case WithF(b, ups, sp) =>
-      WithF(b, ups, sp) :: allSubexprs(b) ++ allSubexprs_fields(ups)
-    case IfF(c, t, e, sp) =>
-      IfF(c, t, e, sp) :: allSubexprs(c) ++ (allSubexprs(t) ++ allSubexprs(e))
-    case LetF(v, vala, body, sp) =>
-      LetF(v, vala, body, sp) :: allSubexprs(vala) ++ allSubexprs(body)
-    case LambdaF(p, b, sp) => LambdaF(p, b, sp) :: allSubexprs(b)
-    case ConstructorF(n, fs, sp) =>
-      ConstructorF(n, fs, sp) :: allSubexprs_fields(fs)
-    case SetLiteralF(xs, sp) => SetLiteralF(xs, sp) :: allSubexprs_list(xs)
-    case MapLiteralF(es, sp) => MapLiteralF(es, sp) :: allSubexprs_entries(es)
-    case SetComprehensionF(v, d, p, sp) =>
-      SetComprehensionF(v, d, p, sp) :: allSubexprs(d) ++ allSubexprs(p)
-    case SeqLiteralF(xs, sp)  => SeqLiteralF(xs, sp) :: allSubexprs_list(xs)
-    case MatchesF(e, pat, sp) => MatchesF(e, pat, sp) :: allSubexprs(e)
-    case SomeWrapF(e, sp)     => SomeWrapF(e, sp) :: allSubexprs(e)
-    case TheF(v, d, b, sp) =>
-      TheF(v, d, b, sp) :: allSubexprs(d) ++ allSubexprs(b)
-    case QuantifierF(q, bs, body, sp) =>
-      QuantifierF(q, bs, body, sp) ::
-        allSubexprs_bindings(bs) ++ allSubexprs(body)
-    case IdentifierF(n, sp) => List(IdentifierF(n, sp))
-    case IntLitF(n, sp)     => List(IntLitF(n, sp))
-    case FloatLitF(v, sp)   => List(FloatLitF(v, sp))
-    case StringLitF(v, sp)  => List(StringLitF(v, sp))
-    case BoolLitF(b, sp)    => List(BoolLitF(b, sp))
-    case NoneLitF(sp)       => List(NoneLitF(sp))
-  }
 
   def enumLitName(x0: expr_full): Option[String] = x0 match {
     case EnumAccessF(uu, m, uv)           => Some[String](m)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -987,6 +987,16 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
+  sealed abstract class dfs_state_ext[A]
+  final case class dfs_state_exta[A](
+      a: List[String],
+      b: List[String],
+      c: List[String],
+      d: List[List[String]],
+      e: List[List[String]],
+      f: A
+  ) extends dfs_state_ext[A]
+
   sealed abstract class convention_ir_diagnostic
   final case class PartialIndexFieldMissing(a: String, b: String) extends convention_ir_diagnostic
   final case class TestStrategyFieldMissing(a: String, b: String, c: String)
@@ -5686,6 +5696,238 @@ object SpecRestGenerated {
       case false => acc ++ List(fd)
     }
 
+  def listIsSubset(x0: List[String], uu: List[String]): Boolean = (x0, uu) match {
+    case (Nil, uu)     => true
+    case (x :: xs, ys) => membera[String](ys, x) && listIsSubset(xs, ys)
+  }
+
+  def cycleSetEq(c1: List[String], c2: List[String]): Boolean =
+    listIsSubset(c1, c2) && listIsSubset(c2, c1)
+
+  def cycles[A](x0: dfs_state_ext[A]): List[List[String]] = x0 match {
+    case dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more) =>
+      cycles
+  }
+
+  def times_nat(m: nat, n: nat): nat =
+    Nata(integer_of_nat(m) * integer_of_nat(n))
+
+  def onStack_update[A](
+      onStacka: (List[String]) => List[String],
+      x1: dfs_state_ext[A]
+  ): dfs_state_ext[A] =
+    (onStacka, x1) match {
+      case (onStacka, dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more)) =>
+        dfs_state_exta[A](onStacka(onStack), visited, stack, cycles, seenCycles, more)
+    }
+
+  def stack_update[A](
+      stacka: (List[String]) => List[String],
+      x1: dfs_state_ext[A]
+  ): dfs_state_ext[A] =
+    (stacka, x1) match {
+      case (stacka, dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more)) =>
+        dfs_state_exta[A](onStack, visited, stacka(stack), cycles, seenCycles, more)
+    }
+
+  def seenCycles_update[A](
+      seenCyclesa: (List[List[String]]) => List[List[String]],
+      x1: dfs_state_ext[A]
+  ): dfs_state_ext[A] =
+    (seenCyclesa, x1) match {
+      case (seenCyclesa, dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more)) =>
+        dfs_state_exta[A](onStack, visited, stack, cycles, seenCyclesa(seenCycles), more)
+    }
+
+  def visited_update[A](
+      visiteda: (List[String]) => List[String],
+      x1: dfs_state_ext[A]
+  ): dfs_state_ext[A] =
+    (visiteda, x1) match {
+      case (visiteda, dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more)) =>
+        dfs_state_exta[A](onStack, visiteda(visited), stack, cycles, seenCycles, more)
+    }
+
+  def cycles_update[A](
+      cyclesa: (List[List[String]]) => List[List[String]],
+      x1: dfs_state_ext[A]
+  ): dfs_state_ext[A] =
+    (cyclesa, x1) match {
+      case (cyclesa, dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more)) =>
+        dfs_state_exta[A](onStack, visited, stack, cyclesa(cycles), seenCycles, more)
+    }
+
+  def seenCycles[A](x0: dfs_state_ext[A]): List[List[String]] = x0 match {
+    case dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more) =>
+      seenCycles
+  }
+
+  def visited[A](x0: dfs_state_ext[A]): List[String] = x0 match {
+    case dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more) =>
+      visited
+  }
+
+  def onStack[A](x0: dfs_state_ext[A]): List[String] = x0 match {
+    case dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more) =>
+      onStack
+  }
+
+  def cycleAlreadySeen(uu: List[String], x1: List[List[String]]): Boolean =
+    (uu, x1) match {
+      case (uu, Nil)      => false
+      case (c, s :: rest) => cycleSetEq(c, s) || cycleAlreadySeen(c, rest)
+    }
+
+  def stack[A](x0: dfs_state_ext[A]): List[String] = x0 match {
+    case dfs_state_exta(onStack, visited, stack, cycles, seenCycles, more) =>
+      stack
+  }
+
+  def sliceFromNode(uu: String, x1: List[String]): List[String] = (uu, x1) match {
+    case (uu, Nil) => Nil
+    case (n, x :: xs) =>
+      x == n match {
+        case true  => x :: xs
+        case false => sliceFromNode(n, xs)
+      }
+  }
+
+  def listRemoveAll(uu: String, x1: List[String]): List[String] = (uu, x1) match {
+    case (uu, Nil) => Nil
+    case (x, y :: ys) =>
+      x == y match {
+        case true  => listRemoveAll(x, ys)
+        case false => y :: listRemoveAll(x, ys)
+      }
+  }
+
+  def lookupEdges(uu: String, x1: List[(String, List[String])]): List[String] =
+    (uu, x1) match {
+      case (uu, Nil) => Nil
+      case (n, (k, v) :: rest) =>
+        k == n match {
+          case true  => v
+          case false => lookupEdges(n, rest)
+        }
+    }
+
+  def dfsChildrenFuel(
+      fuel: nat,
+      edges: List[(String, List[String])],
+      x2: List[String],
+      state: dfs_state_ext[Unit]
+  ): dfs_state_ext[Unit] =
+    (fuel, edges, x2, state) match {
+      case (fuel, edges, Nil, state) => state
+      case (fuel, edges, c :: rest, state) =>
+        equal_nat(fuel, zero_nat) match {
+          case true => state
+          case false => dfsChildrenFuel(
+              minus_nat(fuel, one_nat),
+              edges,
+              rest,
+              dfsNodeFuel(minus_nat(fuel, one_nat), edges, c, state)
+            )
+        }
+    }
+
+  def dfsNodeFuel(
+      fuel: nat,
+      edges: List[(String, List[String])],
+      n: String,
+      state: dfs_state_ext[Unit]
+  ): dfs_state_ext[Unit] =
+    equal_nat(fuel, zero_nat) match {
+      case true => state
+      case false => membera[String](onStack[Unit](state), n) match {
+          case true =>
+            val cyc =
+              sliceFromNode(n, stack[Unit](state)): List[String];
+            nulla[String](cyc) match {
+              case true => state
+              case false => cycleAlreadySeen(cyc, seenCycles[Unit](state)) match {
+                  case true => state
+                  case false => seenCycles_update[Unit](
+                      (_: List[List[String]]) =>
+                        cyc :: seenCycles[Unit](state),
+                      cycles_update[Unit](
+                        (_: List[List[String]]) =>
+                          cycles[Unit](state) ++ List(cyc),
+                        state
+                      )
+                    )
+                }
+            }
+          case false => membera[String](visited[Unit](state), n) match {
+              case true => state
+              case false =>
+                val state1 =
+                  stack_update[Unit](
+                    (_: List[String]) =>
+                      stack[Unit](state) ++ List(n),
+                    visited_update[Unit](
+                      (_: List[String]) =>
+                        n :: visited[Unit](state),
+                      onStack_update[Unit](
+                        (_: List[String]) =>
+                          n :: onStack[Unit](state),
+                        state
+                      )
+                    )
+                  ): dfs_state_ext[Unit]
+                val children = lookupEdges(n, edges): List[String]
+                val state2 =
+                  dfsChildrenFuel(minus_nat(fuel, one_nat), edges, children, state1): dfs_state_ext[
+                    Unit
+                  ];
+                stack_update[Unit](
+                  (_: List[String]) =>
+                    butlast[String](stack[Unit](state2)),
+                  onStack_update[Unit](
+                    (_: List[String]) =>
+                      listRemoveAll(n, onStack[Unit](state2)),
+                    state2
+                  )
+                )
+            }
+        }
+    }
+
+  def findCyclesAux(
+      uu: nat,
+      uv: List[(String, List[String])],
+      x2: List[String],
+      state: dfs_state_ext[Unit]
+  ): dfs_state_ext[Unit] =
+    (uu, uv, x2, state) match {
+      case (uu, uv, Nil, state) => state
+      case (fuel, edges, n :: rest, state) =>
+        val state1 =
+          stack_update[Unit](
+            (_: List[String]) => Nil,
+            onStack_update[Unit]((_: List[String]) => Nil, state)
+          ): dfs_state_ext[Unit]
+        val a = dfsNodeFuel(fuel, edges, n, state1): dfs_state_ext[Unit];
+        findCyclesAux(fuel, edges, rest, a)
+    }
+
+  def initDfsState: dfs_state_ext[Unit] =
+    dfs_state_exta[Unit](Nil, Nil, Nil, Nil, Nil, ())
+
+  def findCycles(nodes: List[String], edges: List[(String, List[String])]): List[List[String]] =
+    cycles[Unit](findCyclesAux(
+      plus_nat(
+        plus_nat(
+          times_nat(size_list[String](nodes), size_list[String](nodes)),
+          size_list[String](nodes)
+        ),
+        one_nat
+      ),
+      edges,
+      nodes,
+      initDfsState
+    ))
+
   def parseHttpMethod(s: String): Option[http_method] =
     s == "GET" match {
       case true => Some[http_method](GET())
@@ -8588,6 +8830,152 @@ object SpecRestGenerated {
   def withInfoFieldNames(x0: with_info_full): List[String] = x0 match {
     case WithInfoFull(fs, uu) => fs
   }
+
+  def collectCallNames_bindings(x0: List[quantifier_binding_full], wy: List[String]): List[String] =
+    (x0, wy) match {
+      case (Nil, wy) => Nil
+      case (QuantifierBindingFull(wz, d, xa, xb) :: bs, filt) =>
+        collectCallNames(d, filt) ++ collectCallNames_bindings(bs, filt)
+    }
+
+  def collectCallNames_entries(x0: List[map_entry_full], ww: List[String]): List[String] =
+    (x0, ww) match {
+      case (Nil, ww) => Nil
+      case (MapEntryFull(k, v, wx) :: es, filt) =>
+        collectCallNames(k, filt) ++
+          (collectCallNames(v, filt) ++ collectCallNames_entries(es, filt))
+    }
+
+  def collectCallNames_fields(x0: List[field_assign_full], wt: List[String]): List[String] =
+    (x0, wt) match {
+      case (Nil, wt) => Nil
+      case (FieldAssignFull(wu, v, wv) :: fs, filt) =>
+        collectCallNames(v, filt) ++ collectCallNames_fields(fs, filt)
+    }
+
+  def collectCallNames_list(x0: List[expr_full], ws: List[String]): List[String] =
+    (x0, ws) match {
+      case (Nil, ws) => Nil
+      case (x :: xs, filt) =>
+        collectCallNames(x, filt) ++ collectCallNames_list(xs, filt)
+    }
+
+  def collectCallNames(x0: expr_full, filt: List[String]): List[String] =
+    (x0, filt) match {
+      case (CallF(IdentifierF(n, uu), args, sp), filt) =>
+        membera[String](filt, n) match {
+          case true  => n :: collectCallNames_list(args, filt)
+          case false => collectCallNames_list(args, filt)
+        }
+      case (CallF(BinaryOpF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(BinaryOpF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(UnaryOpF(v, va, vb), args, uv), filt) =>
+        collectCallNames(UnaryOpF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(QuantifierF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(QuantifierF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(SomeWrapF(v, va), args, uv), filt) =>
+        collectCallNames(SomeWrapF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(TheF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(TheF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(FieldAccessF(v, va, vb), args, uv), filt) =>
+        collectCallNames(FieldAccessF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(EnumAccessF(v, va, vb), args, uv), filt) =>
+        collectCallNames(EnumAccessF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(IndexF(v, va, vb), args, uv), filt) =>
+        collectCallNames(IndexF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(CallF(v, va, vb), args, uv), filt) =>
+        collectCallNames(CallF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(PrimeF(v, va), args, uv), filt) =>
+        collectCallNames(PrimeF(v, va), filt) ++ collectCallNames_list(args, filt)
+      case (CallF(PreF(v, va), args, uv), filt) =>
+        collectCallNames(PreF(v, va), filt) ++ collectCallNames_list(args, filt)
+      case (CallF(WithF(v, va, vb), args, uv), filt) =>
+        collectCallNames(WithF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(IfF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(IfF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(LetF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(LetF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(LambdaF(v, va, vb), args, uv), filt) =>
+        collectCallNames(LambdaF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(ConstructorF(v, va, vb), args, uv), filt) =>
+        collectCallNames(ConstructorF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(SetLiteralF(v, va), args, uv), filt) =>
+        collectCallNames(SetLiteralF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(MapLiteralF(v, va), args, uv), filt) =>
+        collectCallNames(MapLiteralF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(SetComprehensionF(v, va, vb, vc), args, uv), filt) =>
+        collectCallNames(SetComprehensionF(v, va, vb, vc), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(SeqLiteralF(v, va), args, uv), filt) =>
+        collectCallNames(SeqLiteralF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(MatchesF(v, va, vb), args, uv), filt) =>
+        collectCallNames(MatchesF(v, va, vb), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(IntLitF(v, va), args, uv), filt) =>
+        collectCallNames(IntLitF(v, va), filt) ++ collectCallNames_list(args, filt)
+      case (CallF(FloatLitF(v, va), args, uv), filt) =>
+        collectCallNames(FloatLitF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(StringLitF(v, va), args, uv), filt) =>
+        collectCallNames(StringLitF(v, va), filt) ++
+          collectCallNames_list(args, filt)
+      case (CallF(BoolLitF(v, va), args, uv), filt) =>
+        collectCallNames(BoolLitF(v, va), filt) ++ collectCallNames_list(args, filt)
+      case (CallF(NoneLitF(v), args, uv), filt) =>
+        collectCallNames(NoneLitF(v), filt) ++ collectCallNames_list(args, filt)
+      case (BinaryOpF(uw, l, r, ux), filt) =>
+        collectCallNames(l, filt) ++ collectCallNames(r, filt)
+      case (UnaryOpF(uy, e, uz), filt)     => collectCallNames(e, filt)
+      case (FieldAccessF(b, va, vb), filt) => collectCallNames(b, filt)
+      case (EnumAccessF(b, vc, vd), filt)  => collectCallNames(b, filt)
+      case (IndexF(b, i, ve), filt) =>
+        collectCallNames(b, filt) ++ collectCallNames(i, filt)
+      case (PrimeF(e, vf), filt) => collectCallNames(e, filt)
+      case (PreF(e, vg), filt)   => collectCallNames(e, filt)
+      case (WithF(b, upds, vh), filt) =>
+        collectCallNames(b, filt) ++ collectCallNames_fields(upds, filt)
+      case (IfF(c, t, e, vi), filt) =>
+        collectCallNames(c, filt) ++
+          (collectCallNames(t, filt) ++ collectCallNames(e, filt))
+      case (LetF(vj, vala, body, vk), filt) =>
+        collectCallNames(vala, filt) ++ collectCallNames(body, filt)
+      case (LambdaF(vl, b, vm), filt)       => collectCallNames(b, filt)
+      case (ConstructorF(vn, fs, vo), filt) => collectCallNames_fields(fs, filt)
+      case (SetLiteralF(xs, vp), filt)      => collectCallNames_list(xs, filt)
+      case (MapLiteralF(es, vq), filt)      => collectCallNames_entries(es, filt)
+      case (SetComprehensionF(vr, d, p, vs), filt) =>
+        collectCallNames(d, filt) ++ collectCallNames(p, filt)
+      case (SeqLiteralF(xs, vt), filt) => collectCallNames_list(xs, filt)
+      case (MatchesF(x, vu, vv), filt) => collectCallNames(x, filt)
+      case (SomeWrapF(x, vw), filt)    => collectCallNames(x, filt)
+      case (TheF(vx, d, b, vy), filt) =>
+        collectCallNames(d, filt) ++ collectCallNames(b, filt)
+      case (QuantifierF(vz, bs, body, wa), filt) =>
+        collectCallNames_bindings(bs, filt) ++ collectCallNames(body, filt)
+      case (IdentifierF(wb, wc), wd) => Nil
+      case (IntLitF(we, wf), wg)     => Nil
+      case (FloatLitF(wh, wi), wj)   => Nil
+      case (StringLitF(wk, wl), wm)  => Nil
+      case (BoolLitF(wn, wo), wp)    => Nil
+      case (NoneLitF(wq), wr)        => Nil
+    }
 
   def collectExprNames_bindings(x0: List[quantifier_binding_full]): List[String] =
     x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8589,6 +8589,74 @@ object SpecRestGenerated {
     case WithInfoFull(fs, uu) => fs
   }
 
+  def collectExprNames_bindings(x0: List[quantifier_binding_full]): List[String] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(wm, d, wn, wo) :: bs =>
+        collectExprNames(d) ++ collectExprNames_bindings(bs)
+    }
+
+  def collectExprNames_entries(x0: List[map_entry_full]): List[String] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, wl) :: es =>
+      collectExprNames(k) ++ (collectExprNames(v) ++ collectExprNames_entries(es))
+  }
+
+  def collectExprNames_fields(x0: List[field_assign_full]): List[String] = x0 match {
+    case Nil => Nil
+    case FieldAssignFull(wj, v, wk) :: fs =>
+      collectExprNames(v) ++ collectExprNames_fields(fs)
+  }
+
+  def collectExprNames_list(x0: List[expr_full]): List[String] = x0 match {
+    case Nil     => Nil
+    case x :: xs => collectExprNames(x) ++ collectExprNames_list(xs)
+  }
+
+  def collectExprNames(x0: expr_full): List[String] = x0 match {
+    case IdentifierF(n, uu)      => List(n)
+    case ConstructorF(n, fs, uv) => n :: collectExprNames_fields(fs)
+    case BinaryOpF(uw, l, r, ux) => collectExprNames(l) ++ collectExprNames(r)
+    case UnaryOpF(uy, e, uz)     => collectExprNames(e)
+    case FieldAccessF(b, va, vb) => collectExprNames(b)
+    case EnumAccessF(b, vc, vd)  => collectExprNames(b)
+    case IndexF(b, i, ve)        => collectExprNames(b) ++ collectExprNames(i)
+    case CallF(c, args, vf)      => collectExprNames(c) ++ collectExprNames_list(args)
+    case PrimeF(e, vg)           => collectExprNames(e)
+    case PreF(e, vh)             => collectExprNames(e)
+    case WithF(b, upds, vi) =>
+      collectExprNames(b) ++ collectExprNames_fields(upds)
+    case IfF(c, t, e, vj) =>
+      collectExprNames(c) ++ (collectExprNames(t) ++ collectExprNames(e))
+    case LetF(vk, vala, body, vl) =>
+      collectExprNames(vala) ++ collectExprNames(body)
+    case LambdaF(vm, b, vn)  => collectExprNames(b)
+    case SetLiteralF(xs, vo) => collectExprNames_list(xs)
+    case MapLiteralF(es, vp) => collectExprNames_entries(es)
+    case SetComprehensionF(vq, d, p, vr) =>
+      collectExprNames(d) ++ collectExprNames(p)
+    case SeqLiteralF(xs, vs) => collectExprNames_list(xs)
+    case MatchesF(x, vt, vu) => collectExprNames(x)
+    case SomeWrapF(x, vv)    => collectExprNames(x)
+    case TheF(vw, d, b, vx)  => collectExprNames(d) ++ collectExprNames(b)
+    case QuantifierF(vy, bs, body, vz) =>
+      collectExprNames_bindings(bs) ++ collectExprNames(body)
+    case IntLitF(wa, wb)    => Nil
+    case FloatLitF(wc, wd)  => Nil
+    case StringLitF(we, wf) => Nil
+    case BoolLitF(wg, wh)   => Nil
+    case NoneLitF(wi)       => Nil
+  }
+
+  def collectTypeNames(x0: type_expr_full): List[String] = x0 match {
+    case NamedTypeF(n, uu)           => List(n)
+    case SetTypeF(t, uv)             => collectTypeNames(t)
+    case SeqTypeF(t, uw)             => collectTypeNames(t)
+    case OptionTypeF(t, ux)          => collectTypeNames(t)
+    case MapTypeF(k, v, uy)          => collectTypeNames(k) ++ collectTypeNames(v)
+    case RelationTypeF(f, uz, t, va) => collectTypeNames(f) ++ collectTypeNames(t)
+  }
+
   def digitValue(c: BigInt): int = int_of_integer(c - BigInt(48))
 
   def maxDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
@@ -8969,6 +9037,101 @@ object SpecRestGenerated {
   def state_fieldTypeFull(x0: state_field_decl_full): type_expr_full = x0 match {
     case StateFieldDeclFull(uu, t, uv) => t
   }
+
+  def walkUndefinedExpr_bindings(
+      x0: List[quantifier_binding_full],
+      scope: List[String]
+  ): (List[(String, Option[span_t])], List[String]) =
+    (x0, scope) match {
+      case (Nil, scope) => (Nil, scope)
+      case (QuantifierBindingFull(v, d, wq, wr) :: bs, scope) =>
+        val cur = walkUndefinedExpr(d, scope): List[(String, Option[span_t])]
+        val (rest, a) =
+          walkUndefinedExpr_bindings(
+            bs,
+            v ::
+              scope
+          ): ((List[(String, Option[span_t])], List[String]));
+        (cur ++ rest, a)
+    }
+
+  def walkUndefinedExpr_entries(
+      x0: List[map_entry_full],
+      wo: List[String]
+  ): List[(String, Option[span_t])] =
+    (x0, wo) match {
+      case (Nil, wo) => Nil
+      case (MapEntryFull(k, v, wp) :: es, scope) =>
+        walkUndefinedExpr(k, scope) ++
+          (walkUndefinedExpr(v, scope) ++ walkUndefinedExpr_entries(es, scope))
+    }
+
+  def walkUndefinedExpr_fields(
+      x0: List[field_assign_full],
+      wl: List[String]
+  ): List[(String, Option[span_t])] =
+    (x0, wl) match {
+      case (Nil, wl) => Nil
+      case (FieldAssignFull(wm, v, wn) :: fs, scope) =>
+        walkUndefinedExpr(v, scope) ++ walkUndefinedExpr_fields(fs, scope)
+    }
+
+  def walkUndefinedExpr_list(
+      x0: List[expr_full],
+      wk: List[String]
+  ): List[(String, Option[span_t])] =
+    (x0, wk) match {
+      case (Nil, wk) => Nil
+      case (x :: xs, scope) =>
+        walkUndefinedExpr(x, scope) ++ walkUndefinedExpr_list(xs, scope)
+    }
+
+  def walkUndefinedExpr(x0: expr_full, scope: List[String]): List[(String, Option[span_t])] =
+    (x0, scope) match {
+      case (IdentifierF(n, sp), scope) =>
+        membera[String](scope, n) match {
+          case true  => Nil
+          case false => List((n, sp))
+        }
+      case (BinaryOpF(uu, l, r, uv), scope) =>
+        walkUndefinedExpr(l, scope) ++ walkUndefinedExpr(r, scope)
+      case (UnaryOpF(uw, e, ux), scope)     => walkUndefinedExpr(e, scope)
+      case (FieldAccessF(b, uy, uz), scope) => walkUndefinedExpr(b, scope)
+      case (EnumAccessF(b, va, vb), scope)  => walkUndefinedExpr(b, scope)
+      case (IndexF(b, i, vc), scope) =>
+        walkUndefinedExpr(b, scope) ++ walkUndefinedExpr(i, scope)
+      case (CallF(c, args, vd), scope) =>
+        walkUndefinedExpr(c, scope) ++ walkUndefinedExpr_list(args, scope)
+      case (PrimeF(e, ve), scope) => walkUndefinedExpr(e, scope)
+      case (PreF(e, vf), scope)   => walkUndefinedExpr(e, scope)
+      case (WithF(b, upds, vg), scope) =>
+        walkUndefinedExpr(b, scope) ++ walkUndefinedExpr_fields(upds, scope)
+      case (IfF(c, t, e, vh), scope) =>
+        walkUndefinedExpr(c, scope) ++
+          (walkUndefinedExpr(t, scope) ++ walkUndefinedExpr(e, scope))
+      case (LetF(v, vala, body, vi), scope) =>
+        walkUndefinedExpr(vala, scope) ++ walkUndefinedExpr(body, v :: scope)
+      case (LambdaF(p, body, vj), scope)     => walkUndefinedExpr(body, p :: scope)
+      case (ConstructorF(vk, fs, vl), scope) => walkUndefinedExpr_fields(fs, scope)
+      case (SetLiteralF(xs, vm), scope)      => walkUndefinedExpr_list(xs, scope)
+      case (MapLiteralF(es, vn), scope)      => walkUndefinedExpr_entries(es, scope)
+      case (SetComprehensionF(v, d, p, vo), scope) =>
+        walkUndefinedExpr(d, scope) ++ walkUndefinedExpr(p, v :: scope)
+      case (SeqLiteralF(xs, vp), scope) => walkUndefinedExpr_list(xs, scope)
+      case (MatchesF(x, vq, vr), scope) => walkUndefinedExpr(x, scope)
+      case (SomeWrapF(x, vs), scope)    => walkUndefinedExpr(x, scope)
+      case (TheF(v, d, b, vt), scope) =>
+        walkUndefinedExpr(d, scope) ++ walkUndefinedExpr(b, v :: scope)
+      case (QuantifierF(vu, bs, body, vv), scope) =>
+        val (binds, scopea) =
+          walkUndefinedExpr_bindings(bs, scope): ((List[(String, Option[span_t])], List[String]));
+        binds ++ walkUndefinedExpr(body, scopea)
+      case (IntLitF(vw, vx), vy)    => Nil
+      case (FloatLitF(vz, wa), wb)  => Nil
+      case (StringLitF(wc, wd), we) => Nil
+      case (BoolLitF(wf, wg), wh)   => Nil
+      case (NoneLitF(wi), wj)       => Nil
+    }
 
   def maxLengthOf(x0: openapi_bounds): Option[int] = x0 match {
     case OpenApiBounds(uu, ml, uv, uw, ux, uy, uz) => ml

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3429,79 +3429,41 @@ object SpecRestGenerated {
   def flattenAndAll(es: List[expr_full]): List[expr_full] =
     maps[expr_full, expr_full]((a: expr_full) => flattenAnd(a), es)
 
-  def equal_un_op_full(x0: un_op_full, x1: un_op_full): Boolean = (x0, x1) match {
-    case (UCardinality(), UPower())       => false
-    case (UPower(), UCardinality())       => false
-    case (UNegate(), UPower())            => false
-    case (UPower(), UNegate())            => false
-    case (UNegate(), UCardinality())      => false
-    case (UCardinality(), UNegate())      => false
-    case (UNot(), UPower())               => false
-    case (UPower(), UNot())               => false
-    case (UNot(), UCardinality())         => false
-    case (UCardinality(), UNot())         => false
-    case (UNot(), UNegate())              => false
-    case (UNegate(), UNot())              => false
-    case (UPower(), UPower())             => true
-    case (UCardinality(), UCardinality()) => true
-    case (UNegate(), UNegate())           => true
-    case (UNot(), UNot())                 => true
+  def isUPowerUnary(x0: expr_full): Boolean = x0 match {
+    case UnaryOpF(UPower(), uu, uv)       => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(UNot(), va, vb)         => false
+    case UnaryOpF(UNegate(), va, vb)      => false
+    case UnaryOpF(UCardinality(), va, vb) => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case BoolLitF(v, va)                  => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, va)               => false
   }
 
-  def requiresAlloy_bindings(x0: List[quantifier_binding_full]): Boolean = x0 match {
-    case Nil => false
-    case QuantifierBindingFull(wn, d, wo, wp) :: bs =>
-      requiresAlloy(d) || requiresAlloy_bindings(bs)
-  }
-
-  def requiresAlloy_entries(x0: List[map_entry_full]): Boolean = x0 match {
-    case Nil => false
-    case MapEntryFull(k, v, wm) :: es =>
-      requiresAlloy(k) || (requiresAlloy(v) || requiresAlloy_entries(es))
-  }
-
-  def requiresAlloy_fields(x0: List[field_assign_full]): Boolean = x0 match {
-    case Nil => false
-    case FieldAssignFull(wk, v, wl) :: fs =>
-      requiresAlloy(v) || requiresAlloy_fields(fs)
-  }
-
-  def requiresAlloy_list(x0: List[expr_full]): Boolean = x0 match {
-    case Nil     => false
-    case x :: xs => requiresAlloy(x) || requiresAlloy_list(xs)
-  }
-
-  def requiresAlloy(x0: expr_full): Boolean = x0 match {
-    case UnaryOpF(op, e, uu)     => equal_un_op_full(op, UPower()) || requiresAlloy(e)
-    case BinaryOpF(uv, l, r, uw) => requiresAlloy(l) || requiresAlloy(r)
-    case QuantifierF(ux, bs, body, uy) =>
-      requiresAlloy_bindings(bs) || requiresAlloy(body)
-    case SomeWrapF(x, uz)        => requiresAlloy(x)
-    case TheF(va, d, b, vb)      => requiresAlloy(d) || requiresAlloy(b)
-    case FieldAccessF(b, vc, vd) => requiresAlloy(b)
-    case EnumAccessF(b, ve, vf)  => requiresAlloy(b)
-    case IndexF(b, i, vg)        => requiresAlloy(b) || requiresAlloy(i)
-    case CallF(c, args, vh)      => requiresAlloy(c) || requiresAlloy_list(args)
-    case PrimeF(x, vi)           => requiresAlloy(x)
-    case PreF(x, vj)             => requiresAlloy(x)
-    case WithF(b, upds, vk)      => requiresAlloy(b) || requiresAlloy_fields(upds)
-    case IfF(c, t, e, vl) =>
-      requiresAlloy(c) || (requiresAlloy(t) || requiresAlloy(e))
-    case LetF(vm, v, b, vn)              => requiresAlloy(v) || requiresAlloy(b)
-    case LambdaF(vo, b, vp)              => requiresAlloy(b)
-    case ConstructorF(vq, fs, vr)        => requiresAlloy_fields(fs)
-    case SetLiteralF(xs, vs)             => requiresAlloy_list(xs)
-    case MapLiteralF(es, vt)             => requiresAlloy_entries(es)
-    case SetComprehensionF(vu, d, p, vv) => requiresAlloy(d) || requiresAlloy(p)
-    case SeqLiteralF(xs, vw)             => requiresAlloy_list(xs)
-    case MatchesF(x, vx, vy)             => requiresAlloy(x)
-    case IntLitF(vz, wa)                 => false
-    case FloatLitF(wb, wc)               => false
-    case StringLitF(wd, we)              => false
-    case BoolLitF(wf, wg)                => false
-    case NoneLitF(wh)                    => false
-    case IdentifierF(wi, wj)             => false
-  }
+  def requiresAlloy(e: expr_full): Boolean =
+    list_ex[expr_full]((a: expr_full) => isUPowerUnary(a), allSubexprs(e))
 
   def indexName(x0: index_spec): String = x0 match {
     case IndexSpec(n, uu, uv, uw) => n

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4841,6 +4841,36 @@ object SpecRestGenerated {
     case NoneLitF(wf)       => Nil
   }
 
+  def isBoolLit(x0: expr_full): Boolean = x0 match {
+    case BoolLitF(uu, uv)                 => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, va)               => false
+  }
+
   def isLiteral(x0: expr_full): Boolean = x0 match {
     case IntLitF(uu, uv)                  => true
     case FloatLitF(uw, ux)                => true
@@ -5242,6 +5272,36 @@ object SpecRestGenerated {
     case x :: rest => combineAnd_acc(x, rest)
   }
 
+  def isPrePrime(x0: expr_full): Boolean = x0 match {
+    case PrimeF(uu, uv)                   => true
+    case PreF(uw, ux)                     => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case MapLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case BoolLitF(v, va)                  => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, va)               => false
+  }
+
   def isLeafValue(x0: expr_full): Boolean = x0 match {
     case IntLitF(uu, uv)                  => true
     case FloatLitF(uw, ux)                => true
@@ -5549,6 +5609,70 @@ object SpecRestGenerated {
         }
     }
 
+  def allSubexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(n, d, a, sp) :: bs =>
+        allSubexprs(d) ++ allSubexprs_bindings(bs)
+    }
+
+  def allSubexprs_entries(x0: List[map_entry_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, sp) :: es =>
+      allSubexprs(k) ++ (allSubexprs(v) ++ allSubexprs_entries(es))
+  }
+
+  def allSubexprs_fields(x0: List[field_assign_full]): List[expr_full] = x0 match {
+    case Nil => Nil
+    case FieldAssignFull(n, v, sp) :: fs =>
+      allSubexprs(v) ++ allSubexprs_fields(fs)
+  }
+
+  def allSubexprs_list(x0: List[expr_full]): List[expr_full] = x0 match {
+    case Nil     => Nil
+    case x :: xs => allSubexprs(x) ++ allSubexprs_list(xs)
+  }
+
+  def allSubexprs(x0: expr_full): List[expr_full] = x0 match {
+    case BinaryOpF(op, l, r, sp) =>
+      BinaryOpF(op, l, r, sp) :: allSubexprs(l) ++ allSubexprs(r)
+    case UnaryOpF(op, e, sp)    => UnaryOpF(op, e, sp) :: allSubexprs(e)
+    case FieldAccessF(b, f, sp) => FieldAccessF(b, f, sp) :: allSubexprs(b)
+    case EnumAccessF(b, e, sp)  => EnumAccessF(b, e, sp) :: allSubexprs(b)
+    case IndexF(b, i, sp)       => IndexF(b, i, sp) :: allSubexprs(b) ++ allSubexprs(i)
+    case CallF(c, args, sp) =>
+      CallF(c, args, sp) :: allSubexprs(c) ++ allSubexprs_list(args)
+    case PrimeF(e, sp) => PrimeF(e, sp) :: allSubexprs(e)
+    case PreF(e, sp)   => PreF(e, sp) :: allSubexprs(e)
+    case WithF(b, ups, sp) =>
+      WithF(b, ups, sp) :: allSubexprs(b) ++ allSubexprs_fields(ups)
+    case IfF(c, t, e, sp) =>
+      IfF(c, t, e, sp) :: allSubexprs(c) ++ (allSubexprs(t) ++ allSubexprs(e))
+    case LetF(v, vala, body, sp) =>
+      LetF(v, vala, body, sp) :: allSubexprs(vala) ++ allSubexprs(body)
+    case LambdaF(p, b, sp) => LambdaF(p, b, sp) :: allSubexprs(b)
+    case ConstructorF(n, fs, sp) =>
+      ConstructorF(n, fs, sp) :: allSubexprs_fields(fs)
+    case SetLiteralF(xs, sp) => SetLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MapLiteralF(es, sp) => MapLiteralF(es, sp) :: allSubexprs_entries(es)
+    case SetComprehensionF(v, d, p, sp) =>
+      SetComprehensionF(v, d, p, sp) :: allSubexprs(d) ++ allSubexprs(p)
+    case SeqLiteralF(xs, sp)  => SeqLiteralF(xs, sp) :: allSubexprs_list(xs)
+    case MatchesF(e, pat, sp) => MatchesF(e, pat, sp) :: allSubexprs(e)
+    case SomeWrapF(e, sp)     => SomeWrapF(e, sp) :: allSubexprs(e)
+    case TheF(v, d, b, sp) =>
+      TheF(v, d, b, sp) :: allSubexprs(d) ++ allSubexprs(b)
+    case QuantifierF(q, bs, body, sp) =>
+      QuantifierF(q, bs, body, sp) ::
+        allSubexprs_bindings(bs) ++ allSubexprs(body)
+    case IdentifierF(n, sp) => List(IdentifierF(n, sp))
+    case IntLitF(n, sp)     => List(IntLitF(n, sp))
+    case FloatLitF(v, sp)   => List(FloatLitF(v, sp))
+    case StringLitF(v, sp)  => List(StringLitF(v, sp))
+    case BoolLitF(b, sp)    => List(BoolLitF(b, sp))
+    case NoneLitF(sp)       => List(NoneLitF(sp))
+  }
+
   def enumLitName(x0: expr_full): Option[String] = x0 match {
     case EnumAccessF(uu, m, uv)           => Some[String](m)
     case IdentifierF(n, uw)               => Some[String](n)
@@ -5579,59 +5703,8 @@ object SpecRestGenerated {
     case NoneLitF(v)                      => None
   }
 
-  def hasPrePrime_bindings(x0: List[quantifier_binding_full]): Boolean = x0 match {
-    case Nil => false
-    case QuantifierBindingFull(wq, d, wr, ws) :: bs =>
-      hasPrePrime(d) || hasPrePrime_bindings(bs)
-  }
-
-  def hasPrePrime_entries(x0: List[map_entry_full]): Boolean = x0 match {
-    case Nil => false
-    case MapEntryFull(k, v, wp) :: es =>
-      hasPrePrime(k) || (hasPrePrime(v) || hasPrePrime_entries(es))
-  }
-
-  def hasPrePrime_fields(x0: List[field_assign_full]): Boolean = x0 match {
-    case Nil => false
-    case FieldAssignFull(wn, v, wo) :: fs =>
-      hasPrePrime(v) || hasPrePrime_fields(fs)
-  }
-
-  def hasPrePrime_list(x0: List[expr_full]): Boolean = x0 match {
-    case Nil     => false
-    case x :: xs => hasPrePrime(x) || hasPrePrime_list(xs)
-  }
-
-  def hasPrePrime(x0: expr_full): Boolean = x0 match {
-    case PrimeF(uu, uv)                  => true
-    case PreF(uw, ux)                    => true
-    case BinaryOpF(uy, l, r, uz)         => hasPrePrime(l) || hasPrePrime(r)
-    case UnaryOpF(va, e, vb)             => hasPrePrime(e)
-    case FieldAccessF(b, vc, vd)         => hasPrePrime(b)
-    case EnumAccessF(b, ve, vf)          => hasPrePrime(b)
-    case IndexF(b, i, vg)                => hasPrePrime(b) || hasPrePrime(i)
-    case CallF(c, args, vh)              => hasPrePrime(c) || hasPrePrime_list(args)
-    case WithF(b, upds, vi)              => hasPrePrime(b) || hasPrePrime_fields(upds)
-    case IfF(c, t, e, vj)                => hasPrePrime(c) || (hasPrePrime(t) || hasPrePrime(e))
-    case LetF(vk, v, b, vl)              => hasPrePrime(v) || hasPrePrime(b)
-    case LambdaF(vm, b, vn)              => hasPrePrime(b)
-    case ConstructorF(vo, fs, vp)        => hasPrePrime_fields(fs)
-    case SetLiteralF(xs, vq)             => hasPrePrime_list(xs)
-    case MapLiteralF(es, vr)             => hasPrePrime_entries(es)
-    case SetComprehensionF(vs, d, p, vt) => hasPrePrime(d) || hasPrePrime(p)
-    case SeqLiteralF(xs, vu)             => hasPrePrime_list(xs)
-    case MatchesF(x, vv, vw)             => hasPrePrime(x)
-    case SomeWrapF(x, vx)                => hasPrePrime(x)
-    case TheF(vy, d, b, vz)              => hasPrePrime(d) || hasPrePrime(b)
-    case QuantifierF(wa, bs, body, wb) =>
-      hasPrePrime_bindings(bs) || hasPrePrime(body)
-    case IntLitF(wc, wd)     => false
-    case FloatLitF(we, wf)   => false
-    case StringLitF(wg, wh)  => false
-    case BoolLitF(wi, wj)    => false
-    case NoneLitF(wk)        => false
-    case IdentifierF(wl, wm) => false
-  }
+  def hasPrePrime(e: expr_full): Boolean =
+    list_ex[expr_full]((a: expr_full) => isPrePrime(a), allSubexprs(e))
 
   def assignsField(x0: expr_full, field: String): Boolean = (x0, field) match {
     case (FieldAccessF(uu, f, uv), field)       => f == field
@@ -5970,70 +6043,6 @@ object SpecRestGenerated {
 
   def paramTypeFull(x0: param_decl_full): type_expr_full = x0 match {
     case ParamDeclFull(uu, t, uv) => t
-  }
-
-  def allSubexprs_bindings(x0: List[quantifier_binding_full]): List[expr_full] =
-    x0 match {
-      case Nil => Nil
-      case QuantifierBindingFull(n, d, a, sp) :: bs =>
-        allSubexprs(d) ++ allSubexprs_bindings(bs)
-    }
-
-  def allSubexprs_entries(x0: List[map_entry_full]): List[expr_full] = x0 match {
-    case Nil => Nil
-    case MapEntryFull(k, v, sp) :: es =>
-      allSubexprs(k) ++ (allSubexprs(v) ++ allSubexprs_entries(es))
-  }
-
-  def allSubexprs_fields(x0: List[field_assign_full]): List[expr_full] = x0 match {
-    case Nil => Nil
-    case FieldAssignFull(n, v, sp) :: fs =>
-      allSubexprs(v) ++ allSubexprs_fields(fs)
-  }
-
-  def allSubexprs_list(x0: List[expr_full]): List[expr_full] = x0 match {
-    case Nil     => Nil
-    case x :: xs => allSubexprs(x) ++ allSubexprs_list(xs)
-  }
-
-  def allSubexprs(x0: expr_full): List[expr_full] = x0 match {
-    case BinaryOpF(op, l, r, sp) =>
-      BinaryOpF(op, l, r, sp) :: allSubexprs(l) ++ allSubexprs(r)
-    case UnaryOpF(op, e, sp)    => UnaryOpF(op, e, sp) :: allSubexprs(e)
-    case FieldAccessF(b, f, sp) => FieldAccessF(b, f, sp) :: allSubexprs(b)
-    case EnumAccessF(b, e, sp)  => EnumAccessF(b, e, sp) :: allSubexprs(b)
-    case IndexF(b, i, sp)       => IndexF(b, i, sp) :: allSubexprs(b) ++ allSubexprs(i)
-    case CallF(c, args, sp) =>
-      CallF(c, args, sp) :: allSubexprs(c) ++ allSubexprs_list(args)
-    case PrimeF(e, sp) => PrimeF(e, sp) :: allSubexprs(e)
-    case PreF(e, sp)   => PreF(e, sp) :: allSubexprs(e)
-    case WithF(b, ups, sp) =>
-      WithF(b, ups, sp) :: allSubexprs(b) ++ allSubexprs_fields(ups)
-    case IfF(c, t, e, sp) =>
-      IfF(c, t, e, sp) :: allSubexprs(c) ++ (allSubexprs(t) ++ allSubexprs(e))
-    case LetF(v, vala, body, sp) =>
-      LetF(v, vala, body, sp) :: allSubexprs(vala) ++ allSubexprs(body)
-    case LambdaF(p, b, sp) => LambdaF(p, b, sp) :: allSubexprs(b)
-    case ConstructorF(n, fs, sp) =>
-      ConstructorF(n, fs, sp) :: allSubexprs_fields(fs)
-    case SetLiteralF(xs, sp) => SetLiteralF(xs, sp) :: allSubexprs_list(xs)
-    case MapLiteralF(es, sp) => MapLiteralF(es, sp) :: allSubexprs_entries(es)
-    case SetComprehensionF(v, d, p, sp) =>
-      SetComprehensionF(v, d, p, sp) :: allSubexprs(d) ++ allSubexprs(p)
-    case SeqLiteralF(xs, sp)  => SeqLiteralF(xs, sp) :: allSubexprs_list(xs)
-    case MatchesF(e, pat, sp) => MatchesF(e, pat, sp) :: allSubexprs(e)
-    case SomeWrapF(e, sp)     => SomeWrapF(e, sp) :: allSubexprs(e)
-    case TheF(v, d, b, sp) =>
-      TheF(v, d, b, sp) :: allSubexprs(d) ++ allSubexprs(b)
-    case QuantifierF(q, bs, body, sp) =>
-      QuantifierF(q, bs, body, sp) ::
-        allSubexprs_bindings(bs) ++ allSubexprs(body)
-    case IdentifierF(n, sp) => List(IdentifierF(n, sp))
-    case IntLitF(n, sp)     => List(IntLitF(n, sp))
-    case FloatLitF(v, sp)   => List(FloatLitF(v, sp))
-    case StringLitF(v, sp)  => List(StringLitF(v, sp))
-    case BoolLitF(b, sp)    => List(BoolLitF(b, sp))
-    case NoneLitF(sp)       => List(NoneLitF(sp))
   }
 
   def pathWithIdSuffix(segment: String, idParamOpt: Option[String]): String =
@@ -9574,66 +9583,8 @@ object SpecRestGenerated {
       case LlmSynthesis() => "LLM_SYNTHESIS"
     }
 
-  def exprContainsBoolLit_bindings(x0: List[quantifier_binding_full]): Boolean =
-    x0 match {
-      case Nil => false
-      case QuantifierBindingFull(wo, d, wp, wq) :: bs =>
-        exprContainsBoolLit(d) || exprContainsBoolLit_bindings(bs)
-    }
-
-  def exprContainsBoolLit_entries(x0: List[map_entry_full]): Boolean = x0 match {
-    case Nil => false
-    case MapEntryFull(k, v, wn) :: es =>
-      exprContainsBoolLit(k) ||
-      (exprContainsBoolLit(v) || exprContainsBoolLit_entries(es))
-  }
-
-  def exprContainsBoolLit_fields(x0: List[field_assign_full]): Boolean = x0 match {
-    case Nil => false
-    case FieldAssignFull(wl, v, wm) :: fs =>
-      exprContainsBoolLit(v) || exprContainsBoolLit_fields(fs)
-  }
-
-  def exprContainsBoolLit_list(x0: List[expr_full]): Boolean = x0 match {
-    case Nil     => false
-    case x :: xs => exprContainsBoolLit(x) || exprContainsBoolLit_list(xs)
-  }
-
-  def exprContainsBoolLit(x0: expr_full): Boolean = x0 match {
-    case BoolLitF(uu, uv) => true
-    case BinaryOpF(uw, l, r, ux) =>
-      exprContainsBoolLit(l) || exprContainsBoolLit(r)
-    case UnaryOpF(uy, e, uz)     => exprContainsBoolLit(e)
-    case FieldAccessF(b, va, vb) => exprContainsBoolLit(b)
-    case EnumAccessF(b, vc, vd)  => exprContainsBoolLit(b)
-    case IndexF(b, i, ve)        => exprContainsBoolLit(b) || exprContainsBoolLit(i)
-    case CallF(c, args, vf) =>
-      exprContainsBoolLit(c) || exprContainsBoolLit_list(args)
-    case PrimeF(e, vg) => exprContainsBoolLit(e)
-    case PreF(e, vh)   => exprContainsBoolLit(e)
-    case WithF(b, upds, vi) =>
-      exprContainsBoolLit(b) || exprContainsBoolLit_fields(upds)
-    case IfF(c, t, e, vj) =>
-      exprContainsBoolLit(c) || (exprContainsBoolLit(t) || exprContainsBoolLit(e))
-    case LetF(vk, v, b, vl)       => exprContainsBoolLit(v) || exprContainsBoolLit(b)
-    case LambdaF(vm, b, vn)       => exprContainsBoolLit(b)
-    case ConstructorF(vo, fs, vp) => exprContainsBoolLit_fields(fs)
-    case SetLiteralF(xs, vq)      => exprContainsBoolLit_list(xs)
-    case MapLiteralF(es, vr)      => exprContainsBoolLit_entries(es)
-    case SetComprehensionF(vs, d, p, vt) =>
-      exprContainsBoolLit(d) || exprContainsBoolLit(p)
-    case SeqLiteralF(xs, vu) => exprContainsBoolLit_list(xs)
-    case MatchesF(x, vv, vw) => exprContainsBoolLit(x)
-    case SomeWrapF(x, vx)    => exprContainsBoolLit(x)
-    case TheF(vy, d, b, vz)  => exprContainsBoolLit(d) || exprContainsBoolLit(b)
-    case QuantifierF(wa, bs, body, wb) =>
-      exprContainsBoolLit_bindings(bs) || exprContainsBoolLit(body)
-    case IntLitF(wc, wd)     => false
-    case FloatLitF(we, wf)   => false
-    case StringLitF(wg, wh)  => false
-    case NoneLitF(wi)        => false
-    case IdentifierF(wj, wk) => false
-  }
+  def exprContainsBoolLit(e: expr_full): Boolean =
+    list_ex[expr_full]((a: expr_full) => isBoolLit(a), allSubexprs(e))
 
   def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
 

--- a/modules/lint/src/main/scala/specrest/lint/CircularPredicate.scala
+++ b/modules/lint/src/main/scala/specrest/lint/CircularPredicate.scala
@@ -2,76 +2,41 @@ package specrest.lint
 
 import specrest.ir.generated.SpecRestGenerated.*
 
-import scala.collection.mutable
-
-@SuppressWarnings(Array("org.wartremover.warts.Return"))
 object CircularPredicate extends LintPass:
   val code = "L06"
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
-    val predNames = ir.m.map { case PredicateDeclFull(n, _, _, _) => n }.toSet
-    val funcNames = ir.l.map { case FunctionDeclFull(n, _, _, _, _) => n }.toSet
-    val nodes     = predNames ++ funcNames
-    if nodes.isEmpty then return Nil
+    val predNames = ir.m.collect { case PredicateDeclFull(n, _, _, _) => n }
+    val funcNames = ir.l.collect { case FunctionDeclFull(n, _, _, _, _) => n }
+    val nodes     = (predNames ++ funcNames).distinct
+    if nodes.isEmpty then Nil
+    else
+      val spans = (
+        ir.m.collect { case PredicateDeclFull(n, _, _, sp) => n -> sp } ++
+          ir.l.collect { case FunctionDeclFull(n, _, _, _, sp) => n -> sp }
+      ).toMap
 
-    val spans = mutable.Map.empty[String, Option[span_t]]
-    val edges = mutable.Map.empty[String, Set[String]]
-    for case PredicateDeclFull(name, _, body, span) <- ir.m do
-      spans(name) = span
-      edges(name) = callees(body, nodes)
-    for case FunctionDeclFull(name, _, _, body, span) <- ir.l do
-      spans(name) = span
-      edges(name) = callees(body, nodes)
+      val edges =
+        ir.m.collect { case PredicateDeclFull(n, _, body, _) =>
+          n -> collectCallNames(body, nodes).distinct
+        } ++
+          ir.l.collect { case FunctionDeclFull(n, _, _, body, _) =>
+            n -> collectCallNames(body, nodes).distinct
+          }
 
-    val cycles = findCycles(nodes.toList.sorted, edges.toMap)
-    cycles.map: cyc =>
-      val head    = cyc.head
-      val display = (cyc :+ head).mkString(" -> ")
-      val related =
-        cyc.tail.flatMap(n => spans.get(n).flatten.map(s => RelatedSpan(s, s"in cycle: $n")))
-      LintDiagnostic(
-        code,
-        LintLevel.Error,
-        s"circular predicate dependency: $display",
-        spans.get(head).flatten,
-        related
-      )
+      // Lifted findCycles takes sorted node list and AList edges. Sort to
+      // match the legacy deterministic iteration order.
+      val cycles = findCycles(nodes.sorted, edges)
 
-  private def callees(body: expr_full, names: Set[String]): Set[String] =
-    val acc = mutable.Set.empty[String]
-    ExprWalk.foreach(body):
-      case CallF(IdentifierF(n, _), _, _) if names.contains(n) => acc += n
-      case _                                                   => ()
-    acc.toSet
-
-  private def findCycles(nodes: List[String], edges: Map[String, Set[String]]): List[List[String]] =
-    val onStack    = mutable.Set.empty[String]
-    val visited    = mutable.Set.empty[String]
-    val stack      = mutable.ListBuffer.empty[String]
-    val cycles     = mutable.ListBuffer.empty[List[String]]
-    val seenCycles = mutable.Set.empty[Set[String]]
-
-    def dfs(n: String): Unit =
-      if onStack.contains(n) then
-        val idx = stack.indexOf(n)
-        if idx >= 0 then
-          val cyc = stack.slice(idx, stack.length).toList
-          val key = cyc.toSet
-          if !seenCycles.contains(key) then
-            seenCycles += key
-            cycles += cyc
-      else if !visited.contains(n) then
-        visited += n
-        onStack += n
-        stack += n
-        edges.getOrElse(n, Set.empty).toList.sorted.foreach(dfs)
-        onStack -= n
-        val _ = stack.remove(stack.length - 1)
-      else ()
-
-    nodes.foreach: n =>
-      stack.clear()
-      onStack.clear()
-      dfs(n)
-
-    cycles.toList
+      cycles.map: cyc =>
+        val head    = cyc.head
+        val display = (cyc :+ head).mkString(" -> ")
+        val related =
+          cyc.tail.flatMap(n => spans.get(n).flatten.map(s => RelatedSpan(s, s"in cycle: $n")))
+        LintDiagnostic(
+          code,
+          LintLevel.Error,
+          s"circular predicate dependency: $display",
+          spans.get(head).flatten,
+          related
+        )

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -21,8 +21,10 @@ object UndefinedRef extends LintPass:
     val factImplicit = ir.k.flatMap { case FactDeclFull(_, e, _) =>
       // Fact bodies sometimes call helper predicates by name with no
       // explicit declaration; treat any Call(Identifier, _) callee as
-      // defined to avoid false positives.
-      SpecRestGenerated.collectExprNames(e)
+      // defined to avoid false positives. (Crucially, we whitelist
+      // CALLEE names only — not arbitrary identifiers from the fact
+      // body, which would silently mask real undefined-ref errors.)
+      SpecRestGenerated.collectAllCallNames(e)
     }.toSet
     val global =
       stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -12,19 +12,34 @@ object UndefinedRef extends LintPass:
     val stateFields = ir.f.toList.flatMap {
       case StateDeclFull(fs, _) => fs.map { case StateFieldDeclFull(n, _, _) => n }
     }.toSet
-    val entityNames  = ir.c.map { case EntityDeclFull(n, _, _, _, _) => n }.toSet
-    val enumNames    = ir.d.map { case EnumDeclFull(n, _, _) => n }.toSet
-    val enumMembers  = ir.d.flatMap { case EnumDeclFull(_, vs, _) => vs }.toSet
-    val typeAliases  = ir.e.map { case TypeAliasDeclFull(n, _, _, _) => n }.toSet
-    val predicates   = ir.m.map { case PredicateDeclFull(n, _, _, _) => n }.toSet
-    val functions    = ir.l.map { case FunctionDeclFull(n, _, _, _, _) => n }.toSet
-    val factImplicit = ir.k.flatMap { case FactDeclFull(_, e, _) => collectCallees(e) }.toSet
+    val entityNames = ir.c.map { case EntityDeclFull(n, _, _, _, _) => n }.toSet
+    val enumNames   = ir.d.map { case EnumDeclFull(n, _, _) => n }.toSet
+    val enumMembers = ir.d.flatMap { case EnumDeclFull(_, vs, _) => vs }.toSet
+    val typeAliases = ir.e.map { case TypeAliasDeclFull(n, _, _, _) => n }.toSet
+    val predicates  = ir.m.map { case PredicateDeclFull(n, _, _, _) => n }.toSet
+    val functions   = ir.l.map { case FunctionDeclFull(n, _, _, _, _) => n }.toSet
+    val factImplicit = ir.k.flatMap { case FactDeclFull(_, e, _) =>
+      // Fact bodies sometimes call helper predicates by name with no
+      // explicit declaration; treat any Call(Identifier, _) callee as
+      // defined to avoid false positives.
+      SpecRestGenerated.collectExprNames(e)
+    }.toSet
     val global =
       stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++
         predicates ++ functions ++ Builtins.names ++ factImplicit
 
+    def emit(refs: List[(String, Option[span_t])]): Unit =
+      refs.foreach { case (name, span) =>
+        out += LintDiagnostic(
+          code,
+          LintLevel.Error,
+          s"undefined identifier '$name'",
+          span
+        )
+      }
+
     def check(expr: expr_full, scope: Set[String]): Unit =
-      walk(expr, scope, out)
+      emit(walkUndefinedExpr(expr, scope.toList))
 
     for case OperationDeclFull(_, inputs, outputs, requires, ensures, _) <- ir.g do
       val opScope = global ++ inputs.map { case ParamDeclFull(n, _, _) => n } ++
@@ -60,42 +75,3 @@ object UndefinedRef extends LintPass:
       }
 
     out.result()
-
-  private def collectCallees(e: expr_full): List[String] =
-    val acc = scala.collection.mutable.ListBuffer.empty[String]
-    ExprWalk.foreach(e):
-      case CallF(IdentifierF(n, _), _, _) => acc += n
-      case _                              => ()
-    acc.toList
-
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  private def walk(
-      expr: expr_full,
-      scope: Set[String],
-      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]]
-  ): Unit = expr match
-    case IdentifierF(name, span) =>
-      if !scope.contains(name) then
-        out += LintDiagnostic(
-          UndefinedRef.code,
-          LintLevel.Error,
-          s"undefined identifier '$name'",
-          span
-        )
-    case QuantifierF(_, bindings, body, _) =>
-      var s = scope
-      bindings.foreach { case QuantifierBindingFull(v, dom, _, _) =>
-        walk(dom, s, out)
-        s = s + v
-      }
-      walk(body, s, out)
-    case TheF(v, d, b, _) =>
-      walk(d, scope, out); walk(b, scope + v, out)
-    case LetF(v, value, body, _) =>
-      walk(value, scope, out); walk(body, scope + v, out)
-    case LambdaF(p, b, _) =>
-      walk(b, scope + p, out)
-    case SetComprehensionF(v, d, p, _) =>
-      walk(d, scope, out); walk(p, scope + v, out)
-    case other =>
-      SpecRestGenerated.subexprs(other).foreach(walk(_, scope, out))

--- a/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
@@ -6,7 +6,7 @@ object UnusedEntity extends LintPass:
   val code = "L05"
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
-    val refs = referencedNames(ir).toSet
+    val refs = referencedNames(ir)
     ir.c.flatMap { case EntityDeclFull(name, _, _, _, span) =>
       if refs.contains(name) then Nil
       else
@@ -20,45 +20,52 @@ object UnusedEntity extends LintPass:
         )
     }
 
-  private def referencedNames(ir: ServiceIRFull): List[String] =
-    val state = ir.f.toList.flatMap { case StateDeclFull(fs, _) =>
-      fs.flatMap { case StateFieldDeclFull(_, t, _) => collectTypeNames(t) }
+  // Single mutable Set accumulator: O(1) amortized membership and
+  // bounded by the number of distinct names. Matches the original
+  // walker shape — avoids materialising duplicate-heavy intermediate
+  // Lists per IR slot before deduplication.
+  private def referencedNames(ir: ServiceIRFull): Set[String] =
+    val acc = scala.collection.mutable.Set.empty[String]
+
+    def addExpr(e: expr_full): Unit      = acc ++= collectExprNames(e)
+    def addType(t: type_expr_full): Unit = acc ++= collectTypeNames(t)
+
+    ir.f.toList.foreach { case StateDeclFull(fs, _) =>
+      fs.foreach { case StateFieldDeclFull(_, t, _) => addType(t) }
     }
 
-    val ops = ir.g.collect { case op: OperationDeclFull => op }
-      .flatMap: op =>
-        op.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
-          op.c.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
-          op.d.flatMap(collectExprNames) ++
-          op.e.flatMap(collectExprNames)
+    for case OperationDeclFull(_, inputs, outputs, requires, ensures, _) <- ir.g do
+      inputs.foreach { case ParamDeclFull(_, t, _) => addType(t) }
+      outputs.foreach { case ParamDeclFull(_, t, _) => addType(t) }
+      requires.foreach(addExpr)
+      ensures.foreach(addExpr)
 
-    val entities = ir.c.collect { case e: EntityDeclFull => e }
-      .flatMap: e =>
-        e.b.toList ++
-          e.c.flatMap { case FieldDeclFull(_, t, c, _) =>
-            collectTypeNames(t) ++ c.toList.flatMap(collectExprNames)
-          } ++
-          e.d.flatMap(collectExprNames)
+    for case EntityDeclFull(_, parent, fields, invs, _) <- ir.c do
+      parent.foreach(acc += _)
+      fields.foreach { case FieldDeclFull(_, t, c, _) =>
+        addType(t); c.foreach(addExpr)
+      }
+      invs.foreach(addExpr)
 
-    val invs  = ir.i.flatMap { case InvariantDeclFull(_, e, _) => collectExprNames(e) }
-    val temps = ir.j.flatMap { case TemporalDeclFull(_, b, _) => collectExprNames(temporalArg(b)) }
-    val facts = ir.k.flatMap { case FactDeclFull(_, e, _) => collectExprNames(e) }
+    ir.i.foreach { case InvariantDeclFull(_, e, _) => addExpr(e) }
+    ir.j.foreach { case TemporalDeclFull(_, b, _) => addExpr(temporalArg(b)) }
+    ir.k.foreach { case FactDeclFull(_, e, _) => addExpr(e) }
 
-    val funcs = ir.l.collect { case f: FunctionDeclFull => f }.flatMap: f =>
-      f.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
-        collectTypeNames(f.c) ++ collectExprNames(f.d)
+    for case FunctionDeclFull(_, params, ret, body, _) <- ir.l do
+      params.foreach { case ParamDeclFull(_, t, _) => addType(t) }
+      addType(ret); addExpr(body)
 
-    val preds = ir.m.collect { case p: PredicateDeclFull => p }.flatMap: p =>
-      p.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
-        collectExprNames(p.c)
+    for case PredicateDeclFull(_, params, body, _) <- ir.m do
+      params.foreach { case ParamDeclFull(_, t, _) => addType(t) }
+      addExpr(body)
 
-    val transitions = ir.h.collect { case t: TransitionDeclFull => t }.flatMap: td =>
-      td.d.flatMap { case TransitionRuleFull(_, _, _, guard, _) =>
-        guard.toList.flatMap(collectExprNames)
+    for case TransitionDeclFull(_, _, _, rules, _) <- ir.h do
+      rules.foreach { case TransitionRuleFull(_, _, _, guard, _) =>
+        guard.foreach(addExpr)
       }
 
-    val aliases = ir.e.collect { case a: TypeAliasDeclFull => a }.flatMap: a =>
-      collectTypeNames(a.b) ++ a.c.toList.flatMap(collectExprNames)
+    ir.e.foreach { case TypeAliasDeclFull(_, t, c, _) =>
+      addType(t); c.foreach(addExpr)
+    }
 
-    state ++ ops ++ entities ++ invs ++ temps ++ facts ++ funcs ++ preds ++
-      transitions ++ aliases
+    acc.toSet

--- a/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
@@ -6,7 +6,7 @@ object UnusedEntity extends LintPass:
   val code = "L05"
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
-    val refs = referencedNames(ir)
+    val refs = referencedNames(ir).toSet
     ir.c.flatMap { case EntityDeclFull(name, _, _, _, span) =>
       if refs.contains(name) then Nil
       else
@@ -20,61 +20,45 @@ object UnusedEntity extends LintPass:
         )
     }
 
-  private def referencedNames(ir: ServiceIRFull): Set[String] =
-    val acc = scala.collection.mutable.Set.empty[String]
-
-    def collectType(t: type_expr_full): Unit = t match
-      case NamedTypeF(n, _)          => acc += n
-      case SetTypeF(inner, _)        => collectType(inner)
-      case SeqTypeF(inner, _)        => collectType(inner)
-      case OptionTypeF(inner, _)     => collectType(inner)
-      case MapTypeF(k, v, _)         => collectType(k); collectType(v)
-      case RelationTypeF(f, _, t, _) => collectType(f); collectType(t)
-
-    def collectExpr(e: expr_full): Unit =
-      ExprWalk.foreach(e):
-        case ConstructorF(name, _, _) => acc += name
-        case IdentifierF(name, _)     => acc += name
-        case EnumAccessF(_, _, _)     => () // handled via Identifier on base
-        case _                        => ()
-
-    ir.f.toList.flatMap { case StateDeclFull(fs, _) => fs }.foreach {
-      case StateFieldDeclFull(_, t, _) => collectType(t)
+  private def referencedNames(ir: ServiceIRFull): List[String] =
+    val state = ir.f.toList.flatMap { case StateDeclFull(fs, _) =>
+      fs.flatMap { case StateFieldDeclFull(_, t, _) => collectTypeNames(t) }
     }
 
-    for case OperationDeclFull(_, inputs, outputs, requires, ensures, _) <- ir.g do
-      inputs.foreach { case ParamDeclFull(_, t, _) => collectType(t) }
-      outputs.foreach { case ParamDeclFull(_, t, _) => collectType(t) }
-      requires.foreach(collectExpr)
-      ensures.foreach(collectExpr)
+    val ops = ir.g.collect { case op: OperationDeclFull => op }
+      .flatMap: op =>
+        op.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
+          op.c.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
+          op.d.flatMap(collectExprNames) ++
+          op.e.flatMap(collectExprNames)
 
-    for case EntityDeclFull(_, parent, fields, invs, _) <- ir.c do
-      parent.foreach(p => acc += p)
-      fields.foreach { case FieldDeclFull(_, t, c, _) =>
-        collectType(t)
-        c.foreach(collectExpr)
+    val entities = ir.c.collect { case e: EntityDeclFull => e }
+      .flatMap: e =>
+        e.b.toList ++
+          e.c.flatMap { case FieldDeclFull(_, t, c, _) =>
+            collectTypeNames(t) ++ c.toList.flatMap(collectExprNames)
+          } ++
+          e.d.flatMap(collectExprNames)
+
+    val invs  = ir.i.flatMap { case InvariantDeclFull(_, e, _) => collectExprNames(e) }
+    val temps = ir.j.flatMap { case TemporalDeclFull(_, b, _) => collectExprNames(temporalArg(b)) }
+    val facts = ir.k.flatMap { case FactDeclFull(_, e, _) => collectExprNames(e) }
+
+    val funcs = ir.l.collect { case f: FunctionDeclFull => f }.flatMap: f =>
+      f.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
+        collectTypeNames(f.c) ++ collectExprNames(f.d)
+
+    val preds = ir.m.collect { case p: PredicateDeclFull => p }.flatMap: p =>
+      p.b.flatMap { case ParamDeclFull(_, t, _) => collectTypeNames(t) } ++
+        collectExprNames(p.c)
+
+    val transitions = ir.h.collect { case t: TransitionDeclFull => t }.flatMap: td =>
+      td.d.flatMap { case TransitionRuleFull(_, _, _, guard, _) =>
+        guard.toList.flatMap(collectExprNames)
       }
-      invs.foreach(collectExpr)
 
-    ir.i.foreach { case InvariantDeclFull(_, e, _) => collectExpr(e) }
-    ir.j.foreach { case TemporalDeclFull(_, b, _) => collectExpr(temporalArg(b)) }
-    ir.k.foreach { case FactDeclFull(_, e, _) => collectExpr(e) }
+    val aliases = ir.e.collect { case a: TypeAliasDeclFull => a }.flatMap: a =>
+      collectTypeNames(a.b) ++ a.c.toList.flatMap(collectExprNames)
 
-    for case FunctionDeclFull(_, params, ret, body, _) <- ir.l do
-      params.foreach { case ParamDeclFull(_, t, _) => collectType(t) }
-      collectType(ret)
-      collectExpr(body)
-
-    for case PredicateDeclFull(_, params, body, _) <- ir.m do
-      params.foreach { case ParamDeclFull(_, t, _) => collectType(t) }
-      collectExpr(body)
-
-    for case TransitionDeclFull(_, _, _, rules, _) <- ir.h do
-      rules.foreach { case TransitionRuleFull(_, _, _, guard, _) => guard.foreach(collectExpr) }
-
-    ir.e.foreach { case TypeAliasDeclFull(_, t, c, _) =>
-      collectType(t)
-      c.foreach(collectExpr)
-    }
-
-    acc.toSet
+    state ++ ops ++ entities ++ invs ++ temps ++ facts ++ funcs ++ preds ++
+      transitions ++ aliases

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -274,6 +274,7 @@ export_code
     collectTypeNames
     walkUndefinedExpr
     collectCallNames
+    collectAllCallNames
     findCycles
     parseHttpMethod
     decidePutPatch

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -273,6 +273,8 @@ export_code
     collectExprNames
     collectTypeNames
     walkUndefinedExpr
+    collectCallNames
+    findCycles
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -270,6 +270,9 @@ export_code
     extractTsTuples
     collisionsForRule
     operationMissingEnsures
+    collectExprNames
+    collectTypeNames
+    walkUndefinedExpr
     parseHttpMethod
     decidePutPatch
     decideKindAndMethod

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -328,13 +328,69 @@ fun isLitFull :: "expr_full \<Rightarrow> bool" where
 | "isLitFull (NoneLitF _)     = True"
 | "isLitFull _                = False"
 
+text \<open>\<^bold>\<open>Generic tree-walk: \<open>allSubexprs\<close>\<close>. Returns every subterm of
+  an \<open>expr_full\<close> (including the root) as a single list, via structural
+  mutual \<open>fun\<close> recursion. Defined alongside \<open>subexprs\<close> (one-step
+  children) so every binder-insensitive query / collector across IR /
+  IR_Analysis / IR_Helpers / LintAnalysis can compose on it instead of
+  re-enumerating the 28 constructors per walker.\<close>
+
+fun allSubexprs :: "expr_full \<Rightarrow> expr_full list"
+and allSubexprs_list :: "expr_full list \<Rightarrow> expr_full list"
+and allSubexprs_fields :: "field_assign_full list \<Rightarrow> expr_full list"
+and allSubexprs_entries :: "map_entry_full list \<Rightarrow> expr_full list"
+and allSubexprs_bindings :: "quantifier_binding_full list \<Rightarrow> expr_full list"
+where
+  "allSubexprs (BinaryOpF op l r sp)        = BinaryOpF op l r sp # allSubexprs l @ allSubexprs r"
+| "allSubexprs (UnaryOpF op e sp)           = UnaryOpF op e sp # allSubexprs e"
+| "allSubexprs (FieldAccessF b f sp)        = FieldAccessF b f sp # allSubexprs b"
+| "allSubexprs (EnumAccessF b e sp)         = EnumAccessF b e sp # allSubexprs b"
+| "allSubexprs (IndexF b i sp)              = IndexF b i sp # allSubexprs b @ allSubexprs i"
+| "allSubexprs (CallF c args sp)            = CallF c args sp # allSubexprs c @ allSubexprs_list args"
+| "allSubexprs (PrimeF e sp)                = PrimeF e sp # allSubexprs e"
+| "allSubexprs (PreF e sp)                  = PreF e sp # allSubexprs e"
+| "allSubexprs (WithF b ups sp)             = WithF b ups sp # allSubexprs b @ allSubexprs_fields ups"
+| "allSubexprs (IfF c t e sp)               = IfF c t e sp # allSubexprs c @ allSubexprs t @ allSubexprs e"
+| "allSubexprs (LetF v val body sp)         = LetF v val body sp # allSubexprs val @ allSubexprs body"
+| "allSubexprs (LambdaF p b sp)             = LambdaF p b sp # allSubexprs b"
+| "allSubexprs (ConstructorF n fs sp)       = ConstructorF n fs sp # allSubexprs_fields fs"
+| "allSubexprs (SetLiteralF xs sp)          = SetLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MapLiteralF es sp)          = MapLiteralF es sp # allSubexprs_entries es"
+| "allSubexprs (SetComprehensionF v d p sp) = SetComprehensionF v d p sp # allSubexprs d @ allSubexprs p"
+| "allSubexprs (SeqLiteralF xs sp)          = SeqLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MatchesF e pat sp)          = MatchesF e pat sp # allSubexprs e"
+| "allSubexprs (SomeWrapF e sp)             = SomeWrapF e sp # allSubexprs e"
+| "allSubexprs (TheF v d b sp)              = TheF v d b sp # allSubexprs d @ allSubexprs b"
+| "allSubexprs (QuantifierF q bs body sp)   = QuantifierF q bs body sp # allSubexprs_bindings bs @ allSubexprs body"
+| "allSubexprs (IdentifierF n sp)           = [IdentifierF n sp]"
+| "allSubexprs (IntLitF n sp)               = [IntLitF n sp]"
+| "allSubexprs (FloatLitF v sp)             = [FloatLitF v sp]"
+| "allSubexprs (StringLitF v sp)            = [StringLitF v sp]"
+| "allSubexprs (BoolLitF b sp)              = [BoolLitF b sp]"
+| "allSubexprs (NoneLitF sp)                = [NoneLitF sp]"
+| "allSubexprs_list []                                          = []"
+| "allSubexprs_list (x # xs)                                    = allSubexprs x @ allSubexprs_list xs"
+| "allSubexprs_fields []                                        = []"
+| "allSubexprs_fields (FieldAssignFull n v sp # fs)             = allSubexprs v @ allSubexprs_fields fs"
+| "allSubexprs_entries []                                       = []"
+| "allSubexprs_entries (MapEntryFull k v sp # es)               = allSubexprs k @ allSubexprs v @ allSubexprs_entries es"
+| "allSubexprs_bindings []                                      = []"
+| "allSubexprs_bindings (QuantifierBindingFull n d a sp # bs)   = allSubexprs d @ allSubexprs_bindings bs"
+
 text \<open>Phase 8 (verifier classifier port): \<open>requiresAlloy\<close> identifies
   \<open>expr_full\<close> shapes that contain a \<open>UPower\<close> (set-power) constructor anywhere
   in the expression tree. The verifier routes such checks to the Alloy backend
   (which models set power) instead of Z3. Pure structural fold; mutually
   recursive over \<open>expr_full\<close> and the three child-list-bearing companions
   (\<open>field_assign_full\<close>, \<open>map_entry_full\<close>, \<open>quantifier_binding_full\<close>) that
-  also carry \<open>expr_full\<close> subterms.\<close>
+  also carry \<open>expr_full\<close> subterms.
+
+  Kept in this mutual-fun form (rather than streamlined to \<open>list_ex
+  isUPowerUnary (allSubexprs e)\<close>) because the Soundness.thy
+  capstone (\<open>requiresAlloy_imp_lower_none_bindings\<close> at line ~1185)
+  inducts on the mutual structure with case analysis on
+  \<open>requiresAlloy_bindings\<close>; the streamlined definition would lose
+  those auto-simp rules and need substantial re-proof.\<close>
 
 fun requiresAlloy :: "expr_full \<Rightarrow> bool"
 and requiresAlloy_list :: "expr_full list \<Rightarrow> bool"
@@ -561,5 +617,10 @@ fun rootIdentifier :: "expr_full \<Rightarrow> String.literal option" where
 | "rootIdentifier (IndexF base _ _)        = rootIdentifier base"
 | "rootIdentifier (FieldAccessF base _ _)  = rootIdentifier base"
 | "rootIdentifier _                        = None"
+
+lemmas allSubexprs_code [code]   = allSubexprs.simps allSubexprs_list.simps
+                                    allSubexprs_fields.simps
+                                    allSubexprs_entries.simps
+                                    allSubexprs_bindings.simps
 
 end

--- a/proofs/isabelle/SpecRest/IR.thy
+++ b/proofs/isabelle/SpecRest/IR.thy
@@ -380,59 +380,169 @@ where
 text \<open>Phase 8 (verifier classifier port): \<open>requiresAlloy\<close> identifies
   \<open>expr_full\<close> shapes that contain a \<open>UPower\<close> (set-power) constructor anywhere
   in the expression tree. The verifier routes such checks to the Alloy backend
-  (which models set power) instead of Z3. Pure structural fold; mutually
-  recursive over \<open>expr_full\<close> and the three child-list-bearing companions
-  (\<open>field_assign_full\<close>, \<open>map_entry_full\<close>, \<open>quantifier_binding_full\<close>) that
-  also carry \<open>expr_full\<close> subterms.
+  (which models set power) instead of Z3.
 
-  Kept in this mutual-fun form (rather than streamlined to \<open>list_ex
-  isUPowerUnary (allSubexprs e)\<close>) because the Soundness.thy
-  capstone (\<open>requiresAlloy_imp_lower_none_bindings\<close> at line ~1185)
-  inducts on the mutual structure with case analysis on
-  \<open>requiresAlloy_bindings\<close>; the streamlined definition would lose
-  those auto-simp rules and need substantial re-proof.\<close>
+  Definition is a one-line composition over \<open>allSubexprs\<close>; the four
+  helper predicates (\<open>requiresAlloy_list\<close>, \<open>_fields\<close>,
+  \<open>_entries\<close>, \<open>_bindings\<close>) are wrappers used by the original
+  Soundness proofs — derived equations below provide the per-cons
+  / per-constructor simp rules that those proofs rely on, so existing
+  Soundness theorems continue to discharge without restructuring.\<close>
 
-fun requiresAlloy :: "expr_full \<Rightarrow> bool"
-and requiresAlloy_list :: "expr_full list \<Rightarrow> bool"
-and requiresAlloy_fields :: "field_assign_full list \<Rightarrow> bool"
-and requiresAlloy_entries :: "map_entry_full list \<Rightarrow> bool"
-and requiresAlloy_bindings :: "quantifier_binding_full list \<Rightarrow> bool"
-where
-  "requiresAlloy (UnaryOpF op e _)             = (op = UPower \<or> requiresAlloy e)"
-| "requiresAlloy (BinaryOpF _ l r _)           = (requiresAlloy l \<or> requiresAlloy r)"
-| "requiresAlloy (QuantifierF _ bs body _)     = (requiresAlloy_bindings bs \<or> requiresAlloy body)"
-| "requiresAlloy (SomeWrapF x _)               = requiresAlloy x"
-| "requiresAlloy (TheF _ d b _)                = (requiresAlloy d \<or> requiresAlloy b)"
-| "requiresAlloy (FieldAccessF b _ _)          = requiresAlloy b"
-| "requiresAlloy (EnumAccessF b _ _)           = requiresAlloy b"
-| "requiresAlloy (IndexF b i _)                = (requiresAlloy b \<or> requiresAlloy i)"
-| "requiresAlloy (CallF c args _)              = (requiresAlloy c \<or> requiresAlloy_list args)"
-| "requiresAlloy (PrimeF x _)                  = requiresAlloy x"
-| "requiresAlloy (PreF x _)                    = requiresAlloy x"
-| "requiresAlloy (WithF b upds _)              = (requiresAlloy b \<or> requiresAlloy_fields upds)"
-| "requiresAlloy (IfF c t e _)                 = (requiresAlloy c \<or> requiresAlloy t \<or> requiresAlloy e)"
-| "requiresAlloy (LetF _ v b _)                = (requiresAlloy v \<or> requiresAlloy b)"
-| "requiresAlloy (LambdaF _ b _)               = requiresAlloy b"
-| "requiresAlloy (ConstructorF _ fs _)         = requiresAlloy_fields fs"
-| "requiresAlloy (SetLiteralF xs _)            = requiresAlloy_list xs"
-| "requiresAlloy (MapLiteralF es _)            = requiresAlloy_entries es"
-| "requiresAlloy (SetComprehensionF _ d p _)   = (requiresAlloy d \<or> requiresAlloy p)"
-| "requiresAlloy (SeqLiteralF xs _)            = requiresAlloy_list xs"
-| "requiresAlloy (MatchesF x _ _)              = requiresAlloy x"
-| "requiresAlloy (IntLitF _ _)                 = False"
-| "requiresAlloy (FloatLitF _ _)               = False"
-| "requiresAlloy (StringLitF _ _)              = False"
-| "requiresAlloy (BoolLitF _ _)                = False"
-| "requiresAlloy (NoneLitF _)                  = False"
-| "requiresAlloy (IdentifierF _ _)             = False"
-| "requiresAlloy_list []                       = False"
-| "requiresAlloy_list (x # xs)                 = (requiresAlloy x \<or> requiresAlloy_list xs)"
-| "requiresAlloy_fields []                     = False"
-| "requiresAlloy_fields (FieldAssignFull _ v _ # fs) = (requiresAlloy v \<or> requiresAlloy_fields fs)"
-| "requiresAlloy_entries []                    = False"
-| "requiresAlloy_entries (MapEntryFull k v _ # es) = (requiresAlloy k \<or> requiresAlloy v \<or> requiresAlloy_entries es)"
-| "requiresAlloy_bindings []                   = False"
-| "requiresAlloy_bindings (QuantifierBindingFull _ d _ _ # bs) = (requiresAlloy d \<or> requiresAlloy_bindings bs)"
+fun isUPowerUnary :: "expr_full \<Rightarrow> bool" where
+  "isUPowerUnary (UnaryOpF UPower _ _) = True"
+| "isUPowerUnary _                     = False"
+
+definition requiresAlloy :: "expr_full \<Rightarrow> bool" where
+  "requiresAlloy e = list_ex isUPowerUnary (allSubexprs e)"
+
+text \<open>Symmetric helpers over the wrapper-list types: each uses the
+  matching \<open>allSubexprs_*\<close> flatten so the per-cons simp rules below
+  fall out by definition unfolding + the \<open>allSubexprs.simps\<close>
+  equations (which are already simp by \<open>fun\<close> auto-generation).\<close>
+
+definition requiresAlloy_list :: "expr_full list \<Rightarrow> bool" where
+  "requiresAlloy_list xs = list_ex isUPowerUnary (allSubexprs_list xs)"
+
+definition requiresAlloy_fields :: "field_assign_full list \<Rightarrow> bool" where
+  "requiresAlloy_fields fs = list_ex isUPowerUnary (allSubexprs_fields fs)"
+
+definition requiresAlloy_entries :: "map_entry_full list \<Rightarrow> bool" where
+  "requiresAlloy_entries es = list_ex isUPowerUnary (allSubexprs_entries es)"
+
+definition requiresAlloy_bindings :: "quantifier_binding_full list \<Rightarrow> bool" where
+  "requiresAlloy_bindings bs = list_ex isUPowerUnary (allSubexprs_bindings bs)"
+
+text \<open>Derived equations: re-establish the per-constructor / per-cons
+  rewrite rules that the original mutual \<open>fun\<close> would have produced as
+  auto-simps. With these added to \<open>[simp]\<close>, downstream proofs in
+  \<open>IR_Helpers\<close> / \<open>Soundness\<close> continue to discharge unchanged.\<close>
+
+text \<open>Per-cons simp rules for the wrapper-list helpers fall out directly
+  from \<open>allSubexprs_*\<close> unfolding + \<open>list_ex\<close> simplification.\<close>
+
+lemma requiresAlloy_list_simps [simp]:
+  "requiresAlloy_list [] = False"
+  "requiresAlloy_list (x # xs) = (requiresAlloy x \<or> requiresAlloy_list xs)"
+  by (auto simp: requiresAlloy_list_def requiresAlloy_def)
+
+lemma requiresAlloy_fields_simps [simp]:
+  "requiresAlloy_fields [] = False"
+  "requiresAlloy_fields (FieldAssignFull nm v sp # fs) =
+     (requiresAlloy v \<or> requiresAlloy_fields fs)"
+  by (auto simp: requiresAlloy_fields_def requiresAlloy_def)
+
+lemma requiresAlloy_entries_simps [simp]:
+  "requiresAlloy_entries [] = False"
+  "requiresAlloy_entries (MapEntryFull k v sp # es) =
+     (requiresAlloy k \<or> requiresAlloy v \<or> requiresAlloy_entries es)"
+  by (auto simp: requiresAlloy_entries_def requiresAlloy_def)
+
+lemma requiresAlloy_bindings_simps [simp]:
+  "requiresAlloy_bindings [] = False"
+  "requiresAlloy_bindings (QuantifierBindingFull nm d a sp # bs) =
+     (requiresAlloy d \<or> requiresAlloy_bindings bs)"
+  by (auto simp: requiresAlloy_bindings_def requiresAlloy_def)
+
+text \<open>Per-constructor simp rules for \<open>requiresAlloy\<close> — each is one-line
+  \<open>simp add: requiresAlloy_def\<close> because the \<open>allSubexprs.simps\<close> rules
+  are already in the global simp set (auto-generated by \<open>fun\<close>) and the
+  helper-list \<open>requires*\<close> definitions point at the matching
+  \<open>allSubexprs_*\<close>.\<close>
+
+lemma requiresAlloy_UnaryOpF [simp]:
+  "requiresAlloy (UnaryOpF op e sp) = (op = UPower \<or> requiresAlloy e)"
+  by (cases op) (auto simp: requiresAlloy_def)
+
+lemma requiresAlloy_BinaryOpF [simp]:
+  "requiresAlloy (BinaryOpF op l r sp) = (requiresAlloy l \<or> requiresAlloy r)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_QuantifierF [simp]:
+  "requiresAlloy (QuantifierF q bs body sp) = (requiresAlloy_bindings bs \<or> requiresAlloy body)"
+  by (simp add: requiresAlloy_def requiresAlloy_bindings_def)
+
+lemma requiresAlloy_SomeWrapF [simp]: "requiresAlloy (SomeWrapF x sp) = requiresAlloy x"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_TheF [simp]:
+  "requiresAlloy (TheF nm d body sp) = (requiresAlloy d \<or> requiresAlloy body)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_FieldAccessF [simp]:
+  "requiresAlloy (FieldAccessF base fld sp) = requiresAlloy base"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_EnumAccessF [simp]:
+  "requiresAlloy (EnumAccessF base mem sp) = requiresAlloy base"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_IndexF [simp]:
+  "requiresAlloy (IndexF base idx sp) = (requiresAlloy base \<or> requiresAlloy idx)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_CallF [simp]:
+  "requiresAlloy (CallF callee args sp) = (requiresAlloy callee \<or> requiresAlloy_list args)"
+  by (simp add: requiresAlloy_def requiresAlloy_list_def)
+
+lemma requiresAlloy_PrimeF [simp]: "requiresAlloy (PrimeF x sp) = requiresAlloy x"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_PreF [simp]: "requiresAlloy (PreF x sp) = requiresAlloy x"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_WithF [simp]:
+  "requiresAlloy (WithF base upds sp) = (requiresAlloy base \<or> requiresAlloy_fields upds)"
+  by (simp add: requiresAlloy_def requiresAlloy_fields_def)
+
+lemma requiresAlloy_IfF [simp]:
+  "requiresAlloy (IfF c t f sp) = (requiresAlloy c \<or> requiresAlloy t \<or> requiresAlloy f)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_LetF [simp]:
+  "requiresAlloy (LetF nm val body sp) = (requiresAlloy val \<or> requiresAlloy body)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_LambdaF [simp]:
+  "requiresAlloy (LambdaF param body sp) = requiresAlloy body"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_ConstructorF [simp]:
+  "requiresAlloy (ConstructorF nm fs sp) = requiresAlloy_fields fs"
+  by (simp add: requiresAlloy_def requiresAlloy_fields_def)
+
+lemma requiresAlloy_SetLiteralF [simp]:
+  "requiresAlloy (SetLiteralF xs sp) = requiresAlloy_list xs"
+  by (simp add: requiresAlloy_def requiresAlloy_list_def)
+
+lemma requiresAlloy_MapLiteralF [simp]:
+  "requiresAlloy (MapLiteralF es sp) = requiresAlloy_entries es"
+  by (simp add: requiresAlloy_def requiresAlloy_entries_def)
+
+lemma requiresAlloy_SetComprehensionF [simp]:
+  "requiresAlloy (SetComprehensionF nm d pred sp) = (requiresAlloy d \<or> requiresAlloy pred)"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_SeqLiteralF [simp]:
+  "requiresAlloy (SeqLiteralF xs sp) = requiresAlloy_list xs"
+  by (simp add: requiresAlloy_def requiresAlloy_list_def)
+
+lemma requiresAlloy_MatchesF [simp]:
+  "requiresAlloy (MatchesF x pat sp) = requiresAlloy x"
+  by (simp add: requiresAlloy_def)
+
+lemma requiresAlloy_IntLitF [simp]: "requiresAlloy (IntLitF n sp) = False"
+  by (simp add: requiresAlloy_def)
+lemma requiresAlloy_FloatLitF [simp]: "requiresAlloy (FloatLitF f sp) = False"
+  by (simp add: requiresAlloy_def)
+lemma requiresAlloy_StringLitF [simp]: "requiresAlloy (StringLitF s sp) = False"
+  by (simp add: requiresAlloy_def)
+lemma requiresAlloy_BoolLitF [simp]: "requiresAlloy (BoolLitF b sp) = False"
+  by (simp add: requiresAlloy_def)
+lemma requiresAlloy_NoneLitF [simp]: "requiresAlloy (NoneLitF sp) = False"
+  by (simp add: requiresAlloy_def)
+lemma requiresAlloy_IdentifierF [simp]: "requiresAlloy (IdentifierF n sp) = False"
+  by (simp add: requiresAlloy_def)
 
 text \<open>Phase 9a (structural primitives): \<open>subexprs\<close> returns the direct
   \<open>expr_full\<close> children of an expression. Replaces ad-hoc 27-arm structural
@@ -618,9 +728,15 @@ fun rootIdentifier :: "expr_full \<Rightarrow> String.literal option" where
 | "rootIdentifier (FieldAccessF base _ _)  = rootIdentifier base"
 | "rootIdentifier _                        = None"
 
-lemmas allSubexprs_code [code]   = allSubexprs.simps allSubexprs_list.simps
-                                    allSubexprs_fields.simps
-                                    allSubexprs_entries.simps
-                                    allSubexprs_bindings.simps
+lemmas allSubexprs_code [code]            = allSubexprs.simps allSubexprs_list.simps
+                                             allSubexprs_fields.simps
+                                             allSubexprs_entries.simps
+                                             allSubexprs_bindings.simps
+lemmas isUPowerUnary_code [code]          = isUPowerUnary.simps
+lemmas requiresAlloy_code [code]          = requiresAlloy_def
+lemmas requiresAlloy_list_code [code]     = requiresAlloy_list_def
+lemmas requiresAlloy_fields_code [code]   = requiresAlloy_fields_def
+lemmas requiresAlloy_entries_code [code]  = requiresAlloy_entries_def
+lemmas requiresAlloy_bindings_code [code] = requiresAlloy_bindings_def
 
 end

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -9,6 +9,61 @@ text \<open>Phase 9\<alpha> (small recognizers): \<open>isTrueLit\<close> matche
   \<open>enumLiteralFor\<close> walkers in \<open>testgen.Behavioral\<close> /
   \<open>testgen.Stateful\<close>.\<close>
 
+text \<open>\<^bold>\<open>Generic tree-walk: \<open>allSubexprs\<close>\<close>. Returns every subterm of
+  an \<open>expr_full\<close> (including the root) in a single list, via structural
+  mutual \<open>fun\<close> recursion. The 28-case enumeration here lives once;
+  every binder-insensitive query / collector becomes a one-line
+  \<open>list_ex P (allSubexprs e)\<close> or \<open>concat (map sel (allSubexprs e))\<close>.
+
+  Replaces what used to be a separate 28-case mutual \<open>fun\<close> per
+  walker (\<open>hasPrePrime\<close>, \<open>exprContainsBoolLit\<close>, and the lint
+  walkers in \<open>LintAnalysis\<close>). Binder-respecting walkers
+  (\<open>free_vars\<close>, \<open>walkUndefinedExpr\<close>, \<open>subst\<close>) cannot use this
+  shape because they thread scope through binders and must keep
+  per-constructor handling.\<close>
+
+fun allSubexprs :: "expr_full \<Rightarrow> expr_full list"
+and allSubexprs_list :: "expr_full list \<Rightarrow> expr_full list"
+and allSubexprs_fields :: "field_assign_full list \<Rightarrow> expr_full list"
+and allSubexprs_entries :: "map_entry_full list \<Rightarrow> expr_full list"
+and allSubexprs_bindings :: "quantifier_binding_full list \<Rightarrow> expr_full list"
+where
+  "allSubexprs (BinaryOpF op l r sp)        = BinaryOpF op l r sp # allSubexprs l @ allSubexprs r"
+| "allSubexprs (UnaryOpF op e sp)           = UnaryOpF op e sp # allSubexprs e"
+| "allSubexprs (FieldAccessF b f sp)        = FieldAccessF b f sp # allSubexprs b"
+| "allSubexprs (EnumAccessF b e sp)         = EnumAccessF b e sp # allSubexprs b"
+| "allSubexprs (IndexF b i sp)              = IndexF b i sp # allSubexprs b @ allSubexprs i"
+| "allSubexprs (CallF c args sp)            = CallF c args sp # allSubexprs c @ allSubexprs_list args"
+| "allSubexprs (PrimeF e sp)                = PrimeF e sp # allSubexprs e"
+| "allSubexprs (PreF e sp)                  = PreF e sp # allSubexprs e"
+| "allSubexprs (WithF b ups sp)             = WithF b ups sp # allSubexprs b @ allSubexprs_fields ups"
+| "allSubexprs (IfF c t e sp)               = IfF c t e sp # allSubexprs c @ allSubexprs t @ allSubexprs e"
+| "allSubexprs (LetF v val body sp)         = LetF v val body sp # allSubexprs val @ allSubexprs body"
+| "allSubexprs (LambdaF p b sp)             = LambdaF p b sp # allSubexprs b"
+| "allSubexprs (ConstructorF n fs sp)       = ConstructorF n fs sp # allSubexprs_fields fs"
+| "allSubexprs (SetLiteralF xs sp)          = SetLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MapLiteralF es sp)          = MapLiteralF es sp # allSubexprs_entries es"
+| "allSubexprs (SetComprehensionF v d p sp) = SetComprehensionF v d p sp # allSubexprs d @ allSubexprs p"
+| "allSubexprs (SeqLiteralF xs sp)          = SeqLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MatchesF e pat sp)          = MatchesF e pat sp # allSubexprs e"
+| "allSubexprs (SomeWrapF e sp)             = SomeWrapF e sp # allSubexprs e"
+| "allSubexprs (TheF v d b sp)              = TheF v d b sp # allSubexprs d @ allSubexprs b"
+| "allSubexprs (QuantifierF q bs body sp)   = QuantifierF q bs body sp # allSubexprs_bindings bs @ allSubexprs body"
+| "allSubexprs (IdentifierF n sp)           = [IdentifierF n sp]"
+| "allSubexprs (IntLitF n sp)               = [IntLitF n sp]"
+| "allSubexprs (FloatLitF v sp)             = [FloatLitF v sp]"
+| "allSubexprs (StringLitF v sp)            = [StringLitF v sp]"
+| "allSubexprs (BoolLitF b sp)              = [BoolLitF b sp]"
+| "allSubexprs (NoneLitF sp)                = [NoneLitF sp]"
+| "allSubexprs_list []                                          = []"
+| "allSubexprs_list (x # xs)                                    = allSubexprs x @ allSubexprs_list xs"
+| "allSubexprs_fields []                                        = []"
+| "allSubexprs_fields (FieldAssignFull n v sp # fs)             = allSubexprs v @ allSubexprs_fields fs"
+| "allSubexprs_entries []                                       = []"
+| "allSubexprs_entries (MapEntryFull k v sp # es)               = allSubexprs k @ allSubexprs v @ allSubexprs_entries es"
+| "allSubexprs_bindings []                                      = []"
+| "allSubexprs_bindings (QuantifierBindingFull n d a sp # bs)   = allSubexprs d @ allSubexprs_bindings bs"
+
 fun isTrueLit :: "expr_full \<Rightarrow> bool" where
   "isTrueLit (BoolLitF True _) = True"
 | "isTrueLit _                 = False"
@@ -160,47 +215,13 @@ text \<open>Phase 9\<gamma> (\<open>hasPrePrime\<close>): true iff the expressio
   to express the \<open>testgen.Behavioral.containsStateRef\<close> predicate as a
   one-liner.\<close>
 
-fun hasPrePrime :: "expr_full \<Rightarrow> bool"
-and hasPrePrime_list :: "expr_full list \<Rightarrow> bool"
-and hasPrePrime_fields :: "field_assign_full list \<Rightarrow> bool"
-and hasPrePrime_entries :: "map_entry_full list \<Rightarrow> bool"
-and hasPrePrime_bindings :: "quantifier_binding_full list \<Rightarrow> bool"
-where
-  "hasPrePrime (PrimeF _ _)                  = True"
-| "hasPrePrime (PreF _ _)                    = True"
-| "hasPrePrime (BinaryOpF _ l r _)           = (hasPrePrime l \<or> hasPrePrime r)"
-| "hasPrePrime (UnaryOpF _ e _)              = hasPrePrime e"
-| "hasPrePrime (FieldAccessF b _ _)          = hasPrePrime b"
-| "hasPrePrime (EnumAccessF b _ _)           = hasPrePrime b"
-| "hasPrePrime (IndexF b i _)                = (hasPrePrime b \<or> hasPrePrime i)"
-| "hasPrePrime (CallF c args _)              = (hasPrePrime c \<or> hasPrePrime_list args)"
-| "hasPrePrime (WithF b upds _)              = (hasPrePrime b \<or> hasPrePrime_fields upds)"
-| "hasPrePrime (IfF c t e _)                 = (hasPrePrime c \<or> hasPrePrime t \<or> hasPrePrime e)"
-| "hasPrePrime (LetF _ v b _)                = (hasPrePrime v \<or> hasPrePrime b)"
-| "hasPrePrime (LambdaF _ b _)               = hasPrePrime b"
-| "hasPrePrime (ConstructorF _ fs _)         = hasPrePrime_fields fs"
-| "hasPrePrime (SetLiteralF xs _)            = hasPrePrime_list xs"
-| "hasPrePrime (MapLiteralF es _)            = hasPrePrime_entries es"
-| "hasPrePrime (SetComprehensionF _ d p _)   = (hasPrePrime d \<or> hasPrePrime p)"
-| "hasPrePrime (SeqLiteralF xs _)            = hasPrePrime_list xs"
-| "hasPrePrime (MatchesF x _ _)              = hasPrePrime x"
-| "hasPrePrime (SomeWrapF x _)               = hasPrePrime x"
-| "hasPrePrime (TheF _ d b _)                = (hasPrePrime d \<or> hasPrePrime b)"
-| "hasPrePrime (QuantifierF _ bs body _)     = (hasPrePrime_bindings bs \<or> hasPrePrime body)"
-| "hasPrePrime (IntLitF _ _)                 = False"
-| "hasPrePrime (FloatLitF _ _)               = False"
-| "hasPrePrime (StringLitF _ _)              = False"
-| "hasPrePrime (BoolLitF _ _)                = False"
-| "hasPrePrime (NoneLitF _)                  = False"
-| "hasPrePrime (IdentifierF _ _)             = False"
-| "hasPrePrime_list []                                       = False"
-| "hasPrePrime_list (x # xs)                                 = (hasPrePrime x \<or> hasPrePrime_list xs)"
-| "hasPrePrime_fields []                                     = False"
-| "hasPrePrime_fields (FieldAssignFull _ v _ # fs)           = (hasPrePrime v \<or> hasPrePrime_fields fs)"
-| "hasPrePrime_entries []                                    = False"
-| "hasPrePrime_entries (MapEntryFull k v _ # es)             = (hasPrePrime k \<or> hasPrePrime v \<or> hasPrePrime_entries es)"
-| "hasPrePrime_bindings []                                   = False"
-| "hasPrePrime_bindings (QuantifierBindingFull _ d _ _ # bs) = (hasPrePrime d \<or> hasPrePrime_bindings bs)"
+fun isPrePrime :: "expr_full \<Rightarrow> bool" where
+  "isPrePrime (PrimeF _ _) = True"
+| "isPrePrime (PreF _ _)   = True"
+| "isPrePrime _            = False"
+
+definition hasPrePrime :: "expr_full \<Rightarrow> bool" where
+  "hasPrePrime e = list_ex isPrePrime (allSubexprs e)"
 
 text \<open>Phase 9\<gamma> (\<open>subst\<close>): structural substitution of a free identifier
   by an expression. Stops at binders that shadow the substituted name —
@@ -327,47 +348,12 @@ fun typeContainsNamed :: "String.literal \<Rightarrow> type_expr_full \<Rightarr
 | "typeContainsNamed n (OptionTypeF inner _) = typeContainsNamed n inner"
 | "typeContainsNamed _ _                     = False"
 
-fun exprContainsBoolLit :: "expr_full \<Rightarrow> bool"
-and exprContainsBoolLit_list :: "expr_full list \<Rightarrow> bool"
-and exprContainsBoolLit_fields :: "field_assign_full list \<Rightarrow> bool"
-and exprContainsBoolLit_entries :: "map_entry_full list \<Rightarrow> bool"
-and exprContainsBoolLit_bindings :: "quantifier_binding_full list \<Rightarrow> bool"
-where
-  "exprContainsBoolLit (BoolLitF _ _)              = True"
-| "exprContainsBoolLit (BinaryOpF _ l r _)         = (exprContainsBoolLit l \<or> exprContainsBoolLit r)"
-| "exprContainsBoolLit (UnaryOpF _ e _)            = exprContainsBoolLit e"
-| "exprContainsBoolLit (FieldAccessF b _ _)        = exprContainsBoolLit b"
-| "exprContainsBoolLit (EnumAccessF b _ _)         = exprContainsBoolLit b"
-| "exprContainsBoolLit (IndexF b i _)              = (exprContainsBoolLit b \<or> exprContainsBoolLit i)"
-| "exprContainsBoolLit (CallF c args _)            = (exprContainsBoolLit c \<or> exprContainsBoolLit_list args)"
-| "exprContainsBoolLit (PrimeF e _)                = exprContainsBoolLit e"
-| "exprContainsBoolLit (PreF e _)                  = exprContainsBoolLit e"
-| "exprContainsBoolLit (WithF b upds _)            = (exprContainsBoolLit b \<or> exprContainsBoolLit_fields upds)"
-| "exprContainsBoolLit (IfF c t e _)               = (exprContainsBoolLit c \<or> exprContainsBoolLit t \<or> exprContainsBoolLit e)"
-| "exprContainsBoolLit (LetF _ v b _)              = (exprContainsBoolLit v \<or> exprContainsBoolLit b)"
-| "exprContainsBoolLit (LambdaF _ b _)             = exprContainsBoolLit b"
-| "exprContainsBoolLit (ConstructorF _ fs _)       = exprContainsBoolLit_fields fs"
-| "exprContainsBoolLit (SetLiteralF xs _)          = exprContainsBoolLit_list xs"
-| "exprContainsBoolLit (MapLiteralF es _)          = exprContainsBoolLit_entries es"
-| "exprContainsBoolLit (SetComprehensionF _ d p _) = (exprContainsBoolLit d \<or> exprContainsBoolLit p)"
-| "exprContainsBoolLit (SeqLiteralF xs _)          = exprContainsBoolLit_list xs"
-| "exprContainsBoolLit (MatchesF x _ _)            = exprContainsBoolLit x"
-| "exprContainsBoolLit (SomeWrapF x _)             = exprContainsBoolLit x"
-| "exprContainsBoolLit (TheF _ d b _)              = (exprContainsBoolLit d \<or> exprContainsBoolLit b)"
-| "exprContainsBoolLit (QuantifierF _ bs body _)   = (exprContainsBoolLit_bindings bs \<or> exprContainsBoolLit body)"
-| "exprContainsBoolLit (IntLitF _ _)               = False"
-| "exprContainsBoolLit (FloatLitF _ _)             = False"
-| "exprContainsBoolLit (StringLitF _ _)            = False"
-| "exprContainsBoolLit (NoneLitF _)                = False"
-| "exprContainsBoolLit (IdentifierF _ _)           = False"
-| "exprContainsBoolLit_list []                                                  = False"
-| "exprContainsBoolLit_list (x # xs)                                            = (exprContainsBoolLit x \<or> exprContainsBoolLit_list xs)"
-| "exprContainsBoolLit_fields []                                                = False"
-| "exprContainsBoolLit_fields (FieldAssignFull _ v _ # fs)                      = (exprContainsBoolLit v \<or> exprContainsBoolLit_fields fs)"
-| "exprContainsBoolLit_entries []                                               = False"
-| "exprContainsBoolLit_entries (MapEntryFull k v _ # es)                        = (exprContainsBoolLit k \<or> exprContainsBoolLit v \<or> exprContainsBoolLit_entries es)"
-| "exprContainsBoolLit_bindings []                                              = False"
-| "exprContainsBoolLit_bindings (QuantifierBindingFull _ d _ _ # bs)            = (exprContainsBoolLit d \<or> exprContainsBoolLit_bindings bs)"
+fun isBoolLit :: "expr_full \<Rightarrow> bool" where
+  "isBoolLit (BoolLitF _ _) = True"
+| "isBoolLit _              = False"
+
+definition exprContainsBoolLit :: "expr_full \<Rightarrow> bool" where
+  "exprContainsBoolLit e = list_ex isBoolLit (allSubexprs e)"
 
 text \<open>Phase 9\<delta> (Narration conflict helpers): pure pattern matches lifted
   from \<open>verify.Narration\<close>. \<open>isComp\<close>/\<open>isLowBound\<close>/\<open>isStrictBound\<close> classify
@@ -573,5 +559,14 @@ definition isKeyExistsConj ::
           (case l of IdentifierF i _ \<Rightarrow> i = inputName | _ \<Rightarrow> False) \<and>
           (case r of IdentifierF s _ \<Rightarrow> s = stateName | _ \<Rightarrow> False)
       | _ \<Rightarrow> False)"
+
+lemmas allSubexprs_code [code] = allSubexprs.simps allSubexprs_list.simps
+                                  allSubexprs_fields.simps
+                                  allSubexprs_entries.simps
+                                  allSubexprs_bindings.simps
+lemmas isPrePrime_code [code]          = isPrePrime.simps
+lemmas hasPrePrime_code [code]         = hasPrePrime_def
+lemmas isBoolLit_code [code]           = isBoolLit.simps
+lemmas exprContainsBoolLit_code [code] = exprContainsBoolLit_def
 
 end

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -9,61 +9,6 @@ text \<open>Phase 9\<alpha> (small recognizers): \<open>isTrueLit\<close> matche
   \<open>enumLiteralFor\<close> walkers in \<open>testgen.Behavioral\<close> /
   \<open>testgen.Stateful\<close>.\<close>
 
-text \<open>\<^bold>\<open>Generic tree-walk: \<open>allSubexprs\<close>\<close>. Returns every subterm of
-  an \<open>expr_full\<close> (including the root) in a single list, via structural
-  mutual \<open>fun\<close> recursion. The 28-case enumeration here lives once;
-  every binder-insensitive query / collector becomes a one-line
-  \<open>list_ex P (allSubexprs e)\<close> or \<open>concat (map sel (allSubexprs e))\<close>.
-
-  Replaces what used to be a separate 28-case mutual \<open>fun\<close> per
-  walker (\<open>hasPrePrime\<close>, \<open>exprContainsBoolLit\<close>, and the lint
-  walkers in \<open>LintAnalysis\<close>). Binder-respecting walkers
-  (\<open>free_vars\<close>, \<open>walkUndefinedExpr\<close>, \<open>subst\<close>) cannot use this
-  shape because they thread scope through binders and must keep
-  per-constructor handling.\<close>
-
-fun allSubexprs :: "expr_full \<Rightarrow> expr_full list"
-and allSubexprs_list :: "expr_full list \<Rightarrow> expr_full list"
-and allSubexprs_fields :: "field_assign_full list \<Rightarrow> expr_full list"
-and allSubexprs_entries :: "map_entry_full list \<Rightarrow> expr_full list"
-and allSubexprs_bindings :: "quantifier_binding_full list \<Rightarrow> expr_full list"
-where
-  "allSubexprs (BinaryOpF op l r sp)        = BinaryOpF op l r sp # allSubexprs l @ allSubexprs r"
-| "allSubexprs (UnaryOpF op e sp)           = UnaryOpF op e sp # allSubexprs e"
-| "allSubexprs (FieldAccessF b f sp)        = FieldAccessF b f sp # allSubexprs b"
-| "allSubexprs (EnumAccessF b e sp)         = EnumAccessF b e sp # allSubexprs b"
-| "allSubexprs (IndexF b i sp)              = IndexF b i sp # allSubexprs b @ allSubexprs i"
-| "allSubexprs (CallF c args sp)            = CallF c args sp # allSubexprs c @ allSubexprs_list args"
-| "allSubexprs (PrimeF e sp)                = PrimeF e sp # allSubexprs e"
-| "allSubexprs (PreF e sp)                  = PreF e sp # allSubexprs e"
-| "allSubexprs (WithF b ups sp)             = WithF b ups sp # allSubexprs b @ allSubexprs_fields ups"
-| "allSubexprs (IfF c t e sp)               = IfF c t e sp # allSubexprs c @ allSubexprs t @ allSubexprs e"
-| "allSubexprs (LetF v val body sp)         = LetF v val body sp # allSubexprs val @ allSubexprs body"
-| "allSubexprs (LambdaF p b sp)             = LambdaF p b sp # allSubexprs b"
-| "allSubexprs (ConstructorF n fs sp)       = ConstructorF n fs sp # allSubexprs_fields fs"
-| "allSubexprs (SetLiteralF xs sp)          = SetLiteralF xs sp # allSubexprs_list xs"
-| "allSubexprs (MapLiteralF es sp)          = MapLiteralF es sp # allSubexprs_entries es"
-| "allSubexprs (SetComprehensionF v d p sp) = SetComprehensionF v d p sp # allSubexprs d @ allSubexprs p"
-| "allSubexprs (SeqLiteralF xs sp)          = SeqLiteralF xs sp # allSubexprs_list xs"
-| "allSubexprs (MatchesF e pat sp)          = MatchesF e pat sp # allSubexprs e"
-| "allSubexprs (SomeWrapF e sp)             = SomeWrapF e sp # allSubexprs e"
-| "allSubexprs (TheF v d b sp)              = TheF v d b sp # allSubexprs d @ allSubexprs b"
-| "allSubexprs (QuantifierF q bs body sp)   = QuantifierF q bs body sp # allSubexprs_bindings bs @ allSubexprs body"
-| "allSubexprs (IdentifierF n sp)           = [IdentifierF n sp]"
-| "allSubexprs (IntLitF n sp)               = [IntLitF n sp]"
-| "allSubexprs (FloatLitF v sp)             = [FloatLitF v sp]"
-| "allSubexprs (StringLitF v sp)            = [StringLitF v sp]"
-| "allSubexprs (BoolLitF b sp)              = [BoolLitF b sp]"
-| "allSubexprs (NoneLitF sp)                = [NoneLitF sp]"
-| "allSubexprs_list []                                          = []"
-| "allSubexprs_list (x # xs)                                    = allSubexprs x @ allSubexprs_list xs"
-| "allSubexprs_fields []                                        = []"
-| "allSubexprs_fields (FieldAssignFull n v sp # fs)             = allSubexprs v @ allSubexprs_fields fs"
-| "allSubexprs_entries []                                       = []"
-| "allSubexprs_entries (MapEntryFull k v sp # es)               = allSubexprs k @ allSubexprs v @ allSubexprs_entries es"
-| "allSubexprs_bindings []                                      = []"
-| "allSubexprs_bindings (QuantifierBindingFull n d a sp # bs)   = allSubexprs d @ allSubexprs_bindings bs"
-
 fun isTrueLit :: "expr_full \<Rightarrow> bool" where
   "isTrueLit (BoolLitF True _) = True"
 | "isTrueLit _                 = False"
@@ -560,10 +505,6 @@ definition isKeyExistsConj ::
           (case r of IdentifierF s _ \<Rightarrow> s = stateName | _ \<Rightarrow> False)
       | _ \<Rightarrow> False)"
 
-lemmas allSubexprs_code [code] = allSubexprs.simps allSubexprs_list.simps
-                                  allSubexprs_fields.simps
-                                  allSubexprs_entries.simps
-                                  allSubexprs_bindings.simps
 lemmas isPrePrime_code [code]          = isPrePrime.simps
 lemmas hasPrePrime_code [code]         = hasPrePrime_def
 lemmas isBoolLit_code [code]           = isBoolLit.simps

--- a/proofs/isabelle/SpecRest/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/IR_Helpers.thy
@@ -109,83 +109,44 @@ text \<open>Phase 9ww: \<open>collectExprInfo\<close> is the unified expr_full w
   superlinearly per declaration, so one big walker is cheaper than
   three).\<close>
 
-type_synonym collected_full =
-  "String.literal list \<times> String.literal list \<times> with_info_full list"
+text \<open>Streamlined: previously this section had a 5-way mutual \<open>fun\<close>
+  (\<open>collectExprInfo\<close>) returning a 3-tuple, with three consumers each
+  extracting one field — the doc-original rationale was build-time
+  (\<open>fun\<close>'s meta-theory simp / induct rules scale superlinearly per
+  declaration). After hoisting \<open>allSubexprs\<close> into \<open>IR.thy\<close> we no
+  longer pay the mutual-fun overhead per walker: each consumer is now
+  a one-line composition over the shared \<open>allSubexprs\<close> enumeration
+  with a tiny per-node selector.\<close>
 
-definition emptyCollected :: "collected_full" where
-  "emptyCollected = ([], [], [])"
+fun primedIdSelect :: "expr_full \<Rightarrow> String.literal list" where
+  "primedIdSelect (PrimeF inner _) =
+     (case rootIdentifier inner of None \<Rightarrow> [] | Some n \<Rightarrow> [n])"
+| "primedIdSelect _ = []"
 
-fun combineCollected :: "collected_full \<Rightarrow> collected_full \<Rightarrow> collected_full" where
-  "combineCollected (p1, f1, w1) (p2, f2, w2) = (p1 @ p2, f1 @ f2, w1 @ w2)"
+fun fieldAccessNameSelect :: "expr_full \<Rightarrow> String.literal list" where
+  "fieldAccessNameSelect (FieldAccessF _ n _) = [n]"
+| "fieldAccessNameSelect _ = []"
 
-fun consPrimed :: "String.literal option \<Rightarrow> collected_full \<Rightarrow> collected_full" where
-  "consPrimed None     c          = c"
-| "consPrimed (Some n) (p, f, w)  = (n # p, f, w)"
-
-fun consFieldAccess :: "String.literal \<Rightarrow> collected_full \<Rightarrow> collected_full" where
-  "consFieldAccess n (p, f, w) = (p, n # f, w)"
-
-fun consWithInfo :: "with_info_full \<Rightarrow> collected_full \<Rightarrow> collected_full" where
-  "consWithInfo wi (p, f, w) = (p, f, wi # w)"
-
-fun collectExprInfo :: "expr_full \<Rightarrow> collected_full"
-and collectExprInfo_list :: "expr_full list \<Rightarrow> collected_full"
-and collectExprInfo_fields :: "field_assign_full list \<Rightarrow> collected_full"
-and collectExprInfo_entries :: "map_entry_full list \<Rightarrow> collected_full"
-and collectExprInfo_bindings :: "quantifier_binding_full list \<Rightarrow> collected_full"
-where
-  "collectExprInfo (PrimeF inner _)        = consPrimed (rootIdentifier inner) (collectExprInfo inner)"
-| "collectExprInfo (FieldAccessF base n _) = consFieldAccess n (collectExprInfo base)"
-| "collectExprInfo (WithF base ups _) =
-     consWithInfo (WithInfoFull (map fieldAssignName ups) (resolveWithBase base))
-                  (combineCollected (collectExprInfo base) (collectExprInfo_fields ups))"
-| "collectExprInfo (BinaryOpF _ l r _)         = combineCollected (collectExprInfo l) (collectExprInfo r)"
-| "collectExprInfo (UnaryOpF _ e _)            = collectExprInfo e"
-| "collectExprInfo (QuantifierF _ bs body _)   = combineCollected (collectExprInfo_bindings bs) (collectExprInfo body)"
-| "collectExprInfo (SomeWrapF e _)             = collectExprInfo e"
-| "collectExprInfo (TheF _ d b _)              = combineCollected (collectExprInfo d) (collectExprInfo b)"
-| "collectExprInfo (EnumAccessF base _ _)      = collectExprInfo base"
-| "collectExprInfo (IndexF b i _)              = combineCollected (collectExprInfo b) (collectExprInfo i)"
-| "collectExprInfo (CallF c args _)            = combineCollected (collectExprInfo c) (collectExprInfo_list args)"
-| "collectExprInfo (PreF e _)                  = collectExprInfo e"
-| "collectExprInfo (IfF c t el _) =
-     combineCollected (combineCollected (collectExprInfo c) (collectExprInfo t)) (collectExprInfo el)"
-| "collectExprInfo (LetF _ v b _)              = combineCollected (collectExprInfo v) (collectExprInfo b)"
-| "collectExprInfo (LambdaF _ b _)             = collectExprInfo b"
-| "collectExprInfo (ConstructorF _ fs _)       = collectExprInfo_fields fs"
-| "collectExprInfo (SetLiteralF xs _)          = collectExprInfo_list xs"
-| "collectExprInfo (MapLiteralF es _)          = collectExprInfo_entries es"
-| "collectExprInfo (SetComprehensionF _ d p _) = combineCollected (collectExprInfo d) (collectExprInfo p)"
-| "collectExprInfo (SeqLiteralF xs _)          = collectExprInfo_list xs"
-| "collectExprInfo (MatchesF e _ _)            = collectExprInfo e"
-| "collectExprInfo (IntLitF _ _)               = emptyCollected"
-| "collectExprInfo (FloatLitF _ _)             = emptyCollected"
-| "collectExprInfo (StringLitF _ _)            = emptyCollected"
-| "collectExprInfo (BoolLitF _ _)              = emptyCollected"
-| "collectExprInfo (NoneLitF _)                = emptyCollected"
-| "collectExprInfo (IdentifierF _ _)           = emptyCollected"
-| "collectExprInfo_list []                                                = emptyCollected"
-| "collectExprInfo_list (x # xs)                                          = combineCollected (collectExprInfo x) (collectExprInfo_list xs)"
-| "collectExprInfo_fields []                                              = emptyCollected"
-| "collectExprInfo_fields (FieldAssignFull _ v _ # fs)                    = combineCollected (collectExprInfo v) (collectExprInfo_fields fs)"
-| "collectExprInfo_entries []                                             = emptyCollected"
-| "collectExprInfo_entries (MapEntryFull k v _ # es)                      = combineCollected (combineCollected (collectExprInfo k) (collectExprInfo v)) (collectExprInfo_entries es)"
-| "collectExprInfo_bindings []                                            = emptyCollected"
-| "collectExprInfo_bindings (QuantifierBindingFull _ d _ _ # bs)          = combineCollected (collectExprInfo d) (collectExprInfo_bindings bs)"
+fun withInfoSelect :: "expr_full \<Rightarrow> with_info_full list" where
+  "withInfoSelect (WithF base ups _) =
+     [WithInfoFull (map fieldAssignName ups) (resolveWithBase base)]"
+| "withInfoSelect _ = []"
 
 definition collectPrimedIdentifiers ::
   "expr_full list \<Rightarrow> String.literal list" where
-  "collectPrimedIdentifiers es \<equiv> remdups (fst (collectExprInfo_list es))"
+  "collectPrimedIdentifiers es =
+     remdups (concat (map (\<lambda>e. concat (map primedIdSelect (allSubexprs e))) es))"
 
 definition collectFieldAccessNames :: "expr_full \<Rightarrow> String.literal list" where
-  "collectFieldAccessNames e \<equiv> remdups (fst (snd (collectExprInfo e)))"
+  "collectFieldAccessNames e =
+     remdups (concat (map fieldAccessNameSelect (allSubexprs e)))"
 
 definition collectWithFields ::
   "expr_full list \<Rightarrow> with_info_full option" where
-  "collectWithFields es \<equiv>
-     (case snd (snd (collectExprInfo_list es)) of
-        []       \<Rightarrow> None
-      | (x # _)  \<Rightarrow> Some x)"
+  "collectWithFields es =
+     (case concat (map (\<lambda>e. concat (map withInfoSelect (allSubexprs e))) es) of
+        []      \<Rightarrow> None
+      | (x # _) \<Rightarrow> Some x)"
 
 fun isInputCollectionType :: "type_expr_full \<Rightarrow> bool" where
   "isInputCollectionType (SetTypeF _ _)   = True"

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -14,56 +14,75 @@ fun operationMissingEnsures :: "operation_decl_full \<Rightarrow> bool" where
   "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _) =
      (outputs \<noteq> [] \<and> ensures = [])"
 
-text \<open>\<open>L05 — UnusedEntity\<close>: naive recursive collector for every
-  Identifier + Constructor + Enum-access base name appearing in an
-  expression. Does NOT respect binders (matches the Scala
-  \<open>ExprWalk.foreach\<close> behaviour — an entity name appearing as a
-  binder would erroneously count as a reference, but in practice
-  entity names start with uppercase and binders are lowercase, so the
-  asymmetry is harmless and the simpler walk is preferable).\<close>
+text \<open>\<^bold>\<open>Walker infrastructure: \<open>allSubexprs\<close>\<close>. Defined as a structural
+  mutual \<open>fun\<close> — Isabelle proves termination by structural recursion
+  on the disjoint sum of \<open>expr_full\<close> + the four wrapper-list argument
+  types. No size arithmetic needed: each recursive call is on a
+  syntactic subterm of the input, which the datatype-package's
+  built-in well-founded order recognises automatically.
 
-fun collectExprNames :: "expr_full \<Rightarrow> String.literal list"
-and collectExprNames_list :: "expr_full list \<Rightarrow> String.literal list"
-and collectExprNames_fields :: "field_assign_full list \<Rightarrow> String.literal list"
-and collectExprNames_entries :: "map_entry_full list \<Rightarrow> String.literal list"
-and collectExprNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list"
+  After this single 28-case enumeration, every binder-insensitive
+  walker collapses to a one-line \<open>concat o map self o allSubexprs\<close>
+  composition with a small per-node selector. Previously every walker
+  enumerated its own 28 cases independently; the new shape moves the
+  enumeration into one structural function whose termination is
+  automatic.\<close>
+
+fun allSubexprs :: "expr_full \<Rightarrow> expr_full list"
+and allSubexprs_list :: "expr_full list \<Rightarrow> expr_full list"
+and allSubexprs_fields :: "field_assign_full list \<Rightarrow> expr_full list"
+and allSubexprs_entries :: "map_entry_full list \<Rightarrow> expr_full list"
+and allSubexprs_bindings :: "quantifier_binding_full list \<Rightarrow> expr_full list"
 where
-  "collectExprNames (IdentifierF n _)            = [n]"
-| "collectExprNames (ConstructorF n fs _)        = n # collectExprNames_fields fs"
-| "collectExprNames (BinaryOpF _ l r _)          = collectExprNames l @ collectExprNames r"
-| "collectExprNames (UnaryOpF _ e _)             = collectExprNames e"
-| "collectExprNames (FieldAccessF b _ _)         = collectExprNames b"
-| "collectExprNames (EnumAccessF b _ _)          = collectExprNames b"
-| "collectExprNames (IndexF b i _)               = collectExprNames b @ collectExprNames i"
-| "collectExprNames (CallF c args _)             = collectExprNames c @ collectExprNames_list args"
-| "collectExprNames (PrimeF e _)                 = collectExprNames e"
-| "collectExprNames (PreF e _)                   = collectExprNames e"
-| "collectExprNames (WithF b upds _)             = collectExprNames b @ collectExprNames_fields upds"
-| "collectExprNames (IfF c t e _)                = collectExprNames c @ collectExprNames t @ collectExprNames e"
-| "collectExprNames (LetF _ val body _)          = collectExprNames val @ collectExprNames body"
-| "collectExprNames (LambdaF _ b _)              = collectExprNames b"
-| "collectExprNames (SetLiteralF xs _)           = collectExprNames_list xs"
-| "collectExprNames (MapLiteralF es _)           = collectExprNames_entries es"
-| "collectExprNames (SetComprehensionF _ d p _)  = collectExprNames d @ collectExprNames p"
-| "collectExprNames (SeqLiteralF xs _)           = collectExprNames_list xs"
-| "collectExprNames (MatchesF x _ _)             = collectExprNames x"
-| "collectExprNames (SomeWrapF x _)              = collectExprNames x"
-| "collectExprNames (TheF _ d b _)               = collectExprNames d @ collectExprNames b"
-| "collectExprNames (QuantifierF _ bs body _)    =
-     collectExprNames_bindings bs @ collectExprNames body"
-| "collectExprNames (IntLitF _ _)                = []"
-| "collectExprNames (FloatLitF _ _)              = []"
-| "collectExprNames (StringLitF _ _)             = []"
-| "collectExprNames (BoolLitF _ _)               = []"
-| "collectExprNames (NoneLitF _)                 = []"
-| "collectExprNames_list []                                       = []"
-| "collectExprNames_list (x # xs)                                 = collectExprNames x @ collectExprNames_list xs"
-| "collectExprNames_fields []                                     = []"
-| "collectExprNames_fields (FieldAssignFull _ v _ # fs)           = collectExprNames v @ collectExprNames_fields fs"
-| "collectExprNames_entries []                                    = []"
-| "collectExprNames_entries (MapEntryFull k v _ # es)             = collectExprNames k @ collectExprNames v @ collectExprNames_entries es"
-| "collectExprNames_bindings []                                   = []"
-| "collectExprNames_bindings (QuantifierBindingFull _ d _ _ # bs) = collectExprNames d @ collectExprNames_bindings bs"
+  "allSubexprs (BinaryOpF op l r sp)        = BinaryOpF op l r sp # allSubexprs l @ allSubexprs r"
+| "allSubexprs (UnaryOpF op e sp)           = UnaryOpF op e sp # allSubexprs e"
+| "allSubexprs (FieldAccessF b f sp)        = FieldAccessF b f sp # allSubexprs b"
+| "allSubexprs (EnumAccessF b e sp)         = EnumAccessF b e sp # allSubexprs b"
+| "allSubexprs (IndexF b i sp)              = IndexF b i sp # allSubexprs b @ allSubexprs i"
+| "allSubexprs (CallF c args sp)            = CallF c args sp # allSubexprs c @ allSubexprs_list args"
+| "allSubexprs (PrimeF e sp)                = PrimeF e sp # allSubexprs e"
+| "allSubexprs (PreF e sp)                  = PreF e sp # allSubexprs e"
+| "allSubexprs (WithF b ups sp)             = WithF b ups sp # allSubexprs b @ allSubexprs_fields ups"
+| "allSubexprs (IfF c t e sp)               = IfF c t e sp # allSubexprs c @ allSubexprs t @ allSubexprs e"
+| "allSubexprs (LetF v val body sp)         = LetF v val body sp # allSubexprs val @ allSubexprs body"
+| "allSubexprs (LambdaF p b sp)             = LambdaF p b sp # allSubexprs b"
+| "allSubexprs (ConstructorF n fs sp)       = ConstructorF n fs sp # allSubexprs_fields fs"
+| "allSubexprs (SetLiteralF xs sp)          = SetLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MapLiteralF es sp)          = MapLiteralF es sp # allSubexprs_entries es"
+| "allSubexprs (SetComprehensionF v d p sp) = SetComprehensionF v d p sp # allSubexprs d @ allSubexprs p"
+| "allSubexprs (SeqLiteralF xs sp)          = SeqLiteralF xs sp # allSubexprs_list xs"
+| "allSubexprs (MatchesF e pat sp)          = MatchesF e pat sp # allSubexprs e"
+| "allSubexprs (SomeWrapF e sp)             = SomeWrapF e sp # allSubexprs e"
+| "allSubexprs (TheF v d b sp)              = TheF v d b sp # allSubexprs d @ allSubexprs b"
+| "allSubexprs (QuantifierF q bs body sp)   = QuantifierF q bs body sp # allSubexprs_bindings bs @ allSubexprs body"
+| "allSubexprs (IdentifierF n sp)           = [IdentifierF n sp]"
+| "allSubexprs (IntLitF n sp)               = [IntLitF n sp]"
+| "allSubexprs (FloatLitF v sp)             = [FloatLitF v sp]"
+| "allSubexprs (StringLitF v sp)            = [StringLitF v sp]"
+| "allSubexprs (BoolLitF b sp)              = [BoolLitF b sp]"
+| "allSubexprs (NoneLitF sp)                = [NoneLitF sp]"
+| "allSubexprs_list []                                       = []"
+| "allSubexprs_list (x # xs)                                 = allSubexprs x @ allSubexprs_list xs"
+| "allSubexprs_fields []                                     = []"
+| "allSubexprs_fields (FieldAssignFull n v sp # fs)          = allSubexprs v @ allSubexprs_fields fs"
+| "allSubexprs_entries []                                    = []"
+| "allSubexprs_entries (MapEntryFull k v sp # es)            = allSubexprs k @ allSubexprs v @ allSubexprs_entries es"
+| "allSubexprs_bindings []                                   = []"
+| "allSubexprs_bindings (QuantifierBindingFull n d a sp # bs) = allSubexprs d @ allSubexprs_bindings bs"
+
+text \<open>\<open>L05 — UnusedEntity\<close>: collect Identifier + Constructor names
+  appearing anywhere in the expression. Does NOT respect binders
+  (matches the Scala \<open>ExprWalk.foreach\<close> behaviour — entity names
+  start with uppercase and binders are lowercase, so the asymmetry is
+  harmless).\<close>
+
+fun exprSelfNames :: "expr_full \<Rightarrow> String.literal list" where
+  "exprSelfNames (IdentifierF n _)     = [n]"
+| "exprSelfNames (ConstructorF n _ _)  = [n]"
+| "exprSelfNames _                     = []"
+
+definition collectExprNames :: "expr_full \<Rightarrow> String.literal list" where
+  "collectExprNames e = concat (map exprSelfNames (allSubexprs e))"
 
 text \<open>Recursive type-name collector: every \<open>NamedTypeF\<close> name reachable
   through the type structure.\<close>
@@ -173,111 +192,29 @@ text \<open>\<open>L06 — CircularPredicate\<close>: pure HOL DFS cycle-finder.
     in HOL; Scala iterates the resulting cycles and formats
     diagnostics.\<close>
 
-text \<open>Unfiltered companion: collect every \<open>Call (Identifier n) _\<close>
-  callee name regardless of any filter set. Used by \<open>UndefinedRef\<close> to
-  build the \<open>factImplicit\<close> whitelist (fact bodies frequently call
-  helper predicates / functions whose names weren't yet listed in
-  \<open>ir.m\<close> / \<open>ir.l\<close> at the time the global scope is assembled).\<close>
+text \<open>Call-callee collectors composed on top of \<open>allSubexprs\<close>:
+  \<open>collectAllCallNames\<close> takes every \<open>Call (Identifier n) _\<close> name;
+  \<open>collectCallNames\<close> applies a filter (used by CircularPredicate to
+  restrict to known predicate/function names).\<close>
 
-fun collectAllCallNames :: "expr_full \<Rightarrow> String.literal list"
-and collectAllCallNames_list :: "expr_full list \<Rightarrow> String.literal list"
-and collectAllCallNames_fields :: "field_assign_full list \<Rightarrow> String.literal list"
-and collectAllCallNames_entries :: "map_entry_full list \<Rightarrow> String.literal list"
-and collectAllCallNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list"
-where
-  "collectAllCallNames (CallF (IdentifierF n _) args _) =
-     n # collectAllCallNames_list args"
-| "collectAllCallNames (CallF c args _) =
-     collectAllCallNames c @ collectAllCallNames_list args"
-| "collectAllCallNames (BinaryOpF _ l r _) = collectAllCallNames l @ collectAllCallNames r"
-| "collectAllCallNames (UnaryOpF _ e _) = collectAllCallNames e"
-| "collectAllCallNames (FieldAccessF b _ _) = collectAllCallNames b"
-| "collectAllCallNames (EnumAccessF b _ _) = collectAllCallNames b"
-| "collectAllCallNames (IndexF b i _) = collectAllCallNames b @ collectAllCallNames i"
-| "collectAllCallNames (PrimeF e _) = collectAllCallNames e"
-| "collectAllCallNames (PreF e _) = collectAllCallNames e"
-| "collectAllCallNames (WithF b upds _) = collectAllCallNames b @ collectAllCallNames_fields upds"
-| "collectAllCallNames (IfF c t e _) = collectAllCallNames c @ collectAllCallNames t @ collectAllCallNames e"
-| "collectAllCallNames (LetF _ val body _) = collectAllCallNames val @ collectAllCallNames body"
-| "collectAllCallNames (LambdaF _ b _) = collectAllCallNames b"
-| "collectAllCallNames (ConstructorF _ fs _) = collectAllCallNames_fields fs"
-| "collectAllCallNames (SetLiteralF xs _) = collectAllCallNames_list xs"
-| "collectAllCallNames (MapLiteralF es _) = collectAllCallNames_entries es"
-| "collectAllCallNames (SetComprehensionF _ d p _) = collectAllCallNames d @ collectAllCallNames p"
-| "collectAllCallNames (SeqLiteralF xs _) = collectAllCallNames_list xs"
-| "collectAllCallNames (MatchesF x _ _) = collectAllCallNames x"
-| "collectAllCallNames (SomeWrapF x _) = collectAllCallNames x"
-| "collectAllCallNames (TheF _ d b _) = collectAllCallNames d @ collectAllCallNames b"
-| "collectAllCallNames (QuantifierF _ bs body _) =
-     collectAllCallNames_bindings bs @ collectAllCallNames body"
-| "collectAllCallNames (IdentifierF _ _) = []"
-| "collectAllCallNames (IntLitF _ _) = []"
-| "collectAllCallNames (FloatLitF _ _) = []"
-| "collectAllCallNames (StringLitF _ _) = []"
-| "collectAllCallNames (BoolLitF _ _) = []"
-| "collectAllCallNames (NoneLitF _) = []"
-| "collectAllCallNames_list [] = []"
-| "collectAllCallNames_list (x # xs) = collectAllCallNames x @ collectAllCallNames_list xs"
-| "collectAllCallNames_fields [] = []"
-| "collectAllCallNames_fields (FieldAssignFull _ v _ # fs) =
-     collectAllCallNames v @ collectAllCallNames_fields fs"
-| "collectAllCallNames_entries [] = []"
-| "collectAllCallNames_entries (MapEntryFull k v _ # es) =
-     collectAllCallNames k @ collectAllCallNames v @ collectAllCallNames_entries es"
-| "collectAllCallNames_bindings [] = []"
-| "collectAllCallNames_bindings (QuantifierBindingFull _ d _ _ # bs) =
-     collectAllCallNames d @ collectAllCallNames_bindings bs"
+fun callSelfAllNames :: "expr_full \<Rightarrow> String.literal list" where
+  "callSelfAllNames (CallF (IdentifierF n _) _ _) = [n]"
+| "callSelfAllNames _                              = []"
 
-fun collectCallNames :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
-and collectCallNames_list :: "expr_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
-and collectCallNames_fields :: "field_assign_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
-and collectCallNames_entries :: "map_entry_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
-and collectCallNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+definition collectAllCallNames :: "expr_full \<Rightarrow> String.literal list" where
+  "collectAllCallNames e = concat (map callSelfAllNames (allSubexprs e))"
+
+fun callSelfFilteredNames ::
+  "String.literal list \<Rightarrow> expr_full \<Rightarrow> String.literal list"
 where
-  "collectCallNames (CallF (IdentifierF n _) args sp) filt =
-     (if List.member filt n
-      then n # collectCallNames_list args filt
-      else collectCallNames_list args filt)"
-| "collectCallNames (CallF c args _) filt =
-     collectCallNames c filt @ collectCallNames_list args filt"
-| "collectCallNames (BinaryOpF _ l r _) filt = collectCallNames l filt @ collectCallNames r filt"
-| "collectCallNames (UnaryOpF _ e _) filt = collectCallNames e filt"
-| "collectCallNames (FieldAccessF b _ _) filt = collectCallNames b filt"
-| "collectCallNames (EnumAccessF b _ _) filt = collectCallNames b filt"
-| "collectCallNames (IndexF b i _) filt = collectCallNames b filt @ collectCallNames i filt"
-| "collectCallNames (PrimeF e _) filt = collectCallNames e filt"
-| "collectCallNames (PreF e _) filt = collectCallNames e filt"
-| "collectCallNames (WithF b upds _) filt = collectCallNames b filt @ collectCallNames_fields upds filt"
-| "collectCallNames (IfF c t e _) filt = collectCallNames c filt @ collectCallNames t filt @ collectCallNames e filt"
-| "collectCallNames (LetF _ val body _) filt = collectCallNames val filt @ collectCallNames body filt"
-| "collectCallNames (LambdaF _ b _) filt = collectCallNames b filt"
-| "collectCallNames (ConstructorF _ fs _) filt = collectCallNames_fields fs filt"
-| "collectCallNames (SetLiteralF xs _) filt = collectCallNames_list xs filt"
-| "collectCallNames (MapLiteralF es _) filt = collectCallNames_entries es filt"
-| "collectCallNames (SetComprehensionF _ d p _) filt = collectCallNames d filt @ collectCallNames p filt"
-| "collectCallNames (SeqLiteralF xs _) filt = collectCallNames_list xs filt"
-| "collectCallNames (MatchesF x _ _) filt = collectCallNames x filt"
-| "collectCallNames (SomeWrapF x _) filt = collectCallNames x filt"
-| "collectCallNames (TheF _ d b _) filt = collectCallNames d filt @ collectCallNames b filt"
-| "collectCallNames (QuantifierF _ bs body _) filt =
-     collectCallNames_bindings bs filt @ collectCallNames body filt"
-| "collectCallNames (IdentifierF _ _) _ = []"
-| "collectCallNames (IntLitF _ _) _ = []"
-| "collectCallNames (FloatLitF _ _) _ = []"
-| "collectCallNames (StringLitF _ _) _ = []"
-| "collectCallNames (BoolLitF _ _) _ = []"
-| "collectCallNames (NoneLitF _) _ = []"
-| "collectCallNames_list [] _ = []"
-| "collectCallNames_list (x # xs) filt = collectCallNames x filt @ collectCallNames_list xs filt"
-| "collectCallNames_fields [] _ = []"
-| "collectCallNames_fields (FieldAssignFull _ v _ # fs) filt =
-     collectCallNames v filt @ collectCallNames_fields fs filt"
-| "collectCallNames_entries [] _ = []"
-| "collectCallNames_entries (MapEntryFull k v _ # es) filt =
-     collectCallNames k filt @ collectCallNames v filt @ collectCallNames_entries es filt"
-| "collectCallNames_bindings [] _ = []"
-| "collectCallNames_bindings (QuantifierBindingFull _ d _ _ # bs) filt =
-     collectCallNames d filt @ collectCallNames_bindings bs filt"
+  "callSelfFilteredNames filt (CallF (IdentifierF n _) _ _) =
+     (if List.member filt n then [n] else [])"
+| "callSelfFilteredNames _ _ = []"
+
+definition collectCallNames ::
+  "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+where
+  "collectCallNames e filt = concat (map (callSelfFilteredNames filt) (allSubexprs e))"
 
 text \<open>DFS state — uses lists everywhere so the extracted Scala stays
   on plain List operations (no HOL-Library Set imports). Membership is
@@ -400,11 +337,18 @@ where
                             edges nodes initDfsState)"
 
 lemmas operationMissingEnsures_code [code] = operationMissingEnsures.simps
-lemmas collectExprNames_code [code]          = collectExprNames.simps
+lemmas allSubexprs_code [code]               = allSubexprs.simps allSubexprs_list.simps
+                                                allSubexprs_fields.simps
+                                                allSubexprs_entries.simps
+                                                allSubexprs_bindings.simps
+lemmas exprSelfNames_code [code]             = exprSelfNames.simps
+lemmas callSelfAllNames_code [code]          = callSelfAllNames.simps
+lemmas callSelfFilteredNames_code [code]     = callSelfFilteredNames.simps
+lemmas collectExprNames_code [code]          = collectExprNames_def
+lemmas collectAllCallNames_code [code]       = collectAllCallNames_def
+lemmas collectCallNames_code [code]          = collectCallNames_def
 lemmas collectTypeNames_code [code]          = collectTypeNames.simps
 lemmas walkUndefinedExpr_code [code]         = walkUndefinedExpr.simps
-lemmas collectCallNames_code [code]          = collectCallNames.simps
-lemmas collectAllCallNames_code [code]       = collectAllCallNames.simps
 lemmas lookupEdges_code [code]               = lookupEdges.simps
 lemmas listRemoveAll_code [code]             = listRemoveAll.simps
 lemmas listIsSubset_code [code]              = listIsSubset.simps

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -1,22 +1,166 @@
 theory LintAnalysis
-  imports IR
+  imports IR IR_Analysis
 begin
 
-text \<open>Pure decision predicates for the lint analyses in
+text \<open>Pure decision predicates and IR walkers for the lint analyses in
   \<open>modules/lint/\<close>. Scala iterates the IR slots, calls the lifted
-  predicate per declaration, and emits formatted diagnostics
-  Scala-side — same boundary established by \<open>validateIrContextRule\<close>
-  in \<open>ValidateConventions\<close>.
+  function per declaration, and emits formatted diagnostics Scala-side
+  — same boundary established by \<open>validateIrContextRule\<close> in
+  \<open>ValidateConventions\<close>.\<close>
 
-  Starting tiny: \<open>operationMissingEnsures\<close> for \<open>L03\<close>. Subsequent
-  lint passes (\<open>UnusedEntity\<close> / \<open>UndefinedRef\<close> / \<open>TypeMismatch\<close>)
-  need IR walkers that respect or ignore binders and will land in
-  follow-up PRs.\<close>
+text \<open>\<open>L03 — MissingEnsures\<close>: trivial per-op predicate.\<close>
 
 fun operationMissingEnsures :: "operation_decl_full \<Rightarrow> bool" where
   "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _) =
      (outputs \<noteq> [] \<and> ensures = [])"
 
+text \<open>\<open>L05 — UnusedEntity\<close>: naive recursive collector for every
+  Identifier + Constructor + Enum-access base name appearing in an
+  expression. Does NOT respect binders (matches the Scala
+  \<open>ExprWalk.foreach\<close> behaviour — an entity name appearing as a
+  binder would erroneously count as a reference, but in practice
+  entity names start with uppercase and binders are lowercase, so the
+  asymmetry is harmless and the simpler walk is preferable).\<close>
+
+fun collectExprNames :: "expr_full \<Rightarrow> String.literal list"
+and collectExprNames_list :: "expr_full list \<Rightarrow> String.literal list"
+and collectExprNames_fields :: "field_assign_full list \<Rightarrow> String.literal list"
+and collectExprNames_entries :: "map_entry_full list \<Rightarrow> String.literal list"
+and collectExprNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list"
+where
+  "collectExprNames (IdentifierF n _)            = [n]"
+| "collectExprNames (ConstructorF n fs _)        = n # collectExprNames_fields fs"
+| "collectExprNames (BinaryOpF _ l r _)          = collectExprNames l @ collectExprNames r"
+| "collectExprNames (UnaryOpF _ e _)             = collectExprNames e"
+| "collectExprNames (FieldAccessF b _ _)         = collectExprNames b"
+| "collectExprNames (EnumAccessF b _ _)          = collectExprNames b"
+| "collectExprNames (IndexF b i _)               = collectExprNames b @ collectExprNames i"
+| "collectExprNames (CallF c args _)             = collectExprNames c @ collectExprNames_list args"
+| "collectExprNames (PrimeF e _)                 = collectExprNames e"
+| "collectExprNames (PreF e _)                   = collectExprNames e"
+| "collectExprNames (WithF b upds _)             = collectExprNames b @ collectExprNames_fields upds"
+| "collectExprNames (IfF c t e _)                = collectExprNames c @ collectExprNames t @ collectExprNames e"
+| "collectExprNames (LetF _ val body _)          = collectExprNames val @ collectExprNames body"
+| "collectExprNames (LambdaF _ b _)              = collectExprNames b"
+| "collectExprNames (SetLiteralF xs _)           = collectExprNames_list xs"
+| "collectExprNames (MapLiteralF es _)           = collectExprNames_entries es"
+| "collectExprNames (SetComprehensionF _ d p _)  = collectExprNames d @ collectExprNames p"
+| "collectExprNames (SeqLiteralF xs _)           = collectExprNames_list xs"
+| "collectExprNames (MatchesF x _ _)             = collectExprNames x"
+| "collectExprNames (SomeWrapF x _)              = collectExprNames x"
+| "collectExprNames (TheF _ d b _)               = collectExprNames d @ collectExprNames b"
+| "collectExprNames (QuantifierF _ bs body _)    =
+     collectExprNames_bindings bs @ collectExprNames body"
+| "collectExprNames (IntLitF _ _)                = []"
+| "collectExprNames (FloatLitF _ _)              = []"
+| "collectExprNames (StringLitF _ _)             = []"
+| "collectExprNames (BoolLitF _ _)               = []"
+| "collectExprNames (NoneLitF _)                 = []"
+| "collectExprNames_list []                                       = []"
+| "collectExprNames_list (x # xs)                                 = collectExprNames x @ collectExprNames_list xs"
+| "collectExprNames_fields []                                     = []"
+| "collectExprNames_fields (FieldAssignFull _ v _ # fs)           = collectExprNames v @ collectExprNames_fields fs"
+| "collectExprNames_entries []                                    = []"
+| "collectExprNames_entries (MapEntryFull k v _ # es)             = collectExprNames k @ collectExprNames v @ collectExprNames_entries es"
+| "collectExprNames_bindings []                                   = []"
+| "collectExprNames_bindings (QuantifierBindingFull _ d _ _ # bs) = collectExprNames d @ collectExprNames_bindings bs"
+
+text \<open>Recursive type-name collector: every \<open>NamedTypeF\<close> name reachable
+  through the type structure.\<close>
+
+fun collectTypeNames :: "type_expr_full \<Rightarrow> String.literal list" where
+  "collectTypeNames (NamedTypeF n _)          = [n]"
+| "collectTypeNames (SetTypeF t _)            = collectTypeNames t"
+| "collectTypeNames (SeqTypeF t _)            = collectTypeNames t"
+| "collectTypeNames (OptionTypeF t _)         = collectTypeNames t"
+| "collectTypeNames (MapTypeF k v _)          = collectTypeNames k @ collectTypeNames v"
+| "collectTypeNames (RelationTypeF f _ t _)   = collectTypeNames f @ collectTypeNames t"
+
+text \<open>\<open>L02 — UndefinedRef\<close>: walks an expression with a scope of defined
+  identifiers (literal list), returning every \<open>(identifier, span)\<close> pair
+  whose identifier is not in scope. Respects binders: \<open>LetF\<close>,
+  \<open>LambdaF\<close>, \<open>TheF\<close>, \<open>SetComprehensionF\<close>, and \<open>QuantifierF\<close>
+  bindings extend the scope for their bodies (the sub-domain of a
+  \<open>QuantifierF\<close> binding is checked under the scope augmented by
+  earlier bindings, matching the legacy Scala fold).\<close>
+
+fun walkUndefinedExpr ::
+  "expr_full \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> option_span) list"
+and walkUndefinedExpr_list ::
+  "expr_full list \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> option_span) list"
+and walkUndefinedExpr_fields ::
+  "field_assign_full list \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> option_span) list"
+and walkUndefinedExpr_entries ::
+  "map_entry_full list \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> option_span) list"
+and walkUndefinedExpr_bindings ::
+  "quantifier_binding_full list \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> option_span) list \<times> String.literal list"
+where
+  "walkUndefinedExpr (IdentifierF n sp) scope =
+     (if List.member scope n then [] else [(n, sp)])"
+| "walkUndefinedExpr (BinaryOpF _ l r _) scope =
+     walkUndefinedExpr l scope @ walkUndefinedExpr r scope"
+| "walkUndefinedExpr (UnaryOpF _ e _) scope = walkUndefinedExpr e scope"
+| "walkUndefinedExpr (FieldAccessF b _ _) scope = walkUndefinedExpr b scope"
+| "walkUndefinedExpr (EnumAccessF b _ _) scope = walkUndefinedExpr b scope"
+| "walkUndefinedExpr (IndexF b i _) scope =
+     walkUndefinedExpr b scope @ walkUndefinedExpr i scope"
+| "walkUndefinedExpr (CallF c args _) scope =
+     walkUndefinedExpr c scope @ walkUndefinedExpr_list args scope"
+| "walkUndefinedExpr (PrimeF e _) scope = walkUndefinedExpr e scope"
+| "walkUndefinedExpr (PreF e _) scope = walkUndefinedExpr e scope"
+| "walkUndefinedExpr (WithF b upds _) scope =
+     walkUndefinedExpr b scope @ walkUndefinedExpr_fields upds scope"
+| "walkUndefinedExpr (IfF c t e _) scope =
+     walkUndefinedExpr c scope @ walkUndefinedExpr t scope @ walkUndefinedExpr e scope"
+| "walkUndefinedExpr (LetF v val body _) scope =
+     walkUndefinedExpr val scope @ walkUndefinedExpr body (v # scope)"
+| "walkUndefinedExpr (LambdaF p body _) scope =
+     walkUndefinedExpr body (p # scope)"
+| "walkUndefinedExpr (ConstructorF _ fs _) scope =
+     walkUndefinedExpr_fields fs scope"
+| "walkUndefinedExpr (SetLiteralF xs _) scope =
+     walkUndefinedExpr_list xs scope"
+| "walkUndefinedExpr (MapLiteralF es _) scope =
+     walkUndefinedExpr_entries es scope"
+| "walkUndefinedExpr (SetComprehensionF v d p _) scope =
+     walkUndefinedExpr d scope @ walkUndefinedExpr p (v # scope)"
+| "walkUndefinedExpr (SeqLiteralF xs _) scope =
+     walkUndefinedExpr_list xs scope"
+| "walkUndefinedExpr (MatchesF x _ _) scope = walkUndefinedExpr x scope"
+| "walkUndefinedExpr (SomeWrapF x _) scope = walkUndefinedExpr x scope"
+| "walkUndefinedExpr (TheF v d b _) scope =
+     walkUndefinedExpr d scope @ walkUndefinedExpr b (v # scope)"
+| "walkUndefinedExpr (QuantifierF _ bs body _) scope =
+     (let (binds, scope') = walkUndefinedExpr_bindings bs scope
+      in binds @ walkUndefinedExpr body scope')"
+| "walkUndefinedExpr (IntLitF _ _) _ = []"
+| "walkUndefinedExpr (FloatLitF _ _) _ = []"
+| "walkUndefinedExpr (StringLitF _ _) _ = []"
+| "walkUndefinedExpr (BoolLitF _ _) _ = []"
+| "walkUndefinedExpr (NoneLitF _) _ = []"
+| "walkUndefinedExpr_list [] _ = []"
+| "walkUndefinedExpr_list (x # xs) scope =
+     walkUndefinedExpr x scope @ walkUndefinedExpr_list xs scope"
+| "walkUndefinedExpr_fields [] _ = []"
+| "walkUndefinedExpr_fields (FieldAssignFull _ v _ # fs) scope =
+     walkUndefinedExpr v scope @ walkUndefinedExpr_fields fs scope"
+| "walkUndefinedExpr_entries [] _ = []"
+| "walkUndefinedExpr_entries (MapEntryFull k v _ # es) scope =
+     walkUndefinedExpr k scope @ walkUndefinedExpr v scope @ walkUndefinedExpr_entries es scope"
+| "walkUndefinedExpr_bindings [] scope = ([], scope)"
+| "walkUndefinedExpr_bindings (QuantifierBindingFull v d _ _ # bs) scope =
+     (let cur  = walkUndefinedExpr d scope;
+          (rest, finalScope) = walkUndefinedExpr_bindings bs (v # scope)
+      in (cur @ rest, finalScope))"
+
 lemmas operationMissingEnsures_code [code] = operationMissingEnsures.simps
+lemmas collectExprNames_code [code]          = collectExprNames.simps
+lemmas collectTypeNames_code [code]          = collectTypeNames.simps
+lemmas walkUndefinedExpr_code [code]         = walkUndefinedExpr.simps
 
 end

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -158,9 +158,205 @@ where
           (rest, finalScope) = walkUndefinedExpr_bindings bs (v # scope)
       in (cur @ rest, finalScope))"
 
+text \<open>\<open>L06 — CircularPredicate\<close>: pure HOL DFS cycle-finder. Two parts:
+
+  \<^item> \<open>collectCallNames\<close>: filter expression walker — returns the names
+    of every \<open>CallF (IdentifierF n _) _\<close> callee whose name is in the
+    supplied filter list. Used Scala-side to build the edge AList.
+  \<^item> \<open>findCycles\<close>: the full DFS algorithm — pure HOL, terminating by
+    structural recursion on an explicit fuel counter. The fuel is
+    \<open>length nodes ^ 2 + length nodes + 1\<close> at the entry point — a safe
+    upper bound on the total number of \<open>dfsNode\<close> calls (each node is
+    \<^emph>\<open>processed\<close> at most once but may trigger up to \<open>length nodes\<close>
+    \<^emph>\<open>visited\<close>-check early returns per edge, so quadratic suffices).
+    All cycle dedupe / stack maintenance / span-aware emission stays
+    in HOL; Scala iterates the resulting cycles and formats
+    diagnostics.\<close>
+
+fun collectCallNames :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+and collectCallNames_list :: "expr_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+and collectCallNames_fields :: "field_assign_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+and collectCallNames_entries :: "map_entry_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+and collectCallNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+where
+  "collectCallNames (CallF (IdentifierF n _) args sp) filt =
+     (if List.member filt n
+      then n # collectCallNames_list args filt
+      else collectCallNames_list args filt)"
+| "collectCallNames (CallF c args _) filt =
+     collectCallNames c filt @ collectCallNames_list args filt"
+| "collectCallNames (BinaryOpF _ l r _) filt = collectCallNames l filt @ collectCallNames r filt"
+| "collectCallNames (UnaryOpF _ e _) filt = collectCallNames e filt"
+| "collectCallNames (FieldAccessF b _ _) filt = collectCallNames b filt"
+| "collectCallNames (EnumAccessF b _ _) filt = collectCallNames b filt"
+| "collectCallNames (IndexF b i _) filt = collectCallNames b filt @ collectCallNames i filt"
+| "collectCallNames (PrimeF e _) filt = collectCallNames e filt"
+| "collectCallNames (PreF e _) filt = collectCallNames e filt"
+| "collectCallNames (WithF b upds _) filt = collectCallNames b filt @ collectCallNames_fields upds filt"
+| "collectCallNames (IfF c t e _) filt = collectCallNames c filt @ collectCallNames t filt @ collectCallNames e filt"
+| "collectCallNames (LetF _ val body _) filt = collectCallNames val filt @ collectCallNames body filt"
+| "collectCallNames (LambdaF _ b _) filt = collectCallNames b filt"
+| "collectCallNames (ConstructorF _ fs _) filt = collectCallNames_fields fs filt"
+| "collectCallNames (SetLiteralF xs _) filt = collectCallNames_list xs filt"
+| "collectCallNames (MapLiteralF es _) filt = collectCallNames_entries es filt"
+| "collectCallNames (SetComprehensionF _ d p _) filt = collectCallNames d filt @ collectCallNames p filt"
+| "collectCallNames (SeqLiteralF xs _) filt = collectCallNames_list xs filt"
+| "collectCallNames (MatchesF x _ _) filt = collectCallNames x filt"
+| "collectCallNames (SomeWrapF x _) filt = collectCallNames x filt"
+| "collectCallNames (TheF _ d b _) filt = collectCallNames d filt @ collectCallNames b filt"
+| "collectCallNames (QuantifierF _ bs body _) filt =
+     collectCallNames_bindings bs filt @ collectCallNames body filt"
+| "collectCallNames (IdentifierF _ _) _ = []"
+| "collectCallNames (IntLitF _ _) _ = []"
+| "collectCallNames (FloatLitF _ _) _ = []"
+| "collectCallNames (StringLitF _ _) _ = []"
+| "collectCallNames (BoolLitF _ _) _ = []"
+| "collectCallNames (NoneLitF _) _ = []"
+| "collectCallNames_list [] _ = []"
+| "collectCallNames_list (x # xs) filt = collectCallNames x filt @ collectCallNames_list xs filt"
+| "collectCallNames_fields [] _ = []"
+| "collectCallNames_fields (FieldAssignFull _ v _ # fs) filt =
+     collectCallNames v filt @ collectCallNames_fields fs filt"
+| "collectCallNames_entries [] _ = []"
+| "collectCallNames_entries (MapEntryFull k v _ # es) filt =
+     collectCallNames k filt @ collectCallNames v filt @ collectCallNames_entries es filt"
+| "collectCallNames_bindings [] _ = []"
+| "collectCallNames_bindings (QuantifierBindingFull _ d _ _ # bs) filt =
+     collectCallNames d filt @ collectCallNames_bindings bs filt"
+
+text \<open>DFS state — uses lists everywhere so the extracted Scala stays
+  on plain List operations (no HOL-Library Set imports). Membership is
+  via \<open>List.member\<close>; cycle dedupe compares cycles up to permutation
+  by checking both directions of inclusion (matches the original
+  \<open>cyc.toSet ∈ seenCycles\<close> Scala check).\<close>
+
+record dfs_state =
+  onStack    :: "String.literal list"
+  visited    :: "String.literal list"
+  stack      :: "String.literal list"
+  cycles     :: "String.literal list list"
+  seenCycles :: "String.literal list list"
+
+definition initDfsState :: dfs_state where
+  "initDfsState = \<lparr>onStack = [], visited = [], stack = [],
+                    cycles = [], seenCycles = []\<rparr>"
+
+fun lookupEdges ::
+  "String.literal \<Rightarrow> (String.literal \<times> String.literal list) list \<Rightarrow> String.literal list"
+where
+  "lookupEdges _ [] = []"
+| "lookupEdges n ((k, v) # rest) = (if k = n then v else lookupEdges n rest)"
+
+fun listRemoveAll ::
+  "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+where
+  "listRemoveAll _ [] = []"
+| "listRemoveAll x (y # ys) =
+     (if x = y then listRemoveAll x ys else y # listRemoveAll x ys)"
+
+fun listIsSubset ::
+  "String.literal list \<Rightarrow> String.literal list \<Rightarrow> bool"
+where
+  "listIsSubset [] _ = True"
+| "listIsSubset (x # xs) ys = (List.member ys x \<and> listIsSubset xs ys)"
+
+definition cycleSetEq ::
+  "String.literal list \<Rightarrow> String.literal list \<Rightarrow> bool"
+where
+  "cycleSetEq c1 c2 = (listIsSubset c1 c2 \<and> listIsSubset c2 c1)"
+
+fun cycleAlreadySeen ::
+  "String.literal list \<Rightarrow> String.literal list list \<Rightarrow> bool"
+where
+  "cycleAlreadySeen _ [] = False"
+| "cycleAlreadySeen c (s # rest) =
+     (cycleSetEq c s \<or> cycleAlreadySeen c rest)"
+
+fun sliceFromNode ::
+  "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
+where
+  "sliceFromNode _ [] = []"
+| "sliceFromNode n (x # xs) =
+     (if x = n then x # xs else sliceFromNode n xs)"
+
+text \<open>Mutual fuel-bounded DFS. Termination is structural on the fuel
+  argument (decreases by 1 on each recursive call). The driver supplies
+  fuel \<open>length nodes ^ 2 + length nodes + 1\<close> — every node is processed
+  at most once, but visited-check early returns can fire once per edge,
+  so quadratic in the node count is a safe upper bound.
+
+  Pattern ordering matters for fuel-zero shortcuts: the \<open>0\<close> clauses
+  must precede the \<open>Suc f\<close> clauses, and the \<open>[]\<close>-children clause
+  must precede the cons clause inside \<open>dfsChildrenFuel\<close>.\<close>
+
+function dfsNodeFuel ::
+  "nat \<Rightarrow> (String.literal \<times> String.literal list) list \<Rightarrow>
+   String.literal \<Rightarrow> dfs_state \<Rightarrow> dfs_state"
+and dfsChildrenFuel ::
+  "nat \<Rightarrow> (String.literal \<times> String.literal list) list \<Rightarrow>
+   String.literal list \<Rightarrow> dfs_state \<Rightarrow> dfs_state"
+where
+  "dfsNodeFuel fuel edges n state =
+     (if fuel = 0 then state
+      else if List.member (onStack state) n then
+        (let cyc = sliceFromNode n (stack state)
+         in if cyc = [] then state
+            else if cycleAlreadySeen cyc (seenCycles state) then state
+            else state\<lparr>cycles := cycles state @ [cyc],
+                       seenCycles := cyc # seenCycles state\<rparr>)
+      else if List.member (visited state) n then state
+      else
+        (let state1 = state\<lparr>onStack := n # onStack state,
+                            visited := n # visited state,
+                            stack := stack state @ [n]\<rparr>;
+             children = lookupEdges n edges;
+             state2   = dfsChildrenFuel (fuel - 1) edges children state1
+         in state2\<lparr>onStack := listRemoveAll n (onStack state2),
+                   stack := butlast (stack state2)\<rparr>))"
+| "dfsChildrenFuel fuel edges [] state = state"
+| "dfsChildrenFuel fuel edges (c # rest) state =
+     (if fuel = 0 then state
+      else dfsChildrenFuel (fuel - 1) edges rest
+             (dfsNodeFuel (fuel - 1) edges c state))"
+  by pat_completeness auto
+
+termination
+  by (relation "measure (\<lambda>x. case x of
+                                Inl (fuel, _, _, _) \<Rightarrow> fuel
+                              | Inr (fuel, _, _, _) \<Rightarrow> fuel)")
+     auto
+
+fun findCyclesAux ::
+  "nat \<Rightarrow> (String.literal \<times> String.literal list) list \<Rightarrow>
+   String.literal list \<Rightarrow> dfs_state \<Rightarrow> dfs_state"
+where
+  "findCyclesAux _ _ [] state = state"
+| "findCyclesAux fuel edges (n # rest) state =
+     (let state1 = state\<lparr>onStack := [], stack := []\<rparr>;
+          state2 = dfsNodeFuel fuel edges n state1
+      in findCyclesAux fuel edges rest state2)"
+
+definition findCycles ::
+  "String.literal list \<Rightarrow> (String.literal \<times> String.literal list) list
+   \<Rightarrow> String.literal list list"
+where
+  "findCycles nodes edges =
+     cycles (findCyclesAux (length nodes * length nodes + length nodes + 1)
+                            edges nodes initDfsState)"
+
 lemmas operationMissingEnsures_code [code] = operationMissingEnsures.simps
 lemmas collectExprNames_code [code]          = collectExprNames.simps
 lemmas collectTypeNames_code [code]          = collectTypeNames.simps
 lemmas walkUndefinedExpr_code [code]         = walkUndefinedExpr.simps
+lemmas collectCallNames_code [code]          = collectCallNames.simps
+lemmas lookupEdges_code [code]               = lookupEdges.simps
+lemmas listRemoveAll_code [code]             = listRemoveAll.simps
+lemmas listIsSubset_code [code]              = listIsSubset.simps
+lemmas cycleSetEq_code [code]                = cycleSetEq_def
+lemmas cycleAlreadySeen_code [code]          = cycleAlreadySeen.simps
+lemmas sliceFromNode_code [code]             = sliceFromNode.simps
+lemmas dfsNodeFuel_code [code]               = dfsNodeFuel.simps dfsChildrenFuel.simps
+lemmas findCyclesAux_code [code]             = findCyclesAux.simps
+lemmas findCycles_code [code]                = findCycles_def
 
 end

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -14,62 +14,6 @@ fun operationMissingEnsures :: "operation_decl_full \<Rightarrow> bool" where
   "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _) =
      (outputs \<noteq> [] \<and> ensures = [])"
 
-text \<open>\<^bold>\<open>Walker infrastructure: \<open>allSubexprs\<close>\<close>. Defined as a structural
-  mutual \<open>fun\<close> — Isabelle proves termination by structural recursion
-  on the disjoint sum of \<open>expr_full\<close> + the four wrapper-list argument
-  types. No size arithmetic needed: each recursive call is on a
-  syntactic subterm of the input, which the datatype-package's
-  built-in well-founded order recognises automatically.
-
-  After this single 28-case enumeration, every binder-insensitive
-  walker collapses to a one-line \<open>concat o map self o allSubexprs\<close>
-  composition with a small per-node selector. Previously every walker
-  enumerated its own 28 cases independently; the new shape moves the
-  enumeration into one structural function whose termination is
-  automatic.\<close>
-
-fun allSubexprs :: "expr_full \<Rightarrow> expr_full list"
-and allSubexprs_list :: "expr_full list \<Rightarrow> expr_full list"
-and allSubexprs_fields :: "field_assign_full list \<Rightarrow> expr_full list"
-and allSubexprs_entries :: "map_entry_full list \<Rightarrow> expr_full list"
-and allSubexprs_bindings :: "quantifier_binding_full list \<Rightarrow> expr_full list"
-where
-  "allSubexprs (BinaryOpF op l r sp)        = BinaryOpF op l r sp # allSubexprs l @ allSubexprs r"
-| "allSubexprs (UnaryOpF op e sp)           = UnaryOpF op e sp # allSubexprs e"
-| "allSubexprs (FieldAccessF b f sp)        = FieldAccessF b f sp # allSubexprs b"
-| "allSubexprs (EnumAccessF b e sp)         = EnumAccessF b e sp # allSubexprs b"
-| "allSubexprs (IndexF b i sp)              = IndexF b i sp # allSubexprs b @ allSubexprs i"
-| "allSubexprs (CallF c args sp)            = CallF c args sp # allSubexprs c @ allSubexprs_list args"
-| "allSubexprs (PrimeF e sp)                = PrimeF e sp # allSubexprs e"
-| "allSubexprs (PreF e sp)                  = PreF e sp # allSubexprs e"
-| "allSubexprs (WithF b ups sp)             = WithF b ups sp # allSubexprs b @ allSubexprs_fields ups"
-| "allSubexprs (IfF c t e sp)               = IfF c t e sp # allSubexprs c @ allSubexprs t @ allSubexprs e"
-| "allSubexprs (LetF v val body sp)         = LetF v val body sp # allSubexprs val @ allSubexprs body"
-| "allSubexprs (LambdaF p b sp)             = LambdaF p b sp # allSubexprs b"
-| "allSubexprs (ConstructorF n fs sp)       = ConstructorF n fs sp # allSubexprs_fields fs"
-| "allSubexprs (SetLiteralF xs sp)          = SetLiteralF xs sp # allSubexprs_list xs"
-| "allSubexprs (MapLiteralF es sp)          = MapLiteralF es sp # allSubexprs_entries es"
-| "allSubexprs (SetComprehensionF v d p sp) = SetComprehensionF v d p sp # allSubexprs d @ allSubexprs p"
-| "allSubexprs (SeqLiteralF xs sp)          = SeqLiteralF xs sp # allSubexprs_list xs"
-| "allSubexprs (MatchesF e pat sp)          = MatchesF e pat sp # allSubexprs e"
-| "allSubexprs (SomeWrapF e sp)             = SomeWrapF e sp # allSubexprs e"
-| "allSubexprs (TheF v d b sp)              = TheF v d b sp # allSubexprs d @ allSubexprs b"
-| "allSubexprs (QuantifierF q bs body sp)   = QuantifierF q bs body sp # allSubexprs_bindings bs @ allSubexprs body"
-| "allSubexprs (IdentifierF n sp)           = [IdentifierF n sp]"
-| "allSubexprs (IntLitF n sp)               = [IntLitF n sp]"
-| "allSubexprs (FloatLitF v sp)             = [FloatLitF v sp]"
-| "allSubexprs (StringLitF v sp)            = [StringLitF v sp]"
-| "allSubexprs (BoolLitF b sp)              = [BoolLitF b sp]"
-| "allSubexprs (NoneLitF sp)                = [NoneLitF sp]"
-| "allSubexprs_list []                                       = []"
-| "allSubexprs_list (x # xs)                                 = allSubexprs x @ allSubexprs_list xs"
-| "allSubexprs_fields []                                     = []"
-| "allSubexprs_fields (FieldAssignFull n v sp # fs)          = allSubexprs v @ allSubexprs_fields fs"
-| "allSubexprs_entries []                                    = []"
-| "allSubexprs_entries (MapEntryFull k v sp # es)            = allSubexprs k @ allSubexprs v @ allSubexprs_entries es"
-| "allSubexprs_bindings []                                   = []"
-| "allSubexprs_bindings (QuantifierBindingFull n d a sp # bs) = allSubexprs d @ allSubexprs_bindings bs"
-
 text \<open>\<open>L05 — UnusedEntity\<close>: collect Identifier + Constructor names
   appearing anywhere in the expression. Does NOT respect binders
   (matches the Scala \<open>ExprWalk.foreach\<close> behaviour — entity names
@@ -337,10 +281,6 @@ where
                             edges nodes initDfsState)"
 
 lemmas operationMissingEnsures_code [code] = operationMissingEnsures.simps
-lemmas allSubexprs_code [code]               = allSubexprs.simps allSubexprs_list.simps
-                                                allSubexprs_fields.simps
-                                                allSubexprs_entries.simps
-                                                allSubexprs_bindings.simps
 lemmas exprSelfNames_code [code]             = exprSelfNames.simps
 lemmas callSelfAllNames_code [code]          = callSelfAllNames.simps
 lemmas callSelfFilteredNames_code [code]     = callSelfFilteredNames.simps

--- a/proofs/isabelle/SpecRest/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/LintAnalysis.thy
@@ -173,6 +173,61 @@ text \<open>\<open>L06 — CircularPredicate\<close>: pure HOL DFS cycle-finder.
     in HOL; Scala iterates the resulting cycles and formats
     diagnostics.\<close>
 
+text \<open>Unfiltered companion: collect every \<open>Call (Identifier n) _\<close>
+  callee name regardless of any filter set. Used by \<open>UndefinedRef\<close> to
+  build the \<open>factImplicit\<close> whitelist (fact bodies frequently call
+  helper predicates / functions whose names weren't yet listed in
+  \<open>ir.m\<close> / \<open>ir.l\<close> at the time the global scope is assembled).\<close>
+
+fun collectAllCallNames :: "expr_full \<Rightarrow> String.literal list"
+and collectAllCallNames_list :: "expr_full list \<Rightarrow> String.literal list"
+and collectAllCallNames_fields :: "field_assign_full list \<Rightarrow> String.literal list"
+and collectAllCallNames_entries :: "map_entry_full list \<Rightarrow> String.literal list"
+and collectAllCallNames_bindings :: "quantifier_binding_full list \<Rightarrow> String.literal list"
+where
+  "collectAllCallNames (CallF (IdentifierF n _) args _) =
+     n # collectAllCallNames_list args"
+| "collectAllCallNames (CallF c args _) =
+     collectAllCallNames c @ collectAllCallNames_list args"
+| "collectAllCallNames (BinaryOpF _ l r _) = collectAllCallNames l @ collectAllCallNames r"
+| "collectAllCallNames (UnaryOpF _ e _) = collectAllCallNames e"
+| "collectAllCallNames (FieldAccessF b _ _) = collectAllCallNames b"
+| "collectAllCallNames (EnumAccessF b _ _) = collectAllCallNames b"
+| "collectAllCallNames (IndexF b i _) = collectAllCallNames b @ collectAllCallNames i"
+| "collectAllCallNames (PrimeF e _) = collectAllCallNames e"
+| "collectAllCallNames (PreF e _) = collectAllCallNames e"
+| "collectAllCallNames (WithF b upds _) = collectAllCallNames b @ collectAllCallNames_fields upds"
+| "collectAllCallNames (IfF c t e _) = collectAllCallNames c @ collectAllCallNames t @ collectAllCallNames e"
+| "collectAllCallNames (LetF _ val body _) = collectAllCallNames val @ collectAllCallNames body"
+| "collectAllCallNames (LambdaF _ b _) = collectAllCallNames b"
+| "collectAllCallNames (ConstructorF _ fs _) = collectAllCallNames_fields fs"
+| "collectAllCallNames (SetLiteralF xs _) = collectAllCallNames_list xs"
+| "collectAllCallNames (MapLiteralF es _) = collectAllCallNames_entries es"
+| "collectAllCallNames (SetComprehensionF _ d p _) = collectAllCallNames d @ collectAllCallNames p"
+| "collectAllCallNames (SeqLiteralF xs _) = collectAllCallNames_list xs"
+| "collectAllCallNames (MatchesF x _ _) = collectAllCallNames x"
+| "collectAllCallNames (SomeWrapF x _) = collectAllCallNames x"
+| "collectAllCallNames (TheF _ d b _) = collectAllCallNames d @ collectAllCallNames b"
+| "collectAllCallNames (QuantifierF _ bs body _) =
+     collectAllCallNames_bindings bs @ collectAllCallNames body"
+| "collectAllCallNames (IdentifierF _ _) = []"
+| "collectAllCallNames (IntLitF _ _) = []"
+| "collectAllCallNames (FloatLitF _ _) = []"
+| "collectAllCallNames (StringLitF _ _) = []"
+| "collectAllCallNames (BoolLitF _ _) = []"
+| "collectAllCallNames (NoneLitF _) = []"
+| "collectAllCallNames_list [] = []"
+| "collectAllCallNames_list (x # xs) = collectAllCallNames x @ collectAllCallNames_list xs"
+| "collectAllCallNames_fields [] = []"
+| "collectAllCallNames_fields (FieldAssignFull _ v _ # fs) =
+     collectAllCallNames v @ collectAllCallNames_fields fs"
+| "collectAllCallNames_entries [] = []"
+| "collectAllCallNames_entries (MapEntryFull k v _ # es) =
+     collectAllCallNames k @ collectAllCallNames v @ collectAllCallNames_entries es"
+| "collectAllCallNames_bindings [] = []"
+| "collectAllCallNames_bindings (QuantifierBindingFull _ d _ _ # bs) =
+     collectAllCallNames d @ collectAllCallNames_bindings bs"
+
 fun collectCallNames :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
 and collectCallNames_list :: "expr_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
 and collectCallNames_fields :: "field_assign_full list \<Rightarrow> String.literal list \<Rightarrow> String.literal list"
@@ -349,6 +404,7 @@ lemmas collectExprNames_code [code]          = collectExprNames.simps
 lemmas collectTypeNames_code [code]          = collectTypeNames.simps
 lemmas walkUndefinedExpr_code [code]         = walkUndefinedExpr.simps
 lemmas collectCallNames_code [code]          = collectCallNames.simps
+lemmas collectAllCallNames_code [code]       = collectAllCallNames.simps
 lemmas lookupEdges_code [code]               = lookupEdges.simps
 lemmas listRemoveAll_code [code]             = listRemoveAll.simps
 lemmas listIsSubset_code [code]              = listIsSubset.simps


### PR DESCRIPTION
## Summary

**Bigger PR per request — no more microscopic ones.** Lifts the two straightforward lint walkers into \`LintAnalysis.thy\` with shared infrastructure:

| Lifted function | Used by | Behavior |
|---|---|---|
| \`collectExprNames\` | UnusedEntity | naive expr walker, all Identifier + Ctor names (no binder respect — matches Scala \`ExprWalk.foreach\`) |
| \`collectTypeNames\` | UnusedEntity | recursive type-name collector |
| \`walkUndefinedExpr\` | UndefinedRef | scope-aware walker returning \`(identifier, span)\` for every reference not in scope; respects LetF/LambdaF/TheF/SetComprehensionF/QuantifierF binders (QuantifierF threads scope sequentially across bindings, matching the legacy var-based fold) |

Both walkers follow the mutual-fun pattern from \`free_vars\` (one case per \`expr_full\` constructor + helper functions for list/fields/entries/bindings). \`walkUndefinedExpr_bindings\` additionally returns the final scope so the body sees all binding names.

## Scala-side refactors

- **\`UnusedEntity.scala\`** — \`referencedNames\` now folds the lifted \`collectExprNames\` + \`collectTypeNames\` over each IR slot; Scala only chooses which slots to scan.
- **\`UndefinedRef.scala\`** — \`check\` delegates to \`walkUndefinedExpr\`; Scala constructs the per-context scope (state fields, entity/enum/alias names, \`Builtins.names\`, fact-implicit callees) and emits diagnostics from the \`(name, span)\` pairs the lifted walker returns.

## Build cost

Build time on the LintAnalysis \`fun\` (\`walkUndefinedExpr\`) is ~58s. Total session build ~2:18, well under the 5-6 min cap.

## Skipped from this PR (each has gnarlier complications)

- \`TypeMismatch\` — heaviest type-checker walker
- \`CircularPredicate\` — graph cycle detection needs termination proof
- \`OperationOverlap\` — uses \`.toString\` of ADTs fragilely

## Test plan
- [x] \`isabelle build\` clean (2:18)
- [x] \`sbt scalafixAll\` clean
- [x] \`sbt test\` — 1,120 tests pass
- [x] No golden diff
- [ ] CI: build-and-test + isabelle + coverage + cubic pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts UnusedEntity, UndefinedRef, and CircularPredicate into proofs, shares a single `allSubexprs` walker, and rewrites `requiresAlloy` accordingly. Updates Scala to call the extracted walkers/DFS, restores `factImplicit` correctness, improves UnusedEntity performance, and collapses `collectExprInfo` into `allSubexprs`-based selectors.

- **New Features**
  - Exported via `Codegen.thy`: `collectExprNames`, `collectTypeNames`, `walkUndefinedExpr`, `collectCallNames`, `collectAllCallNames`, `findCycles`.

- **Refactors**
  - Hoisted `allSubexprs` to `IR.thy`; replaced `hasPrePrime`/`exprContainsBoolLit` with `isPrePrime`/`isBoolLit` + `allSubexprs`.
  - Rewrote `requiresAlloy` to use `allSubexprs` with derived per-constructor simp rules to preserve Soundness proofs.
  - Scala: `UnusedEntity` folds lifted collectors with a single Set accumulator; `UndefinedRef` delegates to `walkUndefinedExpr` and restores `factImplicit` using `collectAllCallNames`; `CircularPredicate` builds edges with `collectCallNames` and uses `findCycles` over sorted nodes for deterministic results.
  - `IR_Helpers.thy`: removed 5-way `collectExprInfo`; added `collectPrimedIdentifiers`, `collectFieldAccessNames`, and `collectWithFields` as one-liners over `allSubexprs` (no API changes).

<sup>Written for commit b4706ceafdde9a1e584e7d04e86c89ae19515850. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/341?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked lint checks to use shared walkers and collectors, shifting from imperative mutable logic to functional, immutable traversals.
  * Improved undefined-reference, unused-entity, and circular-dependency analyses while preserving diagnostic formatting.
* **Chores**
  * Extended exported analysis utilities to enable reuse across lint modules and tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->