### PR TITLE
docs: fix diagram rendering (stretched width, no theme, mobile legibility)

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -9,3 +9,20 @@
 details[open] > summary .fd-tree-chevron {
   rotate: 90deg;
 }
+
+.fd-mermaid svg,
+.fd-railroad svg {
+  display: block;
+  margin-inline: auto;
+  height: auto;
+  max-width: 100%;
+}
+
+/* Below the narrow breakpoint, shrinking a wide diagram to column width makes
+   its text illegible; keep intrinsic size and let the wrapper scroll instead. */
+@media (max-width: 640px) {
+  .fd-mermaid svg,
+  .fd-railroad svg {
+    max-width: none;
+  }
+}

--- a/docs/components/mdx/mermaid.tsx
+++ b/docs/components/mdx/mermaid.tsx
@@ -1,52 +1,42 @@
 import { renderMermaidSVG } from "beautiful-mermaid";
 import { createHash } from "node:crypto";
 
-const RESPONSIVE_TWEAKS = `
-.fd-mermaid svg {
-  display: block;
-  width: 100%;
-  height: auto;
-  max-width: 100%;
-}
-`;
-
 const cache = new Map<string, string>();
 const CACHE_LIMIT = 64;
 
-function renderResponsive(chart: string): string {
+function render(chart: string): string {
   const key = createHash("sha1").update(chart).digest("hex");
   const cached = cache.get(key);
   if (cached !== undefined) return cached;
 
-  const raw = renderMermaidSVG(chart, {
+  const svg = renderMermaidSVG(chart, {
     bg: "var(--color-fd-background)",
     fg: "var(--color-fd-foreground)",
-    interactive: true,
+    surface: "var(--color-fd-card)",
+    border: "var(--color-fd-border)",
+    line: "var(--color-fd-border)",
+    accent: "var(--color-fd-primary)",
+    muted: "var(--color-fd-muted-foreground)",
     transparent: true,
   });
-  const responsive = raw
-    .replace(/(<svg\b[^>]*?)\swidth="[^"]*"/, "$1")
-    .replace(/(<svg\b[^>]*?)\sheight="[^"]*"/, "$1")
-    .replace(/<svg\b/, '<svg preserveAspectRatio="xMidYMid meet"');
 
   if (cache.size >= CACHE_LIMIT) {
     const firstKey = cache.keys().next().value;
     if (firstKey) cache.delete(firstKey);
   }
-  cache.set(key, responsive);
-  return responsive;
+  cache.set(key, svg);
+  return svg;
 }
 
 export function Mermaid({ chart }: { chart: string }) {
   let html: string;
   try {
-    html = renderResponsive(chart);
+    html = render(chart);
   } catch {
     return <pre>{chart}</pre>;
   }
   return (
-    <div className="fd-mermaid not-prose my-4 w-full overflow-x-auto">
-      <style>{RESPONSIVE_TWEAKS}</style>
+    <div className="fd-mermaid not-prose my-4 max-h-[80vh] overflow-auto">
       <div dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/docs/components/mdx/railroad-diagram.tsx
+++ b/docs/components/mdx/railroad-diagram.tsx
@@ -1,15 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const RESPONSIVE_TWEAKS = `
-.fd-railroad svg {
-  display: block;
-  margin: 0 auto;
-  max-width: 100%;
-  height: auto;
-}
-`;
-
 const cache = new Map<string, string>();
 
 function readSvg(name: string): string {
@@ -30,11 +21,10 @@ export function RailroadDiagram({ name, alt }: Props) {
   const svg = readSvg(name);
   return (
     <div
-      className="fd-railroad not-prose my-4 w-full overflow-x-auto"
+      className="fd-railroad not-prose my-4 max-h-[80vh] overflow-auto"
       role="img"
       aria-label={alt}
     >
-      <style>{RESPONSIVE_TWEAKS}</style>
       <div dangerouslySetInnerHTML={{ __html: svg }} />
     </div>
   );


### PR DESCRIPTION
Closes #312.

## Problem

Mermaid and railroad SVGs were stripped of their `width`/`height` attributes and forced to `width: 100%`. The consequences matched the issue:

1. **Stretched / sparse.** A diagram narrower than the ~836px content column was upscaled to fill it, blowing the boxes apart and inflating the text.
2. **No height bound.** Tall `flowchart TD` diagrams had no cap.
3. **Illegible on mobile.** `width: 100%` shrank a wide diagram to ~343px on a phone, dropping node text to a few px.
4. **No consistent style.** Only `bg`/`fg` were passed to the renderer, so every diagram color-mixed to grey, and the responsive CSS was injected as a duplicate inline `<style>` on *every* diagram instance.

## A note on the suggested implementation

The issue sketch imports `mermaid` and passes `{ theme, themeVariables: { fontSize } }`. That API does not exist in `beautiful-mermaid@1.1.3` (which is what this repo uses): it is a zero-DOM ELK reimplementation, `mermaid` is not a dependency, and `RenderOptions` has no `theme`/`themeVariables`/`fontSize`. Following the sketch verbatim would not compile. The real theming hook is the color-role options (`bg`, `fg`, `surface`, `border`, `line`, `accent`, `muted`) plus `font`, which is what this PR uses.

## Changes

- **Render at intrinsic size** (`mermaid.tsx`): drop the `width`/`height` strip. CSS caps with `max-width: 100%` so diagrams fit the column on desktop and are *never upscaled*. Below the 640px breakpoint, `max-width: none` keeps the diagram at full size and lets the wrapper scroll, so node text stays legible instead of shrinking to a few px.
- **Height cap**: wrapper gets `max-h-[80vh] overflow-auto`; oversized diagrams scroll inside their own box, not the page.
- **Theme-aware colors**: wire the renderer's color roles to Fumadocs tokens (`--color-fd-background/foreground/card/border/primary/muted-foreground`). These pass through as CSS variables, so colors track the light/dark toggle automatically with no client re-render (the component is an RSC). Dropped the no-op `interactive` flag (xychart-only).
- **One source of style** (`global.css`): the shared `.fd-mermaid svg` / `.fd-railroad svg` rule lives here now; removed the per-instance inline `<style>`. Railroad diagrams were already theme-aware via `currentColor`, so `build-railroad.mjs` is unchanged; they gain the height cap and lose the duplicated style block.

## Before / after

Measured intrinsic SVG sizes (the fix is most visible where a diagram is not already column-width):

| Diagram | Before | After |
| --- | --- | --- |
| `isabelle-proofs` (TD, desktop) | `836x710` (upscaled, sparse) | `538x456` (natural, centered) |
| `architecture` (mobile 375px) | `343x86` (whole diagram crushed, ~4px text) | `1121x281` (full size, horizontal scroll, legible) |
| `architecture` (LR, desktop) | `836x210` | `836x210` (unchanged size; now themed) |
| railroad (`parser`) | `573x362` | `573x362` (unchanged; gains height cap) |

Comparison images are saved locally at `/tmp/shots/compare-proofs.png`, `/tmp/shots/compare-mobile.png`, and `/tmp/shots/compare-architecture.png`. They need to be dragged into this description to render inline (GitHub's attachment CDN is not reachable from the CLI).

## Validation

- `npx tsc --noEmit`: clean.
- `npx next build`: compiles and pre-renders all 47 static pages (the diagram-heavy `/research/03` page included) with no error.
- Rendered `/design/architecture`, `/design/isabelle-proofs`, `/pipelines/parser-implementation` at 1440x900 and 375px via headless Chrome to capture the before/after above.

## Deviations from the literal acceptance criteria (with rationale)

- **Width cap is the content column, not a hard `720px`.** Fitting the natural reading column keeps desktop diagrams crisp; a fixed 720px would shrink them (and their text) more than necessary. Nothing exceeds the column, so there is no page overflow.
- **No CSS `font-size` pin.** Node positions are pre-computed by the layout engine, so overriding `font-size` post-layout would push labels out of their boxes. The legibility guarantee here is "never rescale off the authored size" (no upscale on desktop, no shrink on mobile), which is what the AC is really after.