### PR TITLE
feat(proofs): lift CallF via trusted pre-lower inlining (function/predicate calls)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -9115,6 +9115,280 @@ object SpecRestGenerated {
     case MapEntryFull(x1, x2, x3) => x1
   }
 
+  def is_binder_full(x0: expr_full): Boolean = x0 match {
+    case LetF(uu, uv, uw, ux)              => true
+    case QuantifierF(uy, uz, va, vb)       => true
+    case LambdaF(vc, vd, ve)               => true
+    case SetComprehensionF(vf, vg, vh, vi) => true
+    case TheF(vj, vk, vl, vm)              => true
+    case BinaryOpF(v, va, vb, vc)          => false
+    case UnaryOpF(v, va, vb)               => false
+    case SomeWrapF(v, va)                  => false
+    case FieldAccessF(v, va, vb)           => false
+    case EnumAccessF(v, va, vb)            => false
+    case IndexF(v, va, vb)                 => false
+    case CallF(v, va, vb)                  => false
+    case PrimeF(v, va)                     => false
+    case PreF(v, va)                       => false
+    case WithF(v, va, vb)                  => false
+    case IfF(v, va, vb, vc)                => false
+    case ConstructorF(v, va, vb)           => false
+    case SetLiteralF(v, va)                => false
+    case MapLiteralF(v, va)                => false
+    case SeqLiteralF(v, va)                => false
+    case MatchesF(v, va, vb)               => false
+    case IntLitF(v, va)                    => false
+    case FloatLitF(v, va)                  => false
+    case StringLitF(v, va)                 => false
+    case BoolLitF(v, va)                   => false
+    case NoneLitF(v)                       => false
+    case IdentifierF(v, va)                => false
+  }
+
+  def capture_safe(body: expr_full, params: List[String], args: List[expr_full]): Boolean =
+    !list_ex[expr_full]((a: expr_full) => is_binder_full(a), allSubexprs(body)) &&
+      list_all[expr_full](
+        (a: expr_full) =>
+          list_all[String](
+            (p: String) =>
+              !string_in_list(p, free_vars(a)),
+            params
+          ),
+        args
+      )
+
+  def prdParams(x0: predicate_decl_full): List[param_decl_full] = x0 match {
+    case PredicateDeclFull(x1, x2, x3, x4) => x2
+  }
+
+  def fncParams(x0: function_decl_full): List[param_decl_full] = x0 match {
+    case FunctionDeclFull(x1, x2, x3, x4, x5) => x2
+  }
+
+  def prdName(x0: predicate_decl_full): String = x0 match {
+    case PredicateDeclFull(x1, x2, x3, x4) => x1
+  }
+
+  def prdBody(x0: predicate_decl_full): expr_full = x0 match {
+    case PredicateDeclFull(x1, x2, x3, x4) => x3
+  }
+
+  def fncName(x0: function_decl_full): String = x0 match {
+    case FunctionDeclFull(x1, x2, x3, x4, x5) => x1
+  }
+
+  def fncBody(x0: function_decl_full): expr_full = x0 match {
+    case FunctionDeclFull(x1, x2, x3, x4, x5) => x4
+  }
+
+  def prmName(x0: param_decl_full): String = x0 match {
+    case ParamDeclFull(x1, x2, x3) => x1
+  }
+
+  def subst_params(uu: List[String], uv: List[expr_full], body: expr_full): expr_full =
+    (uu, uv, body) match {
+      case (p :: ps, a :: args, body) => subst_params(ps, args, subst(p, a, body))
+      case (Nil, uv, body)            => body
+      case (uu, Nil, body)            => body
+    }
+
+  def inline_calls_bindings(
+      vm: List[function_decl_full],
+      vn: List[predicate_decl_full],
+      x2: List[quantifier_binding_full]
+  ): List[quantifier_binding_full] =
+    (vm, vn, x2) match {
+      case (vm, vn, Nil) => Nil
+      case (fs, ps, QuantifierBindingFull(n, d, kk, sp) :: rest) =>
+        QuantifierBindingFull(n, inline_calls(fs, ps, d), kk, sp) ::
+          inline_calls_bindings(fs, ps, rest)
+    }
+
+  def inline_calls_entries(
+      vk: List[function_decl_full],
+      vl: List[predicate_decl_full],
+      x2: List[map_entry_full]
+  ): List[map_entry_full] =
+    (vk, vl, x2) match {
+      case (vk, vl, Nil) => Nil
+      case (fs, ps, MapEntryFull(k, v, sp) :: rest) =>
+        MapEntryFull(inline_calls(fs, ps, k), inline_calls(fs, ps, v), sp) ::
+          inline_calls_entries(fs, ps, rest)
+    }
+
+  def inline_calls_fields(
+      vi: List[function_decl_full],
+      vj: List[predicate_decl_full],
+      x2: List[field_assign_full]
+  ): List[field_assign_full] =
+    (vi, vj, x2) match {
+      case (vi, vj, Nil) => Nil
+      case (fs, ps, FieldAssignFull(f, v, sp) :: rest) =>
+        FieldAssignFull(f, inline_calls(fs, ps, v), sp) ::
+          inline_calls_fields(fs, ps, rest)
+    }
+
+  def inline_calls_list(
+      vg: List[function_decl_full],
+      vh: List[predicate_decl_full],
+      x2: List[expr_full]
+  ): List[expr_full] =
+    (vg, vh, x2) match {
+      case (vg, vh, Nil) => Nil
+      case (fs, ps, e :: es) =>
+        inline_calls(fs, ps, e) :: inline_calls_list(fs, ps, es)
+    }
+
+  def inline_calls(
+      fs: List[function_decl_full],
+      ps: List[predicate_decl_full],
+      x2: expr_full
+  ): expr_full =
+    (fs, ps, x2) match {
+      case (fs, ps, CallF(callee, args, sp)) =>
+        val argsa = inline_calls_list(fs, ps, args): List[expr_full];
+        callee match {
+          case BinaryOpF(_, _, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case UnaryOpF(_, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case QuantifierF(_, _, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case SomeWrapF(_, _)  => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case TheF(_, _, _, _) => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case FieldAccessF(_, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case EnumAccessF(_, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case IndexF(_, _, _)  => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case CallF(_, _, _)   => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case PrimeF(_, _)     => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case PreF(_, _)       => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case WithF(_, _, _)   => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case IfF(_, _, _, _)  => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case LetF(_, _, _, _) => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case LambdaF(_, _, _) => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case ConstructorF(_, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case SetLiteralF(_, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case MapLiteralF(_, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case SetComprehensionF(_, _, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case SeqLiteralF(_, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case MatchesF(_, _, _) =>
+            CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case IntLitF(_, _)    => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case FloatLitF(_, _)  => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case StringLitF(_, _) => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case BoolLitF(_, _)   => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case NoneLitF(_)      => CallF(inline_calls(fs, ps, callee), argsa, sp)
+          case IdentifierF(nm, _) =>
+            find[function_decl_full](
+              (f: function_decl_full) =>
+                fncName(f) == nm,
+              fs
+            ) match {
+              case None =>
+                find[predicate_decl_full](
+                  (q: predicate_decl_full) =>
+                    prdName(q) == nm,
+                  ps
+                ) match {
+                  case None => CallF(callee, argsa, sp)
+                  case Some(pr) =>
+                    equal_nat(
+                      size_list[param_decl_full](prdParams(pr)),
+                      size_list[expr_full](argsa)
+                    ) &&
+                      capture_safe(
+                        prdBody(pr),
+                        map[param_decl_full, String](
+                          (a: param_decl_full) => prmName(a),
+                          prdParams(pr)
+                        ),
+                        argsa
+                      ) match {
+                      case true => subst_params(
+                          map[param_decl_full, String](
+                            (a: param_decl_full) => prmName(a),
+                            prdParams(pr)
+                          ),
+                          argsa,
+                          prdBody(pr)
+                        )
+                      case false => CallF(callee, argsa, sp)
+                    }
+                }
+              case Some(f) =>
+                equal_nat(size_list[param_decl_full](fncParams(f)), size_list[expr_full](argsa)) &&
+                  capture_safe(
+                    fncBody(f),
+                    map[param_decl_full, String](
+                      (a: param_decl_full) =>
+                        prmName(a),
+                      fncParams(f)
+                    ),
+                    argsa
+                  ) match {
+                  case true => subst_params(
+                      map[param_decl_full, String](
+                        (a: param_decl_full) => prmName(a),
+                        fncParams(f)
+                      ),
+                      argsa,
+                      fncBody(f)
+                    )
+                  case false => CallF(callee, argsa, sp)
+                }
+            }
+        }
+      case (fs, ps, BinaryOpF(op, l, r, sp)) =>
+        BinaryOpF(op, inline_calls(fs, ps, l), inline_calls(fs, ps, r), sp)
+      case (fs, ps, UnaryOpF(op, e, sp)) =>
+        UnaryOpF(op, inline_calls(fs, ps, e), sp)
+      case (fs, ps, FieldAccessF(b, f, sp)) =>
+        FieldAccessF(inline_calls(fs, ps, b), f, sp)
+      case (fs, ps, EnumAccessF(b, m, sp)) =>
+        EnumAccessF(inline_calls(fs, ps, b), m, sp)
+      case (fs, ps, IndexF(b, i, sp)) =>
+        IndexF(inline_calls(fs, ps, b), inline_calls(fs, ps, i), sp)
+      case (fs, ps, PrimeF(e, sp)) => PrimeF(inline_calls(fs, ps, e), sp)
+      case (fs, ps, PreF(e, sp))   => PreF(inline_calls(fs, ps, e), sp)
+      case (fs, ps, WithF(b, upds, sp)) =>
+        WithF(inline_calls(fs, ps, b), inline_calls_fields(fs, ps, upds), sp)
+      case (fs, ps, IfF(c, t, e, sp)) =>
+        IfF(inline_calls(fs, ps, c), inline_calls(fs, ps, t), inline_calls(fs, ps, e), sp)
+      case (fs, ps, LetF(v, vala, body, sp)) =>
+        LetF(v, inline_calls(fs, ps, vala), inline_calls(fs, ps, body), sp)
+      case (fs, ps, LambdaF(p, b, sp)) => LambdaF(p, inline_calls(fs, ps, b), sp)
+      case (fs, ps, ConstructorF(n, flds, sp)) =>
+        ConstructorF(n, inline_calls_fields(fs, ps, flds), sp)
+      case (fs, ps, SetLiteralF(xs, sp)) =>
+        SetLiteralF(inline_calls_list(fs, ps, xs), sp)
+      case (fs, ps, MapLiteralF(es, sp)) =>
+        MapLiteralF(inline_calls_entries(fs, ps, es), sp)
+      case (fs, ps, SetComprehensionF(v, d, p, sp)) =>
+        SetComprehensionF(v, inline_calls(fs, ps, d), inline_calls(fs, ps, p), sp)
+      case (fs, ps, SeqLiteralF(xs, sp)) =>
+        SeqLiteralF(inline_calls_list(fs, ps, xs), sp)
+      case (fs, ps, MatchesF(e, pat, sp)) =>
+        MatchesF(inline_calls(fs, ps, e), pat, sp)
+      case (fs, ps, SomeWrapF(e, sp)) => SomeWrapF(inline_calls(fs, ps, e), sp)
+      case (fs, ps, TheF(v, d, b, sp)) =>
+        TheF(v, inline_calls(fs, ps, d), inline_calls(fs, ps, b), sp)
+      case (fs, ps, QuantifierF(q, bs, body, sp)) =>
+        QuantifierF(q, inline_calls_bindings(fs, ps, bs), inline_calls(fs, ps, body), sp)
+      case (uu, uv, IntLitF(n, sp))     => IntLitF(n, sp)
+      case (uw, ux, FloatLitF(n, sp))   => FloatLitF(n, sp)
+      case (uy, uz, StringLitF(n, sp))  => StringLitF(n, sp)
+      case (va, vb, BoolLitF(v, sp))    => BoolLitF(v, sp)
+      case (vc, vd, NoneLitF(sp))       => NoneLitF(sp)
+      case (ve, vf, IdentifierF(n, sp)) => IdentifierF(n, sp)
+    }
+
   def isEntityType(x0: type_expr_full, name: String): Boolean = (x0, name) match {
     case (NamedTypeF(n, uu), name)          => n == name
     case (SetTypeF(v, va), uw)              => false
@@ -11390,10 +11664,6 @@ object SpecRestGenerated {
 
   def mpeValue(x0: map_entry_full): expr_full = x0 match {
     case MapEntryFull(x1, x2, x3) => x2
-  }
-
-  def prmName(x0: param_decl_full): String = x0 match {
-    case ParamDeclFull(x1, x2, x3) => x1
   }
 
   def prmSpan(x0: param_decl_full): Option[span_t] = x0 match {
@@ -14194,14 +14464,6 @@ object SpecRestGenerated {
     case FieldDeclFull(x1, x2, x3, x4) => x3
   }
 
-  def fncBody(x0: function_decl_full): expr_full = x0 match {
-    case FunctionDeclFull(x1, x2, x3, x4, x5) => x4
-  }
-
-  def fncName(x0: function_decl_full): String = x0 match {
-    case FunctionDeclFull(x1, x2, x3, x4, x5) => x1
-  }
-
   def fncSpan(x0: function_decl_full): Option[span_t] = x0 match {
     case FunctionDeclFull(x1, x2, x3, x4, x5) => x5
   }
@@ -14739,14 +15001,6 @@ object SpecRestGenerated {
     case InvariantDeclFull(x1, x2, x3) => x3
   }
 
-  def prdBody(x0: predicate_decl_full): expr_full = x0 match {
-    case PredicateDeclFull(x1, x2, x3, x4) => x3
-  }
-
-  def prdName(x0: predicate_decl_full): String = x0 match {
-    case PredicateDeclFull(x1, x2, x3, x4) => x1
-  }
-
   def prdSpan(x0: predicate_decl_full): Option[span_t] = x0 match {
     case PredicateDeclFull(x1, x2, x3, x4) => x4
   }
@@ -15085,10 +15339,6 @@ object SpecRestGenerated {
 
   def cvrSpan(x0: convention_rule_full): Option[span_t] = x0 match {
     case ConventionRuleFull(x1, x2, x3, x4, x5) => x5
-  }
-
-  def fncParams(x0: function_decl_full): List[param_decl_full] = x0 match {
-    case FunctionDeclFull(x1, x2, x3, x4, x5) => x2
   }
 
   def operName(x0: operation_decl_full): String = x0 match {
@@ -15521,10 +15771,6 @@ object SpecRestGenerated {
 
   def fncRetType(x0: function_decl_full): type_expr_full = x0 match {
     case FunctionDeclFull(x1, x2, x3, x4, x5) => x3
-  }
-
-  def prdParams(x0: predicate_decl_full): List[param_decl_full] = x0 match {
-    case PredicateDeclFull(x1, x2, x3, x4) => x2
   }
 
   def svcInvariants(x0: service_ir_full): List[invariant_decl_full] = x0 match {

--- a/modules/verify/src/main/scala/specrest/verify/Consistency.scala
+++ b/modules/verify/src/main/scala/specrest/verify/Consistency.scala
@@ -70,11 +70,52 @@ object Consistency:
     case Preservation(ir: service_ir_full, op: operation_decl_full, inv: NamedInvariant)
     case Temporal(ir: service_ir_full, decl: temporal_decl_full)
 
+  // Beta-reduce user function/predicate calls via the verified, capture-guarded
+  // `inline_calls` desugar before classification. Done at the IR level here, not
+  // in `Translator`, because the trust classifier runs `lower` on these raw exprs
+  // to pick Sound-vs-best-effort: it must see the inlined body too, else a
+  // now-verifiable call would still route best-effort. Capped fixpoint; a residual
+  // `CallF` (recursive / binder-containing / capture-risky) stays best-effort.
+  private def inlineExpr(
+      fs: List[function_decl_full],
+      ps: List[predicate_decl_full],
+      expr: expr_full
+  ): expr_full =
+    def hasUserCall(e: expr_full): Boolean =
+      allSubexprs(e).exists {
+        case CallF(IdentifierF(nm, _), _, _) =>
+          fs.exists(f => fncName(f) == nm) || ps.exists(p => prdName(p) == nm)
+        case _ => false
+      }
+    @annotation.tailrec
+    def loop(e: expr_full, fuel: Int): expr_full =
+      if fuel <= 0 || !hasUserCall(e) then e
+      else loop(inline_calls(fs, ps, e), fuel - 1)
+    loop(expr, 16)
+
+  private def inlineService(ir: service_ir_full): service_ir_full =
+    val fs = svcFunctions(ir)
+    val ps = svcPredicates(ir)
+    if fs.isEmpty && ps.isEmpty then ir
+    else
+      def inl(e: expr_full): expr_full = inlineExpr(fs, ps, e)
+      ir match
+        // positional fields: ServiceIRFull g=operations i=invariants;
+        // OperationDeclFull d=requires e=ensures; InvariantDeclFull b=body
+        case s: ServiceIRFull =>
+          s.copy(
+            g = s.g.map { case op: OperationDeclFull =>
+              op.copy(d = op.d.map(inl), e = op.e.map(inl))
+            },
+            i = s.i.map { case inv: InvariantDeclFull => inv.copy(b = inl(inv.b)) }
+          )
+
   def runConsistencyChecks(
-      ir: service_ir_full,
+      ir0: service_ir_full,
       config: VerificationConfig,
       dump: Option[DumpSink] = None
   ): IO[ConsistencyReport] =
+    val ir    = inlineService(ir0)
     val plans = planChecks(ir)
     val enums = Trust.enumNames(ir)
     val results: IO[List[CheckResult]] =

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -55,6 +55,22 @@ class ConsistencyTest extends CatsEffectSuite:
       s"expected every check Sat (Entity{...} must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
     )
 
+  test("function/predicate calls inline + verify via Z3 (CallF lifted to the verified subset)"):
+    val spec =
+      """service CallDemo {
+        |  function dbl(n: Int): Int = n + n
+        |  predicate isPos(n: Int) = n > 0
+        |  invariant callsInline:
+        |    dbl(3) = 6 and isPos(dbl(1))
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("call_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+      s"expected every check Sat (calls must inline + verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+    )
+
   test("unsat_invariants has contradictory_invariants diagnostic"):
     for
       ir     <- SpecFixtures.loadIR("unsat_invariants")

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -162,6 +162,8 @@ export_code
     lowerSetList
     requiresAlloy
     subexprs
+    allSubexprs
+    inline_calls
     stripSpans
     typeStripSpans
     peelSmtRelationRef

--- a/proofs/isabelle/SpecRest/core/IR_Analysis.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Analysis.thy
@@ -228,6 +228,96 @@ where
 | "subst_bindings x r (QuantifierBindingFull n d kk sp # bs) =
      QuantifierBindingFull n (subst x r d) kk sp # subst_bindings x r bs"
 
+fun is_binder_full :: "expr_full \<Rightarrow> bool" where
+  "is_binder_full (LetF _ _ _ _)               = True"
+| "is_binder_full (QuantifierF _ _ _ _)        = True"
+| "is_binder_full (LambdaF _ _ _)              = True"
+| "is_binder_full (SetComprehensionF _ _ _ _)  = True"
+| "is_binder_full (TheF _ _ _ _)               = True"
+| "is_binder_full _                            = False"
+
+text \<open>\<open>inline_calls\<close> is a \<^emph>\<open>trusted\<close> pre-\<open>lower\<close> desugar (like \<open>lower\<close> itself: \<open>CallF\<close>
+  has no \<open>eval\<close>, so its meaning-preservation can't be stated against the verified
+  semantics). It beta-reduces a call to a user function/predicate by substituting
+  its arguments for the parameters in the body. To stay capture-free with the
+  non-renaming \<open>subst\<close>, it inlines a call ONLY when the callee body is binder-free
+  and no argument mentions a parameter name; otherwise the \<open>CallF\<close> is left in place
+  (it then falls outside \<open>lower\<close> and the check routes best-effort). It inlines one
+  level; the Scala driver iterates to a fixpoint (capped), so nested non-recursive
+  calls resolve and recursive ones stop.\<close>
+
+definition capture_safe :: "expr_full \<Rightarrow> String.literal list \<Rightarrow> expr_full list \<Rightarrow> bool" where
+  "capture_safe body params args \<equiv>
+     (\<not> list_ex is_binder_full (allSubexprs body))
+       \<and> list_all (\<lambda>a. list_all (\<lambda>p. \<not> string_in_list p (free_vars a)) params) args"
+
+fun subst_params :: "String.literal list \<Rightarrow> expr_full list \<Rightarrow> expr_full \<Rightarrow> expr_full" where
+  "subst_params (p # ps) (a # args) body = subst_params ps args (subst p a body)"
+| "subst_params _ _ body = body"
+
+fun inline_calls :: "function_decl_full list \<Rightarrow> predicate_decl_full list \<Rightarrow> expr_full \<Rightarrow> expr_full"
+and inline_calls_list :: "function_decl_full list \<Rightarrow> predicate_decl_full list \<Rightarrow> expr_full list \<Rightarrow> expr_full list"
+and inline_calls_fields :: "function_decl_full list \<Rightarrow> predicate_decl_full list \<Rightarrow> field_assign_full list \<Rightarrow> field_assign_full list"
+and inline_calls_entries :: "function_decl_full list \<Rightarrow> predicate_decl_full list \<Rightarrow> map_entry_full list \<Rightarrow> map_entry_full list"
+and inline_calls_bindings :: "function_decl_full list \<Rightarrow> predicate_decl_full list \<Rightarrow> quantifier_binding_full list \<Rightarrow> quantifier_binding_full list"
+where
+  "inline_calls fs ps (CallF callee args sp) =
+     (let args' = inline_calls_list fs ps args
+      in case callee of
+           IdentifierF nm sp1 \<Rightarrow>
+             (case List.find (\<lambda>f. fncName f = nm) fs of
+                Some f \<Rightarrow>
+                  (if length (fncParams f) = length args'
+                        \<and> capture_safe (fncBody f) (map prmName (fncParams f)) args'
+                     then subst_params (map prmName (fncParams f)) args' (fncBody f)
+                     else CallF callee args' sp)
+              | None \<Rightarrow>
+                  (case List.find (\<lambda>q. prdName q = nm) ps of
+                     Some pr \<Rightarrow>
+                       (if length (prdParams pr) = length args'
+                             \<and> capture_safe (prdBody pr) (map prmName (prdParams pr)) args'
+                          then subst_params (map prmName (prdParams pr)) args' (prdBody pr)
+                          else CallF callee args' sp)
+                   | None \<Rightarrow> CallF callee args' sp))
+         | _ \<Rightarrow> CallF (inline_calls fs ps callee) args' sp)"
+| "inline_calls fs ps (BinaryOpF op l r sp)        = BinaryOpF op (inline_calls fs ps l) (inline_calls fs ps r) sp"
+| "inline_calls fs ps (UnaryOpF op e sp)           = UnaryOpF op (inline_calls fs ps e) sp"
+| "inline_calls fs ps (FieldAccessF b f sp)        = FieldAccessF (inline_calls fs ps b) f sp"
+| "inline_calls fs ps (EnumAccessF b m sp)         = EnumAccessF (inline_calls fs ps b) m sp"
+| "inline_calls fs ps (IndexF b i sp)              = IndexF (inline_calls fs ps b) (inline_calls fs ps i) sp"
+| "inline_calls fs ps (PrimeF e sp)                = PrimeF (inline_calls fs ps e) sp"
+| "inline_calls fs ps (PreF e sp)                  = PreF (inline_calls fs ps e) sp"
+| "inline_calls fs ps (WithF b upds sp)            = WithF (inline_calls fs ps b) (inline_calls_fields fs ps upds) sp"
+| "inline_calls fs ps (IfF c t e sp)               = IfF (inline_calls fs ps c) (inline_calls fs ps t) (inline_calls fs ps e) sp"
+| "inline_calls fs ps (LetF v val body sp)         = LetF v (inline_calls fs ps val) (inline_calls fs ps body) sp"
+| "inline_calls fs ps (LambdaF p b sp)             = LambdaF p (inline_calls fs ps b) sp"
+| "inline_calls fs ps (ConstructorF n flds sp)     = ConstructorF n (inline_calls_fields fs ps flds) sp"
+| "inline_calls fs ps (SetLiteralF xs sp)          = SetLiteralF (inline_calls_list fs ps xs) sp"
+| "inline_calls fs ps (MapLiteralF es sp)          = MapLiteralF (inline_calls_entries fs ps es) sp"
+| "inline_calls fs ps (SetComprehensionF v d p sp) = SetComprehensionF v (inline_calls fs ps d) (inline_calls fs ps p) sp"
+| "inline_calls fs ps (SeqLiteralF xs sp)          = SeqLiteralF (inline_calls_list fs ps xs) sp"
+| "inline_calls fs ps (MatchesF e pat sp)          = MatchesF (inline_calls fs ps e) pat sp"
+| "inline_calls fs ps (SomeWrapF e sp)             = SomeWrapF (inline_calls fs ps e) sp"
+| "inline_calls fs ps (TheF v d b sp)              = TheF v (inline_calls fs ps d) (inline_calls fs ps b) sp"
+| "inline_calls fs ps (QuantifierF q bs body sp)   = QuantifierF q (inline_calls_bindings fs ps bs) (inline_calls fs ps body) sp"
+| "inline_calls _ _ (IntLitF n sp)                 = IntLitF n sp"
+| "inline_calls _ _ (FloatLitF n sp)               = FloatLitF n sp"
+| "inline_calls _ _ (StringLitF n sp)              = StringLitF n sp"
+| "inline_calls _ _ (BoolLitF v sp)                = BoolLitF v sp"
+| "inline_calls _ _ (NoneLitF sp)                  = NoneLitF sp"
+| "inline_calls _ _ (IdentifierF n sp)             = IdentifierF n sp"
+| "inline_calls_list _ _ []                        = []"
+| "inline_calls_list fs ps (e # es)                = inline_calls fs ps e # inline_calls_list fs ps es"
+| "inline_calls_fields _ _ []                      = []"
+| "inline_calls_fields fs ps (FieldAssignFull f v sp # rest) =
+     FieldAssignFull f (inline_calls fs ps v) sp # inline_calls_fields fs ps rest"
+| "inline_calls_entries _ _ []                     = []"
+| "inline_calls_entries fs ps (MapEntryFull k v sp # rest) =
+     MapEntryFull (inline_calls fs ps k) (inline_calls fs ps v) sp # inline_calls_entries fs ps rest"
+| "inline_calls_bindings _ _ []                    = []"
+| "inline_calls_bindings fs ps (QuantifierBindingFull n d kk sp # rest) =
+     QuantifierBindingFull n (inline_calls fs ps d) kk sp # inline_calls_bindings fs ps rest"
+
 text \<open>Phase 9\<delta> (lint TypeMismatch / L01): \<open>lit_class\<close> classifies an
   expression literal into a small ADT; \<open>litClass\<close> recognises which class
   (if any) an \<open>expr_full\<close> belongs to; \<open>binOpName\<close> renders a binary


### PR DESCRIPTION
## Summary
- Lifts `CallF` (user function/predicate calls) into the verified Z3 subset via a **trusted pre-`lower` inline pass**, so calls verify soundly instead of being encoded as uninterpreted functions.
- **`inline_calls`** (`IR_Analysis.thy`): beta-reduces a call by substituting args for params in the callee body. Capture-guarded (callee body binder-free **and** no argument mentions a parameter) because the existing `subst` does not rename under binders; otherwise the `CallF` is left in place and the check routes best-effort. `CallF` has no `eval`, so this is trusted like `lower` itself (no soundness lemma is statable against the verified semantics). No new `expr` constructor.
- **`Consistency.inlineService`**: applies the inline at the IR level (capped fixpoint) *before* classification, so both the trust classifier (`lower` on raw decls) and the encoder see the inlined bodies. `Translator.translate` stays pure, so `SmtLibGoldenTest` output is unchanged.
- The parser preamble's `predicate isValidURI(s) = s matches /.../` now inlines to a verified `Matches` (lifted in #389), extending Z3 coverage of `url_shortener` with no verdict drift.

## Test plan
- [x] Full proof build green (pre-commit hook, zero `sorry`)
- [x] `verify/test` — 210/210
- [x] `cli/test` — 65/65
- [x] New `ConsistencyTest`: `CallDemo` (`function dbl`, `predicate isPos`) verifies **Sat via Z3** (inlined, not skipped)
- [x] `SmtLibGoldenTest` unchanged (`translate` stays pure)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts user function and predicate calls (`CallF`) into the verified Z3 subset by inlining them before `lower`. Call-heavy specs now verify via Z3 instead of routing best-effort.

- **New Features**
  - Added trusted pre-`lower` inlining via `inline_calls` (beta-reduces calls when capture-safe: binder-free body, args don’t mention params).
  - Applied capped fixpoint inlining at the IR level with `Consistency.inlineService` so both the trust classifier and the encoder see inlined bodies; `Translator.translate` stays pure (`SmtLibGoldenTest` unchanged).
  - Parser preamble’s `isValidURI(s)` now inlines to verified `Matches`, extending Z3 coverage for `url_shortener` with no verdict drift.

<sup>Written for commit a089babe21135bf7bcd87378e799413c12c9fa02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verification now performs inlining of user-defined function and predicate calls before running consistency checks, improving how verification handles nested invocations.

* **Tests**
  * Added test coverage for call inlining during verification with Z3 backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->