### PR TITLE
refactor(proofs): drop 6 vestigial verified-subset IR records

### DIFF
--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -95,42 +95,6 @@ record enum_decl =
   enm_members :: "String.literal list"
   enm_span    :: "option_span"
 
-record state_scalar =
-  ss_name :: "String.literal"
-  ss_ty   :: "type_expr"
-  ss_span :: "option_span"
-
-record state_relation =
-  sr_name  :: "String.literal"
-  sr_key   :: "type_expr"
-  sr_value :: "type_expr"
-  sr_span  :: "option_span"
-
-record state_decl =
-  st_scalars   :: "state_scalar list"
-  st_relations :: "state_relation list"
-  st_span      :: "option_span"
-
-record invariant_decl =
-  inv_name :: "String.literal"
-  inv_body :: "expr"
-  inv_span :: "option_span"
-
-record operation_decl =
-  op_name     :: "String.literal"
-  op_requires :: "expr list"
-  op_ensures  :: "expr list"
-  op_span     :: "option_span"
-
-record service_ir =
-  svc_name       :: "String.literal"
-  svc_enums      :: "enum_decl list"
-  svc_entities   :: "entity_decl list"
-  svc_state      :: "state_decl"
-  svc_invariants :: "invariant_decl list"
-  svc_operations :: "operation_decl list"
-  svc_span       :: "option_span"
-
 text \<open>Issue #202: full input-language IR (canonical for Scala consumers).
   Coexists with the verified-subset above. The verified-subset stays as records
   (proof-internal); the full-language IR uses datatypes — Code_Target_Scala


### PR DESCRIPTION
## Summary

`IR.thy` defined two parallel decl families — the proof-internal verified-subset records and the extracted `*_full` spec datatypes. Six of the verified-subset **records were dead**: `service_ir`, `state_decl`, `invariant_decl`, `operation_decl`, `state_scalar`, `state_relation`.

They formed a closed cluster: `service_ir` had **zero external references**, and the other five were reachable only from within `service_ir`/`state_decl`. `eval`/`translate` consume their own `schema`/`state`/`expr` types (not these records), none are listed in `Codegen.thy`'s `export_code`, and no Scala module references them. The live eval-schema records — `field_decl`, `entity_decl`, `enum_decl` — are kept.

This is the dead-code half of the #361 / naming-debt discussion: the verified-subset vs `_full` split itself is load-bearing (surface AST vs elaborated core; `lower` is a schema-aware elaboration), but these particular records were vestigial.

## Verification
- `isabelle build SpecRest_Soundness SpecRest_Codegen` green; **soundness still closes with zero `sorry`**.
- `SpecRestGenerated.scala` is **byte-identical** after re-export (no extraction drift) — confirms the records weren't extracted.
- 1 file changed, 36 deletions.

## Test plan
- [x] Full Isabelle build (Core/Soundness/Codegen) via pre-commit hook
- [x] Re-export drift check (generated Scala unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed six unused verified-subset IR records from `IR.thy` to simplify the proof-internal IR and remove dead code. No behavior or generated code changes.

- **Refactors**
  - Removed records: `service_ir`, `state_decl`, `invariant_decl`, `operation_decl`, `state_scalar`, `state_relation`.
  - These had no external references, were not exported, and are not used by `eval`/`translate`. Full build and soundness pass; Scala output remains identical.

<sup>Written for commit 889fb4d17d0a9ab71fe3cb7a3a33ff0ab31f71c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

