### PR TITLE
Decouple FastAPI db models from api schemas; build in the service

### DIFF
--- a/docs/content/docs/targets/python/fastapi/postgres.mdx
+++ b/docs/content/docs/targets/python/fastapi/postgres.mdx
@@ -121,6 +121,26 @@ Multi-entity specs (e.g. `fixtures/spec/ecommerce.spec`) produce one parallel
 
 Template sources: `modules/codegen/src/main/resources/templates/python/fastapi/`.
 
+## Code layering
+
+The four `app/` layers keep a strict one-way dependency that mirrors FastAPI's idiomatic split
+between the API boundary and persistence: routers depend on services, and services depend on
+models and schemas. Nothing flows the other way.
+
+- **`schemas/`** (Pydantic v2) is the API boundary. The read DTO sets
+  `model_config = ConfigDict(from_attributes=True)`, so an ORM row becomes its response shape
+  via `ReadSchema.model_validate(row)` rather than a hand-written mapper.
+- **`models/`** (SQLAlchemy 2.0) is pure persistence: `Mapped[...]` columns and `__tablename__`,
+  and nothing more. A model never imports a schema and defines no custom `__init__`; it is built
+  through SQLAlchemy's keyword constructor.
+- **`services/`** is the only layer aware of both shapes. A create handler constructs the model
+  with explicit keyword arguments (`Model(field=body.field, ...)`, unwrapping `SecretStr` inputs
+  via `get_secret_value()` where present) and reads it back with `model_validate`.
+
+The result is deliberately free of `*_to_*` converter functions, `**model_dump()` splats into the
+ORM constructor, and dynamic imports. The API-to-DB mapping lives only in the service, where
+cross-layer knowledge belongs.
+
 ## Naming conventions
 
 Derived names are locked in `modules/profile/src/main/scala/specrest/profile/Targets.scala` and the convention engine under

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/url_mapping.py
@@ -8,7 +8,6 @@ from sqlalchemy import DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-from app.schemas.url_mapping import UrlMappingCreate
 
 
 class UrlMapping(Base):
@@ -24,16 +23,3 @@ class UrlMapping(Base):
 
     click_count: Mapped[int] = mapped_column(Integer)
 
-
-    def __init__(self, body: UrlMappingCreate) -> None:
-        super().__init__(
-
-            code=body.code,
-
-            url=body.url,
-
-            created_at=body.created_at,
-
-            click_count=body.click_count,
-
-        )

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/url_mapping.py
@@ -8,7 +8,6 @@ from sqlalchemy import DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-from app.schemas.url_mapping import UrlMappingCreate
 
 
 class UrlMapping(Base):
@@ -24,16 +23,3 @@ class UrlMapping(Base):
 
     click_count: Mapped[int] = mapped_column(Integer)
 
-
-    def __init__(self, body: UrlMappingCreate) -> None:
-        super().__init__(
-
-            code=body.code,
-
-            url=body.url,
-
-            created_at=body.created_at,
-
-            click_count=body.click_count,
-
-        )

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/url_mapping.py
@@ -8,7 +8,6 @@ from sqlalchemy import DateTime, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-from app.schemas.url_mapping import UrlMappingCreate
 
 
 class UrlMapping(Base):
@@ -24,16 +23,3 @@ class UrlMapping(Base):
 
     click_count: Mapped[int] = mapped_column(Integer)
 
-
-    def __init__(self, body: UrlMappingCreate) -> None:
-        super().__init__(
-
-            code=body.code,
-
-            url=body.url,
-
-            created_at=body.created_at,
-
-            click_count=body.click_count,
-
-        )

--- a/modules/codegen/src/main/resources/templates/python/fastapi/models/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/models/entity.py.hbs
@@ -10,7 +10,6 @@ from sqlalchemy.dialects.postgresql import {{join postgresImports ", "}}
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
-from app.schemas.{{snake_case entity.entityName}} import {{entity.createSchemaName}}
 
 
 class {{entity.modelClassName}}(Base):
@@ -20,10 +19,3 @@ class {{entity.modelClassName}}(Base):
 {{#each nonIdFields}}
     {{this.columnName}}: {{this.ormFieldType}} = mapped_column({{this.ormColumnType}}{{#if this.nullable}}, nullable=True{{/if}})
 {{/each}}
-
-    def __init__(self, body: {{entity.createSchemaName}}) -> None:
-        super().__init__(
-{{#each initFields}}
-            {{this.columnName}}={{this.bodyAccessor}},
-{{/each}}
-        )

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
@@ -34,7 +34,11 @@ class {{entity.entityName}}Service:
         return result  # type: ignore[no-any-return]
 {{else if (eq this.routeKind "create")}}
     async def {{this.handlerName}}(self, body: {{../entity.createSchemaName}}) -> {{../entity.readSchemaName}}:
-        row = {{../entity.modelClassName}}(body)
+        row = {{../entity.modelClassName}}(
+{{#each this.initFields}}
+            {{this.columnName}}={{this.bodyAccessor}},
+{{/each}}
+        )
         self._session.add(row)
         await self._session.flush()
         return {{../entity.readSchemaName}}.model_validate(row)

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -84,7 +84,8 @@ final private case class EnrichedOperation(
     customRequestSchema: Option[CustomRequestSchema],
     dafnyMethod: Option[String],
     dafnyCallArgs: List[String],
-    kernelHandlerSignature: String
+    kernelHandlerSignature: String,
+    initFields: List[ModelInitFieldView]
 )
 
 final private case class EntityImports(
@@ -119,7 +120,6 @@ final private case class ModelCtx(
     table: Option[table_spec],
     entityOperations: List[EnrichedOperation],
     nonIdFields: List[ProfiledField],
-    initFields: List[ModelInitFieldView],
     sqlalchemyImports: List[String],
     postgresImports: List[String],
     stdlibImports: List[StdlibImport]
@@ -236,7 +236,6 @@ object EmitPython:
         nonIdFields.filterNot(f => SensitiveFields.isSensitive(f.columnName))
       val nonIdFieldViews      = nonIdFields.map(schemaInputField)
       val readFieldViews       = readFieldsRaw.map(schemaReadField)
-      val initFieldViews       = nonIdFields.map(modelInitField)
       val customRequestSchemas = entityOps.flatMap(_.customRequestSchema)
       val schemaStdlib         = collectSchemaStdlibImports(entity, customRequestSchemas)
       val needsSecretStr =
@@ -254,7 +253,6 @@ object EmitPython:
         table = table,
         entityOperations = entityOps,
         nonIdFields = modelFields,
-        initFields = initFieldViews,
         sqlalchemyImports = imports.sqlalchemyImports,
         postgresImports = imports.postgresImports,
         stdlibImports = imports.stdlibImports
@@ -599,6 +597,10 @@ object EmitPython:
       case _: BatchMutation => "BatchMutation"
       case _: Transition    => "Transition"
 
+    val createInitFields = routeKind match
+      case _: RkCreate => entity.fields.filterNot(_.fieldName == "id").map(modelInitField)
+      case _           => List.empty[ModelInitFieldView]
+
     EnrichedOperation(
       operationName = op.operationName,
       handlerName = op.handlerName,
@@ -620,7 +622,8 @@ object EmitPython:
       customRequestSchema = customRequestSchema,
       dafnyMethod = op.dafnyMethod,
       dafnyCallArgs = dafnyArgs,
-      kernelHandlerSignature = kernelSig
+      kernelHandlerSignature = kernelSig,
+      initFields = createInitFields
     )
 
   private def kernelSignatureAndArgs(

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -274,25 +274,17 @@ class EmitTest extends CatsEffectSuite:
         s"UserRead must not surface password_hash; got:\n$readBlock"
       )
 
-  test("model emits typed __init__ taking the Create schema"):
+  test("db model is pure persistence: no schema import, no custom __init__"):
     SpecFixtures.loadProfiled("auth_service").map: profiled =>
       val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
       val model = files("app/models/user.py")
       assert(
-        model.contains("from app.schemas.user import UserCreate"),
-        s"user model should import UserCreate; got:\n$model"
+        !model.contains("from app.schemas"),
+        s"db model must not import api schemas; got:\n$model"
       )
       assert(
-        model.contains("def __init__(self, body: UserCreate) -> None:"),
-        s"User.__init__ should take a typed UserCreate; got:\n$model"
-      )
-      assert(
-        model.contains("password_hash=body.password_hash.get_secret_value()"),
-        s"User.__init__ should unwrap password_hash via get_secret_value(); got:\n$model"
-      )
-      assert(
-        model.contains("email=body.email"),
-        s"User.__init__ should pass email through; got:\n$model"
+        !model.contains("def __init__"),
+        s"db model must not define a custom __init__; got:\n$model"
       )
 
   test("no service handler splats model_dump() into the ORM constructor"):
@@ -307,13 +299,17 @@ class EmitTest extends CatsEffectSuite:
             s"$name: services still call model_dump(): ${offenders.map(_.path)}"
           )
 
-  test("matching create-shape op renders typed row = Model(body) handler"):
+  test("create-shape op constructs the model with explicit fields in the service"):
     SpecFixtures.loadProfiled("secret_create").map: profiled =>
       val files   = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
       val service = files("app/services/account.py")
       assert(
-        service.contains("row = Account(body)"),
-        s"create handler should call Account(body); got:\n$service"
+        service.contains("row = Account("),
+        s"create handler should construct Account(...); got:\n$service"
+      )
+      assert(
+        !service.contains("Account(body)"),
+        s"create handler should not pass the schema to the constructor; got:\n$service"
       )
       assert(
         !service.contains("NotImplementedError"),
@@ -322,35 +318,40 @@ class EmitTest extends CatsEffectSuite:
 
   test("secret_create — schema, model, service line up across the boundary"):
     SpecFixtures.loadProfiled("secret_create").map: profiled =>
-      val files  = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
-      val schema = files("app/schemas/account.py")
-      val model  = files("app/models/account.py")
+      val files   = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val schema  = files("app/schemas/account.py")
+      val model   = files("app/models/account.py")
+      val service = files("app/services/account.py")
       assert(
         schema.contains("password_hash: SecretStr"),
         s"AccountCreate should use SecretStr; got:\n$schema"
       )
       assert(
-        model.contains("password_hash=body.password_hash.get_secret_value()"),
-        s"Account.__init__ should unwrap SecretStr; got:\n$model"
+        !model.contains("from app.schemas"),
+        s"Account model must stay pure persistence; got:\n$model"
       )
       assert(
-        model.contains("email=body.email") && model.contains("display_name=body.display_name"),
-        s"Account.__init__ should pass plain fields through; got:\n$model"
+        service.contains("password_hash=body.password_hash.get_secret_value()"),
+        s"create handler should unwrap SecretStr; got:\n$service"
+      )
+      assert(
+        service.contains("email=body.email") && service.contains("display_name=body.display_name"),
+        s"create handler should pass plain fields through; got:\n$service"
       )
 
   test("nullable sensitive field unwraps via guarded get_secret_value"):
     SpecFixtures.loadProfiled("secret_create").map: profiled =>
-      val files = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
-      val model = files("app/models/account.py")
+      val files   = Emit.emitProject(profiled).map(f => f.path -> f.content).toMap
+      val service = files("app/services/account.py")
       assert(
-        model.contains(
+        service.contains(
           "reset_token=body.reset_token.get_secret_value() " +
             "if body.reset_token is not None else None"
         ),
-        s"nullable sensitive field should guard get_secret_value() against None; got:\n$model"
+        s"nullable sensitive field should guard get_secret_value() against None; got:\n$service"
       )
 
-  test("every entity model file emits a typed __init__ regardless of field count"):
+  test("every entity model file is pure persistence (no __init__, no schema import)"):
     val cases = List("secret_create", "auth_service", "url_shortener", "todo_list", "ecommerce")
     cases.foldLeft(IO.unit): (acc, name) =>
       acc.flatMap: _ =>
@@ -359,10 +360,10 @@ class EmitTest extends CatsEffectSuite:
             f.path.startsWith("app/models/") &&
               f.path.endsWith(".py") &&
               !f.path.endsWith("__init__.py") &&
-              !f.content.contains("def __init__(self, body:")
+              (f.content.contains("def __init__") || f.content.contains("from app.schemas"))
           assert(
             offenders.isEmpty,
-            s"$name: model files missing typed __init__: ${offenders.map(_.path)}"
+            s"$name: model files still coupled to schemas: ${offenders.map(_.path)}"
           )
 
   test("schema without sensitive fields does not import SecretStr"):


### PR DESCRIPTION
## Summary
- The generated SQLAlchemy model imported its Pydantic `Create` schema and defined `__init__(self, body: CreateSchema)` to field-copy from it. That inverts the layering (the db layer depending on the api layer) and welds a converter onto the model. It was also the model's only constructor, so the admin seed's `Model(**payload)` was incompatible with it (a dormant `TypeError`, since no stateful test calls `/seed/`).
- The model is now **pure persistence**: `Mapped[...]` columns + `__tablename__`, no schema import, no custom `__init__`. The schema-to-model construction moves to the **service** create handler as explicit keyword args, preserving `SecretStr` `get_secret_value()` unwrapping; read-back stays `ReadSchema.model_validate(row)`.
- The default SQLAlchemy constructor makes the admin seed `Model(**payload)` valid again, so create and seed share one construction path.
- Docs: a "Code layering" remark on the FastAPI target page.

## Notes
- `url_shortener`'s `Shorten` is a `NotImplementedError` stub (routed `RkOther` with a custom `ShortenRequest`), so its service is unchanged and only the model golden loses the dead `__init__`. The construction path is exercised by `secret_create` in `EmitTest`.
- Python-only; the Go/TS emitters use different idioms and are untouched.

## Test plan
- [x] codegen 355/0, testgen 285/0 (incl. `EmitPythonTest` golden compare, rewritten `EmitTest`, `AdminRouterTest`)
- [x] scalafmt + pre-commit hooks pass
- [ ] CI full matrix (incl. `python-build` alembic round-trip)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples FastAPI SQLAlchemy models from Pydantic API schemas. Models are now pure persistence, and create handlers build rows with explicit fields, fixing the dormant `Model(**payload)` seed path error.

- **Refactors**
  - Removed schema imports and custom `__init__` from models; keep only `Mapped[...]` columns and `__tablename__`.
  - Create handlers now construct models with keyword args and unwrap `SecretStr` via `get_secret_value()`.
  - Read path stays `ReadSchema.model_validate(row)`.
  - Codegen updated: move `initFields` to the create operation; adjusted `models/services` templates; regenerated goldens (e.g., `url_shortener` models).
  - Tests flipped to assert pure models and service-side construction; docs add a “Code layering” note for the FastAPI target.

<sup>Written for commit 3da135819e38340021f4d0a88bba2ea5ea41d226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Code layering" section explaining the strict one-way dependency structure among FastAPI app layers, clarifying how schemas, models, and services interact.

* **Code Generation**
  * Generated database models now maintain pure persistence layer with no direct coupling to API schemas.
  * Service layer constructs models using explicit field mapping instead of schema-based initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->