### PR TITLE
feat(ir): extract Isabelle int as native BigInt

### DIFF
--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -7,7 +7,6 @@ import specrest.convention.DiagnosticLevel as ConvDiagLevel
 import specrest.convention.Validate
 import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.SpanT
-import specrest.ir.generated.SpecRestGenerated.int_of_integer
 import specrest.lint.Lint
 import specrest.lint.LintDiagnostic
 import specrest.lint.LintLevel
@@ -68,7 +67,7 @@ object Check:
 
   private def renderConv(specFile: String, d: ConventionDiagnostic): String =
     val loc =
-      d.span.collect { case SpanT(int_of_integer(line), int_of_integer(col), _, _) =>
+      d.span.collect { case SpanT(line, col, _, _) =>
         s"$specFile:$line:$col: "
       }.getOrElse("")
     d.level match
@@ -77,7 +76,7 @@ object Check:
 
   private def renderLint(specFile: String, d: LintDiagnostic): String =
     val loc =
-      d.span.collect { case SpanT(int_of_integer(line), int_of_integer(col), _, _) =>
+      d.span.collect { case SpanT(line, col, _, _) =>
         s"$specFile:$line:$col: "
       }.getOrElse("")
     d.level match
@@ -100,6 +99,6 @@ object Check:
 
   private[cli] def renderBuildError(specFile: String, e: VerifyError.Build): String =
     e.span match
-      case Some(SpanT(int_of_integer(line), int_of_integer(col), _, _)) =>
+      case Some(SpanT(line, col, _, _)) =>
         s"$specFile:$line:$col: Build error: ${e.message}"
       case _ => s"$specFile: Build error: ${e.message}"

--- a/modules/cli/src/main/scala/specrest/cli/Inspect.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Inspect.scala
@@ -95,8 +95,8 @@ object Inspect:
           .left
           .map { err =>
             val loc = err.span.fold("") {
-              case SpanT(int_of_integer(line), int_of_integer(col), _, _) =>
-                s" at ${line.toLong}:${col.toLong}"
+              case SpanT(line, col, _, _) =>
+                s" at $line:$col"
             }
             s"Dafny generation failed$loc: ${err.message}"
           }
@@ -123,8 +123,8 @@ object Inspect:
   ): Either[String, String] =
     DafnyGenerator.generate(ir).left.map { err =>
       val loc = err.span.fold("") {
-        case SpanT(int_of_integer(line), int_of_integer(col), _, _) =>
-          s" at ${line.toLong}:${col.toLong}"
+        case SpanT(line, col, _, _) =>
+          s" at $line:$col"
       }
       s"Dafny generation failed$loc: ${err.message}"
     }.flatMap { dafny =>

--- a/modules/codegen/src/main/scala/specrest/codegen/OperationContext.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/OperationContext.scala
@@ -23,7 +23,7 @@ object OperationContext:
   def initialRouteKind(op: ProfiledOperation): route_kind =
     classify(
       op.endpoint.method,
-      int_of_integer(BigInt(op.endpoint.successStatus)),
+      BigInt(op.endpoint.successStatus),
       Nata(BigInt(op.endpoint.pathParams.length)),
       op.kind,
       op.endpoint.queryParams.nonEmpty || op.endpoint.bodyParams.nonEmpty

--- a/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/migration/Dialect.scala
@@ -19,7 +19,7 @@ final case class SaType(expr: String, importModule: Option[String]) derives CanE
 private[migration] object DialectAdapter:
   def toLifted(t: CanonicalType): canonical_type = t match
     case CanonicalType.Text        => CtText()
-    case CanonicalType.Varchar(n)  => CtVarchar(int_of_integer(BigInt(n)))
+    case CanonicalType.Varchar(n)  => CtVarchar(BigInt(n))
     case CanonicalType.Int4        => CtInt4()
     case CanonicalType.Serial4     => CtSerial4()
     case CanonicalType.Int8        => CtInt8()
@@ -30,7 +30,7 @@ private[migration] object DialectAdapter:
     case CanonicalType.DateOnly    => CtDateOnly()
     case CanonicalType.Uuid        => CtUuid()
     case CanonicalType.Numeric(p, sOpt) =>
-      CtNumeric(int_of_integer(BigInt(p)), sOpt.map(s => int_of_integer(BigInt(s))))
+      CtNumeric(BigInt(p), sOpt.map(s => BigInt(s)))
     case CanonicalType.Bytes => CtBytes()
     case CanonicalType.Json  => CtJson()
 

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -71,11 +71,10 @@ private[openapi] object SchemaObjectAdapter:
     case ls: specrest.ir.generated.SpecRestGenerated.SOBSchema => SOBSchema(fromLifted(ls.a))
     case lb: specrest.ir.generated.SpecRestGenerated.SOBBool   => SOBBool(lb.a)
 
-  private def asInt(i: int): Int = i match
-    case int_of_integer(v) => v.toInt
+  private def asInt(i: BigInt): Int = i.toInt
 
   private def decimalToDouble(d: decimal_lit): Double = d match
-    case DecimalLit(int_of_integer(m), int_of_integer(e)) =>
+    case DecimalLit(m, e) =>
       BigDecimal(m.bigInteger, -e.toInt).doubleValue
 
 final case class ParameterObject(

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -6,7 +6,7 @@ import specrest.ir.generated.SpecRestGenerated.*
 class OpenApiConstraintsTest extends CatsEffectSuite:
 
   private def ident(n: String): IdentifierF = IdentifierF(n, None)
-  private def intL(n: Int): IntLitF         = IntLitF(int_of_integer(BigInt(n)), None)
+  private def intL(n: Int): IntLitF         = IntLitF(BigInt(n), None)
   private def floatL(v: String): FloatLitF  = FloatLitF(v, None)
   private val valueRef: IdentifierF         = ident("value")
   private val lenOfValue: expr_full         = CallF(ident("len"), List(valueRef), None)
@@ -17,14 +17,14 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
   private def walk(e: expr_full): openapi_bounds =
     visitConstraintOpenApi(e, emptyOpenApiBounds)
 
-  private def i(n: Int): int                   = int_of_integer(BigInt(n))
+  private def i(n: Int): BigInt                = BigInt(n)
   private def dec(m: Int, e: Int): decimal_lit = DecimalLit(i(m), i(e))
 
   // Named accessors over the positional Isabelle-extracted case class.
   extension (b: openapi_bounds)
-    private def minLength: Option[int] = b match
+    private def minLength: Option[BigInt] = b match
       case OpenApiBounds(v, _, _, _, _, _, _) => v
-    private def maxLength: Option[int] = b match
+    private def maxLength: Option[BigInt] = b match
       case OpenApiBounds(_, v, _, _, _, _, _) => v
     private def minimum: Option[decimal_lit] = b match
       case OpenApiBounds(_, _, v, _, _, _, _) => v
@@ -71,7 +71,7 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
 
   // -- decimalToNonNegInt -------------------------------------------------
 
-  List[(String, decimal_lit, Option[int])](
+  List[(String, decimal_lit, Option[BigInt])](
     ("plain integer", dec(5, 0), Some(i(5))),
     ("zero", dec(0, 0), Some(i(0))),
     ("trailing-zero-fractional", dec(10, -1), Some(i(1))), // 1.0
@@ -102,7 +102,7 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
 
   // -- RaLenCmp (Int path) ------------------------------------------------
 
-  List[(String, bin_op_full, Int, openapi_bounds => Option[int], Int)](
+  List[(String, bin_op_full, Int, openapi_bounds => Option[BigInt], Int)](
     ("BGe → minLength", BGe(), 3, _.minLength, 3),
     ("BGt → minLength +1 (length is integer-valued)", BGt(), 3, _.minLength, 4),
     ("BLe → maxLength", BLe(), 10, _.maxLength, 10),

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -287,9 +287,9 @@ object Schema:
         case _: CcSkip => Nil
         case CcRegexMatch(pat) =>
           List(s"$colName ~ '${escapeSqlString(pat)}'")
-        case CcLenCompare(op, int_of_integer(n)) =>
+        case CcLenCompare(op, n) =>
           sqlOp(op).toList.map(o => s"length($colName) $o $n")
-        case CcValueCompare(op, int_of_integer(n)) =>
+        case CcValueCompare(op, n) =>
           sqlOp(op).toList.map(o => s"$colName $o $n")
         case CcLenLitCompare(op, rhs) =>
           sqlOp(op).toList.map(o => s"length($colName) $o ${literalValue(rhs)}")
@@ -297,10 +297,10 @@ object Schema:
           sqlOp(op).toList.map(o => s"$colName $o ${literalValue(rhs)}")
 
   private def literalValue(e: expr_full): String = e match
-    case IntLitF(int_of_integer(v), _) => v.toString
-    case FloatLitF(v, _)               => v
-    case StringLitF(v, _)              => s"'${escapeSqlString(v)}'"
-    case _                             => "NULL"
+    case IntLitF(v, _)    => v.toString
+    case FloatLitF(v, _)  => v
+    case StringLitF(v, _) => s"'${escapeSqlString(v)}'"
+    case _                => "NULL"
 
   private def extractInvariantChecks(
       inv: expr_full,
@@ -312,8 +312,8 @@ object Schema:
         case IcInClause(fieldName, elements) =>
           val colName = Naming.toColumnName(fieldName)
           val values = elements.collect {
-            case StringLitF(v, _)              => s"'${escapeSqlString(v)}'"
-            case IntLitF(int_of_integer(v), _) => v.toString
+            case StringLitF(v, _) => s"'${escapeSqlString(v)}'"
+            case IntLitF(v, _)    => v.toString
           }
           // Lifted predicate already required all elements to be literals.
           // The Scala collect narrows further to String/Int (Float / Bool /

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -90,7 +90,7 @@ object Validate:
           seen.get(key) match
             case Some(existing) =>
               val loc = existing.e
-                .map { case SpanT(int_of_integer(sl), int_of_integer(sc), _, _) =>
+                .map { case SpanT(sl, sc, _, _) =>
                   s" (first defined at $sl:$sc)"
                 }
                 .getOrElse("")
@@ -164,7 +164,7 @@ object Validate:
     case BadHttpMethod(v) =>
       s"""invalid value for ${rule
           .a}.http_method — expected one of GET, POST, PUT, PATCH, DELETE, got "$v""""
-    case HttpStatusOutOfRange(int_of_integer(v)) =>
+    case HttpStatusOutOfRange(v) =>
       s"invalid value for ${rule.a}.http_status_success — expected integer between 100 and 599, got $v"
     case _: HttpPathMissingSlash =>
       s"invalid value for ${rule.a}.http_path — path must start with '/'"

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -555,11 +555,11 @@ object Generator:
     case other      => other
 
   private def renderExpr(ctx: Ctx, e: expr_full)(using DafnyLabel): String = e match
-    case IntLitF(int_of_integer(v), _) => v.toString
-    case BoolLitF(v, _)                => v.toString
-    case StringLitF(s, _)              => "\"" + escapeString(s) + "\""
-    case NoneLitF(_)                   => "None"
-    case FloatLitF(v, _)               => v
+    case IntLitF(v, _)    => v.toString
+    case BoolLitF(v, _)   => v.toString
+    case StringLitF(s, _) => "\"" + escapeString(s) + "\""
+    case NoneLitF(_)      => "None"
+    case FloatLitF(v, _)  => v
     case IdentifierF(n, _) =>
       if ctx.boundVars.contains(n) then n
       else if ctx.stateFields.contains(n) then stateRef(n, ctx.stateMode)
@@ -765,16 +765,16 @@ object Generator:
     case IdentifierF(n, _) => s"I($n)"
     case BinaryOpF(op, l, r, _) =>
       s"B(${op.getClass.getSimpleName},${structuralSig(l)},${structuralSig(r)})"
-    case UnaryOpF(op, x, _)            => s"U(${op.getClass.getSimpleName},${structuralSig(x)})"
-    case FieldAccessF(b, f, _)         => s"F(${structuralSig(b)},$f)"
-    case IndexF(b, i, _)               => s"X(${structuralSig(b)},${structuralSig(i)})"
-    case PrimeF(x, _)                  => s"P(${structuralSig(x)})"
-    case PreF(x, _)                    => s"R(${structuralSig(x)})"
-    case CallF(c, args, _)             => s"C(${structuralSig(c)},${args.map(structuralSig).mkString(",")})"
-    case IntLitF(int_of_integer(v), _) => s"i$v"
-    case StringLitF(s, _)              => s"s${s.hashCode}"
-    case BoolLitF(v, _)                => s"b$v"
-    case _                             => s"O(${e.getClass.getSimpleName}${e.hashCode})"
+    case UnaryOpF(op, x, _)    => s"U(${op.getClass.getSimpleName},${structuralSig(x)})"
+    case FieldAccessF(b, f, _) => s"F(${structuralSig(b)},$f)"
+    case IndexF(b, i, _)       => s"X(${structuralSig(b)},${structuralSig(i)})"
+    case PrimeF(x, _)          => s"P(${structuralSig(x)})"
+    case PreF(x, _)            => s"R(${structuralSig(x)})"
+    case CallF(c, args, _)     => s"C(${structuralSig(c)},${args.map(structuralSig).mkString(",")})"
+    case IntLitF(v, _)         => s"i$v"
+    case StringLitF(s, _)      => s"s${s.hashCode}"
+    case BoolLitF(v, _)        => s"b$v"
+    case _                     => s"O(${e.getClass.getSimpleName}${e.hashCode})"
 
   private def stateRef(name: String, mode: StateMode): String = mode match
     case StateMode.Direct => s"st.$name"

--- a/modules/convention/src/test/scala/specrest/convention/PartialIndexConventionsTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/PartialIndexConventionsTest.scala
@@ -12,7 +12,7 @@ object PartialIndexConventionsTest:
   ): ConventionRuleFull =
     ConventionRuleFull(target, prop, col, parseConventionValue(prop, v), None)
   private def stringL(s: String): StringLitF = StringLitF(s, None)
-  private def intL(n: Int): IntLitF          = IntLitF(int_of_integer(BigInt(n)), None)
+  private def intL(n: Int): IntLitF          = IntLitF(BigInt(n), None)
   private def conv(rs: List[convention_rule_full]): conventions_decl_full =
     ConventionsDeclFull(rs, None)
 

--- a/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
@@ -9,7 +9,7 @@ class StrategyHeuristicTest extends CatsEffectSuite:
 
   private val state                    = List("store")
   private def id(n: String): expr_full = IdentifierF(n, None)
-  private def lit(n: Int): expr_full   = IntLitF(int_of_integer(BigInt(n)), None)
+  private def lit(n: Int): expr_full   = IntLitF(BigInt(n), None)
 
   private def strategyOf(ensures: List[expr_full]): synthesis_strategy =
     classifyStrategy(ensures, state, Nil)

--- a/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
@@ -115,7 +115,7 @@ class StrategyOverrideTest extends CatsEffectSuite:
   test("strategy with non-string value is rejected"):
     val ir = baseIR(
       typeAliases = List(TypeAliasDeclFull("LongURL", NamedTypeF("String", None), None, None)),
-      rules = List(rule("LongURL", "strategy", IntLitF(int_of_integer(BigInt(42)), None)))
+      rules = List(rule("LongURL", "strategy", IntLitF(BigInt(42), None)))
     )
     val diagnostics = Validate.validateConventions(ir.n, ir)
     assert(

--- a/modules/convention/src/test/scala/specrest/convention/TestStrategyOverrideTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/TestStrategyOverrideTest.scala
@@ -136,7 +136,7 @@ class TestStrategyOverrideTest extends CatsEffectSuite:
         "User",
         "test_strategy",
         Some("password_hash"),
-        IntLitF(int_of_integer(BigInt(42)), None)
+        IntLitF(BigInt(42), None)
       ))
     )
     val diagnostics = Validate.validateConventions(ir.n, ir)

--- a/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
+++ b/modules/ir/src/main/scala/specrest/ir/PrettyPrint.scala
@@ -9,7 +9,7 @@ object PrettyPrint:
   private def render(e: expr_full): String = e match
     case IntLitF(v, _) =>
       v match
-        case int_of_integer(b) => b.toString
+        case b => b.toString
     case FloatLitF(v, _) => v
     case StringLitF(v, _) =>
       val escaped = v.flatMap:

--- a/modules/ir/src/main/scala/specrest/ir/Serialize.scala
+++ b/modules/ir/src/main/scala/specrest/ir/Serialize.scala
@@ -6,14 +6,6 @@ import specrest.ir.generated.SpecRestGenerated.*
 
 object Serialize:
 
-  private def intToLong(i: int): Long = i match
-    case int_of_integer(b) => b.toLong
-
-  private def longToInt(l: Long): int = int_of_integer(BigInt(l))
-
-  private def intToBigInt(i: int): BigInt = i match
-    case int_of_integer(b) => b
-
   given Encoder[bin_op_full] = Encoder.encodeString.contramap:
     case _: BAnd       => "and"
     case _: BOr        => "or"
@@ -120,23 +112,18 @@ object Serialize:
   given Codec[span_t] = Codec.from(
     Decoder.instance: c =>
       for
-        sl <- c.get[Int]("startLine")
-        sc <- c.get[Int]("startCol")
-        el <- c.get[Int]("endLine")
-        ec <- c.get[Int]("endCol")
-      yield SpanT(
-        int_of_integer(BigInt(sl)),
-        int_of_integer(BigInt(sc)),
-        int_of_integer(BigInt(el)),
-        int_of_integer(BigInt(ec))
-      ),
+        sl <- c.get[BigInt]("startLine")
+        sc <- c.get[BigInt]("startCol")
+        el <- c.get[BigInt]("endLine")
+        ec <- c.get[BigInt]("endCol")
+      yield SpanT(sl, sc, el, ec),
     Encoder.AsObject.instance:
       case SpanT(sl, sc, el, ec) =>
         JsonObject(
-          "startLine" -> intToBigInt(sl).toInt.asJson,
-          "startCol"  -> intToBigInt(sc).toInt.asJson,
-          "endLine"   -> intToBigInt(el).toInt.asJson,
-          "endCol"    -> intToBigInt(ec).toInt.asJson
+          "startLine" -> sl.asJson,
+          "startCol"  -> sc.asJson,
+          "endLine"   -> el.asJson,
+          "endCol"    -> ec.asJson
         )
   )
 
@@ -269,7 +256,7 @@ object Serialize:
         kindObj("SeqLiteral", "elements" -> es.asJson).addSpan(sp)
       case MatchesF(x, p, sp) =>
         kindObj("Matches", "expr" -> x.asJson, "pattern" -> p.asJson).addSpan(sp)
-      case IntLitF(v, sp)     => kindObj("IntLit", "value" -> intToLong(v).asJson).addSpan(sp)
+      case IntLitF(v, sp)     => kindObj("IntLit", "value" -> v.asJson).addSpan(sp)
       case FloatLitF(v, sp)   => kindObj("FloatLit", "value" -> v.toDouble.asJson).addSpan(sp)
       case StringLitF(v, sp)  => kindObj("StringLit", "value" -> v.asJson).addSpan(sp)
       case BoolLitF(v, sp)    => kindObj("BoolLit", "value" -> v.asJson).addSpan(sp)
@@ -407,7 +394,7 @@ object Serialize:
           s <- sp
         yield MatchesF(e, p, s)
       case "IntLit" =>
-        for v <- c.get[Long]("value"); s <- sp yield IntLitF(longToInt(v), s)
+        for v <- c.get[BigInt]("value"); s <- sp yield IntLitF(v, s)
       case "FloatLit" =>
         for v <- c.get[Double]("value"); s <- sp yield FloatLitF(v.toString, s)
       case "StringLit"  => for v <- c.get[String]("value"); s <- sp yield StringLitF(v, s)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -24,32 +24,24 @@ object Str_Literal {
 
 object SpecRestGenerated {
 
-  sealed abstract class int
-  final case class int_of_integer(a: BigInt) extends int
-
   sealed abstract class num
   final case class Onea()       extends num
   final case class Bit0(a: num) extends num
   final case class Bit1(a: num) extends num
 
-  def one_inta: int = int_of_integer(BigInt(1))
+  def one_inta: BigInt = BigInt(1)
 
   trait one[A] {
     val `SpecRestGenerated.one`: A
   }
   def one[A](implicit A: one[A]): A = A.`SpecRestGenerated.one`
   object one {
-    implicit def `SpecRestGenerated.one_int`: one[int] = new one[int] {
+    implicit def `SpecRestGenerated.one_int`: one[BigInt] = new one[BigInt] {
       val `SpecRestGenerated.one` = one_inta
     }
   }
 
-  def integer_of_int(x0: int): BigInt = x0 match {
-    case int_of_integer(k) => k
-  }
-
-  def times_inta(k: int, l: int): int =
-    int_of_integer(integer_of_int(k) * integer_of_int(l))
+  def times_inta(k: BigInt, l: BigInt): BigInt = k * l
 
   trait times[A] {
     val `SpecRestGenerated.times`: (A, A) => A
@@ -57,48 +49,23 @@ object SpecRestGenerated {
   def times[A](a: A, b: A)(implicit A: times[A]): A =
     A.`SpecRestGenerated.times`(a, b)
   object times {
-    implicit def `SpecRestGenerated.times_int`: times[int] = new times[int] {
-      val `SpecRestGenerated.times` = (a: int, b: int) => times_inta(a, b)
+    implicit def `SpecRestGenerated.times_int`: times[BigInt] = new times[BigInt] {
+      val `SpecRestGenerated.times` = (a: BigInt, b: BigInt) => times_inta(a, b)
     }
   }
 
   trait power[A] extends one[A] with times[A] {}
   object power {
-    implicit def `SpecRestGenerated.power_int`: power[int] = new power[int] {
-      val `SpecRestGenerated.times` = (a: int, b: int) => times_inta(a, b)
+    implicit def `SpecRestGenerated.power_int`: power[BigInt] = new power[BigInt] {
+      val `SpecRestGenerated.times` = (a: BigInt, b: BigInt) => times_inta(a, b)
       val `SpecRestGenerated.one`   = one_inta
     }
   }
 
-  def less_eq_int(k: int, l: int): Boolean =
-    integer_of_int(k) <= integer_of_int(l)
-
-  trait ord[A] {
-    val `SpecRestGenerated.less_eq`: (A, A) => Boolean
-    val `SpecRestGenerated.less`: (A, A) => Boolean
-  }
-  def less_eq[A](a: A, b: A)(implicit A: ord[A]): Boolean =
-    A.`SpecRestGenerated.less_eq`(a, b)
-  def less[A](a: A, b: A)(implicit A: ord[A]): Boolean =
-    A.`SpecRestGenerated.less`(a, b)
-  object ord {
-    implicit def `SpecRestGenerated.ord_integer`: ord[BigInt] = new ord[BigInt] {
-      val `SpecRestGenerated.less_eq` = (a: BigInt, b: BigInt) => a <= b
-      val `SpecRestGenerated.less`    = (a: BigInt, b: BigInt) => a < b
-    }
-    implicit def `SpecRestGenerated.ord_int`: ord[int] = new ord[int] {
-      val `SpecRestGenerated.less_eq` = (a: int, b: int) => less_eq_int(a, b)
-      val `SpecRestGenerated.less`    = (a: int, b: int) => less_int(a, b)
-    }
-  }
-
-  def less_int(k: int, l: int): Boolean = integer_of_int(k) < integer_of_int(l)
-
-  def equal_int(k: int, l: int): Boolean =
-    integer_of_int(k) == integer_of_int(l)
+  def equal_int(k: BigInt, l: BigInt): Boolean = k == l
 
   sealed abstract class span_t
-  final case class SpanT(a: int, b: int, c: int, d: int) extends span_t
+  final case class SpanT(a: BigInt, b: BigInt, c: BigInt, d: BigInt) extends span_t
 
   def equal_span_ta(x0: span_t, x1: span_t): Boolean = (x0, x1) match {
     case (SpanT(x1, x2, x3, x4), SpanT(y1, y2, y3, y4)) =>
@@ -168,7 +135,7 @@ object SpecRestGenerated {
 
   sealed abstract class smt_val
   final case class SBool(a: Boolean)                              extends smt_val
-  final case class SInt(a: int)                                   extends smt_val
+  final case class SInt(a: BigInt)                                extends smt_val
   final case class SEnumElem(a: String, b: String)                extends smt_val
   final case class SEntityElem(a: String, b: String)              extends smt_val
   final case class SSet(a: List[smt_val])                         extends smt_val
@@ -240,7 +207,7 @@ object SpecRestGenerated {
 
   sealed abstract class ir_value
   final case class VBool(a: Boolean)                                extends ir_value
-  final case class VInt(a: int)                                     extends ir_value
+  final case class VInt(a: BigInt)                                  extends ir_value
   final case class VEnum(a: String, b: String)                      extends ir_value
   final case class VEntity(a: String, b: String)                    extends ir_value
   final case class VSet(a: List[ir_value])                          extends ir_value
@@ -339,6 +306,21 @@ object SpecRestGenerated {
                     equal_option[String](x8, y8)))))))
     }
 
+  trait ord[A] {
+    val `SpecRestGenerated.less_eq`: (A, A) => Boolean
+    val `SpecRestGenerated.less`: (A, A) => Boolean
+  }
+  def less_eq[A](a: A, b: A)(implicit A: ord[A]): Boolean =
+    A.`SpecRestGenerated.less_eq`(a, b)
+  def less[A](a: A, b: A)(implicit A: ord[A]): Boolean =
+    A.`SpecRestGenerated.less`(a, b)
+  object ord {
+    implicit def `SpecRestGenerated.ord_integer`: ord[BigInt] = new ord[BigInt] {
+      val `SpecRestGenerated.less_eq` = (a: BigInt, b: BigInt) => a <= b
+      val `SpecRestGenerated.less`    = (a: BigInt, b: BigInt) => a < b
+    }
+  }
+
   sealed abstract class foreign_key_spec
   final case class ForeignKeySpec(a: String, b: String, c: String, d: String)
       extends foreign_key_spec
@@ -376,7 +358,7 @@ object SpecRestGenerated {
 
   sealed abstract class expr
   final case class BoolLit(a: Boolean, b: Option[span_t]) extends expr
-  final case class IntLit(a: int, b: Option[span_t])      extends expr
+  final case class IntLit(a: BigInt, b: Option[span_t])   extends expr
   final case class Ident(a: String, b: Option[span_t])    extends expr
   final case class UnNot(a: expr, b: Option[span_t])      extends expr
   final case class UnNeg(a: expr, b: Option[span_t])      extends expr
@@ -507,7 +489,7 @@ object SpecRestGenerated {
       extends expr_full
   final case class SeqLiteralF(a: List[expr_full], b: Option[span_t])   extends expr_full
   final case class MatchesF(a: expr_full, b: String, c: Option[span_t]) extends expr_full
-  final case class IntLitF(a: int, b: Option[span_t])                   extends expr_full
+  final case class IntLitF(a: BigInt, b: Option[span_t])                extends expr_full
   final case class FloatLitF(a: String, b: Option[span_t])              extends expr_full
   final case class StringLitF(a: String, b: Option[span_t])             extends expr_full
   final case class BoolLitF(a: Boolean, b: Option[span_t])              extends expr_full
@@ -530,7 +512,7 @@ object SpecRestGenerated {
 
   sealed abstract class smt_term
   final case class BLit(a: Boolean)                               extends smt_term
-  final case class ILit(a: int)                                   extends smt_term
+  final case class ILit(a: BigInt)                                extends smt_term
   final case class TVar(a: String)                                extends smt_term
   final case class EnumElemConst(a: String, b: String)            extends smt_term
   final case class TNot(a: smt_term)                              extends smt_term
@@ -569,7 +551,7 @@ object SpecRestGenerated {
 
   sealed abstract class parsed_value
   final case class PvString(a: String)             extends parsed_value
-  final case class PvInt(a: int)                   extends parsed_value
+  final case class PvInt(a: BigInt)                extends parsed_value
   final case class PvBool(a: Boolean)              extends parsed_value
   final case class PvStrPair(a: String, b: String) extends parsed_value
   final case class PvExpr(a: expr_full)            extends parsed_value
@@ -630,15 +612,15 @@ object SpecRestGenerated {
       extends param_decl_full
 
   sealed abstract class validation_failure
-  final case class ExpectedString()             extends validation_failure
-  final case class ExpectedInteger()            extends validation_failure
-  final case class ExpectedBoolean()            extends validation_failure
-  final case class EmptyString()                extends validation_failure
-  final case class BadHttpMethod(a: String)     extends validation_failure
-  final case class HttpStatusOutOfRange(a: int) extends validation_failure
-  final case class HttpPathMissingSlash()       extends validation_failure
-  final case class BadTestStrategy(a: String)   extends validation_failure
-  final case class BadStrategyFormat(a: String) extends validation_failure
+  final case class ExpectedString()                extends validation_failure
+  final case class ExpectedInteger()               extends validation_failure
+  final case class ExpectedBoolean()               extends validation_failure
+  final case class EmptyString()                   extends validation_failure
+  final case class BadHttpMethod(a: String)        extends validation_failure
+  final case class HttpStatusOutOfRange(a: BigInt) extends validation_failure
+  final case class HttpPathMissingSlash()          extends validation_failure
+  final case class BadTestStrategy(a: String)      extends validation_failure
+  final case class BadStrategyFormat(a: String)    extends validation_failure
 
   sealed abstract class convention_value
   final case class CvOk(a: parsed_value)                      extends convention_value
@@ -883,7 +865,7 @@ object SpecRestGenerated {
   ) extends tyctx_ext[A]
 
   sealed abstract class int_constraint
-  final case class IntConstraint(a: Option[int], b: Option[int], c: List[String])
+  final case class IntConstraint(a: Option[BigInt], b: Option[BigInt], c: List[String])
       extends int_constraint
 
   sealed abstract class dialect_caps
@@ -911,15 +893,15 @@ object SpecRestGenerated {
   final case class LlmSynthesis() extends synthesis_strategy
 
   sealed abstract class refinement_atom
-  final case class RaLenCmp(a: bin_op_full, b: int)     extends refinement_atom
-  final case class RaValueCmp(a: bin_op_full, b: int)   extends refinement_atom
-  final case class RaMatches(a: String)                 extends refinement_atom
-  final case class RaMatchesIdent(a: String, b: String) extends refinement_atom
-  final case class RaPredCall(a: String)                extends refinement_atom
-  final case class RaUnknown(a: expr_full)              extends refinement_atom
+  final case class RaLenCmp(a: bin_op_full, b: BigInt)   extends refinement_atom
+  final case class RaValueCmp(a: bin_op_full, b: BigInt) extends refinement_atom
+  final case class RaMatches(a: String)                  extends refinement_atom
+  final case class RaMatchesIdent(a: String, b: String)  extends refinement_atom
+  final case class RaPredCall(a: String)                 extends refinement_atom
+  final case class RaUnknown(a: expr_full)               extends refinement_atom
 
   sealed abstract class decimal_lit
-  final case class DecimalLit(a: int, b: int) extends decimal_lit
+  final case class DecimalLit(a: BigInt, b: BigInt) extends decimal_lit
 
   sealed abstract class schema_object_or_bool
   final case class SOBSchema(a: schema_object) extends schema_object_or_bool
@@ -929,14 +911,14 @@ object SpecRestGenerated {
   final case class SchemaObject(
       a: Option[List[String]],
       b: Option[String],
-      c: Option[int],
-      d: Option[int],
+      c: Option[BigInt],
+      d: Option[BigInt],
       e: Option[decimal_lit],
       f: Option[decimal_lit],
       g: Option[decimal_lit],
       h: Option[decimal_lit],
-      i: Option[int],
-      j: Option[int],
+      i: Option[BigInt],
+      j: Option[BigInt],
       k: Option[String],
       l: Option[List[String]],
       m: Option[schema_object],
@@ -988,25 +970,25 @@ object SpecRestGenerated {
   final case class AbsPrefixCall(a: String) extends alloy_binop_shape
 
   sealed abstract class canonical_type
-  final case class CtText()                          extends canonical_type
-  final case class CtVarchar(a: int)                 extends canonical_type
-  final case class CtInt4()                          extends canonical_type
-  final case class CtSerial4()                       extends canonical_type
-  final case class CtInt8()                          extends canonical_type
-  final case class CtSerial8()                       extends canonical_type
-  final case class CtFloat8()                        extends canonical_type
-  final case class CtBool()                          extends canonical_type
-  final case class CtTimestamptz()                   extends canonical_type
-  final case class CtDateOnly()                      extends canonical_type
-  final case class CtUuid()                          extends canonical_type
-  final case class CtNumeric(a: int, b: Option[int]) extends canonical_type
-  final case class CtBytes()                         extends canonical_type
-  final case class CtJson()                          extends canonical_type
+  final case class CtText()                                extends canonical_type
+  final case class CtVarchar(a: BigInt)                    extends canonical_type
+  final case class CtInt4()                                extends canonical_type
+  final case class CtSerial4()                             extends canonical_type
+  final case class CtInt8()                                extends canonical_type
+  final case class CtSerial8()                             extends canonical_type
+  final case class CtFloat8()                              extends canonical_type
+  final case class CtBool()                                extends canonical_type
+  final case class CtTimestamptz()                         extends canonical_type
+  final case class CtDateOnly()                            extends canonical_type
+  final case class CtUuid()                                extends canonical_type
+  final case class CtNumeric(a: BigInt, b: Option[BigInt]) extends canonical_type
+  final case class CtBytes()                               extends canonical_type
+  final case class CtJson()                                extends canonical_type
 
   sealed abstract class string_constraint
   final case class StringConstraint(
-      a: Option[int],
-      b: Option[int],
+      a: Option[BigInt],
+      b: Option[BigInt],
       c: List[String],
       d: List[String],
       e: List[String]
@@ -1057,8 +1039,8 @@ object SpecRestGenerated {
   sealed abstract class column_check_class
   final case class CcSkip()                                        extends column_check_class
   final case class CcRegexMatch(a: String)                         extends column_check_class
-  final case class CcLenCompare(a: bin_op_full, b: int)            extends column_check_class
-  final case class CcValueCompare(a: bin_op_full, b: int)          extends column_check_class
+  final case class CcLenCompare(a: bin_op_full, b: BigInt)         extends column_check_class
+  final case class CcValueCompare(a: bin_op_full, b: BigInt)       extends column_check_class
   final case class CcLenLitCompare(a: bin_op_full, b: expr_full)   extends column_check_class
   final case class CcValueLitCompare(a: bin_op_full, b: expr_full) extends column_check_class
 
@@ -1091,8 +1073,8 @@ object SpecRestGenerated {
 
   sealed abstract class openapi_bounds
   final case class OpenApiBounds(
-      a: Option[int],
-      b: Option[int],
+      a: Option[BigInt],
+      b: Option[BigInt],
       c: Option[decimal_lit],
       d: Option[decimal_lit],
       e: Option[decimal_lit],
@@ -1153,8 +1135,8 @@ object SpecRestGenerated {
 
   def comp[A, B, C](f: A => B, g: C => A): C => B = (x: C) => f(g(x))
 
-  def nat: int => nat =
-    comp[BigInt, nat, int]((a: BigInt) => nat_of_integer(a), (a: int) => integer_of_int(a))
+  def nat: BigInt => nat =
+    comp[BigInt, nat, BigInt]((a: BigInt) => nat_of_integer(a), (a: BigInt) => a)
 
   def integer_of_nat(x0: nat): BigInt = x0 match {
     case Nata(x) => x
@@ -1392,8 +1374,7 @@ object SpecRestGenerated {
   def divide_integer(k: BigInt, l: BigInt): BigInt =
     fst[BigInt, BigInt](divmod_integer(k, l))
 
-  def divide_int(k: int, l: int): int =
-    int_of_integer(divide_integer(integer_of_int(k), integer_of_int(l)))
+  def divide_int(k: BigInt, l: BigInt): BigInt = divide_integer(k, l)
 
   def sm_sort_members[A](x0: smt_model_ext[A]): List[(String, List[String])] =
     x0 match {
@@ -1413,7 +1394,7 @@ object SpecRestGenerated {
   ): Option[List[String]] =
     map_of[String, List[String]](sm_sort_members[Unit](m), sort_name)
 
-  def uminus_int(k: int): int = int_of_integer(-integer_of_int(k))
+  def uminus_int(k: BigInt): BigInt = -k
 
   def length_tailrec[A](x0: List[A], n: nat): nat = (x0, n) match {
     case (Nil, n)     => n
@@ -1422,8 +1403,7 @@ object SpecRestGenerated {
 
   def size_list[A](xs: List[A]): nat = length_tailrec[A](xs, zero_nat)
 
-  def minus_int(k: int, l: int): int =
-    int_of_integer(integer_of_int(k) - integer_of_int(l))
+  def minus_int(k: BigInt, l: BigInt): BigInt = k - l
 
   def sm_const_vals[A](x0: smt_model_ext[A]): List[(String, smt_val)] = x0 match {
     case smt_model_exta(
@@ -1457,12 +1437,13 @@ object SpecRestGenerated {
   def set_intersect_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
     dedupe_smt_vals(filter[smt_val]((a: smt_val) => contains_smt_val(r, a), l))
 
-  def zero_int: int = int_of_integer(BigInt(0))
+  def zero_int: BigInt = BigInt(0)
 
-  def plus_int(k: int, l: int): int =
-    int_of_integer(integer_of_int(k) + integer_of_int(l))
+  def plus_int(k: BigInt, l: BigInt): BigInt = k + l
 
-  def int_of_nat(n: nat): int = int_of_integer(integer_of_nat(n))
+  def int_of_nat(n: nat): BigInt = integer_of_nat(n)
+
+  def less_int(k: BigInt, l: BigInt): Boolean = k < l
 
   def sm_pred_fields[A](x0: smt_model_ext[A]): List[(String, List[(String, smt_val)])] =
     x0 match {
@@ -3281,6 +3262,8 @@ object SpecRestGenerated {
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
     map_of[String, ir_value](env, name)
 
+  def less_eq_int(k: BigInt, l: BigInt): Boolean = k <= l
+
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
     (uu, uv, uw) match {
       case (EqOp(), Some(a), Some(b)) =>
@@ -3964,16 +3947,15 @@ object SpecRestGenerated {
     case (p, x :: xs) => p(x) && list_all[A](p, xs)
   }
 
-  def isRedirectStatus(s: int): Boolean =
-    equal_int(s, int_of_integer(BigInt(301))) ||
-      (equal_int(s, int_of_integer(BigInt(302))) ||
-        (equal_int(s, int_of_integer(BigInt(303))) ||
-          (equal_int(s, int_of_integer(BigInt(307))) ||
-            equal_int(s, int_of_integer(BigInt(308))))))
+  def isRedirectStatus(s: BigInt): Boolean =
+    equal_int(s, BigInt(301)) ||
+      (equal_int(s, BigInt(302)) ||
+        (equal_int(s, BigInt(303)) ||
+          (equal_int(s, BigInt(307)) || equal_int(s, BigInt(308)))))
 
   def classifyShape(
       method: http_method,
-      status: int,
+      status: BigInt,
       pathParamCount: nat,
       kind: operation_kind
   ): route_kind =
@@ -4085,7 +4067,7 @@ object SpecRestGenerated {
 
   def classify(
       method: http_method,
-      status: int,
+      status: BigInt,
       pathParamCount: nat,
       kind: operation_kind,
       hasFilterInputs: Boolean
@@ -4399,15 +4381,17 @@ object SpecRestGenerated {
       case RaValueCmp(BIff(), _) =>
         (emptyIntConstraint, List("unsupported int comparison"))
       case RaValueCmp(BEq(), n) =>
-        (IntConstraint(Some[int](n), Some[int](n), Nil), Nil)
+        (IntConstraint(Some[BigInt](n), Some[BigInt](n), Nil), Nil)
       case RaValueCmp(BNeq(), _) =>
         (emptyIntConstraint, List("unsupported int comparison"))
       case RaValueCmp(BLt(), n) =>
-        (IntConstraint(None, Some[int](minus_int(n, one_inta)), Nil), Nil)
+        (IntConstraint(None, Some[BigInt](minus_int(n, one_inta)), Nil), Nil)
       case RaValueCmp(BGt(), n) =>
-        (IntConstraint(Some[int](plus_int(n, one_inta)), None, Nil), Nil)
-      case RaValueCmp(BLe(), n) => (IntConstraint(None, Some[int](n), Nil), Nil)
-      case RaValueCmp(BGe(), n) => (IntConstraint(Some[int](n), None, Nil), Nil)
+        (IntConstraint(Some[BigInt](plus_int(n, one_inta)), None, Nil), Nil)
+      case RaValueCmp(BLe(), n) =>
+        (IntConstraint(None, Some[BigInt](n), Nil), Nil)
+      case RaValueCmp(BGe(), n) =>
+        (IntConstraint(Some[BigInt](n), None, Nil), Nil)
       case RaValueCmp(BIn(), _) =>
         (emptyIntConstraint, List("unsupported int comparison"))
       case RaValueCmp(BNotIn(), _) =>
@@ -4465,7 +4449,7 @@ object SpecRestGenerated {
     case BDiv()       => BDiv()
   }
 
-  def rangeOf(e: expr_full): Option[(String, (bin_op_full, int))] =
+  def rangeOf(e: expr_full): Option[(String, (bin_op_full, BigInt))] =
     e match {
       case BinaryOpF(op, l, r, _) =>
         (l, r) match {
@@ -4518,7 +4502,7 @@ object SpecRestGenerated {
           case (IntLitF(_, _), NoneLitF(_))                   => None
           case (IntLitF(v, _), IdentifierF(n, _)) =>
             isComp(op) match {
-              case true  => Some[(String, (bin_op_full, int))]((n, (mirrorBinOp(op), v)))
+              case true  => Some[(String, (bin_op_full, BigInt))]((n, (mirrorBinOp(op), v)))
               case false => None
             }
           case (FloatLitF(_, _), _)                               => None
@@ -4548,7 +4532,7 @@ object SpecRestGenerated {
           case (IdentifierF(_, _), MatchesF(_, _, _))             => None
           case (IdentifierF(n, _), IntLitF(v, _)) =>
             isComp(op) match {
-              case true  => Some[(String, (bin_op_full, int))]((n, (op, v)))
+              case true  => Some[(String, (bin_op_full, BigInt))]((n, (op, v)))
               case false => None
             }
           case (IdentifierF(_, _), FloatLitF(_, _))   => None
@@ -4861,7 +4845,7 @@ object SpecRestGenerated {
     case BDiff()      => "--"
   }
 
-  def highBoundEffective(x0: bin_op_full, n: int): int = (x0, n) match {
+  def highBoundEffective(x0: bin_op_full, n: BigInt): BigInt = (x0, n) match {
     case (BLt(), n)        => minus_int(n, one_inta)
     case (BAnd(), n)       => n
     case (BOr(), n)        => n
@@ -4884,7 +4868,7 @@ object SpecRestGenerated {
     case (BDiv(), n)       => n
   }
 
-  def lowBoundEffective(x0: bin_op_full, n: int): int = (x0, n) match {
+  def lowBoundEffective(x0: bin_op_full, n: BigInt): BigInt = (x0, n) match {
     case (BGt(), n)        => plus_int(n, one_inta)
     case (BAnd(), n)       => n
     case (BOr(), n)        => n
@@ -4930,7 +4914,7 @@ object SpecRestGenerated {
     case BDiv()       => false
   }
 
-  def conflicts(aOp: bin_op_full, aB: int, bOp: bin_op_full, bB: int): Boolean =
+  def conflicts(aOp: bin_op_full, aB: BigInt, bOp: bin_op_full, bB: BigInt): Boolean =
     isLowBound(aOp) && !isLowBound(bOp) match {
       case true => less_int(highBoundEffective(bOp, bB), lowBoundEffective(aOp, aB))
       case false => !isLowBound(aOp) && isLowBound(bOp) match {
@@ -5339,17 +5323,17 @@ object SpecRestGenerated {
       case RaLenCmp(BIff(), _) =>
         (emptyStringConstraint, List("unsupported len comparison"))
       case RaLenCmp(BEq(), n) =>
-        (StringConstraint(Some[int](n), Some[int](n), Nil, Nil, Nil), Nil)
+        (StringConstraint(Some[BigInt](n), Some[BigInt](n), Nil, Nil, Nil), Nil)
       case RaLenCmp(BNeq(), _) =>
         (emptyStringConstraint, List("unsupported len comparison"))
       case RaLenCmp(BLt(), n) =>
-        (StringConstraint(None, Some[int](minus_int(n, one_inta)), Nil, Nil, Nil), Nil)
+        (StringConstraint(None, Some[BigInt](minus_int(n, one_inta)), Nil, Nil, Nil), Nil)
       case RaLenCmp(BGt(), n) =>
-        (StringConstraint(Some[int](plus_int(n, one_inta)), None, Nil, Nil, Nil), Nil)
+        (StringConstraint(Some[BigInt](plus_int(n, one_inta)), None, Nil, Nil, Nil), Nil)
       case RaLenCmp(BLe(), n) =>
-        (StringConstraint(None, Some[int](n), Nil, Nil, Nil), Nil)
+        (StringConstraint(None, Some[BigInt](n), Nil, Nil, Nil), Nil)
       case RaLenCmp(BGe(), n) =>
-        (StringConstraint(Some[int](n), None, Nil, Nil, Nil), Nil)
+        (StringConstraint(Some[BigInt](n), None, Nil, Nil, Nil), Nil)
       case RaLenCmp(BIn(), _) =>
         (emptyStringConstraint, List("unsupported len comparison"))
       case RaLenCmp(BNotIn(), _) =>
@@ -5746,18 +5730,18 @@ object SpecRestGenerated {
       case false => b
     }
 
-  def mergeMaxInt(a: Option[int], b: Option[int]): Option[int] =
+  def mergeMaxInt(a: Option[BigInt], b: Option[BigInt]): Option[BigInt] =
     (a, b) match {
       case (None, y)          => y
-      case (Some(x), None)    => Some[int](x)
-      case (Some(x), Some(y)) => Some[int](min[int](x, y))
+      case (Some(x), None)    => Some[BigInt](x)
+      case (Some(x), Some(y)) => Some[BigInt](min[BigInt](x, y))
     }
 
-  def mergeMinInt(a: Option[int], b: Option[int]): Option[int] =
+  def mergeMinInt(a: Option[BigInt], b: Option[BigInt]): Option[BigInt] =
     (a, b) match {
       case (None, y)          => y
-      case (Some(x), None)    => Some[int](x)
-      case (Some(x), Some(y)) => Some[int](max[int](x, y))
+      case (Some(x), None)    => Some[BigInt](x)
+      case (Some(x), Some(y)) => Some[BigInt](max[BigInt](x, y))
     }
 
   def boolSigs: List[alloy_sig] =
@@ -5901,22 +5885,22 @@ object SpecRestGenerated {
   def mysqlCaps: dialect_caps =
     DialectCaps(false, true, false, true, true, false)
 
-  def desiredSize(x0: bin_op_full, n: int): Option[int] = (x0, n) match {
-    case (BGt(), n) => Some[int](max[int](zero_int, plus_int(n, one_inta)))
-    case (BGe(), n) => Some[int](max[int](zero_int, n))
+  def desiredSize(x0: bin_op_full, n: BigInt): Option[BigInt] = (x0, n) match {
+    case (BGt(), n) => Some[BigInt](max[BigInt](zero_int, plus_int(n, one_inta)))
+    case (BGe(), n) => Some[BigInt](max[BigInt](zero_int, n))
     case (BEq(), n) =>
       less_eq_int(zero_int, n) match {
-        case true  => Some[int](n)
+        case true  => Some[BigInt](n)
         case false => None
       }
     case (BLt(), n) =>
       less_int(zero_int, n) match {
-        case true  => Some[int](zero_int)
+        case true  => Some[BigInt](zero_int)
         case false => None
       }
     case (BLe(), n) =>
       less_eq_int(zero_int, n) match {
-        case true  => Some[int](zero_int)
+        case true  => Some[BigInt](zero_int)
         case false => None
       }
     case (BAnd(), uv)       => None
@@ -7591,7 +7575,7 @@ object SpecRestGenerated {
       digitsRev(n)
     )))
 
-  def showInt(n: int): String =
+  def showInt(n: BigInt): String =
     less_int(n, zero_int) match {
       case true  => "-" + showNat(nat.apply(uminus_int(n)))
       case false => showNat(nat.apply(n))
@@ -8101,7 +8085,7 @@ object SpecRestGenerated {
         }
     }
 
-  def arraySchema(items: schema_object, mnI: Option[int], mxI: Option[int]): schema_object =
+  def arraySchema(items: schema_object, mnI: Option[BigInt], mxI: Option[BigInt]): schema_object =
     SchemaObject(
       Some[List[String]](List("array")),
       None,
@@ -9591,11 +9575,11 @@ object SpecRestGenerated {
       false
     )
 
-  def boundsMinLength(x0: openapi_bounds): Option[int] = x0 match {
+  def boundsMinLength(x0: openapi_bounds): Option[BigInt] = x0 match {
     case OpenApiBounds(mnL, uu, uv, uw, ux, uy, uz) => mnL
   }
 
-  def boundsMaxLength(x0: openapi_bounds): Option[int] = x0 match {
+  def boundsMaxLength(x0: openapi_bounds): Option[BigInt] = x0 match {
     case OpenApiBounds(uu, mxL, uv, uw, ux, uy, uz) => mxL
   }
 
@@ -9646,14 +9630,10 @@ object SpecRestGenerated {
   def decimalGt(x0: decimal_lit, x1: decimal_lit): Boolean = (x0, x1) match {
     case (DecimalLit(m1, e1), DecimalLit(m2, e2)) =>
       less_eq_int(e1, e2) match {
-        case true => less_int(
-            times_inta(m2, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e2, e1)))),
-            m1
-          )
-        case false => less_int(
-            m2,
-            times_inta(m1, power[int](int_of_integer(BigInt(10)), nat.apply(minus_int(e1, e2))))
-          )
+        case true =>
+          less_int(times_inta(m2, power[BigInt](BigInt(10), nat.apply(minus_int(e2, e1)))), m1)
+        case false =>
+          less_int(m2, times_inta(m1, power[BigInt](BigInt(10), nat.apply(minus_int(e1, e2)))))
       }
   }
 
@@ -9735,39 +9715,39 @@ object SpecRestGenerated {
       case BDiv()       => bounds
     }
 
-  def withMinLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
+  def withMinLength(v: Option[BigInt], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
       case (v, OpenApiBounds(uu, ml, mn, mx, emn, emx, p)) =>
         OpenApiBounds(v, ml, mn, mx, emn, emx, p)
     }
 
-  def withMaxLength(v: Option[int], x1: openapi_bounds): openapi_bounds =
+  def withMaxLength(v: Option[BigInt], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
       case (v, OpenApiBounds(nl, uu, mn, mx, emn, emx, p)) =>
         OpenApiBounds(nl, v, mn, mx, emn, emx, p)
     }
 
-  def tightenIntMin(cur: Option[int], n: int): Option[int] =
+  def tightenIntMin(cur: Option[BigInt], n: BigInt): Option[BigInt] =
     cur match {
-      case None    => Some[int](n)
-      case Some(x) => Some[int](max[int](x, n))
+      case None    => Some[BigInt](n)
+      case Some(x) => Some[BigInt](max[BigInt](x, n))
     }
 
-  def tightenIntMax(cur: Option[int], n: int): Option[int] =
+  def tightenIntMax(cur: Option[BigInt], n: BigInt): Option[BigInt] =
     cur match {
-      case None    => Some[int](n)
-      case Some(x) => Some[int](min[int](x, n))
+      case None    => Some[BigInt](n)
+      case Some(x) => Some[BigInt](min[BigInt](x, n))
     }
 
-  def minLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+  def minLengthOf(x0: openapi_bounds): Option[BigInt] = x0 match {
     case OpenApiBounds(nl, uu, uv, uw, ux, uy, uz) => nl
   }
 
-  def maxLengthOf(x0: openapi_bounds): Option[int] = x0 match {
+  def maxLengthOf(x0: openapi_bounds): Option[BigInt] = x0 match {
     case OpenApiBounds(uu, ml, uv, uw, ux, uy, uz) => ml
   }
 
-  def applyLengthBoundOpenApi(op: bin_op_full, n: int, bounds: openapi_bounds): openapi_bounds =
+  def applyLengthBoundOpenApi(op: bin_op_full, n: BigInt, bounds: openapi_bounds): openapi_bounds =
     less_int(n, zero_int) match {
       case true => bounds
       case false => op match {
@@ -9806,21 +9786,19 @@ object SpecRestGenerated {
         }
     }
 
-  def modulo_int(k: int, l: int): int =
-    int_of_integer(modulo_integer(integer_of_int(k), integer_of_int(l)))
+  def modulo_int(k: BigInt, l: BigInt): BigInt = modulo_integer(k, l)
 
-  def decimalToNonNegInt(x0: decimal_lit): Option[int] = x0 match {
+  def decimalToNonNegInt(x0: decimal_lit): Option[BigInt] = x0 match {
     case DecimalLit(m, e) =>
       less_int(m, zero_int) match {
         case true => None
         case false => less_eq_int(zero_int, e) match {
-            case true =>
-              Some[int](times_inta(m, power[int](int_of_integer(BigInt(10)), nat.apply(e))))
+            case true => Some[BigInt](times_inta(m, power[BigInt](BigInt(10), nat.apply(e))))
             case false =>
               val p =
-                power[int](int_of_integer(BigInt(10)), nat.apply(uminus_int(e))): int;
+                power[BigInt](BigInt(10), nat.apply(uminus_int(e))): BigInt;
               equal_int(modulo_int(m, p), zero_int) match {
-                case true  => Some[int](divide_int(m, p))
+                case true  => Some[BigInt](divide_int(m, p))
                 case false => None
               }
           }
@@ -9829,16 +9807,16 @@ object SpecRestGenerated {
 
   def isDigitAscii(c: BigInt): Boolean = BigInt(48) <= c && c <= BigInt(57)
 
-  def digitValue(c: BigInt): int = int_of_integer(c - BigInt(48))
+  def digitValue(c: BigInt): BigInt = c - BigInt(48)
 
-  def consumeDigitsAux(x0: List[BigInt], acc: int, count: nat): (int, (nat, List[BigInt])) =
+  def consumeDigitsAux(x0: List[BigInt], acc: BigInt, count: nat): (BigInt, (nat, List[BigInt])) =
     (x0, acc, count) match {
       case (Nil, acc, count) => (acc, (count, Nil))
       case (c :: cs, acc, count) =>
         isDigitAscii(c) match {
           case true => consumeDigitsAux(
               cs,
-              plus_int(times_inta(acc, int_of_integer(BigInt(10))), digitValue(c)),
+              plus_int(times_inta(acc, BigInt(10)), digitValue(c)),
               plus_nat(count, one_nat)
             )
           case false => (acc, (count, c :: cs))
@@ -9855,7 +9833,7 @@ object SpecRestGenerated {
             case true  => (uminus_int(one_inta), rs)
             case false => (one_inta, cs0)
           }
-      }): ((int, List[BigInt]));
+      }): ((BigInt, List[BigInt]));
     consumeDigitsAux(cs1, zero_int, zero_nat) match {
       case (intPart, (intLen, Nil)) =>
         equal_nat(intLen, zero_nat) match {
@@ -9866,17 +9844,14 @@ object SpecRestGenerated {
         c == BigInt(46) match {
           case true =>
             val (fracPart, (fracLen, rest2)) =
-              consumeDigitsAux(rs, zero_int, zero_nat): ((int, (nat, List[BigInt])));
+              consumeDigitsAux(rs, zero_int, zero_nat): ((BigInt, (nat, List[BigInt])));
             nulla[BigInt](rest2) &&
               (less_nat(zero_nat, intLen) &&
                 less_nat(zero_nat, fracLen)) match {
               case true => Some[decimal_lit](DecimalLit(
                   times_inta(
                     sign,
-                    plus_int(
-                      times_inta(intPart, power[int](int_of_integer(BigInt(10)), fracLen)),
-                      fracPart
-                    )
+                    plus_int(times_inta(intPart, power[BigInt](BigInt(10), fracLen)), fracPart)
                   ),
                   uminus_int(int_of_nat(fracLen))
                 ))
@@ -9959,7 +9934,7 @@ object SpecRestGenerated {
       case IdentifierF(_, _)                     => bounds
     }
 
-  def decimalOfInt(n: int): decimal_lit = DecimalLit(n, zero_int)
+  def decimalOfInt(n: BigInt): decimal_lit = DecimalLit(n, zero_int)
 
   def withPattern(v: Option[String], x1: openapi_bounds): openapi_bounds =
     (v, x1) match {
@@ -10656,8 +10631,8 @@ object SpecRestGenerated {
       flattenAnd(e)
     )
 
-  def asIntLit(x0: expr_full): Option[int] = x0 match {
-    case IntLitF(n, uu)                   => Some[int](n)
+  def asIntLit(x0: expr_full): Option[BigInt] = x0 match {
+    case IntLitF(n, uu)                   => Some[BigInt](n)
     case BinaryOpF(v, va, vb, vc)         => None
     case UnaryOpF(v, va, vb)              => None
     case QuantifierF(v, va, vb, vc)       => None
@@ -13690,8 +13665,7 @@ object SpecRestGenerated {
     asIntLit(e) match {
       case None => CvBad(ExpectedInteger(), e)
       case Some(n) =>
-        less_eq_int(int_of_integer(BigInt(100)), n) &&
-          less_eq_int(n, int_of_integer(BigInt(599))) match {
+        less_eq_int(BigInt(100), n) && less_eq_int(n, BigInt(599)) match {
           case true  => CvOk(PvInt(n))
           case false => CvBad(HttpStatusOutOfRange(n), e)
         }

--- a/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
+++ b/modules/ir/src/test/scala/specrest/ir/PrettyPrintTest.scala
@@ -4,7 +4,7 @@ import specrest.ir.generated.SpecRestGenerated.*
 
 class PrettyPrintTest extends munit.CatsEffectSuite:
 
-  private def i(n: Int): expr_full        = IntLitF(int_of_integer(BigInt(n)), None)
+  private def i(n: Int): expr_full        = IntLitF(BigInt(n), None)
   private def s(t: String): expr_full     = StringLitF(t, None)
   private def b(v: Boolean): expr_full    = BoolLitF(v, None)
   private def id(name: String): expr_full = IdentifierF(name, None)

--- a/modules/lint/src/test/scala/specrest/lint/MissingEnsuresTest.scala
+++ b/modules/lint/src/test/scala/specrest/lint/MissingEnsuresTest.scala
@@ -2,7 +2,6 @@ package specrest.lint
 
 import munit.CatsEffectSuite
 import specrest.ir.generated.SpecRestGenerated.SpanT
-import specrest.ir.generated.SpecRestGenerated.int_of_integer
 import specrest.ir.generated.SpecRestGenerated.less_int
 import specrest.lint.testutil.SpecFixtures
 
@@ -17,7 +16,7 @@ class MissingEnsuresTest extends CatsEffectSuite:
       assertEquals(d.level, LintLevel.Warning)
       assert(d.message.contains("Read"), d.message)
       assert(
-        d.span.exists { case SpanT(line, _, _, _) => less_int(int_of_integer(BigInt(0)), line) },
+        d.span.exists { case SpanT(line, _, _, _) => less_int(BigInt(0), line) },
         s"expected span, got ${d.span}"
       )
 

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -15,12 +15,10 @@ private def spanFrom(ctx: ParserRuleContext): SpanT =
   val start = ctx.getStart
   val stop  = Option(ctx.getStop).getOrElse(start)
   SpanT(
-    int_of_integer(BigInt(start.getLine)),
-    int_of_integer(BigInt(start.getCharPositionInLine)),
-    int_of_integer(BigInt(stop.getLine)),
-    int_of_integer(
-      BigInt(stop.getCharPositionInLine + Option(stop.getText).map(_.length).getOrElse(1))
-    )
+    BigInt(start.getLine),
+    BigInt(start.getCharPositionInLine),
+    BigInt(stop.getLine),
+    BigInt(stop.getCharPositionInLine + Option(stop.getText).map(_.length).getOrElse(1))
   )
 
 private def sp(ctx: ParserRuleContext): Option[SpanT] = Some(spanFrom(ctx))
@@ -477,7 +475,7 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr_full]]:
     expr(ctx.expr).map(e => PreF(e, sp(ctx)))
 
   override def visitIntLitExpr(ctx: IntLitExprContext): BuildResult[expr_full] =
-    Right(IntLitF(int_of_integer(BigInt(ctx.INT_LIT.getText.toLong)), sp(ctx)))
+    Right(IntLitF(BigInt(ctx.INT_LIT.getText), sp(ctx)))
 
   override def visitFloatLitExpr(ctx: FloatLitExprContext): BuildResult[expr_full] =
     Right(FloatLitF(ctx.FLOAT_LIT.getText, sp(ctx)))

--- a/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Backend.scala
@@ -6,7 +6,6 @@ import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
 import specrest.ir.generated.SpecRestGenerated.StringConstraint
 import specrest.ir.generated.SpecRestGenerated.expr_full
 import specrest.ir.generated.SpecRestGenerated.int_constraint
-import specrest.ir.generated.SpecRestGenerated.integer_of_int
 import specrest.ir.generated.SpecRestGenerated.span_t
 import specrest.ir.generated.SpecRestGenerated.string_constraint
 import specrest.profile.ProfiledService
@@ -114,8 +113,8 @@ object PythonHypothesisStrategy extends StrategyBackend:
 
   def constrainedString(c: string_constraint): String = c match
     case StringConstraint(minOpt, maxOpt, regexes, predicateHelpers, _) =>
-      val minSize = minOpt.map(integer_of_int(_).toInt)
-      val maxSize = maxOpt.map(integer_of_int(_).toInt)
+      val minSize = minOpt.map(_.toInt)
+      val maxSize = maxOpt.map(_.toInt)
       val (primaryRegex, extraRegexes) = regexes match
         case head :: tail => (Some(head), tail)
         case Nil          => (None, Nil)
@@ -140,8 +139,8 @@ object PythonHypothesisStrategy extends StrategyBackend:
   def constrainedInt(c: int_constraint): String = c match
     case IntConstraint(minOpt, maxOpt, _) =>
       val args = List(
-        minOpt.map(n => s"min_value=${integer_of_int(n).toLong}"),
-        maxOpt.map(n => s"max_value=${integer_of_int(n).toLong}")
+        minOpt.map(n => s"min_value=${n}"),
+        maxOpt.map(n => s"max_value=${n}")
       ).flatten.mkString(", ")
       if args.isEmpty then "st.integers()" else s"st.integers($args)"
 
@@ -245,8 +244,8 @@ object TsFastCheckStrategy extends StrategyBackend:
 
   def constrainedString(c: string_constraint): String = c match
     case StringConstraint(minOpt, maxOpt, regexes, predicateHelpers, _) =>
-      val minSize = minOpt.map(integer_of_int(_).toInt)
-      val maxSize = maxOpt.map(integer_of_int(_).toInt)
+      val minSize = minOpt.map(_.toInt)
+      val maxSize = maxOpt.map(_.toInt)
       val (primaryRegex, extraRegexes) = regexes match
         case head :: tail => (Some(head), tail)
         case Nil          => (None, Nil)
@@ -272,8 +271,8 @@ object TsFastCheckStrategy extends StrategyBackend:
   def constrainedInt(c: int_constraint): String = c match
     case IntConstraint(minOpt, maxOpt, _) =>
       val args = List(
-        minOpt.map(n => s"min: ${integer_of_int(n).toLong}"),
-        maxOpt.map(n => s"max: ${integer_of_int(n).toLong}")
+        minOpt.map(n => s"min: ${n}"),
+        maxOpt.map(n => s"max: ${n}")
       ).flatten.mkString(", ")
       if args.isEmpty then "fc.integer()" else s"fc.integer({ $args })"
 

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -1210,7 +1210,7 @@ object Behavioral:
           f       <- findFieldDeclFull(entity.c, field).collect { case f: FieldDeclFull => f }
           inner   <- collectionElementType(f.b, ir)
           size    <- desiredSize(op, n)
-          fillers <- buildFillers(integer_of_int(size).toInt, inner, ir)
+          fillers <- buildFillers(size.toInt, inner, ir)
         yield List(ListOfSize(field, fillers))
 
       case _ => None
@@ -1264,9 +1264,9 @@ object Behavioral:
       case _      => 0
 
     private def numericLiteralPy(e: expr_full): Option[String] = e match
-      case IntLitF(int_of_integer(v), _) => Some(v.toString)
-      case FloatLitF(v, _)               => Some(v.toString)
-      case _                             => None
+      case IntLitF(v, _)   => Some(v.toString)
+      case FloatLitF(v, _) => Some(v.toString)
+      case _               => None
 
     private def literalForElementType(
         lit: expr_full,
@@ -1275,11 +1275,11 @@ object Behavioral:
     ): Option[String] =
       val _ = inner
       lit match
-        case StringLitF(s, _)              => Some(ExprToPython.pyString(s))
-        case IntLitF(int_of_integer(v), _) => Some(v.toString)
-        case FloatLitF(v, _)               => Some(v.toString)
-        case BoolLitF(v, _)                => Some(if v then "True" else "False")
-        case EnumAccessF(_, member, _)     => Some(ExprToPython.pyString(member))
+        case StringLitF(s, _)          => Some(ExprToPython.pyString(s))
+        case IntLitF(v, _)             => Some(v.toString)
+        case FloatLitF(v, _)           => Some(v.toString)
+        case BoolLitF(v, _)            => Some(if v then "True" else "False")
+        case EnumAccessF(_, member, _) => Some(ExprToPython.pyString(member))
         case IdentifierF(name, _) =>
           val enumNames = ir.d.collect { case _e: EnumDeclFull => _e.b }.flatten.toSet
           if enumNames.contains(name) then Some(ExprToPython.pyString(name))
@@ -1293,11 +1293,11 @@ object Behavioral:
           val enumNames = ir.d.collect { case _e: EnumDeclFull => _e.b }.flatten.toSet
           if enumNames.contains(name) then Some(ExprToPython.pyString(name))
           else None
-        case StringLitF(s, _)              => Some(ExprToPython.pyString(s))
-        case IntLitF(int_of_integer(v), _) => Some(v.toString)
-        case BoolLitF(v, _)                => Some(if v then "True" else "False")
-        case FloatLitF(v, _)               => Some(v.toString)
-        case _                             => None
+        case StringLitF(s, _) => Some(ExprToPython.pyString(s))
+        case IntLitF(v, _)    => Some(v.toString)
+        case BoolLitF(v, _)   => Some(if v then "True" else "False")
+        case FloatLitF(v, _)  => Some(v.toString)
+        case _                => None
 
     private def notNoneAnchorFor(f: FieldDeclFull, ir: ServiceIRFull): Option[String] =
       val inner = f.b match

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -50,7 +50,7 @@ object ExprToPython extends ExprBackend:
 
   def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
     case BoolLitF(v, _)   => Translated.Emit(if v then "True" else "False")
-    case IntLitF(n, _)    => Translated.Emit(integer_of_int(n).toString)
+    case IntLitF(n, _)    => Translated.Emit(n.toString)
     case FloatLitF(d, _)  => Translated.Emit(d.toString)
     case StringLitF(s, _) => Translated.Emit(pyString(s))
     case NoneLitF(_)      => Translated.Emit("None")

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -105,7 +105,7 @@ object GoExprBackend extends ExprBackend:
 
   def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
     case BoolLitF(v, _)   => Translated.Emit(if v then "true" else "false")
-    case IntLitF(n, _)    => Translated.Emit(s"int64(${integer_of_int(n).toString})")
+    case IntLitF(n, _)    => Translated.Emit(s"int64($n)")
     case FloatLitF(d, _)  => Translated.Emit(d.toString)
     case StringLitF(s, _) => Translated.Emit(GoLit.str(s))
     case NoneLitF(_)      => Translated.Emit("nil")

--- a/modules/testgen/src/main/scala/specrest/testgen/GoRapidStrategy.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoRapidStrategy.scala
@@ -3,7 +3,6 @@ package specrest.testgen
 import specrest.ir.generated.SpecRestGenerated.IntConstraint
 import specrest.ir.generated.SpecRestGenerated.StringConstraint
 import specrest.ir.generated.SpecRestGenerated.int_constraint
-import specrest.ir.generated.SpecRestGenerated.integer_of_int
 import specrest.ir.generated.SpecRestGenerated.string_constraint
 
 object GoRapidStrategy extends StrategyBackend:
@@ -39,8 +38,8 @@ object GoRapidStrategy extends StrategyBackend:
 
   def constrainedString(c: string_constraint): String = c match
     case StringConstraint(minOpt, maxOpt, regexes, predicateHelpers, _) =>
-      val minSize = minOpt.map(integer_of_int(_).toInt)
-      val maxSize = maxOpt.map(integer_of_int(_).toInt)
+      val minSize = minOpt.map(_.toInt)
+      val maxSize = maxOpt.map(_.toInt)
       val (primaryRegex, extraRegexes) = regexes match
         case head :: tail => (Some(head), tail)
         case Nil          => (None, Nil)
@@ -62,7 +61,7 @@ object GoRapidStrategy extends StrategyBackend:
 
   def constrainedInt(c: int_constraint): String = c match
     case IntConstraint(minOpt, maxOpt, _) =>
-      (minOpt.map(integer_of_int(_).toLong), maxOpt.map(integer_of_int(_).toLong)) match
+      (minOpt.map(_.toLong), maxOpt.map(_.toLong)) match
         case (Some(lo), Some(hi)) => s"genIntRange($lo, $hi)"
         case (Some(lo), None)     => s"genIntMin($lo)"
         case (None, Some(hi))     => s"genIntMax($hi)"

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -61,7 +61,7 @@ object TsExprBackend extends ExprBackend:
 
   def translate(expr: expr_full, ctx: TestCtx): Translated = expr match
     case BoolLitF(v, _)   => Translated.Emit(if v then "true" else "false")
-    case IntLitF(n, _)    => Translated.Emit(integer_of_int(n).toString)
+    case IntLitF(n, _)    => Translated.Emit(n.toString)
     case FloatLitF(d, _)  => Translated.Emit(d.toString)
     case StringLitF(s, _) => Translated.Emit(TsLit.str(s))
     case NoneLitF(_)      => Translated.Emit("null")

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -20,8 +20,8 @@ class BackendTest extends CatsEffectSuite:
       extras: List[String] = Nil
   ): int_constraint =
     IntConstraint(
-      min.map(l => int_of_integer(BigInt(l))),
-      max.map(l => int_of_integer(BigInt(l))),
+      min.map(l => BigInt(l)),
+      max.map(l => BigInt(l)),
       extras
     )
 
@@ -33,8 +33,8 @@ class BackendTest extends CatsEffectSuite:
       extras: List[String] = Nil
   ): string_constraint =
     StringConstraint(
-      min.map(l => int_of_integer(BigInt(l))),
-      max.map(l => int_of_integer(BigInt(l))),
+      min.map(l => BigInt(l)),
+      max.map(l => BigInt(l)),
       regexes,
       preds,
       extras
@@ -112,7 +112,7 @@ class BackendTest extends CatsEffectSuite:
       unbackedStateFields = unbacked
     )
 
-  private def i1(n: Int): expr_full = IntLitF(int_of_integer(BigInt(n)), None)
+  private def i1(n: Int): expr_full = IntLitF(BigInt(n), None)
   private def pyText(e: expr_full, c: TestCtx): String = ExprToPython.translate(e, c) match
     case Translated.Emit(t)    => t
     case Translated.Skip(r, _) => s"<skip:$r>"

--- a/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/ExprToPythonTest.scala
@@ -5,7 +5,7 @@ import specrest.ir.generated.SpecRestGenerated.*
 
 class ExprToPythonTest extends CatsEffectSuite:
 
-  private def i(n: Int): expr_full        = IntLitF(int_of_integer(BigInt(n)), None)
+  private def i(n: Int): expr_full        = IntLitF(BigInt(n), None)
   private def s(t: String): expr_full     = StringLitF(t, None)
   private def b(v: Boolean): expr_full    = BoolLitF(v, None)
   private def id(name: String): expr_full = IdentifierF(name, None)

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -728,7 +728,7 @@ class StatefulTest extends CatsEffectSuite:
     val arg = BinaryOpF(
       BGt(),
       IdentifierF("counter", None),
-      IntLitF(int_of_integer(BigInt(0)), None),
+      IntLitF(BigInt(0), None),
       None
     )
     val ir = serviceWithTemporals(
@@ -752,7 +752,7 @@ class StatefulTest extends CatsEffectSuite:
     val arg = BinaryOpF(
       BGt(),
       IdentifierF("counter", None),
-      IntLitF(int_of_integer(BigInt(10)), None),
+      IntLitF(BigInt(10), None),
       None
     )
     val ir = serviceWithTemporals(

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -23,7 +23,7 @@ class StrategiesTest extends CatsEffectSuite:
   private def ident(n: String): IdentifierF  = IdentifierF(n, None)
   private def boolL(b: Boolean): BoolLitF    = BoolLitF(b, None)
   private def stringL(s: String): StringLitF = StringLitF(s, None)
-  private def intL(n: Int): IntLitF          = IntLitF(int_of_integer(BigInt(n)), None)
+  private def intL(n: Int): IntLitF          = IntLitF(BigInt(n), None)
   private def alias(
       name: String,
       t: type_expr_full,

--- a/modules/testgen/src/test/scala/specrest/testgen/TemplatesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TemplatesTest.scala
@@ -18,7 +18,7 @@ class TemplatesTest extends CatsEffectSuite:
 
   private def named(t: String): NamedTypeF  = NamedTypeF(t, None)
   private def ident(n: String): IdentifierF = IdentifierF(n, None)
-  private def intL(n: Int): IntLitF         = IntLitF(int_of_integer(BigInt(n)), None)
+  private def intL(n: Int): IntLitF         = IntLitF(BigInt(n), None)
   private def boolL(b: Boolean): BoolLitF   = BoolLitF(b, None)
   private def paramD(name: String, t: type_expr_full): ParamDeclFull =
     ParamDeclFull(name, t, None)

--- a/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Diagnostic.scala
@@ -226,4 +226,4 @@ object Diagnostic:
     s"$loc: $levelWord: ${diag.message}"
 
   private def formatLocation(specFile: String, span: span_t): String =
-    span match { case SpanT(int_of_integer(a), int_of_integer(b), _, _) => s"$specFile:$a:$b" }
+    span match { case SpanT(a, b, _, _) => s"$specFile:$a:$b" }

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -23,10 +23,10 @@ object IrValueDecoder:
           case _       => None
       case Z3Sort.Int =>
         NegNumRe.findFirstMatchIn(raw) match
-          case Some(m) => Some(VInt(int_of_integer(BigInt(s"-${m.group(1)}"))))
+          case Some(m) => Some(VInt(BigInt(s"-${m.group(1)}")))
           case None =>
             if PlainIntRe.matches(raw) then
-              scala.util.Try(BigInt(raw)).toOption.map(b => VInt(int_of_integer(b)))
+              scala.util.Try(BigInt(raw)).toOption.map(b => VInt(b))
             else None
       case Z3Sort.Uninterp(_) =>
         rawToLabel.get(raw) match

--- a/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
+++ b/modules/verify/src/main/scala/specrest/verify/JsonReport.scala
@@ -50,12 +50,12 @@ object JsonReport:
     )
 
   private def spanJson(s: span_t): Json = s match
-    case SpanT(int_of_integer(a), int_of_integer(b), int_of_integer(c), int_of_integer(d)) =>
+    case SpanT(a, b, c, d) =>
       Json.obj(
-        "startLine" -> Json.fromInt(a.toInt),
-        "startCol"  -> Json.fromInt(b.toInt),
-        "endLine"   -> Json.fromInt(c.toInt),
-        "endCol"    -> Json.fromInt(d.toInt)
+        "startLine" -> Json.fromBigInt(a),
+        "startCol"  -> Json.fromBigInt(b),
+        "endLine"   -> Json.fromBigInt(c),
+        "endCol"    -> Json.fromBigInt(d)
       )
 
   private def relatedSpanJson(r: RelatedSpan): Json =

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -20,7 +20,7 @@ object Narration:
   )
 
   private def spanLine(s: span_t): Long = s match
-    case SpanT(int_of_integer(a), _, _, _) => a.toLong
+    case SpanT(a, _, _, _) => a.toLong
 
   def narrate(category: DiagnosticCategory, ctx: Context): Option[String] =
     val raw = category match

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -254,7 +254,7 @@ object Translator:
       renderExpr(ctx.copy(currentStateSig = ctx.postStateSig), inner)
     case PreF(inner, _) =>
       renderExpr(ctx.copy(currentStateSig = "State"), inner)
-    case IntLitF(int_of_integer(v), _) => v.toString
+    case IntLitF(v, _) => v.toString
     case BoolLitF(v, _) =>
       if v then "(True = True)" else "(True = False)"
     case StringLitF(s, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -197,7 +197,7 @@ private object Backend:
           val rendered = args.map(a => renderExpr(rctx, a)).toArray
           decl.asInstanceOf[FuncDecl[Sort]]
             .apply(rendered.asInstanceOf[Array[Z3AstExpr[Sort]]]*)
-    case Z3Expr.IntLit(v, _)  => rctx.ctx.mkInt(v)
+    case Z3Expr.IntLit(v, _)  => rctx.ctx.mkInt(v.toString)
     case Z3Expr.BoolLit(v, _) => rctx.ctx.mkBool(v)
     case Z3Expr.And(args, _)  => rctx.ctx.mkAnd(args.map(a => renderBool(rctx, a))*)
     case Z3Expr.Or(args, _)   => rctx.ctx.mkOr(args.map(a => renderBool(rctx, a))*)

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -39,7 +39,7 @@ object SmtLib:
       if args.isEmpty then func
       else s"($func ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.IntLit(v, _) =>
-      if v < 0 then s"(- ${-v})" else v.toString
+      if v.signum < 0 then s"(- ${-v})" else v.toString
     case Z3Expr.BoolLit(v, _) =>
       if v then "true" else "false"
     case Z3Expr.And(args, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -600,18 +600,18 @@ object Translator:
       expr: expr_full,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr = expr match
-    case IntLitF(int_of_integer(v), _) => Z3Expr.IntLit(v.toLong)
-    case BoolLitF(v, _)                => Z3Expr.BoolLit(v)
-    case StringLitF(v, _)              => stringLiteralConst(ctx, v)
-    case IdentifierF(name, _)          => resolveIdentifier(ctx, name, env)
-    case BinaryOpF(op, l, r, _)        => translateBinaryOp(ctx, op, l, r, env)
-    case u @ UnaryOpF(_, _, _)         => translateUnaryOp(ctx, u, env)
-    case q @ QuantifierF(_, _, _, _)   => translateQuantifier(ctx, q, env)
-    case f @ FieldAccessF(_, _, _)     => translateFieldAccess(ctx, f, env)
-    case i @ IndexF(_, _, _)           => translateIndex(ctx, i, env)
-    case c @ CallF(_, _, _)            => translateCall(ctx, c, env)
-    case m @ MatchesF(_, _, _)         => translateMatches(ctx, m, env)
-    case e @ EnumAccessF(_, _, _)      => translateEnumAccess(ctx, e)
+    case IntLitF(v, _)               => Z3Expr.IntLit(v)
+    case BoolLitF(v, _)              => Z3Expr.BoolLit(v)
+    case StringLitF(v, _)            => stringLiteralConst(ctx, v)
+    case IdentifierF(name, _)        => resolveIdentifier(ctx, name, env)
+    case BinaryOpF(op, l, r, _)      => translateBinaryOp(ctx, op, l, r, env)
+    case u @ UnaryOpF(_, _, _)       => translateUnaryOp(ctx, u, env)
+    case q @ QuantifierF(_, _, _, _) => translateQuantifier(ctx, q, env)
+    case f @ FieldAccessF(_, _, _)   => translateFieldAccess(ctx, f, env)
+    case i @ IndexF(_, _, _)         => translateIndex(ctx, i, env)
+    case c @ CallF(_, _, _)          => translateCall(ctx, c, env)
+    case m @ MatchesF(_, _, _)       => translateMatches(ctx, m, env)
+    case e @ EnumAccessF(_, _, _)    => translateEnumAccess(ctx, e)
     case PrimeF(inner, _) =>
       withStateMode(ctx, StateMode.Post, () => translateExpr(ctx, inner, env))
     case PreF(inner, _) =>
@@ -881,7 +881,7 @@ object Translator:
   ): Z3Expr = expr.a match
     case UNot() => Z3Expr.Not(translateExpr(ctx, expr.b, env))
     case UNegate() =>
-      Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(0), translateExpr(ctx, expr.b, env)))
+      Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), translateExpr(ctx, expr.b, env)))
     case UCardinality() => translateCardinality(ctx, expr.b)
     case UPower() =>
       fail(
@@ -913,7 +913,7 @@ object Translator:
           ctx.assertions += Z3Expr.Cmp(
             CmpOp.Ge,
             Z3Expr.App(funcName, Nil),
-            Z3Expr.IntLit(0)
+            Z3Expr.IntLit(BigInt(0))
           )
         Z3Expr.App(funcName, Nil)
       case _ =>
@@ -1698,7 +1698,7 @@ object Translator:
             Z3Expr.App(postCardName, Nil),
             Z3Expr.Arith(
               ArithOp.Sub,
-              List(Z3Expr.App(preCardName, Nil), Z3Expr.IntLit(analysis.removedKeys.length.toLong))
+              List(Z3Expr.App(preCardName, Nil), Z3Expr.IntLit(BigInt(analysis.removedKeys.length)))
             )
           )
     else if analysis.removedKeys.isEmpty && analysis.fieldUpdatedKeys.nonEmpty then
@@ -1772,7 +1772,7 @@ object Translator:
       ctx.assertions += Z3Expr.Cmp(
         CmpOp.Ge,
         Z3Expr.App(funcName, Nil),
-        Z3Expr.IntLit(0)
+        Z3Expr.IntLit(BigInt(0))
       )
 
   private def synthesizeCardinalityAxioms(
@@ -1797,7 +1797,7 @@ object Translator:
                 else
                   Z3Expr.Arith(
                     if delta > 0 then ArithOp.Add else ArithOp.Sub,
-                    List(preRef, Z3Expr.IntLit(math.abs(delta).toLong))
+                    List(preRef, Z3Expr.IntLit(BigInt(math.abs(delta))))
                   )
               ctx.assertions += Z3Expr.Cmp(CmpOp.Eq, postRef, rhs)
           case _ => ()
@@ -1895,9 +1895,9 @@ object Translator:
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
     term match
-      case BLit(b)                 => Z3Expr.BoolLit(b)
-      case ILit(int_of_integer(n)) => Z3Expr.IntLit(n.toLong)
-      case TVar(name)              => resolveIdentifier(ctx, name, env)
+      case BLit(b)    => Z3Expr.BoolLit(b)
+      case ILit(n)    => Z3Expr.IntLit(n)
+      case TVar(name) => resolveIdentifier(ctx, name, env)
       case EnumElemConst(en, mem) =>
         val funcName = s"${en}_$mem"
         if !ctx.funcs.contains(funcName) then
@@ -1924,7 +1924,7 @@ object Translator:
       case TLt(l, r) =>
         Z3Expr.Cmp(CmpOp.Lt, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
       case TNeg(t) =>
-        Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(0), encodeFromSmtTerm(ctx, t, env)))
+        Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), encodeFromSmtTerm(ctx, t, env)))
       case TAdd(l, r) =>
         Z3Expr.Arith(
           ArithOp.Add,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -66,7 +66,7 @@ object SetOpKind:
 enum Z3Expr derives CanEqual:
   case Var(name: String, sort: Z3Sort, span: Option[span_t] = None)
   case App(func: String, args: List[Z3Expr], span: Option[span_t] = None)
-  case IntLit(value: Long, span: Option[span_t] = None)
+  case IntLit(value: BigInt, span: Option[span_t] = None)
   case BoolLit(value: Boolean, span: Option[span_t] = None)
   case And(args: List[Z3Expr], span: Option[span_t] = None)
   case Or(args: List[Z3Expr], span: Option[span_t] = None)

--- a/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
@@ -7,7 +7,7 @@ class CheckValueHasTyTest extends CatsEffectSuite:
 
   private val schemaOpt: Option[span_t] = None
 
-  private def mkInt(n: Int): int_of_integer = int_of_integer(BigInt(n))
+  private def mkInt(n: Int): BigInt = BigInt(n)
 
   private val orderEntity = EntityDeclFull(
     "Order",
@@ -50,7 +50,7 @@ class CheckValueHasTyTest extends CatsEffectSuite:
 
   test("check_value_has_ty accepts the primitive shapes"):
     assert(check_value_has_ty(ctx, VBool(true), TBool()))
-    assert(check_value_has_ty(ctx, VInt(int_of_integer(BigInt(42))), TInt()))
+    assert(check_value_has_ty(ctx, VInt(BigInt(42)), TInt()))
     assert(check_value_has_ty(ctx, VEnum("Status", "Open"), TEnum("Status")))
     assert(check_value_has_ty(ctx, VEntity("Order", "0"), TEntity("Order")))
 

--- a/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
@@ -4,7 +4,7 @@ import specrest.ir.generated.SpecRestGenerated.*
 
 class ClassifierTest extends munit.CatsEffectSuite:
 
-  private def intLit(n: Long): expr_full = IntLitF(int_of_integer(BigInt(n)), None)
+  private def intLit(n: Long): expr_full = IntLitF(BigInt(n), None)
   private def id(s: String): expr_full   = IdentifierF(s, None)
   private def bb(v: Boolean): expr_full  = BoolLitF(v, None)
 

--- a/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
@@ -8,7 +8,7 @@ class TrustTest extends CatsEffectSuite:
   private val enums: List[String] = List("Color", "Status")
 
   private def lit(b: Boolean): expr_full = BoolLitF(b, None)
-  private def i(n: Int): expr_full       = IntLitF(int_of_integer(BigInt(n)), None)
+  private def i(n: Int): expr_full       = IntLitF(BigInt(n), None)
   private def id(s: String): expr_full   = IdentifierF(s, None)
 
   private val classifyCases: List[(String, expr_full, TrustLevel)] = List(

--- a/modules/verify/src/test/scala/specrest/verify/cert/generated/A8RoundTripOracleTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/generated/A8RoundTripOracleTest.scala
@@ -24,20 +24,20 @@ class A8RoundTripOracleTest extends FunSuite:
   test("A8: extracted translate produces shape-correct SmtTerm headers"):
     val cases: List[(expr_full, String)] = List(
       BoolLitF(true, None)                                                 -> "BLit(true)",
-      IntLitF(int_of_integer(BigInt(7)), None)                             -> "ILit(int_of_integer(",
+      IntLitF(BigInt(7), None)                                             -> "ILit(",
       IdentifierF("foo", None)                                             -> "TVar(foo)",
       UnaryOpF(UNot(), BoolLitF(true, None), None)                         -> "TNot(",
       BinaryOpF(BAnd(), BoolLitF(true, None), BoolLitF(false, None), None) -> "TAnd(",
       BinaryOpF(
         BAdd(),
-        IntLitF(int_of_integer(BigInt(1)), None),
-        IntLitF(int_of_integer(BigInt(2)), None),
+        IntLitF(BigInt(1), None),
+        IntLitF(BigInt(2), None),
         None
       ) -> "TAdd(",
       BinaryOpF(
         BLt(),
-        IntLitF(int_of_integer(BigInt(1)), None),
-        IntLitF(int_of_integer(BigInt(2)), None),
+        IntLitF(BigInt(1), None),
+        IntLitF(BigInt(2), None),
         None
       ) -> "TLt("
     )
@@ -81,10 +81,10 @@ object SpecRestGeneratedTestProbes:
 
   val allProbes: List[(String, expr_full)] = List(
     "BoolLit"             -> BoolLitF(true, None),
-    "IntLit"              -> IntLitF(int_of_integer(BigInt(42)), None),
+    "IntLit"              -> IntLitF(BigInt(42), None),
     "Identifier"          -> IdentifierF("x", None),
     "UnaryOp.Not"         -> UnaryOpF(UNot(), BoolLitF(true, None), None),
-    "UnaryOp.Negate"      -> UnaryOpF(UNegate(), IntLitF(int_of_integer(BigInt(1)), None), None),
+    "UnaryOp.Negate"      -> UnaryOpF(UNegate(), IntLitF(BigInt(1), None), None),
     "UnaryOp.Cardinality" -> UnaryOpF(UCardinality(), IdentifierF("rel", None), None),
     "BinaryOp.And"        -> BinaryOpF(BAnd(), BoolLitF(true, None), BoolLitF(false, None), None),
     "BinaryOp.Or"         -> BinaryOpF(BOr(), BoolLitF(true, None), BoolLitF(false, None), None),
@@ -92,43 +92,43 @@ object SpecRestGeneratedTestProbes:
     "BinaryOp.Iff"        -> BinaryOpF(BIff(), BoolLitF(true, None), BoolLitF(false, None), None),
     "BinaryOp.Eq" -> BinaryOpF(
       BEq(),
-      IntLitF(int_of_integer(BigInt(1)), None),
-      IntLitF(int_of_integer(BigInt(2)), None),
+      IntLitF(BigInt(1), None),
+      IntLitF(BigInt(2), None),
       None
     ),
     "BinaryOp.Lt" -> BinaryOpF(
       BLt(),
-      IntLitF(int_of_integer(BigInt(1)), None),
-      IntLitF(int_of_integer(BigInt(2)), None),
+      IntLitF(BigInt(1), None),
+      IntLitF(BigInt(2), None),
       None
     ),
     "BinaryOp.Ge" -> BinaryOpF(
       BGe(),
-      IntLitF(int_of_integer(BigInt(1)), None),
-      IntLitF(int_of_integer(BigInt(2)), None),
+      IntLitF(BigInt(1), None),
+      IntLitF(BigInt(2), None),
       None
     ),
     "BinaryOp.Add" -> BinaryOpF(
       BAdd(),
-      IntLitF(int_of_integer(BigInt(1)), None),
-      IntLitF(int_of_integer(BigInt(2)), None),
+      IntLitF(BigInt(1), None),
+      IntLitF(BigInt(2), None),
       None
     ),
     "BinaryOp.In" -> BinaryOpF(BIn(), IdentifierF("v", None), IdentifierF("rel", None), None),
-    "Let"         -> LetF("x", IntLitF(int_of_integer(BigInt(1)), None), IdentifierF("x", None), None),
+    "Let"         -> LetF("x", IntLitF(BigInt(1), None), IdentifierF("x", None), None),
     "EnumAccess"  -> EnumAccessF(IdentifierF("Color", None), "Red", None),
     "Prime"       -> PrimeF(IdentifierF("count", None), None),
     "Pre"         -> PreF(IdentifierF("count", None), None),
     "FieldAccess" -> FieldAccessF(IdentifierF("u", None), "name", None),
-    "Index"       -> IndexF(IdentifierF("arr", None), IntLitF(int_of_integer(BigInt(0)), None), None),
+    "Index"       -> IndexF(IdentifierF("arr", None), IntLitF(BigInt(0), None), None),
     "Index.Pre" -> IndexF(
       PreF(IdentifierF("arr", None), None),
-      IntLitF(int_of_integer(BigInt(0)), None),
+      IntLitF(BigInt(0), None),
       None
     ),
     "Index.Prime" -> IndexF(
       PrimeF(IdentifierF("arr", None), None),
-      IntLitF(int_of_integer(BigInt(0)), None),
+      IntLitF(BigInt(0), None),
       None
     ),
     "Quantifier.All.enum" -> QuantifierF(

--- a/modules/verify/src/test/scala/specrest/verify/cert/generated/SpecRestGeneratedTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/cert/generated/SpecRestGeneratedTest.scala
@@ -43,24 +43,24 @@ class SpecRestGeneratedTest extends FunSuite:
   test("extracted translate covers all 23 expr cases (smoke)"):
     val probes: List[G.expr] = List(
       G.BoolLit(true, None),
-      G.IntLit(G.int_of_integer(BigInt(0)), None),
+      G.IntLit(BigInt(0), None),
       G.Ident("x", None),
       G.UnNot(G.BoolLit(true, None), None),
-      G.UnNeg(G.IntLit(G.int_of_integer(BigInt(0)), None), None),
+      G.UnNeg(G.IntLit(BigInt(0), None), None),
       G.BoolBin(G.AndOp(), G.BoolLit(true, None), G.BoolLit(false, None), None),
       G.Arith(
         G.AddOp(),
-        G.IntLit(G.int_of_integer(BigInt(1)), None),
-        G.IntLit(G.int_of_integer(BigInt(2)), None),
+        G.IntLit(BigInt(1), None),
+        G.IntLit(BigInt(2), None),
         None
       ),
       G.Cmp(
         G.LtOp(),
-        G.IntLit(G.int_of_integer(BigInt(1)), None),
-        G.IntLit(G.int_of_integer(BigInt(2)), None),
+        G.IntLit(BigInt(1), None),
+        G.IntLit(BigInt(2), None),
         None
       ),
-      G.LetIn("x", G.IntLit(G.int_of_integer(BigInt(0)), None), G.Ident("x", None), None),
+      G.LetIn("x", G.IntLit(BigInt(0), None), G.Ident("x", None), None),
       G.EnumAccess("Color", "Red", None),
       G.Member(G.Ident("u", None), "users", None),
       G.ForallEnum("c", "Color", G.BoolLit(true, None), None),

--- a/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/certificates/UnsatCoreTest.scala
@@ -28,7 +28,7 @@ class UnsatCoreTest extends CatsEffectSuite:
         cs.span match
           case SpanT(line, _, _, _) =>
             assert(
-              BigInt(1) <= integer_of_int(line),
+              BigInt(1) <= line,
               s"invalid span line: ${cs.span}"
             )
 
@@ -55,7 +55,7 @@ class UnsatCoreTest extends CatsEffectSuite:
       )
       val lines = core.map: cs =>
         cs.span match
-          case SpanT(l, _, _, _) => integer_of_int(l)
+          case SpanT(l, _, _, _) => l
       .toSet
       assert(
         lines.subsetOf(Set(BigInt(10), BigInt(13))),

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -41,7 +41,7 @@ class BackendTest extends CatsEffectSuite:
       sorts = Nil,
       funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
       assertions = List(
-        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(0))
+        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(BigInt(0)))
       ),
       artifact = emptyArtifact
     )
@@ -52,8 +52,8 @@ class BackendTest extends CatsEffectSuite:
       sorts = Nil,
       funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
       assertions = List(
-        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(10)),
-        Z3Expr.Cmp(CmpOp.Le, Z3Expr.App("x", Nil), Z3Expr.IntLit(5))
+        Z3Expr.Cmp(CmpOp.Ge, Z3Expr.App("x", Nil), Z3Expr.IntLit(BigInt(10))),
+        Z3Expr.Cmp(CmpOp.Le, Z3Expr.App("x", Nil), Z3Expr.IntLit(BigInt(5)))
       ),
       artifact = emptyArtifact
     )
@@ -73,10 +73,13 @@ class BackendTest extends CatsEffectSuite:
       sorts = Nil,
       funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
       assertions = List(
-        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(3)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(BigInt(3))),
         Z3Expr.SetMember(
           Z3Expr.App("x", Nil),
-          Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+          Z3Expr.SetLit(
+            Z3Sort.Int,
+            List(Z3Expr.IntLit(BigInt(1)), Z3Expr.IntLit(BigInt(2)), Z3Expr.IntLit(BigInt(3)))
+          )
         )
       ),
       artifact = emptyArtifact
@@ -88,10 +91,13 @@ class BackendTest extends CatsEffectSuite:
       sorts = Nil,
       funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Int)),
       assertions = List(
-        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(4)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.IntLit(BigInt(4))),
         Z3Expr.SetMember(
           Z3Expr.App("x", Nil),
-          Z3Expr.SetLit(Z3Sort.Int, List(Z3Expr.IntLit(1), Z3Expr.IntLit(2), Z3Expr.IntLit(3)))
+          Z3Expr.SetLit(
+            Z3Sort.Int,
+            List(Z3Expr.IntLit(BigInt(1)), Z3Expr.IntLit(BigInt(2)), Z3Expr.IntLit(BigInt(3)))
+          )
         )
       ),
       artifact = emptyArtifact

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
@@ -35,7 +35,7 @@ class SmtLibRenderTest extends munit.CatsEffectSuite:
           Z3Expr.Cmp(
             CmpOp.Ge,
             Z3Expr.App("age", List(Z3Expr.Var("u", userSort))),
-            Z3Expr.IntLit(0)
+            Z3Expr.IntLit(BigInt(0))
           )
         )
       ),
@@ -49,8 +49,8 @@ class SmtLibRenderTest extends munit.CatsEffectSuite:
 
   test("renderExpr covers every Z3Expr kind"):
     import Z3Expr.*
-    assertEquals(SmtLib.renderExpr(IntLit(42)), "42")
-    assertEquals(SmtLib.renderExpr(IntLit(-7)), "(- 7)")
+    assertEquals(SmtLib.renderExpr(IntLit(BigInt(42))), "42")
+    assertEquals(SmtLib.renderExpr(IntLit(BigInt(-7))), "(- 7)")
     assertEquals(SmtLib.renderExpr(BoolLit(true)), "true")
     assertEquals(SmtLib.renderExpr(BoolLit(false)), "false")
     assertEquals(SmtLib.renderExpr(And(Nil)), "true")
@@ -66,19 +66,22 @@ class SmtLibRenderTest extends munit.CatsEffectSuite:
       "(=> true false)"
     )
     assertEquals(
-      SmtLib.renderExpr(Cmp(CmpOp.Eq, IntLit(1), IntLit(2))),
+      SmtLib.renderExpr(Cmp(CmpOp.Eq, IntLit(BigInt(1)), IntLit(BigInt(2)))),
       "(= 1 2)"
     )
     assertEquals(
-      SmtLib.renderExpr(Cmp(CmpOp.Neq, IntLit(1), IntLit(2))),
+      SmtLib.renderExpr(Cmp(CmpOp.Neq, IntLit(BigInt(1)), IntLit(BigInt(2)))),
       "(distinct 1 2)"
     )
     assertEquals(
-      SmtLib.renderExpr(Arith(ArithOp.Add, List(IntLit(1), IntLit(2), IntLit(3)))),
+      SmtLib.renderExpr(Arith(
+        ArithOp.Add,
+        List(IntLit(BigInt(1)), IntLit(BigInt(2)), IntLit(BigInt(3)))
+      )),
       "(+ 1 2 3)"
     )
     assertEquals(SmtLib.renderExpr(App("foo", Nil)), "foo")
-    assertEquals(SmtLib.renderExpr(App("foo", List(IntLit(5)))), "(foo 5)")
+    assertEquals(SmtLib.renderExpr(App("foo", List(IntLit(BigInt(5))))), "(foo 5)")
 
   test("renderSort(SetOf) nests and renders (Set T)"):
     val intSet    = Z3Sort.SetOf(Z3Sort.Int)
@@ -103,12 +106,12 @@ class SmtLibRenderTest extends munit.CatsEffectSuite:
       "((as const (Set Int)) false)"
     )
     assertEquals(
-      SmtLib.renderExpr(SetLit(Z3Sort.Int, List(IntLit(1), IntLit(2)))),
+      SmtLib.renderExpr(SetLit(Z3Sort.Int, List(IntLit(BigInt(1)), IntLit(BigInt(2))))),
       "(store (store ((as const (Set Int)) false) 1 true) 2 true)"
     )
     val s = App("s", Nil)
     val t = App("t", Nil)
-    assertEquals(SmtLib.renderExpr(SetMember(IntLit(3), s)), "(select s 3)")
+    assertEquals(SmtLib.renderExpr(SetMember(IntLit(BigInt(3)), s)), "(select s 3)")
     assertEquals(
       SmtLib.renderExpr(SetBinOp(SetOpKind.Union, s, t)),
       "(union s t)"

--- a/proofs/isabelle/SpecRest/Codegen.thy
+++ b/proofs/isabelle/SpecRest/Codegen.thy
@@ -95,6 +95,21 @@ text \<open>Type and constructor names follow Isabelle convention: lowercase \<o
   and the hand-written ones are \<open>TriggerAggregate\<close>/\<open>MigrationOp\<close>. A follow-up
   PR that retires the hand-written enums can re-introduce PascalCase renames here.\<close>
 
+text \<open>Emit \<open>int\<close> directly as Scala \<open>BigInt\<close> instead of the \<open>Code_Target_Int\<close>
+  wrapper \<open>int_of_integer(BigInt)\<close>. \<open>integer\<close> is a \<open>typedef\<close> copy of \<open>int\<close>
+  (\<open>Code_Numeral\<close>) with \<open>int_of_integer\<close>/\<open>integer_of_int\<close> its proven-inverse
+  morphisms, and the imported \<open>Code_Target_Int\<close> already serializes \<open>integer\<close> to
+  \<open>BigInt\<close>. Collapsing \<open>int\<close> onto the same \<open>BigInt\<close> and printing the bijection as
+  identity removes both conversions everywhere — the verified \<open>plus_int\<close>/\<open>equal_int\<close>
+  code equations compose into native \<open>+\<close>/\<open>==\<close>. The \<open>ord\<close> instance for \<open>int\<close> is
+  dropped because it would otherwise be a second \<open>ord[BigInt]\<close> given alongside
+  \<open>integer\<close>'s; ordering resolves through the surviving \<open>ord_integer\<close>.\<close>
+code_printing
+  type_constructor Int.int \<rightharpoonup> (Scala) "BigInt"
+| constant Code_Numeral.int_of_integer \<rightharpoonup> (Scala) "(_)"
+| constant Code_Numeral.integer_of_int \<rightharpoonup> (Scala) "(_)"
+| class_instance Int.int :: ord \<rightharpoonup> (Scala) -
+
 export_code
     translate
     eval


### PR DESCRIPTION
## Summary
- Map HOL `int` directly to Scala `BigInt` in the Isabelle extraction via `Code_Target_Int` `code_printing` (4 lines in `Codegen.thy`): `type_constructor Int.int -> BigInt`, the `int_of_integer`/`integer_of_int` bijection printed as identity, and `int`'s redundant `ord` instance dropped. The verified `plus_int`/`equal_int`/... code equations compose straight into native `BigInt` arithmetic, so the generated `int_of_integer(BigInt)` wrapper disappears entirely.
- Migrate consumers off the wrapper: ~165 `int_of_integer(...)`/`integer_of_int(...)` calls unwrapped, type-position `int` -> `BigInt`, dead imports removed.
- Fix latent `Long`/`Int` truncation along the **whole** integer path so a spec literal `>= 2^63` stays faithful end-to-end:
  - parser: `BigInt(text)` instead of `BigInt(text.toLong)`
  - JSON codec (`Serialize`, `JsonReport`): encode/decode int values and spans as `BigInt`
  - Z3: widen `Z3Expr.IntLit` to `BigInt` and emit `ctx.mkInt(v.toString)`
- Streamline redundant recasts the change exposed (e.g. `${n.toString}`/`${n.toLong}` in interpolations).
- OpenAPI schema constraints (`minLength`/`maxItems`) intentionally keep `Int` — a legitimate external-format boundary.

### Soundness note
`integer` is a `typedef` copy of `int`; `Code_Target_Int` (already imported) already trusts `integer -> BigInt`. Collapsing `int` onto the same `BigInt` and printing the proven bijection as identity adds only trivially-auditable serialization rules — consistent with the existing `String.literal -> String` trust.

## Test plan
- [x] `isabelle build SpecRest` + extraction drift check (pre-commit hook) — generated file matches fresh extraction
- [x] `sbt compile` + `Test/compile` across all modules
- [x] Full `sbt test` green, incl. real-Z3 `BackendTest`, `SmtLibRenderTest`, JSON round-trip / A8 oracle
- [x] `scalafmtAll` + `scalafixAll` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map Isabelle HOL `int` directly to Scala `BigInt`, eliminating the `int_of_integer` wrapper and preserving arbitrary-precision integers end-to-end. Fixes prior truncation paths and simplifies consumers across parsing, JSON, and Z3.

- **Refactors**
  - Emit `int` as `BigInt` via `Code_Target_Int` `code_printing`; drop `int`’s redundant `ord` instance.
  - Remove ~165 `int_of_integer(...)`/`integer_of_int(...)` calls; update types and clean imports.
  - Streamline integer recasts; keep OpenAPI schema constraints using Scala `Int` by design.

- **Bug Fixes**
  - Prevent `Long`/`Int` truncation across the pipeline:
    - Parser uses `BigInt(text)`.
    - JSON encodes/decodes int values and spans as `BigInt`.
    - Widen `Z3Expr.IntLit` to `BigInt` and emit with `ctx.mkInt(v.toString)`.

<sup>Written for commit 4a4c53748cfeec3393fd032a2a633b1cb6cd815c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/358?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal numeric representation and handling for greater consistency across the verification engine, code generation, and specification parsing modules. Updated how integer values and source location coordinates are processed and tracked for enhanced reliability throughout the analysis pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->