### PR TITLE
feat(proofs): extend H3 typing layer to the lifted native sorts (#383)

### DIFF
--- a/docs/content/docs/design/isabelle-proofs.mdx
+++ b/docs/content/docs/design/isabelle-proofs.mdx
@@ -76,7 +76,7 @@ graph TD
 | `IR_Analysis.thy`    | ~415   | The Phase-9 lifted primitives (`isTrueLit`, `enumLiteralOf`, `combineAnd`, `decomposeAtom` + `refinement_atom`, `free_vars` / `subst` / `hasPrePrime` mutual recs, `litClass` + diagnostic helpers) |
 | `IR_Lower.thy`       | ~210   | `lower` and the `lower_forall_*` / `lower_with_assigns` mutual lowering from `expr_full` to the verified subset `expr` |
 | `Smt.thy`            | ~320   | The SMT IR (`smt_term`, `smt_val`, `smt_model`) and `smt_eval` |
-| `Semantics.thy`      | ~1190  | `ir_value`, `state`, `tyctx`, the typing judgement, `eval`, `check_value_has_ty` |
+| `Semantics.thy`      | ~1310  | `ir_value`, `state`, `tyctx`, the typing judgement, `eval`, `check_value_has_ty` |
 | `Translate.thy`      | ~50    | The translator `translate :: expr ⇒ smt_term` (small but central) |
 | `Soundness.thy`      | ~2970  | All 157 lemmas that close `soundness` |
 | `Codegen.thy`        | ~115   | `export_code` directives — the contract with the consumer Scala layer |

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -527,9 +527,13 @@ object SpecRestGenerated {
   final case class TBool()            extends ty
   final case class TInt()             extends ty
   final case class TReal()            extends ty
+  final case class TStr()             extends ty
   final case class TEnum(a: String)   extends ty
   final case class TEntity(a: String) extends ty
   final case class TSet(a: ty)        extends ty
+  final case class TOption(a: ty)     extends ty
+  final case class TSeq(a: ty)        extends ty
+  final case class TMap(a: ty, b: ty) extends ty
 
   sealed abstract class smt_term
   final case class BLit(a: Boolean)                                extends smt_term
@@ -720,9 +724,14 @@ object SpecRestGenerated {
   sealed abstract class schema_type
   final case class BoolT()                                   extends schema_type
   final case class IntT()                                    extends schema_type
+  final case class RealT()                                   extends schema_type
+  final case class StrT()                                    extends schema_type
   final case class EnumT(a: String)                          extends schema_type
   final case class EntityT(a: String)                        extends schema_type
   final case class RelationT(a: schema_type, b: schema_type) extends schema_type
+  final case class OptionT(a: schema_type)                   extends schema_type
+  final case class SeqT(a: schema_type)                      extends schema_type
+  final case class MapT(a: schema_type, b: schema_type)      extends schema_type
 
   sealed abstract class column_spec
   final case class ColumnSpec(a: String, b: String, c: Boolean, d: Option[String])
@@ -6106,9 +6115,19 @@ object SpecRestGenerated {
   def typeExprToTy(x0: schema_type): Option[ty] = x0 match {
     case BoolT()           => Some[ty](TBool())
     case IntT()            => Some[ty](TInt())
+    case RealT()           => Some[ty](TReal())
+    case StrT()            => Some[ty](TStr())
     case EnumT(n)          => Some[ty](TEnum(n))
     case EntityT(n)        => Some[ty](TEntity(n))
     case RelationT(uu, uv) => None
+    case OptionT(t) =>
+      map_option[ty, ty]((a: ty) => TOption(a), typeExprToTy(t))
+    case SeqT(t) => map_option[ty, ty]((a: ty) => TSeq(a), typeExprToTy(t))
+    case MapT(k, v) => (typeExprToTy(k), typeExprToTy(v)) match {
+        case (None, _)            => None
+        case (Some(_), None)      => None
+        case (Some(tk), Some(tv)) => Some[ty](TMap(tk, tv))
+      }
   }
 
   def min[A: ord](a: A, b: A): A =
@@ -9830,19 +9849,21 @@ object SpecRestGenerated {
   def typeExprFullToTy(enums: List[String], entities: List[String], x2: type_expr): Option[ty] =
     (enums, entities, x2) match {
       case (enums, entities, NamedTypeF(n, uu)) =>
-        n == "Bool" match {
+        n == "Bool" || n == "Boolean" match {
           case true => Some[ty](TBool())
-          case false => n == "Int" match {
+          case false => n == "Int" || (n == "DateTime" || n == "Date") match {
               case true => Some[ty](TInt())
               case false => n == "Float" ||
-                  (n == "Double" ||
-                    (n == "Decimal" || n == "Money")) match {
+                  (n == "Decimal" || n == "Money") match {
                   case true => Some[ty](TReal())
-                  case false => membera[String](enums, n) match {
-                      case true => Some[ty](TEnum(n))
-                      case false => membera[String](entities, n) match {
-                          case true  => Some[ty](TEntity(n))
-                          case false => None
+                  case false => n == "String" match {
+                      case true => Some[ty](TStr())
+                      case false => membera[String](enums, n) match {
+                          case true => Some[ty](TEnum(n))
+                          case false => membera[String](entities, n) match {
+                              case true  => Some[ty](TEntity(n))
+                              case false => None
+                            }
                         }
                     }
                 }
@@ -9850,10 +9871,17 @@ object SpecRestGenerated {
         }
       case (enums, entities, SetTypeF(inner, uv)) =>
         map_option[ty, ty]((a: ty) => TSet(a), typeExprFullToTy(enums, entities, inner))
-      case (uw, ux, MapTypeF(v, va, vb))          => None
-      case (uw, ux, SeqTypeF(v, va))              => None
-      case (uw, ux, OptionTypeF(v, va))           => None
-      case (uw, ux, RelationTypeF(v, va, vb, vc)) => None
+      case (enums, entities, OptionTypeF(inner, uw)) =>
+        map_option[ty, ty]((a: ty) => TOption(a), typeExprFullToTy(enums, entities, inner))
+      case (enums, entities, SeqTypeF(inner, ux)) =>
+        map_option[ty, ty]((a: ty) => TSeq(a), typeExprFullToTy(enums, entities, inner))
+      case (enums, entities, MapTypeF(k, v, uy)) =>
+        (typeExprFullToTy(enums, entities, k), typeExprFullToTy(enums, entities, v)) match {
+          case (None, _)            => None
+          case (Some(_), None)      => None
+          case (Some(tk), Some(tv)) => Some[ty](TMap(tk, tv))
+        }
+      case (uz, va, RelationTypeF(v, vc, vd, ve)) => None
     }
 
   def schemaFieldType(gamma: tyctx_ext[Unit], ename: String, fname: String): Option[ty] =
@@ -12406,47 +12434,126 @@ object SpecRestGenerated {
     }
 
   def equal_ty(x0: ty, x1: ty): Boolean = (x0, x1) match {
-    case (TEntity(x5), TSet(x6))    => false
-    case (TSet(x6), TEntity(x5))    => false
-    case (TEnum(x4), TSet(x6))      => false
-    case (TSet(x6), TEnum(x4))      => false
-    case (TEnum(x4), TEntity(x5))   => false
-    case (TEntity(x5), TEnum(x4))   => false
-    case (TReal(), TSet(x6))        => false
-    case (TSet(x6), TReal())        => false
-    case (TReal(), TEntity(x5))     => false
-    case (TEntity(x5), TReal())     => false
-    case (TReal(), TEnum(x4))       => false
-    case (TEnum(x4), TReal())       => false
-    case (TInt(), TSet(x6))         => false
-    case (TSet(x6), TInt())         => false
-    case (TInt(), TEntity(x5))      => false
-    case (TEntity(x5), TInt())      => false
-    case (TInt(), TEnum(x4))        => false
-    case (TEnum(x4), TInt())        => false
-    case (TInt(), TReal())          => false
-    case (TReal(), TInt())          => false
-    case (TBool(), TSet(x6))        => false
-    case (TSet(x6), TBool())        => false
-    case (TBool(), TEntity(x5))     => false
-    case (TEntity(x5), TBool())     => false
-    case (TBool(), TEnum(x4))       => false
-    case (TEnum(x4), TBool())       => false
-    case (TBool(), TReal())         => false
-    case (TReal(), TBool())         => false
-    case (TBool(), TInt())          => false
-    case (TInt(), TBool())          => false
-    case (TSet(x6), TSet(y6))       => equal_ty(x6, y6)
-    case (TEntity(x5), TEntity(y5)) => x5 == y5
-    case (TEnum(x4), TEnum(y4))     => x4 == y4
+    case (TSeq(x9), TMap(x101, x102))    => false
+    case (TMap(x101, x102), TSeq(x9))    => false
+    case (TOption(x8), TMap(x101, x102)) => false
+    case (TMap(x101, x102), TOption(x8)) => false
+    case (TOption(x8), TSeq(x9))         => false
+    case (TSeq(x9), TOption(x8))         => false
+    case (TSet(x7), TMap(x101, x102))    => false
+    case (TMap(x101, x102), TSet(x7))    => false
+    case (TSet(x7), TSeq(x9))            => false
+    case (TSeq(x9), TSet(x7))            => false
+    case (TSet(x7), TOption(x8))         => false
+    case (TOption(x8), TSet(x7))         => false
+    case (TEntity(x6), TMap(x101, x102)) => false
+    case (TMap(x101, x102), TEntity(x6)) => false
+    case (TEntity(x6), TSeq(x9))         => false
+    case (TSeq(x9), TEntity(x6))         => false
+    case (TEntity(x6), TOption(x8))      => false
+    case (TOption(x8), TEntity(x6))      => false
+    case (TEntity(x6), TSet(x7))         => false
+    case (TSet(x7), TEntity(x6))         => false
+    case (TEnum(x5), TMap(x101, x102))   => false
+    case (TMap(x101, x102), TEnum(x5))   => false
+    case (TEnum(x5), TSeq(x9))           => false
+    case (TSeq(x9), TEnum(x5))           => false
+    case (TEnum(x5), TOption(x8))        => false
+    case (TOption(x8), TEnum(x5))        => false
+    case (TEnum(x5), TSet(x7))           => false
+    case (TSet(x7), TEnum(x5))           => false
+    case (TEnum(x5), TEntity(x6))        => false
+    case (TEntity(x6), TEnum(x5))        => false
+    case (TStr(), TMap(x101, x102))      => false
+    case (TMap(x101, x102), TStr())      => false
+    case (TStr(), TSeq(x9))              => false
+    case (TSeq(x9), TStr())              => false
+    case (TStr(), TOption(x8))           => false
+    case (TOption(x8), TStr())           => false
+    case (TStr(), TSet(x7))              => false
+    case (TSet(x7), TStr())              => false
+    case (TStr(), TEntity(x6))           => false
+    case (TEntity(x6), TStr())           => false
+    case (TStr(), TEnum(x5))             => false
+    case (TEnum(x5), TStr())             => false
+    case (TReal(), TMap(x101, x102))     => false
+    case (TMap(x101, x102), TReal())     => false
+    case (TReal(), TSeq(x9))             => false
+    case (TSeq(x9), TReal())             => false
+    case (TReal(), TOption(x8))          => false
+    case (TOption(x8), TReal())          => false
+    case (TReal(), TSet(x7))             => false
+    case (TSet(x7), TReal())             => false
+    case (TReal(), TEntity(x6))          => false
+    case (TEntity(x6), TReal())          => false
+    case (TReal(), TEnum(x5))            => false
+    case (TEnum(x5), TReal())            => false
+    case (TReal(), TStr())               => false
+    case (TStr(), TReal())               => false
+    case (TInt(), TMap(x101, x102))      => false
+    case (TMap(x101, x102), TInt())      => false
+    case (TInt(), TSeq(x9))              => false
+    case (TSeq(x9), TInt())              => false
+    case (TInt(), TOption(x8))           => false
+    case (TOption(x8), TInt())           => false
+    case (TInt(), TSet(x7))              => false
+    case (TSet(x7), TInt())              => false
+    case (TInt(), TEntity(x6))           => false
+    case (TEntity(x6), TInt())           => false
+    case (TInt(), TEnum(x5))             => false
+    case (TEnum(x5), TInt())             => false
+    case (TInt(), TStr())                => false
+    case (TStr(), TInt())                => false
+    case (TInt(), TReal())               => false
+    case (TReal(), TInt())               => false
+    case (TBool(), TMap(x101, x102))     => false
+    case (TMap(x101, x102), TBool())     => false
+    case (TBool(), TSeq(x9))             => false
+    case (TSeq(x9), TBool())             => false
+    case (TBool(), TOption(x8))          => false
+    case (TOption(x8), TBool())          => false
+    case (TBool(), TSet(x7))             => false
+    case (TSet(x7), TBool())             => false
+    case (TBool(), TEntity(x6))          => false
+    case (TEntity(x6), TBool())          => false
+    case (TBool(), TEnum(x5))            => false
+    case (TEnum(x5), TBool())            => false
+    case (TBool(), TStr())               => false
+    case (TStr(), TBool())               => false
+    case (TBool(), TReal())              => false
+    case (TReal(), TBool())              => false
+    case (TBool(), TInt())               => false
+    case (TInt(), TBool())               => false
+    case (TMap(x101, x102), TMap(y101, y102)) =>
+      equal_ty(x101, y101) && equal_ty(x102, y102)
+    case (TSeq(x9), TSeq(y9))       => equal_ty(x9, y9)
+    case (TOption(x8), TOption(y8)) => equal_ty(x8, y8)
+    case (TSet(x7), TSet(y7))       => equal_ty(x7, y7)
+    case (TEntity(x6), TEntity(y6)) => x6 == y6
+    case (TEnum(x5), TEnum(y5))     => x5 == y5
+    case (TStr(), TStr())           => true
     case (TReal(), TReal())         => true
     case (TInt(), TInt())           => true
     case (TBool(), TBool())         => true
   }
 
-  def check_value_has_ty_list(wh: tyctx_ext[Unit], x1: List[ir_value], wi: ty): Boolean =
-    (wh, x1, wi) match {
-      case (wh, Nil, wi) => true
+  def check_value_has_ty_pairs(
+      vc: tyctx_ext[Unit],
+      x1: List[(ir_value, ir_value)],
+      vd: ty,
+      ve: ty
+  ): Boolean =
+    (vc, x1, vd, ve) match {
+      case (vc, Nil, vd, ve) => true
+      case (gamma, (k, w) :: ps, tk, tv) =>
+        check_value_has_ty(gamma, k, tk) &&
+        (check_value_has_ty(gamma, w, tv) &&
+          check_value_has_ty_pairs(gamma, ps, tk, tv))
+    }
+
+  def check_value_has_ty_list(va: tyctx_ext[Unit], x1: List[ir_value], vb: ty): Boolean =
+    (va, x1, vb) match {
+      case (va, Nil, vb) => true
       case (gamma, v :: vs, t) =>
         check_value_has_ty(gamma, v, t) && check_value_has_ty_list(gamma, vs, t)
     }
@@ -12456,30 +12563,91 @@ object SpecRestGenerated {
       case (gamma, VBool(uu), t)          => equal_ty(t, TBool())
       case (gamma, VInt(uv), t)           => equal_ty(t, TInt())
       case (gamma, VReal(uw), t)          => equal_ty(t, TReal())
-      case (gamma, VEnum(ename, ux), t)   => equal_ty(t, TEnum(ename))
-      case (gamma, VEntity(ename, uy), t) => equal_ty(t, TEntity(ename))
-      case (gamma, VSet(vs), TSet(t))     => check_value_has_ty_list(gamma, vs, t)
-      case (gamma, VSet(uz), TBool())     => false
-      case (gamma, VSet(va), TInt())      => false
-      case (gamma, VSet(vb), TReal())     => false
-      case (gamma, VSet(vc), TEnum(vd))   => false
-      case (gamma, VSet(ve), TEntity(vf)) => false
-      case (gamma, VEntityWith(base, fld, overridea), TEntity(ename)) =>
-        check_value_has_ty(gamma, base, TEntity(ename)) &&
-        (schemaFieldType(gamma, ename, fld) match {
-          case None    => false
-          case Some(a) => check_value_has_ty(gamma, overridea, a)
-        })
-      case (gamma, VEntityWith(vg, vh, vi), TBool())   => false
-      case (gamma, VEntityWith(vj, vk, vl), TInt())    => false
-      case (gamma, VEntityWith(vm, vn, vo), TReal())   => false
-      case (gamma, VEntityWith(vp, vq, vr), TEnum(vt)) => false
-      case (gamma, VEntityWith(vu, vv, vw), TSet(vx))  => false
-      case (gamma, VNone(), vy)                        => false
-      case (gamma, VSome(vz), wa)                      => false
-      case (gamma, VStr(wb), wc)                       => false
-      case (gamma, VSeq(wd), we)                       => false
-      case (gamma, VMap(wf), wg)                       => false
+      case (gamma, VStr(ux), t)           => equal_ty(t, TStr())
+      case (gamma, VEnum(ename, uy), t)   => equal_ty(t, TEnum(ename))
+      case (gamma, VEntity(ename, uz), t) => equal_ty(t, TEntity(ename))
+      case (gamma, VSet(vs), t) =>
+        t match {
+          case TBool()    => false
+          case TInt()     => false
+          case TReal()    => false
+          case TStr()     => false
+          case TEnum(_)   => false
+          case TEntity(_) => false
+          case TSet(a)    => check_value_has_ty_list(gamma, vs, a)
+          case TOption(_) => false
+          case TSeq(_)    => false
+          case TMap(_, _) => false
+        }
+      case (gamma, VEntityWith(base, fld, overridea), t) =>
+        t match {
+          case TBool()  => false
+          case TInt()   => false
+          case TReal()  => false
+          case TStr()   => false
+          case TEnum(_) => false
+          case TEntity(ename) =>
+            check_value_has_ty(gamma, base, TEntity(ename)) &&
+            (schemaFieldType(gamma, ename, fld) match {
+              case None    => false
+              case Some(a) => check_value_has_ty(gamma, overridea, a)
+            })
+          case TSet(_)    => false
+          case TOption(_) => false
+          case TSeq(_)    => false
+          case TMap(_, _) => false
+        }
+      case (gamma, VNone(), t) => t match {
+          case TBool()    => false
+          case TInt()     => false
+          case TReal()    => false
+          case TStr()     => false
+          case TEnum(_)   => false
+          case TEntity(_) => false
+          case TSet(_)    => false
+          case TOption(_) => true
+          case TSeq(_)    => false
+          case TMap(_, _) => false
+        }
+      case (gamma, VSome(v), t) =>
+        t match {
+          case TBool()    => false
+          case TInt()     => false
+          case TReal()    => false
+          case TStr()     => false
+          case TEnum(_)   => false
+          case TEntity(_) => false
+          case TSet(_)    => false
+          case TOption(a) => check_value_has_ty(gamma, v, a)
+          case TSeq(_)    => false
+          case TMap(_, _) => false
+        }
+      case (gamma, VSeq(vs), t) =>
+        t match {
+          case TBool()    => false
+          case TInt()     => false
+          case TReal()    => false
+          case TStr()     => false
+          case TEnum(_)   => false
+          case TEntity(_) => false
+          case TSet(_)    => false
+          case TOption(_) => false
+          case TSeq(a)    => check_value_has_ty_list(gamma, vs, a)
+          case TMap(_, _) => false
+        }
+      case (gamma, VMap(ps), t) =>
+        t match {
+          case TBool()    => false
+          case TInt()     => false
+          case TReal()    => false
+          case TStr()     => false
+          case TEnum(_)   => false
+          case TEntity(_) => false
+          case TSet(_)    => false
+          case TOption(_) => false
+          case TSeq(_)    => false
+          case TMap(a, b) => check_value_has_ty_pairs(gamma, ps, a, b)
+        }
     }
 
   def tc_relations[A](x0: tyctx_ext[A]): List[state_field_decl] = x0 match {

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -315,13 +315,13 @@ object Translator:
         ctx.declareSort(sort)
         ctx.typeAliases(talName(t)) = TypeAliasInfo(sort)
 
-  // Z3 sort policy for the spec's built-in primitives. This is irreducibly
-  // verify-local: the proof's `ty` has only TInt/TBool (no fractional sort) and
-  // its numeric classifier lumps integral with fractional, so the Int-vs-Real
-  // split cannot be derived upstream. Integral and temporal types share Int
-  // (temporal values are epoch seconds); fractional types use Real. String and
-  // other opaque primitives are absent here and fall to uninterpreted in
-  // sortForNamedType (where String-refinement aliases get their own handling).
+  // Z3 sort policy for the spec's built-in primitives. Must stay aligned with
+  // the proof's `typeExprFullToTy` name policy (Semantics.thy): integral and
+  // temporal names share Int/TInt (temporal values are epoch seconds),
+  // fractional names map to Real/TReal, Bool/Boolean to Bool/TBool. String is
+  // handled in sortForNamedType (native string sort / TStr, where
+  // String-refinement aliases get their own handling); opaque primitives
+  // (Duration, UUID) are absent on both sides and fall to uninterpreted.
   private def primitiveSortOf(name: String): Option[Z3Sort] = name match
     case "Int" | "DateTime" | "Date"   => Some(Z3Sort.Int)
     case "Float" | "Decimal" | "Money" => Some(Z3Sort.Real)

--- a/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
@@ -76,3 +76,42 @@ class CheckValueHasTyTest extends CatsEffectSuite:
     val badSet = VSet(List(VInt(mkInt(1)), VBool(true)))
     assert(check_value_has_ty(ctx, okSet, TSet(TInt())))
     assert(!check_value_has_ty(ctx, badSet, TSet(TInt())))
+
+  List(
+    ("VStr at TStr", VStr("hello"): ir_value, TStr(): ty, true),
+    ("VStr at TInt", VStr("hello"), TInt(), false),
+    ("VNone at any TOption", VNone(), TOption(TInt()), true),
+    ("VNone at non-option", VNone(), TInt(), false),
+    ("VSome wraps element type", VSome(VInt(mkInt(1))), TOption(TInt()), true),
+    ("VSome with mismatched element", VSome(VBool(true)), TOption(TInt()), false),
+    ("VSeq: all elements typed", VSeq(List(VStr("a"), VStr("b"))), TSeq(TStr()), true),
+    ("VSeq: mixed elements rejected", VSeq(List(VStr("a"), VInt(mkInt(1)))), TSeq(TStr()), false),
+    ("VSeq at TSet rejected", VSeq(List(VInt(mkInt(1)))), TSet(TInt()), false),
+    (
+      "VMap: keys and values typed",
+      VMap(List((VStr("k"), VInt(mkInt(1))))),
+      TMap(TStr(), TInt()),
+      true
+    ),
+    (
+      "VMap: mistyped value rejected",
+      VMap(List((VStr("k"), VBool(true)))),
+      TMap(TStr(), TInt()),
+      false
+    ),
+    (
+      "VMap: mistyped key rejected",
+      VMap(List((VInt(mkInt(1)), VInt(mkInt(2))))),
+      TMap(TStr(), TInt()),
+      false
+    )
+  ).foreach:
+    case (name, value, expected, ok) =>
+      test(s"native sorts: $name"):
+        assertEquals(check_value_has_ty(ctx, value, expected), ok)
+
+  test("nested native sorts compose"):
+    val v = VSome(VMap(List((VStr("k"), VSeq(List(VInt(mkInt(1))))))))
+    val t = TOption(TMap(TStr(), TSeq(TInt())))
+    assert(check_value_has_ty(ctx, v, t))
+    assert(!check_value_has_ty(ctx, v, TOption(TMap(TStr(), TSeq(TBool())))))

--- a/proofs/isabelle/STATUS.md
+++ b/proofs/isabelle/STATUS.md
@@ -40,9 +40,9 @@ pivot (issue #193).
 
 - **`fun` proof tactics that work for binary operators**:
   `using assms by (cases op; auto split: option.splits smt_val.splits)` — but only when the IH gives
-  the smt*eval result *forward* (i.e., `smt_eval ... = Some *`), not *backward* (`Some _ = smt_eval
-  ...`). The fix is the `smt_eval_of_eval_\*` helper lemmas: take an IH and a concrete eval result
-  and produce the forward-direction smt_eval equation.
+  the `smt_eval` result _forward_ (i.e., `smt_eval ... = Some _`), not _backward_
+  (`Some _ = smt_eval ...`). The fix is the `smt_eval_of_eval_*` helper lemmas: take an IH and a
+  concrete eval result and produce the forward-direction `smt_eval` equation.
 - **Per-op success-path lemmas mirror Lean's structure** (`Soundness.lean` lines 596-1894). Each
   takes concrete `eval ... = Some (VInt _)` style hypotheses and closes by
   `using ... helper[OF ... ...] by simp`.
@@ -136,9 +136,9 @@ not incremental PRs:
   9v extension:_ `T_Let` rule for `LetF x v body` covering local-binding scope, paired with
   `env_agrees_strict_cons` / `agrees_strict_cons` (Semantics.thy) showing that extending env by a
   typed value preserves agreement with the extended context. The umbrella generalises
-  `arbitrary: e' v env` so the body-IH instantiates at the extended env `(x, va) # env`. T*Let is
+  `arbitrary: e' v env` so the body-IH instantiates at the extended env `(x, va) # env`. `T_Let` is
   the first scope-extending rule, validating the design for future binder-introducing rules
-  (T_Quantifier, T_With, etc.). _Phase 9w extension:_ three more rules — `T_Prime` and `T_Pre`
+  (`T_Quantifier`, `T_With`, etc.). _Phase 9w extension:_ three more rules — `T_Prime` and `T_Pre`
   (type-propagating temporal wrappers; eval is the identity, lower wraps with `Prime` / `Pre`
   constructors, the umbrella case delegates to the inner IH after stripping the wrapper) and
   `T_EnumAccess` (the leaf rule for `EnumAccessF (IdentifierF en _) mem` typing as `TEnum en`; the
@@ -206,50 +206,46 @@ not incremental PRs:
   package generates a per-update IH automatically (each `v` in updates gets its own preservation IH
   at its declared field type `ft`). Three helper lemmas in Soundness.thy: `wf_z3_fields_iff` (the
   equivalence `wf_z3_fields updates ↔ ∀(_, v, _) ∈ updates. wf_z3 v` — cheaper than the mutual
-  `.induct` which doesn't exist standalone in the wf*z3 / wf_z3_list / wf_z3_fields mutual group);
-  `lower_with_assigns_eval_implies_base_eval` (the chain's outer eval succeeds ⟹ the base's eval
-  also succeeds — used to discharge the IH(1) base-eval premise);
+  `.induct` which doesn't exist standalone in the `wf_z3` / `wf_z3_list` / `wf_z3_fields` mutual
+  group); `lower_with_assigns_eval_implies_base_eval` (the chain's outer eval succeeds ⟹ the base's
+  eval also succeeds — used to discharge the IH(1) base-eval premise);
   `lower_with_assigns_preserves_entity` (the chain preserves `TEntity ename` — by structural
   induction on updates, each `WithRec` wrap re-applies `vt_entity_with` to preserve the entity type;
-  post-Phase-9ww-followup the rule now requires the override be typed at the declared field type,
-  so the lemma takes a per-update `updates_typed` premise threaded from `T_With.IH(2)`). The
-  umbrella case composes the three helpers and closes via the tightened `vt_entity_with`.
+  post-Phase-9ww-followup the rule now requires the override be typed at the declared field type, so
+  the lemma takes a per-update `updates_typed` premise threaded from `T_With.IH(2)`). The umbrella
+  case composes the three helpers and closes via the tightened `vt_entity_with`.
 
   _Phase 9ww-followup (PR #286):_ tightened `vt_entity_with` per the H3-blocker raised by
-  coderabbitai on PR #285. Old rule: `base ::v TEntity ename ⟹ VEntityWith base fld override ::v
-  TEntity ename` (override unconstrained), which let a derivation type any garbage value as an
-  entity field override and so `entity_field_well_typed Γ st` was unprovable for non-TInt schemas.
-  New rule: `value_has_ty Γ base (TEntity ename) ⟹ schemaFieldType Γ ename fld = Some ft ⟹
-  value_has_ty Γ override ft ⟹ value_has_ty Γ (VEntityWith base fld override) (TEntity ename)`.
+  coderabbitai on PR #285. Old rule:
+  `base ::v TEntity ename ⟹ VEntityWith base fld override ::v TEntity ename` (override
+  unconstrained), which let a derivation type any garbage value as an entity field override and so
+  `entity_field_well_typed Γ st` was unprovable for non-TInt schemas. New rule:
+  `value_has_ty Γ base (TEntity ename) ⟹ schemaFieldType Γ ename fld = Some ft ⟹ value_has_ty Γ override ft ⟹ value_has_ty Γ (VEntityWith base fld override) (TEntity ename)`.
   Required parameterising `value_has_ty` by `tyctx` (the override-typing premise consults
   `schemaFieldType Γ`), dropping the infix `::v`, and threading `Γ` through `env_agrees`,
   `state_agrees_scalars`, `env_agrees_strict` and their tc_env-update simp companions.
-  `lower_with_assigns_preserves_entity` took the per-update typing premise (a universally
-  quantified IH-shaped predicate), and the H3 `T_With` case feeds it from `T_With.IH(2)`. ~100
-  references rewritten; Isabelle build 5:49 → 6:02, no Scala-side diff.
+  `lower_with_assigns_preserves_entity` took the per-update typing premise (a universally quantified
+  IH-shaped predicate), and the H3 `T_With` case feeds it from `T_With.IH(2)`. ~100 references
+  rewritten; Isabelle build 5:49 → 6:02, no Scala-side diff.
 
-  _Phase 9ww-followup runtime integration (PR #287):_ `value_has_ty` made
-  executable via mutual-fun `check_value_has_ty` + `check_value_has_ty_list`
-  with `check_value_has_ty_iff` bridging back to the inductive. Added
-  `tyctxFromService :: service_ir_full ⇒ tyctx` + `enumNameFull` so Scala
-  consumers construct the typing context directly from the IR via autogen.
-  Wired into `Z3CounterExample.decode` — each decoded entity-field /
-  state-relation entry / state-constant / input runs through
-  `check_value_has_ty`; failures collect into
-  `DecodedCounterExample.typingFailures` (asserted empty on the real
-  `broken_url_shortener.spec` counterexample, demonstrating the
-  proof-extracted typing predicate agrees with the runtime Scala decoder).
-  `IrValueDecoder.decodeZ3` is the irreducible Z3-string → `ir_value`
-  parser; everything else (tyctx construction, type-check, sortToTy) calls
-  autogen directly without Scala-side wrappers.
+  _Phase 9ww-followup runtime integration (PR #287):_ `value_has_ty` made executable via mutual-fun
+  `check_value_has_ty` + `check_value_has_ty_list` with `check_value_has_ty_iff` bridging back to
+  the inductive. Added `tyctxFromService :: service_ir_full ⇒ tyctx` + `enumNameFull` so Scala
+  consumers construct the typing context directly from the IR via autogen. Wired into
+  `Z3CounterExample.decode` — each decoded entity-field / state-relation entry / state-constant /
+  input runs through `check_value_has_ty`; failures collect into
+  `DecodedCounterExample.typingFailures` (asserted empty on the real `broken_url_shortener.spec`
+  counterexample, demonstrating the proof-extracted typing predicate agrees with the runtime Scala
+  decoder). `IrValueDecoder.decodeZ3` is the irreducible Z3-string → `ir_value` parser; everything
+  else (tyctx construction, type-check, sortToTy) calls autogen directly without Scala-side
+  wrappers.
 
-  _Phase 9ee
-  extension:_ `T_Forall_QAll` (single-binding universal quantifier). The rule binds the body in a
-  context extended by `(var, t_dom)` for any `t_dom` — the body must type at `TBool`, no constraint
-  on whether `dnm` is an enum or relation at the typing level (lowering's `string_in_list dnm enums`
-  decides the routing, and the umbrella case handles both `ForallEnum` and `ForallRel` branches).
-  Two helper lemmas in Semantics.thy: `eval_forall_enum_some_imp_bool` and
-  `eval_forall_rel_some_imp_bool` (both: whenever the fold-evaluator returns `Some v`, `v` is
+  _Phase 9ee extension:_ `T_Forall_QAll` (single-binding universal quantifier). The rule binds the
+  body in a context extended by `(var, t_dom)` for any `t_dom` — the body must type at `TBool`, no
+  constraint on whether `dnm` is an enum or relation at the typing level (lowering's
+  `string_in_list dnm enums` decides the routing, and the umbrella case handles both `ForallEnum`
+  and `ForallRel` branches). Two helper lemmas in Semantics.thy: `eval_forall_enum_some_imp_bool`
+  and `eval_forall_rel_some_imp_bool` (both: whenever the fold-evaluator returns `Some v`, `v` is
   `VBool`, by structural list induction on members / domain — the body-eval is gated through the
   `VBool b` pattern). The umbrella case splits on `string_in_list dnm enums` and dispatches per
   branch; each branch extracts the inner schema / relation lookup, applies the appropriate helper,
@@ -309,16 +305,42 @@ not incremental PRs:
   both cardinalities (single, multi) — 16 tight rules total. _Phase 9ww-followup:_ removed the 8
   loose generic `T_Forall_*` rules (`T_Forall_QAll` / `_Cons` and the analogous `QNo` / `QExists` /
   `QSome` variants) that left `t_dom` as a free meta-variable bypassing schema lookup. PR #285
-  review (cubic + coderabbitai) flagged them as strict over-generalisations; the 16 tight
-  `_Enum` / `_Rel` rules already provide sound coverage. Soundness proofs lose their generic
-  umbrella cases (8 trivial `by simp` + 8 ~30-line `string_in_list dnm enums` case-splits, ~265
-  lines net deletion); the tight Enum/Rel proofs are untouched and discharge every quantifier
-  derivation post-removal. Umbrella now covers 43 typing rules. _Phase 9mm init-friendliness:_ small family of empty / init lemmas to
-  ease caller verification — `schema_field_type_empty`, `schema_relation_value_type_empty`,
-  `entity_field_well_typed_empty`, `relation_value_well_typed_empty`, `env_agrees_strict_empty` (all
-  `[simp]`), plus a `tyctx_empty` definition and an `agrees_strict_empty` theorem closing
+  review (cubic + coderabbitai) flagged them as strict over-generalisations; the 16 tight `_Enum` /
+  `_Rel` rules already provide sound coverage. Soundness proofs lose their generic umbrella cases (8
+  trivial `by simp` + 8 ~30-line `string_in_list dnm enums` case-splits, ~265 lines net deletion);
+  the tight Enum/Rel proofs are untouched and discharge every quantifier derivation post-removal.
+  Umbrella now covers 43 typing rules. _Phase 9mm init-friendliness:_ small family of empty / init
+  lemmas to ease caller verification — `schema_field_type_empty`,
+  `schema_relation_value_type_empty`, `entity_field_well_typed_empty`,
+  `relation_value_well_typed_empty`, `env_agrees_strict_empty` (all `[simp]`), plus a `tyctx_empty`
+  definition and an `agrees_strict_empty` theorem closing
   `agrees_strict [] state_empty tyctx_empty`. These let a spec author bootstrap `agrees_strict` from
-  a trivial-initial scenario without manually unfolding the four well-typedness conjuncts.
+  a trivial-initial scenario without manually unfolding the four well-typedness conjuncts. _Phase
+  9nn extension (issue #383):_ the typing layer covers the lifted native sorts. `ty` gains `TStr` /
+  `TOption ty` / `TSeq ty` / `TMap ty ty`; `value_has_ty` gains `vt_str` / `vt_none` (polymorphic:
+  `VNone : TOption t` for any `t`) / `vt_some` / `vt_seq` / `vt_map` (pairwise key+value premises).
+  `check_value_has_ty` gains a `check_value_has_ty_pairs` mutual companion and is now a `function`
+  with a hand `measure` — the pairs branch recurses into both components of each pair, which the
+  lexicographic-order search cannot synthesise; the measure reuses the datatype's `size_prod`
+  component so the `VMap` descent matches `ir_value.size` verbatim. The ctor-matched value arms
+  dispatch on `ty` via a `case` RHS (non-recursive `False` default), so future `ty` growth does not
+  multiply equation rows. `typeExprFullToTy` covers `String` / `OptionTypeF` / `SeqTypeF` /
+  `MapTypeF` and aligns its primitive-name policy with the verify layer's `primitiveSortOf`
+  (`Boolean`; `DateTime` / `Date` as epoch ints; the phantom `Double` alias dropped — nothing
+  produces it); `schemaFieldType` / `schemaRelationValueType` inherit the coverage for free.
+  `schema_type` gains the matching `RealT` / `StrT` / `OptionT` / `SeqT` / `MapT` forms with
+  `typeExprToTy` cases. `expr_has_ty` gains nine rules — `T_StrLit`, `T_NoneLit` (polymorphic option
+  type, mirroring `T_SetLit_Empty`), `T_SomeWrap`, `T_SeqLit_Empty` / `T_SeqLit_Cons`,
+  `T_MapLit_Empty` / `T_MapLit_Cons`, plus `T_If` and `T_Matches` closing the remaining batch-3 lift
+  gaps (#378's `Ite` and the natural `TStr` consumer). String equality typing was already free via
+  `T_Cmp_Eq`'s `t1 = t2` branch. `well_typed_imp_wf_z3` absorbs all nine new cases in its trailing
+  `auto` (`wf_z3` was already `True` for these constructs); `h3_preservation` gets nine explicit
+  cases (`T_SeqLit_Cons` mirrors `T_SetLit_Cons` minus the dedupe fold; `T_MapLit_Cons` threads
+  per-entry IHs directly from the Cons-style rule — no universally-quantified helper needed; `T_If`
+  dispatches on the scrutinee's `VBool`). Umbrella now covers 52 typing rules. The verify-layer
+  stopgap removal (`lacksVerifiedTy` skip, `sortToTy` native-sort `None`s) is the follow-up PR on
+  #383.
+
 - **`wf_z3` syntactic subset proven sufficient for `lower`** (`Soundness.thy` §Phase 9j, dual of
   9i): a syntactic predicate `wf_z3` carves out the Z3-verifiable fragment of `expr_full` and the
   capstone `wf_z3_imp_lower_some` proves `wf_z3 e ⟹ lower enums e ≠ None`. This upgrades

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -31,9 +31,14 @@ type_synonym option_span = "span_t option"
 datatype (plugins only: code size) schema_type =
     BoolT
   | IntT
+  | RealT
+  | StrT
   | EnumT "String.literal"
   | EntityT "String.literal"
   | RelationT "schema_type" "schema_type"
+  | OptionT "schema_type"
+  | SeqT "schema_type"
+  | MapT "schema_type" "schema_type"
 
 datatype (plugins only: code size) bool_bin_op =
     AndOp

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -216,9 +216,13 @@ datatype (plugins only: code size) ty =
     TBool
   | TInt
   | TReal
+  | TStr
   | TEnum "String.literal"
   | TEntity "String.literal"
   | TSet ty
+  | TOption ty
+  | TSeq ty
+  | TMap ty ty
 
 definition numeric_ty :: "ty \<Rightarrow> bool" where
   "numeric_ty t \<longleftrightarrow> t = TInt \<or> t = TReal"
@@ -249,15 +253,25 @@ fun typeExprFullToTy ::
   "String.literal list \<Rightarrow> String.literal list
      \<Rightarrow> type_expr \<Rightarrow> ty option" where
   "typeExprFullToTy enums entities (NamedTypeF n _) =
-     (if n = STR ''Bool'' then Some TBool
-      else if n = STR ''Int'' then Some TInt
-      else if n = STR ''Float'' \<or> n = STR ''Double''
-              \<or> n = STR ''Decimal'' \<or> n = STR ''Money'' then Some TReal
+     (if n = STR ''Bool'' \<or> n = STR ''Boolean'' then Some TBool
+      else if n = STR ''Int'' \<or> n = STR ''DateTime''
+              \<or> n = STR ''Date'' then Some TInt
+      else if n = STR ''Float'' \<or> n = STR ''Decimal''
+              \<or> n = STR ''Money'' then Some TReal
+      else if n = STR ''String'' then Some TStr
       else if n \<in> set enums then Some (TEnum n)
       else if n \<in> set entities then Some (TEntity n)
       else None)"
 | "typeExprFullToTy enums entities (SetTypeF inner _) =
      map_option TSet (typeExprFullToTy enums entities inner)"
+| "typeExprFullToTy enums entities (OptionTypeF inner _) =
+     map_option TOption (typeExprFullToTy enums entities inner)"
+| "typeExprFullToTy enums entities (SeqTypeF inner _) =
+     map_option TSeq (typeExprFullToTy enums entities inner)"
+| "typeExprFullToTy enums entities (MapTypeF k v _) =
+     (case (typeExprFullToTy enums entities k, typeExprFullToTy enums entities v) of
+        (Some tk, Some tv) \<Rightarrow> Some (TMap tk tv)
+      | _ \<Rightarrow> None)"
 | "typeExprFullToTy _ _ _ = None"
 
 definition schemaFieldType ::
@@ -304,6 +318,15 @@ inductive value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Right
                      \<Longrightarrow> value_has_ty \<Gamma> override ft
                      \<Longrightarrow> value_has_ty \<Gamma> (VEntityWith base fld override)
                                        (TEntity ename)"
+| vt_str:         "value_has_ty \<Gamma> (VStr s) TStr"
+| vt_none:        "value_has_ty \<Gamma> VNone (TOption t)"
+| vt_some:        "value_has_ty \<Gamma> v t
+                     \<Longrightarrow> value_has_ty \<Gamma> (VSome v) (TOption t)"
+| vt_seq:         "(\<forall>v \<in> set vs. value_has_ty \<Gamma> v t)
+                     \<Longrightarrow> value_has_ty \<Gamma> (VSeq vs) (TSeq t)"
+| vt_map:         "(\<forall>(k, w) \<in> set ps.
+                      value_has_ty \<Gamma> k tk \<and> value_has_ty \<Gamma> w tv)
+                     \<Longrightarrow> value_has_ty \<Gamma> (VMap ps) (TMap tk tv)"
 
 inductive_cases value_has_ty_bool_cases [elim!]: "value_has_ty \<Gamma> (VBool b) t"
 inductive_cases value_has_ty_int_cases [elim!]: "value_has_ty \<Gamma> (VInt n) t"
@@ -341,6 +364,14 @@ lemma value_has_ty_VEntity_iff [simp]:
   "value_has_ty \<Gamma> (VEntity ename eid) t \<longleftrightarrow> t = TEntity ename"
   by (auto intro: vt_entity)
 
+lemma value_has_ty_VStr_iff [simp]:
+  "value_has_ty \<Gamma> (VStr s) t \<longleftrightarrow> t = TStr"
+  by (auto intro: vt_str)
+
+lemma value_has_ty_VNone_iff [simp]:
+  "value_has_ty \<Gamma> VNone t \<longleftrightarrow> (\<exists>t'. t = TOption t')"
+  by (auto intro: vt_none)
+
 lemma schemaFieldType_tc_env_update [simp]:
   "schemaFieldType (\<Gamma>\<lparr>tc_env := xs\<rparr>) ename fname
      = schemaFieldType \<Gamma> ename fname"
@@ -369,49 +400,79 @@ qed
 text \<open>Executable equivalent of \<open>value_has_ty\<close>. The \<open>inductive\<close>
   form expresses the typing relation in HOL but is not by-default
   extractable by \<open>Code_Target_Scala\<close>; \<open>check_value_has_ty\<close>
-  enumerates the six rules as a mutual structural \<open>fun\<close>, so
+  enumerates the rules as a mutual structural \<open>fun\<close>, so
   Scala consumers (Z3 counterexample decoding, etc.) can decide
   typing at runtime. \<open>check_value_has_ty_iff\<close> bridges back to the
   inductive so proofs reading the \<open>value_has_ty\<close>-shaped form can
-  use either.\<close>
+  use either. The ctor-matched values dispatch on \<open>ty\<close> via a
+  \<open>case\<close> RHS (non-recursive \<open>False\<close> default) rather than
+  enumerated per-\<open>ty\<close> equations, so extending \<open>ty\<close> does not
+  multiply rows.\<close>
 
-fun check_value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Rightarrow> bool"
+function check_value_has_ty :: "tyctx \<Rightarrow> ir_value \<Rightarrow> ty \<Rightarrow> bool"
 and check_value_has_ty_list ::
   "tyctx \<Rightarrow> ir_value list \<Rightarrow> ty \<Rightarrow> bool"
+and check_value_has_ty_pairs ::
+  "tyctx \<Rightarrow> (ir_value \<times> ir_value) list \<Rightarrow> ty \<Rightarrow> ty \<Rightarrow> bool"
 where
   "check_value_has_ty \<Gamma> (VBool _) t = (t = TBool)"
 | "check_value_has_ty \<Gamma> (VInt _) t = (t = TInt)"
 | "check_value_has_ty \<Gamma> (VReal _) t = (t = TReal)"
+| "check_value_has_ty \<Gamma> (VStr _) t = (t = TStr)"
 | "check_value_has_ty \<Gamma> (VEnum ename _) t = (t = TEnum ename)"
 | "check_value_has_ty \<Gamma> (VEntity ename _) t = (t = TEntity ename)"
-| "check_value_has_ty \<Gamma> (VSet vs) (TSet t) = check_value_has_ty_list \<Gamma> vs t"
-| "check_value_has_ty \<Gamma> (VSet _) TBool = False"
-| "check_value_has_ty \<Gamma> (VSet _) TInt = False"
-| "check_value_has_ty \<Gamma> (VSet _) TReal = False"
-| "check_value_has_ty \<Gamma> (VSet _) (TEnum _) = False"
-| "check_value_has_ty \<Gamma> (VSet _) (TEntity _) = False"
-| "check_value_has_ty \<Gamma> (VEntityWith base fld override) (TEntity ename) =
-     (check_value_has_ty \<Gamma> base (TEntity ename) \<and>
-      (case schemaFieldType \<Gamma> ename fld of
-         None    \<Rightarrow> False
-       | Some ft \<Rightarrow> check_value_has_ty \<Gamma> override ft))"
-| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TBool = False"
-| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TInt = False"
-| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) TReal = False"
-| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TEnum _) = False"
-| "check_value_has_ty \<Gamma> (VEntityWith _ _ _) (TSet _) = False"
-| "check_value_has_ty \<Gamma> VNone _ = False"
-| "check_value_has_ty \<Gamma> (VSome _) _ = False"
-| "check_value_has_ty \<Gamma> (VStr _) _ = False"
-| "check_value_has_ty \<Gamma> (VSeq _) _ = False"
-| "check_value_has_ty \<Gamma> (VMap _) _ = False"
+| "check_value_has_ty \<Gamma> (VSet vs) t =
+     (case t of TSet t' \<Rightarrow> check_value_has_ty_list \<Gamma> vs t' | _ \<Rightarrow> False)"
+| "check_value_has_ty \<Gamma> (VEntityWith base fld override) t =
+     (case t of
+        TEntity ename \<Rightarrow>
+          check_value_has_ty \<Gamma> base (TEntity ename) \<and>
+          (case schemaFieldType \<Gamma> ename fld of
+             None    \<Rightarrow> False
+           | Some ft \<Rightarrow> check_value_has_ty \<Gamma> override ft)
+      | _ \<Rightarrow> False)"
+| "check_value_has_ty \<Gamma> VNone t =
+     (case t of TOption _ \<Rightarrow> True | _ \<Rightarrow> False)"
+| "check_value_has_ty \<Gamma> (VSome v) t =
+     (case t of TOption t' \<Rightarrow> check_value_has_ty \<Gamma> v t' | _ \<Rightarrow> False)"
+| "check_value_has_ty \<Gamma> (VSeq vs) t =
+     (case t of TSeq t' \<Rightarrow> check_value_has_ty_list \<Gamma> vs t' | _ \<Rightarrow> False)"
+| "check_value_has_ty \<Gamma> (VMap ps) t =
+     (case t of TMap tk tv \<Rightarrow> check_value_has_ty_pairs \<Gamma> ps tk tv
+      | _ \<Rightarrow> False)"
 | "check_value_has_ty_list _ [] _ = True"
 | "check_value_has_ty_list \<Gamma> (v # vs) t =
      (check_value_has_ty \<Gamma> v t \<and> check_value_has_ty_list \<Gamma> vs t)"
+| "check_value_has_ty_pairs _ [] _ _ = True"
+| "check_value_has_ty_pairs \<Gamma> ((k, w) # ps) tk tv =
+     (check_value_has_ty \<Gamma> k tk \<and> check_value_has_ty \<Gamma> w tv \<and>
+      check_value_has_ty_pairs \<Gamma> ps tk tv)"
+  by pat_completeness (auto split: ty.splits)
+
+text \<open>The lexicographic-order search cannot synthesise the
+  sum-of-components measure the \<open>check_value_has_ty_pairs\<close>
+  branch needs (\<open>check\<close> recurses into both the key and the value
+  of each pair), so the measure is given by hand, reusing the
+  datatype's own \<open>size_prod\<close> component so the \<open>VMap\<close> descent
+  matches \<open>ir_value.size\<close> verbatim.\<close>
+
+termination
+  by (relation "measure (case_sum
+        (\<lambda>(\<Gamma>, v, t). size v)
+        (case_sum
+          (\<lambda>(\<Gamma>, vs, t). size_list size vs)
+          (\<lambda>(\<Gamma>, ps, tk, tv). size_list (size_prod size size) ps)))")
+     auto
 
 lemma check_value_has_ty_list_all:
   "check_value_has_ty_list \<Gamma> vs t \<longleftrightarrow> (\<forall>v \<in> set vs. check_value_has_ty \<Gamma> v t)"
   by (induction vs) auto
+
+lemma check_value_has_ty_pairs_all:
+  "check_value_has_ty_pairs \<Gamma> ps tk tv
+     \<longleftrightarrow> (\<forall>(k, w) \<in> set ps.
+            check_value_has_ty \<Gamma> k tk \<and> check_value_has_ty \<Gamma> w tv)"
+  by (induction ps) auto
 
 lemma check_value_has_ty_sound_mutual:
   shows
@@ -420,15 +481,25 @@ lemma check_value_has_ty_sound_mutual:
   and check_list_imp_vty:
       "check_value_has_ty_list \<Gamma> vs t
          \<Longrightarrow> (\<forall>v \<in> set vs. value_has_ty \<Gamma> v t)"
-  by (induction rule: check_value_has_ty_check_value_has_ty_list.induct)
-     (auto intro: vt_bool vt_int vt_enum vt_entity vt_set vt_entity_with
-           split: option.splits)
+  and check_pairs_imp_vty:
+      "check_value_has_ty_pairs \<Gamma> ps tk tv
+         \<Longrightarrow> (\<forall>(k, w) \<in> set ps.
+               value_has_ty \<Gamma> k tk \<and> value_has_ty \<Gamma> w tv)"
+  by (induction
+        rule: check_value_has_ty_check_value_has_ty_list_check_value_has_ty_pairs.induct)
+     (auto intro: value_has_ty.intros split: option.splits ty.splits)
 
 lemma vty_imp_check_value_has_ty:
   "value_has_ty \<Gamma> v t \<Longrightarrow> check_value_has_ty \<Gamma> v t"
 proof (induction \<Gamma> v t rule: value_has_ty.induct)
   case (vt_set vs \<Gamma> t)
   thus ?case by (simp add: check_value_has_ty_list_all)
+next
+  case (vt_seq vs \<Gamma> t)
+  thus ?case by (simp add: check_value_has_ty_list_all)
+next
+  case (vt_map ps \<Gamma> tk tv)
+  thus ?case by (auto simp: check_value_has_ty_pairs_all)
 qed auto
 
 lemma check_value_has_ty_iff:
@@ -446,9 +517,17 @@ text \<open>Phase H2b (schema typing). A partial translation from
 fun typeExprToTy :: "schema_type \<Rightarrow> ty option" where
   "typeExprToTy BoolT           = Some TBool"
 | "typeExprToTy IntT            = Some TInt"
+| "typeExprToTy RealT           = Some TReal"
+| "typeExprToTy StrT            = Some TStr"
 | "typeExprToTy (EnumT n)       = Some (TEnum n)"
 | "typeExprToTy (EntityT n)     = Some (TEntity n)"
 | "typeExprToTy (RelationT _ _) = None"
+| "typeExprToTy (OptionT t)     = map_option TOption (typeExprToTy t)"
+| "typeExprToTy (SeqT t)        = map_option TSeq (typeExprToTy t)"
+| "typeExprToTy (MapT k v)      =
+     (case (typeExprToTy k, typeExprToTy v) of
+        (Some tk, Some tv) \<Rightarrow> Some (TMap tk tv)
+      | _ \<Rightarrow> None)"
 
 text \<open>The spec-level analogue of \<open>peel_relation_ref :: expr \<Rightarrow>
   String.literal option\<close>, lifted to \<open>expr\<close>. Recognises the
@@ -1070,6 +1149,35 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr \<Rightarrow> ty \<Rightarrow
                 (QuantifierBindingFull var (IdentifierF dnm sp_id) m sp_b
                   # b2 # rest_bs)
                 body sp) TBool"
+| T_StrLit:
+    "expr_has_ty \<Gamma> (StringLitF s sp) TStr"
+| T_NoneLit:
+    "expr_has_ty \<Gamma> (NoneLitF sp) (TOption t)"
+| T_SomeWrap:
+    "expr_has_ty \<Gamma> e t
+       \<Longrightarrow> expr_has_ty \<Gamma> (SomeWrapF e sp) (TOption t)"
+| T_SeqLit_Empty:
+    "expr_has_ty \<Gamma> (SeqLiteralF [] sp) (TSeq t)"
+| T_SeqLit_Cons:
+    "expr_has_ty \<Gamma> e t
+       \<Longrightarrow> expr_has_ty \<Gamma> (SeqLiteralF rest sp) (TSeq t)
+       \<Longrightarrow> expr_has_ty \<Gamma> (SeqLiteralF (e # rest) sp) (TSeq t)"
+| T_MapLit_Empty:
+    "expr_has_ty \<Gamma> (MapLiteralF [] sp) (TMap tk tv)"
+| T_MapLit_Cons:
+    "expr_has_ty \<Gamma> k tk
+       \<Longrightarrow> expr_has_ty \<Gamma> w tv
+       \<Longrightarrow> expr_has_ty \<Gamma> (MapLiteralF rest sp) (TMap tk tv)
+       \<Longrightarrow> expr_has_ty \<Gamma>
+             (MapLiteralF (MapEntryFull k w sp' # rest) sp) (TMap tk tv)"
+| T_If:
+    "expr_has_ty \<Gamma> c TBool
+       \<Longrightarrow> expr_has_ty \<Gamma> a t
+       \<Longrightarrow> expr_has_ty \<Gamma> b t
+       \<Longrightarrow> expr_has_ty \<Gamma> (IfF c a b sp) t"
+| T_Matches:
+    "expr_has_ty \<Gamma> e TStr
+       \<Longrightarrow> expr_has_ty \<Gamma> (MatchesF e pat sp) TBool"
 
 lemmas expr_has_ty_intros [intro] =
   T_BoolLit T_IntLit T_FloatLit T_Ident_Lex T_Ident_State
@@ -1085,6 +1193,8 @@ lemmas expr_has_ty_intros [intro] =
   T_Forall_QExists_Enum_Cons T_Forall_QExists_Rel_Cons
   T_Forall_QSome_Enum T_Forall_QSome_Rel
   T_Forall_QSome_Enum_Cons T_Forall_QSome_Rel_Cons
+  T_StrLit T_NoneLit T_SomeWrap T_SeqLit_Empty T_SeqLit_Cons
+  T_MapLit_Empty T_MapLit_Cons T_If T_Matches
 
 fun as_bool :: "ir_value \<Rightarrow> bool option" where
   "as_bool (VBool b) = Some b"

--- a/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
@@ -389,6 +389,86 @@ next
 next
   case (T_Forall_QSome_Rel_Cons dnm \<Gamma> tv var b2 rest_bs body sp sp_id m sp_b)
   thus ?case by simp
+next
+  case (T_StrLit \<Gamma> s sp)
+  thus ?case by auto
+next
+  case (T_NoneLit \<Gamma> sp t)
+  thus ?case by auto
+next
+  case (T_SomeWrap \<Gamma> e t sp)
+  from T_SomeWrap.prems(2) obtain va where
+      ev: "eval fs ps fuel sch st env e = Some va" and veq: "v = VSome va"
+    by (auto split: option.splits)
+  have "value_has_ty \<Gamma> va t"
+    using T_SomeWrap.IH[OF T_SomeWrap.prems(1) ev] .
+  thus ?case using veq by (simp add: vt_some)
+next
+  case (T_SeqLit_Empty \<Gamma> sp t)
+  from T_SeqLit_Empty.prems(2) have "v = VSeq []" by simp
+  thus ?case by (simp add: vt_seq)
+next
+  case (T_SeqLit_Cons \<Gamma> e t rest sp)
+  from T_SeqLit_Cons.prems(2) obtain va vs where
+      ev_e: "eval fs ps fuel sch st env e = Some va"
+      and ev_rest: "eval_list fs ps fuel sch st env rest = Some vs"
+      and veq: "v = VSeq (va # vs)"
+    by (auto split: option.splits)
+  have va_ty: "value_has_ty \<Gamma> va t"
+    using T_SeqLit_Cons.IH(1)[OF T_SeqLit_Cons.prems(1) ev_e] .
+  have ev_rest_seq:
+      "eval fs ps fuel sch st env (SeqLiteralF rest sp) = Some (VSeq vs)"
+    using ev_rest by simp
+  have "value_has_ty \<Gamma> (VSeq vs) (TSeq t)"
+    using T_SeqLit_Cons.IH(2)[OF T_SeqLit_Cons.prems(1) ev_rest_seq] .
+  hence "\<forall>w \<in> set vs. value_has_ty \<Gamma> w t"
+    by (auto elim: value_has_ty_seq_cases)
+  thus ?case using va_ty veq by (auto intro!: vt_seq)
+next
+  case (T_MapLit_Empty \<Gamma> sp tk tv)
+  from T_MapLit_Empty.prems(2) have "v = VMap []" by simp
+  thus ?case by (auto intro: vt_map)
+next
+  case (T_MapLit_Cons \<Gamma> k tk w tv rest sp sp')
+  from T_MapLit_Cons.prems(2) obtain kv wv qs where
+      ev_k: "eval fs ps fuel sch st env k = Some kv"
+      and ev_w: "eval fs ps fuel sch st env w = Some wv"
+      and ev_rest: "eval_entries fs ps fuel sch st env rest = Some qs"
+      and veq: "v = VMap ((kv, wv) # qs)"
+    by (auto split: option.splits)
+  have k_ty: "value_has_ty \<Gamma> kv tk"
+    using T_MapLit_Cons.IH(1)[OF T_MapLit_Cons.prems(1) ev_k] .
+  have w_ty: "value_has_ty \<Gamma> wv tv"
+    using T_MapLit_Cons.IH(2)[OF T_MapLit_Cons.prems(1) ev_w] .
+  have ev_rest_map:
+      "eval fs ps fuel sch st env (MapLiteralF rest sp) = Some (VMap qs)"
+    using ev_rest by simp
+  have "value_has_ty \<Gamma> (VMap qs) (TMap tk tv)"
+    using T_MapLit_Cons.IH(3)[OF T_MapLit_Cons.prems(1) ev_rest_map] .
+  hence "\<forall>(kk, ww) \<in> set qs. value_has_ty \<Gamma> kk tk \<and> value_has_ty \<Gamma> ww tv"
+    by (auto elim: value_has_ty_map_cases)
+  thus ?case using k_ty w_ty veq by (auto intro!: vt_map)
+next
+  case (T_If \<Gamma> c a t b sp)
+  from T_If.prems(2) consider
+      (tt) "eval fs ps fuel sch st env c = Some (VBool True)"
+           "eval fs ps fuel sch st env a = Some v"
+    | (ff) "eval fs ps fuel sch st env c = Some (VBool False)"
+           "eval fs ps fuel sch st env b = Some v"
+    by (auto split: option.splits ir_value.splits bool.splits)
+  thus ?case
+  proof cases
+    case tt
+    show ?thesis using T_If.IH(2)[OF T_If.prems(1) tt(2)] .
+  next
+    case ff
+    show ?thesis using T_If.IH(3)[OF T_If.prems(1) ff(2)] .
+  qed
+next
+  case (T_Matches \<Gamma> e pat sp)
+  from T_Matches.prems(2) obtain b where "v = VBool b"
+    by (auto split: option.splits ir_value.splits)
+  thus ?case by simp
 qed
 
 theorem cat_h_progress_and_preservation_direct:


### PR DESCRIPTION
Closes the proof-coverage half of #383: Option/String/Seq/Map values were encode-sound (#378-#381) but untypable in the H3 layer. The verify-layer stopgap removal (`lacksVerifiedTy` / `sortToTy`) follows in a stacked PR.

## Typing layer (`core/Semantics.thy`)

- `ty` gains `TStr` / `TOption ty` / `TSeq ty` / `TMap ty ty`.
- `value_has_ty` gains `vt_str`, `vt_none` (polymorphic: `VNone : TOption t` for any `t`), `vt_some`, `vt_seq`, `vt_map` (pairwise key+value premises), plus `VStr`/`VNone` iff simp lemmas. The pre-declared `inductive_cases` for these value forms now produce real elims.
- `check_value_has_ty` becomes a `function` with a hand `measure`: the new `check_value_has_ty_pairs` companion recurses into **both** components of each map pair, which the lexicographic-order search cannot synthesise (it only tries per-component projections). The measure reuses the datatype's own `size_prod` component so the `VMap` descent matches `ir_value.size` verbatim. Ctor-matched value arms (`VSet`, `VEntityWith`, and the five new ones) dispatch on `ty` via a `case` RHS with a non-recursive `False` default - future `ty` growth no longer multiplies equation rows.
- `expr_has_ty` gains **nine** rules: `T_StrLit`, `T_NoneLit` (polymorphic option type, mirroring `T_SetLit_Empty`), `T_SomeWrap`, `T_SeqLit_Empty`/`T_SeqLit_Cons`, `T_MapLit_Empty`/`T_MapLit_Cons`, plus `T_If` and `T_Matches` - the last two close the remaining batch-3 gaps (#378's `Ite` was equally untypable, and `matches` is the natural `TStr` consumer). String equality typing was already free via `T_Cmp_Eq`'s `t1 = t2` branch.

## Preservation re-proved zero-sorry

- `well_typed_imp_wf_z3` absorbs all nine cases in its trailing `auto` (`wf_z3` was already `True` for these constructs).
- `h3_preservation` gets nine explicit cases: `T_SeqLit_Cons` mirrors `T_SetLit_Cons` minus the dedupe fold; `T_MapLit_Cons` threads per-entry IHs directly from the Cons-style rule (no universally-quantified helper needed); `T_If` dispatches on the scrutinee's `VBool`. The capstone `cat_h_progress_and_preservation_direct` widens automatically. Umbrella now covers **52 typing rules**.

## Adjacent gaps folded in

- `typeExprFullToTy` name policy aligned with the verify layer's `primitiveSortOf`: `Boolean` -> `TBool`, `DateTime`/`Date` -> `TInt` (epoch ints), `String` -> `TStr`; the phantom `Double` alias dropped (nothing in the grammar, profiles, or aliases produces it - it mapped to `TReal` proof-side but an *uninterpreted* sort verify-side). The stale `primitiveSortOf` comment ("ty has only TInt/TBool") rewritten as an alignment invariant.
- `schema_type` gains the matching `RealT`/`StrT`/`OptionT`/`SeqT`/`MapT` forms with `typeExprToTy` cases.
- `schemaFieldType` / `schemaRelationValueType` inherit all coverage through `typeExprFullToTy` - no separate change needed.

## Scala side

- `SpecRestGenerated.scala` regenerated via the README pipeline (+241/-161).
- `CheckValueHasTyTest`: 13 new parametrized cases (per-sort accept/reject + nested `Option[Map[String, Seq[Int]]]` composition). 20/20 green; full verify suite 223/223.

## STATUS.md note

The ledger predates the docs-npm prettier bump and was no longer prettier-stable: bare snake_case identifiers outside code spans (`T_Quantifier` et al.) parse as markdown emphasis and prettier destructively rewrote them on every hook run - this is the rollback trap that has eaten STATUS.md edits since PR #289. Identifiers are now backticked, three previously-mangled passages restored, and the file reflowed to the current prettier's fixed point, so future edits commit cleanly.

Build: Core 1:32 / Codegen 0:50 / Soundness 0:18, zero sorries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the H3 typing layer with native `String`, `Option`, `Seq`, and `Map` so lifted values and literals type-check end to end. Re-proved preservation, updated the executable checker, and aligned schema/name policy with the verify layer (proof side of #383).

- New Features
  - Types and value checking: added `TStr`, `TOption`, `TSeq`, `TMap` with `vt_str`, polymorphic `vt_none`, `vt_some`, `vt_seq`, `vt_map`. Made `check_value_has_ty` a `function` with a custom measure and a `check_value_has_ty_pairs` helper; ctor-matched branches dispatch via `case` to avoid equation blowup.
  - Expressions: added rules for string literal, none/some, seq/map literals (empty/cons), `if`, and `matches`.
  - Schema and proofs: `schema_type` gained `RealT`, `StrT`, `OptionT`, `SeqT`, `MapT`; `typeExprFullToTy` now covers `String`/`OptionTypeF`/`SeqTypeF`/`MapTypeF` and maps `Boolean` and `DateTime`/`Date` to `TBool`/`TInt`. Reproved `well_typed_imp_wf_z3` and extended preservation (umbrella now 52 rules). Added tests, including nested `Option[Map[String, Seq[Int]]]`.

- Refactors
  - Aligned primitive-name policy with the verify layer (`primitiveSortOf`): dropped the unused `Double` alias; regenerated `SpecRestGenerated.scala`.
  - Stabilized `STATUS.md` formatting by backticking identifiers to stop prettier churn.

<sup>Written for commit b620d4aafc06355d5ef29635568509b9626721b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the formal type system to support additional built-in types: strings, optional values, sequences, and maps.

* **Documentation**
  * Updated proof documentation with refined guidance on typing rules and new type constructor support.

* **Tests**
  * Added comprehensive test coverage for type checking of newly supported types and their nested combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->