### PR TITLE
feat: playground archive download + scrollable output panes

### DIFF
--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Highlighter } from "shiki";
 import { PLAYGROUND_EXAMPLES } from "@/lib/playground-examples.generated";
+import { makeZip } from "@/lib/zip";
 
 type Target =
   | "check"
@@ -579,7 +580,7 @@ function OutputPane(props: {
         </TabButton>
       </div>
       {props.tab === "files" && showFilesTab ? (
-        <div className="flex flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col">
           <div className="flex items-center gap-2 border-b border-fd-border bg-fd-secondary/20 px-2 py-1.5 text-xs">
             <span className="text-fd-muted-foreground">file</span>
             <select
@@ -594,18 +595,40 @@ function OutputPane(props: {
                 </option>
               ))}
             </select>
+            <button
+              type="button"
+              onClick={() => downloadZip(files, props.state)}
+              className="shrink-0 rounded border border-fd-border bg-fd-background px-2 py-1 font-medium hover:bg-fd-accent"
+              title="Download all generated files as a .zip (large files are truncated as shown)"
+            >
+              Download .zip
+            </button>
           </div>
-          <pre className="m-0 flex-1 overflow-auto whitespace-pre bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
+          <pre className="m-0 min-h-0 flex-1 overflow-auto whitespace-pre bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
             {fileEntry?.content ?? "// no file selected"}
           </pre>
         </div>
       ) : (
-        <pre className="m-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
+        <pre className="m-0 min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-fd-background p-3 font-mono text-[12px] leading-relaxed text-fd-foreground">
           {props.tab === "stdout" ? stdoutText(props.state) : stderrText(props.state)}
         </pre>
       )}
     </div>
   );
+}
+
+function downloadZip(files: FileEntry[], state: RunState): void {
+  if (files.length === 0) return;
+  const target = state.kind === "ok" ? state.target : "output";
+  const blob = makeZip(files.map((f) => ({ path: f.path, content: f.content })));
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `spec-to-rest-${target}.zip`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
 }
 
 function TabButton(props: {

--- a/docs/lib/zip.ts
+++ b/docs/lib/zip.ts
@@ -35,6 +35,9 @@ const u32 = (n: number): Uint8Array =>
 // "download generated files" button.
 export function makeZip(files: { path: string; content: string }[]): Blob {
   const encoder = new TextEncoder();
+  // General-purpose bit 11 (EFS): marks filenames as UTF-8 so non-ASCII paths
+  // decode correctly on extraction.
+  const utf8 = u16(0x800);
   const localParts: Uint8Array[] = [];
   const centralParts: Uint8Array[] = [];
   let offset = 0;
@@ -47,7 +50,7 @@ export function makeZip(files: { path: string; content: string }[]): Blob {
     const localHeader = concatBytes([
       u32(0x04034b50),
       u16(20),
-      u16(0),
+      utf8,
       u16(0),
       u16(0),
       u16(0),
@@ -65,7 +68,7 @@ export function makeZip(files: { path: string; content: string }[]): Blob {
         u32(0x02014b50),
         u16(20),
         u16(20),
-        u16(0),
+        utf8,
         u16(0),
         u16(0),
         u16(0),

--- a/docs/lib/zip.ts
+++ b/docs/lib/zip.ts
@@ -1,0 +1,101 @@
+const CRC_TABLE: Uint32Array = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) crc = CRC_TABLE[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array<ArrayBuffer> {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const p of parts) {
+    out.set(p, at);
+    at += p.length;
+  }
+  return out;
+}
+
+const u16 = (n: number): Uint8Array => new Uint8Array([n & 0xff, (n >>> 8) & 0xff]);
+const u32 = (n: number): Uint8Array =>
+  new Uint8Array([n & 0xff, (n >>> 8) & 0xff, (n >>> 16) & 0xff, (n >>> 24) & 0xff]);
+
+// Store-only (no compression) ZIP writer. Deflate would only shrink the payload,
+// not change correctness, so this stays dependency-free for the playground's
+// "download generated files" button.
+export function makeZip(files: { path: string; content: string }[]): Blob {
+  const encoder = new TextEncoder();
+  const localParts: Uint8Array[] = [];
+  const centralParts: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const file of files) {
+    const name = encoder.encode(file.path);
+    const data = encoder.encode(file.content);
+    const crc = crc32(data);
+
+    const localHeader = concatBytes([
+      u32(0x04034b50),
+      u16(20),
+      u16(0),
+      u16(0),
+      u16(0),
+      u16(0),
+      u32(crc),
+      u32(data.length),
+      u32(data.length),
+      u16(name.length),
+      u16(0),
+      name,
+    ]);
+    localParts.push(localHeader, data);
+
+    centralParts.push(
+      concatBytes([
+        u32(0x02014b50),
+        u16(20),
+        u16(20),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32(crc),
+        u32(data.length),
+        u32(data.length),
+        u16(name.length),
+        u16(0),
+        u16(0),
+        u16(0),
+        u16(0),
+        u32(0),
+        u32(offset),
+        name,
+      ]),
+    );
+    offset += localHeader.length + data.length;
+  }
+
+  const central = concatBytes(centralParts);
+  const end = concatBytes([
+    u32(0x06054b50),
+    u16(0),
+    u16(0),
+    u16(files.length),
+    u16(files.length),
+    u32(central.length),
+    u32(offset),
+    u16(0),
+  ]);
+
+  return new Blob([concatBytes(localParts), central, end], { type: "application/zip" });
+}


### PR DESCRIPTION
## Summary
- **Download** generated files: a "Download .zip" button in the playground's files tab bundles all generated files into `spec-to-rest-<target>.zip` via a dependency-free, store-only zip writer (`lib/zip.ts`). Truncated large files are archived as displayed (noted in the button tooltip).
- **Scroll fix**: the output `<pre>` panes and the files-tab wrapper were `flex-1 overflow-auto` without `min-h-0`, so they grew to content height and were clipped by the pane's `overflow-hidden` instead of scrolling. Adding `min-h-0` makes stdout/stderr and the file viewer scroll vertically (e.g. long synth output). The spec/left pane was already fine because it uses absolute `inset-0`.

## Test plan
- [x] Zip validity: built with the same logic, `unzip -t` passes (CRC + structure OK), contents round-trip exactly.
- [x] `tsc --noEmit` clean for `playground.tsx` and `lib/zip.ts`.
- [ ] Not browser-tested locally (the playground `/api/compile` shells to the spec-to-rest backend binary, unavailable here) - eyeball scroll + download on the PR preview / deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Download .zip” button to the playground files tab and fix scrolling in output panes. Also set UTF‑8 filename flags so non‑ASCII paths extract correctly.

- **New Features**
  - Added “Download .zip” in the files tab that bundles all generated files into `spec-to-rest-<target>.zip` using a dependency‑free, store‑only ZIP writer in `docs/lib/zip.ts`.
  - Truncated large files are archived exactly as shown in the UI.

- **Bug Fixes**
  - Fixed non‑scrolling output and file panes by adding `min-h-0` to the `<pre>` panes and the files tab container, enabling proper vertical scrolling.
  - Marked ZIP filenames as UTF‑8 (EFS bit 11) so non‑ASCII generated paths extract correctly on unzip.

<sup>Written for commit 752a8c3cf3f96b39f8d196b42f0b73817bf07fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ZIP download support in the playground, enabling users to export all generated files as a single `.zip` archive.
  * Added a "Download .zip" button in the files tab for quick access.
  * Improved files pane layout for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->