### PR TITLE
Lift emitter decision-kernels into Isabelle (Category D, #361)

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/SensitiveFields.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/SensitiveFields.scala
@@ -1,21 +1,5 @@
 package specrest.codegen
 
 object SensitiveFields:
-  private val Exact: Set[String] = Set(
-    "password",
-    "password_hash",
-    "secret",
-    "token",
-    "api_key"
-  )
-
-  private val Suffixes: List[String] = List(
-    "_hash",
-    "_secret",
-    "_password",
-    "_api_key",
-    "_token"
-  )
-
   def isSensitive(name: String): Boolean =
-    Exact.contains(name) || Suffixes.exists(name.endsWith)
+    specrest.ir.generated.SpecRestGenerated.isSensitiveField(name)

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -1,7 +1,6 @@
 package specrest.codegen.openapi
 
 import specrest.codegen.OperationContext
-import specrest.codegen.SensitiveFields
 import specrest.convention.Naming
 import specrest.convention.ParamSpec
 import specrest.ir.PrettyPrint
@@ -177,65 +176,36 @@ object Schema:
 
 object Components:
 
-  final private case class DecoratedField(name: String, schema: SchemaObject, nullable: Boolean)
-
   def buildComponents(profiled: ProfiledService, ctx: BuildContext): ComponentsObject =
     val schemas = collection.mutable.LinkedHashMap.empty[String, SchemaObject]
     schemas("ErrorResponse") = errorResponseSchema
     for entity <- profiled.entities do
       ctx.entityDecls.get(entity.entityName).foreach: decl =>
         val decorated = decorateFields(entity, decl, ctx)
-        schemas(entity.createSchemaName) = createSchema(decorated, entity)
-        schemas(entity.readSchemaName) = readSchema(decorated, entity)
-        schemas(entity.updateSchemaName) = updateSchema(decorated, entity)
+        val (createL, (readL, updateL)) =
+          specrest.ir.generated.SpecRestGenerated.buildEntitySchemas(entity.entityName, decorated)
+        schemas(entity.createSchemaName) = SchemaObjectAdapter.fromLifted(createL)
+        schemas(entity.readSchemaName) = SchemaObjectAdapter.fromLifted(readL)
+        schemas(entity.updateSchemaName) = SchemaObjectAdapter.fromLifted(updateL)
     ComponentsObject(schemas.toMap)
 
   private def decorateFields(
       entity: ProfiledEntity,
       decl: EntityDeclFull,
       ctx: BuildContext
-  ): List[DecoratedField] =
+  ): List[(String, (schema_object, Boolean))] =
     val irFields = decl.c.collect { case f: FieldDeclFull => f }
     entity.fields.zipWithIndex.map: (profiledField, idx) =>
       irFields(idx) match
         case FieldDeclFull(_, irType, irConstraint, _) =>
-          val fs = Schema.fieldToSchema(irType, irConstraint, ctx)
-          DecoratedField(profiledField.columnName, fs.schema, fs.nullable)
-
-  private def nonIdFields(fs: List[DecoratedField]): List[DecoratedField] =
-    fs.filterNot(_.name == "id")
-
-  private def fieldProperty(f: DecoratedField): SchemaObject =
-    if f.nullable then Schema.makeNullable(f.schema) else f.schema
-
-  private def createSchema(fields: List[DecoratedField], entity: ProfiledEntity): SchemaObject =
-    val fs = nonIdFields(fields)
-    SchemaObject(
-      `type` = Some(List("object")),
-      description = Some(s"Create payload for ${entity.entityName}"),
-      required = Some(fs.filterNot(_.nullable).map(_.name)),
-      properties = Some(fs.map(f => f.name -> fieldProperty(f)).toMap)
-    )
-
-  private def readSchema(fields: List[DecoratedField], entity: ProfiledEntity): SchemaObject =
-    val fs    = nonIdFields(fields).filterNot(f => SensitiveFields.isSensitive(f.name))
-    val props = collection.mutable.LinkedHashMap.empty[String, SchemaObject]
-    props("id") = SchemaObject(`type` = Some(List("integer")))
-    for f <- fs do props(f.name) = fieldProperty(f)
-    SchemaObject(
-      `type` = Some(List("object")),
-      description = Some(s"Read view for ${entity.entityName}"),
-      required = Some("id" +: fs.filterNot(_.nullable).map(_.name)),
-      properties = Some(props.toMap)
-    )
-
-  private def updateSchema(fields: List[DecoratedField], entity: ProfiledEntity): SchemaObject =
-    val fs = nonIdFields(fields)
-    SchemaObject(
-      `type` = Some(List("object")),
-      description = Some(s"Update payload for ${entity.entityName}"),
-      properties = Some(fs.map(f => f.name -> Schema.makeNullable(f.schema)).toMap)
-    )
+          val (lifted, nullable) = specrest.ir.generated.SpecRestGenerated.fieldToSchema(
+            irType,
+            irConstraint,
+            ctx.aliasAList,
+            ctx.enumAList,
+            ctx.entityNamesList
+          )
+          (profiledField.columnName, (lifted, nullable))
 
   private def errorResponseSchema: SchemaObject =
     SchemaObject(

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -189,69 +189,10 @@ object Generator:
   private def renderEntityInvariant(ctx: Ctx, expr: expr_full, entityName: String)(using
       DafnyLabel
   ): String =
-    val rewritten = rewriteEntityFieldRefs(expr, ctx.ir, entityName)
+    val rewritten =
+      specrest.ir.generated.SpecRestGenerated
+        .rewriteEntityFieldRefs(entityFieldNames(ctx.ir.c, entityName), expr)
     renderExpr(ctx, rewritten)
-
-  private def rewriteEntityFieldRefs(
-      expr: expr_full,
-      ir: ServiceIRFull,
-      entityName: String
-  ): expr_full =
-    val fieldNames = entityFieldNames(ir.c, entityName).toSet
-    def go(e: expr_full, bound: Set[String]): expr_full = e match
-      case IdentifierF(n, sp) if fieldNames.contains(n) && !bound.contains(n) =>
-        FieldAccessF(IdentifierF("x", sp), n, sp)
-      case LetF(v, value, body, sp) =>
-        LetF(v, go(value, bound), go(body, bound + v), sp)
-      case LambdaF(p, body, sp) =>
-        LambdaF(p, go(body, bound + p), sp)
-      case QuantifierF(q, bs, body, sp) =>
-        val bsBound = bs.collect { case b: QuantifierBindingFull => b.a }.toSet
-        val bsRewritten = bs.map {
-          case QuantifierBindingFull(a, dom, kind, bsp) =>
-            QuantifierBindingFull(a, go(dom, bound), kind, bsp)
-        }
-        QuantifierF(q, bsRewritten, go(body, bound ++ bsBound), sp)
-      case SetComprehensionF(v, dom, pred, sp) =>
-        SetComprehensionF(v, go(dom, bound), go(pred, bound + v), sp)
-      case TheF(v, dom, body, sp) =>
-        TheF(v, go(dom, bound), go(body, bound + v), sp)
-      case BinaryOpF(op, l, r, sp) => BinaryOpF(op, go(l, bound), go(r, bound), sp)
-      case UnaryOpF(op, x, sp)     => UnaryOpF(op, go(x, bound), sp)
-      case FieldAccessF(b, f, sp)  => FieldAccessF(go(b, bound), f, sp)
-      case IndexF(b, i, sp)        => IndexF(go(b, bound), go(i, bound), sp)
-      case CallF(c, args, sp)      => CallF(go(c, bound), args.map(go(_, bound)), sp)
-      case PrimeF(x, sp)           => PrimeF(go(x, bound), sp)
-      case PreF(x, sp)             => PreF(go(x, bound), sp)
-      case IfF(c, t, el, sp)       => IfF(go(c, bound), go(t, bound), go(el, bound), sp)
-      case SomeWrapF(x, sp)        => SomeWrapF(go(x, bound), sp)
-      case ConstructorF(n, fs, sp) =>
-        ConstructorF(
-          n,
-          fs.map {
-            case FieldAssignFull(fn, v, fsp) => FieldAssignFull(fn, go(v, bound), fsp)
-          },
-          sp
-        )
-      case WithF(b, fs, sp) =>
-        WithF(
-          go(b, bound),
-          fs.map {
-            case FieldAssignFull(fn, v, fsp) => FieldAssignFull(fn, go(v, bound), fsp)
-          },
-          sp
-        )
-      case MapLiteralF(es, sp) =>
-        MapLiteralF(
-          es.map {
-            case MapEntryFull(k, v, esp) => MapEntryFull(go(k, bound), go(v, bound), esp)
-          },
-          sp
-        )
-      case SetLiteralF(es, sp) => SetLiteralF(es.map(go(_, bound)), sp)
-      case SeqLiteralF(es, sp) => SeqLiteralF(es.map(go(_, bound)), sp)
-      case other               => other
-    go(expr, Set.empty)
 
   private def renderStateClass(ctx: Ctx)(using DafnyLabel): Option[String] =
     if ctx.stateFields.isEmpty then None

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -269,7 +269,14 @@ object Generator:
     val requiresClauses = invariantClauses ++ aliasInputClauses ++ rawRequires
 
     val ensCtx = mctx.copy(stateMode = StateMode.Old)
-    val rawEnsures = flattenAndAll(op.e.map(desugarOptionGuards(_, mctx)))
+    val optNames =
+      mctx.inputTypes.collect { case (n, _: OptionTypeF) => n }.toList :::
+        mctx.outputTypes.collect {
+          case (n, _: OptionTypeF) if !mctx.inputTypes.contains(n) => n
+        }.toList
+    val rawEnsures = flattenAndAll(
+      op.e.map(e => specrest.ir.generated.SpecRestGenerated.desugarOptionGuards(optNames, e))
+    )
       .map(injectWFGuards(_, ensCtx))
       .map(renderExpr(ensCtx, _))
       .filter(_ != "true")
@@ -387,46 +394,6 @@ object Generator:
     }
 
     (externs.to(ListMap), patterns.toList)
-
-  private def desugarOptionGuards(expr: expr_full, ctx: Ctx): expr_full =
-    def isOption(name: String): Boolean =
-      ctx.inputTypes.get(name).orElse(ctx.outputTypes.get(name)).exists {
-        case _: OptionTypeF => true
-        case _              => false
-      }
-    def unwrap(body: expr_full, p: String): expr_full =
-      subst(p, FieldAccessF(IdentifierF(p, None), "value", None), body)
-    def go(e: expr_full): expr_full = e match
-      case BinaryOpF(
-            BImplies(),
-            guard @ BinaryOpF(BNeq(), IdentifierF(p, _), NoneLitF(_), _),
-            body,
-            sp
-          ) if isOption(p) =>
-        BinaryOpF(BImplies(), guard, go(unwrap(body, p)), sp)
-      case BinaryOpF(
-            BOr(),
-            guard @ BinaryOpF(BEq(), IdentifierF(p, _), NoneLitF(_), _),
-            body,
-            sp
-          ) if isOption(p) =>
-        BinaryOpF(BOr(), guard, go(unwrap(body, p)), sp)
-      case BinaryOpF(
-            BOr(),
-            body,
-            guard @ BinaryOpF(BEq(), IdentifierF(p, _), NoneLitF(_), _),
-            sp
-          ) if isOption(p) =>
-        BinaryOpF(BOr(), go(unwrap(body, p)), guard, sp)
-      case BinaryOpF(op, l, r, sp) => BinaryOpF(op, go(l), go(r), sp)
-      case UnaryOpF(op, x, sp)     => UnaryOpF(op, go(x), sp)
-      case QuantifierF(q, bs, body, sp) =>
-        val bsRewritten = bs.map { case QuantifierBindingFull(a, dom, kind, bsp) =>
-          QuantifierBindingFull(a, go(dom), kind, bsp)
-        }
-        QuantifierF(q, bsRewritten, go(body), sp)
-      case other => other
-    go(expr)
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
     collectPrimedIdentifiers(ensures).toSet

--- a/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
+++ b/modules/convention/src/main/scala/specrest/convention/dafny/Generator.scala
@@ -4,7 +4,6 @@ import specrest.convention.Builtins
 import specrest.ir.generated.SpecRestGenerated.*
 
 import scala.collection.immutable.ListMap
-import scala.collection.mutable
 import scala.util.boundary
 
 final case class DafnyError(message: String, span: Option[span_t])
@@ -312,88 +311,32 @@ object Generator:
         Some(s"${name}Where($paramName)")
       case _ => None
 
-  private val knownBuiltins = Set("len", "dom", "ran")
-
   private def classifyExterns(ir: ServiceIRFull): (ListMap[String, ExternInfo], List[String]) =
-    val externs  = mutable.LinkedHashMap.empty[String, ExternInfo]
-    val patterns = mutable.LinkedHashSet.empty[String]
-
-    def record(name: String, arity: Int, kind: ExternKind): Unit =
-      externs.get(name) match
-        case None => externs(name) = ExternInfo(kind, arity)
-        case Some(prev) =>
-          val newKind =
-            if prev.kind == ExternKind.IntFunction || kind == ExternKind.IntFunction then
-              ExternKind.IntFunction
-            else ExternKind.Predicate
-          externs(name) = ExternInfo(newKind, math.max(prev.arity, arity))
-
-    def walk(e: expr_full, expected: ExternKind): Unit = e match
-      case CallF(IdentifierF(n, _), args, _) if knownBuiltins.contains(n) =>
-        args.foreach(walk(_, ExternKind.IntFunction))
-      case CallF(IdentifierF(n, _), args, _) =>
-        record(n, args.length, expected)
-        args.foreach(walk(_, ExternKind.IntFunction))
-      case CallF(_, args, _) =>
-        args.foreach(walk(_, ExternKind.IntFunction))
-      case BinaryOpF(BAnd() | BOr() | BImplies() | BIff(), l, r, _) =>
-        walk(l, ExternKind.Predicate); walk(r, ExternKind.Predicate)
-      case UnaryOpF(_: UNot, x, _) => walk(x, ExternKind.Predicate)
-      case BinaryOpF(_, l, r, _) =>
-        walk(l, ExternKind.IntFunction); walk(r, ExternKind.IntFunction)
-      case UnaryOpF(_, x, _)     => walk(x, ExternKind.IntFunction)
-      case PrimeF(x, _)          => walk(x, expected)
-      case PreF(x, _)            => walk(x, expected)
-      case SomeWrapF(x, _)       => walk(x, ExternKind.IntFunction)
-      case FieldAccessF(b, _, _) => walk(b, ExternKind.IntFunction)
-      case IndexF(b, i, _)       => walk(b, ExternKind.IntFunction); walk(i, ExternKind.IntFunction)
-      case MapLiteralF(es, _) =>
-        es.foreach { case MapEntryFull(k, v, _) =>
-          walk(k, ExternKind.IntFunction); walk(v, ExternKind.IntFunction)
+    def items(e: expr_full): List[extern_item] =
+      specrest.ir.generated.SpecRestGenerated.collectExternItems(EkPredicate(), e)
+    val all: List[extern_item] =
+      ir.i.collect { case InvariantDeclFull(_, e, _) => e }.flatMap(items) :::
+        ir.j.collect { case TemporalDeclFull(_, b, _) => temporalArg(b) }.flatMap(items) :::
+        ir.k.collect { case FactDeclFull(_, e, _) => e }.flatMap(items) :::
+        ir.c.collect { case e: EntityDeclFull => e }.flatMap { e =>
+          e.d.flatMap(items) :::
+            e.c.collect { case FieldDeclFull(_, _, Some(w), _) => w }.flatMap(items)
+        } :::
+        ir.e.collect { case TypeAliasDeclFull(_, _, Some(w), _) => w }.flatMap(items) :::
+        ir.g.collect { case op: OperationDeclFull => op }.flatMap { op =>
+          op.d.flatMap(items) ::: op.e.flatMap(items)
         }
-      case SetLiteralF(es, _) => es.foreach(walk(_, ExternKind.IntFunction))
-      case SeqLiteralF(es, _) => es.foreach(walk(_, ExternKind.IntFunction))
-      case IfF(c, t, e, _) =>
-        walk(c, ExternKind.Predicate); walk(t, expected); walk(e, expected)
-      case LetF(_, v, b, _) => walk(v, ExternKind.IntFunction); walk(b, expected)
-      case QuantifierF(_, bs, body, _) =>
-        bs.foreach { case b: QuantifierBindingFull =>
-          walk(b.b, ExternKind.IntFunction)
-        }
-        walk(body, ExternKind.Predicate)
-      case SetComprehensionF(_, dom, pred, _) =>
-        walk(dom, ExternKind.IntFunction); walk(pred, ExternKind.Predicate)
-      case ConstructorF(_, fs, _) =>
-        fs.foreach { case FieldAssignFull(_, v, _) => walk(v, ExternKind.IntFunction) }
-      case WithF(b, fs, _) =>
-        walk(b, ExternKind.IntFunction)
-        fs.foreach { case FieldAssignFull(_, v, _) => walk(v, ExternKind.IntFunction) }
-      case TheF(_, dom, body, _) =>
-        walk(dom, ExternKind.IntFunction); walk(body, ExternKind.Predicate)
-      case LambdaF(_, body, _) => walk(body, ExternKind.IntFunction)
-      case MatchesF(x, p, _)   => patterns += p; walk(x, ExternKind.IntFunction)
-      case _                   => ()
+    val (externsAlist, patterns) =
+      specrest.ir.generated.SpecRestGenerated.classifyExternItems(all)
+    val externs = ListMap.from(externsAlist.map { case (n, info) => n -> toScalaExternInfo(info) })
+    (externs, patterns)
 
-    ir.i.foreach { case InvariantDeclFull(_, e, _) => walk(e, ExternKind.Predicate) }
-    ir.j.foreach { case TemporalDeclFull(_, b, _) => walk(temporalArg(b), ExternKind.Predicate) }
-    ir.k.foreach { case FactDeclFull(_, e, _) => walk(e, ExternKind.Predicate) }
-    ir.c.foreach { case e: EntityDeclFull =>
-      e.d.foreach(walk(_, ExternKind.Predicate))
-      e.c.foreach {
-        case FieldDeclFull(_, _, Some(w), _) => walk(w, ExternKind.Predicate)
-        case _                               => ()
-      }
-    }
-    ir.e.foreach {
-      case TypeAliasDeclFull(_, _, Some(w), _) => walk(w, ExternKind.Predicate)
-      case _                                   => ()
-    }
-    ir.g.foreach { case op: OperationDeclFull =>
-      op.d.foreach(walk(_, ExternKind.Predicate))
-      op.e.foreach(walk(_, ExternKind.Predicate))
-    }
-
-    (externs.to(ListMap), patterns.toList)
+  private def toScalaExternInfo(info: extern_info): ExternInfo = info match
+    case ExInfo(k, arity) =>
+      val kind = k match
+        case _: EkPredicate   => ExternKind.Predicate
+        case _: EkIntFunction => ExternKind.IntFunction
+      ExternInfo(kind, arity.toInt)
 
   private def primedStateFields(ensures: List[expr_full]): Set[String] =
     collectPrimedIdentifiers(ensures).toSet

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -6337,6 +6337,20 @@ object SpecRestGenerated {
       case Some(idNm) => "/" + segment + "/{" + idNm + "}"
     }
 
+  def decideNullable(refOpt: Option[String], typeOpt: Option[List[String]]): nullable_decision =
+    refOpt match {
+      case None =>
+        typeOpt match {
+          case None => NdWrapAnyOfNull()
+          case Some(currentTypes) =>
+            membera[String](currentTypes, "null") match {
+              case true  => NdNoop()
+              case false => NdAppendNull()
+            }
+        }
+      case Some(_) => NdWrapAnyOfNull()
+    }
+
   def nullSchema: schema_object =
     SchemaObject(
       Some[List[String]](List("null")),
@@ -6360,6 +6374,164 @@ object SpecRestGenerated {
       None,
       false
     )
+
+  def makeNullableLifted(x0: schema_object): schema_object = x0 match {
+    case SchemaObject(
+          ty,
+          fmt,
+          minL,
+          maxL,
+          mn,
+          mx,
+          emn,
+          emx,
+          mnI,
+          mxI,
+          pat,
+          en,
+          it,
+          rf,
+          rq,
+          pr,
+          ap,
+          aof,
+          desc,
+          inE
+        ) => decideNullable(rf, ty) match {
+        case NdNoop() =>
+          SchemaObject(
+            ty,
+            fmt,
+            minL,
+            maxL,
+            mn,
+            mx,
+            emn,
+            emx,
+            mnI,
+            mxI,
+            pat,
+            en,
+            it,
+            rf,
+            rq,
+            pr,
+            ap,
+            aof,
+            desc,
+            inE
+          )
+        case NdWrapAnyOfNull() =>
+          SchemaObject(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some[List[schema_object]](List(
+              SchemaObject(
+                ty,
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              ),
+              nullSchema
+            )),
+            None,
+            false
+          )
+        case NdAppendNull() =>
+          ty match {
+            case None =>
+              SchemaObject(
+                ty,
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              )
+            case Some(currentTypes) =>
+              SchemaObject(
+                Some[List[String]](currentTypes ++ List("null")),
+                fmt,
+                minL,
+                maxL,
+                mn,
+                mx,
+                emn,
+                emx,
+                mnI,
+                mxI,
+                pat,
+                en,
+                it,
+                rf,
+                rq,
+                pr,
+                ap,
+                aof,
+                desc,
+                inE
+              )
+          }
+      }
+  }
+
+  def fieldPropertySchema(s: schema_object, nullable: Boolean): schema_object =
+    nullable match {
+      case true  => makeNullableLifted(s)
+      case false => s
+    }
+
+  def fieldProps(x0: List[(String, (schema_object, Boolean))]): List[(String, schema_object)] =
+    x0 match {
+      case Nil => Nil
+      case (n, (s, nu)) :: rest =>
+        (n, fieldPropertySchema(s, nu)) :: fieldProps(rest)
+    }
 
   def textSchema: schema_object =
     SchemaObject(
@@ -9046,6 +9218,27 @@ object SpecRestGenerated {
   def freshKey(base: String, seen: List[String]): String =
     freshKeyAux(Suc(size_list[String](seen)), base, seen, zero_nat)
 
+  def sensitiveSuffixNames: List[String] =
+    List("_hash", "_secret", "_password", "_api_key", "_token")
+
+  def sensitiveExactNames: List[String] =
+    List("password", "password_hash", "secret", "token", "api_key")
+
+  def isSensitiveField(name: String): Boolean =
+    string_in_list(name, sensitiveExactNames) ||
+      list_ex[String]((sfx: String) => literalEndsWith(sfx, name), sensitiveSuffixNames)
+
+  def dropSensitive(x0: List[(String, (schema_object, Boolean))])
+      : List[(String, (schema_object, Boolean))] =
+    x0 match {
+      case Nil => Nil
+      case (n, (s, nu)) :: rest =>
+        isSensitiveField(n) match {
+          case true  => dropSensitive(rest)
+          case false => (n, (s, nu)) :: dropSensitive(rest)
+        }
+    }
+
   def openApiSchemaFuel(am: List[(String, type_alias_decl_full)]): nat =
     plus_nat(size_list[(String, type_alias_decl_full)](am), nat_of_integer(BigInt(100)))
 
@@ -9318,165 +9511,6 @@ object SpecRestGenerated {
         None,
         false
       )
-  }
-
-  def decideNullable(refOpt: Option[String], typeOpt: Option[List[String]]): nullable_decision =
-    refOpt match {
-      case None =>
-        typeOpt match {
-          case None => NdWrapAnyOfNull()
-          case Some(currentTypes) =>
-            membera[String](currentTypes, "null") match {
-              case true  => NdNoop()
-              case false => NdAppendNull()
-            }
-        }
-      case Some(_) => NdWrapAnyOfNull()
-    }
-
-  def makeNullableLifted(x0: schema_object): schema_object = x0 match {
-    case SchemaObject(
-          ty,
-          fmt,
-          minL,
-          maxL,
-          mn,
-          mx,
-          emn,
-          emx,
-          mnI,
-          mxI,
-          pat,
-          en,
-          it,
-          rf,
-          rq,
-          pr,
-          ap,
-          aof,
-          desc,
-          inE
-        ) => decideNullable(rf, ty) match {
-        case NdNoop() =>
-          SchemaObject(
-            ty,
-            fmt,
-            minL,
-            maxL,
-            mn,
-            mx,
-            emn,
-            emx,
-            mnI,
-            mxI,
-            pat,
-            en,
-            it,
-            rf,
-            rq,
-            pr,
-            ap,
-            aof,
-            desc,
-            inE
-          )
-        case NdWrapAnyOfNull() =>
-          SchemaObject(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some[List[schema_object]](List(
-              SchemaObject(
-                ty,
-                fmt,
-                minL,
-                maxL,
-                mn,
-                mx,
-                emn,
-                emx,
-                mnI,
-                mxI,
-                pat,
-                en,
-                it,
-                rf,
-                rq,
-                pr,
-                ap,
-                aof,
-                desc,
-                inE
-              ),
-              nullSchema
-            )),
-            None,
-            false
-          )
-        case NdAppendNull() =>
-          ty match {
-            case None =>
-              SchemaObject(
-                ty,
-                fmt,
-                minL,
-                maxL,
-                mn,
-                mx,
-                emn,
-                emx,
-                mnI,
-                mxI,
-                pat,
-                en,
-                it,
-                rf,
-                rq,
-                pr,
-                ap,
-                aof,
-                desc,
-                inE
-              )
-            case Some(currentTypes) =>
-              SchemaObject(
-                Some[List[String]](currentTypes ++ List("null")),
-                fmt,
-                minL,
-                maxL,
-                mn,
-                mx,
-                emn,
-                emx,
-                mnI,
-                mxI,
-                pat,
-                en,
-                it,
-                rf,
-                rq,
-                pr,
-                ap,
-                aof,
-                desc,
-                inE
-              )
-          }
-      }
   }
 
   def emptySchemaObject: schema_object =
@@ -10142,6 +10176,16 @@ object SpecRestGenerated {
   ): (schema_object, Boolean) =
     fieldToSchemaAux(openApiSchemaFuel(am), ty, cOpt, am, em, ens)
 
+  def requiredNames(x0: List[(String, (schema_object, Boolean))]): List[String] =
+    x0 match {
+      case Nil => Nil
+      case (n, (uu, nu)) :: rest =>
+        nu match {
+          case true  => requiredNames(rest)
+          case false => n :: requiredNames(rest)
+        }
+    }
+
   def literalStartsWith(pre: String, s: String): Boolean = {
     val xs = Str_Literal.asciisOfLiteral(s): List[BigInt]
     val ys = Str_Literal.asciisOfLiteral(pre): List[BigInt];
@@ -10474,6 +10518,17 @@ object SpecRestGenerated {
     case AddTrigger(wa)                      => false
     case DropTrigger(wb)                     => false
   }
+
+  def nonIdDecorated(x0: List[(String, (schema_object, Boolean))])
+      : List[(String, (schema_object, Boolean))] =
+    x0 match {
+      case Nil => Nil
+      case (n, (s, nu)) :: rest =>
+        n == "id" match {
+          case true  => nonIdDecorated(rest)
+          case false => (n, (s, nu)) :: nonIdDecorated(rest)
+        }
+    }
 
   def effectiveRouteKind(initial: route_kind, matchesCreateShape: Boolean): route_kind =
     isRkCreate(initial) && !matchesCreateShape match {
@@ -11741,6 +11796,37 @@ object SpecRestGenerated {
       case (NoneLitF(wi), wj)       => Nil
     }
 
+  def readSchemaLifted(
+      ename: String,
+      decorated: List[(String, (schema_object, Boolean))]
+  ): schema_object = {
+    val fs =
+      dropSensitive(nonIdDecorated(decorated)): List[(String, (schema_object, Boolean))];
+    SchemaObject(
+      Some[List[String]](List("object")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[List[String]]("id" :: requiredNames(fs)),
+      Some[List[(String, schema_object)]](("id", integerSchema) ::
+        fieldProps(fs)),
+      None,
+      None,
+      Some[String]("Read view for " + ename),
+      false
+    )
+  }
+
   def typeExprToSchema(
       ty: type_expr_full,
       bounds: openapi_bounds,
@@ -12389,6 +12475,83 @@ object SpecRestGenerated {
 
   def collectAllCallNames(e: expr_full): List[String] =
     maps[expr_full, String]((a: expr_full) => callSelfAllNames(a), allSubexprs(e))
+
+  def fieldPropsNullable(x0: List[(String, (schema_object, Boolean))])
+      : List[(String, schema_object)] =
+    x0 match {
+      case Nil => Nil
+      case (n, (s, uu)) :: rest =>
+        (n, makeNullableLifted(s)) :: fieldPropsNullable(rest)
+    }
+
+  def updateSchemaLifted(
+      ename: String,
+      decorated: List[(String, (schema_object, Boolean))]
+  ): schema_object = {
+    val fs =
+      nonIdDecorated(decorated): List[(String, (schema_object, Boolean))];
+    SchemaObject(
+      Some[List[String]](List("object")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[List[(String, schema_object)]](fieldPropsNullable(fs)),
+      None,
+      None,
+      Some[String]("Update payload for " + ename),
+      false
+    )
+  }
+
+  def createSchemaLifted(
+      ename: String,
+      decorated: List[(String, (schema_object, Boolean))]
+  ): schema_object = {
+    val fs =
+      nonIdDecorated(decorated): List[(String, (schema_object, Boolean))];
+    SchemaObject(
+      Some[List[String]](List("object")),
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      None,
+      Some[List[String]](requiredNames(fs)),
+      Some[List[(String, schema_object)]](fieldProps(fs)),
+      None,
+      None,
+      Some[String]("Create payload for " + ename),
+      false
+    )
+  }
+
+  def buildEntitySchemas(
+      ename: String,
+      decorated: List[(String, (schema_object, Boolean))]
+  ): (schema_object, (schema_object, schema_object)) =
+    (
+      createSchemaLifted(ename, decorated),
+      (readSchemaLifted(ename, decorated), updateSchemaLifted(ename, decorated))
+    )
 
   def extractVerbBeforeKebab(opName: String, entityOpt: Option[String]): String =
     entityOpt match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -907,6 +907,11 @@ object SpecRestGenerated {
   final case class enum_decl_exta[A](a: String, b: List[String], c: Option[span_t], d: A)
       extends enum_decl_ext[A]
 
+  sealed abstract class user_call_class
+  final case class UcUnknown()             extends user_call_class
+  final case class UcWrongArity(a: BigInt) extends user_call_class
+  final case class UcOk()                  extends user_call_class
+
   sealed abstract class alloy_unop_shape
   final case class AusNot()         extends alloy_unop_shape
   final case class AusCardinality() extends alloy_unop_shape
@@ -5769,6 +5774,16 @@ object SpecRestGenerated {
       case (Some(x), Some(y)) => Some[BigInt](max[BigInt](x, y))
     }
 
+  def lookupArity(x0: List[(String, BigInt)], uu: String): Option[BigInt] =
+    (x0, uu) match {
+      case (Nil, uu) => None
+      case ((nm, ar) :: rest, fname) =>
+        nm == fname match {
+          case true  => Some[BigInt](ar)
+          case false => lookupArity(rest, fname)
+        }
+    }
+
   def boolSigs: List[alloy_sig] =
     List(
       AlloySigLifted("Bool", true, false, None, Nil),
@@ -9091,6 +9106,18 @@ object SpecRestGenerated {
       )
     )
 
+  def quantBindingIsIn(x0: quantifier_binding_full): Boolean = x0 match {
+    case QuantifierBindingFull(uu, uv, BkIn(), uw)   => true
+    case QuantifierBindingFull(v, va, BkColon(), vc) => false
+  }
+
+  def quantifierAllIn(bs: List[quantifier_binding_full]): Boolean =
+    list_all[quantifier_binding_full](
+      (a: quantifier_binding_full) =>
+        quantBindingIsIn(a),
+      bs
+    )
+
   def foldTrust(enums: List[String], exprs: List[expr_full]): trust_level =
     list_all[expr_full]((e: expr_full) => !is_none[expr](lower(enums, e)), exprs) match {
       case true  => TlSound()
@@ -10262,6 +10289,24 @@ object SpecRestGenerated {
     less_eq_nat(size_list[BigInt](ys), size_list[BigInt](xs)) &&
     equal_list[BigInt](take[BigInt](size_list[BigInt](ys), xs), ys)
   }
+
+  def classifyUserCall(
+      fnArities: List[(String, BigInt)],
+      predArities: List[(String, BigInt)],
+      fname: String,
+      argCount: BigInt
+  ): user_call_class =
+    (lookupArity(fnArities, fname) match {
+      case None    => lookupArity(predArities, fname)
+      case Some(a) => Some[BigInt](a)
+    }) match {
+      case None => UcUnknown()
+      case Some(n) =>
+        equal_int(n, argCount) match {
+          case true  => UcOk()
+          case false => UcWrongArity(n)
+        }
+    }
 
   def signalsHasCollectionInput(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, uz, va, vb, h) => h

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -893,6 +893,17 @@ object SpecRestGenerated {
   final case class IntConstraint(a: Option[BigInt], b: Option[BigInt], c: List[String])
       extends int_constraint
 
+  sealed abstract class extern_kind
+  final case class EkPredicate()   extends extern_kind
+  final case class EkIntFunction() extends extern_kind
+
+  sealed abstract class extern_info
+  final case class ExInfo(a: extern_kind, b: BigInt) extends extern_info
+
+  sealed abstract class extern_item
+  final case class EiExtern(a: String, b: BigInt, c: extern_kind) extends extern_item
+  final case class EiPattern(a: String)                           extends extern_item
+
   sealed abstract class dialect_caps
   final case class DialectCaps(
       a: Boolean,
@@ -10015,6 +10026,41 @@ object SpecRestGenerated {
     case OperationClassification(uu, k, uv, uw, ux, uy, uz) => k
   }
 
+  def equal_extern_kind(x0: extern_kind, x1: extern_kind): Boolean = (x0, x1) match {
+    case (EkPredicate(), EkIntFunction())   => false
+    case (EkIntFunction(), EkPredicate())   => false
+    case (EkIntFunction(), EkIntFunction()) => true
+    case (EkPredicate(), EkPredicate())     => true
+  }
+
+  def mergeExternInfo(x0: extern_info, arity: BigInt, kind: extern_kind): extern_info =
+    (x0, arity, kind) match {
+      case (ExInfo(prevKind, prevArity), arity, kind) =>
+        ExInfo(
+          equal_extern_kind(prevKind, EkIntFunction()) ||
+            equal_extern_kind(kind, EkIntFunction()) match {
+            case true  => EkIntFunction()
+            case false => EkPredicate()
+          },
+          max[BigInt](prevArity, arity)
+        )
+    }
+
+  def upsertExtern(
+      x0: List[(String, extern_info)],
+      name: String,
+      arity: BigInt,
+      kind: extern_kind
+  ): List[(String, extern_info)] =
+    (x0, name, arity, kind) match {
+      case (Nil, name, arity, kind) => List((name, ExInfo(kind, arity)))
+      case ((n, info) :: rest, name, arity, kind) =>
+        n == name match {
+          case true  => (n, mergeExternInfo(info, arity, kind)) :: rest
+          case false => (n, info) :: upsertExtern(rest, name, arity, kind)
+        }
+    }
+
   def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
     c match {
       case BinaryOpF(op, l, r, _) =>
@@ -12511,6 +12557,26 @@ object SpecRestGenerated {
     case OperationClassification(uu, uv, uw, ux, uy, uz, sg) => sg
   }
 
+  def foldExternItems(
+      x0: List[extern_item],
+      externs: List[(String, extern_info)],
+      patterns: List[String]
+  ): (List[(String, extern_info)], List[String]) =
+    (x0, externs, patterns) match {
+      case (Nil, externs, patterns) => (externs, patterns)
+      case (EiExtern(name, arity, kind) :: rest, externs, patterns) =>
+        foldExternItems(rest, upsertExtern(externs, name, arity, kind), patterns)
+      case (EiPattern(p) :: rest, externs, patterns) =>
+        foldExternItems(
+          rest,
+          externs,
+          string_in_list(p, patterns) match {
+            case true  => patterns
+            case false => patterns ++ List(p)
+          }
+        )
+    }
+
   def sqliteTypeRender(x0: canonical_type): String = x0 match {
     case CtText()        => "TEXT"
     case CtVarchar(uu)   => "TEXT"
@@ -13224,6 +13290,8 @@ object SpecRestGenerated {
     case ServiceIRFull(uu, uv, uw, es, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
   }
 
+  def knownBuiltinNames: List[String] = List("len", "dom", "ran")
+
   def saTypeImportModule(x0: sa_type): Option[String] = x0 match {
     case SaType(uu, m) => m
   }
@@ -13825,6 +13893,145 @@ object SpecRestGenerated {
     case AqNo()     => "no"
   }
 
+  def equal_un_op_full(x0: un_op_full, x1: un_op_full): Boolean = (x0, x1) match {
+    case (UCardinality(), UPower())       => false
+    case (UPower(), UCardinality())       => false
+    case (UNegate(), UPower())            => false
+    case (UPower(), UNegate())            => false
+    case (UNegate(), UCardinality())      => false
+    case (UCardinality(), UNegate())      => false
+    case (UNot(), UPower())               => false
+    case (UPower(), UNot())               => false
+    case (UNot(), UCardinality())         => false
+    case (UCardinality(), UNot())         => false
+    case (UNot(), UNegate())              => false
+    case (UNegate(), UNot())              => false
+    case (UPower(), UPower())             => true
+    case (UCardinality(), UCardinality()) => true
+    case (UNegate(), UNegate())           => true
+    case (UNot(), UNot())                 => true
+  }
+
+  def collectExternItemsBindings(x0: List[quantifier_binding_full]): List[extern_item] =
+    x0 match {
+      case Nil => Nil
+      case QuantifierBindingFull(a, d, kind, sp) :: bs =>
+        collectExternItems(EkIntFunction(), d) ++ collectExternItemsBindings(bs)
+    }
+
+  def collectExternItemsEntries(x0: List[map_entry_full]): List[extern_item] =
+    x0 match {
+      case Nil => Nil
+      case MapEntryFull(k, v, sp) :: es =>
+        collectExternItems(EkIntFunction(), k) ++
+          (collectExternItems(EkIntFunction(), v) ++ collectExternItemsEntries(es))
+    }
+
+  def collectExternItemsFields(x0: List[field_assign_full]): List[extern_item] =
+    x0 match {
+      case Nil => Nil
+      case FieldAssignFull(f, v, sp) :: fs =>
+        collectExternItems(EkIntFunction(), v) ++ collectExternItemsFields(fs)
+    }
+
+  def collectExternItemsArgs(x0: List[expr_full]): List[extern_item] = x0 match {
+    case Nil => Nil
+    case e :: es =>
+      collectExternItems(EkIntFunction(), e) ++ collectExternItemsArgs(es)
+  }
+
+  def collectExternItems(expected: extern_kind, x1: expr_full): List[extern_item] =
+    (expected, x1) match {
+      case (expected, CallF(c, args, sp)) =>
+        c match {
+          case BinaryOpF(_, _, _, _)         => collectExternItemsArgs(args)
+          case UnaryOpF(_, _, _)             => collectExternItemsArgs(args)
+          case QuantifierF(_, _, _, _)       => collectExternItemsArgs(args)
+          case SomeWrapF(_, _)               => collectExternItemsArgs(args)
+          case TheF(_, _, _, _)              => collectExternItemsArgs(args)
+          case FieldAccessF(_, _, _)         => collectExternItemsArgs(args)
+          case EnumAccessF(_, _, _)          => collectExternItemsArgs(args)
+          case IndexF(_, _, _)               => collectExternItemsArgs(args)
+          case CallF(_, _, _)                => collectExternItemsArgs(args)
+          case PrimeF(_, _)                  => collectExternItemsArgs(args)
+          case PreF(_, _)                    => collectExternItemsArgs(args)
+          case WithF(_, _, _)                => collectExternItemsArgs(args)
+          case IfF(_, _, _, _)               => collectExternItemsArgs(args)
+          case LetF(_, _, _, _)              => collectExternItemsArgs(args)
+          case LambdaF(_, _, _)              => collectExternItemsArgs(args)
+          case ConstructorF(_, _, _)         => collectExternItemsArgs(args)
+          case SetLiteralF(_, _)             => collectExternItemsArgs(args)
+          case MapLiteralF(_, _)             => collectExternItemsArgs(args)
+          case SetComprehensionF(_, _, _, _) => collectExternItemsArgs(args)
+          case SeqLiteralF(_, _)             => collectExternItemsArgs(args)
+          case MatchesF(_, _, _)             => collectExternItemsArgs(args)
+          case IntLitF(_, _)                 => collectExternItemsArgs(args)
+          case FloatLitF(_, _)               => collectExternItemsArgs(args)
+          case StringLitF(_, _)              => collectExternItemsArgs(args)
+          case BoolLitF(_, _)                => collectExternItemsArgs(args)
+          case NoneLitF(_)                   => collectExternItemsArgs(args)
+          case IdentifierF(n, _) =>
+            string_in_list(n, knownBuiltinNames) match {
+              case true => collectExternItemsArgs(args)
+              case false => EiExtern(n, int_of_nat(size_list[expr_full](args)), expected) ::
+                  collectExternItemsArgs(args)
+            }
+        }
+      case (expected, BinaryOpF(op, l, r, sp)) =>
+        equal_bin_op_full(op, BAnd()) ||
+          (equal_bin_op_full(op, BOr()) ||
+            (equal_bin_op_full(op, BImplies()) ||
+              equal_bin_op_full(op, BIff()))) match {
+          case true => collectExternItems(EkPredicate(), l) ++
+              collectExternItems(EkPredicate(), r)
+          case false => collectExternItems(EkIntFunction(), l) ++
+              collectExternItems(EkIntFunction(), r)
+        }
+      case (expected, UnaryOpF(op, x, sp)) =>
+        equal_un_op_full(op, UNot()) match {
+          case true  => collectExternItems(EkPredicate(), x)
+          case false => collectExternItems(EkIntFunction(), x)
+        }
+      case (expected, PrimeF(x, sp))    => collectExternItems(expected, x)
+      case (expected, PreF(x, sp))      => collectExternItems(expected, x)
+      case (expected, SomeWrapF(x, sp)) => collectExternItems(EkIntFunction(), x)
+      case (expected, FieldAccessF(b, f, sp)) =>
+        collectExternItems(EkIntFunction(), b)
+      case (expected, IndexF(b, i, sp)) =>
+        collectExternItems(EkIntFunction(), b) ++
+          collectExternItems(EkIntFunction(), i)
+      case (expected, MapLiteralF(es, sp)) => collectExternItemsEntries(es)
+      case (expected, SetLiteralF(es, sp)) => collectExternItemsArgs(es)
+      case (expected, SeqLiteralF(es, sp)) => collectExternItemsArgs(es)
+      case (expected, IfF(c, t, e, sp)) =>
+        collectExternItems(EkPredicate(), c) ++
+          (collectExternItems(expected, t) ++ collectExternItems(expected, e))
+      case (expected, LetF(v, vala, b, sp)) =>
+        collectExternItems(EkIntFunction(), vala) ++ collectExternItems(expected, b)
+      case (expected, QuantifierF(q, bs, body, sp)) =>
+        collectExternItemsBindings(bs) ++ collectExternItems(EkPredicate(), body)
+      case (expected, SetComprehensionF(v, dm, pr, sp)) =>
+        collectExternItems(EkIntFunction(), dm) ++
+          collectExternItems(EkPredicate(), pr)
+      case (expected, ConstructorF(n, fs, sp)) => collectExternItemsFields(fs)
+      case (expected, WithF(b, fs, sp)) =>
+        collectExternItems(EkIntFunction(), b) ++ collectExternItemsFields(fs)
+      case (expected, TheF(v, dm, body, sp)) =>
+        collectExternItems(EkIntFunction(), dm) ++
+          collectExternItems(EkPredicate(), body)
+      case (expected, LambdaF(p, body, sp)) =>
+        collectExternItems(EkIntFunction(), body)
+      case (expected, MatchesF(x, p, sp)) =>
+        EiPattern(p) :: collectExternItems(EkIntFunction(), x)
+      case (uu, EnumAccessF(v, va, vb)) => Nil
+      case (uu, IntLitF(v, va))         => Nil
+      case (uu, FloatLitF(v, va))       => Nil
+      case (uu, StringLitF(v, va))      => Nil
+      case (uu, BoolLitF(v, va))        => Nil
+      case (uu, NoneLitF(v))            => Nil
+      case (uu, IdentifierF(v, va))     => Nil
+    }
+
   def fieldNameIfStateIndex(e: expr_full, inputName: String, stateName: String): Option[String] =
     e match {
       case BinaryOpF(_, _, _, _)                                     => None
@@ -14070,6 +14277,9 @@ object SpecRestGenerated {
   def signalsPreservedRelations(x0: analysis_signals): List[String] = x0 match {
     case AnalysisSignals(uu, p, uv, uw, ux, uy, uz, va, vb) => p
   }
+
+  def classifyExternItems(items: List[extern_item]): (List[(String, extern_info)], List[String]) =
+    foldExternItems(items, Nil, Nil)
 
   def desugarOptionGuards(opts: List[String], e: expr_full): expr_full =
     desugarGo(plus_nat(size_list[expr_full](allSubexprs(e)), nat_of_integer(BigInt(100))), opts, e)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -13195,6 +13195,131 @@ object SpecRestGenerated {
     case AnalysisSignals(uu, p, uv, uw, ux, uy, uz, va, vb) => p
   }
 
+  def rewriteFieldRefsBindings(
+      vk: List[String],
+      vl: List[String],
+      x2: List[quantifier_binding_full]
+  ): List[quantifier_binding_full] =
+    (vk, vl, x2) match {
+      case (vk, vl, Nil) => Nil
+      case (flds, bound, QuantifierBindingFull(a, d, kk, sp) :: bs) =>
+        QuantifierBindingFull(a, rewriteFieldRefsAux(flds, bound, d), kk, sp) ::
+          rewriteFieldRefsBindings(flds, bound, bs)
+    }
+
+  def rewriteFieldRefsEntries(
+      vi: List[String],
+      vj: List[String],
+      x2: List[map_entry_full]
+  ): List[map_entry_full] =
+    (vi, vj, x2) match {
+      case (vi, vj, Nil) => Nil
+      case (flds, bound, MapEntryFull(k, v, sp) :: es) =>
+        MapEntryFull(
+          rewriteFieldRefsAux(flds, bound, k),
+          rewriteFieldRefsAux(flds, bound, v),
+          sp
+        ) ::
+          rewriteFieldRefsEntries(flds, bound, es)
+    }
+
+  def rewriteFieldRefsFields(
+      vg: List[String],
+      vh: List[String],
+      x2: List[field_assign_full]
+  ): List[field_assign_full] =
+    (vg, vh, x2) match {
+      case (vg, vh, Nil) => Nil
+      case (flds, bound, FieldAssignFull(f, v, sp) :: fs) =>
+        FieldAssignFull(f, rewriteFieldRefsAux(flds, bound, v), sp) ::
+          rewriteFieldRefsFields(flds, bound, fs)
+    }
+
+  def rewriteFieldRefsList(
+      ve: List[String],
+      vf: List[String],
+      x2: List[expr_full]
+  ): List[expr_full] =
+    (ve, vf, x2) match {
+      case (ve, vf, Nil) => Nil
+      case (flds, bound, e :: es) =>
+        rewriteFieldRefsAux(flds, bound, e) :: rewriteFieldRefsList(flds, bound, es)
+    }
+
+  def rewriteFieldRefsAux(flds: List[String], bound: List[String], x2: expr_full): expr_full =
+    (flds, bound, x2) match {
+      case (flds, bound, IdentifierF(n, sp)) =>
+        string_in_list(n, flds) && !string_in_list(n, bound) match {
+          case true  => FieldAccessF(IdentifierF("x", sp), n, sp)
+          case false => IdentifierF(n, sp)
+        }
+      case (flds, bound, BinaryOpF(op, l, r, sp)) =>
+        BinaryOpF(op, rewriteFieldRefsAux(flds, bound, l), rewriteFieldRefsAux(flds, bound, r), sp)
+      case (flds, bound, UnaryOpF(op, e, sp)) =>
+        UnaryOpF(op, rewriteFieldRefsAux(flds, bound, e), sp)
+      case (flds, bound, FieldAccessF(b, f, sp)) =>
+        FieldAccessF(rewriteFieldRefsAux(flds, bound, b), f, sp)
+      case (flds, bound, EnumAccessF(b, m, sp)) => EnumAccessF(b, m, sp)
+      case (flds, bound, IndexF(b, i, sp)) =>
+        IndexF(rewriteFieldRefsAux(flds, bound, b), rewriteFieldRefsAux(flds, bound, i), sp)
+      case (flds, bound, CallF(c, args, sp)) =>
+        CallF(rewriteFieldRefsAux(flds, bound, c), rewriteFieldRefsList(flds, bound, args), sp)
+      case (flds, bound, PrimeF(e, sp)) =>
+        PrimeF(rewriteFieldRefsAux(flds, bound, e), sp)
+      case (flds, bound, PreF(e, sp)) =>
+        PreF(rewriteFieldRefsAux(flds, bound, e), sp)
+      case (flds, bound, WithF(b, upds, sp)) =>
+        WithF(rewriteFieldRefsAux(flds, bound, b), rewriteFieldRefsFields(flds, bound, upds), sp)
+      case (flds, bound, IfF(c, t, e, sp)) =>
+        IfF(
+          rewriteFieldRefsAux(flds, bound, c),
+          rewriteFieldRefsAux(flds, bound, t),
+          rewriteFieldRefsAux(flds, bound, e),
+          sp
+        )
+      case (flds, bound, LetF(v, vala, body, sp)) =>
+        LetF(
+          v,
+          rewriteFieldRefsAux(flds, bound, vala),
+          rewriteFieldRefsAux(flds, v :: bound, body),
+          sp
+        )
+      case (flds, bound, LambdaF(p, b, sp)) =>
+        LambdaF(p, rewriteFieldRefsAux(flds, p :: bound, b), sp)
+      case (flds, bound, ConstructorF(n, fs, sp)) =>
+        ConstructorF(n, rewriteFieldRefsFields(flds, bound, fs), sp)
+      case (flds, bound, SetLiteralF(xs, sp)) =>
+        SetLiteralF(rewriteFieldRefsList(flds, bound, xs), sp)
+      case (flds, bound, MapLiteralF(es, sp)) =>
+        MapLiteralF(rewriteFieldRefsEntries(flds, bound, es), sp)
+      case (flds, bound, SetComprehensionF(v, d, p, sp)) =>
+        SetComprehensionF(
+          v,
+          rewriteFieldRefsAux(flds, bound, d),
+          rewriteFieldRefsAux(flds, v :: bound, p),
+          sp
+        )
+      case (flds, bound, SeqLiteralF(xs, sp)) =>
+        SeqLiteralF(rewriteFieldRefsList(flds, bound, xs), sp)
+      case (flds, bound, MatchesF(e, pat, sp)) => MatchesF(e, pat, sp)
+      case (flds, bound, SomeWrapF(e, sp)) =>
+        SomeWrapF(rewriteFieldRefsAux(flds, bound, e), sp)
+      case (flds, bound, TheF(v, d, b, sp)) =>
+        TheF(v, rewriteFieldRefsAux(flds, bound, d), rewriteFieldRefsAux(flds, v :: bound, b), sp)
+      case (flds, bound, QuantifierF(q, bs, body, sp)) =>
+        QuantifierF(
+          q,
+          rewriteFieldRefsBindings(flds, bound, bs),
+          rewriteFieldRefsAux(flds, qb_names(bs) ++ bound, body),
+          sp
+        )
+      case (uu, uv, IntLitF(n, sp))    => IntLitF(n, sp)
+      case (uw, ux, FloatLitF(n, sp))  => FloatLitF(n, sp)
+      case (uy, uz, StringLitF(n, sp)) => StringLitF(n, sp)
+      case (va, vb, BoolLitF(v, sp))   => BoolLitF(v, sp)
+      case (vc, vd, NoneLitF(sp))      => NoneLitF(sp)
+    }
+
   def capsTransactionalDdl(x0: dialect_caps): Boolean = x0 match {
     case DialectCaps(uu, uv, uw, ux, uy, f) => f
   }
@@ -13809,6 +13934,9 @@ object SpecRestGenerated {
       case (name, targetEntity, strategy, ClassificationResult(k, m, rule, sig)) =>
         OperationClassification(name, k, m, rule, targetEntity, strategy, sig)
     }
+
+  def rewriteEntityFieldRefs(flds: List[String], e: expr_full): expr_full =
+    rewriteFieldRefsAux(flds, Nil, e)
 
   def capsFkEnforcedByDefault(x0: dialect_caps): Boolean = x0 match {
     case DialectCaps(uu, uv, uw, d, ux, uy) => d

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -752,6 +752,19 @@ object SpecRestGenerated {
   final case class RkRedirect() extends route_kind
   final case class RkOther()    extends route_kind
 
+  sealed abstract class ident_ctx
+  final case class IdentCtx(
+      a: List[String],
+      b: List[String],
+      c: Option[String],
+      d: List[String],
+      e: List[String],
+      f: List[String],
+      g: List[String],
+      h: List[String],
+      i: List[String]
+  ) extends ident_ctx
+
   sealed abstract class sa_type
   final case class SaType(a: String, b: Option[String]) extends sa_type
 
@@ -777,6 +790,18 @@ object SpecRestGenerated {
   sealed abstract class database_schema
   final case class DatabaseSchema(a: List[table_spec], b: List[trigger_spec])
       extends database_schema
+
+  sealed abstract class ident_class
+  final case class IcReserved()      extends ident_class
+  final case class IcBound()         extends ident_class
+  final case class IcBareBody()      extends ident_class
+  final case class IcOutput()        extends ident_class
+  final case class IcInput()         extends ident_class
+  final case class IcStateField()    extends ident_class
+  final case class IcUnbackedState() extends ident_class
+  final case class IcEnumType()      extends ident_class
+  final case class IcEnumValue()     extends ident_class
+  final case class IcUnbound()       extends ident_class
 
   sealed abstract class alloy_field_multiplicity
   final case class AfmOne()  extends alloy_field_multiplicity
@@ -6566,6 +6591,51 @@ object SpecRestGenerated {
 
   def tc_enums[A](x0: tyctx_ext[A]): List[String] = x0 match {
     case tyctx_exta(tc_env, tc_schema, tc_entities, tc_relations, tc_enums, more) => tc_enums
+  }
+
+  def classifyIdent(x0: ident_ctx, name: String): ident_class = (x0, name) match {
+    case (
+          IdentCtx(
+            reserved,
+            bound,
+            bareBody,
+            outputs,
+            inputs,
+            stateFields,
+            unbackedState,
+            enumTypes,
+            enumValues
+          ),
+          name
+        ) => string_in_list(name, reserved) &&
+        (string_in_list(name, bound) || string_in_list(name, inputs)) match {
+        case true => IcReserved()
+        case false => string_in_list(name, bound) match {
+            case true => IcBound()
+            case false => equal_option[String](bareBody, Some[String](name)) match {
+                case true => IcBareBody()
+                case false => string_in_list(name, outputs) match {
+                    case true => IcOutput()
+                    case false => string_in_list(name, inputs) match {
+                        case true => IcInput()
+                        case false => string_in_list(name, stateFields) match {
+                            case true => string_in_list(name, unbackedState) match {
+                                case true  => IcUnbackedState()
+                                case false => IcStateField()
+                              }
+                            case false => string_in_list(name, enumTypes) match {
+                                case true => IcEnumType()
+                                case false => string_in_list(name, enumValues) match {
+                                    case true  => IcEnumValue()
+                                    case false => IcUnbound()
+                                  }
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
   }
 
   def alloyUnopShape(x0: un_op_full): alloy_unop_shape = x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -6307,6 +6307,9 @@ object SpecRestGenerated {
       case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
     }
 
+  def typeWalkFuel(aliases: List[type_alias_decl_full]): nat =
+    plus_nat(size_list[type_alias_decl_full](aliases), nat_of_integer(BigInt(100)))
+
   def optConcat(a: Option[List[alloy_sig]], b: Option[List[alloy_sig]]): Option[List[alloy_sig]] =
     a match {
       case None => None
@@ -6652,6 +6655,42 @@ object SpecRestGenerated {
           }
       }
   }
+
+  def lookupAliasTarget(x0: List[type_alias_decl_full], uu: String): Option[type_expr_full] =
+    (x0, uu) match {
+      case (Nil, uu) => None
+      case (TypeAliasDeclFull(nm, tgt, uv, uw) :: rest, n) =>
+        nm == n match {
+          case true  => Some[type_expr_full](tgt)
+          case false => lookupAliasTarget(rest, n)
+        }
+    }
+
+  def isNumericTypeAux(fuel: nat, uu: List[type_alias_decl_full], uv: type_expr_full): Boolean =
+    equal_nat(fuel, zero_nat) match {
+      case true => false
+      case false => uv match {
+          case NamedTypeF(n, _) =>
+            n == "Int" ||
+              (n == "Long" ||
+                (n == "Float" || n == "Double")) match {
+              case true => true
+              case false => lookupAliasTarget(uu, n) match {
+                  case None    => false
+                  case Some(a) => isNumericTypeAux(minus_nat(fuel, one_nat), uu, a)
+                }
+            }
+          case SetTypeF(_, _)    => false
+          case MapTypeF(_, _, _) => false
+          case SeqTypeF(_, _)    => false
+          case OptionTypeF(inner, _) =>
+            isNumericTypeAux(minus_nat(fuel, one_nat), uu, inner)
+          case RelationTypeF(_, _, _, _) => false
+        }
+    }
+
+  def isNumericType(aliases: List[type_alias_decl_full], t: type_expr_full): Boolean =
+    isNumericTypeAux(typeWalkFuel(aliases), aliases, t)
 
   def alloyUnopShape(x0: un_op_full): alloy_unop_shape = x0 match {
     case UNot()         => AusNot()
@@ -8443,6 +8482,51 @@ object SpecRestGenerated {
   def serviceEntities(x0: service_ir_full): List[entity_decl_full] = x0 match {
     case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
   }
+
+  def isDateTimeTypeAux(fuel: nat, uu: List[type_alias_decl_full], uv: type_expr_full): Boolean =
+    equal_nat(fuel, zero_nat) match {
+      case true => false
+      case false => uv match {
+          case NamedTypeF(n, _) =>
+            n == "DateTime" match {
+              case true => true
+              case false => lookupAliasTarget(uu, n) match {
+                  case None    => false
+                  case Some(a) => isDateTimeTypeAux(minus_nat(fuel, one_nat), uu, a)
+                }
+            }
+          case SetTypeF(_, _)    => false
+          case MapTypeF(_, _, _) => false
+          case SeqTypeF(_, _)    => false
+          case OptionTypeF(inner, _) =>
+            isDateTimeTypeAux(minus_nat(fuel, one_nat), uu, inner)
+          case RelationTypeF(_, _, _, _) => false
+        }
+    }
+
+  def isDateTimeType(aliases: List[type_alias_decl_full], t: type_expr_full): Boolean =
+    isDateTimeTypeAux(typeWalkFuel(aliases), aliases, t)
+
+  def isOptionalTypeAux(fuel: nat, uu: List[type_alias_decl_full], uv: type_expr_full): Boolean =
+    equal_nat(fuel, zero_nat) match {
+      case true => false
+      case false => uv match {
+          case NamedTypeF(n, _) =>
+            lookupAliasTarget(uu, n) match {
+              case None => false
+              case Some(a) =>
+                isOptionalTypeAux(minus_nat(fuel, one_nat), uu, a)
+            }
+          case SetTypeF(_, _)            => false
+          case MapTypeF(_, _, _)         => false
+          case SeqTypeF(_, _)            => false
+          case OptionTypeF(_, _)         => true
+          case RelationTypeF(_, _, _, _) => false
+        }
+    }
+
+  def isOptionalType(aliases: List[type_alias_decl_full], t: type_expr_full): Boolean =
+    isOptionalTypeAux(typeWalkFuel(aliases), aliases, t)
 
   def alloyBinopShape(x0: bin_op_full): alloy_binop_shape = x0 match {
     case BAnd()       => AbsLogical("and")
@@ -12921,6 +13005,35 @@ object SpecRestGenerated {
       case NoneLitF(_)                   => None
       case IdentifierF(_, _)             => None
     }
+
+  def collectionElementTypeAux(
+      fuel: nat,
+      uu: List[type_alias_decl_full],
+      uv: type_expr_full
+  ): Option[type_expr_full] =
+    equal_nat(fuel, zero_nat) match {
+      case true => None
+      case false => uv match {
+          case NamedTypeF(n, _) =>
+            lookupAliasTarget(uu, n) match {
+              case None => None
+              case Some(a) =>
+                collectionElementTypeAux(minus_nat(fuel, one_nat), uu, a)
+            }
+          case SetTypeF(inner, _) => Some[type_expr_full](inner)
+          case MapTypeF(_, _, _)  => None
+          case SeqTypeF(inner, _) => Some[type_expr_full](inner)
+          case OptionTypeF(inner, _) =>
+            collectionElementTypeAux(minus_nat(fuel, one_nat), uu, inner)
+          case RelationTypeF(_, _, _, _) => None
+        }
+    }
+
+  def collectionElementType(
+      aliases: List[type_alias_decl_full],
+      t: type_expr_full
+  ): Option[type_expr_full] =
+    collectionElementTypeAux(typeWalkFuel(aliases), aliases, t)
 
   def splitOnColonAux(uu: List[BigInt], x1: List[BigInt]): Option[(List[BigInt], List[BigInt])] =
     (uu, x1) match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -10308,6 +10308,36 @@ object SpecRestGenerated {
         }
     }
 
+  def isMapLiteralExpr(x0: expr_full): Boolean = x0 match {
+    case MapLiteralF(uu, uv)              => true
+    case BinaryOpF(v, va, vb, vc)         => false
+    case UnaryOpF(v, va, vb)              => false
+    case QuantifierF(v, va, vb, vc)       => false
+    case SomeWrapF(v, va)                 => false
+    case TheF(v, va, vb, vc)              => false
+    case FieldAccessF(v, va, vb)          => false
+    case EnumAccessF(v, va, vb)           => false
+    case IndexF(v, va, vb)                => false
+    case CallF(v, va, vb)                 => false
+    case PrimeF(v, va)                    => false
+    case PreF(v, va)                      => false
+    case WithF(v, va, vb)                 => false
+    case IfF(v, va, vb, vc)               => false
+    case LetF(v, va, vb, vc)              => false
+    case LambdaF(v, va, vb)               => false
+    case ConstructorF(v, va, vb)          => false
+    case SetLiteralF(v, va)               => false
+    case SetComprehensionF(v, va, vb, vc) => false
+    case SeqLiteralF(v, va)               => false
+    case MatchesF(v, va, vb)              => false
+    case IntLitF(v, va)                   => false
+    case FloatLitF(v, va)                 => false
+    case StringLitF(v, va)                => false
+    case BoolLitF(v, va)                  => false
+    case NoneLitF(v)                      => false
+    case IdentifierF(v, va)               => false
+  }
+
   def signalsHasCollectionInput(x0: analysis_signals): Boolean = x0 match {
     case AnalysisSignals(uu, uv, uw, ux, uy, uz, va, vb, h) => h
   }

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -6319,6 +6319,769 @@ object SpecRestGenerated {
         }
     }
 
+  def equal_bin_op_full(x0: bin_op_full, x1: bin_op_full): Boolean = (x0, x1) match {
+    case (BMul(), BDiv())             => false
+    case (BDiv(), BMul())             => false
+    case (BSub(), BDiv())             => false
+    case (BDiv(), BSub())             => false
+    case (BSub(), BMul())             => false
+    case (BMul(), BSub())             => false
+    case (BAdd(), BDiv())             => false
+    case (BDiv(), BAdd())             => false
+    case (BAdd(), BMul())             => false
+    case (BMul(), BAdd())             => false
+    case (BAdd(), BSub())             => false
+    case (BSub(), BAdd())             => false
+    case (BDiff(), BDiv())            => false
+    case (BDiv(), BDiff())            => false
+    case (BDiff(), BMul())            => false
+    case (BMul(), BDiff())            => false
+    case (BDiff(), BSub())            => false
+    case (BSub(), BDiff())            => false
+    case (BDiff(), BAdd())            => false
+    case (BAdd(), BDiff())            => false
+    case (BIntersect(), BDiv())       => false
+    case (BDiv(), BIntersect())       => false
+    case (BIntersect(), BMul())       => false
+    case (BMul(), BIntersect())       => false
+    case (BIntersect(), BSub())       => false
+    case (BSub(), BIntersect())       => false
+    case (BIntersect(), BAdd())       => false
+    case (BAdd(), BIntersect())       => false
+    case (BIntersect(), BDiff())      => false
+    case (BDiff(), BIntersect())      => false
+    case (BUnion(), BDiv())           => false
+    case (BDiv(), BUnion())           => false
+    case (BUnion(), BMul())           => false
+    case (BMul(), BUnion())           => false
+    case (BUnion(), BSub())           => false
+    case (BSub(), BUnion())           => false
+    case (BUnion(), BAdd())           => false
+    case (BAdd(), BUnion())           => false
+    case (BUnion(), BDiff())          => false
+    case (BDiff(), BUnion())          => false
+    case (BUnion(), BIntersect())     => false
+    case (BIntersect(), BUnion())     => false
+    case (BSubset(), BDiv())          => false
+    case (BDiv(), BSubset())          => false
+    case (BSubset(), BMul())          => false
+    case (BMul(), BSubset())          => false
+    case (BSubset(), BSub())          => false
+    case (BSub(), BSubset())          => false
+    case (BSubset(), BAdd())          => false
+    case (BAdd(), BSubset())          => false
+    case (BSubset(), BDiff())         => false
+    case (BDiff(), BSubset())         => false
+    case (BSubset(), BIntersect())    => false
+    case (BIntersect(), BSubset())    => false
+    case (BSubset(), BUnion())        => false
+    case (BUnion(), BSubset())        => false
+    case (BNotIn(), BDiv())           => false
+    case (BDiv(), BNotIn())           => false
+    case (BNotIn(), BMul())           => false
+    case (BMul(), BNotIn())           => false
+    case (BNotIn(), BSub())           => false
+    case (BSub(), BNotIn())           => false
+    case (BNotIn(), BAdd())           => false
+    case (BAdd(), BNotIn())           => false
+    case (BNotIn(), BDiff())          => false
+    case (BDiff(), BNotIn())          => false
+    case (BNotIn(), BIntersect())     => false
+    case (BIntersect(), BNotIn())     => false
+    case (BNotIn(), BUnion())         => false
+    case (BUnion(), BNotIn())         => false
+    case (BNotIn(), BSubset())        => false
+    case (BSubset(), BNotIn())        => false
+    case (BIn(), BDiv())              => false
+    case (BDiv(), BIn())              => false
+    case (BIn(), BMul())              => false
+    case (BMul(), BIn())              => false
+    case (BIn(), BSub())              => false
+    case (BSub(), BIn())              => false
+    case (BIn(), BAdd())              => false
+    case (BAdd(), BIn())              => false
+    case (BIn(), BDiff())             => false
+    case (BDiff(), BIn())             => false
+    case (BIn(), BIntersect())        => false
+    case (BIntersect(), BIn())        => false
+    case (BIn(), BUnion())            => false
+    case (BUnion(), BIn())            => false
+    case (BIn(), BSubset())           => false
+    case (BSubset(), BIn())           => false
+    case (BIn(), BNotIn())            => false
+    case (BNotIn(), BIn())            => false
+    case (BGe(), BDiv())              => false
+    case (BDiv(), BGe())              => false
+    case (BGe(), BMul())              => false
+    case (BMul(), BGe())              => false
+    case (BGe(), BSub())              => false
+    case (BSub(), BGe())              => false
+    case (BGe(), BAdd())              => false
+    case (BAdd(), BGe())              => false
+    case (BGe(), BDiff())             => false
+    case (BDiff(), BGe())             => false
+    case (BGe(), BIntersect())        => false
+    case (BIntersect(), BGe())        => false
+    case (BGe(), BUnion())            => false
+    case (BUnion(), BGe())            => false
+    case (BGe(), BSubset())           => false
+    case (BSubset(), BGe())           => false
+    case (BGe(), BNotIn())            => false
+    case (BNotIn(), BGe())            => false
+    case (BGe(), BIn())               => false
+    case (BIn(), BGe())               => false
+    case (BLe(), BDiv())              => false
+    case (BDiv(), BLe())              => false
+    case (BLe(), BMul())              => false
+    case (BMul(), BLe())              => false
+    case (BLe(), BSub())              => false
+    case (BSub(), BLe())              => false
+    case (BLe(), BAdd())              => false
+    case (BAdd(), BLe())              => false
+    case (BLe(), BDiff())             => false
+    case (BDiff(), BLe())             => false
+    case (BLe(), BIntersect())        => false
+    case (BIntersect(), BLe())        => false
+    case (BLe(), BUnion())            => false
+    case (BUnion(), BLe())            => false
+    case (BLe(), BSubset())           => false
+    case (BSubset(), BLe())           => false
+    case (BLe(), BNotIn())            => false
+    case (BNotIn(), BLe())            => false
+    case (BLe(), BIn())               => false
+    case (BIn(), BLe())               => false
+    case (BLe(), BGe())               => false
+    case (BGe(), BLe())               => false
+    case (BGt(), BDiv())              => false
+    case (BDiv(), BGt())              => false
+    case (BGt(), BMul())              => false
+    case (BMul(), BGt())              => false
+    case (BGt(), BSub())              => false
+    case (BSub(), BGt())              => false
+    case (BGt(), BAdd())              => false
+    case (BAdd(), BGt())              => false
+    case (BGt(), BDiff())             => false
+    case (BDiff(), BGt())             => false
+    case (BGt(), BIntersect())        => false
+    case (BIntersect(), BGt())        => false
+    case (BGt(), BUnion())            => false
+    case (BUnion(), BGt())            => false
+    case (BGt(), BSubset())           => false
+    case (BSubset(), BGt())           => false
+    case (BGt(), BNotIn())            => false
+    case (BNotIn(), BGt())            => false
+    case (BGt(), BIn())               => false
+    case (BIn(), BGt())               => false
+    case (BGt(), BGe())               => false
+    case (BGe(), BGt())               => false
+    case (BGt(), BLe())               => false
+    case (BLe(), BGt())               => false
+    case (BLt(), BDiv())              => false
+    case (BDiv(), BLt())              => false
+    case (BLt(), BMul())              => false
+    case (BMul(), BLt())              => false
+    case (BLt(), BSub())              => false
+    case (BSub(), BLt())              => false
+    case (BLt(), BAdd())              => false
+    case (BAdd(), BLt())              => false
+    case (BLt(), BDiff())             => false
+    case (BDiff(), BLt())             => false
+    case (BLt(), BIntersect())        => false
+    case (BIntersect(), BLt())        => false
+    case (BLt(), BUnion())            => false
+    case (BUnion(), BLt())            => false
+    case (BLt(), BSubset())           => false
+    case (BSubset(), BLt())           => false
+    case (BLt(), BNotIn())            => false
+    case (BNotIn(), BLt())            => false
+    case (BLt(), BIn())               => false
+    case (BIn(), BLt())               => false
+    case (BLt(), BGe())               => false
+    case (BGe(), BLt())               => false
+    case (BLt(), BLe())               => false
+    case (BLe(), BLt())               => false
+    case (BLt(), BGt())               => false
+    case (BGt(), BLt())               => false
+    case (BNeq(), BDiv())             => false
+    case (BDiv(), BNeq())             => false
+    case (BNeq(), BMul())             => false
+    case (BMul(), BNeq())             => false
+    case (BNeq(), BSub())             => false
+    case (BSub(), BNeq())             => false
+    case (BNeq(), BAdd())             => false
+    case (BAdd(), BNeq())             => false
+    case (BNeq(), BDiff())            => false
+    case (BDiff(), BNeq())            => false
+    case (BNeq(), BIntersect())       => false
+    case (BIntersect(), BNeq())       => false
+    case (BNeq(), BUnion())           => false
+    case (BUnion(), BNeq())           => false
+    case (BNeq(), BSubset())          => false
+    case (BSubset(), BNeq())          => false
+    case (BNeq(), BNotIn())           => false
+    case (BNotIn(), BNeq())           => false
+    case (BNeq(), BIn())              => false
+    case (BIn(), BNeq())              => false
+    case (BNeq(), BGe())              => false
+    case (BGe(), BNeq())              => false
+    case (BNeq(), BLe())              => false
+    case (BLe(), BNeq())              => false
+    case (BNeq(), BGt())              => false
+    case (BGt(), BNeq())              => false
+    case (BNeq(), BLt())              => false
+    case (BLt(), BNeq())              => false
+    case (BEq(), BDiv())              => false
+    case (BDiv(), BEq())              => false
+    case (BEq(), BMul())              => false
+    case (BMul(), BEq())              => false
+    case (BEq(), BSub())              => false
+    case (BSub(), BEq())              => false
+    case (BEq(), BAdd())              => false
+    case (BAdd(), BEq())              => false
+    case (BEq(), BDiff())             => false
+    case (BDiff(), BEq())             => false
+    case (BEq(), BIntersect())        => false
+    case (BIntersect(), BEq())        => false
+    case (BEq(), BUnion())            => false
+    case (BUnion(), BEq())            => false
+    case (BEq(), BSubset())           => false
+    case (BSubset(), BEq())           => false
+    case (BEq(), BNotIn())            => false
+    case (BNotIn(), BEq())            => false
+    case (BEq(), BIn())               => false
+    case (BIn(), BEq())               => false
+    case (BEq(), BGe())               => false
+    case (BGe(), BEq())               => false
+    case (BEq(), BLe())               => false
+    case (BLe(), BEq())               => false
+    case (BEq(), BGt())               => false
+    case (BGt(), BEq())               => false
+    case (BEq(), BLt())               => false
+    case (BLt(), BEq())               => false
+    case (BEq(), BNeq())              => false
+    case (BNeq(), BEq())              => false
+    case (BIff(), BDiv())             => false
+    case (BDiv(), BIff())             => false
+    case (BIff(), BMul())             => false
+    case (BMul(), BIff())             => false
+    case (BIff(), BSub())             => false
+    case (BSub(), BIff())             => false
+    case (BIff(), BAdd())             => false
+    case (BAdd(), BIff())             => false
+    case (BIff(), BDiff())            => false
+    case (BDiff(), BIff())            => false
+    case (BIff(), BIntersect())       => false
+    case (BIntersect(), BIff())       => false
+    case (BIff(), BUnion())           => false
+    case (BUnion(), BIff())           => false
+    case (BIff(), BSubset())          => false
+    case (BSubset(), BIff())          => false
+    case (BIff(), BNotIn())           => false
+    case (BNotIn(), BIff())           => false
+    case (BIff(), BIn())              => false
+    case (BIn(), BIff())              => false
+    case (BIff(), BGe())              => false
+    case (BGe(), BIff())              => false
+    case (BIff(), BLe())              => false
+    case (BLe(), BIff())              => false
+    case (BIff(), BGt())              => false
+    case (BGt(), BIff())              => false
+    case (BIff(), BLt())              => false
+    case (BLt(), BIff())              => false
+    case (BIff(), BNeq())             => false
+    case (BNeq(), BIff())             => false
+    case (BIff(), BEq())              => false
+    case (BEq(), BIff())              => false
+    case (BImplies(), BDiv())         => false
+    case (BDiv(), BImplies())         => false
+    case (BImplies(), BMul())         => false
+    case (BMul(), BImplies())         => false
+    case (BImplies(), BSub())         => false
+    case (BSub(), BImplies())         => false
+    case (BImplies(), BAdd())         => false
+    case (BAdd(), BImplies())         => false
+    case (BImplies(), BDiff())        => false
+    case (BDiff(), BImplies())        => false
+    case (BImplies(), BIntersect())   => false
+    case (BIntersect(), BImplies())   => false
+    case (BImplies(), BUnion())       => false
+    case (BUnion(), BImplies())       => false
+    case (BImplies(), BSubset())      => false
+    case (BSubset(), BImplies())      => false
+    case (BImplies(), BNotIn())       => false
+    case (BNotIn(), BImplies())       => false
+    case (BImplies(), BIn())          => false
+    case (BIn(), BImplies())          => false
+    case (BImplies(), BGe())          => false
+    case (BGe(), BImplies())          => false
+    case (BImplies(), BLe())          => false
+    case (BLe(), BImplies())          => false
+    case (BImplies(), BGt())          => false
+    case (BGt(), BImplies())          => false
+    case (BImplies(), BLt())          => false
+    case (BLt(), BImplies())          => false
+    case (BImplies(), BNeq())         => false
+    case (BNeq(), BImplies())         => false
+    case (BImplies(), BEq())          => false
+    case (BEq(), BImplies())          => false
+    case (BImplies(), BIff())         => false
+    case (BIff(), BImplies())         => false
+    case (BOr(), BDiv())              => false
+    case (BDiv(), BOr())              => false
+    case (BOr(), BMul())              => false
+    case (BMul(), BOr())              => false
+    case (BOr(), BSub())              => false
+    case (BSub(), BOr())              => false
+    case (BOr(), BAdd())              => false
+    case (BAdd(), BOr())              => false
+    case (BOr(), BDiff())             => false
+    case (BDiff(), BOr())             => false
+    case (BOr(), BIntersect())        => false
+    case (BIntersect(), BOr())        => false
+    case (BOr(), BUnion())            => false
+    case (BUnion(), BOr())            => false
+    case (BOr(), BSubset())           => false
+    case (BSubset(), BOr())           => false
+    case (BOr(), BNotIn())            => false
+    case (BNotIn(), BOr())            => false
+    case (BOr(), BIn())               => false
+    case (BIn(), BOr())               => false
+    case (BOr(), BGe())               => false
+    case (BGe(), BOr())               => false
+    case (BOr(), BLe())               => false
+    case (BLe(), BOr())               => false
+    case (BOr(), BGt())               => false
+    case (BGt(), BOr())               => false
+    case (BOr(), BLt())               => false
+    case (BLt(), BOr())               => false
+    case (BOr(), BNeq())              => false
+    case (BNeq(), BOr())              => false
+    case (BOr(), BEq())               => false
+    case (BEq(), BOr())               => false
+    case (BOr(), BIff())              => false
+    case (BIff(), BOr())              => false
+    case (BOr(), BImplies())          => false
+    case (BImplies(), BOr())          => false
+    case (BAnd(), BDiv())             => false
+    case (BDiv(), BAnd())             => false
+    case (BAnd(), BMul())             => false
+    case (BMul(), BAnd())             => false
+    case (BAnd(), BSub())             => false
+    case (BSub(), BAnd())             => false
+    case (BAnd(), BAdd())             => false
+    case (BAdd(), BAnd())             => false
+    case (BAnd(), BDiff())            => false
+    case (BDiff(), BAnd())            => false
+    case (BAnd(), BIntersect())       => false
+    case (BIntersect(), BAnd())       => false
+    case (BAnd(), BUnion())           => false
+    case (BUnion(), BAnd())           => false
+    case (BAnd(), BSubset())          => false
+    case (BSubset(), BAnd())          => false
+    case (BAnd(), BNotIn())           => false
+    case (BNotIn(), BAnd())           => false
+    case (BAnd(), BIn())              => false
+    case (BIn(), BAnd())              => false
+    case (BAnd(), BGe())              => false
+    case (BGe(), BAnd())              => false
+    case (BAnd(), BLe())              => false
+    case (BLe(), BAnd())              => false
+    case (BAnd(), BGt())              => false
+    case (BGt(), BAnd())              => false
+    case (BAnd(), BLt())              => false
+    case (BLt(), BAnd())              => false
+    case (BAnd(), BNeq())             => false
+    case (BNeq(), BAnd())             => false
+    case (BAnd(), BEq())              => false
+    case (BEq(), BAnd())              => false
+    case (BAnd(), BIff())             => false
+    case (BIff(), BAnd())             => false
+    case (BAnd(), BImplies())         => false
+    case (BImplies(), BAnd())         => false
+    case (BAnd(), BOr())              => false
+    case (BOr(), BAnd())              => false
+    case (BDiv(), BDiv())             => true
+    case (BMul(), BMul())             => true
+    case (BSub(), BSub())             => true
+    case (BAdd(), BAdd())             => true
+    case (BDiff(), BDiff())           => true
+    case (BIntersect(), BIntersect()) => true
+    case (BUnion(), BUnion())         => true
+    case (BSubset(), BSubset())       => true
+    case (BNotIn(), BNotIn())         => true
+    case (BIn(), BIn())               => true
+    case (BGe(), BGe())               => true
+    case (BLe(), BLe())               => true
+    case (BGt(), BGt())               => true
+    case (BLt(), BLt())               => true
+    case (BNeq(), BNeq())             => true
+    case (BEq(), BEq())               => true
+    case (BIff(), BIff())             => true
+    case (BImplies(), BImplies())     => true
+    case (BOr(), BOr())               => true
+    case (BAnd(), BAnd())             => true
+  }
+
+  def neqNoneName(e: expr_full): Option[String] =
+    e match {
+      case BinaryOpF(BAnd(), _, _, _)                                     => None
+      case BinaryOpF(BOr(), _, _, _)                                      => None
+      case BinaryOpF(BImplies(), _, _, _)                                 => None
+      case BinaryOpF(BIff(), _, _, _)                                     => None
+      case BinaryOpF(BEq(), _, _, _)                                      => None
+      case BinaryOpF(BNeq(), BinaryOpF(_, _, _, _), _, _)                 => None
+      case BinaryOpF(BNeq(), UnaryOpF(_, _, _), _, _)                     => None
+      case BinaryOpF(BNeq(), QuantifierF(_, _, _, _), _, _)               => None
+      case BinaryOpF(BNeq(), SomeWrapF(_, _), _, _)                       => None
+      case BinaryOpF(BNeq(), TheF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BNeq(), FieldAccessF(_, _, _), _, _)                 => None
+      case BinaryOpF(BNeq(), EnumAccessF(_, _, _), _, _)                  => None
+      case BinaryOpF(BNeq(), IndexF(_, _, _), _, _)                       => None
+      case BinaryOpF(BNeq(), CallF(_, _, _), _, _)                        => None
+      case BinaryOpF(BNeq(), PrimeF(_, _), _, _)                          => None
+      case BinaryOpF(BNeq(), PreF(_, _), _, _)                            => None
+      case BinaryOpF(BNeq(), WithF(_, _, _), _, _)                        => None
+      case BinaryOpF(BNeq(), IfF(_, _, _, _), _, _)                       => None
+      case BinaryOpF(BNeq(), LetF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BNeq(), LambdaF(_, _, _), _, _)                      => None
+      case BinaryOpF(BNeq(), ConstructorF(_, _, _), _, _)                 => None
+      case BinaryOpF(BNeq(), SetLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BNeq(), MapLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BNeq(), SetComprehensionF(_, _, _, _), _, _)         => None
+      case BinaryOpF(BNeq(), SeqLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BNeq(), MatchesF(_, _, _), _, _)                     => None
+      case BinaryOpF(BNeq(), IntLitF(_, _), _, _)                         => None
+      case BinaryOpF(BNeq(), FloatLitF(_, _), _, _)                       => None
+      case BinaryOpF(BNeq(), StringLitF(_, _), _, _)                      => None
+      case BinaryOpF(BNeq(), BoolLitF(_, _), _, _)                        => None
+      case BinaryOpF(BNeq(), NoneLitF(_), _, _)                           => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), BinaryOpF(_, _, _, _), _) => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), UnaryOpF(_, _, _), _)     => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), QuantifierF(_, _, _, _), _) =>
+        None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), SomeWrapF(_, _), _)               => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), TheF(_, _, _, _), _)              => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), FieldAccessF(_, _, _), _)         => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), EnumAccessF(_, _, _), _)          => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), IndexF(_, _, _), _)               => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), CallF(_, _, _), _)                => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), PrimeF(_, _), _)                  => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), PreF(_, _), _)                    => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), WithF(_, _, _), _)                => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), IfF(_, _, _, _), _)               => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), LetF(_, _, _, _), _)              => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), LambdaF(_, _, _), _)              => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), ConstructorF(_, _, _), _)         => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), SetLiteralF(_, _), _)             => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), MapLiteralF(_, _), _)             => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), SetComprehensionF(_, _, _, _), _) => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), SeqLiteralF(_, _), _)             => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), MatchesF(_, _, _), _)             => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), IntLitF(_, _), _)                 => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), FloatLitF(_, _), _)               => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), StringLitF(_, _), _)              => None
+      case BinaryOpF(BNeq(), IdentifierF(_, _), BoolLitF(_, _), _)                => None
+      case BinaryOpF(BNeq(), IdentifierF(p, _), NoneLitF(_), _) =>
+        Some[String](p)
+      case BinaryOpF(BNeq(), IdentifierF(_, _), IdentifierF(_, _), _) => None
+      case BinaryOpF(BLt(), _, _, _)                                  => None
+      case BinaryOpF(BGt(), _, _, _)                                  => None
+      case BinaryOpF(BLe(), _, _, _)                                  => None
+      case BinaryOpF(BGe(), _, _, _)                                  => None
+      case BinaryOpF(BIn(), _, _, _)                                  => None
+      case BinaryOpF(BNotIn(), _, _, _)                               => None
+      case BinaryOpF(BSubset(), _, _, _)                              => None
+      case BinaryOpF(BUnion(), _, _, _)                               => None
+      case BinaryOpF(BIntersect(), _, _, _)                           => None
+      case BinaryOpF(BDiff(), _, _, _)                                => None
+      case BinaryOpF(BAdd(), _, _, _)                                 => None
+      case BinaryOpF(BSub(), _, _, _)                                 => None
+      case BinaryOpF(BMul(), _, _, _)                                 => None
+      case BinaryOpF(BDiv(), _, _, _)                                 => None
+      case UnaryOpF(_, _, _)                                          => None
+      case QuantifierF(_, _, _, _)                                    => None
+      case SomeWrapF(_, _)                                            => None
+      case TheF(_, _, _, _)                                           => None
+      case FieldAccessF(_, _, _)                                      => None
+      case EnumAccessF(_, _, _)                                       => None
+      case IndexF(_, _, _)                                            => None
+      case CallF(_, _, _)                                             => None
+      case PrimeF(_, _)                                               => None
+      case PreF(_, _)                                                 => None
+      case WithF(_, _, _)                                             => None
+      case IfF(_, _, _, _)                                            => None
+      case LetF(_, _, _, _)                                           => None
+      case LambdaF(_, _, _)                                           => None
+      case ConstructorF(_, _, _)                                      => None
+      case SetLiteralF(_, _)                                          => None
+      case MapLiteralF(_, _)                                          => None
+      case SetComprehensionF(_, _, _, _)                              => None
+      case SeqLiteralF(_, _)                                          => None
+      case MatchesF(_, _, _)                                          => None
+      case IntLitF(_, _)                                              => None
+      case FloatLitF(_, _)                                            => None
+      case StringLitF(_, _)                                           => None
+      case BoolLitF(_, _)                                             => None
+      case NoneLitF(_)                                                => None
+      case IdentifierF(_, _)                                          => None
+    }
+
+  def substValue(p: String, body: expr_full): expr_full =
+    subst(p, FieldAccessF(IdentifierF(p, None), "value", None), body)
+
+  def eqNoneName(e: expr_full): Option[String] =
+    e match {
+      case BinaryOpF(BAnd(), _, _, _)                                    => None
+      case BinaryOpF(BOr(), _, _, _)                                     => None
+      case BinaryOpF(BImplies(), _, _, _)                                => None
+      case BinaryOpF(BIff(), _, _, _)                                    => None
+      case BinaryOpF(BEq(), BinaryOpF(_, _, _, _), _, _)                 => None
+      case BinaryOpF(BEq(), UnaryOpF(_, _, _), _, _)                     => None
+      case BinaryOpF(BEq(), QuantifierF(_, _, _, _), _, _)               => None
+      case BinaryOpF(BEq(), SomeWrapF(_, _), _, _)                       => None
+      case BinaryOpF(BEq(), TheF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BEq(), FieldAccessF(_, _, _), _, _)                 => None
+      case BinaryOpF(BEq(), EnumAccessF(_, _, _), _, _)                  => None
+      case BinaryOpF(BEq(), IndexF(_, _, _), _, _)                       => None
+      case BinaryOpF(BEq(), CallF(_, _, _), _, _)                        => None
+      case BinaryOpF(BEq(), PrimeF(_, _), _, _)                          => None
+      case BinaryOpF(BEq(), PreF(_, _), _, _)                            => None
+      case BinaryOpF(BEq(), WithF(_, _, _), _, _)                        => None
+      case BinaryOpF(BEq(), IfF(_, _, _, _), _, _)                       => None
+      case BinaryOpF(BEq(), LetF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BEq(), LambdaF(_, _, _), _, _)                      => None
+      case BinaryOpF(BEq(), ConstructorF(_, _, _), _, _)                 => None
+      case BinaryOpF(BEq(), SetLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BEq(), MapLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BEq(), SetComprehensionF(_, _, _, _), _, _)         => None
+      case BinaryOpF(BEq(), SeqLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BEq(), MatchesF(_, _, _), _, _)                     => None
+      case BinaryOpF(BEq(), IntLitF(_, _), _, _)                         => None
+      case BinaryOpF(BEq(), FloatLitF(_, _), _, _)                       => None
+      case BinaryOpF(BEq(), StringLitF(_, _), _, _)                      => None
+      case BinaryOpF(BEq(), BoolLitF(_, _), _, _)                        => None
+      case BinaryOpF(BEq(), NoneLitF(_), _, _)                           => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), BinaryOpF(_, _, _, _), _) => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), UnaryOpF(_, _, _), _)     => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), QuantifierF(_, _, _, _), _) =>
+        None
+      case BinaryOpF(BEq(), IdentifierF(_, _), SomeWrapF(_, _), _)               => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), TheF(_, _, _, _), _)              => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), FieldAccessF(_, _, _), _)         => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), EnumAccessF(_, _, _), _)          => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), IndexF(_, _, _), _)               => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), CallF(_, _, _), _)                => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), PrimeF(_, _), _)                  => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), PreF(_, _), _)                    => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), WithF(_, _, _), _)                => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), IfF(_, _, _, _), _)               => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), LetF(_, _, _, _), _)              => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), LambdaF(_, _, _), _)              => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), ConstructorF(_, _, _), _)         => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), SetLiteralF(_, _), _)             => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), MapLiteralF(_, _), _)             => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), SetComprehensionF(_, _, _, _), _) => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), SeqLiteralF(_, _), _)             => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), MatchesF(_, _, _), _)             => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), IntLitF(_, _), _)                 => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), FloatLitF(_, _), _)               => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), StringLitF(_, _), _)              => None
+      case BinaryOpF(BEq(), IdentifierF(_, _), BoolLitF(_, _), _)                => None
+      case BinaryOpF(BEq(), IdentifierF(p, _), NoneLitF(_), _)                   => Some[String](p)
+      case BinaryOpF(BEq(), IdentifierF(_, _), IdentifierF(_, _), _)             => None
+      case BinaryOpF(BNeq(), _, _, _)                                            => None
+      case BinaryOpF(BLt(), _, _, _)                                             => None
+      case BinaryOpF(BGt(), _, _, _)                                             => None
+      case BinaryOpF(BLe(), _, _, _)                                             => None
+      case BinaryOpF(BGe(), _, _, _)                                             => None
+      case BinaryOpF(BIn(), _, _, _)                                             => None
+      case BinaryOpF(BNotIn(), _, _, _)                                          => None
+      case BinaryOpF(BSubset(), _, _, _)                                         => None
+      case BinaryOpF(BUnion(), _, _, _)                                          => None
+      case BinaryOpF(BIntersect(), _, _, _)                                      => None
+      case BinaryOpF(BDiff(), _, _, _)                                           => None
+      case BinaryOpF(BAdd(), _, _, _)                                            => None
+      case BinaryOpF(BSub(), _, _, _)                                            => None
+      case BinaryOpF(BMul(), _, _, _)                                            => None
+      case BinaryOpF(BDiv(), _, _, _)                                            => None
+      case UnaryOpF(_, _, _)                                                     => None
+      case QuantifierF(_, _, _, _)                                               => None
+      case SomeWrapF(_, _)                                                       => None
+      case TheF(_, _, _, _)                                                      => None
+      case FieldAccessF(_, _, _)                                                 => None
+      case EnumAccessF(_, _, _)                                                  => None
+      case IndexF(_, _, _)                                                       => None
+      case CallF(_, _, _)                                                        => None
+      case PrimeF(_, _)                                                          => None
+      case PreF(_, _)                                                            => None
+      case WithF(_, _, _)                                                        => None
+      case IfF(_, _, _, _)                                                       => None
+      case LetF(_, _, _, _)                                                      => None
+      case LambdaF(_, _, _)                                                      => None
+      case ConstructorF(_, _, _)                                                 => None
+      case SetLiteralF(_, _)                                                     => None
+      case MapLiteralF(_, _)                                                     => None
+      case SetComprehensionF(_, _, _, _)                                         => None
+      case SeqLiteralF(_, _)                                                     => None
+      case MatchesF(_, _, _)                                                     => None
+      case IntLitF(_, _)                                                         => None
+      case FloatLitF(_, _)                                                       => None
+      case StringLitF(_, _)                                                      => None
+      case BoolLitF(_, _)                                                        => None
+      case NoneLitF(_)                                                           => None
+      case IdentifierF(_, _)                                                     => None
+    }
+
+  def desugarBindings(
+      fuel: nat,
+      uv: List[String],
+      bs: List[quantifier_binding_full]
+  ): List[quantifier_binding_full] =
+    equal_nat(fuel, zero_nat) match {
+      case true => bs
+      case false => bs match {
+          case Nil => Nil
+          case QuantifierBindingFull(a, d, kind, bsp) :: rest =>
+            QuantifierBindingFull(a, desugarGo(minus_nat(fuel, one_nat), uv, d), kind, bsp) ::
+              desugarBindings(minus_nat(fuel, one_nat), uv, rest)
+        }
+    }
+
+  def desugarGo(fuel: nat, uu: List[String], e: expr_full): expr_full =
+    equal_nat(fuel, zero_nat) match {
+      case true => e
+      case false => e match {
+          case BinaryOpF(op, l, r, sp) =>
+            equal_bin_op_full(op, BImplies()) match {
+              case true => neqNoneName(l) match {
+                  case None =>
+                    BinaryOpF(
+                      op,
+                      desugarGo(minus_nat(fuel, one_nat), uu, l),
+                      desugarGo(minus_nat(fuel, one_nat), uu, r),
+                      sp
+                    )
+                  case Some(p) =>
+                    string_in_list(p, uu) match {
+                      case true => BinaryOpF(
+                          BImplies(),
+                          l,
+                          desugarGo(minus_nat(fuel, one_nat), uu, substValue(p, r)),
+                          sp
+                        )
+                      case false => BinaryOpF(
+                          op,
+                          desugarGo(minus_nat(fuel, one_nat), uu, l),
+                          desugarGo(minus_nat(fuel, one_nat), uu, r),
+                          sp
+                        )
+                    }
+                }
+              case false => equal_bin_op_full(op, BOr()) match {
+                  case true => eqNoneName(l) match {
+                      case None =>
+                        eqNoneName(r) match {
+                          case None =>
+                            BinaryOpF(
+                              op,
+                              desugarGo(minus_nat(fuel, one_nat), uu, l),
+                              desugarGo(minus_nat(fuel, one_nat), uu, r),
+                              sp
+                            )
+                          case Some(q) =>
+                            string_in_list(q, uu) match {
+                              case true => BinaryOpF(
+                                  BOr(),
+                                  desugarGo(minus_nat(fuel, one_nat), uu, substValue(q, l)),
+                                  r,
+                                  sp
+                                )
+                              case false => BinaryOpF(
+                                  op,
+                                  desugarGo(minus_nat(fuel, one_nat), uu, l),
+                                  desugarGo(minus_nat(fuel, one_nat), uu, r),
+                                  sp
+                                )
+                            }
+                        }
+                      case Some(p) =>
+                        string_in_list(p, uu) match {
+                          case true => BinaryOpF(
+                              BOr(),
+                              l,
+                              desugarGo(minus_nat(fuel, one_nat), uu, substValue(p, r)),
+                              sp
+                            )
+                          case false => eqNoneName(r) match {
+                              case None =>
+                                BinaryOpF(
+                                  op,
+                                  desugarGo(minus_nat(fuel, one_nat), uu, l),
+                                  desugarGo(minus_nat(fuel, one_nat), uu, r),
+                                  sp
+                                )
+                              case Some(q) =>
+                                string_in_list(q, uu) match {
+                                  case true => BinaryOpF(
+                                      BOr(),
+                                      desugarGo(minus_nat(fuel, one_nat), uu, substValue(q, l)),
+                                      r,
+                                      sp
+                                    )
+                                  case false => BinaryOpF(
+                                      op,
+                                      desugarGo(minus_nat(fuel, one_nat), uu, l),
+                                      desugarGo(minus_nat(fuel, one_nat), uu, r),
+                                      sp
+                                    )
+                                }
+                            }
+                        }
+                    }
+                  case false => BinaryOpF(
+                      op,
+                      desugarGo(minus_nat(fuel, one_nat), uu, l),
+                      desugarGo(minus_nat(fuel, one_nat), uu, r),
+                      sp
+                    )
+                }
+            }
+          case UnaryOpF(op, x, a) =>
+            UnaryOpF(op, desugarGo(minus_nat(fuel, one_nat), uu, x), a)
+          case QuantifierF(q, bs, body, a) =>
+            QuantifierF(
+              q,
+              desugarBindings(minus_nat(fuel, one_nat), uu, bs),
+              desugarGo(minus_nat(fuel, one_nat), uu, body),
+              a
+            )
+          case SomeWrapF(_, _)               => e
+          case TheF(_, _, _, _)              => e
+          case FieldAccessF(_, _, _)         => e
+          case EnumAccessF(_, _, _)          => e
+          case IndexF(_, _, _)               => e
+          case CallF(_, _, _)                => e
+          case PrimeF(_, _)                  => e
+          case PreF(_, _)                    => e
+          case WithF(_, _, _)                => e
+          case IfF(_, _, _, _)               => e
+          case LetF(_, _, _, _)              => e
+          case LambdaF(_, _, _)              => e
+          case ConstructorF(_, _, _)         => e
+          case SetLiteralF(_, _)             => e
+          case MapLiteralF(_, _)             => e
+          case SetComprehensionF(_, _, _, _) => e
+          case SeqLiteralF(_, _)             => e
+          case MatchesF(_, _, _)             => e
+          case IntLitF(_, _)                 => e
+          case FloatLitF(_, _)               => e
+          case StringLitF(_, _)              => e
+          case BoolLitF(_, _)                => e
+          case NoneLitF(_)                   => e
+          case IdentifierF(_, _)             => e
+        }
+    }
+
   def saTypeExpr(x0: sa_type): String = x0 match {
     case SaType(e, uu) => e
   }
@@ -13307,6 +14070,9 @@ object SpecRestGenerated {
   def signalsPreservedRelations(x0: analysis_signals): List[String] = x0 match {
     case AnalysisSignals(uu, p, uv, uw, ux, uy, uz, va, vb) => p
   }
+
+  def desugarOptionGuards(opts: List[String], e: expr_full): expr_full =
+    desugarGo(plus_nat(size_list[expr_full](allSubexprs(e)), nat_of_integer(BigInt(100))), opts, e)
 
   def rewriteFieldRefsBindings(
       vk: List[String],

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
@@ -64,17 +64,3 @@ object AdminModel:
   def primaryKeyField(e: EntityDeclFull): Option[String] =
     val fs = e.c.collect { case f: FieldDeclFull => f }
     fs.find(_.a == "id").map(_.a).orElse(fs.headOption.map(_.a))
-
-  def isDateTimeType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Boolean =
-    t match
-      case NamedTypeF("DateTime", _) => true
-      case OptionTypeF(inner, _)     => isDateTimeType(inner, ir, seen)
-      case NamedTypeF(name, _) if !seen.contains(name) =>
-        ir.e.collect { case a: TypeAliasDeclFull => a }
-          .find(_.a == name)
-          .exists(alias => isDateTimeType(alias.b, ir, seen + name))
-      case _ => false

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -102,7 +102,7 @@ object AdminRouter:
     val snake  = Naming.toSnakeCase(entity.a)
     val pkName = AdminModel.primaryKeyField(entity).getOrElse("id")
     val dtFields = entity.c.collect:
-      case FieldDeclFull(n, t, _, _) if AdminModel.isDateTimeType(t, ir, Set.empty) => n
+      case FieldDeclFull(n, t, _, _) if isDateTimeType(ir.e, t) => n
     val coercion =
       if dtFields.isEmpty then ""
       else
@@ -123,33 +123,6 @@ object AdminRouter:
         |    await session.refresh(obj)
         |    return {"$pkName": obj.$pkName}
         |""".stripMargin
-
-  private[testgen] def isNumericType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Boolean =
-    t match
-      case NamedTypeF(n, _) if Set("Int", "Long", "Float", "Double").contains(n) => true
-      case OptionTypeF(inner, _)                                                 => isNumericType(inner, ir, seen)
-      case NamedTypeF(name, _) if !seen.contains(name) =>
-        ir.e.collect { case a: TypeAliasDeclFull => a }
-          .find(_.a == name)
-          .exists(alias => isNumericType(alias.b, ir, seen + name))
-      case _ => false
-
-  private[testgen] def isOptionalType(
-      t: type_expr_full,
-      ir: ServiceIRFull,
-      seen: Set[String]
-  ): Boolean =
-    t match
-      case OptionTypeF(_, _) => true
-      case NamedTypeF(name, _) if !seen.contains(name) =>
-        ir.e.collect { case a: TypeAliasDeclFull => a }
-          .find(_.a == name)
-          .exists(alias => isOptionalType(alias.b, ir, seen + name))
-      case _ => false
 
   private def projectionLine(
       f: StateFieldDeclFull,

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -22,7 +22,7 @@ object AdminRouterTs:
         Col(
           tsField = Naming.toCamelCase(f.a),
           columnName = Naming.toColumnName(f.a),
-          isDate = AdminModel.isDateTimeType(f.b, ir, Set.empty)
+          isDate = specrest.ir.generated.SpecRestGenerated.isDateTimeType(ir.e, f.b)
         )
 
     def accessor(e: EntityDeclFull): String = Naming.toCamelCase(e.a)

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -1144,11 +1144,11 @@ object Behavioral:
             fa <- findFieldDeclFull(entity.c, a).collect { case f: FieldDeclFull => f }
             fb <- findFieldDeclFull(entity.c, b).collect { case f: FieldDeclFull => f }
             kind <-
-              if AdminModel.isDateTimeType(fa.b, ir, Set.empty) &&
-                AdminModel.isDateTimeType(fb.b, ir, Set.empty)
+              if isDateTimeType(ir.e, fa.b) &&
+                isDateTimeType(ir.e, fb.b)
               then Some(DateTimeField)
-              else if AdminRouter.isNumericType(fa.b, ir, Set.empty) &&
-                AdminRouter.isNumericType(fb.b, ir, Set.empty)
+              else if isNumericType(ir.e, fa.b) &&
+                isNumericType(ir.e, fb.b)
               then Some(NumericField)
               else None
           yield List(
@@ -1156,7 +1156,7 @@ object Behavioral:
               leftKey = a,
               rightKey = b,
               kind = kind,
-              rightOptional = AdminRouter.isOptionalType(fb.b, ir, Set.empty),
+              rightOptional = isOptionalType(ir.e, fb.b),
               deltaSeconds = orderedDelta(op)
             )
           )
@@ -1166,7 +1166,7 @@ object Behavioral:
             && a != transitionField =>
         for
           fa <- findFieldDeclFull(entity.c, a).collect { case f: FieldDeclFull => f }
-          if AdminRouter.isNumericType(fa.b, ir, Set.empty)
+          if isNumericType(ir.e, fa.b)
           constPy <- numericLiteralPy(rhs)
         yield List(
           OrderedShiftConst(
@@ -1180,7 +1180,7 @@ object Behavioral:
       case BinaryOpF(BEq(), IdentifierF(a, _), NoneLitF(_), _)
           if a != transitionField =>
         findFieldDeclFull(entity.c, a).collect { case f: FieldDeclFull => f }.flatMap: f =>
-          if AdminRouter.isOptionalType(f.b, ir, Set.empty) then
+          if isOptionalType(ir.e, f.b) then
             Some(List(Assign(a, "None")))
           else None
 
@@ -1198,9 +1198,9 @@ object Behavioral:
           if field != transitionField =>
         for
           f     <- findFieldDeclFull(entity.c, field).collect { case f: FieldDeclFull => f }
-          inner <- collectionElementType(f.b, ir)
+          inner <- collectionElementType(ir.e, f.b)
           py    <- literalForElementType(lit, inner, ir)
-        yield List(ListAppend(field, py, AdminRouter.isOptionalType(f.b, ir, Set.empty)))
+        yield List(ListAppend(field, py, isOptionalType(ir.e, f.b)))
 
       case BinaryOpF(op, lenOrCard, IntLitF(n, _), _)
           if op match { case _: (BGt | BGe | BLt | BLe | BEq) => true; case _ => false } =>
@@ -1208,31 +1208,11 @@ object Behavioral:
           field <- isLenOrCardOf(lenOrCard)
           if field != transitionField
           f       <- findFieldDeclFull(entity.c, field).collect { case f: FieldDeclFull => f }
-          inner   <- collectionElementType(f.b, ir)
+          inner   <- collectionElementType(ir.e, f.b)
           size    <- desiredSize(op, n)
           fillers <- buildFillers(size.toInt, inner, ir)
         yield List(ListOfSize(field, fillers))
 
-      case _ => None
-
-    private def collectionElementType(
-        t: type_expr_full,
-        ir: ServiceIRFull
-    ): Option[type_expr_full] =
-      collectionElementTypeIn(t, ir, Set.empty)
-
-    private def collectionElementTypeIn(
-        t: type_expr_full,
-        ir: ServiceIRFull,
-        seen: Set[String]
-    ): Option[type_expr_full] = t match
-      case SetTypeF(inner, _)    => Some(inner)
-      case SeqTypeF(inner, _)    => Some(inner)
-      case OptionTypeF(inner, _) => collectionElementTypeIn(inner, ir, seen)
-      case NamedTypeF(name, _) if !seen.contains(name) =>
-        ir.e
-          .collectFirst { case _a: TypeAliasDeclFull if _a.a == name => _a }
-          .flatMap(alias => collectionElementTypeIn(alias.b, ir, seen + name))
       case _ => None
 
     private def buildFillers(
@@ -1241,7 +1221,7 @@ object Behavioral:
         ir: ServiceIRFull
     ): Option[List[String]] =
       if size == 0 then Some(Nil)
-      else if AdminRouter.isNumericType(inner, ir, Set.empty) then
+      else if isNumericType(ir.e, inner) then
         Some((0 until size).map(_.toString).toList)
       else
         inner match
@@ -1303,9 +1283,9 @@ object Behavioral:
       val inner = f.b match
         case OptionTypeF(t, _) => t
         case t                 => t
-      if AdminModel.isDateTimeType(inner, ir, Set.empty) then
+      if isDateTimeType(ir.e, inner) then
         Some("datetime.datetime(2024, 1, 1).isoformat()")
-      else if AdminRouter.isNumericType(inner, ir, Set.empty) then Some("0")
+      else if isNumericType(ir.e, inner) then Some("0")
       else
         inner match
           case NamedTypeF("String", _) => Some(ExprToPython.pyString("x"))

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -232,19 +232,15 @@ object ExprToPython extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val expectedArity = ctx.userFunctions
-      .get(fname)
-      .map(_.b.size)
-      .orElse(ctx.userPredicates.get(fname).map(_.b.size))
-    expectedArity match
-      case None =>
+    classifyUserCall(ctx.fnArities, ctx.predArities, fname, BigInt(args.size)) match
+      case _: UcUnknown =>
         Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-      case Some(n) if n != args.size =>
+      case w: UcWrongArity =>
         Translated.Skip(
-          s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
+          s"wrong arity for user-defined call '$fname': expected ${w.a}, got ${args.size}",
           span
         )
-      case Some(_) =>
+      case _: UcOk =>
         val parts  = args.map(translate(_, ctx))
         val pyName = Naming.toSnakeCase(fname)
         liftAll(parts, span)(ps => Translated.Emit(s"$pyName(${ps.mkString(", ")})"))
@@ -311,10 +307,7 @@ object ExprToPython extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val isAllIn = bindings.forall:
-      case QuantifierBindingFull(_, _, BkIn(), _) => true
-      case _                                      => false
-    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
+    if !quantifierAllIn(bindings) then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       val domains    = bindings.collect { case QuantifierBindingFull(_, d, _, _) => translate(d, ctx) }

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -141,31 +141,26 @@ object ExprToPython extends ExprBackend:
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
   private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
-    if PythonReservedNames.contains(name) &&
-      (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then Translated.Skip(s"identifier '$name' is a Python-reserved name", span)
-    else if ctx.boundVars.contains(name) then Translated.Emit(name)
-    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("response_data")
-    else if ctx.outputs.contains(name) then Translated.Emit(s"response_data[${pyString(name)}]")
-    else if ctx.inputs.contains(name) then Translated.Emit(name)
-    else if ctx.stateFields.contains(name) then
-      if ctx.unbackedStateFields.contains(name) then
+    classifyIdent(ctx.identCtx(PythonReservedNames.toList), name) match
+      case _: IcReserved => Translated.Skip(s"identifier '$name' is a Python-reserved name", span)
+      case _: IcBound    => Translated.Emit(name)
+      case _: IcBareBody => Translated.Emit("response_data")
+      case _: IcOutput   => Translated.Emit(s"response_data[${pyString(name)}]")
+      case _: IcInput    => Translated.Emit(name)
+      case _: IcStateField =>
+        val dict = ctx.capture match
+          case CaptureMode.PostState => "post_state"
+          case CaptureMode.PreState  => "pre_state"
+        Translated.Emit(s"$dict[${pyString(name)}]")
+      case _: IcUnbackedState =>
         Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
         )
-      else
-        val dict = ctx.capture match
-          case CaptureMode.PostState => "post_state"
-          case CaptureMode.PreState  => "pre_state"
-        Translated.Emit(s"$dict[${pyString(name)}]")
-    else if ctx.enumValues.contains(name) then
-      Translated.Skip(s"enum-type identifier '$name'", span)
-    else
-      ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => Translated.Emit(pyString(name))
-        case None    => Translated.Skip(s"unbound identifier '$name'", span)
+      case _: IcEnumType  => Translated.Skip(s"enum-type identifier '$name'", span)
+      case _: IcEnumValue => Translated.Emit(pyString(name))
+      case _: IcUnbound   => Translated.Skip(s"unbound identifier '$name'", span)
 
   private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match

--- a/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/ExprToPython.scala
@@ -43,7 +43,6 @@ private[testgen] val PythonReservedNames: Set[String] = Set(
   "case"
 )
 
-@SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
 object ExprToPython extends ExprBackend:
 
   def stringLiteral(s: String): String = pyString(s)
@@ -61,7 +60,7 @@ object ExprToPython extends ExprBackend:
     case PreF(inner, _)   => translate(inner, ctx.withCapture(CaptureMode.PreState))
 
     case BinaryOpF(BAdd(), l, r, _)
-        if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
+        if isMapLiteralExpr(l) || isMapLiteralExpr(r) =>
       lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
         Translated.Emit(s"{**($lp), **($rp)}")
       )

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -292,21 +292,17 @@ object GoExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val expectedArity = ctx.userFunctions
-      .get(fname)
-      .map(_.b.size)
-      .orElse(ctx.userPredicates.get(fname).map(_.b.size))
-    expectedArity match
-      case None =>
+    classifyUserCall(ctx.fnArities, ctx.predArities, fname, BigInt(args.size)) match
+      case _: UcUnknown =>
         Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-      case Some(n) if n != args.size =>
+      case w: UcWrongArity =>
         Translated.Skip(
-          s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
+          s"wrong arity for user-defined call '$fname': expected ${w.a}, got ${args.size}",
           span
         )
-      case Some(_) if GoReservedNames.contains(fname) =>
+      case _: UcOk if GoReservedNames.contains(fname) =>
         Translated.Skip(s"user-defined call '$fname' is a Go-reserved name", span)
-      case Some(_) =>
+      case _: UcOk =>
         val parts = args.map(translate(_, ctx))
         ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"$fname(${ps.mkString(", ")})"))
 
@@ -372,10 +368,7 @@ object GoExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val isAllIn = bindings.forall:
-      case QuantifierBindingFull(_, _, BkIn(), _) => true
-      case _                                      => false
-    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
+    if !quantifierAllIn(bindings) then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       if boundNames.exists(GoReservedNames.contains) then

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -200,32 +200,26 @@ object GoExprBackend extends ExprBackend:
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
   private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
-    if GoReservedNames.contains(name) &&
-      (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then Translated.Skip(s"identifier '$name' is a Go-reserved name", span)
-    else if ctx.boundVars.contains(name) then Translated.Emit(name)
-    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("responseData")
-    else if ctx.outputs.contains(name) then
-      Translated.Emit(s"_field(responseData, ${GoLit.str(name)})")
-    else if ctx.inputs.contains(name) then Translated.Emit(name)
-    else if ctx.stateFields.contains(name) then
-      if ctx.unbackedStateFields.contains(name) then
+    classifyIdent(ctx.identCtx(GoReservedNames.toList), name) match
+      case _: IcReserved => Translated.Skip(s"identifier '$name' is a Go-reserved name", span)
+      case _: IcBound    => Translated.Emit(name)
+      case _: IcBareBody => Translated.Emit("responseData")
+      case _: IcOutput   => Translated.Emit(s"_field(responseData, ${GoLit.str(name)})")
+      case _: IcInput    => Translated.Emit(name)
+      case _: IcStateField =>
+        val obj = ctx.capture match
+          case CaptureMode.PostState => "postState"
+          case CaptureMode.PreState  => "preState"
+        Translated.Emit(s"_field($obj, ${GoLit.str(name)})")
+      case _: IcUnbackedState =>
         Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
         )
-      else
-        val obj = ctx.capture match
-          case CaptureMode.PostState => "postState"
-          case CaptureMode.PreState  => "preState"
-        Translated.Emit(s"_field($obj, ${GoLit.str(name)})")
-    else if ctx.enumValues.contains(name) then
-      Translated.Skip(s"enum-type identifier '$name'", span)
-    else
-      ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => Translated.Emit(GoLit.str(name))
-        case None    => Translated.Skip(s"unbound identifier '$name'", span)
+      case _: IcEnumType  => Translated.Skip(s"enum-type identifier '$name'", span)
+      case _: IcEnumValue => Translated.Emit(GoLit.str(name))
+      case _: IcUnbound   => Translated.Skip(s"unbound identifier '$name'", span)
 
   private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -98,7 +98,6 @@ object GoLit:
 // `_all(d, func(v any) bool { return _truthy(body) })`. State is read from the
 // parsed /__test_admin__/state JSON via `_field(postState|preState, "x")` and
 // the response body via `_field(responseData, "x")`.
-@SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
 object GoExprBackend extends ExprBackend:
 
   def stringLiteral(s: String): String = GoLit.str(s)
@@ -116,7 +115,7 @@ object GoExprBackend extends ExprBackend:
     case PreF(inner, _)   => translate(inner, ctx.withCapture(CaptureMode.PreState))
 
     case BinaryOpF(BAdd(), l, r, _)
-        if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
+        if isMapLiteralExpr(l) || isMapLiteralExpr(r) =>
       ExprLift.lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
         Translated.Emit(s"_merge($lp, $rp)")
       )

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -54,7 +54,6 @@ private[testgen] val TsReservedNames: Set[String] = Set(
 // provides: _len, _in, _eq, _union, _inter, _diff, _subset, _powerset. State is
 // read from the parsed /__test_admin__/state JSON objects `preState`/`postState`
 // and the response body object `responseData`.
-@SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf"))
 object TsExprBackend extends ExprBackend:
 
   def stringLiteral(s: String): String = TsLit.str(s)
@@ -72,7 +71,7 @@ object TsExprBackend extends ExprBackend:
     case PreF(inner, _)   => translate(inner, ctx.withCapture(CaptureMode.PreState))
 
     case BinaryOpF(BAdd(), l, r, _)
-        if l.isInstanceOf[MapLiteralF] || r.isInstanceOf[MapLiteralF] =>
+        if isMapLiteralExpr(l) || isMapLiteralExpr(r) =>
       ExprLift.lift2(translate(l, ctx), translate(r, ctx))((lp, rp) =>
         Translated.Emit(s"{ ...($lp), ...($rp) }")
       )

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -154,31 +154,27 @@ object TsExprBackend extends ExprBackend:
     case SomeWrapF(inner, _) => translate(inner, ctx)
 
   private def resolveIdent(name: String, ctx: TestCtx, span: Option[span_t]): Translated =
-    if TsReservedNames.contains(name) &&
-      (ctx.boundVars.contains(name) || ctx.inputs.contains(name))
-    then Translated.Skip(s"identifier '$name' is a TypeScript-reserved name", span)
-    else if ctx.boundVars.contains(name) then Translated.Emit(name)
-    else if ctx.bareBodyOutput.contains(name) then Translated.Emit("responseData")
-    else if ctx.outputs.contains(name) then Translated.Emit(s"responseData[${TsLit.str(name)}]")
-    else if ctx.inputs.contains(name) then Translated.Emit(name)
-    else if ctx.stateFields.contains(name) then
-      if ctx.unbackedStateFields.contains(name) then
+    classifyIdent(ctx.identCtx(TsReservedNames.toList), name) match
+      case _: IcReserved =>
+        Translated.Skip(s"identifier '$name' is a TypeScript-reserved name", span)
+      case _: IcBound    => Translated.Emit(name)
+      case _: IcBareBody => Translated.Emit("responseData")
+      case _: IcOutput   => Translated.Emit(s"responseData[${TsLit.str(name)}]")
+      case _: IcInput    => Translated.Emit(name)
+      case _: IcStateField =>
+        val obj = ctx.capture match
+          case CaptureMode.PostState => "postState"
+          case CaptureMode.PreState  => "preState"
+        Translated.Emit(s"$obj[${TsLit.str(name)}]")
+      case _: IcUnbackedState =>
         Translated.Skip(
           s"state field '$name' is not backed by an entity table; the test-admin " +
             "/state endpoint projects it as null, so it cannot be asserted black-box",
           span
         )
-      else
-        val obj = ctx.capture match
-          case CaptureMode.PostState => "postState"
-          case CaptureMode.PreState  => "preState"
-        Translated.Emit(s"$obj[${TsLit.str(name)}]")
-    else if ctx.enumValues.contains(name) then
-      Translated.Skip(s"enum-type identifier '$name'", span)
-    else
-      ctx.enumValues.find { case (_, vs) => vs.contains(name) } match
-        case Some(_) => Translated.Emit(TsLit.str(name))
-        case None    => Translated.Skip(s"unbound identifier '$name'", span)
+      case _: IcEnumType  => Translated.Skip(s"enum-type identifier '$name'", span)
+      case _: IcEnumValue => Translated.Emit(TsLit.str(name))
+      case _: IcUnbound   => Translated.Skip(s"unbound identifier '$name'", span)
 
   private def binOpText(op: bin_op_full, l: String, r: String): Translated =
     op match

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -245,21 +245,17 @@ object TsExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val expectedArity = ctx.userFunctions
-      .get(fname)
-      .map(_.b.size)
-      .orElse(ctx.userPredicates.get(fname).map(_.b.size))
-    expectedArity match
-      case None =>
+    classifyUserCall(ctx.fnArities, ctx.predArities, fname, BigInt(args.size)) match
+      case _: UcUnknown =>
         Translated.Skip(s"unknown function '$fname/${args.size}' (see #138)", span)
-      case Some(n) if n != args.size =>
+      case w: UcWrongArity =>
         Translated.Skip(
-          s"wrong arity for user-defined call '$fname': expected $n, got ${args.size}",
+          s"wrong arity for user-defined call '$fname': expected ${w.a}, got ${args.size}",
           span
         )
-      case Some(_) if TsReservedNames.contains(fname) =>
+      case _: UcOk if TsReservedNames.contains(fname) =>
         Translated.Skip(s"user-defined call '$fname' is a TypeScript-reserved name", span)
-      case Some(_) =>
+      case _: UcOk =>
         val parts = args.map(translate(_, ctx))
         ExprLift.liftAll(parts, span)(ps => Translated.Emit(s"$fname(${ps.mkString(", ")})"))
 
@@ -329,10 +325,7 @@ object TsExprBackend extends ExprBackend:
       ctx: TestCtx,
       span: Option[span_t]
   ): Translated =
-    val isAllIn = bindings.forall:
-      case QuantifierBindingFull(_, _, BkIn(), _) => true
-      case _                                      => false
-    if !isAllIn then Translated.Skip("quantifier with non-`in` binding", span)
+    if !quantifierAllIn(bindings) then Translated.Skip("quantifier with non-`in` binding", span)
     else
       val boundNames = bindings.collect { case QuantifierBindingFull(n, _, _, _) => n }
       val domains    = bindings.collect { case QuantifierBindingFull(_, d, _, _) => translate(d, ctx) }

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -94,6 +94,12 @@ final case class TestCtx(
       enumValues.values.flatten.toList
     )
 
+  def fnArities: List[(String, BigInt)] =
+    userFunctions.view.mapValues(f => BigInt(f.b.size)).toList
+
+  def predArities: List[(String, BigInt)] =
+    userPredicates.view.mapValues(p => BigInt(p.b.size)).toList
+
 object TestCtx:
   def fromOperation(
       op: OperationDeclFull,

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -81,6 +81,19 @@ final case class TestCtx(
   def withCapture(c: CaptureMode): TestCtx        = copy(capture = c)
   def withBound(names: Iterable[String]): TestCtx = copy(boundVars = boundVars ++ names)
 
+  def identCtx(reserved: List[String]): ident_ctx =
+    IdentCtx(
+      reserved,
+      boundVars.toList,
+      bareBodyOutput,
+      outputs.toList,
+      inputs.toList,
+      stateFields.toList,
+      unbackedStateFields.toList,
+      enumValues.keys.toList,
+      enumValues.values.flatten.toList
+    )
+
 object TestCtx:
   def fromOperation(
       op: OperationDeclFull,

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -41,4 +41,5 @@ session SpecRest_Codegen in codegen = SpecRest_Core +
     ValidateConventions
     AlloyTypes
     AlloyBuildSigs
+    TargetExpr
     Codegen

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -42,4 +42,5 @@ session SpecRest_Codegen in codegen = SpecRest_Core +
     AlloyTypes
     AlloyBuildSigs
     TargetExpr
+    DafnyTransform
     Codegen

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -421,6 +421,7 @@ export_code
     classifyIdent
     classifyUserCall
     quantifierAllIn
+    isMapLiteralExpr
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -425,6 +425,8 @@ export_code
     isMapLiteralExpr
     rewriteEntityFieldRefs
     desugarOptionGuards
+    collectExternItems
+    classifyExternItems
     isNumericType
     isOptionalType
     isDateTimeType

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -424,6 +424,10 @@ export_code
     quantifierAllIn
     isMapLiteralExpr
     rewriteEntityFieldRefs
+    isNumericType
+    isOptionalType
+    isDateTimeType
+    collectionElementType
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -25,6 +25,7 @@ theory Codegen
     AlloyTypes
     AlloyBuildSigs
     VerifierDispatch
+    TargetExpr
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
 begin
@@ -417,6 +418,7 @@ export_code
     literalDropLeft
     literalDropRight
     extractVerbBeforeKebab
+    classifyIdent
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -329,6 +329,8 @@ export_code
     computeFieldBounds
     typeExprToSchema
     fieldToSchema
+    isSensitiveField
+    buildEntitySchemas
     mapAlloyPrimitive
     typeToSigNameAlloy
     alloyFieldTypeOf

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -424,6 +424,7 @@ export_code
     quantifierAllIn
     isMapLiteralExpr
     rewriteEntityFieldRefs
+    desugarOptionGuards
     isNumericType
     isOptionalType
     isDateTimeType

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -26,6 +26,7 @@ theory Codegen
     AlloyBuildSigs
     VerifierDispatch
     TargetExpr
+    DafnyTransform
     "HOL-Library.Code_Target_Int"
     "HOL-Library.Code_Target_Numeral"
 begin
@@ -422,6 +423,7 @@ export_code
     classifyUserCall
     quantifierAllIn
     isMapLiteralExpr
+    rewriteEntityFieldRefs
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -419,6 +419,8 @@ export_code
     literalDropRight
     extractVerbBeforeKebab
     classifyIdent
+    classifyUserCall
+    quantifierAllIn
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
+++ b/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
@@ -1,5 +1,5 @@
 theory DafnyTransform
-  imports SpecRest_Core.IR_Analysis SpecRest_Core.IR_Helpers
+  imports SpecRest_Core.IR_Analysis SpecRest_Core.IR_Helpers "HOL-Library.Code_Target_Numeral"
 begin
 
 text \<open>Lift of \<open>convention.dafny.Generator.rewriteEntityFieldRefs\<close>: rewrite every free
@@ -98,5 +98,83 @@ definition rewriteEntityFieldRefs :: "String.literal list \<Rightarrow> expr_ful
   "rewriteEntityFieldRefs flds e = rewriteFieldRefsAux flds [] e"
 
 lemmas rewriteEntityFieldRefs_code [code] = rewriteEntityFieldRefs_def
+
+text \<open>Lift of \<open>convention.dafny.Generator.desugarOptionGuards\<close>: for an Option-typed
+  parameter \<open>p\<close> (\<open>p \<in> opts\<close>), rewrite the three guard shapes — \<open>p \<noteq> None \<longrightarrow> body\<close>,
+  \<open>p = None \<or> body\<close>, \<open>body \<or> p = None\<close> — by substituting \<open>p\<close> with \<open>p.value\<close> in the body
+  (via the lifted \<open>subst\<close>), so the Dafny side sees a non-nullable value under the guard.
+
+  The Scala recurses on the substituted body, which is not a structural subterm, so a
+  fuel bound is used. The substituted \<open>FieldAccessF\<close> is a desugar leaf (the walk only
+  descends \<open>BinaryOpF\<close>/\<open>UnaryOpF\<close>/\<open>QuantifierF\<close>), so the recursion never goes deeper than
+  the original tree; \<open>length (allSubexprs e) + 100\<close> bounds the node count and the fuel
+  never runs out on any real ensures clause — same output as the Scala.\<close>
+
+definition neqNoneName :: "expr_full \<Rightarrow> String.literal option" where
+  "neqNoneName e =
+     (case e of BinaryOpF BNeq (IdentifierF p _) (NoneLitF _) _ \<Rightarrow> Some p | _ \<Rightarrow> None)"
+
+definition eqNoneName :: "expr_full \<Rightarrow> String.literal option" where
+  "eqNoneName e =
+     (case e of BinaryOpF BEq (IdentifierF p _) (NoneLitF _) _ \<Rightarrow> Some p | _ \<Rightarrow> None)"
+
+definition substValue :: "String.literal \<Rightarrow> expr_full \<Rightarrow> expr_full" where
+  "substValue p body = subst p (FieldAccessF (IdentifierF p None) (STR ''value'') None) body"
+
+function (sequential) desugarGo :: "nat \<Rightarrow> String.literal list \<Rightarrow> expr_full \<Rightarrow> expr_full"
+  and desugarBindings ::
+    "nat \<Rightarrow> String.literal list \<Rightarrow> quantifier_binding_full list \<Rightarrow> quantifier_binding_full list"
+where
+  "desugarGo 0 _ e = e"
+| "desugarGo (Suc fuel) opts e =
+     (case e of
+        BinaryOpF op l r sp \<Rightarrow>
+          (if op = BImplies then
+             (case neqNoneName l of
+                Some p \<Rightarrow> (if string_in_list p opts
+                             then BinaryOpF BImplies l (desugarGo fuel opts (substValue p r)) sp
+                             else BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp)
+              | None \<Rightarrow> BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp)
+           else if op = BOr then
+             (case eqNoneName l of
+                Some p \<Rightarrow> (if string_in_list p opts
+                             then BinaryOpF BOr l (desugarGo fuel opts (substValue p r)) sp
+                             else
+                               (case eqNoneName r of
+                                  Some q \<Rightarrow> (if string_in_list q opts
+                                               then BinaryOpF BOr (desugarGo fuel opts (substValue q l)) r sp
+                                               else BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp)
+                                | None \<Rightarrow> BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp))
+              | None \<Rightarrow>
+                  (case eqNoneName r of
+                     Some q \<Rightarrow> (if string_in_list q opts
+                                  then BinaryOpF BOr (desugarGo fuel opts (substValue q l)) r sp
+                                  else BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp)
+                   | None \<Rightarrow> BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp))
+           else BinaryOpF op (desugarGo fuel opts l) (desugarGo fuel opts r) sp)
+      | UnaryOpF op x sp \<Rightarrow> UnaryOpF op (desugarGo fuel opts x) sp
+      | QuantifierF q bs body sp \<Rightarrow>
+          QuantifierF q (desugarBindings fuel opts bs) (desugarGo fuel opts body) sp
+      | _ \<Rightarrow> e)"
+| "desugarBindings 0 _ bs = bs"
+| "desugarBindings (Suc fuel) opts bs =
+     (case bs of
+        [] \<Rightarrow> []
+      | QuantifierBindingFull a d kind bsp # rest \<Rightarrow>
+          QuantifierBindingFull a (desugarGo fuel opts d) kind bsp # desugarBindings fuel opts rest)"
+  by pat_completeness auto
+
+termination
+  by (relation "measure (\<lambda>p. case p of Inl (fuel, _, _) \<Rightarrow> fuel | Inr (fuel, _, _) \<Rightarrow> fuel)") auto
+
+definition desugarOptionGuards :: "String.literal list \<Rightarrow> expr_full \<Rightarrow> expr_full" where
+  "desugarOptionGuards opts e = desugarGo (length (allSubexprs e) + 100) opts e"
+
+lemmas neqNoneName_code [code]         = neqNoneName_def
+lemmas eqNoneName_code [code]          = eqNoneName_def
+lemmas substValue_code [code]          = substValue_def
+lemmas desugarGo_code [code]           = desugarGo.simps
+lemmas desugarBindings_code [code]     = desugarBindings.simps
+lemmas desugarOptionGuards_code [code] = desugarOptionGuards_def
 
 end

--- a/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
+++ b/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
@@ -177,4 +177,118 @@ lemmas desugarGo_code [code]           = desugarGo.simps
 lemmas desugarBindings_code [code]     = desugarBindings.simps
 lemmas desugarOptionGuards_code [code] = desugarOptionGuards_def
 
+text \<open>Lift of \<open>convention.dafny.Generator.classifyExterns\<close>'s analysis. The Scala walks
+  every spec expression threading an "expected kind" (Predicate vs IntFunction) and records
+  each non-builtin \<open>CallF\<close> callee as an extern, merging duplicates (IntFunction dominates;
+  arity = max) into an insertion-ordered map, plus the \<open>MatchesF\<close> regex patterns into an
+  insertion-ordered set.
+
+  Split into two lifted pieces: \<open>collectExternItems\<close> is the structural walk that emits a flat
+  \<open>extern_item list\<close> in traversal order (the kind-threading is the lifted decision); the Scala
+  driver calls it per top-level declaration in the original order and concatenates. Then
+  \<open>classifyExternItems\<close> folds that list into the order-preserving merged extern alist + the
+  deduplicated pattern list, reproducing the \<open>LinkedHashMap\<close>/\<open>LinkedHashSet\<close> semantics. The
+  info constructor is \<open>ExInfo\<close> (not \<open>ExternInfo\<close>) so it doesn't clash with the Scala
+  \<open>ExternInfo\<close> case class the adapter targets.\<close>
+
+datatype extern_kind = EkPredicate | EkIntFunction
+datatype extern_info = ExInfo extern_kind int
+datatype extern_item = EiExtern String.literal int extern_kind | EiPattern String.literal
+
+definition knownBuiltinNames :: "String.literal list" where
+  "knownBuiltinNames = [STR ''len'', STR ''dom'', STR ''ran'']"
+
+fun collectExternItems :: "extern_kind \<Rightarrow> expr_full \<Rightarrow> extern_item list"
+  and collectExternItemsArgs :: "expr_full list \<Rightarrow> extern_item list"
+  and collectExternItemsFields :: "field_assign_full list \<Rightarrow> extern_item list"
+  and collectExternItemsEntries :: "map_entry_full list \<Rightarrow> extern_item list"
+  and collectExternItemsBindings :: "quantifier_binding_full list \<Rightarrow> extern_item list"
+where
+  "collectExternItems expected (CallF c args sp) =
+     (case c of
+        IdentifierF n _ \<Rightarrow>
+          (if string_in_list n knownBuiltinNames
+             then collectExternItemsArgs args
+             else EiExtern n (int (length args)) expected # collectExternItemsArgs args)
+      | _ \<Rightarrow> collectExternItemsArgs args)"
+| "collectExternItems expected (BinaryOpF op l r sp) =
+     (if op = BAnd \<or> op = BOr \<or> op = BImplies \<or> op = BIff
+        then collectExternItems EkPredicate l @ collectExternItems EkPredicate r
+        else collectExternItems EkIntFunction l @ collectExternItems EkIntFunction r)"
+| "collectExternItems expected (UnaryOpF op x sp) =
+     (if op = UNot then collectExternItems EkPredicate x else collectExternItems EkIntFunction x)"
+| "collectExternItems expected (PrimeF x sp) = collectExternItems expected x"
+| "collectExternItems expected (PreF x sp) = collectExternItems expected x"
+| "collectExternItems expected (SomeWrapF x sp) = collectExternItems EkIntFunction x"
+| "collectExternItems expected (FieldAccessF b f sp) = collectExternItems EkIntFunction b"
+| "collectExternItems expected (IndexF b i sp) =
+     collectExternItems EkIntFunction b @ collectExternItems EkIntFunction i"
+| "collectExternItems expected (MapLiteralF es sp) = collectExternItemsEntries es"
+| "collectExternItems expected (SetLiteralF es sp) = collectExternItemsArgs es"
+| "collectExternItems expected (SeqLiteralF es sp) = collectExternItemsArgs es"
+| "collectExternItems expected (IfF c t e sp) =
+     collectExternItems EkPredicate c @ collectExternItems expected t @ collectExternItems expected e"
+| "collectExternItems expected (LetF v val b sp) =
+     collectExternItems EkIntFunction val @ collectExternItems expected b"
+| "collectExternItems expected (QuantifierF q bs body sp) =
+     collectExternItemsBindings bs @ collectExternItems EkPredicate body"
+| "collectExternItems expected (SetComprehensionF v dm pr sp) =
+     collectExternItems EkIntFunction dm @ collectExternItems EkPredicate pr"
+| "collectExternItems expected (ConstructorF n fs sp) = collectExternItemsFields fs"
+| "collectExternItems expected (WithF b fs sp) =
+     collectExternItems EkIntFunction b @ collectExternItemsFields fs"
+| "collectExternItems expected (TheF v dm body sp) =
+     collectExternItems EkIntFunction dm @ collectExternItems EkPredicate body"
+| "collectExternItems expected (LambdaF p body sp) = collectExternItems EkIntFunction body"
+| "collectExternItems expected (MatchesF x p sp) = EiPattern p # collectExternItems EkIntFunction x"
+| "collectExternItems _ _ = []"
+| "collectExternItemsArgs [] = []"
+| "collectExternItemsArgs (e # es) = collectExternItems EkIntFunction e @ collectExternItemsArgs es"
+| "collectExternItemsFields [] = []"
+| "collectExternItemsFields (FieldAssignFull f v sp # fs) =
+     collectExternItems EkIntFunction v @ collectExternItemsFields fs"
+| "collectExternItemsEntries [] = []"
+| "collectExternItemsEntries (MapEntryFull k v sp # es) =
+     collectExternItems EkIntFunction k @ collectExternItems EkIntFunction v
+       @ collectExternItemsEntries es"
+| "collectExternItemsBindings [] = []"
+| "collectExternItemsBindings (QuantifierBindingFull a d kind sp # bs) =
+     collectExternItems EkIntFunction d @ collectExternItemsBindings bs"
+
+fun mergeExternInfo :: "extern_info \<Rightarrow> int \<Rightarrow> extern_kind \<Rightarrow> extern_info" where
+  "mergeExternInfo (ExInfo prevKind prevArity) arity kind =
+     ExInfo (if prevKind = EkIntFunction \<or> kind = EkIntFunction then EkIntFunction else EkPredicate)
+            (max prevArity arity)"
+
+fun upsertExtern ::
+  "(String.literal \<times> extern_info) list \<Rightarrow> String.literal \<Rightarrow> int \<Rightarrow> extern_kind
+    \<Rightarrow> (String.literal \<times> extern_info) list"
+where
+  "upsertExtern [] name arity kind = [(name, ExInfo kind arity)]"
+| "upsertExtern ((n, info) # rest) name arity kind =
+     (if n = name then (n, mergeExternInfo info arity kind) # rest
+      else (n, info) # upsertExtern rest name arity kind)"
+
+fun foldExternItems ::
+  "extern_item list \<Rightarrow> (String.literal \<times> extern_info) list \<Rightarrow> String.literal list
+    \<Rightarrow> (String.literal \<times> extern_info) list \<times> String.literal list"
+where
+  "foldExternItems [] externs patterns = (externs, patterns)"
+| "foldExternItems (EiExtern name arity kind # rest) externs patterns =
+     foldExternItems rest (upsertExtern externs name arity kind) patterns"
+| "foldExternItems (EiPattern p # rest) externs patterns =
+     foldExternItems rest externs (if string_in_list p patterns then patterns else patterns @ [p])"
+
+definition classifyExternItems ::
+  "extern_item list \<Rightarrow> (String.literal \<times> extern_info) list \<times> String.literal list"
+where
+  "classifyExternItems items = foldExternItems items [] []"
+
+lemmas knownBuiltinNames_code [code]   = knownBuiltinNames_def
+lemmas collectExternItems_code [code]  = collectExternItems.simps
+lemmas mergeExternInfo_code [code]     = mergeExternInfo.simps
+lemmas upsertExtern_code [code]        = upsertExtern.simps
+lemmas foldExternItems_code [code]     = foldExternItems.simps
+lemmas classifyExternItems_code [code] = classifyExternItems_def
+
 end

--- a/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
+++ b/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
@@ -1,0 +1,102 @@
+theory DafnyTransform
+  imports SpecRest_Core.IR_Analysis SpecRest_Core.IR_Helpers
+begin
+
+text \<open>Lift of \<open>convention.dafny.Generator.rewriteEntityFieldRefs\<close>: rewrite every free
+  reference to an entity field name \<open>n\<close> into \<open>x.n\<close> (a \<open>FieldAccessF\<close> on the entity
+  receiver \<open>x\<close>), leaving names shadowed by an enclosing binder untouched. Structural
+  recursion threading the bound-variable scope — the same shape as \<open>subst\<close>; the field-name
+  set is supplied by the already-lifted \<open>entityFieldNames\<close>.
+
+  Mirrors the Scala exactly: \<open>EnumAccessF\<close> and \<open>MatchesF\<close> are NOT descended into — the
+  original's \<open>case other => other\<close> leaves them (and the literals) unchanged. The introduced
+  receiver \<open>x\<close> is never re-rewritten because the rewrite returns the \<open>FieldAccessF\<close> directly
+  without recursing on it.\<close>
+
+fun rewriteFieldRefsAux ::
+    "String.literal list \<Rightarrow> String.literal list \<Rightarrow> expr_full \<Rightarrow> expr_full"
+  and rewriteFieldRefsList ::
+    "String.literal list \<Rightarrow> String.literal list \<Rightarrow> expr_full list \<Rightarrow> expr_full list"
+  and rewriteFieldRefsFields ::
+    "String.literal list \<Rightarrow> String.literal list \<Rightarrow> field_assign_full list \<Rightarrow> field_assign_full list"
+  and rewriteFieldRefsEntries ::
+    "String.literal list \<Rightarrow> String.literal list \<Rightarrow> map_entry_full list \<Rightarrow> map_entry_full list"
+  and rewriteFieldRefsBindings ::
+    "String.literal list \<Rightarrow> String.literal list \<Rightarrow> quantifier_binding_full list
+      \<Rightarrow> quantifier_binding_full list"
+where
+  "rewriteFieldRefsAux flds bound (IdentifierF n sp) =
+     (if string_in_list n flds \<and> \<not> string_in_list n bound
+        then FieldAccessF (IdentifierF (STR ''x'') sp) n sp
+        else IdentifierF n sp)"
+| "rewriteFieldRefsAux flds bound (BinaryOpF op l r sp) =
+     BinaryOpF op (rewriteFieldRefsAux flds bound l) (rewriteFieldRefsAux flds bound r) sp"
+| "rewriteFieldRefsAux flds bound (UnaryOpF op e sp) =
+     UnaryOpF op (rewriteFieldRefsAux flds bound e) sp"
+| "rewriteFieldRefsAux flds bound (FieldAccessF b f sp) =
+     FieldAccessF (rewriteFieldRefsAux flds bound b) f sp"
+| "rewriteFieldRefsAux flds bound (EnumAccessF b m sp) = EnumAccessF b m sp"
+| "rewriteFieldRefsAux flds bound (IndexF b i sp) =
+     IndexF (rewriteFieldRefsAux flds bound b) (rewriteFieldRefsAux flds bound i) sp"
+| "rewriteFieldRefsAux flds bound (CallF c args sp) =
+     CallF (rewriteFieldRefsAux flds bound c) (rewriteFieldRefsList flds bound args) sp"
+| "rewriteFieldRefsAux flds bound (PrimeF e sp) =
+     PrimeF (rewriteFieldRefsAux flds bound e) sp"
+| "rewriteFieldRefsAux flds bound (PreF e sp) =
+     PreF (rewriteFieldRefsAux flds bound e) sp"
+| "rewriteFieldRefsAux flds bound (WithF b upds sp) =
+     WithF (rewriteFieldRefsAux flds bound b) (rewriteFieldRefsFields flds bound upds) sp"
+| "rewriteFieldRefsAux flds bound (IfF c t e sp) =
+     IfF (rewriteFieldRefsAux flds bound c) (rewriteFieldRefsAux flds bound t)
+         (rewriteFieldRefsAux flds bound e) sp"
+| "rewriteFieldRefsAux flds bound (LetF v val body sp) =
+     LetF v (rewriteFieldRefsAux flds bound val)
+            (rewriteFieldRefsAux flds (v # bound) body) sp"
+| "rewriteFieldRefsAux flds bound (LambdaF p b sp) =
+     LambdaF p (rewriteFieldRefsAux flds (p # bound) b) sp"
+| "rewriteFieldRefsAux flds bound (ConstructorF n fs sp) =
+     ConstructorF n (rewriteFieldRefsFields flds bound fs) sp"
+| "rewriteFieldRefsAux flds bound (SetLiteralF xs sp) =
+     SetLiteralF (rewriteFieldRefsList flds bound xs) sp"
+| "rewriteFieldRefsAux flds bound (MapLiteralF es sp) =
+     MapLiteralF (rewriteFieldRefsEntries flds bound es) sp"
+| "rewriteFieldRefsAux flds bound (SetComprehensionF v d p sp) =
+     SetComprehensionF v (rewriteFieldRefsAux flds bound d)
+                         (rewriteFieldRefsAux flds (v # bound) p) sp"
+| "rewriteFieldRefsAux flds bound (SeqLiteralF xs sp) =
+     SeqLiteralF (rewriteFieldRefsList flds bound xs) sp"
+| "rewriteFieldRefsAux flds bound (MatchesF e pat sp) = MatchesF e pat sp"
+| "rewriteFieldRefsAux flds bound (SomeWrapF e sp) =
+     SomeWrapF (rewriteFieldRefsAux flds bound e) sp"
+| "rewriteFieldRefsAux flds bound (TheF v d b sp) =
+     TheF v (rewriteFieldRefsAux flds bound d) (rewriteFieldRefsAux flds (v # bound) b) sp"
+| "rewriteFieldRefsAux flds bound (QuantifierF q bs body sp) =
+     QuantifierF q (rewriteFieldRefsBindings flds bound bs)
+                   (rewriteFieldRefsAux flds (qb_names bs @ bound) body) sp"
+| "rewriteFieldRefsAux _ _ (IntLitF n sp)    = IntLitF n sp"
+| "rewriteFieldRefsAux _ _ (FloatLitF n sp)  = FloatLitF n sp"
+| "rewriteFieldRefsAux _ _ (StringLitF n sp) = StringLitF n sp"
+| "rewriteFieldRefsAux _ _ (BoolLitF v sp)   = BoolLitF v sp"
+| "rewriteFieldRefsAux _ _ (NoneLitF sp)     = NoneLitF sp"
+| "rewriteFieldRefsList _ _ [] = []"
+| "rewriteFieldRefsList flds bound (e # es) =
+     rewriteFieldRefsAux flds bound e # rewriteFieldRefsList flds bound es"
+| "rewriteFieldRefsFields _ _ [] = []"
+| "rewriteFieldRefsFields flds bound (FieldAssignFull f v sp # fs) =
+     FieldAssignFull f (rewriteFieldRefsAux flds bound v) sp
+       # rewriteFieldRefsFields flds bound fs"
+| "rewriteFieldRefsEntries _ _ [] = []"
+| "rewriteFieldRefsEntries flds bound (MapEntryFull k v sp # es) =
+     MapEntryFull (rewriteFieldRefsAux flds bound k) (rewriteFieldRefsAux flds bound v) sp
+       # rewriteFieldRefsEntries flds bound es"
+| "rewriteFieldRefsBindings _ _ [] = []"
+| "rewriteFieldRefsBindings flds bound (QuantifierBindingFull a d kk sp # bs) =
+     QuantifierBindingFull a (rewriteFieldRefsAux flds bound d) kk sp
+       # rewriteFieldRefsBindings flds bound bs"
+
+definition rewriteEntityFieldRefs :: "String.literal list \<Rightarrow> expr_full \<Rightarrow> expr_full" where
+  "rewriteEntityFieldRefs flds e = rewriteFieldRefsAux flds [] e"
+
+lemmas rewriteEntityFieldRefs_code [code] = rewriteEntityFieldRefs_def
+
+end

--- a/proofs/isabelle/SpecRest/codegen/OpenApiSchema.thy
+++ b/proofs/isabelle/SpecRest/codegen/OpenApiSchema.thy
@@ -1,5 +1,5 @@
 theory OpenApiSchema
-  imports OpenApiConstraints SchemaTraversal
+  imports OpenApiConstraints SchemaTraversal ParsePath
 begin
 
 text \<open>Lifted core of the OpenAPI \<open>SchemaObject\<close> datatype and the
@@ -310,6 +310,116 @@ where
   "fieldToSchema ty cOpt am em ens =
      fieldToSchemaAux (openApiSchemaFuel am) ty cOpt am em ens"
 
+text \<open>Sensitive-field predicate. Lift of \<open>specrest.codegen.SensitiveFields.isSensitive\<close>:
+  an exact-name set plus a name-suffix set. The Scala \<open>SensitiveFields\<close> facade now
+  delegates to this, so the Python emitter and testgen redaction share one source.\<close>
+
+definition sensitiveExactNames :: "String.literal list" where
+  "sensitiveExactNames =
+     [STR ''password'', STR ''password_hash'', STR ''secret'', STR ''token'', STR ''api_key'']"
+
+definition sensitiveSuffixNames :: "String.literal list" where
+  "sensitiveSuffixNames =
+     [STR ''_hash'', STR ''_secret'', STR ''_password'', STR ''_api_key'', STR ''_token'']"
+
+definition isSensitiveField :: "String.literal \<Rightarrow> bool" where
+  "isSensitiveField name =
+     (string_in_list name sensitiveExactNames \<or>
+      list_ex (\<lambda>sfx. literalEndsWith sfx name) sensitiveSuffixNames)"
+
+text \<open>Entity-level OpenAPI schema assembly. Lift of
+  \<open>OpenApi.Components.{create,read,update}Schema\<close> over the lifted \<open>schema_object\<close>:
+  the Scala adapter converts the three results once each rather than per field, and the
+  lossy \<open>schema_object \<rightarrow> Scala SchemaObject\<close> round-trip is avoided. Input is the decorated
+  field list \<open>(column_name, field_schema, nullable)\<close> from the lifted \<open>fieldToSchema\<close>.
+
+  \<^item> \<open>id\<close> is dropped from every payload (\<open>nonIdDecorated\<close>).
+  \<^item> create: \<open>required\<close> = non-nullable field names; each property nullable-wrapped per its flag.
+  \<^item> read: drops sensitive fields, injects an integer \<open>id\<close> property, \<open>required\<close> = \<open>id\<close> + non-nullable.
+  \<^item> update: every property is nullable-wrapped, no \<open>required\<close>.\<close>
+
+fun nonIdDecorated ::
+  "(String.literal \<times> schema_object \<times> bool) list \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list"
+where
+  "nonIdDecorated [] = []"
+| "nonIdDecorated ((n, s, nu) # rest) =
+     (if n = STR ''id'' then nonIdDecorated rest else (n, s, nu) # nonIdDecorated rest)"
+
+fun dropSensitive ::
+  "(String.literal \<times> schema_object \<times> bool) list \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list"
+where
+  "dropSensitive [] = []"
+| "dropSensitive ((n, s, nu) # rest) =
+     (if isSensitiveField n then dropSensitive rest else (n, s, nu) # dropSensitive rest)"
+
+fun requiredNames ::
+  "(String.literal \<times> schema_object \<times> bool) list \<Rightarrow> String.literal list"
+where
+  "requiredNames [] = []"
+| "requiredNames ((n, _, nu) # rest) =
+     (if nu then requiredNames rest else n # requiredNames rest)"
+
+definition fieldPropertySchema :: "schema_object \<Rightarrow> bool \<Rightarrow> schema_object" where
+  "fieldPropertySchema s nullable = (if nullable then makeNullableLifted s else s)"
+
+fun fieldProps ::
+  "(String.literal \<times> schema_object \<times> bool) list \<Rightarrow> (String.literal \<times> schema_object) list"
+where
+  "fieldProps [] = []"
+| "fieldProps ((n, s, nu) # rest) = (n, fieldPropertySchema s nu) # fieldProps rest"
+
+fun fieldPropsNullable ::
+  "(String.literal \<times> schema_object \<times> bool) list \<Rightarrow> (String.literal \<times> schema_object) list"
+where
+  "fieldPropsNullable [] = []"
+| "fieldPropsNullable ((n, s, _) # rest) = (n, makeNullableLifted s) # fieldPropsNullable rest"
+
+definition createSchemaLifted ::
+  "String.literal \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list \<Rightarrow> schema_object"
+where
+  "createSchemaLifted ename decorated =
+    (let fs = nonIdDecorated decorated
+     in SchemaObject (Some [STR ''object''])
+          None None None None None None None None None None None None None
+          (Some (requiredNames fs))
+          (Some (fieldProps fs))
+          None None
+          (Some (STR ''Create payload for '' + ename))
+          False)"
+
+definition readSchemaLifted ::
+  "String.literal \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list \<Rightarrow> schema_object"
+where
+  "readSchemaLifted ename decorated =
+    (let fs = dropSensitive (nonIdDecorated decorated)
+     in SchemaObject (Some [STR ''object''])
+          None None None None None None None None None None None None None
+          (Some (STR ''id'' # requiredNames fs))
+          (Some ((STR ''id'', integerSchema) # fieldProps fs))
+          None None
+          (Some (STR ''Read view for '' + ename))
+          False)"
+
+definition updateSchemaLifted ::
+  "String.literal \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list \<Rightarrow> schema_object"
+where
+  "updateSchemaLifted ename decorated =
+    (let fs = nonIdDecorated decorated
+     in SchemaObject (Some [STR ''object''])
+          None None None None None None None None None None None None None
+          None
+          (Some (fieldPropsNullable fs))
+          None None
+          (Some (STR ''Update payload for '' + ename))
+          False)"
+
+definition buildEntitySchemas ::
+  "String.literal \<Rightarrow> (String.literal \<times> schema_object \<times> bool) list
+    \<Rightarrow> schema_object \<times> schema_object \<times> schema_object"
+where
+  "buildEntitySchemas ename decorated =
+     (createSchemaLifted ename decorated, readSchemaLifted ename decorated, updateSchemaLifted ename decorated)"
+
 lemmas emptySchemaObject_code [code]      = emptySchemaObject_def
 lemmas primitiveDefToSchema_code [code]   = primitiveDefToSchema.simps
 lemmas mergeConstraintsLifted_code [code] = mergeConstraintsLifted.simps
@@ -329,5 +439,18 @@ lemmas openApiSchemaFuel_code [code]      = openApiSchemaFuel_def
 lemmas typeExprToSchemaAux_code [code]    = typeExprToSchemaAux.simps fieldToSchemaAux.simps
 lemmas typeExprToSchema_code [code]       = typeExprToSchema_def
 lemmas fieldToSchema_code [code]          = fieldToSchema_def
+lemmas sensitiveExactNames_code [code]    = sensitiveExactNames_def
+lemmas sensitiveSuffixNames_code [code]   = sensitiveSuffixNames_def
+lemmas isSensitiveField_code [code]       = isSensitiveField_def
+lemmas nonIdDecorated_code [code]         = nonIdDecorated.simps
+lemmas dropSensitive_code [code]          = dropSensitive.simps
+lemmas requiredNames_code [code]          = requiredNames.simps
+lemmas fieldPropertySchema_code [code]    = fieldPropertySchema_def
+lemmas fieldProps_code [code]             = fieldProps.simps
+lemmas fieldPropsNullable_code [code]     = fieldPropsNullable.simps
+lemmas createSchemaLifted_code [code]     = createSchemaLifted_def
+lemmas readSchemaLifted_code [code]       = readSchemaLifted_def
+lemmas updateSchemaLifted_code [code]     = updateSchemaLifted_def
+lemmas buildEntitySchemas_code [code]     = buildEntitySchemas_def
 
 end

--- a/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
+++ b/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
@@ -112,4 +112,97 @@ fun isMapLiteralExpr :: "expr_full \<Rightarrow> bool" where
 
 lemmas isMapLiteralExpr_code [code] = isMapLiteralExpr.simps
 
+text \<open>Type-expression walkers shared by the testgen admin / behavioral backends
+  (\<open>AdminRouter.isNumericType\<close>/\<open>isOptionalType\<close>, \<open>AdminModel.isDateTimeType\<close>,
+  \<open>Behavioral.collectionElementType\<close>). Each resolves a \<open>NamedTypeF\<close> through the spec's
+  type-alias table. The Scala uses a \<open>seen\<close>-set to stop alias cycles; here a fuel bound
+  (\<open>length aliases + 100\<close>, the \<open>typeExprToSchemaAux\<close> convention) plays the same role —
+  identical on every realistic spec, and both reject cyclic aliases.\<close>
+
+fun lookupAliasTarget ::
+  "type_alias_decl_full list \<Rightarrow> String.literal \<Rightarrow> type_expr_full option"
+where
+  "lookupAliasTarget [] _ = None"
+| "lookupAliasTarget (TypeAliasDeclFull nm tgt _ _ # rest) n =
+     (if nm = n then Some tgt else lookupAliasTarget rest n)"
+
+definition typeWalkFuel :: "type_alias_decl_full list \<Rightarrow> nat" where
+  "typeWalkFuel aliases = length aliases + 100"
+
+fun isNumericTypeAux :: "nat \<Rightarrow> type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isNumericTypeAux 0 _ _ = False"
+| "isNumericTypeAux (Suc fuel) aliases t =
+     (case t of
+        NamedTypeF n _ \<Rightarrow>
+          (if n = STR ''Int'' \<or> n = STR ''Long'' \<or> n = STR ''Float'' \<or> n = STR ''Double''
+             then True
+           else (case lookupAliasTarget aliases n of
+                   Some tgt \<Rightarrow> isNumericTypeAux fuel aliases tgt
+                 | None \<Rightarrow> False))
+      | OptionTypeF inner _ \<Rightarrow> isNumericTypeAux fuel aliases inner
+      | _ \<Rightarrow> False)"
+
+fun isOptionalTypeAux :: "nat \<Rightarrow> type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isOptionalTypeAux 0 _ _ = False"
+| "isOptionalTypeAux (Suc fuel) aliases t =
+     (case t of
+        OptionTypeF _ _ \<Rightarrow> True
+      | NamedTypeF n _ \<Rightarrow>
+          (case lookupAliasTarget aliases n of
+             Some tgt \<Rightarrow> isOptionalTypeAux fuel aliases tgt
+           | None \<Rightarrow> False)
+      | _ \<Rightarrow> False)"
+
+fun isDateTimeTypeAux :: "nat \<Rightarrow> type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isDateTimeTypeAux 0 _ _ = False"
+| "isDateTimeTypeAux (Suc fuel) aliases t =
+     (case t of
+        NamedTypeF n _ \<Rightarrow>
+          (if n = STR ''DateTime'' then True
+           else (case lookupAliasTarget aliases n of
+                   Some tgt \<Rightarrow> isDateTimeTypeAux fuel aliases tgt
+                 | None \<Rightarrow> False))
+      | OptionTypeF inner _ \<Rightarrow> isDateTimeTypeAux fuel aliases inner
+      | _ \<Rightarrow> False)"
+
+fun collectionElementTypeAux ::
+  "nat \<Rightarrow> type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> type_expr_full option"
+where
+  "collectionElementTypeAux 0 _ _ = None"
+| "collectionElementTypeAux (Suc fuel) aliases t =
+     (case t of
+        SetTypeF inner _ \<Rightarrow> Some inner
+      | SeqTypeF inner _ \<Rightarrow> Some inner
+      | OptionTypeF inner _ \<Rightarrow> collectionElementTypeAux fuel aliases inner
+      | NamedTypeF n _ \<Rightarrow>
+          (case lookupAliasTarget aliases n of
+             Some tgt \<Rightarrow> collectionElementTypeAux fuel aliases tgt
+           | None \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
+
+definition isNumericType :: "type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isNumericType aliases t = isNumericTypeAux (typeWalkFuel aliases) aliases t"
+
+definition isOptionalType :: "type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isOptionalType aliases t = isOptionalTypeAux (typeWalkFuel aliases) aliases t"
+
+definition isDateTimeType :: "type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> bool" where
+  "isDateTimeType aliases t = isDateTimeTypeAux (typeWalkFuel aliases) aliases t"
+
+definition collectionElementType ::
+  "type_alias_decl_full list \<Rightarrow> type_expr_full \<Rightarrow> type_expr_full option"
+where
+  "collectionElementType aliases t = collectionElementTypeAux (typeWalkFuel aliases) aliases t"
+
+lemmas lookupAliasTarget_code [code]        = lookupAliasTarget.simps
+lemmas typeWalkFuel_code [code]             = typeWalkFuel_def
+lemmas isNumericTypeAux_code [code]         = isNumericTypeAux.simps
+lemmas isOptionalTypeAux_code [code]        = isOptionalTypeAux.simps
+lemmas isDateTimeTypeAux_code [code]        = isDateTimeTypeAux.simps
+lemmas collectionElementTypeAux_code [code] = collectionElementTypeAux.simps
+lemmas isNumericType_code [code]            = isNumericType_def
+lemmas isOptionalType_code [code]           = isOptionalType_def
+lemmas isDateTimeType_code [code]           = isDateTimeType_def
+lemmas collectionElementType_code [code]    = collectionElementType_def
+
 end

--- a/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
+++ b/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
@@ -1,0 +1,64 @@
+theory TargetExpr
+  imports SpecRest_Core.IR
+begin
+
+text \<open>Language-neutral decision kernels shared by the per-target expression backends
+  (\<open>testgen.ExprToPython\<close>, \<open>TsExprBackend\<close>, \<open>GoExprBackend\<close>). The three backends walk
+  \<open>expr_full\<close> with byte-identical structure and differ only in the rendered tokens;
+  this theory lifts the parts that are pure decisions, so each backend becomes a
+  renderer over the lifted result.
+
+  \<open>classifyIdent\<close> lifts the identifier-resolution precedence cascade — the
+  \<open>resolveIdent\<close> head shared verbatim by all three backends. Given the lexical / IR
+  context it classifies a bare identifier into one of ten outcomes; the backend
+  renders each outcome in its own syntax (an output reference is
+  \<open>response_data["x"]\<close> in Python, \<open>responseData["x"]\<close> in TypeScript,
+  \<open>_field(responseData, "x")\<close> in Go) and labels the reserved-name skip with its own
+  language. Single-sourcing the precedence makes the skip decision identical across
+  targets by construction.
+
+  \<open>ident_ctx\<close> is a positional datatype (not a \<open>record\<close>) so it extracts cleanly via
+  \<open>Code_Target_Scala\<close>, mirroring the \<open>schema_object\<close> convention.\<close>
+
+datatype ident_ctx = IdentCtx
+  "String.literal list"   \<comment> \<open>reserved words (per target language)\<close>
+  "String.literal list"   \<comment> \<open>bound variables in scope\<close>
+  "String.literal option" \<comment> \<open>the bare-body output name, if any\<close>
+  "String.literal list"   \<comment> \<open>operation outputs\<close>
+  "String.literal list"   \<comment> \<open>operation inputs\<close>
+  "String.literal list"   \<comment> \<open>state field names\<close>
+  "String.literal list"   \<comment> \<open>state fields the /state endpoint cannot project\<close>
+  "String.literal list"   \<comment> \<open>enum type names\<close>
+  "String.literal list"   \<comment> \<open>all enum member values (flattened)\<close>
+
+datatype ident_class =
+    IcReserved
+  | IcBound
+  | IcBareBody
+  | IcOutput
+  | IcInput
+  | IcStateField
+  | IcUnbackedState
+  | IcEnumType
+  | IcEnumValue
+  | IcUnbound
+
+fun classifyIdent :: "ident_ctx \<Rightarrow> String.literal \<Rightarrow> ident_class" where
+  "classifyIdent
+     (IdentCtx reserved bound bareBody outputs inputs stateFields unbackedState enumTypes enumValues)
+     name =
+    (if string_in_list name reserved \<and> (string_in_list name bound \<or> string_in_list name inputs)
+       then IcReserved
+     else if string_in_list name bound then IcBound
+     else if bareBody = Some name then IcBareBody
+     else if string_in_list name outputs then IcOutput
+     else if string_in_list name inputs then IcInput
+     else if string_in_list name stateFields
+       then (if string_in_list name unbackedState then IcUnbackedState else IcStateField)
+     else if string_in_list name enumTypes then IcEnumType
+     else if string_in_list name enumValues then IcEnumValue
+     else IcUnbound)"
+
+lemmas classifyIdent_code [code] = classifyIdent.simps
+
+end

--- a/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
+++ b/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
@@ -102,4 +102,14 @@ lemmas classifyUserCall_code [code] = classifyUserCall_def
 lemmas quantBindingIsIn_code [code] = quantBindingIsIn.simps
 lemmas quantifierAllIn_code [code]  = quantifierAllIn_def
 
+text \<open>\<open>isMapLiteralExpr\<close> recognises a \<open>MapLiteralF\<close>. Lifts the
+  \<open>isInstanceOf[MapLiteralF]\<close> guard each backend uses to route a \<open>BAdd\<close> over
+  map literals to a dict-merge, removing the reflection (and the wart suppression).\<close>
+
+fun isMapLiteralExpr :: "expr_full \<Rightarrow> bool" where
+  "isMapLiteralExpr (MapLiteralF _ _) = True"
+| "isMapLiteralExpr _ = False"
+
+lemmas isMapLiteralExpr_code [code] = isMapLiteralExpr.simps
+
 end

--- a/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
+++ b/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
@@ -61,4 +61,45 @@ fun classifyIdent :: "ident_ctx \<Rightarrow> String.literal \<Rightarrow> ident
 
 lemmas classifyIdent_code [code] = classifyIdent.simps
 
+text \<open>\<open>classifyUserCall\<close> lifts the arity dispatch shared by the three backends'
+  \<open>userDefinedCall\<close>: look the call name up among the user-defined function then
+  predicate arities and compare to the supplied argument count. The backend renders
+  the unknown / wrong-arity skips (identical neutral messages) and, on \<open>UcOk\<close>, emits
+  the call in its own syntax (Python snake-cases the name with no reserved-name guard;
+  TypeScript and Go keep the name and add their own reserved-name skip).\<close>
+
+fun lookupArity :: "(String.literal \<times> int) list \<Rightarrow> String.literal \<Rightarrow> int option" where
+  "lookupArity [] _ = None"
+| "lookupArity ((nm, ar) # rest) fname =
+     (if nm = fname then Some ar else lookupArity rest fname)"
+
+datatype user_call_class = UcUnknown | UcWrongArity int | UcOk
+
+definition classifyUserCall ::
+  "(String.literal \<times> int) list \<Rightarrow> (String.literal \<times> int) list
+    \<Rightarrow> String.literal \<Rightarrow> int \<Rightarrow> user_call_class"
+where
+  "classifyUserCall fnArities predArities fname argCount =
+    (case (case lookupArity fnArities fname of
+             Some n \<Rightarrow> Some n
+           | None \<Rightarrow> lookupArity predArities fname) of
+       None \<Rightarrow> UcUnknown
+     | Some n \<Rightarrow> (if n = argCount then UcOk else UcWrongArity n))"
+
+text \<open>\<open>quantifierAllIn\<close> lifts the gate at the head of each backend's \<open>quantifier\<close>:
+  the comprehension form is only emitted when every binding uses \<open>in\<close> (\<open>BkIn\<close>); a
+  \<open>:\<close>-binding (\<open>BkColon\<close>) forces the shared skip.\<close>
+
+fun quantBindingIsIn :: "quantifier_binding_full \<Rightarrow> bool" where
+  "quantBindingIsIn (QuantifierBindingFull _ _ BkIn _) = True"
+| "quantBindingIsIn _ = False"
+
+definition quantifierAllIn :: "quantifier_binding_full list \<Rightarrow> bool" where
+  "quantifierAllIn bs = list_all quantBindingIsIn bs"
+
+lemmas lookupArity_code [code]      = lookupArity.simps
+lemmas classifyUserCall_code [code] = classifyUserCall_def
+lemmas quantBindingIsIn_code [code] = quantBindingIsIn.simps
+lemmas quantifierAllIn_code [code]  = quantifierAllIn_def
+
 end


### PR DESCRIPTION
Implements the Category D lift backlog from #361 — moving pure decision logic out from under the hand-written emitters into Isabelle/HOL, leaving only string rendering in Scala. Each lift regenerates `SpecRestGenerated.scala` and is verified byte-identical against the existing golden/conformance suites.

## Landed (green)

- **D1 — OpenAPI entity-schema assembly.** `OpenApi.Components.{create,read,update}Schema` lifted into `OpenApiSchema.thy` as `buildEntitySchemas` over the lifted `schema_object`, composing the existing `fieldToSchema` / `makeNullableLifted` primitives. The Scala adapter now converts the three entity schemas once each instead of per field (drops the lossy `schema_object → Scala SchemaObject` reverse trip).
- **D5 (partial) — `isSensitive`.** Lifted as `isSensitiveField` (exact-name set + suffix match via `literalEndsWith`); the Scala `SensitiveFields` facade delegates, single-sourcing the OpenAPI read view, the Python emitter, and testgen redaction.

Verification: `codegen` 356 + `testgen` 285 tests pass; pre-commit `isabelle build SpecRest` (Core/Soundness/Codegen) green; regen drift gate clean.

## Remaining on this branch

- [ ] **D2 — unify the 3× `expr_full` walk** (`ExprToPython`/`TsExprBackend`/`GoExprBackend`) behind one lifted `to_target` render-plan. The flagship; largest effort.
- [ ] **D3 — guard recognizer** (`Behavioral.GuardSatisfier`) → lifted `recognize`, reusing `TopoSort.thy`.
- [ ] **D4 — Dafny AST transforms** (`convention/dafny/Generator.scala`).
- [ ] **D5 — type-walkers** (`isNumericType`/`isOptionalType`/…): deferred — low dedup value, alias-resolution termination fuss; tracked in #361.
- [ ] Update `STATUS.md` §3 once the above land.

## Test plan

- [x] `sbt codegen/test` (D1 OpenAPI goldens)
- [x] `sbt testgen/test` (SensitiveFields delegation)
- [ ] `sbt test` (full) before marking ready
- [x] Isabelle build + regen drift gate (pre-commit)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted OpenAPI entity-schema assembly, sensitive-field predicate, shared expression kernels, Dafny field-ref/option-guard rewrites, extern classification, and testgen type-walkers into Isabelle/HOL so Scala only renders. Outputs remain byte-identical; part of #361 (Category D).

- **New Features**
  - D1: `OpenApi.Components.{create,read,update}Schema` lifted as `buildEntitySchemas` in `OpenApiSchema.thy`; Scala adapts via `SchemaObjectAdapter.fromLifted`.
  - D5: `isSensitiveField` plus type-walkers `isNumericType`/`isOptionalType`/`isDateTimeType`/`collectionElementType` lifted in `TargetExpr.thy`.
  - D2: `classifyIdent`, `classifyUserCall`, `quantifierAllIn`, `isMapLiteralExpr` lifted in `TargetExpr.thy`; exported via `specrest.ir.generated.SpecRestGenerated`.
  - D4: `rewriteEntityFieldRefs`, `desugarOptionGuards`, and extern analysis via `collectExternItems`/`classifyExternItems` lifted in `DafnyTransform.thy`.

- **Refactors**
  - `specrest.codegen.openapi.OpenApi.Components` uses lifted `buildEntitySchemas` and `fieldToSchema`; `specrest.codegen.SensitiveFields.isSensitive` delegates to `isSensitiveField`.
  - Python/TS/Go expr backends now render over lifted decisions; removed reflection and wart suppressions.
  - Admin/testgen now use lifted type-walkers; removed local helpers from `AdminModel`, `AdminRouter`, and `Behavioral`.
  - `convention.dafny.Generator` delegates to lifted rewrites and extern classification; adapts results to its `ExternInfo`/`ListMap`.
  - Added `TargetExpr.thy` and `DafnyTransform.thy` to Isabelle build and exports; regenerated `SpecRestGenerated.scala`. Outputs are byte-identical and `codegen`/`testgen`/`convention` suites pass.

<sup>Written for commit 6d0d10eda1b02a0ebfb5e6ff1d1f72fa597daa29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized sensitive-field detection and moved OpenAPI create/read/update schema assembly to a shared generator.
  * Standardized identifier, user-call, quantifier and map-literal handling across language backends for consistent translation.

* **New Features**
  * Introduced reusable transforms and classification helpers to streamline codegen and runtime translations.

* **Formal**
  * Expanded formal artifacts to export and verify the new code-generation helpers and schema-building logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->