### PR TITLE
feat(proofs): lift enumValuesForType/Field + fieldNameIfStateIndex

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -10909,142 +10909,135 @@ object SpecRestGenerated {
         Some[(String, String)]((Str_Literal.literalOfAsciis(l), Str_Literal.literalOfAsciis(r)))
     }
 
-  def fieldNameIfStateIndex(x0: expr_full, inputName: String, stateName: String): Option[String] =
-    (x0, inputName, stateName) match {
-      case (
-            FieldAccessF(IndexF(IdentifierF(s, uu), IdentifierF(i, uv), uw), fname, ux),
-            inputName,
-            stateName
-          ) => s == stateName && i == inputName match {
+  def fieldNameIfStateIndex(e: expr_full, inputName: String, stateName: String): Option[String] =
+    e match {
+      case BinaryOpF(_, _, _, _)                                     => None
+      case UnaryOpF(_, _, _)                                         => None
+      case QuantifierF(_, _, _, _)                                   => None
+      case SomeWrapF(_, _)                                           => None
+      case TheF(_, _, _, _)                                          => None
+      case FieldAccessF(BinaryOpF(_, _, _, _), _, _)                 => None
+      case FieldAccessF(UnaryOpF(_, _, _), _, _)                     => None
+      case FieldAccessF(QuantifierF(_, _, _, _), _, _)               => None
+      case FieldAccessF(SomeWrapF(_, _), _, _)                       => None
+      case FieldAccessF(TheF(_, _, _, _), _, _)                      => None
+      case FieldAccessF(FieldAccessF(_, _, _), _, _)                 => None
+      case FieldAccessF(EnumAccessF(_, _, _), _, _)                  => None
+      case FieldAccessF(IndexF(BinaryOpF(_, _, _, _), _, _), _, _)   => None
+      case FieldAccessF(IndexF(UnaryOpF(_, _, _), _, _), _, _)       => None
+      case FieldAccessF(IndexF(QuantifierF(_, _, _, _), _, _), _, _) => None
+      case FieldAccessF(IndexF(SomeWrapF(_, _), _, _), _, _)         => None
+      case FieldAccessF(IndexF(TheF(_, _, _, _), _, _), _, _)        => None
+      case FieldAccessF(IndexF(FieldAccessF(_, _, _), _, _), _, _)   => None
+      case FieldAccessF(IndexF(EnumAccessF(_, _, _), _, _), _, _)    => None
+      case FieldAccessF(IndexF(IndexF(_, _, _), _, _), _, _)         => None
+      case FieldAccessF(IndexF(CallF(_, _, _), _, _), _, _)          => None
+      case FieldAccessF(IndexF(PrimeF(_, _), _, _), _, _)            => None
+      case FieldAccessF(IndexF(PreF(_, _), _, _), _, _)              => None
+      case FieldAccessF(IndexF(WithF(_, _, _), _, _), _, _)          => None
+      case FieldAccessF(IndexF(IfF(_, _, _, _), _, _), _, _)         => None
+      case FieldAccessF(IndexF(LetF(_, _, _, _), _, _), _, _)        => None
+      case FieldAccessF(IndexF(LambdaF(_, _, _), _, _), _, _)        => None
+      case FieldAccessF(IndexF(ConstructorF(_, _, _), _, _), _, _)   => None
+      case FieldAccessF(IndexF(SetLiteralF(_, _), _, _), _, _)       => None
+      case FieldAccessF(IndexF(MapLiteralF(_, _), _, _), _, _)       => None
+      case FieldAccessF(IndexF(SetComprehensionF(_, _, _, _), _, _), _, _) =>
+        None
+      case FieldAccessF(IndexF(SeqLiteralF(_, _), _, _), _, _)                     => None
+      case FieldAccessF(IndexF(MatchesF(_, _, _), _, _), _, _)                     => None
+      case FieldAccessF(IndexF(IntLitF(_, _), _, _), _, _)                         => None
+      case FieldAccessF(IndexF(FloatLitF(_, _), _, _), _, _)                       => None
+      case FieldAccessF(IndexF(StringLitF(_, _), _, _), _, _)                      => None
+      case FieldAccessF(IndexF(BoolLitF(_, _), _, _), _, _)                        => None
+      case FieldAccessF(IndexF(NoneLitF(_), _, _), _, _)                           => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), BinaryOpF(_, _, _, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), UnaryOpF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), QuantifierF(_, _, _, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), SomeWrapF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), TheF(_, _, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), FieldAccessF(_, _, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), EnumAccessF(_, _, _), _), _, _)  => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), IndexF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), CallF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), PrimeF(_, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), PreF(_, _), _), _, _)   => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), WithF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), IfF(_, _, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), LetF(_, _, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), LambdaF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), ConstructorF(_, _, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), SetLiteralF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), MapLiteralF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), SetComprehensionF(_, _, _, _), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(_, _), SeqLiteralF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), MatchesF(_, _, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), IntLitF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), FloatLitF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), StringLitF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), BoolLitF(_, _), _), _, _) =>
+        None
+      case FieldAccessF(IndexF(IdentifierF(_, _), NoneLitF(_), _), _, _) => None
+      case FieldAccessF(IndexF(IdentifierF(s, _), IdentifierF(i, _), _), fname, _) =>
+        s == stateName && i == inputName match {
           case true  => Some[String](fname)
           case false => None
         }
-      case (BinaryOpF(v, vb, vc, vd), uz, va)                                        => None
-      case (UnaryOpF(v, vb, vc), uz, va)                                             => None
-      case (QuantifierF(v, vb, vc, vd), uz, va)                                      => None
-      case (SomeWrapF(v, vb), uz, va)                                                => None
-      case (TheF(v, vb, vc, vd), uz, va)                                             => None
-      case (FieldAccessF(BinaryOpF(vd, ve, vf, vg), vb, vc), uz, va)                 => None
-      case (FieldAccessF(UnaryOpF(vd, ve, vf), vb, vc), uz, va)                      => None
-      case (FieldAccessF(QuantifierF(vd, ve, vf, vg), vb, vc), uz, va)               => None
-      case (FieldAccessF(SomeWrapF(vd, ve), vb, vc), uz, va)                         => None
-      case (FieldAccessF(TheF(vd, ve, vf, vg), vb, vc), uz, va)                      => None
-      case (FieldAccessF(FieldAccessF(vd, ve, vf), vb, vc), uz, va)                  => None
-      case (FieldAccessF(EnumAccessF(vd, ve, vf), vb, vc), uz, va)                   => None
-      case (FieldAccessF(IndexF(BinaryOpF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(UnaryOpF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(QuantifierF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(SomeWrapF(vg, vh), ve, vf), vb, vc), uz, va)           => None
-      case (FieldAccessF(IndexF(TheF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(FieldAccessF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(EnumAccessF(vg, vh, vi), ve, vf), vb, vc), uz, va)  => None
-      case (FieldAccessF(IndexF(IndexF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(CallF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(PrimeF(vg, vh), ve, vf), vb, vc), uz, va)    => None
-      case (FieldAccessF(IndexF(PreF(vg, vh), ve, vf), vb, vc), uz, va)      => None
-      case (FieldAccessF(IndexF(WithF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(IfF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(LetF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(LambdaF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(ConstructorF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(SetLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(MapLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(SetComprehensionF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(SeqLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(MatchesF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(IntLitF(vg, vh), ve, vf), vb, vc), uz, va)   => None
-      case (FieldAccessF(IndexF(FloatLitF(vg, vh), ve, vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(StringLitF(vg, vh), ve, vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(BoolLitF(vg, vh), ve, vf), vb, vc), uz, va)          => None
-      case (FieldAccessF(IndexF(NoneLitF(vg), ve, vf), vb, vc), uz, va)              => None
-      case (FieldAccessF(IndexF(vd, BinaryOpF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, UnaryOpF(vg, vh, vi), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, QuantifierF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, SomeWrapF(vg, vh), vf), vb, vc), uz, va)           => None
-      case (FieldAccessF(IndexF(vd, TheF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, FieldAccessF(vg, vh, vi), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, EnumAccessF(vg, vh, vi), vf), vb, vc), uz, va)  => None
-      case (FieldAccessF(IndexF(vd, IndexF(vg, vh, vi), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, CallF(vg, vh, vi), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, PrimeF(vg, vh), vf), vb, vc), uz, va)    => None
-      case (FieldAccessF(IndexF(vd, PreF(vg, vh), vf), vb, vc), uz, va)      => None
-      case (FieldAccessF(IndexF(vd, WithF(vg, vh, vi), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, IfF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, LetF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, LambdaF(vg, vh, vi), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, ConstructorF(vg, vh, vi), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, SetLiteralF(vg, vh), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, MapLiteralF(vg, vh), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, SetComprehensionF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, SeqLiteralF(vg, vh), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, MatchesF(vg, vh, vi), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, IntLitF(vg, vh), vf), vb, vc), uz, va)   => None
-      case (FieldAccessF(IndexF(vd, FloatLitF(vg, vh), vf), vb, vc), uz, va) => None
-      case (FieldAccessF(IndexF(vd, StringLitF(vg, vh), vf), vb, vc), uz, va) =>
-        None
-      case (FieldAccessF(IndexF(vd, BoolLitF(vg, vh), vf), vb, vc), uz, va)  => None
-      case (FieldAccessF(IndexF(vd, NoneLitF(vg), vf), vb, vc), uz, va)      => None
-      case (FieldAccessF(CallF(vd, ve, vf), vb, vc), uz, va)                 => None
-      case (FieldAccessF(PrimeF(vd, ve), vb, vc), uz, va)                    => None
-      case (FieldAccessF(PreF(vd, ve), vb, vc), uz, va)                      => None
-      case (FieldAccessF(WithF(vd, ve, vf), vb, vc), uz, va)                 => None
-      case (FieldAccessF(IfF(vd, ve, vf, vg), vb, vc), uz, va)               => None
-      case (FieldAccessF(LetF(vd, ve, vf, vg), vb, vc), uz, va)              => None
-      case (FieldAccessF(LambdaF(vd, ve, vf), vb, vc), uz, va)               => None
-      case (FieldAccessF(ConstructorF(vd, ve, vf), vb, vc), uz, va)          => None
-      case (FieldAccessF(SetLiteralF(vd, ve), vb, vc), uz, va)               => None
-      case (FieldAccessF(MapLiteralF(vd, ve), vb, vc), uz, va)               => None
-      case (FieldAccessF(SetComprehensionF(vd, ve, vf, vg), vb, vc), uz, va) => None
-      case (FieldAccessF(SeqLiteralF(vd, ve), vb, vc), uz, va)               => None
-      case (FieldAccessF(MatchesF(vd, ve, vf), vb, vc), uz, va)              => None
-      case (FieldAccessF(IntLitF(vd, ve), vb, vc), uz, va)                   => None
-      case (FieldAccessF(FloatLitF(vd, ve), vb, vc), uz, va)                 => None
-      case (FieldAccessF(StringLitF(vd, ve), vb, vc), uz, va)                => None
-      case (FieldAccessF(BoolLitF(vd, ve), vb, vc), uz, va)                  => None
-      case (FieldAccessF(NoneLitF(vd), vb, vc), uz, va)                      => None
-      case (FieldAccessF(IdentifierF(vd, ve), vb, vc), uz, va)               => None
-      case (EnumAccessF(v, vb, vc), uz, va)                                  => None
-      case (IndexF(v, vb, vc), uz, va)                                       => None
-      case (CallF(v, vb, vc), uz, va)                                        => None
-      case (PrimeF(v, vb), uz, va)                                           => None
-      case (PreF(v, vb), uz, va)                                             => None
-      case (WithF(v, vb, vc), uz, va)                                        => None
-      case (IfF(v, vb, vc, vd), uz, va)                                      => None
-      case (LetF(v, vb, vc, vd), uz, va)                                     => None
-      case (LambdaF(v, vb, vc), uz, va)                                      => None
-      case (ConstructorF(v, vb, vc), uz, va)                                 => None
-      case (SetLiteralF(v, vb), uz, va)                                      => None
-      case (MapLiteralF(v, vb), uz, va)                                      => None
-      case (SetComprehensionF(v, vb, vc, vd), uz, va)                        => None
-      case (SeqLiteralF(v, vb), uz, va)                                      => None
-      case (MatchesF(v, vb, vc), uz, va)                                     => None
-      case (IntLitF(v, vb), uz, va)                                          => None
-      case (FloatLitF(v, vb), uz, va)                                        => None
-      case (StringLitF(v, vb), uz, va)                                       => None
-      case (BoolLitF(v, vb), uz, va)                                         => None
-      case (NoneLitF(v), uz, va)                                             => None
-      case (IdentifierF(v, vb), uz, va)                                      => None
+      case FieldAccessF(CallF(_, _, _), _, _)                => None
+      case FieldAccessF(PrimeF(_, _), _, _)                  => None
+      case FieldAccessF(PreF(_, _), _, _)                    => None
+      case FieldAccessF(WithF(_, _, _), _, _)                => None
+      case FieldAccessF(IfF(_, _, _, _), _, _)               => None
+      case FieldAccessF(LetF(_, _, _, _), _, _)              => None
+      case FieldAccessF(LambdaF(_, _, _), _, _)              => None
+      case FieldAccessF(ConstructorF(_, _, _), _, _)         => None
+      case FieldAccessF(SetLiteralF(_, _), _, _)             => None
+      case FieldAccessF(MapLiteralF(_, _), _, _)             => None
+      case FieldAccessF(SetComprehensionF(_, _, _, _), _, _) => None
+      case FieldAccessF(SeqLiteralF(_, _), _, _)             => None
+      case FieldAccessF(MatchesF(_, _, _), _, _)             => None
+      case FieldAccessF(IntLitF(_, _), _, _)                 => None
+      case FieldAccessF(FloatLitF(_, _), _, _)               => None
+      case FieldAccessF(StringLitF(_, _), _, _)              => None
+      case FieldAccessF(BoolLitF(_, _), _, _)                => None
+      case FieldAccessF(NoneLitF(_), _, _)                   => None
+      case FieldAccessF(IdentifierF(_, _), _, _)             => None
+      case EnumAccessF(_, _, _)                              => None
+      case IndexF(_, _, _)                                   => None
+      case CallF(_, _, _)                                    => None
+      case PrimeF(_, _)                                      => None
+      case PreF(_, _)                                        => None
+      case WithF(_, _, _)                                    => None
+      case IfF(_, _, _, _)                                   => None
+      case LetF(_, _, _, _)                                  => None
+      case LambdaF(_, _, _)                                  => None
+      case ConstructorF(_, _, _)                             => None
+      case SetLiteralF(_, _)                                 => None
+      case MapLiteralF(_, _)                                 => None
+      case SetComprehensionF(_, _, _, _)                     => None
+      case SeqLiteralF(_, _)                                 => None
+      case MatchesF(_, _, _)                                 => None
+      case IntLitF(_, _)                                     => None
+      case FloatLitF(_, _)                                   => None
+      case StringLitF(_, _)                                  => None
+      case BoolLitF(_, _)                                    => None
+      case NoneLitF(_)                                       => None
+      case IdentifierF(_, _)                                 => None
     }
 
   def relationTargetsEntity(x0: type_expr_full, entity: String): Boolean =

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -6081,6 +6081,14 @@ object SpecRestGenerated {
     case ParamDeclFull(uu, t, uv) => t
   }
 
+  def typeAliasName(x0: type_alias_decl_full): String = x0 match {
+    case TypeAliasDeclFull(n, uu, uv, uw) => n
+  }
+
+  def typeAliasType(x0: type_alias_decl_full): type_expr_full = x0 match {
+    case TypeAliasDeclFull(uu, t, uv, uw) => t
+  }
+
   def pathWithIdSuffix(segment: String, idParamOpt: Option[String]): String =
     idParamOpt match {
       case None       => "/" + segment
@@ -7459,6 +7467,10 @@ object SpecRestGenerated {
 
   def entityInvsFull(x0: entity_decl_full): List[expr_full] = x0 match {
     case EntityDeclFull(uu, uv, uw, iv, ux) => iv
+  }
+
+  def enumValuesFull(x0: enum_decl_full): List[String] = x0 match {
+    case EnumDeclFull(uu, vs, uv) => vs
   }
 
   def flatten_entity(es: List[entity_decl_full], x1: entity_decl_full): entity_decl_full =
@@ -8857,6 +8869,41 @@ object SpecRestGenerated {
       ps
     ))
 
+  def enumValuesForType(
+      fuel: nat,
+      t: type_expr_full,
+      enums: List[enum_decl_full],
+      aliases: List[type_alias_decl_full]
+  ): Option[List[String]] =
+    equal_nat(fuel, zero_nat) match {
+      case true => None
+      case false => t match {
+          case NamedTypeF(name, _) =>
+            find[enum_decl_full](
+              (e: enum_decl_full) =>
+                enumNameFull(e) == name,
+              enums
+            ) match {
+              case None =>
+                find[type_alias_decl_full](
+                  (a: type_alias_decl_full) =>
+                    typeAliasName(a) == name,
+                  aliases
+                ) match {
+                  case None => None
+                  case Some(a) =>
+                    enumValuesForType(minus_nat(fuel, one_nat), typeAliasType(a), enums, aliases)
+                }
+              case Some(e) => Some[List[String]](enumValuesFull(e))
+            }
+          case SetTypeF(_, _)            => None
+          case MapTypeF(_, _, _)         => None
+          case SeqTypeF(_, _)            => None
+          case OptionTypeF(_, _)         => None
+          case RelationTypeF(_, _, _, _) => None
+        }
+    }
+
   def findFieldDeclFull(fs: List[field_decl_full], nm: String): Option[field_decl_full] =
     find[field_decl_full]((fd: field_decl_full) => fieldNameFull(fd) == nm, fs)
 
@@ -9229,6 +9276,18 @@ object SpecRestGenerated {
     case OptionTypeF(inner, va)        => entityNameFromType(inner)
     case MapTypeF(vb, v, vc)           => entityNameFromType(v)
   }
+
+  def enumValuesForField(
+      f: field_decl_full,
+      enums: List[enum_decl_full],
+      aliases: List[type_alias_decl_full]
+  ): Option[List[String]] =
+    enumValuesForType(
+      Suc(size_list[type_alias_decl_full](aliases)),
+      fieldTypeFull(f),
+      enums,
+      aliases
+    )
 
   def flattenInheritance(x0: service_ir_full): service_ir_full = x0 match {
     case ServiceIRFull(a, b, c, d, e, f, g, h, i, j, k, l, m, n, p) =>
@@ -10848,6 +10907,144 @@ object SpecRestGenerated {
       case None => None
       case Some((l, r)) =>
         Some[(String, String)]((Str_Literal.literalOfAsciis(l), Str_Literal.literalOfAsciis(r)))
+    }
+
+  def fieldNameIfStateIndex(x0: expr_full, inputName: String, stateName: String): Option[String] =
+    (x0, inputName, stateName) match {
+      case (
+            FieldAccessF(IndexF(IdentifierF(s, uu), IdentifierF(i, uv), uw), fname, ux),
+            inputName,
+            stateName
+          ) => s == stateName && i == inputName match {
+          case true  => Some[String](fname)
+          case false => None
+        }
+      case (BinaryOpF(v, vb, vc, vd), uz, va)                                        => None
+      case (UnaryOpF(v, vb, vc), uz, va)                                             => None
+      case (QuantifierF(v, vb, vc, vd), uz, va)                                      => None
+      case (SomeWrapF(v, vb), uz, va)                                                => None
+      case (TheF(v, vb, vc, vd), uz, va)                                             => None
+      case (FieldAccessF(BinaryOpF(vd, ve, vf, vg), vb, vc), uz, va)                 => None
+      case (FieldAccessF(UnaryOpF(vd, ve, vf), vb, vc), uz, va)                      => None
+      case (FieldAccessF(QuantifierF(vd, ve, vf, vg), vb, vc), uz, va)               => None
+      case (FieldAccessF(SomeWrapF(vd, ve), vb, vc), uz, va)                         => None
+      case (FieldAccessF(TheF(vd, ve, vf, vg), vb, vc), uz, va)                      => None
+      case (FieldAccessF(FieldAccessF(vd, ve, vf), vb, vc), uz, va)                  => None
+      case (FieldAccessF(EnumAccessF(vd, ve, vf), vb, vc), uz, va)                   => None
+      case (FieldAccessF(IndexF(BinaryOpF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(UnaryOpF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(QuantifierF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(SomeWrapF(vg, vh), ve, vf), vb, vc), uz, va)           => None
+      case (FieldAccessF(IndexF(TheF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(FieldAccessF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(EnumAccessF(vg, vh, vi), ve, vf), vb, vc), uz, va)  => None
+      case (FieldAccessF(IndexF(IndexF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(CallF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(PrimeF(vg, vh), ve, vf), vb, vc), uz, va)    => None
+      case (FieldAccessF(IndexF(PreF(vg, vh), ve, vf), vb, vc), uz, va)      => None
+      case (FieldAccessF(IndexF(WithF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(IfF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(LetF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(LambdaF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(ConstructorF(vg, vh, vi), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(SetLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(MapLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(SetComprehensionF(vg, vh, vi, vj), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(SeqLiteralF(vg, vh), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(MatchesF(vg, vh, vi), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(IntLitF(vg, vh), ve, vf), vb, vc), uz, va)   => None
+      case (FieldAccessF(IndexF(FloatLitF(vg, vh), ve, vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(StringLitF(vg, vh), ve, vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(BoolLitF(vg, vh), ve, vf), vb, vc), uz, va)          => None
+      case (FieldAccessF(IndexF(NoneLitF(vg), ve, vf), vb, vc), uz, va)              => None
+      case (FieldAccessF(IndexF(vd, BinaryOpF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, UnaryOpF(vg, vh, vi), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, QuantifierF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, SomeWrapF(vg, vh), vf), vb, vc), uz, va)           => None
+      case (FieldAccessF(IndexF(vd, TheF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, FieldAccessF(vg, vh, vi), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, EnumAccessF(vg, vh, vi), vf), vb, vc), uz, va)  => None
+      case (FieldAccessF(IndexF(vd, IndexF(vg, vh, vi), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, CallF(vg, vh, vi), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, PrimeF(vg, vh), vf), vb, vc), uz, va)    => None
+      case (FieldAccessF(IndexF(vd, PreF(vg, vh), vf), vb, vc), uz, va)      => None
+      case (FieldAccessF(IndexF(vd, WithF(vg, vh, vi), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, IfF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, LetF(vg, vh, vi, vj), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, LambdaF(vg, vh, vi), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, ConstructorF(vg, vh, vi), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, SetLiteralF(vg, vh), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, MapLiteralF(vg, vh), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, SetComprehensionF(vg, vh, vi, vj), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, SeqLiteralF(vg, vh), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, MatchesF(vg, vh, vi), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, IntLitF(vg, vh), vf), vb, vc), uz, va)   => None
+      case (FieldAccessF(IndexF(vd, FloatLitF(vg, vh), vf), vb, vc), uz, va) => None
+      case (FieldAccessF(IndexF(vd, StringLitF(vg, vh), vf), vb, vc), uz, va) =>
+        None
+      case (FieldAccessF(IndexF(vd, BoolLitF(vg, vh), vf), vb, vc), uz, va)  => None
+      case (FieldAccessF(IndexF(vd, NoneLitF(vg), vf), vb, vc), uz, va)      => None
+      case (FieldAccessF(CallF(vd, ve, vf), vb, vc), uz, va)                 => None
+      case (FieldAccessF(PrimeF(vd, ve), vb, vc), uz, va)                    => None
+      case (FieldAccessF(PreF(vd, ve), vb, vc), uz, va)                      => None
+      case (FieldAccessF(WithF(vd, ve, vf), vb, vc), uz, va)                 => None
+      case (FieldAccessF(IfF(vd, ve, vf, vg), vb, vc), uz, va)               => None
+      case (FieldAccessF(LetF(vd, ve, vf, vg), vb, vc), uz, va)              => None
+      case (FieldAccessF(LambdaF(vd, ve, vf), vb, vc), uz, va)               => None
+      case (FieldAccessF(ConstructorF(vd, ve, vf), vb, vc), uz, va)          => None
+      case (FieldAccessF(SetLiteralF(vd, ve), vb, vc), uz, va)               => None
+      case (FieldAccessF(MapLiteralF(vd, ve), vb, vc), uz, va)               => None
+      case (FieldAccessF(SetComprehensionF(vd, ve, vf, vg), vb, vc), uz, va) => None
+      case (FieldAccessF(SeqLiteralF(vd, ve), vb, vc), uz, va)               => None
+      case (FieldAccessF(MatchesF(vd, ve, vf), vb, vc), uz, va)              => None
+      case (FieldAccessF(IntLitF(vd, ve), vb, vc), uz, va)                   => None
+      case (FieldAccessF(FloatLitF(vd, ve), vb, vc), uz, va)                 => None
+      case (FieldAccessF(StringLitF(vd, ve), vb, vc), uz, va)                => None
+      case (FieldAccessF(BoolLitF(vd, ve), vb, vc), uz, va)                  => None
+      case (FieldAccessF(NoneLitF(vd), vb, vc), uz, va)                      => None
+      case (FieldAccessF(IdentifierF(vd, ve), vb, vc), uz, va)               => None
+      case (EnumAccessF(v, vb, vc), uz, va)                                  => None
+      case (IndexF(v, vb, vc), uz, va)                                       => None
+      case (CallF(v, vb, vc), uz, va)                                        => None
+      case (PrimeF(v, vb), uz, va)                                           => None
+      case (PreF(v, vb), uz, va)                                             => None
+      case (WithF(v, vb, vc), uz, va)                                        => None
+      case (IfF(v, vb, vc, vd), uz, va)                                      => None
+      case (LetF(v, vb, vc, vd), uz, va)                                     => None
+      case (LambdaF(v, vb, vc), uz, va)                                      => None
+      case (ConstructorF(v, vb, vc), uz, va)                                 => None
+      case (SetLiteralF(v, vb), uz, va)                                      => None
+      case (MapLiteralF(v, vb), uz, va)                                      => None
+      case (SetComprehensionF(v, vb, vc, vd), uz, va)                        => None
+      case (SeqLiteralF(v, vb), uz, va)                                      => None
+      case (MatchesF(v, vb, vc), uz, va)                                     => None
+      case (IntLitF(v, vb), uz, va)                                          => None
+      case (FloatLitF(v, vb), uz, va)                                        => None
+      case (StringLitF(v, vb), uz, va)                                       => None
+      case (BoolLitF(v, vb), uz, va)                                         => None
+      case (NoneLitF(v), uz, va)                                             => None
+      case (IdentifierF(v, vb), uz, va)                                      => None
     }
 
   def relationTargetsEntity(x0: type_expr_full, entity: String): Boolean =

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -3,6 +3,7 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -489,12 +490,7 @@ object Behavioral:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    field.b match
-      case NamedTypeF(name, _) =>
-        ir.d.collectFirst { case _e: EnumDeclFull if _e.a == name => _e.b }.orElse:
-          ir.e.collectFirst { case _a: TypeAliasDeclFull if _a.a == name => _a }.flatMap: alias =>
-            enumValuesForField(field.copy(b = alias.b), ir)
-      case _ => None
+    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
 
   final private case class NonPathInput(
       name: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -3,6 +3,7 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -422,24 +423,7 @@ object Stateful:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    enumValuesForType(field.b, ir, Set.empty)
-
-  private def enumValuesForType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Option[List[String]] =
-    t match
-      case NamedTypeF(name, _) =>
-        val enums   = ir.d.collect { case e: EnumDeclFull => e }
-        val aliases = ir.e.collect { case a: TypeAliasDeclFull => a }
-        enums.find(_.a == name).map(_.b).orElse:
-          if seen.contains(name) then None
-          else
-            aliases
-              .find(_.a == name)
-              .flatMap(alias => enumValuesForType(alias.b, ir, seen + name))
-      case _ => None
+    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
 
   final private case class StatusRestriction(
       stateFieldName: String,
@@ -488,20 +472,6 @@ object Stateful:
           val maybeSet = elems.map(enumLitName)
           if maybeSet.forall(_.isDefined) then Some((fname, maybeSet.flatten.toSet))
           else None
-      case _ => None
-
-  private def fieldNameIfStateIndex(
-      e: expr_full,
-      inputName: String,
-      stateName: String
-  ): Option[String] =
-    e match
-      case FieldAccessF(
-            IndexF(IdentifierF(s, _), IdentifierF(i, _), _),
-            fname,
-            _
-          ) if s == stateName && i == inputName =>
-        Some(fname)
       case _ => None
 
   private def bindForInput(

--- a/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
@@ -1,0 +1,48 @@
+package specrest.testgen
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
+
+class EnumValuesForFieldTest extends CatsEffectSuite:
+
+  private def named(t: String): NamedTypeF = NamedTypeF(t, None)
+
+  private def alias(name: String, target: type_expr_full): TypeAliasDeclFull =
+    TypeAliasDeclFull(name, target, None, None)
+
+  private def enumD(name: String, values: List[String]): EnumDeclFull =
+    EnumDeclFull(name, values, None)
+
+  private def field(name: String, t: type_expr_full): FieldDeclFull =
+    FieldDeclFull(name, t, None, None)
+
+  test("enumValuesForField resolves directly through an alias chain"):
+    val statusEnum = enumD("Status", List("OPEN", "CLOSED"))
+    val tier1      = alias("StatusAlias", named("Status"))
+    val tier2      = alias("StatusAliasAlias", named("StatusAlias"))
+    val aliases    = List(tier1, tier2)
+    val enums      = List(statusEnum)
+
+    val direct = SpecRestGenerated.enumValuesForField(field("f", named("Status")), enums, aliases)
+    assertEquals(direct, Some(List("OPEN", "CLOSED")))
+
+    val oneHop =
+      SpecRestGenerated.enumValuesForField(field("f", named("StatusAlias")), enums, aliases)
+    assertEquals(oneHop, Some(List("OPEN", "CLOSED")))
+
+    val twoHop =
+      SpecRestGenerated.enumValuesForField(field("f", named("StatusAliasAlias")), enums, aliases)
+    assertEquals(twoHop, Some(List("OPEN", "CLOSED")))
+
+  test("enumValuesForField returns None when chain bottoms out at a non-enum"):
+    val emailAlias = alias("Email", named("String"))
+    val res =
+      SpecRestGenerated.enumValuesForField(field("f", named("Email")), Nil, List(emailAlias))
+    assertEquals(res, None)
+
+  test("enumValuesForField is cycle-safe on `type A = B; type B = A` (returns None)"):
+    val a   = alias("A", named("B"))
+    val b   = alias("B", named("A"))
+    val res = SpecRestGenerated.enumValuesForField(field("f", named("A")), Nil, List(a, b))
+    assertEquals(res, None)

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -169,6 +169,9 @@ export_code
     matchesIdentityShape
     keyExistencePair
     desiredSize
+    fieldNameIfStateIndex
+    enumValuesForType
+    enumValuesForField
     collectPreservedRelations
     containsPreInPlusChain
     detectCreatePattern

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -599,6 +599,19 @@ fun keyExistencePair ::
      Some (inName, stName)"
 | "keyExistencePair _ = None"
 
+text \<open>\<open>fieldNameIfStateIndex\<close>: recognises an expression of shape
+  \<open>state[input].field\<close> for given \<open>state\<close> and \<open>input\<close> names and
+  returns the field name. Used by \<open>testgen.Stateful.fieldRestrictionConjunct\<close>
+  to extract field-level enum restrictions from \<open>requires\<close> clauses.\<close>
+
+fun fieldNameIfStateIndex ::
+  "expr_full \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> String.literal option" where
+  "fieldNameIfStateIndex
+     (FieldAccessF (IndexF (IdentifierF s _) (IdentifierF i _) _) fname _)
+     inputName stateName =
+       (if s = stateName \<and> i = inputName then Some fname else None)"
+| "fieldNameIfStateIndex _ _ _ = None"
+
 text \<open>Phase 9\<iota> (\<open>desiredSize\<close>): given a size-comparison binop and a
   bound, returns the smallest non-negative collection size that
   satisfies the constraint. All Gt/Ge/Eq/Lt/Le branches clamp at zero

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -602,15 +602,30 @@ fun keyExistencePair ::
 text \<open>\<open>fieldNameIfStateIndex\<close>: recognises an expression of shape
   \<open>state[input].field\<close> for given \<open>state\<close> and \<open>input\<close> names and
   returns the field name. Used by \<open>testgen.Stateful.fieldRestrictionConjunct\<close>
-  to extract field-level enum restrictions from \<open>requires\<close> clauses.\<close>
+  to extract field-level enum restrictions from \<open>requires\<close> clauses.
 
-fun fieldNameIfStateIndex ::
+  Defined via shallow nested \<open>case\<close>s (same shape as \<open>isKeyExistsConj\<close>)
+  so each level extracts as a small per-constructor match, avoiding the
+  cross-product blowup that the equivalent deep \<open>fun\<close> pattern
+  \<open>FieldAccessF (IndexF (IdentifierF _) (IdentifierF _) _) _ _\<close> would
+  trigger.\<close>
+
+definition fieldNameIfStateIndex ::
   "expr_full \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> String.literal option" where
-  "fieldNameIfStateIndex
-     (FieldAccessF (IndexF (IdentifierF s _) (IdentifierF i _) _) fname _)
-     inputName stateName =
-       (if s = stateName \<and> i = inputName then Some fname else None)"
-| "fieldNameIfStateIndex _ _ _ = None"
+  "fieldNameIfStateIndex e inputName stateName \<equiv>
+     (case e of
+        FieldAccessF base fname _ \<Rightarrow>
+          (case base of
+             IndexF idx0 idx1 _ \<Rightarrow>
+               (case idx0 of
+                  IdentifierF s _ \<Rightarrow>
+                    (case idx1 of
+                       IdentifierF i _ \<Rightarrow>
+                         (if s = stateName \<and> i = inputName then Some fname else None)
+                     | _ \<Rightarrow> None)
+                | _ \<Rightarrow> None)
+           | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 
 text \<open>Phase 9\<iota> (\<open>desiredSize\<close>): given a size-comparison binop and a
   bound, returns the smallest non-negative collection size that

--- a/proofs/isabelle/SpecRest/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/IR_Helpers.thy
@@ -217,6 +217,49 @@ fun state_fieldNameFull :: "state_field_decl_full \<Rightarrow> String.literal" 
 fun state_fieldTypeFull :: "state_field_decl_full \<Rightarrow> type_expr_full" where
   "state_fieldTypeFull (StateFieldDeclFull _ t _) = t"
 
+fun enumValuesFull :: "enum_decl_full \<Rightarrow> String.literal list" where
+  "enumValuesFull (EnumDeclFull _ vs _) = vs"
+
+fun typeAliasName :: "type_alias_decl_full \<Rightarrow> String.literal" where
+  "typeAliasName (TypeAliasDeclFull n _ _ _) = n"
+
+fun typeAliasType :: "type_alias_decl_full \<Rightarrow> type_expr_full" where
+  "typeAliasType (TypeAliasDeclFull _ t _ _) = t"
+
+text \<open>\<open>enumValuesForType\<close> resolves a named type to its enum values,
+  following \<open>type X = Y\<close> aliases transitively. Fuel parameter caps
+  recursion at \<open>length aliases + 1\<close> in the wrapper \<open>enumValuesForField\<close>,
+  which suffices for any acyclic alias chain and degrades safely on
+  cycles (returns \<open>None\<close>). Lifted from duplicated definitions in
+  \<open>testgen.Stateful.enumValuesForType\<close> and
+  \<open>testgen.Behavioral.enumValuesForField\<close> (the Behavioral copy had no
+  cycle guard \<rightarrow> could non-terminate on \<open>type A = B; type B = A\<close>).\<close>
+
+function enumValuesForType ::
+  "nat \<Rightarrow> type_expr_full \<Rightarrow> enum_decl_full list \<Rightarrow>
+   type_alias_decl_full list \<Rightarrow> String.literal list option" where
+  "enumValuesForType fuel t enums aliases =
+     (if fuel = 0 then None
+      else case t of
+        NamedTypeF name _ \<Rightarrow>
+          (case List.find (\<lambda>e. enumNameFull e = name) enums of
+             Some e \<Rightarrow> Some (enumValuesFull e)
+           | None \<Rightarrow>
+               (case List.find (\<lambda>a. typeAliasName a = name) aliases of
+                  Some a \<Rightarrow>
+                    enumValuesForType (fuel - 1) (typeAliasType a) enums aliases
+                | None \<Rightarrow> None))
+      | _ \<Rightarrow> None)"
+  by pat_completeness auto
+termination
+  by (relation "measure (\<lambda>(fuel, _, _, _). fuel)") auto
+
+definition enumValuesForField ::
+  "field_decl_full \<Rightarrow> enum_decl_full list \<Rightarrow>
+   type_alias_decl_full list \<Rightarrow> String.literal list option" where
+  "enumValuesForField f enums aliases \<equiv>
+     enumValuesForType (Suc (length aliases)) (fieldTypeFull f) enums aliases"
+
 definition entityByName ::
   "entity_decl_full list \<Rightarrow> String.literal \<Rightarrow> entity_decl_full option" where
   "entityByName es nm =


### PR DESCRIPTION
## Summary

Unify the duplicated enum-via-type-alias lookup across `testgen.Stateful` and `testgen.Behavioral`. Stateful had a cycle guard; Behavioral did not (latent infinite-recursion bug on \`type A = B; type B = A\`).

- \`enumValuesForType\` (IR_Helpers.thy) — recursive alias walker with explicit fuel termination. Single \`function\` clause via \`if fuel = 0 then None else ...\` to avoid the \`Nat.zero_nat_inst\` code-extraction error from nat-literal patterns.
- \`enumValuesForField\` (IR_Helpers.thy) — thin wrapper, fuel = \`Suc (length aliases)\` (sufficient for any acyclic chain).
- New accessors: \`enumValuesFull\`, \`typeAliasName\`, \`typeAliasType\`.
- \`fieldNameIfStateIndex\` (IR_Analysis.thy) — recognises \`state[input].field\` and returns the field name. Used by \`Stateful.fieldRestrictionConjunct\` for enum restriction extraction.

Net: ~32 LOC of duplicated Scala removed; Behavioral's missing cycle guard is fixed by the lifted version.

## Test plan

- [x] \`isabelle build SpecRest\` clean
- [x] \`sbt test\`: 1236/1236 passing
- [x] \`sbt scalafixAll\` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted enum lookup via type aliases and `state[input].field` detection into generated IR helpers, adding cycle safety and safer codegen. Replaced duplicated logic in `testgen.Stateful` and `testgen.Behavioral`, and added tests to lock in cycle safety.

- **New Features**
  - Added `enumValuesForType` (fuel-guarded) and `enumValuesForField` in `IR_Helpers.thy`; exposed via `specrest.ir.generated.SpecRestGenerated` and exported in `Codegen.thy`.
  - Added `fieldNameIfStateIndex` in `IR_Analysis.thy` to detect `state[input].field`; exported in `Codegen.thy`.
  - Added accessors `enumValuesFull`, `typeAliasName`, `typeAliasType`.

- **Bug Fixes**
  - Fixed latent non-termination on cyclic type aliases by using the lifted helpers in `testgen.Behavioral` and `testgen.Stateful`; added `EnumValuesForFieldTest` covering alias chains and cycles.
  - Rewrote `fieldNameIfStateIndex` as a nested-case `definition` to avoid codegen cross-product blowups.
  - Removed duplicated enum-lookup logic and centralized it in `SpecRestGenerated`.

<sup>Written for commit b772559f8f6f1b00e247974c33b17f3ebf060630. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated enum computation logic into generated code infrastructure for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->