### PR TITLE
feat(parser): authentication DSL syntax + IR support (M8.1)

### DIFF
--- a/docs/content/docs/spec-language.mdx
+++ b/docs/content/docs/spec-language.mdx
@@ -106,6 +106,40 @@ operation Shorten {
 `requires:` lists preconditions; `ensures:` lists postconditions. Each takes
 one or more expressions, conjoined.
 
+### Security schemes
+
+A service-wide `security { ... }` block declares named credential schemes; an
+operation opts in with a `requires_auth:` clause naming one or more of them.
+
+```spec
+security {
+  bearer: Bearer(bearer_format: "JWT")
+  api_key: ApiKey(header: "X-API-Key")
+  basic: Basic
+}
+
+operation GetProfile {
+  requires_auth: bearer, api_key
+
+  output: profile: User
+
+  ensures:
+    true
+}
+```
+
+Three scheme kinds exist. `Bearer` takes an optional `bearer_format`; `ApiKey`
+takes exactly one location argument (`header`, `query`, or `cookie`) whose value
+is the parameter name; `Basic` takes no arguments. A comma list in
+`requires_auth:` means the schemes are alternatives (a client may satisfy any
+one of them - OpenAPI security-array semantics). Operations without the clause
+are public. Referencing an undeclared scheme or declaring two schemes with the
+same name is a compile-time error.
+
+Auth is pure metadata at this stage: classification, verification, and test
+generation ignore it. OpenAPI `securitySchemes` emission and generated runtime
+guards build on these declarations (issues #54, #55).
+
 ### Invariants
 
 Invariants are properties that must hold across all states. The body comes after a colon. There

--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -1181,16 +1181,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 67,
+              "startLine" : 74,
               "startCol" : 19,
-              "endLine" : 67,
+              "endLine" : 74,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 67,
+            "startLine" : 74,
             "startCol" : 12,
-            "endLine" : 67,
+            "endLine" : 74,
             "endCol" : 24
           }
         },
@@ -1201,16 +1201,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 67,
+              "startLine" : 74,
               "startCol" : 36,
-              "endLine" : 67,
+              "endLine" : 74,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 67,
+            "startLine" : 74,
             "startCol" : 26,
-            "endLine" : 67,
+            "endLine" : 74,
             "endCol" : 42
           }
         },
@@ -1221,16 +1221,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 68,
+              "startLine" : 75,
               "startCol" : 26,
-              "endLine" : 68,
+              "endLine" : 75,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 68,
+            "startLine" : 75,
             "startCol" : 12,
-            "endLine" : 68,
+            "endLine" : 75,
             "endCol" : 32
           }
         }
@@ -1243,16 +1243,16 @@
             "kind" : "NamedType",
             "name" : "User",
             "span" : {
-              "startLine" : 69,
+              "startLine" : 76,
               "startCol" : 18,
-              "endLine" : 69,
+              "endLine" : 76,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 69,
+            "startLine" : 76,
             "startCol" : 12,
-            "endLine" : 69,
+            "endLine" : 76,
             "endCol" : 22
           }
         }
@@ -1265,9 +1265,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 72,
+              "startLine" : 79,
               "startCol" : 6,
-              "endLine" : 72,
+              "endLine" : 79,
               "endCol" : 11
             }
           },
@@ -1275,16 +1275,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 72,
+              "startLine" : 79,
               "startCol" : 19,
-              "endLine" : 72,
+              "endLine" : 79,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 72,
+            "startLine" : 79,
             "startCol" : 6,
-            "endLine" : 72,
+            "endLine" : 79,
             "endCol" : 32
           }
         },
@@ -1297,9 +1297,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 73,
+                "startLine" : 80,
                 "startCol" : 6,
-                "endLine" : 73,
+                "endLine" : 80,
                 "endCol" : 9
               }
             },
@@ -1308,17 +1308,17 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 73,
+                  "startLine" : 80,
                   "startCol" : 10,
-                  "endLine" : 73,
+                  "endLine" : 80,
                   "endCol" : 18
                 }
               }
             ],
             "span" : {
-              "startLine" : 73,
+              "startLine" : 80,
               "startCol" : 6,
-              "endLine" : 73,
+              "endLine" : 80,
               "endCol" : 19
             }
           },
@@ -1326,16 +1326,16 @@
             "kind" : "IntLit",
             "value" : 8,
             "span" : {
-              "startLine" : 73,
+              "startLine" : 80,
               "startCol" : 23,
-              "endLine" : 73,
+              "endLine" : 80,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 73,
+            "startLine" : 80,
             "startCol" : 6,
-            "endLine" : 73,
+            "endLine" : 80,
             "endCol" : 24
           }
         },
@@ -1348,9 +1348,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 74,
+                "startLine" : 81,
                 "startCol" : 6,
-                "endLine" : 74,
+                "endLine" : 81,
                 "endCol" : 9
               }
             },
@@ -1359,17 +1359,17 @@
                 "kind" : "Identifier",
                 "name" : "display_name",
                 "span" : {
-                  "startLine" : 74,
+                  "startLine" : 81,
                   "startCol" : 10,
-                  "endLine" : 74,
+                  "endLine" : 81,
                   "endCol" : 22
                 }
               }
             ],
             "span" : {
-              "startLine" : 74,
+              "startLine" : 81,
               "startCol" : 6,
-              "endLine" : 74,
+              "endLine" : 81,
               "endCol" : 23
             }
           },
@@ -1377,16 +1377,16 @@
             "kind" : "IntLit",
             "value" : 1,
             "span" : {
-              "startLine" : 74,
+              "startLine" : 81,
               "startCol" : 27,
-              "endLine" : 74,
+              "endLine" : 81,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 74,
+            "startLine" : 81,
             "startCol" : 6,
-            "endLine" : 74,
+            "endLine" : 81,
             "endCol" : 28
           }
         }
@@ -1401,17 +1401,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 77,
+                "startLine" : 84,
                 "startCol" : 6,
-                "endLine" : 77,
+                "endLine" : 84,
                 "endCol" : 10
               }
             },
             "field" : "id",
             "span" : {
-              "startLine" : 77,
+              "startLine" : 84,
               "startCol" : 6,
-              "endLine" : 77,
+              "endLine" : 84,
               "endCol" : 13
             }
           },
@@ -1421,23 +1421,23 @@
               "kind" : "Identifier",
               "name" : "next_user_id",
               "span" : {
-                "startLine" : 77,
+                "startLine" : 84,
                 "startCol" : 20,
-                "endLine" : 77,
+                "endLine" : 84,
                 "endCol" : 32
               }
             },
             "span" : {
-              "startLine" : 77,
+              "startLine" : 84,
               "startCol" : 16,
-              "endLine" : 77,
+              "endLine" : 84,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 77,
+            "startLine" : 84,
             "startCol" : 6,
-            "endLine" : 77,
+            "endLine" : 84,
             "endCol" : 33
           }
         },
@@ -1450,17 +1450,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 78,
+                "startLine" : 85,
                 "startCol" : 6,
-                "endLine" : 78,
+                "endLine" : 85,
                 "endCol" : 10
               }
             },
             "field" : "email",
             "span" : {
-              "startLine" : 78,
+              "startLine" : 85,
               "startCol" : 6,
-              "endLine" : 78,
+              "endLine" : 85,
               "endCol" : 16
             }
           },
@@ -1468,16 +1468,16 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 78,
+              "startLine" : 85,
               "startCol" : 19,
-              "endLine" : 78,
+              "endLine" : 85,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 78,
+            "startLine" : 85,
             "startCol" : 6,
-            "endLine" : 78,
+            "endLine" : 85,
             "endCol" : 24
           }
         },
@@ -1490,17 +1490,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 79,
+                "startLine" : 86,
                 "startCol" : 6,
-                "endLine" : 79,
+                "endLine" : 86,
                 "endCol" : 10
               }
             },
             "field" : "password_hash",
             "span" : {
-              "startLine" : 79,
+              "startLine" : 86,
               "startCol" : 6,
-              "endLine" : 79,
+              "endLine" : 86,
               "endCol" : 24
             }
           },
@@ -1510,9 +1510,9 @@
               "kind" : "Identifier",
               "name" : "hash",
               "span" : {
-                "startLine" : 79,
+                "startLine" : 86,
                 "startCol" : 27,
-                "endLine" : 79,
+                "endLine" : 86,
                 "endCol" : 31
               }
             },
@@ -1521,24 +1521,24 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 79,
+                  "startLine" : 86,
                   "startCol" : 32,
-                  "endLine" : 79,
+                  "endLine" : 86,
                   "endCol" : 40
                 }
               }
             ],
             "span" : {
-              "startLine" : 79,
+              "startLine" : 86,
               "startCol" : 27,
-              "endLine" : 79,
+              "endLine" : 86,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 79,
+            "startLine" : 86,
             "startCol" : 6,
-            "endLine" : 79,
+            "endLine" : 86,
             "endCol" : 41
           }
         },
@@ -1551,17 +1551,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 80,
+                "startLine" : 87,
                 "startCol" : 6,
-                "endLine" : 80,
+                "endLine" : 87,
                 "endCol" : 10
               }
             },
             "field" : "display_name",
             "span" : {
-              "startLine" : 80,
+              "startLine" : 87,
               "startCol" : 6,
-              "endLine" : 80,
+              "endLine" : 87,
               "endCol" : 23
             }
           },
@@ -1569,16 +1569,16 @@
             "kind" : "Identifier",
             "name" : "display_name",
             "span" : {
-              "startLine" : 80,
+              "startLine" : 87,
               "startCol" : 26,
-              "endLine" : 80,
+              "endLine" : 87,
               "endCol" : 38
             }
           },
           "span" : {
-            "startLine" : 80,
+            "startLine" : 87,
             "startCol" : 6,
-            "endLine" : 80,
+            "endLine" : 87,
             "endCol" : 38
           }
         },
@@ -1591,17 +1591,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 81,
+                "startLine" : 88,
                 "startCol" : 6,
-                "endLine" : 81,
+                "endLine" : 88,
                 "endCol" : 10
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 81,
+              "startLine" : 88,
               "startCol" : 6,
-              "endLine" : 81,
+              "endLine" : 88,
               "endCol" : 20
             }
           },
@@ -1609,16 +1609,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 81,
+              "startLine" : 88,
               "startCol" : 23,
-              "endLine" : 81,
+              "endLine" : 88,
               "endCol" : 27
             }
           },
           "span" : {
-            "startLine" : 81,
+            "startLine" : 88,
             "startCol" : 6,
-            "endLine" : 81,
+            "endLine" : 88,
             "endCol" : 27
           }
         },
@@ -1631,33 +1631,33 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 82,
+                "startLine" : 89,
                 "startCol" : 6,
-                "endLine" : 82,
+                "endLine" : 89,
                 "endCol" : 10
               }
             },
             "field" : "last_login",
             "span" : {
-              "startLine" : 82,
+              "startLine" : 89,
               "startCol" : 6,
-              "endLine" : 82,
+              "endLine" : 89,
               "endCol" : 21
             }
           },
           "right" : {
             "kind" : "NoneLit",
             "span" : {
-              "startLine" : 82,
+              "startLine" : 89,
               "startCol" : 24,
-              "endLine" : 82,
+              "endLine" : 89,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 82,
+            "startLine" : 89,
             "startCol" : 6,
-            "endLine" : 82,
+            "endLine" : 89,
             "endCol" : 28
           }
         },
@@ -1670,16 +1670,16 @@
               "kind" : "Identifier",
               "name" : "next_user_id",
               "span" : {
-                "startLine" : 83,
+                "startLine" : 90,
                 "startCol" : 6,
-                "endLine" : 83,
+                "endLine" : 90,
                 "endCol" : 18
               }
             },
             "span" : {
-              "startLine" : 83,
+              "startLine" : 90,
               "startCol" : 6,
-              "endLine" : 83,
+              "endLine" : 90,
               "endCol" : 19
             }
           },
@@ -1692,16 +1692,16 @@
                 "kind" : "Identifier",
                 "name" : "next_user_id",
                 "span" : {
-                  "startLine" : 83,
+                  "startLine" : 90,
                   "startCol" : 26,
-                  "endLine" : 83,
+                  "endLine" : 90,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 83,
+                "startLine" : 90,
                 "startCol" : 22,
-                "endLine" : 83,
+                "endLine" : 90,
                 "endCol" : 39
               }
             },
@@ -1709,23 +1709,23 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 83,
+                "startLine" : 90,
                 "startCol" : 42,
-                "endLine" : 83,
+                "endLine" : 90,
                 "endCol" : 43
               }
             },
             "span" : {
-              "startLine" : 83,
+              "startLine" : 90,
               "startCol" : 22,
-              "endLine" : 83,
+              "endLine" : 90,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 83,
+            "startLine" : 90,
             "startCol" : 6,
-            "endLine" : 83,
+            "endLine" : 90,
             "endCol" : 43
           }
         },
@@ -1738,16 +1738,16 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 84,
+                "startLine" : 91,
                 "startCol" : 6,
-                "endLine" : 84,
+                "endLine" : 91,
                 "endCol" : 11
               }
             },
             "span" : {
-              "startLine" : 84,
+              "startLine" : 91,
               "startCol" : 6,
-              "endLine" : 84,
+              "endLine" : 91,
               "endCol" : 12
             }
           },
@@ -1760,16 +1760,16 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 84,
+                  "startLine" : 91,
                   "startCol" : 19,
-                  "endLine" : 84,
+                  "endLine" : 91,
                   "endCol" : 24
                 }
               },
               "span" : {
-                "startLine" : 84,
+                "startLine" : 91,
                 "startCol" : 15,
-                "endLine" : 84,
+                "endLine" : 91,
                 "endCol" : 25
               }
             },
@@ -1783,17 +1783,17 @@
                       "kind" : "Identifier",
                       "name" : "user",
                       "span" : {
-                        "startLine" : 84,
+                        "startLine" : 91,
                         "startCol" : 29,
-                        "endLine" : 84,
+                        "endLine" : 91,
                         "endCol" : 33
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 84,
+                      "startLine" : 91,
                       "startCol" : 29,
-                      "endLine" : 84,
+                      "endLine" : 91,
                       "endCol" : 36
                     }
                   },
@@ -1801,38 +1801,38 @@
                     "kind" : "Identifier",
                     "name" : "user",
                     "span" : {
-                      "startLine" : 84,
+                      "startLine" : 91,
                       "startCol" : 40,
-                      "endLine" : 84,
+                      "endLine" : 91,
                       "endCol" : 44
                     }
                   },
                   "span" : {
-                    "startLine" : 84,
+                    "startLine" : 91,
                     "startCol" : 29,
-                    "endLine" : 84,
+                    "endLine" : 91,
                     "endCol" : 36
                   }
                 }
               ],
               "span" : {
-                "startLine" : 84,
+                "startLine" : 91,
                 "startCol" : 28,
-                "endLine" : 84,
+                "endLine" : 91,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 84,
+              "startLine" : 91,
               "startCol" : 15,
-              "endLine" : 84,
+              "endLine" : 91,
               "endCol" : 45
             }
           },
           "span" : {
-            "startLine" : 84,
+            "startLine" : 91,
             "startCol" : 6,
-            "endLine" : 84,
+            "endLine" : 91,
             "endCol" : 45
           }
         },
@@ -1845,16 +1845,16 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 85,
+                "startLine" : 92,
                 "startCol" : 6,
-                "endLine" : 85,
+                "endLine" : 92,
                 "endCol" : 19
               }
             },
             "span" : {
-              "startLine" : 85,
+              "startLine" : 92,
               "startCol" : 6,
-              "endLine" : 85,
+              "endLine" : 92,
               "endCol" : 20
             }
           },
@@ -1867,16 +1867,16 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 85,
+                  "startLine" : 92,
                   "startCol" : 27,
-                  "endLine" : 85,
+                  "endLine" : 92,
                   "endCol" : 40
                 }
               },
               "span" : {
-                "startLine" : 85,
+                "startLine" : 92,
                 "startCol" : 23,
-                "endLine" : 85,
+                "endLine" : 92,
                 "endCol" : 41
               }
             },
@@ -1888,9 +1888,9 @@
                     "kind" : "Identifier",
                     "name" : "email",
                     "span" : {
-                      "startLine" : 85,
+                      "startLine" : 92,
                       "startCol" : 45,
-                      "endLine" : 85,
+                      "endLine" : 92,
                       "endCol" : 50
                     }
                   },
@@ -1898,38 +1898,38 @@
                     "kind" : "Identifier",
                     "name" : "user",
                     "span" : {
-                      "startLine" : 85,
+                      "startLine" : 92,
                       "startCol" : 54,
-                      "endLine" : 85,
+                      "endLine" : 92,
                       "endCol" : 58
                     }
                   },
                   "span" : {
-                    "startLine" : 85,
+                    "startLine" : 92,
                     "startCol" : 45,
-                    "endLine" : 85,
+                    "endLine" : 92,
                     "endCol" : 50
                   }
                 }
               ],
               "span" : {
-                "startLine" : 85,
+                "startLine" : 92,
                 "startCol" : 44,
-                "endLine" : 85,
+                "endLine" : 92,
                 "endCol" : 59
               }
             },
             "span" : {
-              "startLine" : 85,
+              "startLine" : 92,
               "startCol" : 23,
-              "endLine" : 85,
+              "endLine" : 92,
               "endCol" : 59
             }
           },
           "span" : {
-            "startLine" : 85,
+            "startLine" : 92,
             "startCol" : 6,
-            "endLine" : 85,
+            "endLine" : 92,
             "endCol" : 59
           }
         },
@@ -1945,23 +1945,23 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 86,
+                  "startLine" : 93,
                   "startCol" : 7,
-                  "endLine" : 86,
+                  "endLine" : 93,
                   "endCol" : 12
                 }
               },
               "span" : {
-                "startLine" : 86,
+                "startLine" : 93,
                 "startCol" : 7,
-                "endLine" : 86,
+                "endLine" : 93,
                 "endCol" : 13
               }
             },
             "span" : {
-              "startLine" : 86,
+              "startLine" : 93,
               "startCol" : 6,
-              "endLine" : 86,
+              "endLine" : 93,
               "endCol" : 13
             }
           },
@@ -1977,23 +1977,23 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 86,
+                    "startLine" : 93,
                     "startCol" : 21,
-                    "endLine" : 86,
+                    "endLine" : 93,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 86,
+                  "startLine" : 93,
                   "startCol" : 17,
-                  "endLine" : 86,
+                  "endLine" : 93,
                   "endCol" : 27
                 }
               },
               "span" : {
-                "startLine" : 86,
+                "startLine" : 93,
                 "startCol" : 16,
-                "endLine" : 86,
+                "endLine" : 93,
                 "endCol" : 27
               }
             },
@@ -2001,31 +2001,31 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 86,
+                "startLine" : 93,
                 "startCol" : 30,
-                "endLine" : 86,
+                "endLine" : 93,
                 "endCol" : 31
               }
             },
             "span" : {
-              "startLine" : 86,
+              "startLine" : 93,
               "startCol" : 16,
-              "endLine" : 86,
+              "endLine" : 93,
               "endCol" : 31
             }
           },
           "span" : {
-            "startLine" : 86,
+            "startLine" : 93,
             "startCol" : 6,
-            "endLine" : 86,
+            "endLine" : 93,
             "endCol" : 31
           }
         }
       ],
       "span" : {
-        "startLine" : 66,
+        "startLine" : 73,
         "startCol" : 2,
-        "endLine" : 87,
+        "endLine" : 94,
         "endCol" : 3
       }
     },
@@ -2040,16 +2040,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 90,
+              "startLine" : 97,
               "startCol" : 19,
-              "endLine" : 90,
+              "endLine" : 97,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 90,
+            "startLine" : 97,
             "startCol" : 12,
-            "endLine" : 90,
+            "endLine" : 97,
             "endCol" : 24
           }
         },
@@ -2060,16 +2060,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 90,
+              "startLine" : 97,
               "startCol" : 36,
-              "endLine" : 90,
+              "endLine" : 97,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 90,
+            "startLine" : 97,
             "startCol" : 26,
-            "endLine" : 90,
+            "endLine" : 97,
             "endCol" : 42
           }
         }
@@ -2082,16 +2082,16 @@
             "kind" : "NamedType",
             "name" : "Session",
             "span" : {
-              "startLine" : 91,
+              "startLine" : 98,
               "startCol" : 21,
-              "endLine" : 91,
+              "endLine" : 98,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 91,
+            "startLine" : 98,
             "startCol" : 12,
-            "endLine" : 91,
+            "endLine" : 98,
             "endCol" : 28
           }
         }
@@ -2104,9 +2104,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 94,
+              "startLine" : 101,
               "startCol" : 6,
-              "endLine" : 94,
+              "endLine" : 101,
               "endCol" : 11
             }
           },
@@ -2114,16 +2114,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 94,
+              "startLine" : 101,
               "startCol" : 15,
-              "endLine" : 94,
+              "endLine" : 101,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 94,
+            "startLine" : 101,
             "startCol" : 6,
-            "endLine" : 94,
+            "endLine" : 101,
             "endCol" : 28
           }
         },
@@ -2138,9 +2138,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 95,
+                  "startLine" : 102,
                   "startCol" : 6,
-                  "endLine" : 95,
+                  "endLine" : 102,
                   "endCol" : 19
                 }
               },
@@ -2148,24 +2148,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 95,
+                  "startLine" : 102,
                   "startCol" : 20,
-                  "endLine" : 95,
+                  "endLine" : 102,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 95,
+                "startLine" : 102,
                 "startCol" : 6,
-                "endLine" : 95,
+                "endLine" : 102,
                 "endCol" : 26
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 95,
+              "startLine" : 102,
               "startCol" : 6,
-              "endLine" : 95,
+              "endLine" : 102,
               "endCol" : 36
             }
           },
@@ -2173,16 +2173,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 95,
+              "startLine" : 102,
               "startCol" : 39,
-              "endLine" : 95,
+              "endLine" : 102,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 95,
+            "startLine" : 102,
             "startCol" : 6,
-            "endLine" : 95,
+            "endLine" : 102,
             "endCol" : 43
           }
         },
@@ -2197,9 +2197,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 96,
+                  "startLine" : 103,
                   "startCol" : 6,
-                  "endLine" : 96,
+                  "endLine" : 103,
                   "endCol" : 19
                 }
               },
@@ -2207,24 +2207,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 96,
+                  "startLine" : 103,
                   "startCol" : 20,
-                  "endLine" : 96,
+                  "endLine" : 103,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 96,
+                "startLine" : 103,
                 "startCol" : 6,
-                "endLine" : 96,
+                "endLine" : 103,
                 "endCol" : 26
               }
             },
             "field" : "password_hash",
             "span" : {
-              "startLine" : 96,
+              "startLine" : 103,
               "startCol" : 6,
-              "endLine" : 96,
+              "endLine" : 103,
               "endCol" : 40
             }
           },
@@ -2234,9 +2234,9 @@
               "kind" : "Identifier",
               "name" : "hash",
               "span" : {
-                "startLine" : 96,
+                "startLine" : 103,
                 "startCol" : 43,
-                "endLine" : 96,
+                "endLine" : 103,
                 "endCol" : 47
               }
             },
@@ -2245,24 +2245,24 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 96,
+                  "startLine" : 103,
                   "startCol" : 48,
-                  "endLine" : 96,
+                  "endLine" : 103,
                   "endCol" : 56
                 }
               }
             ],
             "span" : {
-              "startLine" : 96,
+              "startLine" : 103,
               "startCol" : 43,
-              "endLine" : 96,
+              "endLine" : 103,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 96,
+            "startLine" : 103,
             "startCol" : 6,
-            "endLine" : 96,
+            "endLine" : 103,
             "endCol" : 57
           }
         },
@@ -2275,9 +2275,9 @@
               "kind" : "Identifier",
               "name" : "recentFailedAttempts",
               "span" : {
-                "startLine" : 97,
+                "startLine" : 104,
                 "startCol" : 6,
-                "endLine" : 97,
+                "endLine" : 104,
                 "endCol" : 26
               }
             },
@@ -2286,17 +2286,17 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 97,
+                  "startLine" : 104,
                   "startCol" : 27,
-                  "endLine" : 97,
+                  "endLine" : 104,
                   "endCol" : 32
                 }
               }
             ],
             "span" : {
-              "startLine" : 97,
+              "startLine" : 104,
               "startCol" : 6,
-              "endLine" : 97,
+              "endLine" : 104,
               "endCol" : 33
             }
           },
@@ -2304,16 +2304,16 @@
             "kind" : "IntLit",
             "value" : 5,
             "span" : {
-              "startLine" : 97,
+              "startLine" : 104,
               "startCol" : 36,
-              "endLine" : 97,
+              "endLine" : 104,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 97,
+            "startLine" : 104,
             "startCol" : 6,
-            "endLine" : 97,
+            "endLine" : 104,
             "endCol" : 37
           }
         }
@@ -2328,9 +2328,9 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 100,
+                "startLine" : 107,
                 "startCol" : 17,
-                "endLine" : 100,
+                "endLine" : 107,
                 "endCol" : 30
               }
             },
@@ -2338,16 +2338,16 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 100,
+                "startLine" : 107,
                 "startCol" : 31,
-                "endLine" : 100,
+                "endLine" : 107,
                 "endCol" : 36
               }
             },
             "span" : {
-              "startLine" : 100,
+              "startLine" : 107,
               "startCol" : 17,
-              "endLine" : 100,
+              "endLine" : 107,
               "endCol" : 37
             }
           },
@@ -2378,17 +2378,17 @@
                             "kind" : "Identifier",
                             "name" : "session",
                             "span" : {
-                              "startLine" : 101,
+                              "startLine" : 108,
                               "startCol" : 8,
-                              "endLine" : 101,
+                              "endLine" : 108,
                               "endCol" : 15
                             }
                           },
                           "field" : "user_id",
                           "span" : {
-                            "startLine" : 101,
+                            "startLine" : 108,
                             "startCol" : 8,
-                            "endLine" : 101,
+                            "endLine" : 108,
                             "endCol" : 23
                           }
                         },
@@ -2398,24 +2398,24 @@
                             "kind" : "Identifier",
                             "name" : "user",
                             "span" : {
-                              "startLine" : 101,
+                              "startLine" : 108,
                               "startCol" : 26,
-                              "endLine" : 101,
+                              "endLine" : 108,
                               "endCol" : 30
                             }
                           },
                           "field" : "id",
                           "span" : {
-                            "startLine" : 101,
+                            "startLine" : 108,
                             "startCol" : 26,
-                            "endLine" : 101,
+                            "endLine" : 108,
                             "endCol" : 33
                           }
                         },
                         "span" : {
-                          "startLine" : 101,
+                          "startLine" : 108,
                           "startCol" : 8,
-                          "endLine" : 101,
+                          "endLine" : 108,
                           "endCol" : 33
                         }
                       },
@@ -2428,17 +2428,17 @@
                             "kind" : "Identifier",
                             "name" : "session",
                             "span" : {
-                              "startLine" : 102,
+                              "startLine" : 109,
                               "startCol" : 12,
-                              "endLine" : 102,
+                              "endLine" : 109,
                               "endCol" : 19
                             }
                           },
                           "field" : "is_revoked",
                           "span" : {
-                            "startLine" : 102,
+                            "startLine" : 109,
                             "startCol" : 12,
-                            "endLine" : 102,
+                            "endLine" : 109,
                             "endCol" : 30
                           }
                         },
@@ -2446,23 +2446,23 @@
                           "kind" : "BoolLit",
                           "value" : false,
                           "span" : {
-                            "startLine" : 102,
+                            "startLine" : 109,
                             "startCol" : 33,
-                            "endLine" : 102,
+                            "endLine" : 109,
                             "endCol" : 38
                           }
                         },
                         "span" : {
-                          "startLine" : 102,
+                          "startLine" : 109,
                           "startCol" : 12,
-                          "endLine" : 102,
+                          "endLine" : 109,
                           "endCol" : 38
                         }
                       },
                       "span" : {
-                        "startLine" : 101,
+                        "startLine" : 108,
                         "startCol" : 8,
-                        "endLine" : 102,
+                        "endLine" : 109,
                         "endCol" : 38
                       }
                     },
@@ -2475,17 +2475,17 @@
                           "kind" : "Identifier",
                           "name" : "session",
                           "span" : {
-                            "startLine" : 103,
+                            "startLine" : 110,
                             "startCol" : 12,
-                            "endLine" : 103,
+                            "endLine" : 110,
                             "endCol" : 19
                           }
                         },
                         "field" : "access_expires_at",
                         "span" : {
-                          "startLine" : 103,
+                          "startLine" : 110,
                           "startCol" : 12,
-                          "endLine" : 103,
+                          "endLine" : 110,
                           "endCol" : 37
                         }
                       },
@@ -2495,32 +2495,32 @@
                           "kind" : "Identifier",
                           "name" : "now",
                           "span" : {
-                            "startLine" : 103,
+                            "startLine" : 110,
                             "startCol" : 40,
-                            "endLine" : 103,
+                            "endLine" : 110,
                             "endCol" : 43
                           }
                         },
                         "args" : [
                         ],
                         "span" : {
-                          "startLine" : 103,
+                          "startLine" : 110,
                           "startCol" : 40,
-                          "endLine" : 103,
+                          "endLine" : 110,
                           "endCol" : 45
                         }
                       },
                       "span" : {
-                        "startLine" : 103,
+                        "startLine" : 110,
                         "startCol" : 12,
-                        "endLine" : 103,
+                        "endLine" : 110,
                         "endCol" : 45
                       }
                     },
                     "span" : {
-                      "startLine" : 101,
+                      "startLine" : 108,
                       "startCol" : 8,
-                      "endLine" : 103,
+                      "endLine" : 110,
                       "endCol" : 45
                     }
                   },
@@ -2533,17 +2533,17 @@
                         "kind" : "Identifier",
                         "name" : "session",
                         "span" : {
-                          "startLine" : 104,
+                          "startLine" : 111,
                           "startCol" : 12,
-                          "endLine" : 104,
+                          "endLine" : 111,
                           "endCol" : 19
                         }
                       },
                       "field" : "refresh_expires_at",
                       "span" : {
-                        "startLine" : 104,
+                        "startLine" : 111,
                         "startCol" : 12,
-                        "endLine" : 104,
+                        "endLine" : 111,
                         "endCol" : 38
                       }
                     },
@@ -2553,31 +2553,31 @@
                         "kind" : "Identifier",
                         "name" : "session",
                         "span" : {
-                          "startLine" : 104,
+                          "startLine" : 111,
                           "startCol" : 41,
-                          "endLine" : 104,
+                          "endLine" : 111,
                           "endCol" : 48
                         }
                       },
                       "field" : "access_expires_at",
                       "span" : {
-                        "startLine" : 104,
+                        "startLine" : 111,
                         "startCol" : 41,
-                        "endLine" : 104,
+                        "endLine" : 111,
                         "endCol" : 66
                       }
                     },
                     "span" : {
-                      "startLine" : 104,
+                      "startLine" : 111,
                       "startCol" : 12,
-                      "endLine" : 104,
+                      "endLine" : 111,
                       "endCol" : 66
                     }
                   },
                   "span" : {
-                    "startLine" : 101,
+                    "startLine" : 108,
                     "startCol" : 8,
-                    "endLine" : 104,
+                    "endLine" : 111,
                     "endCol" : 66
                   }
                 },
@@ -2590,16 +2590,16 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 105,
+                        "startLine" : 112,
                         "startCol" : 12,
-                        "endLine" : 105,
+                        "endLine" : 112,
                         "endCol" : 20
                       }
                     },
                     "span" : {
-                      "startLine" : 105,
+                      "startLine" : 112,
                       "startCol" : 12,
-                      "endLine" : 105,
+                      "endLine" : 112,
                       "endCol" : 21
                     }
                   },
@@ -2612,16 +2612,16 @@
                         "kind" : "Identifier",
                         "name" : "sessions",
                         "span" : {
-                          "startLine" : 105,
+                          "startLine" : 112,
                           "startCol" : 28,
-                          "endLine" : 105,
+                          "endLine" : 112,
                           "endCol" : 36
                         }
                       },
                       "span" : {
-                        "startLine" : 105,
+                        "startLine" : 112,
                         "startCol" : 24,
-                        "endLine" : 105,
+                        "endLine" : 112,
                         "endCol" : 37
                       }
                     },
@@ -2635,17 +2635,17 @@
                               "kind" : "Identifier",
                               "name" : "session",
                               "span" : {
-                                "startLine" : 105,
+                                "startLine" : 112,
                                 "startCol" : 41,
-                                "endLine" : 105,
+                                "endLine" : 112,
                                 "endCol" : 48
                               }
                             },
                             "field" : "id",
                             "span" : {
-                              "startLine" : 105,
+                              "startLine" : 112,
                               "startCol" : 41,
-                              "endLine" : 105,
+                              "endLine" : 112,
                               "endCol" : 51
                             }
                           },
@@ -2653,45 +2653,45 @@
                             "kind" : "Identifier",
                             "name" : "session",
                             "span" : {
-                              "startLine" : 105,
+                              "startLine" : 112,
                               "startCol" : 55,
-                              "endLine" : 105,
+                              "endLine" : 112,
                               "endCol" : 62
                             }
                           },
                           "span" : {
-                            "startLine" : 105,
+                            "startLine" : 112,
                             "startCol" : 41,
-                            "endLine" : 105,
+                            "endLine" : 112,
                             "endCol" : 51
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 105,
+                        "startLine" : 112,
                         "startCol" : 40,
-                        "endLine" : 105,
+                        "endLine" : 112,
                         "endCol" : 63
                       }
                     },
                     "span" : {
-                      "startLine" : 105,
+                      "startLine" : 112,
                       "startCol" : 24,
-                      "endLine" : 105,
+                      "endLine" : 112,
                       "endCol" : 63
                     }
                   },
                   "span" : {
-                    "startLine" : 105,
+                    "startLine" : 112,
                     "startCol" : 12,
-                    "endLine" : 105,
+                    "endLine" : 112,
                     "endCol" : 63
                   }
                 },
                 "span" : {
-                  "startLine" : 101,
+                  "startLine" : 108,
                   "startCol" : 8,
-                  "endLine" : 105,
+                  "endLine" : 112,
                   "endCol" : 63
                 }
               },
@@ -2708,16 +2708,16 @@
                         "kind" : "Identifier",
                         "name" : "users",
                         "span" : {
-                          "startLine" : 106,
+                          "startLine" : 113,
                           "startCol" : 12,
-                          "endLine" : 106,
+                          "endLine" : 113,
                           "endCol" : 17
                         }
                       },
                       "span" : {
-                        "startLine" : 106,
+                        "startLine" : 113,
                         "startCol" : 12,
-                        "endLine" : 106,
+                        "endLine" : 113,
                         "endCol" : 18
                       }
                     },
@@ -2727,32 +2727,32 @@
                         "kind" : "Identifier",
                         "name" : "user",
                         "span" : {
-                          "startLine" : 106,
+                          "startLine" : 113,
                           "startCol" : 19,
-                          "endLine" : 106,
+                          "endLine" : 113,
                           "endCol" : 23
                         }
                       },
                       "field" : "id",
                       "span" : {
-                        "startLine" : 106,
+                        "startLine" : 113,
                         "startCol" : 19,
-                        "endLine" : 106,
+                        "endLine" : 113,
                         "endCol" : 26
                       }
                     },
                     "span" : {
-                      "startLine" : 106,
+                      "startLine" : 113,
                       "startCol" : 12,
-                      "endLine" : 106,
+                      "endLine" : 113,
                       "endCol" : 27
                     }
                   },
                   "field" : "last_login",
                   "span" : {
-                    "startLine" : 106,
+                    "startLine" : 113,
                     "startCol" : 12,
-                    "endLine" : 106,
+                    "endLine" : 113,
                     "endCol" : 38
                   }
                 },
@@ -2764,39 +2764,39 @@
                       "kind" : "Identifier",
                       "name" : "now",
                       "span" : {
-                        "startLine" : 106,
+                        "startLine" : 113,
                         "startCol" : 46,
-                        "endLine" : 106,
+                        "endLine" : 113,
                         "endCol" : 49
                       }
                     },
                     "args" : [
                     ],
                     "span" : {
-                      "startLine" : 106,
+                      "startLine" : 113,
                       "startCol" : 46,
-                      "endLine" : 106,
+                      "endLine" : 113,
                       "endCol" : 51
                     }
                   },
                   "span" : {
-                    "startLine" : 106,
+                    "startLine" : 113,
                     "startCol" : 41,
-                    "endLine" : 106,
+                    "endLine" : 113,
                     "endCol" : 52
                   }
                 },
                 "span" : {
-                  "startLine" : 106,
+                  "startLine" : 113,
                   "startCol" : 12,
-                  "endLine" : 106,
+                  "endLine" : 113,
                   "endCol" : 52
                 }
               },
               "span" : {
-                "startLine" : 101,
+                "startLine" : 108,
                 "startCol" : 8,
-                "endLine" : 106,
+                "endLine" : 113,
                 "endCol" : 52
               }
             },
@@ -2809,16 +2809,16 @@
                   "kind" : "Identifier",
                   "name" : "login_attempts",
                   "span" : {
-                    "startLine" : 107,
+                    "startLine" : 114,
                     "startCol" : 12,
-                    "endLine" : 107,
+                    "endLine" : 114,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 107,
+                  "startLine" : 114,
                   "startCol" : 12,
-                  "endLine" : 107,
+                  "endLine" : 114,
                   "endCol" : 27
                 }
               },
@@ -2831,16 +2831,16 @@
                     "kind" : "Identifier",
                     "name" : "login_attempts",
                     "span" : {
-                      "startLine" : 107,
+                      "startLine" : 114,
                       "startCol" : 34,
-                      "endLine" : 107,
+                      "endLine" : 114,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 107,
+                    "startLine" : 114,
                     "startCol" : 30,
-                    "endLine" : 107,
+                    "endLine" : 114,
                     "endCol" : 49
                   }
                 },
@@ -2857,16 +2857,16 @@
                             "kind" : "Identifier",
                             "name" : "email",
                             "span" : {
-                              "startLine" : 108,
+                              "startLine" : 115,
                               "startCol" : 39,
-                              "endLine" : 108,
+                              "endLine" : 115,
                               "endCol" : 44
                             }
                           },
                           "span" : {
-                            "startLine" : 108,
+                            "startLine" : 115,
                             "startCol" : 31,
-                            "endLine" : 108,
+                            "endLine" : 115,
                             "endCol" : 44
                           }
                         },
@@ -2878,25 +2878,25 @@
                               "kind" : "Identifier",
                               "name" : "now",
                               "span" : {
-                                "startLine" : 109,
+                                "startLine" : 116,
                                 "startCol" : 43,
-                                "endLine" : 109,
+                                "endLine" : 116,
                                 "endCol" : 46
                               }
                             },
                             "args" : [
                             ],
                             "span" : {
-                              "startLine" : 109,
+                              "startLine" : 116,
                               "startCol" : 43,
-                              "endLine" : 109,
+                              "endLine" : 116,
                               "endCol" : 48
                             }
                           },
                           "span" : {
-                            "startLine" : 109,
+                            "startLine" : 116,
                             "startCol" : 31,
-                            "endLine" : 109,
+                            "endLine" : 116,
                             "endCol" : 48
                           }
                         },
@@ -2906,68 +2906,68 @@
                             "kind" : "BoolLit",
                             "value" : true,
                             "span" : {
-                              "startLine" : 110,
+                              "startLine" : 117,
                               "startCol" : 41,
-                              "endLine" : 110,
+                              "endLine" : 117,
                               "endCol" : 45
                             }
                           },
                           "span" : {
-                            "startLine" : 110,
+                            "startLine" : 117,
                             "startCol" : 31,
-                            "endLine" : 110,
+                            "endLine" : 117,
                             "endCol" : 45
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 108,
+                        "startLine" : 115,
                         "startCol" : 16,
-                        "endLine" : 110,
+                        "endLine" : 117,
                         "endCol" : 47
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 108,
+                    "startLine" : 115,
                     "startCol" : 15,
-                    "endLine" : 110,
+                    "endLine" : 117,
                     "endCol" : 48
                   }
                 },
                 "span" : {
-                  "startLine" : 107,
+                  "startLine" : 114,
                   "startCol" : 30,
-                  "endLine" : 110,
+                  "endLine" : 117,
                   "endCol" : 48
                 }
               },
               "span" : {
-                "startLine" : 107,
+                "startLine" : 114,
                 "startCol" : 12,
-                "endLine" : 110,
+                "endLine" : 117,
                 "endCol" : 48
               }
             },
             "span" : {
-              "startLine" : 101,
+              "startLine" : 108,
               "startCol" : 8,
-              "endLine" : 110,
+              "endLine" : 117,
               "endCol" : 48
             }
           },
           "span" : {
-            "startLine" : 100,
+            "startLine" : 107,
             "startCol" : 6,
-            "endLine" : 110,
+            "endLine" : 117,
             "endCol" : 48
           }
         }
       ],
       "span" : {
-        "startLine" : 89,
+        "startLine" : 96,
         "startCol" : 2,
-        "endLine" : 111,
+        "endLine" : 118,
         "endCol" : 3
       }
     },
@@ -2982,16 +2982,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 114,
+              "startLine" : 121,
               "startCol" : 18,
-              "endLine" : 114,
+              "endLine" : 121,
               "endCol" : 23
             }
           },
           "span" : {
-            "startLine" : 114,
+            "startLine" : 121,
             "startCol" : 11,
-            "endLine" : 114,
+            "endLine" : 121,
             "endCol" : 23
           }
         },
@@ -3002,16 +3002,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 114,
+              "startLine" : 121,
               "startCol" : 35,
-              "endLine" : 114,
+              "endLine" : 121,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 114,
+            "startLine" : 121,
             "startCol" : 25,
-            "endLine" : 114,
+            "endLine" : 121,
             "endCol" : 41
           }
         }
@@ -3026,9 +3026,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 117,
+              "startLine" : 124,
               "startCol" : 6,
-              "endLine" : 117,
+              "endLine" : 124,
               "endCol" : 11
             }
           },
@@ -3036,16 +3036,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 117,
+              "startLine" : 124,
               "startCol" : 15,
-              "endLine" : 117,
+              "endLine" : 124,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 117,
+            "startLine" : 124,
             "startCol" : 6,
-            "endLine" : 117,
+            "endLine" : 124,
             "endCol" : 28
           }
         },
@@ -3060,9 +3060,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 118,
+                  "startLine" : 125,
                   "startCol" : 6,
-                  "endLine" : 118,
+                  "endLine" : 125,
                   "endCol" : 19
                 }
               },
@@ -3070,24 +3070,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 118,
+                  "startLine" : 125,
                   "startCol" : 20,
-                  "endLine" : 118,
+                  "endLine" : 125,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 118,
+                "startLine" : 125,
                 "startCol" : 6,
-                "endLine" : 118,
+                "endLine" : 125,
                 "endCol" : 26
               }
             },
             "field" : "password_hash",
             "span" : {
-              "startLine" : 118,
+              "startLine" : 125,
               "startCol" : 6,
-              "endLine" : 118,
+              "endLine" : 125,
               "endCol" : 40
             }
           },
@@ -3097,9 +3097,9 @@
               "kind" : "Identifier",
               "name" : "hash",
               "span" : {
-                "startLine" : 118,
+                "startLine" : 125,
                 "startCol" : 44,
-                "endLine" : 118,
+                "endLine" : 125,
                 "endCol" : 48
               }
             },
@@ -3108,24 +3108,24 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 118,
+                  "startLine" : 125,
                   "startCol" : 49,
-                  "endLine" : 118,
+                  "endLine" : 125,
                   "endCol" : 57
                 }
               }
             ],
             "span" : {
-              "startLine" : 118,
+              "startLine" : 125,
               "startCol" : 44,
-              "endLine" : 118,
+              "endLine" : 125,
               "endCol" : 58
             }
           },
           "span" : {
-            "startLine" : 118,
+            "startLine" : 125,
             "startCol" : 6,
-            "endLine" : 118,
+            "endLine" : 125,
             "endCol" : 58
           }
         }
@@ -3140,16 +3140,16 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 121,
+                "startLine" : 128,
                 "startCol" : 6,
-                "endLine" : 121,
+                "endLine" : 128,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 121,
+              "startLine" : 128,
               "startCol" : 6,
-              "endLine" : 121,
+              "endLine" : 128,
               "endCol" : 15
             }
           },
@@ -3157,16 +3157,16 @@
             "kind" : "Identifier",
             "name" : "sessions",
             "span" : {
-              "startLine" : 121,
+              "startLine" : 128,
               "startCol" : 18,
-              "endLine" : 121,
+              "endLine" : 128,
               "endCol" : 26
             }
           },
           "span" : {
-            "startLine" : 121,
+            "startLine" : 128,
             "startCol" : 6,
-            "endLine" : 121,
+            "endLine" : 128,
             "endCol" : 26
           }
         },
@@ -3179,16 +3179,16 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 122,
+                "startLine" : 129,
                 "startCol" : 6,
-                "endLine" : 122,
+                "endLine" : 129,
                 "endCol" : 11
               }
             },
             "span" : {
-              "startLine" : 122,
+              "startLine" : 129,
               "startCol" : 6,
-              "endLine" : 122,
+              "endLine" : 129,
               "endCol" : 12
             }
           },
@@ -3196,16 +3196,16 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 122,
+              "startLine" : 129,
               "startCol" : 15,
-              "endLine" : 122,
+              "endLine" : 129,
               "endCol" : 20
             }
           },
           "span" : {
-            "startLine" : 122,
+            "startLine" : 129,
             "startCol" : 6,
-            "endLine" : 122,
+            "endLine" : 129,
             "endCol" : 20
           }
         },
@@ -3218,16 +3218,16 @@
               "kind" : "Identifier",
               "name" : "login_attempts",
               "span" : {
-                "startLine" : 123,
+                "startLine" : 130,
                 "startCol" : 6,
-                "endLine" : 123,
+                "endLine" : 130,
                 "endCol" : 20
               }
             },
             "span" : {
-              "startLine" : 123,
+              "startLine" : 130,
               "startCol" : 6,
-              "endLine" : 123,
+              "endLine" : 130,
               "endCol" : 21
             }
           },
@@ -3240,16 +3240,16 @@
                 "kind" : "Identifier",
                 "name" : "login_attempts",
                 "span" : {
-                  "startLine" : 123,
+                  "startLine" : 130,
                   "startCol" : 28,
-                  "endLine" : 123,
+                  "endLine" : 130,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 123,
+                "startLine" : 130,
                 "startCol" : 24,
-                "endLine" : 123,
+                "endLine" : 130,
                 "endCol" : 43
               }
             },
@@ -3266,16 +3266,16 @@
                         "kind" : "Identifier",
                         "name" : "email",
                         "span" : {
-                          "startLine" : 124,
+                          "startLine" : 131,
                           "startCol" : 34,
-                          "endLine" : 124,
+                          "endLine" : 131,
                           "endCol" : 39
                         }
                       },
                       "span" : {
-                        "startLine" : 124,
+                        "startLine" : 131,
                         "startCol" : 26,
-                        "endLine" : 124,
+                        "endLine" : 131,
                         "endCol" : 39
                       }
                     },
@@ -3287,25 +3287,25 @@
                           "kind" : "Identifier",
                           "name" : "now",
                           "span" : {
-                            "startLine" : 125,
+                            "startLine" : 132,
                             "startCol" : 38,
-                            "endLine" : 125,
+                            "endLine" : 132,
                             "endCol" : 41
                           }
                         },
                         "args" : [
                         ],
                         "span" : {
-                          "startLine" : 125,
+                          "startLine" : 132,
                           "startCol" : 38,
-                          "endLine" : 125,
+                          "endLine" : 132,
                           "endCol" : 43
                         }
                       },
                       "span" : {
-                        "startLine" : 125,
+                        "startLine" : 132,
                         "startCol" : 26,
-                        "endLine" : 125,
+                        "endLine" : 132,
                         "endCol" : 43
                       }
                     },
@@ -3315,54 +3315,54 @@
                         "kind" : "BoolLit",
                         "value" : false,
                         "span" : {
-                          "startLine" : 126,
+                          "startLine" : 133,
                           "startCol" : 36,
-                          "endLine" : 126,
+                          "endLine" : 133,
                           "endCol" : 41
                         }
                       },
                       "span" : {
-                        "startLine" : 126,
+                        "startLine" : 133,
                         "startCol" : 26,
-                        "endLine" : 126,
+                        "endLine" : 133,
                         "endCol" : 41
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 124,
+                    "startLine" : 131,
                     "startCol" : 11,
-                    "endLine" : 126,
+                    "endLine" : 133,
                     "endCol" : 43
                   }
                 }
               ],
               "span" : {
-                "startLine" : 124,
+                "startLine" : 131,
                 "startCol" : 10,
-                "endLine" : 126,
+                "endLine" : 133,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 123,
+              "startLine" : 130,
               "startCol" : 24,
-              "endLine" : 126,
+              "endLine" : 133,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 123,
+            "startLine" : 130,
             "startCol" : 6,
-            "endLine" : 126,
+            "endLine" : 133,
             "endCol" : 44
           }
         }
       ],
       "span" : {
-        "startLine" : 113,
+        "startLine" : 120,
         "startCol" : 2,
-        "endLine" : 127,
+        "endLine" : 134,
         "endCol" : 3
       }
     },
@@ -3377,16 +3377,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 130,
+              "startLine" : 137,
               "startCol" : 27,
-              "endLine" : 130,
+              "endLine" : 137,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 130,
+            "startLine" : 137,
             "startCol" : 12,
-            "endLine" : 130,
+            "endLine" : 137,
             "endCol" : 32
           }
         }
@@ -3399,16 +3399,16 @@
             "kind" : "NamedType",
             "name" : "Session",
             "span" : {
-              "startLine" : 131,
+              "startLine" : 138,
               "startCol" : 25,
-              "endLine" : 131,
+              "endLine" : 138,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 131,
+            "startLine" : 138,
             "startCol" : 12,
-            "endLine" : 131,
+            "endLine" : 138,
             "endCol" : 32
           }
         }
@@ -3424,17 +3424,17 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 134,
+                  "startLine" : 142,
                   "startCol" : 16,
-                  "endLine" : 134,
+                  "endLine" : 142,
                   "endCol" : 24
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 134,
+                "startLine" : 142,
                 "startCol" : 11,
-                "endLine" : 134,
+                "endLine" : 142,
                 "endCol" : 24
               }
             }
@@ -3456,9 +3456,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 135,
+                        "startLine" : 143,
                         "startCol" : 8,
-                        "endLine" : 135,
+                        "endLine" : 143,
                         "endCol" : 16
                       }
                     },
@@ -3466,24 +3466,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 135,
+                        "startLine" : 143,
                         "startCol" : 17,
-                        "endLine" : 135,
+                        "endLine" : 143,
                         "endCol" : 18
                       }
                     },
                     "span" : {
-                      "startLine" : 135,
+                      "startLine" : 143,
                       "startCol" : 8,
-                      "endLine" : 135,
+                      "endLine" : 143,
                       "endCol" : 19
                     }
                   },
                   "field" : "refresh_token",
                   "span" : {
-                    "startLine" : 135,
+                    "startLine" : 143,
                     "startCol" : 8,
-                    "endLine" : 135,
+                    "endLine" : 143,
                     "endCol" : 33
                   }
                 },
@@ -3491,16 +3491,16 @@
                   "kind" : "Identifier",
                   "name" : "refresh_token",
                   "span" : {
-                    "startLine" : 135,
+                    "startLine" : 143,
                     "startCol" : 36,
-                    "endLine" : 135,
+                    "endLine" : 143,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 135,
+                  "startLine" : 143,
                   "startCol" : 8,
-                  "endLine" : 135,
+                  "endLine" : 143,
                   "endCol" : 49
                 }
               },
@@ -3515,9 +3515,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 136,
+                        "startLine" : 144,
                         "startCol" : 12,
-                        "endLine" : 136,
+                        "endLine" : 144,
                         "endCol" : 20
                       }
                     },
@@ -3525,24 +3525,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 136,
+                        "startLine" : 144,
                         "startCol" : 21,
-                        "endLine" : 136,
+                        "endLine" : 144,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 136,
+                      "startLine" : 144,
                       "startCol" : 12,
-                      "endLine" : 136,
+                      "endLine" : 144,
                       "endCol" : 23
                     }
                   },
                   "field" : "is_revoked",
                   "span" : {
-                    "startLine" : 136,
+                    "startLine" : 144,
                     "startCol" : 12,
-                    "endLine" : 136,
+                    "endLine" : 144,
                     "endCol" : 34
                   }
                 },
@@ -3550,23 +3550,23 @@
                   "kind" : "BoolLit",
                   "value" : false,
                   "span" : {
-                    "startLine" : 136,
+                    "startLine" : 144,
                     "startCol" : 37,
-                    "endLine" : 136,
+                    "endLine" : 144,
                     "endCol" : 42
                   }
                 },
                 "span" : {
-                  "startLine" : 136,
+                  "startLine" : 144,
                   "startCol" : 12,
-                  "endLine" : 136,
+                  "endLine" : 144,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 135,
+                "startLine" : 143,
                 "startCol" : 8,
-                "endLine" : 136,
+                "endLine" : 144,
                 "endCol" : 42
               }
             },
@@ -3581,9 +3581,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 137,
+                      "startLine" : 145,
                       "startCol" : 12,
-                      "endLine" : 137,
+                      "endLine" : 145,
                       "endCol" : 20
                     }
                   },
@@ -3591,24 +3591,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 137,
+                      "startLine" : 145,
                       "startCol" : 21,
-                      "endLine" : 137,
+                      "endLine" : 145,
                       "endCol" : 22
                     }
                   },
                   "span" : {
-                    "startLine" : 137,
+                    "startLine" : 145,
                     "startCol" : 12,
-                    "endLine" : 137,
+                    "endLine" : 145,
                     "endCol" : 23
                   }
                 },
                 "field" : "refresh_expires_at",
                 "span" : {
-                  "startLine" : 137,
+                  "startLine" : 145,
                   "startCol" : 12,
-                  "endLine" : 137,
+                  "endLine" : 145,
                   "endCol" : 42
                 }
               },
@@ -3618,39 +3618,39 @@
                   "kind" : "Identifier",
                   "name" : "now",
                   "span" : {
-                    "startLine" : 137,
+                    "startLine" : 145,
                     "startCol" : 45,
-                    "endLine" : 137,
+                    "endLine" : 145,
                     "endCol" : 48
                   }
                 },
                 "args" : [
                 ],
                 "span" : {
-                  "startLine" : 137,
+                  "startLine" : 145,
                   "startCol" : 45,
-                  "endLine" : 137,
+                  "endLine" : 145,
                   "endCol" : 50
                 }
               },
               "span" : {
-                "startLine" : 137,
+                "startLine" : 145,
                 "startCol" : 12,
-                "endLine" : 137,
+                "endLine" : 145,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 135,
+              "startLine" : 143,
               "startCol" : 8,
-              "endLine" : 137,
+              "endLine" : 145,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 134,
+            "startLine" : 142,
             "startCol" : 6,
-            "endLine" : 137,
+            "endLine" : 145,
             "endCol" : 50
           }
         }
@@ -3666,9 +3666,9 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 140,
+                "startLine" : 148,
                 "startCol" : 34,
-                "endLine" : 140,
+                "endLine" : 148,
                 "endCol" : 42
               }
             },
@@ -3683,9 +3683,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 141,
+                      "startLine" : 149,
                       "startCol" : 8,
-                      "endLine" : 141,
+                      "endLine" : 149,
                       "endCol" : 16
                     }
                   },
@@ -3693,24 +3693,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 141,
+                      "startLine" : 149,
                       "startCol" : 17,
-                      "endLine" : 141,
+                      "endLine" : 149,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 141,
+                    "startLine" : 149,
                     "startCol" : 8,
-                    "endLine" : 141,
+                    "endLine" : 149,
                     "endCol" : 19
                   }
                 },
                 "field" : "refresh_token",
                 "span" : {
-                  "startLine" : 141,
+                  "startLine" : 149,
                   "startCol" : 8,
-                  "endLine" : 141,
+                  "endLine" : 149,
                   "endCol" : 33
                 }
               },
@@ -3718,23 +3718,23 @@
                 "kind" : "Identifier",
                 "name" : "refresh_token",
                 "span" : {
-                  "startLine" : 141,
+                  "startLine" : 149,
                   "startCol" : 36,
-                  "endLine" : 141,
+                  "endLine" : 149,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 141,
+                "startLine" : 149,
                 "startCol" : 8,
-                "endLine" : 141,
+                "endLine" : 149,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 140,
+              "startLine" : 148,
               "startCol" : 25,
-              "endLine" : 141,
+              "endLine" : 149,
               "endCol" : 49
             }
           },
@@ -3763,16 +3763,16 @@
                             "kind" : "Identifier",
                             "name" : "sessions",
                             "span" : {
-                              "startLine" : 142,
+                              "startLine" : 150,
                               "startCol" : 8,
-                              "endLine" : 142,
+                              "endLine" : 150,
                               "endCol" : 16
                             }
                           },
                           "span" : {
-                            "startLine" : 142,
+                            "startLine" : 150,
                             "startCol" : 8,
-                            "endLine" : 142,
+                            "endLine" : 150,
                             "endCol" : 17
                           }
                         },
@@ -3780,24 +3780,24 @@
                           "kind" : "Identifier",
                           "name" : "old_session",
                           "span" : {
-                            "startLine" : 142,
+                            "startLine" : 150,
                             "startCol" : 18,
-                            "endLine" : 142,
+                            "endLine" : 150,
                             "endCol" : 29
                           }
                         },
                         "span" : {
-                          "startLine" : 142,
+                          "startLine" : 150,
                           "startCol" : 8,
-                          "endLine" : 142,
+                          "endLine" : 150,
                           "endCol" : 30
                         }
                       },
                       "field" : "is_revoked",
                       "span" : {
-                        "startLine" : 142,
+                        "startLine" : 150,
                         "startCol" : 8,
-                        "endLine" : 142,
+                        "endLine" : 150,
                         "endCol" : 41
                       }
                     },
@@ -3805,16 +3805,16 @@
                       "kind" : "BoolLit",
                       "value" : true,
                       "span" : {
-                        "startLine" : 142,
+                        "startLine" : 150,
                         "startCol" : 44,
-                        "endLine" : 142,
+                        "endLine" : 150,
                         "endCol" : 48
                       }
                     },
                     "span" : {
-                      "startLine" : 142,
+                      "startLine" : 150,
                       "startCol" : 8,
-                      "endLine" : 142,
+                      "endLine" : 150,
                       "endCol" : 48
                     }
                   },
@@ -3827,17 +3827,17 @@
                         "kind" : "Identifier",
                         "name" : "new_session",
                         "span" : {
-                          "startLine" : 143,
+                          "startLine" : 151,
                           "startCol" : 12,
-                          "endLine" : 143,
+                          "endLine" : 151,
                           "endCol" : 23
                         }
                       },
                       "field" : "user_id",
                       "span" : {
-                        "startLine" : 143,
+                        "startLine" : 151,
                         "startCol" : 12,
-                        "endLine" : 143,
+                        "endLine" : 151,
                         "endCol" : 31
                       }
                     },
@@ -3851,16 +3851,16 @@
                             "kind" : "Identifier",
                             "name" : "sessions",
                             "span" : {
-                              "startLine" : 143,
+                              "startLine" : 151,
                               "startCol" : 38,
-                              "endLine" : 143,
+                              "endLine" : 151,
                               "endCol" : 46
                             }
                           },
                           "span" : {
-                            "startLine" : 143,
+                            "startLine" : 151,
                             "startCol" : 34,
-                            "endLine" : 143,
+                            "endLine" : 151,
                             "endCol" : 47
                           }
                         },
@@ -3868,38 +3868,38 @@
                           "kind" : "Identifier",
                           "name" : "old_session",
                           "span" : {
-                            "startLine" : 143,
+                            "startLine" : 151,
                             "startCol" : 48,
-                            "endLine" : 143,
+                            "endLine" : 151,
                             "endCol" : 59
                           }
                         },
                         "span" : {
-                          "startLine" : 143,
+                          "startLine" : 151,
                           "startCol" : 34,
-                          "endLine" : 143,
+                          "endLine" : 151,
                           "endCol" : 60
                         }
                       },
                       "field" : "user_id",
                       "span" : {
-                        "startLine" : 143,
+                        "startLine" : 151,
                         "startCol" : 34,
-                        "endLine" : 143,
+                        "endLine" : 151,
                         "endCol" : 68
                       }
                     },
                     "span" : {
-                      "startLine" : 143,
+                      "startLine" : 151,
                       "startCol" : 12,
-                      "endLine" : 143,
+                      "endLine" : 151,
                       "endCol" : 68
                     }
                   },
                   "span" : {
-                    "startLine" : 142,
+                    "startLine" : 150,
                     "startCol" : 8,
-                    "endLine" : 143,
+                    "endLine" : 151,
                     "endCol" : 68
                   }
                 },
@@ -3912,17 +3912,17 @@
                       "kind" : "Identifier",
                       "name" : "new_session",
                       "span" : {
-                        "startLine" : 144,
+                        "startLine" : 152,
                         "startCol" : 12,
-                        "endLine" : 144,
+                        "endLine" : 152,
                         "endCol" : 23
                       }
                     },
                     "field" : "is_revoked",
                     "span" : {
-                      "startLine" : 144,
+                      "startLine" : 152,
                       "startCol" : 12,
-                      "endLine" : 144,
+                      "endLine" : 152,
                       "endCol" : 34
                     }
                   },
@@ -3930,23 +3930,23 @@
                     "kind" : "BoolLit",
                     "value" : false,
                     "span" : {
-                      "startLine" : 144,
+                      "startLine" : 152,
                       "startCol" : 37,
-                      "endLine" : 144,
+                      "endLine" : 152,
                       "endCol" : 42
                     }
                   },
                   "span" : {
-                    "startLine" : 144,
+                    "startLine" : 152,
                     "startCol" : 12,
-                    "endLine" : 144,
+                    "endLine" : 152,
                     "endCol" : 42
                   }
                 },
                 "span" : {
-                  "startLine" : 142,
+                  "startLine" : 150,
                   "startCol" : 8,
-                  "endLine" : 144,
+                  "endLine" : 152,
                   "endCol" : 42
                 }
               },
@@ -3959,17 +3959,17 @@
                     "kind" : "Identifier",
                     "name" : "new_session",
                     "span" : {
-                      "startLine" : 145,
+                      "startLine" : 153,
                       "startCol" : 12,
-                      "endLine" : 145,
+                      "endLine" : 153,
                       "endCol" : 23
                     }
                   },
                   "field" : "access_expires_at",
                   "span" : {
-                    "startLine" : 145,
+                    "startLine" : 153,
                     "startCol" : 12,
-                    "endLine" : 145,
+                    "endLine" : 153,
                     "endCol" : 41
                   }
                 },
@@ -3979,32 +3979,32 @@
                     "kind" : "Identifier",
                     "name" : "now",
                     "span" : {
-                      "startLine" : 145,
+                      "startLine" : 153,
                       "startCol" : 44,
-                      "endLine" : 145,
+                      "endLine" : 153,
                       "endCol" : 47
                     }
                   },
                   "args" : [
                   ],
                   "span" : {
-                    "startLine" : 145,
+                    "startLine" : 153,
                     "startCol" : 44,
-                    "endLine" : 145,
+                    "endLine" : 153,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 145,
+                  "startLine" : 153,
                   "startCol" : 12,
-                  "endLine" : 145,
+                  "endLine" : 153,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 142,
+                "startLine" : 150,
                 "startCol" : 8,
-                "endLine" : 145,
+                "endLine" : 153,
                 "endCol" : 49
               }
             },
@@ -4017,16 +4017,16 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 146,
+                    "startLine" : 154,
                     "startCol" : 12,
-                    "endLine" : 146,
+                    "endLine" : 154,
                     "endCol" : 20
                   }
                 },
                 "span" : {
-                  "startLine" : 146,
+                  "startLine" : 154,
                   "startCol" : 12,
-                  "endLine" : 146,
+                  "endLine" : 154,
                   "endCol" : 21
                 }
               },
@@ -4042,16 +4042,16 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 146,
+                        "startLine" : 154,
                         "startCol" : 28,
-                        "endLine" : 146,
+                        "endLine" : 154,
                         "endCol" : 36
                       }
                     },
                     "span" : {
-                      "startLine" : 146,
+                      "startLine" : 154,
                       "startCol" : 24,
-                      "endLine" : 146,
+                      "endLine" : 154,
                       "endCol" : 37
                     }
                   },
@@ -4063,9 +4063,9 @@
                           "kind" : "Identifier",
                           "name" : "old_session",
                           "span" : {
-                            "startLine" : 147,
+                            "startLine" : 155,
                             "startCol" : 16,
-                            "endLine" : 147,
+                            "endLine" : 155,
                             "endCol" : 27
                           }
                         },
@@ -4079,16 +4079,16 @@
                                 "kind" : "Identifier",
                                 "name" : "sessions",
                                 "span" : {
-                                  "startLine" : 147,
+                                  "startLine" : 155,
                                   "startCol" : 35,
-                                  "endLine" : 147,
+                                  "endLine" : 155,
                                   "endCol" : 43
                                 }
                               },
                               "span" : {
-                                "startLine" : 147,
+                                "startLine" : 155,
                                 "startCol" : 31,
-                                "endLine" : 147,
+                                "endLine" : 155,
                                 "endCol" : 44
                               }
                             },
@@ -4096,16 +4096,16 @@
                               "kind" : "Identifier",
                               "name" : "old_session",
                               "span" : {
-                                "startLine" : 147,
+                                "startLine" : 155,
                                 "startCol" : 45,
-                                "endLine" : 147,
+                                "endLine" : 155,
                                 "endCol" : 56
                               }
                             },
                             "span" : {
-                              "startLine" : 147,
+                              "startLine" : 155,
                               "startCol" : 31,
-                              "endLine" : 147,
+                              "endLine" : 155,
                               "endCol" : 57
                             }
                           },
@@ -4116,46 +4116,46 @@
                                 "kind" : "BoolLit",
                                 "value" : true,
                                 "span" : {
-                                  "startLine" : 148,
+                                  "startLine" : 156,
                                   "startCol" : 38,
-                                  "endLine" : 148,
+                                  "endLine" : 156,
                                   "endCol" : 42
                                 }
                               },
                               "span" : {
-                                "startLine" : 148,
+                                "startLine" : 156,
                                 "startCol" : 25,
-                                "endLine" : 148,
+                                "endLine" : 156,
                                 "endCol" : 42
                               }
                             }
                           ],
                           "span" : {
-                            "startLine" : 147,
+                            "startLine" : 155,
                             "startCol" : 31,
-                            "endLine" : 148,
+                            "endLine" : 156,
                             "endCol" : 44
                           }
                         },
                         "span" : {
-                          "startLine" : 147,
+                          "startLine" : 155,
                           "startCol" : 16,
-                          "endLine" : 147,
+                          "endLine" : 155,
                           "endCol" : 27
                         }
                       }
                     ],
                     "span" : {
-                      "startLine" : 147,
+                      "startLine" : 155,
                       "startCol" : 15,
-                      "endLine" : 148,
+                      "endLine" : 156,
                       "endCol" : 45
                     }
                   },
                   "span" : {
-                    "startLine" : 146,
+                    "startLine" : 154,
                     "startCol" : 24,
-                    "endLine" : 148,
+                    "endLine" : 156,
                     "endCol" : 45
                   }
                 },
@@ -4169,17 +4169,17 @@
                           "kind" : "Identifier",
                           "name" : "new_session",
                           "span" : {
-                            "startLine" : 149,
+                            "startLine" : 157,
                             "startCol" : 16,
-                            "endLine" : 149,
+                            "endLine" : 157,
                             "endCol" : 27
                           }
                         },
                         "field" : "id",
                         "span" : {
-                          "startLine" : 149,
+                          "startLine" : 157,
                           "startCol" : 16,
-                          "endLine" : 149,
+                          "endLine" : 157,
                           "endCol" : 30
                         }
                       },
@@ -4187,60 +4187,64 @@
                         "kind" : "Identifier",
                         "name" : "new_session",
                         "span" : {
-                          "startLine" : 149,
+                          "startLine" : 157,
                           "startCol" : 34,
-                          "endLine" : 149,
+                          "endLine" : 157,
                           "endCol" : 45
                         }
                       },
                       "span" : {
-                        "startLine" : 149,
+                        "startLine" : 157,
                         "startCol" : 16,
-                        "endLine" : 149,
+                        "endLine" : 157,
                         "endCol" : 30
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 149,
+                    "startLine" : 157,
                     "startCol" : 15,
-                    "endLine" : 149,
+                    "endLine" : 157,
                     "endCol" : 46
                   }
                 },
                 "span" : {
-                  "startLine" : 146,
+                  "startLine" : 154,
                   "startCol" : 24,
-                  "endLine" : 149,
+                  "endLine" : 157,
                   "endCol" : 46
                 }
               },
               "span" : {
-                "startLine" : 146,
+                "startLine" : 154,
                 "startCol" : 12,
-                "endLine" : 149,
+                "endLine" : 157,
                 "endCol" : 46
               }
             },
             "span" : {
-              "startLine" : 142,
+              "startLine" : 150,
               "startCol" : 8,
-              "endLine" : 149,
+              "endLine" : 157,
               "endCol" : 46
             }
           },
           "span" : {
-            "startLine" : 140,
+            "startLine" : 148,
             "startCol" : 6,
-            "endLine" : 149,
+            "endLine" : 157,
             "endCol" : 46
           }
         }
       ],
+      "requiresAuth" : [
+        "bearer",
+        "api_key"
+      ],
       "span" : {
-        "startLine" : 129,
+        "startLine" : 136,
         "startCol" : 2,
-        "endLine" : 150,
+        "endLine" : 158,
         "endCol" : 3
       }
     },
@@ -4255,16 +4259,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 153,
+              "startLine" : 161,
               "startCol" : 19,
-              "endLine" : 153,
+              "endLine" : 161,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 153,
+            "startLine" : 161,
             "startCol" : 12,
-            "endLine" : 153,
+            "endLine" : 161,
             "endCol" : 24
           }
         }
@@ -4277,16 +4281,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 154,
+              "startLine" : 162,
               "startCol" : 25,
-              "endLine" : 154,
+              "endLine" : 162,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 154,
+            "startLine" : 162,
             "startCol" : 12,
-            "endLine" : 154,
+            "endLine" : 162,
             "endCol" : 30
           }
         }
@@ -4299,9 +4303,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 157,
+              "startLine" : 165,
               "startCol" : 6,
-              "endLine" : 157,
+              "endLine" : 165,
               "endCol" : 11
             }
           },
@@ -4309,16 +4313,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 157,
+              "startLine" : 165,
               "startCol" : 15,
-              "endLine" : 157,
+              "endLine" : 165,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 157,
+            "startLine" : 165,
             "startCol" : 6,
-            "endLine" : 157,
+            "endLine" : 165,
             "endCol" : 28
           }
         },
@@ -4333,9 +4337,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 158,
+                  "startLine" : 166,
                   "startCol" : 6,
-                  "endLine" : 158,
+                  "endLine" : 166,
                   "endCol" : 19
                 }
               },
@@ -4343,24 +4347,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 158,
+                  "startLine" : 166,
                   "startCol" : 20,
-                  "endLine" : 158,
+                  "endLine" : 166,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 158,
+                "startLine" : 166,
                 "startCol" : 6,
-                "endLine" : 158,
+                "endLine" : 166,
                 "endCol" : 26
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 158,
+              "startLine" : 166,
               "startCol" : 6,
-              "endLine" : 158,
+              "endLine" : 166,
               "endCol" : 36
             }
           },
@@ -4368,16 +4372,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 158,
+              "startLine" : 166,
               "startCol" : 39,
-              "endLine" : 158,
+              "endLine" : 166,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 158,
+            "startLine" : 166,
             "startCol" : 6,
-            "endLine" : 158,
+            "endLine" : 166,
             "endCol" : 43
           }
         }
@@ -4395,24 +4399,24 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 161,
+                    "startLine" : 169,
                     "startCol" : 16,
-                    "endLine" : 161,
+                    "endLine" : 169,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 161,
+                  "startLine" : 169,
                   "startCol" : 16,
-                  "endLine" : 161,
+                  "endLine" : 169,
                   "endCol" : 25
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 161,
+                "startLine" : 169,
                 "startCol" : 11,
-                "endLine" : 161,
+                "endLine" : 169,
                 "endCol" : 25
               }
             }
@@ -4430,9 +4434,9 @@
                   "kind" : "Identifier",
                   "name" : "s",
                   "span" : {
-                    "startLine" : 162,
+                    "startLine" : 170,
                     "startCol" : 8,
-                    "endLine" : 162,
+                    "endLine" : 170,
                     "endCol" : 9
                   }
                 },
@@ -4442,23 +4446,23 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 162,
+                      "startLine" : 170,
                       "startCol" : 21,
-                      "endLine" : 162,
+                      "endLine" : 170,
                       "endCol" : 29
                     }
                   },
                   "span" : {
-                    "startLine" : 162,
+                    "startLine" : 170,
                     "startCol" : 17,
-                    "endLine" : 162,
+                    "endLine" : 170,
                     "endCol" : 30
                   }
                 },
                 "span" : {
-                  "startLine" : 162,
+                  "startLine" : 170,
                   "startCol" : 8,
-                  "endLine" : 162,
+                  "endLine" : 170,
                   "endCol" : 30
                 }
               },
@@ -4475,16 +4479,16 @@
                         "kind" : "Identifier",
                         "name" : "sessions",
                         "span" : {
-                          "startLine" : 163,
+                          "startLine" : 171,
                           "startCol" : 12,
-                          "endLine" : 163,
+                          "endLine" : 171,
                           "endCol" : 20
                         }
                       },
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 171,
                         "startCol" : 12,
-                        "endLine" : 163,
+                        "endLine" : 171,
                         "endCol" : 21
                       }
                     },
@@ -4492,24 +4496,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 171,
                         "startCol" : 22,
-                        "endLine" : 163,
+                        "endLine" : 171,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 163,
+                      "startLine" : 171,
                       "startCol" : 12,
-                      "endLine" : 163,
+                      "endLine" : 171,
                       "endCol" : 24
                     }
                   },
                   "field" : "user_id",
                   "span" : {
-                    "startLine" : 163,
+                    "startLine" : 171,
                     "startCol" : 12,
-                    "endLine" : 163,
+                    "endLine" : 171,
                     "endCol" : 32
                   }
                 },
@@ -4521,9 +4525,9 @@
                       "kind" : "Identifier",
                       "name" : "user_by_email",
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 171,
                         "startCol" : 35,
-                        "endLine" : 163,
+                        "endLine" : 171,
                         "endCol" : 48
                       }
                     },
@@ -4531,38 +4535,38 @@
                       "kind" : "Identifier",
                       "name" : "email",
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 171,
                         "startCol" : 49,
-                        "endLine" : 163,
+                        "endLine" : 171,
                         "endCol" : 54
                       }
                     },
                     "span" : {
-                      "startLine" : 163,
+                      "startLine" : 171,
                       "startCol" : 35,
-                      "endLine" : 163,
+                      "endLine" : 171,
                       "endCol" : 55
                     }
                   },
                   "field" : "id",
                   "span" : {
-                    "startLine" : 163,
+                    "startLine" : 171,
                     "startCol" : 35,
-                    "endLine" : 163,
+                    "endLine" : 171,
                     "endCol" : 58
                   }
                 },
                 "span" : {
-                  "startLine" : 163,
+                  "startLine" : 171,
                   "startCol" : 12,
-                  "endLine" : 163,
+                  "endLine" : 171,
                   "endCol" : 58
                 }
               },
               "span" : {
-                "startLine" : 162,
+                "startLine" : 170,
                 "startCol" : 8,
-                "endLine" : 163,
+                "endLine" : 171,
                 "endCol" : 58
               }
             },
@@ -4579,16 +4583,16 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 164,
+                        "startLine" : 172,
                         "startCol" : 12,
-                        "endLine" : 164,
+                        "endLine" : 172,
                         "endCol" : 20
                       }
                     },
                     "span" : {
-                      "startLine" : 164,
+                      "startLine" : 172,
                       "startCol" : 12,
-                      "endLine" : 164,
+                      "endLine" : 172,
                       "endCol" : 21
                     }
                   },
@@ -4596,24 +4600,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 164,
+                      "startLine" : 172,
                       "startCol" : 22,
-                      "endLine" : 164,
+                      "endLine" : 172,
                       "endCol" : 23
                     }
                   },
                   "span" : {
-                    "startLine" : 164,
+                    "startLine" : 172,
                     "startCol" : 12,
-                    "endLine" : 164,
+                    "endLine" : 172,
                     "endCol" : 24
                   }
                 },
                 "field" : "access_expires_at",
                 "span" : {
-                  "startLine" : 164,
+                  "startLine" : 172,
                   "startCol" : 12,
-                  "endLine" : 164,
+                  "endLine" : 172,
                   "endCol" : 42
                 }
               },
@@ -4623,39 +4627,39 @@
                   "kind" : "Identifier",
                   "name" : "now",
                   "span" : {
-                    "startLine" : 164,
+                    "startLine" : 172,
                     "startCol" : 45,
-                    "endLine" : 164,
+                    "endLine" : 172,
                     "endCol" : 48
                   }
                 },
                 "args" : [
                 ],
                 "span" : {
-                  "startLine" : 164,
+                  "startLine" : 172,
                   "startCol" : 45,
-                  "endLine" : 164,
+                  "endLine" : 172,
                   "endCol" : 50
                 }
               },
               "span" : {
-                "startLine" : 164,
+                "startLine" : 172,
                 "startCol" : 12,
-                "endLine" : 164,
+                "endLine" : 172,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 162,
+              "startLine" : 170,
               "startCol" : 8,
-              "endLine" : 164,
+              "endLine" : 172,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 161,
+            "startLine" : 169,
             "startCol" : 6,
-            "endLine" : 164,
+            "endLine" : 172,
             "endCol" : 50
           }
         },
@@ -4668,16 +4672,16 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 165,
+                "startLine" : 173,
                 "startCol" : 6,
-                "endLine" : 165,
+                "endLine" : 173,
                 "endCol" : 11
               }
             },
             "span" : {
-              "startLine" : 165,
+              "startLine" : 173,
               "startCol" : 6,
-              "endLine" : 165,
+              "endLine" : 173,
               "endCol" : 12
             }
           },
@@ -4685,24 +4689,24 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 165,
+              "startLine" : 173,
               "startCol" : 15,
-              "endLine" : 165,
+              "endLine" : 173,
               "endCol" : 20
             }
           },
           "span" : {
-            "startLine" : 165,
+            "startLine" : 173,
             "startCol" : 6,
-            "endLine" : 165,
+            "endLine" : 173,
             "endCol" : 20
           }
         }
       ],
       "span" : {
-        "startLine" : 152,
+        "startLine" : 160,
         "startCol" : 2,
-        "endLine" : 166,
+        "endLine" : 174,
         "endCol" : 3
       }
     },
@@ -4717,16 +4721,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 169,
+              "startLine" : 177,
               "startCol" : 25,
-              "endLine" : 169,
+              "endLine" : 177,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 169,
+            "startLine" : 177,
             "startCol" : 12,
-            "endLine" : 169,
+            "endLine" : 177,
             "endCol" : 30
           }
         },
@@ -4737,16 +4741,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 169,
+              "startLine" : 177,
               "startCol" : 46,
-              "endLine" : 169,
+              "endLine" : 177,
               "endCol" : 52
             }
           },
           "span" : {
-            "startLine" : 169,
+            "startLine" : 177,
             "startCol" : 32,
-            "endLine" : 169,
+            "endLine" : 177,
             "endCol" : 52
           }
         }
@@ -4764,17 +4768,17 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 172,
+                  "startLine" : 180,
                   "startCol" : 16,
-                  "endLine" : 172,
+                  "endLine" : 180,
                   "endCol" : 24
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 172,
+                "startLine" : 180,
                 "startCol" : 11,
-                "endLine" : 172,
+                "endLine" : 180,
                 "endCol" : 24
               }
             }
@@ -4796,9 +4800,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 173,
+                        "startLine" : 181,
                         "startCol" : 8,
-                        "endLine" : 173,
+                        "endLine" : 181,
                         "endCol" : 16
                       }
                     },
@@ -4806,24 +4810,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 173,
+                        "startLine" : 181,
                         "startCol" : 17,
-                        "endLine" : 173,
+                        "endLine" : 181,
                         "endCol" : 18
                       }
                     },
                     "span" : {
-                      "startLine" : 173,
+                      "startLine" : 181,
                       "startCol" : 8,
-                      "endLine" : 173,
+                      "endLine" : 181,
                       "endCol" : 19
                     }
                   },
                   "field" : "access_token",
                   "span" : {
-                    "startLine" : 173,
+                    "startLine" : 181,
                     "startCol" : 8,
-                    "endLine" : 173,
+                    "endLine" : 181,
                     "endCol" : 32
                   }
                 },
@@ -4831,16 +4835,16 @@
                   "kind" : "Identifier",
                   "name" : "reset_token",
                   "span" : {
-                    "startLine" : 173,
+                    "startLine" : 181,
                     "startCol" : 35,
-                    "endLine" : 173,
+                    "endLine" : 181,
                     "endCol" : 46
                   }
                 },
                 "span" : {
-                  "startLine" : 173,
+                  "startLine" : 181,
                   "startCol" : 8,
-                  "endLine" : 173,
+                  "endLine" : 181,
                   "endCol" : 46
                 }
               },
@@ -4855,9 +4859,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 174,
+                        "startLine" : 182,
                         "startCol" : 12,
-                        "endLine" : 174,
+                        "endLine" : 182,
                         "endCol" : 20
                       }
                     },
@@ -4865,24 +4869,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 174,
+                        "startLine" : 182,
                         "startCol" : 21,
-                        "endLine" : 174,
+                        "endLine" : 182,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 174,
+                      "startLine" : 182,
                       "startCol" : 12,
-                      "endLine" : 174,
+                      "endLine" : 182,
                       "endCol" : 23
                     }
                   },
                   "field" : "is_revoked",
                   "span" : {
-                    "startLine" : 174,
+                    "startLine" : 182,
                     "startCol" : 12,
-                    "endLine" : 174,
+                    "endLine" : 182,
                     "endCol" : 34
                   }
                 },
@@ -4890,23 +4894,23 @@
                   "kind" : "BoolLit",
                   "value" : false,
                   "span" : {
-                    "startLine" : 174,
+                    "startLine" : 182,
                     "startCol" : 37,
-                    "endLine" : 174,
+                    "endLine" : 182,
                     "endCol" : 42
                   }
                 },
                 "span" : {
-                  "startLine" : 174,
+                  "startLine" : 182,
                   "startCol" : 12,
-                  "endLine" : 174,
+                  "endLine" : 182,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 173,
+                "startLine" : 181,
                 "startCol" : 8,
-                "endLine" : 174,
+                "endLine" : 182,
                 "endCol" : 42
               }
             },
@@ -4921,9 +4925,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 175,
+                      "startLine" : 183,
                       "startCol" : 12,
-                      "endLine" : 175,
+                      "endLine" : 183,
                       "endCol" : 20
                     }
                   },
@@ -4931,24 +4935,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 175,
+                      "startLine" : 183,
                       "startCol" : 21,
-                      "endLine" : 175,
+                      "endLine" : 183,
                       "endCol" : 22
                     }
                   },
                   "span" : {
-                    "startLine" : 175,
+                    "startLine" : 183,
                     "startCol" : 12,
-                    "endLine" : 175,
+                    "endLine" : 183,
                     "endCol" : 23
                   }
                 },
                 "field" : "access_expires_at",
                 "span" : {
-                  "startLine" : 175,
+                  "startLine" : 183,
                   "startCol" : 12,
-                  "endLine" : 175,
+                  "endLine" : 183,
                   "endCol" : 41
                 }
               },
@@ -4958,39 +4962,39 @@
                   "kind" : "Identifier",
                   "name" : "now",
                   "span" : {
-                    "startLine" : 175,
+                    "startLine" : 183,
                     "startCol" : 44,
-                    "endLine" : 175,
+                    "endLine" : 183,
                     "endCol" : 47
                   }
                 },
                 "args" : [
                 ],
                 "span" : {
-                  "startLine" : 175,
+                  "startLine" : 183,
                   "startCol" : 44,
-                  "endLine" : 175,
+                  "endLine" : 183,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 175,
+                "startLine" : 183,
                 "startCol" : 12,
-                "endLine" : 175,
+                "endLine" : 183,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 173,
+              "startLine" : 181,
               "startCol" : 8,
-              "endLine" : 175,
+              "endLine" : 183,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 172,
+            "startLine" : 180,
             "startCol" : 6,
-            "endLine" : 175,
+            "endLine" : 183,
             "endCol" : 49
           }
         },
@@ -5003,9 +5007,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 176,
+                "startLine" : 184,
                 "startCol" : 6,
-                "endLine" : 176,
+                "endLine" : 184,
                 "endCol" : 9
               }
             },
@@ -5014,17 +5018,17 @@
                 "kind" : "Identifier",
                 "name" : "new_password",
                 "span" : {
-                  "startLine" : 176,
+                  "startLine" : 184,
                   "startCol" : 10,
-                  "endLine" : 176,
+                  "endLine" : 184,
                   "endCol" : 22
                 }
               }
             ],
             "span" : {
-              "startLine" : 176,
+              "startLine" : 184,
               "startCol" : 6,
-              "endLine" : 176,
+              "endLine" : 184,
               "endCol" : 23
             }
           },
@@ -5032,16 +5036,16 @@
             "kind" : "IntLit",
             "value" : 8,
             "span" : {
-              "startLine" : 176,
+              "startLine" : 184,
               "startCol" : 27,
-              "endLine" : 176,
+              "endLine" : 184,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 176,
+            "startLine" : 184,
             "startCol" : 6,
-            "endLine" : 176,
+            "endLine" : 184,
             "endCol" : 28
           }
         }
@@ -5057,9 +5061,9 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 179,
+                "startLine" : 187,
                 "startCol" : 24,
-                "endLine" : 179,
+                "endLine" : 187,
                 "endCol" : 32
               }
             },
@@ -5074,9 +5078,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 180,
+                      "startLine" : 188,
                       "startCol" : 8,
-                      "endLine" : 180,
+                      "endLine" : 188,
                       "endCol" : 16
                     }
                   },
@@ -5084,24 +5088,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 180,
+                      "startLine" : 188,
                       "startCol" : 17,
-                      "endLine" : 180,
+                      "endLine" : 188,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 180,
+                    "startLine" : 188,
                     "startCol" : 8,
-                    "endLine" : 180,
+                    "endLine" : 188,
                     "endCol" : 19
                   }
                 },
                 "field" : "access_token",
                 "span" : {
-                  "startLine" : 180,
+                  "startLine" : 188,
                   "startCol" : 8,
-                  "endLine" : 180,
+                  "endLine" : 188,
                   "endCol" : 32
                 }
               },
@@ -5109,23 +5113,23 @@
                 "kind" : "Identifier",
                 "name" : "reset_token",
                 "span" : {
-                  "startLine" : 180,
+                  "startLine" : 188,
                   "startCol" : 35,
-                  "endLine" : 180,
+                  "endLine" : 188,
                   "endCol" : 46
                 }
               },
               "span" : {
-                "startLine" : 180,
+                "startLine" : 188,
                 "startCol" : 8,
-                "endLine" : 180,
+                "endLine" : 188,
                 "endCol" : 46
               }
             },
             "span" : {
-              "startLine" : 179,
+              "startLine" : 187,
               "startCol" : 15,
-              "endLine" : 180,
+              "endLine" : 188,
               "endCol" : 46
             }
           },
@@ -5142,16 +5146,16 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 181,
+                      "startLine" : 189,
                       "startCol" : 26,
-                      "endLine" : 181,
+                      "endLine" : 189,
                       "endCol" : 34
                     }
                   },
                   "span" : {
-                    "startLine" : 181,
+                    "startLine" : 189,
                     "startCol" : 22,
-                    "endLine" : 181,
+                    "endLine" : 189,
                     "endCol" : 35
                   }
                 },
@@ -5159,24 +5163,24 @@
                   "kind" : "Identifier",
                   "name" : "s",
                   "span" : {
-                    "startLine" : 181,
+                    "startLine" : 189,
                     "startCol" : 36,
-                    "endLine" : 181,
+                    "endLine" : 189,
                     "endCol" : 37
                   }
                 },
                 "span" : {
-                  "startLine" : 181,
+                  "startLine" : 189,
                   "startCol" : 22,
-                  "endLine" : 181,
+                  "endLine" : 189,
                   "endCol" : 38
                 }
               },
               "field" : "user_id",
               "span" : {
-                "startLine" : 181,
+                "startLine" : 189,
                 "startCol" : 22,
-                "endLine" : 181,
+                "endLine" : 189,
                 "endCol" : 46
               }
             },
@@ -5196,16 +5200,16 @@
                         "kind" : "Identifier",
                         "name" : "users",
                         "span" : {
-                          "startLine" : 182,
+                          "startLine" : 190,
                           "startCol" : 10,
-                          "endLine" : 182,
+                          "endLine" : 190,
                           "endCol" : 15
                         }
                       },
                       "span" : {
-                        "startLine" : 182,
+                        "startLine" : 190,
                         "startCol" : 10,
-                        "endLine" : 182,
+                        "endLine" : 190,
                         "endCol" : 16
                       }
                     },
@@ -5213,24 +5217,24 @@
                       "kind" : "Identifier",
                       "name" : "user_id",
                       "span" : {
-                        "startLine" : 182,
+                        "startLine" : 190,
                         "startCol" : 17,
-                        "endLine" : 182,
+                        "endLine" : 190,
                         "endCol" : 24
                       }
                     },
                     "span" : {
-                      "startLine" : 182,
+                      "startLine" : 190,
                       "startCol" : 10,
-                      "endLine" : 182,
+                      "endLine" : 190,
                       "endCol" : 25
                     }
                   },
                   "field" : "password_hash",
                   "span" : {
-                    "startLine" : 182,
+                    "startLine" : 190,
                     "startCol" : 10,
-                    "endLine" : 182,
+                    "endLine" : 190,
                     "endCol" : 39
                   }
                 },
@@ -5240,9 +5244,9 @@
                     "kind" : "Identifier",
                     "name" : "hash",
                     "span" : {
-                      "startLine" : 182,
+                      "startLine" : 190,
                       "startCol" : 42,
-                      "endLine" : 182,
+                      "endLine" : 190,
                       "endCol" : 46
                     }
                   },
@@ -5251,24 +5255,24 @@
                       "kind" : "Identifier",
                       "name" : "new_password",
                       "span" : {
-                        "startLine" : 182,
+                        "startLine" : 190,
                         "startCol" : 47,
-                        "endLine" : 182,
+                        "endLine" : 190,
                         "endCol" : 59
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 182,
+                    "startLine" : 190,
                     "startCol" : 42,
-                    "endLine" : 182,
+                    "endLine" : 190,
                     "endCol" : 60
                   }
                 },
                 "span" : {
-                  "startLine" : 182,
+                  "startLine" : 190,
                   "startCol" : 10,
-                  "endLine" : 182,
+                  "endLine" : 190,
                   "endCol" : 60
                 }
               },
@@ -5285,16 +5289,16 @@
                         "kind" : "Identifier",
                         "name" : "sessions",
                         "span" : {
-                          "startLine" : 183,
+                          "startLine" : 191,
                           "startCol" : 14,
-                          "endLine" : 183,
+                          "endLine" : 191,
                           "endCol" : 22
                         }
                       },
                       "span" : {
-                        "startLine" : 183,
+                        "startLine" : 191,
                         "startCol" : 14,
-                        "endLine" : 183,
+                        "endLine" : 191,
                         "endCol" : 23
                       }
                     },
@@ -5302,24 +5306,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 183,
+                        "startLine" : 191,
                         "startCol" : 24,
-                        "endLine" : 183,
+                        "endLine" : 191,
                         "endCol" : 25
                       }
                     },
                     "span" : {
-                      "startLine" : 183,
+                      "startLine" : 191,
                       "startCol" : 14,
-                      "endLine" : 183,
+                      "endLine" : 191,
                       "endCol" : 26
                     }
                   },
                   "field" : "is_revoked",
                   "span" : {
-                    "startLine" : 183,
+                    "startLine" : 191,
                     "startCol" : 14,
-                    "endLine" : 183,
+                    "endLine" : 191,
                     "endCol" : 37
                   }
                 },
@@ -5327,45 +5331,45 @@
                   "kind" : "BoolLit",
                   "value" : true,
                   "span" : {
-                    "startLine" : 183,
+                    "startLine" : 191,
                     "startCol" : 40,
-                    "endLine" : 183,
+                    "endLine" : 191,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 183,
+                  "startLine" : 191,
                   "startCol" : 14,
-                  "endLine" : 183,
+                  "endLine" : 191,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 182,
+                "startLine" : 190,
                 "startCol" : 10,
-                "endLine" : 183,
+                "endLine" : 191,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 181,
+              "startLine" : 189,
               "startCol" : 8,
-              "endLine" : 183,
+              "endLine" : 191,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 179,
+            "startLine" : 187,
             "startCol" : 6,
-            "endLine" : 183,
+            "endLine" : 191,
             "endCol" : 44
           }
         }
       ],
       "span" : {
-        "startLine" : 168,
+        "startLine" : 176,
         "startCol" : 2,
-        "endLine" : 184,
+        "endLine" : 192,
         "endCol" : 3
       }
     },
@@ -5380,16 +5384,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 187,
+              "startLine" : 195,
               "startCol" : 25,
-              "endLine" : 187,
+              "endLine" : 195,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 187,
+            "startLine" : 195,
             "startCol" : 11,
-            "endLine" : 187,
+            "endLine" : 195,
             "endCol" : 30
           }
         }
@@ -5407,17 +5411,17 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 190,
+                  "startLine" : 199,
                   "startCol" : 16,
-                  "endLine" : 190,
+                  "endLine" : 199,
                   "endCol" : 24
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 190,
+                "startLine" : 199,
                 "startCol" : 11,
-                "endLine" : 190,
+                "endLine" : 199,
                 "endCol" : 24
               }
             }
@@ -5436,9 +5440,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 191,
+                      "startLine" : 200,
                       "startCol" : 8,
-                      "endLine" : 191,
+                      "endLine" : 200,
                       "endCol" : 16
                     }
                   },
@@ -5446,24 +5450,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 191,
+                      "startLine" : 200,
                       "startCol" : 17,
-                      "endLine" : 191,
+                      "endLine" : 200,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 191,
+                    "startLine" : 200,
                     "startCol" : 8,
-                    "endLine" : 191,
+                    "endLine" : 200,
                     "endCol" : 19
                   }
                 },
                 "field" : "access_token",
                 "span" : {
-                  "startLine" : 191,
+                  "startLine" : 200,
                   "startCol" : 8,
-                  "endLine" : 191,
+                  "endLine" : 200,
                   "endCol" : 32
                 }
               },
@@ -5471,16 +5475,16 @@
                 "kind" : "Identifier",
                 "name" : "access_token",
                 "span" : {
-                  "startLine" : 191,
+                  "startLine" : 200,
                   "startCol" : 35,
-                  "endLine" : 191,
+                  "endLine" : 200,
                   "endCol" : 47
                 }
               },
               "span" : {
-                "startLine" : 191,
+                "startLine" : 200,
                 "startCol" : 8,
-                "endLine" : 191,
+                "endLine" : 200,
                 "endCol" : 47
               }
             },
@@ -5495,9 +5499,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 192,
+                      "startLine" : 201,
                       "startCol" : 12,
-                      "endLine" : 192,
+                      "endLine" : 201,
                       "endCol" : 20
                     }
                   },
@@ -5505,24 +5509,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 192,
+                      "startLine" : 201,
                       "startCol" : 21,
-                      "endLine" : 192,
+                      "endLine" : 201,
                       "endCol" : 22
                     }
                   },
                   "span" : {
-                    "startLine" : 192,
+                    "startLine" : 201,
                     "startCol" : 12,
-                    "endLine" : 192,
+                    "endLine" : 201,
                     "endCol" : 23
                   }
                 },
                 "field" : "is_revoked",
                 "span" : {
-                  "startLine" : 192,
+                  "startLine" : 201,
                   "startCol" : 12,
-                  "endLine" : 192,
+                  "endLine" : 201,
                   "endCol" : 34
                 }
               },
@@ -5530,30 +5534,30 @@
                 "kind" : "BoolLit",
                 "value" : false,
                 "span" : {
-                  "startLine" : 192,
+                  "startLine" : 201,
                   "startCol" : 37,
-                  "endLine" : 192,
+                  "endLine" : 201,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 192,
+                "startLine" : 201,
                 "startCol" : 12,
-                "endLine" : 192,
+                "endLine" : 201,
                 "endCol" : 42
               }
             },
             "span" : {
-              "startLine" : 191,
+              "startLine" : 200,
               "startCol" : 8,
-              "endLine" : 192,
+              "endLine" : 201,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 190,
+            "startLine" : 199,
             "startCol" : 6,
-            "endLine" : 192,
+            "endLine" : 201,
             "endCol" : 42
           }
         }
@@ -5569,9 +5573,9 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 195,
+                "startLine" : 204,
                 "startCol" : 24,
-                "endLine" : 195,
+                "endLine" : 204,
                 "endCol" : 32
               }
             },
@@ -5586,9 +5590,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 196,
+                      "startLine" : 205,
                       "startCol" : 8,
-                      "endLine" : 196,
+                      "endLine" : 205,
                       "endCol" : 16
                     }
                   },
@@ -5596,24 +5600,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 196,
+                      "startLine" : 205,
                       "startCol" : 17,
-                      "endLine" : 196,
+                      "endLine" : 205,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 196,
+                    "startLine" : 205,
                     "startCol" : 8,
-                    "endLine" : 196,
+                    "endLine" : 205,
                     "endCol" : 19
                   }
                 },
                 "field" : "access_token",
                 "span" : {
-                  "startLine" : 196,
+                  "startLine" : 205,
                   "startCol" : 8,
-                  "endLine" : 196,
+                  "endLine" : 205,
                   "endCol" : 32
                 }
               },
@@ -5621,23 +5625,23 @@
                 "kind" : "Identifier",
                 "name" : "access_token",
                 "span" : {
-                  "startLine" : 196,
+                  "startLine" : 205,
                   "startCol" : 35,
-                  "endLine" : 196,
+                  "endLine" : 205,
                   "endCol" : 47
                 }
               },
               "span" : {
-                "startLine" : 196,
+                "startLine" : 205,
                 "startCol" : 8,
-                "endLine" : 196,
+                "endLine" : 205,
                 "endCol" : 47
               }
             },
             "span" : {
-              "startLine" : 195,
+              "startLine" : 204,
               "startCol" : 15,
-              "endLine" : 196,
+              "endLine" : 205,
               "endCol" : 47
             }
           },
@@ -5657,16 +5661,16 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 197,
+                        "startLine" : 206,
                         "startCol" : 8,
-                        "endLine" : 197,
+                        "endLine" : 206,
                         "endCol" : 16
                       }
                     },
                     "span" : {
-                      "startLine" : 197,
+                      "startLine" : 206,
                       "startCol" : 8,
-                      "endLine" : 197,
+                      "endLine" : 206,
                       "endCol" : 17
                     }
                   },
@@ -5674,24 +5678,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 197,
+                      "startLine" : 206,
                       "startCol" : 18,
-                      "endLine" : 197,
+                      "endLine" : 206,
                       "endCol" : 19
                     }
                   },
                   "span" : {
-                    "startLine" : 197,
+                    "startLine" : 206,
                     "startCol" : 8,
-                    "endLine" : 197,
+                    "endLine" : 206,
                     "endCol" : 20
                   }
                 },
                 "field" : "is_revoked",
                 "span" : {
-                  "startLine" : 197,
+                  "startLine" : 206,
                   "startCol" : 8,
-                  "endLine" : 197,
+                  "endLine" : 206,
                   "endCol" : 31
                 }
               },
@@ -5699,16 +5703,16 @@
                 "kind" : "BoolLit",
                 "value" : true,
                 "span" : {
-                  "startLine" : 197,
+                  "startLine" : 206,
                   "startCol" : 34,
-                  "endLine" : 197,
+                  "endLine" : 206,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 197,
+                "startLine" : 206,
                 "startCol" : 8,
-                "endLine" : 197,
+                "endLine" : 206,
                 "endCol" : 38
               }
             },
@@ -5721,16 +5725,16 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 198,
+                    "startLine" : 207,
                     "startCol" : 12,
-                    "endLine" : 198,
+                    "endLine" : 207,
                     "endCol" : 17
                   }
                 },
                 "span" : {
-                  "startLine" : 198,
+                  "startLine" : 207,
                   "startCol" : 12,
-                  "endLine" : 198,
+                  "endLine" : 207,
                   "endCol" : 18
                 }
               },
@@ -5738,38 +5742,41 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 198,
+                  "startLine" : 207,
                   "startCol" : 21,
-                  "endLine" : 198,
+                  "endLine" : 207,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 198,
+                "startLine" : 207,
                 "startCol" : 12,
-                "endLine" : 198,
+                "endLine" : 207,
                 "endCol" : 26
               }
             },
             "span" : {
-              "startLine" : 197,
+              "startLine" : 206,
               "startCol" : 8,
-              "endLine" : 198,
+              "endLine" : 207,
               "endCol" : 26
             }
           },
           "span" : {
-            "startLine" : 195,
+            "startLine" : 204,
             "startCol" : 6,
-            "endLine" : 198,
+            "endLine" : 207,
             "endCol" : 26
           }
         }
       ],
+      "requiresAuth" : [
+        "bearer"
+      ],
       "span" : {
-        "startLine" : 186,
+        "startLine" : 194,
         "startCol" : 2,
-        "endLine" : 199,
+        "endLine" : 208,
         "endCol" : 3
       }
     }
@@ -5790,17 +5797,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 212,
+                "startLine" : 221,
                 "startCol" : 14,
-                "endLine" : 212,
+                "endLine" : 221,
                 "endCol" : 19
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 212,
+              "startLine" : 221,
               "startCol" : 8,
-              "endLine" : 212,
+              "endLine" : 221,
               "endCol" : 19
             }
           },
@@ -5810,17 +5817,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 212,
+                "startLine" : 221,
                 "startCol" : 27,
-                "endLine" : 212,
+                "endLine" : 221,
                 "endCol" : 32
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 212,
+              "startLine" : 221,
               "startCol" : 21,
-              "endLine" : 212,
+              "endLine" : 221,
               "endCol" : 32
             }
           }
@@ -5835,9 +5842,9 @@
               "kind" : "Identifier",
               "name" : "u1",
               "span" : {
-                "startLine" : 213,
+                "startLine" : 222,
                 "startCol" : 6,
-                "endLine" : 213,
+                "endLine" : 222,
                 "endCol" : 8
               }
             },
@@ -5845,16 +5852,16 @@
               "kind" : "Identifier",
               "name" : "u2",
               "span" : {
-                "startLine" : 213,
+                "startLine" : 222,
                 "startCol" : 12,
-                "endLine" : 213,
+                "endLine" : 222,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 213,
+              "startLine" : 222,
               "startCol" : 6,
-              "endLine" : 213,
+              "endLine" : 222,
               "endCol" : 14
             }
           },
@@ -5869,9 +5876,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 213,
+                    "startLine" : 222,
                     "startCol" : 23,
-                    "endLine" : 213,
+                    "endLine" : 222,
                     "endCol" : 28
                   }
                 },
@@ -5879,24 +5886,24 @@
                   "kind" : "Identifier",
                   "name" : "u1",
                   "span" : {
-                    "startLine" : 213,
+                    "startLine" : 222,
                     "startCol" : 29,
-                    "endLine" : 213,
+                    "endLine" : 222,
                     "endCol" : 31
                   }
                 },
                 "span" : {
-                  "startLine" : 213,
+                  "startLine" : 222,
                   "startCol" : 23,
-                  "endLine" : 213,
+                  "endLine" : 222,
                   "endCol" : 32
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 213,
+                "startLine" : 222,
                 "startCol" : 23,
-                "endLine" : 213,
+                "endLine" : 222,
                 "endCol" : 38
               }
             },
@@ -5908,9 +5915,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 213,
+                    "startLine" : 222,
                     "startCol" : 42,
-                    "endLine" : 213,
+                    "endLine" : 222,
                     "endCol" : 47
                   }
                 },
@@ -5918,52 +5925,52 @@
                   "kind" : "Identifier",
                   "name" : "u2",
                   "span" : {
-                    "startLine" : 213,
+                    "startLine" : 222,
                     "startCol" : 48,
-                    "endLine" : 213,
+                    "endLine" : 222,
                     "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 213,
+                  "startLine" : 222,
                   "startCol" : 42,
-                  "endLine" : 213,
+                  "endLine" : 222,
                   "endCol" : 51
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 213,
+                "startLine" : 222,
                 "startCol" : 42,
-                "endLine" : 213,
+                "endLine" : 222,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 213,
+              "startLine" : 222,
               "startCol" : 23,
-              "endLine" : 213,
+              "endLine" : 222,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 213,
+            "startLine" : 222,
             "startCol" : 6,
-            "endLine" : 213,
+            "endLine" : 222,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 212,
+          "startLine" : 221,
           "startCol" : 4,
-          "endLine" : 213,
+          "endLine" : 222,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 211,
+        "startLine" : 220,
         "startCol" : 2,
-        "endLine" : 213,
+        "endLine" : 222,
         "endCol" : 57
       }
     },
@@ -5980,17 +5987,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 216,
+                "startLine" : 225,
                 "startCol" : 17,
-                "endLine" : 216,
+                "endLine" : 225,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 216,
+              "startLine" : 225,
               "startCol" : 8,
-              "endLine" : 216,
+              "endLine" : 225,
               "endCol" : 30
             }
           }
@@ -6012,9 +6019,9 @@
                     "kind" : "Identifier",
                     "name" : "user_by_email",
                     "span" : {
-                      "startLine" : 217,
+                      "startLine" : 226,
                       "startCol" : 6,
-                      "endLine" : 217,
+                      "endLine" : 226,
                       "endCol" : 19
                     }
                   },
@@ -6022,24 +6029,24 @@
                     "kind" : "Identifier",
                     "name" : "email",
                     "span" : {
-                      "startLine" : 217,
+                      "startLine" : 226,
                       "startCol" : 20,
-                      "endLine" : 217,
+                      "endLine" : 226,
                       "endCol" : 25
                     }
                   },
                   "span" : {
-                    "startLine" : 217,
+                    "startLine" : 226,
                     "startCol" : 6,
-                    "endLine" : 217,
+                    "endLine" : 226,
                     "endCol" : 26
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 217,
+                  "startLine" : 226,
                   "startCol" : 6,
-                  "endLine" : 217,
+                  "endLine" : 226,
                   "endCol" : 29
                 }
               },
@@ -6047,16 +6054,16 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 217,
+                  "startLine" : 226,
                   "startCol" : 33,
-                  "endLine" : 217,
+                  "endLine" : 226,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 217,
+                "startLine" : 226,
                 "startCol" : 6,
-                "endLine" : 217,
+                "endLine" : 226,
                 "endCol" : 38
               }
             },
@@ -6069,9 +6076,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 218,
+                    "startLine" : 227,
                     "startCol" : 10,
-                    "endLine" : 218,
+                    "endLine" : 227,
                     "endCol" : 15
                   }
                 },
@@ -6083,9 +6090,9 @@
                       "kind" : "Identifier",
                       "name" : "user_by_email",
                       "span" : {
-                        "startLine" : 218,
+                        "startLine" : 227,
                         "startCol" : 16,
-                        "endLine" : 218,
+                        "endLine" : 227,
                         "endCol" : 29
                       }
                     },
@@ -6093,31 +6100,31 @@
                       "kind" : "Identifier",
                       "name" : "email",
                       "span" : {
-                        "startLine" : 218,
+                        "startLine" : 227,
                         "startCol" : 30,
-                        "endLine" : 218,
+                        "endLine" : 227,
                         "endCol" : 35
                       }
                     },
                     "span" : {
-                      "startLine" : 218,
+                      "startLine" : 227,
                       "startCol" : 16,
-                      "endLine" : 218,
+                      "endLine" : 227,
                       "endCol" : 36
                     }
                   },
                   "field" : "id",
                   "span" : {
-                    "startLine" : 218,
+                    "startLine" : 227,
                     "startCol" : 16,
-                    "endLine" : 218,
+                    "endLine" : 227,
                     "endCol" : 39
                   }
                 },
                 "span" : {
-                  "startLine" : 218,
+                  "startLine" : 227,
                   "startCol" : 10,
-                  "endLine" : 218,
+                  "endLine" : 227,
                   "endCol" : 40
                 }
               },
@@ -6127,9 +6134,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 218,
+                    "startLine" : 227,
                     "startCol" : 43,
-                    "endLine" : 218,
+                    "endLine" : 227,
                     "endCol" : 56
                   }
                 },
@@ -6137,30 +6144,30 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 218,
+                    "startLine" : 227,
                     "startCol" : 57,
-                    "endLine" : 218,
+                    "endLine" : 227,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 218,
+                  "startLine" : 227,
                   "startCol" : 43,
-                  "endLine" : 218,
+                  "endLine" : 227,
                   "endCol" : 63
                 }
               },
               "span" : {
-                "startLine" : 218,
+                "startLine" : 227,
                 "startCol" : 10,
-                "endLine" : 218,
+                "endLine" : 227,
                 "endCol" : 63
               }
             },
             "span" : {
-              "startLine" : 217,
+              "startLine" : 226,
               "startCol" : 6,
-              "endLine" : 218,
+              "endLine" : 227,
               "endCol" : 63
             }
           },
@@ -6175,9 +6182,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 219,
+                    "startLine" : 228,
                     "startCol" : 10,
-                    "endLine" : 219,
+                    "endLine" : 228,
                     "endCol" : 23
                   }
                 },
@@ -6185,24 +6192,24 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 219,
+                    "startLine" : 228,
                     "startCol" : 24,
-                    "endLine" : 219,
+                    "endLine" : 228,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 228,
                   "startCol" : 10,
-                  "endLine" : 219,
+                  "endLine" : 228,
                   "endCol" : 30
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 219,
+                "startLine" : 228,
                 "startCol" : 10,
-                "endLine" : 219,
+                "endLine" : 228,
                 "endCol" : 36
               }
             },
@@ -6210,37 +6217,37 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 219,
+                "startLine" : 228,
                 "startCol" : 39,
-                "endLine" : 219,
+                "endLine" : 228,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 219,
+              "startLine" : 228,
               "startCol" : 10,
-              "endLine" : 219,
+              "endLine" : 228,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 217,
+            "startLine" : 226,
             "startCol" : 6,
-            "endLine" : 219,
+            "endLine" : 228,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 216,
+          "startLine" : 225,
           "startCol" : 4,
-          "endLine" : 219,
+          "endLine" : 228,
           "endCol" : 44
         }
       },
       "span" : {
-        "startLine" : 215,
+        "startLine" : 224,
         "startCol" : 2,
-        "endLine" : 219,
+        "endLine" : 228,
         "endCol" : 44
       }
     },
@@ -6257,17 +6264,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 222,
+                "startLine" : 231,
                 "startCol" : 13,
-                "endLine" : 222,
+                "endLine" : 231,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 222,
+              "startLine" : 231,
               "startCol" : 8,
-              "endLine" : 222,
+              "endLine" : 231,
               "endCol" : 18
             }
           }
@@ -6289,9 +6296,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 223,
+                      "startLine" : 232,
                       "startCol" : 6,
-                      "endLine" : 223,
+                      "endLine" : 232,
                       "endCol" : 11
                     }
                   },
@@ -6299,24 +6306,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 223,
+                      "startLine" : 232,
                       "startCol" : 12,
-                      "endLine" : 223,
+                      "endLine" : 232,
                       "endCol" : 13
                     }
                   },
                   "span" : {
-                    "startLine" : 223,
+                    "startLine" : 232,
                     "startCol" : 6,
-                    "endLine" : 223,
+                    "endLine" : 232,
                     "endCol" : 14
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 223,
+                  "startLine" : 232,
                   "startCol" : 6,
-                  "endLine" : 223,
+                  "endLine" : 232,
                   "endCol" : 17
                 }
               },
@@ -6324,16 +6331,16 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 223,
+                  "startLine" : 232,
                   "startCol" : 20,
-                  "endLine" : 223,
+                  "endLine" : 232,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 223,
+                "startLine" : 232,
                 "startCol" : 6,
-                "endLine" : 223,
+                "endLine" : 232,
                 "endCol" : 21
               }
             },
@@ -6348,9 +6355,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 224,
+                      "startLine" : 233,
                       "startCol" : 10,
-                      "endLine" : 224,
+                      "endLine" : 233,
                       "endCol" : 15
                     }
                   },
@@ -6358,24 +6365,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 224,
+                      "startLine" : 233,
                       "startCol" : 16,
-                      "endLine" : 224,
+                      "endLine" : 233,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 224,
+                    "startLine" : 233,
                     "startCol" : 10,
-                    "endLine" : 224,
+                    "endLine" : 233,
                     "endCol" : 18
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 233,
                   "startCol" : 10,
-                  "endLine" : 224,
+                  "endLine" : 233,
                   "endCol" : 24
                 }
               },
@@ -6383,23 +6390,23 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 233,
                   "startCol" : 28,
-                  "endLine" : 224,
+                  "endLine" : 233,
                   "endCol" : 41
                 }
               },
               "span" : {
-                "startLine" : 224,
+                "startLine" : 233,
                 "startCol" : 10,
-                "endLine" : 224,
+                "endLine" : 233,
                 "endCol" : 41
               }
             },
             "span" : {
-              "startLine" : 223,
+              "startLine" : 232,
               "startCol" : 6,
-              "endLine" : 224,
+              "endLine" : 233,
               "endCol" : 41
             }
           },
@@ -6412,9 +6419,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 225,
+                  "startLine" : 234,
                   "startCol" : 10,
-                  "endLine" : 225,
+                  "endLine" : 234,
                   "endCol" : 23
                 }
               },
@@ -6426,9 +6433,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 225,
+                      "startLine" : 234,
                       "startCol" : 24,
-                      "endLine" : 225,
+                      "endLine" : 234,
                       "endCol" : 29
                     }
                   },
@@ -6436,31 +6443,31 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 225,
+                      "startLine" : 234,
                       "startCol" : 30,
-                      "endLine" : 225,
+                      "endLine" : 234,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 225,
+                    "startLine" : 234,
                     "startCol" : 24,
-                    "endLine" : 225,
+                    "endLine" : 234,
                     "endCol" : 32
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 225,
+                  "startLine" : 234,
                   "startCol" : 24,
-                  "endLine" : 225,
+                  "endLine" : 234,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 225,
+                "startLine" : 234,
                 "startCol" : 10,
-                "endLine" : 225,
+                "endLine" : 234,
                 "endCol" : 39
               }
             },
@@ -6470,9 +6477,9 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 225,
+                  "startLine" : 234,
                   "startCol" : 42,
-                  "endLine" : 225,
+                  "endLine" : 234,
                   "endCol" : 47
                 }
               },
@@ -6480,44 +6487,44 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 225,
+                  "startLine" : 234,
                   "startCol" : 48,
-                  "endLine" : 225,
+                  "endLine" : 234,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 225,
+                "startLine" : 234,
                 "startCol" : 42,
-                "endLine" : 225,
+                "endLine" : 234,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 225,
+              "startLine" : 234,
               "startCol" : 10,
-              "endLine" : 225,
+              "endLine" : 234,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 223,
+            "startLine" : 232,
             "startCol" : 6,
-            "endLine" : 225,
+            "endLine" : 234,
             "endCol" : 50
           }
         },
         "span" : {
-          "startLine" : 222,
+          "startLine" : 231,
           "startCol" : 4,
-          "endLine" : 225,
+          "endLine" : 234,
           "endCol" : 50
         }
       },
       "span" : {
-        "startLine" : 221,
+        "startLine" : 230,
         "startCol" : 2,
-        "endLine" : 225,
+        "endLine" : 234,
         "endCol" : 50
       }
     },
@@ -6534,17 +6541,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 237,
                 "startCol" : 13,
-                "endLine" : 228,
+                "endLine" : 237,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 228,
+              "startLine" : 237,
               "startCol" : 8,
-              "endLine" : 228,
+              "endLine" : 237,
               "endCol" : 21
             }
           }
@@ -6560,9 +6567,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 229,
+                  "startLine" : 238,
                   "startCol" : 6,
-                  "endLine" : 229,
+                  "endLine" : 238,
                   "endCol" : 14
                 }
               },
@@ -6570,24 +6577,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 229,
+                  "startLine" : 238,
                   "startCol" : 15,
-                  "endLine" : 229,
+                  "endLine" : 238,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 229,
+                "startLine" : 238,
                 "startCol" : 6,
-                "endLine" : 229,
+                "endLine" : 238,
                 "endCol" : 17
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 229,
+              "startLine" : 238,
               "startCol" : 6,
-              "endLine" : 229,
+              "endLine" : 238,
               "endCol" : 25
             }
           },
@@ -6595,30 +6602,30 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 229,
+              "startLine" : 238,
               "startCol" : 29,
-              "endLine" : 229,
+              "endLine" : 238,
               "endCol" : 34
             }
           },
           "span" : {
-            "startLine" : 229,
+            "startLine" : 238,
             "startCol" : 6,
-            "endLine" : 229,
+            "endLine" : 238,
             "endCol" : 34
           }
         },
         "span" : {
-          "startLine" : 228,
+          "startLine" : 237,
           "startCol" : 4,
-          "endLine" : 229,
+          "endLine" : 238,
           "endCol" : 34
         }
       },
       "span" : {
-        "startLine" : 227,
+        "startLine" : 236,
         "startCol" : 2,
-        "endLine" : 229,
+        "endLine" : 238,
         "endCol" : 34
       }
     },
@@ -6635,17 +6642,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 232,
+                "startLine" : 241,
                 "startCol" : 13,
-                "endLine" : 232,
+                "endLine" : 241,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 232,
+              "startLine" : 241,
               "startCol" : 8,
-              "endLine" : 232,
+              "endLine" : 241,
               "endCol" : 21
             }
           }
@@ -6661,9 +6668,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 232,
+                  "startLine" : 241,
                   "startCol" : 24,
-                  "endLine" : 232,
+                  "endLine" : 241,
                   "endCol" : 32
                 }
               },
@@ -6671,24 +6678,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 232,
+                  "startLine" : 241,
                   "startCol" : 33,
-                  "endLine" : 232,
+                  "endLine" : 241,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 232,
+                "startLine" : 241,
                 "startCol" : 24,
-                "endLine" : 232,
+                "endLine" : 241,
                 "endCol" : 35
               }
             },
             "field" : "id",
             "span" : {
-              "startLine" : 232,
+              "startLine" : 241,
               "startCol" : 24,
-              "endLine" : 232,
+              "endLine" : 241,
               "endCol" : 38
             }
           },
@@ -6696,30 +6703,30 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 232,
+              "startLine" : 241,
               "startCol" : 41,
-              "endLine" : 232,
+              "endLine" : 241,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 232,
+            "startLine" : 241,
             "startCol" : 24,
-            "endLine" : 232,
+            "endLine" : 241,
             "endCol" : 42
           }
         },
         "span" : {
-          "startLine" : 232,
+          "startLine" : 241,
           "startCol" : 4,
-          "endLine" : 232,
+          "endLine" : 241,
           "endCol" : 42
         }
       },
       "span" : {
-        "startLine" : 231,
+        "startLine" : 240,
         "startCol" : 2,
-        "endLine" : 232,
+        "endLine" : 241,
         "endCol" : 42
       }
     },
@@ -6736,17 +6743,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 235,
+                "startLine" : 244,
                 "startCol" : 13,
-                "endLine" : 235,
+                "endLine" : 244,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 235,
+              "startLine" : 244,
               "startCol" : 8,
-              "endLine" : 235,
+              "endLine" : 244,
               "endCol" : 18
             }
           }
@@ -6758,9 +6765,9 @@
             "kind" : "Identifier",
             "name" : "u",
             "span" : {
-              "startLine" : 235,
+              "startLine" : 244,
               "startCol" : 21,
-              "endLine" : 235,
+              "endLine" : 244,
               "endCol" : 22
             }
           },
@@ -6768,30 +6775,30 @@
             "kind" : "Identifier",
             "name" : "next_user_id",
             "span" : {
-              "startLine" : 235,
+              "startLine" : 244,
               "startCol" : 25,
-              "endLine" : 235,
+              "endLine" : 244,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 235,
+            "startLine" : 244,
             "startCol" : 21,
-            "endLine" : 235,
+            "endLine" : 244,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 235,
+          "startLine" : 244,
           "startCol" : 4,
-          "endLine" : 235,
+          "endLine" : 244,
           "endCol" : 37
         }
       },
       "span" : {
-        "startLine" : 234,
+        "startLine" : 243,
         "startCol" : 2,
-        "endLine" : 235,
+        "endLine" : 244,
         "endCol" : 37
       }
     },
@@ -6808,17 +6815,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 238,
+                "startLine" : 247,
                 "startCol" : 13,
-                "endLine" : 238,
+                "endLine" : 247,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 238,
+              "startLine" : 247,
               "startCol" : 8,
-              "endLine" : 238,
+              "endLine" : 247,
               "endCol" : 21
             }
           }
@@ -6830,9 +6837,9 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 238,
+              "startLine" : 247,
               "startCol" : 24,
-              "endLine" : 238,
+              "endLine" : 247,
               "endCol" : 25
             }
           },
@@ -6840,30 +6847,30 @@
             "kind" : "Identifier",
             "name" : "next_session_id",
             "span" : {
-              "startLine" : 238,
+              "startLine" : 247,
               "startCol" : 28,
-              "endLine" : 238,
+              "endLine" : 247,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 238,
+            "startLine" : 247,
             "startCol" : 24,
-            "endLine" : 238,
+            "endLine" : 247,
             "endCol" : 43
           }
         },
         "span" : {
-          "startLine" : 238,
+          "startLine" : 247,
           "startCol" : 4,
-          "endLine" : 238,
+          "endLine" : 247,
           "endCol" : 43
         }
       },
       "span" : {
-        "startLine" : 237,
+        "startLine" : 246,
         "startCol" : 2,
-        "endLine" : 238,
+        "endLine" : 247,
         "endCol" : 43
       }
     },
@@ -6880,17 +6887,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 256,
                 "startCol" : 14,
-                "endLine" : 247,
+                "endLine" : 256,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 247,
+              "startLine" : 256,
               "startCol" : 8,
-              "endLine" : 247,
+              "endLine" : 256,
               "endCol" : 22
             }
           },
@@ -6900,17 +6907,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 256,
                 "startCol" : 30,
-                "endLine" : 247,
+                "endLine" : 256,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 247,
+              "startLine" : 256,
               "startCol" : 24,
-              "endLine" : 247,
+              "endLine" : 256,
               "endCol" : 38
             }
           }
@@ -6925,9 +6932,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 248,
+                "startLine" : 257,
                 "startCol" : 6,
-                "endLine" : 248,
+                "endLine" : 257,
                 "endCol" : 8
               }
             },
@@ -6935,16 +6942,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 248,
+                "startLine" : 257,
                 "startCol" : 12,
-                "endLine" : 248,
+                "endLine" : 257,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 248,
+              "startLine" : 257,
               "startCol" : 6,
-              "endLine" : 248,
+              "endLine" : 257,
               "endCol" : 14
             }
           },
@@ -6959,9 +6966,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 258,
                     "startCol" : 8,
-                    "endLine" : 249,
+                    "endLine" : 258,
                     "endCol" : 16
                   }
                 },
@@ -6969,24 +6976,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 258,
                     "startCol" : 17,
-                    "endLine" : 249,
+                    "endLine" : 258,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 249,
+                  "startLine" : 258,
                   "startCol" : 8,
-                  "endLine" : 249,
+                  "endLine" : 258,
                   "endCol" : 20
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 249,
+                "startLine" : 258,
                 "startCol" : 8,
-                "endLine" : 249,
+                "endLine" : 258,
                 "endCol" : 33
               }
             },
@@ -6998,9 +7005,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 258,
                     "startCol" : 37,
-                    "endLine" : 249,
+                    "endLine" : 258,
                     "endCol" : 45
                   }
                 },
@@ -7008,52 +7015,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 258,
                     "startCol" : 46,
-                    "endLine" : 249,
+                    "endLine" : 258,
                     "endCol" : 48
                   }
                 },
                 "span" : {
-                  "startLine" : 249,
+                  "startLine" : 258,
                   "startCol" : 37,
-                  "endLine" : 249,
+                  "endLine" : 258,
                   "endCol" : 49
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 249,
+                "startLine" : 258,
                 "startCol" : 37,
-                "endLine" : 249,
+                "endLine" : 258,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 249,
+              "startLine" : 258,
               "startCol" : 8,
-              "endLine" : 249,
+              "endLine" : 258,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 248,
+            "startLine" : 257,
             "startCol" : 6,
-            "endLine" : 249,
+            "endLine" : 258,
             "endCol" : 62
           }
         },
         "span" : {
-          "startLine" : 247,
+          "startLine" : 256,
           "startCol" : 4,
-          "endLine" : 249,
+          "endLine" : 258,
           "endCol" : 62
         }
       },
       "span" : {
-        "startLine" : 246,
+        "startLine" : 255,
         "startCol" : 2,
-        "endLine" : 249,
+        "endLine" : 258,
         "endCol" : 62
       }
     },
@@ -7070,17 +7077,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 252,
+                "startLine" : 261,
                 "startCol" : 14,
-                "endLine" : 252,
+                "endLine" : 261,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 252,
+              "startLine" : 261,
               "startCol" : 8,
-              "endLine" : 252,
+              "endLine" : 261,
               "endCol" : 22
             }
           },
@@ -7090,17 +7097,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 252,
+                "startLine" : 261,
                 "startCol" : 30,
-                "endLine" : 252,
+                "endLine" : 261,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 252,
+              "startLine" : 261,
               "startCol" : 24,
-              "endLine" : 252,
+              "endLine" : 261,
               "endCol" : 38
             }
           }
@@ -7115,9 +7122,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 253,
+                "startLine" : 262,
                 "startCol" : 6,
-                "endLine" : 253,
+                "endLine" : 262,
                 "endCol" : 8
               }
             },
@@ -7125,16 +7132,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 253,
+                "startLine" : 262,
                 "startCol" : 12,
-                "endLine" : 253,
+                "endLine" : 262,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 253,
+              "startLine" : 262,
               "startCol" : 6,
-              "endLine" : 253,
+              "endLine" : 262,
               "endCol" : 14
             }
           },
@@ -7149,9 +7156,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 254,
+                    "startLine" : 263,
                     "startCol" : 8,
-                    "endLine" : 254,
+                    "endLine" : 263,
                     "endCol" : 16
                   }
                 },
@@ -7159,24 +7166,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 254,
+                    "startLine" : 263,
                     "startCol" : 17,
-                    "endLine" : 254,
+                    "endLine" : 263,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 254,
+                  "startLine" : 263,
                   "startCol" : 8,
-                  "endLine" : 254,
+                  "endLine" : 263,
                   "endCol" : 20
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 254,
+                "startLine" : 263,
                 "startCol" : 8,
-                "endLine" : 254,
+                "endLine" : 263,
                 "endCol" : 34
               }
             },
@@ -7188,9 +7195,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 254,
+                    "startLine" : 263,
                     "startCol" : 38,
-                    "endLine" : 254,
+                    "endLine" : 263,
                     "endCol" : 46
                   }
                 },
@@ -7198,52 +7205,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 254,
+                    "startLine" : 263,
                     "startCol" : 47,
-                    "endLine" : 254,
+                    "endLine" : 263,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 254,
+                  "startLine" : 263,
                   "startCol" : 38,
-                  "endLine" : 254,
+                  "endLine" : 263,
                   "endCol" : 50
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 254,
+                "startLine" : 263,
                 "startCol" : 38,
-                "endLine" : 254,
+                "endLine" : 263,
                 "endCol" : 64
               }
             },
             "span" : {
-              "startLine" : 254,
+              "startLine" : 263,
               "startCol" : 8,
-              "endLine" : 254,
+              "endLine" : 263,
               "endCol" : 64
             }
           },
           "span" : {
-            "startLine" : 253,
+            "startLine" : 262,
             "startCol" : 6,
-            "endLine" : 254,
+            "endLine" : 263,
             "endCol" : 64
           }
         },
         "span" : {
-          "startLine" : 252,
+          "startLine" : 261,
           "startCol" : 4,
-          "endLine" : 254,
+          "endLine" : 263,
           "endCol" : 64
         }
       },
       "span" : {
-        "startLine" : 251,
+        "startLine" : 260,
         "startCol" : 2,
-        "endLine" : 254,
+        "endLine" : 263,
         "endCol" : 64
       }
     }
@@ -7264,16 +7271,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 203,
+              "startLine" : 212,
               "startCol" : 39,
-              "endLine" : 203,
+              "endLine" : 212,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 203,
+            "startLine" : 212,
             "startCol" : 32,
-            "endLine" : 203,
+            "endLine" : 212,
             "endCol" : 44
           }
         }
@@ -7282,9 +7289,9 @@
         "kind" : "NamedType",
         "name" : "Int",
         "span" : {
-          "startLine" : 203,
+          "startLine" : 212,
           "startCol" : 47,
-          "endLine" : 203,
+          "endLine" : 212,
           "endCol" : 50
         }
       },
@@ -7298,9 +7305,9 @@
             "kind" : "Identifier",
             "name" : "login_attempts",
             "span" : {
-              "startLine" : 204,
+              "startLine" : 213,
               "startCol" : 12,
-              "endLine" : 204,
+              "endLine" : 213,
               "endCol" : 26
             }
           },
@@ -7319,17 +7326,17 @@
                     "kind" : "Identifier",
                     "name" : "a",
                     "span" : {
-                      "startLine" : 205,
+                      "startLine" : 214,
                       "startCol" : 7,
-                      "endLine" : 205,
+                      "endLine" : 214,
                       "endCol" : 8
                     }
                   },
                   "field" : "email",
                   "span" : {
-                    "startLine" : 205,
+                    "startLine" : 214,
                     "startCol" : 7,
-                    "endLine" : 205,
+                    "endLine" : 214,
                     "endCol" : 14
                   }
                 },
@@ -7337,16 +7344,16 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 205,
+                    "startLine" : 214,
                     "startCol" : 17,
-                    "endLine" : 205,
+                    "endLine" : 214,
                     "endCol" : 22
                   }
                 },
                 "span" : {
-                  "startLine" : 205,
+                  "startLine" : 214,
                   "startCol" : 7,
-                  "endLine" : 205,
+                  "endLine" : 214,
                   "endCol" : 22
                 }
               },
@@ -7359,17 +7366,17 @@
                     "kind" : "Identifier",
                     "name" : "a",
                     "span" : {
-                      "startLine" : 206,
+                      "startLine" : 215,
                       "startCol" : 11,
-                      "endLine" : 206,
+                      "endLine" : 215,
                       "endCol" : 12
                     }
                   },
                   "field" : "success",
                   "span" : {
-                    "startLine" : 206,
+                    "startLine" : 215,
                     "startCol" : 11,
-                    "endLine" : 206,
+                    "endLine" : 215,
                     "endCol" : 20
                   }
                 },
@@ -7377,23 +7384,23 @@
                   "kind" : "BoolLit",
                   "value" : false,
                   "span" : {
-                    "startLine" : 206,
+                    "startLine" : 215,
                     "startCol" : 23,
-                    "endLine" : 206,
+                    "endLine" : 215,
                     "endCol" : 28
                   }
                 },
                 "span" : {
-                  "startLine" : 206,
+                  "startLine" : 215,
                   "startCol" : 11,
-                  "endLine" : 206,
+                  "endLine" : 215,
                   "endCol" : 28
                 }
               },
               "span" : {
-                "startLine" : 205,
+                "startLine" : 214,
                 "startCol" : 7,
-                "endLine" : 206,
+                "endLine" : 215,
                 "endCol" : 28
               }
             },
@@ -7406,17 +7413,17 @@
                   "kind" : "Identifier",
                   "name" : "a",
                   "span" : {
-                    "startLine" : 207,
+                    "startLine" : 216,
                     "startCol" : 11,
-                    "endLine" : 207,
+                    "endLine" : 216,
                     "endCol" : 12
                   }
                 },
                 "field" : "timestamp",
                 "span" : {
-                  "startLine" : 207,
+                  "startLine" : 216,
                   "startCol" : 11,
-                  "endLine" : 207,
+                  "endLine" : 216,
                   "endCol" : 22
                 }
               },
@@ -7429,18 +7436,18 @@
                     "kind" : "Identifier",
                     "name" : "now",
                     "span" : {
-                      "startLine" : 207,
+                      "startLine" : 216,
                       "startCol" : 25,
-                      "endLine" : 207,
+                      "endLine" : 216,
                       "endCol" : 28
                     }
                   },
                   "args" : [
                   ],
                   "span" : {
-                    "startLine" : 207,
+                    "startLine" : 216,
                     "startCol" : 25,
-                    "endLine" : 207,
+                    "endLine" : 216,
                     "endCol" : 30
                   }
                 },
@@ -7450,9 +7457,9 @@
                     "kind" : "Identifier",
                     "name" : "minutes",
                     "span" : {
-                      "startLine" : 207,
+                      "startLine" : 216,
                       "startCol" : 33,
-                      "endLine" : 207,
+                      "endLine" : 216,
                       "endCol" : 40
                     }
                   },
@@ -7461,59 +7468,59 @@
                       "kind" : "IntLit",
                       "value" : 15,
                       "span" : {
-                        "startLine" : 207,
+                        "startLine" : 216,
                         "startCol" : 41,
-                        "endLine" : 207,
+                        "endLine" : 216,
                         "endCol" : 43
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 207,
+                    "startLine" : 216,
                     "startCol" : 33,
-                    "endLine" : 207,
+                    "endLine" : 216,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 207,
+                  "startLine" : 216,
                   "startCol" : 25,
-                  "endLine" : 207,
+                  "endLine" : 216,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 207,
+                "startLine" : 216,
                 "startCol" : 11,
-                "endLine" : 207,
+                "endLine" : 216,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 205,
+              "startLine" : 214,
               "startCol" : 7,
-              "endLine" : 207,
+              "endLine" : 216,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 204,
+            "startLine" : 213,
             "startCol" : 5,
-            "endLine" : 207,
+            "endLine" : 216,
             "endCol" : 46
           }
         },
         "span" : {
-          "startLine" : 204,
+          "startLine" : 213,
           "startCol" : 4,
-          "endLine" : 207,
+          "endLine" : 216,
           "endCol" : 46
         }
       },
       "span" : {
-        "startLine" : 203,
+        "startLine" : 212,
         "startCol" : 2,
-        "endLine" : 207,
+        "endLine" : 216,
         "endCol" : 46
       }
     }
@@ -7637,9 +7644,9 @@
           "value" : "/auth/register"
         },
         "span" : {
-          "startLine" : 264,
+          "startLine" : 273,
           "startCol" : 4,
-          "endLine" : 264,
+          "endLine" : 273,
           "endCol" : 41
         }
       },
@@ -7653,9 +7660,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 265,
+          "startLine" : 274,
           "startCol" : 4,
-          "endLine" : 265,
+          "endLine" : 274,
           "endCol" : 38
         }
       },
@@ -7669,9 +7676,9 @@
           "value" : "/auth/login"
         },
         "span" : {
-          "startLine" : 267,
+          "startLine" : 276,
           "startCol" : 4,
-          "endLine" : 267,
+          "endLine" : 276,
           "endCol" : 35
         }
       },
@@ -7685,9 +7692,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 268,
+          "startLine" : 277,
           "startCol" : 4,
-          "endLine" : 268,
+          "endLine" : 277,
           "endCol" : 30
         }
       },
@@ -7701,9 +7708,9 @@
           "value" : 200
         },
         "span" : {
-          "startLine" : 269,
+          "startLine" : 278,
           "startCol" : 4,
-          "endLine" : 269,
+          "endLine" : 278,
           "endCol" : 35
         }
       },
@@ -7717,9 +7724,9 @@
           "value" : "/auth/refresh"
         },
         "span" : {
-          "startLine" : 271,
+          "startLine" : 280,
           "startCol" : 4,
-          "endLine" : 271,
+          "endLine" : 280,
           "endCol" : 44
         }
       },
@@ -7733,9 +7740,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 272,
+          "startLine" : 281,
           "startCol" : 4,
-          "endLine" : 272,
+          "endLine" : 281,
           "endCol" : 37
         }
       },
@@ -7749,9 +7756,9 @@
           "value" : "/auth/password-reset"
         },
         "span" : {
-          "startLine" : 274,
+          "startLine" : 283,
           "startCol" : 4,
-          "endLine" : 274,
+          "endLine" : 283,
           "endCol" : 59
         }
       },
@@ -7765,9 +7772,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 275,
+          "startLine" : 284,
           "startCol" : 4,
-          "endLine" : 275,
+          "endLine" : 284,
           "endCol" : 45
         }
       },
@@ -7781,9 +7788,9 @@
           "value" : "/auth/password-reset/confirm"
         },
         "span" : {
-          "startLine" : 277,
+          "startLine" : 286,
           "startCol" : 4,
-          "endLine" : 277,
+          "endLine" : 286,
           "endCol" : 60
         }
       },
@@ -7797,9 +7804,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 278,
+          "startLine" : 287,
           "startCol" : 4,
-          "endLine" : 278,
+          "endLine" : 287,
           "endCol" : 38
         }
       },
@@ -7813,9 +7820,9 @@
           "value" : "/auth/logout"
         },
         "span" : {
-          "startLine" : 280,
+          "startLine" : 289,
           "startCol" : 4,
-          "endLine" : 280,
+          "endLine" : 289,
           "endCol" : 37
         }
       },
@@ -7829,9 +7836,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 281,
+          "startLine" : 290,
           "startCol" : 4,
-          "endLine" : 281,
+          "endLine" : 290,
           "endCol" : 31
         }
       },
@@ -7845,24 +7852,53 @@
           "value" : 204
         },
         "span" : {
-          "startLine" : 282,
+          "startLine" : 291,
           "startCol" : 4,
-          "endLine" : 282,
+          "endLine" : 291,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 263,
+      "startLine" : 272,
       "startCol" : 2,
-      "endLine" : 283,
+      "endLine" : 292,
       "endCol" : 3
     }
   },
+  "security" : [
+    {
+      "kind" : {
+        "scheme" : "Bearer",
+        "bearerFormat" : "JWT"
+      },
+      "name" : "bearer",
+      "span" : {
+        "startLine" : 67,
+        "startCol" : 4,
+        "endLine" : 67,
+        "endCol" : 40
+      }
+    },
+    {
+      "kind" : {
+        "scheme" : "ApiKey",
+        "location" : "header",
+        "name" : "X-API-Key"
+      },
+      "name" : "api_key",
+      "span" : {
+        "startLine" : 68,
+        "startCol" : 4,
+        "endLine" : 68,
+        "endCol" : 40
+      }
+    }
+  ],
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 284,
+    "endLine" : 293,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/auth_service.spec
+++ b/fixtures/spec/auth_service.spec
@@ -61,6 +61,13 @@ service AuthService {
     next_session_id: Int
   }
 
+  // --- Security schemes ---
+
+  security {
+    bearer: Bearer(bearer_format: "JWT")
+    api_key: ApiKey(header: "X-API-Key")
+  }
+
   // --- Operations ---
 
   operation Register {
@@ -129,6 +136,7 @@ service AuthService {
   operation RefreshToken {
     input:  refresh_token: Token
     output: new_session: Session
+    requires_auth: bearer, api_key
 
     requires:
       some s in sessions |
@@ -185,6 +193,7 @@ service AuthService {
 
   operation Logout {
     input: access_token: Token
+    requires_auth: bearer
 
     requires:
       some s in sessions |

--- a/modules/cli/src/main/scala/specrest/cli/Check.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Check.scala
@@ -44,7 +44,8 @@ object Check:
 
                     val convDiags =
                       Validate.validateConventions(svcConventions(ir), ir) ++
-                        Validate.validateRoutes(ir)
+                        Validate.validateRoutes(ir) ++
+                        Validate.validateSecurity(ir)
                     val lintDiags = Lint.run(ir)
 
                     val convErrors   = convDiags.filter(_.level == ConvDiagLevel.Error)

--- a/modules/cli/src/main/scala/specrest/cli/Compile.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Compile.scala
@@ -102,7 +102,7 @@ object Compile:
               case Left(err) =>
                 IO.delay(log.error(Check.renderBuildError(specFile, err))).as(ExitCodes.Violations)
               case Right(ir) =>
-                val routeDiags = Validate.validateRoutes(ir)
+                val routeDiags = Validate.validateRoutes(ir) ++ Validate.validateSecurity(ir)
                 val gate =
                   if routeDiags.nonEmpty then
                     IO.delay(routeDiags.foreach(d => log.error(Check.renderConv(specFile, d))))

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -180,7 +180,8 @@ class OpenApiTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
 
   test("components include Create / Read / Update schemas + ErrorResponse"):

--- a/modules/convention/src/main/scala/specrest/convention/Validate.scala
+++ b/modules/convention/src/main/scala/specrest/convention/Validate.scala
@@ -83,6 +83,37 @@ object Validate:
             "http_path"
           )
 
+  def validateSecurity(ir: ServiceIRFull): List[ConventionDiagnostic] =
+    val schemes  = svcSecurity(ir)
+    val declared = schemes.map(ssdName).toSet
+    val duplicates = schemes
+      .groupBy(ssdName)
+      .valuesIterator
+      .filter(_.sizeIs > 1)
+      .flatMap(_.drop(1))
+      .map: s =>
+        ConventionDiagnostic(
+          DiagnosticLevel.Error,
+          s"duplicate security scheme '${ssdName(s)}'",
+          ssdSpan(s),
+          ssdName(s),
+          "security"
+        )
+      .toList
+    val undeclaredRefs = svcOperations(ir).flatMap: op =>
+      operRequiresAuth(op).getOrElse(Nil).filterNot(declared.contains).map: ref =>
+        val hint =
+          if declared.isEmpty then "no security block is declared"
+          else s"declared schemes: ${declared.toList.sorted.mkString(", ")}"
+        ConventionDiagnostic(
+          DiagnosticLevel.Error,
+          s"operation '${operName(op)}' requires_auth references undeclared security scheme '$ref'; $hint",
+          operSpan(op),
+          operName(op),
+          "requires_auth"
+        )
+    duplicates ++ undeclaredRefs
+
   def validateConventions(
       conventions: Option[conventions_decl],
       ir: ServiceIRFull

--- a/modules/convention/src/test/scala/specrest/convention/SecurityValidateTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/SecurityValidateTest.scala
@@ -1,0 +1,79 @@
+package specrest.convention
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.ServiceIRFull
+import specrest.parser.Builder
+import specrest.parser.Parse
+
+class SecurityValidateTest extends CatsEffectSuite:
+
+  private def loadIR(spec: String) =
+    Parse.parseSpec(spec).flatMap:
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).map:
+          case Right(ir) => ir
+          case Left(err) => fail(s"build error: $err")
+      case Left(err) => fail(s"parse error: $err")
+
+  private def service(security: String, requiresAuth: String): String =
+    s"""|service Demo {
+        |  state {
+        |    count: Int
+        |  }
+        |$security
+        |  operation Increment {
+        |$requiresAuth
+        |    requires:
+        |      true
+        |
+        |    ensures:
+        |      count' = count + 1
+        |  }
+        |}
+        |""".stripMargin
+
+  private val bearerBlock =
+    """|  security {
+       |    bearer: Bearer(bearer_format: "JWT")
+       |  }
+       |""".stripMargin
+
+  test("declared scheme reference produces no diagnostics"):
+    loadIR(service(bearerBlock, "    requires_auth: bearer")).map: ir =>
+      assertEquals(Validate.validateSecurity(ir), Nil)
+
+  test("no security usage at all produces no diagnostics"):
+    loadIR(service("", "")).map: ir =>
+      assertEquals(Validate.validateSecurity(ir), Nil)
+
+  test("undeclared scheme reference is an error naming op, scheme, and declared set"):
+    loadIR(service(bearerBlock, "    requires_auth: api_key")).map: ir =>
+      val diags = Validate.validateSecurity(ir)
+      assertEquals(diags.size, 1)
+      val d = diags.head
+      assertEquals(d.level, DiagnosticLevel.Error)
+      assert(d.message.contains("'Increment'"), d.message)
+      assert(d.message.contains("'api_key'"), d.message)
+      assert(d.message.contains("declared schemes: bearer"), d.message)
+      assertEquals(d.target, "Increment")
+      assertEquals(d.property, "requires_auth")
+      assert(d.span.isDefined, "diagnostic carries the operation span")
+
+  test("reference with no security block declared says so"):
+    loadIR(service("", "    requires_auth: bearer")).map: ir =>
+      val diags = Validate.validateSecurity(ir)
+      assertEquals(diags.size, 1)
+      assert(diags.head.message.contains("no security block is declared"), diags.head.message)
+
+  test("duplicate scheme names are an error on the second declaration"):
+    val dup =
+      """|  security {
+         |    bearer: Bearer
+         |    bearer: Basic
+         |  }
+         |""".stripMargin
+    loadIR(service(dup, "    requires_auth: bearer")).map: ir =>
+      val diags = Validate.validateSecurity(ir)
+      assertEquals(diags.size, 1)
+      assert(diags.head.message.contains("duplicate security scheme 'bearer'"), diags.head.message)
+      assertEquals(diags.head.level, DiagnosticLevel.Error)

--- a/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/StrategyOverrideTest.scala
@@ -33,7 +33,8 @@ class StrategyOverrideTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = if rules.isEmpty then None else Some(ConventionsDeclFull(rules, None)),
-      o = None
+      o = Nil,
+      p = None
     )
 
   test("strategy on type alias is accepted"):
@@ -54,7 +55,7 @@ class StrategyOverrideTest extends CatsEffectSuite:
 
   test("strategy on operation is rejected"):
     val ir = baseIR(
-      operations = List(OperationDeclFull("Shorten", Nil, Nil, Nil, Nil, None)),
+      operations = List(OperationDeclFull("Shorten", Nil, Nil, Nil, Nil, None, None)),
       rules = List(stringRule("Shorten", "strategy", "tests.strategies_user:foo"))
     )
     val diagnostics = Validate.validateConventions(svcConventions(ir), ir)

--- a/modules/convention/src/test/scala/specrest/convention/TestStrategyOverrideTest.scala
+++ b/modules/convention/src/test/scala/specrest/convention/TestStrategyOverrideTest.scala
@@ -42,7 +42,8 @@ class TestStrategyOverrideTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = if rules.isEmpty then None else Some(ConventionsDeclFull(rules, None)),
-      o = None
+      o = Nil,
+      p = None
     )
 
   private val userEntity = EntityDeclFull(
@@ -66,6 +67,7 @@ class TestStrategyOverrideTest extends CatsEffectSuite:
     Nil,
     Nil,
     Nil,
+    None,
     None
   )
 
@@ -242,7 +244,7 @@ class TestStrategyOverrideTest extends CatsEffectSuite:
 
   test("multiple http_method rules with different string qualifiers do not bypass dup detection"):
     val ir = baseIR(
-      operations = List(OperationDeclFull("Login", Nil, Nil, Nil, Nil, None)),
+      operations = List(OperationDeclFull("Login", Nil, Nil, Nil, Nil, None, None)),
       rules = List(
         rule("Login", "http_method", Some("x"), StringLitF("POST", None)),
         rule("Login", "http_method", Some("y"), StringLitF("GET", None))

--- a/modules/ir/src/main/scala/specrest/ir/Serialize.scala
+++ b/modules/ir/src/main/scala/specrest/ir/Serialize.scala
@@ -541,15 +541,16 @@ object Serialize:
     yield ParamDeclFull(n, t, sp)
 
   given operationDeclEnc: Encoder[operation_decl] = Encoder.AsObject.instance:
-    case OperationDeclFull(n, i, o, r, e, sp) =>
-      kindObj(
+    case OperationDeclFull(n, i, o, r, e, ra, sp) =>
+      val base = kindObj(
         "Operation",
         "name"     -> n.asJson,
         "inputs"   -> i.asJson,
         "outputs"  -> o.asJson,
         "requires" -> r.asJson,
         "ensures"  -> e.asJson
-      ).addSpan(sp)
+      )
+      ra.fold(base)(xs => base.add("requiresAuth", xs.asJson)).addSpan(sp)
 
   given operationDeclDec: Decoder[operation_decl] = Decoder.instance: c =>
     for
@@ -558,8 +559,9 @@ object Serialize:
       o  <- c.getOrElse[List[param_decl]]("outputs")(Nil)
       r  <- c.getOrElse[List[expr]]("requires")(Nil)
       e  <- c.getOrElse[List[expr]]("ensures")(Nil)
+      ra <- c.getOrElse[Option[List[String]]]("requiresAuth")(None)
       sp <- c.getOrElse[Option[span_t]]("span")(None)
-    yield OperationDeclFull(n, i, o, r, e, sp)
+    yield OperationDeclFull(n, i, o, r, e, ra, sp)
 
   given transitionRuleEnc: Encoder[transition_rule] = Encoder.AsObject.instance:
     case TransitionRuleFull(f, t, v, g, sp) =>
@@ -697,9 +699,50 @@ object Serialize:
       sp <- c.getOrElse[Option[span_t]]("span")(None)
     yield ConventionsDeclFull(r, sp)
 
+  given securitySchemeKindEnc: Encoder[security_scheme_kind] = Encoder.instance:
+    case SsBearer(fmt) =>
+      Json.fromJsonObject(
+        fmt.fold(JsonObject("scheme" -> "Bearer".asJson))(f =>
+          JsonObject("scheme" -> "Bearer".asJson, "bearerFormat" -> f.asJson)
+        )
+      )
+    case SsApiKey(location, name) =>
+      Json.fromJsonObject(
+        JsonObject(
+          "scheme"   -> "ApiKey".asJson,
+          "location" -> location.asJson,
+          "name"     -> name.asJson
+        )
+      )
+    case SsBasic() => Json.fromJsonObject(JsonObject("scheme" -> "Basic".asJson))
+
+  given securitySchemeKindDec: Decoder[security_scheme_kind] = Decoder.instance: c =>
+    c.get[String]("scheme").flatMap:
+      case "Bearer" =>
+        c.getOrElse[Option[String]]("bearerFormat")(None).map(SsBearer(_))
+      case "ApiKey" =>
+        for
+          location <- c.get[String]("location")
+          name     <- c.get[String]("name")
+        yield SsApiKey(location, name)
+      case "Basic" => Right(SsBasic())
+      case other =>
+        Left(io.circe.DecodingFailure(s"Unknown security scheme kind: $other", c.history))
+
+  given securitySchemeDeclEnc: Encoder[security_scheme_decl] = Encoder.AsObject.instance:
+    case SecuritySchemeDeclFull(n, k, sp) =>
+      kindObj("SecurityScheme", "name" -> n.asJson, "kind" -> k.asJson).addSpan(sp)
+
+  given securitySchemeDeclDec: Decoder[security_scheme_decl] = Decoder.instance: c =>
+    for
+      n  <- c.get[String]("name")
+      k  <- c.get[security_scheme_kind]("kind")
+      sp <- c.getOrElse[Option[span_t]]("span")(None)
+    yield SecuritySchemeDeclFull(n, k, sp)
+
   given serviceIREnc: Encoder[service_ir] = Encoder.AsObject.instance:
-    case ServiceIRFull(n, im, en, es, ta, st, op, tr, iv, tm, fa, fn, pr, cv, sp) =>
-      kindObj(
+    case ServiceIRFull(n, im, en, es, ta, st, op, tr, iv, tm, fa, fn, pr, cv, se, sp) =>
+      val base = kindObj(
         "Service",
         "name"        -> n.asJson,
         "imports"     -> im.asJson,
@@ -715,7 +758,8 @@ object Serialize:
         "functions"   -> fn.asJson,
         "predicates"  -> pr.asJson,
         "conventions" -> nullable(cv)
-      ).addSpan(sp)
+      )
+      (if se.isEmpty then base else base.add("security", se.asJson)).addSpan(sp)
 
   given serviceIRDec: Decoder[service_ir] = Decoder.instance: c =>
     for
@@ -733,8 +777,9 @@ object Serialize:
       fn <- c.getOrElse[List[function_decl]]("functions")(Nil)
       pr <- c.getOrElse[List[predicate_decl]]("predicates")(Nil)
       cv <- c.getOrElse[Option[conventions_decl]]("conventions")(None)
+      se <- c.getOrElse[List[security_scheme_decl]]("security")(Nil)
       sp <- c.getOrElse[Option[span_t]]("span")(None)
-    yield ServiceIRFull(n, im, en, es, ta, st, op, tr, iv, tm, fa, fn, pr, cv, sp)
+    yield ServiceIRFull(n, im, en, es, ta, st, op, tr, iv, tm, fa, fn, pr, cv, se, sp)
 
   def toJson(ir: service_ir): Json = ir.asJson
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -590,6 +590,15 @@ object SpecRestGenerated {
   final case class ParamDeclFull(a: String, b: type_expr, c: Option[span_t])
       extends param_decl
 
+  sealed abstract class security_scheme_kind
+  final case class SsBearer(a: Option[String])    extends security_scheme_kind
+  final case class SsApiKey(a: String, b: String) extends security_scheme_kind
+  final case class SsBasic()                      extends security_scheme_kind
+
+  sealed abstract class security_scheme_decl
+  final case class SecuritySchemeDeclFull(a: String, b: security_scheme_kind, c: Option[span_t])
+      extends security_scheme_decl
+
   sealed abstract class validation_failure
   final case class ExpectedString()                extends validation_failure
   final case class ExpectedInteger()               extends validation_failure
@@ -659,7 +668,8 @@ object SpecRestGenerated {
       c: List[param_decl],
       d: List[expr],
       e: List[expr],
-      f: Option[span_t]
+      f: Option[List[String]],
+      g: Option[span_t]
   ) extends operation_decl
 
   sealed abstract class invariant_decl
@@ -718,7 +728,8 @@ object SpecRestGenerated {
       l: List[function_decl],
       m: List[predicate_decl],
       n: Option[conventions_decl],
-      o: Option[span_t]
+      o: List[security_scheme_decl],
+      p: Option[span_t]
   ) extends service_ir
 
   sealed abstract class schema_type
@@ -5396,11 +5407,11 @@ object SpecRestGenerated {
   }
 
   def svcName(x0: service_ir): String = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x1
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x1
   }
 
   def svcSpan(x0: service_ir): Option[span_t] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x15
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x16
   }
 
   def stdSpan(x0: state_decl): Option[span_t] = x0 match {
@@ -6097,15 +6108,15 @@ object SpecRestGenerated {
   }
 
   def svcEnums(x0: service_ir): List[enum_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x4
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x4
   }
 
   def svcFacts(x0: service_ir): List[fact_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x11
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x11
   }
 
   def svcState(x0: service_ir): Option[state_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x6
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x6
   }
 
   def combineAnd_acc(acc: expr, x1: List[expr]): expr = (acc, x1) match {
@@ -6417,7 +6428,7 @@ object SpecRestGenerated {
   }
 
   def serviceEnums(x0: service_ir): List[enum_decl] = x0 match {
-    case ServiceIRFull(uu, uv, uw, en, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => en
+    case ServiceIRFull(uu, uv, uw, en, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh, vi) => en
   }
 
   def typeExprToTy(x0: schema_type): Option[ty] = x0 match {
@@ -6479,7 +6490,7 @@ object SpecRestGenerated {
     list_ex[expr]((a: expr) => isBoolLit(a), allSubexprs(e))
 
   def operationHasBoolLit(x0: operation_decl): Boolean = x0 match {
-    case OperationDeclFull(uu, uv, uw, requiresa, ensures, ux) =>
+    case OperationDeclFull(uu, uv, uw, requiresa, ensures, ux, uy) =>
       list_ex[expr]((a: expr) => exprContainsBoolLit(a), requiresa) ||
       list_ex[expr]((a: expr) => exprContainsBoolLit(a), ensures)
   }
@@ -6524,7 +6535,7 @@ object SpecRestGenerated {
   ): Boolean =
     (x0, stateFields, inputFields) match {
       case (
-            ServiceIRFull(uu, uv, es, uw, ux, uy, ops, uz, invs, temps, va, vb, vc, vd, ve),
+            ServiceIRFull(uu, uv, es, uw, ux, uy, ops, uz, invs, temps, va, vb, vc, vd, ve, vf),
             stateFields,
             inputFields
           ) => list_ex[entity_decl]((a: entity_decl) => entityHasBoolField(a), es) ||
@@ -7934,7 +7945,7 @@ object SpecRestGenerated {
   }
 
   def svcImports(x0: service_ir): List[String] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x2
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x2
   }
 
   def tmpBody(x0: temporal_decl): temporal_body = x0 match {
@@ -9825,7 +9836,11 @@ object SpecRestGenerated {
   }
 
   def svcEntities(x0: service_ir): List[entity_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x3
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x3
+  }
+
+  def svcSecurity(x0: service_ir): List[security_scheme_decl] = x0 match {
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x15
   }
 
   def trlVia(x0: transition_rule): String = x0 match {
@@ -10410,7 +10425,7 @@ object SpecRestGenerated {
     }
 
   def serviceEntities(x0: service_ir): List[entity_decl] = x0 match {
-    case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+    case ServiceIRFull(uu, uv, es, uw, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh, vi) => es
   }
 
   def isDateTimeTypeAux(fuel: nat, uu: List[type_alias_decl], uv: type_expr): Boolean =
@@ -10512,19 +10527,19 @@ object SpecRestGenerated {
   }
 
   def operName(x0: operation_decl): String = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x1
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x1
   }
 
   def operSpan(x0: operation_decl): Option[span_t] = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x6
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x7
   }
 
   def svcFunctions(x0: service_ir): List[function_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x12
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x12
   }
 
   def svcTemporals(x0: service_ir): List[temporal_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x10
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x10
   }
 
   def trnName(x0: transition_decl): String = x0 match {
@@ -11151,7 +11166,7 @@ object SpecRestGenerated {
     }
 
   def serviceStateFields(x0: service_ir): List[state_field_decl] = x0 match {
-    case ServiceIRFull(uu, uv, uw, ux, uy, st, uz, va, vb, vc, vd, ve, vf, vg, vh) => st match {
+    case ServiceIRFull(uu, uv, uw, ux, uy, st, uz, va, vb, vc, vd, ve, vf, vg, vh, vi) => st match {
         case None                       => Nil
         case Some(StateDeclFull(fs, _)) => fs
       }
@@ -11282,15 +11297,15 @@ object SpecRestGenerated {
   }
 
   def svcInvariants(x0: service_ir): List[invariant_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x9
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x9
   }
 
   def svcOperations(x0: service_ir): List[operation_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x7
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x7
   }
 
   def svcPredicates(x0: service_ir): List[predicate_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x13
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x13
   }
 
   def stfName(x0: state_field_decl): String = x0 match {
@@ -12565,7 +12580,7 @@ object SpecRestGenerated {
   }
 
   def operInputs(x0: operation_decl): List[param_decl] = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x2
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x2
   }
 
   def qbdVar(x0: quantifier_binding): String = x0 match {
@@ -12573,15 +12588,15 @@ object SpecRestGenerated {
   }
 
   def svcConventions(x0: service_ir): Option[conventions_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x14
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x14
   }
 
   def svcTransitions(x0: service_ir): List[transition_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x8
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x8
   }
 
   def svcTypeAliases(x0: service_ir): List[type_alias_decl] = x0 match {
-    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => x5
+    case ServiceIRFull(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => x5
   }
 
   def trnEntity(x0: transition_decl): String = x0 match {
@@ -13214,7 +13229,7 @@ object SpecRestGenerated {
   }
 
   def serviceIrInvariants(x0: service_ir): List[invariant_decl] = x0 match {
-    case ServiceIRFull(uu, uv, uw, ux, uy, uz, va, vb, invs, vc, vd, ve, vf, vg, vh) => invs
+    case ServiceIRFull(uu, uv, uw, ux, uy, uz, va, vb, invs, vc, vd, ve, vf, vg, vh, vi) => invs
   }
 
   def invariantBody(x0: invariant_decl): expr = x0 match {
@@ -13486,11 +13501,11 @@ object SpecRestGenerated {
   }
 
   def operEnsures(x0: operation_decl): List[expr] = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x5
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x5
   }
 
   def operOutputs(x0: operation_decl): List[param_decl] = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x3
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x3
   }
 
   def qbdKind(x0: quantifier_binding): binding_kind = x0 match {
@@ -13538,7 +13553,7 @@ object SpecRestGenerated {
   }
 
   def emptyServiceIrFull(nm: String): service_ir =
-    ServiceIRFull(nm, Nil, Nil, Nil, Nil, None, Nil, Nil, Nil, Nil, Nil, Nil, Nil, None, None)
+    ServiceIRFull(nm, Nil, Nil, Nil, Nil, None, Nil, Nil, Nil, Nil, Nil, Nil, Nil, None, Nil, None)
 
   def extractFieldAssignRhs(x0: expr, field: String): List[expr] = (x0, field) match {
     case (BinaryOpF(BEq(), lhs, rhs, uu), field) =>
@@ -13618,7 +13633,7 @@ object SpecRestGenerated {
     enumValuesForType(Suc(size_list[type_alias_decl](aliases)), fieldTypeFull(f), enums, aliases)
 
   def flattenInheritance(x0: service_ir): service_ir = x0 match {
-    case ServiceIRFull(a, b, c, d, e, f, g, h, i, j, k, l, m, n, p) =>
+    case ServiceIRFull(a, b, c, d, e, f, g, h, i, j, k, l, m, n, sec, p) =>
       ServiceIRFull(
         a,
         b,
@@ -13638,6 +13653,7 @@ object SpecRestGenerated {
         l,
         m,
         n,
+        sec,
         p
       )
   }
@@ -13920,7 +13936,7 @@ object SpecRestGenerated {
     }
 
   def operationRequires(x0: operation_decl): List[expr] = x0 match {
-    case OperationDeclFull(uu, uv, uw, requiresa, ux, uy) => requiresa
+    case OperationDeclFull(uu, uv, uw, requiresa, ux, uy, uz) => requiresa
   }
 
   def trustEnabled(enums: List[String], op: operation_decl, ir: service_ir): trust_level =
@@ -13974,7 +13990,7 @@ object SpecRestGenerated {
   }
 
   def operRequires(x0: operation_decl): List[expr] = x0 match {
-    case OperationDeclFull(x1, x2, x3, x4, x5, x6) => x4
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x4
   }
 
   def detectCreatePattern(es: List[expr], stateFields: List[String]): Option[String] =
@@ -14313,6 +14329,18 @@ object SpecRestGenerated {
     case (UCardinality(), UCardinality()) => true
     case (UNegate(), UNegate())           => true
     case (UNot(), UNot())                 => true
+  }
+
+  def ssdKind(x0: security_scheme_decl): security_scheme_kind = x0 match {
+    case SecuritySchemeDeclFull(x1, x2, x3) => x2
+  }
+
+  def ssdName(x0: security_scheme_decl): String = x0 match {
+    case SecuritySchemeDeclFull(x1, x2, x3) => x1
+  }
+
+  def ssdSpan(x0: security_scheme_decl): Option[span_t] = x0 match {
+    case SecuritySchemeDeclFull(x1, x2, x3) => x3
   }
 
   def identifierNameSelect(x0: expr): List[String] = x0 match {
@@ -14679,7 +14707,7 @@ object SpecRestGenerated {
     }
 
   def serviceIrEnums(x0: service_ir): List[enum_decl] = x0 match {
-    case ServiceIRFull(uu, uv, uw, es, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh) => es
+    case ServiceIRFull(uu, uv, uw, es, ux, uy, uz, va, vb, vc, vd, ve, vf, vg, vh, vi) => es
   }
 
   def knownBuiltinNames: List[String] = List("len", "dom", "ran")
@@ -15609,7 +15637,7 @@ object SpecRestGenerated {
     }
 
   def operationEnsures(x0: operation_decl): List[expr] = x0 match {
-    case OperationDeclFull(uu, uv, uw, ux, ensures, uy) => ensures
+    case OperationDeclFull(uu, uv, uw, ux, ensures, uy, uz) => ensures
   }
 
   def classifyAlloyIdentifier(
@@ -15787,6 +15815,10 @@ object SpecRestGenerated {
         case true  => " INT NOT NULL AUTO_INCREMENT"
         case false => " BIGINT NOT NULL AUTO_INCREMENT"
       })
+
+  def operRequiresAuth(x0: operation_decl): Option[List[String]] = x0 match {
+    case OperationDeclFull(x1, x2, x3, x4, x5, x6, x7) => x6
+  }
 
   def collectFieldAccessNames(e: expr): List[String] =
     remdups[String](maps[expr, String]((a: expr) => fieldAccessNameSelect(a), allSubexprs(e)))
@@ -16309,7 +16341,7 @@ object SpecRestGenerated {
     ))
 
   def operationMissingEnsures(x0: operation_decl): Boolean = x0 match {
-    case OperationDeclFull(uu, uv, outputs, uw, ensures, ux) =>
+    case OperationDeclFull(uu, uv, outputs, uw, ensures, ux, uy) =>
       !nulla[param_decl](outputs) && nulla[expr](ensures)
   }
 
@@ -16558,9 +16590,9 @@ object SpecRestGenerated {
   def findOperationByName(x0: List[operation_decl], uu: String): Option[operation_decl] =
     (x0, uu) match {
       case (Nil, uu) => None
-      case (OperationDeclFull(n, a, b, c, d, e) :: rest, nm) =>
+      case (OperationDeclFull(n, a, b, c, d, ra, e) :: rest, nm) =>
         n == nm match {
-          case true  => Some[operation_decl](OperationDeclFull(n, a, b, c, d, e))
+          case true  => Some[operation_decl](OperationDeclFull(n, a, b, c, d, ra, e))
           case false => findOperationByName(rest, nm)
         }
     }
@@ -16707,7 +16739,7 @@ object SpecRestGenerated {
 
   def operationHasParamNamed(x0: operation_decl, nm: String): Boolean =
     (x0, nm) match {
-      case (OperationDeclFull(uu, inputs, uv, uw, ux, uy), nm) =>
+      case (OperationDeclFull(uu, inputs, uv, uw, ux, uy, uz), nm) =>
         paramListHasName(inputs, nm)
     }
 

--- a/modules/parser/src/main/antlr4/Spec.g4
+++ b/modules/parser/src/main/antlr4/Spec.g4
@@ -40,6 +40,7 @@ serviceMember
     | functionDecl
     | predicateDecl
     | conventionBlock
+    | securityBlock
     ;
 
 // ─── Entity ──────────────────────────────────────────────────
@@ -130,6 +131,7 @@ operationClause
     | outputClause
     | requiresClause
     | ensuresClause
+    | requiresAuthClause
     ;
 
 inputClause
@@ -154,6 +156,10 @@ requiresClause
 
 ensuresClause
     : ENSURES COLON expr+
+    ;
+
+requiresAuthClause
+    : REQUIRES_AUTH COLON lowerIdent (COMMA lowerIdent)*
     ;
 
 // ─── Transition (state machine) ─────────────────────────────
@@ -202,6 +208,20 @@ conventionBlock
 
 conventionRule
     : UPPER_IDENT DOT lowerIdent (DOT lowerIdent)? STRING_LIT? EQ expr
+    ;
+
+// ─── Security schemes ────────────────────────────────────────
+
+securityBlock
+    : SECURITY LBRACE securitySchemeDecl* RBRACE
+    ;
+
+securitySchemeDecl
+    : lowerIdent COLON UPPER_IDENT (LPAREN securitySchemeArg (COMMA securitySchemeArg)* RPAREN)?
+    ;
+
+securitySchemeArg
+    : lowerIdent COLON STRING_LIT
     ;
 
 // ─── Expressions ─────────────────────────────────────────────
@@ -353,7 +373,7 @@ lowerIdent
     | INPUT | OUTPUT | FIELD | STATE
     | ONE | LONE | SET_MULT
     | VIA | WHEN | WHERE | WITH | EXTENDS
-    | REQUIRES | ENSURES
+    | REQUIRES | ENSURES | REQUIRES_AUTH | SECURITY
     | ENTITY | OPERATION | TRANSITION | INVARIANT | TEMPORAL | FACT
     | CONVENTIONS | FUNCTION | PREDICATE | TYPE | ENUM | IMPORT
     | SERVICE
@@ -376,6 +396,7 @@ INVARIANT   : 'invariant' ;
 TEMPORAL    : 'temporal' ;
 FACT        : 'fact' ;
 CONVENTIONS : 'conventions' ;
+SECURITY    : 'security' ;
 IMPORT      : 'import' ;
 FUNCTION    : 'function' ;
 PREDICATE   : 'predicate' ;
@@ -383,6 +404,7 @@ EXTENDS     : 'extends' ;
 
 INPUT       : 'input' ;
 OUTPUT      : 'output' ;
+REQUIRES_AUTH : 'requires_auth' ;
 REQUIRES    : 'requires' ;
 ENSURES     : 'ensures' ;
 FIELD       : 'field' ;

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -339,7 +339,11 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
               (if allowed.isEmpty then "" else s"; expected ${allowed.mkString(", ")}"),
             ctx
           ))
-        case None => Right(args.toMap)
+        case None =>
+          args.groupBy(_._1).collectFirst { case (k, vs) if vs.sizeIs > 1 => k } match
+            case Some(k) =>
+              Left(buildErr(s"security scheme '$name': duplicate argument '$k'", ctx))
+            case None => Right(args.toMap)
     val kindE: BuildResult[security_scheme_kind] = kind match
       case "Bearer" => only("bearer_format").map(m => SsBearer(m.get("bearer_format")))
       case "ApiKey" =>

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -90,7 +90,8 @@ final private case class ServiceAcc(
     k: List[FactDeclFull] = Nil,
     l: List[FunctionDeclFull] = Nil,
     m: List[PredicateDeclFull] = Nil,
-    n: Option[ConventionsDeclFull] = None
+    n: Option[ConventionsDeclFull] = None,
+    security: List[SecuritySchemeDeclFull] = Nil
 )
 
 @SuppressWarnings(Array("org.wartremover.warts.Null"))
@@ -140,7 +141,8 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
         l = acc.l.reverse,
         m = acc.m.reverse,
         n = acc.n,
-        o = sp(ctx)
+        o = acc.security.reverse,
+        p = sp(ctx)
       )
 
   private def processMember(acc: ServiceAcc, m: ServiceMemberContext): BuildResult[ServiceAcc] =
@@ -171,6 +173,10 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
       if acc.n.isDefined then
         Left(buildErr("duplicate conventions block", m.conventionBlock))
       else buildConventions(m.conventionBlock).map(c => acc.copy(n = Some(c)))
+    else if m.securityBlock ne null then
+      m.securityBlock.securitySchemeDecl.asScala.toList
+        .traverseB(buildSecurityScheme)
+        .map(ss => acc.copy(security = ss.reverse ::: acc.security))
     else Right(acc)
 
   private def buildEntity(ctx: EntityDeclContext): BuildResult[EntityDeclFull] =
@@ -230,31 +236,35 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
         List[ParamDeclFull],
         List[ParamDeclFull],
         List[expr],
-        List[expr]
+        List[expr],
+        Option[List[String]]
     )] =
-      Right((Nil, Nil, Nil, Nil))
+      Right((Nil, Nil, Nil, Nil, None))
     val collected = clauses.foldLeft(acc0):
       case (accE, clause) =>
-        accE.flatMap: (ins, outs, reqs, ens) =>
+        accE.flatMap: (ins, outs, reqs, ens, auth) =>
           if clause.inputClause ne null then
             clause.inputClause.paramList.param.asScala.toList
               .traverseB(buildParam)
-              .map(ps => (ins ++ ps, outs, reqs, ens))
+              .map(ps => (ins ++ ps, outs, reqs, ens, auth))
           else if clause.outputClause ne null then
             clause.outputClause.paramList.param.asScala.toList
               .traverseB(buildParam)
-              .map(ps => (ins, outs ++ ps, reqs, ens))
+              .map(ps => (ins, outs ++ ps, reqs, ens, auth))
           else if clause.requiresClause ne null then
             clause.requiresClause.expr.asScala.toList
               .traverseB(expr)
-              .map(es => (ins, outs, reqs ++ es, ens))
+              .map(es => (ins, outs, reqs ++ es, ens, auth))
           else if clause.ensuresClause ne null then
             clause.ensuresClause.expr.asScala.toList
               .traverseB(expr)
-              .map(es => (ins, outs, reqs, ens ++ es))
-          else Right((ins, outs, reqs, ens))
-    collected.map: (ins, outs, reqs, ens) =>
-      OperationDeclFull(name, ins, outs, reqs, ens, sp(ctx))
+              .map(es => (ins, outs, reqs, ens ++ es, auth))
+          else if clause.requiresAuthClause ne null then
+            val names = clause.requiresAuthClause.lowerIdent.asScala.toList.map(_.getText)
+            Right((ins, outs, reqs, ens, Some(auth.getOrElse(Nil) ++ names)))
+          else Right((ins, outs, reqs, ens, auth))
+    collected.map: (ins, outs, reqs, ens, auth) =>
+      OperationDeclFull(name, ins, outs, reqs, ens, auth, sp(ctx))
 
   private def buildParam(ctx: ParamContext): BuildResult[ParamDeclFull] =
     buildTypeExpr(ctx.typeExpr).map(t => ParamDeclFull(ctx.lowerIdent.getText, t, sp(ctx)))
@@ -313,6 +323,43 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
     ctx.conventionRule.asScala.toList
       .traverseB(buildConventionRule)
       .map(rules => ConventionsDeclFull(rules, sp(ctx)))
+
+  private def buildSecurityScheme(
+      ctx: SecuritySchemeDeclContext
+  ): BuildResult[SecuritySchemeDeclFull] =
+    val name = ctx.lowerIdent.getText
+    val kind = ctx.UPPER_IDENT.getText
+    val args = ctx.securitySchemeArg.asScala.toList
+      .map(a => a.lowerIdent.getText -> unquote(a.STRING_LIT.getText))
+    def only(allowed: String*): BuildResult[Map[String, String]] =
+      args.find(a => !allowed.contains(a._1)) match
+        case Some((bad, _)) =>
+          Left(buildErr(
+            s"security scheme '$name': unknown $kind argument '$bad'" +
+              (if allowed.isEmpty then "" else s"; expected ${allowed.mkString(", ")}"),
+            ctx
+          ))
+        case None => Right(args.toMap)
+    val kindE: BuildResult[security_scheme_kind] = kind match
+      case "Bearer" => only("bearer_format").map(m => SsBearer(m.get("bearer_format")))
+      case "ApiKey" =>
+        only("header", "query", "cookie").flatMap: m =>
+          m.toList match
+            case List((location, keyName)) => Right(SsApiKey(location, keyName))
+            case Nil =>
+              Left(buildErr(
+                s"security scheme '$name': ApiKey needs a location argument (header, query, or cookie)",
+                ctx
+              ))
+            case _ =>
+              Left(buildErr(s"security scheme '$name': ApiKey takes exactly one location", ctx))
+      case "Basic" => only().map(_ => SsBasic())
+      case other =>
+        Left(buildErr(
+          s"unknown security scheme kind '$other'; expected Bearer, ApiKey, or Basic",
+          ctx
+        ))
+    kindE.map(k => SecuritySchemeDeclFull(name, k, sp(ctx)))
 
   private def buildConventionRule(ctx: ConventionRuleContext): BuildResult[ConventionRuleFull] =
     val target          = ctx.UPPER_IDENT.getText

--- a/modules/parser/src/test/scala/specrest/parser/FlattenInheritanceTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/FlattenInheritanceTest.scala
@@ -33,6 +33,7 @@ class FlattenInheritanceTest extends CatsEffectSuite:
       Nil,
       Nil,
       None,
+      Nil,
       None
     )
 

--- a/modules/parser/src/test/scala/specrest/parser/SecurityGrammarTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/SecurityGrammarTest.scala
@@ -93,6 +93,15 @@ class SecurityGrammarTest extends CatsEffectSuite:
       .map: err =>
         assert(err.contains("ApiKey needs a location argument"), err)
 
+  test("duplicate scheme arguments are a build error (not silently last-wins)"):
+    SpecFixtures
+      .buildExpectingError(
+        "dup-arg",
+        service("  security {\n    k: ApiKey(header: \"A\", header: \"B\")\n  }\n")
+      )
+      .map: err =>
+        assert(err.contains("duplicate argument 'header'"), err)
+
   test("Bearer with an unknown argument is a build error"):
     SpecFixtures
       .buildExpectingError(

--- a/modules/parser/src/test/scala/specrest/parser/SecurityGrammarTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/SecurityGrammarTest.scala
@@ -1,0 +1,134 @@
+package specrest.parser
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.parser.testutil.SpecFixtures
+
+class SecurityGrammarTest extends CatsEffectSuite:
+
+  private given CanEqual[security_scheme_kind, security_scheme_kind] = CanEqual.derived
+
+  private def service(body: String): String =
+    s"""|service Demo {
+        |  state {
+        |    count: Int
+        |  }
+        |
+        |$body
+        |}
+        |""".stripMargin
+
+  private val schemes =
+    """|  security {
+       |    bearer: Bearer(bearer_format: "JWT")
+       |    api_key: ApiKey(header: "X-API-Key")
+       |    basic: Basic
+       |  }
+       |""".stripMargin
+
+  test("security block populates svcSecurity with all three scheme kinds"):
+    SpecFixtures.buildFromSource("schemes", service(schemes)).map: ir =>
+      val ss = svcSecurity(ir)
+      assertEquals(ss.map(ssdName), List("bearer", "api_key", "basic"))
+      assertEquals(ssdKind(ss(0)), SsBearer(Some("JWT")): security_scheme_kind)
+      assertEquals(ssdKind(ss(1)), SsApiKey("header", "X-API-Key"): security_scheme_kind)
+      assertEquals(ssdKind(ss(2)), SsBasic(): security_scheme_kind)
+      assert(ss.forall(s => ssdSpan(s).isDefined), "scheme decls carry spans")
+
+  test("Bearer without arguments has no bearer format"):
+    SpecFixtures
+      .buildFromSource("bare-bearer", service("  security {\n    bearer: Bearer\n  }\n"))
+      .map: ir =>
+        assertEquals(ssdKind(svcSecurity(ir).head), SsBearer(None): security_scheme_kind)
+
+  test("no security block means empty svcSecurity"):
+    SpecFixtures.buildFromSource("none", service("")).map: ir =>
+      assertEquals(svcSecurity(ir), Nil)
+
+  test("requires_auth: single scheme lands on the operation"):
+    val src = service(
+      schemes +
+        """|  operation Increment {
+           |    requires_auth: bearer
+           |    requires: true
+           |    ensures: count' = count + 1
+           |  }
+           |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("single", src).map: ir =>
+      assertEquals(operRequiresAuth(svcOperations(ir).head), Some(List("bearer")))
+
+  test("requires_auth: comma list keeps order (OR alternatives)"):
+    val src = service(
+      schemes +
+        """|  operation Increment {
+           |    requires_auth: bearer, api_key
+           |    ensures: count' = count + 1
+           |  }
+           |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("list", src).map: ir =>
+      assertEquals(operRequiresAuth(svcOperations(ir).head), Some(List("bearer", "api_key")))
+
+  test("operation without requires_auth has None (public, no annotation)"):
+    val src = service(
+      schemes +
+        """|  operation Increment {
+           |    ensures: count' = count + 1
+           |  }
+           |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("public", src).map: ir =>
+      assertEquals(operRequiresAuth(svcOperations(ir).head), None)
+
+  test("unknown scheme kind is a build error"):
+    SpecFixtures
+      .buildExpectingError("bad-kind", service("  security {\n    oa: OAuth2\n  }\n"))
+      .map: err =>
+        assert(err.contains("unknown security scheme kind 'OAuth2'"), err)
+
+  test("ApiKey without a location argument is a build error"):
+    SpecFixtures
+      .buildExpectingError("bad-apikey", service("  security {\n    k: ApiKey\n  }\n"))
+      .map: err =>
+        assert(err.contains("ApiKey needs a location argument"), err)
+
+  test("Bearer with an unknown argument is a build error"):
+    SpecFixtures
+      .buildExpectingError(
+        "bad-bearer-arg",
+        service("  security {\n    b: Bearer(formaat: \"JWT\")\n  }\n")
+      )
+      .map: err =>
+        assert(err.contains("unknown Bearer argument 'formaat'"), err)
+
+  test("security scheme names work as identifiers elsewhere (soft keywords)"):
+    val src = service(
+      """|  operation Touch {
+         |    input: security: String
+         |    ensures: count' = count
+         |  }
+         |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("soft-kw", src).map: ir =>
+      assertEquals(prmName(operInputs(svcOperations(ir).head).head), "security")
+
+  test("IR JSON round-trips security schemes and requiresAuth"):
+    val src = service(
+      schemes +
+        """|  operation Increment {
+           |    requires_auth: bearer, api_key
+           |    ensures: count' = count + 1
+           |  }
+           |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("roundtrip", src).map: ir =>
+      val json = specrest.ir.Serialize.toPrettyString(ir)
+      specrest.ir.Serialize.fromJson(json) match
+        case Left(e) => fail(s"round-trip decode failed: $e")
+        case Right(decoded) =>
+          assertEquals(svcSecurity(decoded).map(ssdName), List("bearer", "api_key", "basic"))
+          assertEquals(
+            operRequiresAuth(svcOperations(decoded).head),
+            Some(List("bearer", "api_key"))
+          )

--- a/modules/parser/src/test/scala/specrest/parser/testutil/SpecFixtures.scala
+++ b/modules/parser/src/test/scala/specrest/parser/testutil/SpecFixtures.scala
@@ -23,3 +23,12 @@ object SpecFixtures:
           case Left(err) =>
             IO.raiseError(new AssertionError(s"build error for $label: ${err.message}"))
           case Right(ir) => IO.pure(ir)
+
+  def buildExpectingError(label: String, source: String): IO[String] =
+    Parse.parseSpec(source).flatMap:
+      case Left(err) => IO.pure(err.errors.map(_.message).mkString("; "))
+      case Right(parsed) =>
+        Builder.buildIR(parsed.tree).flatMap:
+          case Left(err) => IO.pure(err.message)
+          case Right(_) =>
+            IO.raiseError(new AssertionError(s"expected a parse/build error for $label"))

--- a/modules/profile/src/main/scala/specrest/profile/Annotate.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Annotate.scala
@@ -172,5 +172,6 @@ object Annotate:
       requestBodyFields =
         operInputs(op).map(p => profileField(prmName(p), prmType(p), profile, ctx)),
       responseFields =
-        operOutputs(op).map(p => profileField(prmName(p), prmType(p), profile, ctx))
+        operOutputs(op).map(p => profileField(prmName(p), prmType(p), profile, ctx)),
+      requiresAuth = operRequiresAuth(op).getOrElse(Nil)
     )

--- a/modules/profile/src/main/scala/specrest/profile/Types.scala
+++ b/modules/profile/src/main/scala/specrest/profile/Types.scala
@@ -76,7 +76,10 @@ final case class ProfiledOperation(
     targetEntity: Option[String],
     requestBodyFields: List[ProfiledField],
     responseFields: List[ProfiledField],
-    dafnyMethod: Option[String] = None
+    dafnyMethod: Option[String] = None,
+    // alternative security scheme names (OpenAPI security-array OR semantics);
+    // empty = public
+    requiresAuth: List[String] = Nil
 )
 
 final case class ProfiledService(

--- a/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StatefulTest.scala
@@ -675,7 +675,8 @@ class StatefulTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
     val profile = SynthFixture.asSynthesized(specrest.profile.Annotate.buildProfiledService(
       ir,
@@ -713,7 +714,7 @@ class StatefulTest extends CatsEffectSuite:
       // A valid Hypothesis state machine needs >= 1 @rule; without an operation the
       // machine (even with temporals/invariants) is rejected at runtime, so the
       // temporal-emission path is only reachable when at least one rule exists.
-      g = List(OperationDeclFull("Tick", Nil, Nil, List(BoolLitF(true, None)), Nil, None)),
+      g = List(OperationDeclFull("Tick", Nil, Nil, List(BoolLitF(true, None)), Nil, None, None)),
       h = Nil,
       i = Nil,
       j = temporals,
@@ -721,7 +722,8 @@ class StatefulTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
 
   test("temporal always(P) emits @invariant block prefixed with temporal_always_"):

--- a/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StrategiesTest.scala
@@ -67,7 +67,7 @@ class StrategiesTest extends CatsEffectSuite:
       requires: List[expr] = Nil,
       ensures: List[expr] = Nil
   ): OperationDeclFull =
-    OperationDeclFull(name, inputs, outputs, requires, ensures, None)
+    OperationDeclFull(name, inputs, outputs, requires, ensures, None, None)
   private def conventionRule(
       target: String,
       property: String,
@@ -104,7 +104,8 @@ class StrategiesTest extends CatsEffectSuite:
       l = Nil,
       m = predicates,
       n = conventions,
-      o = None
+      o = Nil,
+      p = None
     )
 
   test("ShortCode (regex + length) → from_regex with len filter"):

--- a/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/StructuralTest.scala
@@ -152,7 +152,8 @@ class StructuralTest extends CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
     val profile  = specrest.profile.Annotate.buildProfiledService(ir, "python-fastapi-postgres")
     val out      = Structural.emitFor(profile)

--- a/modules/testgen/src/test/scala/specrest/testgen/TemplatesTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/TemplatesTest.scala
@@ -43,7 +43,8 @@ class TemplatesTest extends CatsEffectSuite:
       l = functions,
       m = predicates,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
 
   test("conftest template loads and contains the admin-availability fixture"):

--- a/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/CheckValueHasTyTest.scala
@@ -39,6 +39,7 @@ class CheckValueHasTyTest extends CatsEffectSuite:
       Nil,
       Nil,
       None,
+      Nil,
       None
     )
 

--- a/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ClassifierTest.scala
@@ -69,7 +69,8 @@ class ClassifierTest extends munit.CatsEffectSuite:
       l = Nil,
       m = Nil,
       n = None,
-      o = None
+      o = Nil,
+      p = None
     )
     assertEquals(Classifier.classifyGlobal(ir), VerifierTool.Alloy)
 
@@ -87,6 +88,7 @@ class ClassifierTest extends munit.CatsEffectSuite:
           None
         )
       ),
+      None,
       None
     )
     val inv = InvariantDeclFull(Some("p"), bb(true), None)

--- a/proofs/isabelle/SpecRest/codegen/AlloyTypes.thy
+++ b/proofs/isabelle/SpecRest/codegen/AlloyTypes.thy
@@ -92,7 +92,7 @@ fun entityHasBoolField :: "entity_decl \<Rightarrow> bool" where
      (\<exists>f \<in> set fs. fieldTypeHasBool f)"
 
 fun operationHasBoolLit :: "operation_decl \<Rightarrow> bool" where
-  "operationHasBoolLit (OperationDeclFull _ _ _ requires ensures _) =
+  "operationHasBoolLit (OperationDeclFull _ _ _ requires ensures _ _) =
      ((\<exists>e \<in> set requires. exprContainsBoolLit e) \<or>
       (\<exists>e \<in> set ensures. exprContainsBoolLit e))"
 
@@ -109,7 +109,7 @@ fun needsBoolSig ::
    \<Rightarrow> bool"
 where
   "needsBoolSig
-      (ServiceIRFull _ _ es _ _ _ ops _ invs temps _ _ _ _ _)
+      (ServiceIRFull _ _ es _ _ _ ops _ invs temps _ _ _ _ _ _)
       stateFields inputFields = (
      (\<exists>e \<in> set es. entityHasBoolField e) \<or>
      (\<exists>kv \<in> set stateFields. typeContainsNamed (STR ''Bool'') (snd kv)) \<or>

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -454,7 +454,7 @@ export_code
     stfName stfType stfSpan
     stdFields stdSpan
     prmName prmType prmSpan
-    operName operInputs operOutputs operRequires operEnsures operSpan
+    operName operInputs operOutputs operRequires operEnsures operRequiresAuth operSpan
     trlFrom trlTo trlVia trlGuard trlSpan
     trnName trnEntity trnField trnRules trnSpan
     invName invBody invSpan
@@ -464,12 +464,13 @@ export_code
     prdName prdParams prdBody prdSpan
     cvrTarget cvrProperty cvrQualifier cvrValue cvrSpan
     cvdRules cvdSpan
+    ssdName ssdKind ssdSpan
     fasName fasValue fasSpan
     mpeKey mpeValue mpeSpan
     qbdVar qbdCollection qbdKind qbdSpan
     svcName svcImports svcEntities svcEnums svcTypeAliases svcState
     svcOperations svcTransitions svcInvariants svcTemporals svcFacts
-    svcFunctions svcPredicates svcConventions svcSpan
+    svcFunctions svcPredicates svcConventions svcSecurity svcSpan
   in Scala
   module_name SpecRestGenerated
   file_prefix "SpecRestGenerated"

--- a/proofs/isabelle/SpecRest/codegen/LintAnalysis.thy
+++ b/proofs/isabelle/SpecRest/codegen/LintAnalysis.thy
@@ -11,7 +11,7 @@ text \<open>Pure decision predicates and IR walkers for the lint analyses in
 text \<open>\<open>L03 — MissingEnsures\<close>: trivial per-op predicate.\<close>
 
 fun operationMissingEnsures :: "operation_decl \<Rightarrow> bool" where
-  "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _) =
+  "operationMissingEnsures (OperationDeclFull _ _ outputs _ ensures _ _) =
      (outputs \<noteq> [] \<and> ensures = [])"
 
 text \<open>\<open>L05 — UnusedEntity\<close>: collect Identifier + Constructor names

--- a/proofs/isabelle/SpecRest/codegen/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/codegen/ValidateConventions.thy
@@ -176,8 +176,8 @@ fun findOperationByName ::
   "operation_decl list \<Rightarrow> String.literal \<Rightarrow> operation_decl option"
 where
   "findOperationByName [] _ = None"
-| "findOperationByName (OperationDeclFull n a b c d e # rest) nm =
-     (if n = nm then Some (OperationDeclFull n a b c d e)
+| "findOperationByName (OperationDeclFull n a b c d ra e # rest) nm =
+     (if n = nm then Some (OperationDeclFull n a b c d ra e)
       else findOperationByName rest nm)"
 
 fun paramListHasName ::
@@ -190,7 +190,7 @@ where
 fun operationHasParamNamed ::
   "operation_decl \<Rightarrow> String.literal \<Rightarrow> bool"
 where
-  "operationHasParamNamed (OperationDeclFull _ inputs _ _ _ _) nm =
+  "operationHasParamNamed (OperationDeclFull _ inputs _ _ _ _ _) nm =
      paramListHasName inputs nm"
 
 fun validateIrContextRule ::

--- a/proofs/isabelle/SpecRest/codegen/VerifierDispatch.thy
+++ b/proofs/isabelle/SpecRest/codegen/VerifierDispatch.thy
@@ -51,22 +51,22 @@ fun invariantBody :: "invariant_decl \<Rightarrow> expr" where
   "invariantBody (InvariantDeclFull _ b _) = b"
 
 fun operationRequires :: "operation_decl \<Rightarrow> expr list" where
-  "operationRequires (OperationDeclFull _ _ _ requires _ _) = requires"
+  "operationRequires (OperationDeclFull _ _ _ requires _ _ _) = requires"
 
 fun operationEnsures :: "operation_decl \<Rightarrow> expr list" where
-  "operationEnsures (OperationDeclFull _ _ _ _ ensures _) = ensures"
+  "operationEnsures (OperationDeclFull _ _ _ _ ensures _ _) = ensures"
 
 fun enumDeclName :: "enum_decl \<Rightarrow> String.literal" where
   "enumDeclName (EnumDeclFull n _ _) = n"
 
 fun serviceIrEntities :: "service_ir \<Rightarrow> entity_decl list" where
-  "serviceIrEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _) = es"
+  "serviceIrEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _ _) = es"
 
 fun serviceIrEnums :: "service_ir \<Rightarrow> enum_decl list" where
-  "serviceIrEnums (ServiceIRFull _ _ _ es _ _ _ _ _ _ _ _ _ _ _) = es"
+  "serviceIrEnums (ServiceIRFull _ _ _ es _ _ _ _ _ _ _ _ _ _ _ _) = es"
 
 fun serviceIrInvariants :: "service_ir \<Rightarrow> invariant_decl list" where
-  "serviceIrInvariants (ServiceIRFull _ _ _ _ _ _ _ _ invs _ _ _ _ _ _) = invs"
+  "serviceIrInvariants (ServiceIRFull _ _ _ _ _ _ _ _ invs _ _ _ _ _ _ _) = invs"
 
 definition invariantBodies :: "service_ir \<Rightarrow> expr list" where
   "invariantBodies ir = map invariantBody (serviceIrInvariants ir)"

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -197,7 +197,7 @@ datatype (plugins only: code size) param_decl =
     ParamDeclFull (prmName: "String.literal") (prmType: type_expr) (prmSpan: option_span)
 
 datatype (plugins only: code size) operation_decl =
-    OperationDeclFull (operName: "String.literal") (operInputs: "param_decl list") (operOutputs: "param_decl list") (operRequires: "expr list") (operEnsures: "expr list") (operSpan: option_span)
+    OperationDeclFull (operName: "String.literal") (operInputs: "param_decl list") (operOutputs: "param_decl list") (operRequires: "expr list") (operEnsures: "expr list") (operRequiresAuth: "(String.literal list) option") (operSpan: option_span)
 
 datatype (plugins only: code size) transition_rule =
     TransitionRuleFull (trlFrom: "String.literal") (trlTo: "String.literal") (trlVia: "String.literal") (trlGuard: "expr option") (trlSpan: option_span)
@@ -278,6 +278,21 @@ datatype (plugins only: code size) convention_rule =
 datatype (plugins only: code size) conventions_decl =
     ConventionsDeclFull (cvdRules: "convention_rule list") (cvdSpan: option_span)
 
+text \<open>Security schemes (M8.1, issue #53): named credential declarations from the
+  spec's \<open>security { ... }\<close> block. \<open>operRequiresAuth\<close> on an operation lists
+  alternative scheme names (OpenAPI security-array OR semantics); \<open>None\<close>
+  means the operation carries no annotation and is public. Auth is pure
+  metadata: classification, verification and evaluation ignore it.\<close>
+
+datatype (plugins only: code size) security_scheme_kind =
+    SsBearer "String.literal option"
+  | SsApiKey "String.literal" "String.literal"
+  | SsBasic
+
+datatype (plugins only: code size) security_scheme_decl =
+    SecuritySchemeDeclFull (ssdName: "String.literal") (ssdKind: security_scheme_kind)
+                           (ssdSpan: option_span)
+
 datatype (plugins only: code size) service_ir =
     ServiceIRFull (svcName: "String.literal") (svcImports: "String.literal list")
                   (svcEntities: "entity_decl list") (svcEnums: "enum_decl list")
@@ -286,7 +301,7 @@ datatype (plugins only: code size) service_ir =
                   (svcInvariants: "invariant_decl list") (svcTemporals: "temporal_decl list")
                   (svcFacts: "fact_decl list") (svcFunctions: "function_decl list")
                   (svcPredicates: "predicate_decl list") (svcConventions: "conventions_decl option")
-                  (svcSpan: option_span)
+                  (svcSecurity: "security_scheme_decl list") (svcSpan: option_span)
 
 text \<open>\<open>string_in_list\<close> is the monomorphic membership predicate over
   \<open>String.literal list\<close>. Hoisted to the top of the file because using

--- a/proofs/isabelle/SpecRest/core/IR_Helpers.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Helpers.thy
@@ -429,8 +429,8 @@ fun flatten_entity ::
                      sp))"
 
 fun flattenInheritance :: "service_ir \<Rightarrow> service_ir" where
-  "flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n p) =
-     ServiceIRFull a b (map (flatten_entity c) c) d e f g h i j k l m n p"
+  "flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n sec p) =
+     ServiceIRFull a b (map (flatten_entity c) c) d e f g h i j k l m n sec p"
 
 text \<open>Phase 9f — the Phase 9 structural primitives are now backed by proof,
   not merely totality.
@@ -481,8 +481,8 @@ lemma flatten_entity_noparent:
 
 lemma flattenInheritance_id_on_parentless:
   assumes "list_all (\<lambda>x. entityParentFull x = None) c"
-  shows "flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n p)
-           = ServiceIRFull a b c d e f g h i j k l m n p"
+  shows "flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n sec p)
+           = ServiceIRFull a b c d e f g h i j k l m n sec p"
 proof -
   have "map (flatten_entity c) c = c"
     using assms by (intro map_idI) (auto simp: list_all_iff flatten_entity_noparent)
@@ -515,8 +515,8 @@ fun flatten_entity2 ::
                      sp))"
 
 fun flattenInheritance2 :: "service_ir \<Rightarrow> service_ir" where
-  "flattenInheritance2 (ServiceIRFull a b c d e f g h i j k l m n p) =
-     ServiceIRFull a b (map (flatten_entity2 c) c) d e f g h i j k l m n p"
+  "flattenInheritance2 (ServiceIRFull a b c d e f g h i j k l m n sec p) =
+     ServiceIRFull a b (map (flatten_entity2 c) c) d e f g h i j k l m n sec p"
 
 lemma flatten_entity2_parent_cleared:
   "entityParentFull (flatten_entity2 es e) = None"
@@ -533,7 +533,7 @@ lemma flatten_entity2_eq_on_noparent:
 lemma flattenInheritance2_idem:
   "flattenInheritance2 (flattenInheritance2 s) = flattenInheritance2 s"
 proof (cases s)
-  case (ServiceIRFull a b c d ee f g h i j k l m n p)
+  case (ServiceIRFull a b c d ee f g h i j k l m n sec p)
   let ?c' = "map (flatten_entity2 c) c"
   have "list_all (\<lambda>x. entityParentFull x = None) ?c'"
     by (simp add: list_all_iff flatten_entity2_parent_cleared)
@@ -544,8 +544,8 @@ qed
 
 lemma flattenInheritance2_eq_on_parentless:
   assumes "list_all (\<lambda>x. entityParentFull x = None) c"
-  shows "flattenInheritance2 (ServiceIRFull a b c d e f g h i j k l m n p)
-           = flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n p)"
+  shows "flattenInheritance2 (ServiceIRFull a b c d e f g h i j k l m n sec p)
+           = flattenInheritance (ServiceIRFull a b c d e f g h i j k l m n sec p)"
 proof -
   have a: "map (flatten_entity2 c) c = c"
     using assms by (intro map_idI) (auto simp: list_all_iff flatten_entity2_noparent)
@@ -556,7 +556,7 @@ qed
 
 definition emptyServiceIrFull :: "String.literal \<Rightarrow> service_ir" where
   "emptyServiceIrFull nm =
-     ServiceIRFull nm [] [] [] [] None [] [] [] [] [] [] [] None None"
+     ServiceIRFull nm [] [] [] [] None [] [] [] [] [] [] [] None [] None"
 
 text \<open>Issue #202 close-out: \<open>lower\<close> projects \<open>expr\<close> onto the
   verified-subset \<open>expr\<close>. Out-of-subset constructors return \<open>None\<close>. Span

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -849,14 +849,14 @@ text \<open>\<open>tyctxFromService\<close> bootstraps the schema-typed half of 
   preservation case for binders, set by the verifier at use.\<close>
 
 fun serviceEntities :: "service_ir \<Rightarrow> entity_decl list" where
-  "serviceEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _) = es"
+  "serviceEntities (ServiceIRFull _ _ es _ _ _ _ _ _ _ _ _ _ _ _ _) = es"
 
 fun serviceEnums :: "service_ir \<Rightarrow> enum_decl list" where
-  "serviceEnums (ServiceIRFull _ _ _ en _ _ _ _ _ _ _ _ _ _ _) = en"
+  "serviceEnums (ServiceIRFull _ _ _ en _ _ _ _ _ _ _ _ _ _ _ _) = en"
 
 fun serviceStateFields ::
   "service_ir \<Rightarrow> state_field_decl list" where
-  "serviceStateFields (ServiceIRFull _ _ _ _ _ st _ _ _ _ _ _ _ _ _) =
+  "serviceStateFields (ServiceIRFull _ _ _ _ _ st _ _ _ _ _ _ _ _ _ _) =
      (case st of None \<Rightarrow> []
                | Some (StateDeclFull fs _) \<Rightarrow> fs)"
 


### PR DESCRIPTION
## What

Implements #53 (M8.1), transposed from the issue's pre-rewrite paths to the current Scala + Isabelle architecture. The spec language gains:

```text
security {
  bearer: Bearer(bearer_format: "JWT")
  api_key: ApiKey(header: "X-API-Key")
  basic: Basic
}

operation GetProfile {
  requires_auth: bearer, api_key
  ...
}
```

A comma list in `requires_auth:` means **OR-alternatives** (OpenAPI security-array semantics). Operations without the clause are public (`operRequiresAuth = None`, so a future explicit-public marker stays distinguishable). Auth is pure metadata: classification, verification, and evaluation ignore it.

## How it lands in each layer

- **IR (Isabelle `core/IR.thy`)**: `security_scheme_kind` (`SsBearer` optional format / `SsApiKey` location+name / `SsBasic` - a sealed datatype with room for OAuth2 as a new constructor without breaking changes), single-constructor `security_scheme_decl` with named selectors, `svcSecurity` on `ServiceIRFull`, `operRequiresAuth` on `operation_decl`. All ~23 positional pattern-match sites updated, extraction regenerated, all three sessions build zero-sorry.
- **Grammar (`Spec.g4`)**: `security` / `requires_auth` are soft keywords (still usable as identifiers, like `requires`/`ensures`).
- **Builder**: scheme-kind dispatch with precise build errors - unknown kind, unknown argument per kind, ApiKey location validation (exactly one of `header`/`query`/`cookie`).
- **Serialize**: sparse JSON (fields omitted when absent), so the 20 non-auth golden IR files are byte-identical and pre-existing IR JSON decodes unchanged. auth_service's golden diff is dominated by span shifts from the new fixture lines.
- **Validation** (`Validate.validateSecurity`, wired into both `check` and `compile`): undeclared scheme references (error names the operation, the scheme, and the declared set) and duplicate scheme names, both with spans. No reserved-name check for `AdminBearer` (#409's scheme): scheme names are `lowerIdent`, so the collision is structurally impossible.
- **Profile**: `ProfiledOperation.requiresAuth: List[String]` (empty = public) - the exact field M8.2 (#54) and M8.3 (#55) consume.

## Acceptance criteria from #53

- [x] Grammar accepts Bearer and ApiKey declarations (and Basic)
- [x] `auth_service.spec` fixture adopts the new syntax; parse + build + serialize round-trips against the regenerated golden
- [x] `svcSecurity` and `operRequiresAuth` populated and covered in parser tests (`SecurityGrammarTest`, incl. JSON round-trip)
- [x] Validation catches references to undeclared schemes with a clear, span-carrying diagnostic (`SecurityValidateTest`)

Docs: new "Security schemes" section in the spec-language reference.

All suites green: ir 43 / parser 114 / convention 228 / verify 46 / codegen 359 / testgen 286 / cli 65 / arch 4; Isabelle Core+Soundness+Codegen zero-sorry; extraction diff-gate satisfied.

Unblocks #54 (OpenAPI security emission) and #55 (FastAPI runtime wiring).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an authentication DSL with a service-wide security block and an operation-level requires_auth, plus full IR support and validation. Implements #53 (M8.1); auth stays metadata-only.

- **New Features**
  - Grammar: `security { ... }` block and `requires_auth:` clause; both are soft keywords.
  - IR: `security_scheme_kind` (`SsBearer`, `SsApiKey`, `SsBasic`), `security_scheme_decl`, `svcSecurity` on service, and `operRequiresAuth: Option[List[String]]` on operations.
  - Serialize: sparse JSON; omit `requiresAuth` when absent and `security` when empty; existing non-auth IR JSON stays byte-identical; old JSON still decodes.
  - Validation: `validateSecurity` checks duplicate scheme names and undeclared references; wired into both check and compile with span-carrying diagnostics.
  - Profile: `ProfiledOperation.requiresAuth` added (empty = public). Docs and tests added, fixtures updated.

- **Bug Fixes**
  - Parser now rejects duplicate security scheme arguments (e.g., repeated `bearer_format` or `header`) instead of silently taking the last value.

<sup>Written for commit bf28ae8c3daebe5f744ee1b637ef3593542bcb53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Services can declare named security schemes (Bearer, ApiKey, Basic)
  * Operations can specify required authentication via `requires_auth`
  * Added compile-time validation for duplicate and undeclared security schemes
  * Security configurations are now included in code generation

* **Documentation**
  * Added "Security schemes" section to Spec Language Reference documenting authentication declarations and usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->