### PR TITLE
feat(proofs): lift classifyColumnCheckAtom (column-refinement CHECK derivation)

### DIFF
--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -282,45 +282,19 @@ object Schema:
   private def escapeSqlString(s: String): String = s.replace("'", "''")
 
   private def extractChecks(colName: String, constraint: expr_full): List[String] =
-    val checks = List.newBuilder[String]
-    visitConstraint(constraint, colName, checks)
-    checks.result()
-
-  // A field typed by a refined alias (`type Email = String where value matches ...`) must carry
-  // that alias's `where` predicate as a column CHECK, exactly as an inline field refinement does.
-  // Walks the alias chain (and through Option), with a visited guard against cyclic aliases.
-  private def visitConstraint(
-      expr: expr_full,
-      colName: String,
-      checks: scala.collection.mutable.Builder[String, List[String]]
-  ): Unit =
-    flattenAnd(expr).foreach(atom => applyAtom(atom, colName, checks))
-
-  private def applyAtom(
-      expr: expr_full,
-      colName: String,
-      checks: scala.collection.mutable.Builder[String, List[String]]
-  ): Unit =
-    decomposeAtom(expr) match
-      case RaMatches(pat) =>
-        checks += s"$colName ~ '${escapeSqlString(pat)}'"
-      case RaMatchesIdent(_, pat) =>
-        checks += s"$colName ~ '${escapeSqlString(pat)}'"
-      case RaLenCmp(op, int_of_integer(n)) =>
-        sqlOp(op).foreach(o => checks += s"length($colName) $o $n")
-      case RaValueCmp(op, int_of_integer(n)) =>
-        sqlOp(op).foreach(o => checks += s"$colName $o $n")
-      case _: RaPredCall => ()
-      case _: RaUnknown  =>
-        // Float / String literals not covered by decomposeAtom
-        expr match
-          case BinaryOpF(op, lhs, rhs, _) if isLiteral(rhs) =>
-            sqlOp(op).foreach: o =>
-              if isLenOfValue(lhs) then
-                checks += s"length($colName) $o ${literalValue(rhs)}"
-              else if isValueRef(lhs) then
-                checks += s"$colName $o ${literalValue(rhs)}"
-          case _ => ()
+    flattenAnd(constraint).flatMap: atom =>
+      classifyColumnCheckAtom(atom) match
+        case _: CcSkip => Nil
+        case CcRegexMatch(pat) =>
+          List(s"$colName ~ '${escapeSqlString(pat)}'")
+        case CcLenCompare(op, int_of_integer(n)) =>
+          sqlOp(op).toList.map(o => s"length($colName) $o $n")
+        case CcValueCompare(op, int_of_integer(n)) =>
+          sqlOp(op).toList.map(o => s"$colName $o $n")
+        case CcLenLitCompare(op, rhs) =>
+          sqlOp(op).toList.map(o => s"length($colName) $o ${literalValue(rhs)}")
+        case CcValueLitCompare(op, rhs) =>
+          sqlOp(op).toList.map(o => s"$colName $o ${literalValue(rhs)}")
 
   private def literalValue(e: expr_full): String = e match
     case IntLitF(int_of_integer(v), _) => v.toString

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -983,6 +983,14 @@ object SpecRestGenerated {
       f: Option[String]
   ) extends trigger_candidate
 
+  sealed abstract class column_check_class
+  final case class CcSkip()                                        extends column_check_class
+  final case class CcRegexMatch(a: String)                         extends column_check_class
+  final case class CcLenCompare(a: bin_op_full, b: int)            extends column_check_class
+  final case class CcValueCompare(a: bin_op_full, b: int)          extends column_check_class
+  final case class CcLenLitCompare(a: bin_op_full, b: expr_full)   extends column_check_class
+  final case class CcValueLitCompare(a: bin_op_full, b: expr_full) extends column_check_class
+
   sealed abstract class detected_aggregate
   final case class DetectedAggregate(a: String, b: String, c: trigger_aggregate, d: Option[String])
       extends detected_aggregate
@@ -12144,6 +12152,55 @@ object SpecRestGenerated {
   }
 
   def anonInvariantName(idx: nat): String = "anon_" + showNat(idx)
+
+  def classifyColumnCheckAtom(e: expr_full): column_check_class =
+    decomposeAtom(e) match {
+      case RaLenCmp(a, b)       => CcLenCompare(a, b)
+      case RaValueCmp(a, b)     => CcValueCompare(a, b)
+      case RaMatches(a)         => CcRegexMatch(a)
+      case RaMatchesIdent(_, a) => CcRegexMatch(a)
+      case RaPredCall(_)        => CcSkip()
+      case RaUnknown(_) =>
+        e match {
+          case BinaryOpF(op, lhs, rhs, _) =>
+            isLiteral(rhs) && !is_none[String](sqlOp(op)) match {
+              case true => isLenOfValue(lhs) match {
+                  case true => CcLenLitCompare(op, rhs)
+                  case false => isValueRef(lhs) match {
+                      case true  => CcValueLitCompare(op, rhs)
+                      case false => CcSkip()
+                    }
+                }
+              case false => CcSkip()
+            }
+          case UnaryOpF(_, _, _)             => CcSkip()
+          case QuantifierF(_, _, _, _)       => CcSkip()
+          case SomeWrapF(_, _)               => CcSkip()
+          case TheF(_, _, _, _)              => CcSkip()
+          case FieldAccessF(_, _, _)         => CcSkip()
+          case EnumAccessF(_, _, _)          => CcSkip()
+          case IndexF(_, _, _)               => CcSkip()
+          case CallF(_, _, _)                => CcSkip()
+          case PrimeF(_, _)                  => CcSkip()
+          case PreF(_, _)                    => CcSkip()
+          case WithF(_, _, _)                => CcSkip()
+          case IfF(_, _, _, _)               => CcSkip()
+          case LetF(_, _, _, _)              => CcSkip()
+          case LambdaF(_, _, _)              => CcSkip()
+          case ConstructorF(_, _, _)         => CcSkip()
+          case SetLiteralF(_, _)             => CcSkip()
+          case MapLiteralF(_, _)             => CcSkip()
+          case SetComprehensionF(_, _, _, _) => CcSkip()
+          case SeqLiteralF(_, _)             => CcSkip()
+          case MatchesF(_, _, _)             => CcSkip()
+          case IntLitF(_, _)                 => CcSkip()
+          case FloatLitF(_, _)               => CcSkip()
+          case StringLitF(_, _)              => CcSkip()
+          case BoolLitF(_, _)                => CcSkip()
+          case NoneLitF(_)                   => CcSkip()
+          case IdentifierF(_, _)             => CcSkip()
+        }
+    }
 
   def findEnumValuesInTypeAux(
       fuel: nat,

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -293,6 +293,7 @@ export_code
     extractPartialIndexRules
     appendPartialIndexes
     classifyInvariantAtom
+    classifyColumnCheckAtom
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/SchemaDerive.thy
@@ -351,10 +351,60 @@ definition classifyInvariantAtom :: "expr_full \<Rightarrow> invariant_check_cla
                   else IcSkip)))
     | _ \<Rightarrow> IcSkip)"
 
+text \<open>Column-CHECK atom classifier for \<open>Schema.applyAtom\<close>. Mirrors
+  \<open>classifyInvariantAtom\<close>/\<open>invariant_check_class\<close> but for *field
+  refinements* (the per-column \<open>where value matches \<dots>\<close> / \<open>len(value) > n\<close>
+  forms) rather than entity invariants: returns a structured template the
+  Scala caller formats into the SQL CHECK string.
+
+  Inputs are the atomic expressions produced by \<open>flattenAnd refinement\<close>,
+  one per field-level constraint. Each atom maps to one template:
+
+  \<^item> \<open>CcRegexMatch\<close>: regex via \<open>RaMatches\<close> or \<open>RaMatchesIdent\<close> (the
+    identifier-qualified form ignores the qualifier — the lifted classifier
+    matches the pre-existing Scala behaviour, which is to bind the regex to
+    the column being walked regardless of identifier).
+  \<^item> \<open>CcLenCompare\<close>: \<open>length(col) op n\<close> via \<open>RaLenCmp\<close>.
+  \<^item> \<open>CcValueCompare\<close>: \<open>col op n\<close> via \<open>RaValueCmp\<close>.
+  \<^item> \<open>CcLenLitCompare\<close> / \<open>CcValueLitCompare\<close>: \<open>BinaryOpF op lhs rhs\<close>
+    with \<open>isLiteral rhs\<close>, \<open>sqlOp op \<noteq> None\<close>, and \<open>lhs\<close> shaped as
+    \<open>len(value)\<close> / \<open>value\<close>. Reaches this branch only when
+    \<open>decomposeAtom\<close> returned \<open>RaUnknown\<close>, i.e. RHS is a non-integer
+    literal (Float / String) — \<open>decomposeAtom\<close> only recognises \<open>IntLitF\<close>
+    on the RHS for length/value comparisons.
+  \<^item> \<open>CcSkip\<close>: \<open>RaPredCall\<close>, or an unrecognised shape.\<close>
+
+datatype column_check_class =
+    CcSkip
+  | CcRegexMatch "String.literal"               \<comment> \<open>regex pattern\<close>
+  | CcLenCompare bin_op_full int                \<comment> \<open>op, n\<close>
+  | CcValueCompare bin_op_full int              \<comment> \<open>op, n\<close>
+  | CcLenLitCompare bin_op_full expr_full       \<comment> \<open>op, literal\<close>
+  | CcValueLitCompare bin_op_full expr_full     \<comment> \<open>op, literal\<close>
+
+definition classifyColumnCheckAtom :: "expr_full \<Rightarrow> column_check_class" where
+  "classifyColumnCheckAtom e =
+     (case decomposeAtom e of
+        RaMatches pat \<Rightarrow> CcRegexMatch pat
+      | RaMatchesIdent _ pat \<Rightarrow> CcRegexMatch pat
+      | RaLenCmp op n \<Rightarrow> CcLenCompare op n
+      | RaValueCmp op n \<Rightarrow> CcValueCompare op n
+      | RaPredCall _ \<Rightarrow> CcSkip
+      | RaUnknown _ \<Rightarrow>
+          (case e of
+             BinaryOpF op lhs rhs _ \<Rightarrow>
+               (if isLiteral rhs \<and> sqlOp op \<noteq> None
+                then (if isLenOfValue lhs then CcLenLitCompare op rhs
+                      else if isValueRef lhs then CcValueLitCompare op rhs
+                      else CcSkip)
+                else CcSkip)
+           | _ \<Rightarrow> CcSkip))"
+
 lemmas extractPartialIndexRuleOpt_code [code] = extractPartialIndexRuleOpt.simps
 lemmas extractPartialIndexRules_code [code] = extractPartialIndexRules_def
 lemmas partialIndexSpec_code [code] = partialIndexSpec_def
 lemmas appendPartialIndexes_code [code] = appendPartialIndexes.simps
 lemmas classifyInvariantAtom_code [code] = classifyInvariantAtom_def
+lemmas classifyColumnCheckAtom_code [code] = classifyColumnCheckAtom_def
 
 end


### PR DESCRIPTION
## Summary

`Schema.applyAtom` dispatched on the shape of each conjunct of a flattened field refinement, emitting one SQL CHECK fragment per recognised atom:

- **Regex match** if `decomposeAtom` returned `RaMatches` / `RaMatchesIdent`
- **`length(col) op n`** / **`col op n`** if `RaLenCmp` / `RaValueCmp`
- **Non-int literal fallback** (Float/String RHS) when `decomposeAtom` returned `RaUnknown` and the expression was a recognised `BinaryOpF` against a literal — `len(value) op lit` or `value op lit`
- **Skip** otherwise (`RaPredCall`, unrecognised shape)

The structural decision is liftable; SQL string emission stays Scala (depends on `escapeSqlString` apostrophe-doubling and `literalValue` per-literal-type formatting).

This is the column-refinement parallel to `classifyInvariantAtom` (lifted in #340) — same template, different input domain (per-field `where value matches …` predicates rather than entity invariants).

## New typed sum in `SchemaDerive.thy`

```isabelle
datatype column_check_class =
    CcSkip
  | CcRegexMatch literal               -- pattern
  | CcLenCompare bin_op_full int       -- op, n
  | CcValueCompare bin_op_full int     -- op, n
  | CcLenLitCompare bin_op_full expr_full  -- op, literal-expr
  | CcValueLitCompare bin_op_full expr_full

classifyColumnCheckAtom : expr_full => column_check_class
```

All predicates the lifted dispatcher uses (`decomposeAtom`, `isLiteral`, `sqlOp`, `isLenOfValue`, `isValueRef`) were already in `IR_Analysis` / `SchemaDerive` from earlier PRs — no new helpers needed.

## Scala-side

`extractChecks` becomes a single functional pipeline that mirrors `extractInvariantChecks`:

```scala
flattenAnd(constraint).flatMap: atom =>
  classifyColumnCheckAtom(atom) match
    case _: CcSkip            => Nil
    case CcRegexMatch(pat)    => List(s"$colName ~ '${escapeSqlString(pat)}'")
    case CcLenCompare(op, n)  => sqlOp(op).toList.map(o => s"length($colName) $o $n")
    case CcValueCompare(op,n) => sqlOp(op).toList.map(o => s"$colName $o $n")
    case CcLenLitCompare(op, rhs) =>
      sqlOp(op).toList.map(o => s"length($colName) $o ${literalValue(rhs)}")
    case CcValueLitCompare(op, rhs) =>
      sqlOp(op).toList.map(o => s"$colName $o ${literalValue(rhs)}")
```

Removes:
- `visitConstraint` helper (intermediate mutable-builder threading)
- `applyAtom` helper (the inline `decomposeAtom` + RaUnknown→BinaryOpF fallback dispatcher)

`Schema.scala` shrinks by ~25 LOC; the structural decision is now in HOL.

## Test plan
- [x] `isabelle build SpecRest` clean
- [x] `sbt convention/compile` clean
- [x] `sbt convention/test` — all suites pass
- [x] SQL CHECK output byte-identical (no golden diff)
- [ ] CI: isabelle-build (extraction drift) + build-and-test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted column refinement CHECK derivation into the proofs layer and simplified the Scala pipeline for generating column `CHECK` clauses. SQL output is unchanged.

- **Refactors**
  - Added `column_check_class` and `classifyColumnCheckAtom` in Isabelle; exported via codegen.
  - Generated Scala now includes the ADT and classifier in `SpecRestGenerated.scala`.
  - Rewrote `Schema.extractChecks` to a single `flatMap` over `classifyColumnCheckAtom`; removed `visitConstraint` and `applyAtom` (~25 LOC less).
  - Matches the `classifyInvariantAtom` pattern for consistency.
  - Byte-identical SQL `CHECK` output; tests pass.

<sup>Written for commit 07da2a1d63efb6bf78d54dff02557e1f4316af7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/351?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized SQL CHECK constraint generation to improve code efficiency and maintainability. Refactored the constraint expression processing logic to better classify and handle constraint patterns. These changes streamline the schema generation process while maintaining comprehensive support for all constraint types in database definitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->