### PR TITLE
feat(proofs): lift TypeMismatch (L01) per-node classifier

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -930,6 +930,14 @@ object SpecRestGenerated {
       d: analysis_signals
   ) extends classification_result
 
+  sealed abstract class type_mismatch_kind
+  final case class TmUnaryNotOnNonBool(a: lit_class)                   extends type_mismatch_kind
+  final case class TmUnaryNegOnNonNumeric(a: lit_class)                extends type_mismatch_kind
+  final case class TmArithLitMisuse(a: bin_op_full, b: lit_class)      extends type_mismatch_kind
+  final case class TmCompareLitMisuse(a: bin_op_full, b: lit_class)    extends type_mismatch_kind
+  final case class TmLogicalLitMisuse(a: bin_op_full, b: lit_class)    extends type_mismatch_kind
+  final case class TmMembershipLitMisuse(a: bin_op_full, b: lit_class) extends type_mismatch_kind
+
   sealed abstract class decimal_lit
   final case class DecimalLit(a: int, b: int) extends decimal_lit
 
@@ -1001,6 +1009,8 @@ object SpecRestGenerated {
   final case class PartialIndexFieldMissing(a: String, b: String) extends convention_ir_diagnostic
   final case class TestStrategyFieldMissing(a: String, b: String, c: String)
       extends convention_ir_diagnostic
+
+  def id[A]: A => A = (x: A) => x
 
   def max[A: ord](a: A, b: A): A =
     less_eq[A](a, b) match {
@@ -5289,6 +5299,29 @@ object SpecRestGenerated {
     case x :: rest => combineAnd_acc(x, rest)
   }
 
+  def isArithBin(x0: bin_op_full): Boolean = x0 match {
+    case BAdd()       => true
+    case BSub()       => true
+    case BMul()       => true
+    case BDiv()       => true
+    case BAnd()       => false
+    case BOr()        => false
+    case BImplies()   => false
+    case BIff()       => false
+    case BEq()        => false
+    case BNeq()       => false
+    case BLt()        => false
+    case BGt()        => false
+    case BLe()        => false
+    case BGe()        => false
+    case BIn()        => false
+    case BNotIn()     => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+  }
+
   def isPrePrime(x0: expr_full): Boolean = x0 match {
     case PrimeF(uu, uv)                   => true
     case PreF(uw, ux)                     => true
@@ -5980,6 +6013,29 @@ object SpecRestGenerated {
     case (SeqTypeF(v, va), uw)              => false
     case (OptionTypeF(v, va), uw)           => false
     case (RelationTypeF(v, va, vb, vc), uw) => false
+  }
+
+  def isLogicalBin(x0: bin_op_full): Boolean = x0 match {
+    case BAnd()       => true
+    case BOr()        => true
+    case BImplies()   => true
+    case BIff()       => true
+    case BEq()        => false
+    case BNeq()       => false
+    case BLt()        => false
+    case BGt()        => false
+    case BLe()        => false
+    case BGe()        => false
+    case BIn()        => false
+    case BNotIn()     => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+    case BAdd()       => false
+    case BSub()       => false
+    case BMul()       => false
+    case BDiv()       => false
   }
 
   def fieldTypeFull(x0: field_decl_full): type_expr_full = x0 match {
@@ -7715,6 +7771,177 @@ object SpecRestGenerated {
   def signalsDeletesKey(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, d, ux, uy, uz, va, vb) => d
   }
+
+  def equal_lit_class(x0: lit_class, x1: lit_class): Boolean = (x0, x1) match {
+    case (LcCollection(), LcNone())       => false
+    case (LcNone(), LcCollection())       => false
+    case (LcStringLike(), LcNone())       => false
+    case (LcNone(), LcStringLike())       => false
+    case (LcStringLike(), LcCollection()) => false
+    case (LcCollection(), LcStringLike()) => false
+    case (LcBool(), LcNone())             => false
+    case (LcNone(), LcBool())             => false
+    case (LcBool(), LcCollection())       => false
+    case (LcCollection(), LcBool())       => false
+    case (LcBool(), LcStringLike())       => false
+    case (LcStringLike(), LcBool())       => false
+    case (LcNumeric(), LcNone())          => false
+    case (LcNone(), LcNumeric())          => false
+    case (LcNumeric(), LcCollection())    => false
+    case (LcCollection(), LcNumeric())    => false
+    case (LcNumeric(), LcStringLike())    => false
+    case (LcStringLike(), LcNumeric())    => false
+    case (LcNumeric(), LcBool())          => false
+    case (LcBool(), LcNumeric())          => false
+    case (LcNone(), LcNone())             => true
+    case (LcCollection(), LcCollection()) => true
+    case (LcStringLike(), LcStringLike()) => true
+    case (LcBool(), LcBool())             => true
+    case (LcNumeric(), LcNumeric())       => true
+  }
+
+  def isMembershipBin(x0: bin_op_full): Boolean = x0 match {
+    case BIn()        => true
+    case BNotIn()     => true
+    case BAnd()       => false
+    case BOr()        => false
+    case BImplies()   => false
+    case BIff()       => false
+    case BEq()        => false
+    case BNeq()       => false
+    case BLt()        => false
+    case BGt()        => false
+    case BLe()        => false
+    case BGe()        => false
+    case BSubset()    => false
+    case BUnion()     => false
+    case BIntersect() => false
+    case BDiff()      => false
+    case BAdd()       => false
+    case BSub()       => false
+    case BMul()       => false
+    case BDiv()       => false
+  }
+
+  def typeMismatchAt(e: expr_full): Option[(type_mismatch_kind, Option[span_t])] =
+    e match {
+      case BinaryOpF(op, l, r, sp) =>
+        val cs =
+          map_filter[Option[lit_class], lit_class](
+            id[Option[lit_class]],
+            List(litClass(l), litClass(r))
+          ): List[lit_class];
+        isArithBin(op) match {
+          case true => map_option[lit_class, (type_mismatch_kind, Option[span_t])](
+              (c: lit_class) =>
+                (TmArithLitMisuse(op, c), sp),
+              find[lit_class](
+                (c: lit_class) =>
+                  equal_lit_class(c, LcBool()) ||
+                    equal_lit_class(c, LcNone()),
+                cs
+              )
+            )
+          case false => isComp(op) match {
+              case true => map_option[lit_class, (type_mismatch_kind, Option[span_t])](
+                  (c: lit_class) =>
+                    (TmCompareLitMisuse(op, c), sp),
+                  find[lit_class](
+                    (c: lit_class) =>
+                      equal_lit_class(c, LcBool()) || equal_lit_class(c, LcNone()),
+                    cs
+                  )
+                )
+              case false => isLogicalBin(op) match {
+                  case true => map_option[lit_class, (type_mismatch_kind, Option[span_t])](
+                      (c: lit_class) =>
+                        (TmLogicalLitMisuse(op, c), sp),
+                      find[lit_class]((c: lit_class) => !equal_lit_class(c, LcBool()), cs)
+                    )
+                  case false => isMembershipBin(op) match {
+                      case true => litClass(r) match {
+                          case None => None
+                          case Some(LcNumeric()) =>
+                            Some[(type_mismatch_kind, Option[span_t])]((
+                              TmMembershipLitMisuse(op, LcNumeric()),
+                              sp
+                            ))
+                          case Some(LcBool()) =>
+                            Some[(type_mismatch_kind, Option[span_t])]((
+                              TmMembershipLitMisuse(op, LcBool()),
+                              sp
+                            ))
+                          case Some(LcStringLike()) =>
+                            Some[(type_mismatch_kind, Option[span_t])]((
+                              TmMembershipLitMisuse(op, LcStringLike()),
+                              sp
+                            ))
+                          case Some(LcCollection()) => None
+                          case Some(LcNone()) =>
+                            Some[(type_mismatch_kind, Option[span_t])]((
+                              TmMembershipLitMisuse(op, LcNone()),
+                              sp
+                            ))
+                        }
+                      case false => None
+                    }
+                }
+            }
+        }
+      case UnaryOpF(UNot(), inner, sp) =>
+        litClass(inner) match {
+          case None => None
+          case Some(LcNumeric()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNotOnNonBool(LcNumeric()), sp))
+          case Some(LcBool()) => None
+          case Some(LcStringLike()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNotOnNonBool(LcStringLike()), sp))
+          case Some(LcCollection()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNotOnNonBool(LcCollection()), sp))
+          case Some(LcNone()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNotOnNonBool(LcNone()), sp))
+        }
+      case UnaryOpF(UNegate(), inner, sp) =>
+        litClass(inner) match {
+          case None              => None
+          case Some(LcNumeric()) => None
+          case Some(LcBool()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNegOnNonNumeric(LcBool()), sp))
+          case Some(LcStringLike()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNegOnNonNumeric(LcStringLike()), sp))
+          case Some(LcCollection()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNegOnNonNumeric(LcCollection()), sp))
+          case Some(LcNone()) =>
+            Some[(type_mismatch_kind, Option[span_t])]((TmUnaryNegOnNonNumeric(LcNone()), sp))
+        }
+      case UnaryOpF(UCardinality(), _, _) => None
+      case UnaryOpF(UPower(), _, _)       => None
+      case QuantifierF(_, _, _, _)        => None
+      case SomeWrapF(_, _)                => None
+      case TheF(_, _, _, _)               => None
+      case FieldAccessF(_, _, _)          => None
+      case EnumAccessF(_, _, _)           => None
+      case IndexF(_, _, _)                => None
+      case CallF(_, _, _)                 => None
+      case PrimeF(_, _)                   => None
+      case PreF(_, _)                     => None
+      case WithF(_, _, _)                 => None
+      case IfF(_, _, _, _)                => None
+      case LetF(_, _, _, _)               => None
+      case LambdaF(_, _, _)               => None
+      case ConstructorF(_, _, _)          => None
+      case SetLiteralF(_, _)              => None
+      case MapLiteralF(_, _)              => None
+      case SetComprehensionF(_, _, _, _)  => None
+      case SeqLiteralF(_, _)              => None
+      case MatchesF(_, _, _)              => None
+      case IntLitF(_, _)                  => None
+      case FloatLitF(_, _)                => None
+      case StringLitF(_, _)               => None
+      case BoolLitF(_, _)                 => None
+      case NoneLitF(_)                    => None
+      case IdentifierF(_, _)              => None
+    }
 
   def containsPreInPlusChain(x0: expr_full, field: String): Boolean =
     (x0, field) match {
@@ -10841,6 +11068,12 @@ object SpecRestGenerated {
     x0 match {
       case OperationClassification(uu, uv, uw, ux, t, uy, uz) => t
     }
+
+  def typeMismatchDiagnostics(e: expr_full): List[(type_mismatch_kind, Option[span_t])] =
+    map_filter[expr_full, (type_mismatch_kind, Option[span_t])](
+      (a: expr_full) => typeMismatchAt(a),
+      allSubexprs(e)
+    )
 
   def collectPrimedIdentifiers(es: List[expr_full]): List[String] =
     remdups[String](maps[expr_full, String](

--- a/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
+++ b/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
@@ -1,39 +1,18 @@
 package specrest.lint
 
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
-@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 object TypeMismatch extends LintPass:
   val code = "L01"
 
   def run(ir: ServiceIRFull): List[LintDiagnostic] =
     val out = List.newBuilder[LintDiagnostic]
-    val visit: expr_full => Unit =
-      case BinaryOpF(op, left, right, span) =>
-        checkBinary(op, left, right, span, out)
-      case UnaryOpF(UNot(), operand, span) =>
-        litClass(operand) match
-          case Some(c) if !isBool(c) =>
-            out += LintDiagnostic(
-              code,
-              LintLevel.Error,
-              s"logical 'not' applied to a ${describeLitClass(c)} literal",
-              span
-            )
-          case _ => ()
-      case UnaryOpF(UNegate(), operand, span) =>
-        litClass(operand) match
-          case Some(c) if !isNumeric(c) =>
-            out += LintDiagnostic(
-              code,
-              LintLevel.Error,
-              s"arithmetic '-' applied to a ${describeLitClass(c)} literal",
-              span
-            )
-          case _ => ()
-      case _ => ()
 
-    def visitAll(e: expr_full): Unit = ExprWalk.foreach(e)(visit)
+    def visitAll(e: expr_full): Unit =
+      SpecRestGenerated.typeMismatchDiagnostics(e).foreach { case (kind, span) =>
+        out += LintDiagnostic(code, LintLevel.Error, render(kind), span)
+      }
 
     for case OperationDeclFull(_, _, _, requires, ensures, _) <- ir.g do
       requires.foreach(visitAll)
@@ -51,72 +30,16 @@ object TypeMismatch extends LintPass:
 
     out.result()
 
-  private def isBool(c: lit_class): Boolean = c match
-    case LcBool() => true
-    case _        => false
-
-  private def isNumeric(c: lit_class): Boolean = c match
-    case LcNumeric() => true
-    case _           => false
-
-  private def isBoolOrNone(c: lit_class): Boolean = c match
-    case LcBool() | LcNone() => true
-    case _                   => false
-
-  private def isNonCollection(c: lit_class): Boolean = c match
-    case LcNumeric() | LcBool() | LcStringLike() | LcNone() => true
-    case _                                                  => false
-
-  private def checkBinary(
-      op: bin_op_full,
-      left: expr_full,
-      right: expr_full,
-      span: Option[span_t],
-      out: scala.collection.mutable.Builder[LintDiagnostic, List[LintDiagnostic]]
-  ): Unit =
-    val lc = litClass(left)
-    val rc = litClass(right)
-    op match
-      case BAdd() | BSub() | BMul() | BDiv() =>
-        // `+` and `-` are overloaded for set/map union and diff in this DSL,
-        // and `+` for string concatenation. Only flag when a literal is clearly
-        // never a number (Bool or None) — those cases admit no overload.
-        val bad = lc.exists(isBoolOrNone) || rc.exists(isBoolOrNone)
-        if bad then
-          out += LintDiagnostic(
-            code,
-            LintLevel.Error,
-            s"arithmetic '${binOpName(op)}' has a ${describeLitClass((lc ++ rc).find(isBoolOrNone).get)} literal operand",
-            span
-          )
-      case BLt() | BGt() | BLe() | BGe() =>
-        // Comparisons can apply to numbers, strings (lexicographic), or sets
-        // (subset/superset). Only flag on Bool/None literals (never ordered).
-        val bad = lc.exists(isBoolOrNone) || rc.exists(isBoolOrNone)
-        if bad then
-          out += LintDiagnostic(
-            code,
-            LintLevel.Error,
-            s"comparison '${binOpName(op)}' has a ${describeLitClass((lc ++ rc).find(isBoolOrNone).get)} literal operand",
-            span
-          )
-      case BAnd() | BOr() | BImplies() | BIff() =>
-        val bad = lc.exists(!isBool(_)) || rc.exists(!isBool(_))
-        if bad then
-          val offender = (lc ++ rc).find(!isBool(_)).get
-          out += LintDiagnostic(
-            code,
-            LintLevel.Error,
-            s"logical '${binOpName(op)}' applied to a ${describeLitClass(offender)} literal",
-            span
-          )
-      case BIn() | BNotIn() =>
-        val bad = rc.exists(isNonCollection)
-        if bad then
-          out += LintDiagnostic(
-            code,
-            LintLevel.Error,
-            s"'${binOpName(op)}' right operand is a ${describeLitClass(rc.get)} literal, not a collection",
-            span
-          )
-      case _ => ()
+  private def render(kind: type_mismatch_kind): String = kind match
+    case TmUnaryNotOnNonBool(c) =>
+      s"logical 'not' applied to a ${describeLitClass(c)} literal"
+    case TmUnaryNegOnNonNumeric(c) =>
+      s"arithmetic '-' applied to a ${describeLitClass(c)} literal"
+    case TmArithLitMisuse(op, c) =>
+      s"arithmetic '${binOpName(op)}' has a ${describeLitClass(c)} literal operand"
+    case TmCompareLitMisuse(op, c) =>
+      s"comparison '${binOpName(op)}' has a ${describeLitClass(c)} literal operand"
+    case TmLogicalLitMisuse(op, c) =>
+      s"logical '${binOpName(op)}' applied to a ${describeLitClass(c)} literal"
+    case TmMembershipLitMisuse(op, c) =>
+      s"'${binOpName(op)}' right operand is a ${describeLitClass(c)} literal, not a collection"

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -107,6 +107,8 @@ export_code
     binOpName
     typeContainsNamed
     exprContainsBoolLit
+    typeMismatchAt
+    typeMismatchDiagnostics
     rangeOf
     conflicts
     negate

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -366,6 +366,82 @@ fun conflicts :: "bin_op_full \<Rightarrow> int \<Rightarrow> bin_op_full \<Righ
       then lowBoundEffective bOp bB > highBoundEffective aOp aB
       else False)"
 
+text \<open>Phase 9\<delta> (lint TypeMismatch / L01 \<open>typeMismatchDiagnostics\<close>): full
+  per-node classifier for type-mismatch diagnostics. Classify each
+  \<open>expr_full\<close> independently into an optional \<open>type_mismatch_kind\<close>
+  (\<open>typeMismatchAt\<close>); compose with the shared \<open>allSubexprs\<close> enumeration
+  to collect all diagnostics for a top-level expression
+  (\<open>typeMismatchDiagnostics\<close>). Reuses \<open>isComp\<close> (Narration helper above)
+  for comparison classification. Message rendering stays Scala-side.\<close>
+
+fun isArithBin :: "bin_op_full \<Rightarrow> bool" where
+  "isArithBin BAdd = True"
+| "isArithBin BSub = True"
+| "isArithBin BMul = True"
+| "isArithBin BDiv = True"
+| "isArithBin _    = False"
+
+fun isLogicalBin :: "bin_op_full \<Rightarrow> bool" where
+  "isLogicalBin BAnd     = True"
+| "isLogicalBin BOr      = True"
+| "isLogicalBin BImplies = True"
+| "isLogicalBin BIff     = True"
+| "isLogicalBin _        = False"
+
+fun isMembershipBin :: "bin_op_full \<Rightarrow> bool" where
+  "isMembershipBin BIn    = True"
+| "isMembershipBin BNotIn = True"
+| "isMembershipBin _      = False"
+
+datatype (plugins only: code size) type_mismatch_kind =
+    TmUnaryNotOnNonBool lit_class
+  | TmUnaryNegOnNonNumeric lit_class
+  | TmArithLitMisuse bin_op_full lit_class
+  | TmCompareLitMisuse bin_op_full lit_class
+  | TmLogicalLitMisuse bin_op_full lit_class
+  | TmMembershipLitMisuse bin_op_full lit_class
+
+text \<open>\<open>(lc ++ rc).find(p)\<close> in Scala on \<open>Option[lit_class]\<close> pair flattens
+  to a list (left-first) and finds the first matching class. In Isabelle:
+  \<open>List.find p (List.map_filter id [lc, rc])\<close>.\<close>
+
+definition typeMismatchAt ::
+  "expr_full \<Rightarrow> (type_mismatch_kind \<times> span_t option) option" where
+  "typeMismatchAt e \<equiv>
+     (case e of
+        UnaryOpF UNot inner sp \<Rightarrow>
+          (case litClass inner of
+             Some LcBool \<Rightarrow> None
+           | Some c     \<Rightarrow> Some (TmUnaryNotOnNonBool c, sp)
+           | None       \<Rightarrow> None)
+      | UnaryOpF UNegate inner sp \<Rightarrow>
+          (case litClass inner of
+             Some LcNumeric \<Rightarrow> None
+           | Some c        \<Rightarrow> Some (TmUnaryNegOnNonNumeric c, sp)
+           | None          \<Rightarrow> None)
+      | BinaryOpF op l r sp \<Rightarrow>
+          (let cs = List.map_filter id [litClass l, litClass r] in
+            if isArithBin op then
+              map_option (\<lambda>c. (TmArithLitMisuse op c, sp))
+                (List.find (\<lambda>c. c = LcBool \<or> c = LcNone) cs)
+            else if isComp op then
+              map_option (\<lambda>c. (TmCompareLitMisuse op c, sp))
+                (List.find (\<lambda>c. c = LcBool \<or> c = LcNone) cs)
+            else if isLogicalBin op then
+              map_option (\<lambda>c. (TmLogicalLitMisuse op c, sp))
+                (List.find (\<lambda>c. c \<noteq> LcBool) cs)
+            else if isMembershipBin op then
+              (case litClass r of
+                 Some LcCollection \<Rightarrow> None
+               | Some c             \<Rightarrow> Some (TmMembershipLitMisuse op c, sp)
+               | None               \<Rightarrow> None)
+            else None)
+      | _ \<Rightarrow> None)"
+
+definition typeMismatchDiagnostics ::
+  "expr_full \<Rightarrow> (type_mismatch_kind \<times> span_t option) list" where
+  "typeMismatchDiagnostics e = List.map_filter typeMismatchAt (allSubexprs e)"
+
 text \<open>Phase 9\<epsilon> (small recognizers, scattered consumers):
   \<open>negate\<close> — partial logical negation of comparison-shaped exprs (used
   by testgen guard satisfier); \<open>isLenOrCardOf\<close> — extracts the bare
@@ -505,9 +581,11 @@ definition isKeyExistsConj ::
           (case r of IdentifierF s _ \<Rightarrow> s = stateName | _ \<Rightarrow> False)
       | _ \<Rightarrow> False)"
 
-lemmas isPrePrime_code [code]          = isPrePrime.simps
-lemmas hasPrePrime_code [code]         = hasPrePrime_def
-lemmas isBoolLit_code [code]           = isBoolLit.simps
-lemmas exprContainsBoolLit_code [code] = exprContainsBoolLit_def
+lemmas isPrePrime_code [code]              = isPrePrime.simps
+lemmas hasPrePrime_code [code]             = hasPrePrime_def
+lemmas isBoolLit_code [code]               = isBoolLit.simps
+lemmas exprContainsBoolLit_code [code]     = exprContainsBoolLit_def
+lemmas typeMismatchAt_code [code]          = typeMismatchAt_def
+lemmas typeMismatchDiagnostics_code [code] = typeMismatchDiagnostics_def
 
 end


### PR DESCRIPTION
## Summary

- Lift the per-node analysis of TypeMismatch (L01) into Isabelle as `typeMismatchAt :: expr_full ⇒ (type_mismatch_kind × span_t option) option` + `typeMismatchDiagnostics` collector composed via `List.map_filter typeMismatchAt (allSubexprs e)`.
- Scala TypeMismatch.scala collapses from a hand-written mutable-builder visitor (~115 LOC) to a thin IR-slot iterator + 12-line message renderer.
- Reuses existing `isComp` / `litClass` / `allSubexprs` / `List.find` / `List.map_filter` — only three small new op classifiers (`isArithBin`, `isLogicalBin`, `isMembershipBin`); no duplicate predicates.

The `type_mismatch_kind` ADT captures the six diagnostic shapes (`TmUnaryNotOnNonBool`, `TmUnaryNegOnNonNumeric`, `TmArithLitMisuse`, `TmCompareLitMisuse`, `TmLogicalLitMisuse`, `TmMembershipLitMisuse`); message templates stay Scala-side where string interpolation is natural.

## Test plan

- [x] `isabelle build SpecRest` clean at 2:17
- [x] `sbt test`: 1236/1236 passing (all 10 modules)
- [x] `sbt scalafixAll` clean
- [x] Lint module specifically: L01 fixture tests (and-of-int, +-of-bool, comparison >= string) still match by message substring

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted L01 TypeMismatch classification into Isabelle as `typeMismatchAt` and `typeMismatchDiagnostics`, and updated the Scala lint to consume it. This removes duplicate logic, simplifies `TypeMismatch.scala`, and keeps message rendering in Scala.

- New Features
  - Added `type_mismatch_kind` ADT and per-node classifier (`typeMismatchAt`) plus collector (`typeMismatchDiagnostics`), exported via codegen.
  - Introduced small op classifiers `isArithBin`, `isLogicalBin`, `isMembershipBin` and reused `isComp`.

- Refactors
  - Replaced the mutable visitor in `specrest.lint.TypeMismatch` with a thin iterator that renders messages from `type_mismatch_kind` (about −95 LOC).
  - Scala now calls `specrest.ir.generated.SpecRestGenerated.typeMismatchDiagnostics`, avoiding predicate duplication.

<sup>Written for commit aa699a3a4694f83ac30dbc5f5ad480594e72c476. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/342?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored type-mismatch detection infrastructure to enhance consistency and maintainability in diagnostic error reporting.
  * Expanded type-mismatch analysis to comprehensively cover arithmetic, logical, and membership operators, plus various literal types.
  * Improved diagnostic rendering mechanisms for clearer error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->