### PR TITLE
fix(ci): eliminate build warnings at their sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches: [main]
-    tags: ["v*"]
     paths-ignore: ["docs/**"]
   pull_request:
 

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -20,8 +20,6 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
-
       - uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1
 
       - uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.2.3

--- a/.github/workflows/isabelle-build.yml
+++ b/.github/workflows/isabelle-build.yml
@@ -19,6 +19,9 @@ env:
   ISABELLE_VERSION: "2025-2"
   ML_OPTIONS: "--minheap 2000 --maxheap 6000 --gcthreads 4"
 
+permissions:
+  contents: read
+
 jobs:
   isabelle:
     runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,11 @@ lazy val commonMainDeps = Seq(
 
 lazy val commonTestDeps = Seq(
   "org.scalameta" %% "munit"             % munitVersion   % Test,
-  "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test
+  "org.typelevel" %% "munit-cats-effect" % munitCEVersion % Test,
+  // Transitive deps (alloy, httpclient5) bind slf4j-api 1.7.x; without an
+  // implementation every forked test JVM prints the StaticLoggerBinder
+  // warning triple. The no-op binding is the intended resolution.
+  "org.slf4j" % "slf4j-nop" % "1.7.36" % Test
 )
 
 // The `dependsOn` graph below is the module architecture; it is asserted explicitly by
@@ -272,7 +276,17 @@ lazy val cli = (project in file("modules/cli"))
       // shared library can be loaded per-execution (build-time init fails since
       // the .so isn't available until the binary extracts it on first call).
       "--initialize-at-run-time=com.microsoft.z3.Native",
-      "--initialize-at-run-time=com.microsoft.z3.Version"
+      "--initialize-at-run-time=com.microsoft.z3.Version",
+      // openai-java-core ships agent-dumped native-image configs captured
+      // during its own Gradle test run: the proxy/serialization entries
+      // reference byte-buddy, gradle test workers, and junit - none on this
+      // classpath, so they can never apply and only emit ~46 build warnings.
+      // jni/reflect/resource configs stay (synth needs them at runtime).
+      // Still unfixed upstream as of openai-java 4.39.1.
+      "--exclude-config",
+      ".*openai-java-core.*\\.jar,META-INF/native-image/proxy-config\\.json",
+      "--exclude-config",
+      ".*openai-java-core.*\\.jar,META-INF/native-image/serialization-config\\.json"
     )
   )
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -42,11 +45,13 @@ jobs:
       SPEC_TEST_PROFILE: ${{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Install dependencies

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -40,11 +43,13 @@ jobs:
       SPEC_TEST_PROFILE: ${{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Install dependencies

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -21,11 +24,13 @@ jobs:
       SPEC_TEST_PROFILE: ${{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Install dependencies

--- a/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -36,11 +39,13 @@ jobs:
       SPEC_TEST_PROFILE: $\{{ github.event_name == 'schedule' && 'exhaustive' || 'thorough' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
       - name: Install dependencies


### PR DESCRIPTION
Root-cause pass over every warning class in the build workflows - nothing silenced, each fixed at its source.

| Warning class | Volume | Root cause | Fix |
|---|---|---|---|
| `Cannot register dynamic proxy` / `Could not resolve ... serialization` | ~46 per native build x 3 workflows | **openai-java-core ships agent-dumped native-image configs captured during its own Gradle test run** - proxy entries for byte-buddy, serialization entries for gradle test workers/junit; those classes are not on our classpath, so the entries can never apply | `--exclude-config` for exactly those two files (jni/reflect/resource stay - synth needs them at runtime). Verified still unfixed upstream in 4.39.1 - worth an upstream issue |
| SLF4J `StaticLoggerBinder` triple | x4 per test run | transitive slf4j-api 1.7.x (alloy, httpclient5) with no binding | `slf4j-nop` in Test scope - the intended resolution |
| zizmor `cache-poisoning` (high) | ci.yml | `tags: [v*]` trigger + caches; the tag run was fully redundant (no publish steps - native.yml owns tags) | trigger dropped; also saves one full CI run per release |
| zizmor `excessive-permissions` | isabelle-build.yml | no permissions block | `permissions: contents: read` |
| zizmor `unpinned-uses` / `artipacked` / `excessive-permissions` | **the bulk - flagged via golden fixtures of GENERATED project CI** | the python/fastapi scaffold emitted `actions/checkout@v4`-style tags, no permissions, persisted credentials | template now emits SHA-pinned actions (same pins as this repo), permissions block, `persist-credentials: false`; goldens regenerated (ci.yml only - the emit-date churn in alembic excluded) |
| `Path Validation Error` cache warning | dependency-submission.yml | coursier cache step provably saved nothing in that job | dead step removed |

### The macos GC warning ("ensure more than 2.83GB...")
Not a config bug: the builder already allocates dynamically (75.6% of the runner's 7GB). The constraint is the macos-arm64 runner's physical RAM; the durable lever is demand reduction - the planned `smtEval` factoring (largest flow graph) and, longer-term, slimming openai-java's 3.2MB reflect-config (14,528 reflective types), which we keep for now because synth needs reflection at runtime.

### Validation
- native-image analysis probe: **0** proxy/serialization warnings (was 46)
- codegen/ir/verify suites green (355+43+210), **no SLF4J output**
- local zizmor: **no findings**
- the generated-project CI hardening benefits every user project the scaffolder emits, not just our fixtures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all CI and build warnings at their sources. Native-image and tests are now clean (0 proxy/serialization warnings, no SLF4J output) and zizmor reports no findings.

- **Bug Fixes**
  - Native-image: exclude `openai-java-core` proxy/serialization configs that referenced absent classes; keep jni/reflect/resource.
  - Tests: add `slf4j-nop` in Test scope to silence `StaticLoggerBinder`.
  - CI: remove redundant tag trigger from `ci.yml` to avoid cache poisoning and a duplicate release run.
  - CI: add `permissions: contents: read` to `isabelle-build.yml`; remove no-op coursier cache step from dependency submission.
  - Scaffolder: Python/FastAPI template now pins actions by SHA, adds `permissions`, and sets `persist-credentials: false`; golden fixtures updated.

<sup>Written for commit c63d6ddc699e1a0e45951a9eb5f92092b4439435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

