### PR TITLE
feat(proofs): lift StringLit to the Z3 native String theory

### DIFF
--- a/fixtures/golden/smt/convention_errors.smt2
+++ b/fixtures/golden/smt/convention_errors.smt2
@@ -3,7 +3,6 @@
 (set-option :timeout 30000)
 ;; sorts
 (declare-sort Status 0)
-(declare-sort String 0)
 (declare-sort Widget 0)
 ;; funcs
 (declare-fun Status_ACTIVE () Status)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -158,20 +158,31 @@ object SpecRestGenerated {
   final case class SEntityWith(a: smt_val, b: String, c: smt_val) extends smt_val
   final case class SNone()                                        extends smt_val
   final case class SSome(a: smt_val)                              extends smt_val
+  final case class SStr(a: String)                                extends smt_val
 
   def equal_smt_vala(x0: smt_val, x1: smt_val): Boolean = (x0, x1) match {
+    case (SSome(x9), SStr(x10))                              => false
+    case (SStr(x10), SSome(x9))                              => false
+    case (SNone(), SStr(x10))                                => false
+    case (SStr(x10), SNone())                                => false
     case (SNone(), SSome(x9))                                => false
     case (SSome(x9), SNone())                                => false
+    case (SEntityWith(x71, x72, x73), SStr(x10))             => false
+    case (SStr(x10), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SSome(x9))             => false
     case (SSome(x9), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SNone())               => false
     case (SNone(), SEntityWith(x71, x72, x73))               => false
+    case (SSet(x6), SStr(x10))                               => false
+    case (SStr(x10), SSet(x6))                               => false
     case (SSet(x6), SSome(x9))                               => false
     case (SSome(x9), SSet(x6))                               => false
     case (SSet(x6), SNone())                                 => false
     case (SNone(), SSet(x6))                                 => false
     case (SSet(x6), SEntityWith(x71, x72, x73))              => false
     case (SEntityWith(x71, x72, x73), SSet(x6))              => false
+    case (SEntityElem(x51, x52), SStr(x10))                  => false
+    case (SStr(x10), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SSome(x9))                  => false
     case (SSome(x9), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SNone())                    => false
@@ -180,6 +191,8 @@ object SpecRestGenerated {
     case (SEntityWith(x71, x72, x73), SEntityElem(x51, x52)) => false
     case (SEntityElem(x51, x52), SSet(x6))                   => false
     case (SSet(x6), SEntityElem(x51, x52))                   => false
+    case (SEnumElem(x41, x42), SStr(x10))                    => false
+    case (SStr(x10), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SSome(x9))                    => false
     case (SSome(x9), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SNone())                      => false
@@ -190,6 +203,8 @@ object SpecRestGenerated {
     case (SSet(x6), SEnumElem(x41, x42))                     => false
     case (SEnumElem(x41, x42), SEntityElem(x51, x52))        => false
     case (SEntityElem(x51, x52), SEnumElem(x41, x42))        => false
+    case (SReal(x3), SStr(x10))                              => false
+    case (SStr(x10), SReal(x3))                              => false
     case (SReal(x3), SSome(x9))                              => false
     case (SSome(x9), SReal(x3))                              => false
     case (SReal(x3), SNone())                                => false
@@ -202,6 +217,8 @@ object SpecRestGenerated {
     case (SEntityElem(x51, x52), SReal(x3))                  => false
     case (SReal(x3), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SReal(x3))                    => false
+    case (SInt(x2), SStr(x10))                               => false
+    case (SStr(x10), SInt(x2))                               => false
     case (SInt(x2), SSome(x9))                               => false
     case (SSome(x9), SInt(x2))                               => false
     case (SInt(x2), SNone())                                 => false
@@ -216,6 +233,8 @@ object SpecRestGenerated {
     case (SEnumElem(x41, x42), SInt(x2))                     => false
     case (SInt(x2), SReal(x3))                               => false
     case (SReal(x3), SInt(x2))                               => false
+    case (SBool(x1), SStr(x10))                              => false
+    case (SStr(x10), SBool(x1))                              => false
     case (SBool(x1), SSome(x9))                              => false
     case (SSome(x9), SBool(x1))                              => false
     case (SBool(x1), SNone())                                => false
@@ -232,6 +251,7 @@ object SpecRestGenerated {
     case (SReal(x3), SBool(x1))                              => false
     case (SBool(x1), SInt(x2))                               => false
     case (SInt(x2), SBool(x1))                               => false
+    case (SStr(x10), SStr(y10))                              => x10 == y10
     case (SSome(x9), SSome(y9))                              => equal_smt_vala(x9, y9)
     case (SEntityWith(x71, x72, x73), SEntityWith(y71, y72, y73)) =>
       equal_smt_vala(x71, y71) && (x72 == y72 && equal_smt_vala(x73, y73))
@@ -273,20 +293,31 @@ object SpecRestGenerated {
   final case class VEntityWith(a: ir_value, b: String, c: ir_value) extends ir_value
   final case class VNone()                                          extends ir_value
   final case class VSome(a: ir_value)                               extends ir_value
+  final case class VStr(a: String)                                  extends ir_value
 
   def equal_ir_valuea(x0: ir_value, x1: ir_value): Boolean = (x0, x1) match {
+    case (VSome(x9), VStr(x10))                          => false
+    case (VStr(x10), VSome(x9))                          => false
+    case (VNone(), VStr(x10))                            => false
+    case (VStr(x10), VNone())                            => false
     case (VNone(), VSome(x9))                            => false
     case (VSome(x9), VNone())                            => false
+    case (VEntityWith(x71, x72, x73), VStr(x10))         => false
+    case (VStr(x10), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VSome(x9))         => false
     case (VSome(x9), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VNone())           => false
     case (VNone(), VEntityWith(x71, x72, x73))           => false
+    case (VSet(x6), VStr(x10))                           => false
+    case (VStr(x10), VSet(x6))                           => false
     case (VSet(x6), VSome(x9))                           => false
     case (VSome(x9), VSet(x6))                           => false
     case (VSet(x6), VNone())                             => false
     case (VNone(), VSet(x6))                             => false
     case (VSet(x6), VEntityWith(x71, x72, x73))          => false
     case (VEntityWith(x71, x72, x73), VSet(x6))          => false
+    case (VEntity(x51, x52), VStr(x10))                  => false
+    case (VStr(x10), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VSome(x9))                  => false
     case (VSome(x9), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VNone())                    => false
@@ -295,6 +326,8 @@ object SpecRestGenerated {
     case (VEntityWith(x71, x72, x73), VEntity(x51, x52)) => false
     case (VEntity(x51, x52), VSet(x6))                   => false
     case (VSet(x6), VEntity(x51, x52))                   => false
+    case (VEnum(x41, x42), VStr(x10))                    => false
+    case (VStr(x10), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VSome(x9))                    => false
     case (VSome(x9), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VNone())                      => false
@@ -305,6 +338,8 @@ object SpecRestGenerated {
     case (VSet(x6), VEnum(x41, x42))                     => false
     case (VEnum(x41, x42), VEntity(x51, x52))            => false
     case (VEntity(x51, x52), VEnum(x41, x42))            => false
+    case (VReal(x3), VStr(x10))                          => false
+    case (VStr(x10), VReal(x3))                          => false
     case (VReal(x3), VSome(x9))                          => false
     case (VSome(x9), VReal(x3))                          => false
     case (VReal(x3), VNone())                            => false
@@ -317,6 +352,8 @@ object SpecRestGenerated {
     case (VEntity(x51, x52), VReal(x3))                  => false
     case (VReal(x3), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VReal(x3))                    => false
+    case (VInt(x2), VStr(x10))                           => false
+    case (VStr(x10), VInt(x2))                           => false
     case (VInt(x2), VSome(x9))                           => false
     case (VSome(x9), VInt(x2))                           => false
     case (VInt(x2), VNone())                             => false
@@ -331,6 +368,8 @@ object SpecRestGenerated {
     case (VEnum(x41, x42), VInt(x2))                     => false
     case (VInt(x2), VReal(x3))                           => false
     case (VReal(x3), VInt(x2))                           => false
+    case (VBool(x1), VStr(x10))                          => false
+    case (VStr(x10), VBool(x1))                          => false
     case (VBool(x1), VSome(x9))                          => false
     case (VSome(x9), VBool(x1))                          => false
     case (VBool(x1), VNone())                            => false
@@ -347,6 +386,7 @@ object SpecRestGenerated {
     case (VReal(x3), VBool(x1))                          => false
     case (VBool(x1), VInt(x2))                           => false
     case (VInt(x2), VBool(x1))                           => false
+    case (VStr(x10), VStr(y10))                          => x10 == y10
     case (VSome(x9), VSome(y9))                          => equal_ir_valuea(x9, y9)
     case (VEntityWith(x71, x72, x73), VEntityWith(y71, y72, y73)) =>
       equal_ir_valuea(x71, y71) && (x72 == y72 && equal_ir_valuea(x73, y73))
@@ -497,6 +537,7 @@ object SpecRestGenerated {
   final case class Ite(a: expr, b: expr, c: expr, d: Option[span_t]) extends expr
   final case class NoneE(a: Option[span_t])                          extends expr
   final case class SomeE(a: expr, b: Option[span_t])                 extends expr
+  final case class StrLit(a: String, b: Option[span_t])              extends expr
 
   sealed abstract class nat
   final case class Nata(a: BigInt) extends nat
@@ -657,6 +698,7 @@ object SpecRestGenerated {
   final case class TIte(a: smt_term, b: smt_term, c: smt_term)    extends smt_term
   final case class TNone()                                        extends smt_term
   final case class TSome(a: smt_term)                             extends smt_term
+  final case class TStrLit(a: String)                             extends smt_term
 
   sealed abstract class multiplicity
   final case class MultOne()  extends multiplicity
@@ -1705,6 +1747,7 @@ object SpecRestGenerated {
       case (uv, SSet(v), ux)          => None
       case (uv, SNone(), ux)          => None
       case (uv, SSome(v), ux)         => None
+      case (uv, SStr(v), ux)          => None
     }
 
   def sm_pred_domain[A](x0: smt_model_ext[A]): List[(String, List[smt_val])] =
@@ -1827,6 +1870,7 @@ object SpecRestGenerated {
     case TPrime(TIte(va, vb, vc))        => None
     case TPrime(TNone())                 => None
     case TPrime(TSome(va))               => None
+    case TPrime(TStrLit(va))             => None
     case TPre(BLit(va))                  => None
     case TPre(ILit(va))                  => None
     case TPre(RLit(va))                  => None
@@ -1861,10 +1905,12 @@ object SpecRestGenerated {
     case TPre(TIte(va, vb, vc))          => None
     case TPre(TNone())                   => None
     case TPre(TSome(va))                 => None
+    case TPre(TStrLit(va))               => None
     case TWithRec(v, va, vb)             => None
     case TIte(v, va, vb)                 => None
     case TNone()                         => None
     case TSome(v)                        => None
+    case TStrLit(v)                      => None
   }
 
   def set_diff_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
@@ -1898,6 +1944,7 @@ object SpecRestGenerated {
               case Some(SEntityWith(_, _, _)) => None
               case Some(SNone())              => None
               case Some(SSome(_))             => None
+              case Some(SStr(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -1907,6 +1954,7 @@ object SpecRestGenerated {
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
         }
     }
 
@@ -1934,6 +1982,7 @@ object SpecRestGenerated {
               case Some(SEntityWith(_, _, _)) => None
               case Some(SNone())              => None
               case Some(SSome(_))             => None
+              case Some(SStr(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -1943,6 +1992,7 @@ object SpecRestGenerated {
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
         }
     }
 
@@ -1975,6 +2025,7 @@ object SpecRestGenerated {
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
         }
       case (m, env, TAnd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -1989,6 +2040,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
+          case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -1997,6 +2049,7 @@ object SpecRestGenerated {
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TOr(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2011,6 +2064,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
+          case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2019,6 +2073,7 @@ object SpecRestGenerated {
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TImplies(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2033,6 +2088,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
+          case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2041,6 +2097,7 @@ object SpecRestGenerated {
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TEq(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2067,6 +2124,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SNone())))
           case (Some(SInt(a)), Some(SSome(smt_val))) =>
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SSome(smt_val))))
+          case (Some(SInt(a)), Some(SStr(literal))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SStr(literal))))
           case (Some(SReal(_)), None) => None
           case (Some(SReal(a)), Some(SBool(bool))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SBool(bool))))
@@ -2086,6 +2145,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SNone())))
           case (Some(SReal(a)), Some(SSome(smt_val))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SSome(smt_val))))
+          case (Some(SReal(a)), Some(SStr(literal))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SStr(literal))))
           case (Some(SEnumElem(_, _)), None) => None
           case (Some(SEnumElem(literal1, literal2)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SEnumElem(literal1, literal2), b)))
@@ -2104,6 +2165,9 @@ object SpecRestGenerated {
           case (Some(SSome(_)), None) => None
           case (Some(SSome(smt_val)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SSome(smt_val), b)))
+          case (Some(SStr(_)), None) => None
+          case (Some(SStr(literal)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SStr(literal), b)))
         }
       case (m, env, TLt(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2121,6 +2185,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
+          case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2133,12 +2198,14 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
+          case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TNeg(t)) =>
         smtEval(m, env, t) match {
@@ -2152,6 +2219,7 @@ object SpecRestGenerated {
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
         }
       case (m, env, TAdd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2169,6 +2237,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
+          case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2181,12 +2250,14 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
+          case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TSub(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2204,6 +2275,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
+          case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2216,12 +2288,14 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
+          case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TMul(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2239,6 +2313,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
+          case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2251,12 +2326,14 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
+          case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TDiv(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2280,6 +2357,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
+          case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2298,12 +2376,14 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
+          case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
+          case (Some(SStr(_)), _)                           => None
         }
       case (m, env, TInDom(rel_name, arg)) =>
         smtEval(m, env, arg) match {
@@ -2361,6 +2441,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SEntityWith(_, _, _))) => None
           case (Some(_), Some(SNone()))              => None
           case (Some(_), Some(SSome(_)))             => None
+          case (Some(_), Some(SStr(_)))              => None
         }
       case (m, env, TSetMember(elem, set_t)) =>
         (smtEval(m, env, elem), smtEval(m, env, set_t)) match {
@@ -2376,6 +2457,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SEntityWith(_, _, _))) => None
           case (Some(_), Some(SNone()))              => None
           case (Some(_), Some(SSome(_)))             => None
+          case (Some(_), Some(SStr(_)))              => None
         }
       case (m, env, TSetUnion(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2396,9 +2478,11 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
+          case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
+          case (Some(SStr(_)), _)                          => None
         }
       case (m, env, TSetIntersect(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2419,9 +2503,11 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
+          case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
+          case (Some(SStr(_)), _)                          => None
         }
       case (m, env, TSetDiff(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2442,9 +2528,11 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SEntityWith(_, _, _))) => None
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
+          case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
+          case (Some(SStr(_)), _)                          => None
         }
       case (m, env, TPrime(t)) => smtEval(m, env, t)
       case (m, env, TPre(t))   => smtEval(m, env, t)
@@ -2467,10 +2555,12 @@ object SpecRestGenerated {
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
         }
       case (m, env, TNone()) => Some[smt_val](SNone())
       case (m, env, TSome(t)) =>
         map_option[smt_val, smt_val]((a: smt_val) => SSome(a), smtEval(m, env, t))
+      case (m, env, TStrLit(v)) => Some[smt_val](SStr(v))
     }
 
   def binOpToTs(x0: bin_op_full): String = x0 match {
@@ -2850,6 +2940,7 @@ object SpecRestGenerated {
     case Prime(Ite(vb, vc, vd, ve), va)        => None
     case Prime(NoneE(vb), va)                  => None
     case Prime(SomeE(vb, vc), va)              => None
+    case Prime(StrLit(vb, vc), va)             => None
     case Pre(BoolLit(vb, vc), va)              => None
     case Pre(IntLit(vb, vc), va)               => None
     case Pre(RealLit(vb, vc), va)              => None
@@ -2876,6 +2967,7 @@ object SpecRestGenerated {
     case Pre(Ite(vb, vc, vd, ve), va)          => None
     case Pre(NoneE(vb), va)                    => None
     case Pre(SomeE(vb, vc), va)                => None
+    case Pre(StrLit(vb, vc), va)               => None
     case CardRel(v, va)                        => None
     case IndexRel(v, va, vb)                   => None
     case FieldAccess(v, va, vb)                => None
@@ -2887,6 +2979,7 @@ object SpecRestGenerated {
     case Ite(v, va, vb, vc)                    => None
     case NoneE(v)                              => None
     case SomeE(v, va)                          => None
+    case StrLit(v, va)                         => None
   }
 
   def one_rat: rat = Frct((one_inta, one_inta))
@@ -2963,14 +3056,14 @@ object SpecRestGenerated {
   }
 
   def lower_with_assigns(
-      wk: List[String],
+      wi: List[String],
       x1: List[field_assign_full],
       base: expr,
-      wl: Option[span_t]
+      wj: Option[span_t]
   ): Option[expr] =
-    (wk, x1, base, wl) match {
-      case (wk, Nil, base, wl) => Some[expr](base)
-      case (enums, FieldAssignFull(fld, v, wm) :: rest, base, sp) =>
+    (wi, x1, base, wj) match {
+      case (wi, Nil, base, wj) => Some[expr](base)
+      case (enums, FieldAssignFull(fld, v, wk) :: rest, base, sp) =>
         lower(enums, v) match {
           case None => None
           case Some(va) =>
@@ -2978,9 +3071,9 @@ object SpecRestGenerated {
         }
     }
 
-  def lowerSetList(wj: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
-    (wj, x1, sp) match {
-      case (wj, Nil, sp) => Some[expr](SetEmpty(sp))
+  def lowerSetList(wh: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (wh, x1, sp) match {
+      case (wh, Nil, sp) => Some[expr](SetEmpty(sp))
       case (enums, e :: rest, sp) =>
         (lower(enums, e), lowerSetList(enums, rest, sp)) match {
           case (None, _)           => None
@@ -2995,16 +3088,16 @@ object SpecRestGenerated {
     case (uw, IdentifierF(x, sp)) => Some[expr](Ident(x, sp))
     case (ux, FloatLitF(s, sp)) =>
       map_option[rat, expr]((r: rat) => RealLit(r, sp), decimalToRat(s))
-    case (uy, StringLitF(uz, va))                => None
-    case (vb, NoneLitF(sp))                      => Some[expr](NoneE(sp))
-    case (vc, LambdaF(vd, ve, vf))               => None
-    case (vg, CallF(vh, vi, vj))                 => None
-    case (vk, ConstructorF(vl, vm, vn))          => None
-    case (vo, MapLiteralF(vp, vq))               => None
-    case (vr, SeqLiteralF(vs, vt))               => None
-    case (vu, SetComprehensionF(vv, vw, vx, vy)) => None
-    case (vz, TheF(wa, wb, wc, wd))              => None
-    case (we, MatchesF(wf, wg, wh))              => None
+    case (uy, StringLitF(v, sp))                 => Some[expr](StrLit(v, sp))
+    case (uz, NoneLitF(sp))                      => Some[expr](NoneE(sp))
+    case (va, LambdaF(vb, vc, vd))               => None
+    case (ve, CallF(vf, vg, vh))                 => None
+    case (vi, ConstructorF(vj, vk, vl))          => None
+    case (vm, MapLiteralF(vn, vo))               => None
+    case (vp, SeqLiteralF(vq, vr))               => None
+    case (vs, SetComprehensionF(vt, vu, vv, vw)) => None
+    case (vx, TheF(vy, vz, wa, wb))              => None
+    case (wc, MatchesF(wd, we, wf))              => None
     case (enums, QuantifierF(k, bs, body, sp)) =>
       lower(enums, body) match {
         case None => None
@@ -3528,7 +3621,7 @@ object SpecRestGenerated {
         case (Some(_), None)     => None
         case (Some(va), Some(b)) => Some[expr](LetIn(x, va, b, sp))
       }
-    case (wi, EnumAccessF(base, mem, sp)) =>
+    case (wg, EnumAccessF(base, mem, sp)) =>
       base match {
         case BinaryOpF(_, _, _, _)         => None
         case UnaryOpF(_, _, _)             => None
@@ -3641,6 +3734,7 @@ object SpecRestGenerated {
       case (uv, VSet(v), ux)      => None
       case (uv, VNone(), ux)      => None
       case (uv, VSome(v), ux)     => None
+      case (uv, VStr(v), ux)      => None
     }
 
   def sch_enums[A](x0: schema_ext[A]): List[enum_decl_ext[Unit]] = x0 match {
@@ -3731,6 +3825,7 @@ object SpecRestGenerated {
       case (IntersectOp(), Some(VEntityWith(va, vb, vc)), uw) => None
       case (IntersectOp(), Some(VNone()), uw)                 => None
       case (IntersectOp(), Some(VSome(va)), uw)               => None
+      case (IntersectOp(), Some(VStr(va)), uw)                => None
       case (IntersectOp(), uv, None)                          => None
       case (IntersectOp(), uv, Some(VBool(va)))               => None
       case (IntersectOp(), uv, Some(VInt(va)))                => None
@@ -3740,6 +3835,7 @@ object SpecRestGenerated {
       case (IntersectOp(), uv, Some(VEntityWith(va, vb, vc))) => None
       case (IntersectOp(), uv, Some(VNone()))                 => None
       case (IntersectOp(), uv, Some(VSome(va)))               => None
+      case (IntersectOp(), uv, Some(VStr(va)))                => None
       case (DiffOp(), None, uw)                               => None
       case (DiffOp(), Some(VBool(va)), uw)                    => None
       case (DiffOp(), Some(VInt(va)), uw)                     => None
@@ -3749,6 +3845,7 @@ object SpecRestGenerated {
       case (DiffOp(), Some(VEntityWith(va, vb, vc)), uw)      => None
       case (DiffOp(), Some(VNone()), uw)                      => None
       case (DiffOp(), Some(VSome(va)), uw)                    => None
+      case (DiffOp(), Some(VStr(va)), uw)                     => None
       case (DiffOp(), uv, None)                               => None
       case (DiffOp(), uv, Some(VBool(va)))                    => None
       case (DiffOp(), uv, Some(VInt(va)))                     => None
@@ -3758,6 +3855,7 @@ object SpecRestGenerated {
       case (DiffOp(), uv, Some(VEntityWith(va, vb, vc)))      => None
       case (DiffOp(), uv, Some(VNone()))                      => None
       case (DiffOp(), uv, Some(VSome(va)))                    => None
+      case (DiffOp(), uv, Some(VStr(va)))                     => None
       case (uu, None, uw)                                     => None
       case (uu, Some(VBool(va)), uw)                          => None
       case (uu, Some(VInt(va)), uw)                           => None
@@ -3767,6 +3865,7 @@ object SpecRestGenerated {
       case (uu, Some(VEntityWith(va, vb, vc)), uw)            => None
       case (uu, Some(VNone()), uw)                            => None
       case (uu, Some(VSome(va)), uw)                          => None
+      case (uu, Some(VStr(va)), uw)                           => None
       case (uu, uv, None)                                     => None
       case (uu, uv, Some(VBool(va)))                          => None
       case (uu, uv, Some(VInt(va)))                           => None
@@ -3776,6 +3875,7 @@ object SpecRestGenerated {
       case (uu, uv, Some(VEntityWith(va, vb, vc)))            => None
       case (uu, uv, Some(VNone()))                            => None
       case (uu, uv, Some(VSome(va)))                          => None
+      case (uu, uv, Some(VStr(va)))                           => None
     }
 
   def eval_arith(uu: arith_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
@@ -3834,12 +3934,14 @@ object SpecRestGenerated {
       case (SubOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (SubOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (SubOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (SubOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (SubOp(), Some(VEnum(va, vb)), uw)                        => None
       case (SubOp(), Some(VEntity(va, vb)), uw)                      => None
       case (SubOp(), Some(VSet(va)), uw)                             => None
       case (SubOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (SubOp(), Some(VNone()), uw)                              => None
       case (SubOp(), Some(VSome(va)), uw)                            => None
+      case (SubOp(), Some(VStr(va)), uw)                             => None
       case (SubOp(), uv, None)                                       => None
       case (SubOp(), uv, Some(VBool(va)))                            => None
       case (SubOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -3848,6 +3950,7 @@ object SpecRestGenerated {
       case (SubOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (SubOp(), uv, Some(VNone()))                              => None
       case (SubOp(), uv, Some(VSome(va)))                            => None
+      case (SubOp(), uv, Some(VStr(va)))                             => None
       case (MulOp(), None, uw)                                       => None
       case (MulOp(), Some(VBool(va)), uw)                            => None
       case (MulOp(), Some(VReal(va)), None)                          => None
@@ -3858,12 +3961,14 @@ object SpecRestGenerated {
       case (MulOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (MulOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (MulOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (MulOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (MulOp(), Some(VEnum(va, vb)), uw)                        => None
       case (MulOp(), Some(VEntity(va, vb)), uw)                      => None
       case (MulOp(), Some(VSet(va)), uw)                             => None
       case (MulOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (MulOp(), Some(VNone()), uw)                              => None
       case (MulOp(), Some(VSome(va)), uw)                            => None
+      case (MulOp(), Some(VStr(va)), uw)                             => None
       case (MulOp(), uv, None)                                       => None
       case (MulOp(), uv, Some(VBool(va)))                            => None
       case (MulOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -3872,6 +3977,7 @@ object SpecRestGenerated {
       case (MulOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (MulOp(), uv, Some(VNone()))                              => None
       case (MulOp(), uv, Some(VSome(va)))                            => None
+      case (MulOp(), uv, Some(VStr(va)))                             => None
       case (DivOp(), None, uw)                                       => None
       case (DivOp(), Some(VBool(va)), uw)                            => None
       case (DivOp(), Some(VReal(va)), None)                          => None
@@ -3882,12 +3988,14 @@ object SpecRestGenerated {
       case (DivOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (DivOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (DivOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (DivOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (DivOp(), Some(VEnum(va, vb)), uw)                        => None
       case (DivOp(), Some(VEntity(va, vb)), uw)                      => None
       case (DivOp(), Some(VSet(va)), uw)                             => None
       case (DivOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (DivOp(), Some(VNone()), uw)                              => None
       case (DivOp(), Some(VSome(va)), uw)                            => None
+      case (DivOp(), Some(VStr(va)), uw)                             => None
       case (DivOp(), uv, None)                                       => None
       case (DivOp(), uv, Some(VBool(va)))                            => None
       case (DivOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -3896,6 +4004,7 @@ object SpecRestGenerated {
       case (DivOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (DivOp(), uv, Some(VNone()))                              => None
       case (DivOp(), uv, Some(VSome(va)))                            => None
+      case (DivOp(), uv, Some(VStr(va)))                             => None
       case (uu, None, uw)                                            => None
       case (uu, Some(VBool(va)), uw)                                 => None
       case (uu, Some(VReal(va)), None)                               => None
@@ -3906,12 +4015,14 @@ object SpecRestGenerated {
       case (uu, Some(VReal(va)), Some(VEntityWith(vb, vc, vd)))      => None
       case (uu, Some(VReal(va)), Some(VNone()))                      => None
       case (uu, Some(VReal(va)), Some(VSome(vb)))                    => None
+      case (uu, Some(VReal(va)), Some(VStr(vb)))                     => None
       case (uu, Some(VEnum(va, vb)), uw)                             => None
       case (uu, Some(VEntity(va, vb)), uw)                           => None
       case (uu, Some(VSet(va)), uw)                                  => None
       case (uu, Some(VEntityWith(va, vb, vc)), uw)                   => None
       case (uu, Some(VNone()), uw)                                   => None
       case (uu, Some(VSome(va)), uw)                                 => None
+      case (uu, Some(VStr(va)), uw)                                  => None
       case (uu, uv, None)                                            => None
       case (uu, uv, Some(VBool(va)))                                 => None
       case (uu, uv, Some(VEnum(va, vb)))                             => None
@@ -3920,6 +4031,7 @@ object SpecRestGenerated {
       case (uu, uv, Some(VEntityWith(va, vb, vc)))                   => None
       case (uu, uv, Some(VNone()))                                   => None
       case (uu, uv, Some(VSome(va)))                                 => None
+      case (uu, uv, Some(VStr(va)))                                  => None
     }
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
@@ -3945,6 +4057,7 @@ object SpecRestGenerated {
       case (VInt(_), VEntityWith(_, _, _))  => equal_ir_valuea(x, y)
       case (VInt(_), VNone())               => equal_ir_valuea(x, y)
       case (VInt(_), VSome(_))              => equal_ir_valuea(x, y)
+      case (VInt(_), VStr(_))               => equal_ir_valuea(x, y)
       case (VReal(_), VBool(_))             => equal_ir_valuea(x, y)
       case (VReal(a), VInt(b))              => equal_rat(a, of_int(b))
       case (VReal(_), VReal(_))             => equal_ir_valuea(x, y)
@@ -3954,12 +4067,14 @@ object SpecRestGenerated {
       case (VReal(_), VEntityWith(_, _, _)) => equal_ir_valuea(x, y)
       case (VReal(_), VNone())              => equal_ir_valuea(x, y)
       case (VReal(_), VSome(_))             => equal_ir_valuea(x, y)
+      case (VReal(_), VStr(_))              => equal_ir_valuea(x, y)
       case (VEnum(_, _), _)                 => equal_ir_valuea(x, y)
       case (VEntity(_, _), _)               => equal_ir_valuea(x, y)
       case (VSet(_), _)                     => equal_ir_valuea(x, y)
       case (VEntityWith(_, _, _), _)        => equal_ir_valuea(x, y)
       case (VNone(), _)                     => equal_ir_valuea(x, y)
       case (VSome(_), _)                    => equal_ir_valuea(x, y)
+      case (VStr(_), _)                     => equal_ir_valuea(x, y)
     }
 
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
@@ -4010,12 +4125,14 @@ object SpecRestGenerated {
       case (LtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (LtOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (LtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (LtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (LtOp(), Some(VEnum(va, vb)), uw)                        => None
       case (LtOp(), Some(VEntity(va, vb)), uw)                      => None
       case (LtOp(), Some(VSet(va)), uw)                             => None
       case (LtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (LtOp(), Some(VNone()), uw)                              => None
       case (LtOp(), Some(VSome(va)), uw)                            => None
+      case (LtOp(), Some(VStr(va)), uw)                             => None
       case (LtOp(), uv, None)                                       => None
       case (LtOp(), uv, Some(VBool(va)))                            => None
       case (LtOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4024,6 +4141,7 @@ object SpecRestGenerated {
       case (LtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (LtOp(), uv, Some(VNone()))                              => None
       case (LtOp(), uv, Some(VSome(va)))                            => None
+      case (LtOp(), uv, Some(VStr(va)))                             => None
       case (LeOp(), None, uw)                                       => None
       case (LeOp(), Some(VBool(va)), uw)                            => None
       case (LeOp(), Some(VReal(va)), None)                          => None
@@ -4034,12 +4152,14 @@ object SpecRestGenerated {
       case (LeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (LeOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (LeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (LeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (LeOp(), Some(VEnum(va, vb)), uw)                        => None
       case (LeOp(), Some(VEntity(va, vb)), uw)                      => None
       case (LeOp(), Some(VSet(va)), uw)                             => None
       case (LeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (LeOp(), Some(VNone()), uw)                              => None
       case (LeOp(), Some(VSome(va)), uw)                            => None
+      case (LeOp(), Some(VStr(va)), uw)                             => None
       case (LeOp(), uv, None)                                       => None
       case (LeOp(), uv, Some(VBool(va)))                            => None
       case (LeOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4048,6 +4168,7 @@ object SpecRestGenerated {
       case (LeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (LeOp(), uv, Some(VNone()))                              => None
       case (LeOp(), uv, Some(VSome(va)))                            => None
+      case (LeOp(), uv, Some(VStr(va)))                             => None
       case (GtOp(), None, uw)                                       => None
       case (GtOp(), Some(VBool(va)), uw)                            => None
       case (GtOp(), Some(VReal(va)), None)                          => None
@@ -4058,12 +4179,14 @@ object SpecRestGenerated {
       case (GtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (GtOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (GtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (GtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (GtOp(), Some(VEnum(va, vb)), uw)                        => None
       case (GtOp(), Some(VEntity(va, vb)), uw)                      => None
       case (GtOp(), Some(VSet(va)), uw)                             => None
       case (GtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (GtOp(), Some(VNone()), uw)                              => None
       case (GtOp(), Some(VSome(va)), uw)                            => None
+      case (GtOp(), Some(VStr(va)), uw)                             => None
       case (GtOp(), uv, None)                                       => None
       case (GtOp(), uv, Some(VBool(va)))                            => None
       case (GtOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4072,6 +4195,7 @@ object SpecRestGenerated {
       case (GtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (GtOp(), uv, Some(VNone()))                              => None
       case (GtOp(), uv, Some(VSome(va)))                            => None
+      case (GtOp(), uv, Some(VStr(va)))                             => None
       case (GeOp(), None, uw)                                       => None
       case (GeOp(), Some(VBool(va)), uw)                            => None
       case (GeOp(), Some(VReal(va)), None)                          => None
@@ -4082,12 +4206,14 @@ object SpecRestGenerated {
       case (GeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
       case (GeOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (GeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
+      case (GeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
       case (GeOp(), Some(VEnum(va, vb)), uw)                        => None
       case (GeOp(), Some(VEntity(va, vb)), uw)                      => None
       case (GeOp(), Some(VSet(va)), uw)                             => None
       case (GeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
       case (GeOp(), Some(VNone()), uw)                              => None
       case (GeOp(), Some(VSome(va)), uw)                            => None
+      case (GeOp(), Some(VStr(va)), uw)                             => None
       case (GeOp(), uv, None)                                       => None
       case (GeOp(), uv, Some(VBool(va)))                            => None
       case (GeOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4096,6 +4222,7 @@ object SpecRestGenerated {
       case (GeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
       case (GeOp(), uv, Some(VNone()))                              => None
       case (GeOp(), uv, Some(VSome(va)))                            => None
+      case (GeOp(), uv, Some(VStr(va)))                             => None
       case (uu, None, uw)                                           => None
       case (uu, uv, None)                                           => None
     }
@@ -4126,6 +4253,7 @@ object SpecRestGenerated {
               case Some(VEntityWith(_, _, _)) => None
               case Some(VNone())              => None
               case Some(VSome(_))             => None
+              case Some(VStr(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4135,6 +4263,7 @@ object SpecRestGenerated {
           case Some(VEntityWith(_, _, _)) => None
           case Some(VNone())              => None
           case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
         }
     }
 
@@ -4163,6 +4292,7 @@ object SpecRestGenerated {
               case Some(VEntityWith(_, _, _)) => None
               case Some(VNone())              => None
               case Some(VSome(_))             => None
+              case Some(VStr(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4172,6 +4302,7 @@ object SpecRestGenerated {
           case Some(VEntityWith(_, _, _)) => None
           case Some(VNone())              => None
           case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
         }
     }
 
@@ -4201,6 +4332,7 @@ object SpecRestGenerated {
           case Some(VEntityWith(_, _, _)) => None
           case Some(VNone())              => None
           case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
         }
       case (s, st, env, UnNeg(e, uz)) =>
         eval(s, st, env, e) match {
@@ -4214,6 +4346,7 @@ object SpecRestGenerated {
           case Some(VEntityWith(_, _, _)) => None
           case Some(VNone())              => None
           case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
         }
       case (s, st, env, BoolBin(op, l, r, va)) =>
         (eval(s, st, env, l), eval(s, st, env, r)) match {
@@ -4229,6 +4362,7 @@ object SpecRestGenerated {
           case (Some(VBool(_)), Some(VEntityWith(_, _, _))) => None
           case (Some(VBool(_)), Some(VNone()))              => None
           case (Some(VBool(_)), Some(VSome(_)))             => None
+          case (Some(VBool(_)), Some(VStr(_)))              => None
           case (Some(VInt(_)), _)                           => None
           case (Some(VReal(_)), _)                          => None
           case (Some(VEnum(_, _)), _)                       => None
@@ -4237,6 +4371,7 @@ object SpecRestGenerated {
           case (Some(VEntityWith(_, _, _)), _)              => None
           case (Some(VNone()), _)                           => None
           case (Some(VSome(_)), _)                          => None
+          case (Some(VStr(_)), _)                           => None
         }
       case (s, st, env, Arith(op, l, r, vb)) =>
         eval_arith(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4311,6 +4446,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VEntityWith(_, _, _))) => None
           case (Some(_), Some(VNone()))              => None
           case (Some(_), Some(VSome(_)))             => None
+          case (Some(_), Some(VStr(_)))              => None
         }
       case (s, st, env, SetMember(elem, set_e, vp)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
@@ -4326,6 +4462,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VEntityWith(_, _, _))) => None
           case (Some(_), Some(VNone()))              => None
           case (Some(_), Some(VSome(_)))             => None
+          case (Some(_), Some(VStr(_)))              => None
         }
       case (s, st, env, SetBin(op, l, r, vq)) =>
         eval_set_bin(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4348,10 +4485,12 @@ object SpecRestGenerated {
           case Some(VEntityWith(_, _, _)) => None
           case Some(VNone())              => None
           case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
         }
       case (s, st, env, NoneE(vt)) => Some[ir_value](VNone())
       case (s, st, env, SomeE(e, vu)) =>
         map_option[ir_value, ir_value]((a: ir_value) => VSome(a), eval(s, st, env, e))
+      case (s, st, env, StrLit(v, vv)) => Some[ir_value](VStr(v))
     }
 
   def map_filter[A, B](f: A => Option[B], x1: List[A]): List[B] = (f, x1) match {
@@ -5508,6 +5647,7 @@ object SpecRestGenerated {
     case Ite(c, a, b, wf) => TIte(translate(c), translate(a), translate(b))
     case NoneE(wg)        => TNone()
     case SomeE(e, wh)     => TSome(translate(e))
+    case StrLit(v, wi)    => TStrLit(v)
   }
 
   def litClass(x0: expr_full): Option[lit_class] = x0 match {
@@ -12586,9 +12726,9 @@ object SpecRestGenerated {
     case (TBool(), TBool())         => true
   }
 
-  def check_value_has_ty_list(wb: tyctx_ext[Unit], x1: List[ir_value], wc: ty): Boolean =
-    (wb, x1, wc) match {
-      case (wb, Nil, wc) => true
+  def check_value_has_ty_list(wd: tyctx_ext[Unit], x1: List[ir_value], we: ty): Boolean =
+    (wd, x1, we) match {
+      case (wd, Nil, we) => true
       case (gamma, v :: vs, t) =>
         check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
     }
@@ -12619,6 +12759,7 @@ object SpecRestGenerated {
       case (gamma, VEntityWith(vu, vv, vw), TSet(vx))  => false
       case (gamma, VNone(), vy)                        => false
       case (gamma, VSome(vz), wa)                      => false
+      case (gamma, VStr(wb), wc)                       => false
     }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl_full] = x0 match {

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -49,3 +49,7 @@ object IrValueDecoder:
         None
       case Z3Sort.OptionOf(_) =>
         None
+      case Z3Sort.Str =>
+        if raw.length >= 2 && raw.startsWith("\"") && raw.endsWith("\"") then
+          Some(VStr(raw.substring(1, raw.length - 1)))
+        else Some(VStr(raw))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -164,6 +164,7 @@ private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3S
         Z3Sort.key(s),
         optionSortFor(ctx, sortMap, resolveSort(ctx, sortMap, elem))
       )
+    case Z3Sort.Str => ctx.getStringSort
 
 @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
 private def optionSortFor(
@@ -284,6 +285,8 @@ private object Backend:
     case Z3Expr.OptSome(value, _) =>
       val v = renderExpr(rctx, value)
       optionSortFor(rctx.ctx, rctx.sortMap, v.getSort).getConstructors()(1).apply(v)
+    case Z3Expr.StrLit(s, _) =>
+      rctx.ctx.mkString(s)
 
   def renderBool(rctx: RenderCtx, e: Z3Expr): BoolExpr =
     renderExpr(rctx, e).asInstanceOf[BoolExpr]

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -135,6 +135,7 @@ object Z3CounterExample:
       else None
     case Z3Sort.SetOf(elem) => sortToTy(elem, ctx).map(TSet.apply)
     case Z3Sort.OptionOf(_) => None
+    case Z3Sort.Str         => None
 
   private def validateType(
       expr: Z3AstExpr[?],

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -33,6 +33,7 @@ object SmtLib:
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"(Set ${renderSort(e)})"
     case Z3Sort.OptionOf(e) => s"(Option ${renderSort(e)})"
+    case Z3Sort.Str         => "String"
 
   private def renderFuncDecl(f: Z3FunctionDecl): String =
     val args = f.argSorts.map(renderSort).mkString(" ")
@@ -93,6 +94,8 @@ object SmtLib:
       s"(as none (Option ${renderSort(elemSort)}))"
     case Z3Expr.OptSome(value, _) =>
       s"(some ${renderExpr(value)})"
+    case Z3Expr.StrLit(s, _) =>
+      "\"" + s.replace("\"", "\"\"") + "\""
 
   private def emptySetLit(elemSort: Z3Sort): String =
     s"((as const (Set ${renderSort(elemSort)})) false)"

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -20,8 +20,6 @@ private def fail(ctx: TranslateCtx, msg: String): Nothing =
 extension (e: expr_full)
   private def spanOpt: Option[span_t] = spanOf(e)
 
-private val StringSortName = "String"
-
 private enum StateMode derives CanEqual:
   case Pre, Post
 
@@ -611,11 +609,12 @@ object Translator:
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"Set_${sortNameOf(e)}"
     case Z3Sort.OptionOf(e) => s"Option_${sortNameOf(e)}"
+    case Z3Sort.Str         => "String"
 
   private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort =
     primitiveSortOf(name).getOrElse:
       name match
-        case "String" => Z3Sort.Uninterp(StringSortName)
+        case "String" => Z3Sort.Str
         case _ =>
           ctx.entities.get(name).map(_.sort).orElse {
             ctx.enums.get(name).map(_.sort)
@@ -645,7 +644,7 @@ object Translator:
           Z3Expr.RealLit(num, den)
         case None => fail(ctx, s"malformed float literal: '$s'")
     case BoolLitF(v, _)              => Z3Expr.BoolLit(v)
-    case StringLitF(v, _)            => stringLiteralConst(ctx, v)
+    case StringLitF(v, _)            => Z3Expr.StrLit(v)
     case IdentifierF(name, _)        => resolveIdentifier(ctx, name, env)
     case BinaryOpF(op, l, r, _)      => translateBinaryOp(ctx, op, l, r, env)
     case u @ UnaryOpF(_, _, _)       => translateUnaryOp(ctx, u, env)
@@ -1120,7 +1119,7 @@ object Translator:
   ): Z3Expr =
     val arg = translateExpr(ctx, expr.a, env)
     val argSort =
-      inferSort(ctx, expr.a, env, Some(arg)).getOrElse(Z3Sort.Uninterp(StringSortName))
+      inferSort(ctx, expr.a, env, Some(arg)).getOrElse(Z3Sort.Str)
     val baseName = ctx.matchesNameFor(expr.b)
     val funcName = s"${baseName}_${sortNameOf(argSort)}"
     if !ctx.funcs.contains(funcName) then
@@ -1222,12 +1221,6 @@ object Translator:
       case _ =>
         fail(ctx, "enum access base must be an identifier")
 
-  private def stringLiteralConst(ctx: TranslateCtx, value: String): Z3Expr =
-    val name = ctx.stringLitNameFor(value)
-    if !ctx.funcs.contains(name) then
-      ctx.declareFunc(Z3FunctionDecl(name, Nil, Z3Sort.Uninterp(StringSortName)))
-    Z3Expr.App(name, Nil)
-
   private def resolveIdentifier(
       ctx: TranslateCtx,
       name: String,
@@ -1290,7 +1283,7 @@ object Translator:
     case IntLitF(_, _)                     => Some(Z3Sort.Int)
     case FloatLitF(_, _)                   => Some(Z3Sort.Real)
     case BoolLitF(_, _)                    => Some(Z3Sort.Bool)
-    case StringLitF(_, _)                  => Some(Z3Sort.Uninterp(StringSortName))
+    case StringLitF(_, _)                  => Some(Z3Sort.Str)
     case CallF(IdentifierF(name, _), _, _) => Some(callReturnSort(name, ctx))
     case SetLiteralF(elements, _) =>
       elements.iterator.flatMap(e => inferSort(ctx, e, env, None)).nextOption().map(Z3Sort.SetOf(_))
@@ -1327,6 +1320,7 @@ object Translator:
       inferSortOfZ3Expr(ctx, t).orElse(inferSortOfZ3Expr(ctx, e))
     case Z3Expr.OptNone(elemSort, _) => Some(Z3Sort.OptionOf(elemSort))
     case Z3Expr.OptSome(value, _)    => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
+    case Z3Expr.StrLit(_, _)         => Some(Z3Sort.Str)
 
   private def tryLowerDomEquality(
       ctx: TranslateCtx,
@@ -2188,6 +2182,8 @@ object Translator:
         )
       case TSome(t) =>
         Z3Expr.OptSome(encodeFromSmtTerm(ctx, t, env))
+      case TStrLit(s) =>
+        Z3Expr.StrLit(s)
 
   private def encodeNoneEq(
       ctx: TranslateCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -9,6 +9,7 @@ enum Z3Sort derives CanEqual:
   case Uninterp(name: String)
   case SetOf(elem: Z3Sort)
   case OptionOf(elem: Z3Sort)
+  case Str
 
 object Z3Sort:
   val IntS: Z3Sort  = Int
@@ -25,6 +26,7 @@ object Z3Sort:
     case Bool        => "Bool"
     case SetOf(e)    => s"Set(${key(e)})"
     case OptionOf(e) => s"Option(${key(e)})"
+    case Str         => "Str"
 
   def eq(a: Z3Sort, b: Z3Sort): Boolean = key(a) == key(b)
 
@@ -96,6 +98,7 @@ enum Z3Expr derives CanEqual:
   case Ite(cond: Z3Expr, thenE: Z3Expr, elseE: Z3Expr, span: Option[span_t] = None)
   case OptNone(elemSort: Z3Sort, span: Option[span_t] = None)
   case OptSome(value: Z3Expr, span: Option[span_t] = None)
+  case StrLit(value: String, span: Option[span_t] = None)
 
   def spanOpt: Option[span_t] = this match
     case e: Var        => e.span
@@ -117,6 +120,7 @@ enum Z3Expr derives CanEqual:
     case e: Ite        => e.span
     case e: OptNone    => e.span
     case e: OptSome    => e.span
+    case e: StrLit     => e.span
 
   def withSpan(s: Option[span_t]): Z3Expr =
     if s.isEmpty then this
@@ -141,6 +145,7 @@ enum Z3Expr derives CanEqual:
         case e: Ite        => e.copy(span = s)
         case e: OptNone    => e.copy(span = s)
         case e: OptSome    => e.copy(span = s)
+        case e: StrLit     => e.copy(span = s)
 
 final case class ArtifactEntityField(name: String, sort: Z3Sort, funcName: String)
 final case class ArtifactEntity(name: String, sort: Z3Sort, fields: List[ArtifactEntityField])

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -264,3 +264,30 @@ class BackendTest extends CatsEffectSuite:
         artifact = emptyArtifact
       )
       runScript(script).map(r => assertEquals(r.status, expected))
+
+  List(
+    (
+      "x = \"a\" and x = \"b\" is unsat (distinct literals)",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.StrLit("a")),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.StrLit("b"))
+      ),
+      CheckStatus.Unsat
+    ),
+    (
+      "x = \"a\" and x != \"b\" is sat",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.StrLit("a")),
+        Z3Expr.Not(Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), Z3Expr.StrLit("b")))
+      ),
+      CheckStatus.Sat
+    )
+  ).foreach: (name, assertions, expected) =>
+    test(s"string theory renders and solves: $name"):
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.Str)),
+        assertions = assertions,
+        artifact = emptyArtifact
+      )
+      runScript(script).map(r => assertEquals(r.status, expected))

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -205,3 +205,10 @@ class TranslatorSetOpsTest extends CatsEffectSuite:
       assert(out.contains("declare-datatype Option"), s"expected Option datatype decl; got:\n$out")
       assert(out.contains("none"), s"expected 'none'; got:\n$out")
       assert(out.contains("(some "), s"expected '(some ...)'; got:\n$out")
+
+  test("string literals use the native String theory (no uninterpreted sort)"):
+    smtOf(
+      specWithInvariant("name: String", "name = \"active\"")
+    ).map: out =>
+      assert(out.contains("\"active\""), s"expected native string literal; got:\n$out")
+      assert(!out.contains("declare-sort String"), s"String should be native; got:\n$out")

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -90,6 +90,7 @@ datatype (plugins only: code size) expr =
   | Ite "expr" "expr" "expr" "option_span"
   | NoneE "option_span"
   | SomeE "expr" "option_span"
+  | StrLit "String.literal" "option_span"
 
 text \<open>Issue #210 (M_L.4.l): \<open>IndexRel\<close>'s base is widened from a bare
   relation name to an arbitrary \<open>expr\<close>, so the operation-side

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -34,7 +34,7 @@ where
 | "lower _ (IntLitF n sp)      = Some (IntLit n sp)"
 | "lower _ (IdentifierF x sp)  = Some (Ident x sp)"
 | "lower _ (FloatLitF s sp)    = map_option (\<lambda>r. RealLit r sp) (decimalToRat s)"
-| "lower _ (StringLitF _ _)    = None"
+| "lower _ (StringLitF v sp)   = Some (StrLit v sp)"
 | "lower _ (NoneLitF sp)       = Some (NoneE sp)"
 | "lower _ (LambdaF _ _ _)     = None"
 | "lower _ (CallF _ _ _)       = None"

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -12,6 +12,7 @@ datatype (plugins only: code size) ir_value =
   | VEntityWith "ir_value" "String.literal" "ir_value"
   | VNone
   | VSome "ir_value"
+  | VStr "String.literal"
 
 type_synonym env = "(String.literal \<times> ir_value) list"
 
@@ -292,6 +293,7 @@ inductive_cases value_has_ty_entity_with_cases [elim!]:
   "value_has_ty \<Gamma> (VEntityWith base fld override) t"
 inductive_cases value_has_ty_none_cases [elim!]: "value_has_ty \<Gamma> VNone t"
 inductive_cases value_has_ty_some_cases [elim!]: "value_has_ty \<Gamma> (VSome v) t"
+inductive_cases value_has_ty_str_cases [elim!]: "value_has_ty \<Gamma> (VStr s) t"
 
 lemma value_has_ty_VBool_iff [simp]:
   "value_has_ty \<Gamma> (VBool b) t \<longleftrightarrow> t = TBool"
@@ -374,6 +376,7 @@ where
 | "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TSet _) = False"
 | "check_value_has_ty \<Gamma> VNone _ = False"
 | "check_value_has_ty \<Gamma> (VSome _) _ = False"
+| "check_value_has_ty \<Gamma> (VStr _) _ = False"
 | "check_value_has_ty_list _ [] _ = True"
 | "check_value_has_ty_list \<Gamma> (v # vs) t =
      (check_value_has_ty \<Gamma> v t \<and> check_value_has_ty_list \<Gamma> vs t)"
@@ -1218,6 +1221,7 @@ where
       | _ \<Rightarrow> None)"
 | "eval s st env (NoneE _)   = Some VNone"
 | "eval s st env (SomeE e _) = map_option VSome (eval s st env e)"
+| "eval s st env (StrLit v _) = Some (VStr v)"
 
 | "eval_forall_enum s st env var en [] body = Some (VBool True)"
 | "eval_forall_enum s st env var en (mem # rest) body =

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -18,6 +18,7 @@ datatype (plugins only: code size) smt_val =
   | SEntityWith "smt_val" "String.literal" "smt_val"
   | SNone
   | SSome "smt_val"
+  | SStr "String.literal"
 
 datatype (plugins only: code size) smt_term =
     BLit bool
@@ -55,6 +56,7 @@ datatype (plugins only: code size) smt_term =
   | TIte "smt_term" "smt_term" "smt_term"
   | TNone
   | TSome "smt_term"
+  | TStrLit "String.literal"
 
 record smt_model =
   sm_sort_members :: "(String.literal \<times> String.literal list) list"
@@ -321,6 +323,7 @@ where
       | _ \<Rightarrow> None)"
 | "smtEval m env TNone     = Some SNone"
 | "smtEval m env (TSome t) = map_option SSome (smtEval m env t)"
+| "smtEval m env (TStrLit v) = Some (SStr v)"
 
 | "smtEval_forall_enum m env var sort_name [] body = Some (SBool True)"
 | "smtEval_forall_enum m env var sort_name (mem # rest) body =

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -49,5 +49,6 @@ fun translate :: "expr \<Rightarrow> smt_term" where
 | "translate (Ite c a b _)                 = TIte (translate c) (translate a) (translate b)"
 | "translate (NoneE _)                     = TNone"
 | "translate (SomeE e _)                   = TSome (translate e)"
+| "translate (StrLit v _)                  = TStrLit v"
 
 end

--- a/proofs/isabelle/SpecRest/soundness/Preservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation.thy
@@ -55,7 +55,7 @@ where
 | "wf_z3 (SetLiteralF es _)        = wf_z3_list es"
 | "wf_z3 (QuantifierF _ bs body _) = (wf_z3_bindings bs \<and> wf_z3 body)"
 | "wf_z3 (FloatLitF s _)           = (decimalToRat s \<noteq> None)"
-| "wf_z3 (StringLitF _ _)          = False"
+| "wf_z3 (StringLitF _ _)          = True"
 | "wf_z3 (NoneLitF _)              = True"
 | "wf_z3 (LambdaF _ _ _)           = False"
 | "wf_z3 (CallF _ _ _)             = False"

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -79,6 +79,8 @@ next
   case (NoneE sp) show ?case by (rule soundness_NoneE)
 next
   case (SomeE e sp) show ?case using soundness_SomeE[OF SomeE.IH] .
+next
+  case (StrLit v sp) show ?case by (rule soundness_StrLit)
 qed
 
 section \<open>Issue #202 Phase 3 — lower-soundness corollary\<close>

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
@@ -21,6 +21,7 @@ fun value_to_smt :: "ir_value \<Rightarrow> smt_val" where
      SEntityWith (value_to_smt base) fld (value_to_smt v)"
 | "value_to_smt VNone            = SNone"
 | "value_to_smt (VSome v)        = SSome (value_to_smt v)"
+| "value_to_smt (VStr s)         = SStr s"
 
 abbreviation value_to_smt_opt :: "ir_value option \<Rightarrow> smt_val option" where
   "value_to_smt_opt \<equiv> map_option value_to_smt"
@@ -138,6 +139,9 @@ next
     case (VSome v')
     thus ?thesis using VSome.IH[of v'] by simp
   qed auto
+next
+  case (VStr s)
+  show ?case by (cases v2) auto
 qed
 
 lemma map_value_to_smt_inj_simp [simp]:
@@ -303,6 +307,10 @@ lemma contains_smt_val_map_SNone [simp]:
 lemma contains_smt_val_map_SSome [simp]:
   "contains_smt_val (map value_to_smt vs) (SSome (value_to_smt v)) = contains_value vs (VSome v)"
   using contains_value_map_value_to_smt[of vs "VSome v"] by simp
+
+lemma contains_smt_val_map_SStr [simp]:
+  "contains_smt_val (map value_to_smt vs) (SStr s) = contains_value vs (VStr s)"
+  using contains_value_map_value_to_smt[of vs "VStr s"] by simp
 
 
 lemma set_union_values_map_value_to_smt:

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Scalar.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Scalar.thy
@@ -189,4 +189,9 @@ proof -
   show ?thesis using ih' by (cases "eval s st env e") simp_all
 qed
 
+lemma soundness_StrLit:
+  "value_to_smt_opt (eval s st env (StrLit v sp))
+     = smtEval (correlate_model s st) (correlate_env env) (translate (StrLit v sp))"
+  by simp
+
 end


### PR DESCRIPTION
## Summary
Lifts string literals into the verified subset, mapping to Z3's native String sort (`getStringSort`/`mkString`). Proven sound (zero `sorry`); generated Scala + Z3 backend updated; the now-redundant `(declare-sort String 0)` line was dropped from the convention-errors golden.

Stacked on #379 (base `feat/proofs-lift-option`) — merge that first.

## Verification
Isabelle build green, zero `sorry`; generated Scala drift-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted string literals to Z3’s native String theory and verified `StringLit` end to end. This removes the custom uninterpreted `String` sort, fixes equality (`"a" != "b"`), and keeps proofs sound.

- New Features
  - Added `StrLit` (IR), `TStrLit` (SMT), and `VStr`/`SStr`.
  - Introduced `Z3Sort.Str` and `Z3Expr.StrLit`; backend uses `getStringSort`/`mkString`.
  - Updated lowering, eval/smtEval, translator, SMT rendering, counterexample decoding, and Isabelle proofs (`soundness_StrLit`, `wf_z3`) for strings.

- Bug Fixes
  - Replaced per-literal constants with native strings to make distinct literals unequal.
  - Removed `(declare-sort String 0)` from SMT output; golden updated.
  - Added tests for native string rendering and sat/unsat behavior.

<sup>Written for commit 935e8619c8cf334b68ffd79e41f5ac7869d68e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

