### PR TITLE
Lift Option-flatten IR queries; collapse consumer boilerplate

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -7140,6 +7140,20 @@ object SpecRestGenerated {
     case FieldDeclFull(uu, t, uv, uw) => t
   }
 
+  def stdFields(x0: state_decl_full): List[state_field_decl_full] = x0 match {
+    case StateDeclFull(x1, x2) => x1
+  }
+
+  def svcState(x0: service_ir_full): Option[state_decl_full] = x0 match {
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x6
+  }
+
+  def irStateFields(ir: service_ir_full): List[state_field_decl_full] =
+    svcState(ir) match {
+      case None    => Nil
+      case Some(a) => stdFields(a)
+    }
+
   def paramTypeFull(x0: param_decl_full): type_expr_full = x0 match {
     case ParamDeclFull(uu, t, uv) => t
   }
@@ -10145,10 +10159,6 @@ object SpecRestGenerated {
     case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x11
   }
 
-  def svcState(x0: service_ir_full): Option[state_decl_full] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x6
-  }
-
   def isKeyExistsConj(c: expr_full, inputName: String, stateName: String): Boolean =
     c match {
       case BinaryOpF(op, l, r, _) =>
@@ -11399,10 +11409,6 @@ object SpecRestGenerated {
     case FieldAssignFull(x1, x2, x3) => x3
   }
 
-  def stdFields(x0: state_decl_full): List[state_field_decl_full] = x0 match {
-    case StateDeclFull(x1, x2) => x1
-  }
-
   def describeLitClass(x0: lit_class): String = x0 match {
     case LcNumeric()    => "numeric"
     case LcBool()       => "boolean"
@@ -11638,6 +11644,27 @@ object SpecRestGenerated {
 
   def findFieldDeclFull(fs: List[field_decl_full], nm: String): Option[field_decl_full] =
     find[field_decl_full]((fd: field_decl_full) => fieldNameFull(fd) == nm, fs)
+
+  def svcConventions(x0: service_ir_full): Option[conventions_decl_full] = x0 match {
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x14
+  }
+
+  def cvdRules(x0: conventions_decl_full): List[convention_rule_full] = x0 match {
+    case ConventionsDeclFull(x1, x2) => x1
+  }
+
+  def irConventionRules(ir: service_ir_full): List[convention_rule_full] =
+    svcConventions(ir) match {
+      case None    => Nil
+      case Some(a) => cvdRules(a)
+    }
+
+  def stfName(x0: state_field_decl_full): String = x0 match {
+    case StateFieldDeclFull(x1, x2, x3) => x1
+  }
+
+  def irStateFieldNames(ir: service_ir_full): List[String] =
+    map[state_field_decl_full, String]((a: state_field_decl_full) => stfName(a), irStateFields(ir))
 
   def isDestructiveOp(x0: migration_op): Boolean = x0 match {
     case CreateTable(uu)                     => false
@@ -13560,10 +13587,6 @@ object SpecRestGenerated {
     case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x13
   }
 
-  def stfName(x0: state_field_decl_full): String = x0 match {
-    case StateFieldDeclFull(x1, x2, x3) => x1
-  }
-
   def stfSpan(x0: state_field_decl_full): Option[span_t] = x0 match {
     case StateFieldDeclFull(x1, x2, x3) => x3
   }
@@ -14324,10 +14347,6 @@ object SpecRestGenerated {
     case ConventionRuleFull(x1, x2, x3, x4, x5) => x1
   }
 
-  def cvdRules(x0: conventions_decl_full): List[convention_rule_full] = x0 match {
-    case ConventionsDeclFull(x1, x2) => x1
-  }
-
   def entInvariants(x0: entity_decl_full): List[expr_full] = x0 match {
     case EntityDeclFull(x1, x2, x3, x4, x5) => x4
   }
@@ -14338,10 +14357,6 @@ object SpecRestGenerated {
 
   def qbdVar(x0: quantifier_binding_full): String = x0 match {
     case QuantifierBindingFull(x1, x2, x3, x4) => x1
-  }
-
-  def svcConventions(x0: service_ir_full): Option[conventions_decl_full] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x14
   }
 
   def svcTransitions(x0: service_ir_full): List[transition_decl_full] = x0 match {

--- a/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UndefinedRef.scala
@@ -8,7 +8,7 @@ object UndefinedRef extends LintPass:
 
   def run(ir: service_ir_full): List[LintDiagnostic] =
     val out         = List.newBuilder[LintDiagnostic]
-    val stateFields = svcState(ir).toList.flatMap(sd => stdFields(sd).map(stfName)).toSet
+    val stateFields = irStateFieldNames(ir).toSet
     val entityNames = svcEntities(ir).map(entName).toSet
     val enumNames   = svcEnums(ir).map(enmName).toSet
     val enumMembers = svcEnums(ir).flatMap(enmVariants).toSet

--- a/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
+++ b/modules/lint/src/main/scala/specrest/lint/UnusedEntity.scala
@@ -31,7 +31,7 @@ object UnusedEntity extends LintPass:
     def addExpr(e: expr_full): Unit      = acc ++= collectExprNames(e)
     def addType(t: type_expr_full): Unit = acc ++= collectTypeNames(t)
 
-    svcState(ir).toList.foreach(sd => stdFields(sd).foreach(sf => addType(stfType(sf))))
+    irStateFields(ir).foreach(sf => addType(stfType(sf)))
 
     for op <- svcOperations(ir) do
       operInputs(op).foreach(p => addType(prmType(p)))

--- a/modules/parser/src/test/scala/specrest/parser/ConventionGrammarTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/ConventionGrammarTest.scala
@@ -30,7 +30,7 @@ class ConventionGrammarTest extends CatsEffectSuite:
     SpecFixtures
       .buildFromSource("two-seg", withConventions("""    Register.http_method = "POST""""))
       .map: ir =>
-        val rules = svcConventions(ir).toList.flatMap(cvdRules)
+        val rules = irConventionRules(ir)
         assertEquals(rules.size, 1)
         val r = rules.head
         assertEquals(cvrTarget(r), "Register")
@@ -44,7 +44,7 @@ class ConventionGrammarTest extends CatsEffectSuite:
         withConventions("""    User.password_hash.test_strategy = "redacted"""")
       )
       .map: ir =>
-        val rules = svcConventions(ir).toList.flatMap(cvdRules)
+        val rules = irConventionRules(ir)
         assertEquals(rules.size, 1)
         val r = rules.head
         assertEquals(cvrTarget(r), "User")
@@ -61,7 +61,7 @@ class ConventionGrammarTest extends CatsEffectSuite:
         withConventions("""    Register.http_header "Location" = "/users/{id}"""")
       )
       .map: ir =>
-        val rules = svcConventions(ir).toList.flatMap(cvdRules)
+        val rules = irConventionRules(ir)
         assertEquals(rules.size, 1)
         val r = rules.head
         assertEquals(cvrTarget(r), "Register")

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
@@ -15,8 +15,7 @@ object AdminModel:
     case EntityRow
 
   def unbackedStateFieldNames(ir: ServiceIRFull): Set[String] =
-    svcState(ir).toList
-      .flatMap(stdFields)
+    irStateFields(ir)
       .filter(f => projectionFor(f, ir).isEmpty)
       .map(stfName)
       .toSet

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -21,7 +21,7 @@ object AdminRouter:
           .map(e => s"    await session.execute(delete(${entName(e)}))")
           .mkString("\n")
 
-    val stateFieldsList = svcState(ir).toList.flatMap(stdFields)
+    val stateFieldsList = irStateFields(ir)
     val stateProjections =
       if stateFieldsList.isEmpty then "    return {}"
       else

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
@@ -5,10 +5,9 @@ import specrest.ir.generated.SpecRestGenerated.entFields
 import specrest.ir.generated.SpecRestGenerated.entName
 import specrest.ir.generated.SpecRestGenerated.entity_decl_full
 import specrest.ir.generated.SpecRestGenerated.fldName
-import specrest.ir.generated.SpecRestGenerated.stdFields
+import specrest.ir.generated.SpecRestGenerated.irStateFields
 import specrest.ir.generated.SpecRestGenerated.stfName
 import specrest.ir.generated.SpecRestGenerated.svcEntities
-import specrest.ir.generated.SpecRestGenerated.svcState
 import specrest.ir.generated.SpecRestGenerated.svcTransitions
 import specrest.ir.generated.SpecRestGenerated.trnEntity
 import specrest.profile.ProfiledService
@@ -39,7 +38,7 @@ object AdminRouterGo:
           )
           .mkString("\n")
 
-    val stateFields = svcState(ir).toList.flatMap(stdFields)
+    val stateFields = irStateFields(ir)
     val stateAssigns = stateFields
       .map: f =>
         AdminModel.projectionFor(f, ir) match

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -6,11 +6,10 @@ import specrest.ir.generated.SpecRestGenerated.entName
 import specrest.ir.generated.SpecRestGenerated.entity_decl_full
 import specrest.ir.generated.SpecRestGenerated.fldName
 import specrest.ir.generated.SpecRestGenerated.fldType
+import specrest.ir.generated.SpecRestGenerated.irStateFields
 import specrest.ir.generated.SpecRestGenerated.isDateTimeType
-import specrest.ir.generated.SpecRestGenerated.stdFields
 import specrest.ir.generated.SpecRestGenerated.stfName
 import specrest.ir.generated.SpecRestGenerated.svcEntities
-import specrest.ir.generated.SpecRestGenerated.svcState
 import specrest.ir.generated.SpecRestGenerated.svcTransitions
 import specrest.ir.generated.SpecRestGenerated.svcTypeAliases
 import specrest.ir.generated.SpecRestGenerated.trnEntity
@@ -59,7 +58,7 @@ object AdminRouterTs:
           .map(e => s"      await (prisma as unknown as AnyPrisma).${accessor(e)}.deleteMany();")
           .mkString("\n")
 
-    val stateFields = svcState(ir).toList.flatMap(stdFields)
+    val stateFields = irStateFields(ir)
     val neededEntities = stateFields
       .flatMap(f => AdminModel.projectionFor(f, ir).map(_.entityName))
       .distinct

--- a/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Behavioral.scala
@@ -111,7 +111,7 @@ object Behavioral:
       ir: ServiceIRFull,
       coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
 
     val requiresHasStateRef =
@@ -167,7 +167,7 @@ object Behavioral:
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
     val inputs      = operInputs(opDecl).map(prmName).toSet
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
 
     operRequires(opDecl).zipWithIndex.flatMap: (req, idx) =>
       keyExistencePair(req).filter((in, st) =>
@@ -213,7 +213,7 @@ object Behavioral:
       coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
 
     if operRequires(opDecl).exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
     then
@@ -259,7 +259,7 @@ object Behavioral:
       coveredByTransit: Set[String]
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
     val temporals   = svcTemporals(ir)
     if temporals.isEmpty then Nil
     else if operRequires(opDecl).exists(e =>
@@ -706,8 +706,7 @@ object Behavioral:
     s"    response = client.$method($pathExpr$bodyExpr$queryExpr)\n"
 
   private def stateFieldForEntity(entityName: String, ir: ServiceIRFull): Option[String] =
-    svcState(ir).toList
-      .flatMap(stdFields)
+    irStateFields(ir)
       .find(f => relationTargetsEntity(stfType(f), entityName))
       .map(stfName)
 
@@ -894,8 +893,7 @@ object Behavioral:
       case _ => None
 
   private def entityForStateField(stateFieldName: String, ir: ServiceIRFull): Option[String] =
-    svcState(ir).toList
-      .flatMap(stdFields)
+    irStateFields(ir)
       .find(f => stfName(f) == stateFieldName)
       .map(stfType)
       .flatMap(relationTargetEntityName)

--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -43,7 +43,7 @@ object GoBehavioral:
       ir: ServiceIRFull
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
     val requiresHasStateRef =
       operRequires(opDecl).exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
     val nonTrivialRequires = operRequires(opDecl).exists(!isTrueLit(_))

--- a/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Stateful.scala
@@ -364,7 +364,7 @@ object Stateful:
       (Right(List(ruleBody)), roleSkips)
 
   private def stateFieldNames(ir: ServiceIRFull): Set[String] =
-    svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    irStateFieldNames(ir).toSet
 
   private def inferCreateRole(
       pop: ProfiledOperation,
@@ -714,7 +714,7 @@ object Stateful:
         )
 
   private[testgen] def invariantCtx(ir: ServiceIRFull): TestCtx =
-    val stateFieldsAll = svcState(ir).toList.flatMap(stdFields)
+    val stateFieldsAll = irStateFields(ir)
     TestCtx(
       inputs = Set.empty,
       outputs = Set.empty,

--- a/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Strategies.scala
@@ -39,7 +39,7 @@ object TestStrategyOverrides:
   val Empty: TestStrategyOverrides = TestStrategyOverrides(Map.empty, Map.empty)
 
   def from(ir: ServiceIRFull): TestStrategyOverrides =
-    val rules = svcConventions(ir).toList.flatMap(cvdRules).collect:
+    val rules = irConventionRules(ir).collect:
       case ConventionRuleFull(target, "test_strategy", Some(field), CvOk(PvBool(live)), _) =>
         (target, field, if live then "live" else "redacted")
     val opNames     = svcOperations(ir).map(operName).toSet
@@ -72,7 +72,7 @@ object Strategies:
     svcTransitions(ir).map(trnEntity).toSet
 
   private def strategyOverrides(ir: ServiceIRFull): Map[String, StrategyImport] =
-    svcConventions(ir).toList.flatMap(cvdRules).flatMap:
+    irConventionRules(ir).flatMap:
       case ConventionRuleFull(target, "strategy", _, CvOk(PvStrPair(m, s)), _) =>
         Some(target -> StrategyImport(m, s))
       case _ => None

--- a/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Structural.scala
@@ -91,9 +91,8 @@ object Structural:
     TestCtx(
       inputs = Set.empty,
       outputs = Set.empty,
-      stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet,
-      mapStateFields = svcState(ir).toList
-        .flatMap(stdFields)
+      stateFields = irStateFieldNames(ir).toSet,
+      mapStateFields = irStateFields(ir)
         .filter(f => stfType(f).isInstanceOf[MapTypeF])
         .map(stfName)
         .toSet,
@@ -118,7 +117,7 @@ object Structural:
     if !isCreateLike then Nil
     else
       val opSnake         = Naming.toSnakeCase(operName(opDecl))
-      val stateFields     = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+      val stateFields     = irStateFieldNames(ir).toSet
       val outputNames     = operOutputs(opDecl).map(prmName).toSet
       val outputNamesList = outputNames.toList
       val stateFieldsList = stateFields.toList

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -44,7 +44,7 @@ object TsBehavioral:
       ir: ServiceIRFull
   ): List[Either[TestSkip, GeneratedTest]] =
     val opSnake     = Naming.toSnakeCase(operName(opDecl))
-    val stateFields = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+    val stateFields = irStateFieldNames(ir).toSet
     val requiresHasStateRef =
       operRequires(opDecl).exists(e => hasPrePrime(e) || free_vars(e).exists(stateFields.contains))
     val nonTrivialRequires = operRequires(opDecl).exists(!isTrueLit(_))

--- a/modules/testgen/src/main/scala/specrest/testgen/Types.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/Types.scala
@@ -107,11 +107,9 @@ object TestCtx:
       capture: CaptureMode,
       bareBodyOutput: Option[String] = None
   ): TestCtx =
-    val stateNames = svcState(ir).toList.flatMap(s => stdFields(s).map(stfName)).toSet
-    val mapStateNames = svcState(ir).toList.flatMap { s =>
-      stdFields(s).filter(f => isMapType(stfType(f))).map(stfName)
-    }.toSet
-    val enumVals = svcEnums(ir).map(e => enmName(e) -> enmVariants(e).toSet).toMap
+    val stateNames    = irStateFieldNames(ir).toSet
+    val mapStateNames = irStateFields(ir).filter(f => isMapType(stfType(f))).map(stfName).toSet
+    val enumVals      = svcEnums(ir).map(e => enmName(e) -> enmVariants(e).toSet).toMap
     TestCtx(
       inputs = operInputs(op).map(prmName).toSet,
       outputs = operOutputs(op).map(prmName).toSet,

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -49,7 +49,7 @@ class SkipRateProbeTest extends CatsEffectSuite:
       (total, skipped, rate)
 
   private def baseCtx(ir: ServiceIRFull) =
-    val stateFields = svcState(ir).toList.flatMap(stdFields)
+    val stateFields = irStateFields(ir)
     val stateNames  = stateFields.map(stfName).toSet
     val enumVals    = svcEnums(ir).map(e => enmName(e) -> enmVariants(e).toSet).toMap
     val mapNames = stateFields.collect {

--- a/modules/verify/src/main/scala/specrest/verify/Narration.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Narration.scala
@@ -103,7 +103,7 @@ object Narration:
 
   private def contributingField(e: expr_full, ir: service_ir_full): Option[String] =
     collectFieldAccessNames(e).headOption.orElse:
-      val stateFieldNames = svcState(ir).toList.flatMap(stdFields).map(stfName).toSet
+      val stateFieldNames = irStateFieldNames(ir).toSet
       collectIdentifierNames(e).find(stateFieldNames.contains)
 
   private def describePreInputs(

--- a/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/alloy/Translator.scala
@@ -125,7 +125,7 @@ object Translator:
     }
 
   private def buildCtxWithInputs(ir: service_ir_full, op: operation_decl_full): Ctx =
-    val stateFields = svcState(ir).toList.flatMap(stdFields)
+    val stateFields = irStateFields(ir)
       .map(sf => stfName(sf) -> stfType(sf))
     val inputFields = operInputs(op).map(p => prmName(p) -> prmType(p))
     Ctx(ir, stateFields.toMap, inputFields.toMap)
@@ -164,7 +164,7 @@ object Translator:
           AlloyFact(Some(s"${operName(op)}_ensures_$i"), renderExpr(postCtx, e), e.spanOpt)
 
         val mentionedInEnsures = primedStateFields(operEnsures(op))
-        val frameFacts = svcState(ir).toList.flatMap(stdFields)
+        val frameFacts = irStateFields(ir)
           .collect {
             case sf if !mentionedInEnsures.contains(stfName(sf)) =>
               AlloyFact(
@@ -216,7 +216,7 @@ object Translator:
     collectPrimedIdentifiers(ensures).toSet
 
   private def buildCtx(ir: service_ir_full): Ctx =
-    val stateFields = svcState(ir).toList.flatMap(stdFields)
+    val stateFields = irStateFields(ir)
       .map(sf => stfName(sf) -> stfType(sf))
     Ctx(ir, stateFields.toMap)
 

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -169,6 +169,9 @@ export_code
     entityFieldDeclLookup
     entityHasField
     entityFieldNames
+    irStateFields
+    irStateFieldNames
+    irConventionRules
     entityNameInList
     isCollectionType
     rootIdentifier

--- a/proofs/isabelle/SpecRest/core/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Helpers.thy
@@ -292,6 +292,24 @@ definition entityFieldNames ::
         None    \<Rightarrow> []
       | Some ed \<Rightarrow> map fieldNameFull (entityFieldsFull ed))"
 
+definition irStateFields ::
+  "service_ir_full \<Rightarrow> state_field_decl_full list" where
+  "irStateFields ir \<equiv>
+     (case svcState ir of
+        None   \<Rightarrow> []
+      | Some s \<Rightarrow> stdFields s)"
+
+definition irStateFieldNames ::
+  "service_ir_full \<Rightarrow> String.literal list" where
+  "irStateFieldNames ir \<equiv> map stfName (irStateFields ir)"
+
+definition irConventionRules ::
+  "service_ir_full \<Rightarrow> convention_rule_full list" where
+  "irConventionRules ir \<equiv>
+     (case svcConventions ir of
+        None   \<Rightarrow> []
+      | Some c \<Rightarrow> cvdRules c)"
+
 definition entityNameInList ::
   "entity_decl_full list \<Rightarrow> String.literal \<Rightarrow> String.literal option" where
   "entityNameInList es nm \<equiv>


### PR DESCRIPTION
## Summary

Follow-up to #364. After the selector migration, the two `Option`-typed service fields
(`svcState`, `svcConventions`) still forced repeated flatten boilerplate in consumers:
`svcState(ir).toList.flatMap(stdFields)…` and `svcConventions(ir).toList.flatMap(cvdRules)`.

This lifts three pure derivations into the verified layer (`IR_Helpers.thy`, exported alongside
`entityFieldNames`/`findOperationByName`) and collapses the consumer chains:

- `irStateFields(ir): List[state_field_decl_full]`  — flatten `svcState` over `stdFields`
- `irStateFieldNames(ir): List[String]`             — `map stfName` over `irStateFields`
- `irConventionRules(ir): List[convention_rule_full]` — flatten `svcConventions` over `cvdRules`

~25 sites collapse, e.g. `svcState(ir).toList.flatMap(stdFields).map(stfName).toSet` →
`irStateFieldNames(ir).toSet`. Sites that pass the `Option` through directly (`svcState(ir) match`,
`validateConventions(svcConventions(ir), ir)`, …) are untouched.

`ir`-prefixed because bare `stateFields`/`stateFieldNames` clash with local binders in codegen theories.

## Deliberately not touched

- The bulk `.toSet`/`.toMap`/`.toList` conversions — idiomatic Scala adapting extracted `List`s to its
  own structures; not reducible without losing clarity.
- The `expr_full`/`type_expr_full` `match` dispatch in the emitters — inherent 27-variant sum-type
  dispatch, and outside the soundness core; a shared fold would be high-risk for little gain.

## Test plan
- [x] Proofs build green, zero `sorry` (pre-commit hook re-ran Core/Soundness/Codegen).
- [x] Drift-gate safe — generated diff is additive (+3 functions; `export_code` only reorders their
      dependency selectors, no logic change).
- [x] Full `sbt test` green across all modules; `scalafmtCheckAll` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted Option-flatten IR queries into the verified layer and removed consumer boilerplate. Adds three helpers and updates call sites with no behavior changes.

- **New Features**
  - Added `irStateFields`, `irStateFieldNames`, and `irConventionRules` in `IR_Helpers.thy`; exported and generated in `SpecRestGenerated.scala`.

- **Refactors**
  - Replaced ~25 chains like `svcState(ir).toList.flatMap(stdFields)` and `svcConventions(ir).toList.flatMap(cvdRules)` across lint, testgen, verify, and parser tests.
  - Left sites that pass `Option` values through unchanged.
  - Proofs and test suite are green; codegen is additive only.

<sup>Written for commit 5ee47820c4ba6f9e194c4ba9c4777754428ee42e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal state field and convention rule derivation across test generation, linting, and verification modules using unified helper functions. Improves code consistency and maintainability without affecting user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HardMax71/spec_to_rest/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->