### PR TITLE
feat(proofs): lift Narration helpers + matchesIdentityShape recognizer

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -9022,6 +9022,68 @@ object SpecRestGenerated {
   def emptyServiceIrFull(nm: String): service_ir_full =
     ServiceIRFull(nm, Nil, Nil, Nil, Nil, None, Nil, Nil, Nil, Nil, Nil, Nil, Nil, None, None)
 
+  def extractFieldAssignRhs(x0: expr_full, field: String): List[expr_full] =
+    (x0, field) match {
+      case (BinaryOpF(BEq(), lhs, rhs, uu), field) =>
+        assignsField(lhs, field) match {
+          case true  => List(rhs)
+          case false => Nil
+        }
+      case (BinaryOpF(BAnd(), l, r, uv), field) =>
+        extractFieldAssignRhs(l, field) ++ extractFieldAssignRhs(r, field)
+      case (BinaryOpF(BOr(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BImplies(), va, vb, vc), ux)   => Nil
+      case (BinaryOpF(BIff(), va, vb, vc), ux)       => Nil
+      case (BinaryOpF(BNeq(), va, vb, vc), ux)       => Nil
+      case (BinaryOpF(BLt(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BGt(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BLe(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BGe(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BIn(), va, vb, vc), ux)        => Nil
+      case (BinaryOpF(BNotIn(), va, vb, vc), ux)     => Nil
+      case (BinaryOpF(BSubset(), va, vb, vc), ux)    => Nil
+      case (BinaryOpF(BUnion(), va, vb, vc), ux)     => Nil
+      case (BinaryOpF(BIntersect(), va, vb, vc), ux) => Nil
+      case (BinaryOpF(BDiff(), va, vb, vc), ux)      => Nil
+      case (BinaryOpF(BAdd(), va, vb, vc), ux)       => Nil
+      case (BinaryOpF(BSub(), va, vb, vc), ux)       => Nil
+      case (BinaryOpF(BMul(), va, vb, vc), ux)       => Nil
+      case (BinaryOpF(BDiv(), va, vb, vc), ux)       => Nil
+      case (UnaryOpF(v, va, vb), ux)                 => Nil
+      case (QuantifierF(v, va, vb, vc), ux)          => Nil
+      case (SomeWrapF(v, va), ux)                    => Nil
+      case (TheF(v, va, vb, vc), ux)                 => Nil
+      case (FieldAccessF(v, va, vb), ux)             => Nil
+      case (EnumAccessF(v, va, vb), ux)              => Nil
+      case (IndexF(v, va, vb), ux)                   => Nil
+      case (CallF(v, va, vb), ux)                    => Nil
+      case (PrimeF(v, va), ux)                       => Nil
+      case (PreF(v, va), ux)                         => Nil
+      case (WithF(v, va, vb), ux)                    => Nil
+      case (IfF(v, va, vb, vc), ux)                  => Nil
+      case (LetF(v, va, vb, vc), ux)                 => Nil
+      case (LambdaF(v, va, vb), ux)                  => Nil
+      case (ConstructorF(v, va, vb), ux)             => Nil
+      case (SetLiteralF(v, va), ux)                  => Nil
+      case (MapLiteralF(v, va), ux)                  => Nil
+      case (SetComprehensionF(v, va, vb, vc), ux)    => Nil
+      case (SeqLiteralF(v, va), ux)                  => Nil
+      case (MatchesF(v, va, vb), ux)                 => Nil
+      case (IntLitF(v, va), ux)                      => Nil
+      case (FloatLitF(v, va), ux)                    => Nil
+      case (StringLitF(v, va), ux)                   => Nil
+      case (BoolLitF(v, va), ux)                     => Nil
+      case (NoneLitF(v), ux)                         => Nil
+      case (IdentifierF(v, va), ux)                  => Nil
+    }
+
+  def ensuresRhsForField(ensures: List[expr_full], field: String): Option[expr_full] =
+    maps[expr_full, expr_full]((e: expr_full) => extractFieldAssignRhs(e, field), ensures) match {
+      case Nil         => None
+      case List(r)     => Some[expr_full](r)
+      case _ :: _ :: _ => None
+    }
+
   def entityNameFromType(x0: type_expr_full): Option[String] = x0 match {
     case RelationTypeF(uu, uv, to, uw) => typeName(to)
     case NamedTypeF(n, ux)             => Some[String](n)
@@ -9728,6 +9790,36 @@ object SpecRestGenerated {
   def exprContainsBoolLit(e: expr_full): Boolean =
     list_ex[expr_full]((a: expr_full) => isBoolLit(a), allSubexprs(e))
 
+  def identifierNameSelect(x0: expr_full): List[String] = x0 match {
+    case IdentifierF(n, uu)               => List(n)
+    case BinaryOpF(v, va, vb, vc)         => Nil
+    case UnaryOpF(v, va, vb)              => Nil
+    case QuantifierF(v, va, vb, vc)       => Nil
+    case SomeWrapF(v, va)                 => Nil
+    case TheF(v, va, vb, vc)              => Nil
+    case FieldAccessF(v, va, vb)          => Nil
+    case EnumAccessF(v, va, vb)           => Nil
+    case IndexF(v, va, vb)                => Nil
+    case CallF(v, va, vb)                 => Nil
+    case PrimeF(v, va)                    => Nil
+    case PreF(v, va)                      => Nil
+    case WithF(v, va, vb)                 => Nil
+    case IfF(v, va, vb, vc)               => Nil
+    case LetF(v, va, vb, vc)              => Nil
+    case LambdaF(v, va, vb)               => Nil
+    case ConstructorF(v, va, vb)          => Nil
+    case SetLiteralF(v, va)               => Nil
+    case MapLiteralF(v, va)               => Nil
+    case SetComprehensionF(v, va, vb, vc) => Nil
+    case SeqLiteralF(v, va)               => Nil
+    case MatchesF(v, va, vb)              => Nil
+    case IntLitF(v, va)                   => Nil
+    case FloatLitF(v, va)                 => Nil
+    case StringLitF(v, va)                => Nil
+    case BoolLitF(v, va)                  => Nil
+    case NoneLitF(v)                      => Nil
+  }
+
   def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
 
   def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
@@ -10066,6 +10158,67 @@ object SpecRestGenerated {
     asBoolLit(e) match {
       case None    => CvBad(ExpectedBoolean(), e)
       case Some(b) => CvOk(PvBool(b))
+    }
+
+  def matchesIdentityShape(x0: expr_full, name: String): Option[String] =
+    (x0, name) match {
+      case (MatchesF(IdentifierF(p, uu), pattern, uv), name) =>
+        p == name match {
+          case true  => Some[String](pattern)
+          case false => None
+        }
+      case (BinaryOpF(v, va, vb, vc), ux)                            => None
+      case (UnaryOpF(v, va, vb), ux)                                 => None
+      case (QuantifierF(v, va, vb, vc), ux)                          => None
+      case (SomeWrapF(v, va), ux)                                    => None
+      case (TheF(v, va, vb, vc), ux)                                 => None
+      case (FieldAccessF(v, va, vb), ux)                             => None
+      case (EnumAccessF(v, va, vb), ux)                              => None
+      case (IndexF(v, va, vb), ux)                                   => None
+      case (CallF(v, va, vb), ux)                                    => None
+      case (PrimeF(v, va), ux)                                       => None
+      case (PreF(v, va), ux)                                         => None
+      case (WithF(v, va, vb), ux)                                    => None
+      case (IfF(v, va, vb, vc), ux)                                  => None
+      case (LetF(v, va, vb, vc), ux)                                 => None
+      case (LambdaF(v, va, vb), ux)                                  => None
+      case (ConstructorF(v, va, vb), ux)                             => None
+      case (SetLiteralF(v, va), ux)                                  => None
+      case (MapLiteralF(v, va), ux)                                  => None
+      case (SetComprehensionF(v, va, vb, vc), ux)                    => None
+      case (SeqLiteralF(v, va), ux)                                  => None
+      case (MatchesF(BinaryOpF(vc, vd, ve, vf), va, vb), ux)         => None
+      case (MatchesF(UnaryOpF(vc, vd, ve), va, vb), ux)              => None
+      case (MatchesF(QuantifierF(vc, vd, ve, vf), va, vb), ux)       => None
+      case (MatchesF(SomeWrapF(vc, vd), va, vb), ux)                 => None
+      case (MatchesF(TheF(vc, vd, ve, vf), va, vb), ux)              => None
+      case (MatchesF(FieldAccessF(vc, vd, ve), va, vb), ux)          => None
+      case (MatchesF(EnumAccessF(vc, vd, ve), va, vb), ux)           => None
+      case (MatchesF(IndexF(vc, vd, ve), va, vb), ux)                => None
+      case (MatchesF(CallF(vc, vd, ve), va, vb), ux)                 => None
+      case (MatchesF(PrimeF(vc, vd), va, vb), ux)                    => None
+      case (MatchesF(PreF(vc, vd), va, vb), ux)                      => None
+      case (MatchesF(WithF(vc, vd, ve), va, vb), ux)                 => None
+      case (MatchesF(IfF(vc, vd, ve, vf), va, vb), ux)               => None
+      case (MatchesF(LetF(vc, vd, ve, vf), va, vb), ux)              => None
+      case (MatchesF(LambdaF(vc, vd, ve), va, vb), ux)               => None
+      case (MatchesF(ConstructorF(vc, vd, ve), va, vb), ux)          => None
+      case (MatchesF(SetLiteralF(vc, vd), va, vb), ux)               => None
+      case (MatchesF(MapLiteralF(vc, vd), va, vb), ux)               => None
+      case (MatchesF(SetComprehensionF(vc, vd, ve, vf), va, vb), ux) => None
+      case (MatchesF(SeqLiteralF(vc, vd), va, vb), ux)               => None
+      case (MatchesF(MatchesF(vc, vd, ve), va, vb), ux)              => None
+      case (MatchesF(IntLitF(vc, vd), va, vb), ux)                   => None
+      case (MatchesF(FloatLitF(vc, vd), va, vb), ux)                 => None
+      case (MatchesF(StringLitF(vc, vd), va, vb), ux)                => None
+      case (MatchesF(BoolLitF(vc, vd), va, vb), ux)                  => None
+      case (MatchesF(NoneLitF(vc), va, vb), ux)                      => None
+      case (IntLitF(v, va), ux)                                      => None
+      case (FloatLitF(v, va), ux)                                    => None
+      case (StringLitF(v, va), ux)                                   => None
+      case (BoolLitF(v, va), ux)                                     => None
+      case (NoneLitF(v), ux)                                         => None
+      case (IdentifierF(v, va), ux)                                  => None
     }
 
   def entityFieldDeclLookup(
@@ -10574,6 +10727,12 @@ object SpecRestGenerated {
       case (RelationTypeF(v, vb, OptionTypeF(ve, vf), vd), va)           => false
       case (RelationTypeF(v, vb, RelationTypeF(ve, vf, vg, vh), vd), va) => false
     }
+
+  def collectIdentifierNames(e: expr_full): List[String] =
+    remdups[String](maps[expr_full, String](
+      (a: expr_full) => identifierNameSelect(a),
+      allSubexprs(e)
+    ))
 
   def withInfoBaseIdentifier(x0: with_info_full): Option[String] = x0 match {
     case WithInfoFull(uu, b) => b

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -365,7 +365,4 @@ object Strategies:
       .filter(_.b.size == 1)
       .flatMap: pr =>
         val paramName = pr.b.head match { case ParamDeclFull(n, _, _) => n }
-        pr.c match
-          case MatchesF(IdentifierF(p, _), pattern, _) if p == paramName =>
-            Some(pattern)
-          case _ => None
+        matchesIdentityShape(pr.c, paramName)

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -103,32 +103,14 @@ object Narration:
       lines.result().mkString("\n")
 
   private def contributingField(e: expr_full, ir: ServiceIRFull): Option[String] =
-    val fields      = scala.collection.mutable.LinkedHashSet.empty[String]
-    val identifiers = scala.collection.mutable.LinkedHashSet.empty[String]
-    def walk(x: expr_full): Unit =
-      x match
-        case FieldAccessF(_, field, _) => fields += field
-        case IdentifierF(n, _)         => identifiers += n
-        case _                         => ()
-      SpecRestGenerated.subexprs(x).foreach(walk)
-    walk(e)
-    fields.headOption.orElse:
+    SpecRestGenerated.collectFieldAccessNames(e).headOption.orElse:
       val stateFieldNames = ir.f.toList.flatMap {
         case StateDeclFull(fs, _) => fs.collect { case StateFieldDeclFull(n, _, _) => n }
       }.toSet
-      identifiers.iterator.find(stateFieldNames.contains)
+      SpecRestGenerated.collectIdentifierNames(e).find(stateFieldNames.contains)
 
   private def ensuresRhsForField(op: OperationDeclFull, field: String): Option[expr_full] =
-    val candidates = op.e.flatMap(extractRhs(_, field))
-    candidates match
-      case Nil      => None
-      case r :: Nil => Some(r)
-      case _        => None
-
-  private def extractRhs(e: expr_full, field: String): List[expr_full] = e match
-    case BinaryOpF(_: BEq, lhs, rhs, _) if assignsField(lhs, field) => List(rhs)
-    case BinaryOpF(_: BAnd, l, r, _)                                => extractRhs(l, field) ++ extractRhs(r, field)
-    case _                                                          => Nil
+    SpecRestGenerated.ensuresRhsForField(op.e, field)
 
   private def describePreInputs(
       ce: DecodedCounterExample,

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -163,6 +163,10 @@ export_code
     flattenEnsures
     collectPrimedIdentifiers
     collectFieldAccessNames
+    collectIdentifierNames
+    extractFieldAssignRhs
+    ensuresRhsForField
+    matchesIdentityShape
     collectPreservedRelations
     containsPreInPlusChain
     detectCreatePattern

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -581,6 +581,18 @@ definition isKeyExistsConj ::
           (case r of IdentifierF s _ \<Rightarrow> s = stateName | _ \<Rightarrow> False)
       | _ \<Rightarrow> False)"
 
+text \<open>Phase 9\<theta> (\<open>matchesIdentityShape\<close>): recognises an expression of
+  shape \<open>matches(IdentifierF n _, pattern)\<close> where \<open>n\<close> equals the given
+  parameter name. Lifted from \<open>testgen.Strategies.inlineMatchesPredicate\<close>
+  — used to detect single-arg predicate bodies that delegate entirely to
+  a regex match (so a strategy filter can inline the pattern directly).\<close>
+
+fun matchesIdentityShape ::
+  "expr_full \<Rightarrow> String.literal \<Rightarrow> String.literal option" where
+  "matchesIdentityShape (MatchesF (IdentifierF p _) pattern _) name =
+     (if p = name then Some pattern else None)"
+| "matchesIdentityShape _ _ = None"
+
 lemmas isPrePrime_code [code]              = isPrePrime.simps
 lemmas hasPrePrime_code [code]             = hasPrePrime_def
 lemmas isBoolLit_code [code]               = isBoolLit.simps

--- a/proofs/isabelle/SpecRest/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/IR_Helpers.thy
@@ -127,6 +127,10 @@ fun fieldAccessNameSelect :: "expr_full \<Rightarrow> String.literal list" where
   "fieldAccessNameSelect (FieldAccessF _ n _) = [n]"
 | "fieldAccessNameSelect _ = []"
 
+fun identifierNameSelect :: "expr_full \<Rightarrow> String.literal list" where
+  "identifierNameSelect (IdentifierF n _) = [n]"
+| "identifierNameSelect _ = []"
+
 fun withInfoSelect :: "expr_full \<Rightarrow> with_info_full list" where
   "withInfoSelect (WithF base ups _) =
      [WithInfoFull (map fieldAssignName ups) (resolveWithBase base)]"
@@ -140,6 +144,10 @@ definition collectPrimedIdentifiers ::
 definition collectFieldAccessNames :: "expr_full \<Rightarrow> String.literal list" where
   "collectFieldAccessNames e =
      remdups (concat (map fieldAccessNameSelect (allSubexprs e)))"
+
+definition collectIdentifierNames :: "expr_full \<Rightarrow> String.literal list" where
+  "collectIdentifierNames e =
+     remdups (concat (map identifierNameSelect (allSubexprs e)))"
 
 definition collectWithFields ::
   "expr_full list \<Rightarrow> with_info_full option" where
@@ -262,6 +270,29 @@ fun assignsField ::
 | "assignsField (PrimeF inner _)     field = assignsField inner field"
 | "assignsField (IndexF base _ _)    field = assignsField base field"
 | "assignsField _                    _     = False"
+
+text \<open>Narration counterexample helpers: \<open>extractFieldAssignRhs\<close> descends
+  through \<open>BAnd\<close>-chains and returns the RHS of every \<open>field = rhs\<close>
+  assignment (decided by \<open>assignsField\<close>) that targets the given field.
+  \<open>ensuresRhsForField\<close> aggregates across an \<open>ensures\<close> clause list and
+  returns the singleton RHS iff exactly one assignment targets the field
+  (multiple matches are ambiguous \<rightarrow> \<open>None\<close>). Lifted from
+  \<open>verify.Narration\<close>.\<close>
+
+fun extractFieldAssignRhs ::
+  "expr_full \<Rightarrow> String.literal \<Rightarrow> expr_full list" where
+  "extractFieldAssignRhs (BinaryOpF BEq lhs rhs _) field =
+     (if assignsField lhs field then [rhs] else [])"
+| "extractFieldAssignRhs (BinaryOpF BAnd l r _) field =
+     extractFieldAssignRhs l field @ extractFieldAssignRhs r field"
+| "extractFieldAssignRhs _ _ = []"
+
+definition ensuresRhsForField ::
+  "expr_full list \<Rightarrow> String.literal \<Rightarrow> expr_full option" where
+  "ensuresRhsForField ensures field \<equiv>
+     (case concat (map (\<lambda>e. extractFieldAssignRhs e field) ensures) of
+        [r] \<Rightarrow> Some r
+      | _   \<Rightarrow> None)"
 
 fun entityNameFromType ::
   "type_expr_full \<Rightarrow> String.literal option" where


### PR DESCRIPTION
## Summary

Three small but repeated recognizers lifted into the shared proof layer:

- `collectIdentifierNames` (IR_Helpers.thy) — companion to existing `collectFieldAccessNames`. One-line def: `remdups (concat (map identifierNameSelect (allSubexprs e)))`. Used by `Narration.contributingField`.
- `extractFieldAssignRhs` / `ensuresRhsForField` (IR_Helpers.thy) — descends `BAnd`-chained `field = rhs` assignment trees via `assignsField` (already lifted) and returns the unique RHS per target field. Used by `Narration.ensuresRhsForField`.
- `matchesIdentityShape` (IR_Analysis.thy) — recognises single-arg predicate body `matches(IdentifierF n _, pattern)`. Used by `Strategies.inlineMatchesPredicate`.

Scala collapses: `Narration.contributingField` 14 LOC → 6 LOC pipeline; `extractRhs` removed entirely; `inlineMatchesPredicate`'s pattern match becomes one call.

## Test plan

- [x] \`isabelle build SpecRest\` clean at 2:21
- [x] \`sbt test\`: 1236/1236 passing (all modules)
- [x] \`sbt scalafixAll\` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted three common IR recognizers into the shared proof layer to unify logic and simplify Scala call sites. This reduces LOC in `verify.Narration` and `testgen.Strategies` and makes the helpers available via codegen.

- New Features
  - Added collectIdentifierNames to gather identifier names across subexpressions.
  - Added extractFieldAssignRhs and ensuresRhsForField to find the unique RHS of BAnd-chained field assignments.
  - Added matchesIdentityShape to detect matches(IdentifierF n _, pattern) for a given parameter.

- Refactors
  - `verify.Narration.contributingField` now uses collectFieldAccessNames + collectIdentifierNames.
  - `verify.Narration.ensuresRhsForField` delegates to ensuresRhsForField; removed custom extractRhs.
  - `testgen.Strategies.inlineMatchesPredicate` now uses matchesIdentityShape.

<sup>Written for commit be858c8de9f5de376069a6fd961d1fd01cbdf283. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

