### PR TITLE
refactor(scala): drop SpecRestGenerated. qualifier noise + trivial wrappers

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -1,7 +1,6 @@
 package specrest.codegen.migration
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object SchemaDiff:
 
@@ -11,7 +10,7 @@ object SchemaDiff:
     validateAutoIncrementAlters(prev, next)
     val prevChecks = checkAssign(schemaTables(prev))
     val nextChecks = checkAssign(schemaTables(next))
-    SpecRestGenerated.computeDiff(prev, next, prevChecks, nextChecks) match
+    computeDiff(prev, next, prevChecks, nextChecks) match
       case Some(ops) => ops
       case None =>
         val names = (schemaTables(prev) ++ schemaTables(next))
@@ -71,7 +70,7 @@ object SchemaDiff:
     ("\\b" + java.util.regex.Pattern.quote(column) + "\\b").r.findFirstIn(sql).isDefined
 
   def topoSort(tables: List[table_spec]): List[table_spec] =
-    SpecRestGenerated.sortTablesByFk(tables) match
+    sortTablesByFk(tables) match
       case Some(sorted) => sorted
       case None =>
         val names = tables.map(tableName).mkString(", ")

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/SchemaDiff.scala
@@ -1,6 +1,6 @@
 package specrest.codegen.migration
 
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 object SchemaDiff:
 

--- a/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/DialectProfileEmitTest.scala
@@ -7,6 +7,7 @@ import specrest.codegen.migration.Mysql
 import specrest.codegen.migration.Postgres
 import specrest.codegen.migration.Sqlite
 import specrest.codegen.testutil.SpecFixtures
+import specrest.ir.generated.SpecRestGenerated.IndexSpec
 
 class DialectProfileEmitTest extends CatsEffectSuite:
 
@@ -37,7 +38,7 @@ class DialectProfileEmitTest extends CatsEffectSuite:
 
   dialects.foreach: d =>
     test(s"${d.id}: partial-index diagnostic iff partial indexes unsupported"):
-      val ix = specrest.ir.generated.SpecRestGenerated.IndexSpec(
+      val ix = IndexSpec(
         s"idx_${d.id}_x",
         List("status"),
         false,

--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -1,7 +1,8 @@
 package specrest.convention
 
 import specrest.ir.*
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
 
 object Path:
 
@@ -59,7 +60,7 @@ object Path:
   ): http_method =
     val override_ = getConvention(conv, classificationOperationName(c), "http_method")
       .flatMap(parseHttpMethod)
-    resolveMethod(override_, classificationMethod(c))
+    SpecRestGenerated.resolveMethod(override_, classificationMethod(c))
 
   private def resolvePath(
       c: operation_classification,
@@ -82,7 +83,7 @@ object Path:
     derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)
 
   private def findIdParam(op: OperationDeclFull, ir: ServiceIRFull): Option[String] =
-    findIdParam(op.b, ir.f)
+    SpecRestGenerated.findIdParam(op.b, ir.f)
 
   private def extractActionVerb(opName: String, entityName: Option[String]): String =
     Naming.toKebabCase(extractVerbBeforeKebab(opName, entityName))
@@ -98,7 +99,7 @@ object Path:
       effective: http_method
   ): Int =
     val overrideStr = getConvention(conv, classificationOperationName(c), "http_status_success")
-    resolveStatus(overrideStr, effective, classificationKind(c)).toInt
+    SpecRestGenerated.resolveStatus(overrideStr, effective, classificationKind(c)).toInt
 
   def getConvention(
       conv: Option[conventions_decl_full],

--- a/modules/convention/src/main/scala/specrest/convention/Path.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Path.scala
@@ -1,8 +1,7 @@
 package specrest.convention
 
 import specrest.ir.*
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object Path:
 
@@ -60,7 +59,7 @@ object Path:
   ): http_method =
     val override_ = getConvention(conv, classificationOperationName(c), "http_method")
       .flatMap(parseHttpMethod)
-    SpecRestGenerated.resolveMethod(override_, classificationMethod(c))
+    resolveMethod(override_, classificationMethod(c))
 
   private def resolvePath(
       c: operation_classification,
@@ -80,13 +79,13 @@ object Path:
     val segment = entity.map(Naming.toPathSegment).getOrElse(opKebab)
     val action  = extractActionVerb(op.a, entity)
     val idOpt   = findIdParam(op, ir)
-    SpecRestGenerated.derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)
+    derivePathPattern(classificationKind(c), segment, idOpt, action, opKebab)
 
   private def findIdParam(op: OperationDeclFull, ir: ServiceIRFull): Option[String] =
-    SpecRestGenerated.findIdParam(op.b, ir.f)
+    findIdParam(op.b, ir.f)
 
   private def extractActionVerb(opName: String, entityName: Option[String]): String =
-    Naming.toKebabCase(SpecRestGenerated.extractVerbBeforeKebab(opName, entityName))
+    Naming.toKebabCase(extractVerbBeforeKebab(opName, entityName))
 
   private val PathParamRegex = """\{(\w+)\}""".r
 
@@ -99,7 +98,7 @@ object Path:
       effective: http_method
   ): Int =
     val overrideStr = getConvention(conv, classificationOperationName(c), "http_status_success")
-    SpecRestGenerated.resolveStatus(overrideStr, effective, classificationKind(c)).toInt
+    resolveStatus(overrideStr, effective, classificationKind(c)).toInt
 
   def getConvention(
       conv: Option[conventions_decl_full],

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -1,6 +1,6 @@
 package specrest.convention
 
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.ir.idx
 
 object Schema:

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -1,7 +1,6 @@
 package specrest.convention
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 import specrest.ir.idx
 
 object Schema:
@@ -117,7 +116,7 @@ object Schema:
       mapped.check.foreach(checks += _)
       field.c.foreach: c =>
         checks ++= extractChecks(colName, c)
-      for refinement <- SpecRestGenerated.aliasRefinements(field.b, cctx.aliasAList) do
+      for refinement <- aliasRefinements(field.b, cctx.aliasAList) do
         checks ++= extractChecks(colName, refinement)
 
     for inv <- entity.d do

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -1,7 +1,7 @@
 package specrest.convention.dafny
 
 import specrest.convention.Builtins
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -1,8 +1,7 @@
 package specrest.convention.dafny
 
 import specrest.convention.Builtins
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable

--- a/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
+++ b/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
@@ -1,9 +1,0 @@
-package specrest.lint
-
-import specrest.ir.generated.*
-
-object ExprWalk:
-
-  def foreach(expr: expr_full)(visit: expr_full => Unit): Unit =
-    visit(expr)
-    subexprs(expr).foreach(foreach(_)(visit))

--- a/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
+++ b/modules/lint/src/main/scala/specrest/lint/ExprWalk.scala
@@ -1,10 +1,9 @@
 package specrest.lint
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object ExprWalk:
 
   def foreach(expr: expr_full)(visit: expr_full => Unit): Unit =
     visit(expr)
-    SpecRestGenerated.subexprs(expr).foreach(foreach(_)(visit))
+    subexprs(expr).foreach(foreach(_)(visit))

--- a/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
+++ b/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
@@ -1,6 +1,6 @@
 package specrest.lint
 
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 object OperationOverlap extends LintPass:
   val code = "L04"

--- a/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
+++ b/modules/lint/src/main/scala/specrest/lint/OperationOverlap.scala
@@ -1,7 +1,6 @@
 package specrest.lint
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object OperationOverlap extends LintPass:
   val code = "L04"
@@ -40,10 +39,10 @@ object OperationOverlap extends LintPass:
     )
 
   private def paramShape(p: ParamDeclFull): (String, String) =
-    (p.a, SpecRestGenerated.typeStripSpans(p.b).toString)
+    (p.a, typeStripSpans(p.b).toString)
 
   private def normalizedRequires(rs: List[expr_full]): List[String] =
     flattenAndAll(rs)
       .filterNot(isTrueLit)
-      .map(e => SpecRestGenerated.stripSpans(e).toString)
+      .map(e => stripSpans(e).toString)
       .sorted

--- a/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
+++ b/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
@@ -1,6 +1,6 @@
 package specrest.lint
 
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 object TypeMismatch extends LintPass:
   val code = "L01"

--- a/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
+++ b/modules/lint/src/main/scala/specrest/lint/TypeMismatch.scala
@@ -1,7 +1,6 @@
 package specrest.lint
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object TypeMismatch extends LintPass:
   val code = "L01"
@@ -10,7 +9,7 @@ object TypeMismatch extends LintPass:
     val out = List.newBuilder[LintDiagnostic]
 
     def visitAll(e: expr_full): Unit =
-      SpecRestGenerated.typeMismatchDiagnostics(e).foreach { case (kind, span) =>
+      typeMismatchDiagnostics(e).foreach { case (kind, span) =>
         out += LintDiagnostic(code, LintLevel.Error, render(kind), span)
       }
 

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -1,7 +1,7 @@
 package specrest.lint
 
 import specrest.convention.Builtins
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 object UndefinedRef extends LintPass:
   val code = "L02"

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -1,8 +1,7 @@
 package specrest.lint
 
 import specrest.convention.Builtins
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object UndefinedRef extends LintPass:
   val code = "L02"
@@ -24,7 +23,7 @@ object UndefinedRef extends LintPass:
       // defined to avoid false positives. (Crucially, we whitelist
       // CALLEE names only — not arbitrary identifiers from the fact
       // body, which would silently mask real undefined-ref errors.)
-      SpecRestGenerated.collectAllCallNames(e)
+      collectAllCallNames(e)
     }.toSet
     val global =
       stateFields ++ entityNames ++ enumNames ++ enumMembers ++ typeAliases ++

--- a/modules/parser/src/test/scala/specrest/parser/FlattenInheritanceTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/FlattenInheritanceTest.scala
@@ -1,16 +1,12 @@
 package specrest.parser
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.EntityDeclFull
-import specrest.ir.generated.SpecRestGenerated.IdentifierF
-import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
-import specrest.ir.generated.SpecRestGenerated.expr_full
+import specrest.ir.generated.SpecRestGenerated.*
 
 class FlattenInheritanceTest extends CatsEffectSuite:
 
   private def flat(s: ServiceIRFull): ServiceIRFull =
-    SpecRestGenerated.flattenInheritance(s) match
+    flattenInheritance(s) match
       case sv: ServiceIRFull => sv
 
   private def childInvs(s: ServiceIRFull): List[expr_full] =

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -3,7 +3,8 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -489,7 +490,7 @@ object Behavioral:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    enumValuesForField(field, ir.d, ir.e)
+    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
 
   final private case class NonPathInput(
       name: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -3,8 +3,7 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -490,7 +489,7 @@ object Behavioral:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
+    enumValuesForField(field, ir.d, ir.e)
 
   final private case class NonPathInput(
       name: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -176,7 +176,7 @@ object GoBehavioral:
       sb.append("}\n")
     GeneratedTest(name = name, body = sb.toString, skipReason = None)
 
-  private def prettyOneLine(e: specrest.ir.generated.SpecRestGenerated.expr_full): String =
+  private def prettyOneLine(e: expr_full): String =
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim
 
   private def goIdent(s: String): String =

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -3,7 +3,8 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -422,7 +423,7 @@ object Stateful:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    enumValuesForField(field, ir.d, ir.e)
+    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
 
   final private case class StatusRestriction(
       stateFieldName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -3,8 +3,7 @@ package specrest.testgen
 import specrest.convention.EndpointSpec
 import specrest.convention.Naming
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
@@ -423,7 +422,7 @@ object Stateful:
       field: FieldDeclFull,
       ir: ServiceIRFull
   ): Option[List[String]] =
-    SpecRestGenerated.enumValuesForField(field, ir.d, ir.e)
+    enumValuesForField(field, ir.d, ir.e)
 
   final private case class StatusRestriction(
       stateFieldName: String,

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -175,7 +175,7 @@ object TsBehavioral:
       sb.append("});\n")
     GeneratedTest(name = name, body = sb.toString, skipReason = None)
 
-  private def prettyOneLine(e: specrest.ir.generated.SpecRestGenerated.expr_full): String =
+  private def prettyOneLine(e: expr_full): String =
     PrettyPrint.expr(e).replace("\n", " ").replace("\r", " ").trim
 
   private val RuntimeHelpers =

--- a/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
@@ -1,7 +1,7 @@
 package specrest.testgen
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 class EnumValuesForFieldTest extends CatsEffectSuite:
 

--- a/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/EnumValuesForFieldTest.scala
@@ -1,8 +1,7 @@
 package specrest.testgen
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 class EnumValuesForFieldTest extends CatsEffectSuite:
 
@@ -24,25 +23,25 @@ class EnumValuesForFieldTest extends CatsEffectSuite:
     val aliases    = List(tier1, tier2)
     val enums      = List(statusEnum)
 
-    val direct = SpecRestGenerated.enumValuesForField(field("f", named("Status")), enums, aliases)
+    val direct = enumValuesForField(field("f", named("Status")), enums, aliases)
     assertEquals(direct, Some(List("OPEN", "CLOSED")))
 
     val oneHop =
-      SpecRestGenerated.enumValuesForField(field("f", named("StatusAlias")), enums, aliases)
+      enumValuesForField(field("f", named("StatusAlias")), enums, aliases)
     assertEquals(oneHop, Some(List("OPEN", "CLOSED")))
 
     val twoHop =
-      SpecRestGenerated.enumValuesForField(field("f", named("StatusAliasAlias")), enums, aliases)
+      enumValuesForField(field("f", named("StatusAliasAlias")), enums, aliases)
     assertEquals(twoHop, Some(List("OPEN", "CLOSED")))
 
   test("enumValuesForField returns None when chain bottoms out at a non-enum"):
     val emailAlias = alias("Email", named("String"))
     val res =
-      SpecRestGenerated.enumValuesForField(field("f", named("Email")), Nil, List(emailAlias))
+      enumValuesForField(field("f", named("Email")), Nil, List(emailAlias))
     assertEquals(res, None)
 
   test("enumValuesForField is cycle-safe on `type A = B; type B = A` (returns None)"):
     val a   = alias("A", named("B"))
     val b   = alias("B", named("A"))
-    val res = SpecRestGenerated.enumValuesForField(field("f", named("A")), Nil, List(a, b))
+    val res = enumValuesForField(field("f", named("A")), Nil, List(a, b))
     assertEquals(res, None)

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -1,7 +1,6 @@
 package specrest.verify
 
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 enum DiagnosticCategory derives CanEqual:
   case ContradictoryInvariants, UnsatisfiablePrecondition, UnreachableOperation,
@@ -191,7 +190,7 @@ object Diagnostic:
         out += "powerset"
         walk(op, depthQuant)
       case _ =>
-        SpecRestGenerated.subexprs(x).foreach(walk(_, depthQuant))
+        subexprs(x).foreach(walk(_, depthQuant))
     walk(e, 0)
     out.result().distinct
 

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -1,6 +1,6 @@
 package specrest.verify
 
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 enum DiagnosticCategory derives CanEqual:
   case ContradictoryInvariants, UnsatisfiablePrecondition, UnreachableOperation,

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -1,7 +1,7 @@
 package specrest.verify
 
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 object Narration:
 

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -1,8 +1,7 @@
 package specrest.verify
 
 import specrest.ir.PrettyPrint
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 object Narration:
 
@@ -103,14 +102,14 @@ object Narration:
       lines.result().mkString("\n")
 
   private def contributingField(e: expr_full, ir: ServiceIRFull): Option[String] =
-    SpecRestGenerated.collectFieldAccessNames(e).headOption.orElse:
+    collectFieldAccessNames(e).headOption.orElse:
       val stateFieldNames = ir.f.toList.flatMap {
         case StateDeclFull(fs, _) => fs.collect { case StateFieldDeclFull(n, _, _) => n }
       }.toSet
-      SpecRestGenerated.collectIdentifierNames(e).find(stateFieldNames.contains)
+      collectIdentifierNames(e).find(stateFieldNames.contains)
 
   private def ensuresRhsForField(op: OperationDeclFull, field: String): Option[expr_full] =
-    SpecRestGenerated.ensuresRhsForField(op.e, field)
+    ensuresRhsForField(op.e, field)
 
   private def describePreInputs(
       ce: DecodedCounterExample,

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -38,7 +38,7 @@ object Narration:
       ce      <- ctx.counterexample
       field   <- contributingField(invDecl.b, ctx.ir)
     yield
-      val rhs    = ensuresRhsForField(op, field)
+      val rhs    = ensuresRhsForField(op.e, field)
       val opName = ctx.operationName.getOrElse(op.a)
       val lines  = List.newBuilder[String]
       lines += "Why this violates the invariant:"
@@ -107,9 +107,6 @@ object Narration:
         case StateDeclFull(fs, _) => fs.collect { case StateFieldDeclFull(n, _, _) => n }
       }.toSet
       collectIdentifierNames(e).find(stateFieldNames.contains)
-
-  private def ensuresRhsForField(op: OperationDeclFull, field: String): Option[expr_full] =
-    ensuresRhsForField(op.e, field)
 
   private def describePreInputs(
       ce: DecodedCounterExample,

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -4,7 +4,7 @@ import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Model
 import com.microsoft.z3.Sort
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.DecodedConstant
 import specrest.verify.DecodedCounterExample
 import specrest.verify.DecodedEntity

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -4,8 +4,7 @@ import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Model
 import com.microsoft.z3.Sort
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 import specrest.verify.DecodedConstant
 import specrest.verify.DecodedCounterExample
 import specrest.verify.DecodedEntity
@@ -30,7 +29,7 @@ object Z3CounterExample:
   ): DecodedCounterExample =
     val rawToLabel  = mutable.LinkedHashMap.empty[String, String]
     val typingFails = mutable.ListBuffer.empty[String]
-    val ctx         = SpecRestGenerated.tyctxFromService(ir)
+    val ctx         = tyctxFromService(ir)
 
     for e <- artifact.enums do
       for member <- e.members do
@@ -126,8 +125,8 @@ object Z3CounterExample:
     case Z3Sort.Bool => Some(TBool())
     case Z3Sort.Int  => Some(TInt())
     case Z3Sort.Uninterp(name) =>
-      if SpecRestGenerated.tc_enums(ctx).contains(name) then Some(TEnum(name))
-      else if SpecRestGenerated.tc_entities(ctx)
+      if tc_enums(ctx).contains(name) then Some(TEnum(name))
+      else if tc_entities(ctx)
           .exists { case EntityDeclFull(n, _, _, _, _) => n == name }
       then
         Some(TEntity(name))
@@ -150,7 +149,7 @@ object Z3CounterExample:
           case None =>
             sink += s"$site: could not decode '${expr.toString.trim}' at sort ${Z3Sort.key(sort)}"
           case Some(value) =>
-            if !SpecRestGenerated.check_value_has_ty(ctx, value, expectedTy) then
+            if !check_value_has_ty(ctx, value, expectedTy) then
               sink += s"$site: decoded value did not match expected type ${expectedTy}"
 
   private def inputsOfSort(

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2,7 +2,8 @@ package specrest.verify.z3
 
 import cats.effect.IO
 import specrest.ir.*
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated
+import specrest.ir.generated.SpecRestGenerated.*
 
 import scala.collection.mutable
 import scala.util.boundary
@@ -590,7 +591,7 @@ object Translator:
   def translateExpr(ctx: TranslateCtx, expr: expr_full, env: mutable.Map[String, Z3Expr]): Z3Expr =
     val enums = ctx.enums.keys.toList
     val out = lower(enums, expr) match
-      case Some(eSubset) => encodeFromSmtTerm(ctx, translate(eSubset), env)
+      case Some(eSubset) => encodeFromSmtTerm(ctx, SpecRestGenerated.translate(eSubset), env)
       case None          => translateExprRaw(ctx, expr, env)
     out.withSpan(expr.spanOpt)
 

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2,8 +2,7 @@ package specrest.verify.z3
 
 import cats.effect.IO
 import specrest.ir.*
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 import scala.collection.mutable
 import scala.util.boundary
@@ -18,7 +17,7 @@ private def fail(ctx: TranslateCtx, msg: String): Nothing =
   boundary.break(Left(VerifyError.Translator(msg)))(using ctx.bnd)
 
 extension (e: expr_full)
-  private def spanOpt: Option[span_t] = SpecRestGenerated.spanOf(e)
+  private def spanOpt: Option[span_t] = spanOf(e)
 
 private val StringSortName = "String"
 
@@ -591,7 +590,7 @@ object Translator:
   def translateExpr(ctx: TranslateCtx, expr: expr_full, env: mutable.Map[String, Z3Expr]): Z3Expr =
     val enums = ctx.enums.keys.toList
     val out = lower(enums, expr) match
-      case Some(eSubset) => encodeFromSmtTerm(ctx, SpecRestGenerated.translate(eSubset), env)
+      case Some(eSubset) => encodeFromSmtTerm(ctx, translate(eSubset), env)
       case None          => translateExprRaw(ctx, expr, env)
     out.withSpan(expr.spanOpt)
 
@@ -633,7 +632,7 @@ object Translator:
     finally ctx.stateMode = saved
 
   private def peelRelationRef(t: smt_term, default: StateMode): Option[(String, StateMode)] =
-    SpecRestGenerated.peelSmtRelationRef(t).map: rel =>
+    peelSmtRelationRef(t).map: rel =>
       val mode = t match
         case TPre(_)   => StateMode.Pre
         case TPrime(_) => StateMode.Post
@@ -1887,7 +1886,7 @@ object Translator:
       case PreF(inner, _)    => walkMentionsPost(inner, stateName, insidePrime = false)
       case IdentifierF(n, _) => insidePrime && n == stateName
       case _ =>
-        SpecRestGenerated.subexprs(expr).exists(walkMentionsPost(_, stateName, insidePrime))
+        subexprs(expr).exists(walkMentionsPost(_, stateName, insidePrime))
 
   private def encodeFromSmtTerm(
       ctx: TranslateCtx,

--- a/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
@@ -1,7 +1,7 @@
 package specrest.verify
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.*
+import specrest.ir.generated.SpecRestGenerated.*
 
 class CheckValueHasTyTest extends CatsEffectSuite:
 

--- a/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
@@ -1,8 +1,7 @@
 package specrest.verify
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.SpecRestGenerated
-import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.generated.*
 
 class CheckValueHasTyTest extends CatsEffectSuite:
 
@@ -43,37 +42,37 @@ class CheckValueHasTyTest extends CatsEffectSuite:
       None
     )
 
-  private val ctx = SpecRestGenerated.tyctxFromService(ir)
+  private val ctx = tyctxFromService(ir)
 
   test("tyctxFromService populates entities and enums"):
-    assertEquals(SpecRestGenerated.tc_entities(ctx).size, 1)
-    assertEquals(SpecRestGenerated.tc_enums(ctx), List("Status"))
+    assertEquals(tc_entities(ctx).size, 1)
+    assertEquals(tc_enums(ctx), List("Status"))
 
   test("check_value_has_ty accepts the primitive shapes"):
-    assert(SpecRestGenerated.check_value_has_ty(ctx, VBool(true), TBool()))
-    assert(SpecRestGenerated.check_value_has_ty(ctx, VInt(int_of_integer(BigInt(42))), TInt()))
-    assert(SpecRestGenerated.check_value_has_ty(ctx, VEnum("Status", "Open"), TEnum("Status")))
-    assert(SpecRestGenerated.check_value_has_ty(ctx, VEntity("Order", "0"), TEntity("Order")))
+    assert(check_value_has_ty(ctx, VBool(true), TBool()))
+    assert(check_value_has_ty(ctx, VInt(int_of_integer(BigInt(42))), TInt()))
+    assert(check_value_has_ty(ctx, VEnum("Status", "Open"), TEnum("Status")))
+    assert(check_value_has_ty(ctx, VEntity("Order", "0"), TEntity("Order")))
 
   test("check_value_has_ty rejects shape mismatches"):
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, VBool(true), TInt()))
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, VInt(mkInt(0)), TBool()))
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, VEnum("Status", "X"), TEnum("Other")))
+    assert(!check_value_has_ty(ctx, VBool(true), TInt()))
+    assert(!check_value_has_ty(ctx, VInt(mkInt(0)), TBool()))
+    assert(!check_value_has_ty(ctx, VEnum("Status", "X"), TEnum("Other")))
 
   test("vt_entity_with tightening: well-typed override accepted"):
     val typedActive = VEntityWith(VEntity("Order", "0"), "active", VBool(true))
-    assert(SpecRestGenerated.check_value_has_ty(ctx, typedActive, TEntity("Order")))
+    assert(check_value_has_ty(ctx, typedActive, TEntity("Order")))
 
   test("vt_entity_with tightening: mistyped override rejected"):
     val mistypedActive = VEntityWith(VEntity("Order", "0"), "active", VInt(mkInt(7)))
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, mistypedActive, TEntity("Order")))
+    assert(!check_value_has_ty(ctx, mistypedActive, TEntity("Order")))
 
   test("vt_entity_with tightening: unknown field rejected"):
     val unknownField = VEntityWith(VEntity("Order", "0"), "ghost", VBool(true))
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, unknownField, TEntity("Order")))
+    assert(!check_value_has_ty(ctx, unknownField, TEntity("Order")))
 
   test("VSet: every element must satisfy element type"):
     val okSet  = VSet(List(VInt(mkInt(1)), VInt(mkInt(2))))
     val badSet = VSet(List(VInt(mkInt(1)), VBool(true)))
-    assert(SpecRestGenerated.check_value_has_ty(ctx, okSet, TSet(TInt())))
-    assert(!SpecRestGenerated.check_value_has_ty(ctx, badSet, TSet(TInt())))
+    assert(check_value_has_ty(ctx, okSet, TSet(TInt())))
+    assert(!check_value_has_ty(ctx, badSet, TSet(TInt())))

--- a/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/SuggestionTemplateTest.scala
@@ -1,6 +1,7 @@
 package specrest.verify
 
 import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.testutil.SpecFixtures
 
 class SuggestionTemplateTest extends CatsEffectSuite:
@@ -63,10 +64,10 @@ class SuggestionTemplateTest extends CatsEffectSuite:
   test("solver_timeout suggestion mentions check id and timeout (direct template)"):
     SpecFixtures.loadIR("broken_url_shortener").map: ir =>
       val invDecl =
-        ir.i.collect { case inv: specrest.ir.generated.SpecRestGenerated.InvariantDeclFull => inv }
+        ir.i.collect { case inv: InvariantDeclFull => inv }
           .headOption.getOrElse(fail("expected an invariant"))
       val opsConcrete =
-        ir.g.collect { case op: specrest.ir.generated.SpecRestGenerated.OperationDeclFull => op }
+        ir.g.collect { case op: OperationDeclFull => op }
       val ctx = Diagnostic.SuggestionContext(
         ir = ir,
         op = opsConcrete.headOption,

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -1,7 +1,7 @@
 package specrest.verify.certificates
 
 import munit.CatsEffectSuite
-import specrest.ir.generated.SpecRestGenerated.SpanT
+import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.CheckOutcome
 import specrest.verify.Consistency
 import specrest.verify.VerificationConfig
@@ -28,7 +28,7 @@ class UnsatCoreTest extends CatsEffectSuite:
         cs.span match
           case SpanT(line, _, _, _) =>
             assert(
-              BigInt(1) <= specrest.ir.generated.SpecRestGenerated.integer_of_int(line),
+              BigInt(1) <= integer_of_int(line),
               s"invalid span line: ${cs.span}"
             )
 
@@ -55,7 +55,7 @@ class UnsatCoreTest extends CatsEffectSuite:
       )
       val lines = core.map: cs =>
         cs.span match
-          case SpanT(l, _, _, _) => specrest.ir.generated.SpecRestGenerated.integer_of_int(l)
+          case SpanT(l, _, _, _) => integer_of_int(l)
       .toSet
       assert(
         lines.subsetOf(Set(BigInt(10), BigInt(13))),


### PR DESCRIPTION
## Summary

Two mechanical cleanups, no behavior change.

### Phase A — drop redundant `SpecRestGenerated.` qualifier
22 files were importing both `SpecRestGenerated.*` (wildcard) AND `SpecRestGenerated` (object), then writing `SpecRestGenerated.foo(x)` instead of bare `foo(x)`. Pure noise.

- Drop the object-only import line where the wildcard is already in scope
- Strip the `SpecRestGenerated.` prefix from call sites
- Fix 6 outliers that used the fully-qualified `specrest.ir.generated.SpecRestGenerated.X` mid-expression (TsBehavioral, GoBehavioral, UnsatCoreTest, DialectProfileEmitTest, SuggestionTemplateTest, FlattenInheritanceTest)

### Phase B — drop trivial wrappers around lifted code

- Delete `modules/lint/src/main/scala/specrest/lint/ExprWalk.scala` (zero callers; its body is equivalent to `allSubexprs(e).foreach(visit)` which is already lifted)
- Inline `Narration.ensuresRhsForField` private wrapper at its single call site

### Why no type-shape changes

Investigated routes for collapsing the `sealed abstract class T` + `final case class TCtor extends T` duality (see issue #347). All routes have trust trade-offs that need broader input. Phase A+B is the strict noise removal that has zero trust impact.

## Test plan
- [x] `sbt test`: 1239/1239 passing across all 11 modules
- [x] `sbt scalafixAll` clean
- [x] No generated-file changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies lifted-code calls by removing `SpecRestGenerated.` qualifiers and deleting trivial wrappers, and fixes a sed-induced import regression. No behavior changes; tests stay green.

- **Refactors**
  - Restore `import specrest.ir.generated.SpecRestGenerated.*` where a sed pass broke imports; keep qualified calls where local names shadow lifted ones.
  - Strip `SpecRestGenerated.` from call sites; replace fully qualified `specrest.ir.generated.SpecRestGenerated.X` with short names via imports.
  - Delete `modules/lint/src/main/scala/specrest/lint/ExprWalk.scala`; use `allSubexprs(e).foreach(visit)` directly.
  - Inline `Narration.ensuresRhsForField` at its sole call site; call lifted `ensuresRhsForField` with `op.e`.

<sup>Written for commit 4fba6ea95183db1dab2b5476b8e1f20dd49c36d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/348?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized imports throughout multiple core modules including code generation, convention handling, linting, parsing, test generation, and verification systems to streamline code structure and improve maintainability across the codebase.

* **Chores**
  * Removed an internal expression traversal utility that was previously available in the linting module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->