### PR TITLE
docs: redesign landing, playground, and roadmap

### DIFF
--- a/docs/app/(docs)/[[...slug]]/page.tsx
+++ b/docs/app/(docs)/[[...slug]]/page.tsx
@@ -22,6 +22,7 @@ export default async function Page(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
+  const isHome = !params.slug || params.slug.length === 0;
   const MDX = page.data.body;
   const repoRel = `docs/content/docs/${page.path}`;
   const lastModified = getGitLastModified(repoRel);
@@ -38,16 +39,20 @@ export default async function Page(props: {
 
   return (
     <DocsPage toc={page.data.toc} full={page.data.full}>
-      <div className="flex items-start justify-between gap-4">
-        <DocsTitle>{page.data.title}</DocsTitle>
-        <EditOnGitHub href={editUrl} className="shrink-0 mt-1" />
-      </div>
-      <DocsDescription>{page.data.description}</DocsDescription>
-      {lastUpdatedLabel && (
-        <p className="-mt-2 text-xs text-fd-muted-foreground">
-          Last updated:{" "}
-          <time dateTime={lastModified?.toISOString()}>{lastUpdatedLabel}</time>
-        </p>
+      {!isHome && (
+        <>
+          <div className="flex items-start justify-between gap-4">
+            <DocsTitle>{page.data.title}</DocsTitle>
+            <EditOnGitHub href={editUrl} className="shrink-0 mt-1" />
+          </div>
+          <DocsDescription>{page.data.description}</DocsDescription>
+          {lastUpdatedLabel && (
+            <p className="-mt-2 text-xs text-fd-muted-foreground">
+              Last updated:{" "}
+              <time dateTime={lastModified?.toISOString()}>{lastUpdatedLabel}</time>
+            </p>
+          )}
+        </>
       )}
       <DocsBody>
         <MDX components={getMDXComponents()} />

--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { Highlighter } from "shiki";
 import { PLAYGROUND_EXAMPLES } from "@/lib/playground-examples.generated";
 
 type Target =
@@ -22,7 +23,7 @@ const TARGETS: { value: Target; label: string; description: string }[] = [
   { value: "synth", label: "Synth", description: "LLM CEGIS (BYO API key)" },
 ];
 
-// Pretty display labels are still hardcoded — there's no "human name for a
+// Pretty display labels are still hardcoded - there's no "human name for a
 // framework ID" anywhere in the Scala source. If a fourth framework arrives,
 // add a row here OR fall back to the bare ID via FRAMEWORK_LABEL_FALLBACK.
 const FRAMEWORK_DISPLAY: Record<string, string> = {
@@ -227,18 +228,96 @@ export function Playground() {
         <CompileOptsRow opts={compileOpts} onChange={setCompileOpts} targets={targets} />
       )}
       {showSynthOpts && <SynthOptsRow opts={synthOpts} onChange={setSynthOpts} />}
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-        <SpecEditor spec={spec} onChange={setSpec} onSubmit={submit} />
-        <OutputPane
-          state={state}
-          tab={tab}
-          onTab={setTab}
-          hasFiles={!!hasFiles}
-          selectedFile={selectedFile}
-          onSelectFile={setSelectedFile}
-        />
-      </div>
+      <Split
+        left={<SpecEditor spec={spec} onChange={setSpec} onSubmit={submit} />}
+        right={
+          <OutputPane
+            state={state}
+            tab={tab}
+            onTab={setTab}
+            hasFiles={!!hasFiles}
+            selectedFile={selectedFile}
+            onSelectFile={setSelectedFile}
+          />
+        }
+      />
       <StatusLine state={state} target={target} />
+    </div>
+  );
+}
+
+let specHighlighter: Promise<Highlighter> | null = null;
+
+function getSpecHighlighter(): Promise<Highlighter> {
+  if (!specHighlighter) {
+    specHighlighter = (async () => {
+      const { createHighlighter, createJavaScriptRegexEngine } = await import("shiki");
+      const { specGrammar } = await import("@/lib/grammars");
+      return createHighlighter({
+        engine: createJavaScriptRegexEngine(),
+        langs: [specGrammar],
+        themes: ["github-light", "github-dark"],
+      });
+    })();
+  }
+  return specHighlighter;
+}
+
+async function highlightSpecHtml(code: string): Promise<string> {
+  const hl = await getSpecHighlighter();
+  return hl.codeToHtml(code, {
+    lang: "spec",
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: false,
+  });
+}
+
+function Split(props: { left: React.ReactNode; right: React.ReactNode }) {
+  const [pct, setPct] = useState(50);
+  const ref = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      if (!dragging.current || !ref.current) return;
+      const rect = ref.current.getBoundingClientRect();
+      const p = ((e.clientX - rect.left) / rect.width) * 100;
+      setPct(Math.min(75, Math.max(25, p)));
+    };
+    const up = () => {
+      dragging.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+    return () => {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+    };
+  }, []);
+  return (
+    <div
+      ref={ref}
+      style={{ "--lp": `${pct}%` } as React.CSSProperties}
+      className="flex flex-col gap-3 md:h-[480px] md:flex-row md:gap-0"
+    >
+      <div className="h-[360px] min-h-0 min-w-0 md:h-full md:shrink-0 md:grow-0 md:basis-[var(--lp)]">
+        {props.left}
+      </div>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        onPointerDown={(e) => {
+          e.preventDefault();
+          dragging.current = true;
+          document.body.style.cursor = "col-resize";
+          document.body.style.userSelect = "none";
+        }}
+        className="group hidden shrink-0 cursor-col-resize touch-none items-center justify-center px-1.5 md:flex"
+      >
+        <div className="h-12 w-1 rounded-full bg-fd-border transition group-hover:bg-fd-primary" />
+      </div>
+      <div className="h-[360px] min-h-0 min-w-0 md:h-full md:flex-1">{props.right}</div>
     </div>
   );
 }
@@ -407,25 +486,60 @@ function SpecEditor(props: {
   onChange: (s: string) => void;
   onSubmit: () => void;
 }) {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const [html, setHtml] = useState("");
+  useEffect(() => {
+    let cancelled = false;
+    highlightSpecHtml(props.spec)
+      .then((h) => {
+        if (!cancelled) setHtml(h);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [props.spec]);
+  const syncScroll = () => {
+    if (taRef.current && overlayRef.current) {
+      overlayRef.current.scrollTop = taRef.current.scrollTop;
+      overlayRef.current.scrollLeft = taRef.current.scrollLeft;
+    }
+  };
   return (
-    <div className="flex flex-col overflow-hidden rounded-md border border-fd-border bg-fd-card">
-      <div className="border-b border-fd-border bg-fd-secondary/30 px-3 py-1.5 text-xs font-medium text-fd-muted-foreground">
+    <div className="flex h-full flex-col overflow-hidden rounded-md border border-fd-border bg-fd-card">
+      <div className="flex h-9 items-center border-b border-fd-border bg-fd-secondary/30 px-3 text-xs font-medium text-fd-muted-foreground">
         spec
       </div>
-      <textarea
-        spellCheck={false}
-        autoCorrect="off"
-        autoCapitalize="off"
-        value={props.spec}
-        onChange={(e) => props.onChange(e.target.value)}
-        onKeyDown={(e) => {
-          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
-            e.preventDefault();
-            props.onSubmit();
-          }
-        }}
-        className="block h-[460px] w-full resize-none bg-fd-background p-3 font-mono text-[13px] leading-relaxed text-fd-foreground focus:outline-none"
-      />
+      <div className="relative flex-1 overflow-hidden bg-fd-background">
+        <div
+          ref={overlayRef}
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 overflow-auto p-3 font-mono text-[13px] leading-relaxed text-fd-foreground [&_code]:font-mono [&_pre]:m-0 [&_pre]:!bg-transparent [&_pre]:p-0"
+        >
+          {html ? (
+            <div dangerouslySetInnerHTML={{ __html: html }} />
+          ) : (
+            <pre className="m-0 whitespace-pre p-0">{props.spec}</pre>
+          )}
+        </div>
+        <textarea
+          ref={taRef}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="none"
+          value={props.spec}
+          onChange={(e) => props.onChange(e.target.value)}
+          onScroll={syncScroll}
+          onKeyDown={(e) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+              e.preventDefault();
+              props.onSubmit();
+            }
+          }}
+          className="absolute inset-0 m-0 block resize-none overflow-auto whitespace-pre bg-transparent p-3 font-mono text-[13px] leading-relaxed text-transparent caret-black focus:outline-none dark:caret-white"
+        />
+      </div>
     </div>
   );
 }
@@ -442,10 +556,10 @@ function OutputPane(props: {
   const fileEntry = files.find((f) => f.path === props.selectedFile);
   const showFilesTab = props.hasFiles;
   return (
-    <div className="flex flex-col overflow-hidden rounded-md border border-fd-border bg-fd-card">
+    <div className="flex h-full flex-col overflow-hidden rounded-md border border-fd-border bg-fd-card">
       <div
         role="tablist"
-        className="flex items-center gap-1 border-b border-fd-border bg-fd-secondary/30 px-2 py-1.5"
+        className="flex h-9 items-center gap-1 border-b border-fd-border bg-fd-secondary/30 px-2"
       >
         {showFilesTab && (
           <TabButton active={props.tab === "files"} onClick={() => props.onTab("files")}>
@@ -465,7 +579,7 @@ function OutputPane(props: {
         </TabButton>
       </div>
       {props.tab === "files" && showFilesTab ? (
-        <div className="flex h-[460px] flex-col">
+        <div className="flex flex-1 flex-col">
           <div className="flex items-center gap-2 border-b border-fd-border bg-fd-secondary/20 px-2 py-1.5 text-xs">
             <span className="text-fd-muted-foreground">file</span>
             <select
@@ -486,7 +600,7 @@ function OutputPane(props: {
           </pre>
         </div>
       ) : (
-        <pre className="m-0 h-[460px] overflow-auto whitespace-pre-wrap break-words bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
+        <pre className="m-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
           {props.tab === "stdout" ? stdoutText(props.state) : stderrText(props.state)}
         </pre>
       )}
@@ -551,7 +665,7 @@ function StatusLine({ state, target }: { state: RunState; target: Target }) {
     <p className="text-xs">
       <span className="text-red-600 dark:text-red-400">✗ error</span>{" "}
       <span className="text-fd-muted-foreground">
-        in {state.elapsedMs} ms — {state.message}
+        in {state.elapsedMs} ms - {state.message}
       </span>
     </p>
   );
@@ -583,7 +697,7 @@ function stdoutText(s: RunState): string {
     case "loading":
       return "// Running…";
     case "ok":
-      return s.stdout || "// (no stdout — the subcommand produced no output)";
+      return s.stdout || "// (no stdout - the subcommand produced no output)";
     case "error":
       return `// ERROR: ${s.message}`;
   }

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,25 +6,21 @@ description: A compiler that proves your REST service satisfies its specificatio
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Check, Minus, CircleX } from 'lucide-react';
 
-# spec_to_rest
-
-A compiler that proves your REST service satisfies its specification before
-emitting code. The toolchain is Scala 3, Cats Effect 3, Z3, and Alloy;
-translator soundness is mechanically checked in Isabelle/HOL.
-
-You write the spec: entities, operations with pre/post-conditions, invariants.
-`spec-to-rest verify` discharges the proof obligations against Z3 and Alloy.
-`spec-to-rest compile` emits nothing when any check fails. When it passes, the
-emitter writes a complete service for any of three target stacks (Python/
-FastAPI, Go/chi, TypeScript/Express) across Postgres, SQLite, or MySQL.
-A conformance suite in that target's own language (pytest+Hypothesis,
-Vitest+fast-check, or `go test`+rapid) is emitted alongside the service
-**by default**, single-sourced from the same spec; pass `--no-tests` to opt
-out.
-
-Source is on [GitHub](https://github.com/HardMax71/spec_to_rest). The
-[spec language reference](/spec-language) covers syntax; the
-[verification pipeline](/pipelines/verification) page covers solver routing.
+<div className="not-prose mb-12 mt-2">
+  <h1 className="text-center text-4xl font-bold tracking-tight sm:text-5xl">spec_to_rest</h1>
+  <div className="mx-auto mt-4 max-w-2xl text-center text-base leading-relaxed text-fd-muted-foreground sm:text-lg">
+    A compiler that proves your REST service satisfies its specification - then
+    emits the service, or nothing at all. Scala 3 · Z3 · Alloy, with translator
+    soundness mechanically checked in Isabelle/HOL.
+  </div>
+  <div className="mt-5 text-center text-sm">
+    <a className="underline underline-offset-4 hover:text-fd-primary" href="https://github.com/HardMax71/spec_to_rest">GitHub</a>
+    <span className="mx-2 text-fd-muted-foreground">·</span>
+    <a className="underline underline-offset-4 hover:text-fd-primary" href="/spec-language">Spec language</a>
+    <span className="mx-2 text-fd-muted-foreground">·</span>
+    <a className="underline underline-offset-4 hover:text-fd-primary" href="/pipelines/verification">Verification</a>
+  </div>
+</div>
 
 ## Spec -> Verify -> Emit
 
@@ -33,12 +29,16 @@ and an excerpt of the FastAPI router emitted for the Python target (chi and
 Express render the same spec into their own stacks), all from one `compile`
 invocation:
 
-<div className="not-prose my-6 grid gap-4 lg:grid-cols-[1.1fr_0.9fr_1fr]">
-  <div className="rounded-md border bg-fd-card overflow-hidden">
+<div className="not-prose my-6 grid gap-4 lg:grid-cols-2">
+  <div className="flex flex-col overflow-hidden rounded-xl border bg-fd-card shadow-sm">
     <div className="border-b bg-fd-muted/40 px-4 py-2 font-mono text-xs text-fd-muted-foreground">
       url_shortener.spec
     </div>
-    <pre className="m-0 overflow-x-auto p-4 text-xs leading-relaxed"><code>{`service UrlShortener {
+
+<div className="flex-1 [&_figure]:m-0 [&_figure]:h-full [&_figure]:rounded-none [&_figure]:border-0 [&_figure]:shadow-none [&_pre]:h-full">
+
+```spec
+service UrlShortener {
   type ShortCode = String where
     len(value) >= 6 and len(value) <= 10
 
@@ -65,51 +65,125 @@ invocation:
 
   invariant metadataConsistent:
     dom(store) = dom(metadata)
-}`}</code></pre>
+}
+```
+
+</div>
   </div>
-  <div className="rounded-md border bg-fd-card overflow-hidden">
+  <div className="flex flex-col overflow-hidden rounded-xl border bg-fd-card shadow-sm">
     <div className="border-b bg-fd-muted/40 px-4 py-2 font-mono text-xs text-fd-muted-foreground">
-      verdict
+      verify
     </div>
-    <div className="space-y-2 p-4 font-mono text-xs leading-relaxed">
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] global (invariants jointly sat)</span>
+    <div className="flex flex-1 flex-col p-4 font-mono text-xs leading-relaxed">
+      <div className="text-fd-muted-foreground">$ spec-to-rest verify url_shortener.spec</div>
+      <div className="mt-2 space-y-0.5 text-fd-muted-foreground">
+        <div>Parsed in 3ms</div>
+        <div>Built IR in 2ms</div>
+        <div>Timeout: 5000ms</div>
+        <div>Alloy scope: 5</div>
+        <div>Max parallel: 8</div>
       </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Shorten.requires</span>
+      <div className="mt-3 space-y-1.5">
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> global <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Shorten.requires <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Shorten.enabled <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Shorten.preserves.<wbr/>allURLsValid <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Shorten.preserves.<wbr/>metadataConsistent <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Shorten.preserves.<wbr/>clickCountNonNegative <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Resolve.requires <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Resolve.enabled <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Resolve.preserves.<wbr/>allURLsValid <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Resolve.preserves.<wbr/>metadataConsistent <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Resolve.preserves.<wbr/>clickCountNonNegative <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Delete.requires <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Delete.enabled <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Delete.preserves.<wbr/>allURLsValid <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Delete.preserves.<wbr/>metadataConsistent <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> Delete.preserves.<wbr/>clickCountNonNegative <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> ListAll.requires <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> ListAll.enabled <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> ListAll.preserves.<wbr/>allURLsValid <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> ListAll.preserves.<wbr/>metadataConsistent <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
+        <div className="flex items-start gap-2">
+          <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+          <span><span className="text-fd-muted-foreground">[z3] [sound]</span> ListAll.preserves.<wbr/>clickCountNonNegative <span className="text-fd-muted-foreground">sat</span></span>
+        </div>
       </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Shorten.enabled</span>
-      </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Shorten.preserves.<wbr/>metadataConsistent</span>
-      </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Resolve.requires</span>
-      </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Resolve.preserves.<wbr/>metadataConsistent</span>
-      </div>
-      <div className="flex items-start gap-2">
-        <Check className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
-        <span>[z3] Delete.preserves.<wbr/>metadataConsistent</span>
-      </div>
-      <div className="border-t pt-2 text-fd-muted-foreground">
-        consistency checks passed (exit 0)
+      <div className="mt-auto border-t pt-3">
+        <div className="text-emerald-600 dark:text-emerald-400">✔ url_shortener.spec: 21/21 consistency checks passed (212ms)</div>
+        <div className="mt-1 text-fd-muted-foreground">exit 0</div>
       </div>
     </div>
   </div>
-  <div className="rounded-md border bg-fd-card overflow-hidden">
+  <div className="flex flex-col overflow-hidden rounded-xl border bg-fd-card shadow-sm lg:col-span-2">
     <div className="border-b bg-fd-muted/40 px-4 py-2 font-mono text-xs text-fd-muted-foreground">
       app/routers/url_mapping.py (emitted)
     </div>
-    <pre className="m-0 overflow-x-auto p-4 text-xs leading-relaxed"><code>{`from fastapi import APIRouter, Depends, HTTPException
+
+<div className="[&_figure]:m-0 [&_figure]:rounded-none [&_figure]:border-0 [&_figure]:shadow-none">
+
+```python
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
@@ -140,7 +214,10 @@ async def resolve(
     result = await svc.resolve(code)
     if result is None:
         raise HTTPException(status_code=404, detail="not found")
-    return result`}</code></pre>
+    return result
+```
+
+</div>
   </div>
 </div>
 

--- a/docs/content/docs/install.mdx
+++ b/docs/content/docs/install.mdx
@@ -6,7 +6,7 @@ description: Native binary, Docker image, GitHub Action, or from source
 `spec-to-rest` ships as a self-contained GraalVM native-image binary. Pick the
 form that fits your workflow.
 
-> **Just want to try a spec?** Skip the install — the [playground](/playground) page sends your spec to the same `spec-to-rest` binary running on the docs server (parse + IR + Dafny kernel; up to 50 KB / 8 s per request).
+> **Just want to try a spec?** Skip the install - the [playground](/playground) page sends your spec to the same `spec-to-rest` binary running on the docs server (parse + IR + Dafny kernel; up to 50 KB / 8 s per request).
 
 ## Native binary (recommended)
 
@@ -48,7 +48,7 @@ docker run --rm -v "$PWD:/workspace" \
 Tags: `:vX.Y.Z`, `:X.Y`, `:latest`. The image is `debian:bookworm-slim`-based,
 runs as a non-root `spec` user, and sets `WORKDIR /workspace`. The runtime
 layer adds only the shared libraries the GraalVM native-image binary needs at
-load time (`ca-certificates`, `libstdc++6`, `zlib1g`) — no JVM, no Dafny, no
+load time (`ca-certificates`, `libstdc++6`, `zlib1g`) - no JVM, no Dafny, no
 Python. For `compile --with-synthesis` (needs Dafny) or `test` (needs Python),
 install those on the host and use the native binary instead.
 
@@ -56,7 +56,7 @@ install those on the host and use the native binary instead.
 
 The repo root exposes a composite action that downloads the right release
 archive for the runner platform. The action does **not** modify
-`$GITHUB_PATH` — it exposes the absolute binary path via the `binary-path`
+`$GITHUB_PATH` - it exposes the absolute binary path via the `binary-path`
 output, which subsequent steps invoke directly. This avoids writing to
 GitHub-managed environment files (a defence-in-depth pattern flagged by
 [zizmor](https://docs.zizmor.sh/audits/github-env/)) and keeps the
@@ -135,17 +135,6 @@ sbt cli/nativeImage
 
 The `cli` module aggregates all subcommands; subprojects (`ir`, `parser`,
 `verify`, `codegen`, …) are built transitively.
-
-## Why no npm package?
-
-Earlier design notes assumed a TypeScript/Bun stack and an `npm install -g
-spec-to-rest` install path. The compiler is Scala 3 + GraalVM native-image, so
-the natural distribution is a self-contained native binary — exposing it
-through npm would mean shipping a wrapper package that just downloads the
-same archive this action does at install time. If you are driving CI from `package.json`,
-use the GitHub Action above (zero extra runtime); for local development,
-download the release archive directly. A wrapper is a feasible follow-up if
-there is concrete demand.
 
 ## Subcommand reference
 

--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -34,7 +34,9 @@ to map a section title like `## Hint-Augmentation (M6.7)` back to the activation
 closure date. Older completed milestones are summarised; newer ones get a one-line
 context.
 
-### M_CE.*, Cats Effect 3 migration ([umbrella #95](https://github.com/HardMax71/spec_to_rest/issues/95))
+<Collapsible title="M_CE.*, Cats Effect 3 migration">
+
+Umbrella: [#95](https://github.com/HardMax71/spec_to_rest/issues/95)
 
 | Milestone | Theme | Closed |
 | --------- | ----- | ------ |
@@ -48,7 +50,11 @@ context.
 | M_CE.8 ([#103](https://github.com/HardMax71/spec_to_rest/issues/103)) | Single-API pipeline, synchronous wrappers removed, tests on `CatsEffectSuite` | shipped |
 | M_CE.9 ([#104](https://github.com/HardMax71/spec_to_rest/issues/104)) | [Concurrency docs](/pipelines/concurrency) + JMH `ParallelVerifyBench` with `fixtures/golden/bench/parallel_verify.csv` | shipped |
 
-### M_L.*, Translator soundness ([umbrella #88](https://github.com/HardMax71/spec_to_rest/issues/88), pivot [#193](https://github.com/HardMax71/spec_to_rest/issues/193))
+</Collapsible>
+
+<Collapsible title="M_L.*, Translator soundness">
+
+Umbrella [#88](https://github.com/HardMax71/spec_to_rest/issues/88), pivot [#193](https://github.com/HardMax71/spec_to_rest/issues/193).
 
 Issue [#88](https://github.com/HardMax71/spec_to_rest/issues/88) closed 2026-04-26 after
 decomposition into M_L.0-M_L.4 + the global-proof umbrella
@@ -69,7 +75,9 @@ cutover. See [research/10](/research/10_translator_soundness) for the trust-chai
 | Production routing ([#192](https://github.com/HardMax71/spec_to_rest/issues/192)) | `Translator.translateExpr` routes in-subset shapes through `SpecRestGenerated.translate`; hand-written translator only fires on out-of-subset declaration-level expressions | shipped |
 | Codegen drift gate ([#231](https://github.com/HardMax71/spec_to_rest/pull/231)) | `isabelle-build.yml` regenerates `SpecRestGenerated.scala` and diffs against the committed copy on every PR | shipped |
 
-### M5.*, Test generation
+</Collapsible>
+
+<Collapsible title="M5.*, Test generation">
 
 | Milestone | Theme | Closed |
 | --------- | ----- | ------ |
@@ -86,7 +94,9 @@ cutover. See [research/10](/research/10_translator_soundness) for the trust-chai
 | Per-status bundles for transition-driven entities ([#153](https://github.com/HardMax71/spec_to_rest/issues/153)) | Schemathesis bundle routing by status | shipped |
 | Body and query inputs on `via` operations ([#155](https://github.com/HardMax71/spec_to_rest/issues/155)) | Operation-input plumbing for transition tests | shipped |
 
-### M6.*, LLM synthesis ([umbrella #95-context](https://github.com/HardMax71/spec_to_rest/issues/95))
+</Collapsible>
+
+<Collapsible title="M6.*, LLM synthesis">
 
 | Milestone | Theme | Closed |
 | --------- | ----- | ------ |
@@ -98,12 +108,16 @@ cutover. See [research/10](/research/10_translator_soundness) for the trust-chai
 | M6.6 ([#30](https://github.com/HardMax71/spec_to_rest/issues/30)) | Graduated fallback, L1 prompt ladder + L3 model escalation + L4 skeleton + L5 report; L2 deferred | shipped |
 | M6.7 ([#229](https://github.com/HardMax71/spec_to_rest/issues/229)) | DafnyPro-style hint augmentation in repair prompts; replaces the originally planned [#227](https://github.com/HardMax71/spec_to_rest/issues/227) L2 path (closed wontfix-with-pivot, see [research/12](/research/12_compositional_synthesis_findings)) | shipped |
 
-### Other shipped infrastructure
+</Collapsible>
+
+<Collapsible title="Other shipped infrastructure">
 
 - **Cross-solver verdict agreement** ([#131](https://github.com/HardMax71/spec_to_rest/issues/131)), native cvc5 cross-check job in CI replays each per-check `.smt2` and asserts agreement with the recorded `rawStatus`.
 - **Property-based translator tests** ([#162](https://github.com/HardMax71/spec_to_rest/issues/162)), `TranslatorPropTest.scala` runs 50 random IRs/property over the verified subset.
 - **Typed `__init__(body)` on ORM, `SecretStr` at the schema boundary** ([#212](https://github.com/HardMax71/spec_to_rest/pull/212)), Python codegen ergonomics.
 - **Isabelle codegen drift gate** ([#231](https://github.com/HardMax71/spec_to_rest/pull/231)), `isabelle-build.yml` re-extracts and `diff`s against the committed `SpecRestGenerated.scala` on every PR.
+
+</Collapsible>
 
 ## Verification capabilities
 
@@ -183,15 +197,17 @@ For the prose context, see [Test Generation](/pipelines/test-generation).
 | Multi-target test gen (ts-express Vitest+fast-check, go-chi `go test`+rapid) | **shipped** — [M5.11 (#139)](https://github.com/HardMax71/spec_to_rest/issues/139) via [#278](https://github.com/HardMax71/spec_to_rest/issues/278)/[#279](https://github.com/HardMax71/spec_to_rest/issues/279)/[#280](https://github.com/HardMax71/spec_to_rest/issues/280), closing [#265](https://github.com/HardMax71/spec_to_rest/issues/265) |
 | Default `--with-tests` after M5.4 | **shipped** — [M5.12 (#140)](https://github.com/HardMax71/spec_to_rest/issues/140); test emission is on by default for every supported target. The `--with-tests` flag was dropped (opting in to a default is meaningless); `--no-tests` is the opt-out. |
 
-## Closed not-planned
+<Collapsible title="Closed not-planned (decisions of record)">
 
-Decisions of record. These items have closed issues with explicit rationale; they're not
+These items have closed issues with explicit rationale; they're not
 on the roadmap and will not be picked up unless the underlying constraint changes.
 
 - **Full Z3 proof-term export (Alethe / Z3-native)**, [#90](https://github.com/HardMax71/spec_to_rest/issues/90), closed 2026 not-planned. Z3 has no Alethe export and its native proof format buries quantifier instantiation in opaque steps; superseded by cross-solver agreement ([#131](https://github.com/HardMax71/spec_to_rest/issues/131)) for solver-side defense in depth and by translator-soundness work ([#88](https://github.com/HardMax71/spec_to_rest/issues/88)) for translator-side trust.
 - **L2 operation decomposition for graduated fallback**, [#227](https://github.com/HardMax71/spec_to_rest/issues/227), closed 2026-05-10 wontfix-with-pivot. Replaced by M6.7 hint-augmentation per the literature analysis in [research/12](/research/12_compositional_synthesis_findings) (DafnyComp 7% ceiling, Pass@4 plateau, +16pp from hint augmentation in DafnyPro POPL 2026).
 
-## Cross-references
+</Collapsible>
+
+<Collapsible title="Cross-references">
 
 - [Architecture](/design/architecture), system design without project status
 - [Verification Engine](/pipelines/verification), verifier prose; capability inventory lives [here](#verification-capabilities)
@@ -200,3 +216,5 @@ on the roadmap and will not be picked up unless the underlying constraint change
 - [research/10 Translator Soundness](/research/10_translator_soundness), scoping doc + post-pivot status banner
 - [research/12 Compositional Synthesis](/research/12_compositional_synthesis_findings), decision-of-record for the L2 pivot
 - [`proofs/isabelle/STATUS.md`](https://github.com/HardMax71/spec_to_rest/blob/main/proofs/isabelle/STATUS.md), phase ledger for the Isabelle/HOL proof track
+
+</Collapsible>

--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -192,9 +192,9 @@ the generated tests rather than emitted as `pytest.skip` notes.
 Empirical skip rates on the canonical fixtures (locked in
 [`SkipRateProbeTest`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala)):
 `safe_counter` 60.0% (3 / 5), `url_shortener` 4.8% (1 / 21), `todo_list` 4.0% (2 / 50),
-`edge_cases` 10.3% (3 / 29) — all from unbacked scalar state the admin `/state`
+`edge_cases` 10.3% (3 / 29) - all from unbacked scalar state the admin `/state`
 endpoint projects as null; `ecommerce` 6.6% (5 / 76, mostly unbacked-scalar + 2 from
-a parser scope leak); `auth_service` 9.8% (4 / 41, all unbacked scalar-state — `hash`,
+a parser scope leak); `auth_service` 9.8% (4 / 41, all unbacked scalar-state - `hash`,
 time-unit, and `recentFailedAttempts` builtins translate as of #307). See
 [Test Generation pipeline](/pipelines/test-generation) for the full surface.
 
@@ -222,19 +222,38 @@ conventions {
 }
 ```
 
-Each property is valid against a specific target kind:
+Each property applies to a specific target kind.
 
-| Property              | Valid targets        | Notes |
-|-----------------------|----------------------|-------|
-| `http_method`         | operation            | `"GET" "POST" "PUT" "PATCH" "DELETE"` |
-| `http_path`           | operation            | string literal, `{param}` placeholders allowed |
-| `http_status_success` | operation            | integer status code |
-| `http_header`         | operation            | requires a string-literal qualifier (header name) |
-| `db_table`            | entity               | string literal |
-| `db_timestamps`       | entity               | bool |
-| `plural`              | entity               | string literal, pluralized URL segment |
-| `strategy`            | type alias, enum     | `"module:symbol"` Hypothesis strategy |
-| `test_strategy`       | entity               | requires a field-name qualifier; `EntityName.test_strategy.field = "module:fn"` |
+**Operation**
+
+<TypeTable
+  type={{
+    http_method: { type: 'enum', description: 'HTTP verb: GET, POST, PUT, PATCH, or DELETE.' },
+    http_path: { type: 'string', description: 'Route path; `{param}` placeholders allowed.' },
+    http_status_success: { type: 'int', description: 'Success status code; inferred from the operation classification when unset.' },
+    http_header: { type: 'string', description: 'Response header. Requires a header-name qualifier, e.g. `http_header "Location" = output.url`.' },
+  }}
+/>
+
+**Entity**
+
+<TypeTable
+  type={{
+    db_table: { type: 'string', description: 'Override the generated SQL table name.' },
+    db_timestamps: { type: 'bool', description: 'Toggle generated timestamp columns.' },
+    plural: { type: 'string', description: 'Pluralized URL segment and collection name.' },
+    partial_index: { type: 'string', description: 'Partial-index predicate; requires a column qualifier, e.g. `partial_index "active" = "active = true"`.' },
+    test_strategy: { type: 'string', description: 'Field-level Hypothesis strategy `"module:fn"`; requires a field qualifier (`Entity.test_strategy.field`). Also valid on operations.' },
+  }}
+/>
+
+**Type alias / Enum**
+
+<TypeTable
+  type={{
+    strategy: { type: 'string', description: 'Hypothesis strategy `"module:symbol"` for generated values.' },
+  }}
+/>
 
 The `strategy` and `test_strategy` properties point testgen at user-supplied Hypothesis
 strategies. See


### PR DESCRIPTION
## Summary
Docs-site overhaul (no app/proof code touched). Verified against a local `next dev` — no MDX/compile errors, no hydration warnings.

- **Landing (`index.mdx`)** — centered `spec_to_rest` hero (name + one-line tagline + quick links); the *Spec → Verify → Emit* demo regrouped into **two rows** (spec + verdict on top, the emitted FastAPI router full-width below) so the code isn't clipped; the verdict panel now mirrors the **real CLI output** (preamble + the full 21-check matrix + summary); spec and Python blocks are **syntax-highlighted** via the existing Shiki setup.
- **`page.tsx`** — suppress `DocsTitle` / description / Edit / "Last updated" on the **home page only**, so the MDX hero owns the landing (other pages unchanged).
- **`spec-language.mdx`** — the convention-property table becomes **three grouped `TypeTable`s** (operation / entity / type-alias + enum). While restructuring I corrected the source against `convention/Validate.scala`: added **`partial_index`** (was missing) and noted **`test_strategy`** is valid on operations too.
- **`install.mdx`** — removed the "Why no npm package?" section.
- **`playground.tsx`** — the editable spec box now has **Shiki highlighting** (lazy, reuses the registered `specGrammar`); left/right panes are a **resizable split** with **equal heights**; fixed an `autoCapitalize` hydration mismatch (`off` → `none`).
- **`roadmap.mdx`** — collapsed recent-milestone, closed-not-planned, and cross-reference blocks into `<details>` dropdowns; kept Project phases, Verification capabilities, and the follow-ups expanded.
- Replaced em-dashes with `-` on the edited pages.

## Notes
- Independent of #368 (logo branding) — no overlapping files.
- Deferred: ~211 em-dashes across other docs not touched here.

## Test plan
- [x] `next dev` renders `/`, `/playground`, `/roadmap`, `/spec-language`, `/install` with no MDX/compile errors.
- [x] No `<p>`-in-`<p>` nesting; playground hydration warning resolved.
- [x] Roadmap `Collapsible` tags balanced 7/7; `TypeTable`s render with type badges.
- [ ] Visual pass on deployed docs (hero centering, 2-row demo, playground split/highlight, roadmap dropdowns).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the docs landing, playground, and roadmap to make the first-run experience clearer and the demo easier to follow. Adds syntax highlighting and a resizable split in the playground, updates spec-language docs, and tidies install content.

- New Features
  - Landing: centered hero; Spec → Verify → Emit demo now two rows with a CLI-style verdict; spec/Python blocks syntax-highlighted.
  - Home page: hide title/description/edit/last-updated so the MDX hero owns the landing.
  - Playground: `shiki`-based spec editor and a resizable left/right split with equal heights.
  - Roadmap: recent milestones, closed-not-planned, and cross-references collapsed into details; core sections remain expanded.

- Updates and Fixes
  - Spec Language: replace the property table with three grouped TypeTables; add `partial_index`; note `test_strategy` is valid on operations.
  - Install: remove the “Why no npm package?” section.
  - Fix hydration mismatch in the playground (`autoCapitalize` set to `none`); minor punctuation cleanup across edited pages.

<sup>Written for commit 99903f678e44c06524f84ddc956acc7fcf41b4d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added syntax highlighting to the playground spec editor for improved readability.
  * Introduced resizable split-pane layout in the playground for flexible editor and output sizing.

* **Documentation**
  * Redesigned landing page with improved component-based layout and card-based example visualization.
  * Added collapsible sections to roadmap and documentation for better navigation and content organization.
  * Restructured convention properties documentation with improved type metadata formatting.
  * Updated installation guide with minor clarifications and removed redundant section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->