### PR TITLE
feat(proofs): lift Alloy buildSigs (entity/enum/state/input sig builder)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -796,6 +796,25 @@ object SpecRestGenerated {
   final case class DatabaseSchema(a: List[table_spec], b: List[trigger_spec])
       extends database_schema
 
+  sealed abstract class alloy_field_multiplicity
+  final case class AfmOne()  extends alloy_field_multiplicity
+  final case class AfmLone() extends alloy_field_multiplicity
+  final case class AfmSome() extends alloy_field_multiplicity
+  final case class AfmSet()  extends alloy_field_multiplicity
+
+  sealed abstract class alloy_field
+  final case class AlloyFieldLifted(a: String, b: alloy_field_multiplicity, c: String)
+      extends alloy_field
+
+  sealed abstract class alloy_sig
+  final case class AlloySigLifted(
+      a: String,
+      b: Boolean,
+      c: Boolean,
+      d: Option[String],
+      e: List[alloy_field]
+  ) extends alloy_sig
+
   sealed abstract class column_kind
   final case class CkPrim(a: String)       extends column_kind
   final case class CkEnum(a: List[String]) extends column_kind
@@ -1095,12 +1114,6 @@ object SpecRestGenerated {
   final case class OntEntityRef(a: String)                extends openapi_named_kind
   final case class OntAliasToType(a: type_expr_full)      extends openapi_named_kind
   final case class OntUnknown()                           extends openapi_named_kind
-
-  sealed abstract class alloy_field_multiplicity
-  final case class AfmOne()  extends alloy_field_multiplicity
-  final case class AfmLone() extends alloy_field_multiplicity
-  final case class AfmSome() extends alloy_field_multiplicity
-  final case class AfmSet()  extends alloy_field_multiplicity
 
   sealed abstract class structural_ineligibility
   final case class SceReferencesPrePrime()   extends structural_ineligibility
@@ -5747,6 +5760,13 @@ object SpecRestGenerated {
       case (Some(x), Some(y)) => Some[int](max[int](x, y))
     }
 
+  def boolSigs: List[alloy_sig] =
+    List(
+      AlloySigLifted("Bool", true, false, None, Nil),
+      AlloySigLifted("True", false, true, Some[String]("Bool"), Nil),
+      AlloySigLifted("False", false, true, Some[String]("Bool"), Nil)
+    )
+
   def exprContainsBoolLit(e: expr_full): Boolean =
     list_ex[expr_full]((a: expr_full) => isBoolLit(a), allSubexprs(e))
 
@@ -6261,6 +6281,15 @@ object SpecRestGenerated {
     equal_nat(n, zero_nat) match {
       case true  => one[A]
       case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
+    }
+
+  def optConcat(a: Option[List[alloy_sig]], b: Option[List[alloy_sig]]): Option[List[alloy_sig]] =
+    a match {
+      case None => None
+      case Some(xs) => b match {
+          case None     => None
+          case Some(ys) => Some[List[alloy_sig]](xs ++ ys)
+        }
     }
 
   def saTypeExpr(x0: sa_type): String = x0 match {
@@ -10683,6 +10712,155 @@ object SpecRestGenerated {
 
   def trustGlobal(enums: List[String], ir: service_ir_full): trust_level =
     foldTrust(enums, invariantBodies(ir))
+
+  def fieldDeclTypeOf(x0: field_decl_full): type_expr_full = x0 match {
+    case FieldDeclFull(uu, t, uv, uw) => t
+  }
+
+  def fieldDeclNameOf(x0: field_decl_full): String = x0 match {
+    case FieldDeclFull(n, uu, uv, uw) => n
+  }
+
+  def fieldDeclToAlloyField(fd: field_decl_full): Option[alloy_field] =
+    alloyFieldTypeOf(fieldDeclTypeOf(fd)) match {
+      case None => None
+      case Some(mn) =>
+        Some[alloy_field](AlloyFieldLifted(
+          fieldDeclNameOf(fd),
+          fst[alloy_field_multiplicity, String](mn),
+          snd[alloy_field_multiplicity, String](mn)
+        ))
+    }
+
+  def fieldDeclsToAlloyFields(x0: List[field_decl_full]): Option[List[alloy_field]] =
+    x0 match {
+      case Nil => Some[List[alloy_field]](Nil)
+      case fd :: rest =>
+        fieldDeclToAlloyField(fd) match {
+          case None => None
+          case Some(f) => fieldDeclsToAlloyFields(rest) match {
+              case None     => None
+              case Some(fs) => Some[List[alloy_field]](f :: fs)
+            }
+        }
+    }
+
+  def entityDeclFieldsOf(x0: entity_decl_full): List[field_decl_full] = x0 match {
+    case EntityDeclFull(uu, uv, fs, uw, ux) => fs
+  }
+
+  def entityDeclNameOf(x0: entity_decl_full): String = x0 match {
+    case EntityDeclFull(n, uu, uv, uw, ux) => n
+  }
+
+  def entityToAlloySig(e: entity_decl_full): Option[alloy_sig] =
+    fieldDeclsToAlloyFields(entityDeclFieldsOf(e)) match {
+      case None => None
+      case Some(fs) =>
+        Some[alloy_sig](AlloySigLifted(entityDeclNameOf(e), false, false, None, fs))
+    }
+
+  def entitiesToAlloySigs(x0: List[entity_decl_full]): Option[List[alloy_sig]] =
+    x0 match {
+      case Nil => Some[List[alloy_sig]](Nil)
+      case e :: rest =>
+        entityToAlloySig(e) match {
+          case None => None
+          case Some(s) => entitiesToAlloySigs(rest) match {
+              case None     => None
+              case Some(ss) => Some[List[alloy_sig]](s :: ss)
+            }
+        }
+    }
+
+  def enumMembersToSigs(uu: String, x1: List[String]): List[alloy_sig] =
+    (uu, x1) match {
+      case (uu, Nil) => Nil
+      case (parent, v :: rest) =>
+        AlloySigLifted(v, false, true, Some[String](parent), Nil) ::
+          enumMembersToSigs(parent, rest)
+    }
+
+  def enumDeclValuesOf(x0: enum_decl_full): List[String] = x0 match {
+    case EnumDeclFull(uu, vs, uv) => vs
+  }
+
+  def enumDeclNameOf(x0: enum_decl_full): String = x0 match {
+    case EnumDeclFull(n, uu, uv) => n
+  }
+
+  def enumToAlloySigs(e: enum_decl_full): List[alloy_sig] =
+    AlloySigLifted(enumDeclNameOf(e), true, false, None, Nil) ::
+      enumMembersToSigs(enumDeclNameOf(e), enumDeclValuesOf(e))
+
+  def enumsToAlloySigs(x0: List[enum_decl_full]): List[alloy_sig] = x0 match {
+    case Nil       => Nil
+    case e :: rest => enumToAlloySigs(e) ++ enumsToAlloySigs(rest)
+  }
+
+  def typedNamesToAlloyFields(x0: List[(String, type_expr_full)]): Option[List[alloy_field]] =
+    x0 match {
+      case Nil => Some[List[alloy_field]](Nil)
+      case (name, t) :: rest =>
+        alloyFieldTypeOf(t) match {
+          case None => None
+          case Some(mn) =>
+            typedNamesToAlloyFields(rest) match {
+              case None => None
+              case Some(fs) =>
+                Some[List[alloy_field]](AlloyFieldLifted(
+                  name,
+                  fst[alloy_field_multiplicity, String](mn),
+                  snd[alloy_field_multiplicity, String](mn)
+                ) ::
+                  fs)
+            }
+        }
+    }
+
+  def stateOrInputSig(
+      sigName: String,
+      fs: List[(String, type_expr_full)]
+  ): Option[List[alloy_sig]] =
+    nulla[(String, type_expr_full)](fs) match {
+      case true => Some[List[alloy_sig]](Nil)
+      case false => typedNamesToAlloyFields(fs) match {
+          case None => None
+          case Some(afs) =>
+            Some[List[alloy_sig]](List(AlloySigLifted(sigName, false, true, None, afs)))
+        }
+    }
+
+  def buildAlloySigs(
+      needsBool: Boolean,
+      ents: List[entity_decl_full],
+      enums: List[enum_decl_full],
+      stateFields: List[(String, type_expr_full)],
+      inputFields: List[(String, type_expr_full)],
+      includeStatePost: Boolean
+  ): Option[List[alloy_sig]] = {
+    val boolPart =
+      Some[List[alloy_sig]](needsBool match {
+        case true  => boolSigs
+        case false => Nil
+      }): Option[List[alloy_sig]]
+    val enumPart =
+      Some[List[alloy_sig]](enumsToAlloySigs(enums)): Option[List[alloy_sig]]
+    val entPart = entitiesToAlloySigs(ents): Option[List[alloy_sig]]
+    val statePart =
+      stateOrInputSig("State", stateFields): Option[List[alloy_sig]]
+    val inputPart =
+      stateOrInputSig("Inputs", inputFields): Option[List[alloy_sig]]
+    val postPart =
+      (includeStatePost match {
+        case true  => stateOrInputSig("StatePost", stateFields)
+        case false => Some[List[alloy_sig]](Nil)
+      }): Option[List[alloy_sig]];
+    optConcat(
+      boolPart,
+      optConcat(entPart, optConcat(enumPart, optConcat(statePart, optConcat(inputPart, postPart))))
+    )
+  }
 
   def fieldElementSigNameAlloy(x0: type_expr_full): Option[String] = x0 match {
     case NamedTypeF(name, uu) => Some[String](mapAlloyPrimitive(name))

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -5,7 +5,6 @@ import specrest.ir.*
 import specrest.ir.generated.SpecRestGenerated
 import specrest.ir.generated.SpecRestGenerated.*
 
-import scala.collection.mutable
 import scala.util.boundary
 
 private type AlloyLabel = boundary.Label[Either[VerifyError.AlloyTranslator, Nothing]]
@@ -188,14 +187,25 @@ object Translator:
         ))
     }
 
+  private def runLiftedSigBuild(ctx: Ctx, includeStatePost: Boolean)(using
+      AlloyLabel
+  ): List[AlloySig] =
+    SpecRestGenerated.buildAlloySigs(
+      needsBoolSig(ctx),
+      ctx.ir.c,
+      ctx.ir.d,
+      ctx.stateFields.toList,
+      ctx.inputFields.toList,
+      includeStatePost
+    ) match
+      case Some(sigs) => sigs.map(AlloyAdapter.fromLiftedSig)
+      case None =>
+        failAlloy(
+          "unsupported Alloy field type (supported: NamedType, Set[T], Option[T])"
+        )
+
   private def buildPreservationSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
-    val baseSigs = buildSigs(ctx)
-    if ctx.stateFields.nonEmpty then
-      val stateFields = ctx.stateFields.toList.map: (name, typ) =>
-        val (mult, elem) = alloyFieldTypeOf(typ)
-        AlloyField(name, mult, elem)
-      baseSigs :+ AlloySig("StatePost", isOne = true, fields = stateFields)
-    else baseSigs
+    runLiftedSigBuild(ctx, includeStatePost = true)
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
     collectPrimedIdentifiers(ensures).toSet
@@ -206,32 +216,7 @@ object Translator:
     Ctx(ir, stateFields.toMap)
 
   private def buildSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
-    val sigs = mutable.ArrayBuffer.empty[AlloySig]
-    if needsBoolSig(ctx) then
-      sigs += AlloySig("Bool", abstract_ = true)
-      sigs += AlloySig("True", isOne = true, extends_ = Some("Bool"))
-      sigs += AlloySig("False", isOne = true, extends_ = Some("Bool"))
-    for case EntityDeclFull(name, _, fs, _, _) <- ctx.ir.c do
-      val fields = fs.collect { case FieldDeclFull(fn, ft, _, _) =>
-        val (mult, elem) = alloyFieldTypeOf(ft)
-        AlloyField(fn, mult, elem)
-      }
-      sigs += AlloySig(name, fields = fields)
-    for case EnumDeclFull(name, vs, _) <- ctx.ir.d do
-      sigs += AlloySig(name, abstract_ = true)
-      for v <- vs do
-        sigs += AlloySig(v, isOne = true, extends_ = Some(name))
-    if ctx.stateFields.nonEmpty then
-      val stateFields = ctx.stateFields.toList.map: (name, typ) =>
-        val (mult, elem) = alloyFieldTypeOf(typ)
-        AlloyField(name, mult, elem)
-      sigs += AlloySig("State", isOne = true, fields = stateFields)
-    if ctx.inputFields.nonEmpty then
-      val inputFields = ctx.inputFields.toList.map: (name, typ) =>
-        val (mult, elem) = alloyFieldTypeOf(typ)
-        AlloyField(name, mult, elem)
-      sigs += AlloySig("Inputs", isOne = true, fields = inputFields)
-    sigs.toList
+    runLiftedSigBuild(ctx, includeStatePost = false)
 
   private def needsBoolSig(ctx: Ctx): Boolean =
     SpecRestGenerated.needsBoolSig(
@@ -239,16 +224,6 @@ object Translator:
       ctx.stateFields.toList,
       ctx.inputFields.toList
     )
-
-  private def alloyFieldTypeOf(t: type_expr_full)(using
-      AlloyLabel
-  ): (AlloyFieldMultiplicity, String) =
-    SpecRestGenerated.alloyFieldTypeOf(t) match
-      case Some((m, n)) => (AlloyAdapter.fromLiftedMult(m), n)
-      case None =>
-        failAlloy(
-          s"unsupported Alloy field type (supported: NamedType, Set[T], Option[T]); got $t"
-        )
 
   private def renderExpr(ctx: Ctx, e: expr_full)(using AlloyLabel): String = e match
     case BinaryOpF(op, l, r, _) => renderBinaryOp(ctx, op, l, r)

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Types.scala
@@ -19,6 +19,20 @@ private[alloy] object AlloyAdapter:
     case _: AfmSome => AlloyFieldMultiplicity.Some_
     case _: AfmSet  => AlloyFieldMultiplicity.Set
 
+  def fromLiftedField(f: alloy_field): AlloyField = f match
+    case lifted: specrest.ir.generated.SpecRestGenerated.AlloyFieldLifted =>
+      AlloyField(lifted.a, fromLiftedMult(lifted.b), lifted.c)
+
+  def fromLiftedSig(s: alloy_sig): AlloySig = s match
+    case lifted: specrest.ir.generated.SpecRestGenerated.AlloySigLifted =>
+      AlloySig(
+        name = lifted.a,
+        abstract_ = lifted.b,
+        isOne = lifted.c,
+        extends_ = lifted.d,
+        fields = lifted.e.map(fromLiftedField)
+      )
+
 final case class AlloySig(
     name: String,
     abstract_ : Boolean = false,

--- a/proofs/isabelle/SpecRest/AlloyBuildSigs.thy
+++ b/proofs/isabelle/SpecRest/AlloyBuildSigs.thy
@@ -1,0 +1,214 @@
+theory AlloyBuildSigs
+  imports AlloyTypes
+begin
+
+text \<open>Lifted Alloy signature builder. Mirrors
+  \<open>specrest.verify.alloy.Translator.buildSigs\<close>: walks the IR's
+  entities/enums plus the operation-specific state-field and
+  input-field lists to construct the Alloy sig list. Uses the
+  already-lifted \<open>alloyFieldTypeOf\<close> (\<open>AlloyTypes\<close>) for per-field
+  shape classification.
+
+  No \<open>expr_full\<close> recursion, so the build stays fast — pattern
+  completeness on the \<open>entity_decl_full\<close>/\<open>field_decl_full\<close>
+  datatypes is shallow.
+
+  The lifted function returns \<open>None\<close> when any field type is
+  unsupported (\<open>alloyFieldTypeOf\<close> returned \<open>None\<close>); the Scala
+  caller \<open>failAlloy\<close>'s with the matching diagnostic.\<close>
+
+datatype alloy_field = AlloyFieldLifted
+  "String.literal"                  \<comment> \<open>field name\<close>
+  alloy_field_multiplicity          \<comment> \<open>multiplicity tag\<close>
+  "String.literal"                  \<comment> \<open>element sig name\<close>
+
+datatype alloy_sig = AlloySigLifted
+  "String.literal"                  \<comment> \<open>sig name\<close>
+  bool                              \<comment> \<open>abstract\<close>
+  bool                              \<comment> \<open>isOne\<close>
+  "String.literal option"           \<comment> \<open>extends parent (e.g. Bool/enum)\<close>
+  "alloy_field list"                \<comment> \<open>fields\<close>
+
+fun fieldDeclTypeOf :: "field_decl_full \<Rightarrow> type_expr_full" where
+  "fieldDeclTypeOf (FieldDeclFull _ t _ _) = t"
+
+fun fieldDeclNameOf :: "field_decl_full \<Rightarrow> String.literal" where
+  "fieldDeclNameOf (FieldDeclFull n _ _ _) = n"
+
+fun entityDeclNameOf :: "entity_decl_full \<Rightarrow> String.literal" where
+  "entityDeclNameOf (EntityDeclFull n _ _ _ _) = n"
+
+fun entityDeclFieldsOf :: "entity_decl_full \<Rightarrow> field_decl_full list" where
+  "entityDeclFieldsOf (EntityDeclFull _ _ fs _ _) = fs"
+
+fun enumDeclNameOf :: "enum_decl_full \<Rightarrow> String.literal" where
+  "enumDeclNameOf (EnumDeclFull n _ _) = n"
+
+fun enumDeclValuesOf :: "enum_decl_full \<Rightarrow> String.literal list" where
+  "enumDeclValuesOf (EnumDeclFull _ vs _) = vs"
+
+definition fieldDeclToAlloyField ::
+  "field_decl_full \<Rightarrow> alloy_field option"
+where
+  "fieldDeclToAlloyField fd =
+     (case alloyFieldTypeOf (fieldDeclTypeOf fd) of
+        None \<Rightarrow> None
+      | Some mn \<Rightarrow>
+          Some (AlloyFieldLifted (fieldDeclNameOf fd) (fst mn) (snd mn)))"
+
+fun fieldDeclsToAlloyFields ::
+  "field_decl_full list \<Rightarrow> alloy_field list option"
+where
+  "fieldDeclsToAlloyFields [] = Some []"
+| "fieldDeclsToAlloyFields (fd # rest) =
+     (case fieldDeclToAlloyField fd of
+        None \<Rightarrow> None
+      | Some f \<Rightarrow>
+          (case fieldDeclsToAlloyFields rest of
+             None \<Rightarrow> None
+           | Some fs \<Rightarrow> Some (f # fs)))"
+
+fun typedNamesToAlloyFields ::
+  "(String.literal \<times> type_expr_full) list \<Rightarrow> alloy_field list option"
+where
+  "typedNamesToAlloyFields [] = Some []"
+| "typedNamesToAlloyFields ((name, t) # rest) =
+     (case alloyFieldTypeOf t of
+        None \<Rightarrow> None
+      | Some mn \<Rightarrow>
+          (case typedNamesToAlloyFields rest of
+             None \<Rightarrow> None
+           | Some fs \<Rightarrow> Some (AlloyFieldLifted name (fst mn) (snd mn) # fs)))"
+
+definition boolSigs :: "alloy_sig list" where
+  "boolSigs = [
+     AlloySigLifted (STR ''Bool'') True False None [],
+     AlloySigLifted (STR ''True'') False True (Some (STR ''Bool'')) [],
+     AlloySigLifted (STR ''False'') False True (Some (STR ''Bool'')) []
+   ]"
+
+definition entityToAlloySig ::
+  "entity_decl_full \<Rightarrow> alloy_sig option"
+where
+  "entityToAlloySig e =
+     (case fieldDeclsToAlloyFields (entityDeclFieldsOf e) of
+        None \<Rightarrow> None
+      | Some fs \<Rightarrow>
+          Some (AlloySigLifted (entityDeclNameOf e) False False None fs))"
+
+fun entitiesToAlloySigs ::
+  "entity_decl_full list \<Rightarrow> alloy_sig list option"
+where
+  "entitiesToAlloySigs [] = Some []"
+| "entitiesToAlloySigs (e # rest) =
+     (case entityToAlloySig e of
+        None \<Rightarrow> None
+      | Some s \<Rightarrow>
+          (case entitiesToAlloySigs rest of
+             None \<Rightarrow> None
+           | Some ss \<Rightarrow> Some (s # ss)))"
+
+fun enumMembersToSigs ::
+  "String.literal \<Rightarrow> String.literal list \<Rightarrow> alloy_sig list"
+where
+  "enumMembersToSigs _ [] = []"
+| "enumMembersToSigs parent (v # rest) =
+     AlloySigLifted v False True (Some parent) []
+       # enumMembersToSigs parent rest"
+
+definition enumToAlloySigs ::
+  "enum_decl_full \<Rightarrow> alloy_sig list"
+where
+  "enumToAlloySigs e =
+     AlloySigLifted (enumDeclNameOf e) True False None []
+       # enumMembersToSigs (enumDeclNameOf e) (enumDeclValuesOf e)"
+
+fun enumsToAlloySigs ::
+  "enum_decl_full list \<Rightarrow> alloy_sig list"
+where
+  "enumsToAlloySigs [] = []"
+| "enumsToAlloySigs (e # rest) =
+     enumToAlloySigs e @ enumsToAlloySigs rest"
+
+text \<open>Single helper for State / Inputs / StatePost sig construction.
+  Returns \<open>Some []\<close> when the field list is empty (no sig to emit),
+  \<open>Some [sig]\<close> when it builds cleanly, \<open>None\<close> on field-type
+  failure. Collapses the previous \<open>option option\<close> shape into a
+  flat option of list — the empty list serves as the
+  "no-sig-needed" carrier and extracts cleanly.\<close>
+
+definition stateOrInputSig ::
+  "String.literal \<Rightarrow> (String.literal \<times> type_expr_full) list
+   \<Rightarrow> alloy_sig list option"
+where
+  "stateOrInputSig sigName fs =
+     (if fs = [] then Some []
+      else case typedNamesToAlloyFields fs of
+             None \<Rightarrow> None
+           | Some afs \<Rightarrow> Some [AlloySigLifted sigName False True None afs])"
+
+text \<open>Bind for \<open>option\<close>-of-list — collapses chains of \<open>None\<close>
+  propagation that would otherwise drive the deeply nested
+  case-of-case shape the previous version emitted.\<close>
+
+definition optConcat ::
+  "alloy_sig list option \<Rightarrow> alloy_sig list option \<Rightarrow> alloy_sig list option"
+where
+  "optConcat a b =
+     (case a of
+        None \<Rightarrow> None
+      | Some xs \<Rightarrow>
+          (case b of
+             None \<Rightarrow> None
+           | Some ys \<Rightarrow> Some (xs @ ys)))"
+
+text \<open>Main lifted builder. Concatenates the five sig groups via
+  \<open>optConcat\<close>; the \<open>includeStatePost\<close> flag covers both the
+  \<open>buildSigs\<close> and \<open>buildPreservationSigs\<close> Scala call sites
+  (the only difference between them is the extra \<open>StatePost\<close>
+  sig appended when state fields are non-empty).\<close>
+
+definition buildAlloySigs ::
+  "bool                                       \<comment> \<open>needsBool\<close>
+   \<Rightarrow> entity_decl_full list                    \<comment> \<open>ir.c\<close>
+   \<Rightarrow> enum_decl_full list                      \<comment> \<open>ir.d\<close>
+   \<Rightarrow> (String.literal \<times> type_expr_full) list   \<comment> \<open>stateFields\<close>
+   \<Rightarrow> (String.literal \<times> type_expr_full) list   \<comment> \<open>inputFields\<close>
+   \<Rightarrow> bool                                     \<comment> \<open>includeStatePost\<close>
+   \<Rightarrow> alloy_sig list option"
+where
+  "buildAlloySigs needsBool ents enums stateFields inputFields includeStatePost =
+     (let boolPart = Some (if needsBool then boolSigs else []);
+          enumPart = Some (enumsToAlloySigs enums);
+          entPart  = entitiesToAlloySigs ents;
+          statePart = stateOrInputSig (STR ''State'') stateFields;
+          inputPart = stateOrInputSig (STR ''Inputs'') inputFields;
+          postPart  = (if includeStatePost
+                       then stateOrInputSig (STR ''StatePost'') stateFields
+                       else Some [])
+      in optConcat boolPart
+           (optConcat entPart
+              (optConcat enumPart
+                 (optConcat statePart
+                    (optConcat inputPart postPart)))))"
+
+lemmas fieldDeclTypeOf_code [code]          = fieldDeclTypeOf.simps
+lemmas fieldDeclNameOf_code [code]          = fieldDeclNameOf.simps
+lemmas entityDeclNameOf_code [code]         = entityDeclNameOf.simps
+lemmas entityDeclFieldsOf_code [code]       = entityDeclFieldsOf.simps
+lemmas enumDeclNameOf_code [code]           = enumDeclNameOf.simps
+lemmas enumDeclValuesOf_code [code]         = enumDeclValuesOf.simps
+lemmas fieldDeclToAlloyField_code [code]    = fieldDeclToAlloyField_def
+lemmas fieldDeclsToAlloyFields_code [code]  = fieldDeclsToAlloyFields.simps
+lemmas typedNamesToAlloyFields_code [code]  = typedNamesToAlloyFields.simps
+lemmas boolSigs_code [code]                 = boolSigs_def
+lemmas entityToAlloySig_code [code]         = entityToAlloySig_def
+lemmas entitiesToAlloySigs_code [code]      = entitiesToAlloySigs.simps
+lemmas enumMembersToSigs_code [code]        = enumMembersToSigs.simps
+lemmas enumToAlloySigs_code [code]          = enumToAlloySigs_def
+lemmas enumsToAlloySigs_code [code]         = enumsToAlloySigs.simps
+lemmas stateOrInputSig_code [code]          = stateOrInputSig_def
+lemmas optConcat_code [code]                = optConcat_def
+lemmas buildAlloySigs_code [code]           = buildAlloySigs_def
+
+end

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -23,6 +23,7 @@ theory Codegen
     LintAnalysis
     Classify
     AlloyTypes
+    AlloyBuildSigs
     VerifierDispatch
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
@@ -326,6 +327,7 @@ export_code
     enumNameInList
     domainSigNameAlloy
     classifyAlloyBindingIdentifier
+    buildAlloySigs
     classifyGlobalVerifier
     classifyInvariantVerifier
     classifyRequiresVerifier

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -31,5 +31,6 @@ session SpecRest = HOL +
     LintAnalysis
     Classify
     AlloyTypes
+    AlloyBuildSigs
     VerifierDispatch
     Codegen


### PR DESCRIPTION
## Summary

Lifts `Alloy.Translator.buildSigs` + `buildPreservationSigs` as a single parameterised builder that walks the IR's entities/enums plus the operation-specific state-field and input-field lists to construct the Alloy sig list. Uses already-lifted `alloyFieldTypeOf` for per-field shape classification.

**No `expr_full` recursion** — the structural decision lives entirely on `entity_decl_full` / `field_decl_full` / `enum_decl_full`, which have shallow pattern completeness. Build stays at 3:14 incremental. (A recursive `renderExpr` lift over `expr_full` triggers Isabelle's pattern-completeness explosion that the project memory warns about — that's a separate, harder lift target.)

## New theory: `proofs/isabelle/SpecRest/AlloyBuildSigs.thy`

```isabelle
datatype alloy_field = AlloyFieldLifted literal multiplicity literal
datatype alloy_sig   = AlloySigLifted literal bool bool literal_opt fields

-- selectors + per-decl converters:
fieldDeclTypeOf, fieldDeclNameOf, entityDeclNameOf,
entityDeclFieldsOf, enumDeclNameOf, enumDeclValuesOf
fieldDeclToAlloyField, fieldDeclsToAlloyFields,
typedNamesToAlloyFields
boolSigs, entityToAlloySig, entitiesToAlloySigs,
enumMembersToSigs, enumToAlloySigs, enumsToAlloySigs
stateOrInputSig, optConcat

-- main entry:
buildAlloySigs : bool => entities => enums
              => stateFields => inputFields
              => bool (includeStatePost)
              => alloy_sig list option
```

Returns `None` iff any field type is unsupported. The `includeStatePost` flag covers both Scala call sites — the only difference between `buildSigs` and `buildPreservationSigs` is the extra `StatePost` sig appended when state fields are non-empty.

## Scala-side: single helper, two call sites

`Translator.scala`:

```scala
private def runLiftedSigBuild(ctx: Ctx, includeStatePost: Boolean)
                             (using AlloyLabel): List[AlloySig] =
  SpecRestGenerated.buildAlloySigs(
    needsBoolSig(ctx),
    ctx.ir.c, ctx.ir.d,
    ctx.stateFields.toList, ctx.inputFields.toList,
    includeStatePost
  ) match
    case Some(sigs) => sigs.map(AlloyAdapter.fromLiftedSig)
    case None       => failAlloy("unsupported Alloy field type ...")

private def buildSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
  runLiftedSigBuild(ctx, includeStatePost = false)

private def buildPreservationSigs(ctx: Ctx)(using AlloyLabel): List[AlloySig] =
  runLiftedSigBuild(ctx, includeStatePost = true)
```

**Drops**: `mutable.ArrayBuffer` collection, `alloyFieldTypeOf` Scala wrapper (only caller was the old `buildSigs` body), `mutable` import.

`Types.scala`: `AlloyAdapter.fromLiftedSig` + `.fromLiftedField` for the positional → named-field record conversion (mirrors the `DialectAdapter` / `SchemaObjectAdapter` pattern from #349 / #352 / #353).

## Test plan
- [x] `isabelle build SpecRest` clean (3:14 incremental)
- [x] `sbt verify/compile` clean
- [x] `sbt verify/test`: all suites pass (`BackendTest` 16, `ConsistencyTest` 14, `ParallelTest` 10, `NarrationTest` 6, ...); Alloy module output byte-identical end-to-end through `ConsistencyTest`
- [x] `sbt scalafixAll` clean
- [ ] CI: isabelle-build (extraction drift) + build-and-test


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted Alloy signature building into Isabelle and unified the Scala path for `buildSigs` and `buildPreservationSigs`. This simplifies generation for entities, enums, state, inputs, and optional `StatePost`, with consistent behavior and no mutable collections.

- **New Features**
  - Added `proofs/isabelle/SpecRest/AlloyBuildSigs.thy` with `buildAlloySigs` that builds sigs from IR entities/enums and state/input fields, including `Bool` and enum member sigs when needed.
  - Returns `None` on unsupported field types; Scala translates this to a clear failure.
  - Codegen exports `buildAlloySigs`.

- **Refactors**
  - `Translator.scala` now uses a single `runLiftedSigBuild` for both call sites; removed `mutable.ArrayBuffer` and the local `alloyFieldTypeOf` wrapper.
  - Added adapters in `Types.scala` to convert lifted sigs/fields to `AlloySig`/`AlloyField`.
  - Output remains byte-identical; all tests pass.

<sup>Written for commit 69c97b10e42fd6fefaf98ba128d42a8e165b4ff9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/357?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal signature building logic to reduce code duplication and improve maintainability through a centralized helper mechanism.

* **Chores**
  * Reorganized module dependencies and infrastructure to support improved separation of concerns in the verification system's signature construction layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/357?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->