### PR TITLE
feat(proofs): lift set comprehension into the verified Z3 subset

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -614,6 +614,8 @@ object SpecRestGenerated {
       extends expr
   final case class ForallRel(a: String, b: String, c: expr, d: Option[span_t])
       extends expr
+  final case class ForallSet(a: String, b: expr, c: expr, d: Option[span_t])
+      extends expr
   final case class Prime(a: expr, b: Option[span_t])                  extends expr
   final case class Pre(a: expr, b: Option[span_t])                    extends expr
   final case class CardRel(a: String, b: Option[span_t])              extends expr
@@ -781,6 +783,7 @@ object SpecRestGenerated {
   final case class TLetIn(a: String, b: smt_term, c: smt_term)     extends smt_term
   final case class TForallEnum(a: String, b: String, c: smt_term)  extends smt_term
   final case class TForallRel(a: String, b: String, c: smt_term)   extends smt_term
+  final case class TForallSet(a: String, b: smt_term, c: smt_term) extends smt_term
   final case class TIndexRel(a: smt_term, b: smt_term)             extends smt_term
   final case class TFieldAccess(a: smt_term, b: String)            extends smt_term
   final case class TSetEmpty()                                     extends smt_term
@@ -1929,6 +1932,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TForallSet(v, va, vb)  => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -1974,6 +1978,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TForallSet(v, va, vb)  => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -2563,6 +2568,22 @@ object SpecRestGenerated {
           case None    => None
           case Some(d) => smtEval_forall_rel(m, env, vara, d, body)
         }
+      case (m, env, TForallSet(vara, setT, body)) =>
+        smtEval(m, env, setT) match {
+          case None                       => None
+          case Some(SBool(_))             => None
+          case Some(SInt(_))              => None
+          case Some(SReal(_))             => None
+          case Some(SEnumElem(_, _))      => None
+          case Some(SEntityElem(_, _))    => None
+          case Some(SSet(elems))          => smtEval_forall_rel(m, env, vara, elems, body)
+          case Some(SEntityWith(_, _, _)) => None
+          case Some(SNone())              => None
+          case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
+        }
       case (m, env, TIndexRel(base, key)) =>
         (peelSmtRelationRef(base), smtEval(m, env, key)) match {
           case (None, _)            => None
@@ -2805,6 +2826,7 @@ object SpecRestGenerated {
     case Member(v, va, vb)         => None
     case ForallEnum(v, va, vb, vc) => None
     case ForallRel(v, va, vb, vc)  => None
+    case ForallSet(v, va, vb, vc)  => None
     case Prime(v, va)              => None
     case Pre(v, va)                => None
     case CardRel(v, va)            => None
@@ -3144,14 +3166,20 @@ object SpecRestGenerated {
       predE: expr,
       sp: Option[span_t]
   ): expr = {
-    val body =
-      BoolBin(IffOp(), SetMember(Ident(vara, None), Ident("0cmp", None), sp), predE, sp): expr
-    val quant =
+    val memX = SetMember(Ident(vara, None), Ident("0cmp", None), sp): expr
+    val memD =
       (string_in_list(dnm, enums) match {
-        case true  => ForallEnum(vara, dnm, body, sp)
-        case false => ForallRel(vara, dnm, body, sp)
-      }): expr;
-    LetIn("0cmp", setE, quant, sp)
+        case true  => BoolLit(true, sp)
+        case false => Member(Ident(vara, None), dnm, sp)
+      }): expr
+    val dir1 =
+      (string_in_list(dnm, enums) match {
+        case true  => ForallEnum(vara, dnm, BoolBin(ImpliesOp(), predE, memX, sp), sp)
+        case false => ForallRel(vara, dnm, BoolBin(ImpliesOp(), predE, memX, sp), sp)
+      }): expr
+    val dir2 =
+      ForallSet(vara, Ident("0cmp", None), BoolBin(AndOp(), memD, predE, sp), sp): expr;
+    LetIn("0cmp", setE, BoolBin(AndOp(), dir1, dir2, sp), sp)
   }
 
   def peel_relation_ref(x0: expr): Option[String] = x0 match {
@@ -3171,6 +3199,7 @@ object SpecRestGenerated {
     case Member(v, va, vb)         => None
     case ForallEnum(v, va, vb, vc) => None
     case ForallRel(v, va, vb, vc)  => None
+    case ForallSet(v, va, vb, vc)  => None
     case CardRel(v, va)            => None
     case IndexRel(v, va, vb)       => None
     case FieldAccess(v, va, vb)    => None
@@ -5190,27 +5219,43 @@ object SpecRestGenerated {
           case None          => None
           case Some(rel_dom) => eval_forall_rel(s, st, env, vara, rel_dom, body)
         }
-      case (s, st, env, Prime(e, vi)) => eval(s, st, env, e)
-      case (s, st, env, Pre(e, vj))   => eval(s, st, env, e)
-      case (s, st, env, CardRel(rel_name, vk)) =>
+      case (s, st, env, ForallSet(vara, setE, body, vi)) =>
+        eval(s, st, env, setE) match {
+          case None                       => None
+          case Some(VBool(_))             => None
+          case Some(VInt(_))              => None
+          case Some(VReal(_))             => None
+          case Some(VEnum(_, _))          => None
+          case Some(VEntity(_, _))        => None
+          case Some(VSet(elems))          => eval_forall_rel(s, st, env, vara, elems, body)
+          case Some(VEntityWith(_, _, _)) => None
+          case Some(VNone())              => None
+          case Some(VSome(_))             => None
+          case Some(VStr(_))              => None
+          case Some(VSeq(_))              => None
+          case Some(VMap(_))              => None
+        }
+      case (s, st, env, Prime(e, vj)) => eval(s, st, env, e)
+      case (s, st, env, Pre(e, vk))   => eval(s, st, env, e)
+      case (s, st, env, CardRel(rel_name, vl)) =>
         state_relation_domain(st, rel_name) match {
           case None => None
           case Some(rel_dom) =>
             Some[ir_value](VInt(int_of_nat(size_list[ir_value](rel_dom))))
         }
-      case (s, st, env, IndexRel(base, key, vl)) =>
+      case (s, st, env, IndexRel(base, key, vm)) =>
         (peel_relation_ref(base), eval(s, st, env, key)) match {
           case (None, _)            => None
           case (Some(_), None)      => None
           case (Some(rel), Some(a)) => state_lookup_key(st, rel, a)
         }
-      case (s, st, env, FieldAccess(base, fname, vm)) =>
+      case (s, st, env, FieldAccess(base, fname, vn)) =>
         eval(s, st, env, base) match {
           case None    => None
           case Some(v) => value_field_lookup(st, v, fname)
         }
-      case (s, st, env, SetEmpty(vn)) => Some[ir_value](VSet(Nil))
-      case (s, st, env, SetInsert(elem, set_e, vo)) =>
+      case (s, st, env, SetEmpty(vo)) => Some[ir_value](VSet(Nil))
+      case (s, st, env, SetInsert(elem, set_e, vp)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
           case (None, _)                      => None
           case (Some(_), None)                => None
@@ -5228,7 +5273,7 @@ object SpecRestGenerated {
           case (Some(_), Some(VSeq(_)))              => None
           case (Some(_), Some(VMap(_)))              => None
         }
-      case (s, st, env, SetMember(elem, set_e, vp)) =>
+      case (s, st, env, SetMember(elem, set_e, vq)) =>
         (eval(s, st, env, elem), eval(s, st, env, set_e)) match {
           case (None, _)                      => None
           case (Some(_), None)                => None
@@ -5246,15 +5291,15 @@ object SpecRestGenerated {
           case (Some(_), Some(VSeq(_)))              => None
           case (Some(_), Some(VMap(_)))              => None
         }
-      case (s, st, env, SetBin(op, l, r, vq)) =>
+      case (s, st, env, SetBin(op, l, r, vr)) =>
         eval_set_bin(op, eval(s, st, env, l), eval(s, st, env, r))
-      case (s, st, env, WithRec(base, fld, value_e, vr)) =>
+      case (s, st, env, WithRec(base, fld, value_e, vs)) =>
         (eval(s, st, env, base), eval(s, st, env, value_e)) match {
           case (None, _)           => None
           case (Some(_), None)     => None
           case (Some(bv), Some(v)) => Some[ir_value](VEntityWith(bv, fld, v))
         }
-      case (s, st, env, Ite(c, a, b, vs)) =>
+      case (s, st, env, Ite(c, a, b, vt)) =>
         eval(s, st, env, c) match {
           case None                       => None
           case Some(VBool(true))          => eval(s, st, env, a)
@@ -5271,12 +5316,12 @@ object SpecRestGenerated {
           case Some(VSeq(_))              => None
           case Some(VMap(_))              => None
         }
-      case (s, st, env, NoneE(vt)) => Some[ir_value](VNone())
-      case (s, st, env, SomeE(e, vu)) =>
+      case (s, st, env, NoneE(vu)) => Some[ir_value](VNone())
+      case (s, st, env, SomeE(e, vv)) =>
         map_option[ir_value, ir_value]((a: ir_value) => VSome(a), eval(s, st, env, e))
-      case (s, st, env, StrLit(v, vv)) => Some[ir_value](VStr(v))
-      case (s, st, env, SeqEmpty(vw))  => Some[ir_value](VSeq(Nil))
-      case (s, st, env, SeqCons(e, rest, vx)) =>
+      case (s, st, env, StrLit(v, vw)) => Some[ir_value](VStr(v))
+      case (s, st, env, SeqEmpty(vx))  => Some[ir_value](VSeq(Nil))
+      case (s, st, env, SeqCons(e, rest, vy)) =>
         (eval(s, st, env, e), eval(s, st, env, rest)) match {
           case (None, _)                             => None
           case (Some(_), None)                       => None
@@ -5293,8 +5338,8 @@ object SpecRestGenerated {
           case (Some(v), Some(VSeq(vs)))             => Some[ir_value](VSeq(v :: vs))
           case (Some(_), Some(VMap(_)))              => None
         }
-      case (s, st, env, MapEmpty(vy)) => Some[ir_value](VMap(Nil))
-      case (s, st, env, MapCons(k, v, rest, vz)) =>
+      case (s, st, env, MapEmpty(vz)) => Some[ir_value](VMap(Nil))
+      case (s, st, env, MapCons(k, v, rest, wa)) =>
         (eval(s, st, env, k), (eval(s, st, env, v), eval(s, st, env, rest))) match {
           case (None, _)                                        => None
           case (Some(_), (None, _))                             => None
@@ -6450,30 +6495,32 @@ object SpecRestGenerated {
     case ForallEnum(vara, en, body, vr) => TForallEnum(vara, en, translate(body))
     case ForallRel(vara, rel_n, body, vs) =>
       TForallRel(vara, rel_n, translate(body))
-    case Prime(e, vt)                 => TPrime(translate(e))
-    case Pre(e, vu)                   => TPre(translate(e))
-    case CardRel(rel_name, vv)        => TCardRel(rel_name)
-    case IndexRel(base, key, vw)      => TIndexRel(translate(base), translate(key))
-    case FieldAccess(base, fname, vx) => TFieldAccess(translate(base), fname)
-    case SetEmpty(vy)                 => TSetEmpty()
-    case SetInsert(elem, set_e, vz) =>
+    case ForallSet(vara, setE, body, vt) =>
+      TForallSet(vara, translate(setE), translate(body))
+    case Prime(e, vu)                 => TPrime(translate(e))
+    case Pre(e, vv)                   => TPre(translate(e))
+    case CardRel(rel_name, vw)        => TCardRel(rel_name)
+    case IndexRel(base, key, vx)      => TIndexRel(translate(base), translate(key))
+    case FieldAccess(base, fname, vy) => TFieldAccess(translate(base), fname)
+    case SetEmpty(vz)                 => TSetEmpty()
+    case SetInsert(elem, set_e, wa) =>
       TSetInsert(translate(elem), translate(set_e))
-    case SetMember(elem, set_e, wa) =>
+    case SetMember(elem, set_e, wb) =>
       TSetMember(translate(elem), translate(set_e))
-    case SetBin(UnionOp(), l, r, wb) => TSetUnion(translate(l), translate(r))
-    case SetBin(IntersectOp(), l, r, wc) =>
+    case SetBin(UnionOp(), l, r, wc) => TSetUnion(translate(l), translate(r))
+    case SetBin(IntersectOp(), l, r, wd) =>
       TSetIntersect(translate(l), translate(r))
-    case SetBin(DiffOp(), l, r, wd) => TSetDiff(translate(l), translate(r))
-    case WithRec(base, fld, val_e, we) =>
+    case SetBin(DiffOp(), l, r, we) => TSetDiff(translate(l), translate(r))
+    case WithRec(base, fld, val_e, wf) =>
       TWithRec(translate(base), fld, translate(val_e))
-    case Ite(c, a, b, wf)     => TIte(translate(c), translate(a), translate(b))
-    case NoneE(wg)            => TNone()
-    case SomeE(e, wh)         => TSome(translate(e))
-    case StrLit(v, wi)        => TStrLit(v)
-    case SeqEmpty(wj)         => TSeqEmpty()
-    case SeqCons(e, rest, wk) => TSeqCons(translate(e), translate(rest))
-    case MapEmpty(wl)         => TMapEmpty()
-    case MapCons(k, v, rest, wm) =>
+    case Ite(c, a, b, wg)     => TIte(translate(c), translate(a), translate(b))
+    case NoneE(wh)            => TNone()
+    case SomeE(e, wi)         => TSome(translate(e))
+    case StrLit(v, wj)        => TStrLit(v)
+    case SeqEmpty(wk)         => TSeqEmpty()
+    case SeqCons(e, rest, wl) => TSeqCons(translate(e), translate(rest))
+    case MapEmpty(wm)         => TMapEmpty()
+    case MapCons(k, v, rest, wn) =>
       TMapCons(translate(k), translate(v), translate(rest))
   }
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3136,6 +3136,22 @@ object SpecRestGenerated {
         }
     }
 
+  def lower_set_comp_eq(
+      enums: List[String],
+      vara: String,
+      dnm: String,
+      setE: expr,
+      predE: expr,
+      sp: Option[span_t]
+  ): expr = {
+    val body =
+      BoolBin(IffOp(), SetMember(Ident(vara, None), setE, sp), predE, sp): expr;
+    string_in_list(dnm, enums) match {
+      case true  => ForallEnum(vara, dnm, body, sp)
+      case false => ForallRel(vara, dnm, body, sp)
+    }
+  }
+
   def peel_relation_ref(x0: expr): Option[String] = x0 match {
     case Ident(rel, uu)            => Some[String](rel)
     case Pre(b, uv)                => identName(b)
@@ -3400,10 +3416,378 @@ object SpecRestGenerated {
               Some[expr](BoolBin(IffOp(), la, ra, sp))
           }
         case BEq() =>
-          (lower(enums, l), lower(enums, r)) match {
-            case (None, _)            => None
-            case (Some(_), None)      => None
-            case (Some(la), Some(ra)) => Some[expr](Cmp(EqOp(), la, ra, sp))
+          r match {
+            case BinaryOpF(_, _, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case UnaryOpF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case QuantifierF(_, _, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SomeWrapF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case TheF(_, _, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case FieldAccessF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case EnumAccessF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case IndexF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case CallF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case PrimeF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case PreF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case WithF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case IfF(_, _, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case LetF(_, _, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case LambdaF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case ConstructorF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetLiteralF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case MapLiteralF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, BinaryOpF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, UnaryOpF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, QuantifierF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, SomeWrapF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, TheF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, FieldAccessF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, EnumAccessF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, IndexF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, CallF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, PrimeF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, PreF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, WithF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, IfF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, LetF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, LambdaF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, ConstructorF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, SetLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, MapLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, SetComprehensionF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, SeqLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, MatchesF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, IntLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, FloatLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, StringLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, BoolLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(_, NoneLitF(_), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case SetComprehensionF(vara, IdentifierF(dnm, _), p, _) =>
+              (lower(enums, l), lower(enums, p)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(pa)) =>
+                  Some[expr](lower_set_comp_eq(enums, vara, dnm, la, pa, sp))
+              }
+            case SeqLiteralF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case MatchesF(_, _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case IntLitF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case FloatLitF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case StringLitF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case BoolLitF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case NoneLitF(_) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
+            case IdentifierF(_, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(ra)) =>
+                  Some[expr](Cmp(EqOp(), la, ra, sp))
+              }
           }
         case BNeq() =>
           (lower(enums, l), lower(enums, r)) match {
@@ -3545,11 +3929,176 @@ object SpecRestGenerated {
                 case (Some(_), None)      => None
                 case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
               }
-            case SetComprehensionF(_, _, _, _) =>
+            case SetComprehensionF(_, BinaryOpF(_, _, _, _), _, _) =>
               (lower(enums, l), lower(enums, r)) match {
                 case (None, _)            => None
                 case (Some(_), None)      => None
                 case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, UnaryOpF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, QuantifierF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, SomeWrapF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, TheF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, FieldAccessF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, EnumAccessF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, IndexF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, CallF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, PrimeF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, PreF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, WithF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, IfF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, LetF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, LambdaF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, ConstructorF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, SetLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, MapLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, SetComprehensionF(_, _, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, SeqLiteralF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, MatchesF(_, _, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, IntLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, FloatLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, StringLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, BoolLitF(_, _), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(_, NoneLitF(_), _, _) =>
+              (lower(enums, l), lower(enums, r)) match {
+                case (None, _)            => None
+                case (Some(_), None)      => None
+                case (Some(la), Some(ra)) => Some[expr](SetMember(la, ra, sp))
+              }
+            case SetComprehensionF(vara, IdentifierF(dnm, _), p, _) =>
+              (lower(enums, l), lower(enums, p)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(la), Some(pa)) =>
+                  Some[expr](LetIn(
+                    vara,
+                    la,
+                    string_in_list(dnm, enums) match {
+                      case true  => pa
+                      case false => BoolBin(AndOp(), Member(Ident(vara, None), dnm, sp), pa, sp)
+                    },
+                    sp
+                  ))
               }
             case SeqLiteralF(_, _) =>
               (lower(enums, l), lower(enums, r)) match {

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3145,11 +3145,13 @@ object SpecRestGenerated {
       sp: Option[span_t]
   ): expr = {
     val body =
-      BoolBin(IffOp(), SetMember(Ident(vara, None), setE, sp), predE, sp): expr;
-    string_in_list(dnm, enums) match {
-      case true  => ForallEnum(vara, dnm, body, sp)
-      case false => ForallRel(vara, dnm, body, sp)
-    }
+      BoolBin(IffOp(), SetMember(Ident(vara, None), Ident("0cmp", None), sp), predE, sp): expr
+    val quant =
+      (string_in_list(dnm, enums) match {
+        case true  => ForallEnum(vara, dnm, body, sp)
+        case false => ForallRel(vara, dnm, body, sp)
+      }): expr;
+    LetIn("0cmp", setE, quant, sp)
   }
 
   def peel_relation_ref(x0: expr): Option[String] = x0 match {

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2072,6 +2072,9 @@ object Translator:
             inferSortOfZ3Expr(ctx, rhs) match
               case Some(Z3Sort.SetOf(_)) => Z3Expr.SetMember(key, rhs)
               case _                     => fail(ctx, s"membership '$rel' requires a relation or set-typed constant")
+          case _ if ctx.entities.contains(rel) =>
+            // entity domain is the whole sort (as `resolveBindingDomain` treats `forall u in <Entity>`), so any value of that sort is a member
+            Z3Expr.BoolLit(true)
           case _ =>
             env.get(rel) match
               case Some(bound) =>
@@ -2109,6 +2112,21 @@ object Translator:
           QKind.ForAll,
           List(Z3Binding(varName, sort)),
           guarded
+        )
+
+      case TForallSet(varName, setT, body) =>
+        val setZ = encodeFromSmtTerm(ctx, setT, env)
+        val elemSort = inferSortOfZ3Expr(ctx, setZ) match
+          case Some(Z3Sort.SetOf(e)) => e
+          case _ =>
+            fail(ctx, "universal quantification requires a set-sorted domain")
+        val newEnv = env.clone()
+        newEnv(varName) = Z3Expr.Var(varName, elemSort)
+        val inner = encodeFromSmtTerm(ctx, body, newEnv)
+        Z3Expr.Quantifier(
+          QKind.ForAll,
+          List(Z3Binding(varName, elemSort)),
+          Z3Expr.Implies(Z3Expr.SetMember(Z3Expr.Var(varName, elemSort), setZ), inner)
         )
 
       case TIndexRel(base, key) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2073,8 +2073,17 @@ object Translator:
               case Some(Z3Sort.SetOf(_)) => Z3Expr.SetMember(key, rhs)
               case _                     => fail(ctx, s"membership '$rel' requires a relation or set-typed constant")
           case _ if ctx.entities.contains(rel) =>
-            // entity domain is the whole sort (as `resolveBindingDomain` treats `forall u in <Entity>`), so any value of that sort is a member
-            Z3Expr.BoolLit(true)
+            // entity domain is the whole sort (as `resolveBindingDomain` treats `forall u in <Entity>`), so a value OF that sort is a member; a cross-sort element is a type confusion the verified `T_BIn_Rel` rule does not exclude
+            val entitySort = ctx.entities(rel).sort
+            inferSortOfZ3Expr(ctx, key) match
+              case Some(s) if Z3Sort.eq(s, entitySort) => Z3Expr.BoolLit(true)
+              case Some(s) =>
+                fail(
+                  ctx,
+                  s"membership '$rel' requires an element of the entity sort $entitySort; got $s"
+                )
+              case None =>
+                fail(ctx, s"membership '$rel' requires an element with an inferrable sort")
           case _ =>
             env.get(rel) match
               case Some(bound) =>
@@ -2120,13 +2129,16 @@ object Translator:
           case Some(Z3Sort.SetOf(e)) => e
           case _ =>
             fail(ctx, "universal quantification requires a set-sorted domain")
-        val newEnv = env.clone()
-        newEnv(varName) = Z3Expr.Var(varName, elemSort)
+        // fresh binder so an outer identifier of the same name inside `setZ` is not captured
+        val freshName = ctx.freshSkolem(s"forall_set_$varName")
+        val binderVar = Z3Expr.Var(freshName, elemSort)
+        val newEnv    = env.clone()
+        newEnv(varName) = binderVar
         val inner = encodeFromSmtTerm(ctx, body, newEnv)
         Z3Expr.Quantifier(
           QKind.ForAll,
-          List(Z3Binding(varName, elemSort)),
-          Z3Expr.Implies(Z3Expr.SetMember(Z3Expr.Var(varName, elemSort), setZ), inner)
+          List(Z3Binding(freshName, elemSort)),
+          Z3Expr.Implies(Z3Expr.SetMember(binderVar, setZ), inner)
         )
 
       case TIndexRel(base, key) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -99,7 +99,7 @@ class ConsistencyTest extends CatsEffectSuite:
         s"set_ops skips must be soundness-limitation only; got: ${unexpectedSkips.map(_.id)}"
       )
 
-  test("set_comp_demo — global skips with soundness_limitation (set comprehension out of subset)"):
+  test("set_comp_demo — global verifies via Z3 (set comprehension now in the verified subset)"):
     for
       ir     <- SpecFixtures.loadIR("set_comp_demo")
       report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
@@ -107,11 +107,7 @@ class ConsistencyTest extends CatsEffectSuite:
       val global = report.checks.find(_.id == "global").getOrElse(
         fail("expected a global check")
       )
-      assertEquals(global.status, CheckOutcome.Skipped)
-      assertEquals(
-        global.diagnostic.map(_.category),
-        Some(DiagnosticCategory.SoundnessLimitation)
-      )
+      assertEquals(global.status, CheckOutcome.Sat)
 
   test("powerset_demo — global invariant routes to Alloy and solves sat"):
     for

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -77,6 +77,7 @@ datatype (plugins only: code size) expr =
   | Member "expr" "String.literal" "option_span"
   | ForallEnum "String.literal" "String.literal" "expr" "option_span"
   | ForallRel "String.literal" "String.literal" "expr" "option_span"
+  | ForallSet "String.literal" "expr" "expr" "option_span"
   | Prime "expr" "option_span"
   | Pre "expr" "option_span"
   | CardRel "String.literal" "option_span"

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -23,6 +23,16 @@ where
         None \<Rightarrow> None
       | Some inner \<Rightarrow> lower_forall_step enums b inner sp)"
 
+fun lower_set_comp_eq ::
+    "String.literal list \<Rightarrow> String.literal \<Rightarrow> String.literal
+       \<Rightarrow> expr \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr"
+where
+  "lower_set_comp_eq enums var dnm setE predE sp =
+     (let body = BoolBin IffOp (SetMember (Ident var None) setE sp) predE sp
+      in if string_in_list dnm enums
+           then ForallEnum var dnm body sp
+           else ForallRel var dnm body sp)"
+
 function (sequential) lower :: "String.literal list \<Rightarrow> expr_full \<Rightarrow> expr option"
 and lowerSetList ::
     "String.literal list \<Rightarrow> expr_full list \<Rightarrow> option_span \<Rightarrow> expr option"
@@ -90,9 +100,15 @@ where
              (Some l', Some r') \<Rightarrow> Some (BoolBin IffOp l' r' sp)
            | _ \<Rightarrow> None)
       | BEq \<Rightarrow>
-          (case (lower enums l, lower enums r) of
-             (Some l', Some r') \<Rightarrow> Some (Cmp EqOp l' r' sp)
-           | _ \<Rightarrow> None)
+          (case r of
+             SetComprehensionF var (IdentifierF dnm _) p _ \<Rightarrow>
+               (case (lower enums l, lower enums p) of
+                  (Some l', Some p') \<Rightarrow> Some (lower_set_comp_eq enums var dnm l' p' sp)
+                | _ \<Rightarrow> None)
+           | _ \<Rightarrow>
+               (case (lower enums l, lower enums r) of
+                  (Some l', Some r') \<Rightarrow> Some (Cmp EqOp l' r' sp)
+                | _ \<Rightarrow> None))
       | BNeq \<Rightarrow>
           (case (lower enums l, lower enums r) of
              (Some l', Some r') \<Rightarrow> Some (Cmp NeqOp l' r' sp)
@@ -145,6 +161,15 @@ where
           (case r of
              IdentifierF rel _ \<Rightarrow>
                map_option (\<lambda>l'. Member l' rel sp) (lower enums l)
+           | SetComprehensionF var (IdentifierF dnm _) p _ \<Rightarrow>
+               (case (lower enums l, lower enums p) of
+                  (Some l', Some p') \<Rightarrow>
+                    Some (LetIn var l'
+                           (if string_in_list dnm enums
+                              then p'
+                              else BoolBin AndOp (Member (Ident var None) dnm sp) p' sp)
+                           sp)
+                | _ \<Rightarrow> None)
            | _ \<Rightarrow>
                (case (lower enums l, lower enums r) of
                   (Some l', Some r') \<Rightarrow> Some (SetMember l' r' sp)
@@ -236,5 +261,29 @@ termination
              | Inr (Inr (Inr (_, entries, _))) \<Rightarrow> Suc (length entries))
        ]")
      auto
+
+lemma lower_BEq_noncomp:
+  assumes "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+  shows "lower enums (BinaryOpF BEq l r sp)
+           = (case (lower enums l, lower enums r) of
+                (Some l', Some r') \<Rightarrow> Some (Cmp EqOp l' r' sp)
+              | _ \<Rightarrow> None)"
+proof (cases r)
+  case (SetComprehensionF v dom pr s)
+  with assms show ?thesis by (cases dom) auto
+qed auto
+
+lemma lower_BIn_noncomp:
+  assumes "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+  shows "lower enums (BinaryOpF BIn l r sp)
+           = (case r of
+                IdentifierF rel _ \<Rightarrow> map_option (\<lambda>l'. Member l' rel sp) (lower enums l)
+              | _ \<Rightarrow> (case (lower enums l, lower enums r) of
+                        (Some l', Some r') \<Rightarrow> Some (SetMember l' r' sp)
+                      | _ \<Rightarrow> None))"
+proof (cases r)
+  case (SetComprehensionF v dom pr s)
+  with assms show ?thesis by (cases dom) auto
+qed auto
 
 end

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -23,15 +23,25 @@ where
         None \<Rightarrow> None
       | Some inner \<Rightarrow> lower_forall_step enums b inner sp)"
 
+text \<open>\<open>X = {var in dnm | predE}\<close> lowers by set extensionality to
+  \<open>\<forall>var\<in>dnm. var \<in> X \<longleftrightarrow> predE\<close>. Binding \<open>X\<close> with a let \<^emph>\<open>before\<close> the
+  quantifier (instead of placing \<open>X\<close> under the binder) keeps it capture-free:
+  \<open>X\<close> is evaluated in the outer scope, so a free \<open>var\<close> inside it (e.g. a state
+  field sharing the binder name) is not captured. The let binder \<open>0cmp\<close> starts
+  with a digit, which the lexer (\<open>[A-Za-z_][A-Za-z0-9_]*\<close>) forbids for source
+  identifiers, so it never collides with a user variable; lexical scoping keeps
+  it correct under nesting.\<close>
 fun lower_set_comp_eq ::
     "String.literal list \<Rightarrow> String.literal \<Rightarrow> String.literal
        \<Rightarrow> expr \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr"
 where
   "lower_set_comp_eq enums var dnm setE predE sp =
-     (let body = BoolBin IffOp (SetMember (Ident var None) setE sp) predE sp
-      in if string_in_list dnm enums
-           then ForallEnum var dnm body sp
-           else ForallRel var dnm body sp)"
+     (let body = BoolBin IffOp
+                   (SetMember (Ident var None) (Ident (STR ''0cmp'') None) sp) predE sp;
+          quant = (if string_in_list dnm enums
+                     then ForallEnum var dnm body sp
+                     else ForallRel var dnm body sp)
+      in LetIn (STR ''0cmp'') setE quant sp)"
 
 function (sequential) lower :: "String.literal list \<Rightarrow> expr_full \<Rightarrow> expr option"
 and lowerSetList ::

--- a/proofs/isabelle/SpecRest/core/IR_Lower.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Lower.thy
@@ -23,25 +23,28 @@ where
         None \<Rightarrow> None
       | Some inner \<Rightarrow> lower_forall_step enums b inner sp)"
 
-text \<open>\<open>X = {var in dnm | predE}\<close> lowers by set extensionality to
-  \<open>\<forall>var\<in>dnm. var \<in> X \<longleftrightarrow> predE\<close>. Binding \<open>X\<close> with a let \<^emph>\<open>before\<close> the
-  quantifier (instead of placing \<open>X\<close> under the binder) keeps it capture-free:
-  \<open>X\<close> is evaluated in the outer scope, so a free \<open>var\<close> inside it (e.g. a state
-  field sharing the binder name) is not captured. The let binder \<open>0cmp\<close> starts
-  with a digit, which the lexer (\<open>[A-Za-z_][A-Za-z0-9_]*\<close>) forbids for source
-  identifiers, so it never collides with a user variable; lexical scoping keeps
-  it correct under nesting.\<close>
+text \<open>\<open>X = {var in dnm | predE}\<close> lowers to the FULL set extensionality — both
+  subset directions \<open>(\<forall>var\<in>dnm. predE \<longrightarrow> var\<in>X) \<and> (\<forall>var\<in>X. var\<in>dnm \<and> predE)\<close>.
+  (The bounded \<open>\<forall>var\<in>dnm. var\<in>X \<longleftrightarrow> predE\<close> alone is too weak: it omits \<open>X \<subseteq> dnm\<close>;
+  the second conjunct supplies it.) The second direction quantifies over the set
+  \<^emph>\<open>value\<close> \<open>X\<close> with \<open>ForallSet\<close>. \<open>X\<close> is let-bound to \<open>0cmp\<close> first so it is evaluated
+  in the outer scope (capture-free); the binder \<open>0cmp\<close> starts with a digit, which
+  the lexer (\<open>[A-Za-z_][A-Za-z0-9_]*\<close>) forbids for source identifiers, so it never
+  collides, and lexical scoping keeps it correct under nesting. An enum domain
+  makes its membership trivially true.\<close>
 fun lower_set_comp_eq ::
     "String.literal list \<Rightarrow> String.literal \<Rightarrow> String.literal
        \<Rightarrow> expr \<Rightarrow> expr \<Rightarrow> option_span \<Rightarrow> expr"
 where
   "lower_set_comp_eq enums var dnm setE predE sp =
-     (let body = BoolBin IffOp
-                   (SetMember (Ident var None) (Ident (STR ''0cmp'') None) sp) predE sp;
-          quant = (if string_in_list dnm enums
-                     then ForallEnum var dnm body sp
-                     else ForallRel var dnm body sp)
-      in LetIn (STR ''0cmp'') setE quant sp)"
+     (let memX = SetMember (Ident var None) (Ident (STR ''0cmp'') None) sp;
+          memD = (if string_in_list dnm enums then BoolLit True sp
+                  else Member (Ident var None) dnm sp);
+          dir1 = (if string_in_list dnm enums
+                    then ForallEnum var dnm (BoolBin ImpliesOp predE memX sp) sp
+                    else ForallRel var dnm (BoolBin ImpliesOp predE memX sp) sp);
+          dir2 = ForallSet var (Ident (STR ''0cmp'') None) (BoolBin AndOp memD predE sp) sp
+      in LetIn (STR ''0cmp'') setE (BoolBin AndOp dir1 dir2 sp) sp)"
 
 function (sequential) lower :: "String.literal list \<Rightarrow> expr_full \<Rightarrow> expr option"
 and lowerSetList ::

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -1221,6 +1221,10 @@ where
      (case state_relation_domain st rel_name of
         Some rel_dom \<Rightarrow> eval_forall_rel s st env var rel_dom body
       | None     \<Rightarrow> None)"
+| "eval s st env (ForallSet var setE body _) =
+     (case eval s st env setE of
+        Some (VSet elems) \<Rightarrow> eval_forall_rel s st env var elems body
+      | _ \<Rightarrow> None)"
 | "eval s st env (Prime e _) = eval s st env e"
 | "eval s st env (Pre e _)   = eval s st env e"
 | "eval s st env (CardRel rel_name _) =

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -44,6 +44,7 @@ datatype (plugins only: code size) smt_term =
   | TLetIn "String.literal" "smt_term" "smt_term"
   | TForallEnum "String.literal" "String.literal" "smt_term"
   | TForallRel "String.literal" "String.literal" "smt_term"
+  | TForallSet "String.literal" "smt_term" "smt_term"
   | TIndexRel "smt_term" "smt_term"
   | TFieldAccess "smt_term" "String.literal"
   | TSetEmpty
@@ -291,6 +292,10 @@ where
      (case smt_model_lookup_rel m rel_name of
         Some d \<Rightarrow> smtEval_forall_rel m env var d body
       | None   \<Rightarrow> None)"
+| "smtEval m env (TForallSet var setT body) =
+     (case smtEval m env setT of
+        Some (SSet elems) \<Rightarrow> smtEval_forall_rel m env var elems body
+      | _ \<Rightarrow> None)"
 | "smtEval m env (TIndexRel base key) =
      (case (peelSmtRelationRef base, smtEval m env key) of
         (Some rel, Some kv) \<Rightarrow> smt_model_lookup_key m rel kv

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -34,6 +34,7 @@ fun translate :: "expr \<Rightarrow> smt_term" where
 | "translate (Member elem rel_name _)      = TInDom rel_name (translate elem)"
 | "translate (ForallEnum var en body _)    = TForallEnum var en (translate body)"
 | "translate (ForallRel var rel_n body _)  = TForallRel  var rel_n (translate body)"
+| "translate (ForallSet var setE body _)   = TForallSet  var (translate setE) (translate body)"
 | "translate (Prime e _) = TPrime (translate e)"
 | "translate (Pre e _)   = TPre   (translate e)"
 | "translate (CardRel rel_name _)          = TCardRel rel_name"

--- a/proofs/isabelle/SpecRest/soundness/Preservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation.thy
@@ -47,7 +47,14 @@ where
         | UPower \<Rightarrow> False)"
 | "wf_z3 (BinaryOpF op l r _)      =
      (case op of BSubset \<Rightarrow> (wf_z3 l \<and> wf_z3 r)
-        | BIn \<Rightarrow> (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r))
+        | BEq \<Rightarrow>
+            (case r of
+               SetComprehensionF _ (IdentifierF _ _) p _ \<Rightarrow> wf_z3 l \<and> wf_z3 p
+             | _ \<Rightarrow> wf_z3 l \<and> wf_z3 r)
+        | BIn \<Rightarrow>
+            (case r of
+               SetComprehensionF _ (IdentifierF _ _) p _ \<Rightarrow> wf_z3 l \<and> wf_z3 p
+             | _ \<Rightarrow> (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r)))
         | BNotIn \<Rightarrow> (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r))
         | _ \<Rightarrow> wf_z3 l \<and> wf_z3 r)"
 | "wf_z3 (LetF _ v b _)            = (wf_z3 v \<and> wf_z3 b)"
@@ -78,6 +85,27 @@ where
 | "wf_z3_fields (FieldAssignFull _ v _ # rest) = (wf_z3 v \<and> wf_z3_fields rest)"
 | "wf_z3_entries []                = True"
 | "wf_z3_entries (MapEntryFull k v _ # rest) = (wf_z3 k \<and> wf_z3 v \<and> wf_z3_entries rest)"
+
+lemma not_expr_has_ty_set_comp:
+  "expr_has_ty \<Gamma> (SetComprehensionF v dm pr sp) t \<Longrightarrow> False"
+  by (auto elim: expr_has_ty.cases)
+
+lemma wf_z3_BEq_noncomp:
+  assumes "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+  shows "wf_z3 (BinaryOpF BEq l r sp) = (wf_z3 l \<and> wf_z3 r)"
+proof (cases r)
+  case (SetComprehensionF v dom pr s)
+  with assms show ?thesis by (cases dom) auto
+qed auto
+
+lemma wf_z3_BIn_noncomp:
+  assumes "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+  shows "wf_z3 (BinaryOpF BIn l r sp)
+           = (wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r))"
+proof (cases r)
+  case (SetComprehensionF v dom pr s)
+  with assms show ?thesis by (cases dom) auto
+qed auto
 
 lemma wf_z3_fields_iff:
   "wf_z3_fields updates
@@ -134,17 +162,41 @@ next
   with wf show ?thesis by simp
 qed (use wf ih in \<open>auto split: option.splits\<close>)
 
+lemma lower_eq_comp_some:
+  assumes "lower enums l \<noteq> None" and "lower enums p \<noteq> None"
+  shows "lower enums
+           (BinaryOpF BEq l (SetComprehensionF var (IdentifierF dnm sp2) p sp3) sp)
+           \<noteq> None"
+  using assms by (auto split: option.splits)
+
+lemma lower_in_comp_some:
+  assumes "lower enums l \<noteq> None" and "lower enums p \<noteq> None"
+  shows "lower enums
+           (BinaryOpF BIn l (SetComprehensionF var (IdentifierF dnm sp2) p sp3) sp)
+           \<noteq> None"
+  using assms by (auto split: option.splits)
+
 lemma lower_binop_some:
   assumes l: "wf_z3 l \<Longrightarrow> lower enums l \<noteq> None"
       and r: "wf_z3 r \<Longrightarrow> lower enums r \<noteq> None"
       and wf: "wf_z3 (BinaryOpF op l r sp)"
+      and ncr: "\<nexists>var dnm sp2 p sp3.
+                  r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
   shows "lower enums (BinaryOpF op l r sp) \<noteq> None"
 proof -
   have inout: "lower enums (BinaryOpF op l r sp) \<noteq> None"
     if opc: "op = BIn \<or> op = BNotIn"
   proof -
-    from wf opc have wl: "wf_z3 l"
-        and rd: "(\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r" by auto
+    have wlrd: "wf_z3 l \<and> ((\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r)"
+    proof (rule disjE[OF opc])
+      assume oi: "op = BIn"
+      show ?thesis using wf[unfolded oi wf_z3_BIn_noncomp[OF ncr]] .
+    next
+      assume oi: "op = BNotIn"
+      show ?thesis using wf[unfolded oi] by simp
+    qed
+    from wlrd have wl: "wf_z3 l"
+        and rd: "(\<exists>rel s. r = IdentifierF rel s) \<or> wf_z3 r" by simp_all
     from l wl obtain l' where l': "lower enums l = Some l'" by blast
     from rd show ?thesis
     proof
@@ -152,13 +204,20 @@ proof -
       then obtain rel s where "r = IdentifierF rel s" by blast
       thus ?thesis using l' opc by auto
     next
-      assume "wf_z3 r"
-      with r obtain r' where "lower enums r = Some r'" by blast
-      with l' opc show ?thesis by (cases r) auto
+      assume wr: "wf_z3 r"
+      with r obtain r' where r': "lower enums r = Some r'" by blast
+      from l' r' wr opc show ?thesis by (cases r) (auto split: option.splits)
     qed
   qed
   show ?thesis
   proof (cases op)
+    case BEq
+    from wf[unfolded BEq wf_z3_BEq_noncomp[OF ncr]] have wl: "wf_z3 l" and wr: "wf_z3 r"
+      by simp_all
+    from l wl obtain l' where l': "lower enums l = Some l'" by blast
+    from r wr obtain r' where r': "lower enums r = Some r'" by blast
+    from l' r' BEq show ?thesis by (cases r) (auto split: option.splits)
+  next
     case BIn
     thus ?thesis using inout by blast
   next
@@ -298,7 +357,42 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have r: "wf_z3 r \<Longrightarrow> lower enums r \<noteq> None"
       using sub[of r] BinaryOpF by simp
     show ?thesis unfolding BinaryOpF
-      by (rule lower_binop_some[OF l r less.prems[unfolded BinaryOpF]])
+    proof (cases "\<exists>var dnm sp2 p sp3.
+                    r = SetComprehensionF var (IdentifierF dnm sp2) p sp3")
+      case True
+      then obtain var dnm sp2 p sp3
+        where rc: "r = SetComprehensionF var (IdentifierF dnm sp2) p sp3" by blast
+      have opeq: "op = BEq \<or> op = BIn"
+        using less.prems[unfolded BinaryOpF] rc by (cases op) auto
+      have wlp: "wf_z3 l \<and> wf_z3 p"
+      proof (rule disjE[OF opeq])
+        assume "op = BEq"
+        thus ?thesis using less.prems[unfolded BinaryOpF] rc by simp
+      next
+        assume "op = BIn"
+        thus ?thesis using less.prems[unfolded BinaryOpF] rc by simp
+      qed
+      from wlp have wl: "wf_z3 l" and wp: "wf_z3 p" by simp_all
+      have szp: "size p < size e" using BinaryOpF rc by simp
+      from l wl have lne: "lower enums l \<noteq> None" by blast
+      from sub[OF szp] wp have pne: "lower enums p \<noteq> None" by blast
+      from opeq show "lower enums (BinaryOpF op l r s) \<noteq> None"
+      proof
+        assume oe: "op = BEq"
+        show "lower enums (BinaryOpF op l r s) \<noteq> None"
+          unfolding oe rc by (rule lower_eq_comp_some[OF lne pne])
+      next
+        assume oe: "op = BIn"
+        show "lower enums (BinaryOpF op l r s) \<noteq> None"
+          unfolding oe rc by (rule lower_in_comp_some[OF lne pne])
+      qed
+    next
+      case False
+      hence ncr: "\<nexists>var dnm sp2 p sp3.
+                    r = SetComprehensionF var (IdentifierF dnm sp2) p sp3" by blast
+      show "lower enums (BinaryOpF op l r s) \<noteq> None"
+        by (rule lower_binop_some[OF l r less.prems[unfolded BinaryOpF] ncr])
+    qed
   next
     case (QuantifierF k bs body s)
     have ih: "wf_z3 body \<Longrightarrow> lower enums body \<noteq> None"
@@ -564,7 +658,18 @@ proof (induction rule: expr_has_ty.induct)
   thus ?case by (cases op) auto
 next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
-  thus ?case by (cases op) auto
+  have rnc: "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+    using T_Cmp_Eq.hyps(2) by (auto dest: not_expr_has_ty_set_comp)
+  from T_Cmp_Eq.hyps(4) have d2: "op = BEq \<or> op = BNeq" by auto
+  show ?case
+  proof (rule disjE[OF d2])
+    assume oe: "op = BEq"
+    show ?case unfolding oe
+      by (subst wf_z3_BEq_noncomp[OF rnc]) (simp add: T_Cmp_Eq.IH)
+  next
+    assume oe: "op = BNeq"
+    show ?case unfolding oe using T_Cmp_Eq.IH by simp
+  qed
 next
   case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
@@ -609,7 +714,10 @@ next
   thus ?case by simp
 next
   case (T_BIn_Set \<Gamma> l t r sp)
-  thus ?case by simp
+  have rnc: "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+    using T_BIn_Set.hyps(2) by (auto dest: not_expr_has_ty_set_comp)
+  show ?case
+    by (subst wf_z3_BIn_noncomp[OF rnc]) (simp add: T_BIn_Set.IH)
 next
   case (T_BNotIn_Set \<Gamma> l t r sp)
   thus ?case by simp
@@ -843,11 +951,20 @@ lemma h3_pres_Cmp:
   assumes "op \<in> {BEq, BNeq, BLt, BLe, BGt, BGe}"
       and "lower enums (BinaryOpF op l r sp) = Some e'"
       and "eval sch st env e' = Some v"
+      and ncr: "\<nexists>var dnm sp2 p sp3.
+                  r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
   shows "value_has_ty \<Gamma> v TBool"
 proof -
-  from assms(1,2) obtain l' r' cop where
-       e_eq: "e' = Cmp cop l' r' sp"
-    by (cases op) (auto split: option.splits)
+  have "\<exists>l' r' cop. e' = Cmp cop l' r' sp"
+  proof (cases "op = BEq")
+    case True
+    from assms(2)[unfolded True lower_BEq_noncomp[OF ncr]] show ?thesis
+      by (auto split: option.splits)
+  next
+    case False
+    with assms(1,2) show ?thesis by (cases op) (auto split: option.splits)
+  qed
+  then obtain l' r' cop where e_eq: "e' = Cmp cop l' r' sp" by blast
   from assms(3) e_eq
   have ev: "eval_cmp cop (eval sch st env l') (eval sch st env r') = Some v"
     by simp
@@ -914,10 +1031,24 @@ next
   qed
 next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
-  thus ?case using h3_pres_Cmp by blast
+  have rnc: "\<nexists>var dnm sp2 p sp3.
+               r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+    using T_Cmp_Eq.hyps(2) by (auto dest: not_expr_has_ty_set_comp)
+  show ?case
+  proof (rule h3_pres_Cmp[OF _ T_Cmp_Eq.prems(2) T_Cmp_Eq.prems(3) rnc])
+    show "op \<in> {BEq, BNeq, BLt, BLe, BGt, BGe}"
+      using T_Cmp_Eq.hyps(4) by auto
+  qed
 next
   case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
-  thus ?case using h3_pres_Cmp by blast
+  have rnc: "\<nexists>var dnm sp2 p sp3.
+               r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
+    using T_Cmp_Ord.hyps(2) by (auto dest: not_expr_has_ty_set_comp)
+  show ?case
+  proof (rule h3_pres_Cmp[OF _ T_Cmp_Ord.prems(2) T_Cmp_Ord.prems(3) rnc])
+    show "op \<in> {BEq, BNeq, BLt, BLe, BGt, BGe}"
+      using T_Cmp_Ord.hyps(5) by auto
+  qed
 next
   case (T_Bool_Bin \<Gamma> l r op sp)
   thus ?case using h3_pres_Bool_Bin by blast
@@ -1128,12 +1259,12 @@ next
     by (simp add: v_eq vt_set)
 next
   case (T_BIn_Set \<Gamma> l t r sp)
-  from T_BIn_Set.prems(2) T_BIn_Set.hyps(3)
+  from T_BIn_Set.prems(2) T_BIn_Set.hyps(2,3)
   obtain l' r' where
        l_low: "lower enums l = Some l'"
    and r_low: "lower enums r = Some r'"
    and e_eq: "e' = SetMember l' r' sp"
-    by (cases r) (auto split: option.splits)
+    by (cases r) (auto split: option.splits dest: not_expr_has_ty_set_comp)
   from T_BIn_Set.prems(3) e_eq obtain vl rv where
        ev_l: "eval sch st env l' = Some vl"
    and ev_r: "eval sch st env r' = Some (VSet rv)"
@@ -1143,12 +1274,12 @@ next
     by (simp add: v_eq vt_bool)
 next
   case (T_BNotIn_Set \<Gamma> l t r sp)
-  from T_BNotIn_Set.prems(2) T_BNotIn_Set.hyps(3)
+  from T_BNotIn_Set.prems(2) T_BNotIn_Set.hyps(2,3)
   obtain l' r' where
        l_low: "lower enums l = Some l'"
    and r_low: "lower enums r = Some r'"
    and e_eq: "e' = UnNot (SetMember l' r' sp) sp"
-    by (cases r) (auto split: option.splits)
+    by (cases r) (auto split: option.splits dest: not_expr_has_ty_set_comp)
   from T_BNotIn_Set.prems(3) e_eq obtain vl rv where
        ev_l: "eval sch st env l' = Some vl"
    and ev_r: "eval sch st env r' = Some (VSet rv)"

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -221,19 +221,33 @@ lemma lower_binop_collapse:
   assumes l: "requiresAlloy l \<Longrightarrow> lower enums l = None"
       and r: "requiresAlloy r \<Longrightarrow> lower enums r = None"
       and ra: "requiresAlloy (BinaryOpF op l r sp)"
+      and ncr: "\<nexists>var dnm sp2 p sp3.
+                  r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
   shows "lower enums (BinaryOpF op l r sp) = None"
 proof -
   from ra have d: "requiresAlloy l \<or> requiresAlloy r" by simp
-  have inout: "lower enums (BinaryOpF op l r sp) = None"
-    if opc: "op = BIn \<or> op = BNotIn"
-    using opc l r d by (elim disjE; cases r) (auto split: option.splits)
   show ?thesis
   proof (cases op)
+    case BEq
+    have "lower enums (BinaryOpF op l r sp)
+            = (case (lower enums l, lower enums r) of
+                 (Some l', Some r') \<Rightarrow> Some (Cmp EqOp l' r' sp)
+               | _ \<Rightarrow> None)"
+      unfolding BEq by (rule lower_BEq_noncomp[OF ncr])
+    thus ?thesis using l r d by (auto split: option.splits)
+  next
     case BIn
-    thus ?thesis by (rule inout[OF disjI1])
+    have "lower enums (BinaryOpF op l r sp)
+            = (case r of
+                 IdentifierF rel _ \<Rightarrow> map_option (\<lambda>l'. Member l' rel sp) (lower enums l)
+               | _ \<Rightarrow> (case (lower enums l, lower enums r) of
+                         (Some l', Some r') \<Rightarrow> Some (SetMember l' r' sp)
+                       | _ \<Rightarrow> None))"
+      unfolding BIn by (rule lower_BIn_noncomp[OF ncr])
+    thus ?thesis using l r d by (cases r) (auto split: option.splits)
   next
     case BNotIn
-    thus ?thesis by (rule inout[OF disjI2])
+    with l r d show ?thesis by (cases r) (auto split: option.splits)
   qed (use l r d in \<open>auto split: option.splits\<close>)
 qed
 
@@ -342,7 +356,38 @@ proof (induction e rule: measure_induct_rule[where f = size])
     have r: "requiresAlloy r \<Longrightarrow> lower enums r = None"
       using sub[of r] BinaryOpF by simp
     show ?thesis unfolding BinaryOpF
-      by (rule lower_binop_collapse[OF l r less.prems[unfolded BinaryOpF]])
+    proof (cases "\<exists>var dnm sp2 p sp3.
+                    r = SetComprehensionF var (IdentifierF dnm sp2) p sp3")
+      case True
+      then obtain var dnm sp2 p sp3
+        where rc: "r = SetComprehensionF var (IdentifierF dnm sp2) p sp3" by blast
+      have szp: "size p < size e" using BinaryOpF rc by simp
+      have pcol: "requiresAlloy p \<Longrightarrow> lower enums p = None"
+        using sub[OF szp] by blast
+      have d: "requiresAlloy l \<or> requiresAlloy p"
+        using less.prems[unfolded BinaryOpF] rc by simp
+      have lp: "lower enums l = None \<or> lower enums p = None"
+        using d
+      proof (elim disjE)
+        assume "requiresAlloy l" thus ?thesis using l by simp
+      next
+        assume "requiresAlloy p" thus ?thesis using pcol by simp
+      qed
+      show "lower enums (BinaryOpF op l r s) = None"
+      proof (cases op)
+        case BEq
+        thus ?thesis using lp unfolding rc by (auto split: option.splits)
+      next
+        case BIn
+        thus ?thesis using lp unfolding rc by (auto split: option.splits)
+      qed (use rc in \<open>auto split: option.splits\<close>)
+    next
+      case False
+      hence ncr: "\<nexists>var dnm sp2 p sp3.
+                    r = SetComprehensionF var (IdentifierF dnm sp2) p sp3" by blast
+      show "lower enums (BinaryOpF op l r s) = None"
+        by (rule lower_binop_collapse[OF l r less.prems[unfolded BinaryOpF] ncr])
+    qed
   next
     case (QuantifierF k bs body s)
     have ih: "requiresAlloy body \<Longrightarrow> lower enums body = None"

--- a/proofs/isabelle/SpecRest/soundness/Soundness.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness.thy
@@ -54,6 +54,10 @@ next
       by simp
   qed
 next
+  case (ForallSet var setE body sp)
+  show ?case
+    by (rule soundness_ForallSet[OF ForallSet.IH(1) ForallSet.IH(2)])
+next
   case (Prime e sp) thus ?case by simp
 next
   case (Pre e sp) thus ?case by simp

--- a/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
+++ b/proofs/isabelle/SpecRest/soundness/Soundness_Framework.thy
@@ -683,6 +683,32 @@ lemma soundness_forall_rel_known:
   using hd eval_forall_rel_correlated[OF ihbody, where rd=d and var=var and env=env]
   by simp
 
+lemma soundness_ForallSet:
+  assumes ihset: "value_to_smt_opt (eval s st env setE)
+                    = smtEval (correlate_model s st) (correlate_env env) (translate setE)"
+      and ihbody: "\<And>env'.
+                    value_to_smt_opt (eval s st env' body)
+                      = smtEval (correlate_model s st) (correlate_env env') (translate body)"
+  shows "value_to_smt_opt (eval s st env (ForallSet var setE body sp))
+           = smtEval (correlate_model s st) (correlate_env env) (translate (ForallSet var setE body sp))"
+proof (cases "eval s st env setE")
+  case None
+  thus ?thesis using ihset by simp
+next
+  case (Some sv)
+  hence smtset: "smtEval (correlate_model s st) (correlate_env env) (translate setE)
+                   = Some (value_to_smt sv)"
+    using ihset by simp
+  show ?thesis
+  proof (cases sv)
+    case (VSet elems)
+    show ?thesis
+      using Some VSet smtset
+            eval_forall_rel_correlated[OF ihbody, where rd=elems and var=var and env=env]
+      by simp
+  qed (use Some smtset in simp_all)
+qed
+
 section \<open>Phase 4 — universal soundness theorem\<close>
 
 text \<open>The universal `soundness` meta-theorem (M_L.2 in the Lean track,


### PR DESCRIPTION
## Summary
- Lift set comprehension into the verified Z3 subset by **desugaring in `lower`** (no new `expr`/`smt_term` ctor): `X = {u in D | P}` → a bounded forall over the binding domain (`ForallRel`/`ForallEnum` with an iff body); `y in {u in D | P}` → `let u = y in (u in D /\ P)`. The result uses only already-proven constructs, so translator soundness is free (`lower_soundness` still holds via the universal soundness theorem).
- `wf_z3` now admits the two comprehension forms. Because `foldTrust` is keyed on `lower`, the verifier classifies them `Sound` and routes them to Z3 — where the translator already handles them (`translateSetComprehensionEquality` / `membershipInComprehension`) — instead of skipping with a soundness limitation. No Scala routing change needed.
- Updates the entangled binop meta-proofs: lower-totality (`lower_binop_some` + capstone), `wf_z3` + `well_typed_imp_wf_z3`, type-preservation (`h3_pres_Cmp` + `h3_preservation` Cmp/BIn cases), and `requiresAlloy` disjointness (`lower_binop_collapse` + capstone). Comprehension subcases discharge as vacuous (a comprehension is never well-typed and standalone `wf_z3`/`lower` of it is `False`/`None`).
- Regenerates `SpecRestGenerated.scala`; `set_comp_demo`'s global consistency check flips `Skipped` → `Sat`.

## Test plan
- [x] `isabelle build SpecRest_Soundness` green, zero `sorry`; pre-commit hook's full Core/Soundness/Codegen build passes
- [x] `sbt verify/test` — 197/197 pass (`ConsistencyTest` 14/14; `set_comp_demo` now `Sat`)
- [x] Extracted Scala regenerated via the documented `isabelle export` pipeline + scalafmt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted set comprehension into the verified Z3 subset by lowering, completed equality extensionality with `ForallSet`, and fixed capture/sort issues so comprehension equality and membership verify soundly via Z3.

- **New Features**
  - Equality: `X = {u in D | P}` → `let 0cmp = X in ((forall u in D. P -> u in 0cmp) /\ (forall u in 0cmp. u in D /\ P))` (capture-free; domain must be an identifier).
  - Membership: `y in {u in D | P}` → `let u = y in (u in D /\ P)` (domain must be an identifier).
  - IR/SMT/Translator: add `ForallSet`/`TForallSet` and encode as a guarded Z3 `forall`; use a fresh binder to avoid capture; when checking `u in <Entity>`, validate the element sort matches the entity sort (otherwise error).
  - Proofs: extend `wf_z3`; add `soundness_ForallSet`; update lower-totality, preservation, and `requiresAlloy` disjointness; regenerate extracted Scala.
  - Tests: `set_comp_demo` global now `Sat`.

<sup>Written for commit cb6bcd6e5a87e63fad2f0abcdb7b8ca01e8cf5b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for universal quantification over set values in the expression language and SMT encoding.

* **Bug Fixes**
  * Fixed verification outcome handling for comparisons and membership involving set comprehensions so checks now report satisfiable results correctly.

* **Chores**
  * Strengthened formal soundness and lowering reasoning for set-comprehension cases.

* **Tests**
  * Updated tests to reflect corrected verification outcomes for set-comprehension scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->