### PR TITLE
feat(proofs): lift Alloy translator type kernel + renderExpr classifiers

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -881,6 +881,12 @@ object SpecRestGenerated {
   final case class enum_decl_exta[A](a: String, b: List[String], c: Option[span_t], d: A)
       extends enum_decl_ext[A]
 
+  sealed abstract class alloy_unop_shape
+  final case class AusNot()         extends alloy_unop_shape
+  final case class AusCardinality() extends alloy_unop_shape
+  final case class AusMinusZero()   extends alloy_unop_shape
+  final case class AusUnsupported() extends alloy_unop_shape
+
   sealed abstract class synthesis_strategy
   final case class DirectEmit()   extends synthesis_strategy
   final case class LlmSynthesis() extends synthesis_strategy
@@ -957,6 +963,11 @@ object SpecRestGenerated {
       f: A
   ) extends smt_model_ext[A]
 
+  sealed abstract class alloy_binop_shape
+  final case class AbsLogical(a: String)    extends alloy_binop_shape
+  final case class AbsInfix(a: String)      extends alloy_binop_shape
+  final case class AbsPrefixCall(a: String) extends alloy_binop_shape
+
   sealed abstract class canonical_type
   final case class CtText()                          extends canonical_type
   final case class CtVarchar(a: int)                 extends canonical_type
@@ -1027,6 +1038,18 @@ object SpecRestGenerated {
   sealed abstract class detected_aggregate
   final case class DetectedAggregate(a: String, b: String, c: trigger_aggregate, d: Option[String])
       extends detected_aggregate
+
+  sealed abstract class alloy_identifier_kind
+  final case class AikBoundVar()   extends alloy_identifier_kind
+  final case class AikStateField() extends alloy_identifier_kind
+  final case class AikInputField() extends alloy_identifier_kind
+  final case class AikPlain()      extends alloy_identifier_kind
+
+  sealed abstract class alloy_quantifier_class
+  final case class AqAll()    extends alloy_quantifier_class
+  final case class AqSome()   extends alloy_quantifier_class
+  final case class AqExists() extends alloy_quantifier_class
+  final case class AqNo()     extends alloy_quantifier_class
 
   sealed abstract class operation_classification
   final case class OperationClassification(
@@ -6346,6 +6369,13 @@ object SpecRestGenerated {
     case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_enums
   }
 
+  def alloyUnopShape(x0: un_op_full): alloy_unop_shape = x0 match {
+    case UNot()         => AusNot()
+    case UCardinality() => AusCardinality()
+    case UNegate()      => AusMinusZero()
+    case UPower()       => AusUnsupported()
+  }
+
   def mapEntryIsLeafLeaf(x0: map_entry_full): Boolean = x0 match {
     case MapEntryFull(k, v, uu) => isLeafValue(k) && isLeafValue(v)
   }
@@ -8118,6 +8148,29 @@ object SpecRestGenerated {
 
   def serviceEntities(x0: service_ir_full): List[entity_decl_full] = x0 match {
     case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+  }
+
+  def alloyBinopShape(x0: bin_op_full): alloy_binop_shape = x0 match {
+    case BAnd()       => AbsLogical("and")
+    case BOr()        => AbsLogical("or")
+    case BImplies()   => AbsLogical("implies")
+    case BIff()       => AbsLogical("iff")
+    case BEq()        => AbsInfix("=")
+    case BNeq()       => AbsInfix("!=")
+    case BLt()        => AbsInfix("<")
+    case BLe()        => AbsInfix("<=")
+    case BGt()        => AbsInfix(">")
+    case BGe()        => AbsInfix(">=")
+    case BIn()        => AbsInfix("in")
+    case BNotIn()     => AbsInfix("!in")
+    case BSubset()    => AbsInfix("in")
+    case BUnion()     => AbsInfix("+")
+    case BIntersect() => AbsInfix("&")
+    case BDiff()      => AbsInfix("-")
+    case BAdd()       => AbsPrefixCall("plus")
+    case BSub()       => AbsPrefixCall("minus")
+    case BMul()       => AbsPrefixCall("mul")
+    case BDiv()       => AbsPrefixCall("div")
   }
 
   def signalsDeletesKey(x0: analysis_signals): Boolean = x0 match {
@@ -11420,6 +11473,13 @@ object SpecRestGenerated {
     case TriggerSpec(uu, uv, uw, ux, uy, sfk, uz, va) => sfk
   }
 
+  def alloyQuantifierClass(x0: quant_kind_full): alloy_quantifier_class = x0 match {
+    case QAll()    => AqAll()
+    case QSome()   => AqSome()
+    case QExists() => AqExists()
+    case QNo()     => AqNo()
+  }
+
   def classificationStrategy(x0: operation_classification): synthesis_strategy =
     x0 match {
       case OperationClassification(uu, uv, uw, ux, uy, s, uz) => s
@@ -12282,6 +12342,13 @@ object SpecRestGenerated {
         Some[(String, String)]((Str_Literal.literalOfAsciis(l), Str_Literal.literalOfAsciis(r)))
     }
 
+  def alloyQuantifierKeyword(x0: alloy_quantifier_class): String = x0 match {
+    case AqAll()    => "all"
+    case AqSome()   => "some"
+    case AqExists() => "some"
+    case AqNo()     => "no"
+  }
+
   def fieldNameIfStateIndex(e: expr_full, inputName: String, stateName: String): Option[String] =
     e match {
       case BinaryOpF(_, _, _, _)                                     => None
@@ -12483,6 +12550,36 @@ object SpecRestGenerated {
               ),
               v
             )
+        }
+    }
+
+  def classifyAlloyIdentifier(
+      name: String,
+      boundVars: List[String],
+      stateFields: List[(String, type_expr_full)],
+      inputFields: List[(String, type_expr_full)]
+  ): alloy_identifier_kind =
+    membera[String](boundVars, name) match {
+      case true => AikBoundVar()
+      case false => membera[String](
+          map[(String, type_expr_full), String](
+            (a: (String, type_expr_full)) => fst[String, type_expr_full](a),
+            stateFields
+          ),
+          name
+        ) match {
+          case true => AikStateField()
+          case false => membera[String](
+              map[(String, type_expr_full), String](
+                (a: (String, type_expr_full)) =>
+                  fst[String, type_expr_full](a),
+                inputFields
+              ),
+              name
+            ) match {
+              case true  => AikInputField()
+              case false => AikPlain()
+            }
         }
     }
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -1065,6 +1065,12 @@ object SpecRestGenerated {
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
 
+  sealed abstract class alloy_field_multiplicity
+  final case class AfmOne()  extends alloy_field_multiplicity
+  final case class AfmLone() extends alloy_field_multiplicity
+  final case class AfmSome() extends alloy_field_multiplicity
+  final case class AfmSet()  extends alloy_field_multiplicity
+
   sealed abstract class structural_ineligibility
   final case class SceReferencesPrePrime()   extends structural_ineligibility
   final case class SceReferencesStateField() extends structural_ineligibility
@@ -5704,6 +5710,90 @@ object SpecRestGenerated {
       case (Some(x), Some(y)) => Some[int](max[int](x, y))
     }
 
+  def exprContainsBoolLit(e: expr_full): Boolean =
+    list_ex[expr_full]((a: expr_full) => isBoolLit(a), allSubexprs(e))
+
+  def operationHasBoolLit(x0: operation_decl_full): Boolean = x0 match {
+    case OperationDeclFull(uu, uv, uw, requiresa, ensures, ux) =>
+      list_ex[expr_full]((a: expr_full) => exprContainsBoolLit(a), requiresa) ||
+      list_ex[expr_full]((a: expr_full) => exprContainsBoolLit(a), ensures)
+  }
+
+  def invariantHasBoolLit(x0: invariant_decl_full): Boolean = x0 match {
+    case InvariantDeclFull(uu, body, uv) => exprContainsBoolLit(body)
+  }
+
+  def typeContainsNamed(n: String, x1: type_expr_full): Boolean = (n, x1) match {
+    case (n, NamedTypeF(m, uu))             => n == m
+    case (n, SetTypeF(inner, uv))           => typeContainsNamed(n, inner)
+    case (n, OptionTypeF(inner, uw))        => typeContainsNamed(n, inner)
+    case (ux, MapTypeF(v, va, vb))          => false
+    case (ux, SeqTypeF(v, va))              => false
+    case (ux, RelationTypeF(v, va, vb, vc)) => false
+  }
+
+  def temporalArg(x0: temporal_body): expr_full = x0 match {
+    case TbAlways(e)     => e
+    case TbEventually(e) => e
+    case TbFairness(e)   => e
+    case TbInvalid(e)    => e
+  }
+
+  def temporalHasBoolLit(x0: temporal_decl_full): Boolean = x0 match {
+    case TemporalDeclFull(uu, tb, uv) => exprContainsBoolLit(temporalArg(tb))
+  }
+
+  def fieldTypeHasBool(x0: field_decl_full): Boolean = x0 match {
+    case FieldDeclFull(uu, t, uv, uw) => typeContainsNamed("Bool", t)
+  }
+
+  def entityHasBoolField(x0: entity_decl_full): Boolean = x0 match {
+    case EntityDeclFull(uu, uv, fs, uw, ux) =>
+      list_ex[field_decl_full]((a: field_decl_full) => fieldTypeHasBool(a), fs)
+  }
+
+  def needsBoolSig(
+      x0: service_ir_full,
+      stateFields: List[(String, type_expr_full)],
+      inputFields: List[(String, type_expr_full)]
+  ): Boolean =
+    (x0, stateFields, inputFields) match {
+      case (
+            ServiceIRFull(uu, uv, es, uw, ux, uy, ops, uz, invs, temps, va, vb, vc, vd, ve),
+            stateFields,
+            inputFields
+          ) => list_ex[entity_decl_full](
+          (a: entity_decl_full) =>
+            entityHasBoolField(a),
+          es
+        ) ||
+        (list_ex[(String, type_expr_full)](
+          (kv: (String, type_expr_full)) =>
+            typeContainsNamed("Bool", snd[String, type_expr_full](kv)),
+          stateFields
+        ) ||
+          (list_ex[(String, type_expr_full)](
+            (kv: (String, type_expr_full)) =>
+              typeContainsNamed("Bool", snd[String, type_expr_full](kv)),
+            inputFields
+          ) ||
+            (list_ex[invariant_decl_full](
+              (a: invariant_decl_full) =>
+                invariantHasBoolLit(a),
+              invs
+            ) ||
+              (list_ex[temporal_decl_full](
+                (a: temporal_decl_full) =>
+                  temporalHasBoolLit(a),
+                temps
+              ) ||
+                list_ex[operation_decl_full](
+                  (a: operation_decl_full) =>
+                    operationHasBoolLit(a),
+                  ops
+                )))))
+    }
+
   def setTargetEntityFieldCount(v: Option[nat], x1: analysis_signals): analysis_signals =
     (v, x1) match {
       case (v, AnalysisSignals(m, p, c, d, uu, w, f, t, h)) =>
@@ -7955,13 +8045,6 @@ object SpecRestGenerated {
   def literalDropLeft(n: nat, s: String): String =
     Str_Literal.literalOfAsciis(drop[BigInt](n, Str_Literal.asciisOfLiteral(s)))
 
-  def temporalArg(x0: temporal_body): expr_full = x0 match {
-    case TbAlways(e)     => e
-    case TbEventually(e) => e
-    case TbFairness(e)   => e
-    case TbInvalid(e)    => e
-  }
-
   def triggerAggregateOf(x0: trigger_spec): trigger_aggregate = x0 match {
     case TriggerSpec(uu, uv, uw, ux, uy, uz, a, va) => a
   }
@@ -8675,6 +8758,46 @@ object SpecRestGenerated {
         )
       )
     )
+
+  def mapAlloyPrimitive(name: String): String =
+    name == "Int" match {
+      case true => "Int"
+      case false => name == "Bool" match {
+          case true => "Bool"
+          case false => name == "String" match {
+              case true  => "String"
+              case false => name
+            }
+        }
+    }
+
+  def typeToSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
+    case NamedTypeF(name, uu)         => Some[String](mapAlloyPrimitive(name))
+    case SetTypeF(v, va)              => None
+    case MapTypeF(v, va, vb)          => None
+    case SeqTypeF(v, va)              => None
+    case OptionTypeF(v, va)           => None
+    case RelationTypeF(v, va, vb, vc) => None
+  }
+
+  def alloyFieldTypeOf(x0: type_expr_full): Option[(alloy_field_multiplicity, String)] =
+    x0 match {
+      case NamedTypeF(name, uu) =>
+        Some[(alloy_field_multiplicity, String)]((AfmOne(), mapAlloyPrimitive(name)))
+      case SetTypeF(inner, uv) =>
+        typeToSigNameAlloy(inner) match {
+          case None    => None
+          case Some(n) => Some[(alloy_field_multiplicity, String)]((AfmSet(), n))
+        }
+      case OptionTypeF(inner, uw) =>
+        typeToSigNameAlloy(inner) match {
+          case None    => None
+          case Some(n) => Some[(alloy_field_multiplicity, String)]((AfmLone(), n))
+        }
+      case MapTypeF(v, va, vb)          => None
+      case SeqTypeF(v, va)              => None
+      case RelationTypeF(v, va, vb, vc) => None
+    }
 
   def classificationKind(x0: operation_classification): operation_kind = x0 match {
     case OperationClassification(uu, k, uv, uw, ux, uy, uz) => k
@@ -10539,15 +10662,6 @@ object SpecRestGenerated {
       case IdentifierF(v, va)               => None
     }
 
-  def typeContainsNamed(n: String, x1: type_expr_full): Boolean = (n, x1) match {
-    case (n, NamedTypeF(m, uu))             => n == m
-    case (n, SetTypeF(inner, uv))           => typeContainsNamed(n, inner)
-    case (n, OptionTypeF(inner, uw))        => typeContainsNamed(n, inner)
-    case (ux, MapTypeF(v, va, vb))          => false
-    case (ux, SeqTypeF(v, va))              => false
-    case (ux, RelationTypeF(v, va, vb, vc)) => false
-  }
-
   def emptyServiceIrFull(nm: String): service_ir_full =
     ServiceIRFull(nm, Nil, Nil, Nil, Nil, None, Nil, Nil, Nil, Nil, Nil, Nil, Nil, None, None)
 
@@ -11316,9 +11430,6 @@ object SpecRestGenerated {
       case DirectEmit()   => "DIRECT_EMIT"
       case LlmSynthesis() => "LLM_SYNTHESIS"
     }
-
-  def exprContainsBoolLit(e: expr_full): Boolean =
-    list_ex[expr_full]((a: expr_full) => isBoolLit(a), allSubexprs(e))
 
   def identifierNameSelect(x0: expr_full): List[String] = x0 match {
     case IdentifierF(n, uu)               => List(n)
@@ -12710,6 +12821,27 @@ object SpecRestGenerated {
 
   def literalIsEmpty(s: String): Boolean =
     nulla[BigInt](Str_Literal.asciisOfLiteral(s))
+
+  def fieldElementSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
+    case NamedTypeF(name, uu) => Some[String](mapAlloyPrimitive(name))
+    case SetTypeF(NamedTypeF(name, uv), uw) =>
+      Some[String](mapAlloyPrimitive(name))
+    case OptionTypeF(NamedTypeF(name, ux), uy) =>
+      Some[String](mapAlloyPrimitive(name))
+    case SetTypeF(SetTypeF(vb, vc), va)                 => None
+    case SetTypeF(MapTypeF(vb, vc, vd), va)             => None
+    case SetTypeF(SeqTypeF(vb, vc), va)                 => None
+    case SetTypeF(OptionTypeF(vb, vc), va)              => None
+    case SetTypeF(RelationTypeF(vb, vc, vd, ve), va)    => None
+    case MapTypeF(v, va, vb)                            => None
+    case SeqTypeF(v, va)                                => None
+    case OptionTypeF(SetTypeF(vb, vc), va)              => None
+    case OptionTypeF(MapTypeF(vb, vc, vd), va)          => None
+    case OptionTypeF(SeqTypeF(vb, vc), va)              => None
+    case OptionTypeF(OptionTypeF(vb, vc), va)           => None
+    case OptionTypeF(RelationTypeF(vb, vc, vd, ve), va) => None
+    case RelationTypeF(v, va, vb, vc)                   => None
+  }
 
   def classificationTargetEntity(x0: operation_classification): Option[String] =
     x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -1114,6 +1114,12 @@ object SpecRestGenerated {
   final case class TestStrategyFieldMissing(a: String, b: String, c: String)
       extends convention_ir_diagnostic
 
+  sealed abstract class alloy_binding_identifier_resolution
+  final case class AbirEntity(a: String) extends alloy_binding_identifier_resolution
+  final case class AbirEnum(a: String)   extends alloy_binding_identifier_resolution
+  final case class AbirStateOrInput()    extends alloy_binding_identifier_resolution
+  final case class AbirPlain()           extends alloy_binding_identifier_resolution
+
   def id[A]: A => A = (x: A) => x
 
   def max[A: ord](a: A, b: A): A =
@@ -6376,6 +6382,16 @@ object SpecRestGenerated {
     case UPower()       => AusUnsupported()
   }
 
+  def enumNameInList(x0: List[enum_decl_full], uu: String): Option[String] =
+    (x0, uu) match {
+      case (Nil, uu) => None
+      case (EnumDeclFull(en, uv, uw) :: es, n) =>
+        en == n match {
+          case true  => Some[String](en)
+          case false => enumNameInList(es, n)
+        }
+    }
+
   def mapEntryIsLeafLeaf(x0: map_entry_full): Boolean = x0 match {
     case MapEntryFull(k, v, uu) => isLeafValue(k) && isLeafValue(v)
   }
@@ -10637,6 +10653,79 @@ object SpecRestGenerated {
     case (uu, (uv, v)) :: rest => v :: valuesOf(rest)
   }
 
+  def fieldElementSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
+    case NamedTypeF(name, uu) => Some[String](mapAlloyPrimitive(name))
+    case SetTypeF(NamedTypeF(name, uv), uw) =>
+      Some[String](mapAlloyPrimitive(name))
+    case OptionTypeF(NamedTypeF(name, ux), uy) =>
+      Some[String](mapAlloyPrimitive(name))
+    case SetTypeF(SetTypeF(vb, vc), va)                 => None
+    case SetTypeF(MapTypeF(vb, vc, vd), va)             => None
+    case SetTypeF(SeqTypeF(vb, vc), va)                 => None
+    case SetTypeF(OptionTypeF(vb, vc), va)              => None
+    case SetTypeF(RelationTypeF(vb, vc, vd, ve), va)    => None
+    case MapTypeF(v, va, vb)                            => None
+    case SeqTypeF(v, va)                                => None
+    case OptionTypeF(SetTypeF(vb, vc), va)              => None
+    case OptionTypeF(MapTypeF(vb, vc, vd), va)          => None
+    case OptionTypeF(SeqTypeF(vb, vc), va)              => None
+    case OptionTypeF(OptionTypeF(vb, vc), va)           => None
+    case OptionTypeF(RelationTypeF(vb, vc, vd, ve), va) => None
+    case RelationTypeF(v, va, vb, vc)                   => None
+  }
+
+  def domainSigNameAlloy(
+      e: expr_full,
+      stateFields: List[(String, type_expr_full)],
+      inputFields: List[(String, type_expr_full)],
+      entities: List[entity_decl_full],
+      enums: List[enum_decl_full]
+  ): Option[String] =
+    e match {
+      case BinaryOpF(_, _, _, _)         => None
+      case UnaryOpF(_, _, _)             => None
+      case QuantifierF(_, _, _, _)       => None
+      case SomeWrapF(_, _)               => None
+      case TheF(_, _, _, _)              => None
+      case FieldAccessF(_, _, _)         => None
+      case EnumAccessF(_, _, _)          => None
+      case IndexF(_, _, _)               => None
+      case CallF(_, _, _)                => None
+      case PrimeF(_, _)                  => None
+      case PreF(_, _)                    => None
+      case WithF(_, _, _)                => None
+      case IfF(_, _, _, _)               => None
+      case LetF(_, _, _, _)              => None
+      case LambdaF(_, _, _)              => None
+      case ConstructorF(_, _, _)         => None
+      case SetLiteralF(_, _)             => None
+      case MapLiteralF(_, _)             => None
+      case SetComprehensionF(_, _, _, _) => None
+      case SeqLiteralF(_, _)             => None
+      case MatchesF(_, _, _)             => None
+      case IntLitF(_, _)                 => None
+      case FloatLitF(_, _)               => None
+      case StringLitF(_, _)              => None
+      case BoolLitF(_, _)                => None
+      case NoneLitF(_)                   => None
+      case IdentifierF(name, _) =>
+        map_of[String, type_expr_full](stateFields, name) match {
+          case None =>
+            map_of[String, type_expr_full](inputFields, name) match {
+              case None =>
+                entityNameInList(entities, name) match {
+                  case None => enumNameInList(enums, name) match {
+                      case None    => Some[String](name)
+                      case Some(a) => Some[String](a)
+                    }
+                  case Some(a) => Some[String](a)
+                }
+              case Some(a) => fieldElementSigNameAlloy(a)
+            }
+          case Some(a) => fieldElementSigNameAlloy(a)
+        }
+    }
+
   def classificationMethod(x0: operation_classification): http_method = x0 match {
     case OperationClassification(uu, uv, m, uw, ux, uy, uz) => m
   }
@@ -12919,27 +13008,6 @@ object SpecRestGenerated {
   def literalIsEmpty(s: String): Boolean =
     nulla[BigInt](Str_Literal.asciisOfLiteral(s))
 
-  def fieldElementSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
-    case NamedTypeF(name, uu) => Some[String](mapAlloyPrimitive(name))
-    case SetTypeF(NamedTypeF(name, uv), uw) =>
-      Some[String](mapAlloyPrimitive(name))
-    case OptionTypeF(NamedTypeF(name, ux), uy) =>
-      Some[String](mapAlloyPrimitive(name))
-    case SetTypeF(SetTypeF(vb, vc), va)                 => None
-    case SetTypeF(MapTypeF(vb, vc, vd), va)             => None
-    case SetTypeF(SeqTypeF(vb, vc), va)                 => None
-    case SetTypeF(OptionTypeF(vb, vc), va)              => None
-    case SetTypeF(RelationTypeF(vb, vc, vd, ve), va)    => None
-    case MapTypeF(v, va, vb)                            => None
-    case SeqTypeF(v, va)                                => None
-    case OptionTypeF(SetTypeF(vb, vc), va)              => None
-    case OptionTypeF(MapTypeF(vb, vc, vd), va)          => None
-    case OptionTypeF(SeqTypeF(vb, vc), va)              => None
-    case OptionTypeF(OptionTypeF(vb, vc), va)           => None
-    case OptionTypeF(RelationTypeF(vb, vc, vd, ve), va) => None
-    case RelationTypeF(v, va, vb, vc)                   => None
-  }
-
   def classificationTargetEntity(x0: operation_classification): Option[String] =
     x0 match {
       case OperationClassification(uu, uv, uw, ux, t, uy, uz) => t
@@ -13491,6 +13559,35 @@ object SpecRestGenerated {
       case CvOk(PvExpr(e))       => e
       case CvBad(_, raw)         => raw
       case CvUnknown(raw)        => raw
+    }
+
+  def classifyAlloyBindingIdentifier(
+      name: String,
+      entities: List[entity_decl_full],
+      enums: List[enum_decl_full],
+      stateFields: List[(String, type_expr_full)],
+      inputFields: List[(String, type_expr_full)]
+  ): alloy_binding_identifier_resolution =
+    entityNameInList(entities, name) match {
+      case None =>
+        enumNameInList(enums, name) match {
+          case None =>
+            list_ex[(String, type_expr_full)](
+              (kv: (String, type_expr_full)) =>
+                fst[String, type_expr_full](kv) == name,
+              stateFields
+            ) ||
+              list_ex[(String, type_expr_full)](
+                (kv: (String, type_expr_full)) =>
+                  fst[String, type_expr_full](kv) == name,
+                inputFields
+              ) match {
+              case true  => AbirStateOrInput()
+              case false => AbirPlain()
+            }
+          case Some(a) => AbirEnum(a)
+        }
+      case Some(a) => AbirEntity(a)
     }
 
   def capsRequiresTextIndexPrefix(x0: dialect_caps): Boolean = x0 match {

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -2,6 +2,7 @@ package specrest.verify.alloy
 
 import cats.effect.IO
 import specrest.ir.*
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 import scala.collection.mutable
@@ -233,49 +234,26 @@ object Translator:
     sigs.toList
 
   private def needsBoolSig(ctx: Ctx): Boolean =
-    val containsBool: type_expr_full => Boolean = typeContainsNamed("Bool", _)
-    val inFields =
-      ctx.ir.c.exists {
-        case EntityDeclFull(_, _, fs, _, _) =>
-          fs.exists { case FieldDeclFull(_, t, _, _) => containsBool(t) }
-      } ||
-        ctx.stateFields.values.exists(containsBool) ||
-        ctx.inputFields.values.exists(containsBool)
-    val inExprs =
-      ctx.ir.i.exists { case InvariantDeclFull(_, e, _) => exprContainsBoolLit(e) } ||
-        ctx.ir.j.exists { case TemporalDeclFull(_, b, _) => exprContainsBoolLit(temporalArg(b)) } ||
-        ctx.ir.g.exists {
-          case OperationDeclFull(_, _, _, requires, ensures, _) =>
-            requires.exists(exprContainsBoolLit) || ensures.exists(exprContainsBoolLit)
-        }
-    inFields || inExprs
+    SpecRestGenerated.needsBoolSig(
+      ctx.ir,
+      ctx.stateFields.toList,
+      ctx.inputFields.toList
+    )
 
   private def alloyFieldTypeOf(t: type_expr_full)(using
       AlloyLabel
   ): (AlloyFieldMultiplicity, String) =
-    t match
-      case NamedTypeF(name, _) =>
-        (AlloyFieldMultiplicity.One, mapPrimitive(name))
-      case SetTypeF(inner, _) =>
-        val elem = typeToSigName(inner)
-        (AlloyFieldMultiplicity.Set, elem)
-      case OptionTypeF(inner, _) =>
-        (AlloyFieldMultiplicity.Lone, typeToSigName(inner))
-      case other =>
+    SpecRestGenerated.alloyFieldTypeOf(t) match
+      case Some((m, n)) => (AlloyAdapter.fromLiftedMult(m), n)
+      case None =>
         failAlloy(
-          s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $other"
+          s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $t"
         )
 
-  private def typeToSigName(t: type_expr_full)(using AlloyLabel): String = t match
-    case NamedTypeF(name, _) => mapPrimitive(name)
-    case other =>
-      failAlloy(s"nested type not supported as Alloy element sort: $other")
-
-  private def mapPrimitive(name: String): String = name match
-    case "Int"    => "Int"
-    case "Bool"   => "Bool"
-    case "String" => "String"
-    case other    => other
+  private def fieldElementSigName(t: type_expr_full)(using AlloyLabel): String =
+    SpecRestGenerated.fieldElementSigNameAlloy(t) match
+      case Some(n) => n
+      case None    => failAlloy(s"unsupported quantifier domain field type: $t")
 
   private def renderExpr(ctx: Ctx, e: expr_full)(using AlloyLabel): String = e match
     case BinaryOpF(op, l, r, _)         => renderBinaryOp(ctx, op, l, r)
@@ -412,13 +390,6 @@ object Translator:
       failAlloy(
         "powerset binder domain must be an identifier referring to an entity or set-typed state"
       )
-
-  private def fieldElementSigName(t: type_expr_full)(using AlloyLabel): String = t match
-    case NamedTypeF(name, _)                 => mapPrimitive(name)
-    case SetTypeF(NamedTypeF(name, _), _)    => mapPrimitive(name)
-    case OptionTypeF(NamedTypeF(name, _), _) => mapPrimitive(name)
-    case other =>
-      failAlloy(s"unsupported quantifier domain field type: $other")
 
   private def renderCall(ctx: Ctx, callee: expr_full, args: List[expr_full])(using
       AlloyLabel

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -256,22 +256,30 @@ object Translator:
       case None    => failAlloy(s"unsupported quantifier domain field type: $t")
 
   private def renderExpr(ctx: Ctx, e: expr_full)(using AlloyLabel): String = e match
-    case BinaryOpF(op, l, r, _)         => renderBinaryOp(ctx, op, l, r)
-    case UnaryOpF(UNot(), x, _)         => s"not (${renderExpr(ctx, x)})"
-    case UnaryOpF(UCardinality(), x, _) => s"#(${renderExpr(ctx, x)})"
-    case UnaryOpF(UNegate(), x, _)      => s"minus[0, ${renderExpr(ctx, x)}]"
-    case UnaryOpF(UPower(), _, _) =>
-      failAlloy(
-        "standalone powerset '^s' is only supported as a binder domain (e.g. 'some t in ^s | ...')"
-      )
+    case BinaryOpF(op, l, r, _) => renderBinaryOp(ctx, op, l, r)
+    case UnaryOpF(op, x, _) =>
+      alloyUnopShape(op) match
+        case _: AusNot         => s"not (${renderExpr(ctx, x)})"
+        case _: AusCardinality => s"#(${renderExpr(ctx, x)})"
+        case _: AusMinusZero   => s"minus[0, ${renderExpr(ctx, x)}]"
+        case _: AusUnsupported =>
+          failAlloy(
+            "standalone powerset '^s' is only supported as a binder domain (e.g. 'some t in ^s | ...')"
+          )
     case q @ QuantifierF(_, _, _, _) => renderQuantifier(ctx, q)
     case FieldAccessF(b, f, _)       => s"(${renderExpr(ctx, b)}).$f"
     case EnumAccessF(_, m, _)        => m
     case IdentifierF(name, _) =>
-      if ctx.boundVars.contains(name) then name
-      else if ctx.stateFields.contains(name) then s"${ctx.currentStateSig}.$name"
-      else if ctx.inputFields.contains(name) then s"Inputs.$name"
-      else name
+      classifyAlloyIdentifier(
+        name,
+        ctx.boundVars.toList,
+        ctx.stateFields.toList,
+        ctx.inputFields.toList
+      ) match
+        case _: AikBoundVar   => name
+        case _: AikStateField => s"${ctx.currentStateSig}.$name"
+        case _: AikInputField => s"Inputs.$name"
+        case _: AikPlain      => name
     case PrimeF(inner, _) =>
       renderExpr(ctx.copy(currentStateSig = ctx.postStateSig), inner)
     case PreF(inner, _) =>
@@ -293,27 +301,10 @@ object Translator:
   ): String =
     val lr = renderExpr(ctx, l)
     val rr = renderExpr(ctx, r)
-    op match
-      case BAnd()       => s"(($lr) and ($rr))"
-      case BOr()        => s"(($lr) or ($rr))"
-      case BImplies()   => s"(($lr) implies ($rr))"
-      case BIff()       => s"(($lr) iff ($rr))"
-      case BEq()        => s"($lr = $rr)"
-      case BNeq()       => s"($lr != $rr)"
-      case BLt()        => s"($lr < $rr)"
-      case BLe()        => s"($lr <= $rr)"
-      case BGt()        => s"($lr > $rr)"
-      case BGe()        => s"($lr >= $rr)"
-      case BIn()        => s"($lr in $rr)"
-      case BNotIn()     => s"($lr !in $rr)"
-      case BSubset()    => s"($lr in $rr)"
-      case BUnion()     => s"($lr + $rr)"
-      case BIntersect() => s"($lr & $rr)"
-      case BDiff()      => s"($lr - $rr)"
-      case BAdd()       => s"plus[$lr, $rr]"
-      case BSub()       => s"minus[$lr, $rr]"
-      case BMul()       => s"mul[$lr, $rr]"
-      case BDiv()       => s"div[$lr, $rr]"
+    alloyBinopShape(op) match
+      case AbsLogical(tok)    => s"(($lr) $tok ($rr))"
+      case AbsInfix(tok)      => s"($lr $tok $rr)"
+      case AbsPrefixCall(tok) => s"$tok[$lr, $rr]"
 
   private def renderQuantifier(ctx: Ctx, q: QuantifierF)(using AlloyLabel): String =
     val bindings0 = q.b.collect { case qb: QuantifierBindingFull => qb }
@@ -323,9 +314,9 @@ object Translator:
           case UnaryOpF(UPower(), _, _) => true
           case _                        => false
     }
-    val kind  = q.a
-    val isAll = kind match { case _: QAll => true; case _ => false }
-    val isNo  = kind match { case _: QNo => true; case _ => false }
+    val kindClass = alloyQuantifierClass(q.a)
+    val isAll     = kindClass match { case _: AqAll => true; case _ => false }
+    val isNo      = kindClass match { case _: AqNo => true; case _ => false }
     if hasPowersetBinder && isAll then
       failAlloy(
         "universal quantification over a powerset ('all t in ^s | ...') requires higher-order " +
@@ -337,11 +328,7 @@ object Translator:
         "'no t in ^s | ...' is a negated universal over a powerset; Alloy rejects it as " +
           "higher-order for the same reason as 'all'. Rewrite to a first-order statement."
       )
-    val keyword = kind match
-      case _: QAll    => "all"
-      case _: QSome   => "some"
-      case _: QExists => "some"
-      case _: QNo     => "no"
+    val keyword                         = alloyQuantifierKeyword(kindClass)
     val (binderParts, extraConstraints) = bindings0.map(buildBinding(ctx, _)).unzip
     val bindings                        = binderParts.mkString(", ")
     val innerCtx                        = ctx.copy(boundVars = ctx.boundVars ++ bindings0.map(_.a))
@@ -350,10 +337,8 @@ object Translator:
     val body =
       if extras.isEmpty then bodyInner
       else
-        val joiner = kind match
-          case _: QAll => " implies "
-          case _       => " and "
-        val guard = extras.mkString(" and ")
+        val joiner = if isAll then " implies " else " and "
+        val guard  = extras.mkString(" and ")
         s"($guard)$joiner($bodyInner)"
     s"($keyword $bindings | $body)"
 

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -250,11 +250,6 @@ object Translator:
           s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $t"
         )
 
-  private def fieldElementSigName(t: type_expr_full)(using AlloyLabel): String =
-    SpecRestGenerated.fieldElementSigNameAlloy(t) match
-      case Some(n) => n
-      case None    => failAlloy(s"unsupported quantifier domain field type: $t")
-
   private def renderExpr(ctx: Ctx, e: expr_full)(using AlloyLabel): String = e match
     case BinaryOpF(op, l, r, _) => renderBinaryOp(ctx, op, l, r)
     case UnaryOpF(op, x, _) =>
@@ -351,30 +346,35 @@ object Translator:
         val containment = s"${b.a} in ${renderExpr(ctx, inner)}"
         (s"${b.a}: set $innerType", Some(containment))
       case IdentifierF(name, _) =>
-        val t = entityNameInList(ctx.ir.c, name)
-          .orElse(ctx.ir.d.collectFirst { case e: EnumDeclFull if e.a == name => e.a })
-        t match
-          case Some(sigName) => (s"${b.a}: $sigName", None)
-          case None =>
-            if ctx.stateFields.contains(name) || ctx.inputFields.contains(name) then
-              val elem = domainSigName(ctx, b.b)
-              (s"${b.a}: $elem", Some(s"${b.a} in ${renderExpr(ctx, b.b)}"))
-            else (s"${b.a}: $name", None)
+        classifyAlloyBindingIdentifier(
+          name,
+          ctx.ir.c,
+          ctx.ir.d,
+          ctx.stateFields.toList,
+          ctx.inputFields.toList
+        ) match
+          case AbirEntity(sn) => (s"${b.a}: $sn", None)
+          case AbirEnum(en)   => (s"${b.a}: $en", None)
+          case _: AbirStateOrInput =>
+            val elem = domainSigName(ctx, b.b)
+            (s"${b.a}: $elem", Some(s"${b.a} in ${renderExpr(ctx, b.b)}"))
+          case _: AbirPlain => (s"${b.a}: $name", None)
       case _ =>
         (s"${b.a}: ${renderExpr(ctx, b.b)}", None)
 
-  private def domainSigName(ctx: Ctx, e: expr_full)(using AlloyLabel): String = e match
-    case IdentifierF(name, _) =>
-      ctx.stateFields.get(name).orElse(ctx.inputFields.get(name)) match
-        case Some(t) => fieldElementSigName(t)
-        case None =>
-          entityNameInList(ctx.ir.c, name)
-            .orElse(ctx.ir.d.collectFirst { case e: EnumDeclFull if e.a == name => e.a })
-            .getOrElse(name)
-    case _ =>
-      failAlloy(
-        "powerset binder domain must be an identifier referring to an entity or set-typed state"
-      )
+  private def domainSigName(ctx: Ctx, e: expr_full)(using AlloyLabel): String =
+    SpecRestGenerated.domainSigNameAlloy(
+      e,
+      ctx.stateFields.toList,
+      ctx.inputFields.toList,
+      ctx.ir.c,
+      ctx.ir.d
+    ) match
+      case Some(n) => n
+      case None =>
+        failAlloy(
+          "powerset binder domain must be an identifier referring to an entity or set-typed state"
+        )
 
   private def renderCall(ctx: Ctx, callee: expr_full, args: List[expr_full])(using
       AlloyLabel

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
@@ -12,6 +12,13 @@ object AlloyFieldMultiplicity:
     case Some_ => "some"
     case Set   => "set"
 
+private[alloy] object AlloyAdapter:
+  def fromLiftedMult(m: alloy_field_multiplicity): AlloyFieldMultiplicity = m match
+    case _: AfmOne  => AlloyFieldMultiplicity.One
+    case _: AfmLone => AlloyFieldMultiplicity.Lone
+    case _: AfmSome => AlloyFieldMultiplicity.Some_
+    case _: AfmSet  => AlloyFieldMultiplicity.Set
+
 final case class AlloySig(
     name: String,
     abstract_ : Boolean = false,

--- a/proofs/isabelle/SpecRest/AlloyTypes.thy
+++ b/proofs/isabelle/SpecRest/AlloyTypes.thy
@@ -223,6 +223,92 @@ fun alloyQuantifierKeyword :: "alloy_quantifier_class \<Rightarrow> String.liter
 | "alloyQuantifierKeyword AqExists = STR ''some''"
 | "alloyQuantifierKeyword AqNo     = STR ''no''"
 
+text \<open>Helpers: lookup a name in the enum-decl list (mirrors the Scala
+  \<open>ir.d.collectFirst { case e: EnumDeclFull if e.a == name => e.a }\<close>
+  pattern used in two places). Returns the enum's name unchanged on
+  match, matching the Scala selector.\<close>
+
+fun enumNameInList :: "enum_decl_full list \<Rightarrow> String.literal \<Rightarrow> String.literal option" where
+  "enumNameInList []                          _ = None"
+| "enumNameInList (EnumDeclFull en _ _ # es)  n =
+     (if en = n then Some en else enumNameInList es n)"
+
+text \<open>\<open>domainSigName\<close>: extract the Alloy sig name for a quantifier
+  binder's domain expression. The Scala original is called from two
+  places in \<open>buildBinding\<close>:
+
+  \<^item> Powerset case \<open>some t in ^s\<close>: extract the inner sig of \<open>s\<close>.
+  \<^item> State/Input identifier in \<open>some x in someStateField\<close>: extract the
+    element sig of the field's type.
+
+  Only \<open>IdentifierF\<close> is supported as the domain expression in Alloy
+  v1; non-identifier domains return \<open>None\<close> (Scala caller turns into
+  \<open>failAlloy\<close>). Resolution order: state-field type → input-field type
+  → entity sig name → enum sig name → bare name fallthrough.\<close>
+
+definition domainSigNameAlloy ::
+  "expr_full
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> entity_decl_full list
+   \<Rightarrow> enum_decl_full list
+   \<Rightarrow> String.literal option"
+where
+  "domainSigNameAlloy e stateFields inputFields entities enums = (
+     case e of
+       IdentifierF name _ \<Rightarrow>
+         (case map_of stateFields name of
+            Some t \<Rightarrow> fieldElementSigNameAlloy t
+          | None \<Rightarrow>
+              (case map_of inputFields name of
+                 Some t \<Rightarrow> fieldElementSigNameAlloy t
+               | None \<Rightarrow>
+                   (case entityNameInList entities name of
+                      Some sn \<Rightarrow> Some sn
+                    | None \<Rightarrow>
+                        (case enumNameInList enums name of
+                           Some en \<Rightarrow> Some en
+                         | None \<Rightarrow> Some name))))
+     | _ \<Rightarrow> None)"
+
+text \<open>\<open>buildBinding\<close>'s \<open>IdentifierF\<close>-case resolution. The Scala
+  original tries (entity \<open>orElse\<close> enum) first; on \<open>None\<close>, falls back
+  to a state/input check; on miss there, emits the bare name. The
+  lifted classifier returns one of four resolutions.
+
+  \<^item> \<open>AbirEntity sig\<close>: \<open>$name\<close> refers to an entity decl. Use \<open>sig\<close>.
+  \<^item> \<open>AbirEnum sig\<close>: \<open>$name\<close> refers to an enum decl. Use \<open>sig\<close>.
+  \<^item> \<open>AbirStateOrInput\<close>: \<open>$name\<close> is a state/input field. Caller
+    extracts the element sig via \<open>domainSigNameAlloy\<close> and emits a
+    containment fact.
+  \<^item> \<open>AbirPlain\<close>: \<open>$name\<close> is unresolved. Emit \<open>$name\<close> as-is.\<close>
+
+datatype alloy_binding_identifier_resolution =
+    AbirEntity "String.literal"
+  | AbirEnum "String.literal"
+  | AbirStateOrInput
+  | AbirPlain
+
+definition classifyAlloyBindingIdentifier ::
+  "String.literal
+   \<Rightarrow> entity_decl_full list
+   \<Rightarrow> enum_decl_full list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> alloy_binding_identifier_resolution"
+where
+  "classifyAlloyBindingIdentifier name entities enums stateFields inputFields = (
+     case entityNameInList entities name of
+       Some sn \<Rightarrow> AbirEntity sn
+     | None \<Rightarrow>
+         (case enumNameInList enums name of
+            Some en \<Rightarrow> AbirEnum en
+          | None \<Rightarrow>
+              (if (\<exists>kv \<in> set stateFields. fst kv = name) \<or>
+                  (\<exists>kv \<in> set inputFields. fst kv = name)
+               then AbirStateOrInput
+               else AbirPlain)))"
+
 lemmas mapAlloyPrimitive_code [code]        = mapAlloyPrimitive_def
 lemmas typeToSigNameAlloy_code [code]       = typeToSigNameAlloy.simps
 lemmas alloyFieldTypeOf_code [code]         = alloyFieldTypeOf.simps
@@ -238,5 +324,8 @@ lemmas alloyUnopShape_code [code]           = alloyUnopShape.simps
 lemmas classifyAlloyIdentifier_code [code]  = classifyAlloyIdentifier_def
 lemmas alloyQuantifierClass_code [code]     = alloyQuantifierClass.simps
 lemmas alloyQuantifierKeyword_code [code]   = alloyQuantifierKeyword.simps
+lemmas enumNameInList_code [code]           = enumNameInList.simps
+lemmas domainSigNameAlloy_code [code]       = domainSigNameAlloy_def
+lemmas classifyAlloyBindingIdentifier_code [code] = classifyAlloyBindingIdentifier_def
 
 end

--- a/proofs/isabelle/SpecRest/AlloyTypes.thy
+++ b/proofs/isabelle/SpecRest/AlloyTypes.thy
@@ -1,0 +1,132 @@
+theory AlloyTypes
+  imports IR_Helpers IR_Analysis ParseTemporal
+begin
+
+text \<open>Type-to-sig mapping kernel for the Alloy translator. Lifts the pure
+  per-type classification helpers \<open>alloyFieldTypeOf\<close>, \<open>typeToSigName\<close>,
+  and \<open>fieldElementSigName\<close> from
+  \<open>specrest.verify.alloy.Translator\<close>, which classify a spec
+  \<open>type_expr_full\<close> into an Alloy field shape (multiplicity tag +
+  element sig name).
+
+  Field-multiplicity tags mirror Alloy's keyword set (\<open>one\<close>, \<open>lone\<close>,
+  \<open>some\<close>, \<open>set\<close>). The lifted classifier returns \<open>None\<close> for shapes
+  the Alloy v1 translator doesn't support (nested generics other than
+  \<open>Set[Named]\<close>/\<open>Option[Named]\<close>, relation types, map types); the Scala
+  caller turns \<open>None\<close> into a \<open>boundary/break\<close> \<open>failAlloy\<close>
+  diagnostic with the unsupported shape's class name.\<close>
+
+datatype alloy_field_multiplicity =
+    AfmOne
+  | AfmLone
+  | AfmSome
+  | AfmSet
+
+text \<open>Primitive-name passthrough. The Scala \<open>mapPrimitive\<close> maps
+  \<open>"Int"\<close>/\<open>"Bool"\<close>/\<open>"String"\<close> to themselves and falls through with
+  any other name unchanged — so the function is identity in practice.
+  Lifted here for completeness and to keep the call-site machinery in
+  the proof artefact even if extraction inlines it.\<close>
+
+definition mapAlloyPrimitive :: "String.literal \<Rightarrow> String.literal" where
+  "mapAlloyPrimitive name =
+     (if name = STR ''Int'' then STR ''Int''
+      else if name = STR ''Bool'' then STR ''Bool''
+      else if name = STR ''String'' then STR ''String''
+      else name)"
+
+text \<open>\<open>typeToSigName\<close>: extract the Alloy sig name for a type that's
+  used in an element position (set member, option content). Only
+  \<open>NamedTypeF\<close> is supported in v1; anything else returns \<open>None\<close>.\<close>
+
+fun typeToSigNameAlloy :: "type_expr_full \<Rightarrow> String.literal option" where
+  "typeToSigNameAlloy (NamedTypeF name _) = Some (mapAlloyPrimitive name)"
+| "typeToSigNameAlloy _                   = None"
+
+text \<open>\<open>alloyFieldTypeOf\<close>: classify a field-type's Alloy shape. Returns
+  \<open>None\<close> for unsupported nested types (e.g. \<open>Set[Set[T]]\<close>,
+  \<open>Relation\<close>, \<open>Map\<close>). The Scala caller fails the translation with a
+  matching diagnostic on \<open>None\<close>.\<close>
+
+fun alloyFieldTypeOf ::
+  "type_expr_full \<Rightarrow> (alloy_field_multiplicity \<times> String.literal) option"
+where
+  "alloyFieldTypeOf (NamedTypeF name _) = Some (AfmOne, mapAlloyPrimitive name)"
+| "alloyFieldTypeOf (SetTypeF inner _) =
+     (case typeToSigNameAlloy inner of
+        None \<Rightarrow> None
+      | Some n \<Rightarrow> Some (AfmSet, n))"
+| "alloyFieldTypeOf (OptionTypeF inner _) =
+     (case typeToSigNameAlloy inner of
+        None \<Rightarrow> None
+      | Some n \<Rightarrow> Some (AfmLone, n))"
+| "alloyFieldTypeOf _ = None"
+
+text \<open>\<open>fieldElementSigName\<close>: extract the Alloy sig name from a
+  quantifier-binding domain's field type. The Scala original accepts
+  three shapes (\<open>NamedTypeF\<close>, \<open>SetTypeF (NamedTypeF _ _) _\<close>,
+  \<open>OptionTypeF (NamedTypeF _ _) _\<close>); other shapes are unsupported.\<close>
+
+fun fieldElementSigNameAlloy :: "type_expr_full \<Rightarrow> String.literal option" where
+  "fieldElementSigNameAlloy (NamedTypeF name _) = Some (mapAlloyPrimitive name)"
+| "fieldElementSigNameAlloy (SetTypeF (NamedTypeF name _) _) = Some (mapAlloyPrimitive name)"
+| "fieldElementSigNameAlloy (OptionTypeF (NamedTypeF name _) _) = Some (mapAlloyPrimitive name)"
+| "fieldElementSigNameAlloy _ = None"
+
+text \<open>\<open>needsBoolSig\<close>: predicate deciding whether the Alloy module needs
+  an explicit \<open>Bool\<close> sig hierarchy. True iff any entity field, state
+  field, input field, invariant body, temporal arg, or operation
+  pre/postcondition references the \<open>Bool\<close> type or a \<open>BoolLitF\<close>.
+
+  Takes the IR plus the materialised state-/input-field type lists (as
+  alists of \<open>name \<times> type_expr_full\<close>) because the Scala caller has
+  already extracted those into \<open>Ctx\<close>. State fields are extracted from
+  \<open>state_decl_full\<close>; input fields are operation-specific (different
+  Ctx per operation in the preservation/enabled flows).\<close>
+
+fun fieldTypeHasBool :: "field_decl_full \<Rightarrow> bool" where
+  "fieldTypeHasBool (FieldDeclFull _ t _ _) = typeContainsNamed (STR ''Bool'') t"
+
+fun entityHasBoolField :: "entity_decl_full \<Rightarrow> bool" where
+  "entityHasBoolField (EntityDeclFull _ _ fs _ _) =
+     (\<exists>f \<in> set fs. fieldTypeHasBool f)"
+
+fun operationHasBoolLit :: "operation_decl_full \<Rightarrow> bool" where
+  "operationHasBoolLit (OperationDeclFull _ _ _ requires ensures _) =
+     ((\<exists>e \<in> set requires. exprContainsBoolLit e) \<or>
+      (\<exists>e \<in> set ensures. exprContainsBoolLit e))"
+
+fun invariantHasBoolLit :: "invariant_decl_full \<Rightarrow> bool" where
+  "invariantHasBoolLit (InvariantDeclFull _ body _) = exprContainsBoolLit body"
+
+fun temporalHasBoolLit :: "temporal_decl_full \<Rightarrow> bool" where
+  "temporalHasBoolLit (TemporalDeclFull _ tb _) = exprContainsBoolLit (temporalArg tb)"
+
+fun needsBoolSig ::
+  "service_ir_full
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> bool"
+where
+  "needsBoolSig
+      (ServiceIRFull _ _ es _ _ _ ops _ invs temps _ _ _ _ _)
+      stateFields inputFields = (
+     (\<exists>e \<in> set es. entityHasBoolField e) \<or>
+     (\<exists>kv \<in> set stateFields. typeContainsNamed (STR ''Bool'') (snd kv)) \<or>
+     (\<exists>kv \<in> set inputFields. typeContainsNamed (STR ''Bool'') (snd kv)) \<or>
+     (\<exists>i \<in> set invs. invariantHasBoolLit i) \<or>
+     (\<exists>t \<in> set temps. temporalHasBoolLit t) \<or>
+     (\<exists>op \<in> set ops. operationHasBoolLit op))"
+
+lemmas mapAlloyPrimitive_code [code]        = mapAlloyPrimitive_def
+lemmas typeToSigNameAlloy_code [code]       = typeToSigNameAlloy.simps
+lemmas alloyFieldTypeOf_code [code]         = alloyFieldTypeOf.simps
+lemmas fieldElementSigNameAlloy_code [code] = fieldElementSigNameAlloy.simps
+lemmas fieldTypeHasBool_code [code]         = fieldTypeHasBool.simps
+lemmas entityHasBoolField_code [code]       = entityHasBoolField.simps
+lemmas operationHasBoolLit_code [code]      = operationHasBoolLit.simps
+lemmas invariantHasBoolLit_code [code]      = invariantHasBoolLit.simps
+lemmas temporalHasBoolLit_code [code]       = temporalHasBoolLit.simps
+lemmas needsBoolSig_code [code]             = needsBoolSig.simps
+
+end

--- a/proofs/isabelle/SpecRest/AlloyTypes.thy
+++ b/proofs/isabelle/SpecRest/AlloyTypes.thy
@@ -118,6 +118,111 @@ where
      (\<exists>t \<in> set temps. temporalHasBoolLit t) \<or>
      (\<exists>op \<in> set ops. operationHasBoolLit op))"
 
+text \<open>\<open>renderBinaryOp\<close>'s structural decision: each spec binary operator
+  emits one of three Alloy expression shapes. The token and shape come
+  from the lift; the Scala caller assembles the final string after
+  recursively rendering the operands. Three shapes are distinguished:
+
+  \<^item> \<open>AbsLogical tok\<close>: \<open>(($l) tok ($r))\<close> — parenthesise each
+    operand. Used by the propositional connectives (\<open>and\<close>, \<open>or\<close>,
+    \<open>implies\<close>, \<open>iff\<close>) so precedence is unambiguous.
+  \<^item> \<open>AbsInfix tok\<close>: \<open>($l tok $r)\<close> — single outer parens. Used by
+    \<open>=\<close>/\<open>!=\<close>/\<open><\<close>/\<open><=\<close>/\<open>>\<close>/\<open>>=\<close>/\<open>in\<close>/\<open>!in\<close>/\<open>+\<close>/\<open>&\<close>/\<open>-\<close>.
+    (\<open>BSubset\<close> shares the \<open>in\<close> token with \<open>BIn\<close> — Alloy uses
+    \<open>in\<close> for both membership and subset.)
+  \<^item> \<open>AbsPrefixCall tok\<close>: \<open>tok[$l, $r]\<close> — Alloy's prefix-call form
+    used for the arithmetic builtins \<open>plus\<close>/\<open>minus\<close>/\<open>mul\<close>/\<open>div\<close>.\<close>
+
+datatype alloy_binop_shape =
+    AbsLogical "String.literal"
+  | AbsInfix "String.literal"
+  | AbsPrefixCall "String.literal"
+
+fun alloyBinopShape :: "bin_op_full \<Rightarrow> alloy_binop_shape" where
+  "alloyBinopShape BAnd       = AbsLogical (STR ''and'')"
+| "alloyBinopShape BOr        = AbsLogical (STR ''or'')"
+| "alloyBinopShape BImplies   = AbsLogical (STR ''implies'')"
+| "alloyBinopShape BIff       = AbsLogical (STR ''iff'')"
+| "alloyBinopShape BEq        = AbsInfix (STR ''='')"
+| "alloyBinopShape BNeq       = AbsInfix (STR ''!='')"
+| "alloyBinopShape BLt        = AbsInfix (STR ''<'')"
+| "alloyBinopShape BLe        = AbsInfix (STR ''<='')"
+| "alloyBinopShape BGt        = AbsInfix (STR ''>'')"
+| "alloyBinopShape BGe        = AbsInfix (STR ''>='')"
+| "alloyBinopShape BIn        = AbsInfix (STR ''in'')"
+| "alloyBinopShape BNotIn     = AbsInfix (STR ''!in'')"
+| "alloyBinopShape BSubset    = AbsInfix (STR ''in'')"
+| "alloyBinopShape BUnion     = AbsInfix (STR ''+'')"
+| "alloyBinopShape BIntersect = AbsInfix (STR ''&'')"
+| "alloyBinopShape BDiff      = AbsInfix (STR ''-'')"
+| "alloyBinopShape BAdd       = AbsPrefixCall (STR ''plus'')"
+| "alloyBinopShape BSub       = AbsPrefixCall (STR ''minus'')"
+| "alloyBinopShape BMul       = AbsPrefixCall (STR ''mul'')"
+| "alloyBinopShape BDiv       = AbsPrefixCall (STR ''div'')"
+
+text \<open>\<open>renderExpr\<close>'s unary-operator dispatch. \<open>UPower\<close> as a standalone
+  prefix is unsupported (it requires higher-order Alloy reasoning); the
+  binder-domain form is handled separately in \<open>buildBinding\<close>.\<close>
+
+datatype alloy_unop_shape =
+    AusNot           \<comment> \<open>\<open>not (X)\<close>\<close>
+  | AusCardinality   \<comment> \<open>\<open>#(X)\<close>\<close>
+  | AusMinusZero     \<comment> \<open>\<open>minus[0, X]\<close>\<close>
+  | AusUnsupported   \<comment> \<open>standalone power — Scala caller fails the translation\<close>
+
+fun alloyUnopShape :: "un_op_full \<Rightarrow> alloy_unop_shape" where
+  "alloyUnopShape UNot         = AusNot"
+| "alloyUnopShape UCardinality = AusCardinality"
+| "alloyUnopShape UNegate      = AusMinusZero"
+| "alloyUnopShape UPower       = AusUnsupported"
+
+text \<open>\<open>IdentifierF\<close> resolution classifier. Mirrors the four-way
+  precedence in \<open>renderExpr\<close>'s \<open>IdentifierF\<close> case: a name resolves
+  to a bound variable first, then a state field, then an input field,
+  then falls through unprefixed. The Scala caller emits the prefix
+  (\<open>currentStateSig.\<close> or \<open>Inputs.\<close>) for the field cases.\<close>
+
+datatype alloy_identifier_kind =
+    AikBoundVar
+  | AikStateField
+  | AikInputField
+  | AikPlain
+
+definition classifyAlloyIdentifier ::
+  "String.literal
+   \<Rightarrow> String.literal list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> alloy_identifier_kind"
+where
+  "classifyAlloyIdentifier name boundVars stateFields inputFields = (
+     if name \<in> set boundVars then AikBoundVar
+     else if name \<in> set (map fst stateFields) then AikStateField
+     else if name \<in> set (map fst inputFields) then AikInputField
+     else AikPlain)"
+
+text \<open>Quantifier-keyword classifier. \<open>QExists\<close> shares the \<open>some\<close>
+  keyword with \<open>QSome\<close> (the spec language distinguishes them; Alloy
+  collapses both onto the same surface keyword).\<close>
+
+datatype alloy_quantifier_class =
+    AqAll
+  | AqSome
+  | AqExists
+  | AqNo
+
+fun alloyQuantifierClass :: "quant_kind_full \<Rightarrow> alloy_quantifier_class" where
+  "alloyQuantifierClass QAll    = AqAll"
+| "alloyQuantifierClass QSome   = AqSome"
+| "alloyQuantifierClass QExists = AqExists"
+| "alloyQuantifierClass QNo     = AqNo"
+
+fun alloyQuantifierKeyword :: "alloy_quantifier_class \<Rightarrow> String.literal" where
+  "alloyQuantifierKeyword AqAll    = STR ''all''"
+| "alloyQuantifierKeyword AqSome   = STR ''some''"
+| "alloyQuantifierKeyword AqExists = STR ''some''"
+| "alloyQuantifierKeyword AqNo     = STR ''no''"
+
 lemmas mapAlloyPrimitive_code [code]        = mapAlloyPrimitive_def
 lemmas typeToSigNameAlloy_code [code]       = typeToSigNameAlloy.simps
 lemmas alloyFieldTypeOf_code [code]         = alloyFieldTypeOf.simps
@@ -128,5 +233,10 @@ lemmas operationHasBoolLit_code [code]      = operationHasBoolLit.simps
 lemmas invariantHasBoolLit_code [code]      = invariantHasBoolLit.simps
 lemmas temporalHasBoolLit_code [code]       = temporalHasBoolLit.simps
 lemmas needsBoolSig_code [code]             = needsBoolSig.simps
+lemmas alloyBinopShape_code [code]          = alloyBinopShape.simps
+lemmas alloyUnopShape_code [code]           = alloyUnopShape.simps
+lemmas classifyAlloyIdentifier_code [code]  = classifyAlloyIdentifier_def
+lemmas alloyQuantifierClass_code [code]     = alloyQuantifierClass.simps
+lemmas alloyQuantifierKeyword_code [code]   = alloyQuantifierKeyword.simps
 
 end

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -22,6 +22,7 @@ theory Codegen
     ParsePath
     LintAnalysis
     Classify
+    AlloyTypes
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
 begin
@@ -311,6 +312,11 @@ export_code
     computeFieldBounds
     typeExprToSchema
     fieldToSchema
+    mapAlloyPrimitive
+    typeToSigNameAlloy
+    alloyFieldTypeOf
+    fieldElementSigNameAlloy
+    needsBoolSig
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -317,6 +317,11 @@ export_code
     alloyFieldTypeOf
     fieldElementSigNameAlloy
     needsBoolSig
+    alloyBinopShape
+    alloyUnopShape
+    classifyAlloyIdentifier
+    alloyQuantifierClass
+    alloyQuantifierKeyword
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -322,6 +322,9 @@ export_code
     classifyAlloyIdentifier
     alloyQuantifierClass
     alloyQuantifierKeyword
+    enumNameInList
+    domainSigNameAlloy
+    classifyAlloyBindingIdentifier
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -30,4 +30,5 @@ session SpecRest = HOL +
     ParsePath
     LintAnalysis
     Classify
+    AlloyTypes
     Codegen


### PR DESCRIPTION
## Summary

Establishes the Alloy proof footprint across three commits — every pure structural decision inside `specrest.verify.alloy.Translator` (apart from the recursive `renderExpr` walker itself) is now derived from proofs:

1. **Foundation** — `alloy_field_multiplicity` ADT + type-mapping helpers + `needsBoolSig` IR-wide predicate
2. **renderExpr classifiers** — operator-token + identifier + quantifier-keyword tables
3. **buildBinding + domainSigName resolution** — sig-name lookup + binding-identifier four-way precedence

The Alloy translator is significantly more functional than the Z3 translator (immutable `Ctx`, pure `renderExpr`, `boundary/break` for errors only) — so the lift proceeds in clean incremental commits.

## Commit 1 — type-mapping foundation

```isabelle
datatype alloy_field_multiplicity = AfmOne | AfmLone | AfmSome | AfmSet

mapAlloyPrimitive, typeToSigNameAlloy, alloyFieldTypeOf,
fieldElementSigNameAlloy   -- per-type classification

needsBoolSig : service_ir_full
            => (String.literal × type_expr_full) list  (state fields)
            => (String.literal × type_expr_full) list  (input fields)
            => bool
  -- drives Alloy.buildSigs' Bool/True/False sig hierarchy decision
```

## Commit 2 — renderExpr classifiers

```isabelle
datatype alloy_binop_shape =
    AbsLogical String.literal       -- (($l) tok ($r))
  | AbsInfix String.literal         -- ($l tok $r)
  | AbsPrefixCall String.literal    -- tok[$l, $r]

alloyBinopShape : bin_op_full => alloy_binop_shape  -- 20 cases

datatype alloy_unop_shape = AusNot | AusCardinality | AusMinusZero | AusUnsupported
alloyUnopShape : un_op_full => alloy_unop_shape

datatype alloy_identifier_kind =
    AikBoundVar | AikStateField | AikInputField | AikPlain
classifyAlloyIdentifier : name => boundVars => stateFields => inputFields
                       => alloy_identifier_kind

datatype alloy_quantifier_class = AqAll | AqSome | AqExists | AqNo
alloyQuantifierClass   : quant_kind_full => alloy_quantifier_class
alloyQuantifierKeyword : alloy_quantifier_class => String.literal
  -- "all" | "some" (both QSome and QExists) | "no"
```

## Commit 3 — buildBinding + domainSigName

```isabelle
enumNameInList : enum_decl_full list => String.literal
              => String.literal option

domainSigNameAlloy : expr_full
                  => state-fields alist => input-fields alist
                  => entity decls => enum decls
                  => String.literal option
  -- extracts the Alloy sig name for a quantifier binder's domain.
     Resolution: state-field type -> input-field type -> entity ->
     enum -> bare-name fallthrough. None iff non-IdentifierF.

datatype alloy_binding_identifier_resolution =
    AbirEntity String.literal | AbirEnum String.literal
  | AbirStateOrInput | AbirPlain

classifyAlloyBindingIdentifier : name => entities => enums
                              => state-fields => input-fields
                              => alloy_binding_identifier_resolution
  -- buildBinding's IdentifierF four-way precedence
```

## Scala-side

`Translator.scala` after all three commits:

- `needsBoolSig`: 16 LOC → 5 LOC
- `alloyFieldTypeOf`: 14 LOC → 6 LOC
- `renderBinaryOp`: 20 cases → 4 lines (delegate to `alloyBinopShape`)
- `renderExpr` UnaryOpF / IdentifierF cases: dispatch via lifted classifiers
- `renderQuantifier`: kind keyword + `isAll`/`isNo` guards derived from `alloyQuantifierClass`/`alloyQuantifierKeyword`
- `buildBinding` IdentifierF case: nested orElse-chain → match on `classifyAlloyBindingIdentifier`
- `domainSigName`: 9 LOC → 7 LOC (delegate; `None` → `failAlloy`)
- `fieldElementSigName`, `typeToSigName`, `mapPrimitive`: removed (lifted variants called transitively)

`Types.scala`: adds `AlloyAdapter` (file-local) for the `alloy_field_multiplicity → AlloyFieldMultiplicity` enum conversion (mirrors `DialectAdapter` / `SchemaObjectAdapter` from #349 / #352).

## Why not Z3

The Z3 Translator (2,159 LOC) uses heavy imperative state (`mutable.LinkedHashMap` × 9, `mutable.ArrayBuffer`, `var stateMode`, skolem-counter mutation, `boundary/break` mid-recursion). Clean lift requires a multi-week Scala-side refactor first (state-monad threading or multi-pass restructure). The Alloy translator (now 380 LOC after this PR) has immutable `Ctx` + pure `renderExpr` — ready for incremental lifts now. The natural next "huge block" is a structured `alloy_render_node` ADT capturing the recursive `renderExpr` decision tree.

## Test plan
- [x] `isabelle build SpecRest` clean (3:02 incremental per commit)
- [x] `sbt verify/compile` clean
- [x] `sbt verify/test`: all suites pass (`BackendTest` 16, `ConsistencyTest` 14, `ParallelTest` 10, plus Alloy-specific suites); Alloy output byte-identical through `ConsistencyTest` end-to-end
- [x] `sbt scalafixAll` clean
- [ ] CI: isabelle-build (extraction drift) + build-and-test
