### PR TITLE
feat(codegen): direct-emit scalar state operations (#407)

### DIFF
--- a/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/cmd/server/main.go.hbs
@@ -40,7 +40,9 @@ func main() {
 
 {{#each entities}}{{#if hasOperations}}	{{entityCamel}}Svc := services.New{{entity.modelClassName}}Service(db, cfg)
 	{{entityCamel}}Handler := handlers.New{{entity.modelClassName}}Handler({{entityCamel}}Svc)
-{{/if}}{{/each}}
+{{/if}}{{/each}}{{#if scalarOps.length}}	stateOpsSvc := services.NewStateOpsService(db, cfg)
+	stateOpsHandler := handlers.NewStateOpsHandler(stateOpsSvc)
+{{/if}}
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -61,7 +63,8 @@ func main() {
 	testadmin.Register(r, db)
 
 {{#each entities}}{{#each operations}}	r.{{pascal_case method}}("{{chiPath}}", {{../entityCamel}}Handler.{{handlerName}})
-{{/each}}{{/each}}
+{{/each}}{{/each}}{{#each scalarOps}}	r.{{methodPascal}}("{{chiPath}}", stateOpsHandler.{{handlerName}})
+{{/each}}
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/modules/codegen/src/main/resources/templates/python/fastapi/alembic/versions/001_initial_schema.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/alembic/versions/001_initial_schema.py.hbs
@@ -32,6 +32,8 @@ def upgrade() -> None:
 
 {{else}}
     pass
+{{/each}}{{#each migration.seedStatements}}
+    op.execute("{{{this}}}")
 {{/each}}
 {{#each migration.triggers}}
 {{#each this.upgradeStatements}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
@@ -10,7 +10,9 @@ from app.extensions import register as register_extensions
 from app.redaction import configure_logging
 {{#each entities}}
 from app.routers import {{snake_case (pluralize this.entityName)}}
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+from app.routers import state_ops
+{{/if}}
 
 
 configure_logging()
@@ -56,4 +58,6 @@ if os.environ.get("ENABLE_TEST_ADMIN") == "1":
 
 {{#each entities}}
 app.include_router({{snake_case (pluralize this.entityName)}}.router)
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+app.include_router(state_ops.router)
+{{/if}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/models/__init__.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/models/__init__.py.hbs
@@ -1,11 +1,15 @@
 from app.db.base import Base
 {{#each entities}}
 from app.models.{{snake_case this.entityName}} import {{this.modelClassName}}
-{{/each}}
+{{/each}}{{#if scalarStateFields.length}}
+from app.models.service_state import ServiceState
+{{/if}}
 
 __all__ = [
     "Base",
 {{#each entities}}
     "{{this.modelClassName}}",
-{{/each}}
+{{/each}}{{#if scalarStateFields.length}}
+    "ServiceState",
+{{/if}}
 ]

--- a/modules/codegen/src/main/resources/templates/python/fastapi/models/service_state.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/models/service_state.py.hbs
@@ -9,5 +9,5 @@ class ServiceState(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
 {{#each stateFields}}
-    {{this.columnName}}: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    {{this.columnName}}: Mapped[int] = mapped_column(BigInteger, nullable=False, default={{this.seed}})
 {{/each}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/models/service_state.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/models/service_state.py.hbs
@@ -1,0 +1,13 @@
+from sqlalchemy import BigInteger
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class ServiceState(Base):
+    __tablename__ = "{{tableName}}"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
+{{#each stateFields}}
+    {{this.columnName}}: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+{{/each}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/routers/__init__.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/routers/__init__.py.hbs
@@ -1,9 +1,13 @@
 {{#each entities}}
 from app.routers import {{snake_case (pluralize this.entityName)}}
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+from app.routers import state_ops
+{{/if}}
 
 __all__ = [
 {{#each entities}}
     "{{snake_case (pluralize this.entityName)}}",
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+    "state_ops",
+{{/if}}
 ]

--- a/modules/codegen/src/main/resources/templates/python/fastapi/routers/state_ops.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/routers/state_ops.py.hbs
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_session
+from app.services.state_ops import StateOpsService
+
+router = APIRouter(tags=["state"])
+{{#each scalarOps}}
+
+
+@router.{{this.method}}("{{this.path}}", status_code={{this.successStatus}})
+async def {{this.handlerName}}(
+    session: AsyncSession = Depends(get_session),
+) -> dict[str, int]:
+    svc = StateOpsService(session)
+    result = await svc.{{this.handlerName}}()
+    if result is None:
+        raise HTTPException(status_code=409, detail="precondition failed: {{this.guardPretty}}")
+    return result
+{{/each}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/__init__.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/__init__.py.hbs
@@ -1,9 +1,13 @@
 {{#each entities}}
 from app.services.{{snake_case this.entityName}} import {{this.entityName}}Service
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+from app.services.state_ops import StateOpsService
+{{/if}}
 
 __all__ = [
 {{#each entities}}
     "{{this.entityName}}Service",
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+    "StateOpsService",
+{{/if}}
 ]

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/state_ops.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/state_ops.py.hbs
@@ -1,0 +1,35 @@
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.service_state import ServiceState
+
+
+class StateOpsService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def _snapshot(self) -> dict[str, int]:
+        result = await self._session.execute(select(ServiceState).where(ServiceState.id == 1))
+        row = result.scalar_one()
+        return {
+{{#each stateFields}}
+            "{{this.specName}}": row.{{this.columnName}},
+{{/each}}
+        }
+{{#each scalarOps}}
+
+    async def {{this.handlerName}}(self) -> dict[str, int] | None:
+        # Atomic guarded update: the requires clause rides in the WHERE so a
+        # stale read can never break the verified invariant under concurrency.
+        result = await self._session.execute(
+            update(ServiceState)
+            .where(ServiceState.id == 1)
+{{#each this.guardConds}}
+            .where({{{this}}})
+{{/each}}
+            .values({{{this.valuesArgs}}})
+        )
+        if result.rowcount == 0:
+            return None
+        return await self._snapshot()
+{{/each}}

--- a/modules/codegen/src/main/resources/templates/ts/express/prisma/schema.prisma.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/prisma/schema.prisma.hbs
@@ -16,4 +16,13 @@ model {{entity.modelClassName}} {
   @@map("{{entity.tableName}}")
 }
 
+{{/each}}{{#if scalarStateFields.length}}
+model ServiceState {
+  id BigInt @id
+{{#each scalarStateFields}}
+  {{this.camelName}} BigInt @map("{{this.columnName}}")
 {{/each}}
+
+  @@map("service_state")
+}
+{{/if}}

--- a/modules/codegen/src/main/resources/templates/ts/express/src/routes/index.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/routes/index.ts.hbs
@@ -2,10 +2,14 @@ import type { Express } from 'express';
 
 {{#each entities}}
 import { register{{entity.modelClassName}}Routes } from './{{entityPluralCamel}}.js';
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+import { registerStateOpsRoutes } from './stateOps.js';
+{{/if}}
 
 export const mountRoutes = (app: Express): void => {
 {{#each entities}}
   register{{entity.modelClassName}}Routes(app);
-{{/each}}
+{{/each}}{{#if hasScalarOps}}
+  registerStateOpsRoutes(app);
+{{/if}}
 };

--- a/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
@@ -46,15 +46,17 @@ object ScalarOps:
         val clauses = flattenEnsures(operEnsures(op))
         val updates = clauses.map(c => scalarUpdateOf(scalarNames, c))
         val guards  = flattenEnsures(operRequires(op)).map(r => scalarGuardOf(scalarNames, r))
-        if clauses.nonEmpty && updates.forall(_.isDefined) && guards.forall(_.isDefined) then
+        // Mirrors classifyStrategy's scalar branch exactly (same extracted
+        // recognisers + consistency check), so every DirectEmit scalar op
+        // gets a handler and nothing else does.
+        if clauses.nonEmpty && updates.forall(_.isDefined) && guards.forall(_.isDefined)
+          && operInputs(op).isEmpty && scalarUpdatesConsistent(updates.flatten)
+        then
           profiledByName.get(operName(op)).map: po =>
-            // conjunctive ensures repeating a field collapse to the last clause
+            // identical repeated assignments collapse to one
             val ups = updates.flatten
               .map((n, rhs) => ScalarUpdateView(n, ScalarState.columnName(n), rhs))
-              .groupBy(_.columnName)
-              .values
-              .map(_.last)
-              .toList
+              .distinctBy(_.columnName)
               .sortBy(_.columnName)
             val gs = guards.flatten.collect:
               case SgCmp(n, c, k) => ScalarGuardView(n, ScalarState.columnName(n), c, k)

--- a/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
@@ -1,0 +1,95 @@
+package specrest.codegen
+
+import specrest.convention.ScalarState
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.profile.ProfiledOperation
+import specrest.profile.ProfiledService
+
+final case class ScalarStateFieldView(specName: String, columnName: String, camelName: String)
+
+final case class ScalarUpdateView(specName: String, columnName: String, rhs: scalar_rhs)
+
+final case class ScalarGuardView(
+    specName: String,
+    columnName: String,
+    cmp: scalar_cmp,
+    lit: BigInt
+)
+
+final case class ScalarOpView(
+    operation: ProfiledOperation,
+    updates: List[ScalarUpdateView],
+    guards: List[ScalarGuardView]
+):
+  def guardPretty: String =
+    if guards.isEmpty then "true"
+    else
+      guards
+        .map(g => s"${g.specName} ${ScalarOps.specCmp(g.cmp)} ${g.lit}")
+        .mkString(" and ")
+
+object ScalarOps:
+
+  val TableName: String = ScalarState.TableName
+
+  def stateFields(p: ProfiledService): List[ScalarStateFieldView] =
+    ScalarState.fields(p.ir).map: sf =>
+      val col = ScalarState.columnName(stfName(sf))
+      ScalarStateFieldView(stfName(sf), col, specrest.ir.Naming.toCamelCase(col))
+
+  def views(p: ProfiledService): List[ScalarOpView] =
+    val scalarNames = ScalarState.fieldNames(p.ir)
+    if scalarNames.isEmpty then Nil
+    else
+      val profiledByName = p.operations.map(o => o.operationName -> o).toMap
+      svcOperations(p.ir).flatMap: op =>
+        val clauses = flattenEnsures(operEnsures(op))
+        val updates = clauses.map(c => scalarUpdateOf(scalarNames, c))
+        val guards  = flattenEnsures(operRequires(op)).map(r => scalarGuardOf(scalarNames, r))
+        if clauses.nonEmpty && updates.forall(_.isDefined) && guards.forall(_.isDefined) then
+          profiledByName.get(operName(op)).map: po =>
+            // conjunctive ensures repeating a field collapse to the last clause
+            val ups = updates.flatten
+              .map((n, rhs) => ScalarUpdateView(n, ScalarState.columnName(n), rhs))
+              .groupBy(_.columnName)
+              .values
+              .map(_.last)
+              .toList
+              .sortBy(_.columnName)
+            val gs = guards.flatten.collect:
+              case SgCmp(n, c, k) => ScalarGuardView(n, ScalarState.columnName(n), c, k)
+            ScalarOpView(po, ups, gs)
+        else None
+
+  def renderRhs(r: scalar_rhs, selfRef: String): String = r match
+    case SrLit(k)    => k.toString
+    case SrSelf()    => selfRef
+    case SrAdd(a, b) => s"(${renderRhs(a, selfRef)} + ${renderRhs(b, selfRef)})"
+    case SrSub(a, b) => s"(${renderRhs(a, selfRef)} - ${renderRhs(b, selfRef)})"
+    case SrMul(a, b) => s"(${renderRhs(a, selfRef)} * ${renderRhs(b, selfRef)})"
+
+  def sqlCmp(c: scalar_cmp): String = c match
+    case _: ScGt  => ">"
+    case _: ScGe  => ">="
+    case _: ScLt  => "<"
+    case _: ScLe  => "<="
+    case _: ScEq  => "="
+    case _: ScNeq => "<>"
+
+  def pyCmp(c: scalar_cmp): String = c match
+    case _: ScEq  => "=="
+    case _: ScNeq => "!="
+    case other    => sqlCmp(other)
+
+  def specCmp(c: scalar_cmp): String = c match
+    case _: ScNeq => "!="
+    case _: ScEq  => "="
+    case other    => sqlCmp(other)
+
+  def seedSqlFor(t: table_spec): String =
+    val cols = tableColumns(t).map(columnName)
+    val vals = cols.map(c => if c == "id" then "1" else "0")
+    s"INSERT INTO ${tableName(t)} (${cols.mkString(", ")}) VALUES (${vals.mkString(", ")})"
+
+  def isStateTable(t: table_spec): Boolean =
+    tableName(t) == TableName && tableEntityName(t).isEmpty

--- a/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ScalarOps.scala
@@ -5,7 +5,12 @@ import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
-final case class ScalarStateFieldView(specName: String, columnName: String, camelName: String)
+final case class ScalarStateFieldView(
+    specName: String,
+    columnName: String,
+    camelName: String,
+    seed: BigInt
+)
 
 final case class ScalarUpdateView(specName: String, columnName: String, rhs: scalar_rhs)
 
@@ -33,9 +38,9 @@ object ScalarOps:
   val TableName: String = ScalarState.TableName
 
   def stateFields(p: ProfiledService): List[ScalarStateFieldView] =
-    ScalarState.fields(p.ir).map: sf =>
+    ScalarState.fieldsWithSeeds(p.ir).map: (sf, seed) =>
       val col = ScalarState.columnName(stfName(sf))
-      ScalarStateFieldView(stfName(sf), col, specrest.ir.Naming.toCamelCase(col))
+      ScalarStateFieldView(stfName(sf), col, specrest.ir.Naming.toCamelCase(col), seed)
 
   def views(p: ProfiledService): List[ScalarOpView] =
     val scalarNames = ScalarState.fieldNames(p.ir)
@@ -89,9 +94,12 @@ object ScalarOps:
     case other    => sqlCmp(other)
 
   def seedSqlFor(t: table_spec): String =
-    val cols = tableColumns(t).map(columnName)
-    val vals = cols.map(c => if c == "id" then "1" else "0")
-    s"INSERT INTO ${tableName(t)} (${cols.mkString(", ")}) VALUES (${vals.mkString(", ")})"
+    val cols  = tableColumns(t)
+    val names = cols.map(columnName)
+    val vals = cols.map: c =>
+      if columnName(c) == "id" then ScalarState.SingletonId.toString
+      else columnDefaultValue(c).getOrElse("0")
+    s"INSERT INTO ${tableName(t)} (${names.mkString(", ")}) VALUES (${vals.mkString(", ")})"
 
   def isStateTable(t: table_spec): Boolean =
     tableName(t) == TableName && tableEntityName(t).isEmpty

--- a/modules/codegen/src/main/scala/specrest/codegen/Templates.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Templates.scala
@@ -35,7 +35,10 @@ final case class PythonFastapiPostgresTemplates(
     testHealth: String,
     testLogRedaction: String,
     dafnyAdapter: String,
-    synthService: String
+    synthService: String,
+    modelServiceState: String,
+    serviceStateOps: String,
+    routerStateOps: String
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.Null"))
@@ -88,5 +91,8 @@ object Templates:
       testHealth = loadResource("tests/test_health.py.hbs"),
       testLogRedaction = loadResource("tests/test_log_redaction.py.hbs"),
       dafnyAdapter = loadResource("services/_dafny_adapter.py.hbs"),
-      synthService = loadResource("services/_synth.py.hbs")
+      synthService = loadResource("services/_synth.py.hbs"),
+      modelServiceState = loadResource("models/service_state.py.hbs"),
+      serviceStateOps = loadResource("services/state_ops.py.hbs"),
+      routerStateOps = loadResource("routers/state_ops.py.hbs")
     )

--- a/modules/codegen/src/main/scala/specrest/codegen/Types.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Types.scala
@@ -46,7 +46,9 @@ final case class RenderContext(
     endpoints: List[EndpointSpec],
     schema: database_schema,
     db: DialectView,
-    dafnyKernel: Option[DafnyKernel] = None
+    dafnyKernel: Option[DafnyKernel] = None,
+    scalarStateFields: List[ScalarStateFieldView] = Nil,
+    hasScalarOps: Boolean = false
 )
 
 final case class RenderResult(fileName: String, content: String)
@@ -75,7 +77,9 @@ object RenderContext:
       db = Dialect
         .forDatabase(profiled.profile.database)
         .deployment(Naming.toSnakeCase(svcName(profiled.ir))),
-      dafnyKernel = dafnyKernel
+      dafnyKernel = dafnyKernel,
+      scalarStateFields = ScalarOps.stateFields(profiled),
+      hasScalarOps = ScalarOps.views(profiled).nonEmpty
     )
 
   private def convertProfile(profile: DeploymentProfile): RenderProfile =

--- a/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/alembic/Migration.scala
@@ -1,5 +1,6 @@
 package specrest.codegen.alembic
 
+import specrest.codegen.ScalarOps
 import specrest.codegen.migration.AlembicSyntax
 import specrest.codegen.migration.CanonicalType
 import specrest.codegen.migration.Dialect
@@ -57,6 +58,7 @@ final case class AlembicMigration(
     tablesReversed: List[AlembicTable],
     triggers: List[AlembicTrigger],
     triggersReversed: List[AlembicTrigger],
+    seedStatements: List[String],
     needsPostgresDialect: Boolean
 )
 
@@ -83,6 +85,7 @@ object Migration:
       tablesReversed = tables.reverse,
       triggers = triggers,
       triggersReversed = triggers.reverse,
+      seedStatements = sorted.filter(ScalarOps.isStateTable).map(ScalarOps.seedSqlFor),
       needsPostgresDialect = needsPostgresDialect
     )
 

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -9,6 +9,9 @@ import specrest.codegen.ExtensionStub
 import specrest.codegen.GoTemplates
 import specrest.codegen.OperationContext
 import specrest.codegen.RenderContext
+import specrest.codegen.ScalarOpView
+import specrest.codegen.ScalarOps
+import specrest.codegen.ScalarStateFieldView
 import specrest.codegen.TemplateEngine
 import specrest.codegen.migration.Revision
 import specrest.codegen.migration.SchemaCodec
@@ -117,6 +120,16 @@ final private case class GoDbView(
     dsnRecipe: Option[specrest.codegen.Dsn.Recipe]
 )
 
+final private case class GoScalarOpView(
+    handlerName: String,
+    methodPascal: String,
+    chiPath: String,
+    successStatus: Int,
+    setSql: String,
+    whereSql: String,
+    guardPretty: String
+)
+
 final private case class GoProjectCtx(
     service: GoServiceNames,
     module: String,
@@ -125,7 +138,8 @@ final private case class GoProjectCtx(
     needsUuid: Boolean,
     needsDecimal: Boolean,
     db: GoDbView,
-    dafnyKernel: Option[DafnyKernel]
+    dafnyKernel: Option[DafnyKernel],
+    scalarOps: List[GoScalarOpView]
 )
 
 object EmitGo:
@@ -169,6 +183,9 @@ object EmitGo:
     val needsUuid    = entities.exists(_.needsUuid)
     val needsDecimal = entities.exists(_.needsDecimal)
 
+    val scalarFields = ScalarOps.stateFields(profiled)
+    val scalarOps    = ScalarOps.views(profiled).map(goScalarOp)
+
     val projectCtx = GoProjectCtx(
       service = service,
       module = module,
@@ -177,7 +194,8 @@ object EmitGo:
       needsUuid = needsUuid,
       needsDecimal = needsDecimal,
       db = goDbView(profiled.profile.database, service.snakeName),
-      dafnyKernel = opts.dafnyKernel
+      dafnyKernel = opts.dafnyKernel,
+      scalarOps = scalarOps
     )
 
     val files        = List.newBuilder[EmittedFile]
@@ -259,6 +277,15 @@ object EmitGo:
         s"internal/services/${entityCtx.entitySnake}.go",
         engine.renderAny(templates.serviceEntity, perEntity)
       )
+
+    if scalarFields.nonEmpty then
+      files += EmittedFile("internal/models/service_state.go", goStateModel(scalarFields))
+    if scalarOps.nonEmpty then
+      files += EmittedFile(
+        "internal/services/state_ops.go",
+        goStateService(module, scalarFields, scalarOps)
+      )
+      files += EmittedFile("internal/handlers/state_ops.go", goStateHandler(module, scalarOps))
 
     emitMigrationFiles(profiled, opts, templates, engine, projectCtx.db, files)
 
@@ -418,8 +445,12 @@ object EmitGo:
       val tableOps   = SchemaDiff.topoSort(schemaTables(schema)).map(CreateTable.apply)
       val triggerOps = schemaTriggers(schema).map(AddTrigger.apply)
       val ops        = tableOps ++ triggerOps
+      val seeds = SchemaDiff
+        .topoSort(schemaTables(schema))
+        .filter(ScalarOps.isStateTable)
+        .map(t => ScalarOps.seedSqlFor(t) + ";")
       val view = SqlMigrationView(
-        upgradeStatements = SqlRenderer.upgrade(ops, dialect),
+        upgradeStatements = SqlRenderer.upgrade(ops, dialect) ++ seeds,
         downgradeStatements = SqlRenderer.downgrade(ops, dialect)
       )
       val scope = Map[String, Any](
@@ -472,15 +503,18 @@ object EmitGo:
       currentEntity: Option[GoEntityCtx] = None
   ): Map[String, Any] =
     val base = Map[String, Any](
-      "service"      -> proj.service,
-      "module"       -> proj.module,
-      "profile"      -> ctx.profile,
-      "entities"     -> proj.entities,
-      "needsTime"    -> proj.needsTime,
-      "needsUuid"    -> proj.needsUuid,
-      "needsDecimal" -> proj.needsDecimal,
-      "db"           -> proj.db,
-      "hasDafny"     -> proj.dafnyKernel.isDefined
+      "service"           -> proj.service,
+      "module"            -> proj.module,
+      "profile"           -> ctx.profile,
+      "entities"          -> proj.entities,
+      "needsTime"         -> proj.needsTime,
+      "needsUuid"         -> proj.needsUuid,
+      "needsDecimal"      -> proj.needsDecimal,
+      "db"                -> proj.db,
+      "hasDafny"          -> proj.dafnyKernel.isDefined,
+      "scalarOps"         -> proj.scalarOps,
+      "scalarStateFields" -> ctx.scalarStateFields,
+      "hasScalarOps"      -> ctx.hasScalarOps
     )
     currentEntity match
       case Some(e) =>
@@ -715,6 +749,150 @@ object EmitGo:
       lookupColumn = lookupCol,
       createAssigns = createAssigns
     )
+
+  private def goScalarOp(v: ScalarOpView): GoScalarOpView =
+    val ep = v.operation.endpoint
+    val methodPascal = ep.method match
+      case _: GET    => "Get"
+      case _: POST   => "Post"
+      case _: PUT    => "Put"
+      case _: PATCH  => "Patch"
+      case _: DELETE => "Delete"
+    val setSql = v.updates
+      .map(u => s"${u.columnName} = ${ScalarOps.renderRhs(u.rhs, u.columnName)}")
+      .mkString(", ")
+    val whereSql =
+      ("id = 1" :: v.guards.map(g => s"${g.columnName} ${ScalarOps.sqlCmp(g.cmp)} ${g.lit}"))
+        .mkString(" AND ")
+    GoScalarOpView(
+      handlerName = Naming.toPascalCase(v.operation.operationName, Naming.PascalStrategy.Go),
+      methodPascal = methodPascal,
+      chiPath = ep.path,
+      successStatus = ep.successStatus,
+      setSql = setSql,
+      whereSql = whereSql,
+      guardPretty = v.guardPretty
+    )
+
+  private def goStateModel(fields: List[ScalarStateFieldView]): String =
+    val cols = fields
+      .map: f =>
+        val goField = Naming.toPascalCase(f.columnName, Naming.PascalStrategy.Go)
+        s"""\t$goField int64 `bun:"${f.columnName}" json:"${f.specName}"`"""
+      .mkString("\n")
+    s"""|package models
+        |
+        |import "github.com/uptrace/bun"
+        |
+        |type ServiceState struct {
+        |\tbun.BaseModel `bun:"table:${ScalarOps.TableName}"`
+        |
+        |\tID int64 `bun:"id,pk" json:"id"`
+        |$cols
+        |}
+        |""".stripMargin
+
+  private def goStateService(
+      module: String,
+      fields: List[ScalarStateFieldView],
+      ops: List[GoScalarOpView]
+  ): String =
+    val snapshotPairs = fields
+      .map: f =>
+        val goField = Naming.toPascalCase(f.columnName, Naming.PascalStrategy.Go)
+        s"""\t\t"${f.specName}": st.$goField,"""
+      .mkString("\n")
+    val methods = ops
+      .map: op =>
+        s"""|func (s *StateOpsService) ${op.handlerName}(ctx context.Context) (map[string]int64, bool, error) {
+            |\tres, err := s.db.NewUpdate().Model((*models.ServiceState)(nil)).
+            |\t\tSet("${op.setSql}").
+            |\t\tWhere("${op.whereSql}").
+            |\t\tExec(ctx)
+            |\tif err != nil {
+            |\t\treturn nil, false, err
+            |\t}
+            |\tn, err := res.RowsAffected()
+            |\tif err != nil {
+            |\t\treturn nil, false, err
+            |\t}
+            |\tif n == 0 {
+            |\t\treturn nil, false, nil
+            |\t}
+            |\tsnap, err := s.snapshot(ctx)
+            |\tif err != nil {
+            |\t\treturn nil, false, err
+            |\t}
+            |\treturn snap, true, nil
+            |}
+            |""".stripMargin
+      .mkString("\n")
+    s"""|package services
+        |
+        |import (
+        |\t"context"
+        |
+        |\t"github.com/uptrace/bun"
+        |
+        |\t"$module/internal/config"
+        |\t"$module/internal/models"
+        |)
+        |
+        |type StateOpsService struct {
+        |\tdb  *bun.DB
+        |\tcfg *config.Config
+        |}
+        |
+        |func NewStateOpsService(db *bun.DB, cfg *config.Config) *StateOpsService {
+        |\treturn &StateOpsService{db: db, cfg: cfg}
+        |}
+        |
+        |func (s *StateOpsService) snapshot(ctx context.Context) (map[string]int64, error) {
+        |\tst := new(models.ServiceState)
+        |\tif err := s.db.NewSelect().Model(st).Where("id = 1").Limit(1).Scan(ctx); err != nil {
+        |\t\treturn nil, err
+        |\t}
+        |\treturn map[string]int64{
+        |$snapshotPairs
+        |\t}, nil
+        |}
+        |
+        |$methods""".stripMargin
+
+  private def goStateHandler(module: String, ops: List[GoScalarOpView]): String =
+    val methods = ops
+      .map: op =>
+        s"""|func (h *StateOpsHandler) ${op.handlerName}(w http.ResponseWriter, r *http.Request) {
+            |\tresult, ok, err := h.svc.${op.handlerName}(r.Context())
+            |\tif err != nil {
+            |\t\twriteError(w, http.StatusInternalServerError, err.Error())
+            |\t\treturn
+            |\t}
+            |\tif !ok {
+            |\t\twriteError(w, http.StatusConflict, "precondition failed: ${op.guardPretty}")
+            |\t\treturn
+            |\t}
+            |\twriteJSON(w, ${op.successStatus}, result)
+            |}
+            |""".stripMargin
+      .mkString("\n")
+    s"""|package handlers
+        |
+        |import (
+        |\t"net/http"
+        |
+        |\t"$module/internal/services"
+        |)
+        |
+        |type StateOpsHandler struct {
+        |\tsvc *services.StateOpsService
+        |}
+        |
+        |func NewStateOpsHandler(svc *services.StateOpsService) *StateOpsHandler {
+        |\treturn &StateOpsHandler{svc: svc}
+        |}
+        |
+        |$methods""".stripMargin
 
   private def redirectTarget(
       @scala.annotation.unused op: ProfiledOperation,

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -474,8 +474,13 @@ object EmitGo:
         val ops = SchemaDiff.compute(prev, schema)
         if ops.nonEmpty then
           val nextRev = Revision.next(opts.existingRevisions)
+          // A state table first appearing in a delta still needs its singleton
+          // row; without it every scalar op's guarded UPDATE matches 0 rows.
+          val deltaSeeds = ops.collect:
+            case CreateTable(t) if ScalarOps.isStateTable(t) =>
+              ScalarOps.seedSqlFor(t) + ";"
           val view = SqlMigrationView(
-            upgradeStatements = SqlRenderer.upgrade(ops, dialect),
+            upgradeStatements = SqlRenderer.upgrade(ops, dialect) ++ deltaSeeds,
             downgradeStatements = SqlRenderer.downgrade(ops, dialect)
           )
           val scope = Map[String, Any](

--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -1,6 +1,9 @@
 package specrest.codegen.openapi
 
 import specrest.codegen.OperationContext
+import specrest.codegen.ScalarOpView
+import specrest.codegen.ScalarOps
+import specrest.codegen.ScalarStateFieldView
 import specrest.convention.ParamSpec
 import specrest.ir.Naming
 import specrest.ir.PrettyPrint
@@ -234,6 +237,12 @@ object Paths:
         val operation = buildOperation(op, entity, ctx)
         val existing  = paths.getOrElse(op.endpoint.path, PathItemObject())
         paths(op.endpoint.path) = setMethod(existing, op.endpoint.method, operation)
+    val scalarFields = ScalarOps.stateFields(profiled)
+    for v <- ScalarOps.views(profiled) do
+      val ep        = v.operation.endpoint
+      val operation = buildScalarOperation(v, scalarFields)
+      val existing  = paths.getOrElse(ep.path, PathItemObject())
+      paths(ep.path) = setMethod(existing, ep.method, operation)
     paths("/health") = setMethod(
       paths.getOrElse("/health", PathItemObject()),
       GET(),
@@ -448,6 +457,34 @@ object Paths:
               SchemaObject(ref = Some(s"#/components/schemas/${entity.readSchemaName}"))
             )
           else ResponseObject("Successful response", None, None)
+
+  private def buildScalarOperation(
+      v: ScalarOpView,
+      fields: List[ScalarStateFieldView]
+  ): OperationObject =
+    val stateSchema = SchemaObject(
+      `type` = Some(List("object")),
+      required = Some(fields.map(_.specName)),
+      properties = Some(
+        fields.map(f => f.specName -> SchemaObject(`type` = Some(List("integer")))).toMap
+      )
+    )
+    val ok = Map(
+      v.operation.endpoint.successStatus.toString ->
+        jsonResponse("Successful response", stateSchema)
+    )
+    val conflict =
+      if v.guards.nonEmpty then Map("409" -> errorResponseRef("Precondition failed"))
+      else Map.empty[String, ResponseObject]
+    OperationObject(
+      operationId = v.operation.handlerName,
+      summary = Some(v.operation.operationName),
+      description = None,
+      tags = List("state"),
+      parameters = None,
+      requestBody = None,
+      responses = ok ++ conflict
+    )
 
   private def jsonResponse(description: String, schema: SchemaObject): ResponseObject =
     ResponseObject(

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -8,6 +8,9 @@ import specrest.codegen.ExtensionStub
 import specrest.codegen.OperationContext
 import specrest.codegen.RenderContext
 import specrest.codegen.RenderProfile
+import specrest.codegen.ScalarOpView
+import specrest.codegen.ScalarOps
+import specrest.codegen.ScalarStateFieldView
 import specrest.codegen.SensitiveFields
 import specrest.codegen.ServiceNames
 import specrest.codegen.TemplateEngine
@@ -46,6 +49,26 @@ final case class AlembicDeltaCtx(
     service: ServiceNames,
     profile: RenderProfile,
     migration: AlembicDelta
+)
+
+final case class StateModelCtx(
+    tableName: String,
+    stateFields: List[ScalarStateFieldView]
+)
+
+final case class PyScalarOp(
+    handlerName: String,
+    method: String,
+    path: String,
+    successStatus: Int,
+    guardConds: List[String],
+    valuesArgs: String,
+    guardPretty: String
+)
+
+final case class StateOpsCtx(
+    stateFields: List[ScalarStateFieldView],
+    scalarOps: List[PyScalarOp]
 )
 
 final private case class StdlibImport(module: String, names: List[String])
@@ -214,6 +237,27 @@ object EmitPython:
       ExtensionStub.python,
       preserve = true
     )
+
+    val scalarFields = ScalarOps.stateFields(profiled)
+    val scalarOps    = ScalarOps.views(profiled)
+    if scalarFields.nonEmpty then
+      files += EmittedFile(
+        "app/models/service_state.py",
+        engine.renderAny(
+          templates.modelServiceState,
+          StateModelCtx(ScalarOps.TableName, scalarFields)
+        )
+      )
+    if scalarOps.nonEmpty then
+      val stateCtx = StateOpsCtx(scalarFields, scalarOps.map(pyScalarOp))
+      files += EmittedFile(
+        "app/services/state_ops.py",
+        engine.renderAny(templates.serviceStateOps, stateCtx)
+      )
+      files += EmittedFile(
+        "app/routers/state_ops.py",
+        engine.renderAny(templates.routerStateOps, stateCtx)
+      )
 
     for entity <- ctx.entities do
       val table = schemaTables(ctx.schema).find(t => tableEntityName(t) == entity.entityName)
@@ -689,6 +733,29 @@ object EmitPython:
     if ormColumnType == "JSONB" && dialect.saType(CanonicalType.Json).importModule.isEmpty then
       "JSON"
     else ormColumnType
+
+  private def pyScalarOp(v: ScalarOpView): PyScalarOp =
+    val ep = v.operation.endpoint
+    val method = ep.method match
+      case _: GET    => "get"
+      case _: POST   => "post"
+      case _: PUT    => "put"
+      case _: PATCH  => "patch"
+      case _: DELETE => "delete"
+    val guardConds = v.guards.map: g =>
+      s"ServiceState.${g.columnName} ${ScalarOps.pyCmp(g.cmp)} ${g.lit}"
+    val valuesArgs = v.updates
+      .map(u => s"${u.columnName}=${ScalarOps.renderRhs(u.rhs, s"ServiceState.${u.columnName}")}")
+      .mkString(", ")
+    PyScalarOp(
+      handlerName = v.operation.handlerName,
+      method = method,
+      path = ep.path,
+      successStatus = ep.successStatus,
+      guardConds = guardConds,
+      valuesArgs = valuesArgs,
+      guardPretty = v.guardPretty
+    )
 
   private def collectEntityImports(entity: ProfiledEntity, dialect: Dialect): EntityImports =
     val sqlSet         = mutable.Set.empty[String]

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -399,11 +399,16 @@ object EmitPython:
         if ops.nonEmpty then
           val nextRev = Revision.next(opts.existingRevisions)
           val downRev = Revision.head(opts.existingRevisions).getOrElse("001")
+          // A state table first appearing in a delta still needs its singleton
+          // row; without it every scalar op's guarded UPDATE matches 0 rows.
+          val deltaSeeds = ops.collect:
+            case CreateTable(t) if ScalarOps.isStateTable(t) =>
+              s"""op.execute("${ScalarOps.seedSqlFor(t)}")"""
           val delta = AlembicDelta(
             revision = nextRev,
             downRevision = downRev,
             createdDate = opts.createdDate.getOrElse(java.time.LocalDate.now.toString),
-            upgradeStatements = AlembicRenderer.upgrade(ops, dialect),
+            upgradeStatements = AlembicRenderer.upgrade(ops, dialect) ++ deltaSeeds,
             downgradeStatements = AlembicRenderer.downgrade(ops, dialect),
             needsPostgresDialect = Dialect.hasPostgresDialectTypes(ops, dialect)
           )

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -8,6 +8,9 @@ import specrest.codegen.EnvExample
 import specrest.codegen.ExtensionStub
 import specrest.codegen.OperationContext
 import specrest.codegen.RenderContext
+import specrest.codegen.ScalarOpView
+import specrest.codegen.ScalarOps
+import specrest.codegen.ScalarStateFieldView
 import specrest.codegen.TemplateEngine
 import specrest.codegen.TsTemplates
 import specrest.codegen.migration.Revision
@@ -109,6 +112,15 @@ final private case class TsDbView(
     dsnRecipe: Option[specrest.codegen.Dsn.Recipe]
 )
 
+final private case class TsScalarOpView(
+    handlerName: String,
+    method: String,
+    expressPath: String,
+    successStatus: Int,
+    updateSql: String,
+    guardPretty: String
+)
+
 final private case class TsProjectCtx(
     service: TsServiceNames,
     packageName: String,
@@ -116,7 +128,8 @@ final private case class TsProjectCtx(
     needsDecimal: Boolean,
     needsBuffer: Boolean,
     db: TsDbView,
-    dafnyKernel: Option[DafnyKernel]
+    dafnyKernel: Option[DafnyKernel],
+    scalarOps: List[TsScalarOpView]
 )
 
 object EmitTs:
@@ -180,6 +193,9 @@ object EmitTs:
     val needsDecimal = entities.exists(_.needsDecimal)
     val needsBuffer  = entities.exists(_.needsBuffer)
 
+    val scalarFields = ScalarOps.stateFields(profiled)
+    val scalarOps    = ScalarOps.views(profiled).map(tsScalarOp)
+
     val projectCtx = TsProjectCtx(
       service = service,
       packageName = packageName,
@@ -187,7 +203,8 @@ object EmitTs:
       needsDecimal = needsDecimal,
       needsBuffer = needsBuffer,
       db = db,
-      dafnyKernel = opts.dafnyKernel
+      dafnyKernel = opts.dafnyKernel,
+      scalarOps = scalarOps
     )
 
     val files        = List.newBuilder[EmittedFile]
@@ -237,6 +254,10 @@ object EmitTs:
         s"src/routes/${entityCtx.entityPluralCamel}.ts",
         engine.renderAny(templates.routeEntity, perEntity)
       )
+
+    if scalarOps.nonEmpty then
+      files += EmittedFile("src/services/stateOps.ts", tsStateService(scalarFields, scalarOps))
+      files += EmittedFile("src/routes/stateOps.ts", tsStateRoutes(scalarOps))
 
     projectTail.foreach: (path, tpl) =>
       files += EmittedFile(path, engine.renderAny(tpl, projectScope))
@@ -298,8 +319,12 @@ object EmitTs:
       val tableOps   = SchemaDiff.topoSort(schemaTables(schema)).map(CreateTable.apply)
       val triggerOps = schemaTriggers(schema).map(AddTrigger.apply)
       val ops        = tableOps ++ triggerOps
+      val seeds = SchemaDiff
+        .topoSort(schemaTables(schema))
+        .filter(ScalarOps.isStateTable)
+        .map(t => ScalarOps.seedSqlFor(t) + ";")
       val upScope = Map[String, Any](
-        "migration" -> PrismaMigrationView(SqlRenderer.upgrade(ops, dialect))
+        "migration" -> PrismaMigrationView(SqlRenderer.upgrade(ops, dialect) ++ seeds)
       )
       val downScope = Map[String, Any](
         "migration" -> PrismaMigrationView(SqlRenderer.downgrade(ops, dialect))
@@ -355,6 +380,96 @@ object EmitTs:
       dsnRecipe = db.dsnRecipe,
       envExampleHeaderLine = None
     )
+
+  private def tsScalarOp(v: ScalarOpView): TsScalarOpView =
+    val ep = v.operation.endpoint
+    val method = ep.method match
+      case _: GET    => "get"
+      case _: POST   => "post"
+      case _: PUT    => "put"
+      case _: PATCH  => "patch"
+      case _: DELETE => "delete"
+    val setSql = v.updates
+      .map(u => s"${u.columnName} = ${ScalarOps.renderRhs(u.rhs, u.columnName)}")
+      .mkString(", ")
+    val whereSql =
+      ("id = 1" :: v.guards.map(g => s"${g.columnName} ${ScalarOps.sqlCmp(g.cmp)} ${g.lit}"))
+        .mkString(" AND ")
+    TsScalarOpView(
+      handlerName = Naming.toCamelCase(v.operation.operationName, Naming.CamelStrategy.Ts),
+      method = method,
+      expressPath = ep.path,
+      successStatus = ep.successStatus,
+      updateSql = s"UPDATE ${ScalarOps.TableName} SET $setSql WHERE $whereSql",
+      guardPretty = v.guardPretty
+    )
+
+  private def tsStateService(
+      fields: List[ScalarStateFieldView],
+      ops: List[TsScalarOpView]
+  ): String =
+    val snapshotPairs = fields
+      .map(f => s"    ${f.specName}: Number(row.${f.camelName}),")
+      .mkString("\n")
+    val opFns = ops
+      .map: op =>
+        s"""|export const ${op.handlerName} = async (): Promise<StateSnapshot | null> => {
+            |  // Atomic guarded update: the requires clause rides in the WHERE so a
+            |  // stale read can never break the verified invariant under concurrency.
+            |  const updated = await prisma.$$executeRawUnsafe(
+            |    '${op.updateSql}',
+            |  );
+            |  if (updated === 0) {
+            |    return null;
+            |  }
+            |  return snapshot();
+            |};
+            |""".stripMargin
+      .mkString("\n")
+    s"""|import { prisma } from '../prisma.js';
+        |
+        |export type StateSnapshot = {
+        |${fields.map(f => s"  ${f.specName}: number;").mkString("\n")}
+        |};
+        |
+        |const snapshot = async (): Promise<StateSnapshot> => {
+        |  const row = await prisma.serviceState.findUniqueOrThrow({ where: { id: 1 } });
+        |  return {
+        |$snapshotPairs
+        |  };
+        |};
+        |
+        |$opFns""".stripMargin
+
+  private def tsStateRoutes(ops: List[TsScalarOpView]): String =
+    val routes = ops
+      .map: op =>
+        s"""|  app.${op.method}(
+            |    '${op.expressPath}',
+            |    wrap(async (_req, res) => {
+            |      const result = await stateOps.${op.handlerName}();
+            |      if (result === null) {
+            |        res.status(409).json({ detail: 'precondition failed: ${op.guardPretty}' });
+            |        return;
+            |      }
+            |      res.status(${op.successStatus}).json(result);
+            |    }),
+            |  );
+            |""".stripMargin
+      .mkString("\n")
+    s"""|import type { Express, NextFunction, Request, Response } from 'express';
+        |
+        |import * as stateOps from '../services/stateOps.js';
+        |
+        |const wrap =
+        |  (handler: (req: Request, res: Response) => Promise<void>) =>
+        |  (req: Request, res: Response, next: NextFunction): void => {
+        |    handler(req, res).catch(next);
+        |  };
+        |
+        |export const registerStateOpsRoutes = (app: Express): void => {
+        |$routes};
+        |""".stripMargin
 
   private def tsDbView(database: String, snake: String): TsDbView = database match
     case "postgres" =>
@@ -428,14 +543,17 @@ object EmitTs:
       currentEntity: Option[TsEntityCtx] = None
   ): Map[String, Any] =
     val base = Map[String, Any](
-      "service"      -> proj.service,
-      "packageName"  -> proj.packageName,
-      "profile"      -> ctx.profile,
-      "entities"     -> proj.entities,
-      "needsDecimal" -> proj.needsDecimal,
-      "needsBuffer"  -> proj.needsBuffer,
-      "db"           -> proj.db,
-      "hasDafny"     -> proj.dafnyKernel.isDefined
+      "service"           -> proj.service,
+      "packageName"       -> proj.packageName,
+      "profile"           -> ctx.profile,
+      "entities"          -> proj.entities,
+      "needsDecimal"      -> proj.needsDecimal,
+      "needsBuffer"       -> proj.needsBuffer,
+      "db"                -> proj.db,
+      "hasDafny"          -> proj.dafnyKernel.isDefined,
+      "scalarOps"         -> proj.scalarOps,
+      "scalarStateFields" -> ctx.scalarStateFields,
+      "hasScalarOps"      -> ctx.hasScalarOps
     )
     currentEntity match
       case Some(e) =>

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -345,8 +345,13 @@ object EmitTs:
         val ops = SchemaDiff.compute(prev, schema)
         if ops.nonEmpty then
           val nextRev = Revision.next(opts.existingRevisions)
+          // A state table first appearing in a delta still needs its singleton
+          // row; without it every scalar op's guarded UPDATE matches 0 rows.
+          val deltaSeeds = ops.collect:
+            case CreateTable(t) if ScalarOps.isStateTable(t) =>
+              ScalarOps.seedSqlFor(t) + ";"
           val upScope = Map[String, Any](
-            "migration" -> PrismaMigrationView(SqlRenderer.upgrade(ops, dialect))
+            "migration" -> PrismaMigrationView(SqlRenderer.upgrade(ops, dialect) ++ deltaSeeds)
           )
           val downScope = Map[String, Any](
             "migration" -> PrismaMigrationView(SqlRenderer.downgrade(ops, dialect))

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -19,6 +19,7 @@ object Classify:
     val strategy = classifyStrategy(
       operEnsures(op),
       operRequires(op),
+      operInputs(op).map(prmName),
       stateFieldNames.toList,
       ScalarState.fieldNames(ir),
       outputNames

--- a/modules/convention/src/main/scala/specrest/convention/Classify.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Classify.scala
@@ -16,7 +16,13 @@ object Classify:
     val entityMap    = ir.idx.entityByName
     val targetEntity = resolveTargetEntity(op, ir, entityMap)
     val outputNames  = operOutputs(op).map(prmName)
-    val strategy     = classifyStrategy(operEnsures(op), stateFieldNames.toList, outputNames)
+    val strategy = classifyStrategy(
+      operEnsures(op),
+      operRequires(op),
+      stateFieldNames.toList,
+      ScalarState.fieldNames(ir),
+      outputNames
+    )
     val entityFieldCount: Option[nat] =
       targetEntity.flatMap(entityMap.get).map(e => Nata(BigInt(entFields(e).length)))
     buildOperationClassification(

--- a/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
+++ b/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
@@ -1,0 +1,51 @@
+package specrest.convention
+
+import specrest.ir.Naming
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.ir.idx
+
+object ScalarState:
+
+  val TableName   = "service_state"
+  val SingletonId = 1
+
+  def fields(ir: ServiceIRFull): List[state_field_decl] =
+    svcState(ir) match
+      case None => Nil
+      case Some(sd) =>
+        val scalars = stdFields(sd).filter: sf =>
+          stfType(sf) match
+            case NamedTypeF("Int", _) => true
+            case _                    => false
+        if scalars.isEmpty || entityTableNames(ir).contains(TableName) then Nil
+        else scalars
+
+  def fieldNames(ir: ServiceIRFull): List[String] = fields(ir).map(stfName)
+
+  def columnName(specName: String): String = Naming.toColumnName(specName)
+
+  def stateTable(ir: ServiceIRFull): Option[table_spec] =
+    val scalars = fields(ir)
+    if scalars.isEmpty then None
+    else
+      val idCol = ColumnSpec("id", "BIGINT", false, None)
+      val cols = scalars.map: sf =>
+        ColumnSpec(columnName(stfName(sf)), "BIGINT", false, Some("0"))
+      Some(
+        TableSpec(
+          TableName,
+          "",
+          idCol :: cols,
+          "id",
+          Nil,
+          List(s"id = $SingletonId"),
+          Nil
+        )
+      )
+
+  private def entityTableNames(ir: ServiceIRFull): Set[String] =
+    ir.idx.entities.map { entity =>
+      Path
+        .getConvention(svcConventions(ir), entName(entity), "db_table")
+        .getOrElse(Naming.toTableName(entName(entity)))
+    }.toSet

--- a/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
+++ b/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
@@ -15,29 +15,36 @@ object ScalarState:
   // collide with the singleton PK column. An entity mapped to the reserved
   // table name disables the feature for the service - those ops then route
   // to LLM synthesis, exactly the pre-#407 behaviour, rather than failing
-  // the compile of a previously-valid spec.
-  def fields(ir: ServiceIRFull): List[state_field_decl] =
+  // the compile of a previously-valid spec. A field is also only backed
+  // when a seed satisfying every invariant that mentions it can be derived
+  // structurally - the seeded row is the service's initial state, and a
+  // seed violating an invariant would fail conformance before any call.
+  def fieldsWithSeeds(ir: ServiceIRFull): List[(state_field_decl, BigInt)] =
     svcState(ir) match
       case None => Nil
       case Some(sd) =>
-        val scalars = stdFields(sd).filter: sf =>
-          stfType(sf) match
-            case NamedTypeF("Int", _) => columnName(stfName(sf)) != "id"
-            case _                    => false
+        val scalars = stdFields(sd)
+          .filter: sf =>
+            stfType(sf) match
+              case NamedTypeF("Int", _) => columnName(stfName(sf)) != "id"
+              case _                    => false
+          .flatMap(sf => seedFor(ir, stfName(sf)).map(sf -> _))
         if scalars.isEmpty || entityTableNames(ir).contains(TableName) then Nil
         else scalars
+
+  def fields(ir: ServiceIRFull): List[state_field_decl] = fieldsWithSeeds(ir).map(_._1)
 
   def fieldNames(ir: ServiceIRFull): List[String] = fields(ir).map(stfName)
 
   def columnName(specName: String): String = Naming.toColumnName(specName)
 
   def stateTable(ir: ServiceIRFull): Option[table_spec] =
-    val scalars = fields(ir)
+    val scalars = fieldsWithSeeds(ir)
     if scalars.isEmpty then None
     else
       val idCol = ColumnSpec("id", "BIGINT", false, None)
-      val cols = scalars.map: sf =>
-        ColumnSpec(columnName(stfName(sf)), "BIGINT", false, Some("0"))
+      val cols = scalars.map: (sf, seed) =>
+        ColumnSpec(columnName(stfName(sf)), "BIGINT", false, Some(seed.toString))
       Some(
         TableSpec(
           TableName,
@@ -49,6 +56,32 @@ object ScalarState:
           Nil
         )
       )
+
+  private def seedFor(ir: ServiceIRFull, name: String): Option[BigInt] =
+    val atoms    = svcInvariants(ir).flatMap(inv => flattenEnsures(List(invBody(inv))))
+    val relevant = atoms.filter(a => free_vars(a).contains(name))
+    val parsed   = relevant.map(a => scalarGuardOf(List(name), a))
+    if parsed.exists(_.isEmpty) then None
+    else
+      val cmps = parsed.flatten.collect { case SgCmp(_, c, k) => (c, k) }
+      val lo = (BigInt(0) :: cmps.collect {
+        case (_: ScGe, k) => k
+        case (_: ScGt, k) => k + 1
+        case (_: ScEq, k) => k
+      }).max
+      // bump past != constraints, then require every atom to hold
+      Iterator
+        .iterate(lo)(_ + 1)
+        .take(cmps.size + 1)
+        .find(v => cmps.forall((c, k) => cmpHolds(v, c, k)))
+
+  private def cmpHolds(v: BigInt, c: scalar_cmp, k: BigInt): Boolean = c match
+    case _: ScGt  => v > k
+    case _: ScGe  => v >= k
+    case _: ScLt  => v < k
+    case _: ScLe  => v <= k
+    case _: ScEq  => v == k
+    case _: ScNeq => v != k
 
   private def entityTableNames(ir: ServiceIRFull): Set[String] =
     ir.idx.entities.map { entity =>

--- a/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
+++ b/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
@@ -64,15 +64,23 @@ object ScalarState:
     if parsed.exists(_.isEmpty) then None
     else
       val cmps = parsed.flatten.collect { case SgCmp(_, c, k) => (c, k) }
-      val lo = (BigInt(0) :: cmps.collect {
+      val lowers = cmps.collect:
         case (_: ScGe, k) => k
         case (_: ScGt, k) => k + 1
         case (_: ScEq, k) => k
-      }).max
-      // bump past != constraints, then require every atom to hold
-      Iterator
-        .iterate(lo)(_ + 1)
-        .take(cmps.size + 1)
+      val uppers = cmps.collect:
+        case (_: ScLe, k) => k
+        case (_: ScLt, k) => k - 1
+        case (_: ScEq, k) => k
+      // Prefer the value nearest 0 inside the bounds (so unconstrained and
+      // non-negative fields keep seeding 0, and negative-only invariants
+      // like `x < 0` seed -1), then search outward past any != atoms.
+      val clamped = (lowers.maxOption, uppers.minOption) match
+        case (Some(l), _) if l > 0 => l
+        case (_, Some(h)) if h < 0 => h
+        case _                     => BigInt(0)
+      (0 to cmps.size).iterator
+        .flatMap(i => List(clamped + i, clamped - i).distinct)
         .find(v => cmps.forall((c, k) => cmpHolds(v, c, k)))
 
   private def cmpHolds(v: BigInt, c: scalar_cmp, k: BigInt): Boolean = c match

--- a/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
+++ b/modules/convention/src/main/scala/specrest/convention/ScalarState.scala
@@ -9,13 +9,20 @@ object ScalarState:
   val TableName   = "service_state"
   val SingletonId = 1
 
+  // Bare `Int` only: a type alias to Int may carry a `where` refinement the
+  // state table would not enforce (no derived CHECK yet), so alias-typed
+  // scalars deliberately stay on the LLM path. A field named `id` would
+  // collide with the singleton PK column. An entity mapped to the reserved
+  // table name disables the feature for the service - those ops then route
+  // to LLM synthesis, exactly the pre-#407 behaviour, rather than failing
+  // the compile of a previously-valid spec.
   def fields(ir: ServiceIRFull): List[state_field_decl] =
     svcState(ir) match
       case None => Nil
       case Some(sd) =>
         val scalars = stdFields(sd).filter: sf =>
           stfType(sf) match
-            case NamedTypeF("Int", _) => true
+            case NamedTypeF("Int", _) => columnName(stfName(sf)) != "id"
             case _                    => false
         if scalars.isEmpty || entityTableNames(ir).contains(TableName) then Nil
         else scalars

--- a/modules/convention/src/main/scala/specrest/convention/Schema.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Schema.scala
@@ -51,6 +51,8 @@ object Schema:
             case _ => ()
       case None => ()
 
+    ScalarState.stateTable(ir).foreach(tables += _)
+
     val builtTables        = tables.result()
     val withPartialIndexes = applyPartialIndexConventions(builtTables, entities, svcConventions(ir))
     val triggers           = detectAggregateTriggers(entities, withPartialIndexes)

--- a/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ConventionSmokeTest.scala
@@ -75,11 +75,11 @@ class ConventionSmokeTest extends CatsEffectSuite:
       )
     ),
     StrategyCase(
-      "safe_counter: arithmetic in ensures forces LLM",
+      "safe_counter: scalar-state arithmetic direct-emits (issue #407)",
       "safe_counter",
       List(
-        "Increment" -> LlmSynthesis(),
-        "Decrement" -> LlmSynthesis()
+        "Increment" -> DirectEmit(),
+        "Decrement" -> DirectEmit()
       )
     ),
     StrategyCase(

--- a/modules/convention/src/test/scala/specrest/convention/ScalarStateTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/ScalarStateTest.scala
@@ -1,0 +1,64 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.convention.testutil.SpecFixtures
+import specrest.ir.generated.SpecRestGenerated.*
+
+class ScalarStateTest extends CatsEffectSuite:
+
+  private def counterSpec(invariant: String) =
+    s"""service SeedProbe {
+       |
+       |  state {
+       |    level: Int
+       |  }
+       |
+       |  operation Bump {
+       |    requires:
+       |      true
+       |
+       |    ensures:
+       |      level' = level + 1
+       |  }
+       |
+       |  invariant levelBounds:
+       |    $invariant
+       |}""".stripMargin
+
+  List(
+    ("level >= 0", BigInt(0)),
+    ("level > 0", BigInt(1)),
+    ("level < 0", BigInt(-1)),
+    ("level <= -5", BigInt(-5)),
+    ("level != 0", BigInt(1))
+  ).foreach: (inv, expected) =>
+    test(s"seed for `$inv` is $expected"):
+      SpecFixtures.buildFromSource(inv, counterSpec(inv)).map: ir =>
+        assertEquals(seedOf(ir), Some(expected))
+
+  test("non-atom invariant mention conservatively unbacks the field"):
+    val spec =
+      """service SeedProbe {
+        |
+        |  state {
+        |    level: Int
+        |    others: Int -> lone Int
+        |  }
+        |
+        |  operation Bump {
+        |    requires:
+        |      true
+        |
+        |    ensures:
+        |      level' = level + 1
+        |  }
+        |
+        |  invariant levelFresh:
+        |    level not in others
+        |}""".stripMargin
+    SpecFixtures.buildFromSource("levelFresh", spec).map: ir =>
+      assertEquals(ScalarState.fieldNames(ir), Nil)
+
+  private def seedOf(ir: ServiceIRFull): Option[BigInt] =
+    ScalarState.fieldsWithSeeds(ir).collectFirst:
+      case (sf, seed) if stfName(sf) == "level" => seed

--- a/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
@@ -82,6 +82,13 @@ class StrategyHeuristicTest extends CatsEffectSuite:
       LlmSynthesis(): synthesis_strategy
     )
 
+  test("negative-literal scalar updates → DirectEmit (UNegate spelling)"):
+    val negLit = UnaryOpF(UNegate(), lit(1), None)
+    val toNeg  = beq(prime(id("count")), negLit)
+    val addNeg = beq(prime(id("count")), badd(id("count"), negLit))
+    assertEquals(scalarStrategyOf(List(toNeg)), DirectEmit(): synthesis_strategy)
+    assertEquals(scalarStrategyOf(List(addNeg)), DirectEmit(): synthesis_strategy)
+
   test("empty ensures → LlmSynthesis (regression: no longer vacuously DirectEmit)"):
     assertEquals(strategyOf(Nil), LlmSynthesis(): synthesis_strategy)
 

--- a/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
@@ -12,7 +12,54 @@ class StrategyHeuristicTest extends CatsEffectSuite:
   private def lit(n: Int): expr   = IntLitF(BigInt(n), None)
 
   private def strategyOf(ensures: List[expr]): synthesis_strategy =
-    classifyStrategy(ensures, state, Nil)
+    classifyStrategy(ensures, Nil, state, Nil, Nil)
+
+  private def scalarStrategyOf(
+      ensures: List[expr],
+      requires: List[expr] = Nil
+  ): synthesis_strategy =
+    classifyStrategy(ensures, requires, List("count"), List("count"), Nil)
+
+  private def prime(e: expr): expr         = PrimeF(e, None)
+  private def beq(l: expr, r: expr): expr  = BinaryOpF(BEq(), l, r, None)
+  private def badd(l: expr, r: expr): expr = BinaryOpF(BAdd(), l, r, None)
+  private def bsub(l: expr, r: expr): expr = BinaryOpF(BSub(), l, r, None)
+  private def bgt(l: expr, r: expr): expr  = BinaryOpF(BGt(), l, r, None)
+  private def scalarInc: expr              = beq(prime(id("count")), badd(id("count"), lit(1)))
+
+  test("scalar `count' = count + 1` → DirectEmit"):
+    assertEquals(scalarStrategyOf(List(scalarInc)), DirectEmit(): synthesis_strategy)
+
+  test("scalar `count' = count - 1` with guardable requires → DirectEmit"):
+    val dec = beq(prime(id("count")), bsub(id("count"), lit(1)))
+    assertEquals(
+      scalarStrategyOf(List(dec), requires = List(bgt(id("count"), lit(0)))),
+      DirectEmit(): synthesis_strategy
+    )
+
+  test("scalar update with unguardable requires → LlmSynthesis"):
+    val req = bgt(badd(id("count"), lit(1)), lit(0))
+    assertEquals(
+      scalarStrategyOf(List(scalarInc), requires = List(req)),
+      LlmSynthesis(): synthesis_strategy
+    )
+
+  test("scalar update over input arithmetic `count' = count + n` → LlmSynthesis"):
+    val clause = beq(prime(id("count")), badd(id("count"), id("n")))
+    assertEquals(scalarStrategyOf(List(clause)), LlmSynthesis(): synthesis_strategy)
+
+  test("mixed scalar + relation clauses → LlmSynthesis (purity rule)"):
+    val rel = beq(prime(id("store")), id("store"))
+    assertEquals(
+      classifyStrategy(
+        List(scalarInc, rel),
+        Nil,
+        List("count", "store"),
+        List("count"),
+        Nil
+      ),
+      LlmSynthesis(): synthesis_strategy
+    )
 
   test("empty ensures → LlmSynthesis (regression: no longer vacuously DirectEmit)"):
     assertEquals(strategyOf(Nil), LlmSynthesis(): synthesis_strategy)

--- a/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyHeuristicTest.scala
@@ -12,13 +12,14 @@ class StrategyHeuristicTest extends CatsEffectSuite:
   private def lit(n: Int): expr   = IntLitF(BigInt(n), None)
 
   private def strategyOf(ensures: List[expr]): synthesis_strategy =
-    classifyStrategy(ensures, Nil, state, Nil, Nil)
+    classifyStrategy(ensures, Nil, Nil, state, Nil, Nil)
 
   private def scalarStrategyOf(
       ensures: List[expr],
-      requires: List[expr] = Nil
+      requires: List[expr] = Nil,
+      inputs: List[String] = Nil
   ): synthesis_strategy =
-    classifyStrategy(ensures, requires, List("count"), List("count"), Nil)
+    classifyStrategy(ensures, requires, inputs, List("count"), List("count"), Nil)
 
   private def prime(e: expr): expr         = PrimeF(e, None)
   private def beq(l: expr, r: expr): expr  = BinaryOpF(BEq(), l, r, None)
@@ -54,10 +55,30 @@ class StrategyHeuristicTest extends CatsEffectSuite:
       classifyStrategy(
         List(scalarInc, rel),
         Nil,
+        Nil,
         List("count", "store"),
         List("count"),
         Nil
       ),
+      LlmSynthesis(): synthesis_strategy
+    )
+
+  test("conflicting duplicate scalar assignments → LlmSynthesis"):
+    val other = beq(prime(id("count")), badd(id("count"), lit(2)))
+    assertEquals(
+      scalarStrategyOf(List(scalarInc, other)),
+      LlmSynthesis(): synthesis_strategy
+    )
+
+  test("identical duplicate scalar assignments → DirectEmit"):
+    assertEquals(
+      scalarStrategyOf(List(scalarInc, scalarInc)),
+      DirectEmit(): synthesis_strategy
+    )
+
+  test("scalar update with declared inputs → LlmSynthesis"):
+    assertEquals(
+      scalarStrategyOf(List(scalarInc), inputs = List("x")),
       LlmSynthesis(): synthesis_strategy
     )
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -762,6 +762,21 @@ object SpecRestGenerated {
   final case class VSeq(a: List[ir_value])                          extends ir_value
   final case class VMap(a: List[(ir_value, ir_value)])              extends ir_value
 
+  sealed abstract class scalar_cmp
+  final case class ScGt()  extends scalar_cmp
+  final case class ScGe()  extends scalar_cmp
+  final case class ScLt()  extends scalar_cmp
+  final case class ScLe()  extends scalar_cmp
+  final case class ScEq()  extends scalar_cmp
+  final case class ScNeq() extends scalar_cmp
+
+  sealed abstract class scalar_rhs
+  final case class SrLit(a: BigInt)                    extends scalar_rhs
+  final case class SrSelf()                            extends scalar_rhs
+  final case class SrAdd(a: scalar_rhs, b: scalar_rhs) extends scalar_rhs
+  final case class SrSub(a: scalar_rhs, b: scalar_rhs) extends scalar_rhs
+  final case class SrMul(a: scalar_rhs, b: scalar_rhs) extends scalar_rhs
+
   sealed abstract class http_method
   final case class GET()    extends http_method
   final case class POST()   extends http_method
@@ -792,6 +807,10 @@ object SpecRestGenerated {
       h: List[String],
       i: List[String]
   ) extends ident_ctx
+
+  sealed abstract class scalar_guard
+  final case class SgTrue()                                   extends scalar_guard
+  final case class SgCmp(a: String, b: scalar_cmp, c: BigInt) extends scalar_guard
 
   sealed abstract class sa_type
   final case class SaType(a: String, b: Option[String]) extends sa_type
@@ -4976,6 +4995,123 @@ object SpecRestGenerated {
       map_option[smt_term, smt_term]((a: smt_term) => TSome(a), translate(enums, e))
   }
 
+  def scalarCmpOf(x0: bin_op): Option[scalar_cmp] = x0 match {
+    case BGt()        => Some[scalar_cmp](ScGt())
+    case BGe()        => Some[scalar_cmp](ScGe())
+    case BLt()        => Some[scalar_cmp](ScLt())
+    case BLe()        => Some[scalar_cmp](ScLe())
+    case BEq()        => Some[scalar_cmp](ScEq())
+    case BNeq()       => Some[scalar_cmp](ScNeq())
+    case BAnd()       => None
+    case BOr()        => None
+    case BImplies()   => None
+    case BIff()       => None
+    case BIn()        => None
+    case BNotIn()     => None
+    case BSubset()    => None
+    case BUnion()     => None
+    case BIntersect() => None
+    case BDiff()      => None
+    case BAdd()       => None
+    case BSub()       => None
+    case BMul()       => None
+    case BDiv()       => None
+  }
+
+  def scalarRhsOf(n: String, x1: expr): Option[scalar_rhs] = (n, x1) match {
+    case (n, IntLitF(k, uu)) => Some[scalar_rhs](SrLit(k))
+    case (n, IdentifierF(m, uv)) =>
+      m == n match {
+        case true  => Some[scalar_rhs](SrSelf())
+        case false => None
+      }
+    case (n, PreF(e, uw)) =>
+      e match {
+        case BinaryOpF(_, _, _, _)         => None
+        case UnaryOpF(_, _, _)             => None
+        case QuantifierF(_, _, _, _)       => None
+        case SomeWrapF(_, _)               => None
+        case TheF(_, _, _, _)              => None
+        case FieldAccessF(_, _, _)         => None
+        case EnumAccessF(_, _, _)          => None
+        case IndexF(_, _, _)               => None
+        case CallF(_, _, _)                => None
+        case PrimeF(_, _)                  => None
+        case PreF(_, _)                    => None
+        case WithF(_, _, _)                => None
+        case IfF(_, _, _, _)               => None
+        case LetF(_, _, _, _)              => None
+        case LambdaF(_, _, _)              => None
+        case ConstructorF(_, _, _)         => None
+        case SetLiteralF(_, _)             => None
+        case MapLiteralF(_, _)             => None
+        case SetComprehensionF(_, _, _, _) => None
+        case SeqLiteralF(_, _)             => None
+        case MatchesF(_, _, _)             => None
+        case IntLitF(_, _)                 => None
+        case FloatLitF(_, _)               => None
+        case StringLitF(_, _)              => None
+        case BoolLitF(_, _)                => None
+        case NoneLitF(_)                   => None
+        case IdentifierF(m, _) =>
+          m == n match {
+            case true  => Some[scalar_rhs](SrSelf())
+            case false => None
+          }
+      }
+    case (n, BinaryOpF(op, l, r, ux)) =>
+      (scalarRhsOf(n, l), scalarRhsOf(n, r)) match {
+        case (None, _)       => None
+        case (Some(_), None) => None
+        case (Some(a), Some(b)) =>
+          op match {
+            case BAnd()       => None
+            case BOr()        => None
+            case BImplies()   => None
+            case BIff()       => None
+            case BEq()        => None
+            case BNeq()       => None
+            case BLt()        => None
+            case BGt()        => None
+            case BLe()        => None
+            case BGe()        => None
+            case BIn()        => None
+            case BNotIn()     => None
+            case BSubset()    => None
+            case BUnion()     => None
+            case BIntersect() => None
+            case BDiff()      => None
+            case BAdd()       => Some[scalar_rhs](SrAdd(a, b))
+            case BSub()       => Some[scalar_rhs](SrSub(a, b))
+            case BMul()       => Some[scalar_rhs](SrMul(a, b))
+            case BDiv()       => None
+          }
+      }
+    case (uy, UnaryOpF(v, va, vb))              => None
+    case (uy, QuantifierF(v, va, vb, vc))       => None
+    case (uy, SomeWrapF(v, va))                 => None
+    case (uy, TheF(v, va, vb, vc))              => None
+    case (uy, FieldAccessF(v, va, vb))          => None
+    case (uy, EnumAccessF(v, va, vb))           => None
+    case (uy, IndexF(v, va, vb))                => None
+    case (uy, CallF(v, va, vb))                 => None
+    case (uy, PrimeF(v, va))                    => None
+    case (uy, WithF(v, va, vb))                 => None
+    case (uy, IfF(v, va, vb, vc))               => None
+    case (uy, LetF(v, va, vb, vc))              => None
+    case (uy, LambdaF(v, va, vb))               => None
+    case (uy, ConstructorF(v, va, vb))          => None
+    case (uy, SetLiteralF(v, va))               => None
+    case (uy, MapLiteralF(v, va))               => None
+    case (uy, SetComprehensionF(v, va, vb, vc)) => None
+    case (uy, SeqLiteralF(v, va))               => None
+    case (uy, MatchesF(v, va, vb))              => None
+    case (uy, FloatLitF(v, va))                 => None
+    case (uy, StringLitF(v, va))                => None
+    case (uy, BoolLitF(v, va))                  => None
+    case (uy, NoneLitF(v))                      => None
+  }
+
   def enmName(x0: enum_decl): String = x0 match {
     case EnumDeclFull(x1, x2, x3) => x1
   }
@@ -5780,6 +5916,104 @@ object SpecRestGenerated {
         }
     }
 
+  def scalarGuardOf(scalars: List[String], x1: expr): Option[scalar_guard] =
+    (scalars, x1) match {
+      case (scalars, BoolLitF(b, uu)) =>
+        b match {
+          case true  => Some[scalar_guard](SgTrue())
+          case false => None
+        }
+      case (scalars, BinaryOpF(op, l, r, uv)) =>
+        scalarCmpOf(op) match {
+          case None => None
+          case Some(c) =>
+            (l, r) match {
+              case (BinaryOpF(_, _, _, _), _)                         => None
+              case (UnaryOpF(_, _, _), _)                             => None
+              case (QuantifierF(_, _, _, _), _)                       => None
+              case (SomeWrapF(_, _), _)                               => None
+              case (TheF(_, _, _, _), _)                              => None
+              case (FieldAccessF(_, _, _), _)                         => None
+              case (EnumAccessF(_, _, _), _)                          => None
+              case (IndexF(_, _, _), _)                               => None
+              case (CallF(_, _, _), _)                                => None
+              case (PrimeF(_, _), _)                                  => None
+              case (PreF(_, _), _)                                    => None
+              case (WithF(_, _, _), _)                                => None
+              case (IfF(_, _, _, _), _)                               => None
+              case (LetF(_, _, _, _), _)                              => None
+              case (LambdaF(_, _, _), _)                              => None
+              case (ConstructorF(_, _, _), _)                         => None
+              case (SetLiteralF(_, _), _)                             => None
+              case (MapLiteralF(_, _), _)                             => None
+              case (SetComprehensionF(_, _, _, _), _)                 => None
+              case (SeqLiteralF(_, _), _)                             => None
+              case (MatchesF(_, _, _), _)                             => None
+              case (IntLitF(_, _), _)                                 => None
+              case (FloatLitF(_, _), _)                               => None
+              case (StringLitF(_, _), _)                              => None
+              case (BoolLitF(_, _), _)                                => None
+              case (NoneLitF(_), _)                                   => None
+              case (IdentifierF(_, _), BinaryOpF(_, _, _, _))         => None
+              case (IdentifierF(_, _), UnaryOpF(_, _, _))             => None
+              case (IdentifierF(_, _), QuantifierF(_, _, _, _))       => None
+              case (IdentifierF(_, _), SomeWrapF(_, _))               => None
+              case (IdentifierF(_, _), TheF(_, _, _, _))              => None
+              case (IdentifierF(_, _), FieldAccessF(_, _, _))         => None
+              case (IdentifierF(_, _), EnumAccessF(_, _, _))          => None
+              case (IdentifierF(_, _), IndexF(_, _, _))               => None
+              case (IdentifierF(_, _), CallF(_, _, _))                => None
+              case (IdentifierF(_, _), PrimeF(_, _))                  => None
+              case (IdentifierF(_, _), PreF(_, _))                    => None
+              case (IdentifierF(_, _), WithF(_, _, _))                => None
+              case (IdentifierF(_, _), IfF(_, _, _, _))               => None
+              case (IdentifierF(_, _), LetF(_, _, _, _))              => None
+              case (IdentifierF(_, _), LambdaF(_, _, _))              => None
+              case (IdentifierF(_, _), ConstructorF(_, _, _))         => None
+              case (IdentifierF(_, _), SetLiteralF(_, _))             => None
+              case (IdentifierF(_, _), MapLiteralF(_, _))             => None
+              case (IdentifierF(_, _), SetComprehensionF(_, _, _, _)) => None
+              case (IdentifierF(_, _), SeqLiteralF(_, _))             => None
+              case (IdentifierF(_, _), MatchesF(_, _, _))             => None
+              case (IdentifierF(n, _), IntLitF(k, _)) =>
+                membera[String](scalars, n) match {
+                  case true  => Some[scalar_guard](SgCmp(n, c, k))
+                  case false => None
+                }
+              case (IdentifierF(_, _), FloatLitF(_, _))   => None
+              case (IdentifierF(_, _), StringLitF(_, _))  => None
+              case (IdentifierF(_, _), BoolLitF(_, _))    => None
+              case (IdentifierF(_, _), NoneLitF(_))       => None
+              case (IdentifierF(_, _), IdentifierF(_, _)) => None
+            }
+        }
+      case (uw, UnaryOpF(v, va, vb))              => None
+      case (uw, QuantifierF(v, va, vb, vc))       => None
+      case (uw, SomeWrapF(v, va))                 => None
+      case (uw, TheF(v, va, vb, vc))              => None
+      case (uw, FieldAccessF(v, va, vb))          => None
+      case (uw, EnumAccessF(v, va, vb))           => None
+      case (uw, IndexF(v, va, vb))                => None
+      case (uw, CallF(v, va, vb))                 => None
+      case (uw, PrimeF(v, va))                    => None
+      case (uw, PreF(v, va))                      => None
+      case (uw, WithF(v, va, vb))                 => None
+      case (uw, IfF(v, va, vb, vc))               => None
+      case (uw, LetF(v, va, vb, vc))              => None
+      case (uw, LambdaF(v, va, vb))               => None
+      case (uw, ConstructorF(v, va, vb))          => None
+      case (uw, SetLiteralF(v, va))               => None
+      case (uw, MapLiteralF(v, va))               => None
+      case (uw, SetComprehensionF(v, va, vb, vc)) => None
+      case (uw, SeqLiteralF(v, va))               => None
+      case (uw, MatchesF(v, va, vb))              => None
+      case (uw, IntLitF(v, va))                   => None
+      case (uw, FloatLitF(v, va))                 => None
+      case (uw, StringLitF(v, va))                => None
+      case (uw, NoneLitF(v))                      => None
+      case (uw, IdentifierF(v, va))               => None
+    }
+
   def entName(x0: entity_decl): String = x0 match {
     case EntityDeclFull(x1, x2, x3, x4, x5) => x1
   }
@@ -6275,6 +6509,121 @@ object SpecRestGenerated {
               case false => ClassificationResult(PartialUpdate(), PATCH(), "M4", updated)
             }
         }
+    }
+
+  def scalarUpdateOf(scalars: List[String], x1: expr): Option[(String, scalar_rhs)] =
+    (scalars, x1) match {
+      case (scalars, BinaryOpF(op, lhs, rhs, uu)) =>
+        op match {
+          case BAnd()     => None
+          case BOr()      => None
+          case BImplies() => None
+          case BIff()     => None
+          case BEq() =>
+            lhs match {
+              case BinaryOpF(_, _, _, _)                    => None
+              case UnaryOpF(_, _, _)                        => None
+              case QuantifierF(_, _, _, _)                  => None
+              case SomeWrapF(_, _)                          => None
+              case TheF(_, _, _, _)                         => None
+              case FieldAccessF(_, _, _)                    => None
+              case EnumAccessF(_, _, _)                     => None
+              case IndexF(_, _, _)                          => None
+              case CallF(_, _, _)                           => None
+              case PrimeF(BinaryOpF(_, _, _, _), _)         => None
+              case PrimeF(UnaryOpF(_, _, _), _)             => None
+              case PrimeF(QuantifierF(_, _, _, _), _)       => None
+              case PrimeF(SomeWrapF(_, _), _)               => None
+              case PrimeF(TheF(_, _, _, _), _)              => None
+              case PrimeF(FieldAccessF(_, _, _), _)         => None
+              case PrimeF(EnumAccessF(_, _, _), _)          => None
+              case PrimeF(IndexF(_, _, _), _)               => None
+              case PrimeF(CallF(_, _, _), _)                => None
+              case PrimeF(PrimeF(_, _), _)                  => None
+              case PrimeF(PreF(_, _), _)                    => None
+              case PrimeF(WithF(_, _, _), _)                => None
+              case PrimeF(IfF(_, _, _, _), _)               => None
+              case PrimeF(LetF(_, _, _, _), _)              => None
+              case PrimeF(LambdaF(_, _, _), _)              => None
+              case PrimeF(ConstructorF(_, _, _), _)         => None
+              case PrimeF(SetLiteralF(_, _), _)             => None
+              case PrimeF(MapLiteralF(_, _), _)             => None
+              case PrimeF(SetComprehensionF(_, _, _, _), _) => None
+              case PrimeF(SeqLiteralF(_, _), _)             => None
+              case PrimeF(MatchesF(_, _, _), _)             => None
+              case PrimeF(IntLitF(_, _), _)                 => None
+              case PrimeF(FloatLitF(_, _), _)               => None
+              case PrimeF(StringLitF(_, _), _)              => None
+              case PrimeF(BoolLitF(_, _), _)                => None
+              case PrimeF(NoneLitF(_), _)                   => None
+              case PrimeF(IdentifierF(n, _), _) =>
+                membera[String](scalars, n) match {
+                  case true => map_option[scalar_rhs, (String, scalar_rhs)](
+                      (a: scalar_rhs) => (n, a),
+                      scalarRhsOf(n, rhs)
+                    )
+                  case false => None
+                }
+              case PreF(_, _)                    => None
+              case WithF(_, _, _)                => None
+              case IfF(_, _, _, _)               => None
+              case LetF(_, _, _, _)              => None
+              case LambdaF(_, _, _)              => None
+              case ConstructorF(_, _, _)         => None
+              case SetLiteralF(_, _)             => None
+              case MapLiteralF(_, _)             => None
+              case SetComprehensionF(_, _, _, _) => None
+              case SeqLiteralF(_, _)             => None
+              case MatchesF(_, _, _)             => None
+              case IntLitF(_, _)                 => None
+              case FloatLitF(_, _)               => None
+              case StringLitF(_, _)              => None
+              case BoolLitF(_, _)                => None
+              case NoneLitF(_)                   => None
+              case IdentifierF(_, _)             => None
+            }
+          case BNeq()       => None
+          case BLt()        => None
+          case BGt()        => None
+          case BLe()        => None
+          case BGe()        => None
+          case BIn()        => None
+          case BNotIn()     => None
+          case BSubset()    => None
+          case BUnion()     => None
+          case BIntersect() => None
+          case BDiff()      => None
+          case BAdd()       => None
+          case BSub()       => None
+          case BMul()       => None
+          case BDiv()       => None
+        }
+      case (uv, UnaryOpF(v, va, vb))              => None
+      case (uv, QuantifierF(v, va, vb, vc))       => None
+      case (uv, SomeWrapF(v, va))                 => None
+      case (uv, TheF(v, va, vb, vc))              => None
+      case (uv, FieldAccessF(v, va, vb))          => None
+      case (uv, EnumAccessF(v, va, vb))           => None
+      case (uv, IndexF(v, va, vb))                => None
+      case (uv, CallF(v, va, vb))                 => None
+      case (uv, PrimeF(v, va))                    => None
+      case (uv, PreF(v, va))                      => None
+      case (uv, WithF(v, va, vb))                 => None
+      case (uv, IfF(v, va, vb, vc))               => None
+      case (uv, LetF(v, va, vb, vc))              => None
+      case (uv, LambdaF(v, va, vb))               => None
+      case (uv, ConstructorF(v, va, vb))          => None
+      case (uv, SetLiteralF(v, va))               => None
+      case (uv, MapLiteralF(v, va))               => None
+      case (uv, SetComprehensionF(v, va, vb, vc)) => None
+      case (uv, SeqLiteralF(v, va))               => None
+      case (uv, MatchesF(v, va, vb))              => None
+      case (uv, IntLitF(v, va))                   => None
+      case (uv, FloatLitF(v, va))                 => None
+      case (uv, StringLitF(v, va))                => None
+      case (uv, BoolLitF(v, va))                  => None
+      case (uv, NoneLitF(v))                      => None
+      case (uv, IdentifierF(v, va))               => None
     }
 
   def isSerial4(x0: canonical_type): Boolean = x0 match {
@@ -8123,6 +8472,9 @@ object SpecRestGenerated {
         }
     }
 
+  def isScalarUpdateClause(scalars: List[String], c: expr): Boolean =
+    !is_none[(String, scalar_rhs)](scalarUpdateOf(scalars, c))
+
   def mapEntryIsLeafLeaf(x0: map_entry): Boolean = x0 match {
     case MapEntryFull(k, v, uu) => isLeafValue(k) && isLeafValue(v)
   }
@@ -9243,18 +9595,41 @@ object SpecRestGenerated {
 
   def classifyStrategy(
       ensures: List[expr],
+      reqs: List[expr],
       stateFieldNames: List[String],
+      scalarFieldNames: List[String],
       outputNames: List[String]
   ): synthesis_strategy = {
     val clauses = flattenEnsures(ensures): List[expr];
-    !nulla[expr](clauses) &&
-      list_all[expr](
-        (c: expr) =>
-          isDirectEmitShape(c, stateFieldNames, outputNames),
-        clauses
-      ) match {
-      case true  => DirectEmit()
-      case false => LlmSynthesis()
+    nulla[expr](clauses) match {
+      case true => LlmSynthesis()
+      case false => list_ex[expr](
+          (a: expr) =>
+            isScalarUpdateClause(scalarFieldNames, a),
+          clauses
+        ) match {
+          case true => list_all[expr](
+              (a: expr) =>
+                isScalarUpdateClause(scalarFieldNames, a),
+              clauses
+            ) &&
+              list_all[expr](
+                (r: expr) =>
+                  !is_none[scalar_guard](scalarGuardOf(scalarFieldNames, r)),
+                flattenEnsures(reqs)
+              ) match {
+              case true  => DirectEmit()
+              case false => LlmSynthesis()
+            }
+          case false => list_all[expr](
+              (c: expr) =>
+                isDirectEmitShape(c, stateFieldNames, outputNames),
+              clauses
+            ) match {
+              case true  => DirectEmit()
+              case false => LlmSynthesis()
+            }
+        }
     }
   }
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -8472,6 +8472,50 @@ object SpecRestGenerated {
         }
     }
 
+  def equal_scalar_rhs(x0: scalar_rhs, x1: scalar_rhs): Boolean = (x0, x1) match {
+    case (SrSub(x41, x42), SrMul(x51, x52)) => false
+    case (SrMul(x51, x52), SrSub(x41, x42)) => false
+    case (SrAdd(x31, x32), SrMul(x51, x52)) => false
+    case (SrMul(x51, x52), SrAdd(x31, x32)) => false
+    case (SrAdd(x31, x32), SrSub(x41, x42)) => false
+    case (SrSub(x41, x42), SrAdd(x31, x32)) => false
+    case (SrSelf(), SrMul(x51, x52))        => false
+    case (SrMul(x51, x52), SrSelf())        => false
+    case (SrSelf(), SrSub(x41, x42))        => false
+    case (SrSub(x41, x42), SrSelf())        => false
+    case (SrSelf(), SrAdd(x31, x32))        => false
+    case (SrAdd(x31, x32), SrSelf())        => false
+    case (SrLit(x1), SrMul(x51, x52))       => false
+    case (SrMul(x51, x52), SrLit(x1))       => false
+    case (SrLit(x1), SrSub(x41, x42))       => false
+    case (SrSub(x41, x42), SrLit(x1))       => false
+    case (SrLit(x1), SrAdd(x31, x32))       => false
+    case (SrAdd(x31, x32), SrLit(x1))       => false
+    case (SrLit(x1), SrSelf())              => false
+    case (SrSelf(), SrLit(x1))              => false
+    case (SrMul(x51, x52), SrMul(y51, y52)) =>
+      equal_scalar_rhs(x51, y51) && equal_scalar_rhs(x52, y52)
+    case (SrSub(x41, x42), SrSub(y41, y42)) =>
+      equal_scalar_rhs(x41, y41) && equal_scalar_rhs(x42, y42)
+    case (SrAdd(x31, x32), SrAdd(y31, y32)) =>
+      equal_scalar_rhs(x31, y31) && equal_scalar_rhs(x32, y32)
+    case (SrLit(x1), SrLit(y1)) => equal_int(x1, y1)
+    case (SrSelf(), SrSelf())   => true
+  }
+
+  def scalarUpdatesConsistent(x0: List[(String, scalar_rhs)]): Boolean = x0 match {
+    case Nil => true
+    case (n, r) :: rest =>
+      list_all[(String, scalar_rhs)](
+        (a: (String, scalar_rhs)) => {
+          val (m, s) = a: ((String, scalar_rhs));
+          !(m == n) || equal_scalar_rhs(s, r)
+        },
+        rest
+      ) &&
+      scalarUpdatesConsistent(rest)
+  }
+
   def isScalarUpdateClause(scalars: List[String], c: expr): Boolean =
     !is_none[(String, scalar_rhs)](scalarUpdateOf(scalars, c))
 
@@ -9596,6 +9640,7 @@ object SpecRestGenerated {
   def classifyStrategy(
       ensures: List[expr],
       reqs: List[expr],
+      inputNames: List[String],
       stateFieldNames: List[String],
       scalarFieldNames: List[String],
       outputNames: List[String]
@@ -9613,11 +9658,17 @@ object SpecRestGenerated {
                 isScalarUpdateClause(scalarFieldNames, a),
               clauses
             ) &&
-              list_all[expr](
-                (r: expr) =>
-                  !is_none[scalar_guard](scalarGuardOf(scalarFieldNames, r)),
-                flattenEnsures(reqs)
-              ) match {
+              (nulla[String](inputNames) &&
+                (scalarUpdatesConsistent(map_filter[expr, (String, scalar_rhs)](
+                  (a: expr) =>
+                    scalarUpdateOf(scalarFieldNames, a),
+                  clauses
+                )) &&
+                  list_all[expr](
+                    (r: expr) =>
+                      !is_none[scalar_guard](scalarGuardOf(scalarFieldNames, r)),
+                    flattenEnsures(reqs)
+                  ))) match {
               case true  => DirectEmit()
               case false => LlmSynthesis()
             }

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5018,6 +5018,70 @@ object SpecRestGenerated {
     case BDiv()       => None
   }
 
+  def scalarLitOf(x0: expr): Option[BigInt] = x0 match {
+    case IntLitF(k, uu) => Some[BigInt](k)
+    case UnaryOpF(op, e, uv) =>
+      op match {
+        case UNot() => None
+        case UNegate() => e match {
+            case BinaryOpF(_, _, _, _)         => None
+            case UnaryOpF(_, _, _)             => None
+            case QuantifierF(_, _, _, _)       => None
+            case SomeWrapF(_, _)               => None
+            case TheF(_, _, _, _)              => None
+            case FieldAccessF(_, _, _)         => None
+            case EnumAccessF(_, _, _)          => None
+            case IndexF(_, _, _)               => None
+            case CallF(_, _, _)                => None
+            case PrimeF(_, _)                  => None
+            case PreF(_, _)                    => None
+            case WithF(_, _, _)                => None
+            case IfF(_, _, _, _)               => None
+            case LetF(_, _, _, _)              => None
+            case LambdaF(_, _, _)              => None
+            case ConstructorF(_, _, _)         => None
+            case SetLiteralF(_, _)             => None
+            case MapLiteralF(_, _)             => None
+            case SetComprehensionF(_, _, _, _) => None
+            case SeqLiteralF(_, _)             => None
+            case MatchesF(_, _, _)             => None
+            case IntLitF(k, _)                 => Some[BigInt](uminus_int(k))
+            case FloatLitF(_, _)               => None
+            case StringLitF(_, _)              => None
+            case BoolLitF(_, _)                => None
+            case NoneLitF(_)                   => None
+            case IdentifierF(_, _)             => None
+          }
+        case UCardinality() => None
+        case UPower()       => None
+      }
+    case BinaryOpF(v, va, vb, vc)         => None
+    case QuantifierF(v, va, vb, vc)       => None
+    case SomeWrapF(v, va)                 => None
+    case TheF(v, va, vb, vc)              => None
+    case FieldAccessF(v, va, vb)          => None
+    case EnumAccessF(v, va, vb)           => None
+    case IndexF(v, va, vb)                => None
+    case CallF(v, va, vb)                 => None
+    case PrimeF(v, va)                    => None
+    case PreF(v, va)                      => None
+    case WithF(v, va, vb)                 => None
+    case IfF(v, va, vb, vc)               => None
+    case LetF(v, va, vb, vc)              => None
+    case LambdaF(v, va, vb)               => None
+    case ConstructorF(v, va, vb)          => None
+    case SetLiteralF(v, va)               => None
+    case MapLiteralF(v, va)               => None
+    case SetComprehensionF(v, va, vb, vc) => None
+    case SeqLiteralF(v, va)               => None
+    case MatchesF(v, va, vb)              => None
+    case FloatLitF(v, va)                 => None
+    case StringLitF(v, va)                => None
+    case BoolLitF(v, va)                  => None
+    case NoneLitF(v)                      => None
+    case IdentifierF(v, va)               => None
+  }
+
   def scalarRhsOf(n: String, x1: expr): Option[scalar_rhs] = (n, x1) match {
     case (n, IntLitF(k, uu)) => Some[scalar_rhs](SrLit(k))
     case (n, IdentifierF(m, uv)) =>
@@ -5927,64 +5991,39 @@ object SpecRestGenerated {
         scalarCmpOf(op) match {
           case None => None
           case Some(c) =>
-            (l, r) match {
-              case (BinaryOpF(_, _, _, _), _)                         => None
-              case (UnaryOpF(_, _, _), _)                             => None
-              case (QuantifierF(_, _, _, _), _)                       => None
-              case (SomeWrapF(_, _), _)                               => None
-              case (TheF(_, _, _, _), _)                              => None
-              case (FieldAccessF(_, _, _), _)                         => None
-              case (EnumAccessF(_, _, _), _)                          => None
-              case (IndexF(_, _, _), _)                               => None
-              case (CallF(_, _, _), _)                                => None
-              case (PrimeF(_, _), _)                                  => None
-              case (PreF(_, _), _)                                    => None
-              case (WithF(_, _, _), _)                                => None
-              case (IfF(_, _, _, _), _)                               => None
-              case (LetF(_, _, _, _), _)                              => None
-              case (LambdaF(_, _, _), _)                              => None
-              case (ConstructorF(_, _, _), _)                         => None
-              case (SetLiteralF(_, _), _)                             => None
-              case (MapLiteralF(_, _), _)                             => None
-              case (SetComprehensionF(_, _, _, _), _)                 => None
-              case (SeqLiteralF(_, _), _)                             => None
-              case (MatchesF(_, _, _), _)                             => None
-              case (IntLitF(_, _), _)                                 => None
-              case (FloatLitF(_, _), _)                               => None
-              case (StringLitF(_, _), _)                              => None
-              case (BoolLitF(_, _), _)                                => None
-              case (NoneLitF(_), _)                                   => None
-              case (IdentifierF(_, _), BinaryOpF(_, _, _, _))         => None
-              case (IdentifierF(_, _), UnaryOpF(_, _, _))             => None
-              case (IdentifierF(_, _), QuantifierF(_, _, _, _))       => None
-              case (IdentifierF(_, _), SomeWrapF(_, _))               => None
-              case (IdentifierF(_, _), TheF(_, _, _, _))              => None
-              case (IdentifierF(_, _), FieldAccessF(_, _, _))         => None
-              case (IdentifierF(_, _), EnumAccessF(_, _, _))          => None
-              case (IdentifierF(_, _), IndexF(_, _, _))               => None
-              case (IdentifierF(_, _), CallF(_, _, _))                => None
-              case (IdentifierF(_, _), PrimeF(_, _))                  => None
-              case (IdentifierF(_, _), PreF(_, _))                    => None
-              case (IdentifierF(_, _), WithF(_, _, _))                => None
-              case (IdentifierF(_, _), IfF(_, _, _, _))               => None
-              case (IdentifierF(_, _), LetF(_, _, _, _))              => None
-              case (IdentifierF(_, _), LambdaF(_, _, _))              => None
-              case (IdentifierF(_, _), ConstructorF(_, _, _))         => None
-              case (IdentifierF(_, _), SetLiteralF(_, _))             => None
-              case (IdentifierF(_, _), MapLiteralF(_, _))             => None
-              case (IdentifierF(_, _), SetComprehensionF(_, _, _, _)) => None
-              case (IdentifierF(_, _), SeqLiteralF(_, _))             => None
-              case (IdentifierF(_, _), MatchesF(_, _, _))             => None
-              case (IdentifierF(n, _), IntLitF(k, _)) =>
+            l match {
+              case BinaryOpF(_, _, _, _)         => None
+              case UnaryOpF(_, _, _)             => None
+              case QuantifierF(_, _, _, _)       => None
+              case SomeWrapF(_, _)               => None
+              case TheF(_, _, _, _)              => None
+              case FieldAccessF(_, _, _)         => None
+              case EnumAccessF(_, _, _)          => None
+              case IndexF(_, _, _)               => None
+              case CallF(_, _, _)                => None
+              case PrimeF(_, _)                  => None
+              case PreF(_, _)                    => None
+              case WithF(_, _, _)                => None
+              case IfF(_, _, _, _)               => None
+              case LetF(_, _, _, _)              => None
+              case LambdaF(_, _, _)              => None
+              case ConstructorF(_, _, _)         => None
+              case SetLiteralF(_, _)             => None
+              case MapLiteralF(_, _)             => None
+              case SetComprehensionF(_, _, _, _) => None
+              case SeqLiteralF(_, _)             => None
+              case MatchesF(_, _, _)             => None
+              case IntLitF(_, _)                 => None
+              case FloatLitF(_, _)               => None
+              case StringLitF(_, _)              => None
+              case BoolLitF(_, _)                => None
+              case NoneLitF(_)                   => None
+              case IdentifierF(n, _) =>
                 membera[String](scalars, n) match {
-                  case true  => Some[scalar_guard](SgCmp(n, c, k))
+                  case true =>
+                    map_option[BigInt, scalar_guard]((a: BigInt) => SgCmp(n, c, a), scalarLitOf(r))
                   case false => None
                 }
-              case (IdentifierF(_, _), FloatLitF(_, _))   => None
-              case (IdentifierF(_, _), StringLitF(_, _))  => None
-              case (IdentifierF(_, _), BoolLitF(_, _))    => None
-              case (IdentifierF(_, _), NoneLitF(_))       => None
-              case (IdentifierF(_, _), IdentifierF(_, _)) => None
             }
         }
       case (uw, UnaryOpF(v, va, vb))              => None

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5123,7 +5123,43 @@ object SpecRestGenerated {
             case false => None
           }
       }
-    case (n, BinaryOpF(op, l, r, ux)) =>
+    case (n, UnaryOpF(op, e, ux)) =>
+      op match {
+        case UNot() => None
+        case UNegate() =>
+          e match {
+            case BinaryOpF(_, _, _, _)         => None
+            case UnaryOpF(_, _, _)             => None
+            case QuantifierF(_, _, _, _)       => None
+            case SomeWrapF(_, _)               => None
+            case TheF(_, _, _, _)              => None
+            case FieldAccessF(_, _, _)         => None
+            case EnumAccessF(_, _, _)          => None
+            case IndexF(_, _, _)               => None
+            case CallF(_, _, _)                => None
+            case PrimeF(_, _)                  => None
+            case PreF(_, _)                    => None
+            case WithF(_, _, _)                => None
+            case IfF(_, _, _, _)               => None
+            case LetF(_, _, _, _)              => None
+            case LambdaF(_, _, _)              => None
+            case ConstructorF(_, _, _)         => None
+            case SetLiteralF(_, _)             => None
+            case MapLiteralF(_, _)             => None
+            case SetComprehensionF(_, _, _, _) => None
+            case SeqLiteralF(_, _)             => None
+            case MatchesF(_, _, _)             => None
+            case IntLitF(k, _)                 => Some[scalar_rhs](SrLit(uminus_int(k)))
+            case FloatLitF(_, _)               => None
+            case StringLitF(_, _)              => None
+            case BoolLitF(_, _)                => None
+            case NoneLitF(_)                   => None
+            case IdentifierF(_, _)             => None
+          }
+        case UCardinality() => None
+        case UPower()       => None
+      }
+    case (n, BinaryOpF(op, l, r, uy)) =>
       (scalarRhsOf(n, l), scalarRhsOf(n, r)) match {
         case (None, _)       => None
         case (Some(_), None) => None
@@ -5151,29 +5187,28 @@ object SpecRestGenerated {
             case BDiv()       => None
           }
       }
-    case (uy, UnaryOpF(v, va, vb))              => None
-    case (uy, QuantifierF(v, va, vb, vc))       => None
-    case (uy, SomeWrapF(v, va))                 => None
-    case (uy, TheF(v, va, vb, vc))              => None
-    case (uy, FieldAccessF(v, va, vb))          => None
-    case (uy, EnumAccessF(v, va, vb))           => None
-    case (uy, IndexF(v, va, vb))                => None
-    case (uy, CallF(v, va, vb))                 => None
-    case (uy, PrimeF(v, va))                    => None
-    case (uy, WithF(v, va, vb))                 => None
-    case (uy, IfF(v, va, vb, vc))               => None
-    case (uy, LetF(v, va, vb, vc))              => None
-    case (uy, LambdaF(v, va, vb))               => None
-    case (uy, ConstructorF(v, va, vb))          => None
-    case (uy, SetLiteralF(v, va))               => None
-    case (uy, MapLiteralF(v, va))               => None
-    case (uy, SetComprehensionF(v, va, vb, vc)) => None
-    case (uy, SeqLiteralF(v, va))               => None
-    case (uy, MatchesF(v, va, vb))              => None
-    case (uy, FloatLitF(v, va))                 => None
-    case (uy, StringLitF(v, va))                => None
-    case (uy, BoolLitF(v, va))                  => None
-    case (uy, NoneLitF(v))                      => None
+    case (uz, QuantifierF(v, vb, vc, vd))       => None
+    case (uz, SomeWrapF(v, vb))                 => None
+    case (uz, TheF(v, vb, vc, vd))              => None
+    case (uz, FieldAccessF(v, vb, vc))          => None
+    case (uz, EnumAccessF(v, vb, vc))           => None
+    case (uz, IndexF(v, vb, vc))                => None
+    case (uz, CallF(v, vb, vc))                 => None
+    case (uz, PrimeF(v, vb))                    => None
+    case (uz, WithF(v, vb, vc))                 => None
+    case (uz, IfF(v, vb, vc, vd))               => None
+    case (uz, LetF(v, vb, vc, vd))              => None
+    case (uz, LambdaF(v, vb, vc))               => None
+    case (uz, ConstructorF(v, vb, vc))          => None
+    case (uz, SetLiteralF(v, vb))               => None
+    case (uz, MapLiteralF(v, vb))               => None
+    case (uz, SetComprehensionF(v, vb, vc, vd)) => None
+    case (uz, SeqLiteralF(v, vb))               => None
+    case (uz, MatchesF(v, vb, vc))              => None
+    case (uz, FloatLitF(v, vb))                 => None
+    case (uz, StringLitF(v, vb))                => None
+    case (uz, BoolLitF(v, vb))                  => None
+    case (uz, NoneLitF(v))                      => None
   }
 
   def enmName(x0: enum_decl): String = x0 match {

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminModel.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.ScalarState
 import specrest.ir.generated.SpecRestGenerated.*
 
 object AdminModel:
@@ -13,6 +14,7 @@ object AdminModel:
   enum ProjectionValue derives CanEqual:
     case PrimitiveField(fieldName: String)
     case EntityRow
+    case ScalarStateColumn(columnName: String)
 
   def unbackedStateFieldNames(ir: ServiceIRFull): Set[String] =
     irStateFields(ir)
@@ -24,6 +26,14 @@ object AdminModel:
     stfType(f) match
       case RelationTypeF(k, _, v, _) =>
         inferRelationProjection(k, v, ir)
+      case NamedTypeF(_, _) if ScalarState.fieldNames(ir).contains(stfName(f)) =>
+        Some(
+          Projection(
+            "",
+            "",
+            ProjectionValue.ScalarStateColumn(ScalarState.columnName(stfName(f)))
+          )
+        )
       case NamedTypeF(name, _) =>
         svcEntities(ir)
           .find(e => entName(e) == name)

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.ScalarState
 import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledService
@@ -7,25 +8,42 @@ import specrest.profile.ProfiledService
 object AdminRouter:
 
   def emit(profiled: ProfiledService): String =
-    val ir       = profiled.ir
-    val entities = svcEntities(ir)
+    val ir         = profiled.ir
+    val entities   = svcEntities(ir)
+    val hasScalars = ScalarState.fields(ir).nonEmpty
 
     val entityImports = entities
       .map(e => s"from app.models.${Naming.toSnakeCase(entName(e))} import ${entName(e)}")
       .mkString("\n")
+    val stateImport =
+      if hasScalars then "\nfrom app.models.service_state import ServiceState" else ""
 
+    val scalarResets =
+      if hasScalars then
+        val zeros = ScalarState
+          .fields(ir)
+          .map(sf => s"${ScalarState.columnName(stfName(sf))}=0")
+          .mkString(", ")
+        s"\n    await session.execute(sa_update(ServiceState).values($zeros))"
+      else ""
     val deleteStatements =
-      if entities.isEmpty then "    pass"
+      if entities.isEmpty && !hasScalars then "    pass"
       else
         entities
           .map(e => s"    await session.execute(delete(${entName(e)}))")
-          .mkString("\n")
+          .mkString("\n") + scalarResets
 
     val stateFieldsList = irStateFields(ir)
     val stateProjections =
       if stateFieldsList.isEmpty then "    return {}"
       else
-        val needsRows = stateFieldsList.exists(f => AdminModel.projectionFor(f, ir).isDefined)
+        val projections = stateFieldsList.map(f => f -> AdminModel.projectionFor(f, ir))
+        val needsRows = projections.exists:
+          case (_, Some(p)) =>
+            p.valueShape match
+              case AdminModel.ProjectionValue.ScalarStateColumn(_) => false
+              case _                                               => true
+          case _ => false
         val rowsLine =
           if entities.size == 1 && needsRows then
             val e = entities.head
@@ -37,10 +55,14 @@ object AdminRouter:
                 s"    $v = (await session.execute(select(${entName(e)}))).scalars().all()"
               .mkString("\n") + "\n"
           else ""
+        val stateRowLine =
+          if hasScalars then
+            "    state_row = (await session.execute(select(ServiceState))).scalar_one()\n"
+          else ""
 
         val pairs = stateFieldsList.map(f => projectionLine(f, ir, entities))
         val body  = pairs.mkString(",\n")
-        s"$rowsLine    return {\n$body,\n    }"
+        s"$rowsLine$stateRowLine    return {\n$body,\n    }"
 
     val seedEntities = svcTransitions(ir).map(trnEntity).toSet
     val seedTargets  = entities.filter(e => seedEntities.contains(entName(e)))
@@ -53,11 +75,13 @@ object AdminRouter:
        |
        |from fastapi import APIRouter, Body, Depends, HTTPException
        |from fastapi.responses import Response
-       |from sqlalchemy import delete, select
+       |from sqlalchemy import delete, select${
+        if hasScalars then ", update as sa_update" else ""
+      }
        |from sqlalchemy.ext.asyncio import AsyncSession
        |
        |from app.database import get_session
-       |${if entityImports.nonEmpty then entityImports else ""}
+       |${if entityImports.nonEmpty then entityImports else ""}$stateImport
        |
        |router = APIRouter(prefix="/__test_admin__", tags=["test-admin"])
        |
@@ -130,14 +154,18 @@ object AdminRouter:
   ): String =
     AdminModel.projectionFor(f, ir) match
       case Some(p) =>
-        val rowsRef =
-          if entities.size <= 1 then "rows"
-          else s"rows_${Naming.toSnakeCase(p.entityName)}"
-        val valueExpr = p.valueShape match
-          case AdminModel.ProjectionValue.PrimitiveField(name) => s"row.$name"
-          case AdminModel.ProjectionValue.EntityRow            => "_row_to_dict(row)"
         val key = pyStringLit(stfName(f))
-        s"        $key: {row.${p.keyFieldName}: $valueExpr for row in $rowsRef}"
+        p.valueShape match
+          case AdminModel.ProjectionValue.ScalarStateColumn(col) =>
+            s"        $key: state_row.$col"
+          case other =>
+            val rowsRef =
+              if entities.size <= 1 then "rows"
+              else s"rows_${Naming.toSnakeCase(p.entityName)}"
+            val valueExpr = other match
+              case AdminModel.ProjectionValue.PrimitiveField(name) => s"row.$name"
+              case _                                               => "_row_to_dict(row)"
+            s"        $key: {row.${p.keyFieldName}: $valueExpr for row in $rowsRef}"
       case None =>
         val key = pyStringLit(stfName(f))
         s"        # M5.1: state field '${stfName(f)}' not backed by entity table\n        $key: None"

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouter.scala
@@ -20,11 +20,11 @@ object AdminRouter:
 
     val scalarResets =
       if hasScalars then
-        val zeros = ScalarState
-          .fields(ir)
-          .map(sf => s"${ScalarState.columnName(stfName(sf))}=0")
+        val seeds = ScalarState
+          .fieldsWithSeeds(ir)
+          .map((sf, seed) => s"${ScalarState.columnName(stfName(sf))}=$seed")
           .mkString(", ")
-        s"\n    await session.execute(sa_update(ServiceState).values($zeros))"
+        s"\n    await session.execute(sa_update(ServiceState).values($seeds))"
       else ""
     val deleteStatements =
       if entities.isEmpty && !hasScalars then "    pass"

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.ScalarState
 import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.entFields
 import specrest.ir.generated.SpecRestGenerated.entName
@@ -27,8 +28,18 @@ object AdminRouterGo:
 
     def tbl(e: entity_decl): String = Naming.toTableName(entName(e))
 
+    val scalarFields = ScalarState.fields(ir)
+    val scalarReset =
+      if scalarFields.isEmpty then ""
+      else
+        val sets = scalarFields
+          .map(sf => s"${ScalarState.columnName(stfName(sf))} = 0")
+          .mkString(", ")
+        s"""\n\t\tif _, err := db.ExecContext(ctx, ${GoLit.str(
+            s"UPDATE ${ScalarState.TableName} SET $sets WHERE id = 1"
+          )}); err != nil {\n\t\t\thttp.Error(w, err.Error(), 500)\n\t\t\treturn\n\t\t}"""
     val resetStmts =
-      if entities.isEmpty then "\t\t// no entities"
+      if entities.isEmpty && scalarFields.isEmpty then "\t\t// no entities"
       else
         entities.reverse
           .map(e =>
@@ -36,34 +47,51 @@ object AdminRouterGo:
                 s"DELETE FROM ${tbl(e)}"
               )}); err != nil {\n\t\t\thttp.Error(w, err.Error(), 500)\n\t\t\treturn\n\t\t}"""
           )
-          .mkString("\n")
+          .mkString("\n") + scalarReset
 
     val stateFields = irStateFields(ir)
     val stateAssigns = stateFields
       .map: f =>
         AdminModel.projectionFor(f, ir) match
           case Some(p) =>
-            val keyCol = Naming.toColumnName(p.keyFieldName)
-            val valExpr = p.valueShape match
-              case AdminModel.ProjectionValue.EntityRow => "row"
-              case AdminModel.ProjectionValue.PrimitiveField(name) =>
-                s"row[${GoLit.str(Naming.toColumnName(name))}]"
-            val srcTbl = entities
-              .find(e => entName(e) == p.entityName)
-              .map(tbl)
-              .getOrElse(Naming.toTableName(p.entityName))
-            s"""\t\t{
-               |\t\t\trows, err := queryAll(ctx, db, ${GoLit.str(s"SELECT * FROM $srcTbl")})
-               |\t\t\tif err != nil {
-               |\t\t\t\thttp.Error(w, err.Error(), 500)
-               |\t\t\t\treturn
-               |\t\t\t}
-               |\t\t\tm := map[string]any{}
-               |\t\t\tfor _, row := range rows {
-               |\t\t\t\tm[fmt.Sprintf("%v", row[${GoLit.str(keyCol)}])] = $valExpr
-               |\t\t\t}
-               |\t\t\tstate[${GoLit.str(stfName(f))}] = m
-               |\t\t}""".stripMargin
+            p.valueShape match
+              case AdminModel.ProjectionValue.ScalarStateColumn(col) =>
+                s"""\t\t{
+                   |\t\t\trows, err := queryAll(ctx, db, ${GoLit.str(
+                    s"SELECT $col FROM ${ScalarState.TableName} WHERE id = 1"
+                  )})
+                   |\t\t\tif err != nil {
+                   |\t\t\t\thttp.Error(w, err.Error(), 500)
+                   |\t\t\t\treturn
+                   |\t\t\t}
+                   |\t\t\tif len(rows) > 0 {
+                   |\t\t\t\tstate[${GoLit.str(stfName(f))}] = rows[0][${GoLit.str(col)}]
+                   |\t\t\t} else {
+                   |\t\t\t\tstate[${GoLit.str(stfName(f))}] = nil
+                   |\t\t\t}
+                   |\t\t}""".stripMargin
+              case shape =>
+                val keyCol = Naming.toColumnName(p.keyFieldName)
+                val valExpr = shape match
+                  case AdminModel.ProjectionValue.PrimitiveField(name) =>
+                    s"row[${GoLit.str(Naming.toColumnName(name))}]"
+                  case _ => "row"
+                val srcTbl = entities
+                  .find(e => entName(e) == p.entityName)
+                  .map(tbl)
+                  .getOrElse(Naming.toTableName(p.entityName))
+                s"""\t\t{
+                   |\t\t\trows, err := queryAll(ctx, db, ${GoLit.str(s"SELECT * FROM $srcTbl")})
+                   |\t\t\tif err != nil {
+                   |\t\t\t\thttp.Error(w, err.Error(), 500)
+                   |\t\t\t\treturn
+                   |\t\t\t}
+                   |\t\t\tm := map[string]any{}
+                   |\t\t\tfor _, row := range rows {
+                   |\t\t\t\tm[fmt.Sprintf("%v", row[${GoLit.str(keyCol)}])] = $valExpr
+                   |\t\t\t}
+                   |\t\t\tstate[${GoLit.str(stfName(f))}] = m
+                   |\t\t}""".stripMargin
           case None =>
             s"\t\tstate[${GoLit.str(stfName(f))}] = nil"
       .mkString("\n")

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterGo.scala
@@ -32,8 +32,9 @@ object AdminRouterGo:
     val scalarReset =
       if scalarFields.isEmpty then ""
       else
-        val sets = scalarFields
-          .map(sf => s"${ScalarState.columnName(stfName(sf))} = 0")
+        val sets = ScalarState
+          .fieldsWithSeeds(ir)
+          .map((sf, seed) => s"${ScalarState.columnName(stfName(sf))} = $seed")
           .mkString(", ")
         s"""\n\t\tif _, err := db.ExecContext(ctx, ${GoLit.str(
             s"UPDATE ${ScalarState.TableName} SET $sets WHERE id = 1"

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -58,11 +58,12 @@ object AdminRouterTs:
         val scalarReset =
           if ScalarState.fields(ir).isEmpty then ""
           else
-            val zeros = ScalarState
-              .fields(ir)
-              .map(sf => s"${Naming.toCamelCase(ScalarState.columnName(stfName(sf)))}: 0")
+            val seeds = ScalarState
+              .fieldsWithSeeds(ir)
+              .map: (sf, seed) =>
+                s"${Naming.toCamelCase(ScalarState.columnName(stfName(sf)))}: $seed"
               .mkString(", ")
-            s"\n      await (prisma as unknown as AnyPrisma).serviceState.updateMany({ data: { $zeros } });"
+            s"\n      await (prisma as unknown as AnyPrisma).serviceState.updateMany({ data: { $seeds } });"
         entities.reverse
           .map(e => s"      await (prisma as unknown as AnyPrisma).${accessor(e)}.deleteMany();")
           .mkString("\n") + scalarReset

--- a/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/AdminRouterTs.scala
@@ -1,5 +1,6 @@
 package specrest.testgen
 
+import specrest.convention.ScalarState
 import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.entFields
 import specrest.ir.generated.SpecRestGenerated.entName
@@ -52,17 +53,36 @@ object AdminRouterTs:
       .mkString("\n\n")
 
     val resetStmts =
-      if entities.isEmpty then "      // no entities"
+      if entities.isEmpty && ScalarState.fields(ir).isEmpty then "      // no entities"
       else
+        val scalarReset =
+          if ScalarState.fields(ir).isEmpty then ""
+          else
+            val zeros = ScalarState
+              .fields(ir)
+              .map(sf => s"${Naming.toCamelCase(ScalarState.columnName(stfName(sf)))}: 0")
+              .mkString(", ")
+            s"\n      await (prisma as unknown as AnyPrisma).serviceState.updateMany({ data: { $zeros } });"
         entities.reverse
           .map(e => s"      await (prisma as unknown as AnyPrisma).${accessor(e)}.deleteMany();")
-          .mkString("\n")
+          .mkString("\n") + scalarReset
 
     val stateFields = irStateFields(ir)
-    val neededEntities = stateFields
-      .flatMap(f => AdminModel.projectionFor(f, ir).map(_.entityName))
+    val projections = stateFields.map(f => f -> AdminModel.projectionFor(f, ir))
+    val neededEntities = projections
+      .collect:
+        case (_, Some(p))
+            if p.valueShape match
+              case AdminModel.ProjectionValue.ScalarStateColumn(_) => false
+              case _                                               => true
+            =>
+          p.entityName
       .distinct
-    val rowsDecls = neededEntities
+    val stateRowDecl =
+      if ScalarState.fields(ir).isEmpty then ""
+      else
+        "      const stateRow = await (prisma as unknown as AnyPrisma).serviceState.findFirst();\n"
+    val rowsDecls = stateRowDecl + neededEntities
       .flatMap(en => entities.find(e => entName(e) == en))
       .map: e =>
         s"      const rows_${entName(e)} = await (prisma as unknown as AnyPrisma).${accessor(e)}.findMany();"
@@ -71,17 +91,22 @@ object AdminRouterTs:
       .map: f =>
         AdminModel.projectionFor(f, ir) match
           case Some(p) =>
-            val keyTs = Naming.toCamelCase(p.keyFieldName)
-            val value = p.valueShape match
-              case AdminModel.ProjectionValue.EntityRow =>
-                s"rowToDict_${p.entityName}(r)"
-              case AdminModel.ProjectionValue.PrimitiveField(name) =>
-                s"r.${Naming.toCamelCase(name)}"
-            s"""        ${tsKey(stfName(f))}: Object.fromEntries(
-               |          rows_${p.entityName}.map((r: Record<string, unknown>) => [
-               |            String(r.$keyTs), $value,
-               |          ]),
-               |        ),""".stripMargin
+            p.valueShape match
+              case AdminModel.ProjectionValue.ScalarStateColumn(col) =>
+                val tsField = Naming.toCamelCase(col)
+                s"        ${tsKey(stfName(f))}: stateRow == null ? null : Number((stateRow as Record<string, unknown>).$tsField)," // prisma BigInt does not JSON-serialize
+              case shape =>
+                val keyTs = Naming.toCamelCase(p.keyFieldName)
+                val value = shape match
+                  case AdminModel.ProjectionValue.PrimitiveField(name) =>
+                    s"r.${Naming.toCamelCase(name)}"
+                  case _ =>
+                    s"rowToDict_${p.entityName}(r)"
+                s"""        ${tsKey(stfName(f))}: Object.fromEntries(
+                   |          rows_${p.entityName}.map((r: Record<string, unknown>) => [
+                   |            String(r.$keyTs), $value,
+                   |          ]),
+                   |        ),""".stripMargin
           case None =>
             s"        ${tsKey(stfName(f))}: null,"
       .mkString("\n")
@@ -136,7 +161,9 @@ import { prisma } from '../prisma.js';
 type AnyPrisma = Record<string, {
   deleteMany: () => Promise<unknown>;
   findMany: () => Promise<Array<Record<string, unknown>>>;
+  findFirst: () => Promise<Record<string, unknown> | null>;
   create: (args: { data: Record<string, unknown> }) => Promise<Record<string, unknown>>;
+  updateMany: (args: { data: Record<string, unknown> }) => Promise<unknown>;
 }>;
 
 const enabled = (): boolean => process.env.ENABLE_TEST_ADMIN === '1';

--- a/modules/testgen/src/main/scala/specrest/testgen/StubOps.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/StubOps.scala
@@ -1,6 +1,7 @@
 package specrest.testgen
 
 import specrest.codegen.OperationContext
+import specrest.codegen.ScalarOps
 import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
@@ -9,7 +10,11 @@ object StubOps:
   private given CanEqual[route_kind, route_kind] = CanEqual.derived
 
   def isStub(profiled: ProfiledService, op: ProfiledOperation): Boolean =
-    isFailLoudStub(op.dafnyMethod.isDefined, effectiveKind(profiled, op))
+    // A scalar-state op gets a real emitted body (direct-emit path), so it
+    // counts as "has a body" exactly like a kernel-bound method.
+    val scalarHandled =
+      ScalarOps.views(profiled).exists(_.operation.operationName == op.operationName)
+    isFailLoudStub(op.dafnyMethod.isDefined || scalarHandled, effectiveKind(profiled, op))
 
   // A `list` route returns the array as the bare response body, so its single declared
   // output is the whole body — `response_data`, not `response_data["<name>"]`.

--- a/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/AdminRouterTest.scala
@@ -49,13 +49,14 @@ class AdminRouterTest extends CatsEffectSuite:
       // base_url: scalar — None placeholder
       assert(src.contains("\"base_url\": None"), s"src=$src")
 
-  test("safe_counter (no entities): reset is no-op, state returns empty"):
+  test("safe_counter: reset zeroes the scalar state row, state projects count (#407)"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val src = AdminRouter.emit(profiled)
-      // Reset has nothing to delete
-      assert(src.contains("    pass"))
-      // count is scalar state, no entity backs it
-      assert(src.contains("\"count\": None"))
+      // Reset restores the seeded defaults for the backed scalar
+      assert(src.contains("sa_update(ServiceState).values(count=0)"), s"src=$src")
+      // count is read from the singleton service_state row
+      assert(src.contains("\"count\": state_row.count"), s"src=$src")
+      assert(src.contains("from app.models.service_state import ServiceState"), s"src=$src")
 
   test("entity model imports use snake_case file names matching codegen"):
     loadProfiled("fixtures/spec/url_shortener.spec").map: profiled =>

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -234,12 +234,38 @@ class BackendTest extends CatsEffectSuite:
 
   private def loadIR(path: String) =
     val src = scala.io.Source.fromFile(path).getLines.mkString("\n")
+    loadIRSource(src)
+
+  private def loadIRSource(src: String) =
     Parse.parseSpec(src).flatMap:
       case Right(parsed) =>
         Builder.buildIR(parsed.tree).map:
           case Right(ir) => ir
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
+
+  // An op over a primitive->primitive relation: no entity backs it, so the
+  // behavioral/stateful emitters honest-skip everything (zero tests).
+  private def unbackedStubSpec =
+    """service StubOnly {
+      |
+      |  state {
+      |    counters: Int -> lone Int
+      |  }
+      |
+      |  operation Bump {
+      |    input: k: Int
+      |
+      |    requires:
+      |      true
+      |
+      |    ensures:
+      |      counters'[k] = 1
+      |  }
+      |
+      |  invariant countersNonNegative:
+      |    all k in counters | counters[k] >= 0
+      |}""".stripMargin
 
   test("TsVitestHarness emits the vitest scaffold with TS-shaped paths"):
     loadIR("fixtures/spec/url_shortener.spec").map: ir =>
@@ -315,7 +341,7 @@ class BackendTest extends CatsEffectSuite:
       assert(mod.contains("const NUM_RUNS ="), mod.take(600))
 
   test("TsBehavioral.renderModule emits a test.skip placeholder when zero tests"):
-    loadIR("fixtures/spec/safe_counter.spec").map: ir =>
+    loadIRSource(unbackedStubSpec).map: ir =>
       val out = TsBehavioral.emitFor(SynthFixture.profiled(ir))
       assert(out.tests.isEmpty, s"expected zero behavioral tests; got ${out.tests.map(_.name)}")
       val mod = TsBehavioral.renderModule(ir, out.tests)
@@ -338,8 +364,8 @@ class BackendTest extends CatsEffectSuite:
       assert(f.contains("postState["), f)
       assert(f.contains("invariant violated:"), f)
 
-  test("TsStateful honest-skips when invariants are unbacked (safe_counter)"):
-    loadIR("fixtures/spec/safe_counter.spec").map: ir =>
+  test("TsStateful honest-skips when invariants are unbacked"):
+    loadIRSource(unbackedStubSpec).map: ir =>
       val out = TsStateful.emitFor(SynthFixture.profiled(ir))
       assert(out.file.contains("test.skip("), out.file)
       assert(out.file.contains("no assertable rules/invariants"), out.file)
@@ -350,6 +376,15 @@ class BackendTest extends CatsEffectSuite:
         ),
         s"expected unbacked-state invariant skip; got ${out.skips}"
       )
+
+  test("TsStateful asserts backed-scalar invariants (safe_counter, #407)"):
+    loadIR("fixtures/spec/safe_counter.spec").map: ir =>
+      val out = TsStateful.emitFor(SynthFixture.profiled(ir))
+      assert(
+        !out.skips.exists(_.reason.contains("not backed by an entity table")),
+        s"count is backed since #407; got ${out.skips}"
+      )
+      assert(out.file.contains("invariant violated:"), out.file)
 
   test("Strategies.forIR is backend-parameterized: same IR, per-language specs"):
     loadIR("fixtures/spec/url_shortener.spec").map: ir =>
@@ -506,7 +541,7 @@ class BackendTest extends CatsEffectSuite:
       assert(mod.contains("\"testing\""), mod.take(300))
 
   test("GoBehavioral.renderModule emits a t.Skip placeholder when zero tests"):
-    loadIR("fixtures/spec/safe_counter.spec").map: ir =>
+    loadIRSource(unbackedStubSpec).map: ir =>
       val out = GoBehavioral.emitFor(SynthFixture.profiled(ir))
       assert(out.tests.isEmpty, s"expected zero tests; got ${out.tests.map(_.name)}")
       val mod = GoBehavioral.renderModule(ir, out.tests)
@@ -526,8 +561,8 @@ class BackendTest extends CatsEffectSuite:
       assert(f.contains("invariant violated:"), f)
       assert(f.contains("package tests"), f.take(200))
 
-  test("GoStateful honest-skips when invariants are unbacked (safe_counter)"):
-    loadIR("fixtures/spec/safe_counter.spec").map: ir =>
+  test("GoStateful honest-skips when invariants are unbacked"):
+    loadIRSource(unbackedStubSpec).map: ir =>
       val out = GoStateful.emitFor(SynthFixture.profiled(ir))
       assert(out.file.contains("t.Skip("), out.file)
       assert(

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -233,7 +233,7 @@ class BackendTest extends CatsEffectSuite:
   // ---- TsVitestHarness: TS scaffold + the _runtime.ts contract ----
 
   private def loadIR(path: String) =
-    val src = scala.io.Source.fromFile(path).getLines.mkString("\n")
+    val src = scala.util.Using.resource(scala.io.Source.fromFile(path))(_.getLines.mkString("\n"))
     loadIRSource(src)
 
   private def loadIRSource(src: String) =
@@ -385,6 +385,7 @@ class BackendTest extends CatsEffectSuite:
         s"count is backed since #407; got ${out.skips}"
       )
       assert(out.file.contains("invariant violated:"), out.file)
+      assert(out.file.contains("countNonNegative"), out.file)
 
   test("Strategies.forIR is backend-parameterized: same IR, per-language specs"):
     loadIR("fixtures/spec/url_shortener.spec").map: ir =>

--- a/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BehavioralTest.scala
@@ -48,20 +48,18 @@ class BehavioralTest extends CatsEffectSuite:
           case Left(err) => fail(s"build error: $err")
       case Left(err) => fail(s"parse error: $err")
 
-  test("safe_counter: Increment ensures honest-skipped (unbacked count), Decrement state-dep"):
+  test("safe_counter: Increment ensures emits via backed scalar (#407), Decrement state-dep"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val out = Behavioral.emitFor(profiled)
-      // `count` is pure scalar state with no backing table; asserting `count' = count + 1`
-      // black-box would compare `None`, so the ensures must honest-skip, not emit.
+      // `count` is an Int scalar backed by service_state since #407, so the
+      // ensures asserts post_state["count"] black-box instead of honest-skipping.
       assert(
-        !out.tests.exists(_.name.startsWith("test_increment_ensures")),
-        s"Increment.ensures touches unbacked `count`; must not emit: ${out.tests.map(_.name)}"
+        out.tests.exists(_.name.startsWith("test_increment_ensures")),
+        s"Increment.ensures must emit against the backed scalar: ${out.tests.map(_.name)}"
       )
       assert(
-        out.skips.exists(s =>
-          s.operation == "Increment" && s.reason.contains("not backed by an entity table")
-        ),
-        s"expected Increment unbacked-state skip; got ${out.skips}"
+        !out.skips.exists(_.reason.contains("not backed by an entity table")),
+        s"no unbacked-state skips expected; got ${out.skips}"
       )
       val decSkips = out.skips.filter(_.operation == "Decrement")
       assert(

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -75,7 +75,12 @@ class SkipRateProbeTest extends CatsEffectSuite:
       1,
       "base_url is unbacked scalar state (String, outside the #407 Int scope)"
     ),
-    ("todo_list", 50, 0, "next_id is an Int scalar backed by service_state since #407"),
+    (
+      "todo_list",
+      50,
+      2,
+      "next_id stays unbacked: `next_id not in todos` is invariant-relevant but not a derivable seed bound, so #407 conservatively leaves it on the unbacked path"
+    ),
     (
       "ecommerce",
       76,

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -68,11 +68,21 @@ class SkipRateProbeTest extends CatsEffectSuite:
     )
 
   List(
-    ("safe_counter", 5, 3, "count is unbacked scalar state (admin /state projects null)"),
-    ("url_shortener", 21, 1, "base_url is unbacked scalar state"),
-    ("todo_list", 50, 2, "next_id is unbacked scalar state"),
-    ("ecommerce", 76, 5, "3 unbacked scalar-state ensures + 2 `removed` parser scope leak"),
-    ("edge_cases", 29, 3, "plain is unbacked scalar state"),
+    ("safe_counter", 5, 0, "count is an Int scalar backed by service_state since #407"),
+    (
+      "url_shortener",
+      21,
+      1,
+      "base_url is unbacked scalar state (String, outside the #407 Int scope)"
+    ),
+    ("todo_list", 50, 0, "next_id is an Int scalar backed by service_state since #407"),
+    (
+      "ecommerce",
+      76,
+      4,
+      "2 `removed` parser scope leak + 2 non-Int scalar ensures; Int scalars backed since #407"
+    ),
+    ("edge_cases", 29, 0, "plain is an Int scalar backed by service_state since #407"),
     (
       "auth_service",
       43,

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -114,19 +114,15 @@ class StructuralTest extends CatsEffectSuite:
       val out = Structural.emitFor(profiled)
       assert(!out.file.contains("schema.as_state_machine()"))
       assert(out.file.contains("def test_api_structural(case):"))
-      // `countNonNegative` reads unbacked scalar `count`; the admin /state projects it
-      // as null, so the global-invariant check must honest-skip rather than emit a
-      // `None >= 0` crash.
+      // `countNonNegative` reads the Int scalar `count`, backed by the
+      // service_state table since #407 - the invariant check is emitted.
       assert(
-        !out.file.contains("def _check_invariant_count_non_negative(ctx, response, case):"),
-        s"unbacked-state invariant check must not be emitted:\n${out.file}"
+        out.file.contains("def _check_invariant_count_non_negative("),
+        s"backed-scalar invariant check must be emitted:\n${out.file}"
       )
       assert(
-        out.skips.exists(s =>
-          s.kind.startsWith("structural_invariant") &&
-            s.reason.contains("not backed by an entity table")
-        ),
-        s"expected recorded structural_invariant skip for countNonNegative; got ${out.skips}"
+        !out.skips.exists(_.reason.contains("not backed by an entity table")),
+        s"no unbacked-state structural skips expected; got ${out.skips}"
       )
 
   test("invariant skips use <invariants> sentinel, not <service>"):

--- a/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
@@ -30,7 +30,7 @@ class TestCtxTest extends CatsEffectSuite:
       assertEquals(ctx.outputs, Set.empty[String])
       assertEquals(ctx.capture, CaptureMode.PreState)
 
-  test("ExprToPython honest-skips safe_counter clauses that touch unbacked scalar `count`"):
+  test("ExprToPython translates safe_counter clauses via the backed scalar `count` (#407)"):
     val src = scala.io.Source
       .fromFile("fixtures/spec/safe_counter.spec")
       .getLines
@@ -43,18 +43,13 @@ class TestCtxTest extends CatsEffectSuite:
           s"${operName(op)}.requires" -> ExprToPython.translate(e, reqCtx)
         ) ++
           operEnsures(op).map(e => s"${operName(op)}.ensures" -> ExprToPython.translate(e, ensCtx))
+      // `count` is an Int scalar backed by the service_state table since #407,
+      // so every clause translates - nothing honest-skips.
       val skips = results.collect { case (n, Translated.Skip(r, _)) => n -> r }
-      // `count` is the only state and it is unbacked; every clause that references it
-      // must honest-skip rather than emit a `None`-comparison that crashes at runtime.
-      assert(skips.nonEmpty, s"expected unbacked-state skips; got $results")
-      assert(
-        skips.forall(_._2.contains("not backed by an entity table")),
-        s"safe_counter clauses should only skip for the unbacked-state reason; got $skips"
-      )
-      // `Increment.requires` is the literal `true` — no state reference, stays translatable.
+      assert(skips.isEmpty, s"backed scalar state must not skip; got $skips")
       assert(
         results.exists { case (n, r) =>
-          n == "Increment.requires" && r.isInstanceOf[Translated.Emit]
+          n == "Decrement.ensures" && r.isInstanceOf[Translated.Emit]
         },
-        s"Increment.requires (`true`) must still translate; got $results"
+        s"Decrement.ensures must translate against post_state; got $results"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestCtxTest.scala
@@ -48,8 +48,10 @@ class TestCtxTest extends CatsEffectSuite:
       val skips = results.collect { case (n, Translated.Skip(r, _)) => n -> r }
       assert(skips.isEmpty, s"backed scalar state must not skip; got $skips")
       assert(
-        results.exists { case (n, r) =>
-          n == "Decrement.ensures" && r.isInstanceOf[Translated.Emit]
+        results.exists {
+          case (n, Translated.Emit(code)) =>
+            n == "Decrement.ensures" && code.contains("post_state[\"count\"]")
+          case _ => false
         },
         s"Decrement.ensures must translate against post_state; got $results"
       )

--- a/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TestEmitTest.scala
@@ -80,18 +80,18 @@ class TestEmitTest extends CatsEffectSuite:
       assert(beh.contains("strategy_short_code"))
       assert(beh.contains("def test_shorten_ensures_"), s"no shorten ensures test:\n$beh")
 
-  test("safe_counter behavioral honest-skips Increment (unbacked count), recorded in skips json"):
+  test("safe_counter behavioral emits Increment against the backed scalar (#407)"):
     loadProfiled("fixtures/spec/safe_counter.spec").map: profiled =>
       val files = TestEmit.emit(profiled)
       val beh   = files.find(_.path == "tests/test_behavioral_safe_counter.py").get.content
       assert(
-        !beh.contains("def test_increment_ensures_0("),
-        s"Increment.ensures touches unbacked `count`; must not emit a crashing test:\n$beh"
+        beh.contains("def test_increment_ensures_0("),
+        s"Increment.ensures must emit against the backed scalar `count`:\n$beh"
       )
       val skips = files.find(_.path == "tests/_testgen_skips.json").get.content
       assert(
-        skips.contains("not backed by an entity table"),
-        s"unbacked-state skip must be recorded in the skips manifest:\n$skips"
+        !skips.contains("not backed by an entity table"),
+        s"no unbacked-state skips expected in the manifest:\n$skips"
       )
 
   test("_testgen_skips.json is well-formed and contains no ExprToPython coverage skips"):

--- a/proofs/isabelle/STATUS.md
+++ b/proofs/isabelle/STATUS.md
@@ -361,6 +361,19 @@ not incremental PRs:
   theorems unlock the Phase-9m extraction PR that replaces those circe codecs with calls to
   extracted `SpecRestGenerated.*` functions. The full `expr_full`/`type_expr_full` codec is the next
   size-induction proof.
+- **Scalar direct-emit recognisers** (`Classify.thy`, issue #407): `scalarRhsOf` / `scalarUpdateOf`
+  parse an ensures clause `x' = <arithmetic over x / pre(x) / int literals>` into a structured
+  `scalar_rhs` tree; `scalarGuardOf` parses requires atoms into `scalar_guard`
+  (`SgCmp name scalar_cmp int`, where `scalar_cmp` is a dedicated closed comparator datatype so
+  Scala consumers render guards with an exhaustive match instead of a defensive catch-all over
+  `bin_op`). `classifyStrategy` gained `requires` and `scalarFieldNames` parameters: if ANY
+  flattened ensures clause is a scalar update, ALL must be (a mixed entity/scalar operation would
+  otherwise be emitted by the entity-CRUD path with the scalar clauses silently dropped), and every
+  requires atom must be guardable - the emitters fold guards into the atomic UPDATE's WHERE clause,
+  so an unguardable precondition would let an HTTP caller break a verified invariant at runtime. The
+  same extracted extractors feed both the classifier gate and all three language emitters (single
+  source of truth: the recognised fragment and the emitted SQL cannot drift). Proof-free executable
+  code, like the rest of the classifier.
 - **Alloy backend unverified.** Only the router `requires_alloy` is proven. The `expr_full ⇒ Alloy`
   translation and Alloy semantics have no Isabelle analog — a full second trusted backend. A
   `translate_alloy` + Alloy-semantics + soundness theorem mirrors the entire Z3 effort.

--- a/proofs/isabelle/SpecRest/codegen/Classify.thy
+++ b/proofs/isabelle/SpecRest/codegen/Classify.thy
@@ -174,6 +174,95 @@ text \<open>Top-level \<open>fun\<close> pattern instead of an inline \<open>cas
 fun mapEntryIsLeafLeaf :: "map_entry \<Rightarrow> bool" where
   "mapEntryIsLeafLeaf (MapEntryFull k v _) = (isLeafValue k \<and> isLeafValue v)"
 
+text \<open>Scalar direct-emit recognisers (issue #407). A scalar-update ensures
+  clause assigns an Int-typed state scalar from arithmetic over itself
+  (current or \<open>pre\<close>) and integer literals. The extractors return the
+  structured update / guard rather than a bare bool so the classifier gate
+  and the emitters consume the same parse - the recognised fragment and
+  the emitted SQL cannot drift. Guards are the requires atoms an emitter
+  can fold into the atomic UPDATE's WHERE clause.\<close>
+
+datatype scalar_rhs =
+    SrLit int
+  | SrSelf
+  | SrAdd scalar_rhs scalar_rhs
+  | SrSub scalar_rhs scalar_rhs
+  | SrMul scalar_rhs scalar_rhs
+
+fun scalarRhsOf :: "String.literal \<Rightarrow> expr \<Rightarrow> scalar_rhs option" where
+  "scalarRhsOf n (IntLitF k _) = Some (SrLit k)"
+| "scalarRhsOf n (IdentifierF m _) = (if m = n then Some SrSelf else None)"
+| "scalarRhsOf n (PreF e _) =
+     (case e of
+        IdentifierF m _ \<Rightarrow> (if m = n then Some SrSelf else None)
+      | _ \<Rightarrow> None)"
+| "scalarRhsOf n (BinaryOpF op l r _) =
+     (case (scalarRhsOf n l, scalarRhsOf n r) of
+        (Some a, Some b) \<Rightarrow>
+          (case op of
+             BAdd \<Rightarrow> Some (SrAdd a b)
+           | BSub \<Rightarrow> Some (SrSub a b)
+           | BMul \<Rightarrow> Some (SrMul a b)
+           | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
+| "scalarRhsOf _ _ = None"
+
+fun scalarUpdateOf ::
+  "String.literal list \<Rightarrow> expr \<Rightarrow> (String.literal \<times> scalar_rhs) option"
+where
+  "scalarUpdateOf scalars (BinaryOpF op lhs rhs _) =
+     (case op of
+        BEq \<Rightarrow>
+          (case lhs of
+             PrimeF inner _ \<Rightarrow>
+               (case inner of
+                  IdentifierF n _ \<Rightarrow>
+                    (if n \<in> set scalars
+                     then map_option (Pair n) (scalarRhsOf n rhs)
+                     else None)
+                | _ \<Rightarrow> None)
+           | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
+| "scalarUpdateOf _ _ = None"
+
+datatype scalar_cmp = ScGt | ScGe | ScLt | ScLe | ScEq | ScNeq
+
+datatype scalar_guard =
+    SgTrue
+  | SgCmp String.literal scalar_cmp int
+
+text \<open>\<open>scalar_cmp\<close> is a dedicated closed comparator set (not \<open>bin_op\<close>)
+  so Scala consumers can render guards with an exhaustive match instead
+  of a defensive catch-all over the ~50 \<open>bin_op\<close> constructors.\<close>
+
+fun scalarCmpOf :: "bin_op \<Rightarrow> scalar_cmp option" where
+  "scalarCmpOf BGt  = Some ScGt"
+| "scalarCmpOf BGe  = Some ScGe"
+| "scalarCmpOf BLt  = Some ScLt"
+| "scalarCmpOf BLe  = Some ScLe"
+| "scalarCmpOf BEq  = Some ScEq"
+| "scalarCmpOf BNeq = Some ScNeq"
+| "scalarCmpOf _    = None"
+
+fun scalarGuardOf ::
+  "String.literal list \<Rightarrow> expr \<Rightarrow> scalar_guard option"
+where
+  "scalarGuardOf scalars (BoolLitF b _) = (if b then Some SgTrue else None)"
+| "scalarGuardOf scalars (BinaryOpF op l r _) =
+     (case scalarCmpOf op of
+        None \<Rightarrow> None
+      | Some c \<Rightarrow>
+          (case (l, r) of
+             (IdentifierF n _, IntLitF k _) \<Rightarrow>
+               (if n \<in> set scalars then Some (SgCmp n c k) else None)
+           | _ \<Rightarrow> None))"
+| "scalarGuardOf _ _ = None"
+
+definition isScalarUpdateClause ::
+  "String.literal list \<Rightarrow> expr \<Rightarrow> bool"
+where
+  "isScalarUpdateClause scalars c = (scalarUpdateOf scalars c \<noteq> None)"
+
 text \<open>\<open>isDirectEmitShape\<close>: a single ensures-clause is direct-emit-able when its
   shape matches one of the recognised verified-subset patterns (preserve a
   state field, append-disjoint, cardinality-preserving, single-index update,
@@ -207,15 +296,30 @@ text \<open>\<open>classifyStrategy\<close>: an operation is direct-emit-able wh
   ensures-clause matches one of the recognised shapes, otherwise it falls back
   to LLM synthesis. Takes the ensures body and field-name lists directly so
   the caller can do the \<open>flattenEnsures\<close> + name-set computation at the
-  Scala boundary.\<close>
+  Scala boundary.
+
+  Scalar branch (issue #407): if ANY clause is a scalar update, ALL clauses
+  must be - a mixed entity/scalar operation would otherwise be emitted by
+  the entity-CRUD path with the scalar clauses silently dropped. Scalar
+  operations additionally require every requires-atom to be guardable
+  (foldable into the atomic UPDATE's WHERE clause); verification assumes
+  requires holds on entry, but HTTP callers can invoke the route in any
+  state, so an unguardable precondition would let a runtime call break a
+  verified invariant.\<close>
 
 definition classifyStrategy ::
-  "expr list \<Rightarrow> String.literal list \<Rightarrow> String.literal list \<Rightarrow> synthesis_strategy"
+  "expr list \<Rightarrow> expr list \<Rightarrow> String.literal list \<Rightarrow> String.literal list
+     \<Rightarrow> String.literal list \<Rightarrow> synthesis_strategy"
 where
-  "classifyStrategy ensures stateFieldNames outputNames = (
+  "classifyStrategy ensures reqs stateFieldNames scalarFieldNames outputNames = (
     let clauses = flattenEnsures ensures in
-    if clauses \<noteq> [] \<and>
-       list_all (\<lambda>c. isDirectEmitShape c stateFieldNames outputNames) clauses
+    if clauses = [] then LlmSynthesis
+    else if list_ex (isScalarUpdateClause scalarFieldNames) clauses then
+      (if list_all (isScalarUpdateClause scalarFieldNames) clauses \<and>
+          list_all (\<lambda>r. scalarGuardOf scalarFieldNames r \<noteq> None)
+                   (flattenEnsures reqs)
+       then DirectEmit else LlmSynthesis)
+    else if list_all (\<lambda>c. isDirectEmitShape c stateFieldNames outputNames) clauses
     then DirectEmit else LlmSynthesis)"
 
 definition synthesisStrategyLabel :: "synthesis_strategy \<Rightarrow> String.literal" where
@@ -226,6 +330,11 @@ lemmas decidePutPatch_code [code] = decidePutPatch_def
 lemmas decideKindAndMethod_code [code] = decideKindAndMethod_def
 lemmas isCardinalityRhs_code [code] = isCardinalityRhs.simps
 lemmas isDirectEmitShape_code [code] = isDirectEmitShape_def
+lemmas scalarRhsOf_code [code] = scalarRhsOf.simps
+lemmas scalarUpdateOf_code [code] = scalarUpdateOf.simps
+lemmas scalarCmpOf_code [code] = scalarCmpOf.simps
+lemmas scalarGuardOf_code [code] = scalarGuardOf.simps
+lemmas isScalarUpdateClause_code [code] = isScalarUpdateClause_def
 lemmas classifyStrategy_code [code] = classifyStrategy_def
 lemmas synthesisStrategyLabel_code [code] = synthesisStrategyLabel_def
 

--- a/proofs/isabelle/SpecRest/codegen/Classify.thy
+++ b/proofs/isabelle/SpecRest/codegen/Classify.thy
@@ -263,6 +263,19 @@ definition isScalarUpdateClause ::
 where
   "isScalarUpdateClause scalars c = (scalarUpdateOf scalars c \<noteq> None)"
 
+text \<open>A conjunction assigning the same scalar twice with different
+  right-hand sides has no single-UPDATE interpretation (it is an
+  unsatisfiable ensures); identical repeats are harmless. Checked at
+  classification so the emitters never see a conflicting op.\<close>
+
+fun scalarUpdatesConsistent ::
+  "(String.literal \<times> scalar_rhs) list \<Rightarrow> bool"
+where
+  "scalarUpdatesConsistent [] = True"
+| "scalarUpdatesConsistent ((n, r) # rest) =
+     (list_all (\<lambda>(m, s). m \<noteq> n \<or> s = r) rest \<and>
+      scalarUpdatesConsistent rest)"
+
 text \<open>\<open>isDirectEmitShape\<close>: a single ensures-clause is direct-emit-able when its
   shape matches one of the recognised verified-subset patterns (preserve a
   state field, append-disjoint, cardinality-preserving, single-index update,
@@ -301,21 +314,28 @@ text \<open>\<open>classifyStrategy\<close>: an operation is direct-emit-able wh
   Scalar branch (issue #407): if ANY clause is a scalar update, ALL clauses
   must be - a mixed entity/scalar operation would otherwise be emitted by
   the entity-CRUD path with the scalar clauses silently dropped. Scalar
-  operations additionally require every requires-atom to be guardable
-  (foldable into the atomic UPDATE's WHERE clause); verification assumes
-  requires holds on entry, but HTTP callers can invoke the route in any
-  state, so an unguardable precondition would let a runtime call break a
-  verified invariant.\<close>
+  operations additionally require: no declared inputs (the literal-only
+  handlers take none, and an unused id-shaped input would put a path
+  parameter in the derived route that no handler binds); pairwise
+  consistent updates (\<open>scalarUpdatesConsistent\<close>); and every
+  requires-atom guardable (foldable into the atomic UPDATE's WHERE
+  clause) - verification assumes requires holds on entry, but HTTP
+  callers can invoke the route in any state, so an unguardable
+  precondition would let a runtime call break a verified invariant.\<close>
 
 definition classifyStrategy ::
   "expr list \<Rightarrow> expr list \<Rightarrow> String.literal list \<Rightarrow> String.literal list
-     \<Rightarrow> String.literal list \<Rightarrow> synthesis_strategy"
+     \<Rightarrow> String.literal list \<Rightarrow> String.literal list \<Rightarrow> synthesis_strategy"
 where
-  "classifyStrategy ensures reqs stateFieldNames scalarFieldNames outputNames = (
+  "classifyStrategy ensures reqs inputNames stateFieldNames scalarFieldNames
+     outputNames = (
     let clauses = flattenEnsures ensures in
     if clauses = [] then LlmSynthesis
     else if list_ex (isScalarUpdateClause scalarFieldNames) clauses then
       (if list_all (isScalarUpdateClause scalarFieldNames) clauses \<and>
+          inputNames = [] \<and>
+          scalarUpdatesConsistent
+            (List.map_filter (scalarUpdateOf scalarFieldNames) clauses) \<and>
           list_all (\<lambda>r. scalarGuardOf scalarFieldNames r \<noteq> None)
                    (flattenEnsures reqs)
        then DirectEmit else LlmSynthesis)
@@ -335,6 +355,7 @@ lemmas scalarUpdateOf_code [code] = scalarUpdateOf.simps
 lemmas scalarCmpOf_code [code] = scalarCmpOf.simps
 lemmas scalarGuardOf_code [code] = scalarGuardOf.simps
 lemmas isScalarUpdateClause_code [code] = isScalarUpdateClause_def
+lemmas scalarUpdatesConsistent_code [code] = scalarUpdatesConsistent.simps
 lemmas classifyStrategy_code [code] = classifyStrategy_def
 lemmas synthesisStrategyLabel_code [code] = synthesisStrategyLabel_def
 

--- a/proofs/isabelle/SpecRest/codegen/Classify.thy
+++ b/proofs/isabelle/SpecRest/codegen/Classify.thy
@@ -196,6 +196,10 @@ fun scalarRhsOf :: "String.literal \<Rightarrow> expr \<Rightarrow> scalar_rhs o
      (case e of
         IdentifierF m _ \<Rightarrow> (if m = n then Some SrSelf else None)
       | _ \<Rightarrow> None)"
+| "scalarRhsOf n (UnaryOpF op e _) =
+     (case op of
+        UNegate \<Rightarrow> (case e of IntLitF k _ \<Rightarrow> Some (SrLit (- k)) | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
 | "scalarRhsOf n (BinaryOpF op l r _) =
      (case (scalarRhsOf n l, scalarRhsOf n r) of
         (Some a, Some b) \<Rightarrow>

--- a/proofs/isabelle/SpecRest/codegen/Classify.thy
+++ b/proofs/isabelle/SpecRest/codegen/Classify.thy
@@ -244,6 +244,17 @@ fun scalarCmpOf :: "bin_op \<Rightarrow> scalar_cmp option" where
 | "scalarCmpOf BNeq = Some ScNeq"
 | "scalarCmpOf _    = None"
 
+text \<open>The parser renders a negative literal as \<open>UNegate (IntLitF k)\<close>,
+  so guard atoms accept both spellings.\<close>
+
+fun scalarLitOf :: "expr \<Rightarrow> int option" where
+  "scalarLitOf (IntLitF k _) = Some k"
+| "scalarLitOf (UnaryOpF op e _) =
+     (case op of
+        UNegate \<Rightarrow> (case e of IntLitF k _ \<Rightarrow> Some (- k) | _ \<Rightarrow> None)
+      | _ \<Rightarrow> None)"
+| "scalarLitOf _ = None"
+
 fun scalarGuardOf ::
   "String.literal list \<Rightarrow> expr \<Rightarrow> scalar_guard option"
 where
@@ -252,9 +263,11 @@ where
      (case scalarCmpOf op of
         None \<Rightarrow> None
       | Some c \<Rightarrow>
-          (case (l, r) of
-             (IdentifierF n _, IntLitF k _) \<Rightarrow>
-               (if n \<in> set scalars then Some (SgCmp n c k) else None)
+          (case l of
+             IdentifierF n _ \<Rightarrow>
+               (if n \<in> set scalars
+                then map_option (SgCmp n c) (scalarLitOf r)
+                else None)
            | _ \<Rightarrow> None))"
 | "scalarGuardOf _ _ = None"
 
@@ -353,6 +366,7 @@ lemmas isDirectEmitShape_code [code] = isDirectEmitShape_def
 lemmas scalarRhsOf_code [code] = scalarRhsOf.simps
 lemmas scalarUpdateOf_code [code] = scalarUpdateOf.simps
 lemmas scalarCmpOf_code [code] = scalarCmpOf.simps
+lemmas scalarLitOf_code [code] = scalarLitOf.simps
 lemmas scalarGuardOf_code [code] = scalarGuardOf.simps
 lemmas isScalarUpdateClause_code [code] = isScalarUpdateClause_def
 lemmas scalarUpdatesConsistent_code [code] = scalarUpdatesConsistent.simps

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -393,6 +393,10 @@ export_code
     buildOperationClassification
     isCardinalityRhs
     isDirectEmitShape
+    scalarRhsOf
+    scalarUpdateOf
+    scalarGuardOf
+    isScalarUpdateClause
     classifyStrategy
     synthesisStrategyLabel
     signalsMutatedRelations


### PR DESCRIPTION
Closes #407. `count' = count + 1` no longer needs an LLM: operations whose ensures are arithmetic over Int state scalars classify DIRECT_EMIT and get real, persistent, precondition-guarded handlers in all three frameworks. This is the first actually-working runtime path for scalar specs - the LLM-kernel route never persisted state between requests (fresh `make_state()` per call, #27).

## Architecture

**One source of truth.** The recognisers live in `Classify.thy` and are *extractors*, not booleans: `scalarUpdateOf` parses an ensures clause into a structured `scalar_rhs` tree, `scalarGuardOf` parses requires atoms into `scalar_guard` over a dedicated closed `scalar_cmp` comparator (so every Scala match is exhaustive - no defensive catch-all over `bin_op`'s ~50 ctors). The classifier gate and all three emitters consume the same extraction; the recognised fragment and the emitted SQL cannot drift.

**Classifier rules** (`classifyStrategy` gains `requires` + `scalarFieldNames`):
- *Purity*: if ANY flattened ensures clause is a scalar update, ALL must be - a mixed entity/scalar op would be emitted by the entity-CRUD path with the scalar clauses silently dropped.
- *Guardability*: every requires atom must fold into the UPDATE's WHERE clause. Verification assumes requires holds on entry, but HTTP callers can hit the route in any state - an unguardable precondition would let a runtime call break a verified invariant.

**Persistence.** `deriveSchema` appends a singleton `service_state` table (`id = 1` CHECK, one `BIGINT NOT NULL DEFAULT 0` column per Int scalar), seeded by the initial migration in all three stacks (alembic `op.execute`, raw `.up.sql`, prisma `migration.sql`).

**Handler shape** (identical semantics everywhere):
```sql
UPDATE service_state SET count = (count - 1) WHERE id = 1 AND count > 0
```
One atomic statement; `rowcount = 0` maps to **409** with the pretty-printed precondition. No read-modify-write race can violate the invariant. Responses return the scalar snapshot.

**testgen.** Int scalars are now *backed*: test-admin `/state` projects them from `service_state`, `/reset` restores seeded zeros, `ExprToPython`/Go/Ts translate clauses instead of honest-skipping, and `StubOps` counts scalar-handled ops as having bodies. Coverage broadens beyond safe_counter: `todo_list.next_id` and `edge_cases.plain` ensures now assert black-box too (skip-rate probes: safe_counter 3->0, todo_list 2->0, edge_cases 3->0, ecommerce 5->4).

## Validation

- **Python end-to-end**: emitted SafeCounter (fastapi/sqlite) passes its own full conformance suite against a live server - **15/15**, including `test_increment_ensures_0` asserting `post_state["count"] == pre_state["count"] + 1` and the invariant check. Manual: increment -> `{"count":1}`, decrement at 0 -> `409 precondition failed: count > 0`.
- **Go**: emitted chi project `go build ./...` + `go vet` clean; routes wired, migration seeded.
- **TS**: emitted express project `tsc --noEmit` clean against the *generated* Prisma client (real `serviceState` model); BigInt JSON pitfalls handled via `Number()`.
- **Suites**: convention 99, codegen 355, testgen 286, all green. Proofs zero-sorry. **url_shortener goldens byte-identical** (template conditionals are whitespace-neutral when no scalars exist).

## Scope (v1) and notes

- Int scalars only (`base_url: String` stays unbacked, exactly as before); literal arithmetic `+ - *` over self/`pre(self)`; `ident <cmp> literal` guards. Input-parameterized updates (`count' = count + n`) stay LLM.
- The HTTP method comes from the existing M3/M4 oracle (PATCH for mutation-without-create/delete) - consistent with the rest of the product and overridable via `Op.http_method` conventions; changing the M-rules is its own discussion.
- No spec-level init syntax exists; scalars seed to 0 (satisfies SafeCounter's invariant; init-blocks are future work).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds direct-emit handlers for Int scalar state ops across Go/ Python/ TS with persistent storage in a singleton `service_state` table, atomic guarded updates, and full OpenAPI/test support. Seeds now derive from invariants (including negative-only bounds), negative literals are accepted in both guards and RHS updates, and fields without provable seeds remain unbacked. Addresses #407.

- New Features
  - Classifier recognizes arithmetic over self/`pre(self)` with +, -, *; supports negative literals in guards and RHS; enforces guardable requires; rejects conflicting duplicate assigns; requires no declared inputs; mixed entity/scalar ops fall back to non-scalar.
  - Seeds come from invariant atoms; search is unbiased around 0 and supports negative-only bounds; if invariant mentions can’t be parsed as guard atoms, the field stays unbacked.
  - Adds `service_state` (id=1) with one `BIGINT NOT NULL DEFAULT <seed>` per eligible scalar; initial and delta migrations seed the singleton row in Alembic, Go SQL, and `Prisma`.
  - Emits one-statement, race-free handlers with WHERE-guard; 0 rows → 409 with a readable precondition; success → full scalar snapshot.
    - Python `FastAPI`: `state_ops` router and async `SQLAlchemy` service.
    - Go `chi`: `StateOpsService` + handler; routes registered.
    - TS `Express` + `Prisma`: `stateOps` using raw SQL; BigInt serialized as numbers.
  - OpenAPI adds scalar-state routes and 409 responses. Testgen backs scalars, admin reset restores derived seeds, `/state` projects real values, clauses translate, and scalar ops count as real bodies.

- Migration
  - Regenerate and apply migrations to create and seed `service_state`; delta migrations also seed; for TS, run `prisma generate` after codegen.
  - Scope/eligibility: Int scalars only; simple identifier-vs-literal guards (negative literals ok); updates parsed from RHS (negative literals ok); ops must declare no inputs. Alias-to-Int types, a scalar named `id`, or a reserved `service_state` table disable backing.

<sup>Written for commit c220f3ad709dbd3277a9f5ca62b9d1f0fe711203. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scalar state management and generated ServiceState model and schema
  * New REST endpoints for scalar operations with guard-enforced updates and HTTP 409 on precondition failure
  * Migrations now apply seed SQL for scalar state rows so guarded updates work immediately
  * Admin endpoints updated to reset and inspect scalar state
  * Multi-language support: Python FastAPI, Go, and TypeScript Express

* **Documentation**
  * Updated design notes describing scalar operation handling and recognisers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->