### PR TITLE
feat(proofs): lift Seq + Map literals to Z3 native theories

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -160,20 +160,31 @@ object SpecRestGenerated {
   final case class SSome(a: smt_val)                              extends smt_val
   final case class SStr(a: String)                                extends smt_val
   final case class SSeq(a: List[smt_val])                         extends smt_val
+  final case class SMap(a: List[(smt_val, smt_val)])              extends smt_val
 
   def equal_smt_vala(x0: smt_val, x1: smt_val): Boolean = (x0, x1) match {
+    case (SSeq(x11), SMap(x12))                              => false
+    case (SMap(x12), SSeq(x11))                              => false
+    case (SStr(x10), SMap(x12))                              => false
+    case (SMap(x12), SStr(x10))                              => false
     case (SStr(x10), SSeq(x11))                              => false
     case (SSeq(x11), SStr(x10))                              => false
+    case (SSome(x9), SMap(x12))                              => false
+    case (SMap(x12), SSome(x9))                              => false
     case (SSome(x9), SSeq(x11))                              => false
     case (SSeq(x11), SSome(x9))                              => false
     case (SSome(x9), SStr(x10))                              => false
     case (SStr(x10), SSome(x9))                              => false
+    case (SNone(), SMap(x12))                                => false
+    case (SMap(x12), SNone())                                => false
     case (SNone(), SSeq(x11))                                => false
     case (SSeq(x11), SNone())                                => false
     case (SNone(), SStr(x10))                                => false
     case (SStr(x10), SNone())                                => false
     case (SNone(), SSome(x9))                                => false
     case (SSome(x9), SNone())                                => false
+    case (SEntityWith(x71, x72, x73), SMap(x12))             => false
+    case (SMap(x12), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SSeq(x11))             => false
     case (SSeq(x11), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SStr(x10))             => false
@@ -182,6 +193,8 @@ object SpecRestGenerated {
     case (SSome(x9), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SNone())               => false
     case (SNone(), SEntityWith(x71, x72, x73))               => false
+    case (SSet(x6), SMap(x12))                               => false
+    case (SMap(x12), SSet(x6))                               => false
     case (SSet(x6), SSeq(x11))                               => false
     case (SSeq(x11), SSet(x6))                               => false
     case (SSet(x6), SStr(x10))                               => false
@@ -192,6 +205,8 @@ object SpecRestGenerated {
     case (SNone(), SSet(x6))                                 => false
     case (SSet(x6), SEntityWith(x71, x72, x73))              => false
     case (SEntityWith(x71, x72, x73), SSet(x6))              => false
+    case (SEntityElem(x51, x52), SMap(x12))                  => false
+    case (SMap(x12), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SSeq(x11))                  => false
     case (SSeq(x11), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SStr(x10))                  => false
@@ -204,6 +219,8 @@ object SpecRestGenerated {
     case (SEntityWith(x71, x72, x73), SEntityElem(x51, x52)) => false
     case (SEntityElem(x51, x52), SSet(x6))                   => false
     case (SSet(x6), SEntityElem(x51, x52))                   => false
+    case (SEnumElem(x41, x42), SMap(x12))                    => false
+    case (SMap(x12), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SSeq(x11))                    => false
     case (SSeq(x11), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SStr(x10))                    => false
@@ -218,6 +235,8 @@ object SpecRestGenerated {
     case (SSet(x6), SEnumElem(x41, x42))                     => false
     case (SEnumElem(x41, x42), SEntityElem(x51, x52))        => false
     case (SEntityElem(x51, x52), SEnumElem(x41, x42))        => false
+    case (SReal(x3), SMap(x12))                              => false
+    case (SMap(x12), SReal(x3))                              => false
     case (SReal(x3), SSeq(x11))                              => false
     case (SSeq(x11), SReal(x3))                              => false
     case (SReal(x3), SStr(x10))                              => false
@@ -234,6 +253,8 @@ object SpecRestGenerated {
     case (SEntityElem(x51, x52), SReal(x3))                  => false
     case (SReal(x3), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SReal(x3))                    => false
+    case (SInt(x2), SMap(x12))                               => false
+    case (SMap(x12), SInt(x2))                               => false
     case (SInt(x2), SSeq(x11))                               => false
     case (SSeq(x11), SInt(x2))                               => false
     case (SInt(x2), SStr(x10))                               => false
@@ -252,6 +273,8 @@ object SpecRestGenerated {
     case (SEnumElem(x41, x42), SInt(x2))                     => false
     case (SInt(x2), SReal(x3))                               => false
     case (SReal(x3), SInt(x2))                               => false
+    case (SBool(x1), SMap(x12))                              => false
+    case (SMap(x12), SBool(x1))                              => false
     case (SBool(x1), SSeq(x11))                              => false
     case (SSeq(x11), SBool(x1))                              => false
     case (SBool(x1), SStr(x10))                              => false
@@ -272,6 +295,7 @@ object SpecRestGenerated {
     case (SReal(x3), SBool(x1))                              => false
     case (SBool(x1), SInt(x2))                               => false
     case (SInt(x2), SBool(x1))                               => false
+    case (SMap(x12), SMap(y12))                              => equal_list[(smt_val, smt_val)](x12, y12)
     case (SSeq(x11), SSeq(y11))                              => equal_list[smt_val](x11, y11)
     case (SStr(x10), SStr(y10))                              => x10 == y10
     case (SSome(x9), SSome(y9))                              => equal_smt_vala(x9, y9)
@@ -317,20 +341,31 @@ object SpecRestGenerated {
   final case class VSome(a: ir_value)                               extends ir_value
   final case class VStr(a: String)                                  extends ir_value
   final case class VSeq(a: List[ir_value])                          extends ir_value
+  final case class VMap(a: List[(ir_value, ir_value)])              extends ir_value
 
   def equal_ir_valuea(x0: ir_value, x1: ir_value): Boolean = (x0, x1) match {
+    case (VSeq(x11), VMap(x12))                          => false
+    case (VMap(x12), VSeq(x11))                          => false
+    case (VStr(x10), VMap(x12))                          => false
+    case (VMap(x12), VStr(x10))                          => false
     case (VStr(x10), VSeq(x11))                          => false
     case (VSeq(x11), VStr(x10))                          => false
+    case (VSome(x9), VMap(x12))                          => false
+    case (VMap(x12), VSome(x9))                          => false
     case (VSome(x9), VSeq(x11))                          => false
     case (VSeq(x11), VSome(x9))                          => false
     case (VSome(x9), VStr(x10))                          => false
     case (VStr(x10), VSome(x9))                          => false
+    case (VNone(), VMap(x12))                            => false
+    case (VMap(x12), VNone())                            => false
     case (VNone(), VSeq(x11))                            => false
     case (VSeq(x11), VNone())                            => false
     case (VNone(), VStr(x10))                            => false
     case (VStr(x10), VNone())                            => false
     case (VNone(), VSome(x9))                            => false
     case (VSome(x9), VNone())                            => false
+    case (VEntityWith(x71, x72, x73), VMap(x12))         => false
+    case (VMap(x12), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VSeq(x11))         => false
     case (VSeq(x11), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VStr(x10))         => false
@@ -339,6 +374,8 @@ object SpecRestGenerated {
     case (VSome(x9), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VNone())           => false
     case (VNone(), VEntityWith(x71, x72, x73))           => false
+    case (VSet(x6), VMap(x12))                           => false
+    case (VMap(x12), VSet(x6))                           => false
     case (VSet(x6), VSeq(x11))                           => false
     case (VSeq(x11), VSet(x6))                           => false
     case (VSet(x6), VStr(x10))                           => false
@@ -349,6 +386,8 @@ object SpecRestGenerated {
     case (VNone(), VSet(x6))                             => false
     case (VSet(x6), VEntityWith(x71, x72, x73))          => false
     case (VEntityWith(x71, x72, x73), VSet(x6))          => false
+    case (VEntity(x51, x52), VMap(x12))                  => false
+    case (VMap(x12), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VSeq(x11))                  => false
     case (VSeq(x11), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VStr(x10))                  => false
@@ -361,6 +400,8 @@ object SpecRestGenerated {
     case (VEntityWith(x71, x72, x73), VEntity(x51, x52)) => false
     case (VEntity(x51, x52), VSet(x6))                   => false
     case (VSet(x6), VEntity(x51, x52))                   => false
+    case (VEnum(x41, x42), VMap(x12))                    => false
+    case (VMap(x12), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VSeq(x11))                    => false
     case (VSeq(x11), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VStr(x10))                    => false
@@ -375,6 +416,8 @@ object SpecRestGenerated {
     case (VSet(x6), VEnum(x41, x42))                     => false
     case (VEnum(x41, x42), VEntity(x51, x52))            => false
     case (VEntity(x51, x52), VEnum(x41, x42))            => false
+    case (VReal(x3), VMap(x12))                          => false
+    case (VMap(x12), VReal(x3))                          => false
     case (VReal(x3), VSeq(x11))                          => false
     case (VSeq(x11), VReal(x3))                          => false
     case (VReal(x3), VStr(x10))                          => false
@@ -391,6 +434,8 @@ object SpecRestGenerated {
     case (VEntity(x51, x52), VReal(x3))                  => false
     case (VReal(x3), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VReal(x3))                    => false
+    case (VInt(x2), VMap(x12))                           => false
+    case (VMap(x12), VInt(x2))                           => false
     case (VInt(x2), VSeq(x11))                           => false
     case (VSeq(x11), VInt(x2))                           => false
     case (VInt(x2), VStr(x10))                           => false
@@ -409,6 +454,8 @@ object SpecRestGenerated {
     case (VEnum(x41, x42), VInt(x2))                     => false
     case (VInt(x2), VReal(x3))                           => false
     case (VReal(x3), VInt(x2))                           => false
+    case (VBool(x1), VMap(x12))                          => false
+    case (VMap(x12), VBool(x1))                          => false
     case (VBool(x1), VSeq(x11))                          => false
     case (VSeq(x11), VBool(x1))                          => false
     case (VBool(x1), VStr(x10))                          => false
@@ -429,6 +476,7 @@ object SpecRestGenerated {
     case (VReal(x3), VBool(x1))                          => false
     case (VBool(x1), VInt(x2))                           => false
     case (VInt(x2), VBool(x1))                           => false
+    case (VMap(x12), VMap(y12))                          => equal_list[(ir_value, ir_value)](x12, y12)
     case (VSeq(x11), VSeq(y11))                          => equal_list[ir_value](x11, y11)
     case (VStr(x10), VStr(y10))                          => x10 == y10
     case (VSome(x9), VSome(y9))                          => equal_ir_valuea(x9, y9)
@@ -584,6 +632,9 @@ object SpecRestGenerated {
   final case class StrLit(a: String, b: Option[span_t])              extends expr
   final case class SeqEmpty(a: Option[span_t])                       extends expr
   final case class SeqCons(a: expr, b: expr, c: Option[span_t])      extends expr
+  final case class MapEmpty(a: Option[span_t])                       extends expr
+  final case class MapCons(a: expr, b: expr, c: expr, d: Option[span_t])
+      extends expr
 
   sealed abstract class nat
   final case class Nata(a: BigInt) extends nat
@@ -709,44 +760,46 @@ object SpecRestGenerated {
   final case class TSet(a: ty)        extends ty
 
   sealed abstract class smt_term
-  final case class BLit(a: Boolean)                               extends smt_term
-  final case class ILit(a: BigInt)                                extends smt_term
-  final case class RLit(a: rat)                                   extends smt_term
-  final case class TVar(a: String)                                extends smt_term
-  final case class EnumElemConst(a: String, b: String)            extends smt_term
-  final case class TNot(a: smt_term)                              extends smt_term
-  final case class TAnd(a: smt_term, b: smt_term)                 extends smt_term
-  final case class TOr(a: smt_term, b: smt_term)                  extends smt_term
-  final case class TImplies(a: smt_term, b: smt_term)             extends smt_term
-  final case class TEq(a: smt_term, b: smt_term)                  extends smt_term
-  final case class TLt(a: smt_term, b: smt_term)                  extends smt_term
-  final case class TNeg(a: smt_term)                              extends smt_term
-  final case class TAdd(a: smt_term, b: smt_term)                 extends smt_term
-  final case class TSub(a: smt_term, b: smt_term)                 extends smt_term
-  final case class TMul(a: smt_term, b: smt_term)                 extends smt_term
-  final case class TDiv(a: smt_term, b: smt_term)                 extends smt_term
-  final case class TInDom(a: String, b: smt_term)                 extends smt_term
-  final case class TCardRel(a: String)                            extends smt_term
-  final case class TLetIn(a: String, b: smt_term, c: smt_term)    extends smt_term
-  final case class TForallEnum(a: String, b: String, c: smt_term) extends smt_term
-  final case class TForallRel(a: String, b: String, c: smt_term)  extends smt_term
-  final case class TIndexRel(a: smt_term, b: smt_term)            extends smt_term
-  final case class TFieldAccess(a: smt_term, b: String)           extends smt_term
-  final case class TSetEmpty()                                    extends smt_term
-  final case class TSetInsert(a: smt_term, b: smt_term)           extends smt_term
-  final case class TSetMember(a: smt_term, b: smt_term)           extends smt_term
-  final case class TSetUnion(a: smt_term, b: smt_term)            extends smt_term
-  final case class TSetIntersect(a: smt_term, b: smt_term)        extends smt_term
-  final case class TSetDiff(a: smt_term, b: smt_term)             extends smt_term
-  final case class TPrime(a: smt_term)                            extends smt_term
-  final case class TPre(a: smt_term)                              extends smt_term
-  final case class TWithRec(a: smt_term, b: String, c: smt_term)  extends smt_term
-  final case class TIte(a: smt_term, b: smt_term, c: smt_term)    extends smt_term
-  final case class TNone()                                        extends smt_term
-  final case class TSome(a: smt_term)                             extends smt_term
-  final case class TStrLit(a: String)                             extends smt_term
-  final case class TSeqEmpty()                                    extends smt_term
-  final case class TSeqCons(a: smt_term, b: smt_term)             extends smt_term
+  final case class BLit(a: Boolean)                                extends smt_term
+  final case class ILit(a: BigInt)                                 extends smt_term
+  final case class RLit(a: rat)                                    extends smt_term
+  final case class TVar(a: String)                                 extends smt_term
+  final case class EnumElemConst(a: String, b: String)             extends smt_term
+  final case class TNot(a: smt_term)                               extends smt_term
+  final case class TAnd(a: smt_term, b: smt_term)                  extends smt_term
+  final case class TOr(a: smt_term, b: smt_term)                   extends smt_term
+  final case class TImplies(a: smt_term, b: smt_term)              extends smt_term
+  final case class TEq(a: smt_term, b: smt_term)                   extends smt_term
+  final case class TLt(a: smt_term, b: smt_term)                   extends smt_term
+  final case class TNeg(a: smt_term)                               extends smt_term
+  final case class TAdd(a: smt_term, b: smt_term)                  extends smt_term
+  final case class TSub(a: smt_term, b: smt_term)                  extends smt_term
+  final case class TMul(a: smt_term, b: smt_term)                  extends smt_term
+  final case class TDiv(a: smt_term, b: smt_term)                  extends smt_term
+  final case class TInDom(a: String, b: smt_term)                  extends smt_term
+  final case class TCardRel(a: String)                             extends smt_term
+  final case class TLetIn(a: String, b: smt_term, c: smt_term)     extends smt_term
+  final case class TForallEnum(a: String, b: String, c: smt_term)  extends smt_term
+  final case class TForallRel(a: String, b: String, c: smt_term)   extends smt_term
+  final case class TIndexRel(a: smt_term, b: smt_term)             extends smt_term
+  final case class TFieldAccess(a: smt_term, b: String)            extends smt_term
+  final case class TSetEmpty()                                     extends smt_term
+  final case class TSetInsert(a: smt_term, b: smt_term)            extends smt_term
+  final case class TSetMember(a: smt_term, b: smt_term)            extends smt_term
+  final case class TSetUnion(a: smt_term, b: smt_term)             extends smt_term
+  final case class TSetIntersect(a: smt_term, b: smt_term)         extends smt_term
+  final case class TSetDiff(a: smt_term, b: smt_term)              extends smt_term
+  final case class TPrime(a: smt_term)                             extends smt_term
+  final case class TPre(a: smt_term)                               extends smt_term
+  final case class TWithRec(a: smt_term, b: String, c: smt_term)   extends smt_term
+  final case class TIte(a: smt_term, b: smt_term, c: smt_term)     extends smt_term
+  final case class TNone()                                         extends smt_term
+  final case class TSome(a: smt_term)                              extends smt_term
+  final case class TStrLit(a: String)                              extends smt_term
+  final case class TSeqEmpty()                                     extends smt_term
+  final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
+  final case class TMapEmpty()                                     extends smt_term
+  final case class TMapCons(a: smt_term, b: smt_term, c: smt_term) extends smt_term
 
   sealed abstract class multiplicity
   final case class MultOne()  extends multiplicity
@@ -1797,6 +1850,7 @@ object SpecRestGenerated {
       case (uv, SSome(v), ux)         => None
       case (uv, SStr(v), ux)          => None
       case (uv, SSeq(v), ux)          => None
+      case (uv, SMap(v), ux)          => None
     }
 
   def sm_pred_domain[A](x0: smt_model_ext[A]): List[(String, List[smt_val])] =
@@ -1922,6 +1976,8 @@ object SpecRestGenerated {
     case TPrime(TStrLit(va))             => None
     case TPrime(TSeqEmpty())             => None
     case TPrime(TSeqCons(va, vb))        => None
+    case TPrime(TMapEmpty())             => None
+    case TPrime(TMapCons(va, vb, vc))    => None
     case TPre(BLit(va))                  => None
     case TPre(ILit(va))                  => None
     case TPre(RLit(va))                  => None
@@ -1959,6 +2015,8 @@ object SpecRestGenerated {
     case TPre(TStrLit(va))               => None
     case TPre(TSeqEmpty())               => None
     case TPre(TSeqCons(va, vb))          => None
+    case TPre(TMapEmpty())               => None
+    case TPre(TMapCons(va, vb, vc))      => None
     case TWithRec(v, va, vb)             => None
     case TIte(v, va, vb)                 => None
     case TNone()                         => None
@@ -1966,6 +2024,8 @@ object SpecRestGenerated {
     case TStrLit(v)                      => None
     case TSeqEmpty()                     => None
     case TSeqCons(v, va)                 => None
+    case TMapEmpty()                     => None
+    case TMapCons(v, va, vb)             => None
   }
 
   def set_diff_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
@@ -2001,6 +2061,7 @@ object SpecRestGenerated {
               case Some(SSome(_))             => None
               case Some(SStr(_))              => None
               case Some(SSeq(_))              => None
+              case Some(SMap(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -2012,6 +2073,7 @@ object SpecRestGenerated {
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
           case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
         }
     }
 
@@ -2041,6 +2103,7 @@ object SpecRestGenerated {
               case Some(SSome(_))             => None
               case Some(SStr(_))              => None
               case Some(SSeq(_))              => None
+              case Some(SMap(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -2052,6 +2115,7 @@ object SpecRestGenerated {
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
           case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
         }
     }
 
@@ -2086,6 +2150,7 @@ object SpecRestGenerated {
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
           case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
         }
       case (m, env, TAnd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2102,6 +2167,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SBool(_)), Some(SSeq(_)))              => None
+          case (Some(SBool(_)), Some(SMap(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2112,6 +2178,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TOr(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2128,6 +2195,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SBool(_)), Some(SSeq(_)))              => None
+          case (Some(SBool(_)), Some(SMap(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2138,6 +2206,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TImplies(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2154,6 +2223,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
           case (Some(SBool(_)), Some(SSeq(_)))              => None
+          case (Some(SBool(_)), Some(SMap(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2164,6 +2234,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TEq(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2194,6 +2265,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SStr(literal))))
           case (Some(SInt(a)), Some(SSeq(list))) =>
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SSeq(list))))
+          case (Some(SInt(a)), Some(SMap(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SMap(list))))
           case (Some(SReal(_)), None) => None
           case (Some(SReal(a)), Some(SBool(bool))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SBool(bool))))
@@ -2217,6 +2290,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SStr(literal))))
           case (Some(SReal(a)), Some(SSeq(list))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SSeq(list))))
+          case (Some(SReal(a)), Some(SMap(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SMap(list))))
           case (Some(SEnumElem(_, _)), None) => None
           case (Some(SEnumElem(literal1, literal2)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SEnumElem(literal1, literal2), b)))
@@ -2241,6 +2316,9 @@ object SpecRestGenerated {
           case (Some(SSeq(_)), None) => None
           case (Some(SSeq(list)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SSeq(list), b)))
+          case (Some(SMap(_)), None) => None
+          case (Some(SMap(list)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SMap(list), b)))
         }
       case (m, env, TLt(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2260,6 +2338,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), Some(SSeq(_)))              => None
+          case (Some(SInt(_)), Some(SMap(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2274,6 +2353,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), Some(SSeq(_)))              => None
+          case (Some(SReal(_)), Some(SMap(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2282,6 +2362,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TNeg(t)) =>
         smtEval(m, env, t) match {
@@ -2297,6 +2378,7 @@ object SpecRestGenerated {
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
           case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
         }
       case (m, env, TAdd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2316,6 +2398,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), Some(SSeq(_)))              => None
+          case (Some(SInt(_)), Some(SMap(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2330,6 +2413,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), Some(SSeq(_)))              => None
+          case (Some(SReal(_)), Some(SMap(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2338,6 +2422,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TSub(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2357,6 +2442,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), Some(SSeq(_)))              => None
+          case (Some(SInt(_)), Some(SMap(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2371,6 +2457,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), Some(SSeq(_)))              => None
+          case (Some(SReal(_)), Some(SMap(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2379,6 +2466,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TMul(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2398,6 +2486,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), Some(SSeq(_)))              => None
+          case (Some(SInt(_)), Some(SMap(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2412,6 +2501,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), Some(SSeq(_)))              => None
+          case (Some(SReal(_)), Some(SMap(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2420,6 +2510,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TDiv(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2445,6 +2536,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
           case (Some(SInt(_)), Some(SSeq(_)))              => None
+          case (Some(SInt(_)), Some(SMap(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2465,6 +2557,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
           case (Some(SReal(_)), Some(SSeq(_)))              => None
+          case (Some(SReal(_)), Some(SMap(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2473,6 +2566,7 @@ object SpecRestGenerated {
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
           case (Some(SSeq(_)), _)                           => None
+          case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TInDom(rel_name, arg)) =>
         smtEval(m, env, arg) match {
@@ -2532,6 +2626,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SSome(_)))             => None
           case (Some(_), Some(SStr(_)))              => None
           case (Some(_), Some(SSeq(_)))              => None
+          case (Some(_), Some(SMap(_)))              => None
         }
       case (m, env, TSetMember(elem, set_t)) =>
         (smtEval(m, env, elem), smtEval(m, env, set_t)) match {
@@ -2549,6 +2644,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SSome(_)))             => None
           case (Some(_), Some(SStr(_)))              => None
           case (Some(_), Some(SSeq(_)))              => None
+          case (Some(_), Some(SMap(_)))              => None
         }
       case (m, env, TSetUnion(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2571,11 +2667,13 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SSet(_)), Some(SSeq(_)))              => None
+          case (Some(SSet(_)), Some(SMap(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
           case (Some(SSeq(_)), _)                          => None
+          case (Some(SMap(_)), _)                          => None
         }
       case (m, env, TSetIntersect(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2598,11 +2696,13 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SSet(_)), Some(SSeq(_)))              => None
+          case (Some(SSet(_)), Some(SMap(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
           case (Some(SSeq(_)), _)                          => None
+          case (Some(SMap(_)), _)                          => None
         }
       case (m, env, TSetDiff(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2625,11 +2725,13 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
           case (Some(SSet(_)), Some(SSeq(_)))              => None
+          case (Some(SSet(_)), Some(SMap(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
           case (Some(SSeq(_)), _)                          => None
+          case (Some(SMap(_)), _)                          => None
         }
       case (m, env, TPrime(t)) => smtEval(m, env, t)
       case (m, env, TPre(t))   => smtEval(m, env, t)
@@ -2654,6 +2756,7 @@ object SpecRestGenerated {
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
           case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
         }
       case (m, env, TNone()) => Some[smt_val](SNone())
       case (m, env, TSome(t)) =>
@@ -2675,6 +2778,27 @@ object SpecRestGenerated {
           case (Some(_), Some(SSome(_)))             => None
           case (Some(_), Some(SStr(_)))              => None
           case (Some(v), Some(SSeq(vs)))             => Some[smt_val](SSeq(v :: vs))
+          case (Some(_), Some(SMap(_)))              => None
+        }
+      case (m, env, TMapEmpty()) => Some[smt_val](SMap(Nil))
+      case (m, env, TMapCons(k, v, rest)) =>
+        (smtEval(m, env, k), (smtEval(m, env, v), smtEval(m, env, rest))) match {
+          case (None, _)                                        => None
+          case (Some(_), (None, _))                             => None
+          case (Some(_), (Some(_), None))                       => None
+          case (Some(_), (Some(_), Some(SBool(_))))             => None
+          case (Some(_), (Some(_), Some(SInt(_))))              => None
+          case (Some(_), (Some(_), Some(SReal(_))))             => None
+          case (Some(_), (Some(_), Some(SEnumElem(_, _))))      => None
+          case (Some(_), (Some(_), Some(SEntityElem(_, _))))    => None
+          case (Some(_), (Some(_), Some(SSet(_))))              => None
+          case (Some(_), (Some(_), Some(SEntityWith(_, _, _)))) => None
+          case (Some(_), (Some(_), Some(SNone())))              => None
+          case (Some(_), (Some(_), Some(SSome(_))))             => None
+          case (Some(_), (Some(_), Some(SStr(_))))              => None
+          case (Some(_), (Some(_), Some(SSeq(_))))              => None
+          case (Some(kv), (Some(vv), Some(SMap(ps)))) =>
+            Some[smt_val](SMap((kv, vv) :: ps))
         }
     }
 
@@ -3058,6 +3182,8 @@ object SpecRestGenerated {
     case Prime(StrLit(vb, vc), va)             => None
     case Prime(SeqEmpty(vb), va)               => None
     case Prime(SeqCons(vb, vc, vd), va)        => None
+    case Prime(MapEmpty(vb), va)               => None
+    case Prime(MapCons(vb, vc, vd, ve), va)    => None
     case Pre(BoolLit(vb, vc), va)              => None
     case Pre(IntLit(vb, vc), va)               => None
     case Pre(RealLit(vb, vc), va)              => None
@@ -3087,6 +3213,8 @@ object SpecRestGenerated {
     case Pre(StrLit(vb, vc), va)               => None
     case Pre(SeqEmpty(vb), va)                 => None
     case Pre(SeqCons(vb, vc, vd), va)          => None
+    case Pre(MapEmpty(vb), va)                 => None
+    case Pre(MapCons(vb, vc, vd, ve), va)      => None
     case CardRel(v, va)                        => None
     case IndexRel(v, va, vb)                   => None
     case FieldAccess(v, va, vb)                => None
@@ -3101,6 +3229,8 @@ object SpecRestGenerated {
     case StrLit(v, va)                         => None
     case SeqEmpty(v)                           => None
     case SeqCons(v, va, vb)                    => None
+    case MapEmpty(v)                           => None
+    case MapCons(v, va, vb, vc)                => None
   }
 
   def one_rat: rat = Frct((one_inta, one_inta))
@@ -3177,14 +3307,14 @@ object SpecRestGenerated {
   }
 
   def lower_with_assigns(
-      wf: List[String],
+      wc: List[String],
       x1: List[field_assign_full],
       base: expr,
-      wg: Option[span_t]
+      wd: Option[span_t]
   ): Option[expr] =
-    (wf, x1, base, wg) match {
-      case (wf, Nil, base, wg) => Some[expr](base)
-      case (enums, FieldAssignFull(fld, v, wh) :: rest, base, sp) =>
+    (wc, x1, base, wd) match {
+      case (wc, Nil, base, wd) => Some[expr](base)
+      case (enums, FieldAssignFull(fld, v, we) :: rest, base, sp) =>
         lower(enums, v) match {
           case None => None
           case Some(va) =>
@@ -3192,9 +3322,26 @@ object SpecRestGenerated {
         }
     }
 
-  def lowerSetList(we: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
-    (we, x1, sp) match {
-      case (we, Nil, sp) => Some[expr](SetEmpty(sp))
+  def lowerMapEntries(
+      wg: List[String],
+      x1: List[map_entry_full],
+      sp: Option[span_t]
+  ): Option[expr] =
+    (wg, x1, sp) match {
+      case (wg, Nil, sp) => Some[expr](MapEmpty(sp))
+      case (enums, MapEntryFull(k, v, wh) :: rest, sp) =>
+        (lower(enums, k), (lower(enums, v), lowerMapEntries(enums, rest, sp))) match {
+          case (None, _)                  => None
+          case (Some(_), (None, _))       => None
+          case (Some(_), (Some(_), None)) => None
+          case (Some(ka), (Some(va), Some(m))) =>
+            Some[expr](MapCons(ka, va, m, sp))
+        }
+    }
+
+  def lowerSetList(wb: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (wb, x1, sp) match {
+      case (wb, Nil, sp) => Some[expr](SetEmpty(sp))
       case (enums, e :: rest, sp) =>
         (lower(enums, e), lowerSetList(enums, rest, sp)) match {
           case (None, _)           => None
@@ -3203,9 +3350,9 @@ object SpecRestGenerated {
         }
     }
 
-  def lowerSeqList(wi: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
-    (wi, x1, sp) match {
-      case (wi, Nil, sp) => Some[expr](SeqEmpty(sp))
+  def lowerSeqList(wf: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (wf, x1, sp) match {
+      case (wf, Nil, sp) => Some[expr](SeqEmpty(sp))
       case (enums, e :: rest, sp) =>
         (lower(enums, e), lowerSeqList(enums, rest, sp)) match {
           case (None, _)           => None
@@ -3225,10 +3372,9 @@ object SpecRestGenerated {
     case (va, LambdaF(vb, vc, vd))               => None
     case (ve, CallF(vf, vg, vh))                 => None
     case (vi, ConstructorF(vj, vk, vl))          => None
-    case (vm, MapLiteralF(vn, vo))               => None
-    case (vp, SetComprehensionF(vq, vr, vs, vt)) => None
-    case (vu, TheF(vv, vw, vx, vy))              => None
-    case (vz, MatchesF(wa, wb, wc))              => None
+    case (vm, SetComprehensionF(vn, vo, vp, vq)) => None
+    case (vr, TheF(vs, vt, vu, vv))              => None
+    case (vw, MatchesF(vx, vy, vz))              => None
     case (enums, QuantifierF(k, bs, body, sp)) =>
       lower(enums, body) match {
         case None => None
@@ -3752,7 +3898,7 @@ object SpecRestGenerated {
         case (Some(_), None)     => None
         case (Some(va), Some(b)) => Some[expr](LetIn(x, va, b, sp))
       }
-    case (wd, EnumAccessF(base, mem, sp)) =>
+    case (wa, EnumAccessF(base, mem, sp)) =>
       base match {
         case BinaryOpF(_, _, _, _)         => None
         case UnaryOpF(_, _, _)             => None
@@ -3803,8 +3949,9 @@ object SpecRestGenerated {
         case None        => None
         case Some(basea) => lower_with_assigns(enums, updates, basea, sp)
       }
-    case (enums, SetLiteralF(elems, sp)) => lowerSetList(enums, elems, sp)
-    case (enums, SeqLiteralF(elems, sp)) => lowerSeqList(enums, elems, sp)
+    case (enums, SetLiteralF(elems, sp))   => lowerSetList(enums, elems, sp)
+    case (enums, SeqLiteralF(elems, sp))   => lowerSeqList(enums, elems, sp)
+    case (enums, MapLiteralF(entries, sp)) => lowerMapEntries(enums, entries, sp)
     case (enums, IfF(c, a, b, sp)) =>
       (lower(enums, c), (lower(enums, a), lower(enums, b))) match {
         case (None, _)                        => None
@@ -3868,6 +4015,7 @@ object SpecRestGenerated {
       case (uv, VSome(v), ux)     => None
       case (uv, VStr(v), ux)      => None
       case (uv, VSeq(v), ux)      => None
+      case (uv, VMap(v), ux)      => None
     }
 
   def sch_enums[A](x0: schema_ext[A]): List[enum_decl_ext[Unit]] = x0 match {
@@ -3960,6 +4108,7 @@ object SpecRestGenerated {
       case (IntersectOp(), Some(VSome(va)), uw)               => None
       case (IntersectOp(), Some(VStr(va)), uw)                => None
       case (IntersectOp(), Some(VSeq(va)), uw)                => None
+      case (IntersectOp(), Some(VMap(va)), uw)                => None
       case (IntersectOp(), uv, None)                          => None
       case (IntersectOp(), uv, Some(VBool(va)))               => None
       case (IntersectOp(), uv, Some(VInt(va)))                => None
@@ -3971,6 +4120,7 @@ object SpecRestGenerated {
       case (IntersectOp(), uv, Some(VSome(va)))               => None
       case (IntersectOp(), uv, Some(VStr(va)))                => None
       case (IntersectOp(), uv, Some(VSeq(va)))                => None
+      case (IntersectOp(), uv, Some(VMap(va)))                => None
       case (DiffOp(), None, uw)                               => None
       case (DiffOp(), Some(VBool(va)), uw)                    => None
       case (DiffOp(), Some(VInt(va)), uw)                     => None
@@ -3982,6 +4132,7 @@ object SpecRestGenerated {
       case (DiffOp(), Some(VSome(va)), uw)                    => None
       case (DiffOp(), Some(VStr(va)), uw)                     => None
       case (DiffOp(), Some(VSeq(va)), uw)                     => None
+      case (DiffOp(), Some(VMap(va)), uw)                     => None
       case (DiffOp(), uv, None)                               => None
       case (DiffOp(), uv, Some(VBool(va)))                    => None
       case (DiffOp(), uv, Some(VInt(va)))                     => None
@@ -3993,6 +4144,7 @@ object SpecRestGenerated {
       case (DiffOp(), uv, Some(VSome(va)))                    => None
       case (DiffOp(), uv, Some(VStr(va)))                     => None
       case (DiffOp(), uv, Some(VSeq(va)))                     => None
+      case (DiffOp(), uv, Some(VMap(va)))                     => None
       case (uu, None, uw)                                     => None
       case (uu, Some(VBool(va)), uw)                          => None
       case (uu, Some(VInt(va)), uw)                           => None
@@ -4004,6 +4156,7 @@ object SpecRestGenerated {
       case (uu, Some(VSome(va)), uw)                          => None
       case (uu, Some(VStr(va)), uw)                           => None
       case (uu, Some(VSeq(va)), uw)                           => None
+      case (uu, Some(VMap(va)), uw)                           => None
       case (uu, uv, None)                                     => None
       case (uu, uv, Some(VBool(va)))                          => None
       case (uu, uv, Some(VInt(va)))                           => None
@@ -4015,6 +4168,7 @@ object SpecRestGenerated {
       case (uu, uv, Some(VSome(va)))                          => None
       case (uu, uv, Some(VStr(va)))                           => None
       case (uu, uv, Some(VSeq(va)))                           => None
+      case (uu, uv, Some(VMap(va)))                           => None
     }
 
   def real_arith(x0: arith_op, a: rat, b: rat): Option[ir_value] = (x0, a, b) match {
@@ -4058,6 +4212,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
       case Some(VReal(a)) =>
         y match {
@@ -4073,6 +4228,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
       case Some(VEnum(_, _))          => None
       case Some(VEntity(_, _))        => None
@@ -4082,6 +4238,7 @@ object SpecRestGenerated {
       case Some(VSome(_))             => None
       case Some(VStr(_))              => None
       case Some(VSeq(_))              => None
+      case Some(VMap(_))              => None
     }
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
@@ -4101,6 +4258,7 @@ object SpecRestGenerated {
       case (VInt(_), VSome(_))              => equal_ir_valuea(x, y)
       case (VInt(_), VStr(_))               => equal_ir_valuea(x, y)
       case (VInt(_), VSeq(_))               => equal_ir_valuea(x, y)
+      case (VInt(_), VMap(_))               => equal_ir_valuea(x, y)
       case (VReal(_), VBool(_))             => equal_ir_valuea(x, y)
       case (VReal(a), VInt(b))              => equal_rat(a, of_int(b))
       case (VReal(_), VReal(_))             => equal_ir_valuea(x, y)
@@ -4112,6 +4270,7 @@ object SpecRestGenerated {
       case (VReal(_), VSome(_))             => equal_ir_valuea(x, y)
       case (VReal(_), VStr(_))              => equal_ir_valuea(x, y)
       case (VReal(_), VSeq(_))              => equal_ir_valuea(x, y)
+      case (VReal(_), VMap(_))              => equal_ir_valuea(x, y)
       case (VEnum(_, _), _)                 => equal_ir_valuea(x, y)
       case (VEntity(_, _), _)               => equal_ir_valuea(x, y)
       case (VSet(_), _)                     => equal_ir_valuea(x, y)
@@ -4120,6 +4279,7 @@ object SpecRestGenerated {
       case (VSome(_), _)                    => equal_ir_valuea(x, y)
       case (VStr(_), _)                     => equal_ir_valuea(x, y)
       case (VSeq(_), _)                     => equal_ir_valuea(x, y)
+      case (VMap(_), _)                     => equal_ir_valuea(x, y)
     }
 
   def less_eq_int(k: BigInt, l: BigInt): Boolean = k <= l
@@ -4174,6 +4334,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VReal(ar) =>
                     b match {
@@ -4188,6 +4349,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VEnum(_, _)          => None
                   case VEntity(_, _)        => None
@@ -4197,6 +4359,7 @@ object SpecRestGenerated {
                   case VSome(_)             => None
                   case VStr(_)              => None
                   case VSeq(_)              => None
+                  case VMap(_)              => None
                 }
               case LeOp() =>
                 a match {
@@ -4214,6 +4377,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VReal(ar) =>
                     b match {
@@ -4228,6 +4392,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VEnum(_, _)          => None
                   case VEntity(_, _)        => None
@@ -4237,6 +4402,7 @@ object SpecRestGenerated {
                   case VSome(_)             => None
                   case VStr(_)              => None
                   case VSeq(_)              => None
+                  case VMap(_)              => None
                 }
               case GtOp() =>
                 a match {
@@ -4254,6 +4420,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VReal(ar) =>
                     b match {
@@ -4268,6 +4435,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VEnum(_, _)          => None
                   case VEntity(_, _)        => None
@@ -4277,6 +4445,7 @@ object SpecRestGenerated {
                   case VSome(_)             => None
                   case VStr(_)              => None
                   case VSeq(_)              => None
+                  case VMap(_)              => None
                 }
               case GeOp() =>
                 a match {
@@ -4294,6 +4463,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VReal(ar) =>
                     b match {
@@ -4308,6 +4478,7 @@ object SpecRestGenerated {
                       case VSome(_)             => None
                       case VStr(_)              => None
                       case VSeq(_)              => None
+                      case VMap(_)              => None
                     }
                   case VEnum(_, _)          => None
                   case VEntity(_, _)        => None
@@ -4317,6 +4488,7 @@ object SpecRestGenerated {
                   case VSome(_)             => None
                   case VStr(_)              => None
                   case VSeq(_)              => None
+                  case VMap(_)              => None
                 }
             }
         }
@@ -4350,6 +4522,7 @@ object SpecRestGenerated {
               case Some(VSome(_))             => None
               case Some(VStr(_))              => None
               case Some(VSeq(_))              => None
+              case Some(VMap(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4361,6 +4534,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
     }
 
@@ -4391,6 +4565,7 @@ object SpecRestGenerated {
               case Some(VSome(_))             => None
               case Some(VStr(_))              => None
               case Some(VSeq(_))              => None
+              case Some(VMap(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4402,6 +4577,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
     }
 
@@ -4433,6 +4609,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
       case (s, st, env, UnNeg(e, uz)) =>
         eval(s, st, env, e) match {
@@ -4448,6 +4625,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
       case (s, st, env, BoolBin(op, l, r, va)) =>
         (eval(s, st, env, l), eval(s, st, env, r)) match {
@@ -4465,6 +4643,7 @@ object SpecRestGenerated {
           case (Some(VBool(_)), Some(VSome(_)))             => None
           case (Some(VBool(_)), Some(VStr(_)))              => None
           case (Some(VBool(_)), Some(VSeq(_)))              => None
+          case (Some(VBool(_)), Some(VMap(_)))              => None
           case (Some(VInt(_)), _)                           => None
           case (Some(VReal(_)), _)                          => None
           case (Some(VEnum(_, _)), _)                       => None
@@ -4475,6 +4654,7 @@ object SpecRestGenerated {
           case (Some(VSome(_)), _)                          => None
           case (Some(VStr(_)), _)                           => None
           case (Some(VSeq(_)), _)                           => None
+          case (Some(VMap(_)), _)                           => None
         }
       case (s, st, env, Arith(op, l, r, vb)) =>
         eval_arith(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4551,6 +4731,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VSome(_)))             => None
           case (Some(_), Some(VStr(_)))              => None
           case (Some(_), Some(VSeq(_)))              => None
+          case (Some(_), Some(VMap(_)))              => None
         }
       case (s, st, env, SetMember(elem, set_e, vp)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
@@ -4568,6 +4749,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VSome(_)))             => None
           case (Some(_), Some(VStr(_)))              => None
           case (Some(_), Some(VSeq(_)))              => None
+          case (Some(_), Some(VMap(_)))              => None
         }
       case (s, st, env, SetBin(op, l, r, vq)) =>
         eval_set_bin(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4592,6 +4774,7 @@ object SpecRestGenerated {
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
           case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
         }
       case (s, st, env, NoneE(vt)) => Some[ir_value](VNone())
       case (s, st, env, SomeE(e, vu)) =>
@@ -4613,6 +4796,27 @@ object SpecRestGenerated {
           case (Some(_), Some(VSome(_)))             => None
           case (Some(_), Some(VStr(_)))              => None
           case (Some(v), Some(VSeq(vs)))             => Some[ir_value](VSeq(v :: vs))
+          case (Some(_), Some(VMap(_)))              => None
+        }
+      case (s, st, env, MapEmpty(vy)) => Some[ir_value](VMap(Nil))
+      case (s, st, env, MapCons(k, v, rest, vz)) =>
+        (eval(s, st, env, k), (eval(s, st, env, v), eval(s, st, env, rest))) match {
+          case (None, _)                                        => None
+          case (Some(_), (None, _))                             => None
+          case (Some(_), (Some(_), None))                       => None
+          case (Some(_), (Some(_), Some(VBool(_))))             => None
+          case (Some(_), (Some(_), Some(VInt(_))))              => None
+          case (Some(_), (Some(_), Some(VReal(_))))             => None
+          case (Some(_), (Some(_), Some(VEnum(_, _))))          => None
+          case (Some(_), (Some(_), Some(VEntity(_, _))))        => None
+          case (Some(_), (Some(_), Some(VSet(_))))              => None
+          case (Some(_), (Some(_), Some(VEntityWith(_, _, _)))) => None
+          case (Some(_), (Some(_), Some(VNone())))              => None
+          case (Some(_), (Some(_), Some(VSome(_))))             => None
+          case (Some(_), (Some(_), Some(VStr(_))))              => None
+          case (Some(_), (Some(_), Some(VSeq(_))))              => None
+          case (Some(kv), (Some(vv), Some(VMap(ps)))) =>
+            Some[ir_value](VMap((kv, vv) :: ps))
         }
     }
 
@@ -5773,6 +5977,9 @@ object SpecRestGenerated {
     case StrLit(v, wi)        => TStrLit(v)
     case SeqEmpty(wj)         => TSeqEmpty()
     case SeqCons(e, rest, wk) => TSeqCons(translate(e), translate(rest))
+    case MapEmpty(wl)         => TMapEmpty()
+    case MapCons(k, v, rest, wm) =>
+      TMapCons(translate(k), translate(v), translate(rest))
   }
 
   def litClass(x0: expr_full): Option[lit_class] = x0 match {
@@ -12820,9 +13027,9 @@ object SpecRestGenerated {
     case (TBool(), TBool())         => true
   }
 
-  def check_value_has_ty_list(wf: tyctx_ext[Unit], x1: List[ir_value], wg: ty): Boolean =
-    (wf, x1, wg) match {
-      case (wf, Nil, wg) => true
+  def check_value_has_ty_list(wh: tyctx_ext[Unit], x1: List[ir_value], wi: ty): Boolean =
+    (wh, x1, wi) match {
+      case (wh, Nil, wi) => true
       case (gamma, v :: vs, t) =>
         check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
     }
@@ -12855,6 +13062,7 @@ object SpecRestGenerated {
       case (gamma, VSome(vz), wa)                      => false
       case (gamma, VStr(wb), wc)                       => false
       case (gamma, VSeq(wd), we)                       => false
+      case (gamma, VMap(wf), wg)                       => false
     }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl_full] = x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -159,20 +159,31 @@ object SpecRestGenerated {
   final case class SNone()                                        extends smt_val
   final case class SSome(a: smt_val)                              extends smt_val
   final case class SStr(a: String)                                extends smt_val
+  final case class SSeq(a: List[smt_val])                         extends smt_val
 
   def equal_smt_vala(x0: smt_val, x1: smt_val): Boolean = (x0, x1) match {
+    case (SStr(x10), SSeq(x11))                              => false
+    case (SSeq(x11), SStr(x10))                              => false
+    case (SSome(x9), SSeq(x11))                              => false
+    case (SSeq(x11), SSome(x9))                              => false
     case (SSome(x9), SStr(x10))                              => false
     case (SStr(x10), SSome(x9))                              => false
+    case (SNone(), SSeq(x11))                                => false
+    case (SSeq(x11), SNone())                                => false
     case (SNone(), SStr(x10))                                => false
     case (SStr(x10), SNone())                                => false
     case (SNone(), SSome(x9))                                => false
     case (SSome(x9), SNone())                                => false
+    case (SEntityWith(x71, x72, x73), SSeq(x11))             => false
+    case (SSeq(x11), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SStr(x10))             => false
     case (SStr(x10), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SSome(x9))             => false
     case (SSome(x9), SEntityWith(x71, x72, x73))             => false
     case (SEntityWith(x71, x72, x73), SNone())               => false
     case (SNone(), SEntityWith(x71, x72, x73))               => false
+    case (SSet(x6), SSeq(x11))                               => false
+    case (SSeq(x11), SSet(x6))                               => false
     case (SSet(x6), SStr(x10))                               => false
     case (SStr(x10), SSet(x6))                               => false
     case (SSet(x6), SSome(x9))                               => false
@@ -181,6 +192,8 @@ object SpecRestGenerated {
     case (SNone(), SSet(x6))                                 => false
     case (SSet(x6), SEntityWith(x71, x72, x73))              => false
     case (SEntityWith(x71, x72, x73), SSet(x6))              => false
+    case (SEntityElem(x51, x52), SSeq(x11))                  => false
+    case (SSeq(x11), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SStr(x10))                  => false
     case (SStr(x10), SEntityElem(x51, x52))                  => false
     case (SEntityElem(x51, x52), SSome(x9))                  => false
@@ -191,6 +204,8 @@ object SpecRestGenerated {
     case (SEntityWith(x71, x72, x73), SEntityElem(x51, x52)) => false
     case (SEntityElem(x51, x52), SSet(x6))                   => false
     case (SSet(x6), SEntityElem(x51, x52))                   => false
+    case (SEnumElem(x41, x42), SSeq(x11))                    => false
+    case (SSeq(x11), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SStr(x10))                    => false
     case (SStr(x10), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SSome(x9))                    => false
@@ -203,6 +218,8 @@ object SpecRestGenerated {
     case (SSet(x6), SEnumElem(x41, x42))                     => false
     case (SEnumElem(x41, x42), SEntityElem(x51, x52))        => false
     case (SEntityElem(x51, x52), SEnumElem(x41, x42))        => false
+    case (SReal(x3), SSeq(x11))                              => false
+    case (SSeq(x11), SReal(x3))                              => false
     case (SReal(x3), SStr(x10))                              => false
     case (SStr(x10), SReal(x3))                              => false
     case (SReal(x3), SSome(x9))                              => false
@@ -217,6 +234,8 @@ object SpecRestGenerated {
     case (SEntityElem(x51, x52), SReal(x3))                  => false
     case (SReal(x3), SEnumElem(x41, x42))                    => false
     case (SEnumElem(x41, x42), SReal(x3))                    => false
+    case (SInt(x2), SSeq(x11))                               => false
+    case (SSeq(x11), SInt(x2))                               => false
     case (SInt(x2), SStr(x10))                               => false
     case (SStr(x10), SInt(x2))                               => false
     case (SInt(x2), SSome(x9))                               => false
@@ -233,6 +252,8 @@ object SpecRestGenerated {
     case (SEnumElem(x41, x42), SInt(x2))                     => false
     case (SInt(x2), SReal(x3))                               => false
     case (SReal(x3), SInt(x2))                               => false
+    case (SBool(x1), SSeq(x11))                              => false
+    case (SSeq(x11), SBool(x1))                              => false
     case (SBool(x1), SStr(x10))                              => false
     case (SStr(x10), SBool(x1))                              => false
     case (SBool(x1), SSome(x9))                              => false
@@ -251,6 +272,7 @@ object SpecRestGenerated {
     case (SReal(x3), SBool(x1))                              => false
     case (SBool(x1), SInt(x2))                               => false
     case (SInt(x2), SBool(x1))                               => false
+    case (SSeq(x11), SSeq(y11))                              => equal_list[smt_val](x11, y11)
     case (SStr(x10), SStr(y10))                              => x10 == y10
     case (SSome(x9), SSome(y9))                              => equal_smt_vala(x9, y9)
     case (SEntityWith(x71, x72, x73), SEntityWith(y71, y72, y73)) =>
@@ -294,20 +316,31 @@ object SpecRestGenerated {
   final case class VNone()                                          extends ir_value
   final case class VSome(a: ir_value)                               extends ir_value
   final case class VStr(a: String)                                  extends ir_value
+  final case class VSeq(a: List[ir_value])                          extends ir_value
 
   def equal_ir_valuea(x0: ir_value, x1: ir_value): Boolean = (x0, x1) match {
+    case (VStr(x10), VSeq(x11))                          => false
+    case (VSeq(x11), VStr(x10))                          => false
+    case (VSome(x9), VSeq(x11))                          => false
+    case (VSeq(x11), VSome(x9))                          => false
     case (VSome(x9), VStr(x10))                          => false
     case (VStr(x10), VSome(x9))                          => false
+    case (VNone(), VSeq(x11))                            => false
+    case (VSeq(x11), VNone())                            => false
     case (VNone(), VStr(x10))                            => false
     case (VStr(x10), VNone())                            => false
     case (VNone(), VSome(x9))                            => false
     case (VSome(x9), VNone())                            => false
+    case (VEntityWith(x71, x72, x73), VSeq(x11))         => false
+    case (VSeq(x11), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VStr(x10))         => false
     case (VStr(x10), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VSome(x9))         => false
     case (VSome(x9), VEntityWith(x71, x72, x73))         => false
     case (VEntityWith(x71, x72, x73), VNone())           => false
     case (VNone(), VEntityWith(x71, x72, x73))           => false
+    case (VSet(x6), VSeq(x11))                           => false
+    case (VSeq(x11), VSet(x6))                           => false
     case (VSet(x6), VStr(x10))                           => false
     case (VStr(x10), VSet(x6))                           => false
     case (VSet(x6), VSome(x9))                           => false
@@ -316,6 +349,8 @@ object SpecRestGenerated {
     case (VNone(), VSet(x6))                             => false
     case (VSet(x6), VEntityWith(x71, x72, x73))          => false
     case (VEntityWith(x71, x72, x73), VSet(x6))          => false
+    case (VEntity(x51, x52), VSeq(x11))                  => false
+    case (VSeq(x11), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VStr(x10))                  => false
     case (VStr(x10), VEntity(x51, x52))                  => false
     case (VEntity(x51, x52), VSome(x9))                  => false
@@ -326,6 +361,8 @@ object SpecRestGenerated {
     case (VEntityWith(x71, x72, x73), VEntity(x51, x52)) => false
     case (VEntity(x51, x52), VSet(x6))                   => false
     case (VSet(x6), VEntity(x51, x52))                   => false
+    case (VEnum(x41, x42), VSeq(x11))                    => false
+    case (VSeq(x11), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VStr(x10))                    => false
     case (VStr(x10), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VSome(x9))                    => false
@@ -338,6 +375,8 @@ object SpecRestGenerated {
     case (VSet(x6), VEnum(x41, x42))                     => false
     case (VEnum(x41, x42), VEntity(x51, x52))            => false
     case (VEntity(x51, x52), VEnum(x41, x42))            => false
+    case (VReal(x3), VSeq(x11))                          => false
+    case (VSeq(x11), VReal(x3))                          => false
     case (VReal(x3), VStr(x10))                          => false
     case (VStr(x10), VReal(x3))                          => false
     case (VReal(x3), VSome(x9))                          => false
@@ -352,6 +391,8 @@ object SpecRestGenerated {
     case (VEntity(x51, x52), VReal(x3))                  => false
     case (VReal(x3), VEnum(x41, x42))                    => false
     case (VEnum(x41, x42), VReal(x3))                    => false
+    case (VInt(x2), VSeq(x11))                           => false
+    case (VSeq(x11), VInt(x2))                           => false
     case (VInt(x2), VStr(x10))                           => false
     case (VStr(x10), VInt(x2))                           => false
     case (VInt(x2), VSome(x9))                           => false
@@ -368,6 +409,8 @@ object SpecRestGenerated {
     case (VEnum(x41, x42), VInt(x2))                     => false
     case (VInt(x2), VReal(x3))                           => false
     case (VReal(x3), VInt(x2))                           => false
+    case (VBool(x1), VSeq(x11))                          => false
+    case (VSeq(x11), VBool(x1))                          => false
     case (VBool(x1), VStr(x10))                          => false
     case (VStr(x10), VBool(x1))                          => false
     case (VBool(x1), VSome(x9))                          => false
@@ -386,6 +429,7 @@ object SpecRestGenerated {
     case (VReal(x3), VBool(x1))                          => false
     case (VBool(x1), VInt(x2))                           => false
     case (VInt(x2), VBool(x1))                           => false
+    case (VSeq(x11), VSeq(y11))                          => equal_list[ir_value](x11, y11)
     case (VStr(x10), VStr(y10))                          => x10 == y10
     case (VSome(x9), VSome(y9))                          => equal_ir_valuea(x9, y9)
     case (VEntityWith(x71, x72, x73), VEntityWith(y71, y72, y73)) =>
@@ -538,6 +582,8 @@ object SpecRestGenerated {
   final case class NoneE(a: Option[span_t])                          extends expr
   final case class SomeE(a: expr, b: Option[span_t])                 extends expr
   final case class StrLit(a: String, b: Option[span_t])              extends expr
+  final case class SeqEmpty(a: Option[span_t])                       extends expr
+  final case class SeqCons(a: expr, b: expr, c: Option[span_t])      extends expr
 
   sealed abstract class nat
   final case class Nata(a: BigInt) extends nat
@@ -699,6 +745,8 @@ object SpecRestGenerated {
   final case class TNone()                                        extends smt_term
   final case class TSome(a: smt_term)                             extends smt_term
   final case class TStrLit(a: String)                             extends smt_term
+  final case class TSeqEmpty()                                    extends smt_term
+  final case class TSeqCons(a: smt_term, b: smt_term)             extends smt_term
 
   sealed abstract class multiplicity
   final case class MultOne()  extends multiplicity
@@ -1748,6 +1796,7 @@ object SpecRestGenerated {
       case (uv, SNone(), ux)          => None
       case (uv, SSome(v), ux)         => None
       case (uv, SStr(v), ux)          => None
+      case (uv, SSeq(v), ux)          => None
     }
 
   def sm_pred_domain[A](x0: smt_model_ext[A]): List[(String, List[smt_val])] =
@@ -1871,6 +1920,8 @@ object SpecRestGenerated {
     case TPrime(TNone())                 => None
     case TPrime(TSome(va))               => None
     case TPrime(TStrLit(va))             => None
+    case TPrime(TSeqEmpty())             => None
+    case TPrime(TSeqCons(va, vb))        => None
     case TPre(BLit(va))                  => None
     case TPre(ILit(va))                  => None
     case TPre(RLit(va))                  => None
@@ -1906,11 +1957,15 @@ object SpecRestGenerated {
     case TPre(TNone())                   => None
     case TPre(TSome(va))                 => None
     case TPre(TStrLit(va))               => None
+    case TPre(TSeqEmpty())               => None
+    case TPre(TSeqCons(va, vb))          => None
     case TWithRec(v, va, vb)             => None
     case TIte(v, va, vb)                 => None
     case TNone()                         => None
     case TSome(v)                        => None
     case TStrLit(v)                      => None
+    case TSeqEmpty()                     => None
+    case TSeqCons(v, va)                 => None
   }
 
   def set_diff_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
@@ -1945,6 +2000,7 @@ object SpecRestGenerated {
               case Some(SNone())              => None
               case Some(SSome(_))             => None
               case Some(SStr(_))              => None
+              case Some(SSeq(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -1955,6 +2011,7 @@ object SpecRestGenerated {
           case Some(SNone())              => None
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
         }
     }
 
@@ -1983,6 +2040,7 @@ object SpecRestGenerated {
               case Some(SNone())              => None
               case Some(SSome(_))             => None
               case Some(SStr(_))              => None
+              case Some(SSeq(_))              => None
             }
           case Some(SInt(_))              => None
           case Some(SReal(_))             => None
@@ -1993,6 +2051,7 @@ object SpecRestGenerated {
           case Some(SNone())              => None
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
         }
     }
 
@@ -2026,6 +2085,7 @@ object SpecRestGenerated {
           case Some(SNone())              => None
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
         }
       case (m, env, TAnd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2041,6 +2101,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
+          case (Some(SBool(_)), Some(SSeq(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2050,6 +2111,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TOr(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2065,6 +2127,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
+          case (Some(SBool(_)), Some(SSeq(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2074,6 +2137,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TImplies(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2089,6 +2153,7 @@ object SpecRestGenerated {
           case (Some(SBool(_)), Some(SNone()))              => None
           case (Some(SBool(_)), Some(SSome(_)))             => None
           case (Some(SBool(_)), Some(SStr(_)))              => None
+          case (Some(SBool(_)), Some(SSeq(_)))              => None
           case (Some(SInt(_)), _)                           => None
           case (Some(SReal(_)), _)                          => None
           case (Some(SEnumElem(_, _)), _)                   => None
@@ -2098,6 +2163,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TEq(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2126,6 +2192,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SSome(smt_val))))
           case (Some(SInt(a)), Some(SStr(literal))) =>
             Some[smt_val](SBool(equal_smt_vala(SInt(a), SStr(literal))))
+          case (Some(SInt(a)), Some(SSeq(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SInt(a), SSeq(list))))
           case (Some(SReal(_)), None) => None
           case (Some(SReal(a)), Some(SBool(bool))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SBool(bool))))
@@ -2147,6 +2215,8 @@ object SpecRestGenerated {
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SSome(smt_val))))
           case (Some(SReal(a)), Some(SStr(literal))) =>
             Some[smt_val](SBool(equal_smt_vala(SReal(a), SStr(literal))))
+          case (Some(SReal(a)), Some(SSeq(list))) =>
+            Some[smt_val](SBool(equal_smt_vala(SReal(a), SSeq(list))))
           case (Some(SEnumElem(_, _)), None) => None
           case (Some(SEnumElem(literal1, literal2)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SEnumElem(literal1, literal2), b)))
@@ -2168,6 +2238,9 @@ object SpecRestGenerated {
           case (Some(SStr(_)), None) => None
           case (Some(SStr(literal)), Some(b)) =>
             Some[smt_val](SBool(equal_smt_vala(SStr(literal), b)))
+          case (Some(SSeq(_)), None) => None
+          case (Some(SSeq(list)), Some(b)) =>
+            Some[smt_val](SBool(equal_smt_vala(SSeq(list), b)))
         }
       case (m, env, TLt(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2186,6 +2259,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
+          case (Some(SInt(_)), Some(SSeq(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2199,6 +2273,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
+          case (Some(SReal(_)), Some(SSeq(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2206,6 +2281,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TNeg(t)) =>
         smtEval(m, env, t) match {
@@ -2220,6 +2296,7 @@ object SpecRestGenerated {
           case Some(SNone())              => None
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
         }
       case (m, env, TAdd(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2238,6 +2315,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
+          case (Some(SInt(_)), Some(SSeq(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2251,6 +2329,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
+          case (Some(SReal(_)), Some(SSeq(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2258,6 +2337,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TSub(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2276,6 +2356,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
+          case (Some(SInt(_)), Some(SSeq(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2289,6 +2370,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
+          case (Some(SReal(_)), Some(SSeq(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2296,6 +2378,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TMul(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2314,6 +2397,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
+          case (Some(SInt(_)), Some(SSeq(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2327,6 +2411,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
+          case (Some(SReal(_)), Some(SSeq(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2334,6 +2419,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TDiv(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2358,6 +2444,7 @@ object SpecRestGenerated {
           case (Some(SInt(_)), Some(SNone()))              => None
           case (Some(SInt(_)), Some(SSome(_)))             => None
           case (Some(SInt(_)), Some(SStr(_)))              => None
+          case (Some(SInt(_)), Some(SSeq(_)))              => None
           case (Some(SReal(_)), None)                      => None
           case (Some(SReal(_)), Some(SBool(_)))            => None
           case (Some(SReal(a)), Some(SInt(b))) =>
@@ -2377,6 +2464,7 @@ object SpecRestGenerated {
           case (Some(SReal(_)), Some(SNone()))              => None
           case (Some(SReal(_)), Some(SSome(_)))             => None
           case (Some(SReal(_)), Some(SStr(_)))              => None
+          case (Some(SReal(_)), Some(SSeq(_)))              => None
           case (Some(SEnumElem(_, _)), _)                   => None
           case (Some(SEntityElem(_, _)), _)                 => None
           case (Some(SSet(_)), _)                           => None
@@ -2384,6 +2472,7 @@ object SpecRestGenerated {
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
           case (Some(SStr(_)), _)                           => None
+          case (Some(SSeq(_)), _)                           => None
         }
       case (m, env, TInDom(rel_name, arg)) =>
         smtEval(m, env, arg) match {
@@ -2442,6 +2531,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SNone()))              => None
           case (Some(_), Some(SSome(_)))             => None
           case (Some(_), Some(SStr(_)))              => None
+          case (Some(_), Some(SSeq(_)))              => None
         }
       case (m, env, TSetMember(elem, set_t)) =>
         (smtEval(m, env, elem), smtEval(m, env, set_t)) match {
@@ -2458,6 +2548,7 @@ object SpecRestGenerated {
           case (Some(_), Some(SNone()))              => None
           case (Some(_), Some(SSome(_)))             => None
           case (Some(_), Some(SStr(_)))              => None
+          case (Some(_), Some(SSeq(_)))              => None
         }
       case (m, env, TSetUnion(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2479,10 +2570,12 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
+          case (Some(SSet(_)), Some(SSeq(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
+          case (Some(SSeq(_)), _)                          => None
         }
       case (m, env, TSetIntersect(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2504,10 +2597,12 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
+          case (Some(SSet(_)), Some(SSeq(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
+          case (Some(SSeq(_)), _)                          => None
         }
       case (m, env, TSetDiff(l, r)) =>
         (smtEval(m, env, l), smtEval(m, env, r)) match {
@@ -2529,10 +2624,12 @@ object SpecRestGenerated {
           case (Some(SSet(_)), Some(SNone()))              => None
           case (Some(SSet(_)), Some(SSome(_)))             => None
           case (Some(SSet(_)), Some(SStr(_)))              => None
+          case (Some(SSet(_)), Some(SSeq(_)))              => None
           case (Some(SEntityWith(_, _, _)), _)             => None
           case (Some(SNone()), _)                          => None
           case (Some(SSome(_)), _)                         => None
           case (Some(SStr(_)), _)                          => None
+          case (Some(SSeq(_)), _)                          => None
         }
       case (m, env, TPrime(t)) => smtEval(m, env, t)
       case (m, env, TPre(t))   => smtEval(m, env, t)
@@ -2556,11 +2653,29 @@ object SpecRestGenerated {
           case Some(SNone())              => None
           case Some(SSome(_))             => None
           case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
         }
       case (m, env, TNone()) => Some[smt_val](SNone())
       case (m, env, TSome(t)) =>
         map_option[smt_val, smt_val]((a: smt_val) => SSome(a), smtEval(m, env, t))
-      case (m, env, TStrLit(v)) => Some[smt_val](SStr(v))
+      case (m, env, TStrLit(v))  => Some[smt_val](SStr(v))
+      case (m, env, TSeqEmpty()) => Some[smt_val](SSeq(Nil))
+      case (m, env, TSeqCons(e, rest)) =>
+        (smtEval(m, env, e), smtEval(m, env, rest)) match {
+          case (None, _)                             => None
+          case (Some(_), None)                       => None
+          case (Some(_), Some(SBool(_)))             => None
+          case (Some(_), Some(SInt(_)))              => None
+          case (Some(_), Some(SReal(_)))             => None
+          case (Some(_), Some(SEnumElem(_, _)))      => None
+          case (Some(_), Some(SEntityElem(_, _)))    => None
+          case (Some(_), Some(SSet(_)))              => None
+          case (Some(_), Some(SEntityWith(_, _, _))) => None
+          case (Some(_), Some(SNone()))              => None
+          case (Some(_), Some(SSome(_)))             => None
+          case (Some(_), Some(SStr(_)))              => None
+          case (Some(v), Some(SSeq(vs)))             => Some[smt_val](SSeq(v :: vs))
+        }
     }
 
   def binOpToTs(x0: bin_op_full): String = x0 match {
@@ -2941,6 +3056,8 @@ object SpecRestGenerated {
     case Prime(NoneE(vb), va)                  => None
     case Prime(SomeE(vb, vc), va)              => None
     case Prime(StrLit(vb, vc), va)             => None
+    case Prime(SeqEmpty(vb), va)               => None
+    case Prime(SeqCons(vb, vc, vd), va)        => None
     case Pre(BoolLit(vb, vc), va)              => None
     case Pre(IntLit(vb, vc), va)               => None
     case Pre(RealLit(vb, vc), va)              => None
@@ -2968,6 +3085,8 @@ object SpecRestGenerated {
     case Pre(NoneE(vb), va)                    => None
     case Pre(SomeE(vb, vc), va)                => None
     case Pre(StrLit(vb, vc), va)               => None
+    case Pre(SeqEmpty(vb), va)                 => None
+    case Pre(SeqCons(vb, vc, vd), va)          => None
     case CardRel(v, va)                        => None
     case IndexRel(v, va, vb)                   => None
     case FieldAccess(v, va, vb)                => None
@@ -2980,6 +3099,8 @@ object SpecRestGenerated {
     case NoneE(v)                              => None
     case SomeE(v, va)                          => None
     case StrLit(v, va)                         => None
+    case SeqEmpty(v)                           => None
+    case SeqCons(v, va, vb)                    => None
   }
 
   def one_rat: rat = Frct((one_inta, one_inta))
@@ -3056,14 +3177,14 @@ object SpecRestGenerated {
   }
 
   def lower_with_assigns(
-      wi: List[String],
+      wf: List[String],
       x1: List[field_assign_full],
       base: expr,
-      wj: Option[span_t]
+      wg: Option[span_t]
   ): Option[expr] =
-    (wi, x1, base, wj) match {
-      case (wi, Nil, base, wj) => Some[expr](base)
-      case (enums, FieldAssignFull(fld, v, wk) :: rest, base, sp) =>
+    (wf, x1, base, wg) match {
+      case (wf, Nil, base, wg) => Some[expr](base)
+      case (enums, FieldAssignFull(fld, v, wh) :: rest, base, sp) =>
         lower(enums, v) match {
           case None => None
           case Some(va) =>
@@ -3071,14 +3192,25 @@ object SpecRestGenerated {
         }
     }
 
-  def lowerSetList(wh: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
-    (wh, x1, sp) match {
-      case (wh, Nil, sp) => Some[expr](SetEmpty(sp))
+  def lowerSetList(we: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (we, x1, sp) match {
+      case (we, Nil, sp) => Some[expr](SetEmpty(sp))
       case (enums, e :: rest, sp) =>
         (lower(enums, e), lowerSetList(enums, rest, sp)) match {
           case (None, _)           => None
           case (Some(_), None)     => None
           case (Some(ea), Some(s)) => Some[expr](SetInsert(ea, s, sp))
+        }
+    }
+
+  def lowerSeqList(wi: List[String], x1: List[expr_full], sp: Option[span_t]): Option[expr] =
+    (wi, x1, sp) match {
+      case (wi, Nil, sp) => Some[expr](SeqEmpty(sp))
+      case (enums, e :: rest, sp) =>
+        (lower(enums, e), lowerSeqList(enums, rest, sp)) match {
+          case (None, _)           => None
+          case (Some(_), None)     => None
+          case (Some(ea), Some(s)) => Some[expr](SeqCons(ea, s, sp))
         }
     }
 
@@ -3094,10 +3226,9 @@ object SpecRestGenerated {
     case (ve, CallF(vf, vg, vh))                 => None
     case (vi, ConstructorF(vj, vk, vl))          => None
     case (vm, MapLiteralF(vn, vo))               => None
-    case (vp, SeqLiteralF(vq, vr))               => None
-    case (vs, SetComprehensionF(vt, vu, vv, vw)) => None
-    case (vx, TheF(vy, vz, wa, wb))              => None
-    case (wc, MatchesF(wd, we, wf))              => None
+    case (vp, SetComprehensionF(vq, vr, vs, vt)) => None
+    case (vu, TheF(vv, vw, vx, vy))              => None
+    case (vz, MatchesF(wa, wb, wc))              => None
     case (enums, QuantifierF(k, bs, body, sp)) =>
       lower(enums, body) match {
         case None => None
@@ -3621,7 +3752,7 @@ object SpecRestGenerated {
         case (Some(_), None)     => None
         case (Some(va), Some(b)) => Some[expr](LetIn(x, va, b, sp))
       }
-    case (wg, EnumAccessF(base, mem, sp)) =>
+    case (wd, EnumAccessF(base, mem, sp)) =>
       base match {
         case BinaryOpF(_, _, _, _)         => None
         case UnaryOpF(_, _, _)             => None
@@ -3673,6 +3804,7 @@ object SpecRestGenerated {
         case Some(basea) => lower_with_assigns(enums, updates, basea, sp)
       }
     case (enums, SetLiteralF(elems, sp)) => lowerSetList(enums, elems, sp)
+    case (enums, SeqLiteralF(elems, sp)) => lowerSeqList(enums, elems, sp)
     case (enums, IfF(c, a, b, sp)) =>
       (lower(enums, c), (lower(enums, a), lower(enums, b))) match {
         case (None, _)                        => None
@@ -3735,6 +3867,7 @@ object SpecRestGenerated {
       case (uv, VNone(), ux)      => None
       case (uv, VSome(v), ux)     => None
       case (uv, VStr(v), ux)      => None
+      case (uv, VSeq(v), ux)      => None
     }
 
   def sch_enums[A](x0: schema_ext[A]): List[enum_decl_ext[Unit]] = x0 match {
@@ -3826,6 +3959,7 @@ object SpecRestGenerated {
       case (IntersectOp(), Some(VNone()), uw)                 => None
       case (IntersectOp(), Some(VSome(va)), uw)               => None
       case (IntersectOp(), Some(VStr(va)), uw)                => None
+      case (IntersectOp(), Some(VSeq(va)), uw)                => None
       case (IntersectOp(), uv, None)                          => None
       case (IntersectOp(), uv, Some(VBool(va)))               => None
       case (IntersectOp(), uv, Some(VInt(va)))                => None
@@ -3836,6 +3970,7 @@ object SpecRestGenerated {
       case (IntersectOp(), uv, Some(VNone()))                 => None
       case (IntersectOp(), uv, Some(VSome(va)))               => None
       case (IntersectOp(), uv, Some(VStr(va)))                => None
+      case (IntersectOp(), uv, Some(VSeq(va)))                => None
       case (DiffOp(), None, uw)                               => None
       case (DiffOp(), Some(VBool(va)), uw)                    => None
       case (DiffOp(), Some(VInt(va)), uw)                     => None
@@ -3846,6 +3981,7 @@ object SpecRestGenerated {
       case (DiffOp(), Some(VNone()), uw)                      => None
       case (DiffOp(), Some(VSome(va)), uw)                    => None
       case (DiffOp(), Some(VStr(va)), uw)                     => None
+      case (DiffOp(), Some(VSeq(va)), uw)                     => None
       case (DiffOp(), uv, None)                               => None
       case (DiffOp(), uv, Some(VBool(va)))                    => None
       case (DiffOp(), uv, Some(VInt(va)))                     => None
@@ -3856,6 +3992,7 @@ object SpecRestGenerated {
       case (DiffOp(), uv, Some(VNone()))                      => None
       case (DiffOp(), uv, Some(VSome(va)))                    => None
       case (DiffOp(), uv, Some(VStr(va)))                     => None
+      case (DiffOp(), uv, Some(VSeq(va)))                     => None
       case (uu, None, uw)                                     => None
       case (uu, Some(VBool(va)), uw)                          => None
       case (uu, Some(VInt(va)), uw)                           => None
@@ -3866,6 +4003,7 @@ object SpecRestGenerated {
       case (uu, Some(VNone()), uw)                            => None
       case (uu, Some(VSome(va)), uw)                          => None
       case (uu, Some(VStr(va)), uw)                           => None
+      case (uu, Some(VSeq(va)), uw)                           => None
       case (uu, uv, None)                                     => None
       case (uu, uv, Some(VBool(va)))                          => None
       case (uu, uv, Some(VInt(va)))                           => None
@@ -3876,6 +4014,7 @@ object SpecRestGenerated {
       case (uu, uv, Some(VNone()))                            => None
       case (uu, uv, Some(VSome(va)))                          => None
       case (uu, uv, Some(VStr(va)))                           => None
+      case (uu, uv, Some(VSeq(va)))                           => None
     }
 
   def eval_arith(uu: arith_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
@@ -3935,6 +4074,7 @@ object SpecRestGenerated {
       case (SubOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (SubOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (SubOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (SubOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (SubOp(), Some(VEnum(va, vb)), uw)                        => None
       case (SubOp(), Some(VEntity(va, vb)), uw)                      => None
       case (SubOp(), Some(VSet(va)), uw)                             => None
@@ -3942,6 +4082,7 @@ object SpecRestGenerated {
       case (SubOp(), Some(VNone()), uw)                              => None
       case (SubOp(), Some(VSome(va)), uw)                            => None
       case (SubOp(), Some(VStr(va)), uw)                             => None
+      case (SubOp(), Some(VSeq(va)), uw)                             => None
       case (SubOp(), uv, None)                                       => None
       case (SubOp(), uv, Some(VBool(va)))                            => None
       case (SubOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -3951,6 +4092,7 @@ object SpecRestGenerated {
       case (SubOp(), uv, Some(VNone()))                              => None
       case (SubOp(), uv, Some(VSome(va)))                            => None
       case (SubOp(), uv, Some(VStr(va)))                             => None
+      case (SubOp(), uv, Some(VSeq(va)))                             => None
       case (MulOp(), None, uw)                                       => None
       case (MulOp(), Some(VBool(va)), uw)                            => None
       case (MulOp(), Some(VReal(va)), None)                          => None
@@ -3962,6 +4104,7 @@ object SpecRestGenerated {
       case (MulOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (MulOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (MulOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (MulOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (MulOp(), Some(VEnum(va, vb)), uw)                        => None
       case (MulOp(), Some(VEntity(va, vb)), uw)                      => None
       case (MulOp(), Some(VSet(va)), uw)                             => None
@@ -3969,6 +4112,7 @@ object SpecRestGenerated {
       case (MulOp(), Some(VNone()), uw)                              => None
       case (MulOp(), Some(VSome(va)), uw)                            => None
       case (MulOp(), Some(VStr(va)), uw)                             => None
+      case (MulOp(), Some(VSeq(va)), uw)                             => None
       case (MulOp(), uv, None)                                       => None
       case (MulOp(), uv, Some(VBool(va)))                            => None
       case (MulOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -3978,6 +4122,7 @@ object SpecRestGenerated {
       case (MulOp(), uv, Some(VNone()))                              => None
       case (MulOp(), uv, Some(VSome(va)))                            => None
       case (MulOp(), uv, Some(VStr(va)))                             => None
+      case (MulOp(), uv, Some(VSeq(va)))                             => None
       case (DivOp(), None, uw)                                       => None
       case (DivOp(), Some(VBool(va)), uw)                            => None
       case (DivOp(), Some(VReal(va)), None)                          => None
@@ -3989,6 +4134,7 @@ object SpecRestGenerated {
       case (DivOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (DivOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (DivOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (DivOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (DivOp(), Some(VEnum(va, vb)), uw)                        => None
       case (DivOp(), Some(VEntity(va, vb)), uw)                      => None
       case (DivOp(), Some(VSet(va)), uw)                             => None
@@ -3996,6 +4142,7 @@ object SpecRestGenerated {
       case (DivOp(), Some(VNone()), uw)                              => None
       case (DivOp(), Some(VSome(va)), uw)                            => None
       case (DivOp(), Some(VStr(va)), uw)                             => None
+      case (DivOp(), Some(VSeq(va)), uw)                             => None
       case (DivOp(), uv, None)                                       => None
       case (DivOp(), uv, Some(VBool(va)))                            => None
       case (DivOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4005,6 +4152,7 @@ object SpecRestGenerated {
       case (DivOp(), uv, Some(VNone()))                              => None
       case (DivOp(), uv, Some(VSome(va)))                            => None
       case (DivOp(), uv, Some(VStr(va)))                             => None
+      case (DivOp(), uv, Some(VSeq(va)))                             => None
       case (uu, None, uw)                                            => None
       case (uu, Some(VBool(va)), uw)                                 => None
       case (uu, Some(VReal(va)), None)                               => None
@@ -4016,6 +4164,7 @@ object SpecRestGenerated {
       case (uu, Some(VReal(va)), Some(VNone()))                      => None
       case (uu, Some(VReal(va)), Some(VSome(vb)))                    => None
       case (uu, Some(VReal(va)), Some(VStr(vb)))                     => None
+      case (uu, Some(VReal(va)), Some(VSeq(vb)))                     => None
       case (uu, Some(VEnum(va, vb)), uw)                             => None
       case (uu, Some(VEntity(va, vb)), uw)                           => None
       case (uu, Some(VSet(va)), uw)                                  => None
@@ -4023,6 +4172,7 @@ object SpecRestGenerated {
       case (uu, Some(VNone()), uw)                                   => None
       case (uu, Some(VSome(va)), uw)                                 => None
       case (uu, Some(VStr(va)), uw)                                  => None
+      case (uu, Some(VSeq(va)), uw)                                  => None
       case (uu, uv, None)                                            => None
       case (uu, uv, Some(VBool(va)))                                 => None
       case (uu, uv, Some(VEnum(va, vb)))                             => None
@@ -4032,6 +4182,7 @@ object SpecRestGenerated {
       case (uu, uv, Some(VNone()))                                   => None
       case (uu, uv, Some(VSome(va)))                                 => None
       case (uu, uv, Some(VStr(va)))                                  => None
+      case (uu, uv, Some(VSeq(va)))                                  => None
     }
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
@@ -4058,6 +4209,7 @@ object SpecRestGenerated {
       case (VInt(_), VNone())               => equal_ir_valuea(x, y)
       case (VInt(_), VSome(_))              => equal_ir_valuea(x, y)
       case (VInt(_), VStr(_))               => equal_ir_valuea(x, y)
+      case (VInt(_), VSeq(_))               => equal_ir_valuea(x, y)
       case (VReal(_), VBool(_))             => equal_ir_valuea(x, y)
       case (VReal(a), VInt(b))              => equal_rat(a, of_int(b))
       case (VReal(_), VReal(_))             => equal_ir_valuea(x, y)
@@ -4068,6 +4220,7 @@ object SpecRestGenerated {
       case (VReal(_), VNone())              => equal_ir_valuea(x, y)
       case (VReal(_), VSome(_))             => equal_ir_valuea(x, y)
       case (VReal(_), VStr(_))              => equal_ir_valuea(x, y)
+      case (VReal(_), VSeq(_))              => equal_ir_valuea(x, y)
       case (VEnum(_, _), _)                 => equal_ir_valuea(x, y)
       case (VEntity(_, _), _)               => equal_ir_valuea(x, y)
       case (VSet(_), _)                     => equal_ir_valuea(x, y)
@@ -4075,6 +4228,7 @@ object SpecRestGenerated {
       case (VNone(), _)                     => equal_ir_valuea(x, y)
       case (VSome(_), _)                    => equal_ir_valuea(x, y)
       case (VStr(_), _)                     => equal_ir_valuea(x, y)
+      case (VSeq(_), _)                     => equal_ir_valuea(x, y)
     }
 
   def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
@@ -4126,6 +4280,7 @@ object SpecRestGenerated {
       case (LtOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (LtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (LtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (LtOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (LtOp(), Some(VEnum(va, vb)), uw)                        => None
       case (LtOp(), Some(VEntity(va, vb)), uw)                      => None
       case (LtOp(), Some(VSet(va)), uw)                             => None
@@ -4133,6 +4288,7 @@ object SpecRestGenerated {
       case (LtOp(), Some(VNone()), uw)                              => None
       case (LtOp(), Some(VSome(va)), uw)                            => None
       case (LtOp(), Some(VStr(va)), uw)                             => None
+      case (LtOp(), Some(VSeq(va)), uw)                             => None
       case (LtOp(), uv, None)                                       => None
       case (LtOp(), uv, Some(VBool(va)))                            => None
       case (LtOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4142,6 +4298,7 @@ object SpecRestGenerated {
       case (LtOp(), uv, Some(VNone()))                              => None
       case (LtOp(), uv, Some(VSome(va)))                            => None
       case (LtOp(), uv, Some(VStr(va)))                             => None
+      case (LtOp(), uv, Some(VSeq(va)))                             => None
       case (LeOp(), None, uw)                                       => None
       case (LeOp(), Some(VBool(va)), uw)                            => None
       case (LeOp(), Some(VReal(va)), None)                          => None
@@ -4153,6 +4310,7 @@ object SpecRestGenerated {
       case (LeOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (LeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (LeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (LeOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (LeOp(), Some(VEnum(va, vb)), uw)                        => None
       case (LeOp(), Some(VEntity(va, vb)), uw)                      => None
       case (LeOp(), Some(VSet(va)), uw)                             => None
@@ -4160,6 +4318,7 @@ object SpecRestGenerated {
       case (LeOp(), Some(VNone()), uw)                              => None
       case (LeOp(), Some(VSome(va)), uw)                            => None
       case (LeOp(), Some(VStr(va)), uw)                             => None
+      case (LeOp(), Some(VSeq(va)), uw)                             => None
       case (LeOp(), uv, None)                                       => None
       case (LeOp(), uv, Some(VBool(va)))                            => None
       case (LeOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4169,6 +4328,7 @@ object SpecRestGenerated {
       case (LeOp(), uv, Some(VNone()))                              => None
       case (LeOp(), uv, Some(VSome(va)))                            => None
       case (LeOp(), uv, Some(VStr(va)))                             => None
+      case (LeOp(), uv, Some(VSeq(va)))                             => None
       case (GtOp(), None, uw)                                       => None
       case (GtOp(), Some(VBool(va)), uw)                            => None
       case (GtOp(), Some(VReal(va)), None)                          => None
@@ -4180,6 +4340,7 @@ object SpecRestGenerated {
       case (GtOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (GtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (GtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (GtOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (GtOp(), Some(VEnum(va, vb)), uw)                        => None
       case (GtOp(), Some(VEntity(va, vb)), uw)                      => None
       case (GtOp(), Some(VSet(va)), uw)                             => None
@@ -4187,6 +4348,7 @@ object SpecRestGenerated {
       case (GtOp(), Some(VNone()), uw)                              => None
       case (GtOp(), Some(VSome(va)), uw)                            => None
       case (GtOp(), Some(VStr(va)), uw)                             => None
+      case (GtOp(), Some(VSeq(va)), uw)                             => None
       case (GtOp(), uv, None)                                       => None
       case (GtOp(), uv, Some(VBool(va)))                            => None
       case (GtOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4196,6 +4358,7 @@ object SpecRestGenerated {
       case (GtOp(), uv, Some(VNone()))                              => None
       case (GtOp(), uv, Some(VSome(va)))                            => None
       case (GtOp(), uv, Some(VStr(va)))                             => None
+      case (GtOp(), uv, Some(VSeq(va)))                             => None
       case (GeOp(), None, uw)                                       => None
       case (GeOp(), Some(VBool(va)), uw)                            => None
       case (GeOp(), Some(VReal(va)), None)                          => None
@@ -4207,6 +4370,7 @@ object SpecRestGenerated {
       case (GeOp(), Some(VReal(va)), Some(VNone()))                 => None
       case (GeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
       case (GeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
+      case (GeOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
       case (GeOp(), Some(VEnum(va, vb)), uw)                        => None
       case (GeOp(), Some(VEntity(va, vb)), uw)                      => None
       case (GeOp(), Some(VSet(va)), uw)                             => None
@@ -4214,6 +4378,7 @@ object SpecRestGenerated {
       case (GeOp(), Some(VNone()), uw)                              => None
       case (GeOp(), Some(VSome(va)), uw)                            => None
       case (GeOp(), Some(VStr(va)), uw)                             => None
+      case (GeOp(), Some(VSeq(va)), uw)                             => None
       case (GeOp(), uv, None)                                       => None
       case (GeOp(), uv, Some(VBool(va)))                            => None
       case (GeOp(), uv, Some(VEnum(va, vb)))                        => None
@@ -4223,6 +4388,7 @@ object SpecRestGenerated {
       case (GeOp(), uv, Some(VNone()))                              => None
       case (GeOp(), uv, Some(VSome(va)))                            => None
       case (GeOp(), uv, Some(VStr(va)))                             => None
+      case (GeOp(), uv, Some(VSeq(va)))                             => None
       case (uu, None, uw)                                           => None
       case (uu, uv, None)                                           => None
     }
@@ -4254,6 +4420,7 @@ object SpecRestGenerated {
               case Some(VNone())              => None
               case Some(VSome(_))             => None
               case Some(VStr(_))              => None
+              case Some(VSeq(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4264,6 +4431,7 @@ object SpecRestGenerated {
           case Some(VNone())              => None
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
     }
 
@@ -4293,6 +4461,7 @@ object SpecRestGenerated {
               case Some(VNone())              => None
               case Some(VSome(_))             => None
               case Some(VStr(_))              => None
+              case Some(VSeq(_))              => None
             }
           case Some(VInt(_))              => None
           case Some(VReal(_))             => None
@@ -4303,6 +4472,7 @@ object SpecRestGenerated {
           case Some(VNone())              => None
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
     }
 
@@ -4333,6 +4503,7 @@ object SpecRestGenerated {
           case Some(VNone())              => None
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
       case (s, st, env, UnNeg(e, uz)) =>
         eval(s, st, env, e) match {
@@ -4347,6 +4518,7 @@ object SpecRestGenerated {
           case Some(VNone())              => None
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
       case (s, st, env, BoolBin(op, l, r, va)) =>
         (eval(s, st, env, l), eval(s, st, env, r)) match {
@@ -4363,6 +4535,7 @@ object SpecRestGenerated {
           case (Some(VBool(_)), Some(VNone()))              => None
           case (Some(VBool(_)), Some(VSome(_)))             => None
           case (Some(VBool(_)), Some(VStr(_)))              => None
+          case (Some(VBool(_)), Some(VSeq(_)))              => None
           case (Some(VInt(_)), _)                           => None
           case (Some(VReal(_)), _)                          => None
           case (Some(VEnum(_, _)), _)                       => None
@@ -4372,6 +4545,7 @@ object SpecRestGenerated {
           case (Some(VNone()), _)                           => None
           case (Some(VSome(_)), _)                          => None
           case (Some(VStr(_)), _)                           => None
+          case (Some(VSeq(_)), _)                           => None
         }
       case (s, st, env, Arith(op, l, r, vb)) =>
         eval_arith(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4447,6 +4621,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VNone()))              => None
           case (Some(_), Some(VSome(_)))             => None
           case (Some(_), Some(VStr(_)))              => None
+          case (Some(_), Some(VSeq(_)))              => None
         }
       case (s, st, env, SetMember(elem, set_e, vp)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
@@ -4463,6 +4638,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VNone()))              => None
           case (Some(_), Some(VSome(_)))             => None
           case (Some(_), Some(VStr(_)))              => None
+          case (Some(_), Some(VSeq(_)))              => None
         }
       case (s, st, env, SetBin(op, l, r, vq)) =>
         eval_set_bin(op, eval(s, st, env, l), eval(s, st, env, r))
@@ -4486,11 +4662,29 @@ object SpecRestGenerated {
           case Some(VNone())              => None
           case Some(VSome(_))             => None
           case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
       case (s, st, env, NoneE(vt)) => Some[ir_value](VNone())
       case (s, st, env, SomeE(e, vu)) =>
         map_option[ir_value, ir_value]((a: ir_value) => VSome(a), eval(s, st, env, e))
       case (s, st, env, StrLit(v, vv)) => Some[ir_value](VStr(v))
+      case (s, st, env, SeqEmpty(vw))  => Some[ir_value](VSeq(Nil))
+      case (s, st, env, SeqCons(e, rest, vx)) =>
+        (eval(s, st, env, e), eval(s, st, env, rest)) match {
+          case (None, _)                             => None
+          case (Some(_), None)                       => None
+          case (Some(_), Some(VBool(_)))             => None
+          case (Some(_), Some(VInt(_)))              => None
+          case (Some(_), Some(VReal(_)))             => None
+          case (Some(_), Some(VEnum(_, _)))          => None
+          case (Some(_), Some(VEntity(_, _)))        => None
+          case (Some(_), Some(VSet(_)))              => None
+          case (Some(_), Some(VEntityWith(_, _, _))) => None
+          case (Some(_), Some(VNone()))              => None
+          case (Some(_), Some(VSome(_)))             => None
+          case (Some(_), Some(VStr(_)))              => None
+          case (Some(v), Some(VSeq(vs)))             => Some[ir_value](VSeq(v :: vs))
+        }
     }
 
   def map_filter[A, B](f: A => Option[B], x1: List[A]): List[B] = (f, x1) match {
@@ -5644,10 +5838,12 @@ object SpecRestGenerated {
     case SetBin(DiffOp(), l, r, wd) => TSetDiff(translate(l), translate(r))
     case WithRec(base, fld, val_e, we) =>
       TWithRec(translate(base), fld, translate(val_e))
-    case Ite(c, a, b, wf) => TIte(translate(c), translate(a), translate(b))
-    case NoneE(wg)        => TNone()
-    case SomeE(e, wh)     => TSome(translate(e))
-    case StrLit(v, wi)    => TStrLit(v)
+    case Ite(c, a, b, wf)     => TIte(translate(c), translate(a), translate(b))
+    case NoneE(wg)            => TNone()
+    case SomeE(e, wh)         => TSome(translate(e))
+    case StrLit(v, wi)        => TStrLit(v)
+    case SeqEmpty(wj)         => TSeqEmpty()
+    case SeqCons(e, rest, wk) => TSeqCons(translate(e), translate(rest))
   }
 
   def litClass(x0: expr_full): Option[lit_class] = x0 match {
@@ -12726,9 +12922,9 @@ object SpecRestGenerated {
     case (TBool(), TBool())         => true
   }
 
-  def check_value_has_ty_list(wd: tyctx_ext[Unit], x1: List[ir_value], we: ty): Boolean =
-    (wd, x1, we) match {
-      case (wd, Nil, we) => true
+  def check_value_has_ty_list(wf: tyctx_ext[Unit], x1: List[ir_value], wg: ty): Boolean =
+    (wf, x1, wg) match {
+      case (wf, Nil, wg) => true
       case (gamma, v :: vs, t) =>
         check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
     }
@@ -12760,6 +12956,7 @@ object SpecRestGenerated {
       case (gamma, VNone(), vy)                        => false
       case (gamma, VSome(vz), wa)                      => false
       case (gamma, VStr(wb), wc)                       => false
+      case (gamma, VSeq(wd), we)                       => false
     }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl_full] = x0 match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4017,184 +4017,75 @@ object SpecRestGenerated {
       case (uu, uv, Some(VSeq(va)))                           => None
     }
 
-  def eval_arith(uu: arith_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
-    (uu, uv, uw) match {
-      case (AddOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VInt(plus_int(a, b)))
-      case (SubOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VInt(minus_int(a, b)))
-      case (MulOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VInt(times_inta(a, b)))
-      case (DivOp(), Some(VInt(a)), Some(VInt(b))) =>
+  def real_arith(x0: arith_op, a: rat, b: rat): Option[ir_value] = (x0, a, b) match {
+    case (AddOp(), a, b) => Some[ir_value](VReal(plus_rat(a, b)))
+    case (SubOp(), a, b) => Some[ir_value](VReal(minus_rat(a, b)))
+    case (MulOp(), a, b) => Some[ir_value](VReal(times_rat(a, b)))
+    case (DivOp(), a, b) =>
+      equal_rat(b, zero_rat) match {
+        case true  => None
+        case false => Some[ir_value](VReal(divide_rat(a, b)))
+      }
+  }
+
+  def int_arith(x0: arith_op, a: BigInt, b: BigInt): Option[ir_value] =
+    (x0, a, b) match {
+      case (AddOp(), a, b) => Some[ir_value](VInt(plus_int(a, b)))
+      case (SubOp(), a, b) => Some[ir_value](VInt(minus_int(a, b)))
+      case (MulOp(), a, b) => Some[ir_value](VInt(times_inta(a, b)))
+      case (DivOp(), a, b) =>
         equal_int(b, zero_int) match {
           case true  => None
           case false => Some[ir_value](VInt(divide_int(a, b)))
         }
-      case (AddOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(plus_rat(a, b)))
-      case (SubOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(minus_rat(a, b)))
-      case (MulOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(times_rat(a, b)))
-      case (DivOp(), Some(VReal(a)), Some(VReal(b))) =>
-        equal_rat(b, zero_rat) match {
-          case true  => None
-          case false => Some[ir_value](VReal(divide_rat(a, b)))
+    }
+
+  def eval_arith(op: arith_op, x: Option[ir_value], y: Option[ir_value]): Option[ir_value] =
+    x match {
+      case None           => None
+      case Some(VBool(_)) => None
+      case Some(VInt(a)) =>
+        y match {
+          case None                       => None
+          case Some(VBool(_))             => None
+          case Some(VInt(b))              => int_arith(op, a, b)
+          case Some(VReal(b))             => real_arith(op, of_int(a), b)
+          case Some(VEnum(_, _))          => None
+          case Some(VEntity(_, _))        => None
+          case Some(VSet(_))              => None
+          case Some(VEntityWith(_, _, _)) => None
+          case Some(VNone())              => None
+          case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
-      case (AddOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(plus_rat(of_int(a), b)))
-      case (AddOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VReal(plus_rat(a, of_int(b))))
-      case (SubOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(minus_rat(of_int(a), b)))
-      case (SubOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VReal(minus_rat(a, of_int(b))))
-      case (MulOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VReal(times_rat(of_int(a), b)))
-      case (MulOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VReal(times_rat(a, of_int(b))))
-      case (DivOp(), Some(VInt(a)), Some(VReal(b))) =>
-        equal_rat(b, zero_rat) match {
-          case true  => None
-          case false => Some[ir_value](VReal(divide_rat(of_int(a), b)))
+      case Some(VReal(a)) =>
+        y match {
+          case None                       => None
+          case Some(VBool(_))             => None
+          case Some(VInt(b))              => real_arith(op, a, of_int(b))
+          case Some(VReal(b))             => real_arith(op, a, b)
+          case Some(VEnum(_, _))          => None
+          case Some(VEntity(_, _))        => None
+          case Some(VSet(_))              => None
+          case Some(VEntityWith(_, _, _)) => None
+          case Some(VNone())              => None
+          case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
         }
-      case (DivOp(), Some(VReal(a)), Some(VInt(b))) =>
-        equal_int(b, zero_int) match {
-          case true  => None
-          case false => Some[ir_value](VReal(divide_rat(a, of_int(b))))
-        }
-      case (SubOp(), None, uw)                                       => None
-      case (SubOp(), Some(VBool(va)), uw)                            => None
-      case (SubOp(), Some(VReal(va)), None)                          => None
-      case (SubOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (SubOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (SubOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (SubOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (SubOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (SubOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (SubOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (SubOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (SubOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (SubOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (SubOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (SubOp(), Some(VSet(va)), uw)                             => None
-      case (SubOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (SubOp(), Some(VNone()), uw)                              => None
-      case (SubOp(), Some(VSome(va)), uw)                            => None
-      case (SubOp(), Some(VStr(va)), uw)                             => None
-      case (SubOp(), Some(VSeq(va)), uw)                             => None
-      case (SubOp(), uv, None)                                       => None
-      case (SubOp(), uv, Some(VBool(va)))                            => None
-      case (SubOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (SubOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (SubOp(), uv, Some(VSet(va)))                             => None
-      case (SubOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (SubOp(), uv, Some(VNone()))                              => None
-      case (SubOp(), uv, Some(VSome(va)))                            => None
-      case (SubOp(), uv, Some(VStr(va)))                             => None
-      case (SubOp(), uv, Some(VSeq(va)))                             => None
-      case (MulOp(), None, uw)                                       => None
-      case (MulOp(), Some(VBool(va)), uw)                            => None
-      case (MulOp(), Some(VReal(va)), None)                          => None
-      case (MulOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (MulOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (MulOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (MulOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (MulOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (MulOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (MulOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (MulOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (MulOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (MulOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (MulOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (MulOp(), Some(VSet(va)), uw)                             => None
-      case (MulOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (MulOp(), Some(VNone()), uw)                              => None
-      case (MulOp(), Some(VSome(va)), uw)                            => None
-      case (MulOp(), Some(VStr(va)), uw)                             => None
-      case (MulOp(), Some(VSeq(va)), uw)                             => None
-      case (MulOp(), uv, None)                                       => None
-      case (MulOp(), uv, Some(VBool(va)))                            => None
-      case (MulOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (MulOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (MulOp(), uv, Some(VSet(va)))                             => None
-      case (MulOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (MulOp(), uv, Some(VNone()))                              => None
-      case (MulOp(), uv, Some(VSome(va)))                            => None
-      case (MulOp(), uv, Some(VStr(va)))                             => None
-      case (MulOp(), uv, Some(VSeq(va)))                             => None
-      case (DivOp(), None, uw)                                       => None
-      case (DivOp(), Some(VBool(va)), uw)                            => None
-      case (DivOp(), Some(VReal(va)), None)                          => None
-      case (DivOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (DivOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (DivOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (DivOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (DivOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (DivOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (DivOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (DivOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (DivOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (DivOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (DivOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (DivOp(), Some(VSet(va)), uw)                             => None
-      case (DivOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (DivOp(), Some(VNone()), uw)                              => None
-      case (DivOp(), Some(VSome(va)), uw)                            => None
-      case (DivOp(), Some(VStr(va)), uw)                             => None
-      case (DivOp(), Some(VSeq(va)), uw)                             => None
-      case (DivOp(), uv, None)                                       => None
-      case (DivOp(), uv, Some(VBool(va)))                            => None
-      case (DivOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (DivOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (DivOp(), uv, Some(VSet(va)))                             => None
-      case (DivOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (DivOp(), uv, Some(VNone()))                              => None
-      case (DivOp(), uv, Some(VSome(va)))                            => None
-      case (DivOp(), uv, Some(VStr(va)))                             => None
-      case (DivOp(), uv, Some(VSeq(va)))                             => None
-      case (uu, None, uw)                                            => None
-      case (uu, Some(VBool(va)), uw)                                 => None
-      case (uu, Some(VReal(va)), None)                               => None
-      case (uu, Some(VReal(va)), Some(VBool(vb)))                    => None
-      case (uu, Some(VReal(va)), Some(VEnum(vb, vc)))                => None
-      case (uu, Some(VReal(va)), Some(VEntity(vb, vc)))              => None
-      case (uu, Some(VReal(va)), Some(VSet(vb)))                     => None
-      case (uu, Some(VReal(va)), Some(VEntityWith(vb, vc, vd)))      => None
-      case (uu, Some(VReal(va)), Some(VNone()))                      => None
-      case (uu, Some(VReal(va)), Some(VSome(vb)))                    => None
-      case (uu, Some(VReal(va)), Some(VStr(vb)))                     => None
-      case (uu, Some(VReal(va)), Some(VSeq(vb)))                     => None
-      case (uu, Some(VEnum(va, vb)), uw)                             => None
-      case (uu, Some(VEntity(va, vb)), uw)                           => None
-      case (uu, Some(VSet(va)), uw)                                  => None
-      case (uu, Some(VEntityWith(va, vb, vc)), uw)                   => None
-      case (uu, Some(VNone()), uw)                                   => None
-      case (uu, Some(VSome(va)), uw)                                 => None
-      case (uu, Some(VStr(va)), uw)                                  => None
-      case (uu, Some(VSeq(va)), uw)                                  => None
-      case (uu, uv, None)                                            => None
-      case (uu, uv, Some(VBool(va)))                                 => None
-      case (uu, uv, Some(VEnum(va, vb)))                             => None
-      case (uu, uv, Some(VEntity(va, vb)))                           => None
-      case (uu, uv, Some(VSet(va)))                                  => None
-      case (uu, uv, Some(VEntityWith(va, vb, vc)))                   => None
-      case (uu, uv, Some(VNone()))                                   => None
-      case (uu, uv, Some(VSome(va)))                                 => None
-      case (uu, uv, Some(VStr(va)))                                  => None
-      case (uu, uv, Some(VSeq(va)))                                  => None
+      case Some(VEnum(_, _))          => None
+      case Some(VEntity(_, _))        => None
+      case Some(VSet(_))              => None
+      case Some(VEntityWith(_, _, _)) => None
+      case Some(VNone())              => None
+      case Some(VSome(_))             => None
+      case Some(VStr(_))              => None
+      case Some(VSeq(_))              => None
     }
 
   def env_lookup(env: List[(String, ir_value)], name: String): Option[ir_value] =
     map_of[String, ir_value](env, name)
-
-  def less_eq_int(k: BigInt, l: BigInt): Boolean = k <= l
-
-  def less_eq_rat(p: rat, q: rat): Boolean = {
-    val (a, c) = quotient_of(p): ((BigInt, BigInt))
-    val (b, d) = quotient_of(q): ((BigInt, BigInt));
-    less_eq_int(times_inta(a, d), times_inta(c, b))
-  }
 
   def ir_val_eq(x: ir_value, y: ir_value): Boolean =
     (x, y) match {
@@ -4231,166 +4122,204 @@ object SpecRestGenerated {
       case (VSeq(_), _)                     => equal_ir_valuea(x, y)
     }
 
-  def eval_cmp(uu: cmp_op, uv: Option[ir_value], uw: Option[ir_value]): Option[ir_value] =
-    (uu, uv, uw) match {
-      case (EqOp(), Some(a), Some(b))  => Some[ir_value](VBool(ir_val_eq(a, b)))
-      case (NeqOp(), Some(a), Some(b)) => Some[ir_value](VBool(!ir_val_eq(a, b)))
-      case (LtOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_int(a, b)))
-      case (LeOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_eq_int(a, b)))
-      case (GtOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_int(b, a)))
-      case (GeOp(), Some(VInt(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_eq_int(b, a)))
-      case (LtOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_rat(a, b)))
-      case (LeOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_eq_rat(a, b)))
-      case (GtOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_rat(b, a)))
-      case (GeOp(), Some(VReal(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_eq_rat(b, a)))
-      case (LtOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_rat(of_int(a), b)))
-      case (LtOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_rat(a, of_int(b))))
-      case (LeOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_eq_rat(of_int(a), b)))
-      case (LeOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_eq_rat(a, of_int(b))))
-      case (GtOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_rat(b, of_int(a))))
-      case (GtOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_rat(of_int(b), a)))
-      case (GeOp(), Some(VInt(a)), Some(VReal(b))) =>
-        Some[ir_value](VBool(less_eq_rat(b, of_int(a))))
-      case (GeOp(), Some(VReal(a)), Some(VInt(b))) =>
-        Some[ir_value](VBool(less_eq_rat(of_int(b), a)))
-      case (NeqOp(), None, uw)                                      => None
-      case (NeqOp(), uv, None)                                      => None
-      case (LtOp(), None, uw)                                       => None
-      case (LtOp(), Some(VBool(va)), uw)                            => None
-      case (LtOp(), Some(VReal(va)), None)                          => None
-      case (LtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (LtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (LtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (LtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (LtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (LtOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (LtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (LtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (LtOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (LtOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (LtOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (LtOp(), Some(VSet(va)), uw)                             => None
-      case (LtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (LtOp(), Some(VNone()), uw)                              => None
-      case (LtOp(), Some(VSome(va)), uw)                            => None
-      case (LtOp(), Some(VStr(va)), uw)                             => None
-      case (LtOp(), Some(VSeq(va)), uw)                             => None
-      case (LtOp(), uv, None)                                       => None
-      case (LtOp(), uv, Some(VBool(va)))                            => None
-      case (LtOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (LtOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (LtOp(), uv, Some(VSet(va)))                             => None
-      case (LtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (LtOp(), uv, Some(VNone()))                              => None
-      case (LtOp(), uv, Some(VSome(va)))                            => None
-      case (LtOp(), uv, Some(VStr(va)))                             => None
-      case (LtOp(), uv, Some(VSeq(va)))                             => None
-      case (LeOp(), None, uw)                                       => None
-      case (LeOp(), Some(VBool(va)), uw)                            => None
-      case (LeOp(), Some(VReal(va)), None)                          => None
-      case (LeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (LeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (LeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (LeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (LeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (LeOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (LeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (LeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (LeOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (LeOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (LeOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (LeOp(), Some(VSet(va)), uw)                             => None
-      case (LeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (LeOp(), Some(VNone()), uw)                              => None
-      case (LeOp(), Some(VSome(va)), uw)                            => None
-      case (LeOp(), Some(VStr(va)), uw)                             => None
-      case (LeOp(), Some(VSeq(va)), uw)                             => None
-      case (LeOp(), uv, None)                                       => None
-      case (LeOp(), uv, Some(VBool(va)))                            => None
-      case (LeOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (LeOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (LeOp(), uv, Some(VSet(va)))                             => None
-      case (LeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (LeOp(), uv, Some(VNone()))                              => None
-      case (LeOp(), uv, Some(VSome(va)))                            => None
-      case (LeOp(), uv, Some(VStr(va)))                             => None
-      case (LeOp(), uv, Some(VSeq(va)))                             => None
-      case (GtOp(), None, uw)                                       => None
-      case (GtOp(), Some(VBool(va)), uw)                            => None
-      case (GtOp(), Some(VReal(va)), None)                          => None
-      case (GtOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (GtOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (GtOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (GtOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (GtOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (GtOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (GtOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (GtOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (GtOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (GtOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (GtOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (GtOp(), Some(VSet(va)), uw)                             => None
-      case (GtOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (GtOp(), Some(VNone()), uw)                              => None
-      case (GtOp(), Some(VSome(va)), uw)                            => None
-      case (GtOp(), Some(VStr(va)), uw)                             => None
-      case (GtOp(), Some(VSeq(va)), uw)                             => None
-      case (GtOp(), uv, None)                                       => None
-      case (GtOp(), uv, Some(VBool(va)))                            => None
-      case (GtOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (GtOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (GtOp(), uv, Some(VSet(va)))                             => None
-      case (GtOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (GtOp(), uv, Some(VNone()))                              => None
-      case (GtOp(), uv, Some(VSome(va)))                            => None
-      case (GtOp(), uv, Some(VStr(va)))                             => None
-      case (GtOp(), uv, Some(VSeq(va)))                             => None
-      case (GeOp(), None, uw)                                       => None
-      case (GeOp(), Some(VBool(va)), uw)                            => None
-      case (GeOp(), Some(VReal(va)), None)                          => None
-      case (GeOp(), Some(VReal(va)), Some(VBool(vb)))               => None
-      case (GeOp(), Some(VReal(va)), Some(VEnum(vb, vc)))           => None
-      case (GeOp(), Some(VReal(va)), Some(VEntity(vb, vc)))         => None
-      case (GeOp(), Some(VReal(va)), Some(VSet(vb)))                => None
-      case (GeOp(), Some(VReal(va)), Some(VEntityWith(vb, vc, vd))) => None
-      case (GeOp(), Some(VReal(va)), Some(VNone()))                 => None
-      case (GeOp(), Some(VReal(va)), Some(VSome(vb)))               => None
-      case (GeOp(), Some(VReal(va)), Some(VStr(vb)))                => None
-      case (GeOp(), Some(VReal(va)), Some(VSeq(vb)))                => None
-      case (GeOp(), Some(VEnum(va, vb)), uw)                        => None
-      case (GeOp(), Some(VEntity(va, vb)), uw)                      => None
-      case (GeOp(), Some(VSet(va)), uw)                             => None
-      case (GeOp(), Some(VEntityWith(va, vb, vc)), uw)              => None
-      case (GeOp(), Some(VNone()), uw)                              => None
-      case (GeOp(), Some(VSome(va)), uw)                            => None
-      case (GeOp(), Some(VStr(va)), uw)                             => None
-      case (GeOp(), Some(VSeq(va)), uw)                             => None
-      case (GeOp(), uv, None)                                       => None
-      case (GeOp(), uv, Some(VBool(va)))                            => None
-      case (GeOp(), uv, Some(VEnum(va, vb)))                        => None
-      case (GeOp(), uv, Some(VEntity(va, vb)))                      => None
-      case (GeOp(), uv, Some(VSet(va)))                             => None
-      case (GeOp(), uv, Some(VEntityWith(va, vb, vc)))              => None
-      case (GeOp(), uv, Some(VNone()))                              => None
-      case (GeOp(), uv, Some(VSome(va)))                            => None
-      case (GeOp(), uv, Some(VStr(va)))                             => None
-      case (GeOp(), uv, Some(VSeq(va)))                             => None
-      case (uu, None, uw)                                           => None
-      case (uu, uv, None)                                           => None
+  def less_eq_int(k: BigInt, l: BigInt): Boolean = k <= l
+
+  def less_eq_rat(p: rat, q: rat): Boolean = {
+    val (a, c) = quotient_of(p): ((BigInt, BigInt))
+    val (b, d) = quotient_of(q): ((BigInt, BigInt));
+    less_eq_int(times_inta(a, d), times_inta(c, b))
+  }
+
+  def real_cmp(x0: cmp_op, a: rat, b: rat): Option[ir_value] = (x0, a, b) match {
+    case (LtOp(), a, b)    => Some[ir_value](VBool(less_rat(a, b)))
+    case (LeOp(), a, b)    => Some[ir_value](VBool(less_eq_rat(a, b)))
+    case (GtOp(), a, b)    => Some[ir_value](VBool(less_rat(b, a)))
+    case (GeOp(), a, b)    => Some[ir_value](VBool(less_eq_rat(b, a)))
+    case (EqOp(), uv, uw)  => None
+    case (NeqOp(), uv, uw) => None
+  }
+
+  def int_cmp(x0: cmp_op, a: BigInt, b: BigInt): Option[ir_value] = (x0, a, b) match {
+    case (LtOp(), a, b)    => Some[ir_value](VBool(less_int(a, b)))
+    case (LeOp(), a, b)    => Some[ir_value](VBool(less_eq_int(a, b)))
+    case (GtOp(), a, b)    => Some[ir_value](VBool(less_int(b, a)))
+    case (GeOp(), a, b)    => Some[ir_value](VBool(less_eq_int(b, a)))
+    case (EqOp(), uv, uw)  => None
+    case (NeqOp(), uv, uw) => None
+  }
+
+  def eval_cmp(op: cmp_op, x: Option[ir_value], y: Option[ir_value]): Option[ir_value] =
+    x match {
+      case None => None
+      case Some(a) =>
+        y match {
+          case None => None
+          case Some(b) =>
+            op match {
+              case EqOp()  => Some[ir_value](VBool(ir_val_eq(a, b)))
+              case NeqOp() => Some[ir_value](VBool(!ir_val_eq(a, b)))
+              case LtOp() =>
+                a match {
+                  case VBool(_) => None
+                  case VInt(ai) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(aa)             => int_cmp(op, ai, aa)
+                      case VReal(aa)            => real_cmp(op, of_int(ai), aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VReal(ar) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(bi)             => real_cmp(op, ar, of_int(bi))
+                      case VReal(aa)            => real_cmp(op, ar, aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VEnum(_, _)          => None
+                  case VEntity(_, _)        => None
+                  case VSet(_)              => None
+                  case VEntityWith(_, _, _) => None
+                  case VNone()              => None
+                  case VSome(_)             => None
+                  case VStr(_)              => None
+                  case VSeq(_)              => None
+                }
+              case LeOp() =>
+                a match {
+                  case VBool(_) => None
+                  case VInt(ai) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(aa)             => int_cmp(op, ai, aa)
+                      case VReal(aa)            => real_cmp(op, of_int(ai), aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VReal(ar) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(bi)             => real_cmp(op, ar, of_int(bi))
+                      case VReal(aa)            => real_cmp(op, ar, aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VEnum(_, _)          => None
+                  case VEntity(_, _)        => None
+                  case VSet(_)              => None
+                  case VEntityWith(_, _, _) => None
+                  case VNone()              => None
+                  case VSome(_)             => None
+                  case VStr(_)              => None
+                  case VSeq(_)              => None
+                }
+              case GtOp() =>
+                a match {
+                  case VBool(_) => None
+                  case VInt(ai) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(aa)             => int_cmp(op, ai, aa)
+                      case VReal(aa)            => real_cmp(op, of_int(ai), aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VReal(ar) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(bi)             => real_cmp(op, ar, of_int(bi))
+                      case VReal(aa)            => real_cmp(op, ar, aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VEnum(_, _)          => None
+                  case VEntity(_, _)        => None
+                  case VSet(_)              => None
+                  case VEntityWith(_, _, _) => None
+                  case VNone()              => None
+                  case VSome(_)             => None
+                  case VStr(_)              => None
+                  case VSeq(_)              => None
+                }
+              case GeOp() =>
+                a match {
+                  case VBool(_) => None
+                  case VInt(ai) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(aa)             => int_cmp(op, ai, aa)
+                      case VReal(aa)            => real_cmp(op, of_int(ai), aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VReal(ar) =>
+                    b match {
+                      case VBool(_)             => None
+                      case VInt(bi)             => real_cmp(op, ar, of_int(bi))
+                      case VReal(aa)            => real_cmp(op, ar, aa)
+                      case VEnum(_, _)          => None
+                      case VEntity(_, _)        => None
+                      case VSet(_)              => None
+                      case VEntityWith(_, _, _) => None
+                      case VNone()              => None
+                      case VSome(_)             => None
+                      case VStr(_)              => None
+                      case VSeq(_)              => None
+                    }
+                  case VEnum(_, _)          => None
+                  case VEntity(_, _)        => None
+                  case VSet(_)              => None
+                  case VEntityWith(_, _, _) => None
+                  case VNone()              => None
+                  case VSome(_)             => None
+                  case VStr(_)              => None
+                  case VSeq(_)              => None
+                }
+            }
+        }
     }
 
   def eval_forall_enum(
@@ -10121,124 +10050,91 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => Nil
   }
 
-  def resolveWithBase(x0: expr_full): Option[String] = x0 match {
-    case IdentifierF(uu, uv)                          => None
-    case IndexF(PreF(IdentifierF(n, uw), ux), uy, uz) => Some[String](n)
-    case IndexF(IdentifierF(n, va), vb, vc)           => Some[String](n)
-    case IndexF(BinaryOpF(v, va, vb, vc), vd, ve) =>
-      rootIdentifier(BinaryOpF(v, va, vb, vc))
-    case IndexF(UnaryOpF(v, va, vb), vd, ve) =>
-      rootIdentifier(UnaryOpF(v, va, vb))
-    case IndexF(QuantifierF(v, va, vb, vc), vd, ve) =>
-      rootIdentifier(QuantifierF(v, va, vb, vc))
-    case IndexF(SomeWrapF(v, va), vd, ve) => rootIdentifier(SomeWrapF(v, va))
-    case IndexF(TheF(v, va, vb, vc), vd, ve) =>
-      rootIdentifier(TheF(v, va, vb, vc))
-    case IndexF(FieldAccessF(v, va, vb), vd, ve) =>
-      rootIdentifier(FieldAccessF(v, va, vb))
-    case IndexF(EnumAccessF(v, va, vb), vd, ve) =>
-      rootIdentifier(EnumAccessF(v, va, vb))
-    case IndexF(IndexF(v, va, vb), vd, ve) => rootIdentifier(IndexF(v, va, vb))
-    case IndexF(CallF(v, va, vb), vd, ve)  => rootIdentifier(CallF(v, va, vb))
-    case IndexF(PrimeF(v, va), vd, ve)     => rootIdentifier(PrimeF(v, va))
-    case IndexF(PreF(BinaryOpF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(BinaryOpF(vb, vc, vf, vg), va))
-    case IndexF(PreF(UnaryOpF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(UnaryOpF(vb, vc, vf), va))
-    case IndexF(PreF(QuantifierF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(QuantifierF(vb, vc, vf, vg), va))
-    case IndexF(PreF(SomeWrapF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(SomeWrapF(vb, vc), va))
-    case IndexF(PreF(TheF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(TheF(vb, vc, vf, vg), va))
-    case IndexF(PreF(FieldAccessF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(FieldAccessF(vb, vc, vf), va))
-    case IndexF(PreF(EnumAccessF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(EnumAccessF(vb, vc, vf), va))
-    case IndexF(PreF(IndexF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(IndexF(vb, vc, vf), va))
-    case IndexF(PreF(CallF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(CallF(vb, vc, vf), va))
-    case IndexF(PreF(PrimeF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(PrimeF(vb, vc), va))
-    case IndexF(PreF(PreF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(PreF(vb, vc), va))
-    case IndexF(PreF(WithF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(WithF(vb, vc, vf), va))
-    case IndexF(PreF(IfF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(IfF(vb, vc, vf, vg), va))
-    case IndexF(PreF(LetF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(LetF(vb, vc, vf, vg), va))
-    case IndexF(PreF(LambdaF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(LambdaF(vb, vc, vf), va))
-    case IndexF(PreF(ConstructorF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(ConstructorF(vb, vc, vf), va))
-    case IndexF(PreF(SetLiteralF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(SetLiteralF(vb, vc), va))
-    case IndexF(PreF(MapLiteralF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(MapLiteralF(vb, vc), va))
-    case IndexF(PreF(SetComprehensionF(vb, vc, vf, vg), va), vd, ve) =>
-      rootIdentifier(PreF(SetComprehensionF(vb, vc, vf, vg), va))
-    case IndexF(PreF(SeqLiteralF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(SeqLiteralF(vb, vc), va))
-    case IndexF(PreF(MatchesF(vb, vc, vf), va), vd, ve) =>
-      rootIdentifier(PreF(MatchesF(vb, vc, vf), va))
-    case IndexF(PreF(IntLitF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(IntLitF(vb, vc), va))
-    case IndexF(PreF(FloatLitF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(FloatLitF(vb, vc), va))
-    case IndexF(PreF(StringLitF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(StringLitF(vb, vc), va))
-    case IndexF(PreF(BoolLitF(vb, vc), va), vd, ve) =>
-      rootIdentifier(PreF(BoolLitF(vb, vc), va))
-    case IndexF(PreF(NoneLitF(vb), va), vd, ve) =>
-      rootIdentifier(PreF(NoneLitF(vb), va))
-    case IndexF(WithF(v, va, vb), vd, ve)   => rootIdentifier(WithF(v, va, vb))
-    case IndexF(IfF(v, va, vb, vc), vd, ve) => rootIdentifier(IfF(v, va, vb, vc))
-    case IndexF(LetF(v, va, vb, vc), vd, ve) =>
-      rootIdentifier(LetF(v, va, vb, vc))
-    case IndexF(LambdaF(v, va, vb), vd, ve) => rootIdentifier(LambdaF(v, va, vb))
-    case IndexF(ConstructorF(v, va, vb), vd, ve) =>
-      rootIdentifier(ConstructorF(v, va, vb))
-    case IndexF(SetLiteralF(v, va), vd, ve) => rootIdentifier(SetLiteralF(v, va))
-    case IndexF(MapLiteralF(v, va), vd, ve) => rootIdentifier(MapLiteralF(v, va))
-    case IndexF(SetComprehensionF(v, va, vb, vc), vd, ve) =>
-      rootIdentifier(SetComprehensionF(v, va, vb, vc))
-    case IndexF(SeqLiteralF(v, va), vd, ve) => rootIdentifier(SeqLiteralF(v, va))
-    case IndexF(MatchesF(v, va, vb), vd, ve) =>
-      rootIdentifier(MatchesF(v, va, vb))
-    case IndexF(IntLitF(v, va), vd, ve)    => rootIdentifier(IntLitF(v, va))
-    case IndexF(FloatLitF(v, va), vd, ve)  => rootIdentifier(FloatLitF(v, va))
-    case IndexF(StringLitF(v, va), vd, ve) => rootIdentifier(StringLitF(v, va))
-    case IndexF(BoolLitF(v, va), vd, ve)   => rootIdentifier(BoolLitF(v, va))
-    case IndexF(NoneLitF(v), vd, ve)       => rootIdentifier(NoneLitF(v))
-    case BinaryOpF(v, va, vb, vc)          => rootIdentifier(BinaryOpF(v, va, vb, vc))
-    case UnaryOpF(v, va, vb)               => rootIdentifier(UnaryOpF(v, va, vb))
-    case QuantifierF(v, va, vb, vc)        => rootIdentifier(QuantifierF(v, va, vb, vc))
-    case SomeWrapF(v, va)                  => rootIdentifier(SomeWrapF(v, va))
-    case TheF(v, va, vb, vc)               => rootIdentifier(TheF(v, va, vb, vc))
-    case FieldAccessF(v, va, vb)           => rootIdentifier(FieldAccessF(v, va, vb))
-    case EnumAccessF(v, va, vb)            => rootIdentifier(EnumAccessF(v, va, vb))
-    case CallF(v, va, vb)                  => rootIdentifier(CallF(v, va, vb))
-    case PrimeF(v, va)                     => rootIdentifier(PrimeF(v, va))
-    case PreF(v, va)                       => rootIdentifier(PreF(v, va))
-    case WithF(v, va, vb)                  => rootIdentifier(WithF(v, va, vb))
-    case IfF(v, va, vb, vc)                => rootIdentifier(IfF(v, va, vb, vc))
-    case LetF(v, va, vb, vc)               => rootIdentifier(LetF(v, va, vb, vc))
-    case LambdaF(v, va, vb)                => rootIdentifier(LambdaF(v, va, vb))
-    case ConstructorF(v, va, vb)           => rootIdentifier(ConstructorF(v, va, vb))
-    case SetLiteralF(v, va)                => rootIdentifier(SetLiteralF(v, va))
-    case MapLiteralF(v, va)                => rootIdentifier(MapLiteralF(v, va))
-    case SetComprehensionF(v, va, vb, vc) =>
-      rootIdentifier(SetComprehensionF(v, va, vb, vc))
-    case SeqLiteralF(v, va)  => rootIdentifier(SeqLiteralF(v, va))
-    case MatchesF(v, va, vb) => rootIdentifier(MatchesF(v, va, vb))
-    case IntLitF(v, va)      => rootIdentifier(IntLitF(v, va))
-    case FloatLitF(v, va)    => rootIdentifier(FloatLitF(v, va))
-    case StringLitF(v, va)   => rootIdentifier(StringLitF(v, va))
-    case BoolLitF(v, va)     => rootIdentifier(BoolLitF(v, va))
-    case NoneLitF(v)         => rootIdentifier(NoneLitF(v))
-  }
+  def resolveWithBase(e: expr_full): Option[String] =
+    e match {
+      case BinaryOpF(_, _, _, _)   => rootIdentifier(e)
+      case UnaryOpF(_, _, _)       => rootIdentifier(e)
+      case QuantifierF(_, _, _, _) => rootIdentifier(e)
+      case SomeWrapF(_, _)         => rootIdentifier(e)
+      case TheF(_, _, _, _)        => rootIdentifier(e)
+      case FieldAccessF(_, _, _)   => rootIdentifier(e)
+      case EnumAccessF(_, _, _)    => rootIdentifier(e)
+      case IndexF(base, _, _) =>
+        base match {
+          case BinaryOpF(_, _, _, _)                  => rootIdentifier(base)
+          case UnaryOpF(_, _, _)                      => rootIdentifier(base)
+          case QuantifierF(_, _, _, _)                => rootIdentifier(base)
+          case SomeWrapF(_, _)                        => rootIdentifier(base)
+          case TheF(_, _, _, _)                       => rootIdentifier(base)
+          case FieldAccessF(_, _, _)                  => rootIdentifier(base)
+          case EnumAccessF(_, _, _)                   => rootIdentifier(base)
+          case IndexF(_, _, _)                        => rootIdentifier(base)
+          case CallF(_, _, _)                         => rootIdentifier(base)
+          case PrimeF(_, _)                           => rootIdentifier(base)
+          case PreF(BinaryOpF(_, _, _, _), _)         => rootIdentifier(base)
+          case PreF(UnaryOpF(_, _, _), _)             => rootIdentifier(base)
+          case PreF(QuantifierF(_, _, _, _), _)       => rootIdentifier(base)
+          case PreF(SomeWrapF(_, _), _)               => rootIdentifier(base)
+          case PreF(TheF(_, _, _, _), _)              => rootIdentifier(base)
+          case PreF(FieldAccessF(_, _, _), _)         => rootIdentifier(base)
+          case PreF(EnumAccessF(_, _, _), _)          => rootIdentifier(base)
+          case PreF(IndexF(_, _, _), _)               => rootIdentifier(base)
+          case PreF(CallF(_, _, _), _)                => rootIdentifier(base)
+          case PreF(PrimeF(_, _), _)                  => rootIdentifier(base)
+          case PreF(PreF(_, _), _)                    => rootIdentifier(base)
+          case PreF(WithF(_, _, _), _)                => rootIdentifier(base)
+          case PreF(IfF(_, _, _, _), _)               => rootIdentifier(base)
+          case PreF(LetF(_, _, _, _), _)              => rootIdentifier(base)
+          case PreF(LambdaF(_, _, _), _)              => rootIdentifier(base)
+          case PreF(ConstructorF(_, _, _), _)         => rootIdentifier(base)
+          case PreF(SetLiteralF(_, _), _)             => rootIdentifier(base)
+          case PreF(MapLiteralF(_, _), _)             => rootIdentifier(base)
+          case PreF(SetComprehensionF(_, _, _, _), _) => rootIdentifier(base)
+          case PreF(SeqLiteralF(_, _), _)             => rootIdentifier(base)
+          case PreF(MatchesF(_, _, _), _)             => rootIdentifier(base)
+          case PreF(IntLitF(_, _), _)                 => rootIdentifier(base)
+          case PreF(FloatLitF(_, _), _)               => rootIdentifier(base)
+          case PreF(StringLitF(_, _), _)              => rootIdentifier(base)
+          case PreF(BoolLitF(_, _), _)                => rootIdentifier(base)
+          case PreF(NoneLitF(_), _)                   => rootIdentifier(base)
+          case PreF(IdentifierF(n, _), _)             => Some[String](n)
+          case WithF(_, _, _)                         => rootIdentifier(base)
+          case IfF(_, _, _, _)                        => rootIdentifier(base)
+          case LetF(_, _, _, _)                       => rootIdentifier(base)
+          case LambdaF(_, _, _)                       => rootIdentifier(base)
+          case ConstructorF(_, _, _)                  => rootIdentifier(base)
+          case SetLiteralF(_, _)                      => rootIdentifier(base)
+          case MapLiteralF(_, _)                      => rootIdentifier(base)
+          case SetComprehensionF(_, _, _, _)          => rootIdentifier(base)
+          case SeqLiteralF(_, _)                      => rootIdentifier(base)
+          case MatchesF(_, _, _)                      => rootIdentifier(base)
+          case IntLitF(_, _)                          => rootIdentifier(base)
+          case FloatLitF(_, _)                        => rootIdentifier(base)
+          case StringLitF(_, _)                       => rootIdentifier(base)
+          case BoolLitF(_, _)                         => rootIdentifier(base)
+          case NoneLitF(_)                            => rootIdentifier(base)
+          case IdentifierF(n, _)                      => Some[String](n)
+        }
+      case CallF(_, _, _)                => rootIdentifier(e)
+      case PrimeF(_, _)                  => rootIdentifier(e)
+      case PreF(_, _)                    => rootIdentifier(e)
+      case WithF(_, _, _)                => rootIdentifier(e)
+      case IfF(_, _, _, _)               => rootIdentifier(e)
+      case LetF(_, _, _, _)              => rootIdentifier(e)
+      case LambdaF(_, _, _)              => rootIdentifier(e)
+      case ConstructorF(_, _, _)         => rootIdentifier(e)
+      case SetLiteralF(_, _)             => rootIdentifier(e)
+      case MapLiteralF(_, _)             => rootIdentifier(e)
+      case SetComprehensionF(_, _, _, _) => rootIdentifier(e)
+      case SeqLiteralF(_, _)             => rootIdentifier(e)
+      case MatchesF(_, _, _)             => rootIdentifier(e)
+      case IntLitF(_, _)                 => rootIdentifier(e)
+      case FloatLitF(_, _)               => rootIdentifier(e)
+      case StringLitF(_, _)              => rootIdentifier(e)
+      case BoolLitF(_, _)                => rootIdentifier(e)
+      case NoneLitF(_)                   => rootIdentifier(e)
+      case IdentifierF(_, _)             => None
+    }
 
   def fieldAssignName(x0: field_assign_full): String = x0 match {
     case FieldAssignFull(n, uu, uv) => n
@@ -12591,107 +12487,109 @@ object SpecRestGenerated {
     case NoneLitF(v)                                             => None
   }
 
-  def keyExistencePair(x0: expr_full): Option[(String, String)] = x0 match {
-    case BinaryOpF(BIn(), IdentifierF(inName, uu), IdentifierF(stName, uv), uw) =>
-      Some[(String, String)]((inName, stName))
-    case BinaryOpF(BAnd(), va, vb, vc)                           => None
-    case BinaryOpF(BOr(), va, vb, vc)                            => None
-    case BinaryOpF(BImplies(), va, vb, vc)                       => None
-    case BinaryOpF(BIff(), va, vb, vc)                           => None
-    case BinaryOpF(BEq(), va, vb, vc)                            => None
-    case BinaryOpF(BNeq(), va, vb, vc)                           => None
-    case BinaryOpF(BLt(), va, vb, vc)                            => None
-    case BinaryOpF(BGt(), va, vb, vc)                            => None
-    case BinaryOpF(BLe(), va, vb, vc)                            => None
-    case BinaryOpF(BGe(), va, vb, vc)                            => None
-    case BinaryOpF(BNotIn(), va, vb, vc)                         => None
-    case BinaryOpF(BSubset(), va, vb, vc)                        => None
-    case BinaryOpF(BUnion(), va, vb, vc)                         => None
-    case BinaryOpF(BIntersect(), va, vb, vc)                     => None
-    case BinaryOpF(BDiff(), va, vb, vc)                          => None
-    case BinaryOpF(BAdd(), va, vb, vc)                           => None
-    case BinaryOpF(BSub(), va, vb, vc)                           => None
-    case BinaryOpF(BMul(), va, vb, vc)                           => None
-    case BinaryOpF(BDiv(), va, vb, vc)                           => None
-    case BinaryOpF(v, BinaryOpF(vd, ve, vf, vg), vb, vc)         => None
-    case BinaryOpF(v, UnaryOpF(vd, ve, vf), vb, vc)              => None
-    case BinaryOpF(v, QuantifierF(vd, ve, vf, vg), vb, vc)       => None
-    case BinaryOpF(v, SomeWrapF(vd, ve), vb, vc)                 => None
-    case BinaryOpF(v, TheF(vd, ve, vf, vg), vb, vc)              => None
-    case BinaryOpF(v, FieldAccessF(vd, ve, vf), vb, vc)          => None
-    case BinaryOpF(v, EnumAccessF(vd, ve, vf), vb, vc)           => None
-    case BinaryOpF(v, IndexF(vd, ve, vf), vb, vc)                => None
-    case BinaryOpF(v, CallF(vd, ve, vf), vb, vc)                 => None
-    case BinaryOpF(v, PrimeF(vd, ve), vb, vc)                    => None
-    case BinaryOpF(v, PreF(vd, ve), vb, vc)                      => None
-    case BinaryOpF(v, WithF(vd, ve, vf), vb, vc)                 => None
-    case BinaryOpF(v, IfF(vd, ve, vf, vg), vb, vc)               => None
-    case BinaryOpF(v, LetF(vd, ve, vf, vg), vb, vc)              => None
-    case BinaryOpF(v, LambdaF(vd, ve, vf), vb, vc)               => None
-    case BinaryOpF(v, ConstructorF(vd, ve, vf), vb, vc)          => None
-    case BinaryOpF(v, SetLiteralF(vd, ve), vb, vc)               => None
-    case BinaryOpF(v, MapLiteralF(vd, ve), vb, vc)               => None
-    case BinaryOpF(v, SetComprehensionF(vd, ve, vf, vg), vb, vc) => None
-    case BinaryOpF(v, SeqLiteralF(vd, ve), vb, vc)               => None
-    case BinaryOpF(v, MatchesF(vd, ve, vf), vb, vc)              => None
-    case BinaryOpF(v, IntLitF(vd, ve), vb, vc)                   => None
-    case BinaryOpF(v, FloatLitF(vd, ve), vb, vc)                 => None
-    case BinaryOpF(v, StringLitF(vd, ve), vb, vc)                => None
-    case BinaryOpF(v, BoolLitF(vd, ve), vb, vc)                  => None
-    case BinaryOpF(v, NoneLitF(vd), vb, vc)                      => None
-    case BinaryOpF(v, va, BinaryOpF(vd, ve, vf, vg), vc)         => None
-    case BinaryOpF(v, va, UnaryOpF(vd, ve, vf), vc)              => None
-    case BinaryOpF(v, va, QuantifierF(vd, ve, vf, vg), vc)       => None
-    case BinaryOpF(v, va, SomeWrapF(vd, ve), vc)                 => None
-    case BinaryOpF(v, va, TheF(vd, ve, vf, vg), vc)              => None
-    case BinaryOpF(v, va, FieldAccessF(vd, ve, vf), vc)          => None
-    case BinaryOpF(v, va, EnumAccessF(vd, ve, vf), vc)           => None
-    case BinaryOpF(v, va, IndexF(vd, ve, vf), vc)                => None
-    case BinaryOpF(v, va, CallF(vd, ve, vf), vc)                 => None
-    case BinaryOpF(v, va, PrimeF(vd, ve), vc)                    => None
-    case BinaryOpF(v, va, PreF(vd, ve), vc)                      => None
-    case BinaryOpF(v, va, WithF(vd, ve, vf), vc)                 => None
-    case BinaryOpF(v, va, IfF(vd, ve, vf, vg), vc)               => None
-    case BinaryOpF(v, va, LetF(vd, ve, vf, vg), vc)              => None
-    case BinaryOpF(v, va, LambdaF(vd, ve, vf), vc)               => None
-    case BinaryOpF(v, va, ConstructorF(vd, ve, vf), vc)          => None
-    case BinaryOpF(v, va, SetLiteralF(vd, ve), vc)               => None
-    case BinaryOpF(v, va, MapLiteralF(vd, ve), vc)               => None
-    case BinaryOpF(v, va, SetComprehensionF(vd, ve, vf, vg), vc) => None
-    case BinaryOpF(v, va, SeqLiteralF(vd, ve), vc)               => None
-    case BinaryOpF(v, va, MatchesF(vd, ve, vf), vc)              => None
-    case BinaryOpF(v, va, IntLitF(vd, ve), vc)                   => None
-    case BinaryOpF(v, va, FloatLitF(vd, ve), vc)                 => None
-    case BinaryOpF(v, va, StringLitF(vd, ve), vc)                => None
-    case BinaryOpF(v, va, BoolLitF(vd, ve), vc)                  => None
-    case BinaryOpF(v, va, NoneLitF(vd), vc)                      => None
-    case UnaryOpF(v, va, vb)                                     => None
-    case QuantifierF(v, va, vb, vc)                              => None
-    case SomeWrapF(v, va)                                        => None
-    case TheF(v, va, vb, vc)                                     => None
-    case FieldAccessF(v, va, vb)                                 => None
-    case EnumAccessF(v, va, vb)                                  => None
-    case IndexF(v, va, vb)                                       => None
-    case CallF(v, va, vb)                                        => None
-    case PrimeF(v, va)                                           => None
-    case PreF(v, va)                                             => None
-    case WithF(v, va, vb)                                        => None
-    case IfF(v, va, vb, vc)                                      => None
-    case LetF(v, va, vb, vc)                                     => None
-    case LambdaF(v, va, vb)                                      => None
-    case ConstructorF(v, va, vb)                                 => None
-    case SetLiteralF(v, va)                                      => None
-    case MapLiteralF(v, va)                                      => None
-    case SetComprehensionF(v, va, vb, vc)                        => None
-    case SeqLiteralF(v, va)                                      => None
-    case MatchesF(v, va, vb)                                     => None
-    case IntLitF(v, va)                                          => None
-    case FloatLitF(v, va)                                        => None
-    case StringLitF(v, va)                                       => None
-    case BoolLitF(v, va)                                         => None
-    case NoneLitF(v)                                             => None
-    case IdentifierF(v, va)                                      => None
-  }
+  def keyExistencePair(e: expr_full): Option[(String, String)] =
+    e match {
+      case BinaryOpF(BAnd(), _, _, _)                                    => None
+      case BinaryOpF(BOr(), _, _, _)                                     => None
+      case BinaryOpF(BImplies(), _, _, _)                                => None
+      case BinaryOpF(BIff(), _, _, _)                                    => None
+      case BinaryOpF(BEq(), _, _, _)                                     => None
+      case BinaryOpF(BNeq(), _, _, _)                                    => None
+      case BinaryOpF(BLt(), _, _, _)                                     => None
+      case BinaryOpF(BGt(), _, _, _)                                     => None
+      case BinaryOpF(BLe(), _, _, _)                                     => None
+      case BinaryOpF(BGe(), _, _, _)                                     => None
+      case BinaryOpF(BIn(), BinaryOpF(_, _, _, _), _, _)                 => None
+      case BinaryOpF(BIn(), UnaryOpF(_, _, _), _, _)                     => None
+      case BinaryOpF(BIn(), QuantifierF(_, _, _, _), _, _)               => None
+      case BinaryOpF(BIn(), SomeWrapF(_, _), _, _)                       => None
+      case BinaryOpF(BIn(), TheF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BIn(), FieldAccessF(_, _, _), _, _)                 => None
+      case BinaryOpF(BIn(), EnumAccessF(_, _, _), _, _)                  => None
+      case BinaryOpF(BIn(), IndexF(_, _, _), _, _)                       => None
+      case BinaryOpF(BIn(), CallF(_, _, _), _, _)                        => None
+      case BinaryOpF(BIn(), PrimeF(_, _), _, _)                          => None
+      case BinaryOpF(BIn(), PreF(_, _), _, _)                            => None
+      case BinaryOpF(BIn(), WithF(_, _, _), _, _)                        => None
+      case BinaryOpF(BIn(), IfF(_, _, _, _), _, _)                       => None
+      case BinaryOpF(BIn(), LetF(_, _, _, _), _, _)                      => None
+      case BinaryOpF(BIn(), LambdaF(_, _, _), _, _)                      => None
+      case BinaryOpF(BIn(), ConstructorF(_, _, _), _, _)                 => None
+      case BinaryOpF(BIn(), SetLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BIn(), MapLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BIn(), SetComprehensionF(_, _, _, _), _, _)         => None
+      case BinaryOpF(BIn(), SeqLiteralF(_, _), _, _)                     => None
+      case BinaryOpF(BIn(), MatchesF(_, _, _), _, _)                     => None
+      case BinaryOpF(BIn(), IntLitF(_, _), _, _)                         => None
+      case BinaryOpF(BIn(), FloatLitF(_, _), _, _)                       => None
+      case BinaryOpF(BIn(), StringLitF(_, _), _, _)                      => None
+      case BinaryOpF(BIn(), BoolLitF(_, _), _, _)                        => None
+      case BinaryOpF(BIn(), NoneLitF(_), _, _)                           => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), BinaryOpF(_, _, _, _), _) => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), UnaryOpF(_, _, _), _)     => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), QuantifierF(_, _, _, _), _) =>
+        None
+      case BinaryOpF(BIn(), IdentifierF(_, _), SomeWrapF(_, _), _)               => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), TheF(_, _, _, _), _)              => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), FieldAccessF(_, _, _), _)         => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), EnumAccessF(_, _, _), _)          => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), IndexF(_, _, _), _)               => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), CallF(_, _, _), _)                => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), PrimeF(_, _), _)                  => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), PreF(_, _), _)                    => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), WithF(_, _, _), _)                => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), IfF(_, _, _, _), _)               => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), LetF(_, _, _, _), _)              => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), LambdaF(_, _, _), _)              => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), ConstructorF(_, _, _), _)         => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), SetLiteralF(_, _), _)             => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), MapLiteralF(_, _), _)             => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), SetComprehensionF(_, _, _, _), _) => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), SeqLiteralF(_, _), _)             => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), MatchesF(_, _, _), _)             => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), IntLitF(_, _), _)                 => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), FloatLitF(_, _), _)               => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), StringLitF(_, _), _)              => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), BoolLitF(_, _), _)                => None
+      case BinaryOpF(BIn(), IdentifierF(_, _), NoneLitF(_), _)                   => None
+      case BinaryOpF(BIn(), IdentifierF(inName, _), IdentifierF(stName, _), _) =>
+        Some[(String, String)]((inName, stName))
+      case BinaryOpF(BNotIn(), _, _, _)     => None
+      case BinaryOpF(BSubset(), _, _, _)    => None
+      case BinaryOpF(BUnion(), _, _, _)     => None
+      case BinaryOpF(BIntersect(), _, _, _) => None
+      case BinaryOpF(BDiff(), _, _, _)      => None
+      case BinaryOpF(BAdd(), _, _, _)       => None
+      case BinaryOpF(BSub(), _, _, _)       => None
+      case BinaryOpF(BMul(), _, _, _)       => None
+      case BinaryOpF(BDiv(), _, _, _)       => None
+      case UnaryOpF(_, _, _)                => None
+      case QuantifierF(_, _, _, _)          => None
+      case SomeWrapF(_, _)                  => None
+      case TheF(_, _, _, _)                 => None
+      case FieldAccessF(_, _, _)            => None
+      case EnumAccessF(_, _, _)             => None
+      case IndexF(_, _, _)                  => None
+      case CallF(_, _, _)                   => None
+      case PrimeF(_, _)                     => None
+      case PreF(_, _)                       => None
+      case WithF(_, _, _)                   => None
+      case IfF(_, _, _, _)                  => None
+      case LetF(_, _, _, _)                 => None
+      case LambdaF(_, _, _)                 => None
+      case ConstructorF(_, _, _)            => None
+      case SetLiteralF(_, _)                => None
+      case MapLiteralF(_, _)                => None
+      case SetComprehensionF(_, _, _, _)    => None
+      case SeqLiteralF(_, _)                => None
+      case MatchesF(_, _, _)                => None
+      case IntLitF(_, _)                    => None
+      case FloatLitF(_, _)                  => None
+      case StringLitF(_, _)                 => None
+      case BoolLitF(_, _)                   => None
+      case NoneLitF(_)                      => None
+      case IdentifierF(_, _)                => None
+    }
 
   def collectWithFields(es: List[expr_full]): Option[with_info_full] =
     maps[expr_full, with_info_full](

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -51,6 +51,8 @@ object IrValueDecoder:
         None
       case Z3Sort.SeqOf(_) =>
         None
+      case Z3Sort.MapOf(_, _) =>
+        None
       case Z3Sort.Str =>
         if raw.length >= 2 && raw.startsWith("\"") && raw.endsWith("\"") then
           Some(VStr(raw.substring(1, raw.length - 1)))

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -49,6 +49,8 @@ object IrValueDecoder:
         None
       case Z3Sort.OptionOf(_) =>
         None
+      case Z3Sort.SeqOf(_) =>
+        None
       case Z3Sort.Str =>
         if raw.length >= 2 && raw.startsWith("\"") && raw.endsWith("\"") then
           Some(VStr(raw.substring(1, raw.length - 1)))

--- a/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
+++ b/modules/verify/src/main/scala/specrest/verify/IrValueDecoder.scala
@@ -55,5 +55,5 @@ object IrValueDecoder:
         None
       case Z3Sort.Str =>
         if raw.length >= 2 && raw.startsWith("\"") && raw.endsWith("\"") then
-          Some(VStr(raw.substring(1, raw.length - 1)))
+          Some(VStr(raw.substring(1, raw.length - 1).replace("\"\"", "\"")))
         else Some(VStr(raw))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -16,6 +16,8 @@ import com.microsoft.z3.Model
 import com.microsoft.z3.SeqExpr
 import com.microsoft.z3.Sort
 import com.microsoft.z3.Status
+import com.microsoft.z3.Symbol
+import com.microsoft.z3.TupleSort
 import specrest.ir.VerifyError
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.verify.CheckStatus
@@ -146,6 +148,9 @@ private def registerSort(ctx: Context, map: mutable.Map[String, Sort], s: Z3Sort
       registerSort(ctx, map, elem)
     case Z3Sort.SeqOf(elem) =>
       registerSort(ctx, map, elem)
+    case Z3Sort.MapOf(kk, vv) =>
+      registerSort(ctx, map, kk)
+      registerSort(ctx, map, vv)
     case _ => ()
 
 private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3Sort): Sort =
@@ -169,6 +174,19 @@ private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3S
       )
     case Z3Sort.SeqOf(elem) =>
       sortMap.getOrElseUpdate(Z3Sort.key(s), ctx.mkSeqSort(resolveSort(ctx, sortMap, elem)))
+    case Z3Sort.MapOf(kk, vv) =>
+      sortMap.getOrElseUpdate(
+        Z3Sort.key(s), {
+          val entry =
+            mapEntrySortFor(
+              ctx,
+              sortMap,
+              resolveSort(ctx, sortMap, kk),
+              resolveSort(ctx, sortMap, vv)
+            )
+          ctx.mkSeqSort(entry)
+        }
+      )
     case Z3Sort.Str => ctx.getStringSort
 
 @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
@@ -201,6 +219,23 @@ private def optionSortFor(
       }
     )
     .asInstanceOf[DatatypeSort[?]]
+
+private def mapEntrySortFor(
+    ctx: Context,
+    sortMap: mutable.Map[String, Sort],
+    kElem: Sort,
+    vElem: Sort
+): Sort =
+  val kks = kElem.toString.replaceAll("[^A-Za-z0-9]", "_")
+  val vks = vElem.toString.replaceAll("[^A-Za-z0-9]", "_")
+  sortMap.getOrElseUpdate(
+    s"MapEntry:${kElem.toString}:${vElem.toString}",
+    ctx.mkTupleSort(
+      ctx.mkSymbol(s"MapEntry_${kks}_$vks"),
+      Array[Symbol](ctx.mkSymbol(s"key_${kks}_$vks"), ctx.mkSymbol(s"val_${kks}_$vks")),
+      Array[Sort](kElem, vElem)
+    )
+  )
 
 private def declareFuncs(
     ctx: Context,
@@ -301,6 +336,17 @@ private object Backend:
           rctx.ctx.mkUnit(renderExpr(rctx, m).asInstanceOf[Z3AstExpr[Sort]]).asInstanceOf[SeqExpr[
             Sort
           ]]
+        rctx.ctx.mkConcat(acc, unit)
+    case Z3Expr.MapLit(keySort, valueSort, entries, _) =>
+      val kZ      = resolveSort(rctx.ctx, rctx.sortMap, keySort)
+      val vZ      = resolveSort(rctx.ctx, rctx.sortMap, valueSort)
+      val tup     = mapEntrySortFor(rctx.ctx, rctx.sortMap, kZ, vZ).asInstanceOf[TupleSort]
+      val seqSort = rctx.ctx.mkSeqSort(tup)
+      val empty   = rctx.ctx.mkEmptySeq(seqSort).asInstanceOf[SeqExpr[Sort]]
+      entries.foldLeft[SeqExpr[Sort]](empty): (acc, kv) =>
+        val tupVal = tup.mkDecl().apply(renderExpr(rctx, kv._1), renderExpr(rctx, kv._2))
+        val unit =
+          rctx.ctx.mkUnit(tupVal.asInstanceOf[Z3AstExpr[Sort]]).asInstanceOf[SeqExpr[Sort]]
         rctx.ctx.mkConcat(acc, unit)
 
   def renderBool(rctx: RenderCtx, e: Z3Expr): BoolExpr =

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -13,6 +13,7 @@ import com.microsoft.z3.DatatypeSort
 import com.microsoft.z3.Expr as Z3AstExpr
 import com.microsoft.z3.FuncDecl
 import com.microsoft.z3.Model
+import com.microsoft.z3.SeqExpr
 import com.microsoft.z3.Sort
 import com.microsoft.z3.Status
 import specrest.ir.VerifyError
@@ -143,6 +144,8 @@ private def registerSort(ctx: Context, map: mutable.Map[String, Sort], s: Z3Sort
       registerSort(ctx, map, elem)
     case Z3Sort.OptionOf(elem) =>
       registerSort(ctx, map, elem)
+    case Z3Sort.SeqOf(elem) =>
+      registerSort(ctx, map, elem)
     case _ => ()
 
 private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3Sort): Sort =
@@ -164,6 +167,8 @@ private def resolveSort(ctx: Context, sortMap: mutable.Map[String, Sort], s: Z3S
         Z3Sort.key(s),
         optionSortFor(ctx, sortMap, resolveSort(ctx, sortMap, elem))
       )
+    case Z3Sort.SeqOf(elem) =>
+      sortMap.getOrElseUpdate(Z3Sort.key(s), ctx.mkSeqSort(resolveSort(ctx, sortMap, elem)))
     case Z3Sort.Str => ctx.getStringSort
 
 @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
@@ -287,6 +292,16 @@ private object Backend:
       optionSortFor(rctx.ctx, rctx.sortMap, v.getSort).getConstructors()(1).apply(v)
     case Z3Expr.StrLit(s, _) =>
       rctx.ctx.mkString(s)
+    case Z3Expr.SeqLit(elemSort, members, _) =>
+      val elemZ   = resolveSort(rctx.ctx, rctx.sortMap, elemSort)
+      val seqSort = rctx.ctx.mkSeqSort(elemZ)
+      val empty   = rctx.ctx.mkEmptySeq(seqSort).asInstanceOf[SeqExpr[Sort]]
+      members.foldLeft[SeqExpr[Sort]](empty): (acc, m) =>
+        val unit =
+          rctx.ctx.mkUnit(renderExpr(rctx, m).asInstanceOf[Z3AstExpr[Sort]]).asInstanceOf[SeqExpr[
+            Sort
+          ]]
+        rctx.ctx.mkConcat(acc, unit)
 
   def renderBool(rctx: RenderCtx, e: Z3Expr): BoolExpr =
     renderExpr(rctx, e).asInstanceOf[BoolExpr]

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -136,6 +136,7 @@ object Z3CounterExample:
     case Z3Sort.SetOf(elem) => sortToTy(elem, ctx).map(TSet.apply)
     case Z3Sort.OptionOf(_) => None
     case Z3Sort.SeqOf(_)    => None
+    case Z3Sort.MapOf(_, _) => None
     case Z3Sort.Str         => None
 
   private def validateType(

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -135,6 +135,7 @@ object Z3CounterExample:
       else None
     case Z3Sort.SetOf(elem) => sortToTy(elem, ctx).map(TSet.apply)
     case Z3Sort.OptionOf(_) => None
+    case Z3Sort.SeqOf(_)    => None
     case Z3Sort.Str         => None
 
   private def validateType(

--- a/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala
@@ -139,6 +139,14 @@ object Z3CounterExample:
     case Z3Sort.MapOf(_, _) => None
     case Z3Sort.Str         => None
 
+  private def lacksVerifiedTy(s: Z3Sort): Boolean = s match
+    case Z3Sort.Str         => true
+    case Z3Sort.OptionOf(_) => true
+    case Z3Sort.SeqOf(_)    => true
+    case Z3Sort.MapOf(_, _) => true
+    case Z3Sort.SetOf(e)    => lacksVerifiedTy(e)
+    case _                  => false
+
   private def validateType(
       expr: Z3AstExpr[?],
       sort: Z3Sort,
@@ -147,16 +155,18 @@ object Z3CounterExample:
       site: String,
       sink: mutable.ListBuffer[String]
   ): Unit =
-    sortToTy(sort, ctx) match
-      case None =>
-        sink += s"$site: no ty for Z3 sort ${Z3Sort.key(sort)} (raw '${expr.toString.trim}')"
-      case Some(expectedTy) =>
-        IrValueDecoder.decodeZ3(expr, sort, rawToLabel) match
-          case None =>
-            sink += s"$site: could not decode '${expr.toString.trim}' at sort ${Z3Sort.key(sort)}"
-          case Some(value) =>
-            if !check_value_has_ty(ctx, value, expectedTy) then
-              sink += s"$site: decoded value did not match expected type ${expectedTy}"
+    if lacksVerifiedTy(sort) then ()
+    else
+      sortToTy(sort, ctx) match
+        case None =>
+          sink += s"$site: no ty for Z3 sort ${Z3Sort.key(sort)} (raw '${expr.toString.trim}')"
+        case Some(expectedTy) =>
+          IrValueDecoder.decodeZ3(expr, sort, rawToLabel) match
+            case None =>
+              sink += s"$site: could not decode '${expr.toString.trim}' at sort ${Z3Sort.key(sort)}"
+            case Some(value) =>
+              if !check_value_has_ty(ctx, value, expectedTy) then
+                sink += s"$site: decoded value did not match expected type ${expectedTy}"
 
   private def inputsOfSort(
       model: Model,

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -17,6 +17,9 @@ object SmtLib:
     if usesOption(script) then
       lines += "(declare-datatype Option (par (T) ((none) (some (valOf T)))))"
 
+    if usesMap(script) then
+      lines += "(declare-datatype Pair (par (K V) ((mkPair (mapKey K) (mapVal V)))))"
+
     if script.funcs.nonEmpty then lines += ";; funcs"
     for f <- script.funcs do lines += renderFuncDecl(f)
 
@@ -44,11 +47,24 @@ object SmtLib:
   private def containsOption(s: Z3Sort): Boolean = s match
     case Z3Sort.OptionOf(_) => true
     case Z3Sort.SetOf(e)    => containsOption(e)
+    case Z3Sort.SeqOf(e)    => containsOption(e)
+    case Z3Sort.MapOf(k, v) => containsOption(k) || containsOption(v)
     case _                  => false
 
   private def usesOption(script: Z3Script): Boolean =
     script.sorts.exists(containsOption) ||
       script.funcs.exists(f => f.argSorts.exists(containsOption) || containsOption(f.resultSort))
+
+  private def containsMap(s: Z3Sort): Boolean = s match
+    case Z3Sort.MapOf(_, _) => true
+    case Z3Sort.SetOf(e)    => containsMap(e)
+    case Z3Sort.SeqOf(e)    => containsMap(e)
+    case Z3Sort.OptionOf(e) => containsMap(e)
+    case _                  => false
+
+  private def usesMap(script: Z3Script): Boolean =
+    script.sorts.exists(containsMap) ||
+      script.funcs.exists(f => f.argSorts.exists(containsMap) || containsMap(f.resultSort))
 
   def renderExpr(e: Z3Expr): String = e match
     case Z3Expr.Var(name, _, _) => name

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -34,6 +34,7 @@ object SmtLib:
     case Z3Sort.SetOf(e)    => s"(Set ${renderSort(e)})"
     case Z3Sort.OptionOf(e) => s"(Option ${renderSort(e)})"
     case Z3Sort.SeqOf(e)    => s"(Seq ${renderSort(e)})"
+    case Z3Sort.MapOf(k, v) => s"(Seq (Pair ${renderSort(k)} ${renderSort(v)}))"
     case Z3Sort.Str         => "String"
 
   private def renderFuncDecl(f: Z3FunctionDecl): String =
@@ -101,6 +102,11 @@ object SmtLib:
       members.foldLeft(s"(as seq.empty (Seq ${renderSort(elemSort)}))")((acc, m) =>
         s"(seq.++ $acc (seq.unit ${renderExpr(m)}))"
       )
+    case Z3Expr.MapLit(keySort, valueSort, entries, _) =>
+      val empty = s"(as seq.empty (Seq (Pair ${renderSort(keySort)} ${renderSort(valueSort)})))"
+      entries.foldLeft(empty) { case (acc, (k, v)) =>
+        s"(seq.++ $acc (seq.unit (mkPair ${renderExpr(k)} ${renderExpr(v)})))"
+      }
 
   private def emptySetLit(elemSort: Z3Sort): String =
     s"((as const (Set ${renderSort(elemSort)})) false)"

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -33,6 +33,7 @@ object SmtLib:
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"(Set ${renderSort(e)})"
     case Z3Sort.OptionOf(e) => s"(Option ${renderSort(e)})"
+    case Z3Sort.SeqOf(e)    => s"(Seq ${renderSort(e)})"
     case Z3Sort.Str         => "String"
 
   private def renderFuncDecl(f: Z3FunctionDecl): String =
@@ -96,6 +97,10 @@ object SmtLib:
       s"(some ${renderExpr(value)})"
     case Z3Expr.StrLit(s, _) =>
       "\"" + s.replace("\"", "\"\"") + "\""
+    case Z3Expr.SeqLit(elemSort, members, _) =>
+      members.foldLeft(s"(as seq.empty (Seq ${renderSort(elemSort)}))")((acc, m) =>
+        s"(seq.++ $acc (seq.unit ${renderExpr(m)}))"
+      )
 
   private def emptySetLit(elemSort: Z3Sort): String =
     s"((as const (Set ${renderSort(elemSort)})) false)"

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1330,7 +1330,9 @@ object Translator:
         case SetOpKind.Subset                                       => Some(Z3Sort.Bool)
         case SetOpKind.Union | SetOpKind.Intersect | SetOpKind.Diff => inferSortOfZ3Expr(ctx, l)
     case Z3Expr.Ite(_, t, e, _) =>
-      inferSortOfZ3Expr(ctx, t).orElse(inferSortOfZ3Expr(ctx, e))
+      (inferSortOfZ3Expr(ctx, t), inferSortOfZ3Expr(ctx, e)) match
+        case (Some(ts), Some(es)) => if Z3Sort.eq(ts, es) then Some(ts) else None
+        case (ts, es)             => ts.orElse(es)
     case Z3Expr.OptNone(elemSort, _)   => Some(Z3Sort.OptionOf(elemSort))
     case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -596,7 +596,7 @@ object Translator:
     case NamedTypeF(n, _)      => sortForNamedType(ctx, n)
     case OptionTypeF(inner, _) => Z3Sort.OptionOf(sortForType(ctx, inner))
     case SetTypeF(e, _)        => Z3Sort.SetOf(sortForType(ctx, e))
-    case SeqTypeF(e, _)        => Z3Sort.Uninterp(s"Seq_${sortNameOf(sortForType(ctx, e))}")
+    case SeqTypeF(e, _)        => Z3Sort.SeqOf(sortForType(ctx, e))
     case MapTypeF(k, v, _) =>
       Z3Sort.Uninterp(s"Map_${sortNameOf(sortForType(ctx, k))}_${sortNameOf(sortForType(ctx, v))}")
     case RelationTypeF(f, _, t, _) =>
@@ -609,6 +609,7 @@ object Translator:
     case Z3Sort.Uninterp(n) => n
     case Z3Sort.SetOf(e)    => s"Set_${sortNameOf(e)}"
     case Z3Sort.OptionOf(e) => s"Option_${sortNameOf(e)}"
+    case Z3Sort.SeqOf(e)    => s"Seq_${sortNameOf(e)}"
     case Z3Sort.Str         => "String"
 
   private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort =
@@ -915,6 +916,8 @@ object Translator:
       )
     case Z3Expr.OptSome(value, sp) =>
       Z3Expr.OptSome(substituteVar(value, varName, replacement), sp)
+    case Z3Expr.SeqLit(elemSort, members, sp) =>
+      Z3Expr.SeqLit(elemSort, members.map(m => substituteVar(m, varName, replacement)), sp)
     case other => other
 
   private def resolveStateRelationReference(
@@ -1318,9 +1321,10 @@ object Translator:
         case SetOpKind.Union | SetOpKind.Intersect | SetOpKind.Diff => inferSortOfZ3Expr(ctx, l)
     case Z3Expr.Ite(_, t, e, _) =>
       inferSortOfZ3Expr(ctx, t).orElse(inferSortOfZ3Expr(ctx, e))
-    case Z3Expr.OptNone(elemSort, _) => Some(Z3Sort.OptionOf(elemSort))
-    case Z3Expr.OptSome(value, _)    => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
-    case Z3Expr.StrLit(_, _)         => Some(Z3Sort.Str)
+    case Z3Expr.OptNone(elemSort, _)   => Some(Z3Sort.OptionOf(elemSort))
+    case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
+    case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
+    case Z3Expr.SeqLit(elemSort, _, _) => Some(Z3Sort.SeqOf(elemSort))
 
   private def tryLowerDomEquality(
       ctx: TranslateCtx,
@@ -2184,6 +2188,17 @@ object Translator:
         Z3Expr.OptSome(encodeFromSmtTerm(ctx, t, env))
       case TStrLit(s) =>
         Z3Expr.StrLit(s)
+      case TSeqEmpty() =>
+        fail(ctx, "empty sequence literal requires context to infer its element sort")
+      case cons @ TSeqCons(_, _) =>
+        val members = collectSeqMembersTerms(cons).map(t => encodeFromSmtTerm(ctx, t, env))
+        members match
+          case head :: _ =>
+            inferSortOfZ3Expr(ctx, head) match
+              case Some(es) => Z3Expr.SeqLit(es, members)
+              case None     => fail(ctx, "cannot infer sequence element sort")
+          case Nil =>
+            fail(ctx, "empty sequence literal requires context to infer its element sort")
 
   private def encodeNoneEq(
       ctx: TranslateCtx,
@@ -2200,6 +2215,10 @@ object Translator:
     case TSetEmpty()           => Nil
     case TSetInsert(elem, set) => elem :: collectSetLiteralMembersTerms(set)
     case _                     => Nil
+
+  private def collectSeqMembersTerms(term: smt_term): List[smt_term] = term match
+    case TSeqCons(elem, rest) => elem :: collectSeqMembersTerms(rest)
+    case _                    => Nil
 
   private def encodeSetBinOp(
       ctx: TranslateCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -598,7 +598,7 @@ object Translator:
     case SetTypeF(e, _)        => Z3Sort.SetOf(sortForType(ctx, e))
     case SeqTypeF(e, _)        => Z3Sort.SeqOf(sortForType(ctx, e))
     case MapTypeF(k, v, _) =>
-      Z3Sort.Uninterp(s"Map_${sortNameOf(sortForType(ctx, k))}_${sortNameOf(sortForType(ctx, v))}")
+      Z3Sort.MapOf(sortForType(ctx, k), sortForType(ctx, v))
     case RelationTypeF(f, _, t, _) =>
       Z3Sort.Uninterp(s"Rel_${sortNameOf(sortForType(ctx, f))}_${sortNameOf(sortForType(ctx, t))}")
 
@@ -610,6 +610,7 @@ object Translator:
     case Z3Sort.SetOf(e)    => s"Set_${sortNameOf(e)}"
     case Z3Sort.OptionOf(e) => s"Option_${sortNameOf(e)}"
     case Z3Sort.SeqOf(e)    => s"Seq_${sortNameOf(e)}"
+    case Z3Sort.MapOf(k, v) => s"Map_${sortNameOf(k)}_${sortNameOf(v)}"
     case Z3Sort.Str         => "String"
 
   private def sortForNamedType(ctx: TranslateCtx, name: String): Z3Sort =
@@ -918,6 +919,15 @@ object Translator:
       Z3Expr.OptSome(substituteVar(value, varName, replacement), sp)
     case Z3Expr.SeqLit(elemSort, members, sp) =>
       Z3Expr.SeqLit(elemSort, members.map(m => substituteVar(m, varName, replacement)), sp)
+    case Z3Expr.MapLit(keySort, valueSort, entries, sp) =>
+      Z3Expr.MapLit(
+        keySort,
+        valueSort,
+        entries.map { case (k, v) =>
+          (substituteVar(k, varName, replacement), substituteVar(v, varName, replacement))
+        },
+        sp
+      )
     case other => other
 
   private def resolveStateRelationReference(
@@ -1325,6 +1335,8 @@ object Translator:
     case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
     case Z3Expr.SeqLit(elemSort, _, _) => Some(Z3Sort.SeqOf(elemSort))
+    case Z3Expr.MapLit(keySort, valueSort, _, _) =>
+      Some(Z3Sort.MapOf(keySort, valueSort))
 
   private def tryLowerDomEquality(
       ctx: TranslateCtx,
@@ -2199,6 +2211,19 @@ object Translator:
               case None     => fail(ctx, "cannot infer sequence element sort")
           case Nil =>
             fail(ctx, "empty sequence literal requires context to infer its element sort")
+      case TMapEmpty() =>
+        fail(ctx, "empty map literal requires context to infer its key/value sorts")
+      case cons @ TMapCons(_, _, _) =>
+        val entries = collectMapEntriesTerms(cons).map { case (k, v) =>
+          (encodeFromSmtTerm(ctx, k, env), encodeFromSmtTerm(ctx, v, env))
+        }
+        entries match
+          case (hk, hv) :: _ =>
+            (inferSortOfZ3Expr(ctx, hk), inferSortOfZ3Expr(ctx, hv)) match
+              case (Some(ks), Some(vs)) => Z3Expr.MapLit(ks, vs, entries)
+              case _                    => fail(ctx, "cannot infer map key/value sorts")
+          case Nil =>
+            fail(ctx, "empty map literal requires context to infer its key/value sorts")
 
   private def encodeNoneEq(
       ctx: TranslateCtx,
@@ -2218,6 +2243,10 @@ object Translator:
 
   private def collectSeqMembersTerms(term: smt_term): List[smt_term] = term match
     case TSeqCons(elem, rest) => elem :: collectSeqMembersTerms(rest)
+    case _                    => Nil
+
+  private def collectMapEntriesTerms(term: smt_term): List[(smt_term, smt_term)] = term match
+    case TMapCons(k, v, rest) => (k, v) :: collectMapEntriesTerms(rest)
     case _                    => Nil
 
   private def encodeSetBinOp(

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -9,6 +9,7 @@ enum Z3Sort derives CanEqual:
   case Uninterp(name: String)
   case SetOf(elem: Z3Sort)
   case OptionOf(elem: Z3Sort)
+  case SeqOf(elem: Z3Sort)
   case Str
 
 object Z3Sort:
@@ -26,6 +27,7 @@ object Z3Sort:
     case Bool        => "Bool"
     case SetOf(e)    => s"Set(${key(e)})"
     case OptionOf(e) => s"Option(${key(e)})"
+    case SeqOf(e)    => s"Seq(${key(e)})"
     case Str         => "Str"
 
   def eq(a: Z3Sort, b: Z3Sort): Boolean = key(a) == key(b)
@@ -99,6 +101,7 @@ enum Z3Expr derives CanEqual:
   case OptNone(elemSort: Z3Sort, span: Option[span_t] = None)
   case OptSome(value: Z3Expr, span: Option[span_t] = None)
   case StrLit(value: String, span: Option[span_t] = None)
+  case SeqLit(elemSort: Z3Sort, members: List[Z3Expr], span: Option[span_t] = None)
 
   def spanOpt: Option[span_t] = this match
     case e: Var        => e.span
@@ -121,6 +124,7 @@ enum Z3Expr derives CanEqual:
     case e: OptNone    => e.span
     case e: OptSome    => e.span
     case e: StrLit     => e.span
+    case e: SeqLit     => e.span
 
   def withSpan(s: Option[span_t]): Z3Expr =
     if s.isEmpty then this
@@ -146,6 +150,7 @@ enum Z3Expr derives CanEqual:
         case e: OptNone    => e.copy(span = s)
         case e: OptSome    => e.copy(span = s)
         case e: StrLit     => e.copy(span = s)
+        case e: SeqLit     => e.copy(span = s)
 
 final case class ArtifactEntityField(name: String, sort: Z3Sort, funcName: String)
 final case class ArtifactEntity(name: String, sort: Z3Sort, fields: List[ArtifactEntityField])

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -10,6 +10,7 @@ enum Z3Sort derives CanEqual:
   case SetOf(elem: Z3Sort)
   case OptionOf(elem: Z3Sort)
   case SeqOf(elem: Z3Sort)
+  case MapOf(key: Z3Sort, value: Z3Sort)
   case Str
 
 object Z3Sort:
@@ -28,6 +29,7 @@ object Z3Sort:
     case SetOf(e)    => s"Set(${key(e)})"
     case OptionOf(e) => s"Option(${key(e)})"
     case SeqOf(e)    => s"Seq(${key(e)})"
+    case MapOf(k, v) => s"Map(${key(k)},${key(v)})"
     case Str         => "Str"
 
   def eq(a: Z3Sort, b: Z3Sort): Boolean = key(a) == key(b)
@@ -102,6 +104,12 @@ enum Z3Expr derives CanEqual:
   case OptSome(value: Z3Expr, span: Option[span_t] = None)
   case StrLit(value: String, span: Option[span_t] = None)
   case SeqLit(elemSort: Z3Sort, members: List[Z3Expr], span: Option[span_t] = None)
+  case MapLit(
+      keySort: Z3Sort,
+      valueSort: Z3Sort,
+      entries: List[(Z3Expr, Z3Expr)],
+      span: Option[span_t] = None
+  )
 
   def spanOpt: Option[span_t] = this match
     case e: Var        => e.span
@@ -125,6 +133,7 @@ enum Z3Expr derives CanEqual:
     case e: OptSome    => e.span
     case e: StrLit     => e.span
     case e: SeqLit     => e.span
+    case e: MapLit     => e.span
 
   def withSpan(s: Option[span_t]): Z3Expr =
     if s.isEmpty then this
@@ -151,6 +160,7 @@ enum Z3Expr derives CanEqual:
         case e: OptSome    => e.copy(span = s)
         case e: StrLit     => e.copy(span = s)
         case e: SeqLit     => e.copy(span = s)
+        case e: MapLit     => e.copy(span = s)
 
 final case class ArtifactEntityField(name: String, sort: Z3Sort, funcName: String)
 final case class ArtifactEntity(name: String, sort: Z3Sort, fields: List[ArtifactEntityField])

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -321,3 +321,37 @@ class BackendTest extends CatsEffectSuite:
         artifact = emptyArtifact
       )
       runScript(script).map(r => assertEquals(r.status, expected))
+
+  private def mapLit(kvs: (Int, Int)*): Z3Expr =
+    Z3Expr.MapLit(
+      Z3Sort.Int,
+      Z3Sort.Int,
+      kvs.toList.map { case (k, v) => (Z3Expr.IntLit(BigInt(k)), Z3Expr.IntLit(BigInt(v))) }
+    )
+
+  List(
+    (
+      "m = {1->10,2->20} twice is sat",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("m", Nil), mapLit(1 -> 10, 2 -> 20)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("m", Nil), mapLit(1 -> 10, 2 -> 20))
+      ),
+      CheckStatus.Sat
+    ),
+    (
+      "m = {1->10} and m = {2->20} is unsat (distinct maps)",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("m", Nil), mapLit(1 -> 10)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("m", Nil), mapLit(2 -> 20))
+      ),
+      CheckStatus.Unsat
+    )
+  ).foreach: (name, assertions, expected) =>
+    test(s"map theory renders and solves: $name"):
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("m", Nil, Z3Sort.MapOf(Z3Sort.Int, Z3Sort.Int))),
+        assertions = assertions,
+        artifact = emptyArtifact
+      )
+      runScript(script).map(r => assertEquals(r.status, expected))

--- a/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/BackendTest.scala
@@ -291,3 +291,33 @@ class BackendTest extends CatsEffectSuite:
         artifact = emptyArtifact
       )
       runScript(script).map(r => assertEquals(r.status, expected))
+
+  private def seqLit(xs: Int*): Z3Expr =
+    Z3Expr.SeqLit(Z3Sort.Int, xs.toList.map(i => Z3Expr.IntLit(BigInt(i))))
+
+  List(
+    (
+      "x = [1,2] and x = [1,2] is sat",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), seqLit(1, 2)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), seqLit(1, 2))
+      ),
+      CheckStatus.Sat
+    ),
+    (
+      "x = [1] and x = [2] is unsat (distinct sequences)",
+      List(
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), seqLit(1)),
+        Z3Expr.Cmp(CmpOp.Eq, Z3Expr.App("x", Nil), seqLit(2))
+      ),
+      CheckStatus.Unsat
+    )
+  ).foreach: (name, assertions, expected) =>
+    test(s"seq theory renders and solves: $name"):
+      val script = Z3Script(
+        sorts = Nil,
+        funcs = List(Z3FunctionDecl("x", Nil, Z3Sort.SeqOf(Z3Sort.Int))),
+        assertions = assertions,
+        artifact = emptyArtifact
+      )
+      runScript(script).map(r => assertEquals(r.status, expected))

--- a/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/SmtLibRenderTest.scala
@@ -128,3 +128,31 @@ class SmtLibRenderTest extends munit.CatsEffectSuite:
       SmtLib.renderExpr(SetBinOp(SetOpKind.Subset, s, t)),
       "(subset s t)"
     )
+
+  test("map sort declares Pair datatype and renders (Seq (Pair K V))"):
+    val intStrMap = Z3Sort.MapOf(Z3Sort.Int, Z3Sort.Str)
+    val script = Z3Script(
+      sorts = Nil,
+      funcs = List(Z3FunctionDecl("m", Nil, intStrMap)),
+      assertions = Nil,
+      artifact = TranslatorArtifact(Nil, Nil, Nil, Nil, Nil, false)
+    )
+    val out = SmtLib.renderSmtLib(script)
+    assert(
+      out.contains("(declare-datatype Pair (par (K V) ((mkPair (mapKey K) (mapVal V)))))"),
+      out
+    )
+    assert(out.contains("(declare-fun m () (Seq (Pair Int String)))"), out)
+
+  test("renderExpr(MapLit) folds entries into a seq of mkPair tuples"):
+    import Z3Expr.*
+    val lit = MapLit(
+      Z3Sort.Int,
+      Z3Sort.Str,
+      List((IntLit(BigInt(1)), StrLit("a")), (IntLit(BigInt(2)), StrLit("b")))
+    )
+    assertEquals(
+      SmtLib.renderExpr(lit),
+      "(seq.++ (seq.++ (as seq.empty (Seq (Pair Int String))) " +
+        "(seq.unit (mkPair 1 \"a\"))) (seq.unit (mkPair 2 \"b\")))"
+    )

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -212,3 +212,10 @@ class TranslatorSetOpsTest extends CatsEffectSuite:
     ).map: out =>
       assert(out.contains("\"active\""), s"expected native string literal; got:\n$out")
       assert(!out.contains("declare-sort String"), s"String should be native; got:\n$out")
+
+  test("sequence literals lower via the native Seq theory"):
+    smtOf(
+      specWithInvariant("items: Seq[Int]", "items = [1, 2, 3]")
+    ).map: out =>
+      assert(out.contains("(seq.unit "), s"expected (seq.unit ...); got:\n$out")
+      assert(out.contains("(Seq "), s"expected a (Seq ...) sort; got:\n$out")

--- a/proofs/isabelle/SPEEDUP.md
+++ b/proofs/isabelle/SPEEDUP.md
@@ -333,6 +333,51 @@ Files touched:
 - `proofs/isabelle/SpecRest/Codegen.thy` — added `Semantics` to imports (it exports `eval` to
   Scala).
 
+### Tier 2.7 - Shallow `case` bodies for widening-triggered `fun` blowups (2026-06-02)
+
+The Z3-subset lift series (`If`/`Option`/`String`/`Seq`) widened `ir_value` from 7 to 11
+constructors. That re-detonated Tier 2.6 in two _pre-existing_ helper `fun`s that were cheap at 7
+constructors: `eval_arith` and `eval_cmp` (`Semantics.thy`). Both match a two-operand cross-product
+of nested patterns (`eval_arith AddOp (Some (VInt a)) (Some (VInt b)) = ...`); the `fun` package
+compiles that into a decision tree whose `pat_completeness` obligation is combinatorial in the
+datatype width. The session-DB trace fingered them:
+
+```text
+439.82s  fun  Semantics.thy  eval_arith
+206.35s  fun  Semantics.thy  eval_cmp
+```
+
+That is 646 s, 82 % of the 783 s Core build, on two non-recursive funs. Profiling note: the
+session-DB `command_timings` offsets are in Isabelle _symbols_ (`\<Rightarrow>` is one symbol but 11
+bytes), so a byte-slicing line mapper under-reports the line number by ~15. Count symbols (`\<...>`
+as one) to land on the right command.
+
+**Fix:** single-equation `fun` with a nested single-scrutinee `case` body, and the operator dispatch
+pulled into four tiny shallow helpers (`int_arith`/`real_arith`/`int_cmp`/`real_cmp`). The fun's own
+`pat_completeness` becomes trivial (one variable pattern); the `case` translation does the value
+dispatch cheaply, the same mechanism as the `fieldNameIfStateIndex` style already used elsewhere.
+The seven dependent lemmas move off the now-trivial `eval_arith.induct`/`eval_cmp.induct` to
+`split: option.splits ir_value.splits ...` (plus `cases op` where a helper-result shape is needed).
+Two pre-existing funs with the identical disease got the same flattening: `keyExistencePair`
+(`IR_Analysis.thy`) and `resolveWithBase` (`IR_Helpers.thy`).
+
+| Command                 | Before  | After  |
+| ----------------------- | ------- | ------ |
+| `eval_arith`            | 439.8 s | <0.1 s |
+| `eval_cmp`              | 206.4 s | <0.1 s |
+| `keyExistencePair`      | 37.6 s  | <0.1 s |
+| `resolveWithBase`       | 27.0 s  | <0.1 s |
+| Core (wall)             | 13:03   | 1:31   |
+| Full build (cached HOL) | ~14:40  | 2:45   |
+
+The four helpers are new top-level functions and the four rewritten bodies are restructured, so
+`SpecRestGenerated.scala` was regenerated. Verified behaviour-preserving: zero `sorry`,
+`sbt ir/compile` clean, 106 testgen behavioural / stateful / structural tests green.
+
+**Generalises Tier 2.6:** widening a datatype can silently re-detonate any _existing_ `fun` that
+matches its constructors more than one or two levels deep, especially a two-operand cross-product.
+After adding constructors, re-profile and move the match into a `case` body.
+
 ## Failed
 
 ### Tier 3.1 (partial) — Delete `peel_smt_translate_*` `[simp]` lemmas

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -93,6 +93,8 @@ datatype (plugins only: code size) expr =
   | StrLit "String.literal" "option_span"
   | SeqEmpty "option_span"
   | SeqCons "expr" "expr" "option_span"
+  | MapEmpty "option_span"
+  | MapCons "expr" "expr" "expr" "option_span"
 
 text \<open>Issue #210 (M_L.4.l): \<open>IndexRel\<close>'s base is widened from a bare
   relation name to an arbitrary \<open>expr\<close>, so the operation-side

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -91,6 +91,8 @@ datatype (plugins only: code size) expr =
   | NoneE "option_span"
   | SomeE "expr" "option_span"
   | StrLit "String.literal" "option_span"
+  | SeqEmpty "option_span"
+  | SeqCons "expr" "expr" "option_span"
 
 text \<open>Issue #210 (M_L.4.l): \<open>IndexRel\<close>'s base is widened from a bare
   relation name to an arbitrary \<open>expr\<close>, so the operation-side

--- a/proofs/isabelle/SpecRest/core/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Analysis.thy
@@ -595,9 +595,19 @@ text \<open>Phase 9\<iota> (\<open>keyExistencePair\<close>): extractor variant 
 
 fun keyExistencePair ::
   "expr_full \<Rightarrow> (String.literal \<times> String.literal) option" where
-  "keyExistencePair (BinaryOpF BIn (IdentifierF inName _) (IdentifierF stName _) _) =
-     Some (inName, stName)"
-| "keyExistencePair _ = None"
+  "keyExistencePair e =
+     (case e of
+        BinaryOpF op lhs rhs _ \<Rightarrow>
+          (case op of
+             BIn \<Rightarrow>
+               (case lhs of
+                  IdentifierF inName _ \<Rightarrow>
+                    (case rhs of
+                       IdentifierF stName _ \<Rightarrow> Some (inName, stName)
+                     | _ \<Rightarrow> None)
+                | _ \<Rightarrow> None)
+           | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 
 text \<open>\<open>fieldNameIfStateIndex\<close>: recognises an expression of shape
   \<open>state[input].field\<close> for given \<open>state\<close> and \<open>input\<close> names and

--- a/proofs/isabelle/SpecRest/core/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Helpers.thy
@@ -81,11 +81,18 @@ definition detectKeyExistsInRequires ::
        (map (keyExistsInRequiresOf stateFields) (flattenEnsures requires)))"
 
 fun resolveWithBase :: "expr_full \<Rightarrow> String.literal option" where
-  "resolveWithBase (IdentifierF _ _) = None"
-| "resolveWithBase (IndexF (PreF (IdentifierF n _) _) _ _) = Some n"
-| "resolveWithBase (IndexF (IdentifierF n _) _ _)          = Some n"
-| "resolveWithBase (IndexF base _ _)                       = rootIdentifier base"
-| "resolveWithBase other                                   = rootIdentifier other"
+  "resolveWithBase e =
+     (case e of
+        IdentifierF _ _ \<Rightarrow> None
+      | IndexF base _ _ \<Rightarrow>
+          (case base of
+             PreF inner _ \<Rightarrow>
+               (case inner of
+                  IdentifierF n _ \<Rightarrow> Some n
+                | _ \<Rightarrow> rootIdentifier base)
+           | IdentifierF n _ \<Rightarrow> Some n
+           | _ \<Rightarrow> rootIdentifier base)
+      | _ \<Rightarrow> rootIdentifier e)"
 
 fun fieldAssignName :: "field_assign_full \<Rightarrow> String.literal" where
   "fieldAssignName (FieldAssignFull n _ _) = n"

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -29,6 +29,8 @@ and lowerSetList ::
 and lower_with_assigns ::
     "String.literal list \<Rightarrow> field_assign_full list
        \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr option"
+and lowerSeqList ::
+    "String.literal list \<Rightarrow> expr_full list \<Rightarrow> option_span \<Rightarrow> expr option"
 where
   "lower _ (BoolLitF b sp)     = Some (BoolLit b sp)"
 | "lower _ (IntLitF n sp)      = Some (IntLit n sp)"
@@ -40,7 +42,6 @@ where
 | "lower _ (CallF _ _ _)       = None"
 | "lower _ (ConstructorF _ _ _)     = None"
 | "lower _ (MapLiteralF _ _)        = None"
-| "lower _ (SeqLiteralF _ _)        = None"
 | "lower _ (SetComprehensionF _ _ _ _) = None"
 | "lower _ (TheF _ _ _ _)      = None"
 | "lower _ (MatchesF _ _ _)    = None"
@@ -181,6 +182,7 @@ where
         None \<Rightarrow> None
       | Some base' \<Rightarrow> lower_with_assigns enums updates base' sp)"
 | "lower enums (SetLiteralF elems sp) = lowerSetList enums elems sp"
+| "lower enums (SeqLiteralF elems sp) = lowerSeqList enums elems sp"
 | "lower enums (IfF c a b sp) =
      (case (lower enums c, lower enums a, lower enums b) of
         (Some c', Some a', Some b') \<Rightarrow> Some (Ite c' a' b' sp)
@@ -198,18 +200,26 @@ where
      (case lower enums v of
         None \<Rightarrow> None
       | Some v' \<Rightarrow> lower_with_assigns enums rest (WithRec base fld v' sp) sp)"
+
+| "lowerSeqList _ [] sp = Some (SeqEmpty sp)"
+| "lowerSeqList enums (e # rest) sp =
+     (case (lower enums e, lowerSeqList enums rest sp) of
+        (Some e', Some s') \<Rightarrow> Some (SeqCons e' s' sp)
+      | _ \<Rightarrow> None)"
   by pat_completeness auto
 
 termination
   by (relation "measures [
         (\<lambda>p. case p of
-               Inl (_, e) \<Rightarrow> size e
-             | Inr (Inl (_, elems, _)) \<Rightarrow> size_list size elems
-             | Inr (Inr (_, updates, _, _)) \<Rightarrow> size_list size updates),
+               Inl (Inl (_, e)) \<Rightarrow> size e
+             | Inl (Inr (_, elems, _)) \<Rightarrow> size_list size elems
+             | Inr (Inl (_, updates, _, _)) \<Rightarrow> size_list size updates
+             | Inr (Inr (_, elems, _)) \<Rightarrow> size_list size elems),
         (\<lambda>p. case p of
-               Inl _ \<Rightarrow> 0
-             | Inr (Inl (_, elems, _)) \<Rightarrow> Suc (length elems)
-             | Inr (Inr (_, updates, _, _)) \<Rightarrow> Suc (length updates))
+               Inl (Inl _) \<Rightarrow> 0
+             | Inl (Inr (_, elems, _)) \<Rightarrow> Suc (length elems)
+             | Inr (Inl (_, updates, _, _)) \<Rightarrow> Suc (length updates)
+             | Inr (Inr (_, elems, _)) \<Rightarrow> Suc (length elems))
        ]")
      auto
 

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -31,6 +31,8 @@ and lower_with_assigns ::
        \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr option"
 and lowerSeqList ::
     "String.literal list \<Rightarrow> expr_full list \<Rightarrow> option_span \<Rightarrow> expr option"
+and lowerMapEntries ::
+    "String.literal list \<Rightarrow> map_entry_full list \<Rightarrow> option_span \<Rightarrow> expr option"
 where
   "lower _ (BoolLitF b sp)     = Some (BoolLit b sp)"
 | "lower _ (IntLitF n sp)      = Some (IntLit n sp)"
@@ -41,7 +43,6 @@ where
 | "lower _ (LambdaF _ _ _)     = None"
 | "lower _ (CallF _ _ _)       = None"
 | "lower _ (ConstructorF _ _ _)     = None"
-| "lower _ (MapLiteralF _ _)        = None"
 | "lower _ (SetComprehensionF _ _ _ _) = None"
 | "lower _ (TheF _ _ _ _)      = None"
 | "lower _ (MatchesF _ _ _)    = None"
@@ -183,6 +184,7 @@ where
       | Some base' \<Rightarrow> lower_with_assigns enums updates base' sp)"
 | "lower enums (SetLiteralF elems sp) = lowerSetList enums elems sp"
 | "lower enums (SeqLiteralF elems sp) = lowerSeqList enums elems sp"
+| "lower enums (MapLiteralF entries sp) = lowerMapEntries enums entries sp"
 | "lower enums (IfF c a b sp) =
      (case (lower enums c, lower enums a, lower enums b) of
         (Some c', Some a', Some b') \<Rightarrow> Some (Ite c' a' b' sp)
@@ -206,6 +208,12 @@ where
      (case (lower enums e, lowerSeqList enums rest sp) of
         (Some e', Some s') \<Rightarrow> Some (SeqCons e' s' sp)
       | _ \<Rightarrow> None)"
+
+| "lowerMapEntries _ [] sp = Some (MapEmpty sp)"
+| "lowerMapEntries enums (MapEntryFull k v _ # rest) sp =
+     (case (lower enums k, lower enums v, lowerMapEntries enums rest sp) of
+        (Some k', Some v', Some m') \<Rightarrow> Some (MapCons k' v' m' sp)
+      | _ \<Rightarrow> None)"
   by pat_completeness auto
 
 termination
@@ -214,12 +222,14 @@ termination
                Inl (Inl (_, e)) \<Rightarrow> size e
              | Inl (Inr (_, elems, _)) \<Rightarrow> size_list size elems
              | Inr (Inl (_, updates, _, _)) \<Rightarrow> size_list size updates
-             | Inr (Inr (_, elems, _)) \<Rightarrow> size_list size elems),
+             | Inr (Inr (Inl (_, elems, _))) \<Rightarrow> size_list size elems
+             | Inr (Inr (Inr (_, entries, _))) \<Rightarrow> size_list size entries),
         (\<lambda>p. case p of
                Inl (Inl _) \<Rightarrow> 0
              | Inl (Inr (_, elems, _)) \<Rightarrow> Suc (length elems)
              | Inr (Inl (_, updates, _, _)) \<Rightarrow> Suc (length updates)
-             | Inr (Inr (_, elems, _)) \<Rightarrow> Suc (length elems))
+             | Inr (Inr (Inl (_, elems, _))) \<Rightarrow> Suc (length elems)
+             | Inr (Inr (Inr (_, entries, _))) \<Rightarrow> Suc (length entries))
        ]")
      auto
 

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -14,6 +14,7 @@ datatype (plugins only: code size) ir_value =
   | VSome "ir_value"
   | VStr "String.literal"
   | VSeq "ir_value list"
+  | VMap "(ir_value \<times> ir_value) list"
 
 type_synonym env = "(String.literal \<times> ir_value) list"
 
@@ -318,6 +319,7 @@ inductive_cases value_has_ty_none_cases [elim!]: "value_has_ty \<Gamma> VNone t"
 inductive_cases value_has_ty_some_cases [elim!]: "value_has_ty \<Gamma> (VSome v) t"
 inductive_cases value_has_ty_str_cases [elim!]: "value_has_ty \<Gamma> (VStr s) t"
 inductive_cases value_has_ty_seq_cases [elim!]: "value_has_ty \<Gamma> (VSeq vs) t"
+inductive_cases value_has_ty_map_cases [elim!]: "value_has_ty \<Gamma> (VMap ps) t"
 
 lemma value_has_ty_VBool_iff [simp]:
   "value_has_ty \<Gamma> (VBool b) t \<longleftrightarrow> t = TBool"
@@ -402,6 +404,7 @@ where
 | "check_value_has_ty \<Gamma> (VSome _) _ = False"
 | "check_value_has_ty \<Gamma> (VStr _) _ = False"
 | "check_value_has_ty \<Gamma> (VSeq _) _ = False"
+| "check_value_has_ty \<Gamma> (VMap _) _ = False"
 | "check_value_has_ty_list _ [] _ = True"
 | "check_value_has_ty_list \<Gamma> (v # vs) t =
      (check_value_has_ty \<Gamma> v t \<and> check_value_has_ty_list \<Gamma> vs t)"
@@ -1254,6 +1257,11 @@ where
 | "eval s st env (SeqCons e rest _) =
      (case (eval s st env e, eval s st env rest) of
         (Some v, Some (VSeq vs)) \<Rightarrow> Some (VSeq (v # vs))
+      | _ \<Rightarrow> None)"
+| "eval s st env (MapEmpty _) = Some (VMap [])"
+| "eval s st env (MapCons k v rest _) =
+     (case (eval s st env k, eval s st env v, eval s st env rest) of
+        (Some kv, Some vv, Some (VMap ps)) \<Rightarrow> Some (VMap ((kv, vv) # ps))
       | _ \<Rightarrow> None)"
 
 | "eval_forall_enum s st env var en [] body = Some (VBool True)"

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -93,28 +93,32 @@ fun eval_bool_bin :: "bool_bin_op \<Rightarrow> bool \<Rightarrow> bool \<Righta
 | "eval_bool_bin ImpliesOp a b = ((\<not> a) \<or> b)"
 | "eval_bool_bin IffOp a b = (a = b)"
 
+fun int_arith :: "arith_op \<Rightarrow> int \<Rightarrow> int \<Rightarrow> ir_value option" where
+  "int_arith AddOp a b = Some (VInt (a + b))"
+| "int_arith SubOp a b = Some (VInt (a - b))"
+| "int_arith MulOp a b = Some (VInt (a * b))"
+| "int_arith DivOp a b = (if b = 0 then None else Some (VInt (a div b)))"
+
+fun real_arith :: "arith_op \<Rightarrow> rat \<Rightarrow> rat \<Rightarrow> ir_value option" where
+  "real_arith AddOp a b = Some (VReal (a + b))"
+| "real_arith SubOp a b = Some (VReal (a - b))"
+| "real_arith MulOp a b = Some (VReal (a * b))"
+| "real_arith DivOp a b = (if b = 0 then None else Some (VReal (a / b)))"
+
 fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
-  "eval_arith AddOp (Some (VInt a)) (Some (VInt b)) = Some (VInt (a + b))"
-| "eval_arith SubOp (Some (VInt a)) (Some (VInt b)) = Some (VInt (a - b))"
-| "eval_arith MulOp (Some (VInt a)) (Some (VInt b)) = Some (VInt (a * b))"
-| "eval_arith DivOp (Some (VInt a)) (Some (VInt b)) =
-     (if b = 0 then None else Some (VInt (a div b)))"
-| "eval_arith AddOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a + b))"
-| "eval_arith SubOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a - b))"
-| "eval_arith MulOp (Some (VReal a)) (Some (VReal b)) = Some (VReal (a * b))"
-| "eval_arith DivOp (Some (VReal a)) (Some (VReal b)) =
-     (if b = 0 then None else Some (VReal (a / b)))"
-| "eval_arith AddOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a + b))"
-| "eval_arith AddOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a + of_int b))"
-| "eval_arith SubOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a - b))"
-| "eval_arith SubOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a - of_int b))"
-| "eval_arith MulOp (Some (VInt a)) (Some (VReal b)) = Some (VReal (of_int a * b))"
-| "eval_arith MulOp (Some (VReal a)) (Some (VInt b)) = Some (VReal (a * of_int b))"
-| "eval_arith DivOp (Some (VInt a)) (Some (VReal b)) =
-     (if b = 0 then None else Some (VReal (of_int a / b)))"
-| "eval_arith DivOp (Some (VReal a)) (Some (VInt b)) =
-     (if b = 0 then None else Some (VReal (a / of_int b)))"
-| "eval_arith _ _ _ = None"
+  "eval_arith op x y =
+     (case x of
+        Some (VInt a) \<Rightarrow>
+          (case y of
+             Some (VInt b)  \<Rightarrow> int_arith op a b
+           | Some (VReal b) \<Rightarrow> real_arith op (of_int a) b
+           | _              \<Rightarrow> None)
+      | Some (VReal a) \<Rightarrow>
+          (case y of
+             Some (VInt b)  \<Rightarrow> real_arith op a (of_int b)
+           | Some (VReal b) \<Rightarrow> real_arith op a b
+           | _              \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 
 definition ir_val_eq :: "ir_value \<Rightarrow> ir_value \<Rightarrow> bool" where
   "ir_val_eq x y =
@@ -123,26 +127,44 @@ definition ir_val_eq :: "ir_value \<Rightarrow> ir_value \<Rightarrow> bool" whe
       | (VReal a, VInt b) \<Rightarrow> a = of_int b
       | _ \<Rightarrow> x = y)"
 
+fun int_cmp :: "cmp_op \<Rightarrow> int \<Rightarrow> int \<Rightarrow> ir_value option" where
+  "int_cmp LtOp a b = Some (VBool (a < b))"
+| "int_cmp LeOp a b = Some (VBool (a \<le> b))"
+| "int_cmp GtOp a b = Some (VBool (a > b))"
+| "int_cmp GeOp a b = Some (VBool (a \<ge> b))"
+| "int_cmp _ _ _ = None"
+
+fun real_cmp :: "cmp_op \<Rightarrow> rat \<Rightarrow> rat \<Rightarrow> ir_value option" where
+  "real_cmp LtOp a b = Some (VBool (a < b))"
+| "real_cmp LeOp a b = Some (VBool (a \<le> b))"
+| "real_cmp GtOp a b = Some (VBool (a > b))"
+| "real_cmp GeOp a b = Some (VBool (a \<ge> b))"
+| "real_cmp _ _ _ = None"
+
 fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
-  "eval_cmp EqOp  (Some a) (Some b) = Some (VBool (ir_val_eq a b))"
-| "eval_cmp NeqOp (Some a) (Some b) = Some (VBool (\<not> ir_val_eq a b))"
-| "eval_cmp LtOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a < b))"
-| "eval_cmp LeOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a \<le> b))"
-| "eval_cmp GtOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a > b))"
-| "eval_cmp GeOp  (Some (VInt a)) (Some (VInt b)) = Some (VBool (a \<ge> b))"
-| "eval_cmp LtOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a < b))"
-| "eval_cmp LeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<le> b))"
-| "eval_cmp GtOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a > b))"
-| "eval_cmp GeOp  (Some (VReal a)) (Some (VReal b)) = Some (VBool (a \<ge> b))"
-| "eval_cmp LtOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a < b))"
-| "eval_cmp LtOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a < of_int b))"
-| "eval_cmp LeOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a \<le> b))"
-| "eval_cmp LeOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a \<le> of_int b))"
-| "eval_cmp GtOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a > b))"
-| "eval_cmp GtOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a > of_int b))"
-| "eval_cmp GeOp  (Some (VInt a)) (Some (VReal b)) = Some (VBool (of_int a \<ge> b))"
-| "eval_cmp GeOp  (Some (VReal a)) (Some (VInt b)) = Some (VBool (a \<ge> of_int b))"
-| "eval_cmp _ _ _ = None"
+  "eval_cmp op x y =
+     (case x of
+        Some a \<Rightarrow>
+          (case y of
+             Some b \<Rightarrow>
+               (case op of
+                  EqOp  \<Rightarrow> Some (VBool (ir_val_eq a b))
+                | NeqOp \<Rightarrow> Some (VBool (\<not> ir_val_eq a b))
+                | _ \<Rightarrow>
+                    (case a of
+                       VInt ai \<Rightarrow>
+                         (case b of
+                            VInt bi  \<Rightarrow> int_cmp op ai bi
+                          | VReal br \<Rightarrow> real_cmp op (of_int ai) br
+                          | _        \<Rightarrow> None)
+                     | VReal ar \<Rightarrow>
+                         (case b of
+                            VInt bi  \<Rightarrow> real_cmp op ar (of_int bi)
+                          | VReal br \<Rightarrow> real_cmp op ar br
+                          | _        \<Rightarrow> None)
+                     | _ \<Rightarrow> None))
+           | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 
 text \<open>Category H — first proven bricks of the spec front-half (the
   precondition the universal soundness theorem assumes via \<open>eval e = Some\<close>).
@@ -158,7 +180,7 @@ lemma eval_arith_some_imp_numeric:
   "eval_arith op x y = Some v \<Longrightarrow>
      ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
      \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
-  by (induction op x y rule: eval_arith.induct) (auto split: if_splits)
+  by (auto split: option.splits ir_value.splits if_splits)
 
 lemma eval_arith_div_zero:
   "eval_arith DivOp (Some (VInt a)) (Some (VInt 0)) = None"
@@ -167,17 +189,17 @@ lemma eval_arith_div_zero:
 lemma eval_arith_int_total:
   "op \<noteq> DivOp \<or> b \<noteq> 0 \<Longrightarrow>
      \<exists>r. eval_arith op (Some (VInt a)) (Some (VInt b)) = Some (VInt r)"
-  by (cases op) auto
+  by (cases op) (auto split: if_splits)
 
 lemma eval_cmp_some_imp_defined:
   "eval_cmp op x y = Some v \<Longrightarrow> (\<exists>a. x = Some a) \<and> (\<exists>b. y = Some b)"
-  by (induction op x y rule: eval_cmp.induct) auto
+  by (auto split: option.splits ir_value.splits cmp_op.splits)
 
 lemma eval_cmp_order_imp_numeric:
   "op \<in> {LtOp, LeOp, GtOp, GeOp} \<Longrightarrow> eval_cmp op x y = Some v \<Longrightarrow>
      ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
      \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
-  by (induction op x y rule: eval_cmp.induct) auto
+  by (auto split: option.splits ir_value.splits cmp_op.splits if_splits)
 
 text \<open>Category H Phase H1 — value types and value typing.
   The first concrete brick of the missing soundness front-half:
@@ -447,13 +469,16 @@ lemma eval_arith_preservation:
       and "numeric_ty t1" and "numeric_ty t2"
   shows "value_has_ty \<Gamma> v (numeric_join t1 t2)"
   using assms
-  by (induction op x y rule: eval_arith.induct)
-     (auto split: if_splits simp: numeric_ty_def numeric_join_def intro: vt_int vt_real)
+  by (cases op;
+      auto split: option.splits ir_value.splits if_splits
+           simp: numeric_ty_def numeric_join_def intro: vt_int vt_real)
 
 lemma eval_cmp_preservation:
   assumes "eval_cmp op x y = Some v"
   shows "value_has_ty \<Gamma> v TBool"
-  using assms by (induction op x y rule: eval_cmp.induct) (auto intro: vt_bool)
+  using assms
+  by (cases op;
+      auto split: option.splits ir_value.splits if_splits intro: vt_bool)
 
 text \<open>Phase H2 (start) - typing context and environment agreement.
   The H2 phase introduces a typing context \<open>tyenv\<close> for lexical

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -13,6 +13,7 @@ datatype (plugins only: code size) ir_value =
   | VNone
   | VSome "ir_value"
   | VStr "String.literal"
+  | VSeq "ir_value list"
 
 type_synonym env = "(String.literal \<times> ir_value) list"
 
@@ -294,6 +295,7 @@ inductive_cases value_has_ty_entity_with_cases [elim!]:
 inductive_cases value_has_ty_none_cases [elim!]: "value_has_ty \<Gamma> VNone t"
 inductive_cases value_has_ty_some_cases [elim!]: "value_has_ty \<Gamma> (VSome v) t"
 inductive_cases value_has_ty_str_cases [elim!]: "value_has_ty \<Gamma> (VStr s) t"
+inductive_cases value_has_ty_seq_cases [elim!]: "value_has_ty \<Gamma> (VSeq vs) t"
 
 lemma value_has_ty_VBool_iff [simp]:
   "value_has_ty \<Gamma> (VBool b) t \<longleftrightarrow> t = TBool"
@@ -377,6 +379,7 @@ where
 | "check_value_has_ty \<Gamma> VNone _ = False"
 | "check_value_has_ty \<Gamma> (VSome _) _ = False"
 | "check_value_has_ty \<Gamma> (VStr _) _ = False"
+| "check_value_has_ty \<Gamma> (VSeq _) _ = False"
 | "check_value_has_ty_list _ [] _ = True"
 | "check_value_has_ty_list \<Gamma> (v # vs) t =
      (check_value_has_ty \<Gamma> v t \<and> check_value_has_ty_list \<Gamma> vs t)"
@@ -1222,6 +1225,11 @@ where
 | "eval s st env (NoneE _)   = Some VNone"
 | "eval s st env (SomeE e _) = map_option VSome (eval s st env e)"
 | "eval s st env (StrLit v _) = Some (VStr v)"
+| "eval s st env (SeqEmpty _) = Some (VSeq [])"
+| "eval s st env (SeqCons e rest _) =
+     (case (eval s st env e, eval s st env rest) of
+        (Some v, Some (VSeq vs)) \<Rightarrow> Some (VSeq (v # vs))
+      | _ \<Rightarrow> None)"
 
 | "eval_forall_enum s st env var en [] body = Some (VBool True)"
 | "eval_forall_enum s st env var en (mem # rest) body =

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -20,6 +20,7 @@ datatype (plugins only: code size) smt_val =
   | SSome "smt_val"
   | SStr "String.literal"
   | SSeq "smt_val list"
+  | SMap "(smt_val \<times> smt_val) list"
 
 datatype (plugins only: code size) smt_term =
     BLit bool
@@ -60,6 +61,8 @@ datatype (plugins only: code size) smt_term =
   | TStrLit "String.literal"
   | TSeqEmpty
   | TSeqCons "smt_term" "smt_term"
+  | TMapEmpty
+  | TMapCons "smt_term" "smt_term" "smt_term"
 
 record smt_model =
   sm_sort_members :: "(String.literal \<times> String.literal list) list"
@@ -331,6 +334,11 @@ where
 | "smtEval m env (TSeqCons e rest) =
      (case (smtEval m env e, smtEval m env rest) of
         (Some v, Some (SSeq vs)) \<Rightarrow> Some (SSeq (v # vs))
+      | _ \<Rightarrow> None)"
+| "smtEval m env TMapEmpty = Some (SMap [])"
+| "smtEval m env (TMapCons k v rest) =
+     (case (smtEval m env k, smtEval m env v, smtEval m env rest) of
+        (Some kv, Some vv, Some (SMap ps)) \<Rightarrow> Some (SMap ((kv, vv) # ps))
       | _ \<Rightarrow> None)"
 
 | "smtEval_forall_enum m env var sort_name [] body = Some (SBool True)"

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -19,6 +19,7 @@ datatype (plugins only: code size) smt_val =
   | SNone
   | SSome "smt_val"
   | SStr "String.literal"
+  | SSeq "smt_val list"
 
 datatype (plugins only: code size) smt_term =
     BLit bool
@@ -57,6 +58,8 @@ datatype (plugins only: code size) smt_term =
   | TNone
   | TSome "smt_term"
   | TStrLit "String.literal"
+  | TSeqEmpty
+  | TSeqCons "smt_term" "smt_term"
 
 record smt_model =
   sm_sort_members :: "(String.literal \<times> String.literal list) list"
@@ -324,6 +327,11 @@ where
 | "smtEval m env TNone     = Some SNone"
 | "smtEval m env (TSome t) = map_option SSome (smtEval m env t)"
 | "smtEval m env (TStrLit v) = Some (SStr v)"
+| "smtEval m env TSeqEmpty = Some (SSeq [])"
+| "smtEval m env (TSeqCons e rest) =
+     (case (smtEval m env e, smtEval m env rest) of
+        (Some v, Some (SSeq vs)) \<Rightarrow> Some (SSeq (v # vs))
+      | _ \<Rightarrow> None)"
 
 | "smtEval_forall_enum m env var sort_name [] body = Some (SBool True)"
 | "smtEval_forall_enum m env var sort_name (mem # rest) body =

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -52,5 +52,7 @@ fun translate :: "expr \<Rightarrow> smt_term" where
 | "translate (StrLit v _)                  = TStrLit v"
 | "translate (SeqEmpty _)                  = TSeqEmpty"
 | "translate (SeqCons e rest _)            = TSeqCons (translate e) (translate rest)"
+| "translate (MapEmpty _)                  = TMapEmpty"
+| "translate (MapCons k v rest _)          = TMapCons (translate k) (translate v) (translate rest)"
 
 end

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -50,5 +50,7 @@ fun translate :: "expr \<Rightarrow> smt_term" where
 | "translate (NoneE _)                     = TNone"
 | "translate (SomeE e _)                   = TSome (translate e)"
 | "translate (StrLit v _)                  = TStrLit v"
+| "translate (SeqEmpty _)                  = TSeqEmpty"
+| "translate (SeqCons e rest _)            = TSeqCons (translate e) (translate rest)"
 
 end

--- a/proofs/isabelle/SpecRest/soundness/Preservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation.thy
@@ -32,6 +32,7 @@ fun rel_ref_shape :: "expr_full \<Rightarrow> bool" where
 fun wf_z3 :: "expr_full \<Rightarrow> bool"
 and wf_z3_list :: "expr_full list \<Rightarrow> bool"
 and wf_z3_fields :: "field_assign_full list \<Rightarrow> bool"
+and wf_z3_entries :: "map_entry_full list \<Rightarrow> bool"
 where
   "wf_z3 (BoolLitF _ _)            = True"
 | "wf_z3 (IntLitF _ _)             = True"
@@ -60,7 +61,7 @@ where
 | "wf_z3 (LambdaF _ _ _)           = False"
 | "wf_z3 (CallF _ _ _)             = False"
 | "wf_z3 (ConstructorF _ _ _)      = False"
-| "wf_z3 (MapLiteralF _ _)         = False"
+| "wf_z3 (MapLiteralF entries _)   = wf_z3_entries entries"
 | "wf_z3 (SeqLiteralF es _)        = wf_z3_list es"
 | "wf_z3 (SetComprehensionF _ _ _ _) = False"
 | "wf_z3 (SomeWrapF e _)           = wf_z3 e"
@@ -71,6 +72,8 @@ where
 | "wf_z3_list (e # rest)           = (wf_z3 e \<and> wf_z3_list rest)"
 | "wf_z3_fields []                 = True"
 | "wf_z3_fields (FieldAssignFull _ v _ # rest) = (wf_z3 v \<and> wf_z3_fields rest)"
+| "wf_z3_entries []                = True"
+| "wf_z3_entries (MapEntryFull k v _ # rest) = (wf_z3 k \<and> wf_z3 v \<and> wf_z3_entries rest)"
 
 lemma wf_z3_fields_iff:
   "wf_z3_fields updates
@@ -228,6 +231,30 @@ proof (induction xs)
   show ?case using Cons by (auto split: option.splits)
 qed simp
 
+lemma lowerMapEntries_wf_some:
+  assumes "\<And>k v esp. MapEntryFull k v esp \<in> set entries
+             \<Longrightarrow> (wf_z3 k \<longrightarrow> lower enums k \<noteq> None) \<and> (wf_z3 v \<longrightarrow> lower enums v \<noteq> None)"
+      and "wf_z3_entries entries"
+  shows "lowerMapEntries enums entries sp \<noteq> None"
+  using assms
+proof (induction entries)
+  case (Cons e es)
+  obtain k v esp where e_eq: "e = MapEntryFull k v esp" by (cases e)
+  have hk: "wf_z3 k \<longrightarrow> lower enums k \<noteq> None"
+   and hv: "wf_z3 v \<longrightarrow> lower enums v \<noteq> None"
+    using Cons.prems(1)[of k v esp] e_eq by simp_all
+  have tl: "\<And>k v esp. MapEntryFull k v esp \<in> set es \<Longrightarrow>
+              (wf_z3 k \<longrightarrow> lower enums k \<noteq> None) \<and> (wf_z3 v \<longrightarrow> lower enums v \<noteq> None)"
+  proof -
+    fix k v esp assume "MapEntryFull k v esp \<in> set es"
+    hence "MapEntryFull k v esp \<in> set (e # es)" by simp
+    thus "(wf_z3 k \<longrightarrow> lower enums k \<noteq> None) \<and> (wf_z3 v \<longrightarrow> lower enums v \<noteq> None)"
+      using Cons.prems(1) by blast
+  qed
+  from Cons.IH[OF tl] have ih: "wf_z3_entries es \<Longrightarrow> lowerMapEntries enums es sp \<noteq> None" .
+  show ?case using e_eq hk hv ih Cons.prems(2) by (auto split: option.splits)
+qed simp
+
 lemma lower_with_assigns_wf_some:
   assumes "\<And>fld v fsp. FieldAssignFull fld v fsp \<in> set fs
              \<Longrightarrow> wf_z3 v \<Longrightarrow> lower enums v \<noteq> None"
@@ -349,6 +376,25 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have "lowerSeqList enums elems s \<noteq> None"
       by (rule lowerSeqList_wf_some[OF pe wl])
     thus ?thesis unfolding SeqLiteralF by simp
+  next
+    case (MapLiteralF entries s)
+    have pe: "\<And>k v esp. MapEntryFull k v esp \<in> set entries
+                \<Longrightarrow> (wf_z3 k \<longrightarrow> lower enums k \<noteq> None) \<and> (wf_z3 v \<longrightarrow> lower enums v \<noteq> None)"
+    proof -
+      fix k v esp assume m: "MapEntryFull k v esp \<in> set entries"
+      have "size (MapEntryFull k v esp) \<le> size_list size entries"
+        by (rule size_list_estimation'[OF m order_refl])
+      also have "\<dots> < size e" using MapLiteralF by simp
+      finally have lt: "size (MapEntryFull k v esp) < size e" .
+      have "size k < size e" and "size v < size e" using lt by simp_all
+      thus "(wf_z3 k \<longrightarrow> lower enums k \<noteq> None) \<and> (wf_z3 v \<longrightarrow> lower enums v \<noteq> None)"
+        using sub by blast
+    qed
+    have wl: "wf_z3_entries entries"
+      using less.prems MapLiteralF by simp
+    have "lowerMapEntries enums entries s \<noteq> None"
+      by (rule lowerMapEntries_wf_some[OF pe wl])
+    thus ?thesis unfolding MapLiteralF by simp
   next
     case (IfF c a b s)
     have hc: "wf_z3 c \<Longrightarrow> lower enums c \<noteq> None"

--- a/proofs/isabelle/SpecRest/soundness/Preservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation.thy
@@ -61,7 +61,7 @@ where
 | "wf_z3 (CallF _ _ _)             = False"
 | "wf_z3 (ConstructorF _ _ _)      = False"
 | "wf_z3 (MapLiteralF _ _)         = False"
-| "wf_z3 (SeqLiteralF _ _)         = False"
+| "wf_z3 (SeqLiteralF es _)        = wf_z3_list es"
 | "wf_z3 (SetComprehensionF _ _ _ _) = False"
 | "wf_z3 (SomeWrapF e _)           = wf_z3 e"
 | "wf_z3 (TheF _ _ _ _)            = False"
@@ -218,6 +218,16 @@ proof (induction xs)
   show ?case using Cons by (auto split: option.splits)
 qed simp
 
+lemma lowerSeqList_wf_some:
+  assumes "\<And>x. x \<in> set xs \<Longrightarrow> wf_z3 x \<Longrightarrow> lower enums x \<noteq> None"
+      and "wf_z3_list xs"
+  shows "lowerSeqList enums xs sp \<noteq> None"
+  using assms
+proof (induction xs)
+  case (Cons a xs)
+  show ?case using Cons by (auto split: option.splits)
+qed simp
+
 lemma lower_with_assigns_wf_some:
   assumes "\<And>fld v fsp. FieldAssignFull fld v fsp \<in> set fs
              \<Longrightarrow> wf_z3 v \<Longrightarrow> lower enums v \<noteq> None"
@@ -323,6 +333,22 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have "lowerSetList enums elems s \<noteq> None"
       by (rule lowerSetList_wf_some[OF pe wl])
     thus ?thesis unfolding SetLiteralF by simp
+  next
+    case (SeqLiteralF elems s)
+    have pe: "\<And>x. x \<in> set elems \<Longrightarrow> wf_z3 x \<Longrightarrow> lower enums x \<noteq> None"
+    proof -
+      fix x assume m: "x \<in> set elems" and rx: "wf_z3 x"
+      have "size x \<le> size_list size elems"
+        by (rule size_list_estimation'[OF m order_refl])
+      also have "\<dots> < size e" using SeqLiteralF by simp
+      finally have "size x < size e" .
+      thus "lower enums x \<noteq> None" using sub rx by blast
+    qed
+    have wl: "wf_z3_list elems"
+      using less.prems SeqLiteralF by simp
+    have "lowerSeqList enums elems s \<noteq> None"
+      by (rule lowerSeqList_wf_some[OF pe wl])
+    thus ?thesis unfolding SeqLiteralF by simp
   next
     case (IfF c a b s)
     have hc: "wf_z3 c \<Longrightarrow> lower enums c \<noteq> None"

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -81,6 +81,10 @@ next
   case (SomeE e sp) show ?case using soundness_SomeE[OF SomeE.IH] .
 next
   case (StrLit v sp) show ?case by (rule soundness_StrLit)
+next
+  case (SeqEmpty sp) show ?case by (rule soundness_SeqEmpty)
+next
+  case (SeqCons e rest sp) show ?case using soundness_SeqCons[OF SeqCons.IH(1) SeqCons.IH(2)] .
 qed
 
 section \<open>Issue #202 Phase 3 — lower-soundness corollary\<close>
@@ -260,6 +264,16 @@ proof (induction xs)
   show ?case using Cons by (auto split: option.splits)
 qed simp
 
+lemma lowerSeqList_ra_none:
+  assumes "\<And>x. x \<in> set xs \<Longrightarrow> requiresAlloy x \<Longrightarrow> lower enums x = None"
+      and "requiresAlloy_list xs"
+  shows "lowerSeqList enums xs sp = None"
+  using assms
+proof (induction xs)
+  case (Cons a xs)
+  show ?case using Cons by (auto split: option.splits)
+qed simp
+
 lemma lower_with_assigns_ra_none:
   assumes "\<And>fld v fsp. FieldAssignFull fld v fsp \<in> set fs
              \<Longrightarrow> requiresAlloy v \<Longrightarrow> lower enums v = None"
@@ -360,6 +374,22 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have "lowerSetList enums elems s = None"
       by (rule lowerSetList_ra_none[OF pe rl])
     thus ?thesis unfolding SetLiteralF by simp
+  next
+    case (SeqLiteralF elems s)
+    have pe: "\<And>x. x \<in> set elems \<Longrightarrow> requiresAlloy x \<Longrightarrow> lower enums x = None"
+    proof -
+      fix x assume m: "x \<in> set elems" and rx: "requiresAlloy x"
+      have "size x \<le> size_list size elems"
+        by (rule size_list_estimation'[OF m order_refl])
+      also have "\<dots> < size e" using SeqLiteralF by simp
+      finally have "size x < size e" .
+      thus "lower enums x = None" using sub rx by blast
+    qed
+    have rl: "requiresAlloy_list elems"
+      using less.prems SeqLiteralF by simp
+    have "lowerSeqList enums elems s = None"
+      by (rule lowerSeqList_ra_none[OF pe rl])
+    thus ?thesis unfolding SeqLiteralF by simp
   qed (use less.prems sub in \<open>auto split: option.splits\<close>)
 qed
 

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -85,6 +85,10 @@ next
   case (SeqEmpty sp) show ?case by (rule soundness_SeqEmpty)
 next
   case (SeqCons e rest sp) show ?case using soundness_SeqCons[OF SeqCons.IH(1) SeqCons.IH(2)] .
+next
+  case (MapEmpty sp) show ?case by (rule soundness_MapEmpty)
+next
+  case (MapCons k v rest sp) show ?case using soundness_MapCons[OF MapCons.IH(1) MapCons.IH(2) MapCons.IH(3)] .
 qed
 
 section \<open>Issue #202 Phase 3 — lower-soundness corollary\<close>
@@ -274,6 +278,30 @@ proof (induction xs)
   show ?case using Cons by (auto split: option.splits)
 qed simp
 
+lemma lowerMapEntries_ra_none:
+  assumes "\<And>k v esp. MapEntryFull k v esp \<in> set entries
+             \<Longrightarrow> (requiresAlloy k \<longrightarrow> lower enums k = None) \<and> (requiresAlloy v \<longrightarrow> lower enums v = None)"
+      and "requiresAlloy_entries entries"
+  shows "lowerMapEntries enums entries sp = None"
+  using assms
+proof (induction entries)
+  case (Cons e es)
+  obtain k v esp where e_eq: "e = MapEntryFull k v esp" by (cases e)
+  have hk: "requiresAlloy k \<longrightarrow> lower enums k = None"
+   and hv: "requiresAlloy v \<longrightarrow> lower enums v = None"
+    using Cons.prems(1)[of k v esp] e_eq by simp_all
+  have tl: "\<And>k v esp. MapEntryFull k v esp \<in> set es \<Longrightarrow>
+              (requiresAlloy k \<longrightarrow> lower enums k = None) \<and> (requiresAlloy v \<longrightarrow> lower enums v = None)"
+  proof -
+    fix k v esp assume "MapEntryFull k v esp \<in> set es"
+    hence "MapEntryFull k v esp \<in> set (e # es)" by simp
+    thus "(requiresAlloy k \<longrightarrow> lower enums k = None) \<and> (requiresAlloy v \<longrightarrow> lower enums v = None)"
+      using Cons.prems(1) by blast
+  qed
+  from Cons.IH[OF tl] have ih: "requiresAlloy_entries es \<Longrightarrow> lowerMapEntries enums es sp = None" .
+  show ?case using e_eq hk hv ih Cons.prems(2) by (auto split: option.splits)
+qed simp
+
 lemma lower_with_assigns_ra_none:
   assumes "\<And>fld v fsp. FieldAssignFull fld v fsp \<in> set fs
              \<Longrightarrow> requiresAlloy v \<Longrightarrow> lower enums v = None"
@@ -390,6 +418,25 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have "lowerSeqList enums elems s = None"
       by (rule lowerSeqList_ra_none[OF pe rl])
     thus ?thesis unfolding SeqLiteralF by simp
+  next
+    case (MapLiteralF entries s)
+    have pe: "\<And>k v esp. MapEntryFull k v esp \<in> set entries
+                \<Longrightarrow> (requiresAlloy k \<longrightarrow> lower enums k = None) \<and> (requiresAlloy v \<longrightarrow> lower enums v = None)"
+    proof -
+      fix k v esp assume m: "MapEntryFull k v esp \<in> set entries"
+      have "size (MapEntryFull k v esp) \<le> size_list size entries"
+        by (rule size_list_estimation'[OF m order_refl])
+      also have "\<dots> < size e" using MapLiteralF by simp
+      finally have lt: "size (MapEntryFull k v esp) < size e" .
+      have "size k < size e" and "size v < size e" using lt by simp_all
+      thus "(requiresAlloy k \<longrightarrow> lower enums k = None) \<and> (requiresAlloy v \<longrightarrow> lower enums v = None)"
+        using sub by blast
+    qed
+    have rl: "requiresAlloy_entries entries"
+      using less.prems MapLiteralF by simp
+    have "lowerMapEntries enums entries s = None"
+      by (rule lowerMapEntries_ra_none[OF pe rl])
+    thus ?thesis unfolding MapLiteralF by simp
   qed (use less.prems sub in \<open>auto split: option.splits\<close>)
 qed
 

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Collection.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Collection.thy
@@ -189,4 +189,50 @@ proof -
   qed
 qed
 
+lemma soundness_MapEmpty:
+  "value_to_smt_opt (eval s st env (MapEmpty sp))
+     = smtEval (correlate_model s st) (correlate_env env) (translate (MapEmpty sp))"
+  by simp
+
+lemma soundness_MapCons:
+  assumes ihk: "value_to_smt_opt (eval s st env k)
+                  = smtEval (correlate_model s st) (correlate_env env) (translate k)"
+      and ihv: "value_to_smt_opt (eval s st env v)
+                  = smtEval (correlate_model s st) (correlate_env env) (translate v)"
+      and ihr: "value_to_smt_opt (eval s st env rest)
+                  = smtEval (correlate_model s st) (correlate_env env) (translate rest)"
+  shows "value_to_smt_opt (eval s st env (MapCons k v rest sp))
+           = smtEval (correlate_model s st) (correlate_env env) (translate (MapCons k v rest sp))"
+proof -
+  have ihk': "smtEval (correlate_model s st) (correlate_env env) (translate k)
+                = value_to_smt_opt (eval s st env k)" using ihk by simp
+  have ihv': "smtEval (correlate_model s st) (correlate_env env) (translate v)
+                = value_to_smt_opt (eval s st env v)" using ihv by simp
+  have ihr': "smtEval (correlate_model s st) (correlate_env env) (translate rest)
+                = value_to_smt_opt (eval s st env rest)" using ihr by simp
+  show ?thesis
+  proof (cases "eval s st env k")
+    case None thus ?thesis using ihk' by simp
+  next
+    case (Some kv)
+    show ?thesis
+    proof (cases "eval s st env v")
+      case None thus ?thesis using ihk' ihv' \<open>eval s st env k = Some kv\<close> by simp
+    next
+      case (Some vv)
+      show ?thesis
+      proof (cases "eval s st env rest")
+        case None
+        thus ?thesis using ihk' ihv' ihr'
+            \<open>eval s st env k = Some kv\<close> \<open>eval s st env v = Some vv\<close> by simp
+      next
+        case (Some mv)
+        thus ?thesis using ihk' ihv' ihr'
+            \<open>eval s st env k = Some kv\<close> \<open>eval s st env v = Some vv\<close>
+          by (cases mv) simp_all
+      qed
+    qed
+  qed
+qed
+
 end

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Collection.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Collection.thy
@@ -157,4 +157,36 @@ proof -
     by (cases "eval s st env base"; cases "eval s st env value_e") simp_all
 qed
 
+lemma soundness_SeqEmpty:
+  "value_to_smt_opt (eval s st env (SeqEmpty sp))
+     = smtEval (correlate_model s st) (correlate_env env) (translate (SeqEmpty sp))"
+  by simp
+
+lemma soundness_SeqCons:
+  assumes ihe: "value_to_smt_opt (eval s st env e)
+                  = smtEval (correlate_model s st) (correlate_env env) (translate e)"
+      and ihs: "value_to_smt_opt (eval s st env rest)
+                  = smtEval (correlate_model s st) (correlate_env env) (translate rest)"
+  shows "value_to_smt_opt (eval s st env (SeqCons e rest sp))
+           = smtEval (correlate_model s st) (correlate_env env) (translate (SeqCons e rest sp))"
+proof -
+  have ihe': "smtEval (correlate_model s st) (correlate_env env) (translate e)
+                = value_to_smt_opt (eval s st env e)" using ihe by simp
+  have ihs': "smtEval (correlate_model s st) (correlate_env env) (translate rest)
+                = value_to_smt_opt (eval s st env rest)" using ihs by simp
+  show ?thesis
+  proof (cases "eval s st env e")
+    case None thus ?thesis using ihe' by simp
+  next
+    case (Some v)
+    show ?thesis
+    proof (cases "eval s st env rest")
+      case None thus ?thesis using ihe' ihs' \<open>eval s st env e = Some v\<close> by simp
+    next
+      case (Some vs)
+      thus ?thesis using ihe' ihs' \<open>eval s st env e = Some v\<close> by (cases vs) simp_all
+    qed
+  qed
+qed
+
 end

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
@@ -10,7 +10,8 @@ begin
 
 section \<open>Value \<leftrightarrow> SmtVal correlation\<close>
 
-fun value_to_smt :: "ir_value \<Rightarrow> smt_val" where
+function (sequential) value_to_smt :: "ir_value \<Rightarrow> smt_val"
+and value_to_smt_entries :: "(ir_value \<times> ir_value) list \<Rightarrow> (smt_val \<times> smt_val) list" where
   "value_to_smt (VBool b)        = SBool b"
 | "value_to_smt (VInt n)         = SInt n"
 | "value_to_smt (VReal r)        = SReal r"
@@ -23,6 +24,15 @@ fun value_to_smt :: "ir_value \<Rightarrow> smt_val" where
 | "value_to_smt (VSome v)        = SSome (value_to_smt v)"
 | "value_to_smt (VStr s)         = SStr s"
 | "value_to_smt (VSeq vs)        = SSeq (map value_to_smt vs)"
+| "value_to_smt (VMap ps)        = SMap (value_to_smt_entries ps)"
+| "value_to_smt_entries []            = []"
+| "value_to_smt_entries ((k, v) # ps) = (value_to_smt k, value_to_smt v) # value_to_smt_entries ps"
+  by pat_completeness auto
+termination
+  by (relation "measure (\<lambda>x. case x of
+        Inl v \<Rightarrow> size v
+      | Inr ps \<Rightarrow> size_list (size_prod size size) ps)")
+     (auto dest: size_list_estimation'[OF _ order_refl, where f = size])
 
 abbreviation value_to_smt_opt :: "ir_value option \<Rightarrow> smt_val option" where
   "value_to_smt_opt \<equiv> map_option value_to_smt"
@@ -86,6 +96,53 @@ lemma SInt_eq_value_to_smt [simp]:
 lemma SReal_eq_value_to_smt [simp]:
   "(SReal r = value_to_smt v) = (v = VReal r)"
   by (cases v) auto
+
+lemma value_to_smt_entries_inj:
+  assumes "\<And>k v. (k, v) \<in> set xs \<Longrightarrow>
+             (\<forall>k'. value_to_smt k = value_to_smt k' \<longrightarrow> k = k')
+             \<and> (\<forall>v'. value_to_smt v = value_to_smt v' \<longrightarrow> v = v')"
+  shows "(value_to_smt_entries xs = value_to_smt_entries ys) = (xs = ys)"
+  using assms
+proof (induction xs arbitrary: ys)
+  case Nil
+  show ?case
+  proof (cases ys)
+    case Nil thus ?thesis by simp
+  next
+    case (Cons q ys')
+    obtain a b where "q = (a, b)" by (cases q)
+    thus ?thesis using \<open>ys = q # ys'\<close> by simp
+  qed
+next
+  case (Cons p xs)
+  obtain k v where p: "p = (k, v)" by (cases p)
+  have inj_kv: "(\<forall>k'. value_to_smt k = value_to_smt k' \<longrightarrow> k = k')
+                \<and> (\<forall>v'. value_to_smt v = value_to_smt v' \<longrightarrow> v = v')"
+    using Cons.prems[of k v] p by simp
+  have tail: "\<And>k' v'. (k', v') \<in> set xs \<Longrightarrow>
+                (\<forall>k''. value_to_smt k' = value_to_smt k'' \<longrightarrow> k' = k'')
+                \<and> (\<forall>v''. value_to_smt v' = value_to_smt v'' \<longrightarrow> v' = v'')"
+  proof -
+    fix k' v' assume "(k', v') \<in> set xs"
+    hence "(k', v') \<in> set (p # xs)" by simp
+    thus "(\<forall>k''. value_to_smt k' = value_to_smt k'' \<longrightarrow> k' = k'')
+          \<and> (\<forall>v''. value_to_smt v' = value_to_smt v'' \<longrightarrow> v' = v'')"
+      using Cons.prems by blast
+  qed
+  show ?case
+  proof (cases ys)
+    case Nil
+    thus ?thesis using p by simp
+  next
+    case (Cons q ys')
+    obtain a b where q: "q = (a, b)" by (cases q)
+    have ih: "(value_to_smt_entries xs = value_to_smt_entries ys') = (xs = ys')"
+      using Cons.IH[OF tail] .
+    from inj_kv have ka: "(value_to_smt k = value_to_smt a) = (k = a)"
+                 and vb: "(value_to_smt v = value_to_smt b) = (v = b)" by blast+
+    show ?thesis using p q \<open>ys = q # ys'\<close> ka vb ih by simp
+  qed
+qed
 
 lemma map_value_to_smt_inj:
   assumes "\<And>x. x \<in> set xs \<Longrightarrow> (\<forall>y. value_to_smt x = value_to_smt y \<longrightarrow> x = y)"
@@ -155,6 +212,23 @@ next
     qed
     thus ?thesis using \<open>v2 = VSeq ys\<close> by simp
   qed auto
+next
+  case (VMap xs)
+  show ?case
+  proof (cases v2)
+    case (VMap ys)
+    have "(value_to_smt_entries xs = value_to_smt_entries ys) = (xs = ys)"
+    proof (rule value_to_smt_entries_inj)
+      fix k v assume m: "(k, v) \<in> set xs"
+      have "(\<forall>v2. (value_to_smt k = value_to_smt v2) = (k = v2))
+            \<and> (\<forall>v2. (value_to_smt v = value_to_smt v2) = (v = v2))"
+        using VMap.IH[OF m] by simp
+      thus "(\<forall>k'. value_to_smt k = value_to_smt k' \<longrightarrow> k = k')
+            \<and> (\<forall>v'. value_to_smt v = value_to_smt v' \<longrightarrow> v = v')"
+        by blast
+    qed
+    thus ?thesis using \<open>v2 = VMap ys\<close> by simp
+  qed auto
 qed
 
 lemma map_value_to_smt_inj_simp [simp]:
@@ -164,6 +238,32 @@ proof (induction xs arbitrary: ys)
 next
   case (Cons x xs')
   show ?case by (cases ys) (auto simp: Cons.IH)
+qed
+
+lemma value_to_smt_entries_inj_simp [simp]:
+  "(value_to_smt_entries xs = value_to_smt_entries ys) = (xs = ys)"
+proof (induction xs arbitrary: ys)
+  case Nil
+  show ?case
+  proof (cases ys)
+    case Nil thus ?thesis by simp
+  next
+    case (Cons q ys')
+    obtain a b where "q = (a, b)" by (cases q)
+    thus ?thesis using \<open>ys = q # ys'\<close> by simp
+  qed
+next
+  case (Cons p xs')
+  obtain k v where p: "p = (k, v)" by (cases p)
+  show ?case
+  proof (cases ys)
+    case Nil
+    thus ?thesis using p by simp
+  next
+    case (Cons q ys')
+    obtain a b where q: "q = (a, b)" by (cases q)
+    show ?thesis using p q \<open>ys = q # ys'\<close> Cons.IH by simp
+  qed
 qed
 
 section \<open>Correlation lemmas\<close>
@@ -329,6 +429,11 @@ lemma contains_smt_val_map_SSeq [simp]:
   "contains_smt_val (map value_to_smt vs) (SSeq (map value_to_smt xs))
      = contains_value vs (VSeq xs)"
   using contains_value_map_value_to_smt[of vs "VSeq xs"] by simp
+
+lemma contains_smt_val_map_SMap [simp]:
+  "contains_smt_val (map value_to_smt vs) (SMap (value_to_smt_entries ps))
+     = contains_value vs (VMap ps)"
+  using contains_value_map_value_to_smt[of vs "VMap ps"] by simp
 
 
 lemma set_union_values_map_value_to_smt:

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
@@ -22,6 +22,7 @@ fun value_to_smt :: "ir_value \<Rightarrow> smt_val" where
 | "value_to_smt VNone            = SNone"
 | "value_to_smt (VSome v)        = SSome (value_to_smt v)"
 | "value_to_smt (VStr s)         = SStr s"
+| "value_to_smt (VSeq vs)        = SSeq (map value_to_smt vs)"
 
 abbreviation value_to_smt_opt :: "ir_value option \<Rightarrow> smt_val option" where
   "value_to_smt_opt \<equiv> map_option value_to_smt"
@@ -142,6 +143,18 @@ next
 next
   case (VStr s)
   show ?case by (cases v2) auto
+next
+  case (VSeq xs)
+  show ?case
+  proof (cases v2)
+    case (VSeq ys)
+    have "(map value_to_smt xs = map value_to_smt ys) = (xs = ys)"
+    proof (rule map_value_to_smt_inj)
+      fix x assume "x \<in> set xs"
+      thus "\<forall>y. value_to_smt x = value_to_smt y \<longrightarrow> x = y" using VSeq.IH by blast
+    qed
+    thus ?thesis using \<open>v2 = VSeq ys\<close> by simp
+  qed auto
 qed
 
 lemma map_value_to_smt_inj_simp [simp]:
@@ -311,6 +324,11 @@ lemma contains_smt_val_map_SSome [simp]:
 lemma contains_smt_val_map_SStr [simp]:
   "contains_smt_val (map value_to_smt vs) (SStr s) = contains_value vs (VStr s)"
   using contains_value_map_value_to_smt[of vs "VStr s"] by simp
+
+lemma contains_smt_val_map_SSeq [simp]:
+  "contains_smt_val (map value_to_smt vs) (SSeq (map value_to_smt xs))
+     = contains_value vs (VSeq xs)"
+  using contains_value_map_value_to_smt[of vs "VSeq xs"] by simp
 
 
 lemma set_union_values_map_value_to_smt:


### PR DESCRIPTION
## Summary
Top of the proof-lift stack (base `feat/proofs-lift-string`). Three commits:

- **Seq** (`13da7bb7`): lift `SeqLiteral` to the Z3 native Seq theory (`mkSeqSort`/`mkUnit`/`mkConcat`). Proven sound.
- **perf** (`56601be1`): flatten `eval_arith`/`eval_cmp` nested cross-product `fun` patterns. Widening `ir_value` for the Option/String/Seq lifts had detonated their `pat_completeness` (a single fun hit 440s) — Core build had regressed to ~13min. Rewrote as single-equation `case` bodies + shallow helpers; **Core 13:03 → ~1:31**, behaviour-identical, drift-clean. Also flattened two pre-existing `expr_full` funs (`keyExistencePair`, `resolveWithBase`). Documented in `SPEEDUP.md` Tier 2.7.
- **Map** (`311e7d6d`): lift `Map` literals (`MapEmpty`/`MapCons`) to a Z3 **sequence of `(key,value)` tuples** matching the proof's ordered assoc-list. `value_to_smt` is mutual with `value_to_smt_entries` (hand-written `size` termination); injectivity is search-free. Proven sound.

Stacked on #380 (base `feat/proofs-lift-string`) — merge that first.

## Verification
- Isabelle `SpecRest_{Core,Soundness,Codegen}` green, **zero `sorry`** across the stack.
- `verify/test` 193/193 + new BackendTest map cases (equal maps sat, distinct unsat); full `sbt compile` green.
- `SpecRestGenerated.scala` regenerated and drift-checked.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted Seq and Map literals to Z3 native theories with end-to-end soundness, cutting the Isabelle Core build from ~13m to ~1.5m. Sequences use Z3’s Seq; Maps are a Z3 sequence of `(key, value)` tuples matching our ordered assoc‑list semantics.

- New Features
  - Sequences: native Z3 `Seq` via `Z3Sort.SeqOf`/`Z3Expr.SeqLit`; SMT `(Seq ...)` with `seq.unit`/`seq.++`; backend `mkSeqSort`; translator encodes `TSeqCons`; tests for equal/distinct literals.
  - Maps: native as `Seq (Pair K V)` via `Z3Sort.MapOf`/`Z3Expr.MapLit`; backend `TupleSort` + `mkPair` with `seq.unit`/`seq.++`; proofs add `SeqEmpty`/`SeqCons`, `MapEmpty`/`MapCons`, `VSeq`/`VMap`, `SSeq`/`SMap` with eval/translate/smtEval and soundness; tests assert SAT/UNSAT of equal/distinct maps.
  - Performance: flattened `eval_arith`/`eval_cmp` (plus two helpers), Core 13:03 → ~1:31.

- Bug Fixes
  - ITE sort inference returns None when branch sorts differ.
  - String decoder unescapes SMT-LIB doubled quotes for round‑trip.
  - Counterexample typing skips native no‑ty sorts (`Str`/`Seq`/`Map`/`Option`).
  - SMT-LIB export declares parametric `Pair` for Map sorts; option detection recurses through `Seq`/`Map`.

<sup>Written for commit 7e9ee911077036ef9691d30b2adbd4180a22a0e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added support for sequences (lists) and maps (key-value collections) in specification verification
* Extended Z3 theorem prover backend to natively handle the new collection types

**Performance**
* Optimized arithmetic and comparison evaluation in the verification engine

**Tests**
* Added comprehensive test coverage for sequence and map verification scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->