### PR TITLE
fix(docs): align playground editor selection and explain raw IR output

### DIFF
--- a/docs/components/playground.tsx
+++ b/docs/components/playground.tsx
@@ -513,10 +513,13 @@ function SpecEditor(props: {
         spec
       </div>
       <div className="relative flex-1 overflow-hidden bg-fd-background">
+        {/* not-fumadocs-codeblock: fumadocs' shiki.css pads every .line span,
+            which would shift the highlighted overlay right of the transparent
+            textarea's real glyphs and misalign selection. */}
         <div
           ref={overlayRef}
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 overflow-auto p-3 font-mono text-[13px] leading-relaxed text-fd-foreground [&_code]:font-mono [&_pre]:m-0 [&_pre]:!bg-transparent [&_pre]:p-0"
+          className="not-fumadocs-codeblock pointer-events-none absolute inset-0 overflow-auto p-3 font-mono text-[13px] leading-relaxed text-fd-foreground [&_code]:font-mono [&_pre]:m-0 [&_pre]:!bg-transparent [&_pre]:p-0"
         >
           {html ? (
             <div dangerouslySetInnerHTML={{ __html: html }} />
@@ -678,10 +681,20 @@ function StatusLine({ state, target }: { state: RunState; target: Target }) {
         ? ` · ${state.totalFiles} files / ${Math.round((state.totalBytes ?? 0) / 1024)} KB`
         : "";
     return (
-      <p className="text-xs text-fd-muted-foreground">
-        <span className="text-green-600 dark:text-green-400">✓ ok</span> in {state.elapsedMs} ms
-        {extra}
-      </p>
+      <>
+        <p className="text-xs text-fd-muted-foreground">
+          <span className="text-green-600 dark:text-green-400">✓ ok</span> in {state.elapsedMs} ms
+          {extra}
+        </p>
+        {state.target === "ir" && (
+          <p className="text-xs text-fd-muted-foreground">
+            The IR dump is the raw verifier input. <code>SpanT(line, col, line, col)</code> nodes
+            are source positions (1-based lines, 0-based columns), and the{" "}
+            <code>isValidURI</code> / <code>isValidEmail</code> predicates are built-ins merged
+            from the parser preamble - their spans point into the preamble, not your spec.
+          </p>
+        )}
+      </>
     );
   }
   return (


### PR DESCRIPTION
Two playground papercuts:

## Selection misalignment in the spec editor

The editor is a shiki-highlighted overlay above a transparent `<textarea>`. fumadocs' `shiki.css` pads **every `.line` span by 1rem** (`--padding-left: calc(var(--spacing) * 4)`) for any `.shiki` block not inside its `.not-fumadocs-codeblock` escape hatch - so the visible glyphs sat ~2 characters right of the textarea's real text, and selecting made the highlight appear shifted 1-3 chars left on every row. The overlay now opts out via `not-fumadocs-codeblock`. (Verified shiki emits `<span class="line">` per row, so the rule was hitting every line; likely surfaced with the fumadocs bump in #401.)

## "Why does the IR look like that" hint

Running the IR target dumps the raw `ServiceIRFull` toString - `Some(SpanT(...))` wrappers and two predicates the user never wrote. The status line now explains, only for the IR target: `SpanT(line, col, line, col)` nodes are source positions (1-based lines, 0-based cols), and `isValidURI`/`isValidEmail` are built-ins merged from the parser preamble whose spans point into `preamble.spec`, not the user's spec.

`tsc --noEmit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misaligned text selection in the playground spec editor and adds a short hint that explains the raw IR output.

- **Bug Fixes**
  - Aligned the shiki overlay with the transparent textarea by opting out of fumadocs’ `.line` padding via `not-fumadocs-codeblock`.

- **New Features**
  - IR target status line now explains `SpanT(line, col, line, col)` source positions and that `isValidURI` / `isValidEmail` are parser preamble built-ins.

<sup>Written for commit 84f69027aa79e58f6332f010e952f3f64970b211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

