### PR TITLE
ci: enforce Conventional Commit PR titles in the branch-name check

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -1,4 +1,4 @@
-name: Branch name check
+name: PR conventions
 
 on:
   pull_request:
@@ -11,16 +11,32 @@ jobs:
   check-branch-name:
     runs-on: ubuntu-latest
     steps:
-      - name: Check branch name
+      - name: Validate branch name and PR title (Conventional Commits)
         env:
           BRANCH_NAME: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           BRANCH="${BRANCH_NAME}"
-          PATTERN="^((feature|fix|docs|chore|refactor|dependabot)/.+|release-please--.+)$"
-          if [[ ! "$BRANCH" =~ $PATTERN ]]; then
-            echo "::error::Branch name '$BRANCH' does not match required pattern."
-            echo "Branch names must start with: feature/, fix/, docs/, chore/, refactor/, dependabot/, or release-please--"
-            echo "Example: feature/add-parser, fix/grammar-bug, docs/update-readme"
+          TITLE="${PR_TITLE}"
+
+          bot_re='^(release-please--.+|dependabot/.+)$'
+          branch_re='^(feat(ure)?|fix|docs|chore|refactor|perf|ci|build|test|style|revert)/.+'
+          title_re='^(feat|fix|docs|chore|refactor|perf|ci|build|test|style|revert)(\([^)]+\))?!?: .+'
+
+          # Bot branches carry their own title formats and need no changelog entry.
+          if [[ "$BRANCH" =~ $bot_re ]]; then
+            echo "Bot branch '$BRANCH'; skipping conventional checks."
+            exit 0
+          fi
+
+          if [[ ! "$BRANCH" =~ $branch_re ]]; then
+            echo "::error::Branch '$BRANCH' must be <type>/<slug>, type one of: feat (or feature), fix, docs, chore, refactor, perf, ci, build, test, style, revert. Example: refactor/decouple-model-schema"
             exit 1
           fi
-          echo "Branch name '$BRANCH' is valid."
+
+          if [[ ! "$TITLE" =~ $title_re ]]; then
+            echo "::error::PR title '$TITLE' must be a Conventional Commit, '<type>(optional-scope)!?: description'. Use 'feat:' (not 'feature:'). The PR title becomes the squash commit subject that release-please reads, so a non-conventional title is dropped from the CHANGELOG."
+            exit 1
+          fi
+
+          echo "OK: branch '$BRANCH' and PR title '$TITLE' are conventional."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,22 @@
 # Contributing
 
+## Branch names and PR titles
+
+Both are gated by the required `check-branch-name` job (`.github/workflows/branch-name.yml`,
+token-free):
+
+- **Branch:** `<type>/<slug>`, e.g. `refactor/decouple-model-schema`.
+- **PR title:** a [Conventional Commit](https://www.conventionalcommits.org/), e.g.
+  `refactor: decouple model from schema`.
+
+`<type>` is one of `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `ci`, `build`, `test`,
+`style`, `revert` (`feature/` is accepted as an alias of `feat`). The repo squash-merges with the
+**PR title as the commit subject**, and release-please builds `CHANGELOG.md` from those
+Conventional-Commit subjects, so a non-conventional title is silently dropped from the release
+notes. `feat` / `fix` / `refactor` / `perf` / `docs` are surfaced in the changelog; `chore` / `ci` /
+`build` / `test` / `style` go to hidden sections. Bot branches (`dependabot/...`,
+`release-please--...`) are exempt.
+
 ## Architecture enforcement
 
 The module dependency graph in `build.sbt` (`dependsOn`) _is_ the architecture — an illegal


### PR DESCRIPTION
## Summary
- The required `check-branch-name` job validated only the branch name. But the repo squash-merges with the PR title as the commit subject (`squash_merge_commit_title = PR_TITLE`), and release-please builds `CHANGELOG.md` from those subjects, so a valid branch name with a non-conventional title (e.g. #370, #371) was silently dropped from the release notes.
- Expand the same job to also require the PR title to be a **Conventional Commit** (`<type>(optional-scope)!?: description`). The job id is unchanged, so branch protection needs no settings change.
- **Token-free, no new dependency:** it reads `github.head_ref` and `github.event.pull_request.title` from the event context, stays on the safe `pull_request` trigger, and uses no third-party action and no `GITHUB_TOKEN`. That keeps it zizmor-clean and consistent with the other lint workflows (which never pass a token).
- Branch vocabulary aligned to the conventional types; `feature/` is accepted as an alias of `feat`. Bot branches (`dependabot/`, `release-please--`) are exempt.
- CONTRIBUTING documents the branch + PR-title convention.

## Test plan
- [x] Validation logic tested locally: `feat`/`feature` alias, `feat(scope)!:`, Consolidate-style non-conventional titles, bot branches, `featuring/`, and missing colon-space all behave as intended.
- [x] Pre-commit hooks pass (prettier, actionlint/shellcheck, check-yaml).
- [ ] This PR's own `check-branch-name` goes green once opened (the `pull_request` event runs the PR's version of the workflow; branch `chore/...` + title `ci: ...` is valid).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Conventional Commit PR titles in the existing branch-name CI check to keep squash-merge subjects valid and ensure they appear in the changelog. Branch protection stays the same.

- New Features
  - Validate both the branch name `<type>/<slug>` and the PR title as a Conventional Commit.
  - Keep the same job id; no tokens or third-party actions (`pull_request` event, uses `github.head_ref` and `github.event.pull_request.title`).
  - Accept `feature/` as an alias of `feat`; exempt `dependabot/` and `release-please--` branches.
  - Update CONTRIBUTING with the branch and PR title rules.

<sup>Written for commit 595d8de2a33f20d361b149161b4db45202f75762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with branch naming format and PR title conventions using Conventional Commits style to improve changelog generation.

* **Chores**
  * Enhanced validation workflow to enforce branch naming and PR title conventions during pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->