### PR TITLE
feat(codegen): emit spec-declared security schemes into OpenAPI (M8.2)

### DIFF
--- a/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/openapi/OpenApi.scala
@@ -117,6 +117,8 @@ final case class SecuritySchemeObject(
     `type`: String,
     scheme: Option[String] = None,
     bearerFormat: Option[String] = None,
+    in_ : Option[String] = None,
+    name: Option[String] = None,
     description: Option[String] = None
 )
 
@@ -201,10 +203,13 @@ object Components:
         schemas(entity.createSchemaName) = SchemaObjectAdapter.fromLifted(createL)
         schemas(entity.readSchemaName) = SchemaObjectAdapter.fromLifted(readL)
         schemas(entity.updateSchemaName) = SchemaObjectAdapter.fromLifted(updateL)
+    val declaredSchemes = svcSecurity(profiled.ir).map { decl =>
+      ssdName(decl) -> userSecurityScheme(ssdKind(decl))
+    }.toMap
     ComponentsObject(
       schemas = schemas.toMap,
       securitySchemes = Some(
-        Map(
+        declaredSchemes + (
           "AdminBearer" -> SecuritySchemeObject(
             `type` = "http",
             scheme = Some("bearer"),
@@ -216,6 +221,14 @@ object Components:
         )
       )
     )
+
+  private def userSecurityScheme(kind: security_scheme_kind): SecuritySchemeObject = kind match
+    case SsBearer(format) =>
+      SecuritySchemeObject(`type` = "http", scheme = Some("bearer"), bearerFormat = format)
+    case SsApiKey(location, paramName) =>
+      SecuritySchemeObject(`type` = "apiKey", in_ = Some(location), name = Some(paramName))
+    case SsBasic() =>
+      SecuritySchemeObject(`type` = "http", scheme = Some("basic"))
 
   private def decorateFields(
       entity: ProfiledEntity,
@@ -439,8 +452,17 @@ object Paths:
       tags = List(Naming.toSnakeCase(entity.entityName)),
       parameters = if parameters.nonEmpty then Some(parameters) else None,
       requestBody = requestBody,
-      responses = responses
+      responses = responses,
+      security = operationSecurity(op)
     )
+
+  // one single-entry map per scheme name = OR-alternatives (OpenAPI security
+  // array); requiresAuth is empty for public operations, emitting no field
+  private def operationSecurity(
+      op: ProfiledOperation
+  ): Option[List[Map[String, List[String]]]] =
+    if op.requiresAuth.isEmpty then None
+    else Some(op.requiresAuth.map(n => Map(n -> List.empty[String])))
 
   private def buildParameters(op: ProfiledOperation, ctx: BuildContext): List[ParameterObject] =
     op.endpoint.pathParams.map(p => paramObject(p, "path", ctx)) ++
@@ -617,7 +639,8 @@ object Paths:
       tags = List("state"),
       parameters = None,
       requestBody = None,
-      responses = ok ++ conflict
+      responses = ok ++ conflict,
+      security = operationSecurity(v.operation)
     )
 
   private def jsonResponse(description: String, schema: SchemaObject): ResponseObject =
@@ -749,6 +772,7 @@ object OpenApi:
   // Map internal Scala identifiers to proper OpenAPI YAML keys
   private def mapKeyName(scalaKey: String): String = scalaKey match
     case "enum_"      => "enum"
+    case "in_"        => "in"
     case "ref"        => "$ref"
     case "type"       => "type"
     case "xInvariant" => "x-invariant"

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -24,6 +24,61 @@ class OpenApiTest extends CatsEffectSuite:
       val resolve = doc.paths.get("/{code}").flatMap(_.get)
       assert(resolve.isDefined, "expected GET /{code}")
 
+  private def allOperations(doc: openapi.OpenApiDocument) =
+    doc.paths.toList.flatMap: (path, item) =>
+      List(item.get, item.post, item.put, item.patch, item.delete).flatten.map(path -> _)
+
+  test("auth_service: spec-declared schemes are emitted next to AdminBearer (M8.2)"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val doc = OpenApi.buildOpenApiDocument(profiled)
+      val schemes =
+        doc.components.securitySchemes.getOrElse(fail("expected securitySchemes"))
+      assertEquals(schemes.keySet, Set("AdminBearer", "bearer", "api_key"))
+      val bearer = schemes("bearer")
+      assertEquals(bearer.`type`, "http")
+      assertEquals(bearer.scheme, Some("bearer"))
+      assertEquals(bearer.bearerFormat, Some("JWT"))
+      val apiKey = schemes("api_key")
+      assertEquals(apiKey.`type`, "apiKey")
+      assertEquals(apiKey.in_, Some("header"))
+      assertEquals(apiKey.name, Some("X-API-Key"))
+
+  test("auth_service: requires_auth emits per-operation security as OR-alternatives"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val doc  = OpenApi.buildOpenApiDocument(profiled)
+      val byId = allOperations(doc).map((_, op) => op.operationId -> op).toMap
+      assertEquals(
+        byId("logout").security,
+        Some(List(Map("bearer" -> List.empty[String])))
+      )
+      assertEquals(
+        byId("refresh_token").security,
+        Some(List(Map("bearer" -> List.empty[String]), Map("api_key" -> List.empty[String])))
+      )
+      assertEquals(byId("register").security, None)
+      assertEquals(byId("login").security, None)
+
+  test("url_shortener (no security block): only AdminBearer, no op security outside /admin"):
+    SpecFixtures.loadProfiled("url_shortener").map: profiled =>
+      val doc = OpenApi.buildOpenApiDocument(profiled)
+      assertEquals(
+        doc.components.securitySchemes.map(_.keySet),
+        Some(Set("AdminBearer"))
+      )
+      val publicOps =
+        allOperations(doc).filterNot((path, _) => path.startsWith("/admin"))
+      assert(publicOps.forall((_, op) => op.security.isEmpty), "public ops must carry no security")
+
+  test("auth_service YAML renders apiKey in/name and per-op security arrays"):
+    SpecFixtures.loadProfiled("auth_service").map: profiled =>
+      val yaml = OpenApi.serialize(OpenApi.buildOpenApiDocument(profiled))
+      assert(
+        yaml.contains("type: apiKey\n      in: header\n      name: X-API-Key"),
+        s"apiKey scheme block malformed (in_ must render as in):\n$yaml"
+      )
+      assert(yaml.contains("- bearer: []"), s"missing per-op security entry:\n$yaml")
+      assert(yaml.contains("- api_key: []"), s"missing OR-alternative entry:\n$yaml")
+
   test("components.securitySchemes declares AdminBearer (http bearer)"):
     SpecFixtures.loadProfiled("url_shortener").map: profiled =>
       val doc = OpenApi.buildOpenApiDocument(profiled)

--- a/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/OpenApiTest.scala
@@ -45,8 +45,14 @@ class OpenApiTest extends CatsEffectSuite:
 
   test("auth_service: requires_auth emits per-operation security as OR-alternatives"):
     SpecFixtures.loadProfiled("auth_service").map: profiled =>
-      val doc  = OpenApi.buildOpenApiDocument(profiled)
-      val byId = allOperations(doc).map((_, op) => op.operationId -> op).toMap
+      val doc        = OpenApi.buildOpenApiDocument(profiled)
+      val operations = allOperations(doc)
+      assertEquals(
+        operations.map(_._2.operationId).distinct.size,
+        operations.size,
+        "duplicate operationId would hide an operation from this test"
+      )
+      val byId = operations.map((_, op) => op.operationId -> op).toMap
       assertEquals(
         byId("logout").security,
         Some(List(Map("bearer" -> List.empty[String])))


### PR DESCRIPTION
## What

Implements #54 (M8.2): the auth declarations from #53 now flow into the emitted OpenAPI document, landing on the machinery #409 pre-built (`SecuritySchemeObject`, `components.securitySchemes`, per-operation `security`).

### Scheme mapping

| DSL | OpenAPI |
|---|---|
| `Bearer(bearer_format: "JWT")` | `type: http, scheme: bearer, bearerFormat: JWT` |
| `ApiKey(header: "X-API-Key")` | `type: apiKey, in: header, name: X-API-Key` |
| `Basic` | `type: http, scheme: basic` |

Spec-declared schemes join `AdminBearer` in `components.securitySchemes` under their declared names - scheme names are `lowerIdent`, so colliding with `AdminBearer` is structurally impossible. `SecuritySchemeObject` gained `in_`/`name` fields (`in_` serialized as `in`, same pattern as `enum_`).

### Per-operation security

`requiresAuth` renders as one single-entry map per scheme name - OpenAPI security-array OR semantics:

```yaml
security:
- bearer: []
- api_key: []
```

Public operations (empty `requiresAuth`) emit no `security` field. Applied uniformly to entity operations and scalar state operations.

## Acceptance criteria from #54, transposed

- [x] `components.securitySchemes` emitted for every fixture that declares security (auth_service)
- [x] Per-operation `security` emitted only where the operation requires auth. The issue's null-vs-`[]` inheritance semantics don't arise: the DSL has no service-level default (deliberately out of M8.1 scope), so no top-level `security` is emitted and there is nothing to inherit.
- [x] Fixtures without auth: unchanged emission. (The AC's "no securitySchemes block" predates #409 - every doc now carries `AdminBearer` by design; the honest reading is "no *user* schemes", which the url_shortener regression test asserts.)
- [x] Validation harness: the issue's `@seriousme/openapi-schema-validator` was TS-era tooling; the current equivalent is `OpenApiTest`'s structural + YAML serialization assertions, extended here for scheme objects, per-op arrays, and the `in`/`name` rendering.
- [x] Unblocks auth-aware Schemathesis (#26) and runtime wiring (#55).

No golden churn: url_shortener declares no security, so all nine generated-project trees are untouched.

Suites green: codegen 363 / convention 114 / testgen 286 / cli 65; scalafix + scalafmt clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emits spec-declared security schemes and per-operation security into generated OpenAPI. Specs without auth remain unchanged.

- **New Features**
  - Add DSL-declared schemes to components.securitySchemes next to AdminBearer (Bearer + optional bearerFormat, ApiKey with in/name, Basic).
  - Extend SecuritySchemeObject with in_ and name (in_ serializes as in).
  - Emit per-operation security as OR-alternatives (one single-entry map per scheme); omit for public ops; applies to entity and scalar state operations.
  - Tests cover scheme emission, per-op arrays, YAML in/name rendering, unchanged non-auth fixtures, and guard unique operationId before mapping to ensure safe lookups.

<sup>Written for commit 520596566f9a2c53aa6b9d5b796a43ce273fc455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

