### PR TITLE
feat(proofs): lift dialect_caps (Dialect extras follow-up to #349)

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -37,6 +37,16 @@ private[migration] object DialectAdapter:
   def fromLifted(st: sa_type): SaType =
     SaType(saTypeExpr(st), saTypeImportModule(st))
 
+  def fromLiftedCaps(c: dialect_caps): DialectCaps =
+    DialectCaps(
+      supportsPartialIndex = capsSupportsPartialIndex(c),
+      supportsCheckConstraint = capsSupportsCheckConstraint(c),
+      supportsCheckOnAutoIncrement = capsSupportsCheckOnAutoIncrement(c),
+      fkEnforcedByDefault = capsFkEnforcedByDefault(c),
+      requiresTextIndexPrefix = capsRequiresTextIndexPrefix(c),
+      transactionalDdl = capsTransactionalDdl(c)
+    )
+
   // Default for serial-column rendering when the source sqlType doesn't parse:
   // 64-bit serial (matches the original isSerial4-returns-false fallback).
   def parseOrDefault(sqlType: String): canonical_type =
@@ -229,14 +239,7 @@ object Dialect:
 object Postgres extends Dialect:
   val id = "postgres"
 
-  val caps: DialectCaps = DialectCaps(
-    supportsPartialIndex = true,
-    supportsCheckConstraint = true,
-    supportsCheckOnAutoIncrement = true,
-    fkEnforcedByDefault = true,
-    requiresTextIndexPrefix = false,
-    transactionalDdl = true
-  )
+  val caps: DialectCaps = DialectAdapter.fromLiftedCaps(postgresCaps)
 
   def saType(t: CanonicalType): SaType =
     DialectAdapter.fromLifted(postgresSaType(DialectAdapter.toLifted(t)))
@@ -303,14 +306,7 @@ object Postgres extends Dialect:
 object Sqlite extends Dialect:
   val id = "sqlite"
 
-  val caps: DialectCaps = DialectCaps(
-    supportsPartialIndex = true,
-    supportsCheckConstraint = true,
-    supportsCheckOnAutoIncrement = true,
-    fkEnforcedByDefault = false,
-    requiresTextIndexPrefix = false,
-    transactionalDdl = true
-  )
+  val caps: DialectCaps = DialectAdapter.fromLiftedCaps(sqliteCaps)
 
   // SQLite autoincrements only the INTEGER PRIMARY KEY rowid alias; a BIGINT PK is
   // not that alias, so a 64-bit serial must map to INTEGER (rowid is already 64-bit) —
@@ -356,14 +352,7 @@ object Sqlite extends Dialect:
 object Mysql extends Dialect:
   val id = "mysql"
 
-  val caps: DialectCaps = DialectCaps(
-    supportsPartialIndex = false,
-    supportsCheckConstraint = true,
-    supportsCheckOnAutoIncrement = false,
-    fkEnforcedByDefault = true,
-    requiresTextIndexPrefix = true,
-    transactionalDdl = false
-  )
+  val caps: DialectCaps = DialectAdapter.fromLiftedCaps(mysqlCaps)
 
   def saType(t: CanonicalType): SaType =
     DialectAdapter.fromLifted(mysqlSaType(DialectAdapter.toLifted(t)))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -867,6 +867,16 @@ object SpecRestGenerated {
   final case class IntConstraint(a: Option[int], b: Option[int], c: List[String])
       extends int_constraint
 
+  sealed abstract class dialect_caps
+  final case class DialectCaps(
+      a: Boolean,
+      b: Boolean,
+      c: Boolean,
+      d: Boolean,
+      e: Boolean,
+      f: Boolean
+  ) extends dialect_caps
+
   sealed abstract class enum_decl_ext[A]
   final case class enum_decl_exta[A](a: String, b: List[String], c: Option[span_t], d: A)
       extends enum_decl_ext[A]
@@ -5700,6 +5710,9 @@ object SpecRestGenerated {
     case CtJson()         => false
   }
 
+  def mysqlCaps: dialect_caps =
+    DialectCaps(false, true, false, true, true, false)
+
   def desiredSize(x0: bin_op_full, n: int): Option[int] = (x0, n) match {
     case (BGt(), n) => Some[int](max[int](zero_int, plus_int(n, one_inta)))
     case (BGe(), n) => Some[int](max[int](zero_int, n))
@@ -6085,6 +6098,9 @@ object SpecRestGenerated {
   def saTypeExpr(x0: sa_type): String = x0 match {
     case SaType(e, uu) => e
   }
+
+  def sqliteCaps: dialect_caps =
+    DialectCaps(true, true, true, false, false, true)
 
   def isEntityType(x0: type_expr_full, name: String): Boolean = (x0, name) match {
     case (NamedTypeF(n, uu), name)          => n == name
@@ -7911,6 +7927,9 @@ object SpecRestGenerated {
   def signalsDeletesKey(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, d, ux, uy, uz, va, vb) => d
   }
+
+  def postgresCaps: dialect_caps =
+    DialectCaps(true, true, true, true, false, true)
 
   def sqliteSaType(x0: canonical_type): sa_type = x0 match {
     case CtText()        => SaType("sa.Text()", None)
@@ -11283,6 +11302,10 @@ object SpecRestGenerated {
     case AnalysisSignals(uu, p, uv, uw, ux, uy, uz, va, vb) => p
   }
 
+  def capsTransactionalDdl(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(uu, uv, uw, ux, uy, f) => f
+  }
+
   def mysqlSerialColumnDef(name: String, t: canonical_type): String =
     name +
       (isSerial4(t) match {
@@ -12182,6 +12205,10 @@ object SpecRestGenerated {
         OperationClassification(name, k, m, rule, targetEntity, strategy, sig)
     }
 
+  def capsFkEnforcedByDefault(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(uu, uv, uw, d, ux, uy) => d
+  }
+
   def postgresSerialColumnDef(name: String, t: canonical_type): String =
     name +
       (isSerial4(t) match {
@@ -12345,6 +12372,10 @@ object SpecRestGenerated {
 
   def signalsTargetEntityFieldCount(x0: analysis_signals): Option[nat] = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, t, uy, uz, va, vb) => t
+  }
+
+  def capsSupportsPartialIndex(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(a, uu, uv, uw, ux, uy) => a
   }
 
   def findOperationByName(x0: List[operation_decl_full], uu: String): Option[operation_decl_full] =
@@ -12516,6 +12547,14 @@ object SpecRestGenerated {
       case CvUnknown(raw)        => raw
     }
 
+  def capsRequiresTextIndexPrefix(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(uu, uv, uw, ux, e, uy) => e
+  }
+
+  def capsSupportsCheckConstraint(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(uu, b, uv, uw, ux, uy) => b
+  }
+
   def visitConstraintOpenApi(e: expr_full, bounds: openapi_bounds): openapi_bounds =
     foldl[openapi_bounds, expr_full](
       (acc: openapi_bounds) =>
@@ -12577,5 +12616,9 @@ object SpecRestGenerated {
             }
         }
     }
+
+  def capsSupportsCheckOnAutoIncrement(x0: dialect_caps): Boolean = x0 match {
+    case DialectCaps(uu, uv, c, uw, ux, uy) => c
+  }
 
 } /* object SpecRestGenerated */

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -186,6 +186,15 @@ export_code
     postgresSerialColumnDef
     sqliteSerialColumnDef
     mysqlSerialColumnDef
+    postgresCaps
+    sqliteCaps
+    mysqlCaps
+    capsSupportsPartialIndex
+    capsSupportsCheckConstraint
+    capsSupportsCheckOnAutoIncrement
+    capsFkEnforcedByDefault
+    capsRequiresTextIndexPrefix
+    capsTransactionalDdl
     collectPreservedRelations
     containsPreInPlusChain
     detectCreatePattern

--- a/proofs/isabelle/SpecRest/DialectSchema.thy
+++ b/proofs/isabelle/SpecRest/DialectSchema.thy
@@ -180,4 +180,46 @@ fun mysqlSerialColumnDef :: "String.literal \<Rightarrow> canonical_type \<Right
   "mysqlSerialColumnDef name t =
      name + (if isSerial4 t then STR '' INT NOT NULL AUTO_INCREMENT'' else STR '' BIGINT NOT NULL AUTO_INCREMENT'')"
 
+text \<open>Dialect capability matrix: which target-dialect features (partial
+  indexes, CHECK constraints, CHECK on auto-increment, default FK
+  enforcement, text-index-prefix requirement, transactional DDL) each
+  dialect supports. Used by the consumer to gate per-dialect emission
+  shortcuts (e.g. SQLite drops a CHECK on a serial PK because MySQL
+  error 3818 would reject it elsewhere; Postgres keeps it).\<close>
+
+datatype dialect_caps = DialectCaps
+  bool  \<comment> \<open>supportsPartialIndex\<close>
+  bool  \<comment> \<open>supportsCheckConstraint\<close>
+  bool  \<comment> \<open>supportsCheckOnAutoIncrement\<close>
+  bool  \<comment> \<open>fkEnforcedByDefault\<close>
+  bool  \<comment> \<open>requiresTextIndexPrefix\<close>
+  bool  \<comment> \<open>transactionalDdl\<close>
+
+fun capsSupportsPartialIndex :: "dialect_caps \<Rightarrow> bool" where
+  "capsSupportsPartialIndex (DialectCaps a _ _ _ _ _) = a"
+
+fun capsSupportsCheckConstraint :: "dialect_caps \<Rightarrow> bool" where
+  "capsSupportsCheckConstraint (DialectCaps _ b _ _ _ _) = b"
+
+fun capsSupportsCheckOnAutoIncrement :: "dialect_caps \<Rightarrow> bool" where
+  "capsSupportsCheckOnAutoIncrement (DialectCaps _ _ c _ _ _) = c"
+
+fun capsFkEnforcedByDefault :: "dialect_caps \<Rightarrow> bool" where
+  "capsFkEnforcedByDefault (DialectCaps _ _ _ d _ _) = d"
+
+fun capsRequiresTextIndexPrefix :: "dialect_caps \<Rightarrow> bool" where
+  "capsRequiresTextIndexPrefix (DialectCaps _ _ _ _ e _) = e"
+
+fun capsTransactionalDdl :: "dialect_caps \<Rightarrow> bool" where
+  "capsTransactionalDdl (DialectCaps _ _ _ _ _ f) = f"
+
+definition postgresCaps :: dialect_caps where
+  "postgresCaps = DialectCaps True True True True False True"
+
+definition sqliteCaps :: dialect_caps where
+  "sqliteCaps = DialectCaps True True True False False True"
+
+definition mysqlCaps :: dialect_caps where
+  "mysqlCaps = DialectCaps False True False True True False"
+
 end


### PR DESCRIPTION
## Summary

Follow-up to #349 (which lifted the per-dialect saType + serial-column-def tables). This PR lifts the dialect **capability matrix**:

- `dialect_caps` ADT (6-bool record) + per-dialect constants `postgresCaps` / `sqliteCaps` / `mysqlCaps` in `DialectSchema.thy`
- Six per-field selector helpers exposed (`capsSupportsPartialIndex`, ..., `capsTransactionalDdl`)
- `DialectAdapter.fromLiftedCaps` converts lifted → Scala `DialectCaps`
- Each Scala-side `val caps: DialectCaps` collapses from a 7-LOC named-arg constructor call to a one-line delegating call

Net: single source of truth for the capability matrix (postgres/sqlite/mysql differences in transactional DDL, partial-index support, etc.) now lives in `DialectSchema.thy`.

### Not lifted (deferred)
- `regexCheck` per dialect — attempted, reverted: lifting needs literal `'` inside `STR ''...''` strings; Isabelle's String.literal lexer treats `''` as the close delimiter, so embedding a single quote in the content requires either a Char-based encoding or splitting the string. The savings (3 LOC × 3 dialects) aren't worth the encoding gymnastics.
- `alembicServerDefault` — uses Java regex (`stripPgCast`) which doesn't have a clean Isabelle equivalent.
- `partialIndex` — wraps Python string literal escaping; couples to AlembicSyntax helpers.

## Test plan
- [x] \`isabelle build SpecRest\` clean
- [x] \`sbt test\`: 1239/1239 passing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the SQL dialect capability matrix into `DialectSchema.thy` and wired Scala to consume it, creating a single source of truth and simplifying per-dialect `caps` definitions. No behavior change.

- **Refactors**
  - Introduced `dialect_caps` (6-bool ADT) with `postgresCaps`, `sqliteCaps`, `mysqlCaps`.
  - Added selector helpers (`capsSupportsPartialIndex` … `capsTransactionalDdl`) and exported them via `Codegen.thy`.
  - Added `DialectAdapter.fromLiftedCaps` to convert lifted caps to Scala `DialectCaps`; updated Postgres/SQLite/MySQL to use it.
  - Regenerated IR to include the ADT, constants, and selectors.

<sup>Written for commit 877c2e537f492ff1d70f16a13b80b5c19e0e1497. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/350?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced code generator infrastructure to better handle database dialect-specific SQL features for PostgreSQL, SQLite, and MySQL, improving accuracy of generated SQL based on each database's native capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->