### PR TITLE
feat(verify): model temporal and fractional types as Int/Real sorts

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -555,6 +555,30 @@ the effect layer: per-check fibers via `parTraverseN`, `Resource[IO, WasmBackend
 mid-call abort details) are documented in
 [Concurrency & Cancellation](/pipelines/concurrency).
 
+## Scalar types
+
+Each spec primitive maps to a Z3 theory sort. Integral and temporal types share `Int`
+(temporal values are epoch seconds, so ordering and arithmetic on `DateTime` / `Date`
+verify directly); fractional types use Z3 `Real`; everything else is an uninterpreted sort
+that supports equality only.
+
+| Spec type                         | Z3 sort                                    |
+| --------------------------------- | ------------------------------------------ |
+| `Int`, `DateTime`, `Date`         | `Int`                                      |
+| `Float`, `Decimal`, `Money`       | `Real`                                     |
+| `Bool` / `Boolean`                | `Bool`                                     |
+| `String`, `UUID`, entities, enums | uninterpreted                              |
+| `Set[T]`                          | `(Set T)` (see [Set theory](#set-theory))  |
+
+Ordering (`<`, `<=`, `>`, `>=`) and arithmetic (`+`, `-`, `*`, `/`) require numeric operands
+(`Int` or `Real`); Z3 coerces `Int` to `Real` when the two are mixed (e.g. a `Money` field
+compared to an integer literal). Applied to a non-numeric sort, the check is reported as
+skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on any sort.
+
+The integral-vs-fractional split is the one type-to-sort fact made in the Z3 translator
+rather than derived from the proof: the Isabelle `ty` has only `Int`/`Bool` (no fractional
+sort), so it cannot express it.
+
 ## Set theory
 
 `Set[T]` maps to Z3's built-in set theory (extensional `Array T Bool` under the hood). The
@@ -603,6 +627,12 @@ round-tripping. End-to-end behaviour goes in `modules/verify/src/test/scala/spec
 or `modules/verify/src/test/scala/specrest/verify/z3/CounterExampleTest.scala`. Update `fixtures/golden/smt/url_shortener.smt2` by dumping the new SMT
 via `sbt "cli/run verify --dump-smt-out fixtures/golden/smt/url_shortener.smt2 fixtures/spec/url_shortener.spec"`
 when the snapshot legitimately changes.
+
+Adding a new **sort** (e.g. a future fixed-point or bit-vector type) is wider: add the case to
+`Z3Sort` in `Types.scala`, then let the compiler's exhaustiveness errors walk you through
+`resolveSort` (Backend), `renderSort` (SmtLib), `sortToTy` (CounterExample), `IrValueDecoder`,
+and `primitiveSortOf` (Translator). Keep ordering/arithmetic gated on `Z3Sort.isNumeric` so a
+non-numeric sort is skipped rather than handed to the solver ill-sorted.
 
 ## Verify-as-gate in `compile`
 

--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -132,6 +132,7 @@ Per-feature ledger for the verifier. For the prose explanation of each entry, se
 | SMT-LIB artifact export (`--dump-smt`)                              | shipped |
 | Invariant consistency checking (per-op `requires`, dead ops)        | shipped |
 | Primitive-type alias refinement (`type Positive = Int where ...`)     | shipped |
+| Scalar type sorts (`Int`/`Bool`; temporal `DateTime`/`Date` as epoch `Int`; fractional `Float`/`Decimal`/`Money` as `Real`) | shipped (Z3; ordering and arithmetic over these verify, with `Int`/`Real` coercion; non-numeric primitives stay uninterpreted, so ordering/arithmetic on them is skipped as outside the encodable subset, not crashed) |
 | Cardinality on state relations (`#store`, uninterpreted >= 0)        | shipped |
 | Invariant preservation checking (operation pre/post => invariant)    | shipped |
 | `Prime` (`X'`), `Pre(X)`, `With` record update, inline `y in {...}`   | shipped |

--- a/fixtures/golden/smt-errors/edge_cases.txt
+++ b/fixtures/golden/smt-errors/edge_cases.txt
@@ -1,2 +1,0 @@
-
- ERROR  fixtures/spec/edge_cases.spec: translator limitation: expression kind 'FloatLit' is not yet supported by the verifier

--- a/fixtures/golden/smt/convention_errors.smt2
+++ b/fixtures/golden/smt/convention_errors.smt2
@@ -2,7 +2,6 @@
 (set-option :produce-models true)
 (set-option :timeout 30000)
 ;; sorts
-(declare-sort Float 0)
 (declare-sort Status 0)
 (declare-sort String 0)
 (declare-sort Widget 0)
@@ -10,7 +9,7 @@
 (declare-fun Status_ACTIVE () Status)
 (declare-fun Status_INACTIVE () Status)
 (declare-fun Widget_name (Widget) String)
-(declare-fun Widget_weight (Widget) Float)
+(declare-fun Widget_weight (Widget) Real)
 (declare-fun widgets_dom (Int) Bool)
 (declare-fun widgets_map (Int) Widget)
 ;; assertions

--- a/fixtures/golden/smt/url_shortener.smt2
+++ b/fixtures/golden/smt/url_shortener.smt2
@@ -3,7 +3,6 @@
 (set-option :timeout 30000)
 ;; sorts
 (declare-sort BaseURL 0)
-(declare-sort DateTime 0)
 (declare-sort LongURL 0)
 (declare-sort ShortCode 0)
 (declare-sort UrlMapping 0)
@@ -20,7 +19,7 @@
 (declare-fun store_map (ShortCode) LongURL)
 (declare-fun UrlMapping_click_count (UrlMapping) Int)
 (declare-fun UrlMapping_code (UrlMapping) ShortCode)
-(declare-fun UrlMapping_created_at (UrlMapping) DateTime)
+(declare-fun UrlMapping_created_at (UrlMapping) Int)
 (declare-fun UrlMapping_url (UrlMapping) LongURL)
 ;; assertions
 (assert (forall ((self_ShortCode ShortCode)) (and (and (>= (len_ShortCode self_ShortCode) 6) (<= (len_ShortCode self_ShortCode) 10)) (matches_0_ShortCode self_ShortCode))))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -133,59 +133,83 @@ object SpecRestGenerated {
     case (Nil, Nil)               => true
   }
 
+  def equal_proda[A: equal, B: equal](x0: (A, B), x1: (A, B)): Boolean =
+    (x0, x1) match {
+      case ((x1, x2), (y1, y2)) => eq[A](x1, y1) && eq[B](x2, y2)
+    }
+
+  sealed abstract class rat
+  final case class Frct(a: (BigInt, BigInt)) extends rat
+
+  def quotient_of(x0: rat): (BigInt, BigInt) = x0 match {
+    case Frct(x) => x
+  }
+
+  def equal_rat(a: rat, b: rat): Boolean =
+    equal_proda[BigInt, BigInt](quotient_of(a), quotient_of(b))
+
   sealed abstract class smt_val
   final case class SBool(a: Boolean)                              extends smt_val
   final case class SInt(a: BigInt)                                extends smt_val
+  final case class SReal(a: rat)                                  extends smt_val
   final case class SEnumElem(a: String, b: String)                extends smt_val
   final case class SEntityElem(a: String, b: String)              extends smt_val
   final case class SSet(a: List[smt_val])                         extends smt_val
   final case class SEntityWith(a: smt_val, b: String, c: smt_val) extends smt_val
 
   def equal_smt_vala(x0: smt_val, x1: smt_val): Boolean = (x0, x1) match {
-    case (SSet(x5), SEntityWith(x61, x62, x63))              => false
-    case (SEntityWith(x61, x62, x63), SSet(x5))              => false
-    case (SEntityElem(x41, x42), SEntityWith(x61, x62, x63)) => false
-    case (SEntityWith(x61, x62, x63), SEntityElem(x41, x42)) => false
-    case (SEntityElem(x41, x42), SSet(x5))                   => false
-    case (SSet(x5), SEntityElem(x41, x42))                   => false
-    case (SEnumElem(x31, x32), SEntityWith(x61, x62, x63))   => false
-    case (SEntityWith(x61, x62, x63), SEnumElem(x31, x32))   => false
-    case (SEnumElem(x31, x32), SSet(x5))                     => false
-    case (SSet(x5), SEnumElem(x31, x32))                     => false
-    case (SEnumElem(x31, x32), SEntityElem(x41, x42))        => false
-    case (SEntityElem(x41, x42), SEnumElem(x31, x32))        => false
-    case (SInt(x2), SEntityWith(x61, x62, x63))              => false
-    case (SEntityWith(x61, x62, x63), SInt(x2))              => false
-    case (SInt(x2), SSet(x5))                                => false
-    case (SSet(x5), SInt(x2))                                => false
-    case (SInt(x2), SEntityElem(x41, x42))                   => false
-    case (SEntityElem(x41, x42), SInt(x2))                   => false
-    case (SInt(x2), SEnumElem(x31, x32))                     => false
-    case (SEnumElem(x31, x32), SInt(x2))                     => false
-    case (SBool(x1), SEntityWith(x61, x62, x63))             => false
-    case (SEntityWith(x61, x62, x63), SBool(x1))             => false
-    case (SBool(x1), SSet(x5))                               => false
-    case (SSet(x5), SBool(x1))                               => false
-    case (SBool(x1), SEntityElem(x41, x42))                  => false
-    case (SEntityElem(x41, x42), SBool(x1))                  => false
-    case (SBool(x1), SEnumElem(x31, x32))                    => false
-    case (SEnumElem(x31, x32), SBool(x1))                    => false
+    case (SSet(x6), SEntityWith(x71, x72, x73))              => false
+    case (SEntityWith(x71, x72, x73), SSet(x6))              => false
+    case (SEntityElem(x51, x52), SEntityWith(x71, x72, x73)) => false
+    case (SEntityWith(x71, x72, x73), SEntityElem(x51, x52)) => false
+    case (SEntityElem(x51, x52), SSet(x6))                   => false
+    case (SSet(x6), SEntityElem(x51, x52))                   => false
+    case (SEnumElem(x41, x42), SEntityWith(x71, x72, x73))   => false
+    case (SEntityWith(x71, x72, x73), SEnumElem(x41, x42))   => false
+    case (SEnumElem(x41, x42), SSet(x6))                     => false
+    case (SSet(x6), SEnumElem(x41, x42))                     => false
+    case (SEnumElem(x41, x42), SEntityElem(x51, x52))        => false
+    case (SEntityElem(x51, x52), SEnumElem(x41, x42))        => false
+    case (SReal(x3), SEntityWith(x71, x72, x73))             => false
+    case (SEntityWith(x71, x72, x73), SReal(x3))             => false
+    case (SReal(x3), SSet(x6))                               => false
+    case (SSet(x6), SReal(x3))                               => false
+    case (SReal(x3), SEntityElem(x51, x52))                  => false
+    case (SEntityElem(x51, x52), SReal(x3))                  => false
+    case (SReal(x3), SEnumElem(x41, x42))                    => false
+    case (SEnumElem(x41, x42), SReal(x3))                    => false
+    case (SInt(x2), SEntityWith(x71, x72, x73))              => false
+    case (SEntityWith(x71, x72, x73), SInt(x2))              => false
+    case (SInt(x2), SSet(x6))                                => false
+    case (SSet(x6), SInt(x2))                                => false
+    case (SInt(x2), SEntityElem(x51, x52))                   => false
+    case (SEntityElem(x51, x52), SInt(x2))                   => false
+    case (SInt(x2), SEnumElem(x41, x42))                     => false
+    case (SEnumElem(x41, x42), SInt(x2))                     => false
+    case (SInt(x2), SReal(x3))                               => false
+    case (SReal(x3), SInt(x2))                               => false
+    case (SBool(x1), SEntityWith(x71, x72, x73))             => false
+    case (SEntityWith(x71, x72, x73), SBool(x1))             => false
+    case (SBool(x1), SSet(x6))                               => false
+    case (SSet(x6), SBool(x1))                               => false
+    case (SBool(x1), SEntityElem(x51, x52))                  => false
+    case (SEntityElem(x51, x52), SBool(x1))                  => false
+    case (SBool(x1), SEnumElem(x41, x42))                    => false
+    case (SEnumElem(x41, x42), SBool(x1))                    => false
+    case (SBool(x1), SReal(x3))                              => false
+    case (SReal(x3), SBool(x1))                              => false
     case (SBool(x1), SInt(x2))                               => false
     case (SInt(x2), SBool(x1))                               => false
-    case (SEntityWith(x61, x62, x63), SEntityWith(y61, y62, y63)) =>
-      equal_smt_vala(x61, y61) && (x62 == y62 && equal_smt_vala(x63, y63))
-    case (SSet(x5), SSet(y5)) => equal_list[smt_val](x5, y5)
-    case (SEntityElem(x41, x42), SEntityElem(y41, y42)) =>
-      x41 == y41 && x42 == y42
-    case (SEnumElem(x31, x32), SEnumElem(y31, y32)) => x31 == y31 && x32 == y32
+    case (SEntityWith(x71, x72, x73), SEntityWith(y71, y72, y73)) =>
+      equal_smt_vala(x71, y71) && (x72 == y72 && equal_smt_vala(x73, y73))
+    case (SSet(x6), SSet(y6)) => equal_list[smt_val](x6, y6)
+    case (SEntityElem(x51, x52), SEntityElem(y51, y52)) =>
+      x51 == y51 && x52 == y52
+    case (SEnumElem(x41, x42), SEnumElem(y41, y42)) => x41 == y41 && x42 == y42
+    case (SReal(x3), SReal(y3))                     => equal_rat(x3, y3)
     case (SInt(x2), SInt(y2))                       => equal_int(x2, y2)
     case (SBool(x1), SBool(y1))                     => equal_bool(x1, y1)
   }
-
-  def equal_proda[A: equal, B: equal](x0: (A, B), x1: (A, B)): Boolean =
-    (x0, x1) match {
-      case ((x1, x2), (y1, y2)) => eq[A](x1, y1) && eq[B](x2, y2)
-    }
 
   def equal_option[A: equal](x0: Option[A], x1: Option[A]): Boolean = (x0, x1) match {
     case (None, Some(x2))     => false
@@ -208,47 +232,61 @@ object SpecRestGenerated {
   sealed abstract class ir_value
   final case class VBool(a: Boolean)                                extends ir_value
   final case class VInt(a: BigInt)                                  extends ir_value
+  final case class VReal(a: rat)                                    extends ir_value
   final case class VEnum(a: String, b: String)                      extends ir_value
   final case class VEntity(a: String, b: String)                    extends ir_value
   final case class VSet(a: List[ir_value])                          extends ir_value
   final case class VEntityWith(a: ir_value, b: String, c: ir_value) extends ir_value
 
   def equal_ir_valuea(x0: ir_value, x1: ir_value): Boolean = (x0, x1) match {
-    case (VSet(x5), VEntityWith(x61, x62, x63))          => false
-    case (VEntityWith(x61, x62, x63), VSet(x5))          => false
-    case (VEntity(x41, x42), VEntityWith(x61, x62, x63)) => false
-    case (VEntityWith(x61, x62, x63), VEntity(x41, x42)) => false
-    case (VEntity(x41, x42), VSet(x5))                   => false
-    case (VSet(x5), VEntity(x41, x42))                   => false
-    case (VEnum(x31, x32), VEntityWith(x61, x62, x63))   => false
-    case (VEntityWith(x61, x62, x63), VEnum(x31, x32))   => false
-    case (VEnum(x31, x32), VSet(x5))                     => false
-    case (VSet(x5), VEnum(x31, x32))                     => false
-    case (VEnum(x31, x32), VEntity(x41, x42))            => false
-    case (VEntity(x41, x42), VEnum(x31, x32))            => false
-    case (VInt(x2), VEntityWith(x61, x62, x63))          => false
-    case (VEntityWith(x61, x62, x63), VInt(x2))          => false
-    case (VInt(x2), VSet(x5))                            => false
-    case (VSet(x5), VInt(x2))                            => false
-    case (VInt(x2), VEntity(x41, x42))                   => false
-    case (VEntity(x41, x42), VInt(x2))                   => false
-    case (VInt(x2), VEnum(x31, x32))                     => false
-    case (VEnum(x31, x32), VInt(x2))                     => false
-    case (VBool(x1), VEntityWith(x61, x62, x63))         => false
-    case (VEntityWith(x61, x62, x63), VBool(x1))         => false
-    case (VBool(x1), VSet(x5))                           => false
-    case (VSet(x5), VBool(x1))                           => false
-    case (VBool(x1), VEntity(x41, x42))                  => false
-    case (VEntity(x41, x42), VBool(x1))                  => false
-    case (VBool(x1), VEnum(x31, x32))                    => false
-    case (VEnum(x31, x32), VBool(x1))                    => false
+    case (VSet(x6), VEntityWith(x71, x72, x73))          => false
+    case (VEntityWith(x71, x72, x73), VSet(x6))          => false
+    case (VEntity(x51, x52), VEntityWith(x71, x72, x73)) => false
+    case (VEntityWith(x71, x72, x73), VEntity(x51, x52)) => false
+    case (VEntity(x51, x52), VSet(x6))                   => false
+    case (VSet(x6), VEntity(x51, x52))                   => false
+    case (VEnum(x41, x42), VEntityWith(x71, x72, x73))   => false
+    case (VEntityWith(x71, x72, x73), VEnum(x41, x42))   => false
+    case (VEnum(x41, x42), VSet(x6))                     => false
+    case (VSet(x6), VEnum(x41, x42))                     => false
+    case (VEnum(x41, x42), VEntity(x51, x52))            => false
+    case (VEntity(x51, x52), VEnum(x41, x42))            => false
+    case (VReal(x3), VEntityWith(x71, x72, x73))         => false
+    case (VEntityWith(x71, x72, x73), VReal(x3))         => false
+    case (VReal(x3), VSet(x6))                           => false
+    case (VSet(x6), VReal(x3))                           => false
+    case (VReal(x3), VEntity(x51, x52))                  => false
+    case (VEntity(x51, x52), VReal(x3))                  => false
+    case (VReal(x3), VEnum(x41, x42))                    => false
+    case (VEnum(x41, x42), VReal(x3))                    => false
+    case (VInt(x2), VEntityWith(x71, x72, x73))          => false
+    case (VEntityWith(x71, x72, x73), VInt(x2))          => false
+    case (VInt(x2), VSet(x6))                            => false
+    case (VSet(x6), VInt(x2))                            => false
+    case (VInt(x2), VEntity(x51, x52))                   => false
+    case (VEntity(x51, x52), VInt(x2))                   => false
+    case (VInt(x2), VEnum(x41, x42))                     => false
+    case (VEnum(x41, x42), VInt(x2))                     => false
+    case (VInt(x2), VReal(x3))                           => false
+    case (VReal(x3), VInt(x2))                           => false
+    case (VBool(x1), VEntityWith(x71, x72, x73))         => false
+    case (VEntityWith(x71, x72, x73), VBool(x1))         => false
+    case (VBool(x1), VSet(x6))                           => false
+    case (VSet(x6), VBool(x1))                           => false
+    case (VBool(x1), VEntity(x51, x52))                  => false
+    case (VEntity(x51, x52), VBool(x1))                  => false
+    case (VBool(x1), VEnum(x41, x42))                    => false
+    case (VEnum(x41, x42), VBool(x1))                    => false
+    case (VBool(x1), VReal(x3))                          => false
+    case (VReal(x3), VBool(x1))                          => false
     case (VBool(x1), VInt(x2))                           => false
     case (VInt(x2), VBool(x1))                           => false
-    case (VEntityWith(x61, x62, x63), VEntityWith(y61, y62, y63)) =>
-      equal_ir_valuea(x61, y61) && (x62 == y62 && equal_ir_valuea(x63, y63))
-    case (VSet(x5), VSet(y5))                   => equal_list[ir_value](x5, y5)
-    case (VEntity(x41, x42), VEntity(y41, y42)) => x41 == y41 && x42 == y42
-    case (VEnum(x31, x32), VEnum(y31, y32))     => x31 == y31 && x32 == y32
+    case (VEntityWith(x71, x72, x73), VEntityWith(y71, y72, y73)) =>
+      equal_ir_valuea(x71, y71) && (x72 == y72 && equal_ir_valuea(x73, y73))
+    case (VSet(x6), VSet(y6))                   => equal_list[ir_value](x6, y6)
+    case (VEntity(x51, x52), VEntity(y51, y52)) => x51 == y51 && x52 == y52
+    case (VEnum(x41, x42), VEnum(y41, y42))     => x41 == y41 && x42 == y42
+    case (VReal(x3), VReal(y3))                 => equal_rat(x3, y3)
     case (VInt(x2), VInt(y2))                   => equal_int(x2, y2)
     case (VBool(x1), VBool(y1))                 => equal_bool(x1, y1)
   }
@@ -506,6 +544,7 @@ object SpecRestGenerated {
   sealed abstract class ty
   final case class TBool()            extends ty
   final case class TInt()             extends ty
+  final case class TReal()            extends ty
   final case class TEnum(a: String)   extends ty
   final case class TEntity(a: String) extends ty
   final case class TSet(a: ty)        extends ty
@@ -1437,6 +1476,46 @@ object SpecRestGenerated {
 
   def uminus_int(k: BigInt): BigInt = -k
 
+  def uminus_rat(p: rat): rat =
+    Frct {
+      val (a, b) = quotient_of(p): ((BigInt, BigInt));
+      (uminus_int(a), b)
+    }
+
+  def zero_int: BigInt = BigInt(0)
+
+  def less_int(k: BigInt, l: BigInt): Boolean = k < l
+
+  def gcd_int(x0: BigInt, x1: BigInt): BigInt = (x0, x1) match {
+    case (x, y) => x.gcd(y)
+  }
+
+  def snd[A, B](x0: (A, B)): B = x0 match {
+    case (x1, x2) => x2
+  }
+
+  def normalize(p: (BigInt, BigInt)): (BigInt, BigInt) =
+    less_int(zero_int, snd[BigInt, BigInt](p)) match {
+      case true =>
+        val a =
+          gcd_int(fst[BigInt, BigInt](p), snd[BigInt, BigInt](p)): BigInt;
+        (divide_int(fst[BigInt, BigInt](p), a), divide_int(snd[BigInt, BigInt](p), a))
+      case false => equal_int(snd[BigInt, BigInt](p), zero_int) match {
+          case true => (zero_int, one_inta)
+          case false =>
+            val a =
+              uminus_int(gcd_int(fst[BigInt, BigInt](p), snd[BigInt, BigInt](p))): BigInt;
+            (divide_int(fst[BigInt, BigInt](p), a), divide_int(snd[BigInt, BigInt](p), a))
+        }
+    }
+
+  def divide_rat(p: rat, q: rat): rat =
+    Frct {
+      val (a, c) = quotient_of(p): ((BigInt, BigInt))
+      val (b, d) = quotient_of(q): ((BigInt, BigInt));
+      normalize((times_inta(a, d), times_inta(c, b)))
+    }
+
   def length_tailrec[A](x0: List[A], n: nat): nat = (x0, n) match {
     case (Nil, n)     => n
     case (x :: xs, n) => length_tailrec[A](xs, Suc(n))
@@ -1444,7 +1523,21 @@ object SpecRestGenerated {
 
   def size_list[A](xs: List[A]): nat = length_tailrec[A](xs, zero_nat)
 
+  def times_rat(p: rat, q: rat): rat =
+    Frct {
+      val (a, c) = quotient_of(p): ((BigInt, BigInt))
+      val (b, d) = quotient_of(q): ((BigInt, BigInt));
+      normalize((times_inta(a, b), times_inta(c, d)))
+    }
+
   def minus_int(k: BigInt, l: BigInt): BigInt = k - l
+
+  def minus_rat(p: rat, q: rat): rat =
+    Frct {
+      val (a, c) = quotient_of(p): ((BigInt, BigInt))
+      val (b, d) = quotient_of(q): ((BigInt, BigInt));
+      normalize((minus_int(times_inta(a, d), times_inta(b, c)), times_inta(c, d)))
+    }
 
   def sm_const_vals[A](x0: smt_model_ext[A]): List[(String, smt_val)] = x0 match {
     case smt_model_exta(
@@ -1478,13 +1571,24 @@ object SpecRestGenerated {
   def set_intersect_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
     dedupe_smt_vals(filter[smt_val]((a: smt_val) => contains_smt_val(r, a), l))
 
-  def zero_int: BigInt = BigInt(0)
+  def zero_rat: rat = Frct((zero_int, one_inta))
 
   def plus_int(k: BigInt, l: BigInt): BigInt = k + l
 
+  def plus_rat(p: rat, q: rat): rat =
+    Frct {
+      val (a, c) = quotient_of(p): ((BigInt, BigInt))
+      val (b, d) = quotient_of(q): ((BigInt, BigInt));
+      normalize((plus_int(times_inta(a, d), times_inta(b, c)), times_inta(c, d)))
+    }
+
   def int_of_nat(n: nat): BigInt = integer_of_nat(n)
 
-  def less_int(k: BigInt, l: BigInt): Boolean = k < l
+  def less_rat(p: rat, q: rat): Boolean = {
+    val (a, c) = quotient_of(p): ((BigInt, BigInt))
+    val (b, d) = quotient_of(q): ((BigInt, BigInt));
+    less_int(times_inta(a, d), times_inta(c, b))
+  }
 
   def sm_pred_fields[A](x0: smt_model_ext[A]): List[(String, List[(String, smt_val)])] =
     x0 match {
@@ -1518,6 +1622,7 @@ object SpecRestGenerated {
         }
       case (uv, SBool(v), ux)         => None
       case (uv, SInt(v), ux)          => None
+      case (uv, SReal(v), ux)         => None
       case (uv, SEnumElem(v, va), ux) => None
       case (uv, SSet(v), ux)          => None
     }
@@ -1552,10 +1657,6 @@ object SpecRestGenerated {
   def map_option[A, B](f: A => B, x1: Option[A]): Option[B] = (f, x1) match {
     case (f, None)     => None
     case (f, Some(x2)) => Some[B](f(x2))
-  }
-
-  def snd[A, B](x0: (A, B)): B = x0 match {
-    case (x1, x2) => x2
   }
 
   def smt_model_lookup_key(
@@ -1698,12 +1799,14 @@ object SpecRestGenerated {
               case None                       => None
               case Some(SBool(acc))           => Some[smt_val](SBool(b && acc))
               case Some(SInt(_))              => None
+              case Some(SReal(_))             => None
               case Some(SEnumElem(_, _))      => None
               case Some(SEntityElem(_, _))    => None
               case Some(SSet(_))              => None
               case Some(SEntityWith(_, _, _)) => None
             }
           case Some(SInt(_))              => None
+          case Some(SReal(_))             => None
           case Some(SEnumElem(_, _))      => None
           case Some(SEntityElem(_, _))    => None
           case Some(SSet(_))              => None
@@ -1728,12 +1831,14 @@ object SpecRestGenerated {
               case None                       => None
               case Some(SBool(acc))           => Some[smt_val](SBool(b && acc))
               case Some(SInt(_))              => None
+              case Some(SReal(_))             => None
               case Some(SEnumElem(_, _))      => None
               case Some(SEntityElem(_, _))    => None
               case Some(SSet(_))              => None
               case Some(SEntityWith(_, _, _)) => None
             }
           case Some(SInt(_))              => None
+          case Some(SReal(_))             => None
           case Some(SEnumElem(_, _))      => None
           case Some(SEntityElem(_, _))    => None
           case Some(SSet(_))              => None
@@ -1762,6 +1867,7 @@ object SpecRestGenerated {
           case None                       => None
           case Some(SBool(b))             => Some[smt_val](SBool(!b))
           case Some(SInt(_))              => None
+          case Some(SReal(_))             => None
           case Some(SEnumElem(_, _))      => None
           case Some(SEntityElem(_, _))    => None
           case Some(SSet(_))              => None
@@ -1773,11 +1879,13 @@ object SpecRestGenerated {
           case (Some(SBool(_)), None)                       => None
           case (Some(SBool(a)), Some(SBool(b)))             => Some[smt_val](SBool(a && b))
           case (Some(SBool(_)), Some(SInt(_)))              => None
+          case (Some(SBool(_)), Some(SReal(_)))             => None
           case (Some(SBool(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SBool(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SBool(_)), Some(SSet(_)))              => None
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), _)                           => None
+          case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -1789,11 +1897,13 @@ object SpecRestGenerated {
           case (Some(SBool(_)), None)                       => None
           case (Some(SBool(a)), Some(SBool(b)))             => Some[smt_val](SBool(a || b))
           case (Some(SBool(_)), Some(SInt(_)))              => None
+          case (Some(SBool(_)), Some(SReal(_)))             => None
           case (Some(SBool(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SBool(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SBool(_)), Some(SSet(_)))              => None
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), _)                           => None
+          case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -1805,11 +1915,13 @@ object SpecRestGenerated {
           case (Some(SBool(_)), None)                       => None
           case (Some(SBool(a)), Some(SBool(b)))             => Some[smt_val](SBool(!a || b))
           case (Some(SBool(_)), Some(SInt(_)))              => None
+          case (Some(SBool(_)), Some(SReal(_)))             => None
           case (Some(SBool(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SBool(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SBool(_)), Some(SSet(_)))              => None
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), _)                           => None
+          case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -1829,20 +1941,31 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SBool(less_int(a, b)))
+          case (Some(SInt(_)), Some(SReal(_)))             => None
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
-          case (Some(SEnumElem(_, _)), _)                  => None
-          case (Some(SEntityElem(_, _)), _)                => None
-          case (Some(SSet(_)), _)                          => None
-          case (Some(SEntityWith(_, _, _)), _)             => None
+          case (Some(SReal(_)), None)                      => None
+          case (Some(SReal(_)), Some(SBool(_)))            => None
+          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SReal(b))) =>
+            Some[smt_val](SBool(less_rat(a, b)))
+          case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
+          case (Some(SReal(_)), Some(SEntityElem(_, _)))    => None
+          case (Some(SReal(_)), Some(SSet(_)))              => None
+          case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
+          case (Some(SEnumElem(_, _)), _)                   => None
+          case (Some(SEntityElem(_, _)), _)                 => None
+          case (Some(SSet(_)), _)                           => None
+          case (Some(SEntityWith(_, _, _)), _)              => None
         }
       case (m, env, TNeg(t)) =>
         smtEval(m, env, t) match {
           case None                       => None
           case Some(SBool(_))             => None
           case Some(SInt(n))              => Some[smt_val](SInt(uminus_int(n)))
+          case Some(SReal(n))             => Some[smt_val](SReal(uminus_rat(n)))
           case Some(SEnumElem(_, _))      => None
           case Some(SEntityElem(_, _))    => None
           case Some(SSet(_))              => None
@@ -1856,14 +1979,24 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(plus_int(a, b)))
+          case (Some(SInt(_)), Some(SReal(_)))             => None
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
-          case (Some(SEnumElem(_, _)), _)                  => None
-          case (Some(SEntityElem(_, _)), _)                => None
-          case (Some(SSet(_)), _)                          => None
-          case (Some(SEntityWith(_, _, _)), _)             => None
+          case (Some(SReal(_)), None)                      => None
+          case (Some(SReal(_)), Some(SBool(_)))            => None
+          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(plus_rat(a, b)))
+          case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
+          case (Some(SReal(_)), Some(SEntityElem(_, _)))    => None
+          case (Some(SReal(_)), Some(SSet(_)))              => None
+          case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
+          case (Some(SEnumElem(_, _)), _)                   => None
+          case (Some(SEntityElem(_, _)), _)                 => None
+          case (Some(SSet(_)), _)                           => None
+          case (Some(SEntityWith(_, _, _)), _)              => None
         }
       case (m, env, TSub(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -1873,14 +2006,24 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(minus_int(a, b)))
+          case (Some(SInt(_)), Some(SReal(_)))             => None
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
-          case (Some(SEnumElem(_, _)), _)                  => None
-          case (Some(SEntityElem(_, _)), _)                => None
-          case (Some(SSet(_)), _)                          => None
-          case (Some(SEntityWith(_, _, _)), _)             => None
+          case (Some(SReal(_)), None)                      => None
+          case (Some(SReal(_)), Some(SBool(_)))            => None
+          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(minus_rat(a, b)))
+          case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
+          case (Some(SReal(_)), Some(SEntityElem(_, _)))    => None
+          case (Some(SReal(_)), Some(SSet(_)))              => None
+          case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
+          case (Some(SEnumElem(_, _)), _)                   => None
+          case (Some(SEntityElem(_, _)), _)                 => None
+          case (Some(SSet(_)), _)                           => None
+          case (Some(SEntityWith(_, _, _)), _)              => None
         }
       case (m, env, TMul(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -1890,14 +2033,24 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(times_inta(a, b)))
+          case (Some(SInt(_)), Some(SReal(_)))             => None
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
-          case (Some(SEnumElem(_, _)), _)                  => None
-          case (Some(SEntityElem(_, _)), _)                => None
-          case (Some(SSet(_)), _)                          => None
-          case (Some(SEntityWith(_, _, _)), _)             => None
+          case (Some(SReal(_)), None)                      => None
+          case (Some(SReal(_)), Some(SBool(_)))            => None
+          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(times_rat(a, b)))
+          case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
+          case (Some(SReal(_)), Some(SEntityElem(_, _)))    => None
+          case (Some(SReal(_)), Some(SSet(_)))              => None
+          case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
+          case (Some(SEnumElem(_, _)), _)                   => None
+          case (Some(SEntityElem(_, _)), _)                 => None
+          case (Some(SSet(_)), _)                           => None
+          case (Some(SEntityWith(_, _, _)), _)              => None
         }
       case (m, env, TDiv(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -1910,14 +2063,27 @@ object SpecRestGenerated {
               case true  => None
               case false => Some[smt_val](SInt(divide_int(a, b)))
             }
+          case (Some(SInt(_)), Some(SReal(_)))             => None
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
-          case (Some(SEnumElem(_, _)), _)                  => None
-          case (Some(SEntityElem(_, _)), _)                => None
-          case (Some(SSet(_)), _)                          => None
-          case (Some(SEntityWith(_, _, _)), _)             => None
+          case (Some(SReal(_)), None)                      => None
+          case (Some(SReal(_)), Some(SBool(_)))            => None
+          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SReal(b))) =>
+            equal_rat(b, zero_rat) match {
+              case true  => None
+              case false => Some[smt_val](SReal(divide_rat(a, b)))
+            }
+          case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
+          case (Some(SReal(_)), Some(SEntityElem(_, _)))    => None
+          case (Some(SReal(_)), Some(SSet(_)))              => None
+          case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
+          case (Some(SEnumElem(_, _)), _)                   => None
+          case (Some(SEntityElem(_, _)), _)                 => None
+          case (Some(SSet(_)), _)                           => None
+          case (Some(SEntityWith(_, _, _)), _)              => None
         }
       case (m, env, TInDom(rel_name, arg)) =>
         smtEval(m, env, arg) match {
@@ -1967,6 +2133,7 @@ object SpecRestGenerated {
           case (Some(_), None)                    => None
           case (Some(_), Some(SBool(_)))          => None
           case (Some(_), Some(SInt(_)))           => None
+          case (Some(_), Some(SReal(_)))          => None
           case (Some(_), Some(SEnumElem(_, _)))   => None
           case (Some(_), Some(SEntityElem(_, _))) => None
           case (Some(v), Some(SSet(members))) =>
@@ -1979,6 +2146,7 @@ object SpecRestGenerated {
           case (Some(_), None)                    => None
           case (Some(_), Some(SBool(_)))          => None
           case (Some(_), Some(SInt(_)))           => None
+          case (Some(_), Some(SReal(_)))          => None
           case (Some(_), Some(SEnumElem(_, _)))   => None
           case (Some(_), Some(SEntityElem(_, _))) => None
           case (Some(v), Some(SSet(members))) =>
@@ -1990,11 +2158,13 @@ object SpecRestGenerated {
           case (None, _)                                => None
           case (Some(SBool(_)), _)                      => None
           case (Some(SInt(_)), _)                       => None
+          case (Some(SReal(_)), _)                      => None
           case (Some(SEnumElem(_, _)), _)               => None
           case (Some(SEntityElem(_, _)), _)             => None
           case (Some(SSet(_)), None)                    => None
           case (Some(SSet(_)), Some(SBool(_)))          => None
           case (Some(SSet(_)), Some(SInt(_)))           => None
+          case (Some(SSet(_)), Some(SReal(_)))          => None
           case (Some(SSet(_)), Some(SEnumElem(_, _)))   => None
           case (Some(SSet(_)), Some(SEntityElem(_, _))) => None
           case (Some(SSet(a)), Some(SSet(b))) =>
@@ -2007,11 +2177,13 @@ object SpecRestGenerated {
           case (None, _)                                => None
           case (Some(SBool(_)), _)                      => None
           case (Some(SInt(_)), _)                       => None
+          case (Some(SReal(_)), _)                      => None
           case (Some(SEnumElem(_, _)), _)               => None
           case (Some(SEntityElem(_, _)), _)             => None
           case (Some(SSet(_)), None)                    => None
           case (Some(SSet(_)), Some(SBool(_)))          => None
           case (Some(SSet(_)), Some(SInt(_)))           => None
+          case (Some(SSet(_)), Some(SReal(_)))          => None
           case (Some(SSet(_)), Some(SEnumElem(_, _)))   => None
           case (Some(SSet(_)), Some(SEntityElem(_, _))) => None
           case (Some(SSet(a)), Some(SSet(b))) =>
@@ -2024,11 +2196,13 @@ object SpecRestGenerated {
           case (None, _)                                => None
           case (Some(SBool(_)), _)                      => None
           case (Some(SInt(_)), _)                       => None
+          case (Some(SReal(_)), _)                      => None
           case (Some(SEnumElem(_, _)), _)               => None
           case (Some(SEntityElem(_, _)), _)             => None
           case (Some(SSet(_)), None)                    => None
           case (Some(SSet(_)), Some(SBool(_)))          => None
           case (Some(SSet(_)), Some(SInt(_)))           => None
+          case (Some(SSet(_)), Some(SReal(_)))          => None
           case (Some(SSet(_)), Some(SEnumElem(_, _)))   => None
           case (Some(SSet(_)), Some(SEntityElem(_, _))) => None
           case (Some(SSet(a)), Some(SSet(b))) =>
@@ -3116,6 +3290,7 @@ object SpecRestGenerated {
         }
       case (uv, VBool(v), ux)     => None
       case (uv, VInt(v), ux)      => None
+      case (uv, VReal(v), ux)     => None
       case (uv, VEnum(v, va), ux) => None
       case (uv, VSet(v), ux)      => None
     }
@@ -3202,36 +3377,42 @@ object SpecRestGenerated {
       case (IntersectOp(), None, uw)                          => None
       case (IntersectOp(), Some(VBool(va)), uw)               => None
       case (IntersectOp(), Some(VInt(va)), uw)                => None
+      case (IntersectOp(), Some(VReal(va)), uw)               => None
       case (IntersectOp(), Some(VEnum(va, vb)), uw)           => None
       case (IntersectOp(), Some(VEntity(va, vb)), uw)         => None
       case (IntersectOp(), Some(VEntityWith(va, vb, vc)), uw) => None
       case (IntersectOp(), uv, None)                          => None
       case (IntersectOp(), uv, Some(VBool(va)))               => None
       case (IntersectOp(), uv, Some(VInt(va)))                => None
+      case (IntersectOp(), uv, Some(VReal(va)))               => None
       case (IntersectOp(), uv, Some(VEnum(va, vb)))           => None
       case (IntersectOp(), uv, Some(VEntity(va, vb)))         => None
       case (IntersectOp(), uv, Some(VEntityWith(va, vb, vc))) => None
       case (DiffOp(), None, uw)                               => None
       case (DiffOp(), Some(VBool(va)), uw)                    => None
       case (DiffOp(), Some(VInt(va)), uw)                     => None
+      case (DiffOp(), Some(VReal(va)), uw)                    => None
       case (DiffOp(), Some(VEnum(va, vb)), uw)                => None
       case (DiffOp(), Some(VEntity(va, vb)), uw)              => None
       case (DiffOp(), Some(VEntityWith(va, vb, vc)), uw)      => None
       case (DiffOp(), uv, None)                               => None
       case (DiffOp(), uv, Some(VBool(va)))                    => None
       case (DiffOp(), uv, Some(VInt(va)))                     => None
+      case (DiffOp(), uv, Some(VReal(va)))                    => None
       case (DiffOp(), uv, Some(VEnum(va, vb)))                => None
       case (DiffOp(), uv, Some(VEntity(va, vb)))              => None
       case (DiffOp(), uv, Some(VEntityWith(va, vb, vc)))      => None
       case (uu, None, uw)                                     => None
       case (uu, Some(VBool(va)), uw)                          => None
       case (uu, Some(VInt(va)), uw)                           => None
+      case (uu, Some(VReal(va)), uw)                          => None
       case (uu, Some(VEnum(va, vb)), uw)                      => None
       case (uu, Some(VEntity(va, vb)), uw)                    => None
       case (uu, Some(VEntityWith(va, vb, vc)), uw)            => None
       case (uu, uv, None)                                     => None
       case (uu, uv, Some(VBool(va)))                          => None
       case (uu, uv, Some(VInt(va)))                           => None
+      case (uu, uv, Some(VReal(va)))                          => None
       case (uu, uv, Some(VEnum(va, vb)))                      => None
       case (uu, uv, Some(VEntity(va, vb)))                    => None
       case (uu, uv, Some(VEntityWith(va, vb, vc)))            => None
@@ -3250,60 +3431,109 @@ object SpecRestGenerated {
           case true  => None
           case false => Some[ir_value](VInt(divide_int(a, b)))
         }
-      case (SubOp(), None, uw)                          => None
-      case (SubOp(), Some(VBool(va)), uw)               => None
-      case (SubOp(), Some(VEnum(va, vb)), uw)           => None
-      case (SubOp(), Some(VEntity(va, vb)), uw)         => None
-      case (SubOp(), Some(VSet(va)), uw)                => None
-      case (SubOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (SubOp(), uv, None)                          => None
-      case (SubOp(), uv, Some(VBool(va)))               => None
-      case (SubOp(), uv, Some(VEnum(va, vb)))           => None
-      case (SubOp(), uv, Some(VEntity(va, vb)))         => None
-      case (SubOp(), uv, Some(VSet(va)))                => None
-      case (SubOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (MulOp(), None, uw)                          => None
-      case (MulOp(), Some(VBool(va)), uw)               => None
-      case (MulOp(), Some(VEnum(va, vb)), uw)           => None
-      case (MulOp(), Some(VEntity(va, vb)), uw)         => None
-      case (MulOp(), Some(VSet(va)), uw)                => None
-      case (MulOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (MulOp(), uv, None)                          => None
-      case (MulOp(), uv, Some(VBool(va)))               => None
-      case (MulOp(), uv, Some(VEnum(va, vb)))           => None
-      case (MulOp(), uv, Some(VEntity(va, vb)))         => None
-      case (MulOp(), uv, Some(VSet(va)))                => None
-      case (MulOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (DivOp(), None, uw)                          => None
-      case (DivOp(), Some(VBool(va)), uw)               => None
-      case (DivOp(), Some(VEnum(va, vb)), uw)           => None
-      case (DivOp(), Some(VEntity(va, vb)), uw)         => None
-      case (DivOp(), Some(VSet(va)), uw)                => None
-      case (DivOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (DivOp(), uv, None)                          => None
-      case (DivOp(), uv, Some(VBool(va)))               => None
-      case (DivOp(), uv, Some(VEnum(va, vb)))           => None
-      case (DivOp(), uv, Some(VEntity(va, vb)))         => None
-      case (DivOp(), uv, Some(VSet(va)))                => None
-      case (DivOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (uu, None, uw)                               => None
-      case (uu, Some(VBool(va)), uw)                    => None
-      case (uu, Some(VEnum(va, vb)), uw)                => None
-      case (uu, Some(VEntity(va, vb)), uw)              => None
-      case (uu, Some(VSet(va)), uw)                     => None
-      case (uu, Some(VEntityWith(va, vb, vc)), uw)      => None
-      case (uu, uv, None)                               => None
-      case (uu, uv, Some(VBool(va)))                    => None
-      case (uu, uv, Some(VEnum(va, vb)))                => None
-      case (uu, uv, Some(VEntity(va, vb)))              => None
-      case (uu, uv, Some(VSet(va)))                     => None
-      case (uu, uv, Some(VEntityWith(va, vb, vc)))      => None
+      case (AddOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(plus_rat(a, b)))
+      case (SubOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(minus_rat(a, b)))
+      case (MulOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(times_rat(a, b)))
+      case (DivOp(), Some(VReal(a)), Some(VReal(b))) =>
+        equal_rat(b, zero_rat) match {
+          case true  => None
+          case false => Some[ir_value](VReal(divide_rat(a, b)))
+        }
+      case (SubOp(), None, uw)                                       => None
+      case (SubOp(), Some(VBool(va)), uw)                            => None
+      case (SubOp(), Some(VReal(va)), None)                          => None
+      case (SubOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (SubOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (SubOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (SubOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (SubOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (SubOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (SubOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (SubOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (SubOp(), Some(VSet(va)), uw)                             => None
+      case (SubOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (SubOp(), uv, None)                                       => None
+      case (SubOp(), uv, Some(VBool(va)))                            => None
+      case (SubOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (SubOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (SubOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (SubOp(), uv, Some(VSet(va)))                             => None
+      case (SubOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (MulOp(), None, uw)                                       => None
+      case (MulOp(), Some(VBool(va)), uw)                            => None
+      case (MulOp(), Some(VReal(va)), None)                          => None
+      case (MulOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (MulOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (MulOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (MulOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (MulOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (MulOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (MulOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (MulOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (MulOp(), Some(VSet(va)), uw)                             => None
+      case (MulOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (MulOp(), uv, None)                                       => None
+      case (MulOp(), uv, Some(VBool(va)))                            => None
+      case (MulOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (MulOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (MulOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (MulOp(), uv, Some(VSet(va)))                             => None
+      case (MulOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (DivOp(), None, uw)                                       => None
+      case (DivOp(), Some(VBool(va)), uw)                            => None
+      case (DivOp(), Some(VReal(va)), None)                          => None
+      case (DivOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (DivOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (DivOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (DivOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (DivOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (DivOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (DivOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (DivOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (DivOp(), Some(VSet(va)), uw)                             => None
+      case (DivOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (DivOp(), uv, None)                                       => None
+      case (DivOp(), uv, Some(VBool(va)))                            => None
+      case (DivOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (DivOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (DivOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (DivOp(), uv, Some(VSet(va)))                             => None
+      case (DivOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (uu, None, uw)                                            => None
+      case (uu, Some(VBool(va)), uw)                                 => None
+      case (uu, Some(VReal(va)), None)                               => None
+      case (uu, Some(VReal(va)), Some(VBool(vb)))                    => None
+      case (uu, Some(VReal(va)), Some(VInt(vb)))                     => None
+      case (uu, Some(VReal(va)), Some(VEnum(vb, vc)))                => None
+      case (uu, Some(VReal(va)), Some(VEntity(vb, vc)))              => None
+      case (uu, Some(VReal(va)), Some(VSet(vb)))                     => None
+      case (uu, Some(VReal(va)), Some(VEntityWith(vb, vc, vd)))      => None
+      case (uu, Some(VEnum(va, vb)), uw)                             => None
+      case (uu, Some(VEntity(va, vb)), uw)                           => None
+      case (uu, Some(VSet(va)), uw)                                  => None
+      case (uu, Some(VEntityWith(va, vb, vc)), uw)                   => None
+      case (uu, uv, None)                                            => None
+      case (uu, uv, Some(VBool(va)))                                 => None
+      case (uu, Some(VInt(vb)), Some(VReal(va)))                     => None
+      case (uu, uv, Some(VEnum(va, vb)))                             => None
+      case (uu, uv, Some(VEntity(va, vb)))                           => None
+      case (uu, uv, Some(VSet(va)))                                  => None
+      case (uu, uv, Some(VEntityWith(va, vb, vc)))                   => None
     }
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
     map_of[String, ir_value](env, name)
 
   def less_eq_int(k: BigInt, l: BigInt): Boolean = k <= l
+
+  def less_eq_rat(p: rat, q: rat): Boolean = {
+    val (a, c) = quotient_of(p): ((BigInt, BigInt))
+    val (b, d) = quotient_of(q): ((BigInt, BigInt));
+    less_eq_int(times_inta(a, d), times_inta(c, b))
+  }
 
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
     (uu, uv, uw) match {
@@ -3319,58 +3549,98 @@ object SpecRestGenerated {
         Some[ir_value](VBool(less_int(b, a)))
       case (GeOp(), Some(VInt(a)), Some(VInt(b))) =>
         Some[ir_value](VBool(less_eq_int(b, a)))
-      case (NeqOp(), None, uw)                         => None
-      case (NeqOp(), uv, None)                         => None
-      case (LtOp(), None, uw)                          => None
-      case (LtOp(), Some(VBool(va)), uw)               => None
-      case (LtOp(), Some(VEnum(va, vb)), uw)           => None
-      case (LtOp(), Some(VEntity(va, vb)), uw)         => None
-      case (LtOp(), Some(VSet(va)), uw)                => None
-      case (LtOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (LtOp(), uv, None)                          => None
-      case (LtOp(), uv, Some(VBool(va)))               => None
-      case (LtOp(), uv, Some(VEnum(va, vb)))           => None
-      case (LtOp(), uv, Some(VEntity(va, vb)))         => None
-      case (LtOp(), uv, Some(VSet(va)))                => None
-      case (LtOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (LeOp(), None, uw)                          => None
-      case (LeOp(), Some(VBool(va)), uw)               => None
-      case (LeOp(), Some(VEnum(va, vb)), uw)           => None
-      case (LeOp(), Some(VEntity(va, vb)), uw)         => None
-      case (LeOp(), Some(VSet(va)), uw)                => None
-      case (LeOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (LeOp(), uv, None)                          => None
-      case (LeOp(), uv, Some(VBool(va)))               => None
-      case (LeOp(), uv, Some(VEnum(va, vb)))           => None
-      case (LeOp(), uv, Some(VEntity(va, vb)))         => None
-      case (LeOp(), uv, Some(VSet(va)))                => None
-      case (LeOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (GtOp(), None, uw)                          => None
-      case (GtOp(), Some(VBool(va)), uw)               => None
-      case (GtOp(), Some(VEnum(va, vb)), uw)           => None
-      case (GtOp(), Some(VEntity(va, vb)), uw)         => None
-      case (GtOp(), Some(VSet(va)), uw)                => None
-      case (GtOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (GtOp(), uv, None)                          => None
-      case (GtOp(), uv, Some(VBool(va)))               => None
-      case (GtOp(), uv, Some(VEnum(va, vb)))           => None
-      case (GtOp(), uv, Some(VEntity(va, vb)))         => None
-      case (GtOp(), uv, Some(VSet(va)))                => None
-      case (GtOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (GeOp(), None, uw)                          => None
-      case (GeOp(), Some(VBool(va)), uw)               => None
-      case (GeOp(), Some(VEnum(va, vb)), uw)           => None
-      case (GeOp(), Some(VEntity(va, vb)), uw)         => None
-      case (GeOp(), Some(VSet(va)), uw)                => None
-      case (GeOp(), Some(VEntityWith(va, vb, vc)), uw) => None
-      case (GeOp(), uv, None)                          => None
-      case (GeOp(), uv, Some(VBool(va)))               => None
-      case (GeOp(), uv, Some(VEnum(va, vb)))           => None
-      case (GeOp(), uv, Some(VEntity(va, vb)))         => None
-      case (GeOp(), uv, Some(VSet(va)))                => None
-      case (GeOp(), uv, Some(VEntityWith(va, vb, vc))) => None
-      case (uu, None, uw)                              => None
-      case (uu, uv, None)                              => None
+      case (LtOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_rat(a, b)))
+      case (LeOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_eq_rat(a, b)))
+      case (GtOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_rat(b, a)))
+      case (GeOp(), Some(VReal(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_eq_rat(b, a)))
+      case (NeqOp(), None, uw)                                      => None
+      case (NeqOp(), uv, None)                                      => None
+      case (LtOp(), None, uw)                                       => None
+      case (LtOp(), Some(VBool(va)), uw)                            => None
+      case (LtOp(), Some(VReal(va)), None)                          => None
+      case (LtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (LtOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (LtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (LtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (LtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (LtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (LtOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (LtOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (LtOp(), Some(VSet(va)), uw)                             => None
+      case (LtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (LtOp(), uv, None)                                       => None
+      case (LtOp(), uv, Some(VBool(va)))                            => None
+      case (LtOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (LtOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (LtOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (LtOp(), uv, Some(VSet(va)))                             => None
+      case (LtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (LeOp(), None, uw)                                       => None
+      case (LeOp(), Some(VBool(va)), uw)                            => None
+      case (LeOp(), Some(VReal(va)), None)                          => None
+      case (LeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (LeOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (LeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (LeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (LeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (LeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (LeOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (LeOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (LeOp(), Some(VSet(va)), uw)                             => None
+      case (LeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (LeOp(), uv, None)                                       => None
+      case (LeOp(), uv, Some(VBool(va)))                            => None
+      case (LeOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (LeOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (LeOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (LeOp(), uv, Some(VSet(va)))                             => None
+      case (LeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (GtOp(), None, uw)                                       => None
+      case (GtOp(), Some(VBool(va)), uw)                            => None
+      case (GtOp(), Some(VReal(va)), None)                          => None
+      case (GtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (GtOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (GtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (GtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (GtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (GtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (GtOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (GtOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (GtOp(), Some(VSet(va)), uw)                             => None
+      case (GtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (GtOp(), uv, None)                                       => None
+      case (GtOp(), uv, Some(VBool(va)))                            => None
+      case (GtOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (GtOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (GtOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (GtOp(), uv, Some(VSet(va)))                             => None
+      case (GtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (GeOp(), None, uw)                                       => None
+      case (GeOp(), Some(VBool(va)), uw)                            => None
+      case (GeOp(), Some(VReal(va)), None)                          => None
+      case (GeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
+      case (GeOp(), Some(VReal(va)), Some(VInt(vb)))                => None
+      case (GeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
+      case (GeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
+      case (GeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
+      case (GeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
+      case (GeOp(), Some(VEnum(va, vb)), uw)                        => None
+      case (GeOp(), Some(VEntity(va, vb)), uw)                      => None
+      case (GeOp(), Some(VSet(va)), uw)                             => None
+      case (GeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
+      case (GeOp(), uv, None)                                       => None
+      case (GeOp(), uv, Some(VBool(va)))                            => None
+      case (GeOp(), Some(VInt(vb)), Some(VReal(va)))                => None
+      case (GeOp(), uv, Some(VEnum(va, vb)))                        => None
+      case (GeOp(), uv, Some(VEntity(va, vb)))                      => None
+      case (GeOp(), uv, Some(VSet(va)))                             => None
+      case (GeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
+      case (uu, None, uw)                                           => None
+      case (uu, uv, None)                                           => None
     }
 
   def eval_forall_enum(
@@ -3392,12 +3662,14 @@ object SpecRestGenerated {
               case None                       => None
               case Some(VBool(acc))           => Some[ir_value](VBool(b && acc))
               case Some(VInt(_))              => None
+              case Some(VReal(_))             => None
               case Some(VEnum(_, _))          => None
               case Some(VEntity(_, _))        => None
               case Some(VSet(_))              => None
               case Some(VEntityWith(_, _, _)) => None
             }
           case Some(VInt(_))              => None
+          case Some(VReal(_))             => None
           case Some(VEnum(_, _))          => None
           case Some(VEntity(_, _))        => None
           case Some(VSet(_))              => None
@@ -3423,12 +3695,14 @@ object SpecRestGenerated {
               case None                       => None
               case Some(VBool(acc))           => Some[ir_value](VBool(b && acc))
               case Some(VInt(_))              => None
+              case Some(VReal(_))             => None
               case Some(VEnum(_, _))          => None
               case Some(VEntity(_, _))        => None
               case Some(VSet(_))              => None
               case Some(VEntityWith(_, _, _)) => None
             }
           case Some(VInt(_))              => None
+          case Some(VReal(_))             => None
           case Some(VEnum(_, _))          => None
           case Some(VEntity(_, _))        => None
           case Some(VSet(_))              => None
@@ -3454,6 +3728,7 @@ object SpecRestGenerated {
           case None                       => None
           case Some(VBool(b))             => Some[ir_value](VBool(!b))
           case Some(VInt(_))              => None
+          case Some(VReal(_))             => None
           case Some(VEnum(_, _))          => None
           case Some(VEntity(_, _))        => None
           case Some(VSet(_))              => None
@@ -3464,6 +3739,7 @@ object SpecRestGenerated {
           case None                       => None
           case Some(VBool(_))             => None
           case Some(VInt(n))              => Some[ir_value](VInt(uminus_int(n)))
+          case Some(VReal(r))             => Some[ir_value](VReal(uminus_rat(r)))
           case Some(VEnum(_, _))          => None
           case Some(VEntity(_, _))        => None
           case Some(VSet(_))              => None
@@ -3476,11 +3752,13 @@ object SpecRestGenerated {
           case (Some(VBool(a)), Some(VBool(b))) =>
             Some[ir_value](VBool(eval_bool_bin(op, a, b)))
           case (Some(VBool(_)), Some(VInt(_)))              => None
+          case (Some(VBool(_)), Some(VReal(_)))             => None
           case (Some(VBool(_)), Some(VEnum(_, _)))          => None
           case (Some(VBool(_)), Some(VEntity(_, _)))        => None
           case (Some(VBool(_)), Some(VSet(_)))              => None
           case (Some(VBool(_)), Some(VEntityWith(_, _, _))) => None
           case (Some(VInt(_)), _)                           => None
+          case (Some(VReal(_)), _)                          => None
           case (Some(VEnum(_, _)), _)                       => None
           case (Some(VEntity(_, _)), _)                     => None
           case (Some(VSet(_)), _)                           => None
@@ -3551,6 +3829,7 @@ object SpecRestGenerated {
           case (Some(_), None)                => None
           case (Some(_), Some(VBool(_)))      => None
           case (Some(_), Some(VInt(_)))       => None
+          case (Some(_), Some(VReal(_)))      => None
           case (Some(_), Some(VEnum(_, _)))   => None
           case (Some(_), Some(VEntity(_, _))) => None
           case (Some(v), Some(VSet(members))) =>
@@ -3563,6 +3842,7 @@ object SpecRestGenerated {
           case (Some(_), None)                => None
           case (Some(_), Some(VBool(_)))      => None
           case (Some(_), Some(VInt(_)))       => None
+          case (Some(_), Some(VReal(_)))      => None
           case (Some(_), Some(VEnum(_, _)))   => None
           case (Some(_), Some(VEntity(_, _))) => None
           case (Some(v), Some(VSet(members))) =>
@@ -9251,11 +9531,16 @@ object SpecRestGenerated {
           case true => Some[ty](TBool())
           case false => n == "Int" match {
               case true => Some[ty](TInt())
-              case false => membera[String](enums, n) match {
-                  case true => Some[ty](TEnum(n))
-                  case false => membera[String](entities, n) match {
-                      case true  => Some[ty](TEntity(n))
-                      case false => None
+              case false => n == "Float" ||
+                  (n == "Double" ||
+                    (n == "Decimal" || n == "Money")) match {
+                  case true => Some[ty](TReal())
+                  case false => membera[String](enums, n) match {
+                      case true => Some[ty](TEnum(n))
+                      case false => membera[String](entities, n) match {
+                          case true  => Some[ty](TEntity(n))
+                          case false => None
+                        }
                     }
                 }
             }
@@ -11770,36 +12055,47 @@ object SpecRestGenerated {
     }
 
   def equal_ty(x0: ty, x1: ty): Boolean = (x0, x1) match {
-    case (TEntity(x4), TSet(x5))    => false
-    case (TSet(x5), TEntity(x4))    => false
-    case (TEnum(x3), TSet(x5))      => false
-    case (TSet(x5), TEnum(x3))      => false
-    case (TEnum(x3), TEntity(x4))   => false
-    case (TEntity(x4), TEnum(x3))   => false
-    case (TInt(), TSet(x5))         => false
-    case (TSet(x5), TInt())         => false
-    case (TInt(), TEntity(x4))      => false
-    case (TEntity(x4), TInt())      => false
-    case (TInt(), TEnum(x3))        => false
-    case (TEnum(x3), TInt())        => false
-    case (TBool(), TSet(x5))        => false
-    case (TSet(x5), TBool())        => false
-    case (TBool(), TEntity(x4))     => false
-    case (TEntity(x4), TBool())     => false
-    case (TBool(), TEnum(x3))       => false
-    case (TEnum(x3), TBool())       => false
+    case (TEntity(x5), TSet(x6))    => false
+    case (TSet(x6), TEntity(x5))    => false
+    case (TEnum(x4), TSet(x6))      => false
+    case (TSet(x6), TEnum(x4))      => false
+    case (TEnum(x4), TEntity(x5))   => false
+    case (TEntity(x5), TEnum(x4))   => false
+    case (TReal(), TSet(x6))        => false
+    case (TSet(x6), TReal())        => false
+    case (TReal(), TEntity(x5))     => false
+    case (TEntity(x5), TReal())     => false
+    case (TReal(), TEnum(x4))       => false
+    case (TEnum(x4), TReal())       => false
+    case (TInt(), TSet(x6))         => false
+    case (TSet(x6), TInt())         => false
+    case (TInt(), TEntity(x5))      => false
+    case (TEntity(x5), TInt())      => false
+    case (TInt(), TEnum(x4))        => false
+    case (TEnum(x4), TInt())        => false
+    case (TInt(), TReal())          => false
+    case (TReal(), TInt())          => false
+    case (TBool(), TSet(x6))        => false
+    case (TSet(x6), TBool())        => false
+    case (TBool(), TEntity(x5))     => false
+    case (TEntity(x5), TBool())     => false
+    case (TBool(), TEnum(x4))       => false
+    case (TEnum(x4), TBool())       => false
+    case (TBool(), TReal())         => false
+    case (TReal(), TBool())         => false
     case (TBool(), TInt())          => false
     case (TInt(), TBool())          => false
-    case (TSet(x5), TSet(y5))       => equal_ty(x5, y5)
-    case (TEntity(x4), TEntity(y4)) => x4 == y4
-    case (TEnum(x3), TEnum(y3))     => x3 == y3
+    case (TSet(x6), TSet(y6))       => equal_ty(x6, y6)
+    case (TEntity(x5), TEntity(y5)) => x5 == y5
+    case (TEnum(x4), TEnum(y4))     => x4 == y4
+    case (TReal(), TReal())         => true
     case (TInt(), TInt())           => true
     case (TBool(), TBool())         => true
   }
 
-  def check_value_has_ty_list(vt: tyctx_ext[Unit], x1: List[ir_value], vu: ty): Boolean =
-    (vt, x1, vu) match {
-      case (vt, Nil, vu) => true
+  def check_value_has_ty_list(vy: tyctx_ext[Unit], x1: List[ir_value], vz: ty): Boolean =
+    (vy, x1, vz) match {
+      case (vy, Nil, vz) => true
       case (gamma, v :: vs, t) =>
         check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
     }
@@ -11808,23 +12104,26 @@ object SpecRestGenerated {
     (gamma, x1, t) match {
       case (gamma, VBool(uu), t)          => equal_ty(t, TBool())
       case (gamma, VInt(uv), t)           => equal_ty(t, TInt())
-      case (gamma, VEnum(ename, uw), t)   => equal_ty(t, TEnum(ename))
-      case (gamma, VEntity(ename, ux), t) => equal_ty(t, TEntity(ename))
+      case (gamma, VReal(uw), t)          => equal_ty(t, TReal())
+      case (gamma, VEnum(ename, ux), t)   => equal_ty(t, TEnum(ename))
+      case (gamma, VEntity(ename, uy), t) => equal_ty(t, TEntity(ename))
       case (gamma, VSet(vs), TSet(t))     => check_value_has_ty_list(gamma, vs, t)
-      case (gamma, VSet(uy), TBool())     => false
-      case (gamma, VSet(uz), TInt())      => false
-      case (gamma, VSet(va), TEnum(vb))   => false
-      case (gamma, VSet(vc), TEntity(vd)) => false
+      case (gamma, VSet(uz), TBool())     => false
+      case (gamma, VSet(va), TInt())      => false
+      case (gamma, VSet(vb), TReal())     => false
+      case (gamma, VSet(vc), TEnum(vd))   => false
+      case (gamma, VSet(ve), TEntity(vf)) => false
       case (gamma, VEntityWith(base, fld, overridea), TEntity(ename)) =>
         check_value_has_ty(gamma, base, TEntity(ename)) &&
         (schemaFieldType(gamma, ename, fld) match {
           case None    => false
           case Some(a) => check_value_has_ty(gamma, overridea, a)
         })
-      case (gamma, VEntityWith(ve, vf, vg), TBool())   => false
-      case (gamma, VEntityWith(vh, vi, vj), TInt())    => false
-      case (gamma, VEntityWith(vk, vl, vm), TEnum(vn)) => false
-      case (gamma, VEntityWith(vo, vp, vq), TSet(vr))  => false
+      case (gamma, VEntityWith(vg, vh, vi), TBool())   => false
+      case (gamma, VEntityWith(vj, vk, vl), TInt())    => false
+      case (gamma, VEntityWith(vm, vn, vo), TReal())   => false
+      case (gamma, VEntityWith(vp, vq, vr), TEnum(vt)) => false
+      case (gamma, VEntityWith(vu, vv, vw), TSet(vx))  => false
     }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl_full] = x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2290,11 +2290,6 @@ object SpecRestGenerated {
       }
   }
 
-  def tl[A](x0: List[A]): List[A] = x0 match {
-    case Nil        => Nil
-    case x21 :: x22 => x22
-  }
-
   def list_ex[A](p: A => Boolean, x1: List[A]): Boolean = (p, x1) match {
     case (p, Nil)     => false
     case (p, x :: xs) => p(x) || list_ex[A](p, xs)
@@ -2567,98 +2562,6 @@ object SpecRestGenerated {
         }
     }
 
-  def power[A: power](a: A, n: nat): A =
-    equal_nat(n, zero_nat) match {
-      case true  => one[A]
-      case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
-    }
-
-  def asciiToIntAcc(x0: List[BigInt], acc: BigInt): Option[BigInt] = (x0, acc) match {
-    case (Nil, acc) => Some[BigInt](acc)
-    case (c :: cs, acc) =>
-      BigInt(48) <= c && c <= BigInt(57) match {
-        case true  => asciiToIntAcc(cs, plus_int(times_inta(acc, BigInt(10)), c - BigInt(48)))
-        case false => None
-      }
-  }
-
-  def takeWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
-    case (p, Nil) => Nil
-    case (p, x :: xs) =>
-      p(x) match {
-        case true  => x :: takeWhile[A](p, xs)
-        case false => Nil
-      }
-  }
-
-  def dropWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
-    case (p, Nil) => Nil
-    case (p, x :: xs) =>
-      p(x) match {
-        case true  => dropWhile[A](p, xs)
-        case false => x :: xs
-      }
-  }
-
-  def decimalToRat(s: String): Option[rat] = {
-    val cs = Str_Literal.asciisOfLiteral(s): List[BigInt];
-    cs match {
-      case Nil => None
-      case c0 :: _ =>
-        val neg = c0 == BigInt(45): Boolean
-        val body =
-          (neg match {
-            case true  => tl[BigInt](cs)
-            case false => cs
-          }): List[BigInt]
-        val ipart =
-          takeWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body): List[BigInt]
-        val dotrest =
-          dropWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body): List[BigInt];
-        nulla[BigInt](dotrest) match {
-          case true => nulla[BigInt](ipart) match {
-              case true => None
-              case false => asciiToIntAcc(ipart, zero_int) match {
-                  case None => None
-                  case Some(iv) =>
-                    Some[rat](of_int(neg match {
-                      case true  => uminus_int(iv)
-                      case false => iv
-                    }))
-                }
-            }
-          case false =>
-            val fpart = tl[BigInt](dotrest): List[BigInt];
-            nulla[BigInt](ipart) &&
-              nulla[BigInt](fpart) match {
-              case true => None
-              case false => (asciiToIntAcc(ipart, zero_int), asciiToIntAcc(fpart, zero_int)) match {
-                  case (None, _)       => None
-                  case (Some(_), None) => None
-                  case (Some(iv), Some(fv)) =>
-                    val mag =
-                      plus_rat(
-                        of_int(iv),
-                        divide_rat(
-                          of_int(fv),
-                          of_int(power[BigInt](BigInt(10), size_list[BigInt](fpart)))
-                        )
-                      ): rat;
-                    Some[rat](neg match {
-                      case true  => uminus_rat(mag)
-                      case false => mag
-                    })
-                }
-            }
-        }
-    }
-  }
-
-  def floatLitRat(s: String): rat = decimalToRat(s) match {
-    case None    => zero_rat
-    case Some(r) => r
-  }
-
   def peel_relation_ref(x0: expr): Option[String] = x0 match {
     case Ident(rel, uu)                        => Some[String](rel)
     case Pre(Ident(rel, uv), uw)               => Some[String](rel)
@@ -2732,6 +2635,79 @@ object SpecRestGenerated {
     case WithRec(v, va, vb, vc)                => None
   }
 
+  def one_rat: rat = Frct((one_inta, one_inta))
+
+  def power[A: power](a: A, n: nat): A =
+    equal_nat(n, zero_nat) match {
+      case true  => one[A]
+      case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
+    }
+
+  def asciiToIntAcc(x0: List[BigInt], acc: BigInt): Option[BigInt] = (x0, acc) match {
+    case (Nil, acc) => Some[BigInt](acc)
+    case (c :: cs, acc) =>
+      BigInt(48) <= c && c <= BigInt(57) match {
+        case true  => asciiToIntAcc(cs, plus_int(times_inta(acc, BigInt(10)), c - BigInt(48)))
+        case false => None
+      }
+  }
+
+  def takeWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
+    case (p, Nil) => Nil
+    case (p, x :: xs) =>
+      p(x) match {
+        case true  => x :: takeWhile[A](p, xs)
+        case false => Nil
+      }
+  }
+
+  def dropWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
+    case (p, Nil) => Nil
+    case (p, x :: xs) =>
+      p(x) match {
+        case true  => dropWhile[A](p, xs)
+        case false => x :: xs
+      }
+  }
+
+  def decimalToRat(s: String): Option[rat] = {
+    val cs = Str_Literal.asciisOfLiteral(s): List[BigInt]
+    val (neg, body) =
+      (cs match {
+        case Nil => (false, cs)
+        case c :: rest =>
+          c == BigInt(45) match {
+            case true  => (true, rest)
+            case false => (false, cs)
+          }
+      }): ((Boolean, List[BigInt]))
+    val ipart =
+      takeWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body): List[BigInt]
+    val fpart =
+      (dropWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body) match {
+        case Nil       => Nil
+        case _ :: rest => rest
+      }): List[BigInt];
+    nulla[BigInt](ipart) && nulla[BigInt](fpart) match {
+      case true => None
+      case false => (asciiToIntAcc(ipart, zero_int), asciiToIntAcc(fpart, zero_int)) match {
+          case (None, _)       => None
+          case (Some(_), None) => None
+          case (Some(iv), Some(fv)) =>
+            Some[rat](times_rat(
+              neg match {
+                case true  => uminus_rat(one_rat)
+                case false => one_rat
+              },
+              plus_rat(
+                of_int(iv),
+                divide_rat(of_int(fv), of_int(power[BigInt](BigInt(10), size_list[BigInt](fpart))))
+              )
+            ))
+        }
+    }
+  }
+
   def lower_with_assigns(
       wt: List[String],
       x1: List[field_assign_full],
@@ -2760,10 +2736,11 @@ object SpecRestGenerated {
     }
 
   def lower(uu: List[String], x1: expr_full): Option[expr] = (uu, x1) match {
-    case (uu, BoolLitF(b, sp))                   => Some[expr](BoolLit(b, sp))
-    case (uv, IntLitF(n, sp))                    => Some[expr](IntLit(n, sp))
-    case (uw, IdentifierF(x, sp))                => Some[expr](Ident(x, sp))
-    case (ux, FloatLitF(s, sp))                  => Some[expr](RealLit(floatLitRat(s), sp))
+    case (uu, BoolLitF(b, sp))    => Some[expr](BoolLit(b, sp))
+    case (uv, IntLitF(n, sp))     => Some[expr](IntLit(n, sp))
+    case (uw, IdentifierF(x, sp)) => Some[expr](Ident(x, sp))
+    case (ux, FloatLitF(s, sp)) =>
+      map_option[rat, expr]((r: rat) => RealLit(r, sp), decimalToRat(s))
     case (uy, StringLitF(uz, va))                => None
     case (vb, NoneLitF(vc))                      => None
     case (vd, LambdaF(ve, vf, vg))               => None

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -397,6 +397,7 @@ object SpecRestGenerated {
   sealed abstract class expr
   final case class BoolLit(a: Boolean, b: Option[span_t]) extends expr
   final case class IntLit(a: BigInt, b: Option[span_t])   extends expr
+  final case class RealLit(a: rat, b: Option[span_t])     extends expr
   final case class Ident(a: String, b: Option[span_t])    extends expr
   final case class UnNot(a: expr, b: Option[span_t])      extends expr
   final case class UnNeg(a: expr, b: Option[span_t])      extends expr
@@ -552,6 +553,7 @@ object SpecRestGenerated {
   sealed abstract class smt_term
   final case class BLit(a: Boolean)                               extends smt_term
   final case class ILit(a: BigInt)                                extends smt_term
+  final case class RLit(a: rat)                                   extends smt_term
   final case class TVar(a: String)                                extends smt_term
   final case class EnumElemConst(a: String, b: String)            extends smt_term
   final case class TNot(a: smt_term)                              extends smt_term
@@ -1326,6 +1328,8 @@ object SpecRestGenerated {
       }
   }
 
+  def of_int(a: BigInt): rat = Frct((a, one_inta))
+
   def membera[A: equal](x0: List[A], y: A): Boolean = (x0, y) match {
     case (Nil, y)     => false
     case (x :: xs, y) => eq[A](x, y) || membera[A](xs, y)
@@ -1687,6 +1691,7 @@ object SpecRestGenerated {
     case TPrime(TVar(rel))               => Some[String](rel)
     case BLit(v)                         => None
     case ILit(v)                         => None
+    case RLit(v)                         => None
     case EnumElemConst(v, va)            => None
     case TNot(v)                         => None
     case TAnd(v, va)                     => None
@@ -1714,6 +1719,7 @@ object SpecRestGenerated {
     case TSetDiff(v, va)                 => None
     case TPrime(BLit(va))                => None
     case TPrime(ILit(va))                => None
+    case TPrime(RLit(va))                => None
     case TPrime(EnumElemConst(va, vb))   => None
     case TPrime(TNot(va))                => None
     case TPrime(TAnd(va, vb))            => None
@@ -1744,6 +1750,7 @@ object SpecRestGenerated {
     case TPrime(TWithRec(va, vb, vc))    => None
     case TPre(BLit(va))                  => None
     case TPre(ILit(va))                  => None
+    case TPre(RLit(va))                  => None
     case TPre(EnumElemConst(va, vb))     => None
     case TPre(TNot(va))                  => None
     case TPre(TAnd(va, vb))              => None
@@ -1850,6 +1857,7 @@ object SpecRestGenerated {
     (m, env, x2) match {
       case (m, env, BLit(b)) => Some[smt_val](SBool(b))
       case (m, env, ILit(n)) => Some[smt_val](SInt(n))
+      case (m, env, RLit(r)) => Some[smt_val](SReal(r))
       case (m, env, TVar(x)) => smt_env_lookup(env, x) match {
           case None    => smt_model_lookup_const(m, x)
           case Some(a) => Some[smt_val](a)
@@ -2282,6 +2290,11 @@ object SpecRestGenerated {
       }
   }
 
+  def tl[A](x0: List[A]): List[A] = x0 match {
+    case Nil        => Nil
+    case x21 :: x22 => x22
+  }
+
   def list_ex[A](p: A => Boolean, x1: List[A]): Boolean = (p, x1) match {
     case (p, Nil)     => false
     case (p, x :: xs) => p(x) || list_ex[A](p, xs)
@@ -2554,12 +2567,105 @@ object SpecRestGenerated {
         }
     }
 
+  def power[A: power](a: A, n: nat): A =
+    equal_nat(n, zero_nat) match {
+      case true  => one[A]
+      case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
+    }
+
+  def asciiToIntAcc(x0: List[BigInt], acc: BigInt): Option[BigInt] = (x0, acc) match {
+    case (Nil, acc) => Some[BigInt](acc)
+    case (c :: cs, acc) =>
+      BigInt(48) <= c && c <= BigInt(57) match {
+        case true  => asciiToIntAcc(cs, plus_int(times_inta(acc, BigInt(10)), c - BigInt(48)))
+        case false => None
+      }
+  }
+
+  def takeWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
+    case (p, Nil) => Nil
+    case (p, x :: xs) =>
+      p(x) match {
+        case true  => x :: takeWhile[A](p, xs)
+        case false => Nil
+      }
+  }
+
+  def dropWhile[A](p: A => Boolean, x1: List[A]): List[A] = (p, x1) match {
+    case (p, Nil) => Nil
+    case (p, x :: xs) =>
+      p(x) match {
+        case true  => dropWhile[A](p, xs)
+        case false => x :: xs
+      }
+  }
+
+  def decimalToRat(s: String): Option[rat] = {
+    val cs = Str_Literal.asciisOfLiteral(s): List[BigInt];
+    cs match {
+      case Nil => None
+      case c0 :: _ =>
+        val neg = c0 == BigInt(45): Boolean
+        val body =
+          (neg match {
+            case true  => tl[BigInt](cs)
+            case false => cs
+          }): List[BigInt]
+        val ipart =
+          takeWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body): List[BigInt]
+        val dotrest =
+          dropWhile[BigInt]((c: BigInt) => !(c == BigInt(46)), body): List[BigInt];
+        nulla[BigInt](dotrest) match {
+          case true => nulla[BigInt](ipart) match {
+              case true => None
+              case false => asciiToIntAcc(ipart, zero_int) match {
+                  case None => None
+                  case Some(iv) =>
+                    Some[rat](of_int(neg match {
+                      case true  => uminus_int(iv)
+                      case false => iv
+                    }))
+                }
+            }
+          case false =>
+            val fpart = tl[BigInt](dotrest): List[BigInt];
+            nulla[BigInt](ipart) &&
+              nulla[BigInt](fpart) match {
+              case true => None
+              case false => (asciiToIntAcc(ipart, zero_int), asciiToIntAcc(fpart, zero_int)) match {
+                  case (None, _)       => None
+                  case (Some(_), None) => None
+                  case (Some(iv), Some(fv)) =>
+                    val mag =
+                      plus_rat(
+                        of_int(iv),
+                        divide_rat(
+                          of_int(fv),
+                          of_int(power[BigInt](BigInt(10), size_list[BigInt](fpart)))
+                        )
+                      ): rat;
+                    Some[rat](neg match {
+                      case true  => uminus_rat(mag)
+                      case false => mag
+                    })
+                }
+            }
+        }
+    }
+  }
+
+  def floatLitRat(s: String): rat = decimalToRat(s) match {
+    case None    => zero_rat
+    case Some(r) => r
+  }
+
   def peel_relation_ref(x0: expr): Option[String] = x0 match {
     case Ident(rel, uu)                        => Some[String](rel)
     case Pre(Ident(rel, uv), uw)               => Some[String](rel)
     case Prime(Ident(rel, ux), uy)             => Some[String](rel)
     case BoolLit(v, va)                        => None
     case IntLit(v, va)                         => None
+    case RealLit(v, va)                        => None
     case UnNot(v, va)                          => None
     case UnNeg(v, va)                          => None
     case BoolBin(v, va, vb, vc)                => None
@@ -2572,6 +2678,7 @@ object SpecRestGenerated {
     case ForallRel(v, va, vb, vc)              => None
     case Prime(BoolLit(vb, vc), va)            => None
     case Prime(IntLit(vb, vc), va)             => None
+    case Prime(RealLit(vb, vc), va)            => None
     case Prime(UnNot(vb, vc), va)              => None
     case Prime(UnNeg(vb, vc), va)              => None
     case Prime(BoolBin(vb, vc, vd, ve), va)    => None
@@ -2594,6 +2701,7 @@ object SpecRestGenerated {
     case Prime(WithRec(vb, vc, vd, ve), va)    => None
     case Pre(BoolLit(vb, vc), va)              => None
     case Pre(IntLit(vb, vc), va)               => None
+    case Pre(RealLit(vb, vc), va)              => None
     case Pre(UnNot(vb, vc), va)                => None
     case Pre(UnNeg(vb, vc), va)                => None
     case Pre(BoolBin(vb, vc, vd, ve), va)      => None
@@ -2625,14 +2733,14 @@ object SpecRestGenerated {
   }
 
   def lower_with_assigns(
-      wv: List[String],
+      wt: List[String],
       x1: List[field_assign_full],
       base: expr,
-      ww: Option[span_t]
+      wu: Option[span_t]
   ): Option[expr] =
-    (wv, x1, base, ww) match {
-      case (wv, Nil, base, ww) => Some[expr](base)
-      case (enums, FieldAssignFull(fld, v, wx) :: rest, base, sp) =>
+    (wt, x1, base, wu) match {
+      case (wt, Nil, base, wu) => Some[expr](base)
+      case (enums, FieldAssignFull(fld, v, wv) :: rest, base, sp) =>
         lower(enums, v) match {
           case None => None
           case Some(va) =>
@@ -2640,9 +2748,9 @@ object SpecRestGenerated {
         }
     }
 
-  def lowerSetList(wu: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
-    (wu, x1, sp) match {
-      case (wu, Nil, sp) => Some[expr](SetEmpty(sp))
+  def lowerSetList(ws: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (ws, x1, sp) match {
+      case (ws, Nil, sp) => Some[expr](SetEmpty(sp))
       case (enums, e :: rest, sp) =>
         (lower(enums, e), lowerSetList(enums, rest, sp)) match {
           case (None, _)           => None
@@ -2655,19 +2763,19 @@ object SpecRestGenerated {
     case (uu, BoolLitF(b, sp))                   => Some[expr](BoolLit(b, sp))
     case (uv, IntLitF(n, sp))                    => Some[expr](IntLit(n, sp))
     case (uw, IdentifierF(x, sp))                => Some[expr](Ident(x, sp))
-    case (ux, FloatLitF(uy, uz))                 => None
-    case (va, StringLitF(vb, vc))                => None
-    case (vd, NoneLitF(ve))                      => None
-    case (vf, LambdaF(vg, vh, vi))               => None
-    case (vj, CallF(vk, vl, vm))                 => None
-    case (vn, ConstructorF(vo, vp, vq))          => None
-    case (vr, MapLiteralF(vs, vt))               => None
-    case (vu, SeqLiteralF(vv, vw))               => None
-    case (vx, SetComprehensionF(vy, vz, wa, wb)) => None
-    case (wc, SomeWrapF(wd, we))                 => None
-    case (wf, TheF(wg, wh, wi, wj))              => None
-    case (wk, MatchesF(wl, wm, wn))              => None
-    case (wo, IfF(wp, wq, wr, ws))               => None
+    case (ux, FloatLitF(s, sp))                  => Some[expr](RealLit(floatLitRat(s), sp))
+    case (uy, StringLitF(uz, va))                => None
+    case (vb, NoneLitF(vc))                      => None
+    case (vd, LambdaF(ve, vf, vg))               => None
+    case (vh, CallF(vi, vj, vk))                 => None
+    case (vl, ConstructorF(vm, vn, vo))          => None
+    case (vp, MapLiteralF(vq, vr))               => None
+    case (vs, SeqLiteralF(vt, vu))               => None
+    case (vv, SetComprehensionF(vw, vx, vy, vz)) => None
+    case (wa, SomeWrapF(wb, wc))                 => None
+    case (wd, TheF(we, wf, wg, wh))              => None
+    case (wi, MatchesF(wj, wk, wl))              => None
+    case (wm, IfF(wn, wo, wp, wq))               => None
     case (enums, QuantifierF(k, bs, body, sp)) =>
       lower(enums, body) match {
         case None => None
@@ -3191,7 +3299,7 @@ object SpecRestGenerated {
         case (Some(_), None)     => None
         case (Some(va), Some(b)) => Some[expr](LetIn(x, va, b, sp))
       }
-    case (wt, EnumAccessF(base, mem, sp)) =>
+    case (wr, EnumAccessF(base, mem, sp)) =>
       base match {
         case BinaryOpF(_, _, _, _)         => None
         case UnaryOpF(_, _, _)             => None
@@ -3719,11 +3827,12 @@ object SpecRestGenerated {
     (s, st, env, x3) match {
       case (s, st, env, BoolLit(b, uu)) => Some[ir_value](VBool(b))
       case (s, st, env, IntLit(n, uv))  => Some[ir_value](VInt(n))
-      case (s, st, env, Ident(x, uw)) => env_lookup(env, x) match {
+      case (s, st, env, RealLit(r, uw)) => Some[ir_value](VReal(r))
+      case (s, st, env, Ident(x, ux)) => env_lookup(env, x) match {
           case None    => state_lookup_scalar(st, x)
           case Some(a) => Some[ir_value](a)
         }
-      case (s, st, env, UnNot(e, ux)) =>
+      case (s, st, env, UnNot(e, uy)) =>
         eval(s, st, env, e) match {
           case None                       => None
           case Some(VBool(b))             => Some[ir_value](VBool(!b))
@@ -3734,7 +3843,7 @@ object SpecRestGenerated {
           case Some(VSet(_))              => None
           case Some(VEntityWith(_, _, _)) => None
         }
-      case (s, st, env, UnNeg(e, uy)) =>
+      case (s, st, env, UnNeg(e, uz)) =>
         eval(s, st, env, e) match {
           case None                       => None
           case Some(VBool(_))             => None
@@ -3745,7 +3854,7 @@ object SpecRestGenerated {
           case Some(VSet(_))              => None
           case Some(VEntityWith(_, _, _)) => None
         }
-      case (s, st, env, BoolBin(op, l, r, uz)) =>
+      case (s, st, env, BoolBin(op, l, r, va)) =>
         (eval(s, st, env, l), eval(s, st, env, r)) match {
           case (None, _)              => None
           case (Some(VBool(_)), None) => None
@@ -3764,16 +3873,16 @@ object SpecRestGenerated {
           case (Some(VSet(_)), _)                           => None
           case (Some(VEntityWith(_, _, _)), _)              => None
         }
-      case (s, st, env, Arith(op, l, r, va)) =>
+      case (s, st, env, Arith(op, l, r, vb)) =>
         eval_arith(op, eval(s, st, env, l), eval(s, st, env, r))
-      case (s, st, env, Cmp(op, l, r, vb)) =>
+      case (s, st, env, Cmp(op, l, r, vc)) =>
         eval_cmp(op, eval(s, st, env, l), eval(s, st, env, r))
-      case (s, st, env, LetIn(x, v, body, vc)) =>
+      case (s, st, env, LetIn(x, v, body, vd)) =>
         eval(s, st, env, v) match {
           case None     => None
           case Some(va) => eval(s, st, (x, va) :: env, body)
         }
-      case (s, st, env, EnumAccess(en, mem, vd)) =>
+      case (s, st, env, EnumAccess(en, mem, ve)) =>
         schema_lookup_enum(s, en) match {
           case None => None
           case Some(d) =>
@@ -3782,7 +3891,7 @@ object SpecRestGenerated {
               case false => None
             }
         }
-      case (s, st, env, Member(elem, rel_name, ve)) =>
+      case (s, st, env, Member(elem, rel_name, vf)) =>
         eval(s, st, env, elem) match {
           case None => None
           case Some(v) =>
@@ -3792,38 +3901,38 @@ object SpecRestGenerated {
                 Some[ir_value](VBool(contains_value(rel_dom, v)))
             }
         }
-      case (s, st, env, ForallEnum(vara, en, body, vf)) =>
+      case (s, st, env, ForallEnum(vara, en, body, vg)) =>
         schema_lookup_enum(s, en) match {
           case None => None
           case Some(d) =>
             eval_forall_enum(s, st, env, vara, en, enm_members[Unit](d), body)
         }
-      case (s, st, env, ForallRel(vara, rel_name, body, vg)) =>
+      case (s, st, env, ForallRel(vara, rel_name, body, vh)) =>
         state_relation_domain(st, rel_name) match {
           case None          => None
           case Some(rel_dom) => eval_forall_rel(s, st, env, vara, rel_dom, body)
         }
-      case (s, st, env, Prime(e, vh)) => eval(s, st, env, e)
-      case (s, st, env, Pre(e, vi))   => eval(s, st, env, e)
-      case (s, st, env, CardRel(rel_name, vj)) =>
+      case (s, st, env, Prime(e, vi)) => eval(s, st, env, e)
+      case (s, st, env, Pre(e, vj))   => eval(s, st, env, e)
+      case (s, st, env, CardRel(rel_name, vk)) =>
         state_relation_domain(st, rel_name) match {
           case None => None
           case Some(rel_dom) =>
             Some[ir_value](VInt(int_of_nat(size_list[ir_value](rel_dom))))
         }
-      case (s, st, env, IndexRel(base, key, vk)) =>
+      case (s, st, env, IndexRel(base, key, vl)) =>
         (peel_relation_ref(base), eval(s, st, env, key)) match {
           case (None, _)            => None
           case (Some(_), None)      => None
           case (Some(rel), Some(a)) => state_lookup_key(st, rel, a)
         }
-      case (s, st, env, FieldAccess(base, fname, vl)) =>
+      case (s, st, env, FieldAccess(base, fname, vm)) =>
         eval(s, st, env, base) match {
           case None    => None
           case Some(v) => value_field_lookup(st, v, fname)
         }
-      case (s, st, env, SetEmpty(vm)) => Some[ir_value](VSet(Nil))
-      case (s, st, env, SetInsert(elem, set_e, vn)) =>
+      case (s, st, env, SetEmpty(vn)) => Some[ir_value](VSet(Nil))
+      case (s, st, env, SetInsert(elem, set_e, vo)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
           case (None, _)                      => None
           case (Some(_), None)                => None
@@ -3836,7 +3945,7 @@ object SpecRestGenerated {
             Some[ir_value](VSet(dedupe_values(v :: members)))
           case (Some(_), Some(VEntityWith(_, _, _))) => None
         }
-      case (s, st, env, SetMember(elem, set_e, vo)) =>
+      case (s, st, env, SetMember(elem, set_e, vp)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
           case (None, _)                      => None
           case (Some(_), None)                => None
@@ -3849,9 +3958,9 @@ object SpecRestGenerated {
             Some[ir_value](VBool(contains_value(members, v)))
           case (Some(_), Some(VEntityWith(_, _, _))) => None
         }
-      case (s, st, env, SetBin(op, l, r, vp)) =>
+      case (s, st, env, SetBin(op, l, r, vq)) =>
         eval_set_bin(op, eval(s, st, env, l), eval(s, st, env, r))
-      case (s, st, env, WithRec(base, fld, value_e, vq)) =>
+      case (s, st, env, WithRec(base, fld, value_e, vr)) =>
         (eval(s, st, env, base), eval(s, st, env, value_e)) match {
           case (None, _)           => None
           case (Some(_), None)     => None
@@ -4967,47 +5076,48 @@ object SpecRestGenerated {
   def translate(x0: expr): smt_term = x0 match {
     case BoolLit(b, uu)                 => BLit(b)
     case IntLit(n, uv)                  => ILit(n)
-    case Ident(x, uw)                   => TVar(x)
-    case UnNot(e, ux)                   => TNot(translate(e))
-    case UnNeg(e, uy)                   => TNeg(translate(e))
-    case BoolBin(AndOp(), l, r, uz)     => TAnd(translate(l), translate(r))
-    case BoolBin(OrOp(), l, r, va)      => TOr(translate(l), translate(r))
-    case BoolBin(ImpliesOp(), l, r, vb) => TImplies(translate(l), translate(r))
-    case BoolBin(IffOp(), l, r, vc) =>
+    case RealLit(r, uw)                 => RLit(r)
+    case Ident(x, ux)                   => TVar(x)
+    case UnNot(e, uy)                   => TNot(translate(e))
+    case UnNeg(e, uz)                   => TNeg(translate(e))
+    case BoolBin(AndOp(), l, r, va)     => TAnd(translate(l), translate(r))
+    case BoolBin(OrOp(), l, r, vb)      => TOr(translate(l), translate(r))
+    case BoolBin(ImpliesOp(), l, r, vc) => TImplies(translate(l), translate(r))
+    case BoolBin(IffOp(), l, r, vd) =>
       TAnd(TImplies(translate(l), translate(r)), TImplies(translate(r), translate(l)))
-    case Arith(AddOp(), l, r, vd) => TAdd(translate(l), translate(r))
-    case Arith(SubOp(), l, r, ve) => TSub(translate(l), translate(r))
-    case Arith(MulOp(), l, r, vf) => TMul(translate(l), translate(r))
-    case Arith(DivOp(), l, r, vg) => TDiv(translate(l), translate(r))
-    case Cmp(EqOp(), l, r, vh)    => TEq(translate(l), translate(r))
-    case Cmp(NeqOp(), l, r, vi)   => TNot(TEq(translate(l), translate(r)))
-    case Cmp(LtOp(), l, r, vj)    => TLt(translate(l), translate(r))
-    case Cmp(LeOp(), l, r, vk) =>
+    case Arith(AddOp(), l, r, ve) => TAdd(translate(l), translate(r))
+    case Arith(SubOp(), l, r, vf) => TSub(translate(l), translate(r))
+    case Arith(MulOp(), l, r, vg) => TMul(translate(l), translate(r))
+    case Arith(DivOp(), l, r, vh) => TDiv(translate(l), translate(r))
+    case Cmp(EqOp(), l, r, vi)    => TEq(translate(l), translate(r))
+    case Cmp(NeqOp(), l, r, vj)   => TNot(TEq(translate(l), translate(r)))
+    case Cmp(LtOp(), l, r, vk)    => TLt(translate(l), translate(r))
+    case Cmp(LeOp(), l, r, vl) =>
       TOr(TLt(translate(l), translate(r)), TEq(translate(l), translate(r)))
-    case Cmp(GtOp(), l, r, vl) => TLt(translate(r), translate(l))
-    case Cmp(GeOp(), l, r, vm) =>
+    case Cmp(GtOp(), l, r, vm) => TLt(translate(r), translate(l))
+    case Cmp(GeOp(), l, r, vn) =>
       TOr(TLt(translate(r), translate(l)), TEq(translate(l), translate(r)))
-    case LetIn(x, v, body, vn)          => TLetIn(x, translate(v), translate(body))
-    case EnumAccess(en, mem, vo)        => EnumElemConst(en, mem)
-    case Member(elem, rel_name, vp)     => TInDom(rel_name, translate(elem))
-    case ForallEnum(vara, en, body, vq) => TForallEnum(vara, en, translate(body))
-    case ForallRel(vara, rel_n, body, vr) =>
+    case LetIn(x, v, body, vo)          => TLetIn(x, translate(v), translate(body))
+    case EnumAccess(en, mem, vp)        => EnumElemConst(en, mem)
+    case Member(elem, rel_name, vq)     => TInDom(rel_name, translate(elem))
+    case ForallEnum(vara, en, body, vr) => TForallEnum(vara, en, translate(body))
+    case ForallRel(vara, rel_n, body, vs) =>
       TForallRel(vara, rel_n, translate(body))
-    case Prime(e, vs)                 => TPrime(translate(e))
-    case Pre(e, vt)                   => TPre(translate(e))
-    case CardRel(rel_name, vu)        => TCardRel(rel_name)
-    case IndexRel(base, key, vv)      => TIndexRel(translate(base), translate(key))
-    case FieldAccess(base, fname, vw) => TFieldAccess(translate(base), fname)
-    case SetEmpty(vx)                 => TSetEmpty()
-    case SetInsert(elem, set_e, vy) =>
+    case Prime(e, vt)                 => TPrime(translate(e))
+    case Pre(e, vu)                   => TPre(translate(e))
+    case CardRel(rel_name, vv)        => TCardRel(rel_name)
+    case IndexRel(base, key, vw)      => TIndexRel(translate(base), translate(key))
+    case FieldAccess(base, fname, vx) => TFieldAccess(translate(base), fname)
+    case SetEmpty(vy)                 => TSetEmpty()
+    case SetInsert(elem, set_e, vz) =>
       TSetInsert(translate(elem), translate(set_e))
-    case SetMember(elem, set_e, vz) =>
+    case SetMember(elem, set_e, wa) =>
       TSetMember(translate(elem), translate(set_e))
-    case SetBin(UnionOp(), l, r, wa) => TSetUnion(translate(l), translate(r))
-    case SetBin(IntersectOp(), l, r, wb) =>
+    case SetBin(UnionOp(), l, r, wb) => TSetUnion(translate(l), translate(r))
+    case SetBin(IntersectOp(), l, r, wc) =>
       TSetIntersect(translate(l), translate(r))
-    case SetBin(DiffOp(), l, r, wc) => TSetDiff(translate(l), translate(r))
-    case WithRec(base, fld, val_e, wd) =>
+    case SetBin(DiffOp(), l, r, wd) => TSetDiff(translate(l), translate(r))
+    case WithRec(base, fld, val_e, we) =>
       TWithRec(translate(base), fld, translate(val_e))
   }
 
@@ -6591,12 +6701,6 @@ object SpecRestGenerated {
 
   def literalLength(s: String): nat =
     size_list[BigInt](Str_Literal.asciisOfLiteral(s))
-
-  def power[A: power](a: A, n: nat): A =
-    equal_nat(n, zero_nat) match {
-      case true  => one[A]
-      case false => times[A](a, power[A](a, minus_nat(n, one_nat)))
-    }
 
   def typeWalkFuel(aliases: List[type_alias_decl_full]): nat =
     plus_nat(size_list[type_alias_decl_full](aliases), nat_of_integer(BigInt(100)))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -1937,9 +1937,52 @@ object SpecRestGenerated {
         }
       case (m, env, TEq(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
-          case (None, _)          => None
-          case (Some(_), None)    => None
-          case (Some(a), Some(b)) => Some[smt_val](SBool(equal_smt_vala(a, b)))
+          case (None, _)              => None
+          case (Some(SBool(_)), None) => None
+          case (Some(SBool(bool)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SBool(bool), b)))
+          case (Some(SInt(_)), None) => None
+          case (Some(SInt(a)), Some(SBool(bool))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SBool(bool))))
+          case (Some(SInt(a)), Some(SInt(intb))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SInt(intb))))
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            Some[smt_val](SBool(equal_rat(of_int(a), b)))
+          case (Some(SInt(a)), Some(SEnumElem(literal1, literal2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SEnumElem(literal1, literal2))))
+          case (Some(SInt(a)), Some(SEntityElem(literal1, literal2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SEntityElem(literal1, literal2))))
+          case (Some(SInt(a)), Some(SSet(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SSet(list))))
+          case (Some(SInt(a)), Some(SEntityWith(smt_val1, literal, smt_val2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SEntityWith(smt_val1, literal, smt_val2))))
+          case (Some(SReal(_)), None) => None
+          case (Some(SReal(a)), Some(SBool(bool))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SBool(bool))))
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            Some[smt_val](SBool(equal_rat(a, of_int(b))))
+          case (Some(SReal(a)), Some(SReal(ratb))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SReal(ratb))))
+          case (Some(SReal(a)), Some(SEnumElem(literal1, literal2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SEnumElem(literal1, literal2))))
+          case (Some(SReal(a)), Some(SEntityElem(literal1, literal2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SEntityElem(literal1, literal2))))
+          case (Some(SReal(a)), Some(SSet(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SSet(list))))
+          case (Some(SReal(a)), Some(SEntityWith(smt_val1, literal, smt_val2))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SEntityWith(smt_val1, literal, smt_val2))))
+          case (Some(SEnumElem(_, _)), None) => None
+          case (Some(SEnumElem(literal1, literal2)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SEnumElem(literal1, literal2), b)))
+          case (Some(SEntityElem(_, _)), None) => None
+          case (Some(SEntityElem(literal1, literal2)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SEntityElem(literal1, literal2), b)))
+          case (Some(SSet(_)), None) => None
+          case (Some(SSet(list)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SSet(list), b)))
+          case (Some(SEntityWith(_, _, _)), None) => None
+          case (Some(SEntityWith(smt_val1, literal, smt_val2)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SEntityWith(smt_val1, literal, smt_val2), b)))
         }
       case (m, env, TLt(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -1949,14 +1992,16 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SBool(less_int(a, b)))
-          case (Some(SInt(_)), Some(SReal(_)))             => None
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            Some[smt_val](SBool(less_rat(of_int(a), b)))
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
-          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            Some[smt_val](SBool(less_rat(a, of_int(b))))
           case (Some(SReal(a)), Some(SReal(b))) =>
             Some[smt_val](SBool(less_rat(a, b)))
           case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
@@ -1987,14 +2032,16 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(plus_int(a, b)))
-          case (Some(SInt(_)), Some(SReal(_)))             => None
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(plus_rat(of_int(a), b)))
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
-          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            Some[smt_val](SReal(plus_rat(a, of_int(b))))
           case (Some(SReal(a)), Some(SReal(b))) =>
             Some[smt_val](SReal(plus_rat(a, b)))
           case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
@@ -2014,14 +2061,16 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(minus_int(a, b)))
-          case (Some(SInt(_)), Some(SReal(_)))             => None
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(minus_rat(of_int(a), b)))
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
-          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            Some[smt_val](SReal(minus_rat(a, of_int(b))))
           case (Some(SReal(a)), Some(SReal(b))) =>
             Some[smt_val](SReal(minus_rat(a, b)))
           case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
@@ -2041,14 +2090,16 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SBool(_))) => None
           case (Some(SInt(a)), Some(SInt(b))) =>
             Some[smt_val](SInt(times_inta(a, b)))
-          case (Some(SInt(_)), Some(SReal(_)))             => None
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            Some[smt_val](SReal(times_rat(of_int(a), b)))
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
-          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            Some[smt_val](SReal(times_rat(a, of_int(b))))
           case (Some(SReal(a)), Some(SReal(b))) =>
             Some[smt_val](SReal(times_rat(a, b)))
           case (Some(SReal(_)), Some(SEnumElem(_, _)))      => None
@@ -2071,14 +2122,22 @@ object SpecRestGenerated {
               case true  => None
               case false => Some[smt_val](SInt(divide_int(a, b)))
             }
-          case (Some(SInt(_)), Some(SReal(_)))             => None
+          case (Some(SInt(a)), Some(SReal(b))) =>
+            equal_rat(b, zero_rat) match {
+              case true  => None
+              case false => Some[smt_val](SReal(divide_rat(of_int(a), b)))
+            }
           case (Some(SInt(_)), Some(SEnumElem(_, _)))      => None
           case (Some(SInt(_)), Some(SEntityElem(_, _)))    => None
           case (Some(SInt(_)), Some(SSet(_)))              => None
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
-          case (Some(SReal(_)), Some(SInt(_)))             => None
+          case (Some(SReal(a)), Some(SInt(b))) =>
+            equal_int(b, zero_int) match {
+              case true  => None
+              case false => Some[smt_val](SReal(divide_rat(a, of_int(b))))
+            }
           case (Some(SReal(a)), Some(SReal(b))) =>
             equal_rat(b, zero_rat) match {
               case true  => None
@@ -3527,11 +3586,32 @@ object SpecRestGenerated {
           case true  => None
           case false => Some[ir_value](VReal(divide_rat(a, b)))
         }
+      case (AddOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(plus_rat(of_int(a), b)))
+      case (AddOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VReal(plus_rat(a, of_int(b))))
+      case (SubOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(minus_rat(of_int(a), b)))
+      case (SubOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VReal(minus_rat(a, of_int(b))))
+      case (MulOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VReal(times_rat(of_int(a), b)))
+      case (MulOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VReal(times_rat(a, of_int(b))))
+      case (DivOp(), Some(VInt(a)), Some(VReal(b))) =>
+        equal_rat(b, zero_rat) match {
+          case true  => None
+          case false => Some[ir_value](VReal(divide_rat(of_int(a), b)))
+        }
+      case (DivOp(), Some(VReal(a)), Some(VInt(b))) =>
+        equal_int(b, zero_int) match {
+          case true  => None
+          case false => Some[ir_value](VReal(divide_rat(a, of_int(b))))
+        }
       case (SubOp(), None, uw)                                       => None
       case (SubOp(), Some(VBool(va)), uw)                            => None
       case (SubOp(), Some(VReal(va)), None)                          => None
       case (SubOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (SubOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (SubOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (SubOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (SubOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3542,7 +3622,6 @@ object SpecRestGenerated {
       case (SubOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (SubOp(), uv, None)                                       => None
       case (SubOp(), uv, Some(VBool(va)))                            => None
-      case (SubOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (SubOp(), uv, Some(VEnum(va, vb)))                        => None
       case (SubOp(), uv, Some(VEntity(va, vb)))                      => None
       case (SubOp(), uv, Some(VSet(va)))                             => None
@@ -3551,7 +3630,6 @@ object SpecRestGenerated {
       case (MulOp(), Some(VBool(va)), uw)                            => None
       case (MulOp(), Some(VReal(va)), None)                          => None
       case (MulOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (MulOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (MulOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (MulOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (MulOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3562,7 +3640,6 @@ object SpecRestGenerated {
       case (MulOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (MulOp(), uv, None)                                       => None
       case (MulOp(), uv, Some(VBool(va)))                            => None
-      case (MulOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (MulOp(), uv, Some(VEnum(va, vb)))                        => None
       case (MulOp(), uv, Some(VEntity(va, vb)))                      => None
       case (MulOp(), uv, Some(VSet(va)))                             => None
@@ -3571,7 +3648,6 @@ object SpecRestGenerated {
       case (DivOp(), Some(VBool(va)), uw)                            => None
       case (DivOp(), Some(VReal(va)), None)                          => None
       case (DivOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (DivOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (DivOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (DivOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (DivOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3582,7 +3658,6 @@ object SpecRestGenerated {
       case (DivOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (DivOp(), uv, None)                                       => None
       case (DivOp(), uv, Some(VBool(va)))                            => None
-      case (DivOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (DivOp(), uv, Some(VEnum(va, vb)))                        => None
       case (DivOp(), uv, Some(VEntity(va, vb)))                      => None
       case (DivOp(), uv, Some(VSet(va)))                             => None
@@ -3591,7 +3666,6 @@ object SpecRestGenerated {
       case (uu, Some(VBool(va)), uw)                                 => None
       case (uu, Some(VReal(va)), None)                               => None
       case (uu, Some(VReal(va)), Some(VBool(vb)))                    => None
-      case (uu, Some(VReal(va)), Some(VInt(vb)))                     => None
       case (uu, Some(VReal(va)), Some(VEnum(vb, vc)))                => None
       case (uu, Some(VReal(va)), Some(VEntity(vb, vc)))              => None
       case (uu, Some(VReal(va)), Some(VSet(vb)))                     => None
@@ -3602,7 +3676,6 @@ object SpecRestGenerated {
       case (uu, Some(VEntityWith(va, vb, vc)), uw)                   => None
       case (uu, uv, None)                                            => None
       case (uu, uv, Some(VBool(va)))                                 => None
-      case (uu, Some(VInt(vb)), Some(VReal(va)))                     => None
       case (uu, uv, Some(VEnum(va, vb)))                             => None
       case (uu, uv, Some(VEntity(va, vb)))                           => None
       case (uu, uv, Some(VSet(va)))                                  => None
@@ -3620,12 +3693,33 @@ object SpecRestGenerated {
     less_eq_int(times_inta(a, d), times_inta(c, b))
   }
 
+  def ir_val_eq(x: ir_value, y: ir_value): Boolean =
+    (x, y) match {
+      case (VBool(_), _)                    => equal_ir_valuea(x, y)
+      case (VInt(_), VBool(_))              => equal_ir_valuea(x, y)
+      case (VInt(_), VInt(_))               => equal_ir_valuea(x, y)
+      case (VInt(a), VReal(b))              => equal_rat(of_int(a), b)
+      case (VInt(_), VEnum(_, _))           => equal_ir_valuea(x, y)
+      case (VInt(_), VEntity(_, _))         => equal_ir_valuea(x, y)
+      case (VInt(_), VSet(_))               => equal_ir_valuea(x, y)
+      case (VInt(_), VEntityWith(_, _, _))  => equal_ir_valuea(x, y)
+      case (VReal(_), VBool(_))             => equal_ir_valuea(x, y)
+      case (VReal(a), VInt(b))              => equal_rat(a, of_int(b))
+      case (VReal(_), VReal(_))             => equal_ir_valuea(x, y)
+      case (VReal(_), VEnum(_, _))          => equal_ir_valuea(x, y)
+      case (VReal(_), VEntity(_, _))        => equal_ir_valuea(x, y)
+      case (VReal(_), VSet(_))              => equal_ir_valuea(x, y)
+      case (VReal(_), VEntityWith(_, _, _)) => equal_ir_valuea(x, y)
+      case (VEnum(_, _), _)                 => equal_ir_valuea(x, y)
+      case (VEntity(_, _), _)               => equal_ir_valuea(x, y)
+      case (VSet(_), _)                     => equal_ir_valuea(x, y)
+      case (VEntityWith(_, _, _), _)        => equal_ir_valuea(x, y)
+    }
+
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
     (uu, uv, uw) match {
-      case (EqOp(), Some(a), Some(b)) =>
-        Some[ir_value](VBool(equal_ir_valuea(a, b)))
-      case (NeqOp(), Some(a), Some(b)) =>
-        Some[ir_value](VBool(!equal_ir_valuea(a, b)))
+      case (EqOp(), Some(a), Some(b))  => Some[ir_value](VBool(ir_val_eq(a, b)))
+      case (NeqOp(), Some(a), Some(b)) => Some[ir_value](VBool(!ir_val_eq(a, b)))
       case (LtOp(), Some(VInt(a)), Some(VInt(b))) =>
         Some[ir_value](VBool(less_int(a, b)))
       case (LeOp(), Some(VInt(a)), Some(VInt(b))) =>
@@ -3642,13 +3736,28 @@ object SpecRestGenerated {
         Some[ir_value](VBool(less_rat(b, a)))
       case (GeOp(), Some(VReal(a)), Some(VReal(b))) =>
         Some[ir_value](VBool(less_eq_rat(b, a)))
+      case (LtOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_rat(of_int(a), b)))
+      case (LtOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VBool(less_rat(a, of_int(b))))
+      case (LeOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_eq_rat(of_int(a), b)))
+      case (LeOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VBool(less_eq_rat(a, of_int(b))))
+      case (GtOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_rat(b, of_int(a))))
+      case (GtOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VBool(less_rat(of_int(b), a)))
+      case (GeOp(), Some(VInt(a)), Some(VReal(b))) =>
+        Some[ir_value](VBool(less_eq_rat(b, of_int(a))))
+      case (GeOp(), Some(VReal(a)), Some(VInt(b))) =>
+        Some[ir_value](VBool(less_eq_rat(of_int(b), a)))
       case (NeqOp(), None, uw)                                      => None
       case (NeqOp(), uv, None)                                      => None
       case (LtOp(), None, uw)                                       => None
       case (LtOp(), Some(VBool(va)), uw)                            => None
       case (LtOp(), Some(VReal(va)), None)                          => None
       case (LtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (LtOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (LtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (LtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (LtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3659,7 +3768,6 @@ object SpecRestGenerated {
       case (LtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (LtOp(), uv, None)                                       => None
       case (LtOp(), uv, Some(VBool(va)))                            => None
-      case (LtOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (LtOp(), uv, Some(VEnum(va, vb)))                        => None
       case (LtOp(), uv, Some(VEntity(va, vb)))                      => None
       case (LtOp(), uv, Some(VSet(va)))                             => None
@@ -3668,7 +3776,6 @@ object SpecRestGenerated {
       case (LeOp(), Some(VBool(va)), uw)                            => None
       case (LeOp(), Some(VReal(va)), None)                          => None
       case (LeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (LeOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (LeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (LeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (LeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3679,7 +3786,6 @@ object SpecRestGenerated {
       case (LeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (LeOp(), uv, None)                                       => None
       case (LeOp(), uv, Some(VBool(va)))                            => None
-      case (LeOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (LeOp(), uv, Some(VEnum(va, vb)))                        => None
       case (LeOp(), uv, Some(VEntity(va, vb)))                      => None
       case (LeOp(), uv, Some(VSet(va)))                             => None
@@ -3688,7 +3794,6 @@ object SpecRestGenerated {
       case (GtOp(), Some(VBool(va)), uw)                            => None
       case (GtOp(), Some(VReal(va)), None)                          => None
       case (GtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (GtOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (GtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (GtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (GtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3699,7 +3804,6 @@ object SpecRestGenerated {
       case (GtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (GtOp(), uv, None)                                       => None
       case (GtOp(), uv, Some(VBool(va)))                            => None
-      case (GtOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (GtOp(), uv, Some(VEnum(va, vb)))                        => None
       case (GtOp(), uv, Some(VEntity(va, vb)))                      => None
       case (GtOp(), uv, Some(VSet(va)))                             => None
@@ -3708,7 +3812,6 @@ object SpecRestGenerated {
       case (GeOp(), Some(VBool(va)), uw)                            => None
       case (GeOp(), Some(VReal(va)), None)                          => None
       case (GeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (GeOp(), Some(VReal(va)), Some(VInt(vb)))                => None
       case (GeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
       case (GeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
       case (GeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
@@ -3719,7 +3822,6 @@ object SpecRestGenerated {
       case (GeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (GeOp(), uv, None)                                       => None
       case (GeOp(), uv, Some(VBool(va)))                            => None
-      case (GeOp(), Some(VInt(vb)), Some(VReal(va)))                => None
       case (GeOp(), uv, Some(VEnum(va, vb)))                        => None
       case (GeOp(), uv, Some(VEntity(va, vb)))                      => None
       case (GeOp(), uv, Some(VSet(va)))                             => None

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -39,5 +39,5 @@ object IrValueDecoder:
               if parts.length == 2 then Some(VEnum(parts(0), parts(1))) else None
             else None
           case None => None
-      case Z3Sort.SetOf(_) =>
+      case Z3Sort.Real | Z3Sort.SetOf(_) =>
         None

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -1,6 +1,7 @@
 package specrest.verify
 
 import com.microsoft.z3.Expr as Z3AstExpr
+import com.microsoft.z3.RatNum
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.z3.Z3Sort
 
@@ -39,5 +40,10 @@ object IrValueDecoder:
               if parts.length == 2 then Some(VEnum(parts(0), parts(1))) else None
             else None
           case None => None
-      case Z3Sort.Real | Z3Sort.SetOf(_) =>
+      case Z3Sort.Real =>
+        expr match
+          case r: RatNum =>
+            Some(VReal(Frct((BigInt(r.getBigIntNumerator), BigInt(r.getBigIntDenominator)))))
+          case _ => None
+      case Z3Sort.SetOf(_) =>
         None

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -198,11 +198,12 @@ private object Backend:
           val rendered = args.map(a => renderExpr(rctx, a)).toArray
           decl.asInstanceOf[FuncDecl[Sort]]
             .apply(rendered.asInstanceOf[Array[Z3AstExpr[Sort]]]*)
-    case Z3Expr.IntLit(v, _)  => rctx.ctx.mkInt(v.toString)
-    case Z3Expr.BoolLit(v, _) => rctx.ctx.mkBool(v)
-    case Z3Expr.And(args, _)  => rctx.ctx.mkAnd(args.map(a => renderBool(rctx, a))*)
-    case Z3Expr.Or(args, _)   => rctx.ctx.mkOr(args.map(a => renderBool(rctx, a))*)
-    case Z3Expr.Not(arg, _)   => rctx.ctx.mkNot(renderBool(rctx, arg))
+    case Z3Expr.IntLit(v, _)         => rctx.ctx.mkInt(v.toString)
+    case Z3Expr.RealLit(num, den, _) => rctx.ctx.mkReal(s"$num/$den")
+    case Z3Expr.BoolLit(v, _)        => rctx.ctx.mkBool(v)
+    case Z3Expr.And(args, _)         => rctx.ctx.mkAnd(args.map(a => renderBool(rctx, a))*)
+    case Z3Expr.Or(args, _)          => rctx.ctx.mkOr(args.map(a => renderBool(rctx, a))*)
+    case Z3Expr.Not(arg, _)          => rctx.ctx.mkNot(renderBool(rctx, arg))
     case Z3Expr.Implies(l, r, _) =>
       rctx.ctx.mkImplies(renderBool(rctx, l), renderBool(rctx, r))
     case Z3Expr.Cmp(op, l, r, _)           => renderCmp(rctx, op, l, r)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -3,6 +3,7 @@ package specrest.verify.z3
 import cats.effect.IO
 import cats.effect.Resource
 import com.microsoft.z3.ArithExpr
+import com.microsoft.z3.ArithSort
 import com.microsoft.z3.ArrayExpr
 import com.microsoft.z3.ArraySort
 import com.microsoft.z3.BoolExpr
@@ -10,7 +11,6 @@ import com.microsoft.z3.BoolSort
 import com.microsoft.z3.Context
 import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
-import com.microsoft.z3.IntSort
 import com.microsoft.z3.Model
 import com.microsoft.z3.Sort
 import com.microsoft.z3.Status
@@ -145,6 +145,7 @@ private def registerSort(ctx: Context, map: mutable.Map[String, Sort], s: Z3Sort
 private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3Sort): Sort =
   s match
     case Z3Sort.Int  => ctx.getIntSort
+    case Z3Sort.Real => ctx.getRealSort
     case Z3Sort.Bool => ctx.getBoolSort
     case Z3Sort.Uninterp(name) =>
       sortMap.getOrElseUpdate(Z3Sort.key(s), ctx.mkUninterpretedSort(name))
@@ -241,8 +242,8 @@ private object Backend:
   ): Z3AstExpr[ArraySort[Sort, BoolSort]] =
     renderExpr(rctx, e).asInstanceOf[Z3AstExpr[ArraySort[Sort, BoolSort]]]
 
-  private def renderArithExpr(rctx: RenderCtx, e: Z3Expr): ArithExpr[IntSort] =
-    renderExpr(rctx, e).asInstanceOf[ArithExpr[IntSort]]
+  private def renderArithExpr(rctx: RenderCtx, e: Z3Expr): ArithExpr[ArithSort] =
+    renderExpr(rctx, e).asInstanceOf[ArithExpr[ArithSort]]
 
   private def renderCmp(rctx: RenderCtx, op: CmpOp, lhs: Z3Expr, rhs: Z3Expr): BoolExpr =
     if op == CmpOp.Eq || op == CmpOp.Neq then
@@ -264,7 +265,7 @@ private object Backend:
       rctx: RenderCtx,
       op: ArithOp,
       args: List[Z3Expr]
-  ): ArithExpr[IntSort] =
+  ): ArithExpr[ArithSort] =
     if args.isEmpty then backendFail(rctx, "Arith with no args")
     val rendered = args.map(a => renderArithExpr(rctx, a))
     op match

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -3,6 +3,7 @@ package specrest.verify.z3
 import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Model
+import com.microsoft.z3.RatNum
 import com.microsoft.z3.Sort
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.DecodedConstant
@@ -124,7 +125,7 @@ object Z3CounterExample:
   private def sortToTy(sort: Z3Sort, ctx: tyctx_ext[Unit]): Option[ty] = sort match
     case Z3Sort.Bool => Some(TBool())
     case Z3Sort.Int  => Some(TInt())
-    case Z3Sort.Real => None
+    case Z3Sort.Real => Some(TReal())
     case Z3Sort.Uninterp(name) =>
       if tc_enums(ctx).contains(name) then Some(TEnum(name))
       else if tc_entities(ctx)
@@ -232,20 +233,31 @@ object Z3CounterExample:
       case None => DecodedValue("<unknown>", None)
     DecodedConstant(entry.name, side, value)
 
+  // Z3 returns Real model values as RatNum; render them readably (n or n/d).
+  private def formatReal(expr: Z3AstExpr[?]): Option[String] = expr match
+    case r: RatNum =>
+      val num = r.getBigIntNumerator
+      val den = r.getBigIntDenominator
+      Some(if den.compareTo(java.math.BigInteger.ONE) == 0 then num.toString else s"$num/$den")
+    case _ => None
+
   private def decodeValue(
       expr: Z3AstExpr[?],
       rawToLabel: mutable.LinkedHashMap[String, String]
   ): DecodedValue =
-    val text = normalizeZ3Text(expr.toString)
-    rawToLabel.get(text) match
-      case Some(label) => DecodedValue(label, Some(label))
+    formatReal(expr) match
+      case Some(r) => DecodedValue(r, None)
       case None =>
-        if text == "true" || text == "false" then DecodedValue(text, None)
-        else if text.matches("-?\\d+") then DecodedValue(text, None)
-        else
-          matchStringLiteral(text) match
-            case Some(s) => DecodedValue(s"\"$s\"", None)
-            case None    => DecodedValue(prettyUninterp(text), None)
+        val text = normalizeZ3Text(expr.toString)
+        rawToLabel.get(text) match
+          case Some(label) => DecodedValue(label, Some(label))
+          case None =>
+            if text == "true" || text == "false" then DecodedValue(text, None)
+            else if text.matches("-?\\d+") then DecodedValue(text, None)
+            else
+              matchStringLiteral(text) match
+                case Some(s) => DecodedValue(s"\"$s\"", None)
+                case None    => DecodedValue(prettyUninterp(text), None)
 
   private val NegNum       = """^\(-\s+(\d+)\)$""".r
   private val StrLit       = """^str_(\d+)$""".r

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -124,6 +124,7 @@ object Z3CounterExample:
   private def sortToTy(sort: Z3Sort, ctx: tyctx_ext[Unit]): Option[ty] = sort match
     case Z3Sort.Bool => Some(TBool())
     case Z3Sort.Int  => Some(TInt())
+    case Z3Sort.Real => None
     case Z3Sort.Uninterp(name) =>
       if tc_enums(ctx).contains(name) then Some(TEnum(name))
       else if tc_entities(ctx)

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -25,6 +25,7 @@ object SmtLib:
 
   private def renderSort(s: Z3Sort): String = s match
     case Z3Sort.Int         => "Int"
+    case Z3Sort.Real        => "Real"
     case Z3Sort.Bool        => "Bool"
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"(Set ${renderSort(e)})"

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -41,6 +41,9 @@ object SmtLib:
       else s"($func ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.IntLit(v, _) =>
       if v.signum < 0 then s"(- ${-v})" else v.toString
+    case Z3Expr.RealLit(num, den, _) =>
+      val n = if num.signum < 0 then s"(- ${-num}.0)" else s"${num}.0"
+      if den == BigInt(1) then n else s"(/ $n ${den}.0)"
     case Z3Expr.BoolLit(v, _) =>
       if v then "true" else "false"
     case Z3Expr.And(args, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -635,7 +635,10 @@ object Translator:
       expr: expr_full,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr = expr match
-    case IntLitF(v, _)               => Z3Expr.IntLit(v)
+    case IntLitF(v, _) => Z3Expr.IntLit(v)
+    case FloatLitF(s, _) =>
+      val (num, den) = quotient_of(floatLitRat(s))
+      Z3Expr.RealLit(num, den)
     case BoolLitF(v, _)              => Z3Expr.BoolLit(v)
     case StringLitF(v, _)            => stringLiteralConst(ctx, v)
     case IdentifierF(name, _)        => resolveIdentifier(ctx, name, env)
@@ -1271,6 +1274,7 @@ object Translator:
           ctx.entities.get(name).flatMap(_.fields.get(field).map(_._1))
         case _ => None
     case IntLitF(_, _)                     => Some(Z3Sort.Int)
+    case FloatLitF(_, _)                   => Some(Z3Sort.Real)
     case BoolLitF(_, _)                    => Some(Z3Sort.Bool)
     case StringLitF(_, _)                  => Some(Z3Sort.Uninterp(StringSortName))
     case CallF(IdentifierF(name, _), _, _) => Some(callReturnSort(name, ctx))
@@ -1285,10 +1289,11 @@ object Translator:
   // treat `None` as "optimistically numeric" (which is how an ill-sorted operand
   // could otherwise slip past the numeric guards).
   private def inferSortOfZ3Expr(ctx: TranslateCtx, e: Z3Expr): Option[Z3Sort] = e match
-    case Z3Expr.Var(_, sort, _) => Some(sort)
-    case Z3Expr.IntLit(_, _)    => Some(Z3Sort.Int)
-    case Z3Expr.BoolLit(_, _)   => Some(Z3Sort.Bool)
-    case Z3Expr.App(func, _, _) => ctx.funcs.get(func).map(_.resultSort)
+    case Z3Expr.Var(_, sort, _)  => Some(sort)
+    case Z3Expr.IntLit(_, _)     => Some(Z3Sort.Int)
+    case Z3Expr.RealLit(_, _, _) => Some(Z3Sort.Real)
+    case Z3Expr.BoolLit(_, _)    => Some(Z3Sort.Bool)
+    case Z3Expr.App(func, _, _)  => ctx.funcs.get(func).map(_.resultSort)
     case Z3Expr.And(_, _) | Z3Expr.Or(_, _) | Z3Expr.Not(_, _) | Z3Expr.Implies(_, _, _) |
         Z3Expr.Cmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
       Some(Z3Sort.Bool)
@@ -1960,8 +1965,11 @@ object Translator:
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
     term match
-      case BLit(b)    => Z3Expr.BoolLit(b)
-      case ILit(n)    => Z3Expr.IntLit(n)
+      case BLit(b) => Z3Expr.BoolLit(b)
+      case ILit(n) => Z3Expr.IntLit(n)
+      case RLit(r) =>
+        val (num, den) = quotient_of(r)
+        Z3Expr.RealLit(num, den)
       case TVar(name) => resolveIdentifier(ctx, name, env)
       case EnumElemConst(en, mem) =>
         val funcName = s"${en}_$mem"

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -316,11 +316,23 @@ object Translator:
         ctx.declareSort(sort)
         ctx.typeAliases(talName(t)) = TypeAliasInfo(sort)
 
+  // Z3 sort policy for the spec's built-in primitives. This is irreducibly
+  // verify-local: the proof's `ty` has only TInt/TBool (no fractional sort) and
+  // its numeric classifier lumps integral with fractional, so the Int-vs-Real
+  // split cannot be derived upstream. Integral and temporal types share Int
+  // (temporal values are epoch seconds); fractional types use Real. String and
+  // other opaque primitives are absent here and fall to uninterpreted in
+  // sortForNamedType (where String-refinement aliases get their own handling).
+  private def primitiveSortOf(name: String): Option[Z3Sort] = name match
+    case "Int" | "DateTime" | "Date"   => Some(Z3Sort.Int)
+    case "Float" | "Decimal" | "Money" => Some(Z3Sort.Real)
+    case "Bool" | "Boolean"            => Some(Z3Sort.Bool)
+    case _                             => None
+
   private def primitiveUnderlyingSort(t: type_alias_decl_full): Option[Z3Sort] =
     talType(t) match
-      case NamedTypeF("Int", _)  => Some(Z3Sort.Int)
-      case NamedTypeF("Bool", _) => Some(Z3Sort.Bool)
-      case _                     => None
+      case NamedTypeF(n, _) => primitiveSortOf(n)
+      case _                => None
 
   private def emitTypeAliasConstraint(ctx: TranslateCtx, t: type_alias_decl_full): Unit =
     talConstraint(t) match
@@ -334,6 +346,12 @@ object Translator:
           val env     = mutable.Map.empty[String, Z3Expr]
           env("value") = selfRef
           val body = translateExpr(ctx, constraint, env)
+          if inferSortOfZ3Expr(ctx, body).exists(_ != Z3Sort.Bool) then
+            fail(
+              ctx,
+              s"refinement on '${talName(t)}' is not a boolean predicate the verifier can model " +
+                "(it calls an undeclared/strategy-backed predicate)"
+            )
           ctx.assertions += Z3Expr.Quantifier(
             QKind.ForAll,
             List(Z3Binding(varName, sort)),
@@ -581,22 +599,23 @@ object Translator:
 
   private def sortNameOf(s: Z3Sort): String = s match
     case Z3Sort.Int         => "Int"
+    case Z3Sort.Real        => "Real"
     case Z3Sort.Bool        => "Bool"
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"Set_${sortNameOf(e)}"
 
-  private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort = name match
-    case "Int"    => Z3Sort.Int
-    case "Bool"   => Z3Sort.Bool
-    case "String" => Z3Sort.Uninterp(StringSortName)
-    case _ =>
-      ctx.entities.get(name).map(_.sort).orElse {
-        ctx.enums.get(name).map(_.sort)
-      }.orElse {
-        ctx.primitiveAliases.get(name).map(_.underlyingSort)
-      }.orElse {
-        ctx.typeAliases.get(name).map(_.sort)
-      }.getOrElse(Z3Sort.Uninterp(name))
+  private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort =
+    primitiveSortOf(name).getOrElse:
+      name match
+        case "String" => Z3Sort.Uninterp(StringSortName)
+        case _ =>
+          ctx.entities.get(name).map(_.sort).orElse {
+            ctx.enums.get(name).map(_.sort)
+          }.orElse {
+            ctx.primitiveAliases.get(name).map(_.underlyingSort)
+          }.orElse {
+            ctx.typeAliases.get(name).map(_.sort)
+          }.getOrElse(Z3Sort.Uninterp(name))
 
   def translateExpr(ctx: TranslateCtx, expr: expr_full, env: mutable.Map[String, Z3Expr]): Z3Expr =
     val enums = ctx.enums.keys.toList
@@ -679,32 +698,23 @@ object Translator:
       case BImplies() => Z3Expr.Implies(left, right)
       case BIff() =>
         Z3Expr.And(List(Z3Expr.Implies(left, right), Z3Expr.Implies(right, left)))
-      case BEq() | BNeq() | BLt() | BLe() | BGt() | BGe() =>
+      case BEq() | BNeq() =>
+        Z3Expr.Cmp(if isEq then CmpOp.Eq else CmpOp.Neq, left, right)
+      case BLt() | BLe() | BGt() | BGe() =>
+        requireNumericOperands(ctx, op, leftExpr, rightExpr, left, right, env)
         val cmp = op match
-          case BEq()  => CmpOp.Eq
-          case BNeq() => CmpOp.Neq
-          case BLt()  => CmpOp.Lt
-          case BLe()  => CmpOp.Le
-          case BGt()  => CmpOp.Gt
-          case BGe()  => CmpOp.Ge
-          case _      => CmpOp.Eq
+          case BLt() => CmpOp.Lt
+          case BLe() => CmpOp.Le
+          case BGt() => CmpOp.Gt
+          case _     => CmpOp.Ge
         Z3Expr.Cmp(cmp, left, right)
       case BAdd() | BSub() | BMul() | BDiv() =>
-        val leftSort  = inferSort(ctx, leftExpr, env, Some(left))
-        val rightSort = inferSort(ctx, rightExpr, env, Some(right))
-        val leftBad   = leftSort.exists(_ != Z3Sort.Int)
-        val rightBad  = rightSort.exists(_ != Z3Sort.Int)
-        if leftBad || rightBad then
-          fail(
-            ctx,
-            s"arithmetic operator '${binOpToTs(op)}' is only supported on integers (deferred for string/set arithmetic)"
-          )
+        requireNumericOperands(ctx, op, leftExpr, rightExpr, left, right, env)
         val aop = op match
           case BAdd() => ArithOp.Add
           case BSub() => ArithOp.Sub
           case BMul() => ArithOp.Mul
-          case BDiv() => ArithOp.Div
-          case _      => ArithOp.Add
+          case _      => ArithOp.Div
         Z3Expr.Arith(aop, List(left, right))
       case BSubset() | BUnion() | BIntersect() | BDiff() =>
         ensureSetBinOpSorts(ctx, leftExpr, rightExpr, left, right, op, env)
@@ -717,6 +727,21 @@ object Translator:
         Z3Expr.SetBinOp(sop, left, right)
       case _ =>
         fail(ctx, s"binary op '${binOpToTs(op)}' is not supported by the verifier")
+
+  private def requireNumericOperands(
+      ctx: TranslateCtx,
+      op: bin_op_full,
+      leftExpr: expr_full,
+      rightExpr: expr_full,
+      left: Z3Expr,
+      right: Z3Expr,
+      env: mutable.Map[String, Z3Expr]
+  ): Unit =
+    val leftSort  = inferSort(ctx, leftExpr, env, Some(left))
+    val rightSort = inferSort(ctx, rightExpr, env, Some(right))
+    if leftSort.exists(s => !Z3Sort.isNumeric(s)) || rightSort.exists(s => !Z3Sort.isNumeric(s))
+    then
+      fail(ctx, s"'${binOpToTs(op)}' requires numeric operands (Int or Real)")
 
   private def ensureSetBinOpSorts(
       ctx: TranslateCtx,
@@ -1058,9 +1083,9 @@ object Translator:
         fail(ctx, "higher-order call (non-identifier callee) is not supported by the verifier")
 
   private def callReturnSort(name: String, ctx: TranslateCtx): Z3Sort = name match
-    case "len"                               => Z3Sort.Int
-    case n if ctx.predicateNames.contains(n) => Z3Sort.Bool
-    case _                                   => Z3Sort.Uninterp("Any")
+    case "len" | "now" | "seconds" | "minutes" | "hours" | "days" => Z3Sort.Int
+    case n if ctx.predicateNames.contains(n)                      => Z3Sort.Bool
+    case _                                                        => Z3Sort.Uninterp("Any")
 
   private def argSortsMangled(sorts: List[Z3Sort]): String =
     if sorts.isEmpty then "0" else sorts.map(sortNameOf).mkString("_")
@@ -1903,6 +1928,20 @@ object Translator:
       case _ =>
         subexprs(expr).exists(walkMentionsPost(_, stateName, insidePrime))
 
+  // Arithmetic/ordering are valid only on the verifier's numeric theory sorts
+  // (Int for integers and temporal-as-epoch, Real for Float/Decimal/Money). An
+  // operand of any other sort is outside the encodable subset, so the check is
+  // skipped rather than handed to the solver as an ill-sorted term.
+  private def encNumeric(
+      ctx: TranslateCtx,
+      term: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val z = encodeFromSmtTerm(ctx, term, env)
+    if inferSortOfZ3Expr(ctx, z).exists(s => !Z3Sort.isNumeric(s)) then
+      fail(ctx, "ordering/arithmetic requires a numeric type (Int or Real)")
+    z
+
   private def encodeFromSmtTerm(
       ctx: TranslateCtx,
       term: smt_term,
@@ -1922,9 +1961,9 @@ object Translator:
       case TNot(TEq(l, r)) =>
         Z3Expr.Cmp(CmpOp.Neq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
       case TOr(TLt(a1, b1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
-        Z3Expr.Cmp(CmpOp.Le, encodeFromSmtTerm(ctx, a1, env), encodeFromSmtTerm(ctx, b1, env))
+        Z3Expr.Cmp(CmpOp.Le, encNumeric(ctx, a1, env), encNumeric(ctx, b1, env))
       case TOr(TLt(b1, a1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
-        Z3Expr.Cmp(CmpOp.Ge, encodeFromSmtTerm(ctx, a2, env), encodeFromSmtTerm(ctx, b2, env))
+        Z3Expr.Cmp(CmpOp.Ge, encNumeric(ctx, a2, env), encNumeric(ctx, b2, env))
 
       case TNot(t) => Z3Expr.Not(encodeFromSmtTerm(ctx, t, env))
       case TAnd(l, r) =>
@@ -1936,29 +1975,17 @@ object Translator:
       case TEq(l, r) =>
         Z3Expr.Cmp(CmpOp.Eq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
       case TLt(l, r) =>
-        Z3Expr.Cmp(CmpOp.Lt, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+        Z3Expr.Cmp(CmpOp.Lt, encNumeric(ctx, l, env), encNumeric(ctx, r, env))
       case TNeg(t) =>
-        Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), encodeFromSmtTerm(ctx, t, env)))
+        Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), encNumeric(ctx, t, env)))
       case TAdd(l, r) =>
-        Z3Expr.Arith(
-          ArithOp.Add,
-          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
-        )
+        Z3Expr.Arith(ArithOp.Add, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
       case TSub(l, r) =>
-        Z3Expr.Arith(
-          ArithOp.Sub,
-          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
-        )
+        Z3Expr.Arith(ArithOp.Sub, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
       case TMul(l, r) =>
-        Z3Expr.Arith(
-          ArithOp.Mul,
-          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
-        )
+        Z3Expr.Arith(ArithOp.Mul, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
       case TDiv(l, r) =>
-        Z3Expr.Arith(
-          ArithOp.Div,
-          List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
-        )
+        Z3Expr.Arith(ArithOp.Div, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
 
       case TInDom(rel, elem) =>
         val key = encodeFromSmtTerm(ctx, elem, env)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1301,8 +1301,10 @@ object Translator:
         Z3Expr.Cmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
       Some(Z3Sort.Bool)
     case Z3Expr.Arith(_, args, _) =>
-      val argSorts = args.flatMap(inferSortOfZ3Expr(ctx, _))
-      if argSorts.contains(Z3Sort.Real) then Some(Z3Sort.Real) else argSorts.headOption
+      val argSorts = args.map(inferSortOfZ3Expr(ctx, _))
+      if argSorts.nonEmpty && argSorts.forall(_.exists(Z3Sort.isNumeric)) then
+        if argSorts.exists(_.contains(Z3Sort.Real)) then Some(Z3Sort.Real) else Some(Z3Sort.Int)
+      else None
     case Z3Expr.EmptySet(s, _)     => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetLit(s, _, _)    => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetMember(_, _, _) => Some(Z3Sort.Bool)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -637,8 +637,11 @@ object Translator:
   ): Z3Expr = expr match
     case IntLitF(v, _) => Z3Expr.IntLit(v)
     case FloatLitF(s, _) =>
-      val (num, den) = quotient_of(floatLitRat(s))
-      Z3Expr.RealLit(num, den)
+      decimalToRat(s) match
+        case Some(r) =>
+          val (num, den) = quotient_of(r)
+          Z3Expr.RealLit(num, den)
+        case None => fail(ctx, s"malformed float literal: '$s'")
     case BoolLitF(v, _)              => Z3Expr.BoolLit(v)
     case StringLitF(v, _)            => stringLiteralConst(ctx, v)
     case IdentifierF(name, _)        => resolveIdentifier(ctx, name, env)
@@ -1297,7 +1300,9 @@ object Translator:
     case Z3Expr.And(_, _) | Z3Expr.Or(_, _) | Z3Expr.Not(_, _) | Z3Expr.Implies(_, _, _) |
         Z3Expr.Cmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
       Some(Z3Sort.Bool)
-    case Z3Expr.Arith(_, args, _)  => args.headOption.flatMap(inferSortOfZ3Expr(ctx, _))
+    case Z3Expr.Arith(_, args, _) =>
+      val argSorts = args.flatMap(inferSortOfZ3Expr(ctx, _))
+      if argSorts.contains(Z3Sort.Real) then Some(Z3Sort.Real) else argSorts.headOption
     case Z3Expr.EmptySet(s, _)     => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetLit(s, _, _)    => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetMember(_, _, _) => Some(Z3Sort.Bool)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -338,20 +338,26 @@ object Translator:
     talConstraint(t) match
       case None => ()
       case Some(constraint) =>
-        if ctx.primitiveAliases.contains(talName(t)) then ()
-        else
-          val sort    = ctx.typeAliases(talName(t)).sort
-          val varName = s"self_${talName(t)}"
-          val selfRef = Z3Expr.Var(varName, sort)
-          val env     = mutable.Map.empty[String, Z3Expr]
-          env("value") = selfRef
-          val body = translateExpr(ctx, constraint, env)
-          if inferSortOfZ3Expr(ctx, body).exists(_ != Z3Sort.Bool) then
-            fail(
-              ctx,
-              s"refinement on '${talName(t)}' is not a boolean predicate the verifier can model " +
-                "(it calls an undeclared/strategy-backed predicate)"
-            )
+        val name = talName(t)
+        val sort = ctx.primitiveAliases
+          .get(name)
+          .map(_.underlyingSort)
+          .orElse(ctx.typeAliases.get(name).map(_.sort))
+          .getOrElse(Z3Sort.Uninterp(name))
+        val varName = s"self_$name"
+        val env     = mutable.Map.empty[String, Z3Expr]
+        env("value") = Z3Expr.Var(varName, sort)
+        val body = translateExpr(ctx, constraint, env)
+        if !inferSortOfZ3Expr(ctx, body).contains(Z3Sort.Bool) then
+          fail(
+            ctx,
+            s"refinement on '$name' is not a boolean predicate the verifier can model " +
+              "(it calls an undeclared/strategy-backed predicate)"
+          )
+        // Primitive-alias refinements are applied at field-use sites
+        // (refinementConstraintFor); here we only validate they are boolean.
+        // Non-primitive aliases assert the refinement as a quantified fact.
+        if !ctx.primitiveAliases.contains(name) then
           ctx.assertions += Z3Expr.Quantifier(
             QKind.ForAll,
             List(Z3Binding(varName, sort)),
@@ -737,10 +743,10 @@ object Translator:
       right: Z3Expr,
       env: mutable.Map[String, Z3Expr]
   ): Unit =
-    val leftSort  = inferSort(ctx, leftExpr, env, Some(left))
-    val rightSort = inferSort(ctx, rightExpr, env, Some(right))
-    if leftSort.exists(s => !Z3Sort.isNumeric(s)) || rightSort.exists(s => !Z3Sort.isNumeric(s))
-    then
+    val leftSort = inferSort(ctx, leftExpr, env, Some(left)).orElse(inferSortOfZ3Expr(ctx, left))
+    val rightSort =
+      inferSort(ctx, rightExpr, env, Some(right)).orElse(inferSortOfZ3Expr(ctx, right))
+    if !leftSort.exists(Z3Sort.isNumeric) || !rightSort.exists(Z3Sort.isNumeric) then
       fail(ctx, s"'${binOpToTs(op)}' requires numeric operands (Int or Real)")
 
   private def ensureSetBinOpSorts(
@@ -1275,11 +1281,18 @@ object Translator:
         case Some(Z3Expr.Var(_, sort, _)) => Some(sort)
         case _                            => None
 
+  // Total: every Z3Expr node determines its result sort, so callers never have to
+  // treat `None` as "optimistically numeric" (which is how an ill-sorted operand
+  // could otherwise slip past the numeric guards).
   private def inferSortOfZ3Expr(ctx: TranslateCtx, e: Z3Expr): Option[Z3Sort] = e match
-    case Z3Expr.Var(_, sort, _)    => Some(sort)
-    case Z3Expr.IntLit(_, _)       => Some(Z3Sort.Int)
-    case Z3Expr.BoolLit(_, _)      => Some(Z3Sort.Bool)
-    case Z3Expr.App(func, _, _)    => ctx.funcs.get(func).map(_.resultSort)
+    case Z3Expr.Var(_, sort, _) => Some(sort)
+    case Z3Expr.IntLit(_, _)    => Some(Z3Sort.Int)
+    case Z3Expr.BoolLit(_, _)   => Some(Z3Sort.Bool)
+    case Z3Expr.App(func, _, _) => ctx.funcs.get(func).map(_.resultSort)
+    case Z3Expr.And(_, _) | Z3Expr.Or(_, _) | Z3Expr.Not(_, _) | Z3Expr.Implies(_, _, _) |
+        Z3Expr.Cmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
+      Some(Z3Sort.Bool)
+    case Z3Expr.Arith(_, args, _)  => args.headOption.flatMap(inferSortOfZ3Expr(ctx, _))
     case Z3Expr.EmptySet(s, _)     => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetLit(s, _, _)    => Some(Z3Sort.SetOf(s))
     case Z3Expr.SetMember(_, _, _) => Some(Z3Sort.Bool)
@@ -1287,7 +1300,6 @@ object Translator:
       op match
         case SetOpKind.Subset                                       => Some(Z3Sort.Bool)
         case SetOpKind.Union | SetOpKind.Intersect | SetOpKind.Diff => inferSortOfZ3Expr(ctx, l)
-    case _ => None
 
   private def tryLowerDomEquality(
       ctx: TranslateCtx,
@@ -1938,7 +1950,7 @@ object Translator:
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
     val z = encodeFromSmtTerm(ctx, term, env)
-    if inferSortOfZ3Expr(ctx, z).exists(s => !Z3Sort.isNumeric(s)) then
+    if !inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric) then
       fail(ctx, "ordering/arithmetic requires a numeric type (Int or Real)")
     z
 

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -73,6 +73,7 @@ enum Z3Expr derives CanEqual:
   case Var(name: String, sort: Z3Sort, span: Option[span_t] = None)
   case App(func: String, args: List[Z3Expr], span: Option[span_t] = None)
   case IntLit(value: BigInt, span: Option[span_t] = None)
+  case RealLit(num: BigInt, den: BigInt, span: Option[span_t] = None)
   case BoolLit(value: Boolean, span: Option[span_t] = None)
   case And(args: List[Z3Expr], span: Option[span_t] = None)
   case Or(args: List[Z3Expr], span: Option[span_t] = None)
@@ -95,6 +96,7 @@ enum Z3Expr derives CanEqual:
     case e: Var        => e.span
     case e: App        => e.span
     case e: IntLit     => e.span
+    case e: RealLit    => e.span
     case e: BoolLit    => e.span
     case e: And        => e.span
     case e: Or         => e.span
@@ -115,6 +117,7 @@ enum Z3Expr derives CanEqual:
         case e: Var        => e.copy(span = s)
         case e: App        => e.copy(span = s)
         case e: IntLit     => e.copy(span = s)
+        case e: RealLit    => e.copy(span = s)
         case e: BoolLit    => e.copy(span = s)
         case e: And        => e.copy(span = s)
         case e: Or         => e.copy(span = s)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -4,6 +4,7 @@ import specrest.ir.generated.SpecRestGenerated.*
 
 enum Z3Sort derives CanEqual:
   case Int
+  case Real
   case Bool
   case Uninterp(name: String)
   case SetOf(elem: Z3Sort)
@@ -12,9 +13,14 @@ object Z3Sort:
   val IntS: Z3Sort  = Int
   val BoolS: Z3Sort = Bool
 
+  val numeric: Set[Z3Sort] = Set(Int, Real)
+
+  def isNumeric(s: Z3Sort): Boolean = numeric.contains(s)
+
   def key(s: Z3Sort): String = s match
     case Uninterp(n) => s"U:$n"
     case Int         => "Int"
+    case Real        => "Real"
     case Bool        => "Bool"
     case SetOf(e)    => s"Set(${key(e)})"
 

--- a/modules/verify/src/test/scala/specrest/verify/FloatLiteralTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/FloatLiteralTest.scala
@@ -2,7 +2,6 @@ package specrest.verify
 
 import munit.CatsEffectSuite
 import specrest.ir.generated.SpecRestGenerated.decimalToRat
-import specrest.ir.generated.SpecRestGenerated.floatLitRat
 import specrest.ir.generated.SpecRestGenerated.quotient_of
 
 class FloatLiteralTest extends CatsEffectSuite:
@@ -24,7 +23,3 @@ class FloatLiteralTest extends CatsEffectSuite:
   ).foreach: (input, expected) =>
     test(s"decimalToRat parses '$input'"):
       assertEquals(parse(input), expected)
-
-  test("floatLitRat defaults unparseable input to 0"):
-    assertEquals(quotient_of(floatLitRat("not-a-number")), (BigInt(0), BigInt(1)))
-    assertEquals(quotient_of(floatLitRat("9.5")), (BigInt(19), BigInt(2)))

--- a/modules/verify/src/test/scala/specrest/verify/FloatLiteralTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/FloatLiteralTest.scala
@@ -1,0 +1,30 @@
+package specrest.verify
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.decimalToRat
+import specrest.ir.generated.SpecRestGenerated.floatLitRat
+import specrest.ir.generated.SpecRestGenerated.quotient_of
+
+class FloatLiteralTest extends CatsEffectSuite:
+
+  private def parse(s: String): Option[(BigInt, BigInt)] =
+    decimalToRat(s).map(quotient_of)
+
+  List(
+    ("9.5", Some((BigInt(19), BigInt(2)))),
+    ("-3.25", Some((BigInt(-13), BigInt(4)))),
+    ("100", Some((BigInt(100), BigInt(1)))),
+    ("0.0", Some((BigInt(0), BigInt(1)))),
+    ("0.5", Some((BigInt(1), BigInt(2)))),
+    ("-0.25", Some((BigInt(-1), BigInt(4)))),
+    ("12.50", Some((BigInt(25), BigInt(2)))),
+    ("abc", None),
+    ("9.5.3", None),
+    ("", None)
+  ).foreach: (input, expected) =>
+    test(s"decimalToRat parses '$input'"):
+      assertEquals(parse(input), expected)
+
+  test("floatLitRat defaults unparseable input to 0"):
+    assertEquals(quotient_of(floatLitRat("not-a-number")), (BigInt(0), BigInt(1)))
+    assertEquals(quotient_of(floatLitRat("9.5")), (BigInt(19), BigInt(2)))

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -103,14 +103,17 @@ text \<open>Emit \<open>int\<close> directly as Scala \<open>BigInt\<close> inst
   morphisms, and the imported \<open>Code_Target_Int\<close> already serializes \<open>integer\<close> to
   \<open>BigInt\<close>. Collapsing \<open>int\<close> onto the same \<open>BigInt\<close> and printing the bijection as
   identity removes both conversions everywhere — the verified \<open>plus_int\<close>/\<open>equal_int\<close>
-  code equations compose into native \<open>+\<close>/\<open>==\<close>. The \<open>ord\<close> instance for \<open>int\<close> is
-  dropped because it would otherwise be a second \<open>ord[BigInt]\<close> given alongside
-  \<open>integer\<close>'s; ordering resolves through the surviving \<open>ord_integer\<close>.\<close>
+  code equations compose into native \<open>+\<close>/\<open>==\<close>. The \<open>ord\<close> and \<open>equal\<close> instances for
+  \<open>int\<close> are dropped because each would otherwise be a second \<open>ord[BigInt]\<close>/\<open>equal[BigInt]\<close>
+  given alongside \<open>integer\<close>'s (the \<open>equal\<close> clash surfaced once \<open>rat\<close>, via the \<open>VReal\<close>/\<open>SReal\<close>
+  values, made \<open>equal\<close> on \<open>int\<close> reachable); resolution falls through to the surviving
+  \<open>ord_integer\<close>/\<open>equal_integer\<close>, which are the same native \<open><\<close>/\<open>==\<close> on \<open>BigInt\<close>.\<close>
 code_printing
   type_constructor Int.int \<rightharpoonup> (Scala) "BigInt"
 | constant Code_Numeral.int_of_integer \<rightharpoonup> (Scala) "(_)"
 | constant Code_Numeral.integer_of_int \<rightharpoonup> (Scala) "(_)"
 | class_instance Int.int :: ord \<rightharpoonup> (Scala) -
+| class_instance Int.int :: equal \<rightharpoonup> (Scala) -
 
 export_code
     translate

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -1,5 +1,5 @@
 theory IR
-  imports Main
+  imports Main "HOL.Rat"
 begin
 
 datatype (plugins only: code size) span_t = SpanT int int int int
@@ -43,6 +43,7 @@ datatype (plugins only: code size) state_mode = SmPre | SmPost
 datatype (plugins only: code size) expr =
     BoolLit bool "option_span"
   | IntLit int "option_span"
+  | RealLit rat "option_span"
   | Ident "String.literal" "option_span"
   | UnNot "expr" "option_span"
   | UnNeg "expr" "option_span"

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -2,6 +2,28 @@ theory IR
   imports Main "HOL.Rat"
 begin
 
+fun asciiToIntAcc :: "integer list \<Rightarrow> int \<Rightarrow> int option" where
+  "asciiToIntAcc [] acc = Some acc"
+| "asciiToIntAcc (c # cs) acc =
+     (if 48 \<le> c \<and> c \<le> 57
+        then asciiToIntAcc cs (acc * 10 + int_of_integer (c - 48))
+        else None)"
+
+definition decimalToRat :: "String.literal \<Rightarrow> rat option" where
+  "decimalToRat s =
+     (let cs = String.asciis_of_literal s;
+          (neg, body) =
+            (case cs of [] \<Rightarrow> (False, cs)
+                      | c # rest \<Rightarrow> if c = 45 then (True, rest) else (False, cs));
+          ipart = takeWhile (\<lambda>c. c \<noteq> 46) body;
+          fpart = (case dropWhile (\<lambda>c. c \<noteq> 46) body of [] \<Rightarrow> [] | _ # rest \<Rightarrow> rest)
+      in if ipart = [] \<and> fpart = [] then None
+         else case (asciiToIntAcc ipart 0, asciiToIntAcc fpart 0) of
+                (Some iv, Some fv) \<Rightarrow>
+                  Some ((if neg then - 1 else 1) *
+                        (of_int iv + of_int fv / of_int (10 ^ length fpart)))
+              | _ \<Rightarrow> None)"
+
 datatype (plugins only: code size) span_t = SpanT int int int int
 
 type_synonym option_span = "span_t option"

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -2,6 +2,40 @@ theory IR_Lower
   imports IR
 begin
 
+fun asciiToIntAcc :: "integer list \<Rightarrow> int \<Rightarrow> int option" where
+  "asciiToIntAcc [] acc = Some acc"
+| "asciiToIntAcc (c # cs) acc =
+     (if 48 \<le> c \<and> c \<le> 57
+        then asciiToIntAcc cs (acc * 10 + int_of_integer (c - 48))
+        else None)"
+
+definition decimalToRat :: "String.literal \<Rightarrow> rat option" where
+  "decimalToRat s =
+     (let cs = String.asciis_of_literal s
+      in case cs of
+           [] \<Rightarrow> None
+         | c0 # _ \<Rightarrow>
+             (let neg = (c0 = 45);
+                  body = (if neg then tl cs else cs);
+                  ipart = takeWhile (\<lambda>c. c \<noteq> 46) body;
+                  dotrest = dropWhile (\<lambda>c. c \<noteq> 46) body
+              in (if dotrest = [] then
+                    (if ipart = [] then None
+                     else case asciiToIntAcc ipart 0 of
+                            None \<Rightarrow> None
+                          | Some iv \<Rightarrow> Some (of_int (if neg then - iv else iv)))
+                  else
+                    (let fpart = tl dotrest
+                     in (if ipart = [] \<and> fpart = [] then None
+                         else case (asciiToIntAcc ipart 0, asciiToIntAcc fpart 0) of
+                                (Some iv, Some fv) \<Rightarrow>
+                                   (let mag = of_int iv
+                                              + of_int fv / of_int (10 ^ length fpart)
+                                    in Some (if neg then - mag else mag))
+                              | _ \<Rightarrow> None)))))"
+
+definition floatLitRat :: "String.literal \<Rightarrow> rat" where
+  "floatLitRat s = (case decimalToRat s of None \<Rightarrow> 0 | Some r \<Rightarrow> r)"
 
 fun lower_forall_step ::
     "String.literal list \<Rightarrow> quantifier_binding_full
@@ -34,7 +68,7 @@ where
   "lower _ (BoolLitF b sp)     = Some (BoolLit b sp)"
 | "lower _ (IntLitF n sp)      = Some (IntLit n sp)"
 | "lower _ (IdentifierF x sp)  = Some (Ident x sp)"
-| "lower _ (FloatLitF _ _)     = None"
+| "lower _ (FloatLitF s sp)    = Some (RealLit (floatLitRat s) sp)"
 | "lower _ (StringLitF _ _)    = None"
 | "lower _ (NoneLitF _)        = None"
 | "lower _ (LambdaF _ _ _)     = None"

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -2,41 +2,6 @@ theory IR_Lower
   imports IR
 begin
 
-fun asciiToIntAcc :: "integer list \<Rightarrow> int \<Rightarrow> int option" where
-  "asciiToIntAcc [] acc = Some acc"
-| "asciiToIntAcc (c # cs) acc =
-     (if 48 \<le> c \<and> c \<le> 57
-        then asciiToIntAcc cs (acc * 10 + int_of_integer (c - 48))
-        else None)"
-
-definition decimalToRat :: "String.literal \<Rightarrow> rat option" where
-  "decimalToRat s =
-     (let cs = String.asciis_of_literal s
-      in case cs of
-           [] \<Rightarrow> None
-         | c0 # _ \<Rightarrow>
-             (let neg = (c0 = 45);
-                  body = (if neg then tl cs else cs);
-                  ipart = takeWhile (\<lambda>c. c \<noteq> 46) body;
-                  dotrest = dropWhile (\<lambda>c. c \<noteq> 46) body
-              in (if dotrest = [] then
-                    (if ipart = [] then None
-                     else case asciiToIntAcc ipart 0 of
-                            None \<Rightarrow> None
-                          | Some iv \<Rightarrow> Some (of_int (if neg then - iv else iv)))
-                  else
-                    (let fpart = tl dotrest
-                     in (if ipart = [] \<and> fpart = [] then None
-                         else case (asciiToIntAcc ipart 0, asciiToIntAcc fpart 0) of
-                                (Some iv, Some fv) \<Rightarrow>
-                                   (let mag = of_int iv
-                                              + of_int fv / of_int (10 ^ length fpart)
-                                    in Some (if neg then - mag else mag))
-                              | _ \<Rightarrow> None)))))"
-
-definition floatLitRat :: "String.literal \<Rightarrow> rat" where
-  "floatLitRat s = (case decimalToRat s of None \<Rightarrow> 0 | Some r \<Rightarrow> r)"
-
 fun lower_forall_step ::
     "String.literal list \<Rightarrow> quantifier_binding_full
        \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr option"
@@ -68,7 +33,7 @@ where
   "lower _ (BoolLitF b sp)     = Some (BoolLit b sp)"
 | "lower _ (IntLitF n sp)      = Some (IntLit n sp)"
 | "lower _ (IdentifierF x sp)  = Some (Ident x sp)"
-| "lower _ (FloatLitF s sp)    = Some (RealLit (floatLitRat s) sp)"
+| "lower _ (FloatLitF s sp)    = map_option (\<lambda>r. RealLit r sp) (decimalToRat s)"
 | "lower _ (StringLitF _ _)    = None"
 | "lower _ (NoneLitF _)        = None"
 | "lower _ (LambdaF _ _ _)     = None"

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -745,6 +745,9 @@ text \<open>Phase H2 (typing relation, arith fragment). The H2 design
   \<open>env_agrees\<close> / \<open>state_agrees_scalars\<close> agreement halves so the
   H3 progress theorem dispatches per-arm to H1.\<close>
 
+definition numeric_ty :: "ty \<Rightarrow> bool" where
+  "numeric_ty t \<longleftrightarrow> t = TInt \<or> t = TReal"
+
 inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Rightarrow> bool" where
   T_BoolLit:
     "expr_has_ty \<Gamma> (BoolLitF b sp) TBool"
@@ -761,18 +764,20 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
        \<Longrightarrow> map_of (ss_scalars (tc_schema \<Gamma>)) x = Some t
        \<Longrightarrow> expr_has_ty \<Gamma> (IdentifierF x sp) t"
 | T_Arith:
-    "expr_has_ty \<Gamma> l TInt
-       \<Longrightarrow> expr_has_ty \<Gamma> r TInt
+    "expr_has_ty \<Gamma> l t
+       \<Longrightarrow> expr_has_ty \<Gamma> r t
+       \<Longrightarrow> numeric_ty t
        \<Longrightarrow> op \<in> {BAdd, BSub, BMul, BDiv}
-       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TInt"
+       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) t"
 | T_Cmp_Eq:
     "expr_has_ty \<Gamma> l t
        \<Longrightarrow> expr_has_ty \<Gamma> r t
        \<Longrightarrow> op \<in> {BEq, BNeq}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Cmp_Ord:
-    "expr_has_ty \<Gamma> l TInt
-       \<Longrightarrow> expr_has_ty \<Gamma> r TInt
+    "expr_has_ty \<Gamma> l t
+       \<Longrightarrow> expr_has_ty \<Gamma> r t
+       \<Longrightarrow> numeric_ty t
        \<Longrightarrow> op \<in> {BLt, BLe, BGt, BGe}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Bool_Bin:
@@ -784,8 +789,9 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
     "expr_has_ty \<Gamma> e TBool
        \<Longrightarrow> expr_has_ty \<Gamma> (UnaryOpF UNot e sp) TBool"
 | T_Neg:
-    "expr_has_ty \<Gamma> e TInt
-       \<Longrightarrow> expr_has_ty \<Gamma> (UnaryOpF UNegate e sp) TInt"
+    "expr_has_ty \<Gamma> e t
+       \<Longrightarrow> numeric_ty t
+       \<Longrightarrow> expr_has_ty \<Gamma> (UnaryOpF UNegate e sp) t"
 | T_Let:
     "expr_has_ty \<Gamma> v t1
        \<Longrightarrow> expr_has_ty (\<Gamma>\<lparr>tc_env := (x, t1) # tc_env \<Gamma>\<rparr>) body t2

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -1,10 +1,11 @@
 theory Semantics
-  imports IR IR_Helpers IR_Analysis
+  imports IR IR_Helpers IR_Analysis "HOL.Rat"
 begin
 
 datatype (plugins only: code size) ir_value =
     VBool bool
   | VInt int
+  | VReal rat
   | VEnum "String.literal" "String.literal"
   | VEntity "String.literal" "String.literal"
   | VSet "ir_value list"
@@ -94,6 +95,11 @@ fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value
 | "eval_arith MulOp (Some (VInt a)) (Some (VInt b)) = Some (VInt (a * b))"
 | "eval_arith DivOp (Some (VInt a)) (Some (VInt b)) =
      (if b = 0 then None else Some (VInt (a div b)))"
+| "eval_arith AddOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a + b))"
+| "eval_arith SubOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a - b))"
+| "eval_arith MulOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a * b))"
+| "eval_arith DivOp (Some (VReal a)) (Some (VReal b)) =
+     (if b = 0 then None else Some (VReal (a / b)))"
 | "eval_arith _ _ _ = None"
 
 fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
@@ -103,6 +109,10 @@ fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value opt
 | "eval_cmp LeOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a \<le> b))"
 | "eval_cmp GtOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a > b))"
 | "eval_cmp GeOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a \<ge> b))"
+| "eval_cmp LtOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a < b))"
+| "eval_cmp LeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<le> b))"
+| "eval_cmp GtOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a > b))"
+| "eval_cmp GeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<ge> b))"
 | "eval_cmp _ _ _ = None"
 
 text \<open>Category H — first proven bricks of the spec front-half (the
@@ -115,8 +125,10 @@ text \<open>Category H — first proven bricks of the spec front-half (the
   it is *false* here because \<open>eval\<close>'s \<open>Ident\<close> arm legitimately resolves
   from \<open>state\<close>, not only \<open>env\<close>.\<close>
 
-lemma eval_arith_some_imp_int:
-  "eval_arith op x y = Some v \<Longrightarrow> (\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b))"
+lemma eval_arith_some_imp_numeric:
+  "eval_arith op x y = Some v \<Longrightarrow>
+     ((\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b)))
+     \<or> ((\<exists>a. x = Some (VReal a)) \<and> (\<exists>b. y = Some (VReal b)))"
   by (induction op x y rule: eval_arith.induct) (auto split: if_splits)
 
 lemma eval_arith_div_zero:
@@ -132,9 +144,10 @@ lemma eval_cmp_some_imp_defined:
   "eval_cmp op x y = Some v \<Longrightarrow> (\<exists>a. x = Some a) \<and> (\<exists>b. y = Some b)"
   by (induction op x y rule: eval_cmp.induct) auto
 
-lemma eval_cmp_order_imp_int:
+lemma eval_cmp_order_imp_numeric:
   "op \<in> {LtOp, LeOp, GtOp, GeOp} \<Longrightarrow> eval_cmp op x y = Some v \<Longrightarrow>
-     (\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b))"
+     ((\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b)))
+     \<or> ((\<exists>a. x = Some (VReal a)) \<and> (\<exists>b. y = Some (VReal b)))"
   by (induction op x y rule: eval_cmp.induct) auto
 
 text \<open>Category H Phase H1 — value types and value typing.
@@ -150,6 +163,7 @@ text \<open>Category H Phase H1 — value types and value typing.
 datatype (plugins only: code size) ty =
     TBool
   | TInt
+  | TReal
   | TEnum "String.literal"
   | TEntity "String.literal"
   | TSet ty
@@ -179,6 +193,8 @@ fun typeExprFullToTy ::
   "typeExprFullToTy enums entities (NamedTypeF n _) =
      (if n = STR ''Bool'' then Some TBool
       else if n = STR ''Int'' then Some TInt
+      else if n = STR ''Float'' \<or> n = STR ''Double''
+              \<or> n = STR ''Decimal'' \<or> n = STR ''Money'' then Some TReal
       else if n \<in> set enums then Some (TEnum n)
       else if n \<in> set entities then Some (TEntity n)
       else None)"
@@ -220,6 +236,7 @@ text \<open>\<open>value_has_ty\<close> is parameterised by the typing context
 inductive value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Rightarrow> bool" where
   vt_bool:        "value_has_ty \<Gamma> (VBool b) TBool"
 | vt_int:         "value_has_ty \<Gamma> (VInt n) TInt"
+| vt_real:        "value_has_ty \<Gamma> (VReal r) TReal"
 | vt_enum:        "value_has_ty \<Gamma> (VEnum ename ev) (TEnum ename)"
 | vt_entity:      "value_has_ty \<Gamma> (VEntity ename eid) (TEntity ename)"
 | vt_set:         "(\<forall>v \<in> set vs. value_has_ty \<Gamma> v t)
@@ -232,6 +249,7 @@ inductive value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Right
 
 inductive_cases value_has_ty_bool_cases [elim!]: "value_has_ty \<Gamma> (VBool b) t"
 inductive_cases value_has_ty_int_cases [elim!]: "value_has_ty \<Gamma> (VInt n) t"
+inductive_cases value_has_ty_real_cases [elim!]: "value_has_ty \<Gamma> (VReal r) t"
 inductive_cases value_has_ty_enum_cases [elim!]:
   "value_has_ty \<Gamma> (VEnum ename ev) t"
 inductive_cases value_has_ty_entity_cases [elim!]:
@@ -247,6 +265,10 @@ lemma value_has_ty_VBool_iff [simp]:
 lemma value_has_ty_VInt_iff [simp]:
   "value_has_ty \<Gamma> (VInt n) t \<longleftrightarrow> t = TInt"
   by (auto intro: vt_int)
+
+lemma value_has_ty_VReal_iff [simp]:
+  "value_has_ty \<Gamma> (VReal r) t \<longleftrightarrow> t = TReal"
+  by (auto intro: vt_real)
 
 lemma value_has_ty_VEnum_iff [simp]:
   "value_has_ty \<Gamma> (VEnum ename ev) t \<longleftrightarrow> t = TEnum ename"
@@ -296,11 +318,13 @@ and check_value_has_ty_list ::
 where
   "check_value_has_ty \<Gamma> (VBool _) t = (t = TBool)"
 | "check_value_has_ty \<Gamma> (VInt _) t = (t = TInt)"
+| "check_value_has_ty \<Gamma> (VReal _) t = (t = TReal)"
 | "check_value_has_ty \<Gamma> (VEnum ename _) t = (t = TEnum ename)"
 | "check_value_has_ty \<Gamma> (VEntity ename _) t = (t = TEntity ename)"
 | "check_value_has_ty \<Gamma> (VSet vs) (TSet t) = check_value_has_ty_list \<Gamma> vs t"
 | "check_value_has_ty \<Gamma> (VSet _) TBool = False"
 | "check_value_has_ty \<Gamma> (VSet _) TInt = False"
+| "check_value_has_ty \<Gamma> (VSet _) TReal = False"
 | "check_value_has_ty \<Gamma> (VSet _) (TEnum _) = False"
 | "check_value_has_ty \<Gamma> (VSet _) (TEntity _) = False"
 | "check_value_has_ty \<Gamma> (VEntityWith base fld override) (TEntity ename) =
@@ -310,6 +334,7 @@ where
        | Some ft \<Rightarrow> check_value_has_ty \<Gamma> override ft))"
 | "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TBool = False"
 | "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TInt = False"
+| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TReal = False"
 | "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TEnum _) = False"
 | "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TSet _) = False"
 | "check_value_has_ty_list _ [] _ = True"
@@ -374,12 +399,12 @@ fun peelRelationRefFull :: "expr_full \<Rightarrow> String.literal option" where
 
 lemma eval_arith_preservation:
   assumes "eval_arith op x y = Some v"
-      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
-      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b TInt"
-  shows "value_has_ty \<Gamma> v TInt"
-  using assms eval_arith_some_imp_int[OF assms(1)]
+      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a t"
+      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b t"
+  shows "value_has_ty \<Gamma> v t"
+  using assms
   by (induction op x y rule: eval_arith.induct)
-     (auto split: if_splits intro: vt_int)
+     (auto split: if_splits intro: vt_int vt_real)
 
 lemma eval_cmp_preservation:
   assumes "eval_cmp op x y = Some v"
@@ -1076,6 +1101,7 @@ where
 | "eval s st env (UnNeg e _) =
      (case eval s st env e of
         Some (VInt n) \<Rightarrow> Some (VInt (- n))
+      | Some (VReal r) \<Rightarrow> Some (VReal (- r))
       | _             \<Rightarrow> None)"
 | "eval s st env (BoolBin op l r _) =
      (case (eval s st env l, eval s st env r) of

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -750,6 +750,8 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
     "expr_has_ty \<Gamma> (BoolLitF b sp) TBool"
 | T_IntLit:
     "expr_has_ty \<Gamma> (IntLitF n sp) TInt"
+| T_FloatLit:
+    "expr_has_ty \<Gamma> (FloatLitF s sp) TReal"
 | T_Ident_Lex:
     "tyenv_lookup (tc_env \<Gamma>) x = Some t
        \<Longrightarrow> expr_has_ty \<Gamma> (IdentifierF x sp) t"
@@ -991,7 +993,7 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
                 body sp) TBool"
 
 lemmas expr_has_ty_intros [intro] =
-  T_BoolLit T_IntLit T_Ident_Lex T_Ident_State
+  T_BoolLit T_IntLit T_FloatLit T_Ident_Lex T_Ident_State
   T_Arith T_Cmp_Eq T_Cmp_Ord T_Bool_Bin T_Not T_Neg T_Let
   T_Prime T_Pre T_EnumAccess T_Card T_BIn_Rel T_BNotIn_Rel
   T_SetLit_Empty T_SetLit_Cons T_BUnion T_BIntersect T_BDiff
@@ -1090,6 +1092,7 @@ and eval_forall_rel ::
 where
   "eval s st env (BoolLit b _) = Some (VBool b)"
 | "eval s st env (IntLit n _) = Some (VInt n)"
+| "eval s st env (RealLit r _) = Some (VReal r)"
 | "eval s st env (Ident x _) =
      (case env_lookup env x of
         Some v \<Rightarrow> Some v

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -800,8 +800,9 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
        \<Longrightarrow> op \<in> {BAdd, BSub, BMul, BDiv}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) (numeric_join t1 t2)"
 | T_Cmp_Eq:
-    "expr_has_ty \<Gamma> l t
-       \<Longrightarrow> expr_has_ty \<Gamma> r t
+    "expr_has_ty \<Gamma> l t1
+       \<Longrightarrow> expr_has_ty \<Gamma> r t2
+       \<Longrightarrow> t1 = t2 \<or> numeric_ty t1 \<and> numeric_ty t2
        \<Longrightarrow> op \<in> {BEq, BNeq}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Cmp_Ord:

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -100,11 +100,28 @@ fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value
 | "eval_arith MulOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a * b))"
 | "eval_arith DivOp (Some (VReal a)) (Some (VReal b)) =
      (if b = 0 then None else Some (VReal (a / b)))"
+| "eval_arith AddOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a + b))"
+| "eval_arith AddOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a + of_int b))"
+| "eval_arith SubOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a - b))"
+| "eval_arith SubOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a - of_int b))"
+| "eval_arith MulOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a * b))"
+| "eval_arith MulOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a * of_int b))"
+| "eval_arith DivOp (Some (VInt a)) (Some (VReal b)) =
+     (if b = 0 then None else Some (VReal (of_int a / b)))"
+| "eval_arith DivOp (Some (VReal a)) (Some (VInt b)) =
+     (if b = 0 then None else Some (VReal (a / of_int b)))"
 | "eval_arith _ _ _ = None"
 
+definition ir_val_eq :: "ir_value \<Rightarrow> ir_value \<Rightarrow> bool" where
+  "ir_val_eq x y =
+     (case (x, y) of
+        (VInt a, VReal b) \<Rightarrow> of_int a = b
+      | (VReal a, VInt b) \<Rightarrow> a = of_int b
+      | _ \<Rightarrow> x = y)"
+
 fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
-  "eval_cmp EqOp  (Some a) (Some b) = Some (VBool (a = b))"
-| "eval_cmp NeqOp (Some a) (Some b) = Some (VBool (a \<noteq> b))"
+  "eval_cmp EqOp  (Some a) (Some b) = Some (VBool (ir_val_eq a b))"
+| "eval_cmp NeqOp (Some a) (Some b) = Some (VBool (\<not> ir_val_eq a b))"
 | "eval_cmp LtOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a < b))"
 | "eval_cmp LeOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a \<le> b))"
 | "eval_cmp GtOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a > b))"
@@ -113,6 +130,14 @@ fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value opt
 | "eval_cmp LeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<le> b))"
 | "eval_cmp GtOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a > b))"
 | "eval_cmp GeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<ge> b))"
+| "eval_cmp LtOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a < b))"
+| "eval_cmp LtOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a < of_int b))"
+| "eval_cmp LeOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a \<le> b))"
+| "eval_cmp LeOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a \<le> of_int b))"
+| "eval_cmp GtOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a > b))"
+| "eval_cmp GtOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a > of_int b))"
+| "eval_cmp GeOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a \<ge> b))"
+| "eval_cmp GeOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a \<ge> of_int b))"
 | "eval_cmp _ _ _ = None"
 
 text \<open>Category H — first proven bricks of the spec front-half (the
@@ -127,8 +152,8 @@ text \<open>Category H — first proven bricks of the spec front-half (the
 
 lemma eval_arith_some_imp_numeric:
   "eval_arith op x y = Some v \<Longrightarrow>
-     ((\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b)))
-     \<or> ((\<exists>a. x = Some (VReal a)) \<and> (\<exists>b. y = Some (VReal b)))"
+     ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
+     \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
   by (induction op x y rule: eval_arith.induct) (auto split: if_splits)
 
 lemma eval_arith_div_zero:
@@ -146,8 +171,8 @@ lemma eval_cmp_some_imp_defined:
 
 lemma eval_cmp_order_imp_numeric:
   "op \<in> {LtOp, LeOp, GtOp, GeOp} \<Longrightarrow> eval_cmp op x y = Some v \<Longrightarrow>
-     ((\<exists>a. x = Some (VInt a)) \<and> (\<exists>b. y = Some (VInt b)))
-     \<or> ((\<exists>a. x = Some (VReal a)) \<and> (\<exists>b. y = Some (VReal b)))"
+     ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
+     \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
   by (induction op x y rule: eval_cmp.induct) auto
 
 text \<open>Category H Phase H1 — value types and value typing.
@@ -167,6 +192,12 @@ datatype (plugins only: code size) ty =
   | TEnum "String.literal"
   | TEntity "String.literal"
   | TSet ty
+
+definition numeric_ty :: "ty \<Rightarrow> bool" where
+  "numeric_ty t \<longleftrightarrow> t = TInt \<or> t = TReal"
+
+definition numeric_join :: "ty \<Rightarrow> ty \<Rightarrow> ty" where
+  "numeric_join t1 t2 = (if t1 = TReal \<or> t2 = TReal then TReal else TInt)"
 
 text \<open>The typing context \<open>tyctx\<close> and its sub-records are declared
   here (before \<open>value_has_ty\<close>) because \<open>vt_entity_with\<close> needs to
@@ -399,12 +430,13 @@ fun peelRelationRefFull :: "expr_full \<Rightarrow> String.literal option" where
 
 lemma eval_arith_preservation:
   assumes "eval_arith op x y = Some v"
-      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a t"
-      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b t"
-  shows "value_has_ty \<Gamma> v t"
+      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a t1"
+      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b t2"
+      and "numeric_ty t1" and "numeric_ty t2"
+  shows "value_has_ty \<Gamma> v (numeric_join t1 t2)"
   using assms
   by (induction op x y rule: eval_arith.induct)
-     (auto split: if_splits intro: vt_int vt_real)
+     (auto split: if_splits simp: numeric_ty_def numeric_join_def intro: vt_int vt_real)
 
 lemma eval_cmp_preservation:
   assumes "eval_cmp op x y = Some v"
@@ -745,9 +777,6 @@ text \<open>Phase H2 (typing relation, arith fragment). The H2 design
   \<open>env_agrees\<close> / \<open>state_agrees_scalars\<close> agreement halves so the
   H3 progress theorem dispatches per-arm to H1.\<close>
 
-definition numeric_ty :: "ty \<Rightarrow> bool" where
-  "numeric_ty t \<longleftrightarrow> t = TInt \<or> t = TReal"
-
 inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Rightarrow> bool" where
   T_BoolLit:
     "expr_has_ty \<Gamma> (BoolLitF b sp) TBool"
@@ -764,20 +793,22 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
        \<Longrightarrow> map_of (ss_scalars (tc_schema \<Gamma>)) x = Some t
        \<Longrightarrow> expr_has_ty \<Gamma> (IdentifierF x sp) t"
 | T_Arith:
-    "expr_has_ty \<Gamma> l t
-       \<Longrightarrow> expr_has_ty \<Gamma> r t
-       \<Longrightarrow> numeric_ty t
+    "expr_has_ty \<Gamma> l t1
+       \<Longrightarrow> expr_has_ty \<Gamma> r t2
+       \<Longrightarrow> numeric_ty t1
+       \<Longrightarrow> numeric_ty t2
        \<Longrightarrow> op \<in> {BAdd, BSub, BMul, BDiv}
-       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) t"
+       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) (numeric_join t1 t2)"
 | T_Cmp_Eq:
     "expr_has_ty \<Gamma> l t
        \<Longrightarrow> expr_has_ty \<Gamma> r t
        \<Longrightarrow> op \<in> {BEq, BNeq}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Cmp_Ord:
-    "expr_has_ty \<Gamma> l t
-       \<Longrightarrow> expr_has_ty \<Gamma> r t
-       \<Longrightarrow> numeric_ty t
+    "expr_has_ty \<Gamma> l t1
+       \<Longrightarrow> expr_has_ty \<Gamma> r t2
+       \<Longrightarrow> numeric_ty t1
+       \<Longrightarrow> numeric_ty t2
        \<Longrightarrow> op \<in> {BLt, BLe, BGt, BGe}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Bool_Bin:

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -751,7 +751,8 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr_full \<Rightarrow> ty \<Right
 | T_IntLit:
     "expr_has_ty \<Gamma> (IntLitF n sp) TInt"
 | T_FloatLit:
-    "expr_has_ty \<Gamma> (FloatLitF s sp) TReal"
+    "decimalToRat s \<noteq> None
+       \<Longrightarrow> expr_has_ty \<Gamma> (FloatLitF s sp) TReal"
 | T_Ident_Lex:
     "tyenv_lookup (tc_env \<Gamma>) x = Some t
        \<Longrightarrow> expr_has_ty \<Gamma> (IdentifierF x sp) t"

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -20,6 +20,7 @@ datatype (plugins only: code size) smt_val =
 datatype (plugins only: code size) smt_term =
     BLit bool
   | ILit int
+  | RLit rat
   | TVar "String.literal"
   | EnumElemConst "String.literal" "String.literal"
   | TNot "smt_term"
@@ -172,6 +173,7 @@ and smtEval_forall_rel ::
 where
   "smtEval m env (BLit b) = Some (SBool b)"
 | "smtEval m env (ILit n) = Some (SInt n)"
+| "smtEval m env (RLit r) = Some (SReal r)"
 | "smtEval m env (TVar x) =
      (case smt_env_lookup env x of
         Some v \<Rightarrow> Some v

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -1,15 +1,17 @@
 theory Smt
-  imports IR
+  imports IR "HOL.Rat"
 begin
 
 datatype (plugins only: code size) smt_sort =
     SortBool
   | SortInt
+  | SortReal
   | SortUninterp "String.literal"
 
 datatype (plugins only: code size) smt_val =
     SBool bool
   | SInt int
+  | SReal rat
   | SEnumElem "String.literal" "String.literal"
   | SEntityElem "String.literal" "String.literal"
   | SSet "smt_val list"
@@ -204,27 +206,34 @@ where
 | "smtEval m env (TLt l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SBool (a < b))
+      | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SBool (a < b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TNeg t) =
      (case smtEval m env t of
         Some (SInt n) \<Rightarrow> Some (SInt (- n))
+      | Some (SReal n) \<Rightarrow> Some (SReal (- n))
       | _             \<Rightarrow> None)"
 | "smtEval m env (TAdd l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a + b))
+      | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a + b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TSub l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a - b))
+      | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a - b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TMul l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a * b))
+      | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a * b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TDiv l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow>
           (if b = 0 then None else Some (SInt (a div b)))
+      | (Some (SReal a), Some (SReal b)) \<Rightarrow>
+          (if b = 0 then None else Some (SReal (a / b)))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TInDom rel_name arg) =
      (case smtEval m env arg of

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -203,12 +203,16 @@ where
       | _ \<Rightarrow> None)"
 | "smtEval m env (TEq l r) =
      (case (smtEval m env l, smtEval m env r) of
-        (Some a, Some b) \<Rightarrow> Some (SBool (a = b))
+        (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SBool (of_int a = b))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SBool (a = of_int b))
+      | (Some a, Some b) \<Rightarrow> Some (SBool (a = b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TLt l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SBool (a < b))
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SBool (a < b))
+      | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SBool (of_int a < b))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SBool (a < of_int b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TNeg t) =
      (case smtEval m env t of
@@ -219,16 +223,22 @@ where
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a + b))
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a + b))
+      | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SReal (of_int a + b))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SReal (a + of_int b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TSub l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a - b))
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a - b))
+      | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SReal (of_int a - b))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SReal (a - of_int b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TMul l r) =
      (case (smtEval m env l, smtEval m env r) of
         (Some (SInt a), Some (SInt b)) \<Rightarrow> Some (SInt (a * b))
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a * b))
+      | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SReal (of_int a * b))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SReal (a * of_int b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TDiv l r) =
      (case (smtEval m env l, smtEval m env r) of
@@ -236,6 +246,10 @@ where
           (if b = 0 then None else Some (SInt (a div b)))
       | (Some (SReal a), Some (SReal b)) \<Rightarrow>
           (if b = 0 then None else Some (SReal (a / b)))
+      | (Some (SInt a), Some (SReal b)) \<Rightarrow>
+          (if b = 0 then None else Some (SReal (of_int a / b)))
+      | (Some (SReal a), Some (SInt b)) \<Rightarrow>
+          (if b = 0 then None else Some (SReal (a / of_int b)))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TInDom rel_name arg) =
      (case smtEval m env arg of

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -5,6 +5,7 @@ begin
 fun translate :: "expr \<Rightarrow> smt_term" where
   "translate (BoolLit b _) = BLit b"
 | "translate (IntLit n _)  = ILit n"
+| "translate (RealLit r _) = RLit r"
 | "translate (Ident x _)   = TVar x"
 | "translate (UnNot e _)   = TNot (translate e)"
 | "translate (UnNeg e _)   = TNeg (translate e)"

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -1599,13 +1599,13 @@ text \<open>Phase H2 -> 9j bridge. Every well-typed expression in the
 lemma well_typed_imp_wf_z3:
   "expr_has_ty \<Gamma> e t \<Longrightarrow> wf_z3 e"
 proof (induction rule: expr_has_ty.induct)
-  case (T_Arith \<Gamma> l r op sp)
+  case (T_Arith \<Gamma> l t r op sp)
   thus ?case by (cases op) auto
 next
   case (T_Cmp_Eq \<Gamma> l t r op sp)
   thus ?case by (cases op) auto
 next
-  case (T_Cmp_Ord \<Gamma> l r op sp)
+  case (T_Cmp_Ord \<Gamma> l t r op sp)
   thus ?case by (cases op) auto
 next
   case (T_Bool_Bin \<Gamma> l r op sp)
@@ -1821,8 +1821,9 @@ qed
 lemma h3_pres_Neg:
   assumes "lower enums (UnaryOpF UNegate e sp) = Some e'"
       and "eval sch st env e' = Some v"
-      and "\<And>e_sub a. lower enums e = Some e_sub \<Longrightarrow> eval sch st env e_sub = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
-  shows "value_has_ty \<Gamma> v TInt"
+      and "numeric_ty t"
+      and "\<And>e_sub a. lower enums e = Some e_sub \<Longrightarrow> eval sch st env e_sub = Some a \<Longrightarrow> value_has_ty \<Gamma> a t"
+  shows "value_has_ty \<Gamma> v t"
 proof -
   from assms(1) obtain e_sub where
        sub_low: "lower enums e = Some e_sub"
@@ -1832,20 +1833,31 @@ proof -
     by simp
   then obtain a where ea: "eval sch st env e_sub = Some a"
     by (cases "eval sch st env e_sub") auto
-  have "value_has_ty \<Gamma> a TInt" using assms(3)[OF sub_low ea] .
-  hence "\<exists>n. a = VInt n" by (cases a) (auto elim: value_has_ty.cases)
-  then obtain n where "a = VInt n" ..
-  with ea ev have "v = VInt (- n)" by simp
-  thus "value_has_ty \<Gamma> v TInt" by simp
+  have at: "value_has_ty \<Gamma> a t" using assms(4)[OF sub_low ea] .
+  from assms(3) have "t = TInt \<or> t = TReal" by (simp add: numeric_ty_def)
+  then show "value_has_ty \<Gamma> v t"
+  proof
+    assume t: "t = TInt"
+    with at have "value_has_ty \<Gamma> a TInt" by simp
+    then obtain n where "a = VInt n" by (cases a) auto
+    with ea ev have "v = VInt (- n)" by simp
+    with t show ?thesis by simp
+  next
+    assume t: "t = TReal"
+    with at have "value_has_ty \<Gamma> a TReal" by simp
+    then obtain r where "a = VReal r" by (cases a) auto
+    with ea ev have "v = VReal (- r)" by simp
+    with t show ?thesis by simp
+  qed
 qed
 
 lemma h3_pres_Arith:
   assumes "op \<in> {BAdd, BSub, BMul, BDiv}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
-      and "\<And>l' a. lower enums l = Some l' \<Longrightarrow> eval sch st env l' = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
-      and "\<And>r' b. lower enums r = Some r' \<Longrightarrow> eval sch st env r' = Some b \<Longrightarrow> value_has_ty \<Gamma> b TInt"
-  shows "value_has_ty \<Gamma> v TInt"
+      and "\<And>l' a. lower enums l = Some l' \<Longrightarrow> eval sch st env l' = Some a \<Longrightarrow> value_has_ty \<Gamma> a t"
+      and "\<And>r' b. lower enums r = Some r' \<Longrightarrow> eval sch st env r' = Some b \<Longrightarrow> value_has_ty \<Gamma> b t"
+  shows "value_has_ty \<Gamma> v t"
 proof -
   from assms(1,2) obtain l' r' aop where
        l_low: "lower enums l = Some l'"
@@ -1855,13 +1867,13 @@ proof -
   from assms(3) e_eq
   have ev: "eval_arith aop (eval sch st env l') (eval sch st env r') = Some v"
     by simp
-  show "value_has_ty \<Gamma> v TInt"
+  show "value_has_ty \<Gamma> v t"
   proof (rule eval_arith_preservation[OF ev])
     fix a assume "eval sch st env l' = Some a"
-    thus "value_has_ty \<Gamma> a TInt" using assms(4) l_low by blast
+    thus "value_has_ty \<Gamma> a t" using assms(4) l_low by blast
   next
     fix b assume "eval sch st env r' = Some b"
-    thus "value_has_ty \<Gamma> b TInt" using assms(5) r_low by blast
+    thus "value_has_ty \<Gamma> b t" using assms(5) r_low by blast
   qed
 qed
 
@@ -1926,22 +1938,22 @@ next
   case (T_Ident_State \<Gamma> x t sp)
   thus ?case using h3_pres_Ident_State by blast
 next
-  case (T_Arith \<Gamma> l r op sp)
+  case (T_Arith \<Gamma> l t r op sp)
   show ?case
-  proof (rule h3_pres_Arith[OF T_Arith.hyps(3) T_Arith.prems(2) T_Arith.prems(3)])
+  proof (rule h3_pres_Arith[OF T_Arith.hyps(4) T_Arith.prems(2) T_Arith.prems(3)])
     fix l' a assume "lower enums l = Some l'" and "eval sch st env l' = Some a"
-    thus "value_has_ty \<Gamma> a TInt"
+    thus "value_has_ty \<Gamma> a t"
       using T_Arith.IH(1) T_Arith.prems(1) T_Arith.prems(4) by blast
   next
     fix r' b assume "lower enums r = Some r'" and "eval sch st env r' = Some b"
-    thus "value_has_ty \<Gamma> b TInt"
+    thus "value_has_ty \<Gamma> b t"
       using T_Arith.IH(2) T_Arith.prems(1) T_Arith.prems(4) by blast
   qed
 next
   case (T_Cmp_Eq \<Gamma> l t r op sp)
   thus ?case using h3_pres_Cmp by blast
 next
-  case (T_Cmp_Ord \<Gamma> l r op sp)
+  case (T_Cmp_Ord \<Gamma> l t r op sp)
   thus ?case using h3_pres_Cmp by blast
 next
   case (T_Bool_Bin \<Gamma> l r op sp)
@@ -1950,11 +1962,11 @@ next
   case (T_Not \<Gamma> e sp)
   thus ?case using h3_pres_Not by blast
 next
-  case (T_Neg \<Gamma> e sp)
+  case (T_Neg \<Gamma> e t sp)
   show ?case
-  proof (rule h3_pres_Neg[OF T_Neg.prems(2) T_Neg.prems(3)])
+  proof (rule h3_pres_Neg[OF T_Neg.prems(2) T_Neg.prems(3) T_Neg.hyps(2)])
     fix e_sub a assume "lower enums e = Some e_sub" and "eval sch st env e_sub = Some a"
-    thus "value_has_ty \<Gamma> a TInt"
+    thus "value_has_ty \<Gamma> a t"
       using T_Neg.IH T_Neg.prems(1) T_Neg.prems(4) by blast
   qed
 next

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -1176,7 +1176,7 @@ where
 | "wf_z3 (WithF base ups _)        = (wf_z3 base \<and> wf_z3_fields ups)"
 | "wf_z3 (SetLiteralF es _)        = wf_z3_list es"
 | "wf_z3 (QuantifierF _ bs body _) = (wf_z3_bindings bs \<and> wf_z3 body)"
-| "wf_z3 (FloatLitF _ _)           = True"
+| "wf_z3 (FloatLitF s _)           = (decimalToRat s \<noteq> None)"
 | "wf_z3 (StringLitF _ _)          = False"
 | "wf_z3 (NoneLitF _)              = False"
 | "wf_z3 (LambdaF _ _ _)           = False"
@@ -1754,7 +1754,8 @@ lemma h3_pres_FloatLit:
       and "eval sch st env e' = Some v"
   shows "value_has_ty \<Gamma> v TReal"
 proof -
-  from assms(1) have "e' = RealLit (floatLitRat s) sp" by simp
+  from assms(1) obtain r where "e' = RealLit r sp"
+    by (cases "decimalToRat s") auto
   with assms(2) show ?thesis by auto
 qed
 

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -575,6 +575,8 @@ proof (induction e arbitrary: env)
 next
   case (IntLit n sp) show ?case by simp
 next
+  case (RealLit r sp) show ?case by simp
+next
   case (Ident x sp) show ?case by (simp split: option.splits)
 next
   case (UnNot e sp)
@@ -1174,7 +1176,7 @@ where
 | "wf_z3 (WithF base ups _)        = (wf_z3 base \<and> wf_z3_fields ups)"
 | "wf_z3 (SetLiteralF es _)        = wf_z3_list es"
 | "wf_z3 (QuantifierF _ bs body _) = (wf_z3_bindings bs \<and> wf_z3 body)"
-| "wf_z3 (FloatLitF _ _)           = False"
+| "wf_z3 (FloatLitF _ _)           = True"
 | "wf_z3 (StringLitF _ _)          = False"
 | "wf_z3 (NoneLitF _)              = False"
 | "wf_z3 (LambdaF _ _ _)           = False"
@@ -1747,6 +1749,15 @@ proof -
   with assms(2) show ?thesis by auto
 qed
 
+lemma h3_pres_FloatLit:
+  assumes "lower enums (FloatLitF s sp) = Some e'"
+      and "eval sch st env e' = Some v"
+  shows "value_has_ty \<Gamma> v TReal"
+proof -
+  from assms(1) have "e' = RealLit (floatLitRat s) sp" by simp
+  with assms(2) show ?thesis by auto
+qed
+
 lemma h3_pres_Ident_Lex:
   assumes "agrees_strict env st \<Gamma>"
       and "tyenv_lookup (tc_env \<Gamma>) x = Some t"
@@ -1904,6 +1915,9 @@ proof (induction arbitrary: e' v env rule: expr_has_ty.induct)
 next
   case (T_IntLit \<Gamma> n sp)
   thus ?case using h3_pres_IntLit by blast
+next
+  case (T_FloatLit \<Gamma> s sp)
+  thus ?case using h3_pres_FloatLit by blast
 next
   case (T_Ident_Lex \<Gamma> x t sp)
   thus ?case using h3_pres_Ident_Lex by blast

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -567,6 +567,12 @@ lemma int_ge_iff_lt_or_eq: "(a::int) \<ge> b \<longleftrightarrow> b < a \<or> a
 lemma int_le_iff_lt_or_eq: "(a::int) \<le> b \<longleftrightarrow> a < b \<or> a = b"
   by linarith
 
+lemma rat_ge_iff_lt_or_eq: "(a::rat) \<ge> b \<longleftrightarrow> b < a \<or> a = b"
+  by (auto simp: order_le_less)
+
+lemma rat_le_iff_lt_or_eq: "(a::rat) \<le> b \<longleftrightarrow> a < b \<or> a = b"
+  by (auto simp: order_le_less)
+
 theorem soundness:
   "value_to_smt_opt (eval s st env e)
      = smtEval (correlate_model s st) (correlate_env env) (translate e)"
@@ -636,7 +642,8 @@ next
       case (Some b)
       thus ?thesis using ihl' ihr' \<open>eval s st env l = Some a\<close>
         by (cases op; cases a; cases b)
-           (auto simp: int_le_iff_lt_or_eq int_ge_iff_lt_or_eq)
+           (auto simp: int_le_iff_lt_or_eq int_ge_iff_lt_or_eq
+                       rat_le_iff_lt_or_eq rat_ge_iff_lt_or_eq ir_val_eq_def)
     qed
   qed
 next
@@ -663,7 +670,8 @@ next
       case (Some b)
       thus ?thesis using ihl' ihr' \<open>eval s st env l = Some a\<close>
         by (cases op; cases a; cases b)
-           (auto simp: int_le_iff_lt_or_eq int_ge_iff_lt_or_eq)
+           (auto simp: int_le_iff_lt_or_eq int_ge_iff_lt_or_eq
+                       rat_le_iff_lt_or_eq rat_ge_iff_lt_or_eq ir_val_eq_def)
     qed
   qed
 next
@@ -1599,13 +1607,13 @@ text \<open>Phase H2 -> 9j bridge. Every well-typed expression in the
 lemma well_typed_imp_wf_z3:
   "expr_has_ty \<Gamma> e t \<Longrightarrow> wf_z3 e"
 proof (induction rule: expr_has_ty.induct)
-  case (T_Arith \<Gamma> l t r op sp)
+  case (T_Arith \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
   case (T_Cmp_Eq \<Gamma> l t r op sp)
   thus ?case by (cases op) auto
 next
-  case (T_Cmp_Ord \<Gamma> l t r op sp)
+  case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
   case (T_Bool_Bin \<Gamma> l r op sp)
@@ -1855,9 +1863,10 @@ lemma h3_pres_Arith:
   assumes "op \<in> {BAdd, BSub, BMul, BDiv}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
-      and "\<And>l' a. lower enums l = Some l' \<Longrightarrow> eval sch st env l' = Some a \<Longrightarrow> value_has_ty \<Gamma> a t"
-      and "\<And>r' b. lower enums r = Some r' \<Longrightarrow> eval sch st env r' = Some b \<Longrightarrow> value_has_ty \<Gamma> b t"
-  shows "value_has_ty \<Gamma> v t"
+      and "numeric_ty t1" and "numeric_ty t2"
+      and "\<And>l' a. lower enums l = Some l' \<Longrightarrow> eval sch st env l' = Some a \<Longrightarrow> value_has_ty \<Gamma> a t1"
+      and "\<And>r' b. lower enums r = Some r' \<Longrightarrow> eval sch st env r' = Some b \<Longrightarrow> value_has_ty \<Gamma> b t2"
+  shows "value_has_ty \<Gamma> v (numeric_join t1 t2)"
 proof -
   from assms(1,2) obtain l' r' aop where
        l_low: "lower enums l = Some l'"
@@ -1867,13 +1876,13 @@ proof -
   from assms(3) e_eq
   have ev: "eval_arith aop (eval sch st env l') (eval sch st env r') = Some v"
     by simp
-  show "value_has_ty \<Gamma> v t"
-  proof (rule eval_arith_preservation[OF ev])
+  show "value_has_ty \<Gamma> v (numeric_join t1 t2)"
+  proof (rule eval_arith_preservation[OF ev _ _ assms(4) assms(5)])
     fix a assume "eval sch st env l' = Some a"
-    thus "value_has_ty \<Gamma> a t" using assms(4) l_low by blast
+    thus "value_has_ty \<Gamma> a t1" using assms(6) l_low by blast
   next
     fix b assume "eval sch st env r' = Some b"
-    thus "value_has_ty \<Gamma> b t" using assms(5) r_low by blast
+    thus "value_has_ty \<Gamma> b t2" using assms(7) r_low by blast
   qed
 qed
 
@@ -1938,22 +1947,23 @@ next
   case (T_Ident_State \<Gamma> x t sp)
   thus ?case using h3_pres_Ident_State by blast
 next
-  case (T_Arith \<Gamma> l t r op sp)
+  case (T_Arith \<Gamma> l t1 r t2 op sp)
   show ?case
-  proof (rule h3_pres_Arith[OF T_Arith.hyps(4) T_Arith.prems(2) T_Arith.prems(3)])
+  proof (rule h3_pres_Arith[OF T_Arith.hyps(5) T_Arith.prems(2) T_Arith.prems(3)
+                              T_Arith.hyps(3) T_Arith.hyps(4)])
     fix l' a assume "lower enums l = Some l'" and "eval sch st env l' = Some a"
-    thus "value_has_ty \<Gamma> a t"
+    thus "value_has_ty \<Gamma> a t1"
       using T_Arith.IH(1) T_Arith.prems(1) T_Arith.prems(4) by blast
   next
     fix r' b assume "lower enums r = Some r'" and "eval sch st env r' = Some b"
-    thus "value_has_ty \<Gamma> b t"
+    thus "value_has_ty \<Gamma> b t2"
       using T_Arith.IH(2) T_Arith.prems(1) T_Arith.prems(4) by blast
   qed
 next
   case (T_Cmp_Eq \<Gamma> l t r op sp)
   thus ?case using h3_pres_Cmp by blast
 next
-  case (T_Cmp_Ord \<Gamma> l t r op sp)
+  case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
   thus ?case using h3_pres_Cmp by blast
 next
   case (T_Bool_Bin \<Gamma> l r op sp)

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -12,6 +12,7 @@ section \<open>Value \<leftrightarrow> SmtVal correlation\<close>
 fun value_to_smt :: "ir_value \<Rightarrow> smt_val" where
   "value_to_smt (VBool b)        = SBool b"
 | "value_to_smt (VInt n)         = SInt n"
+| "value_to_smt (VReal r)        = SReal r"
 | "value_to_smt (VEnum en mem)   = SEnumElem en mem"
 | "value_to_smt (VEntity en eid) = SEntityElem en eid"
 | "value_to_smt (VSet members)   = SSet (map value_to_smt members)"
@@ -53,6 +54,10 @@ lemma value_to_smt_eq_SInt [simp]:
   "(value_to_smt v = SInt n) = (v = VInt n)"
   by (cases v) auto
 
+lemma value_to_smt_eq_SReal [simp]:
+  "(value_to_smt v = SReal r) = (v = VReal r)"
+  by (cases v) auto
+
 lemma value_to_smt_eq_SEnumElem [simp]:
   "(value_to_smt v = SEnumElem en mem) = (v = VEnum en mem)"
   by (cases v) auto
@@ -73,6 +78,10 @@ lemma SInt_eq_value_to_smt [simp]:
   "(SInt n = value_to_smt v) = (v = VInt n)"
   by (cases v) auto
 
+lemma SReal_eq_value_to_smt [simp]:
+  "(SReal r = value_to_smt v) = (v = VReal r)"
+  by (cases v) auto
+
 lemma map_value_to_smt_inj:
   assumes "\<And>x. x \<in> set xs \<Longrightarrow> (\<forall>y. value_to_smt x = value_to_smt y \<longrightarrow> x = y)"
   shows "(map value_to_smt xs = map value_to_smt ys) = (xs = ys)"
@@ -90,6 +99,8 @@ proof (induction v1 arbitrary: v2)
   case (VBool b) thus ?case by (cases v2) auto
 next
   case (VInt n) thus ?case by (cases v2) auto
+next
+  case (VReal r) thus ?case by (cases v2) auto
 next
   case (VEnum en mem) thus ?case by (cases v2) auto
 next
@@ -259,6 +270,10 @@ lemma contains_smt_val_map_SBool [simp]:
 lemma contains_smt_val_map_SInt [simp]:
   "contains_smt_val (map value_to_smt vs) (SInt n) = contains_value vs (VInt n)"
   using contains_value_map_value_to_smt[of vs "VInt n"] by simp
+
+lemma contains_smt_val_map_SReal [simp]:
+  "contains_smt_val (map value_to_smt vs) (SReal r) = contains_value vs (VReal r)"
+  using contains_value_map_value_to_smt[of vs "VReal r"] by simp
 
 lemma contains_smt_val_map_SEnumElem [simp]:
   "contains_smt_val (map value_to_smt vs) (SEnumElem en mem) = contains_value vs (VEnum en mem)"
@@ -1794,6 +1809,7 @@ qed
 lemma h3_pres_Neg:
   assumes "lower enums (UnaryOpF UNegate e sp) = Some e'"
       and "eval sch st env e' = Some v"
+      and "\<And>e_sub a. lower enums e = Some e_sub \<Longrightarrow> eval sch st env e_sub = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
   shows "value_has_ty \<Gamma> v TInt"
 proof -
   from assms(1) obtain e_sub where
@@ -1802,9 +1818,12 @@ proof -
     by (auto split: option.splits)
   from assms(2) e_eq have ev: "eval sch st env (UnNeg e_sub sp) = Some v"
     by simp
-  then obtain n where "v = VInt (- n)"
-    by (cases "eval sch st env e_sub")
-       (auto split: ir_value.splits)
+  then obtain a where ea: "eval sch st env e_sub = Some a"
+    by (cases "eval sch st env e_sub") auto
+  have "value_has_ty \<Gamma> a TInt" using assms(3)[OF sub_low ea] .
+  hence "\<exists>n. a = VInt n" by (cases a) (auto elim: value_has_ty.cases)
+  then obtain n where "a = VInt n" ..
+  with ea ev have "v = VInt (- n)" by simp
   thus "value_has_ty \<Gamma> v TInt" by simp
 qed
 
@@ -1812,6 +1831,8 @@ lemma h3_pres_Arith:
   assumes "op \<in> {BAdd, BSub, BMul, BDiv}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
+      and "\<And>l' a. lower enums l = Some l' \<Longrightarrow> eval sch st env l' = Some a \<Longrightarrow> value_has_ty \<Gamma> a TInt"
+      and "\<And>r' b. lower enums r = Some r' \<Longrightarrow> eval sch st env r' = Some b \<Longrightarrow> value_has_ty \<Gamma> b TInt"
   shows "value_has_ty \<Gamma> v TInt"
 proof -
   from assms(1,2) obtain l' r' aop where
@@ -1822,19 +1843,13 @@ proof -
   from assms(3) e_eq
   have ev: "eval_arith aop (eval sch st env l') (eval sch st env r') = Some v"
     by simp
-  from eval_arith_some_imp_int[OF ev] obtain a b where
-       el: "eval sch st env l' = Some (VInt a)"
-   and er: "eval sch st env r' = Some (VInt b)"
-    by blast
   show "value_has_ty \<Gamma> v TInt"
   proof (rule eval_arith_preservation[OF ev])
-    fix a' assume "eval sch st env l' = Some a'"
-    with el have "a' = VInt a" by simp
-    thus "value_has_ty \<Gamma> a' TInt" by simp
+    fix a assume "eval sch st env l' = Some a"
+    thus "value_has_ty \<Gamma> a TInt" using assms(4) l_low by blast
   next
-    fix b' assume "eval sch st env r' = Some b'"
-    with er have "b' = VInt b" by simp
-    thus "value_has_ty \<Gamma> b' TInt" by simp
+    fix b assume "eval sch st env r' = Some b"
+    thus "value_has_ty \<Gamma> b TInt" using assms(5) r_low by blast
   qed
 qed
 
@@ -1897,7 +1912,16 @@ next
   thus ?case using h3_pres_Ident_State by blast
 next
   case (T_Arith \<Gamma> l r op sp)
-  thus ?case using h3_pres_Arith by blast
+  show ?case
+  proof (rule h3_pres_Arith[OF T_Arith.hyps(3) T_Arith.prems(2) T_Arith.prems(3)])
+    fix l' a assume "lower enums l = Some l'" and "eval sch st env l' = Some a"
+    thus "value_has_ty \<Gamma> a TInt"
+      using T_Arith.IH(1) T_Arith.prems(1) T_Arith.prems(4) by blast
+  next
+    fix r' b assume "lower enums r = Some r'" and "eval sch st env r' = Some b"
+    thus "value_has_ty \<Gamma> b TInt"
+      using T_Arith.IH(2) T_Arith.prems(1) T_Arith.prems(4) by blast
+  qed
 next
   case (T_Cmp_Eq \<Gamma> l t r op sp)
   thus ?case using h3_pres_Cmp by blast
@@ -1912,7 +1936,12 @@ next
   thus ?case using h3_pres_Not by blast
 next
   case (T_Neg \<Gamma> e sp)
-  thus ?case using h3_pres_Neg by blast
+  show ?case
+  proof (rule h3_pres_Neg[OF T_Neg.prems(2) T_Neg.prems(3)])
+    fix e_sub a assume "lower enums e = Some e_sub" and "eval sch st env e_sub = Some a"
+    thus "value_has_ty \<Gamma> a TInt"
+      using T_Neg.IH T_Neg.prems(1) T_Neg.prems(4) by blast
+  qed
 next
   case (T_Let \<Gamma> vexp t1 x body t2 sp)
   from T_Let.prems(2) obtain v' body' where

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -1610,7 +1610,7 @@ proof (induction rule: expr_has_ty.induct)
   case (T_Arith \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
-  case (T_Cmp_Eq \<Gamma> l t r op sp)
+  case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
   case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
@@ -1960,7 +1960,7 @@ next
       using T_Arith.IH(2) T_Arith.prems(1) T_Arith.prems(4) by blast
   qed
 next
-  case (T_Cmp_Eq \<Gamma> l t r op sp)
+  case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   thus ?case using h3_pres_Cmp by blast
 next
   case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)


### PR DESCRIPTION
## Summary

The Z3 backend mapped every non-`Int` primitive to an uninterpreted sort, so ordering/arithmetic on `DateTime`/`Date` and `Float`/`Decimal`/`Money` reached the backend's blind casts and crashed with a `ClassCastException` (`Expr cannot be cast to ArithExpr/BoolExpr`). Three example specs hit this in the playground (`auth_service`, `strict_strategies_positive/negative`).

- Map temporal types to `Int` (epoch seconds) and fractional types to Z3 `Real`; generalize ordering/arithmetic over numeric sorts (`Int`|`Real`), with `Int`->`Real` coercion left to Z3 (so a `Money` field compared to an integer literal just works).
- Operands of a non-numeric sort, and refinement predicates the verifier cannot model as boolean (e.g. a strategy-backed `where`), now **skip** (translator coverage) instead of crashing.
- Sort-correctness is enforced by ADT value (`Z3Sort.isNumeric`) at the translator construction boundary - **no new `asInstanceOf`** or runtime type-deduction; the single pre-existing FFI cast was only retargeted `IntSort` -> `ArithSort`.
- The integral-vs-fractional split is the one type->sort fact made in the translator rather than derived from the proof: the Isabelle `ty` has only `Int`/`Bool` (no fractional sort), so it cannot express it.

## Result

- `auth_service` temporal invariants now verify (`access_expires_at > created_at`, `> now()`); was 5 crashes, now `5/78` pass.
- `Money`/`Float`/`Decimal` comparison and arithmetic verify (incl. mixed `Int`/`Real`).
- `strict_strategies` refinement predicate skips cleanly. Zero spec crashes across the fixture suite.

## Docs

- New "Scalar types" section in `verification.mdx` (type->sort table + numeric-operand rule), a maintainer note on adding a sort, and a Roadmap capability row.

## Test plan

- [x] `verify/test` 170/170, `cli/test` 65/65
- [x] `scalafixAll` clean
- [x] Full fixture sweep: no casts/crashes; previously-passing fixtures unchanged; intended-violation fixtures still fail correctly
- [x] Regenerated SMT goldens (`convention_errors` Float->Real, `url_shortener` DateTime->Int) confirmed to differ only by the intended sort change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modeled temporals as `Int` and fractionals as `Real` across the verifier and proofs to enable numeric ordering/arithmetic and remove `ClassCastException` crashes. Mixed `Int`/`Real` arithmetic and equality are now proven end-to-end; float literals lower to `Real` via a verified decimal parser.

- **New Features**
  - Numeric sorts: temporals → `Int`, fractionals → `Real`; builtins `now/seconds/minutes/hours/days` return `Int`.
  - Proof/IR: first-class `Real` (`rat`) as `TReal`/`VReal`/`SReal`; arithmetic, ordering, and negation generalized to numeric; mixed `Int`/`Real` coerces to `Real` in eval, typing, and `smtEval` (`numeric_join`).
  - Literals/SMT/UX: float literals parsed with verified `decimalToRat` and rendered as rationals; Z3 `Real` decoded into `VReal`; SMT goldens updated (`Float`→`Real`, `DateTime`→`Int`); docs add scalar type mapping.

- **Bug Fixes**
  - Numeric guards: require all arithmetic operands to be numeric; skip non-numeric terms and non-boolean refinements.
  - Mixed numeric behavior: arithmetic promotes to `Real` when any operand is `Real`; equality types when operands match or are both numeric (aligns with mixed `Int`/`Real` coercion).
  - Malformed float literals are rejected during lowering; removed obsolete translator-error fixture.

<sup>Written for commit af749ad590b95a7183bdcd0426cafb1550f60eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added scalar-type mapping, guidance for adding new sorts, and clarified that ordering/arithmetic apply only to numeric sorts; roadmap updated.

* **New Features**
  * End-to-end real-number support: real literals, mixed int/real arithmetic and comparisons, numeric sort inference, and improved model decoding.

* **Fixtures**
  * Updated SMT fixtures to use unified numeric sorts (Int/Real).

* **Tests**
  * Added tests for decimal/float literal parsing and rational handling.

* **Proofs**
  * Formalization and soundness proofs extended to cover real numbers and mixed numeric behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->