### PR TITLE
feat(proofs): lift verifier dispatch + trust classifier (Classifier + Trust)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -993,6 +993,10 @@ object SpecRestGenerated {
       e: List[String]
   ) extends string_constraint
 
+  sealed abstract class trust_level
+  final case class TlSound()      extends trust_level
+  final case class TlBestEffort() extends trust_level
+
   sealed abstract class classification_result
   final case class ClassificationResult(
       a: operation_kind,
@@ -1021,6 +1025,10 @@ object SpecRestGenerated {
       e: trigger_aggregate,
       f: Option[String]
   ) extends trigger_candidate
+
+  sealed abstract class verifier_tool
+  final case class VtZ3()    extends verifier_tool
+  final case class VtAlloy() extends verifier_tool
 
   sealed abstract class nullable_decision
   final case class NdNoop()          extends nullable_decision
@@ -8828,6 +8836,12 @@ object SpecRestGenerated {
       )
     )
 
+  def foldTrust(enums: List[String], exprs: List[expr_full]): trust_level =
+    list_all[expr_full]((e: expr_full) => !is_none[expr](lower(enums, e)), exprs) match {
+      case true  => TlSound()
+      case false => TlBestEffort()
+    }
+
   def mapAlloyPrimitive(name: String): String =
     name == "Int" match {
       case true => "Int"
@@ -10653,6 +10667,23 @@ object SpecRestGenerated {
     case (uu, (uv, v)) :: rest => v :: valuesOf(rest)
   }
 
+  def serviceIrInvariants(x0: service_ir_full): List[invariant_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, uw, ux, uy, uz, va, vb, invs, vc, vd, ve, vf, vg, vh) => invs
+  }
+
+  def invariantBody(x0: invariant_decl_full): expr_full = x0 match {
+    case InvariantDeclFull(uu, b, uv) => b
+  }
+
+  def invariantBodies(ir: service_ir_full): List[expr_full] =
+    map[invariant_decl_full, expr_full](
+      (a: invariant_decl_full) => invariantBody(a),
+      serviceIrInvariants(ir)
+    )
+
+  def trustGlobal(enums: List[String], ir: service_ir_full): trust_level =
+    foldTrust(enums, invariantBodies(ir))
+
   def fieldElementSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
     case NamedTypeF(name, uu) => Some[String](mapAlloyPrimitive(name))
     case SetTypeF(NamedTypeF(name, uv), uw) =>
@@ -11259,6 +11290,23 @@ object SpecRestGenerated {
     case (uu, (t, uv)) :: rest => t :: targetsOf(rest)
   }
 
+  def enumDeclName(x0: enum_decl_full): String = x0 match {
+    case EnumDeclFull(n, uu, uv) => n
+  }
+
+  def foldVerifier(exprs: List[expr_full]): verifier_tool =
+    list_ex[expr_full]((a: expr_full) => requiresAlloy(a), exprs) match {
+      case true  => VtAlloy()
+      case false => VtZ3()
+    }
+
+  def operationRequires(x0: operation_decl_full): List[expr_full] = x0 match {
+    case OperationDeclFull(uu, uv, uw, requiresa, ux, uy) => requiresa
+  }
+
+  def trustEnabled(enums: List[String], op: operation_decl_full, ir: service_ir_full): trust_level =
+    foldTrust(enums, operationRequires(op) ++ invariantBodies(ir))
+
   def classificationSignals(x0: operation_classification): analysis_signals = x0 match {
     case OperationClassification(uu, uv, uw, ux, uy, uz, sg) => sg
   }
@@ -11561,6 +11609,9 @@ object SpecRestGenerated {
   def triggerSourceForeignKey(x0: trigger_spec): String = x0 match {
     case TriggerSpec(uu, uv, uw, ux, uy, sfk, uz, va) => sfk
   }
+
+  def trustRequires(enums: List[String], op: operation_decl_full): trust_level =
+    foldTrust(enums, operationRequires(op))
 
   def alloyQuantifierClass(x0: quant_kind_full): alloy_quantifier_class = x0 match {
     case QAll()    => AqAll()
@@ -11945,6 +11996,10 @@ object SpecRestGenerated {
       case None    => CvBad(ExpectedBoolean(), e)
       case Some(b) => CvOk(PvBool(b))
     }
+
+  def serviceIrEnums(x0: service_ir_full): List[enum_decl_full] = x0 match {
+    case ServiceIRFull(uu, uv, uw, es, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+  }
 
   def saTypeImportModule(x0: sa_type): Option[String] = x0 match {
     case SaType(uu, m) => m
@@ -12431,6 +12486,9 @@ object SpecRestGenerated {
         Some[(String, String)]((Str_Literal.literalOfAsciis(l), Str_Literal.literalOfAsciis(r)))
     }
 
+  def verifyEnumNames(ir: service_ir_full): List[String] =
+    map[enum_decl_full, String]((a: enum_decl_full) => enumDeclName(a), serviceIrEnums(ir))
+
   def alloyQuantifierKeyword(x0: alloy_quantifier_class): String = x0 match {
     case AqAll()    => "all"
     case AqSome()   => "some"
@@ -12641,6 +12699,10 @@ object SpecRestGenerated {
             )
         }
     }
+
+  def operationEnsures(x0: operation_decl_full): List[expr_full] = x0 match {
+    case OperationDeclFull(uu, uv, uw, ux, ensures, uy) => ensures
+  }
 
   def classifyAlloyIdentifier(
       name: String,
@@ -13007,6 +13069,17 @@ object SpecRestGenerated {
 
   def literalIsEmpty(s: String): Boolean =
     nulla[BigInt](Str_Literal.asciisOfLiteral(s))
+
+  def trustPreservation(
+      enums: List[String],
+      op: operation_decl_full,
+      ivd: invariant_decl_full
+  ): trust_level =
+    foldTrust(
+      enums,
+      invariantBody(ivd) ::
+        operationRequires(op) ++ operationEnsures(op)
+    )
 
   def classificationTargetEntity(x0: operation_classification): Option[String] =
     x0 match {
@@ -13486,6 +13559,9 @@ object SpecRestGenerated {
       case PvExpr(_)       => None
     }
 
+  def classifyGlobalVerifier(ir: service_ir_full): verifier_tool =
+    foldVerifier(invariantBodies(ir))
+
   def collectionElementEntityName(ty: type_expr_full): Option[String] =
     ty match {
       case NamedTypeF(_, _)                       => None
@@ -13560,6 +13636,9 @@ object SpecRestGenerated {
       case CvBad(_, raw)         => raw
       case CvUnknown(raw)        => raw
     }
+
+  def classifyEnabledVerifier(op: operation_decl_full, ir: service_ir_full): verifier_tool =
+    foldVerifier(operationRequires(op) ++ invariantBodies(ir))
 
   def classifyAlloyBindingIdentifier(
       name: String,
@@ -13650,6 +13729,24 @@ object SpecRestGenerated {
             }
         }
     }
+
+  def classifyRequiresVerifier(op: operation_decl_full): verifier_tool =
+    foldVerifier(operationRequires(op))
+
+  def classifyTemporalVerifier: verifier_tool = VtAlloy()
+
+  def classifyInvariantVerifier(ivd: invariant_decl_full): verifier_tool =
+    requiresAlloy(invariantBody(ivd)) match {
+      case true  => VtAlloy()
+      case false => VtZ3()
+    }
+
+  def classifyPreservationVerifier(
+      op: operation_decl_full,
+      ivd: invariant_decl_full
+  ): verifier_tool =
+    foldVerifier(invariantBody(ivd) ::
+      operationRequires(op) ++ operationEnsures(op))
 
   def capsSupportsCheckOnAutoIncrement(x0: dialect_caps): Boolean = x0 match {
     case DialectCaps(uu, uv, c, uw, ux, uy) => c

--- a/modules/verify/src/main/scala/specrest/verify/Classifier.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Classifier.scala
@@ -1,6 +1,6 @@
 package specrest.verify
 
-import specrest.ir.*
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
 enum VerifierTool derives CanEqual:
@@ -11,28 +11,26 @@ object VerifierTool:
     case Z3    => "z3"
     case Alloy => "alloy"
 
+  private[verify] def fromLifted(v: verifier_tool): VerifierTool = v match
+    case _: VtZ3    => Z3
+    case _: VtAlloy => Alloy
+
 object Classifier:
 
   def classifyGlobal(ir: ServiceIRFull): VerifierTool =
-    fold(ir.i.collect { case InvariantDeclFull(_, e, _) => e })
+    VerifierTool.fromLifted(SpecRestGenerated.classifyGlobalVerifier(ir))
 
   def classifyInvariant(inv: InvariantDeclFull): VerifierTool =
-    classify(inv.b)
+    VerifierTool.fromLifted(SpecRestGenerated.classifyInvariantVerifier(inv))
 
   def classifyRequires(op: OperationDeclFull): VerifierTool =
-    fold(op.d)
+    VerifierTool.fromLifted(SpecRestGenerated.classifyRequiresVerifier(op))
 
   def classifyEnabled(op: OperationDeclFull, ir: ServiceIRFull): VerifierTool =
-    fold(op.d ++ ir.i.collect { case InvariantDeclFull(_, e, _) => e })
+    VerifierTool.fromLifted(SpecRestGenerated.classifyEnabledVerifier(op, ir))
 
   def classifyPreservation(op: OperationDeclFull, inv: InvariantDeclFull): VerifierTool =
-    fold(inv.b :: op.d ++ op.e)
+    VerifierTool.fromLifted(SpecRestGenerated.classifyPreservationVerifier(op, inv))
 
   def classifyTemporal(@annotation.unused t: TemporalDeclFull): VerifierTool =
-    VerifierTool.Alloy
-
-  private def classify(e: expr_full): VerifierTool =
-    if requiresAlloy(e) then VerifierTool.Alloy else VerifierTool.Z3
-
-  private def fold(exprs: List[expr_full]): VerifierTool =
-    if exprs.exists(requiresAlloy) then VerifierTool.Alloy else VerifierTool.Z3
+    VerifierTool.fromLifted(SpecRestGenerated.classifyTemporalVerifier)

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -189,17 +189,14 @@ object Consistency:
 
   private def planTrust(plan: CheckPlan, enums: List[String]): TrustLevel = plan match
     case CheckPlan.Global(ir) =>
-      Trust.classify(enums, ir.i.collect { case InvariantDeclFull(_, b, _) => b })
+      TrustLevel.fromLifted(trustGlobal(enums, ir))
     case CheckPlan.Op(_, op, CheckKind.Requires) =>
-      Trust.classify(enums, op.d)
+      TrustLevel.fromLifted(trustRequires(enums, op))
     case CheckPlan.Op(ir, op, CheckKind.Enabled) =>
-      Trust.classify(
-        enums,
-        op.d ++ ir.i.collect { case InvariantDeclFull(_, b, _) => b }
-      )
+      TrustLevel.fromLifted(trustEnabled(enums, op, ir))
     case CheckPlan.Op(_, _, _) => TrustLevel.BestEffort
     case CheckPlan.Preservation(_, op, inv) =>
-      Trust.classify(enums, inv.decl.b :: (op.d ++ op.e))
+      TrustLevel.fromLifted(trustPreservation(enums, op, inv.decl))
     case CheckPlan.Temporal(_, _) => TrustLevel.BestEffort
 
   private def reportFromResults(results: List[CheckResult]): ConsistencyReport =

--- a/modules/verify/src/main/scala/specrest/verify/Trust.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Trust.scala
@@ -1,9 +1,9 @@
 package specrest.verify
 
-import specrest.ir.generated.SpecRestGenerated.EnumDeclFull
+import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.expr_full
-import specrest.ir.generated.SpecRestGenerated.lower
+import specrest.ir.generated.SpecRestGenerated.trust_level
 
 enum TrustLevel derives CanEqual:
   case Sound, BestEffort
@@ -13,14 +13,17 @@ object TrustLevel:
     case Sound      => "sound"
     case BestEffort => "best-effort"
 
+  private[verify] def fromLifted(t: trust_level): TrustLevel = t match
+    case _: SpecRestGenerated.TlSound      => Sound
+    case _: SpecRestGenerated.TlBestEffort => BestEffort
+
 object Trust:
 
   def enumNames(ir: ServiceIRFull): List[String] =
-    ir.d.collect { case EnumDeclFull(n, _, _) => n }
+    SpecRestGenerated.verifyEnumNames(ir)
 
   def classify(enums: List[String], exprs: List[expr_full]): TrustLevel =
-    if exprs.forall(e => lower(enums, e).isDefined) then TrustLevel.Sound
-    else TrustLevel.BestEffort
+    TrustLevel.fromLifted(SpecRestGenerated.foldTrust(enums, exprs))
 
   def classify(enums: List[String], e: expr_full): TrustLevel =
-    if lower(enums, e).isDefined then TrustLevel.Sound else TrustLevel.BestEffort
+    classify(enums, List(e))

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -23,6 +23,7 @@ theory Codegen
     LintAnalysis
     Classify
     AlloyTypes
+    VerifierDispatch
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
 begin
@@ -325,6 +326,17 @@ export_code
     enumNameInList
     domainSigNameAlloy
     classifyAlloyBindingIdentifier
+    classifyGlobalVerifier
+    classifyInvariantVerifier
+    classifyRequiresVerifier
+    classifyEnabledVerifier
+    classifyPreservationVerifier
+    classifyTemporalVerifier
+    trustGlobal
+    trustRequires
+    trustEnabled
+    trustPreservation
+    verifyEnumNames
     parseConventionValue
     synthConventionValue
     showBool

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -31,4 +31,5 @@ session SpecRest = HOL +
     LintAnalysis
     Classify
     AlloyTypes
+    VerifierDispatch
     Codegen

--- a/proofs/isabelle/SpecRest/VerifierDispatch.thy
+++ b/proofs/isabelle/SpecRest/VerifierDispatch.thy
@@ -1,0 +1,160 @@
+theory VerifierDispatch
+  imports IR_Helpers IR_Analysis IR_Lower
+begin
+
+text \<open>Verifier-dispatch and trust classification. Lifts the pure
+  per-formula decisions behind \<open>specrest.verify.Classifier\<close> and
+  \<open>specrest.verify.Trust\<close>:
+
+  \<^item> \<open>verifier_tool\<close>: which backend (\<open>Z3\<close> or \<open>Alloy\<close>) handles a
+    given formula. A formula goes to Alloy iff it contains any
+    Alloy-only construct (\<open>requiresAlloy\<close>, lifted in \<open>IR_Helpers\<close>);
+    otherwise Z3.
+  \<^item> \<open>trust_level\<close>: \<open>Sound\<close> iff every formula's verified-subset
+    \<open>lower\<close> succeeds (i.e. the formula is in the soundness-proven
+    fragment); otherwise \<open>BestEffort\<close>.
+
+  Both classifications are folds over a list of \<open>expr_full\<close>s; this
+  theory provides the \<open>fold\<close> primitives plus the per-check-shape
+  wrappers (global, requires, enabled, preservation, temporal) so the
+  Scala caller becomes a thin delegation.\<close>
+
+datatype verifier_tool = VtZ3 | VtAlloy
+
+datatype trust_level = TlSound | TlBestEffort
+
+text \<open>\<open>foldVerifier\<close>: any formula needs Alloy \<Longrightarrow> bundle goes Alloy.\<close>
+
+definition foldVerifier :: "expr_full list \<Rightarrow> verifier_tool" where
+  "foldVerifier exprs =
+     (if list_ex requiresAlloy exprs then VtAlloy else VtZ3)"
+
+text \<open>\<open>foldTrust\<close>: every formula in the bundle must successfully
+  \<open>lower\<close> into the verified subset for the result to be \<open>Sound\<close>.\<close>
+
+definition foldTrust ::
+  "String.literal list \<Rightarrow> expr_full list \<Rightarrow> trust_level"
+where
+  "foldTrust enums exprs =
+     (if list_all (\<lambda>e. lower enums e \<noteq> None) exprs
+      then TlSound
+      else TlBestEffort)"
+
+text \<open>IR-decomposition selectors. Per-constructor pattern-in-head
+  \<open>fun\<close>s keep the extracted Scala in proper \<open>match\<close> form (Scala 3
+  rejects the \<open>val Ctor(...) = e\<close> shape that \<open>case ... of\<close>
+  produces inside a \<open>definition\<close> as a soft-failure warning, which
+  is escalated to a compile error by \<open>-Werror\<close>).\<close>
+
+fun invariantBody :: "invariant_decl_full \<Rightarrow> expr_full" where
+  "invariantBody (InvariantDeclFull _ b _) = b"
+
+fun operationRequires :: "operation_decl_full \<Rightarrow> expr_full list" where
+  "operationRequires (OperationDeclFull _ _ _ requires _ _) = requires"
+
+fun operationEnsures :: "operation_decl_full \<Rightarrow> expr_full list" where
+  "operationEnsures (OperationDeclFull _ _ _ _ ensures _) = ensures"
+
+fun enumDeclName :: "enum_decl_full \<Rightarrow> String.literal" where
+  "enumDeclName (EnumDeclFull n _ _) = n"
+
+fun serviceIrEntities :: "service_ir_full \<Rightarrow> entity_decl_full list" where
+  "serviceIrEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _) = es"
+
+fun serviceIrEnums :: "service_ir_full \<Rightarrow> enum_decl_full list" where
+  "serviceIrEnums (ServiceIRFull _ _ _ es _ _ _ _ _ _ _ _ _ _ _) = es"
+
+fun serviceIrInvariants :: "service_ir_full \<Rightarrow> invariant_decl_full list" where
+  "serviceIrInvariants (ServiceIRFull _ _ _ _ _ _ _ _ invs _ _ _ _ _ _) = invs"
+
+definition invariantBodies :: "service_ir_full \<Rightarrow> expr_full list" where
+  "invariantBodies ir = map invariantBody (serviceIrInvariants ir)"
+
+text \<open>Per-check-shape verifier dispatchers. Each constructs the
+  exact formula bundle that the original Scala \<open>Classifier\<close>
+  function would, then folds.\<close>
+
+definition classifyGlobalVerifier :: "service_ir_full \<Rightarrow> verifier_tool" where
+  "classifyGlobalVerifier ir = foldVerifier (invariantBodies ir)"
+
+definition classifyInvariantVerifier :: "invariant_decl_full \<Rightarrow> verifier_tool" where
+  "classifyInvariantVerifier ivd =
+     (if requiresAlloy (invariantBody ivd) then VtAlloy else VtZ3)"
+
+definition classifyRequiresVerifier :: "operation_decl_full \<Rightarrow> verifier_tool" where
+  "classifyRequiresVerifier op = foldVerifier (operationRequires op)"
+
+definition classifyEnabledVerifier ::
+  "operation_decl_full \<Rightarrow> service_ir_full \<Rightarrow> verifier_tool"
+where
+  "classifyEnabledVerifier op ir =
+     foldVerifier (operationRequires op @ invariantBodies ir)"
+
+definition classifyPreservationVerifier ::
+  "operation_decl_full \<Rightarrow> invariant_decl_full \<Rightarrow> verifier_tool"
+where
+  "classifyPreservationVerifier op ivd =
+     foldVerifier (invariantBody ivd # operationRequires op @ operationEnsures op)"
+
+text \<open>Temporal checks always go to Alloy (Z3 doesn't support the
+  trace semantics needed for \<open>always\<close>/\<open>eventually\<close>).\<close>
+
+definition classifyTemporalVerifier :: "verifier_tool" where
+  "classifyTemporalVerifier = VtAlloy"
+
+text \<open>Trust classifications mirror the Scala \<open>planTrust\<close> dispatcher
+  in \<open>specrest.verify.Consistency\<close>. Same formula bundles as the
+  verifier classifiers; the difference is what they decide.\<close>
+
+definition trustGlobal ::
+  "String.literal list \<Rightarrow> service_ir_full \<Rightarrow> trust_level"
+where
+  "trustGlobal enums ir = foldTrust enums (invariantBodies ir)"
+
+definition trustRequires ::
+  "String.literal list \<Rightarrow> operation_decl_full \<Rightarrow> trust_level"
+where
+  "trustRequires enums op = foldTrust enums (operationRequires op)"
+
+definition trustEnabled ::
+  "String.literal list \<Rightarrow> operation_decl_full \<Rightarrow> service_ir_full \<Rightarrow> trust_level"
+where
+  "trustEnabled enums op ir =
+     foldTrust enums (operationRequires op @ invariantBodies ir)"
+
+definition trustPreservation ::
+  "String.literal list \<Rightarrow> operation_decl_full \<Rightarrow> invariant_decl_full
+   \<Rightarrow> trust_level"
+where
+  "trustPreservation enums op ivd =
+     foldTrust enums (invariantBody ivd # operationRequires op @ operationEnsures op)"
+
+text \<open>Enum-name extraction from the IR. Lifts \<open>Trust.enumNames\<close>
+  used to feed the \<open>foldTrust\<close> enum-recognition step.\<close>
+
+definition verifyEnumNames :: "service_ir_full \<Rightarrow> String.literal list" where
+  "verifyEnumNames ir = map enumDeclName (serviceIrEnums ir)"
+
+lemmas foldVerifier_code [code]                = foldVerifier_def
+lemmas foldTrust_code [code]                   = foldTrust_def
+lemmas invariantBody_code [code]               = invariantBody.simps
+lemmas operationRequires_code [code]           = operationRequires.simps
+lemmas operationEnsures_code [code]            = operationEnsures.simps
+lemmas enumDeclName_code [code]                = enumDeclName.simps
+lemmas serviceIrEntities_code [code]           = serviceIrEntities.simps
+lemmas serviceIrEnums_code [code]              = serviceIrEnums.simps
+lemmas serviceIrInvariants_code [code]         = serviceIrInvariants.simps
+lemmas invariantBodies_code [code]             = invariantBodies_def
+lemmas classifyGlobalVerifier_code [code]      = classifyGlobalVerifier_def
+lemmas classifyInvariantVerifier_code [code]   = classifyInvariantVerifier_def
+lemmas classifyRequiresVerifier_code [code]    = classifyRequiresVerifier_def
+lemmas classifyEnabledVerifier_code [code]     = classifyEnabledVerifier_def
+lemmas classifyPreservationVerifier_code [code] = classifyPreservationVerifier_def
+lemmas classifyTemporalVerifier_code [code]    = classifyTemporalVerifier_def
+lemmas trustGlobal_code [code]                 = trustGlobal_def
+lemmas trustRequires_code [code]               = trustRequires_def
+lemmas trustEnabled_code [code]                = trustEnabled_def
+lemmas trustPreservation_code [code]           = trustPreservation_def
+lemmas verifyEnumNames_code [code]             = verifyEnumNames_def
+
+end


### PR DESCRIPTION
## Summary

Lifts every pure decision behind the **verifier-backend-selection layer** in `specrest.verify.Classifier` (which Z3 vs Alloy backend handles a given formula bundle) and `specrest.verify.Trust` (whether the bundle fits inside the verified-subset `lower` for soundness).

Both Scala objects shrink to one-line delegations.

## New theory: `proofs/isabelle/SpecRest/VerifierDispatch.thy`

```isabelle
datatype verifier_tool = VtZ3 | VtAlloy
datatype trust_level   = TlSound | TlBestEffort

foldVerifier : expr_full list => verifier_tool
  -- any formula needs Alloy => bundle goes Alloy (uses lifted requiresAlloy)

foldTrust : String.literal list => expr_full list => trust_level
  -- every formula must `lower` cleanly for Sound; else BestEffort

classifyGlobalVerifier, classifyInvariantVerifier,
classifyRequiresVerifier, classifyEnabledVerifier,
classifyPreservationVerifier, classifyTemporalVerifier
  -- per-check-shape dispatchers; bundle exactly the formulas the
     Scala Classifier composes, then fold

trustGlobal, trustRequires, trustEnabled, trustPreservation
  -- parallel set for soundness classification

verifyEnumNames : service_ir_full => String.literal list
  -- IR.d enum-name extraction, lifted from Trust.enumNames
```

Plus IR-decomposition selectors (`invariantBody`, `operationRequires` / `operationEnsures`, `enumDeclName`, `serviceIrEntities` / `serviceIrEnums` / `serviceIrInvariants`, `invariantBodies`); the per-constructor pattern-in-head `fun` shape avoids Scala 3's `val Ctor(...) = e` extraction warning that gets escalated to `-Werror`.

## Scala-side

`modules/verify/src/main/scala/specrest/verify/Classifier.scala`:
Each of the six `classifyX` functions becomes a one-liner delegating to the lifted version via `VerifierTool.fromLifted`. The two private helpers (`classify` / `fold` over `expr_full` lists) are absorbed by `foldVerifier`.

`modules/verify/src/main/scala/specrest/verify/Trust.scala`:
- `Trust.enumNames` → `verifyEnumNames` delegation
- `Trust.classify(enums, exprs)` → `foldTrust` delegation
- `Trust.classify(enums, single)` → calls the list overload

`VerifierTool.fromLifted` and `TrustLevel.fromLifted` are the adapter helpers (mirrors the `DialectAdapter` / `SchemaObjectAdapter` / `AlloyAdapter` pattern from #349 / #352 / #353).

## Test plan
- [x] `isabelle build SpecRest` clean (2:55 incremental)
- [x] `sbt verify/compile` clean
- [x] `sbt verify/test`: all suites pass (BackendTest 16, ConsistencyTest 14, ParallelTest 10, NarrationTest 6, TrustTest, ...); end-to-end verifier dispatch unchanged
- [x] `sbt scalafixAll` clean
- [ ] CI: isabelle-build (extraction drift) + build-and-test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted verifier backend dispatch and trust classification from Scala into Isabelle to make the logic provable and shared via codegen. Scala now delegates to the generated functions; behavior stays the same, and `specrest.verify.Consistency.planTrust` is wired to the lifted trust dispatchers to remove duplication.

- **New Features**
  - Added Isabelle `VerifierDispatch.thy` with `verifier_tool`, `trust_level`, and folds `foldVerifier` and `foldTrust`.
  - Exported per-check classifiers (`classify*Verifier`, `trust*`) and `verifyEnumNames` via codegen.

- **Refactors**
  - `specrest.verify.Classifier` and `specrest.verify.Trust` now delegate to generated functions; added adapters `VerifierTool.fromLifted` and `TrustLevel.fromLifted`.
  - `specrest.verify.Consistency.planTrust` now calls lifted `trustGlobal`/`trustRequires`/`trustEnabled`/`trustPreservation`; removed local bundling logic.
  - Removed local classify/fold helpers; verifier dispatch is unchanged.

<sup>Written for commit cffb3bdf349cab3f8ba81aa7bb4d26f784fc3e8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/354?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Verification dispatch consolidated to use generated classification helpers for all check types, unifying verifier selection.
  * Trust classification now derives from generated trust selectors, simplifying and standardizing trust decisions across checks.
  * Build/export changes added to make these generated dispatchers available to the runtime.
  * Consistency/trust planning updated to rely on the centralized generated trust logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->