### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="https://github.com/HardMax71/spec_to_rest/actions/workflows/isabelle-build.yml"><img src="https://img.shields.io/github/actions/workflow/status/HardMax71/spec_to_rest/isabelle-build.yml?branch=main&label=Isabelle%2FHOL" alt="Isabelle/HOL soundness" /></a>
   <a href="https://github.com/HardMax71/spec_to_rest/releases"><img src="https://img.shields.io/github/v/release/HardMax71/spec_to_rest?label=release" alt="Latest release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/HardMax71/spec_to_rest" alt="License" /></a>
+  <a href="https://deepwiki.com/HardMax71/spec_to_rest"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
 </p>
 
 Given a `.spec` file describing entities, operations, invariants, and preconditions, `spec-to-rest`


### PR DESCRIPTION
## Summary
Adds an "Ask DeepWiki" badge to the README badge row, linking to the DeepWiki page for the repo.

`<a href="https://deepwiki.com/HardMax71/spec_to_rest"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>`

Uses the same HTML `<a><img>` form as the existing CI / Isabelle / release / license badges (the row is an HTML `<p align="center">` block, so markdown image syntax wouldn't render). Docs-only; independent of the proof-lift PR stack (base `main`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Ask DeepWiki" badge to the README’s centered badge row so readers can jump to the project’s DeepWiki page. Uses an HTML <a><img> badge to match the existing badges in the <p align="center"> block.

<sup>Written for commit c5cdd1cf84318c677e8e3253990f3c0929cb5fbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

