### PR TITLE
fix(native-image): pass --exclude-config as two args so release binaries build

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -4,7 +4,11 @@ on:
   push:
     tags: ["v*"]
   pull_request:
-    paths: [".github/workflows/native.yml"]
+    paths:
+      - ".github/workflows/native.yml"
+      - "build.sbt"
+      - "project/plugins.sbt"
+      - "modules/cli/src/main/resources/META-INF/native-image/**"
   workflow_dispatch:
   workflow_call:
     inputs:

--- a/build.sbt
+++ b/build.sbt
@@ -284,9 +284,11 @@ lazy val cli = (project in file("modules/cli"))
       // jni/reflect/resource configs stay (synth needs them at runtime).
       // Still unfixed upstream as of openai-java 4.39.1.
       "--exclude-config",
-      ".*openai-java-core.*\\.jar,META-INF/native-image/proxy-config\\.json",
+      ".*openai-java-core.*\\.jar",
+      "META-INF/native-image/proxy-config\\.json",
       "--exclude-config",
-      ".*openai-java-core.*\\.jar,META-INF/native-image/serialization-config\\.json"
+      ".*openai-java-core.*\\.jar",
+      "META-INF/native-image/serialization-config\\.json"
     )
   )
 


### PR DESCRIPTION
## Symptom

The fly.dev **Site** deploy fails: the Docker build fetches
`releases/latest/download/spec-to-rest-linux-amd64.tar.gz` and gets a 404, so the empty pipe to
`tar` aborts the image build.

## Root cause

`latest` is **v3.0.0**, which has **zero release assets** (v2.2.0 has all four binaries). v3.0.0 is
empty because the release-please run that cut it failed: all four `native / Build (...)` jobs died
at the `native-image` step with `Error: Unknown argument(s): '.../spec-to-rest'` (exit 20), so
`Publish GitHub release` was skipped.

native-image's `--exclude-config` takes **two** space-separated arguments
(`<jar-regexp> <resource-regexp>`; [GraalVM docs](https://www.graalvm.org/latest/reference-manual/native-image/overview/Options/)),
but `build.sbt` joined each pair with a comma into a single token. native-image consumed the
following flag as the second argument, the parse slid out of alignment, and the output path fell off
the end as an unrecognized positional.

Introduced in #403 ("eliminate build warnings"), which added the `--exclude-config` lines to silence
openai-java's bundled-config warnings. It shipped silently because `native.yml` only ran on PRs that
touch `.github/workflows/native.yml`, so the `build.sbt` change was never exercised by a native
build until the v3.0.0 tag triggered it.

## Fix

- **`build.sbt`**: split each `--exclude-config` into `<jar> <resource>` (two args).
- **`native.yml`**: also trigger the PR native build on `build.sbt`, `project/plugins.sbt`, and the
  native-image config under `modules/cli/.../META-INF/native-image`, so a build-config change that
  breaks the image is caught on the PR instead of at release. This PR touches `build.sbt` +
  `native.yml`, so it runs the full four-platform native build (+ smoke test) here and validates the
  fix in CI.

## Recovery (after this merges)

The fix alone does not refill v3.0.0. To restore the playground binary, either:

- **cut v3.0.1** (clean: this `fix:` lands on `main`, release-please proposes v3.0.1, the now-fixed
  native build attaches assets, `latest` becomes v3.0.1), or
- **re-run for v3.0.0**: `gh workflow run native.yml -f tag=v3.0.0 -f upload_to_existing_release=true`
  (attaches binaries built from fixed `main` to the existing release).

Then trigger the site deploy: `gh workflow run deploy-fly.yml` (release-please's `GITHUB_TOKEN`
release does not auto-trigger it).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes native-image builds by passing `--exclude-config` as two separate args and updates CI triggers to catch build breaks on PRs. This unblocks release binaries and prevents the site deploy from 404ing on latest assets.

- **Bug Fixes**
  - In `build.sbt`, pass `--exclude-config` as two args (`<jar-regexp>` and `<resource-regexp>`) to stop native-image parse errors.
  - In `native.yml`, run PR native builds on changes to `build.sbt`, `project/plugins.sbt`, and `modules/cli/src/main/resources/META-INF/native-image/**`.

- **Migration**
  - Publish binaries: cut v3.0.1, or re-run `native.yml` for tag v3.0.0 with `upload_to_existing_release=true`.
  - Then trigger the site deploy: run `deploy-fly.yml`.

<sup>Written for commit 30e21a0cb51ca11dd3abafb3235317db7ac29bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

