### PR TITLE
ci: skip Scala/solver/coverage on docs-only PRs; add missing concurrency

### DIFF
--- a/.github/workflows/branch-name.yml
+++ b/.github/workflows/branch-name.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   check-branch-name:
     runs-on: ubuntu-latest

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,28 @@
+name: changes
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: "true when the change set touches anything outside docs/"
+        value: ${{ jobs.detect.outputs.code }}
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+
   build-and-test:
+    needs: changes
+    # skip only when detection is certain the change set is docs-only; fail open to testing
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/isabelle-build.yml
+++ b/.github/workflows/isabelle-build.yml
@@ -22,6 +22,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   isabelle:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,8 +9,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  changes:
+    uses: ./.github/workflows/changes.yml
+
   coverage:
+    needs: changes
+    # skip only when detection is certain the change set is docs-only; fail open to testing
+    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,23 @@ notes. `feat` / `fix` / `refactor` / `perf` / `docs` are surfaced in the changel
 `build` / `test` / `style` go to hidden sections. Bot branches (`dependabot/...`,
 `release-please--...`) are exempt.
 
+## Continuous integration
+
+Every PR runs the meta checks (`check-branch-name`, `actionlint`, `zizmor`). The target builds
+(`go-build` / `python-build` / `ts-build`) and `isabelle-build` are path-filtered to the sources
+they cover, so they only run when those paths change.
+
+The heavy Scala checks (`build-and-test`, which does compile + scalafmt + scalafix + the full test
+suite; the `z3` / `cvc5` / `alloy` cross-checks; and `coverage`) are required, but they are skipped
+on docs-only PRs (changes confined to `docs/**`). A small reusable workflow
+(`.github/workflows/changes.yml`) detects whether the change set reaches outside `docs/`, and the
+heavy jobs gate on its output. A required job skipped this way reports as "Skipped", which GitHub
+counts as passing, so a docs-only PR shows those checks greyed out and still merges. That is
+expected, not a failure. The gate fails open: if detection cannot run, the full suite runs anyway.
+
+Pushing a new commit to a PR cancels that PR's in-progress runs (`concurrency` with
+`cancel-in-progress`); pushes to `main` always run to completion.
+
 ## Architecture enforcement
 
 The module dependency graph in `build.sbt` (`dependsOn`) _is_ the architecture — an illegal


### PR DESCRIPTION
## What

A full audit of every PR-triggering workflow, the fixes for the waste it found, and a reusable change-detection workflow.

## Audit findings

### Fixed here

**1. Heavy checks ran on docs-only PRs.** `ci.yml` (`build-and-test` + `z3-cross-check` + `cvc5-cross-check` + `alloy-cross-check`) and `quality.yml` (`coverage`) ran in full on docs-only PRs. Both already had `paths-ignore: ["docs/**"]` on their `push` trigger, but their `pull_request` trigger had no filter, so the asymmetry only bit PRs. (Confirmed on the just-merged #414: all of these ran for a CSS/TSX change.)

These are **required status checks**, so the naive fix (adding `paths-ignore` to `pull_request`) would leave them stuck at "Expected / waiting for status to be reported" and make docs PRs unmergeable. Instead:

- new reusable `changes.yml` (`workflow_call`) outputs `code = true` when the change set touches anything outside `docs/`;
- `build-and-test` and `coverage` gate on it; the three cross-checks cascade-skip through their existing `needs: build-and-test`;
- a skipped required job reports as **passing**, so docs PRs stay mergeable while spending zero solver/coverage time;
- the gate **fails open**: `if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}` runs the suite unless detection is certain it is docs-only, so a detection hiccup never silently skips testing.

**2. The most expensive workflows had no `concurrency`.** `ci.yml`, `quality.yml`, and `isabelle-build.yml` lacked a concurrency group, while every other PR-triggering workflow (deploy-fly, go/python/ts-build, docker, native) already had one. So three quick pushes to a PR ran the full suite + solvers + coverage + ~30-min proof builds three times over. Added the standard `group: ${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress` on PRs only (main pushes still all complete). Added it to the cheap `lint-workflows` / `branch-name` too, so every PR-triggered workflow now shares the invariant.

### Reusable "plug-n-play" detector

`changes.yml` is the one-liner. Any workflow that must run on all PRs (so it cannot trigger-filter) but wants to skip work on docs-only changes adds:

```yaml
jobs:
  changes:
    uses: ./.github/workflows/changes.yml
  expensive-job:
    needs: changes
    if: ${{ !cancelled() && needs.changes.outputs.code != 'false' }}
```

The "what counts as docs-only" rule lives in one place (`!docs/**`, matching the existing `paths-ignore`).

### Noted, not changed (possible follow-up)

`quality.yml`'s `coverage` runs `sbt clean coverage test coverageAggregate`, re-executing the entire test suite that `build-and-test` already ran (instrumented, from clean). That is a real per-PR double run of the suite, but collapsing it touches branch protection (both are separate required checks) and the scalafmt / scalafix / compile gates that only `build-and-test` performs, so I left it out of this PR. Happy to do it as a focused follow-up.

## On "skipped required check = passing"

This is GitHub's documented, non-configurable behavior: a required check whose **job** is skipped via `if:` (the workflow still ran) counts as passed; only a check whose **workflow** never triggers (filtered at the trigger) blocks with "waiting for status". This PR uses the former. The definitive confirmation is the first docs-only PR after this merges: `build-and-test` / `coverage` will show "Skipped" yet the PR will be mergeable.

## Validation

- `actionlint` v1.7.12: clean.
- `zizmor` v1.25.2 (`--offline`): no findings on the changed workflows.
- Cross-checked against the required-status-check list (`build-and-test`, `z3/cvc5/alloy-cross-check`, `coverage`, `actionlint`, `zizmor`, `check-branch-name`).

## Docs

`CONTRIBUTING.md` gains a "Continuous integration" section: which checks run on a PR, the docs-only skip (and that a "Skipped" required check counts as passing), and the cancel-in-progress concurrency, so a docs-PR author is not surprised by greyed-out checks.