### PR TITLE
fix(codegen): lint-clean generated output + security audit jobs in generated CI

### DIFF
--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
@@ -37,3 +37,18 @@ jobs:
       - run: go mod tidy
       - run: go vet ./...
       - run: go test ./...
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - name: Audit dependencies (govulncheck)
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Audit dependencies (govulncheck)
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/cmd/server/main.go
@@ -41,7 +41,6 @@ func main() {
 
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -65,7 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"github.com/go-chi/chi/v5"
+
 	"github.com/generated/url-shortener/internal/models"
 	"github.com/generated/url-shortener/internal/services"
+	"github.com/go-chi/chi/v5"
 )
 
 type UrlMappingHandler struct {

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -8,21 +8,19 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-	Code string `bun:"code,notnull" json:"code"`
-	URL string `bun:"url,notnull" json:"url"`
-	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
+	ID            int64     `bun:"id,pk,autoincrement" json:"id"`
+	Code          string    `bun:"code,notnull" json:"code"`
+	URL           string    `bun:"url,notnull" json:"url"`
+	CreatedAt     time.Time `bun:"created_at,notnull" json:"created_at"`
+	ClickCount    int64     `bun:"click_count,notnull" json:"click_count"`
 }
 
 type UrlMappingCreate struct {
-	Code string `json:"code" validate:"required"`
-	URL string `json:"url" validate:"required"`
-	CreatedAt time.Time `json:"created_at" validate:"required"`
-	ClickCount int64 `json:"click_count" validate:"required"`
+	Code       string    `json:"code" validate:"required"`
+	URL        string    `json:"url" validate:"required"`
+	CreatedAt  time.Time `json:"created_at" validate:"required"`
+	ClickCount int64     `json:"click_count" validate:"required"`
 }
-
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
-

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/url_mapping.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"errors"
-
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.down.sql
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.down.sql
@@ -1,7 +1,5 @@
 
 
-
 DROP TABLE url_mappings;
-
 
 

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/migrations/001_initial_schema.up.sql
@@ -1,6 +1,5 @@
 
 
-
 CREATE TABLE url_mappings (
     id BIGINT NOT NULL AUTO_INCREMENT,
     code VARCHAR(255) NOT NULL,
@@ -15,6 +14,5 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 
 

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
@@ -36,3 +36,18 @@ jobs:
       - run: go mod tidy
       - run: go vet ./...
       - run: go test ./...
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - name: Audit dependencies (govulncheck)
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Audit dependencies (govulncheck)
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/cmd/server/main.go
@@ -41,7 +41,6 @@ func main() {
 
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -65,7 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"github.com/go-chi/chi/v5"
+
 	"github.com/generated/url-shortener/internal/models"
 	"github.com/generated/url-shortener/internal/services"
+	"github.com/go-chi/chi/v5"
 )
 
 type UrlMappingHandler struct {

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
@@ -8,21 +8,19 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-	Code string `bun:"code,notnull" json:"code"`
-	URL string `bun:"url,notnull" json:"url"`
-	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
+	ID            int64     `bun:"id,pk,autoincrement" json:"id"`
+	Code          string    `bun:"code,notnull" json:"code"`
+	URL           string    `bun:"url,notnull" json:"url"`
+	CreatedAt     time.Time `bun:"created_at,notnull" json:"created_at"`
+	ClickCount    int64     `bun:"click_count,notnull" json:"click_count"`
 }
 
 type UrlMappingCreate struct {
-	Code string `json:"code" validate:"required"`
-	URL string `json:"url" validate:"required"`
-	CreatedAt time.Time `json:"created_at" validate:"required"`
-	ClickCount int64 `json:"click_count" validate:"required"`
+	Code       string    `json:"code" validate:"required"`
+	URL        string    `json:"url" validate:"required"`
+	CreatedAt  time.Time `json:"created_at" validate:"required"`
+	ClickCount int64     `json:"click_count" validate:"required"`
 }
-
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
-

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/url_mapping.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"errors"
-
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.down.sql
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.down.sql
@@ -1,7 +1,5 @@
 BEGIN;
 
-
 DROP TABLE url_mappings;
-
 
 COMMIT;

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/migrations/001_initial_schema.up.sql
@@ -1,6 +1,5 @@
 BEGIN;
 
-
 CREATE TABLE url_mappings (
     id BIGSERIAL NOT NULL,
     code TEXT NOT NULL,
@@ -15,6 +14,5 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 
 COMMIT;

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Audit dependencies (govulncheck)
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -25,3 +25,18 @@ jobs:
       - run: go mod tidy
       - run: go vet ./...
       - run: go test ./...
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - name: Audit dependencies (govulncheck)
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/cmd/server/main.go
@@ -41,7 +41,6 @@ func main() {
 
 	urlMappingSvc := services.NewUrlMappingService(db, cfg)
 	urlMappingHandler := handlers.NewUrlMappingHandler(urlMappingSvc)
-
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -65,7 +64,6 @@ func main() {
 	r.Get("/urls", urlMappingHandler.ListAll)
 	r.Get("/{code}", urlMappingHandler.Resolve)
 	r.Delete("/{code}", urlMappingHandler.Delete)
-
 	server := &http.Server{
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
 		Handler:      r,

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"github.com/go-chi/chi/v5"
+
 	"github.com/generated/url-shortener/internal/models"
 	"github.com/generated/url-shortener/internal/services"
+	"github.com/go-chi/chi/v5"
 )
 
 type UrlMappingHandler struct {

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -8,21 +8,19 @@ import (
 
 type UrlMapping struct {
 	bun.BaseModel `bun:"table:url_mappings,alias:url_mappings"`
-	ID int64 `bun:"id,pk,autoincrement" json:"id"`
-	Code string `bun:"code,notnull" json:"code"`
-	URL string `bun:"url,notnull" json:"url"`
-	CreatedAt time.Time `bun:"created_at,notnull" json:"created_at"`
-	ClickCount int64 `bun:"click_count,notnull" json:"click_count"`
+	ID            int64     `bun:"id,pk,autoincrement" json:"id"`
+	Code          string    `bun:"code,notnull" json:"code"`
+	URL           string    `bun:"url,notnull" json:"url"`
+	CreatedAt     time.Time `bun:"created_at,notnull" json:"created_at"`
+	ClickCount    int64     `bun:"click_count,notnull" json:"click_count"`
 }
 
 type UrlMappingCreate struct {
-	Code string `json:"code" validate:"required"`
-	URL string `json:"url" validate:"required"`
-	CreatedAt time.Time `json:"created_at" validate:"required"`
-	ClickCount int64 `json:"click_count" validate:"required"`
+	Code       string    `json:"code" validate:"required"`
+	URL        string    `json:"url" validate:"required"`
+	CreatedAt  time.Time `json:"created_at" validate:"required"`
+	ClickCount int64     `json:"click_count" validate:"required"`
 }
-
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
-

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/url_mapping.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"errors"
-
 	"github.com/uptrace/bun"
 
 	"github.com/generated/url-shortener/internal/config"

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.down.sql
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.down.sql
@@ -1,7 +1,5 @@
 
 
-
 DROP TABLE url_mappings;
-
 
 

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/migrations/001_initial_schema.up.sql
@@ -1,6 +1,5 @@
 
 
-
 CREATE TABLE url_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     code TEXT NOT NULL,
@@ -13,6 +12,5 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
       - name: Audit dependencies (pip-audit)
         run: |
           uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
-          uvx pip-audit -r /tmp/requirements.txt
+          uvx pip-audit==2.10.1 -r /tmp/requirements.txt
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/
 
   docker:
     runs-on: ubuntu-latest

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/.github/workflows/ci.yml
@@ -15,20 +15,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-
     services:
       database:
         image: mysql:8.4
         env:
-
           MYSQL_USER: url_shortener
-
           MYSQL_PASSWORD: url_shortener
-
           MYSQL_DATABASE: url_shortener
-
           MYSQL_ROOT_PASSWORD: url_shortener_root
-
         ports:
           - "3306:3306"
         options: >-
@@ -36,7 +30,6 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
-
 
     env:
       DATABASE_URL: mysql+aiomysql://url_shortener:url_shortener@127.0.0.1:3306/url_shortener
@@ -74,16 +67,34 @@ jobs:
         run: make test-conformance PROFILE=$SPEC_TEST_PROFILE
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: conformance-results-${{ env.SPEC_TEST_PROFILE }}
           path: results/
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Audit dependencies (pip-audit)
+        run: |
+          uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
+          uvx pip-audit -r /tmp/requirements.txt
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/
 
   docker:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Seed .env from example
         run: cp .env.example .env
       - name: Build and start stack

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/env.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/env.py
@@ -33,9 +33,7 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-
     context.configure(connection=connection, target_metadata=target_metadata)
-
     with context.begin_transaction():
         context.run_migrations()
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
@@ -9,7 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 
 
-
 revision: str = "001"
 down_revision: str | None = None
 branch_labels: str | Sequence[str] | None = None
@@ -17,40 +16,22 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-
     op.create_table(
         "url_mappings",
-
         sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True, nullable=False),
-
         sa.Column("code", sa.String(length=255), nullable=False),
-
         sa.Column("url", sa.String(length=255), nullable=False),
-
         sa.Column("created_at", sa.DateTime(), nullable=False),
-
         sa.Column("click_count", sa.Integer(), nullable=False),
-
         sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
-
         sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
-
         sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
-
         sa.CheckConstraint("code REGEXP '^[a-zA-Z0-9]+$'", name="ck_url_mappings_2"),
-
         sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
-
         sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
-
     )
 
 
 
-
-
 def downgrade() -> None:
-
-
     op.drop_table("url_mappings")
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/database.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/database.py
@@ -12,7 +12,6 @@ engine = create_async_engine(
     pool_pre_ping=True,
 )
 
-
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/main.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -7,11 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine
 from app.extensions import register as register_extensions
 from app.redaction import configure_logging
-from app.routers import admin
-
-from app.routers import url_mappings
-
-
+from app.routers import admin, url_mappings
 
 configure_logging()
 
@@ -46,6 +42,4 @@ async def health_check() -> dict[str, str]:
 register_extensions(app)
 
 app.include_router(admin.router)
-
 app.include_router(url_mappings.router)
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/__init__.py
@@ -1,11 +1,7 @@
 from app.db.base import Base
-
 from app.models.url_mapping import UrlMapping
-
 
 __all__ = [
     "Base",
-
     "UrlMapping",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/models/url_mapping.py
@@ -1,10 +1,6 @@
-
 from datetime import datetime
 
-
 from sqlalchemy import DateTime, Integer, String
-
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -14,12 +10,7 @@ class UrlMapping(Base):
     __tablename__ = "url_mappings"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-
     code: Mapped[str] = mapped_column(String)
-
     url: Mapped[str] = mapped_column(String)
-
     created_at: Mapped[datetime] = mapped_column(DateTime)
-
     click_count: Mapped[int] = mapped_column(Integer)
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/__init__.py
@@ -1,9 +1,5 @@
-
 from app.routers import url_mappings
 
-
 __all__ = [
-
     "url_mappings",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/admin.py
@@ -1,13 +1,13 @@
-from datetime import datetime, date
+from datetime import date, datetime
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.security import require_admin
 from app.models.url_mapping import UrlMapping
+from app.security import require_admin
 
 router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/url_mappings.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/url_mappings.py
@@ -1,80 +1,48 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Response
-
 from fastapi.responses import RedirectResponse
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 from app.services.url_mapping import UrlMappingService
 
 router = APIRouter(tags=["url_mapping"])
 
 
-
 @router.post("/shorten", status_code=201)
 async def shorten(
-
-
     body: ShortenRequest,
-
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UrlMappingService(session)
-
     return await svc.shorten(body)
-
-
 
 @router.get("/urls", status_code=200)
 async def list_all(
-
-
     session: AsyncSession = Depends(get_session),
 ) -> list[UrlMappingRead]:
     svc = UrlMappingService(session)
-
     return await svc.list_all()
-
-
 
 @router.get("/{code}", status_code=302)
 async def resolve(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> RedirectResponse:
     svc = UrlMappingService(session)
-
     url = await svc.resolve(code)
     return RedirectResponse(url=url, status_code=302)
 
-
-
 @router.delete("/{code}", status_code=204)
 async def delete(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     svc = UrlMappingService(session)
-
     deleted = await svc.delete(code)
     if not deleted:
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code=204)
-
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/__init__.py
@@ -1,15 +1,11 @@
-
 from app.schemas.url_mapping import (
     UrlMappingCreate,
     UrlMappingRead,
     UrlMappingUpdate,
 )
 
-
 __all__ = [
-
     "UrlMappingCreate",
     "UrlMappingRead",
     "UrlMappingUpdate",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/url_mapping.py
@@ -1,59 +1,31 @@
-
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
 
 class UrlMappingCreate(BaseModel):
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
-
 
 
 class UrlMappingRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
 
 
-
 class UrlMappingUpdate(BaseModel):
-
-
     code: str | None = None
-
-
-
     url: str | None = None
-
-
-
     created_at: datetime | None = None
-
-
-
     click_count: int | None = None
 
 
-
-
-
 class ShortenRequest(BaseModel):
-
     url: str
-
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/__init__.py
@@ -1,9 +1,5 @@
-
 from app.services.url_mapping import UrlMappingService
 
-
 __all__ = [
-
     "UrlMappingService",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/url_mapping.py
@@ -1,64 +1,35 @@
-
-from sqlalchemy import delete as sa_delete, select
-
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-
 from app.models.url_mapping import UrlMapping
-
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 
 
 class UrlMappingService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-
-
-
     async def shorten(self, body: ShortenRequest) -> None:
         raise NotImplementedError(
             "Create operation 'Shorten' — implement in M4+"
         )
-
-
-
-
-
 
     async def list_all(self) -> list[UrlMappingRead]:
         result = await self._session.execute(select(UrlMapping))
         rows = result.scalars().all()
         return [UrlMappingRead.model_validate(row) for row in rows]
 
-
-
-
-
-
     async def resolve(self, code: str) -> str:
         raise NotImplementedError(
             "PartialUpdate operation 'Resolve' — implement in M4+"
         )
-
-
-
-
-
 
     async def delete(self, code: str) -> bool:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
         return result.rowcount > 0
-
-

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/pyproject.toml
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/pyproject.toml
@@ -8,36 +8,22 @@ version = "0.1.0"
 description = "Generated from UrlShortener.spec"
 requires-python = ">=3.10"
 dependencies = [
-
     "fastapi>=0.115",
-
     "uvicorn[standard]>=0.34",
-
     "sqlalchemy>=2.0",
-
     "aiomysql>=0.2",
-
     "alembic>=1.14",
-
     "pydantic-settings>=2.0",
-
     "structlog>=24,<26",
-
 ]
 
 [project.optional-dependencies]
 dev = [
-
     "pytest>=8.0",
-
     "pytest-asyncio>=0.24",
-
     "httpx>=0.28",
-
     "ruff>=0.8",
-
     "mypy>=1.13",
-
     "schemathesis>=4.16,<5",
     "mutmut>=3.3,<4",
 ]

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
@@ -83,9 +83,9 @@ jobs:
       - name: Audit dependencies (pip-audit)
         run: |
           uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
-          uvx pip-audit -r /tmp/requirements.txt
+          uvx pip-audit==2.10.1 -r /tmp/requirements.txt
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/
 
   docker:
     runs-on: ubuntu-latest

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/.github/workflows/ci.yml
@@ -15,18 +15,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-
     services:
       database:
         image: postgres:17-alpine
         env:
-
           POSTGRES_USER: url_shortener
-
           POSTGRES_PASSWORD: url_shortener
-
           POSTGRES_DB: url_shortener
-
         ports:
           - "5432:5432"
         options: >-
@@ -34,7 +29,6 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
-
 
     env:
       DATABASE_URL: postgresql+asyncpg://url_shortener:url_shortener@localhost:5432/url_shortener
@@ -72,16 +66,34 @@ jobs:
         run: make test-conformance PROFILE=$SPEC_TEST_PROFILE
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: conformance-results-${{ env.SPEC_TEST_PROFILE }}
           path: results/
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Audit dependencies (pip-audit)
+        run: |
+          uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
+          uvx pip-audit -r /tmp/requirements.txt
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/
 
   docker:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Seed .env from example
         run: cp .env.example .env
       - name: Build and start stack

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/env.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/env.py
@@ -33,9 +33,7 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-
     context.configure(connection=connection, target_metadata=target_metadata)
-
     with context.begin_transaction():
         context.run_migrations()
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
@@ -9,7 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 
 
-
 revision: str = "001"
 down_revision: str | None = None
 branch_labels: str | Sequence[str] | None = None
@@ -17,40 +16,22 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-
     op.create_table(
         "url_mappings",
-
         sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True, nullable=False),
-
         sa.Column("code", sa.Text(), nullable=False),
-
         sa.Column("url", sa.Text(), nullable=False),
-
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
-
         sa.Column("click_count", sa.Integer(), nullable=False),
-
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
-
         sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
-
         sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
-
         sa.CheckConstraint("code ~ '^[a-zA-Z0-9]+$'", name="ck_url_mappings_2"),
-
         sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
-
         sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
-
     )
 
 
 
-
-
 def downgrade() -> None:
-
-
     op.drop_table("url_mappings")
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/database.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/database.py
@@ -12,7 +12,6 @@ engine = create_async_engine(
     pool_pre_ping=True,
 )
 
-
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/main.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -7,11 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine
 from app.extensions import register as register_extensions
 from app.redaction import configure_logging
-from app.routers import admin
-
-from app.routers import url_mappings
-
-
+from app.routers import admin, url_mappings
 
 configure_logging()
 
@@ -46,6 +42,4 @@ async def health_check() -> dict[str, str]:
 register_extensions(app)
 
 app.include_router(admin.router)
-
 app.include_router(url_mappings.router)
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/__init__.py
@@ -1,11 +1,7 @@
 from app.db.base import Base
-
 from app.models.url_mapping import UrlMapping
-
 
 __all__ = [
     "Base",
-
     "UrlMapping",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/models/url_mapping.py
@@ -1,10 +1,6 @@
-
 from datetime import datetime
 
-
 from sqlalchemy import DateTime, Integer, String
-
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -14,12 +10,7 @@ class UrlMapping(Base):
     __tablename__ = "url_mappings"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-
     code: Mapped[str] = mapped_column(String)
-
     url: Mapped[str] = mapped_column(String)
-
     created_at: Mapped[datetime] = mapped_column(DateTime)
-
     click_count: Mapped[int] = mapped_column(Integer)
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/__init__.py
@@ -1,9 +1,5 @@
-
 from app.routers import url_mappings
 
-
 __all__ = [
-
     "url_mappings",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/admin.py
@@ -1,13 +1,13 @@
-from datetime import datetime, date
+from datetime import date, datetime
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.security import require_admin
 from app.models.url_mapping import UrlMapping
+from app.security import require_admin
 
 router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/url_mappings.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/url_mappings.py
@@ -1,80 +1,48 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Response
-
 from fastapi.responses import RedirectResponse
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 from app.services.url_mapping import UrlMappingService
 
 router = APIRouter(tags=["url_mapping"])
 
 
-
 @router.post("/shorten", status_code=201)
 async def shorten(
-
-
     body: ShortenRequest,
-
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UrlMappingService(session)
-
     return await svc.shorten(body)
-
-
 
 @router.get("/urls", status_code=200)
 async def list_all(
-
-
     session: AsyncSession = Depends(get_session),
 ) -> list[UrlMappingRead]:
     svc = UrlMappingService(session)
-
     return await svc.list_all()
-
-
 
 @router.get("/{code}", status_code=302)
 async def resolve(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> RedirectResponse:
     svc = UrlMappingService(session)
-
     url = await svc.resolve(code)
     return RedirectResponse(url=url, status_code=302)
 
-
-
 @router.delete("/{code}", status_code=204)
 async def delete(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     svc = UrlMappingService(session)
-
     deleted = await svc.delete(code)
     if not deleted:
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code=204)
-
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/__init__.py
@@ -1,15 +1,11 @@
-
 from app.schemas.url_mapping import (
     UrlMappingCreate,
     UrlMappingRead,
     UrlMappingUpdate,
 )
 
-
 __all__ = [
-
     "UrlMappingCreate",
     "UrlMappingRead",
     "UrlMappingUpdate",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/url_mapping.py
@@ -1,59 +1,31 @@
-
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
 
 class UrlMappingCreate(BaseModel):
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
-
 
 
 class UrlMappingRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
 
 
-
 class UrlMappingUpdate(BaseModel):
-
-
     code: str | None = None
-
-
-
     url: str | None = None
-
-
-
     created_at: datetime | None = None
-
-
-
     click_count: int | None = None
 
 
-
-
-
 class ShortenRequest(BaseModel):
-
     url: str
-
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/__init__.py
@@ -1,9 +1,5 @@
-
 from app.services.url_mapping import UrlMappingService
 
-
 __all__ = [
-
     "UrlMappingService",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/url_mapping.py
@@ -1,64 +1,35 @@
-
-from sqlalchemy import delete as sa_delete, select
-
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-
 from app.models.url_mapping import UrlMapping
-
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 
 
 class UrlMappingService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-
-
-
     async def shorten(self, body: ShortenRequest) -> None:
         raise NotImplementedError(
             "Create operation 'Shorten' — implement in M4+"
         )
-
-
-
-
-
 
     async def list_all(self) -> list[UrlMappingRead]:
         result = await self._session.execute(select(UrlMapping))
         rows = result.scalars().all()
         return [UrlMappingRead.model_validate(row) for row in rows]
 
-
-
-
-
-
     async def resolve(self, code: str) -> str:
         raise NotImplementedError(
             "PartialUpdate operation 'Resolve' — implement in M4+"
         )
-
-
-
-
-
 
     async def delete(self, code: str) -> bool:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
         return result.rowcount > 0
-
-

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/pyproject.toml
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/pyproject.toml
@@ -8,36 +8,22 @@ version = "0.1.0"
 description = "Generated from UrlShortener.spec"
 requires-python = ">=3.10"
 dependencies = [
-
     "fastapi>=0.115",
-
     "uvicorn[standard]>=0.34",
-
     "sqlalchemy>=2.0",
-
     "asyncpg>=0.30",
-
     "alembic>=1.14",
-
     "pydantic-settings>=2.0",
-
     "structlog>=24,<26",
-
 ]
 
 [project.optional-dependencies]
 dev = [
-
     "pytest>=8.0",
-
     "pytest-asyncio>=0.24",
-
     "httpx>=0.28",
-
     "ruff>=0.8",
-
     "mypy>=1.13",
-
     "schemathesis>=4.16,<5",
     "mutmut>=3.3,<4",
 ]

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
       - name: Audit dependencies (pip-audit)
         run: |
           uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
-          uvx pip-audit -r /tmp/requirements.txt
+          uvx pip-audit==2.10.1 -r /tmp/requirements.txt
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/
 
   docker:
     runs-on: ubuntu-latest

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-
-
     env:
       DATABASE_URL: sqlite+aiosqlite:///./url_shortener.db
       BASE_URL: http://localhost:8000
@@ -53,16 +51,34 @@ jobs:
         run: make test-conformance PROFILE=$SPEC_TEST_PROFILE
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: conformance-results-${{ env.SPEC_TEST_PROFILE }}
           path: results/
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Audit dependencies (pip-audit)
+        run: |
+          uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
+          uvx pip-audit -r /tmp/requirements.txt
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/
 
   docker:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Seed .env from example
         run: cp .env.example .env
       - name: Build and start stack

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/env.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/env.py
@@ -33,7 +33,6 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-
     if connection.dialect.name == "sqlite":
         connection.exec_driver_sql("PRAGMA foreign_keys=ON")
     context.configure(
@@ -41,7 +40,6 @@ def do_run_migrations(connection: Connection) -> None:
         target_metadata=target_metadata,
         render_as_batch=True,
     )
-
     with context.begin_transaction():
         context.run_migrations()
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
@@ -9,7 +9,6 @@ from alembic import op
 import sqlalchemy as sa
 
 
-
 revision: str = "001"
 down_revision: str | None = None
 branch_labels: str | Sequence[str] | None = None
@@ -17,38 +16,21 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-
     op.create_table(
         "url_mappings",
-
         sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
-
         sa.Column("code", sa.Text(), nullable=False),
-
         sa.Column("url", sa.Text(), nullable=False),
-
         sa.Column("created_at", sa.DateTime(), nullable=False),
-
         sa.Column("click_count", sa.Integer(), nullable=False),
-
         sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
-
         sa.CheckConstraint('length(code) >= 6', name="ck_url_mappings_0"),
-
         sa.CheckConstraint('length(code) <= 10', name="ck_url_mappings_1"),
-
         sa.CheckConstraint('length(url) > 0', name="ck_url_mappings_3"),
-
         sa.CheckConstraint('click_count >= 0', name="ck_url_mappings_4"),
-
     )
 
 
 
-
-
 def downgrade() -> None:
-
-
     op.drop_table("url_mappings")
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/database.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/database.py
@@ -1,9 +1,7 @@
 from collections.abc import AsyncIterator
-
 from typing import Any
 
 from sqlalchemy import event
-
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
@@ -13,7 +11,6 @@ engine = create_async_engine(
     echo=False,
     connect_args={"check_same_thread": False},
 )
-
 
 @event.listens_for(engine.sync_engine, "connect")
 def _set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
@@ -29,7 +26,6 @@ def _set_sqlite_pragma(dbapi_connection: Any, connection_record: Any) -> None:
     finally:
         if ac is not None:
             dbapi_connection.autocommit = ac
-
 
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/main.py
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -7,11 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine
 from app.extensions import register as register_extensions
 from app.redaction import configure_logging
-from app.routers import admin
-
-from app.routers import url_mappings
-
-
+from app.routers import admin, url_mappings
 
 configure_logging()
 
@@ -46,6 +42,4 @@ async def health_check() -> dict[str, str]:
 register_extensions(app)
 
 app.include_router(admin.router)
-
 app.include_router(url_mappings.router)
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/__init__.py
@@ -1,11 +1,7 @@
 from app.db.base import Base
-
 from app.models.url_mapping import UrlMapping
-
 
 __all__ = [
     "Base",
-
     "UrlMapping",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/models/url_mapping.py
@@ -1,10 +1,6 @@
-
 from datetime import datetime
 
-
 from sqlalchemy import DateTime, Integer, String
-
-
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -14,12 +10,7 @@ class UrlMapping(Base):
     __tablename__ = "url_mappings"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-
     code: Mapped[str] = mapped_column(String)
-
     url: Mapped[str] = mapped_column(String)
-
     created_at: Mapped[datetime] = mapped_column(DateTime)
-
     click_count: Mapped[int] = mapped_column(Integer)
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/__init__.py
@@ -1,9 +1,5 @@
-
 from app.routers import url_mappings
 
-
 __all__ = [
-
     "url_mappings",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/admin.py
@@ -1,13 +1,13 @@
-from datetime import datetime, date
+from datetime import date, datetime
 
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Depends
 from fastapi.responses import Response
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.security import require_admin
 from app.models.url_mapping import UrlMapping
+from app.security import require_admin
 
 router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin)])
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/url_mappings.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/url_mappings.py
@@ -1,80 +1,48 @@
-
 from fastapi import APIRouter, Depends, HTTPException, Response
-
 from fastapi.responses import RedirectResponse
-
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 from app.services.url_mapping import UrlMappingService
 
 router = APIRouter(tags=["url_mapping"])
 
 
-
 @router.post("/shorten", status_code=201)
 async def shorten(
-
-
     body: ShortenRequest,
-
     session: AsyncSession = Depends(get_session),
 ) -> None:
     svc = UrlMappingService(session)
-
     return await svc.shorten(body)
-
-
 
 @router.get("/urls", status_code=200)
 async def list_all(
-
-
     session: AsyncSession = Depends(get_session),
 ) -> list[UrlMappingRead]:
     svc = UrlMappingService(session)
-
     return await svc.list_all()
-
-
 
 @router.get("/{code}", status_code=302)
 async def resolve(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> RedirectResponse:
     svc = UrlMappingService(session)
-
     url = await svc.resolve(code)
     return RedirectResponse(url=url, status_code=302)
 
-
-
 @router.delete("/{code}", status_code=204)
 async def delete(
-
     code: str,
-
-
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     svc = UrlMappingService(session)
-
     deleted = await svc.delete(code)
     if not deleted:
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code=204)
-
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/__init__.py
@@ -1,15 +1,11 @@
-
 from app.schemas.url_mapping import (
     UrlMappingCreate,
     UrlMappingRead,
     UrlMappingUpdate,
 )
 
-
 __all__ = [
-
     "UrlMappingCreate",
     "UrlMappingRead",
     "UrlMappingUpdate",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/url_mapping.py
@@ -1,59 +1,31 @@
-
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
 
 class UrlMappingCreate(BaseModel):
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
-
 
 
 class UrlMappingRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: int
-
     code: str
-
     url: str
-
     created_at: datetime
-
     click_count: int
 
 
-
 class UrlMappingUpdate(BaseModel):
-
-
     code: str | None = None
-
-
-
     url: str | None = None
-
-
-
     created_at: datetime | None = None
-
-
-
     click_count: int | None = None
 
 
-
-
-
 class ShortenRequest(BaseModel):
-
     url: str
-
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/__init__.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/__init__.py
@@ -1,9 +1,5 @@
-
 from app.services.url_mapping import UrlMappingService
 
-
 __all__ = [
-
     "UrlMappingService",
-
 ]

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/url_mapping.py
@@ -1,64 +1,35 @@
-
-from sqlalchemy import delete as sa_delete, select
-
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-
-
 from app.models.url_mapping import UrlMapping
-
-
 from app.schemas.url_mapping import (
-
     ShortenRequest,
-
     UrlMappingRead,
-
 )
-
 
 
 class UrlMappingService:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
-
-
-
     async def shorten(self, body: ShortenRequest) -> None:
         raise NotImplementedError(
             "Create operation 'Shorten' — implement in M4+"
         )
-
-
-
-
-
 
     async def list_all(self) -> list[UrlMappingRead]:
         result = await self._session.execute(select(UrlMapping))
         rows = result.scalars().all()
         return [UrlMappingRead.model_validate(row) for row in rows]
 
-
-
-
-
-
     async def resolve(self, code: str) -> str:
         raise NotImplementedError(
             "PartialUpdate operation 'Resolve' — implement in M4+"
         )
-
-
-
-
-
 
     async def delete(self, code: str) -> bool:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
         return result.rowcount > 0
-
-

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/pyproject.toml
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/pyproject.toml
@@ -8,36 +8,22 @@ version = "0.1.0"
 description = "Generated from UrlShortener.spec"
 requires-python = ">=3.10"
 dependencies = [
-
     "fastapi>=0.115",
-
     "uvicorn[standard]>=0.34",
-
     "sqlalchemy>=2.0",
-
     "aiosqlite>=0.20",
-
     "alembic>=1.14",
-
     "pydantic-settings>=2.0",
-
     "structlog>=24,<26",
-
 ]
 
 [project.optional-dependencies]
 dev = [
-
     "pytest>=8.0",
-
     "pytest-asyncio>=0.24",
-
     "httpx>=0.28",
-
     "ruff>=0.8",
-
     "mypy>=1.13",
-
     "schemathesis>=4.16,<5",
     "mutmut>=3.3,<4",
 ]

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/.github/workflows/ci.yml
@@ -38,3 +38,20 @@ jobs:
       - run: npx prisma generate
       - run: npm run typecheck
       - run: npm test
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+      - name: Audit dependencies (npm audit)
+        run: |
+          npm install --package-lock-only --no-audit --no-fund
+          npm audit --audit-level=high
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
           npm audit --audit-level=high
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/package.json
@@ -15,34 +15,20 @@
     "migrate": "prisma migrate deploy"
   },
   "dependencies": {
-
     "express": "^4.21.2",
-
     "@prisma/client": "^6.2.0",
-
     "zod": "^3.23.8",
-
     "dotenv": "^16.4.7"
-
   },
   "devDependencies": {
-
     "typescript": "^5.6.3",
-
     "@types/node": "^22.10.1",
-
     "@types/express": "^4.17.21",
-
     "prisma": "^6.2.0",
-
     "vitest": "^2.1.8",
-
     "supertest": "^7.0.0",
-
     "@types/supertest": "^6.0.2",
-
     "tsx": "^4.19.2"
-
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/down.sql
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/down.sql
@@ -1,7 +1,5 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 DROP TABLE url_mappings;
-
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -1,7 +1,6 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 CREATE TABLE url_mappings (
     id BIGINT NOT NULL AUTO_INCREMENT,
     code VARCHAR(255) NOT NULL,
@@ -16,5 +15,4 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/prisma/schema.prisma
@@ -7,21 +7,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model UrlMapping {
-
   id BigInt @id @default(autoincrement())
-
   code String
-
   url String
-
   createdAt DateTime @map("created_at")
-
   clickCount Int @map("click_count")
-
 
   @@map("url_mappings")
 }
-
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/index.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/index.ts
@@ -1,13 +1,9 @@
 import type { Express } from 'express';
 
 import { registerAdminRoutes } from './admin.js';
-
 import { registerUrlMappingRoutes } from './urlMappings.js';
-
 
 export const mountRoutes = (app: Express): void => {
   registerAdminRoutes(app);
-
   registerUrlMappingRoutes(app);
-
 };

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/urlMappings.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/routes/urlMappings.ts
@@ -3,14 +3,10 @@ import type { Express, NextFunction, Request, Response } from 'express';
 import { NotFound } from '../middleware/error.js';
 import { validateBody } from '../middleware/validate.js';
 import * as service from '../services/urlMapping.js';
-
 import {
   UrlMappingCreateSchema,
-
   ShortenRequestSchema,
-
 } from '../schemas/urlMapping.js';
-
 
 const wrap =
   (handler: (req: Request, res: Response) => Promise<void>) =>
@@ -19,32 +15,15 @@ const wrap =
   };
 
 export const registerUrlMappingRoutes = (app: Express): void => {
-
-
-
-
-
-
-
   app.post(
     '/shorten',
-
     validateBody(ShortenRequestSchema),
-
     wrap(async (req, res) => {
-
-
       const body = req.body as service.ShortenRequest;
-
       await service.shorten(body);
       res.status(201).end();
     }),
   );
-
-
-
-
-
 
   app.get(
     '/urls',
@@ -54,45 +33,22 @@ export const registerUrlMappingRoutes = (app: Express): void => {
     }),
   );
 
-
-
-
-
-
-
-
-
-
-
   app.get(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const result = await service.resolve(code);
       if (result === null) {
         throw NotFound();
       }
-
       res.redirect(302, result.url);
-
     }),
   );
-
-
-
-
-
-
-
 
   app.delete(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const ok = await service.delete_(code);
       if (!ok) {
         throw NotFound();
@@ -100,9 +56,5 @@ export const registerUrlMappingRoutes = (app: Express): void => {
       res.status(204).end();
     }),
   );
-
-
-
-
 
 };

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
@@ -1,26 +1,17 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-
   code: z.string(),
-
   url: z.string(),
-
   createdAt: z.coerce.date(),
-
   clickCount: z.number(),
-
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
-
 export const ShortenRequestSchema = z.object({
-
   url: z.string(),
-
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;
-
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/services/urlMapping.ts
@@ -3,57 +3,28 @@ import type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
 
 export type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
-
-
-
-
-
-
-
 
 // TODO: implement shorten; the convention engine could not derive a
 // CRUD shape, so the stub throws to avoid silently reporting success.
 export const shorten = async (body: ShortenRequest): Promise<void> => {
-
-
   void body;
-
   throw new Error('shorten not implemented');
 };
-
-
-
-
-
 
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
   }) as unknown as Promise<UrlMappingRead[]>;
 };
-
-
-
-
-
-
-
-
-
-
 
 // TODO: implement resolve; a redirect operation carries spec side-effects the
 // convention engine cannot derive (e.g. click-count increment), so the stub throws to
@@ -62,23 +33,10 @@ export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   throw new Error('resolve not implemented');
 };
 
-
-
-
-
-
-
-
 export const delete_ = async (code: string): Promise<boolean> => {
-
   const result = await prisma.urlMapping.deleteMany({
     where: { code: code },
   });
   return result.count > 0;
-
 };
-
-
-
-
 

--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/types/urlMapping.ts
@@ -1,52 +1,30 @@
 
-
 export interface UrlMapping {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingCreate {
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingRead {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
-
 
 export interface ShortenRequest {
-
   url: string;
-
 }
-
 
 export interface ErrorResponse {
   detail: string;

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
           npm audit --audit-level=high
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/.github/workflows/ci.yml
@@ -37,3 +37,20 @@ jobs:
       - run: npx prisma generate
       - run: npm run typecheck
       - run: npm test
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+      - name: Audit dependencies (npm audit)
+        run: |
+          npm install --package-lock-only --no-audit --no-fund
+          npm audit --audit-level=high
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/package.json
@@ -15,34 +15,20 @@
     "migrate": "prisma migrate deploy"
   },
   "dependencies": {
-
     "express": "^4.21.2",
-
     "@prisma/client": "^6.2.0",
-
     "zod": "^3.23.8",
-
     "dotenv": "^16.4.7"
-
   },
   "devDependencies": {
-
     "typescript": "^5.6.3",
-
     "@types/node": "^22.10.1",
-
     "@types/express": "^4.17.21",
-
     "prisma": "^6.2.0",
-
     "vitest": "^2.1.8",
-
     "supertest": "^7.0.0",
-
     "@types/supertest": "^6.0.2",
-
     "tsx": "^4.19.2"
-
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/down.sql
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/down.sql
@@ -1,7 +1,5 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 DROP TABLE url_mappings;
-
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -1,7 +1,6 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 CREATE TABLE url_mappings (
     id BIGSERIAL NOT NULL,
     code TEXT NOT NULL,
@@ -16,5 +15,4 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/prisma/schema.prisma
@@ -7,21 +7,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model UrlMapping {
-
   id BigInt @id @default(autoincrement()) @db.BigInt
-
   code String @db.Text
-
   url String @db.Text
-
   createdAt DateTime @map("created_at") @db.Timestamptz()
-
   clickCount Int @map("click_count") @db.Integer
-
 
   @@map("url_mappings")
 }
-
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/index.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/index.ts
@@ -1,13 +1,9 @@
 import type { Express } from 'express';
 
 import { registerAdminRoutes } from './admin.js';
-
 import { registerUrlMappingRoutes } from './urlMappings.js';
-
 
 export const mountRoutes = (app: Express): void => {
   registerAdminRoutes(app);
-
   registerUrlMappingRoutes(app);
-
 };

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/urlMappings.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/routes/urlMappings.ts
@@ -3,14 +3,10 @@ import type { Express, NextFunction, Request, Response } from 'express';
 import { NotFound } from '../middleware/error.js';
 import { validateBody } from '../middleware/validate.js';
 import * as service from '../services/urlMapping.js';
-
 import {
   UrlMappingCreateSchema,
-
   ShortenRequestSchema,
-
 } from '../schemas/urlMapping.js';
-
 
 const wrap =
   (handler: (req: Request, res: Response) => Promise<void>) =>
@@ -19,32 +15,15 @@ const wrap =
   };
 
 export const registerUrlMappingRoutes = (app: Express): void => {
-
-
-
-
-
-
-
   app.post(
     '/shorten',
-
     validateBody(ShortenRequestSchema),
-
     wrap(async (req, res) => {
-
-
       const body = req.body as service.ShortenRequest;
-
       await service.shorten(body);
       res.status(201).end();
     }),
   );
-
-
-
-
-
 
   app.get(
     '/urls',
@@ -54,45 +33,22 @@ export const registerUrlMappingRoutes = (app: Express): void => {
     }),
   );
 
-
-
-
-
-
-
-
-
-
-
   app.get(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const result = await service.resolve(code);
       if (result === null) {
         throw NotFound();
       }
-
       res.redirect(302, result.url);
-
     }),
   );
-
-
-
-
-
-
-
 
   app.delete(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const ok = await service.delete_(code);
       if (!ok) {
         throw NotFound();
@@ -100,9 +56,5 @@ export const registerUrlMappingRoutes = (app: Express): void => {
       res.status(204).end();
     }),
   );
-
-
-
-
 
 };

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
@@ -1,26 +1,17 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-
   code: z.string(),
-
   url: z.string(),
-
   createdAt: z.coerce.date(),
-
   clickCount: z.number(),
-
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
-
 export const ShortenRequestSchema = z.object({
-
   url: z.string(),
-
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;
-
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/services/urlMapping.ts
@@ -3,57 +3,28 @@ import type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
 
 export type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
-
-
-
-
-
-
-
 
 // TODO: implement shorten; the convention engine could not derive a
 // CRUD shape, so the stub throws to avoid silently reporting success.
 export const shorten = async (body: ShortenRequest): Promise<void> => {
-
-
   void body;
-
   throw new Error('shorten not implemented');
 };
-
-
-
-
-
 
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
   }) as unknown as Promise<UrlMappingRead[]>;
 };
-
-
-
-
-
-
-
-
-
-
 
 // TODO: implement resolve; a redirect operation carries spec side-effects the
 // convention engine cannot derive (e.g. click-count increment), so the stub throws to
@@ -62,23 +33,10 @@ export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   throw new Error('resolve not implemented');
 };
 
-
-
-
-
-
-
-
 export const delete_ = async (code: string): Promise<boolean> => {
-
   const result = await prisma.urlMapping.deleteMany({
     where: { code: code },
   });
   return result.count > 0;
-
 };
-
-
-
-
 

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/types/urlMapping.ts
@@ -1,52 +1,30 @@
 
-
 export interface UrlMapping {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingCreate {
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingRead {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
-
 
 export interface ShortenRequest {
-
   url: string;
-
 }
-
 
 export interface ErrorResponse {
   detail: string;

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.github/workflows/ci.yml
@@ -26,3 +26,20 @@ jobs:
       - run: npx prisma generate
       - run: npm run typecheck
       - run: npm test
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+      - name: Audit dependencies (npm audit)
+        run: |
+          npm install --package-lock-only --no-audit --no-fund
+          npm audit --audit-level=high
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.github/workflows/ci.yml
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/.github/workflows/ci.yml
@@ -42,4 +42,4 @@ jobs:
           npm audit --audit-level=high
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/package.json
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/package.json
@@ -15,34 +15,20 @@
     "migrate": "prisma migrate deploy"
   },
   "dependencies": {
-
     "express": "^4.21.2",
-
     "@prisma/client": "^6.2.0",
-
     "zod": "^3.23.8",
-
     "dotenv": "^16.4.7"
-
   },
   "devDependencies": {
-
     "typescript": "^5.6.3",
-
     "@types/node": "^22.10.1",
-
     "@types/express": "^4.17.21",
-
     "prisma": "^6.2.0",
-
     "vitest": "^2.1.8",
-
     "supertest": "^7.0.0",
-
     "@types/supertest": "^6.0.2",
-
     "tsx": "^4.19.2"
-
   },
   "engines": {
     "node": ">=20.0.0"

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/down.sql
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/down.sql
@@ -1,7 +1,5 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 DROP TABLE url_mappings;
-
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/migration.sql
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/migrations/001_initial_schema/migration.sql
@@ -1,7 +1,6 @@
 -- spec-to-rest generated migration. Apply via `npx prisma migrate deploy`.
 -- Each statement is wrapped in an implicit transaction by Prisma.
 
-
 CREATE TABLE url_mappings (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     code TEXT NOT NULL,
@@ -14,5 +13,4 @@ CREATE TABLE url_mappings (
     CONSTRAINT ck_url_mappings_3 CHECK (length(url) > 0),
     CONSTRAINT ck_url_mappings_4 CHECK (click_count >= 0)
 );
-
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/prisma/schema.prisma
@@ -7,21 +7,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model UrlMapping {
-
   id BigInt @id @default(autoincrement())
-
   code String
-
   url String
-
   createdAt DateTime @map("created_at")
-
   clickCount Int @map("click_count")
-
 
   @@map("url_mappings")
 }
-
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/index.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/index.ts
@@ -1,13 +1,9 @@
 import type { Express } from 'express';
 
 import { registerAdminRoutes } from './admin.js';
-
 import { registerUrlMappingRoutes } from './urlMappings.js';
-
 
 export const mountRoutes = (app: Express): void => {
   registerAdminRoutes(app);
-
   registerUrlMappingRoutes(app);
-
 };

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/urlMappings.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/routes/urlMappings.ts
@@ -3,14 +3,10 @@ import type { Express, NextFunction, Request, Response } from 'express';
 import { NotFound } from '../middleware/error.js';
 import { validateBody } from '../middleware/validate.js';
 import * as service from '../services/urlMapping.js';
-
 import {
   UrlMappingCreateSchema,
-
   ShortenRequestSchema,
-
 } from '../schemas/urlMapping.js';
-
 
 const wrap =
   (handler: (req: Request, res: Response) => Promise<void>) =>
@@ -19,32 +15,15 @@ const wrap =
   };
 
 export const registerUrlMappingRoutes = (app: Express): void => {
-
-
-
-
-
-
-
   app.post(
     '/shorten',
-
     validateBody(ShortenRequestSchema),
-
     wrap(async (req, res) => {
-
-
       const body = req.body as service.ShortenRequest;
-
       await service.shorten(body);
       res.status(201).end();
     }),
   );
-
-
-
-
-
 
   app.get(
     '/urls',
@@ -54,45 +33,22 @@ export const registerUrlMappingRoutes = (app: Express): void => {
     }),
   );
 
-
-
-
-
-
-
-
-
-
-
   app.get(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const result = await service.resolve(code);
       if (result === null) {
         throw NotFound();
       }
-
       res.redirect(302, result.url);
-
     }),
   );
-
-
-
-
-
-
-
 
   app.delete(
     '/:code',
     wrap(async (req, res) => {
-
       const code = req.params['code'] ?? '';
-
       const ok = await service.delete_(code);
       if (!ok) {
         throw NotFound();
@@ -100,9 +56,5 @@ export const registerUrlMappingRoutes = (app: Express): void => {
       res.status(204).end();
     }),
   );
-
-
-
-
 
 };

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
@@ -1,26 +1,17 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-
   code: z.string(),
-
   url: z.string(),
-
   createdAt: z.coerce.date(),
-
   clickCount: z.number(),
-
 });
 
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
-
 export const ShortenRequestSchema = z.object({
-
   url: z.string(),
-
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;
-
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/services/urlMapping.ts
@@ -3,57 +3,28 @@ import type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
 
 export type {
   UrlMapping,
   UrlMappingCreate,
   UrlMappingRead,
-
   ShortenRequest,
-
 } from '../types/urlMapping.js';
-
-
-
-
-
-
-
 
 // TODO: implement shorten; the convention engine could not derive a
 // CRUD shape, so the stub throws to avoid silently reporting success.
 export const shorten = async (body: ShortenRequest): Promise<void> => {
-
-
   void body;
-
   throw new Error('shorten not implemented');
 };
-
-
-
-
-
 
 export const listAll = async (): Promise<UrlMappingRead[]> => {
   return prisma.urlMapping.findMany({
     orderBy: { id: 'asc' },
   }) as unknown as Promise<UrlMappingRead[]>;
 };
-
-
-
-
-
-
-
-
-
-
 
 // TODO: implement resolve; a redirect operation carries spec side-effects the
 // convention engine cannot derive (e.g. click-count increment), so the stub throws to
@@ -62,23 +33,10 @@ export const resolve = async (code: string): Promise<UrlMappingRead | null> => {
   throw new Error('resolve not implemented');
 };
 
-
-
-
-
-
-
-
 export const delete_ = async (code: string): Promise<boolean> => {
-
   const result = await prisma.urlMapping.deleteMany({
     where: { code: code },
   });
   return result.count > 0;
-
 };
-
-
-
-
 

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/types/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/types/urlMapping.ts
@@ -1,52 +1,30 @@
 
-
 export interface UrlMapping {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingCreate {
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
 
 export interface UrlMappingRead {
-
   id: number;
-
   code: string;
-
   url: string;
-
   createdAt: Date;
-
   clickCount: number;
-
 }
-
 
 export interface ShortenRequest {
-
   url: string;
-
 }
-
 
 export interface ErrorResponse {
   detail: string;

--- a/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
@@ -45,7 +45,7 @@ jobs:
         with:
           go-version: "1.22"
       - name: Audit dependencies (govulncheck)
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.3.0 ./...
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/github/workflows/ci.yml.hbs
@@ -34,3 +34,18 @@ jobs:
       - run: go mod tidy
       - run: go vet ./...
       - run: go test ./...
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: "1.22"
+      - name: Audit dependencies (govulncheck)
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
@@ -1,14 +1,6 @@
 package handlers
 
-import (
-{{#if entity.usesRequestBody}}	"encoding/json"
-{{/if}}{{#if entity.usesNotFound}}	"errors"
-{{/if}}{{#if entity.hasOperations}}	"net/http"
-{{/if}}{{#if entity.needsStrconv}}	"strconv"
-{{/if}}{{#if entity.usesPathParams}}	"github.com/go-chi/chi/v5"
-{{/if}}{{#if entity.usesRequestBody}}	"{{module}}/internal/models"
-{{/if}}	"{{module}}/internal/services"
-)
+{{{entity.handlerImports}}}
 
 type {{entity.entity.modelClassName}}Handler struct {
 	svc *services.{{entity.entity.modelClassName}}Service
@@ -18,6 +10,7 @@ func New{{entity.entity.modelClassName}}Handler(svc *services.{{entity.entity.mo
 	return &{{entity.entity.modelClassName}}Handler{svc: svc}
 }
 {{#each entity.operations}}
+
 func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.ResponseWriter, r *http.Request) {
 {{#each pathParams}}{{#if isInt}}	{{goName}}Str := chi.URLParam(r, "{{name}}")
 	{{goName}}, {{goName}}Err := strconv.ParseInt({{goName}}Str, 10, 64)

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
@@ -3,21 +3,20 @@ package models
 import (
 {{#if entity.needsTime}}	"time"
 
-{{/if}}	"github.com/uptrace/bun"
-{{#if entity.needsUuid}}	"github.com/google/uuid"
+{{/if}}{{#if entity.needsUuid}}	"github.com/google/uuid"
 {{/if}}{{#if entity.needsDecimal}}	"github.com/shopspring/decimal"
-{{/if}})
+{{/if}}	"github.com/uptrace/bun"
+)
 
 type {{entity.entity.modelClassName}} struct {
-	bun.BaseModel `bun:"table:{{entity.entity.tableName}},alias:{{entity.entity.tableName}}"`
-{{#each entity.fields}}	{{this.goField}} {{this.domainType}} `bun:"{{this.bunTag}}" json:"{{this.jsonTag}}"`
+{{#each entity.modelStructLines}}	{{{this}}}
 {{/each}}{{! }}}
 
 type {{entity.entity.createSchemaName}} struct {
-{{#each entity.nonIdFields}}	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
+{{#each entity.createStructLines}}	{{{this}}}
 {{/each}}{{! }}}
 {{#each entity.customSchemas}}
 type {{this.name}} struct {
-{{#each this.fields}}	{{this.goField}} {{this.domainType}} `json:"{{this.jsonTag}}"{{#unless this.nullable}} validate:"required"{{/unless}}`
+{{#each this.structLines}}	{{{this}}}
 {{/each}}{{! }}}
 {{/each}}

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/services/entity.go.hbs
@@ -20,6 +20,7 @@ func New{{entity.entity.modelClassName}}Service(db *bun.DB, cfg *config.Config) 
 	return &{{entity.entity.modelClassName}}Service{db: db, cfg: cfg}
 }
 {{#each entity.operations}}
+
 {{#if (eq routeKind "create")}}func (s *{{../entity.entity.modelClassName}}Service) {{serviceMethod}}(ctx context.Context, body models.{{requestBodyType}}) (*models.{{../entity.entity.modelClassName}}, error) {
 	m := &models.{{../entity.entity.modelClassName}}{
 {{#each createAssigns}}		{{this}},

--- a/modules/codegen/src/main/resources/templates/python/fastapi/alembic/versions/001_initial_schema.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/alembic/versions/001_initial_schema.py.hbs
@@ -39,8 +39,8 @@ def upgrade() -> None:
 {{#each this.upgradeStatements}}
     {{{this}}}
 {{/each}}
-
 {{/each}}
+
 
 def downgrade() -> None:
 {{#each migration.triggersReversed}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/database.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/database.py.hbs
@@ -1,7 +1,9 @@
 from collections.abc import AsyncIterator
 {{#if db.needsFkPragma}}
 from typing import Any
+{{/if}}
 
+{{#if db.needsFkPragma}}
 from sqlalchemy import event
 {{/if}}
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine

--- a/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
@@ -85,9 +85,9 @@ jobs:
       - name: Audit dependencies (pip-audit)
         run: |
           uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
-          uvx pip-audit -r /tmp/requirements.txt
+          uvx pip-audit==2.10.1 -r /tmp/requirements.txt
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/
 
   docker:
     runs-on: ubuntu-latest

--- a/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/github/workflows/ci.yml.hbs
@@ -14,8 +14,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-
 {{#if db.hasDbService}}
+
     services:
       database:
         image: {{db.dbImage}}
@@ -68,16 +68,34 @@ jobs:
         run: make test-conformance PROFILE=$SPEC_TEST_PROFILE
       - name: Upload JUnit results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: conformance-results-$\{{ env.SPEC_TEST_PROFILE }}
           path: results/
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+      - name: Audit dependencies (pip-audit)
+        run: |
+          uv export --format requirements-txt --no-emit-project > /tmp/requirements.txt
+          uvx pip-audit -r /tmp/requirements.txt
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/
 
   docker:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Seed .env from example
         run: cp .env.example .env
       - name: Build and start stack

--- a/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/main.py.hbs
@@ -1,5 +1,5 @@
-from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -7,13 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.database import engine
 from app.extensions import register as register_extensions
 from app.redaction import configure_logging
-from app.routers import admin
-{{#each entities}}
-from app.routers import {{snake_case (pluralize this.entityName)}}
-{{/each}}{{#if hasScalarOps}}
-from app.routers import state_ops
-{{/if}}
-
+from app.routers import {{routerImport}}
 
 configure_logging()
 

--- a/modules/codegen/src/main/resources/templates/python/fastapi/models/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/models/entity.py.hbs
@@ -1,6 +1,9 @@
 {{#each stdlibImports}}
 from {{this.module}} import {{join this.names ", "}}
 {{/each}}
+{{#if stdlibImports.length}}
+
+{{/if}}
 {{#if sqlalchemyImports.length}}
 from sqlalchemy import {{join sqlalchemyImports ", "}}
 {{/if}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/schemas/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/schemas/entity.py.hbs
@@ -1,6 +1,9 @@
 {{#each stdlibImports}}
 from {{this.module}} import {{join this.names ", "}}
 {{/each}}
+{{#if stdlibImports.length}}
+
+{{/if}}
 from pydantic import BaseModel, ConfigDict{{#if needsSecretStr}}, SecretStr{{/if}}
 
 

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
@@ -1,6 +1,6 @@
-{{#if serviceImports.sqlalchemyCoreImports.length}}
-from sqlalchemy import {{join serviceImports.sqlalchemyCoreImports ", "}}
-{{/if}}
+{{#each serviceImports.sqlalchemyCoreImports}}
+from sqlalchemy import {{this}}
+{{/each}}
 from sqlalchemy.ext.asyncio import AsyncSession
 
 {{#if serviceImports.needsDafnyKernel}}

--- a/modules/codegen/src/main/resources/templates/ts/express/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/github/workflows/ci.yml.hbs
@@ -51,4 +51,4 @@ jobs:
           npm audit --audit-level=high
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Audit workflow files (zizmor)
-        run: uvx zizmor .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/

--- a/modules/codegen/src/main/resources/templates/ts/express/github/workflows/ci.yml.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/github/workflows/ci.yml.hbs
@@ -35,3 +35,20 @@ jobs:
       - run: npx prisma generate
       - run: npm run typecheck
       - run: npm test
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "20"
+      - name: Audit dependencies (npm audit)
+        run: |
+          npm install --package-lock-only --no-audit --no-fund
+          npm audit --audit-level=high
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Audit workflow files (zizmor)
+        run: uvx zizmor .github/workflows/

--- a/modules/codegen/src/main/scala/specrest/codegen/Engine.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Engine.scala
@@ -14,6 +14,8 @@ import scala.jdk.CollectionConverters.*
 final class TemplateEngine:
   private val hbs: Handlebars =
     val h = new Handlebars()
+    // standalone block-tag lines must not leak blank lines into output
+    h.setPrettyPrint(true)
     h.`with`(EscapingStrategy.NOOP)
 
   registerDefaultHelpers(hbs)

--- a/modules/codegen/src/main/scala/specrest/codegen/Types.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/Types.scala
@@ -48,7 +48,8 @@ final case class RenderContext(
     db: DialectView,
     dafnyKernel: Option[DafnyKernel] = None,
     scalarStateFields: List[ScalarStateFieldView] = Nil,
-    hasScalarOps: Boolean = false
+    hasScalarOps: Boolean = false,
+    routerImport: String = "admin"
 )
 
 final case class RenderResult(fileName: String, content: String)
@@ -79,7 +80,14 @@ object RenderContext:
         .deployment(Naming.toSnakeCase(svcName(profiled.ir))),
       dafnyKernel = dafnyKernel,
       scalarStateFields = ScalarOps.stateFields(profiled),
-      hasScalarOps = ScalarOps.views(profiled).nonEmpty
+      hasScalarOps = ScalarOps.views(profiled).nonEmpty,
+      routerImport = {
+        val modules =
+          "admin" ::
+            profiled.entities.map(e => Naming.toSnakeCase(Naming.pluralize(e.entityName))) :::
+            (if ScalarOps.views(profiled).nonEmpty then List("state_ops") else Nil)
+        modules.sorted.mkString(", ")
+      }
     )
 
   private def convertProfile(profile: DeploymentProfile): RenderProfile =

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -26,7 +26,11 @@ import specrest.profile.ProfiledField
 import specrest.profile.ProfiledOperation
 import specrest.profile.ProfiledService
 
-final private case class GoCustomSchema(name: String, fields: List[GoFieldView])
+final private case class GoCustomSchema(
+    name: String,
+    fields: List[GoFieldView],
+    structLines: List[String]
+)
 
 final private case class GoFieldView(
     goField: String,
@@ -94,7 +98,10 @@ final private case class GoEntityCtx(
     usesNotFound: Boolean,
     usesErrors: Boolean,
     usesSqlNoRows: Boolean,
-    customSchemas: List[GoCustomSchema]
+    customSchemas: List[GoCustomSchema],
+    modelStructLines: List[String],
+    createStructLines: List[String],
+    handlerImports: String
 )
 
 final private case class GoServiceNames(name: String, snakeName: String, kebabName: String)
@@ -561,7 +568,9 @@ object EmitGo:
     val usesPathParams  = operations.exists(_.pathParams.nonEmpty)
 
     val customSchemas = operations.flatMap: op =>
-      op.customRequestSchemaName.map(name => GoCustomSchema(name, op.customRequestFields))
+      op.customRequestSchemaName.map(name =>
+        GoCustomSchema(name, op.customRequestFields, schemaStructLines(op.customRequestFields))
+      )
 
     GoEntityCtx(
       service =
@@ -587,8 +596,49 @@ object EmitGo:
       usesNotFound = usesNotFound,
       usesErrors = usesErrors,
       usesSqlNoRows = usesSqlNoRows,
-      customSchemas = customSchemas
+      customSchemas = customSchemas,
+      modelStructLines = padCells(
+        List(
+          "bun.BaseModel",
+          s"`bun:\"table:${entity.tableName},alias:${entity.tableName}\"`"
+        ) :: allFields.map(f =>
+          List(f.goField, f.domainType, s"`bun:\"${f.bunTag}\" json:\"${f.jsonTag}\"`")
+        )
+      ),
+      createStructLines = schemaStructLines(nonIdFields),
+      handlerImports = {
+        val stdlib = List(
+          Option.when(usesRequestBody)("\"encoding/json\""),
+          Option.when(usesNotFound)("\"errors\""),
+          Option.when(operations.nonEmpty)("\"net/http\""),
+          Option.when(operations.exists(_.pathParams.exists(_.isInt)))("\"strconv\"")
+        ).flatten
+        val third =
+          Option.when(usesRequestBody)(s"\"$module/internal/models\"").toList :::
+            List(s"\"$module/internal/services\"") :::
+            Option.when(usesPathParams)("\"github.com/go-chi/chi/v5\"").toList
+        val groups = List(stdlib, third).filter(_.nonEmpty)
+        groups.map(_.map("\t" + _).mkString("\n")).mkString("import (\n", "\n\n", "\n)")
+      }
     )
+
+  private def schemaStructLines(fields: List[GoFieldView]): List[String] =
+    padCells(
+      fields.map: f =>
+        val validate = if f.nullable then "" else " validate:\"required\""
+        List(f.goField, f.domainType, s"`json:\"${f.jsonTag}\"$validate`")
+    )
+
+  // gofmt column alignment for struct field runs: every cell except a row's
+  // last is padded to the column max + 1 (text/tabwriter semantics).
+  private def padCells(rows: List[List[String]]): List[String] =
+    val numCols = rows.map(_.length).maxOption.getOrElse(0)
+    val widths = (0 until numCols).map: i =>
+      rows.filter(_.length > i + 1).map(_(i).length).maxOption.getOrElse(0)
+    rows.map: row =>
+      row.zipWithIndex.map: (cell, i) =>
+        if i == row.length - 1 then cell else cell.padTo(widths(i) + 1, ' ')
+      .mkString
 
   private def toGoField(f: ProfiledField): GoFieldView =
     GoFieldView(

--- a/modules/codegen/src/main/scala/specrest/codegen/python/AdminRouter.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/AdminRouter.scala
@@ -13,11 +13,12 @@ object AdminRouter:
     val entities   = svcEntities(ir)
     val hasScalars = ScalarState.fields(ir).nonEmpty
 
-    val entityImports = entities
-      .map(e => s"from app.models.${Naming.toSnakeCase(entName(e))} import ${entName(e)}")
-      .mkString("\n")
-    val stateImport =
-      if hasScalars then "\nfrom app.models.service_state import ServiceState" else ""
+    val modelImports = (entities
+      .map(e => s"from app.models.${Naming.toSnakeCase(entName(e))} import ${entName(e)}") ++
+      (if hasScalars then List("from app.models.service_state import ServiceState") else Nil)).sorted
+    val firstPartyImports =
+      ("from app.database import get_session" :: modelImports :::
+        List("from app.security import require_admin")).mkString("\n")
 
     val scalarResets =
       if hasScalars then
@@ -71,18 +72,22 @@ object AdminRouter:
       if seedTargets.isEmpty then ""
       else seedTargets.map(e => seedHandler(e, ir)).mkString("\n", "\n", "")
 
-    s"""from datetime import datetime, date
+    val sqlalchemyImports = (
+      (if deleteStatements.contains("delete(") then List("delete") else Nil) :::
+        (if stateProjections.contains("select(") then List("select") else Nil)
+    ) match
+      case Nil   => ""
+      case names => s"\nfrom sqlalchemy import ${names.mkString(", ")}"
+
+    s"""from datetime import date, datetime
        |
-       |from fastapi import APIRouter, Body, Depends
-       |from fastapi.responses import Response
-       |from sqlalchemy import delete, select${
-        if hasScalars then ", update as sa_update" else ""
+       |from fastapi import APIRouter, ${if seedTargets.nonEmpty then "Body, " else ""}Depends
+       |from fastapi.responses import Response$sqlalchemyImports${
+        if hasScalars then "\nfrom sqlalchemy import update as sa_update" else ""
       }
        |from sqlalchemy.ext.asyncio import AsyncSession
        |
-       |from app.database import get_session
-       |from app.security import require_admin
-       |${if entityImports.nonEmpty then entityImports else ""}$stateImport
+       |$firstPartyImports
        |
        |router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(require_admin)])
        |

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -768,7 +768,9 @@ object EmitPython:
     val sqlSet         = mutable.Set.empty[String]
     val pgSet          = mutable.Set.empty[String]
     val stdlibByModule = mutable.Map.empty[String, mutable.Set[String]]
-    for field <- entity.fields do
+    // the id column renders as `mapped_column(primary_key=True)` with no type,
+    // so its column type must not contribute an import
+    for field <- entity.fields.filterNot(_.fieldName == "id") do
       val colType = modelColumnType(field.ormColumnType, dialect)
       if PostgresDialectTypes.contains(colType) then pgSet += colType
       else sqlSet += colType

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitGoTest.scala
@@ -66,8 +66,12 @@ class EmitGoTest extends CatsEffectSuite:
       val model = files("internal/models/url_mapping.go")
       assert(model.contains("type UrlMapping struct"), model)
       assert(model.contains("bun.BaseModel `bun:\"table:url_mappings"), model)
-      assert(model.contains("ID int64 `bun:\"id,pk,autoincrement\" json:\"id\"`"), model)
-      assert(model.contains("Code string `bun:\"code,notnull\" json:\"code\"`"), model)
+      // struct fields are gofmt-aligned (text/tabwriter column padding)
+      assert(
+        model.contains("ID            int64     `bun:\"id,pk,autoincrement\" json:\"id\"`"),
+        model
+      )
+      assert(model.contains("Code          string    `bun:\"code,notnull\" json:\"code\"`"), model)
       assert(model.contains("type UrlMappingCreate struct"), model)
       assert(!model.contains("type ErrorResponse struct"), model)
       assert(model.contains("\"github.com/uptrace/bun\""), model)


### PR DESCRIPTION
## What

Three related improvements to generated projects, all template/emitter-level:

### 1. Blank-line garbage is gone (root cause, not symptom)

The handlebars engine never stripped standalone `{{#if}}`/`{{#each}}` lines, so every block tag on its own line leaked newlines into the output - generated workflows had triple blank lines after `runs-on:`, alembic migrations had a blank between every column and around `pass` bodies. The fix is one engine flag (`setPrettyPrint(true)` - mustache-spec standalone-tag handling) instead of per-template glue hacks. About **1000 stray blank lines** disappear from the golden trees; existing glued-tag templates are unaffected (glued tags are not standalone).

### 2. Generated code is now lint-clean, verified

Removing the blank lines exposed latent lint debt (ruff's isort had been treating the stray blanks as import-block separators). Fixed at the source so every render passes `ruff check` and `gofmt -l` cleanly:

- import blocks are isort-correct across all python templates (group separators, aliased imports on their own line, one merged sorted `from app.routers import ...` line via a new `routerImport` context field)
- the admin router computes its imports from actual usage - `Body`/`delete`/`select` are no longer imported when the spec has no transitions/entities (pre-existing F401s)
- the model `id` column no longer contributes an unused sqlalchemy type import (pre-existing F401 on todo_list)
- Go struct fields are emitted with gofmt column alignment - `padCells` in EmitGo replicates text/tabwriter semantics (pad every cell except a row's last to column max + 1)
- Go handler imports are built as grouped, sorted blocks in the emitter; functions are separated by blank lines again

Verified on url_shortener, safe_counter, and todo_list renders across dialects: `ruff check` and `gofmt -l` both clean.

### 3. Generated CI gains a `security` job (all three targets)

- **deps**: `uv export | pip-audit` (python), `govulncheck ./...` (go), `npm audit --audit-level=high` (ts)
- **workflows**: `zizmor .github/workflows/` in all three (via uvx)

To make the generated workflow pass its own audit, the remaining unpinned actions in the python workflow are now pinned by hash (fetched from the GitHub API, not guessed) and all checkout steps set `persist-credentials: false`. **zizmor reports zero findings on the generated workflows out of the box**, and pip-audit currently passes on the generated dependency set (verified locally).

## Verification

- Full battery green: convention / testgen / codegen / cli / arch + scalafix + scalafmt
- Goldens regenerated for all nine targets (`+379 / -1075`)
- `EmitGoTest` updated for the aligned struct fields

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stray blank lines from all generated files, make Python/Go output lint-clean, and add a CI security job with pinned scanner versions to every generated project. This improves readability and adds automated, reproducible dependency and workflow audits out of the box.

- **New Features**
  - Add a `security` job to generated CI (Go, Python, TS).
  - Run `pip-audit` via `uv export`, `govulncheck`, and `npm audit --audit-level=high`.
  - Audit workflow files with `zizmor`; pin actions by SHA and set `persist-credentials: false` so audits pass.
  - Pin scanner versions: `govulncheck@v1.3.0`, `pip-audit==2.10.1`, `zizmor==1.25.2`.

- **Refactors**
  - Enable Handlebars pretty printing to strip standalone tag newlines, removing ~1000 blank lines across goldens.
  - Emit lint-clean code: Python imports are `isort`-correct with unused imports removed; router imports merged; admin imports computed from usage; SQLAlchemy `id` no longer adds unused types. Go structs are column-aligned (`gofmt`-style), imports grouped/sorted, and functions spaced.
  - Regenerate goldens for all targets; verified `ruff check` and `gofmt -l` clean on sample apps.

<sup>Written for commit d5092438905f67e03baf05d6360cadeae6046794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning to CI workflows, including vulnerability checks and workflow security audits.

* **Bug Fixes**
  * Corrected database migration structures with proper transaction handling and rollback statements.

* **Improvements**
  * Enhanced code formatting consistency and import organization across generated codebases.
  * Optimized build templates for better code generation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->