### PR TITLE
docs: add status badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 <p align="center">Compile formal behavioral specs (<code>.spec</code> DSL) into verified REST services.</p>
 
+<p align="center">
+  <a href="https://github.com/HardMax71/spec_to_rest/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/HardMax71/spec_to_rest/ci.yml?branch=main&label=CI" alt="CI" /></a>
+  <a href="https://github.com/HardMax71/spec_to_rest/actions/workflows/isabelle-build.yml"><img src="https://img.shields.io/github/actions/workflow/status/HardMax71/spec_to_rest/isabelle-build.yml?branch=main&label=Isabelle%2FHOL" alt="Isabelle/HOL soundness" /></a>
+  <a href="https://github.com/HardMax71/spec_to_rest/releases"><img src="https://img.shields.io/github/v/release/HardMax71/spec_to_rest?label=release" alt="Latest release" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/HardMax71/spec_to_rest" alt="License" /></a>
+</p>
+
 Given a `.spec` file describing entities, operations, invariants, and preconditions, `spec-to-rest`
 runs a Z3-backed verification pass against the spec itself and — if verification passes — generates
 a complete, runnable service: models, schemas, routers, migrations, Docker / docker-compose /


### PR DESCRIPTION
## Summary
Adds four centered badges under the README title: CI (`ci.yml`), Isabelle/HOL soundness (`isabelle-build.yml`), latest release, and license. All shields.io, auto-updating, matching the existing centered logo/heading HTML.

## Notes
- I could not render the badges locally; the URLs are standard shields.io / GitHub-Actions formats with verified repo + workflow filenames and an existing `LICENSE`, so they resolve on GitHub. Worth an eyeball on the rendered README.
- As a `docs:` PR it flows into the release-please changelog (#296) under "Documentation"; it does not bump the version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added four auto-updating status badges to the README below the title: CI (`ci.yml`), Isabelle/HOL soundness (`isabelle-build.yml`), latest release, and license. Badges use shields.io and are centered to match the existing header layout.

<sup>Written for commit 90c9abbe7bc63be0d0bbeb9be8f155e9b46c0232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

