### PR TITLE
feat(proofs): lift OpenAPI schema_object + typeExprToSchema recursive walker

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -40,6 +40,44 @@ sealed trait SchemaObjectOrBool derives CanEqual
 final case class SOBSchema(schema: SchemaObject) extends SchemaObjectOrBool
 final case class SOBBool(v: Boolean)             extends SchemaObjectOrBool
 
+private[openapi] object SchemaObjectAdapter:
+
+  def fromLifted(s: schema_object): SchemaObject = s match
+    case lifted: specrest.ir.generated.SpecRestGenerated.SchemaObject =>
+      SchemaObject(
+        `type` = lifted.a,
+        format = lifted.b,
+        minLength = lifted.c.map(asInt),
+        maxLength = lifted.d.map(asInt),
+        minimum = lifted.e.map(decimalToDouble),
+        maximum = lifted.f.map(decimalToDouble),
+        exclusiveMinimum = lifted.g.map(decimalToDouble),
+        exclusiveMaximum = lifted.h.map(decimalToDouble),
+        minItems = lifted.i.map(asInt),
+        maxItems = lifted.j.map(asInt),
+        pattern = lifted.k,
+        enum_ = lifted.l,
+        items = lifted.m.map(fromLifted),
+        ref = lifted.n,
+        required = lifted.o,
+        properties = lifted.p.map(_.iterator.map((k, v) => k -> fromLifted(v)).toMap),
+        additionalProperties = lifted.q.map(fromLiftedSOB),
+        anyOf = lifted.r.map(_.map(fromLifted)),
+        description = lifted.s,
+        includeNullInEnum = lifted.t
+      )
+
+  private def fromLiftedSOB(sob: schema_object_or_bool): SchemaObjectOrBool = sob match
+    case ls: specrest.ir.generated.SpecRestGenerated.SOBSchema => SOBSchema(fromLifted(ls.a))
+    case lb: specrest.ir.generated.SpecRestGenerated.SOBBool   => SOBBool(lb.a)
+
+  private def asInt(i: int): Int = i match
+    case int_of_integer(v) => v.toInt
+
+  private def decimalToDouble(d: decimal_lit): Double = d match
+    case DecimalLit(int_of_integer(m), int_of_integer(e)) =>
+      BigDecimal(m.bigInteger, -e.toInt).doubleValue
+
 final case class ParameterObject(
     name: String,
     in: String,
@@ -172,8 +210,9 @@ final case class FieldSchema(schema: SchemaObject, nullable: Boolean)
 object Schema:
 
   private def primitiveDefToSchema(p: openapi_primitive_def): SchemaObject =
-    p match
-      case OpenApiPrimDef(types, fmt) => SchemaObject(`type` = Some(types), format = fmt)
+    SchemaObjectAdapter.fromLifted(
+      specrest.ir.generated.SpecRestGenerated.primitiveDefToSchema(p)
+    )
 
   def fieldToSchema(
       typeExpr: type_expr_full,
@@ -191,15 +230,12 @@ object Schema:
     FieldSchema(typeExprToSchema(effective, cs, ctx), nullable)
 
   def makeNullable(schema: SchemaObject): SchemaObject =
-    if schema.ref.isDefined then
-      SchemaObject(anyOf = Some(List(schema, SchemaObject(`type` = Some(List("null"))))))
-    else
-      schema.`type` match
-        case None =>
-          SchemaObject(anyOf = Some(List(schema, SchemaObject(`type` = Some(List("null"))))))
-        case Some(current) =>
-          if current.contains("null") then schema
-          else schema.copy(`type` = Some(current :+ "null"))
+    decideNullable(schema.ref, schema.`type`) match
+      case _: NdNoop => schema
+      case _: NdWrapAnyOfNull =>
+        SchemaObject(anyOf = Some(List(schema, SchemaObject(`type` = Some(List("null"))))))
+      case _: NdAppendNull =>
+        schema.copy(`type` = schema.`type`.map(_ :+ "null"))
 
   private def typeExprToSchema(
       typeExpr: type_expr_full,

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -146,88 +146,25 @@ final case class BuildContext(
     entityNamesList: List[String]
 )
 
-// -- Constraints extraction ------------------------------------
-
-final case class JsonSchemaConstraints(
-    minLength: Option[Int] = None,
-    maxLength: Option[Int] = None,
-    minimum: Option[Double] = None,
-    maximum: Option[Double] = None,
-    exclusiveMinimum: Option[Double] = None,
-    exclusiveMaximum: Option[Double] = None,
-    pattern: Option[String] = None,
-    enum_ : Option[List[String]] = None
-)
-
-@SuppressWarnings(Array("org.wartremover.warts.Var"))
-object Constraints:
-
-  def extractFieldConstraints(
-      typeExpr: type_expr_full,
-      constraint: Option[expr_full],
-      aliasAList: List[(String, TypeAliasDeclFull)],
-      enumAList: List[(String, EnumDeclFull)]
-  ): JsonSchemaConstraints =
-    var bounds = emptyOpenApiBounds
-    for pred <- aliasRefinements(typeExpr, aliasAList) do
-      bounds = visitConstraintOpenApi(pred, bounds)
-    constraint match
-      case Some(c) => bounds = visitConstraintOpenApi(c, bounds)
-      case None    => ()
-    val enum_ = findEnumValuesInType(typeExpr, aliasAList, enumAList)
-    boundsToConstraints(bounds, enum_)
-
-  private def boundsToConstraints(
-      b: openapi_bounds,
-      enum_ : Option[List[String]]
-  ): JsonSchemaConstraints =
-    b match
-      case OpenApiBounds(nl, ml, mn, mx, emn, emx, pat) =>
-        JsonSchemaConstraints(
-          minLength = nl.map(asInt),
-          maxLength = ml.map(asInt),
-          minimum = mn.map(decimalToDouble),
-          maximum = mx.map(decimalToDouble),
-          exclusiveMinimum = emn.map(decimalToDouble),
-          exclusiveMaximum = emx.map(decimalToDouble),
-          pattern = pat,
-          enum_ = enum_
-        )
-
-  private def asInt(i: int): Int = i match
-    case int_of_integer(v) => v.toInt
-
-  // decimal_lit DecimalLit(mantissa, exponent) represents mantissa * 10^exponent.
-  // BigDecimal handles arbitrary precision; .doubleValue trims to IEEE 754.
-  private def decimalToDouble(d: decimal_lit): Double = d match
-    case DecimalLit(int_of_integer(m), int_of_integer(e)) =>
-      BigDecimal(m.bigInteger, -e.toInt).doubleValue
-
 // -- Schema generation ----------------------------------------
 
 final case class FieldSchema(schema: SchemaObject, nullable: Boolean)
 
 object Schema:
 
-  private def primitiveDefToSchema(p: openapi_primitive_def): SchemaObject =
-    SchemaObjectAdapter.fromLifted(
-      specrest.ir.generated.SpecRestGenerated.primitiveDefToSchema(p)
-    )
-
   def fieldToSchema(
       typeExpr: type_expr_full,
       constraint: Option[expr_full],
       ctx: BuildContext
   ): FieldSchema =
-    val nullable = typeExpr match
-      case _: OptionTypeF => true
-      case _              => false
-    val effective = typeExpr match
-      case OptionTypeF(inner, _) => inner
-      case t                     => t
-    val cs =
-      Constraints.extractFieldConstraints(effective, constraint, ctx.aliasAList, ctx.enumAList)
-    FieldSchema(typeExprToSchema(effective, cs, ctx), nullable)
+    val (lifted, nullable) = specrest.ir.generated.SpecRestGenerated.fieldToSchema(
+      typeExpr,
+      constraint,
+      ctx.aliasAList,
+      ctx.enumAList,
+      ctx.entityNamesList
+    )
+    FieldSchema(SchemaObjectAdapter.fromLifted(lifted), nullable)
 
   def makeNullable(schema: SchemaObject): SchemaObject =
     decideNullable(schema.ref, schema.`type`) match
@@ -236,73 +173,6 @@ object Schema:
         SchemaObject(anyOf = Some(List(schema, SchemaObject(`type` = Some(List("null"))))))
       case _: NdAppendNull =>
         schema.copy(`type` = schema.`type`.map(_ :+ "null"))
-
-  private def typeExprToSchema(
-      typeExpr: type_expr_full,
-      constraints: JsonSchemaConstraints,
-      ctx: BuildContext
-  ): SchemaObject = typeExpr match
-    case NamedTypeF(name, _) =>
-      namedTypeSchema(name, constraints, ctx)
-    case SetTypeF(inner, _) =>
-      buildArraySchema(inner, constraints, ctx)
-    case SeqTypeF(inner, _) =>
-      buildArraySchema(inner, constraints, ctx)
-    case MapTypeF(_, v, _) =>
-      val value = fieldToSchema(v, None, ctx)
-      val ap    = if value.nullable then makeNullable(value.schema) else value.schema
-      SchemaObject(
-        `type` = Some(List("object")),
-        additionalProperties = Some(SOBSchema(ap))
-      )
-    case OptionTypeF(inner, _) =>
-      typeExprToSchema(inner, constraints, ctx)
-    case RelationTypeF(_, _, _, _) =>
-      SchemaObject(`type` = Some(List("integer")))
-
-  private def namedTypeSchema(
-      name: String,
-      c: JsonSchemaConstraints,
-      ctx: BuildContext
-  ): SchemaObject =
-    classifyOpenApiNamedType(name, ctx.aliasAList, ctx.enumAList, ctx.entityNamesList) match
-      case OntPrimitive(p) =>
-        mergeConstraints(primitiveDefToSchema(p), c)
-      case OntEnum(values) =>
-        SchemaObject(`type` = Some(List("string")), enum_ = Some(values))
-      case OntEntityRef(n) =>
-        SchemaObject(ref = Some(s"#/components/schemas/${n}Read"))
-      case OntAliasToType(base) =>
-        typeExprToSchema(base, c, ctx)
-      case _: OntUnknown =>
-        mergeConstraints(SchemaObject(`type` = Some(List("string"))), c)
-
-  private def buildArraySchema(
-      inner: type_expr_full,
-      c: JsonSchemaConstraints,
-      ctx: BuildContext
-  ): SchemaObject =
-    val innerSchema = fieldToSchema(inner, None, ctx)
-    val items =
-      if innerSchema.nullable then makeNullable(innerSchema.schema) else innerSchema.schema
-    SchemaObject(
-      `type` = Some(List("array")),
-      items = Some(items),
-      minItems = c.minLength,
-      maxItems = c.maxLength
-    )
-
-  private def mergeConstraints(base: SchemaObject, c: JsonSchemaConstraints): SchemaObject =
-    base.copy(
-      minLength = c.minLength.orElse(base.minLength),
-      maxLength = c.maxLength.orElse(base.maxLength),
-      minimum = c.minimum.orElse(base.minimum),
-      maximum = c.maximum.orElse(base.maximum),
-      exclusiveMinimum = c.exclusiveMinimum.orElse(base.exclusiveMinimum),
-      exclusiveMaximum = c.exclusiveMaximum.orElse(base.exclusiveMaximum),
-      pattern = c.pattern.orElse(base.pattern),
-      enum_ = c.enum_.orElse(base.enum_)
-    )
 
 // -- Components / Paths / Build / Serialize --------------------
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -893,6 +893,37 @@ object SpecRestGenerated {
   final case class RaPredCall(a: String)                extends refinement_atom
   final case class RaUnknown(a: expr_full)              extends refinement_atom
 
+  sealed abstract class decimal_lit
+  final case class DecimalLit(a: int, b: int) extends decimal_lit
+
+  sealed abstract class schema_object_or_bool
+  final case class SOBSchema(a: schema_object) extends schema_object_or_bool
+  final case class SOBBool(a: Boolean)         extends schema_object_or_bool
+
+  sealed abstract class schema_object
+  final case class SchemaObject(
+      a: Option[List[String]],
+      b: Option[String],
+      c: Option[int],
+      d: Option[int],
+      e: Option[decimal_lit],
+      f: Option[decimal_lit],
+      g: Option[decimal_lit],
+      h: Option[decimal_lit],
+      i: Option[int],
+      j: Option[int],
+      k: Option[String],
+      l: Option[List[String]],
+      m: Option[schema_object],
+      n: Option[String],
+      o: Option[List[String]],
+      p: Option[List[(String, schema_object)]],
+      q: Option[schema_object_or_bool],
+      r: Option[List[schema_object]],
+      s: Option[String],
+      t: Boolean
+  ) extends schema_object
+
   sealed abstract class aggregate_call
   final case class AggregateCall(a: String, b: trigger_aggregate, c: Option[String])
       extends aggregate_call
@@ -967,9 +998,6 @@ object SpecRestGenerated {
   final case class TmLogicalLitMisuse(a: bin_op_full, b: lit_class)    extends type_mismatch_kind
   final case class TmMembershipLitMisuse(a: bin_op_full, b: lit_class) extends type_mismatch_kind
 
-  sealed abstract class decimal_lit
-  final case class DecimalLit(a: int, b: int) extends decimal_lit
-
   sealed abstract class classified_column
   final case class ClassifiedColumn(a: column_kind, b: Boolean) extends classified_column
 
@@ -982,6 +1010,11 @@ object SpecRestGenerated {
       e: trigger_aggregate,
       f: Option[String]
   ) extends trigger_candidate
+
+  sealed abstract class nullable_decision
+  final case class NdNoop()          extends nullable_decision
+  final case class NdWrapAnyOfNull() extends nullable_decision
+  final case class NdAppendNull()    extends nullable_decision
 
   sealed abstract class column_check_class
   final case class CcSkip()                                        extends column_check_class
@@ -9077,6 +9110,20 @@ object SpecRestGenerated {
     case OpenApiBounds(uu, uv, mn, uw, ux, uy, uz) => mn
   }
 
+  def decideNullable(refOpt: Option[String], typeOpt: Option[List[String]]): nullable_decision =
+    refOpt match {
+      case None =>
+        typeOpt match {
+          case None => NdWrapAnyOfNull()
+          case Some(currentTypes) =>
+            membera[String](currentTypes, "null") match {
+              case true  => NdNoop()
+              case false => NdAppendNull()
+            }
+        }
+      case Some(_) => NdWrapAnyOfNull()
+    }
+
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
     isRkCreate(initial) && !matchesCreateShape match {
       case true  => RkOther()
@@ -10204,6 +10251,30 @@ object SpecRestGenerated {
   def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
 
   def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
+
+  def emptySchemaObject: schema_object =
+    SchemaObject(
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
 
   def parseTemporalBody(e: expr_full): temporal_body =
     e match {
@@ -11383,6 +11454,32 @@ object SpecRestGenerated {
     }
   }
 
+  def primitiveDefToSchema(x0: openapi_primitive_def): schema_object = x0 match {
+    case OpenApiPrimDef(types, fmt) =>
+      SchemaObject(
+        Some[List[String]](types),
+        fmt,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false
+      )
+  }
+
   def classifyInvariantAtom(e: expr_full): invariant_check_class =
     e match {
       case BinaryOpF(op, left, rhs, _) =>
@@ -12152,6 +12249,85 @@ object SpecRestGenerated {
   }
 
   def anonInvariantName(idx: nat): String = "anon_" + showNat(idx)
+
+  def mergeConstraintsLifted(
+      x0: schema_object,
+      x1: openapi_bounds,
+      enumOpt: Option[List[String]]
+  ): schema_object =
+    (x0, x1, enumOpt) match {
+      case (
+            SchemaObject(
+              ty,
+              fmt,
+              bMinL,
+              bMaxL,
+              bMn,
+              bMx,
+              bEmn,
+              bEmx,
+              mnI,
+              mxI,
+              bPat,
+              bEn,
+              it,
+              rf,
+              rq,
+              pr,
+              ap,
+              aof,
+              desc,
+              inE
+            ),
+            OpenApiBounds(cMinL, cMaxL, cMn, cMx, cEmn, cEmx, cPat),
+            enumOpt
+          ) => SchemaObject(
+          ty,
+          fmt,
+          cMinL match {
+            case None    => bMinL
+            case Some(_) => cMinL
+          },
+          cMaxL match {
+            case None    => bMaxL
+            case Some(_) => cMaxL
+          },
+          cMn match {
+            case None    => bMn
+            case Some(_) => cMn
+          },
+          cMx match {
+            case None    => bMx
+            case Some(_) => cMx
+          },
+          cEmn match {
+            case None    => bEmn
+            case Some(_) => cEmn
+          },
+          cEmx match {
+            case None    => bEmx
+            case Some(_) => cEmx
+          },
+          mnI,
+          mxI,
+          cPat match {
+            case None    => bPat
+            case Some(_) => cPat
+          },
+          enumOpt match {
+            case None    => bEn
+            case Some(_) => enumOpt
+          },
+          it,
+          rf,
+          rq,
+          pr,
+          ap,
+          aof,
+          desc,
+          inE
+        )
+    }
 
   def classifyColumnCheckAtom(e: expr_full): column_check_class =
     decomposeAtom(e) match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -6197,6 +6197,54 @@ object SpecRestGenerated {
       case Some(idNm) => "/" + segment + "/{" + idNm + "}"
     }
 
+  def nullSchema: schema_object =
+    SchemaObject(
+      Some[List[String]](List("null")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
+  def textSchema: schema_object =
+    SchemaObject(
+      Some[List[String]](List("string")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
   def isFailLoudStub(hasDafnyMethod: Boolean, effectiveKind: route_kind): Boolean =
     !hasDafnyMethod && isStubShape(effectiveKind)
 
@@ -7880,6 +7928,30 @@ object SpecRestGenerated {
         }
     }
 
+  def arraySchema(items: schema_object, mnI: Option[int], mxI: Option[int]): schema_object =
+    SchemaObject(
+      Some[List[String]](List("array")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      mnI,
+      mxI,
+      None,
+      None,
+      Some[schema_object](items),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
   def literalDropLeft(n: nat, s: String): String =
     Str_Literal.literalOfAsciis(drop[BigInt](n, Str_Literal.asciisOfLiteral(s)))
 
@@ -8755,6 +8827,1111 @@ object SpecRestGenerated {
   def freshKey(base: String, seen: List[String]): String =
     freshKeyAux(Suc(size_list[String](seen)), base, seen, zero_nat)
 
+  def openApiSchemaFuel(am: List[(String, type_alias_decl_full)]): nat =
+    plus_nat(size_list[(String, type_alias_decl_full)](am), nat_of_integer(BigInt(100)))
+
+  def stripOptions(x0: type_expr_full): type_expr_full = x0 match {
+    case OptionTypeF(inner, uu)       => stripOptions(inner)
+    case NamedTypeF(v, va)            => NamedTypeF(v, va)
+    case SetTypeF(v, va)              => SetTypeF(v, va)
+    case MapTypeF(v, va, vb)          => MapTypeF(v, va, vb)
+    case SeqTypeF(v, va)              => SeqTypeF(v, va)
+    case RelationTypeF(v, va, vb, vc) => RelationTypeF(v, va, vb, vc)
+  }
+
+  def findEnumValuesInTypeAux(
+      fuel: nat,
+      uu: type_expr_full,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[(String, enum_decl_full)],
+      ux: List[String]
+  ): Option[List[String]] =
+    equal_nat(fuel, zero_nat) match {
+      case true => None
+      case false => stripOptions(uu) match {
+          case NamedTypeF(name, _) =>
+            map_of[String, enum_decl_full](uw, name) match {
+              case None =>
+                membera[String](ux, name) match {
+                  case true => None
+                  case false => map_of[String, type_alias_decl_full](uv, name) match {
+                      case None => None
+                      case Some(TypeAliasDeclFull(_, base, _, _)) =>
+                        findEnumValuesInTypeAux(minus_nat(fuel, one_nat), base, uv, uw, name :: ux)
+                    }
+                }
+              case Some(EnumDeclFull(_, vs, _)) =>
+                Some[List[String]](vs)
+            }
+          case SetTypeF(_, _)            => None
+          case MapTypeF(_, _, _)         => None
+          case SeqTypeF(_, _)            => None
+          case OptionTypeF(_, _)         => None
+          case RelationTypeF(_, _, _, _) => None
+        }
+    }
+
+  def findEnumValuesInType(
+      ty: type_expr_full,
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)]
+  ): Option[List[String]] =
+    findEnumValuesInTypeAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, em, Nil)
+
+  def openapiPrimitiveOf(nm: String): Option[openapi_primitive_def] =
+    nm == "String" match {
+      case true => Some[openapi_primitive_def](OpenApiPrimDef(List("string"), None))
+      case false => nm == "Int" match {
+          case true => Some[openapi_primitive_def](OpenApiPrimDef(List("integer"), None))
+          case false => nm == "Float" match {
+              case true => Some[openapi_primitive_def](OpenApiPrimDef(List("number"), None))
+              case false => nm == "Bool" match {
+                  case true => Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
+                  case false => nm == "Boolean" match {
+                      case true =>
+                        Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
+                      case false => nm == "DateTime" match {
+                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                              List("string"),
+                              Some[String]("date-time")
+                            ))
+                          case false => nm == "Date" match {
+                              case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                  List("string"),
+                                  Some[String]("date")
+                                ))
+                              case false => nm == "UUID" match {
+                                  case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                      List("string"),
+                                      Some[String]("uuid")
+                                    ))
+                                  case false => nm == "Decimal" match {
+                                      case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                          List("string"),
+                                          Some[String]("decimal")
+                                        ))
+                                      case false => nm == "Bytes" match {
+                                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
+                                              List("string"),
+                                              Some[String]("byte")
+                                            ))
+                                          case false => nm == "Money" match {
+                                              case true =>
+                                                Some[openapi_primitive_def](OpenApiPrimDef(
+                                                  List("integer"),
+                                                  None
+                                                ))
+                                              case false => None
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+  def classifyOpenApiNamedTypeAux(
+      fuel: nat,
+      uu: String,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[(String, enum_decl_full)],
+      ux: List[String],
+      uy: List[String]
+  ): openapi_named_kind =
+    equal_nat(fuel, zero_nat) match {
+      case true => OntUnknown()
+      case false => openapiPrimitiveOf(uu) match {
+          case None =>
+            map_of[String, enum_decl_full](uw, uu) match {
+              case None =>
+                membera[String](ux, uu) match {
+                  case true => OntEntityRef(uu)
+                  case false => membera[String](uy, uu) match {
+                      case true => OntUnknown()
+                      case false => map_of[String, type_alias_decl_full](uv, uu) match {
+                          case None => OntUnknown()
+                          case Some(TypeAliasDeclFull(_, base, _, _)) =>
+                            base match {
+                              case NamedTypeF(n, _) =>
+                                classifyOpenApiNamedTypeAux(
+                                  minus_nat(fuel, one_nat),
+                                  n,
+                                  uv,
+                                  uw,
+                                  ux,
+                                  uu :: uy
+                                )
+                              case SetTypeF(_, _)    => OntAliasToType(base)
+                              case MapTypeF(_, _, _) => OntAliasToType(base)
+                              case SeqTypeF(_, _)    => OntAliasToType(base)
+                              case OptionTypeF(_, _) => OntAliasToType(base)
+                              case RelationTypeF(_, _, _, _) =>
+                                OntAliasToType(base)
+                            }
+                        }
+                    }
+                }
+              case Some(EnumDeclFull(_, vs, _)) => OntEnum(vs)
+            }
+          case Some(a) => OntPrimitive(a)
+        }
+    }
+
+  def classifyOpenApiNamedType(
+      name: String,
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)],
+      entityNames: List[String]
+  ): openapi_named_kind =
+    classifyOpenApiNamedTypeAux(
+      Suc(size_list[(String, type_alias_decl_full)](am)),
+      name,
+      am,
+      em,
+      entityNames,
+      Nil
+    )
+
+  def mergeConstraintsLifted(
+      x0: schema_object,
+      x1: openapi_bounds,
+      enumOpt: Option[List[String]]
+  ): schema_object =
+    (x0, x1, enumOpt) match {
+      case (
+            SchemaObject(
+              ty,
+              fmt,
+              bMinL,
+              bMaxL,
+              bMn,
+              bMx,
+              bEmn,
+              bEmx,
+              mnI,
+              mxI,
+              bPat,
+              bEn,
+              it,
+              rf,
+              rq,
+              pr,
+              ap,
+              aof,
+              desc,
+              inE
+            ),
+            OpenApiBounds(cMinL, cMaxL, cMn, cMx, cEmn, cEmx, cPat),
+            enumOpt
+          ) => SchemaObject(
+          ty,
+          fmt,
+          cMinL match {
+            case None    => bMinL
+            case Some(_) => cMinL
+          },
+          cMaxL match {
+            case None    => bMaxL
+            case Some(_) => cMaxL
+          },
+          cMn match {
+            case None    => bMn
+            case Some(_) => cMn
+          },
+          cMx match {
+            case None    => bMx
+            case Some(_) => cMx
+          },
+          cEmn match {
+            case None    => bEmn
+            case Some(_) => cEmn
+          },
+          cEmx match {
+            case None    => bEmx
+            case Some(_) => cEmx
+          },
+          mnI,
+          mxI,
+          cPat match {
+            case None    => bPat
+            case Some(_) => cPat
+          },
+          enumOpt match {
+            case None    => bEn
+            case Some(_) => enumOpt
+          },
+          it,
+          rf,
+          rq,
+          pr,
+          ap,
+          aof,
+          desc,
+          inE
+        )
+    }
+
+  def primitiveDefToSchema(x0: openapi_primitive_def): schema_object = x0 match {
+    case OpenApiPrimDef(types, fmt) =>
+      SchemaObject(
+        Some[List[String]](types),
+        fmt,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        false
+      )
+  }
+
+  def decideNullable(refOpt: Option[String], typeOpt: Option[List[String]]): nullable_decision =
+    refOpt match {
+      case None =>
+        typeOpt match {
+          case None => NdWrapAnyOfNull()
+          case Some(currentTypes) =>
+            membera[String](currentTypes, "null") match {
+              case true  => NdNoop()
+              case false => NdAppendNull()
+            }
+        }
+      case Some(_) => NdWrapAnyOfNull()
+    }
+
+  def makeNullableLifted(x0: schema_object): schema_object = x0 match {
+    case SchemaObject(
+          ty,
+          fmt,
+          minL,
+          maxL,
+          mn,
+          mx,
+          emn,
+          emx,
+          mnI,
+          mxI,
+          pat,
+          en,
+          it,
+          rf,
+          rq,
+          pr,
+          ap,
+          aof,
+          desc,
+          inE
+        ) => decideNullable(rf, ty) match {
+        case NdNoop() =>
+          SchemaObject(
+            ty,
+            fmt,
+            minL,
+            maxL,
+            mn,
+            mx,
+            emn,
+            emx,
+            mnI,
+            mxI,
+            pat,
+            en,
+            it,
+            rf,
+            rq,
+            pr,
+            ap,
+            aof,
+            desc,
+            inE
+          )
+        case NdWrapAnyOfNull() =>
+          SchemaObject(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some[List[schema_object]](List(
+              SchemaObject(
+                ty,
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              ),
+              nullSchema
+            )),
+            None,
+            false
+          )
+        case NdAppendNull() =>
+          ty match {
+            case None =>
+              SchemaObject(
+                ty,
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              )
+            case Some(currentTypes) =>
+              SchemaObject(
+                Some[List[String]](currentTypes ++ List("null")),
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              )
+          }
+      }
+  }
+
+  def emptySchemaObject: schema_object =
+    SchemaObject(
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
+  def enumStringSchema(values: List[String]): schema_object =
+    SchemaObject(
+      Some[List[String]](List("string")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[List[String]](values),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
+  def mapObjectSchema(ap: schema_object): schema_object =
+    SchemaObject(
+      Some[List[String]](List("object")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[schema_object_or_bool](SOBSchema(ap)),
+      None,
+      None,
+      false
+    )
+
+  def entityRefSchema(name: String): schema_object =
+    SchemaObject(
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[String]("#/components/schemas/" + name + "Read"),
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
+  def boundsMinLength(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(mnL, uu, uv, uw, ux, uy, uz) => mnL
+  }
+
+  def boundsMaxLength(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(uu, mxL, uv, uw, ux, uy, uz) => mxL
+  }
+
+  def integerSchema: schema_object =
+    SchemaObject(
+      Some[List[String]](List("integer")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      false
+    )
+
+  def withExclusiveMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, ml, mn, mx, uu, emx, p)) =>
+        OpenApiBounds(nl, ml, mn, mx, v, emx, p)
+    }
+
+  def withExclusiveMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, ml, mn, mx, emn, uu, p)) =>
+        OpenApiBounds(nl, ml, mn, mx, emn, v, p)
+    }
+
+  def exclusiveMinimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, ux, emn, uy, uz) => emn
+  }
+
+  def exclusiveMaximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, ux, uy, emx, uz) => emx
+  }
+
+  def decimalGt(x0: decimal_lit, x1: decimal_lit): Boolean = (x0, x1) match {
+    case (DecimalLit(m1, e1), DecimalLit(m2, e2)) =>
+      less_eq_int(e1, e2) match {
+        case true => less_int(
+            times_inta(m2, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e2, e1)))),
+            m1
+          )
+        case false => less_int(
+            m2,
+            times_inta(m1, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e1, e2))))
+          )
+      }
+  }
+
+  def maxDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
+    decimalGt(a, b) match {
+      case true  => a
+      case false => b
+    }
+
+  def tightenDecMin(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
+    cur match {
+      case None    => Some[decimal_lit](d)
+      case Some(x) => Some[decimal_lit](maxDecimal(x, d))
+    }
+
+  def minDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
+    decimalGt(a, b) match {
+      case true  => b
+      case false => a
+    }
+
+  def tightenDecMax(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
+    cur match {
+      case None    => Some[decimal_lit](d)
+      case Some(x) => Some[decimal_lit](minDecimal(x, d))
+    }
+
+  def withMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, ml, uu, mx, emn, emx, p)) =>
+        OpenApiBounds(nl, ml, v, mx, emn, emx, p)
+    }
+
+  def withMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, ml, mn, uu, emn, emx, p)) =>
+        OpenApiBounds(nl, ml, mn, v, emn, emx, p)
+    }
+
+  def minimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, mn, uw, ux, uy, uz) => mn
+  }
+
+  def maximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
+    case OpenApiBounds(uu, uv, uw, mx, ux, uy, uz) => mx
+  }
+
+  def applyNumericBoundOpenApi(
+      op: bin_op_full,
+      d: decimal_lit,
+      bounds: openapi_bounds
+  ): openapi_bounds =
+    op match {
+      case BAnd()     => bounds
+      case BOr()      => bounds
+      case BImplies() => bounds
+      case BIff()     => bounds
+      case BEq() =>
+        withMaximum(
+          tightenDecMax(maximumOf(bounds), d),
+          withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
+        )
+      case BNeq() => bounds
+      case BLt() =>
+        withExclusiveMaximum(tightenDecMax(exclusiveMaximumOf(bounds), d), bounds)
+      case BGt() =>
+        withExclusiveMinimum(tightenDecMin(exclusiveMinimumOf(bounds), d), bounds)
+      case BLe()        => withMaximum(tightenDecMax(maximumOf(bounds), d), bounds)
+      case BGe()        => withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
+      case BIn()        => bounds
+      case BNotIn()     => bounds
+      case BSubset()    => bounds
+      case BUnion()     => bounds
+      case BIntersect() => bounds
+      case BDiff()      => bounds
+      case BAdd()       => bounds
+      case BSub()       => bounds
+      case BMul()       => bounds
+      case BDiv()       => bounds
+    }
+
+  def withMinLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(uu, ml, mn, mx, emn, emx, p)) =>
+        OpenApiBounds(v, ml, mn, mx, emn, emx, p)
+    }
+
+  def withMaxLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, uu, mn, mx, emn, emx, p)) =>
+        OpenApiBounds(nl, v, mn, mx, emn, emx, p)
+    }
+
+  def tightenIntMin(cur: Option[int], n: int): Option[int] =
+    cur match {
+      case None    => Some[int](n)
+      case Some(x) => Some[int](max[int](x, n))
+    }
+
+  def tightenIntMax(cur: Option[int], n: int): Option[int] =
+    cur match {
+      case None    => Some[int](n)
+      case Some(x) => Some[int](min[int](x, n))
+    }
+
+  def minLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(nl, uu, uv, uw, ux, uy, uz) => nl
+  }
+
+  def maxLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+    case OpenApiBounds(uu, ml, uv, uw, ux, uy, uz) => ml
+  }
+
+  def applyLengthBoundOpenApi(op: bin_op_full, n: int, bounds: openapi_bounds): openapi_bounds =
+    less_int(n, zero_int) match {
+      case true => bounds
+      case false => op match {
+          case BAnd()     => bounds
+          case BOr()      => bounds
+          case BImplies() => bounds
+          case BIff()     => bounds
+          case BEq() =>
+            withMaxLength(
+              tightenIntMax(maxLengthOf(bounds), n),
+              withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
+            )
+          case BNeq() => bounds
+          case BLt() =>
+            less_int(minus_int(n, one_inta), zero_int) match {
+              case true => bounds
+              case false =>
+                withMaxLength(tightenIntMax(maxLengthOf(bounds), minus_int(n, one_inta)), bounds)
+            }
+          case BGt() =>
+            withMinLength(tightenIntMin(minLengthOf(bounds), plus_int(n, one_inta)), bounds)
+          case BLe() =>
+            withMaxLength(tightenIntMax(maxLengthOf(bounds), n), bounds)
+          case BGe() =>
+            withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
+          case BIn()        => bounds
+          case BNotIn()     => bounds
+          case BSubset()    => bounds
+          case BUnion()     => bounds
+          case BIntersect() => bounds
+          case BDiff()      => bounds
+          case BAdd()       => bounds
+          case BSub()       => bounds
+          case BMul()       => bounds
+          case BDiv()       => bounds
+        }
+    }
+
+  def modulo_int(k: int, l: int): int =
+    int_of_integer(modulo_integer(integer_of_int(k), integer_of_int(l)))
+
+  def decimalToNonNegInt(x0: decimal_lit): Option[int] = x0 match {
+    case DecimalLit(m, e) =>
+      less_int(m, zero_int) match {
+        case true => None
+        case false => less_eq_int(zero_int, e) match {
+            case true =>
+              Some[int](times_inta(m, power[int](int_of_integer(BigInt(10)), nat.apply(e))))
+            case false =>
+              val p =
+                power[int](int_of_integer(BigInt(10)), nat.apply(uminus_int(e))): int;
+              equal_int(modulo_int(m, p), zero_int) match {
+                case true  => Some[int](divide_int(m, p))
+                case false => None
+              }
+          }
+      }
+  }
+
+  def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
+
+  def digitValue(c: BigInt): int = int_of_integer(c - BigInt(48))
+
+  def consumeDigitsAux(x0: List[BigInt], acc: int, count: nat): (int, (nat, List[BigInt])) =
+    (x0, acc, count) match {
+      case (Nil, acc, count) => (acc, (count, Nil))
+      case (c :: cs, acc, count) =>
+        isDigitAscii(c) match {
+          case true => consumeDigitsAux(
+              cs,
+              plus_int(times_inta(acc, int_of_integer(BigInt(10))), digitValue(c)),
+              plus_nat(count, one_nat)
+            )
+          case false => (acc, (count, c :: cs))
+        }
+    }
+
+  def parseDecimalLit(s: String): Option[decimal_lit] = {
+    val cs0 = Str_Literal.asciisOfLiteral(s): List[BigInt]
+    val (sign, cs1) =
+      (cs0 match {
+        case Nil => (one_inta, cs0)
+        case c :: rs =>
+          c == BigInt(45) match {
+            case true  => (uminus_int(one_inta), rs)
+            case false => (one_inta, cs0)
+          }
+      }): ((int, List[BigInt]));
+    consumeDigitsAux(cs1, zero_int, zero_nat) match {
+      case (intPart, (intLen, Nil)) =>
+        equal_nat(intLen, zero_nat) match {
+          case true  => None
+          case false => Some[decimal_lit](DecimalLit(times_inta(sign, intPart), zero_int))
+        }
+      case (intPart, (intLen, c :: rs)) =>
+        c == BigInt(46) match {
+          case true =>
+            val (fracPart, (fracLen, rest2)) =
+              consumeDigitsAux(rs, zero_int, zero_nat): ((int, (nat, List[BigInt])));
+            nulla[BigInt](rest2) &&
+              (less_nat(zero_nat, intLen) &&
+                less_nat(zero_nat, fracLen)) match {
+              case true => Some[decimal_lit](DecimalLit(
+                  times_inta(
+                    sign,
+                    plus_int(
+                      times_inta(intPart, power[int](int_of_integer(BigInt(10)), fracLen)),
+                      fracPart
+                    )
+                  ),
+                  uminus_int(int_of_nat(fracLen))
+                ))
+              case false => None
+            }
+          case false => None
+        }
+    }
+  }
+
+  def applyFloatAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
+    atom match {
+      case BinaryOpF(_, _, BinaryOpF(_, _, _, _), _)         => bounds
+      case BinaryOpF(_, _, UnaryOpF(_, _, _), _)             => bounds
+      case BinaryOpF(_, _, QuantifierF(_, _, _, _), _)       => bounds
+      case BinaryOpF(_, _, SomeWrapF(_, _), _)               => bounds
+      case BinaryOpF(_, _, TheF(_, _, _, _), _)              => bounds
+      case BinaryOpF(_, _, FieldAccessF(_, _, _), _)         => bounds
+      case BinaryOpF(_, _, EnumAccessF(_, _, _), _)          => bounds
+      case BinaryOpF(_, _, IndexF(_, _, _), _)               => bounds
+      case BinaryOpF(_, _, CallF(_, _, _), _)                => bounds
+      case BinaryOpF(_, _, PrimeF(_, _), _)                  => bounds
+      case BinaryOpF(_, _, PreF(_, _), _)                    => bounds
+      case BinaryOpF(_, _, WithF(_, _, _), _)                => bounds
+      case BinaryOpF(_, _, IfF(_, _, _, _), _)               => bounds
+      case BinaryOpF(_, _, LetF(_, _, _, _), _)              => bounds
+      case BinaryOpF(_, _, LambdaF(_, _, _), _)              => bounds
+      case BinaryOpF(_, _, ConstructorF(_, _, _), _)         => bounds
+      case BinaryOpF(_, _, SetLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, MapLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, SetComprehensionF(_, _, _, _), _) => bounds
+      case BinaryOpF(_, _, SeqLiteralF(_, _), _)             => bounds
+      case BinaryOpF(_, _, MatchesF(_, _, _), _)             => bounds
+      case BinaryOpF(_, _, IntLitF(_, _), _)                 => bounds
+      case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
+        parseDecimalLit(v) match {
+          case None => bounds
+          case Some(d) =>
+            isLenOfValue(lhs) match {
+              case true => decimalToNonNegInt(d) match {
+                  case None => bounds
+                  case Some(ni) =>
+                    applyLengthBoundOpenApi(op, ni, bounds)
+                }
+              case false => isValueRef(lhs) match {
+                  case true  => applyNumericBoundOpenApi(op, d, bounds)
+                  case false => bounds
+                }
+            }
+        }
+      case BinaryOpF(_, _, StringLitF(_, _), _)  => bounds
+      case BinaryOpF(_, _, BoolLitF(_, _), _)    => bounds
+      case BinaryOpF(_, _, NoneLitF(_), _)       => bounds
+      case BinaryOpF(_, _, IdentifierF(_, _), _) => bounds
+      case UnaryOpF(_, _, _)                     => bounds
+      case QuantifierF(_, _, _, _)               => bounds
+      case SomeWrapF(_, _)                       => bounds
+      case TheF(_, _, _, _)                      => bounds
+      case FieldAccessF(_, _, _)                 => bounds
+      case EnumAccessF(_, _, _)                  => bounds
+      case IndexF(_, _, _)                       => bounds
+      case CallF(_, _, _)                        => bounds
+      case PrimeF(_, _)                          => bounds
+      case PreF(_, _)                            => bounds
+      case WithF(_, _, _)                        => bounds
+      case IfF(_, _, _, _)                       => bounds
+      case LetF(_, _, _, _)                      => bounds
+      case LambdaF(_, _, _)                      => bounds
+      case ConstructorF(_, _, _)                 => bounds
+      case SetLiteralF(_, _)                     => bounds
+      case MapLiteralF(_, _)                     => bounds
+      case SetComprehensionF(_, _, _, _)         => bounds
+      case SeqLiteralF(_, _)                     => bounds
+      case MatchesF(_, _, _)                     => bounds
+      case IntLitF(_, _)                         => bounds
+      case FloatLitF(_, _)                       => bounds
+      case StringLitF(_, _)                      => bounds
+      case BoolLitF(_, _)                        => bounds
+      case NoneLitF(_)                           => bounds
+      case IdentifierF(_, _)                     => bounds
+    }
+
+  def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
+
+  def withPattern(v: Option[String], x1: openapi_bounds): openapi_bounds =
+    (v, x1) match {
+      case (v, OpenApiBounds(nl, ml, mn, mx, emn, emx, uu)) =>
+        OpenApiBounds(nl, ml, mn, mx, emn, emx, v)
+    }
+
+  def applyAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
+    decomposeAtom(atom) match {
+      case RaLenCmp(op, n) => applyLengthBoundOpenApi(op, n, bounds)
+      case RaValueCmp(op, n) =>
+        applyNumericBoundOpenApi(op, decimalOfInt(n), bounds)
+      case RaMatches(pat)       => withPattern(Some[String](pat), bounds)
+      case RaMatchesIdent(_, _) => applyFloatAtomOpenApi(atom, bounds)
+      case RaPredCall(_)        => applyFloatAtomOpenApi(atom, bounds)
+      case RaUnknown(_)         => applyFloatAtomOpenApi(atom, bounds)
+    }
+
+  def visitConstraintOpenApi(e: expr_full, bounds: openapi_bounds): openapi_bounds =
+    foldl[openapi_bounds, expr_full](
+      (acc: openapi_bounds) =>
+        (atom: expr_full) =>
+          applyAtomOpenApi(atom, acc),
+      bounds,
+      flattenAnd(e)
+    )
+
+  def emptyOpenApiBounds: openapi_bounds =
+    OpenApiBounds(None, None, None, None, None, None, None)
+
+  def aliasRefinementsAux(
+      fuel: nat,
+      uu: type_expr_full,
+      uv: List[(String, type_alias_decl_full)],
+      uw: List[String]
+  ): List[expr_full] =
+    equal_nat(fuel, zero_nat) match {
+      case true => Nil
+      case false => stripOptions(uu) match {
+          case NamedTypeF(name, _) =>
+            membera[String](uw, name) match {
+              case true => Nil
+              case false => map_of[String, type_alias_decl_full](uv, name) match {
+                  case None => Nil
+                  case Some(TypeAliasDeclFull(_, base, predOpt, _)) =>
+                    (predOpt match {
+                      case None    => Nil
+                      case Some(p) => List(p)
+                    }) ++
+                      aliasRefinementsAux(minus_nat(fuel, one_nat), base, uv, name :: uw)
+                }
+            }
+          case SetTypeF(_, _)            => Nil
+          case MapTypeF(_, _, _)         => Nil
+          case SeqTypeF(_, _)            => Nil
+          case OptionTypeF(_, _)         => Nil
+          case RelationTypeF(_, _, _, _) => Nil
+        }
+    }
+
+  def aliasRefinements(
+      ty: type_expr_full,
+      am: List[(String, type_alias_decl_full)]
+  ): List[expr_full] =
+    aliasRefinementsAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, Nil)
+
+  def computeFieldBounds(
+      ty: type_expr_full,
+      cOpt: Option[expr_full],
+      am: List[(String, type_alias_decl_full)]
+  ): openapi_bounds = {
+    val alias_bounds =
+      foldl[openapi_bounds, expr_full](
+        (b: openapi_bounds) =>
+          (p: expr_full) =>
+            visitConstraintOpenApi(p, b),
+        emptyOpenApiBounds,
+        aliasRefinements(ty, am)
+      ): openapi_bounds
+    val final_bounds =
+      (cOpt match {
+        case None    => alias_bounds
+        case Some(c) => visitConstraintOpenApi(c, alias_bounds)
+      }): openapi_bounds;
+    final_bounds
+  }
+
+  def typeExprToSchemaAux(
+      fuel: nat,
+      uu: type_expr_full,
+      uv: openapi_bounds,
+      uw: Option[List[String]],
+      ux: List[(String, type_alias_decl_full)],
+      uy: List[(String, enum_decl_full)],
+      uz: List[String]
+  ): schema_object =
+    equal_nat(fuel, zero_nat) match {
+      case true => emptySchemaObject
+      case false => uu match {
+          case NamedTypeF(name, _) =>
+            classifyOpenApiNamedType(name, ux, uy, uz) match {
+              case OntPrimitive(p) =>
+                mergeConstraintsLifted(primitiveDefToSchema(p), uv, uw)
+              case OntEnum(a)      => enumStringSchema(a)
+              case OntEntityRef(a) => entityRefSchema(a)
+              case OntAliasToType(base) =>
+                typeExprToSchemaAux(minus_nat(fuel, one_nat), base, uv, uw, ux, uy, uz)
+              case OntUnknown() =>
+                mergeConstraintsLifted(textSchema, uv, uw)
+            }
+          case SetTypeF(inner, _) =>
+            val (innerSchema, nullable) =
+              fieldToSchemaAux(minus_nat(fuel, one_nat), inner, None, ux, uy, uz): (
+                  (
+                      schema_object,
+                      Boolean
+                  )
+              )
+            val items =
+              (nullable match {
+                case true  => makeNullableLifted(innerSchema)
+                case false => innerSchema
+              }): schema_object;
+            arraySchema(items, boundsMinLength(uv), boundsMaxLength(uv))
+          case MapTypeF(_, v, _) =>
+            val (valueSchema, nullable) =
+              fieldToSchemaAux(minus_nat(fuel, one_nat), v, None, ux, uy, uz): (
+                  (
+                      schema_object,
+                      Boolean
+                  )
+              )
+            val a =
+              (nullable match {
+                case true  => makeNullableLifted(valueSchema)
+                case false => valueSchema
+              }): schema_object;
+            mapObjectSchema(a)
+          case SeqTypeF(inner, _) =>
+            val (innerSchema, nullable) =
+              fieldToSchemaAux(minus_nat(fuel, one_nat), inner, None, ux, uy, uz): (
+                  (
+                      schema_object,
+                      Boolean
+                  )
+              )
+            val items =
+              (nullable match {
+                case true  => makeNullableLifted(innerSchema)
+                case false => innerSchema
+              }): schema_object;
+            arraySchema(items, boundsMinLength(uv), boundsMaxLength(uv))
+          case OptionTypeF(inner, _) =>
+            typeExprToSchemaAux(minus_nat(fuel, one_nat), inner, uv, uw, ux, uy, uz)
+          case RelationTypeF(_, _, _, _) => integerSchema
+        }
+    }
+
+  def fieldToSchemaAux(
+      fuel: nat,
+      va: type_expr_full,
+      vb: Option[expr_full],
+      vc: List[(String, type_alias_decl_full)],
+      vd: List[(String, enum_decl_full)],
+      ve: List[String]
+  ): (schema_object, Boolean) =
+    equal_nat(fuel, zero_nat) match {
+      case true => (emptySchemaObject, false)
+      case false =>
+        val nullable =
+          (va match {
+            case NamedTypeF(_, _)          => false
+            case SetTypeF(_, _)            => false
+            case MapTypeF(_, _, _)         => false
+            case SeqTypeF(_, _)            => false
+            case OptionTypeF(_, _)         => true
+            case RelationTypeF(_, _, _, _) => false
+          }): Boolean
+        val effective =
+          (va match {
+            case NamedTypeF(a, b)      => NamedTypeF(a, b)
+            case SetTypeF(a, b)        => SetTypeF(a, b)
+            case MapTypeF(a, b, c)     => MapTypeF(a, b, c)
+            case SeqTypeF(a, b)        => SeqTypeF(a, b)
+            case OptionTypeF(inner, _) => inner
+            case RelationTypeF(a, b, c, d) =>
+              RelationTypeF(a, b, c, d)
+          }): type_expr_full
+        val bounds =
+          computeFieldBounds(effective, vb, vc): openapi_bounds
+        val enumOpt =
+          findEnumValuesInType(effective, vc, vd): Option[List[String]];
+        (
+          typeExprToSchemaAux(minus_nat(fuel, one_nat), effective, bounds, enumOpt, vc, vd, ve),
+          nullable
+        )
+    }
+
+  def fieldToSchema(
+      ty: type_expr_full,
+      cOpt: Option[expr_full],
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)],
+      ens: List[String]
+  ): (schema_object, Boolean) =
+    fieldToSchemaAux(openApiSchemaFuel(am), ty, cOpt, am, em, ens)
+
   def literalStartsWith(pre: String, s: String): Boolean = {
     val xs = Str_Literal.asciisOfLiteral(s): List[BigInt]
     val ys = Str_Literal.asciisOfLiteral(pre): List[BigInt];
@@ -9088,42 +10265,6 @@ object SpecRestGenerated {
     case DropTrigger(wb)                     => false
   }
 
-  def decimalGt(x0: decimal_lit, x1: decimal_lit): Boolean = (x0, x1) match {
-    case (DecimalLit(m1, e1), DecimalLit(m2, e2)) =>
-      less_eq_int(e1, e2) match {
-        case true => less_int(
-            times_inta(m2, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e2, e1)))),
-            m1
-          )
-        case false => less_int(
-            m2,
-            times_inta(m1, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e1, e2))))
-          )
-      }
-  }
-
-  def maximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
-    case OpenApiBounds(uu, uv, uw, mx, ux, uy, uz) => mx
-  }
-
-  def minimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
-    case OpenApiBounds(uu, uv, mn, uw, ux, uy, uz) => mn
-  }
-
-  def decideNullable(refOpt: Option[String], typeOpt: Option[List[String]]): nullable_decision =
-    refOpt match {
-      case None =>
-        typeOpt match {
-          case None => NdWrapAnyOfNull()
-          case Some(currentTypes) =>
-            membera[String](currentTypes, "null") match {
-              case true  => NdNoop()
-              case false => NdAppendNull()
-            }
-        }
-      case Some(_) => NdWrapAnyOfNull()
-    }
-
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
     isRkCreate(initial) && !matchesCreateShape match {
       case true  => RkOther()
@@ -9197,15 +10338,6 @@ object SpecRestGenerated {
             }
         }
     }
-
-  def stripOptions(x0: type_expr_full): type_expr_full = x0 match {
-    case OptionTypeF(inner, uu)       => stripOptions(inner)
-    case NamedTypeF(v, va)            => NamedTypeF(v, va)
-    case SetTypeF(v, va)              => SetTypeF(v, va)
-    case MapTypeF(v, va, vb)          => MapTypeF(v, va, vb)
-    case SeqTypeF(v, va)              => SeqTypeF(v, va)
-    case RelationTypeF(v, va, vb, vc) => RelationTypeF(v, va, vb, vc)
-  }
 
   def equal_ty(x0: ty, x1: ty): Boolean = (x0, x1) match {
     case (TEntity(x4), TSet(x5))    => false
@@ -9678,20 +10810,6 @@ object SpecRestGenerated {
     case MapTypeF(k, v, uy)          => collectTypeNames(k) ++ collectTypeNames(v)
     case RelationTypeF(f, uz, t, va) => collectTypeNames(f) ++ collectTypeNames(t)
   }
-
-  def digitValue(c: BigInt): int = int_of_integer(c - BigInt(48))
-
-  def maxDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
-    decimalGt(a, b) match {
-      case true  => a
-      case false => b
-    }
-
-  def minDecimal(a: decimal_lit, b: decimal_lit): decimal_lit =
-    decimalGt(a, b) match {
-      case true  => b
-      case false => a
-    }
 
   def aggregateForName(name: String): Option[trigger_aggregate] =
     name == "sum" match {
@@ -10174,31 +11292,15 @@ object SpecRestGenerated {
       case (NoneLitF(wi), wj)       => Nil
     }
 
-  def maxLengthOf(x0: openapi_bounds): Option[int] = x0 match {
-    case OpenApiBounds(uu, ml, uv, uw, ux, uy, uz) => ml
-  }
-
-  def minLengthOf(x0: openapi_bounds): Option[int] = x0 match {
-    case OpenApiBounds(nl, uu, uv, uw, ux, uy, uz) => nl
-  }
-
-  def withMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, ml, mn, uu, emn, emx, p)) =>
-        OpenApiBounds(nl, ml, mn, v, emn, emx, p)
-    }
-
-  def withMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, ml, uu, mx, emn, emx, p)) =>
-        OpenApiBounds(nl, ml, v, mx, emn, emx, p)
-    }
-
-  def withPattern(v: Option[String], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, ml, mn, mx, emn, emx, uu)) =>
-        OpenApiBounds(nl, ml, mn, mx, emn, emx, v)
-    }
+  def typeExprToSchema(
+      ty: type_expr_full,
+      bounds: openapi_bounds,
+      enumOpt: Option[List[String]],
+      am: List[(String, type_alias_decl_full)],
+      em: List[(String, enum_decl_full)],
+      ens: List[String]
+  ): schema_object =
+    typeExprToSchemaAux(openApiSchemaFuel(am), ty, bounds, enumOpt, am, em, ens)
 
   def triggerSourceForeignKey(x0: trigger_spec): String = x0 match {
     case TriggerSpec(uu, uv, uw, ux, uy, sfk, uz, va) => sfk
@@ -10247,34 +11349,6 @@ object SpecRestGenerated {
     case BoolLitF(v, va)                  => Nil
     case NoneLitF(v)                      => Nil
   }
-
-  def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
-
-  def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
-
-  def emptySchemaObject: schema_object =
-    SchemaObject(
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      None,
-      false
-    )
 
   def parseTemporalBody(e: expr_full): temporal_body =
     e match {
@@ -10856,42 +11930,6 @@ object SpecRestGenerated {
   def collectAllCallNames(e: expr_full): List[String] =
     maps[expr_full, String]((a: expr_full) => callSelfAllNames(a), allSubexprs(e))
 
-  def tightenDecMax(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
-    cur match {
-      case None    => Some[decimal_lit](d)
-      case Some(x) => Some[decimal_lit](minDecimal(x, d))
-    }
-
-  def tightenDecMin(cur: Option[decimal_lit], d: decimal_lit): Option[decimal_lit] =
-    cur match {
-      case None    => Some[decimal_lit](d)
-      case Some(x) => Some[decimal_lit](maxDecimal(x, d))
-    }
-
-  def tightenIntMax(cur: Option[int], n: int): Option[int] =
-    cur match {
-      case None    => Some[int](n)
-      case Some(x) => Some[int](min[int](x, n))
-    }
-
-  def tightenIntMin(cur: Option[int], n: int): Option[int] =
-    cur match {
-      case None    => Some[int](n)
-      case Some(x) => Some[int](max[int](x, n))
-    }
-
-  def withMaxLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, uu, mn, mx, emn, emx, p)) =>
-        OpenApiBounds(nl, v, mn, mx, emn, emx, p)
-    }
-
-  def withMinLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(uu, ml, mn, mx, emn, emx, p)) =>
-        OpenApiBounds(v, ml, mn, mx, emn, emx, p)
-    }
-
   def extractVerbBeforeKebab(opName: String, entityOpt: Option[String]): String =
     entityOpt match {
       case None => opName
@@ -11115,42 +12153,6 @@ object SpecRestGenerated {
       case NoneLitF(_)                   => None
       case IdentifierF(_, _)             => None
     }
-
-  def aliasRefinementsAux(
-      fuel: nat,
-      uu: type_expr_full,
-      uv: List[(String, type_alias_decl_full)],
-      uw: List[String]
-  ): List[expr_full] =
-    equal_nat(fuel, zero_nat) match {
-      case true => Nil
-      case false => stripOptions(uu) match {
-          case NamedTypeF(name, _) =>
-            membera[String](uw, name) match {
-              case true => Nil
-              case false => map_of[String, type_alias_decl_full](uv, name) match {
-                  case None => Nil
-                  case Some(TypeAliasDeclFull(_, base, predOpt, _)) =>
-                    (predOpt match {
-                      case None    => Nil
-                      case Some(p) => List(p)
-                    }) ++
-                      aliasRefinementsAux(minus_nat(fuel, one_nat), base, uv, name :: uw)
-                }
-            }
-          case SetTypeF(_, _)            => Nil
-          case MapTypeF(_, _, _)         => Nil
-          case SeqTypeF(_, _)            => Nil
-          case OptionTypeF(_, _)         => Nil
-          case RelationTypeF(_, _, _, _) => Nil
-        }
-    }
-
-  def aliasRefinements(
-      ty: type_expr_full,
-      am: List[(String, type_alias_decl_full)]
-  ): List[expr_full] =
-    aliasRefinementsAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, Nil)
 
   def splitOnColonAux(uu: List[BigInt], x1: List[BigInt]): Option[(List[BigInt], List[BigInt])] =
     (uu, x1) match {
@@ -11397,88 +12399,6 @@ object SpecRestGenerated {
       (a: expr_full) => fieldAccessNameSelect(a),
       allSubexprs(e)
     ))
-
-  def consumeDigitsAux(x0: List[BigInt], acc: int, count: nat): (int, (nat, List[BigInt])) =
-    (x0, acc, count) match {
-      case (Nil, acc, count) => (acc, (count, Nil))
-      case (c :: cs, acc, count) =>
-        isDigitAscii(c) match {
-          case true => consumeDigitsAux(
-              cs,
-              plus_int(times_inta(acc, int_of_integer(BigInt(10))), digitValue(c)),
-              plus_nat(count, one_nat)
-            )
-          case false => (acc, (count, c :: cs))
-        }
-    }
-
-  def parseDecimalLit(s: String): Option[decimal_lit] = {
-    val cs0 = Str_Literal.asciisOfLiteral(s): List[BigInt]
-    val (sign, cs1) =
-      (cs0 match {
-        case Nil => (one_inta, cs0)
-        case c :: rs =>
-          c == BigInt(45) match {
-            case true  => (uminus_int(one_inta), rs)
-            case false => (one_inta, cs0)
-          }
-      }): ((int, List[BigInt]));
-    consumeDigitsAux(cs1, zero_int, zero_nat) match {
-      case (intPart, (intLen, Nil)) =>
-        equal_nat(intLen, zero_nat) match {
-          case true  => None
-          case false => Some[decimal_lit](DecimalLit(times_inta(sign, intPart), zero_int))
-        }
-      case (intPart, (intLen, c :: rs)) =>
-        c == BigInt(46) match {
-          case true =>
-            val (fracPart, (fracLen, rest2)) =
-              consumeDigitsAux(rs, zero_int, zero_nat): ((int, (nat, List[BigInt])));
-            nulla[BigInt](rest2) &&
-              (less_nat(zero_nat, intLen) &&
-                less_nat(zero_nat, fracLen)) match {
-              case true => Some[decimal_lit](DecimalLit(
-                  times_inta(
-                    sign,
-                    plus_int(
-                      times_inta(intPart, power[int](int_of_integer(BigInt(10)), fracLen)),
-                      fracPart
-                    )
-                  ),
-                  uminus_int(int_of_nat(fracLen))
-                ))
-              case false => None
-            }
-          case false => None
-        }
-    }
-  }
-
-  def primitiveDefToSchema(x0: openapi_primitive_def): schema_object = x0 match {
-    case OpenApiPrimDef(types, fmt) =>
-      SchemaObject(
-        Some[List[String]](types),
-        fmt,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        false
-      )
-  }
 
   def classifyInvariantAtom(e: expr_full): invariant_check_class =
     e match {
@@ -11748,62 +12668,6 @@ object SpecRestGenerated {
       case IdentifierF(_, _)             => IcSkip()
     }
 
-  def openapiPrimitiveOf(nm: String): Option[openapi_primitive_def] =
-    nm == "String" match {
-      case true => Some[openapi_primitive_def](OpenApiPrimDef(List("string"), None))
-      case false => nm == "Int" match {
-          case true => Some[openapi_primitive_def](OpenApiPrimDef(List("integer"), None))
-          case false => nm == "Float" match {
-              case true => Some[openapi_primitive_def](OpenApiPrimDef(List("number"), None))
-              case false => nm == "Bool" match {
-                  case true => Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
-                  case false => nm == "Boolean" match {
-                      case true =>
-                        Some[openapi_primitive_def](OpenApiPrimDef(List("boolean"), None))
-                      case false => nm == "DateTime" match {
-                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
-                              List("string"),
-                              Some[String]("date-time")
-                            ))
-                          case false => nm == "Date" match {
-                              case true => Some[openapi_primitive_def](OpenApiPrimDef(
-                                  List("string"),
-                                  Some[String]("date")
-                                ))
-                              case false => nm == "UUID" match {
-                                  case true => Some[openapi_primitive_def](OpenApiPrimDef(
-                                      List("string"),
-                                      Some[String]("uuid")
-                                    ))
-                                  case false => nm == "Decimal" match {
-                                      case true => Some[openapi_primitive_def](OpenApiPrimDef(
-                                          List("string"),
-                                          Some[String]("decimal")
-                                        ))
-                                      case false => nm == "Bytes" match {
-                                          case true => Some[openapi_primitive_def](OpenApiPrimDef(
-                                              List("string"),
-                                              Some[String]("byte")
-                                            ))
-                                          case false => nm == "Money" match {
-                                              case true =>
-                                                Some[openapi_primitive_def](OpenApiPrimDef(
-                                                  List("integer"),
-                                                  None
-                                                ))
-                                              case false => None
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
   def extractTsTuple(
       x0: convention_rule_full,
       ens: List[String]
@@ -11964,203 +12828,6 @@ object SpecRestGenerated {
     case RelationTypeF(v, va, RelationTypeF(vd, ve, vf, vg), vc) => None
   }
 
-  def withExclusiveMinimum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, ml, mn, mx, uu, emx, p)) =>
-        OpenApiBounds(nl, ml, mn, mx, v, emx, p)
-    }
-
-  def withExclusiveMaximum(v: Option[decimal_lit], x1: openapi_bounds): openapi_bounds =
-    (v, x1) match {
-      case (v, OpenApiBounds(nl, ml, mn, mx, emn, uu, p)) =>
-        OpenApiBounds(nl, ml, mn, mx, emn, v, p)
-    }
-
-  def exclusiveMinimumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
-    case OpenApiBounds(uu, uv, uw, ux, emn, uy, uz) => emn
-  }
-
-  def exclusiveMaximumOf(x0: openapi_bounds): Option[decimal_lit] = x0 match {
-    case OpenApiBounds(uu, uv, uw, ux, uy, emx, uz) => emx
-  }
-
-  def applyNumericBoundOpenApi(
-      op: bin_op_full,
-      d: decimal_lit,
-      bounds: openapi_bounds
-  ): openapi_bounds =
-    op match {
-      case BAnd()     => bounds
-      case BOr()      => bounds
-      case BImplies() => bounds
-      case BIff()     => bounds
-      case BEq() =>
-        withMaximum(
-          tightenDecMax(maximumOf(bounds), d),
-          withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
-        )
-      case BNeq() => bounds
-      case BLt() =>
-        withExclusiveMaximum(tightenDecMax(exclusiveMaximumOf(bounds), d), bounds)
-      case BGt() =>
-        withExclusiveMinimum(tightenDecMin(exclusiveMinimumOf(bounds), d), bounds)
-      case BLe()        => withMaximum(tightenDecMax(maximumOf(bounds), d), bounds)
-      case BGe()        => withMinimum(tightenDecMin(minimumOf(bounds), d), bounds)
-      case BIn()        => bounds
-      case BNotIn()     => bounds
-      case BSubset()    => bounds
-      case BUnion()     => bounds
-      case BIntersect() => bounds
-      case BDiff()      => bounds
-      case BAdd()       => bounds
-      case BSub()       => bounds
-      case BMul()       => bounds
-      case BDiv()       => bounds
-    }
-
-  def applyLengthBoundOpenApi(op: bin_op_full, n: int, bounds: openapi_bounds): openapi_bounds =
-    less_int(n, zero_int) match {
-      case true => bounds
-      case false => op match {
-          case BAnd()     => bounds
-          case BOr()      => bounds
-          case BImplies() => bounds
-          case BIff()     => bounds
-          case BEq() =>
-            withMaxLength(
-              tightenIntMax(maxLengthOf(bounds), n),
-              withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
-            )
-          case BNeq() => bounds
-          case BLt() =>
-            less_int(minus_int(n, one_inta), zero_int) match {
-              case true => bounds
-              case false =>
-                withMaxLength(tightenIntMax(maxLengthOf(bounds), minus_int(n, one_inta)), bounds)
-            }
-          case BGt() =>
-            withMinLength(tightenIntMin(minLengthOf(bounds), plus_int(n, one_inta)), bounds)
-          case BLe() =>
-            withMaxLength(tightenIntMax(maxLengthOf(bounds), n), bounds)
-          case BGe() =>
-            withMinLength(tightenIntMin(minLengthOf(bounds), n), bounds)
-          case BIn()        => bounds
-          case BNotIn()     => bounds
-          case BSubset()    => bounds
-          case BUnion()     => bounds
-          case BIntersect() => bounds
-          case BDiff()      => bounds
-          case BAdd()       => bounds
-          case BSub()       => bounds
-          case BMul()       => bounds
-          case BDiv()       => bounds
-        }
-    }
-
-  def modulo_int(k: int, l: int): int =
-    int_of_integer(modulo_integer(integer_of_int(k), integer_of_int(l)))
-
-  def decimalToNonNegInt(x0: decimal_lit): Option[int] = x0 match {
-    case DecimalLit(m, e) =>
-      less_int(m, zero_int) match {
-        case true => None
-        case false => less_eq_int(zero_int, e) match {
-            case true =>
-              Some[int](times_inta(m, power[int](int_of_integer(BigInt(10)), nat.apply(e))))
-            case false =>
-              val p =
-                power[int](int_of_integer(BigInt(10)), nat.apply(uminus_int(e))): int;
-              equal_int(modulo_int(m, p), zero_int) match {
-                case true  => Some[int](divide_int(m, p))
-                case false => None
-              }
-          }
-      }
-  }
-
-  def applyFloatAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
-    atom match {
-      case BinaryOpF(_, _, BinaryOpF(_, _, _, _), _)         => bounds
-      case BinaryOpF(_, _, UnaryOpF(_, _, _), _)             => bounds
-      case BinaryOpF(_, _, QuantifierF(_, _, _, _), _)       => bounds
-      case BinaryOpF(_, _, SomeWrapF(_, _), _)               => bounds
-      case BinaryOpF(_, _, TheF(_, _, _, _), _)              => bounds
-      case BinaryOpF(_, _, FieldAccessF(_, _, _), _)         => bounds
-      case BinaryOpF(_, _, EnumAccessF(_, _, _), _)          => bounds
-      case BinaryOpF(_, _, IndexF(_, _, _), _)               => bounds
-      case BinaryOpF(_, _, CallF(_, _, _), _)                => bounds
-      case BinaryOpF(_, _, PrimeF(_, _), _)                  => bounds
-      case BinaryOpF(_, _, PreF(_, _), _)                    => bounds
-      case BinaryOpF(_, _, WithF(_, _, _), _)                => bounds
-      case BinaryOpF(_, _, IfF(_, _, _, _), _)               => bounds
-      case BinaryOpF(_, _, LetF(_, _, _, _), _)              => bounds
-      case BinaryOpF(_, _, LambdaF(_, _, _), _)              => bounds
-      case BinaryOpF(_, _, ConstructorF(_, _, _), _)         => bounds
-      case BinaryOpF(_, _, SetLiteralF(_, _), _)             => bounds
-      case BinaryOpF(_, _, MapLiteralF(_, _), _)             => bounds
-      case BinaryOpF(_, _, SetComprehensionF(_, _, _, _), _) => bounds
-      case BinaryOpF(_, _, SeqLiteralF(_, _), _)             => bounds
-      case BinaryOpF(_, _, MatchesF(_, _, _), _)             => bounds
-      case BinaryOpF(_, _, IntLitF(_, _), _)                 => bounds
-      case BinaryOpF(op, lhs, FloatLitF(v, _), _) =>
-        parseDecimalLit(v) match {
-          case None => bounds
-          case Some(d) =>
-            isLenOfValue(lhs) match {
-              case true => decimalToNonNegInt(d) match {
-                  case None => bounds
-                  case Some(ni) =>
-                    applyLengthBoundOpenApi(op, ni, bounds)
-                }
-              case false => isValueRef(lhs) match {
-                  case true  => applyNumericBoundOpenApi(op, d, bounds)
-                  case false => bounds
-                }
-            }
-        }
-      case BinaryOpF(_, _, StringLitF(_, _), _)  => bounds
-      case BinaryOpF(_, _, BoolLitF(_, _), _)    => bounds
-      case BinaryOpF(_, _, NoneLitF(_), _)       => bounds
-      case BinaryOpF(_, _, IdentifierF(_, _), _) => bounds
-      case UnaryOpF(_, _, _)                     => bounds
-      case QuantifierF(_, _, _, _)               => bounds
-      case SomeWrapF(_, _)                       => bounds
-      case TheF(_, _, _, _)                      => bounds
-      case FieldAccessF(_, _, _)                 => bounds
-      case EnumAccessF(_, _, _)                  => bounds
-      case IndexF(_, _, _)                       => bounds
-      case CallF(_, _, _)                        => bounds
-      case PrimeF(_, _)                          => bounds
-      case PreF(_, _)                            => bounds
-      case WithF(_, _, _)                        => bounds
-      case IfF(_, _, _, _)                       => bounds
-      case LetF(_, _, _, _)                      => bounds
-      case LambdaF(_, _, _)                      => bounds
-      case ConstructorF(_, _, _)                 => bounds
-      case SetLiteralF(_, _)                     => bounds
-      case MapLiteralF(_, _)                     => bounds
-      case SetComprehensionF(_, _, _, _)         => bounds
-      case SeqLiteralF(_, _)                     => bounds
-      case MatchesF(_, _, _)                     => bounds
-      case IntLitF(_, _)                         => bounds
-      case FloatLitF(_, _)                       => bounds
-      case StringLitF(_, _)                      => bounds
-      case BoolLitF(_, _)                        => bounds
-      case NoneLitF(_)                           => bounds
-      case IdentifierF(_, _)                     => bounds
-    }
-
-  def applyAtomOpenApi(atom: expr_full, bounds: openapi_bounds): openapi_bounds =
-    decomposeAtom(atom) match {
-      case RaLenCmp(op, n) => applyLengthBoundOpenApi(op, n, bounds)
-      case RaValueCmp(op, n) =>
-        applyNumericBoundOpenApi(op, decimalOfInt(n), bounds)
-      case RaMatches(pat)       => withPattern(Some[String](pat), bounds)
-      case RaMatchesIdent(_, _) => applyFloatAtomOpenApi(atom, bounds)
-      case RaPredCall(_)        => applyFloatAtomOpenApi(atom, bounds)
-      case RaUnknown(_)         => applyFloatAtomOpenApi(atom, bounds)
-    }
-
   def disambiguateKeysAux[A](
       x0: List[(String, A)],
       uu: List[String],
@@ -12250,85 +12917,6 @@ object SpecRestGenerated {
 
   def anonInvariantName(idx: nat): String = "anon_" + showNat(idx)
 
-  def mergeConstraintsLifted(
-      x0: schema_object,
-      x1: openapi_bounds,
-      enumOpt: Option[List[String]]
-  ): schema_object =
-    (x0, x1, enumOpt) match {
-      case (
-            SchemaObject(
-              ty,
-              fmt,
-              bMinL,
-              bMaxL,
-              bMn,
-              bMx,
-              bEmn,
-              bEmx,
-              mnI,
-              mxI,
-              bPat,
-              bEn,
-              it,
-              rf,
-              rq,
-              pr,
-              ap,
-              aof,
-              desc,
-              inE
-            ),
-            OpenApiBounds(cMinL, cMaxL, cMn, cMx, cEmn, cEmx, cPat),
-            enumOpt
-          ) => SchemaObject(
-          ty,
-          fmt,
-          cMinL match {
-            case None    => bMinL
-            case Some(_) => cMinL
-          },
-          cMaxL match {
-            case None    => bMaxL
-            case Some(_) => cMaxL
-          },
-          cMn match {
-            case None    => bMn
-            case Some(_) => cMn
-          },
-          cMx match {
-            case None    => bMx
-            case Some(_) => cMx
-          },
-          cEmn match {
-            case None    => bEmn
-            case Some(_) => cEmn
-          },
-          cEmx match {
-            case None    => bEmx
-            case Some(_) => cEmx
-          },
-          mnI,
-          mxI,
-          cPat match {
-            case None    => bPat
-            case Some(_) => cPat
-          },
-          enumOpt match {
-            case None    => bEn
-            case Some(_) => enumOpt
-          },
-          it,
-          rf,
-          rq,
-          pr,
-          ap,
-          aof,
-          desc,
-          inE
-        )
-    }
-
   def classifyColumnCheckAtom(e: expr_full): column_check_class =
     decomposeAtom(e) match {
       case RaLenCmp(a, b)       => CcLenCompare(a, b)
@@ -12378,45 +12966,6 @@ object SpecRestGenerated {
         }
     }
 
-  def findEnumValuesInTypeAux(
-      fuel: nat,
-      uu: type_expr_full,
-      uv: List[(String, type_alias_decl_full)],
-      uw: List[(String, enum_decl_full)],
-      ux: List[String]
-  ): Option[List[String]] =
-    equal_nat(fuel, zero_nat) match {
-      case true => None
-      case false => stripOptions(uu) match {
-          case NamedTypeF(name, _) =>
-            map_of[String, enum_decl_full](uw, name) match {
-              case None =>
-                membera[String](ux, name) match {
-                  case true => None
-                  case false => map_of[String, type_alias_decl_full](uv, name) match {
-                      case None => None
-                      case Some(TypeAliasDeclFull(_, base, _, _)) =>
-                        findEnumValuesInTypeAux(minus_nat(fuel, one_nat), base, uv, uw, name :: ux)
-                    }
-                }
-              case Some(EnumDeclFull(_, vs, _)) =>
-                Some[List[String]](vs)
-            }
-          case SetTypeF(_, _)            => None
-          case MapTypeF(_, _, _)         => None
-          case SeqTypeF(_, _)            => None
-          case OptionTypeF(_, _)         => None
-          case RelationTypeF(_, _, _, _) => None
-        }
-    }
-
-  def findEnumValuesInType(
-      ty: type_expr_full,
-      am: List[(String, type_alias_decl_full)],
-      em: List[(String, enum_decl_full)]
-  ): Option[List[String]] =
-    findEnumValuesInTypeAux(Suc(size_list[(String, type_alias_decl_full)](am)), ty, am, em, Nil)
-
   def paramListHasName(x0: List[param_decl_full], uu: String): Boolean =
     (x0, uu) match {
       case (Nil, uu) => false
@@ -12448,9 +12997,6 @@ object SpecRestGenerated {
         case true  => " SERIAL NOT NULL"
         case false => " BIGSERIAL NOT NULL"
       })
-
-  def emptyOpenApiBounds: openapi_bounds =
-    OpenApiBounds(None, None, None, None, None, None, None)
 
   def detectAggregateInvariant(invExpr: expr_full): Option[detected_aggregate] =
     invExpr match {
@@ -12663,68 +13209,6 @@ object SpecRestGenerated {
       case RelationTypeF(_, _, _, _)              => None
     }
 
-  def classifyOpenApiNamedTypeAux(
-      fuel: nat,
-      uu: String,
-      uv: List[(String, type_alias_decl_full)],
-      uw: List[(String, enum_decl_full)],
-      ux: List[String],
-      uy: List[String]
-  ): openapi_named_kind =
-    equal_nat(fuel, zero_nat) match {
-      case true => OntUnknown()
-      case false => openapiPrimitiveOf(uu) match {
-          case None =>
-            map_of[String, enum_decl_full](uw, uu) match {
-              case None =>
-                membera[String](ux, uu) match {
-                  case true => OntEntityRef(uu)
-                  case false => membera[String](uy, uu) match {
-                      case true => OntUnknown()
-                      case false => map_of[String, type_alias_decl_full](uv, uu) match {
-                          case None => OntUnknown()
-                          case Some(TypeAliasDeclFull(_, base, _, _)) =>
-                            base match {
-                              case NamedTypeF(n, _) =>
-                                classifyOpenApiNamedTypeAux(
-                                  minus_nat(fuel, one_nat),
-                                  n,
-                                  uv,
-                                  uw,
-                                  ux,
-                                  uu :: uy
-                                )
-                              case SetTypeF(_, _)    => OntAliasToType(base)
-                              case MapTypeF(_, _, _) => OntAliasToType(base)
-                              case SeqTypeF(_, _)    => OntAliasToType(base)
-                              case OptionTypeF(_, _) => OntAliasToType(base)
-                              case RelationTypeF(_, _, _, _) =>
-                                OntAliasToType(base)
-                            }
-                        }
-                    }
-                }
-              case Some(EnumDeclFull(_, vs, _)) => OntEnum(vs)
-            }
-          case Some(a) => OntPrimitive(a)
-        }
-    }
-
-  def classifyOpenApiNamedType(
-      name: String,
-      am: List[(String, type_alias_decl_full)],
-      em: List[(String, enum_decl_full)],
-      entityNames: List[String]
-  ): openapi_named_kind =
-    classifyOpenApiNamedTypeAux(
-      Suc(size_list[(String, type_alias_decl_full)](am)),
-      name,
-      am,
-      em,
-      entityNames,
-      Nil
-    )
-
   def parseNonEmptyStringPv(e: expr_full): convention_value =
     asStringLit(e) match {
       case None => CvBad(ExpectedString(), e)
@@ -12787,15 +13271,6 @@ object SpecRestGenerated {
   def capsSupportsCheckConstraint(x0: dialect_caps): Boolean = x0 match {
     case DialectCaps(uu, b, uv, uw, ux, uy) => b
   }
-
-  def visitConstraintOpenApi(e: expr_full, bounds: openapi_bounds): openapi_bounds =
-    foldl[openapi_bounds, expr_full](
-      (acc: openapi_bounds) =>
-        (atom: expr_full) =>
-          applyAtomOpenApi(atom, acc),
-      bounds,
-      flattenAnd(e)
-    )
 
   def operationHasParamNamed(x0: operation_decl_full, nm: String): Boolean =
     (x0, nm) match {

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -15,6 +15,7 @@ theory Codegen
     RouteKind
     SchemaTraversal
     OpenApiConstraints
+    OpenApiSchema
     ValidateConventions
     DialectSchema
     ParseTemporal
@@ -294,6 +295,10 @@ export_code
     appendPartialIndexes
     classifyInvariantAtom
     classifyColumnCheckAtom
+    emptySchemaObject
+    primitiveDefToSchema
+    mergeConstraintsLifted
+    decideNullable
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -299,6 +299,18 @@ export_code
     primitiveDefToSchema
     mergeConstraintsLifted
     decideNullable
+    makeNullableLifted
+    integerSchema
+    textSchema
+    enumStringSchema
+    entityRefSchema
+    arraySchema
+    mapObjectSchema
+    boundsMinLength
+    boundsMaxLength
+    computeFieldBounds
+    typeExprToSchema
+    fieldToSchema
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/OpenApiSchema.thy
+++ b/proofs/isabelle/SpecRest/OpenApiSchema.thy
@@ -1,0 +1,136 @@
+theory OpenApiSchema
+  imports OpenApiConstraints SchemaTraversal
+begin
+
+text \<open>Lifted core of the OpenAPI \<open>SchemaObject\<close> datatype and the
+  non-recursive construction primitives behind
+  \<open>specrest.codegen.openapi.OpenApi.SchemaObject\<close>,
+  \<open>OpenApi.Schema.primitiveDefToSchema\<close>,
+  \<open>OpenApi.Schema.mergeConstraints\<close>, and
+  \<open>OpenApi.Schema.makeNullable\<close>.
+
+  Field order matches the hand-written Scala case class (positional);
+  the Scala-side \<open>SchemaObjectAdapter\<close> converts the lifted record back
+  into the named-field facade that the YAML emitter reflects over.
+
+  Numeric bounds carry \<open>decimal_lit\<close> here (matching \<open>openapi_bounds\<close>);
+  the Scala adapter coerces to \<open>Double\<close> at the API boundary via the
+  existing \<open>decimalToDouble\<close> helper. This keeps the lifted layer free
+  of \<open>Double\<close> and preserves the user's literal mantissa+exponent shape
+  through to emit-time.
+
+  \<open>schema_object\<close> and \<open>schema_object_or_bool\<close> are mutually recursive
+  (\<open>additionalProperties\<close> may hold either a nested schema or a bool),
+  so they are declared in a single \<open>datatype\<close> block.\<close>
+
+datatype schema_object = SchemaObject
+  "String.literal list option"            \<comment> \<open>type (one or more JSON-schema type tags, ordered)\<close>
+  "String.literal option"                 \<comment> \<open>format\<close>
+  "int option"                            \<comment> \<open>minLength\<close>
+  "int option"                            \<comment> \<open>maxLength\<close>
+  "decimal_lit option"                    \<comment> \<open>minimum\<close>
+  "decimal_lit option"                    \<comment> \<open>maximum\<close>
+  "decimal_lit option"                    \<comment> \<open>exclusiveMinimum\<close>
+  "decimal_lit option"                    \<comment> \<open>exclusiveMaximum\<close>
+  "int option"                            \<comment> \<open>minItems\<close>
+  "int option"                            \<comment> \<open>maxItems\<close>
+  "String.literal option"                 \<comment> \<open>pattern\<close>
+  "String.literal list option"            \<comment> \<open>enum_\<close>
+  "schema_object option"                  \<comment> \<open>items\<close>
+  "String.literal option"                 \<comment> \<open>ref\<close>
+  "String.literal list option"            \<comment> \<open>required\<close>
+  "(String.literal \<times> schema_object) list option" \<comment> \<open>properties (ordered alist)\<close>
+  "schema_object_or_bool option"          \<comment> \<open>additionalProperties\<close>
+  "schema_object list option"             \<comment> \<open>anyOf\<close>
+  "String.literal option"                 \<comment> \<open>description\<close>
+  bool                                    \<comment> \<open>includeNullInEnum\<close>
+and schema_object_or_bool =
+    SOBSchema schema_object
+  | SOBBool bool
+
+text \<open>Field-blank \<open>schema_object\<close>. Used as the base for incremental
+  construction; mirrors the Scala default-argument \<open>SchemaObject()\<close>.\<close>
+
+definition emptySchemaObject :: schema_object where
+  "emptySchemaObject = SchemaObject
+     None None None None None None None None None None
+     None None None None None None None None None False"
+
+text \<open>Lift of \<open>OpenApi.Schema.primitiveDefToSchema\<close>: construct a
+  \<open>schema_object\<close> from a primitive's \<open>type\<close> tags and optional \<open>format\<close>.\<close>
+
+fun primitiveDefToSchema :: "openapi_primitive_def \<Rightarrow> schema_object" where
+  "primitiveDefToSchema (OpenApiPrimDef types fmt) =
+     SchemaObject (Some types) fmt None None None None None None None None
+                  None None None None None None None None None False"
+
+text \<open>Lift of \<open>OpenApi.Schema.mergeConstraints\<close> rewritten to consume the
+  lifted \<open>openapi_bounds\<close> directly, eliminating the Scala-side
+  \<open>JsonSchemaConstraints\<close> intermediate. Each incoming bound takes
+  precedence on \<open>Some\<close>; \<open>None\<close> leaves the base value intact
+  (same as Scala \<open>.orElse\<close> precedence).
+
+  The Scala caller will adopt this in a follow-up PR that drops
+  \<open>JsonSchemaConstraints\<close> and threads \<open>openapi_bounds\<close> through
+  \<open>typeExprToSchema\<close> directly (the current Scala mergeConstraints reads
+  from \<open>JsonSchemaConstraints\<close>, whose \<open>Double\<close> numeric fields are a
+  one-way projection of the original \<open>decimal_lit\<close>; consuming bounds
+  directly avoids the lossy round-trip).\<close>
+
+fun mergeConstraintsLifted ::
+  "schema_object \<Rightarrow> openapi_bounds \<Rightarrow> String.literal list option \<Rightarrow> schema_object"
+where
+  "mergeConstraintsLifted
+      (SchemaObject ty fmt bMinL bMaxL bMn bMx bEmn bEmx mnI mxI bPat bEn it rf rq pr ap aof desc inE)
+      (OpenApiBounds cMinL cMaxL cMn cMx cEmn cEmx cPat)
+      enumOpt =
+    SchemaObject
+      ty fmt
+      (case cMinL of None \<Rightarrow> bMinL | _ \<Rightarrow> cMinL)
+      (case cMaxL of None \<Rightarrow> bMaxL | _ \<Rightarrow> cMaxL)
+      (case cMn   of None \<Rightarrow> bMn   | _ \<Rightarrow> cMn)
+      (case cMx   of None \<Rightarrow> bMx   | _ \<Rightarrow> cMx)
+      (case cEmn  of None \<Rightarrow> bEmn  | _ \<Rightarrow> cEmn)
+      (case cEmx  of None \<Rightarrow> bEmx  | _ \<Rightarrow> cEmx)
+      mnI mxI
+      (case cPat   of None \<Rightarrow> bPat | _ \<Rightarrow> cPat)
+      (case enumOpt of None \<Rightarrow> bEn  | _ \<Rightarrow> enumOpt)
+      it rf rq pr ap aof desc inE"
+
+text \<open>Lift of \<open>OpenApi.Schema.makeNullable\<close> as a *decision classifier*
+  rather than a value-producing function. The original makeNullable
+  inspects only \<open>ref\<close> and \<open>type\<close> on its input and applies one of three
+  shapes (no-op, wrap-in-anyOf-with-null, append-null-to-types). Lifting
+  the *decision* on those two fields avoids round-tripping the Scala
+  \<open>SchemaObject\<close> (whose \<open>Double\<close> numeric fields can't losslessly
+  reverse-convert to \<open>decimal_lit\<close>); the Scala caller applies the
+  chosen shape using its own \<open>SchemaObject\<close>:
+
+  \<^item> \<open>NdWrapAnyOfNull\<close>: \<open>ref\<close> is set, \<emph>or> \<open>type\<close> is absent. Can't
+    merge a \<open>"null"\<close> tag — wrap in \<open>anyOf [s, {type:[null]}]\<close>.
+  \<^item> \<open>NdNoop\<close>: \<open>type\<close> already includes \<open>"null"\<close>.
+  \<^item> \<open>NdAppendNull\<close>: \<open>type\<close> is set and doesn't yet contain \<open>"null"\<close>
+    — append \<open>"null"\<close> to the type list.\<close>
+
+datatype nullable_decision = NdNoop | NdWrapAnyOfNull | NdAppendNull
+
+definition decideNullable ::
+  "String.literal option \<Rightarrow> String.literal list option \<Rightarrow> nullable_decision"
+where
+  "decideNullable refOpt typeOpt = (
+     case refOpt of
+       Some _ \<Rightarrow> NdWrapAnyOfNull
+     | None \<Rightarrow>
+         (case typeOpt of
+            None \<Rightarrow> NdWrapAnyOfNull
+          | Some currentTypes \<Rightarrow>
+              (if STR ''null'' \<in> set currentTypes
+               then NdNoop
+               else NdAppendNull)))"
+
+lemmas emptySchemaObject_code [code]      = emptySchemaObject_def
+lemmas primitiveDefToSchema_code [code]   = primitiveDefToSchema.simps
+lemmas mergeConstraintsLifted_code [code] = mergeConstraintsLifted.simps
+lemmas decideNullable_code [code]         = decideNullable_def
+
+end

--- a/proofs/isabelle/SpecRest/OpenApiSchema.thy
+++ b/proofs/isabelle/SpecRest/OpenApiSchema.thy
@@ -128,9 +128,199 @@ where
                then NdNoop
                else NdAppendNull)))"
 
+text \<open>Lifted variant of \<open>OpenApi.Schema.makeNullable\<close> that operates on a
+  \<open>schema_object\<close> directly (no round-trip through the Scala \<open>SchemaObject\<close>).
+  Used by the lifted recursive walker for the \<open>SetTypeF\<close>/\<open>SeqTypeF\<close>/\<open>MapTypeF\<close>
+  inner-nullable cases; the Scala-side \<open>Schema.makeNullable\<close> keeps using
+  \<open>decideNullable\<close> at the API boundary where the input is a Scala
+  \<open>SchemaObject\<close>.\<close>
+
+definition nullSchema :: schema_object where
+  "nullSchema = SchemaObject (Some [STR ''null'']) None None None None None None None None None
+                             None None None None None None None None None False"
+
+fun makeNullableLifted :: "schema_object \<Rightarrow> schema_object" where
+  "makeNullableLifted
+      (SchemaObject ty fmt minL maxL mn mx emn emx mnI mxI pat en it rf rq pr ap aof desc inE) =
+    (case decideNullable rf ty of
+       NdNoop \<Rightarrow> SchemaObject ty fmt minL maxL mn mx emn emx mnI mxI pat en it rf rq pr ap aof desc inE
+     | NdAppendNull \<Rightarrow>
+         (case ty of
+            Some currentTypes \<Rightarrow>
+              SchemaObject (Some (currentTypes @ [STR ''null'']))
+                           fmt minL maxL mn mx emn emx mnI mxI pat en it rf rq pr ap aof desc inE
+          \<comment> \<open>Unreachable: \<open>decideNullable\<close> only returns \<open>NdAppendNull\<close> when \<open>typeOpt\<close>
+              is \<open>Some\<close>. The \<open>None\<close> branch is fed back into the original schema unchanged so
+              the function remains total.\<close>
+          | None \<Rightarrow>
+              SchemaObject ty fmt minL maxL mn mx emn emx mnI mxI pat en it rf rq pr ap aof desc inE)
+     | NdWrapAnyOfNull \<Rightarrow>
+         SchemaObject None None None None None None None None None None None None None None None None None
+                      (Some [SchemaObject ty fmt minL maxL mn mx emn emx mnI mxI pat en it rf rq pr ap aof desc inE,
+                             nullSchema])
+                      None False)"
+
+text \<open>Constructor helpers for the lifted recursive walker. Each wraps the
+  20-field \<open>SchemaObject\<close> constructor with only the relevant fields set
+  for a given OpenAPI shape (string-typed enum, \<open>$ref\<close>, array with
+  \<open>items\<close>, object with \<open>additionalProperties\<close>, integer for relation FK).\<close>
+
+definition integerSchema :: schema_object where
+  "integerSchema = SchemaObject (Some [STR ''integer'']) None None None None None None None None
+                                None None None None None None None None None None False"
+
+definition textSchema :: schema_object where
+  "textSchema = SchemaObject (Some [STR ''string'']) None None None None None None None None
+                             None None None None None None None None None None False"
+
+definition enumStringSchema :: "String.literal list \<Rightarrow> schema_object" where
+  "enumStringSchema values =
+     SchemaObject (Some [STR ''string'']) None None None None None None None None None
+                  None (Some values) None None None None None None None False"
+
+definition entityRefSchema :: "String.literal \<Rightarrow> schema_object" where
+  "entityRefSchema name =
+     SchemaObject None None None None None None None None None None
+                  None None None
+                  (Some (STR ''#/components/schemas/'' + name + STR ''Read''))
+                  None None None None None False"
+
+definition arraySchema :: "schema_object \<Rightarrow> int option \<Rightarrow> int option \<Rightarrow> schema_object" where
+  "arraySchema items mnI mxI =
+     SchemaObject (Some [STR ''array'']) None None None None None None None mnI mxI
+                  None None (Some items) None None None None None None False"
+
+definition mapObjectSchema :: "schema_object \<Rightarrow> schema_object" where
+  "mapObjectSchema ap =
+     SchemaObject (Some [STR ''object'']) None None None None None None None None None
+                  None None None None None None
+                  (Some (SOBSchema ap)) None None False"
+
+text \<open>Bounds selectors. The lifted recursive walker reads min/max length
+  off the \<open>openapi_bounds\<close> tuple to populate \<open>minItems\<close>/\<open>maxItems\<close>
+  on the array schema, matching the Scala \<open>buildArraySchema\<close> behaviour.\<close>
+
+fun boundsMinLength :: "openapi_bounds \<Rightarrow> int option" where
+  "boundsMinLength (OpenApiBounds mnL _ _ _ _ _ _) = mnL"
+
+fun boundsMaxLength :: "openapi_bounds \<Rightarrow> int option" where
+  "boundsMaxLength (OpenApiBounds _ mxL _ _ _ _ _) = mxL"
+
+text \<open>Compute the constraint bounds for a field's type and optional
+  inline refinement, by folding \<open>visitConstraintOpenApi\<close> over the alias
+  refinement chain and then (if present) the field's own constraint
+  expression. Mirrors \<open>OpenApi.Constraints.extractFieldConstraints\<close>
+  but returns \<open>openapi_bounds\<close> directly (the Scala-side
+  \<open>JsonSchemaConstraints\<close>-with-\<open>Double\<close> intermediate is eliminated).\<close>
+
+definition computeFieldBounds ::
+  "type_expr_full \<Rightarrow> expr_full option \<Rightarrow> alias_map \<Rightarrow> openapi_bounds"
+where
+  "computeFieldBounds ty cOpt am =
+    (let alias_bounds =
+           foldl (\<lambda>b p. visitConstraintOpenApi p b) emptyOpenApiBounds (aliasRefinements ty am);
+         final_bounds =
+           (case cOpt of None \<Rightarrow> alias_bounds
+                       | Some c \<Rightarrow> visitConstraintOpenApi c alias_bounds)
+     in final_bounds)"
+
+text \<open>Recursive lifted walker. Mirrors \<open>OpenApi.Schema.typeExprToSchema\<close>,
+  \<open>buildArraySchema\<close>, and \<open>OpenApi.Schema.fieldToSchema\<close> as a single
+  mutually-recursive \<open>fun\<close> block, with a \<open>nat\<close> fuel decreasing on each
+  recursive call (alias chains and structural recursion share the fuel
+  bound; the entry-point definitions seed with \<open>Suc (length am)\<close> to
+  bound alias-chain depth). \<open>namedTypeSchema\<close> is inlined into the
+  \<open>NamedTypeF\<close> case because \<open>classifyOpenApiNamedType\<close> is a single
+  pure call (already lifted in \<open>SchemaTraversal\<close>).
+
+  Returns from \<open>fieldToSchemaAux\<close> use an \<open>option\<close>-shaped pair
+  \<open>(schema_object, bool)\<close>: the boolean tracks whether the input type
+  expression had an outer \<open>OptionTypeF\<close> wrapper (the Scala
+  \<open>FieldSchema.nullable\<close> flag).\<close>
+
+fun typeExprToSchemaAux ::
+  "nat \<Rightarrow> type_expr_full \<Rightarrow> openapi_bounds \<Rightarrow> String.literal list option
+    \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list \<Rightarrow> schema_object"
+and fieldToSchemaAux ::
+  "nat \<Rightarrow> type_expr_full \<Rightarrow> expr_full option
+    \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list \<Rightarrow> (schema_object \<times> bool)"
+where
+  "typeExprToSchemaAux 0 _ _ _ _ _ _ = emptySchemaObject"
+| "typeExprToSchemaAux (Suc fuel) ty bounds enumOpt am em ens = (case ty of
+     NamedTypeF name _ \<Rightarrow>
+       (case classifyOpenApiNamedType name am em ens of
+          OntPrimitive p \<Rightarrow> mergeConstraintsLifted (primitiveDefToSchema p) bounds enumOpt
+        | OntEnum values \<Rightarrow> enumStringSchema values
+        | OntEntityRef n \<Rightarrow> entityRefSchema n
+        | OntAliasToType base \<Rightarrow> typeExprToSchemaAux fuel base bounds enumOpt am em ens
+        | OntUnknown \<Rightarrow> mergeConstraintsLifted textSchema bounds enumOpt)
+   | SetTypeF inner _ \<Rightarrow>
+       (case fieldToSchemaAux fuel inner None am em ens of (innerSchema, nullable) \<Rightarrow>
+         (let items = (if nullable then makeNullableLifted innerSchema else innerSchema)
+          in arraySchema items (boundsMinLength bounds) (boundsMaxLength bounds)))
+   | SeqTypeF inner _ \<Rightarrow>
+       (case fieldToSchemaAux fuel inner None am em ens of (innerSchema, nullable) \<Rightarrow>
+         (let items = (if nullable then makeNullableLifted innerSchema else innerSchema)
+          in arraySchema items (boundsMinLength bounds) (boundsMaxLength bounds)))
+   | MapTypeF _ v _ \<Rightarrow>
+       (case fieldToSchemaAux fuel v None am em ens of (valueSchema, nullable) \<Rightarrow>
+         (let ap = (if nullable then makeNullableLifted valueSchema else valueSchema)
+          in mapObjectSchema ap))
+   | OptionTypeF inner _ \<Rightarrow> typeExprToSchemaAux fuel inner bounds enumOpt am em ens
+   | RelationTypeF _ _ _ _ \<Rightarrow> integerSchema)"
+
+| "fieldToSchemaAux 0 _ _ _ _ _ = (emptySchemaObject, False)"
+| "fieldToSchemaAux (Suc fuel) ty cOpt am em ens =
+    (let nullable = (case ty of OptionTypeF _ _ \<Rightarrow> True | _ \<Rightarrow> False);
+         effective = (case ty of OptionTypeF inner _ \<Rightarrow> inner | t \<Rightarrow> t);
+         bounds = computeFieldBounds effective cOpt am;
+         enumOpt = findEnumValuesInType effective am em
+     in (typeExprToSchemaAux fuel effective bounds enumOpt am em ens, nullable))"
+
+text \<open>Fuel seed: \<open>length am + 100\<close>. Fuel decrements on every recursive
+  call across both \<open>typeExprToSchemaAux\<close> and \<open>fieldToSchemaAux\<close>; the
+  alias chain inside a NamedType is resolved via the lifted
+  \<open>classifyOpenApiNamedType\<close> which has its own internal fuel
+  (\<open>length am\<close>) and doesn't consume this one. The \<open>+ 100\<close> margin
+  covers structural nesting (each \<open>Set\<close>/\<open>Seq\<close>/\<open>Map\<close> wrap consumes 2
+  fuel as \<open>typeExprToSchemaAux\<close> → \<open>fieldToSchemaAux\<close> → \<open>typeExprToSchemaAux\<close>);
+  real-world type depth is \<le> 10.\<close>
+
+definition openApiSchemaFuel :: "alias_map \<Rightarrow> nat" where
+  "openApiSchemaFuel am = length am + 100"
+
+definition typeExprToSchema ::
+  "type_expr_full \<Rightarrow> openapi_bounds \<Rightarrow> String.literal list option
+    \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list \<Rightarrow> schema_object"
+where
+  "typeExprToSchema ty bounds enumOpt am em ens =
+     typeExprToSchemaAux (openApiSchemaFuel am) ty bounds enumOpt am em ens"
+
+definition fieldToSchema ::
+  "type_expr_full \<Rightarrow> expr_full option
+    \<Rightarrow> alias_map \<Rightarrow> enum_map \<Rightarrow> String.literal list \<Rightarrow> (schema_object \<times> bool)"
+where
+  "fieldToSchema ty cOpt am em ens =
+     fieldToSchemaAux (openApiSchemaFuel am) ty cOpt am em ens"
+
 lemmas emptySchemaObject_code [code]      = emptySchemaObject_def
 lemmas primitiveDefToSchema_code [code]   = primitiveDefToSchema.simps
 lemmas mergeConstraintsLifted_code [code] = mergeConstraintsLifted.simps
 lemmas decideNullable_code [code]         = decideNullable_def
+lemmas nullSchema_code [code]             = nullSchema_def
+lemmas makeNullableLifted_code [code]     = makeNullableLifted.simps
+lemmas integerSchema_code [code]          = integerSchema_def
+lemmas textSchema_code [code]             = textSchema_def
+lemmas enumStringSchema_code [code]       = enumStringSchema_def
+lemmas entityRefSchema_code [code]        = entityRefSchema_def
+lemmas arraySchema_code [code]            = arraySchema_def
+lemmas mapObjectSchema_code [code]        = mapObjectSchema_def
+lemmas boundsMinLength_code [code]        = boundsMinLength.simps
+lemmas boundsMaxLength_code [code]        = boundsMaxLength.simps
+lemmas computeFieldBounds_code [code]     = computeFieldBounds_def
+lemmas openApiSchemaFuel_code [code]      = openApiSchemaFuel_def
+lemmas typeExprToSchemaAux_code [code]    = typeExprToSchemaAux.simps fieldToSchemaAux.simps
+lemmas typeExprToSchema_code [code]       = typeExprToSchema_def
+lemmas fieldToSchema_code [code]          = fieldToSchema_def
 
 end

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -24,6 +24,7 @@ session SpecRest = HOL +
     RouteKind
     SchemaTraversal
     OpenApiConstraints
+    OpenApiSchema
     ValidateConventions
     ParseTemporal
     ParsePath


### PR DESCRIPTION
## Summary

Two-commit OpenAPI mega-lift covering the full `SchemaObject`-shape decision: the 20-field schema_object ADT + the recursive `typeExprToSchema` walker + the alias-chain-bounded mutual recursion `typeExprToSchema ↔ fieldToSchema`. Eliminates the Scala-side `JsonSchemaConstraints` (Double) intermediate.

The hand-written Scala `SchemaObject` case class is preserved — the YAML emitter (`OpenApi.toJava`) reflects over `Product.productElementNames` to map fields to YAML keys, so a positional Isabelle record can't replace it directly. `SchemaObjectAdapter.fromLifted` bridges lifted output to the named-field facade (same pattern as `DialectAdapter` in #349).

## Commit 1 — schema_object foundation

```isabelle
datatype schema_object = SchemaObject ... (20 positional fields)
and schema_object_or_bool = SOBSchema schema_object | SOBBool bool

emptySchemaObject : schema_object             -- field-blank base
primitiveDefToSchema : openapi_primitive_def => schema_object
mergeConstraintsLifted : schema_object => openapi_bounds
                      => String.literal list option => schema_object

datatype nullable_decision = NdNoop | NdWrapAnyOfNull | NdAppendNull
decideNullable : String.literal option => String.literal list option
              => nullable_decision
```

Numeric bounds carry `decimal_lit` (matching `openapi_bounds`); the adapter coerces to `Double` at the boundary via `decimalToDouble`. Lifted layer free of `Double`.

**`makeNullable` lifted as decision classifier, not value transformer**. The Scala caller passes only `ref` and `type` to `decideNullable`, then applies the chosen shape with its own `SchemaObject`. Avoids the lossy `Double → decimal_lit` reverse conversion needed for a round-trip approach.

## Commit 2 — recursive walker

```isabelle
makeNullableLifted : schema_object => schema_object
  -- value-producing variant used internally by the recursive walker
     (no round-trip; input is already lifted)

integerSchema, textSchema, enumStringSchema, entityRefSchema,
arraySchema, mapObjectSchema, nullSchema  -- constructor helpers
boundsMinLength, boundsMaxLength  -- bound selectors

computeFieldBounds : type_expr_full => expr_full option => alias_map
                  => openapi_bounds
  -- mirrors Constraints.extractFieldConstraints but returns
     openapi_bounds directly (no JsonSchemaConstraints intermediate)

typeExprToSchemaAux ↔ fieldToSchemaAux  -- mutual recursion with nat fuel
  decreasing on every call; namedType alias chains resolved via the
  existing classifyOpenApiNamedType (its own internal fuel)

typeExprToSchema, fieldToSchema  -- top-level entry points seeding fuel
  with `openApiSchemaFuel am = length am + 100` (alias-chain bound +
  structural-depth margin)
```

`namedTypeSchema` is inlined into the `NamedTypeF` case (single pure classifier call).

## Scala-side after both commits

`OpenApi.scala` loses:
- `JsonSchemaConstraints` case class (8 fields)
- `Constraints` object (`extractFieldConstraints`, `boundsToConstraints`, `asInt`, `decimalToDouble`)
- `Schema.primitiveDefToSchema` (private, unused after lift)
- `Schema.typeExprToSchema`, `namedTypeSchema`, `buildArraySchema`, `mergeConstraints` (all replaced by lifted walker)

`Schema.fieldToSchema` becomes a thin delegation:

```scala
def fieldToSchema(typeExpr, constraint, ctx): FieldSchema =
  val (lifted, nullable) = SpecRestGenerated.fieldToSchema(
    typeExpr, constraint, ctx.aliasAList, ctx.enumAList, ctx.entityNamesList
  )
  FieldSchema(SchemaObjectAdapter.fromLifted(lifted), nullable)
```

`Schema.makeNullable` stays (uses `decideNullable`):

```scala
def makeNullable(schema: SchemaObject): SchemaObject =
  decideNullable(schema.ref, schema.`type`) match
    case _: NdNoop          => schema
    case _: NdWrapAnyOfNull => SchemaObject(anyOf = Some(List(schema, SchemaObject(`type` = Some(List("null"))))))
    case _: NdAppendNull    => schema.copy(`type` = schema.`type`.map(_ :+ "null"))
```

All YAML emission stays in Scala (the YAML reflector iterates `Product` fields by name, so the hand-written `SchemaObject` case class is preserved). The entire structural decision for what shape of `SchemaObject` a given `(typeExpr, refinement, alias_map, enum_map, entityNames)` tuple produces is now derived from proofs; Scala only converts the lifted result at the boundary.

## Net change vs. main

5 files, +1909 / -1008. The large `SpecRestGenerated.scala` delta is mostly Isabelle reordering definitions during extraction (line moves); actual new logic is ~330 LOC theory + ~30 LOC adapter, with ~200 LOC removed from `OpenApi.scala`.

## Test plan
- [x] `isabelle build SpecRest` clean (3:02 incremental per commit)
- [x] `sbt codegen/compile` clean
- [x] `sbt codegen/test` — all ~150 tests pass including `OpenApiTest` (13 end-to-end YAML golden tests) and `EmitTest` (21 cross-codegen tests). YAML output byte-identical.
- [x] `sbt scalafixAll` clean
- [ ] CI: isabelle-build (extraction drift) + build-and-test
