### PR TITLE
feat(proofs): lift set subset to the verified Z3 subset

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3783,7 +3783,13 @@ object SpecRestGenerated {
             case IdentifierF(rel, _) =>
               map_option[expr, expr]((la: expr) => UnNot(Member(la, rel, sp), sp), lower(enums, l))
           }
-        case BSubset() => None
+        case BSubset() =>
+          (lower(enums, l), lower(enums, r)) match {
+            case (None, _)       => None
+            case (Some(_), None) => None
+            case (Some(la), Some(ra)) =>
+              Some[expr](Cmp(EqOp(), SetBin(DiffOp(), la, ra, sp), SetEmpty(sp), sp))
+          }
         case BUnion() =>
           (lower(enums, l), lower(enums, r)) match {
             case (None, _)       => None

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1993,18 +1993,35 @@ object Translator:
       fail(ctx, "ordering/arithmetic requires a numeric type (Int or Real)")
     z
 
+  private def encodeSetEmptyCmp(
+      ctx: TranslateCtx,
+      op: CmpOp,
+      setTerm: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val sz = encodeFromSmtTerm(ctx, setTerm, env)
+    inferSortOfZ3Expr(ctx, sz) match
+      case Some(Z3Sort.SetOf(elemSort)) =>
+        Z3Expr.Cmp(op, sz, Z3Expr.EmptySet(elemSort))
+      case _ =>
+        fail(ctx, "equality with an empty set literal requires a set-sorted operand")
+
   private def encodeFromSmtTerm(
       ctx: TranslateCtx,
       term: smt_term,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
     term match
-      case TEq(l, TNone())       => encodeNoneEq(ctx, l, env)
-      case TEq(TNone(), r)       => encodeNoneEq(ctx, r, env)
-      case TNot(TEq(l, TNone())) => Z3Expr.Not(encodeNoneEq(ctx, l, env))
-      case TNot(TEq(TNone(), r)) => Z3Expr.Not(encodeNoneEq(ctx, r, env))
-      case BLit(b)               => Z3Expr.BoolLit(b)
-      case ILit(n)               => Z3Expr.IntLit(n)
+      case TEq(l, TNone())           => encodeNoneEq(ctx, l, env)
+      case TEq(TNone(), r)           => encodeNoneEq(ctx, r, env)
+      case TNot(TEq(l, TNone()))     => Z3Expr.Not(encodeNoneEq(ctx, l, env))
+      case TNot(TEq(TNone(), r))     => Z3Expr.Not(encodeNoneEq(ctx, r, env))
+      case TEq(l, TSetEmpty())       => encodeSetEmptyCmp(ctx, CmpOp.Eq, l, env)
+      case TEq(TSetEmpty(), r)       => encodeSetEmptyCmp(ctx, CmpOp.Eq, r, env)
+      case TNot(TEq(l, TSetEmpty())) => encodeSetEmptyCmp(ctx, CmpOp.Neq, l, env)
+      case TNot(TEq(TSetEmpty(), r)) => encodeSetEmptyCmp(ctx, CmpOp.Neq, r, env)
+      case BLit(b)                   => Z3Expr.BoolLit(b)
+      case ILit(n)                   => Z3Expr.IntLit(n)
       case RLit(r) =>
         val (num, den) = quotient_of(r)
         Z3Expr.RealLit(num, den)

--- a/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
@@ -47,7 +47,11 @@ class TrustTest extends CatsEffectSuite:
       TrustLevel.Sound
     ),
     ("BestEffort: UPower", UnaryOpF(UPower(), id("users"), None), TrustLevel.BestEffort),
-    ("BestEffort: BSubset", BinaryOpF(BSubset(), id("a"), id("b"), None), TrustLevel.BestEffort),
+    (
+      "Sound: BSubset (desugars to set-difference emptiness)",
+      BinaryOpF(BSubset(), id("a"), id("b"), None),
+      TrustLevel.Sound
+    ),
     (
       "BestEffort: CallF (predicate inlining not yet covered)",
       CallF(id("isPositive"), List(i(1)), None),

--- a/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/z3/TranslatorSetOpsTest.scala
@@ -92,14 +92,14 @@ class TranslatorSetOpsTest extends CatsEffectSuite:
     ).map: out =>
       assert(out.contains("(setminus "), s"expected (setminus ...); got:\n$out")
 
-  test("`a subset b` emits (subset ...)"):
+  test("`a subset b` desugars to set-difference emptiness"):
     smtOf(
       specWithInvariant(
         "a: Set[Int]\n    b: Set[Int]",
         "a subset b implies b subset a or not (a subset b)"
       )
     ).map: out =>
-      assert(out.contains("(subset "), s"expected (subset ...); got:\n$out")
+      assert(out.contains("(setminus "), s"expected set-difference desugar; got:\n$out")
 
   test("`Set[Int]`-typed state field declares a (Set Int)-valued function"):
     smtOf(specWithInvariant("a: Set[Int]", "true")).map: out =>

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -157,7 +157,11 @@ where
                (case (lower enums l, lower enums r) of
                   (Some l', Some r') \<Rightarrow> Some (UnNot (SetMember l' r' sp) sp)
                 | _ \<Rightarrow> None))
-      | BSubset \<Rightarrow> None)"
+      | BSubset \<Rightarrow>
+          (case (lower enums l, lower enums r) of
+             (Some l', Some r') \<Rightarrow>
+               Some (Cmp EqOp (SetBin DiffOp l' r' sp) (SetEmpty sp) sp)
+           | _ \<Rightarrow> None))"
 
 | "lower enums (LetF x v body sp) =
      (case (lower enums v, lower enums body) of

--- a/proofs/isabelle/SpecRest/soundness/Preservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation.thy
@@ -46,7 +46,7 @@ where
         | UCardinality \<Rightarrow> (\<exists>x s. e = IdentifierF x s)
         | UPower \<Rightarrow> False)"
 | "wf_z3 (BinaryOpF op l r _)      =
-     (case op of BSubset \<Rightarrow> False
+     (case op of BSubset \<Rightarrow> (wf_z3 l \<and> wf_z3 r)
         | BIn \<Rightarrow> (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r))
         | BNotIn \<Rightarrow> (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r))
         | _ \<Rightarrow> wf_z3 l \<and> wf_z3 r)"
@@ -164,9 +164,6 @@ proof -
   next
     case BNotIn
     thus ?thesis using inout by blast
-  next
-    case BSubset
-    with wf show ?thesis by simp
   qed (use l r wf in \<open>auto split: option.splits\<close>)
 qed
 

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -234,9 +234,6 @@ proof -
   next
     case BNotIn
     thus ?thesis by (rule inout[OF disjI2])
-  next
-    case BSubset
-    thus ?thesis by simp
   qed (use l r d in \<open>auto split: option.splits\<close>)
 qed
 


### PR DESCRIPTION
## Summary
- `BinaryOpF BSubset` (`A subset B`) previously routed to Alloy (`wf_z3 = False`, `lower = None`). Lift it into the verified Z3 subset by **desugaring** `A subset B` to `(A \ B) = {}` in `lower`, reusing the already-proven `SetBin DiffOp` / `SetEmpty` / `Cmp EqOp` constructs - no new primitive, `smt_term`, Z3 case, or soundness lemma.
- `wf_z3 (BinaryOpF BSubset l r) = wf_z3 l & wf_z3 r`. The preservation (lower-totality) and `lower_binop_collapse` proofs drop their now-redundant `BSubset` special-cases and discharge it via the standard binary-op catch-all (same shape as `BUnion`/`BDiff`).
- First construct of Batch 3. `SpecRestGenerated.scala` regenerated; `sbt ir/compile` clean; zero `sorry`.

## Test plan
- [ ] `isabelle build` green in CI; no `sorry`/`oops`
- [ ] Scala drift check passes (extraction matches committed)
- [ ] `sbt ir/compile` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lift `A subset B` into the verified Z3 subset by desugaring to `(A \ B) = {}` and add translator support for empty-set equality so the lowering works end-to-end. This removes routing to Alloy and expands Z3 coverage without new primitives or lemmas.

- **New Features**
  - Lower `BSubset` to `Cmp(EqOp, SetBin(DiffOp, A, B), SetEmpty)` in `lower`.
  - `wf_z3` for `BSubset` is now `wf_z3 l && wf_z3 r`; removed special-cases in preservation and soundness.
  - Regenerated `SpecRestGenerated.scala`; proofs compile clean.

- **Bug Fixes**
  - In the Z3 translator, handle `TEq`/`TNot(TEq)` with `TSetEmpty` by inferring the set sort from the other side and emitting a typed empty set.
  - Tests updated: `BSubset` now classified as Sound; subset lowers to set-difference emptiness instead of a native `(subset ...)`.

<sup>Written for commit 8f6ae53db67cec1b69011a86044e1504bee1f52f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

