### PR TITLE
feat(proofs): lift structuralIneligibility + DRY keyExistencePair callers

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -995,6 +995,11 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
+  sealed abstract class structural_ineligibility
+  final case class SceReferencesPrePrime()   extends structural_ineligibility
+  final case class SceReferencesStateField() extends structural_ineligibility
+  final case class SceReferencesNoOutput()   extends structural_ineligibility
+
   sealed abstract class dfs_state_ext[A]
   final case class dfs_state_exta[A](
       a: List[String],
@@ -11554,6 +11559,32 @@ object SpecRestGenerated {
     x0 match {
       case OperationClassification(uu, uv, uw, ux, t, uy, uz) => t
     }
+
+  def structuralIneligibility(
+      e: expr_full,
+      outputs: List[String],
+      stateFields: List[String]
+  ): Option[structural_ineligibility] = {
+    val fvs = free_vars(e): List[String];
+    hasPrePrime(e) match {
+      case true => Some[structural_ineligibility](SceReferencesPrePrime())
+      case false => list_ex[String](
+          (a: String) =>
+            membera[String](stateFields, a),
+          fvs
+        ) match {
+          case true => Some[structural_ineligibility](SceReferencesStateField())
+          case false => !list_ex[String](
+              (a: String) =>
+                membera[String](outputs, a),
+              fvs
+            ) match {
+              case true  => Some[structural_ineligibility](SceReferencesNoOutput())
+              case false => None
+            }
+        }
+    }
+  }
 
   def typeMismatchDiagnostics(e: expr_full): List[(type_mismatch_kind, Option[span_t])] =
     map_filter[expr_full, (type_mismatch_kind, Option[span_t])](

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -438,10 +438,11 @@ object Stateful:
     val stateFields = stateFieldNames(ir)
     val inputs      = opDecl.b.collect { case p: ParamDeclFull => p.a }.toSet
     val conjuncts   = flattenAndAll(opDecl.d)
-    val keyExists = conjuncts.collectFirst:
-      case BinaryOpF(BIn(), IdentifierF(in, _), IdentifierF(state, _), _)
-          if inputs.contains(in) && stateFields.contains(state) =>
-        (in, state)
+    val keyExists = conjuncts.iterator
+      .flatMap(c =>
+        keyExistencePair(c).filter((in, st) => inputs.contains(in) && stateFields.contains(st))
+      )
+      .nextOption()
     keyExists.flatMap: (inputName, stateName) =>
       var perField     = Map.empty[String, Set[String]]
       var unrecognized = false
@@ -917,8 +918,9 @@ object Stateful:
   ): Boolean =
     e match
       case _ if isTrueLit(e) => true
-      case BinaryOpF(BIn(), IdentifierF(in, _), IdentifierF(state, _), _)
-          if bundleInputs.contains(in) && stateFields.contains(state) =>
+      case _
+          if keyExistencePair(e)
+            .exists((in, st) => bundleInputs.contains(in) && stateFields.contains(st)) =>
         true
       case BinaryOpF(BAnd(), l, r, _) =>
         requiresIsSatisfiedByBundles(l, bundleInputs, stateFields) &&

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -164,23 +164,21 @@ object Structural:
       outputs: Set[String],
       stateFields: Set[String]
   ): Boolean =
-    val fvs = free_vars(e)
-    !fvs.exists(stateFields.contains) && !hasPrePrime(e) &&
-    fvs.exists(outputs.contains)
+    structuralIneligibility(e, outputs.toList, stateFields.toList).isEmpty
 
   private def nonPureOutputReason(
       e: expr_full,
       outputs: Set[String],
       stateFields: Set[String]
   ): String =
-    val fvs = free_vars(e)
-    if hasPrePrime(e) then
-      "ensures references pre()/prime() — covered by behavioral/stateful layers"
-    else if fvs.exists(stateFields.contains) then
-      "ensures references state field — covered by stateful invariants"
-    else if !fvs.exists(outputs.contains) then
-      "ensures references no output field; not a structural-checkable shape"
-    else "ensures not eligible for structural check"
+    structuralIneligibility(e, outputs.toList, stateFields.toList) match
+      case Some(SceReferencesPrePrime()) =>
+        "ensures references pre()/prime() — covered by behavioral/stateful layers"
+      case Some(SceReferencesStateField()) =>
+        "ensures references state field — covered by stateful invariants"
+      case Some(SceReferencesNoOutput()) =>
+        "ensures references no output field; not a structural-checkable shape"
+      case None => "ensures not eligible for structural check"
 
   // -- File rendering --------------------------------------------------------
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -123,10 +123,20 @@ object Structural:
       val stateFields = ir.f.toList.flatMap { case StateDeclFull(_fs, _) =>
         _fs.collect { case StateFieldDeclFull(_n, _, _) => _n }
       }.toSet
-      val outputNames = opDecl.c.collect { case ParamDeclFull(_n, _, _) => _n }.toSet
+      val outputNames     = opDecl.c.collect { case ParamDeclFull(_n, _, _) => _n }.toSet
+      val outputNamesList = outputNames.toList
+      val stateFieldsList = stateFields.toList
       opDecl.e.zipWithIndex.flatMap: (clause, idx) =>
-        if !referencesOnlyInputsAndOutputs(clause, outputNames, stateFields) then
-          val reason = nonPureOutputReason(clause, outputNames, stateFields)
+        val inelig = structuralIneligibility(clause, outputNamesList, stateFieldsList)
+        if inelig.isDefined then
+          val reason = inelig match
+            case Some(SceReferencesPrePrime()) =>
+              "ensures references pre()/prime() — covered by behavioral/stateful layers"
+            case Some(SceReferencesStateField()) =>
+              "ensures references state field — covered by stateful invariants"
+            case Some(SceReferencesNoOutput()) =>
+              "ensures references no output field; not a structural-checkable shape"
+            case None => "ensures not eligible for structural check"
           List(Left(TestSkip(opDecl.a, s"structural_ensures[$idx]", reason)))
         else
           val ctx = TestCtx.fromOperation(opDecl, ir, CaptureMode.PostState)
@@ -158,27 +168,6 @@ object Structural:
                 s"    assert $text, ${ExprToPython.pyString(s"ensures violated (${opDecl.a}#$idx)")}\n"
               )
               List(Right(StructuralCheck(checkName, sb.toString)))
-
-  private def referencesOnlyInputsAndOutputs(
-      e: expr_full,
-      outputs: Set[String],
-      stateFields: Set[String]
-  ): Boolean =
-    structuralIneligibility(e, outputs.toList, stateFields.toList).isEmpty
-
-  private def nonPureOutputReason(
-      e: expr_full,
-      outputs: Set[String],
-      stateFields: Set[String]
-  ): String =
-    structuralIneligibility(e, outputs.toList, stateFields.toList) match
-      case Some(SceReferencesPrePrime()) =>
-        "ensures references pre()/prime() — covered by behavioral/stateful layers"
-      case Some(SceReferencesStateField()) =>
-        "ensures references state field — covered by stateful invariants"
-      case Some(SceReferencesNoOutput()) =>
-        "ensures references no output field; not a structural-checkable shape"
-      case None => "ensures not eligible for structural check"
 
   // -- File rendering --------------------------------------------------------
 

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -172,6 +172,7 @@ export_code
     fieldNameIfStateIndex
     enumValuesForType
     enumValuesForField
+    structuralIneligibility
     collectPreservedRelations
     containsPreInPlusChain
     detectCreatePattern

--- a/proofs/isabelle/SpecRest/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/IR_Analysis.thy
@@ -627,6 +627,33 @@ definition fieldNameIfStateIndex ::
            | _ \<Rightarrow> None)
       | _ \<Rightarrow> None)"
 
+text \<open>Phase 9\<kappa> (\<open>structuralIneligibility\<close>): classifies why an
+  \<open>ensures\<close> clause is not structurally checkable (the structural layer
+  emits one HTTP round-trip and asserts a single boolean over the
+  response, so it cannot observe pre/prime/state values). Returns
+  \<open>None\<close> when the clause IS structurally checkable
+  (\<open>\<not> hasPrePrime e \<and> no fv \<in> stateFields \<and> some fv \<in> outputs\<close>),
+  else the categorical reason. Lifted from
+  \<open>testgen.Structural.referencesOnlyInputsAndOutputs\<close> +
+  \<open>nonPureOutputReason\<close>; rendering of the reason text stays Scala-side.\<close>
+
+datatype (plugins only: code size) structural_ineligibility =
+    SceReferencesPrePrime
+  | SceReferencesStateField
+  | SceReferencesNoOutput
+
+definition structuralIneligibility ::
+  "expr_full \<Rightarrow> String.literal list \<Rightarrow> String.literal list \<Rightarrow>
+   structural_ineligibility option" where
+  "structuralIneligibility e outputs stateFields \<equiv>
+     (let fvs = free_vars e in
+        if hasPrePrime e then Some SceReferencesPrePrime
+        else if list_ex (\<lambda>n. List.member stateFields n) fvs
+             then Some SceReferencesStateField
+        else if \<not> list_ex (\<lambda>n. List.member outputs n) fvs
+             then Some SceReferencesNoOutput
+        else None)"
+
 text \<open>Phase 9\<iota> (\<open>desiredSize\<close>): given a size-comparison binop and a
   bound, returns the smallest non-negative collection size that
   satisfies the constraint. All Gt/Ge/Eq/Lt/Le branches clamp at zero


### PR DESCRIPTION
## Summary

- \`structuralIneligibility\` (IR_Analysis.thy) — ADT classifier for why an \`ensures\` clause is not structurally checkable. Lifts both \`Structural.referencesOnlyInputsAndOutputs\` and \`nonPureOutputReason\` into one classifier; reason-text rendering stays Scala-side. Eliminates double-evaluation of \`free_vars\` / \`hasPrePrime\`.
- Refactor Stateful's two inline \`BinaryOpF BIn Identifier Identifier\` patterns (in \`recognizeStatusRestriction\` and \`requiresIsSatisfiedByBundles\`) to use the already-lifted \`keyExistencePair\` + \`.filter\`. Removes the last two open-coded copies of that pattern.

## Test plan

- [x] \`isabelle build SpecRest\` clean
- [x] \`sbt test\`: 1239/1239 passing
- [x] \`sbt scalafixAll\` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `structuralIneligibility` to classify why an ensures clause isn’t structurally checkable and exposes it to Scala. Also deduplicates Stateful key-existence checks and reduces Structural overhead by calling the classifier once and hoisting conversions.

- New Features
  - Added `structural_ineligibility` ADT: `SceReferencesPrePrime`, `SceReferencesStateField`, `SceReferencesNoOutput`.
  - Exported `structuralIneligibility` and used in `Structural` to classify `ensures` clauses.

- Refactors
  - Reused `keyExistencePair(...)` in `Stateful` to replace two inline `BinaryOpF(BIn(), Identifier, Identifier)` recognizers; no behavior change.
  - Inlined `structuralIneligibility` at the call site and invoke it once per clause; hoisted `outputs.toList`/`stateFields.toList` out of the loop; removed `referencesOnlyInputsAndOutputs` and `nonPureOutputReason`.

<sup>Written for commit 5f92f8132b8b8b0fce35effd0830ce6b027b1a60. Summary will update on new commits. <a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

