### PR TITLE
feat(verify): model Duration as the Int sort, completing the #377 temporal lift

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -558,26 +558,27 @@ mid-call abort details) are documented in
 ## Scalar types
 
 Each spec primitive maps to a Z3 theory sort. Integral and temporal types share `Int`
-(temporal values are epoch seconds, so ordering and arithmetic on `DateTime` / `Date`
-verify directly); fractional types use Z3 `Real`; everything else is an uninterpreted sort
-that supports equality only.
+(`DateTime` / `Date` are epoch seconds and `Duration` is a second span, so ordering and
+arithmetic on them verify directly); fractional types use Z3 `Real`; everything else is an
+uninterpreted sort that supports equality only.
 
-| Spec type                         | Z3 sort                                    |
-| --------------------------------- | ------------------------------------------ |
-| `Int`, `DateTime`, `Date`         | `Int`                                      |
-| `Float`, `Decimal`, `Money`       | `Real`                                     |
-| `Bool` / `Boolean`                | `Bool`                                     |
-| `String`, `UUID`, entities, enums | uninterpreted                              |
-| `Set[T]`                          | `(Set T)` (see [Set theory](#set-theory))  |
+| Spec type                              | Z3 sort                                    |
+| -------------------------------------- | ------------------------------------------ |
+| `Int`, `DateTime`, `Date`, `Duration`  | `Int`                                      |
+| `Float`, `Decimal`, `Money`            | `Real`                                     |
+| `Bool` / `Boolean`                     | `Bool`                                     |
+| `String`, `UUID`, entities, enums      | uninterpreted                              |
+| `Set[T]`                               | `(Set T)` (see [Set theory](#set-theory))  |
 
 Ordering (`<`, `<=`, `>`, `>=`) and arithmetic (`+`, `-`, `*`, `/`) require numeric operands
 (`Int` or `Real`); Z3 coerces `Int` to `Real` when the two are mixed (e.g. a `Money` field
 compared to an integer literal). Applied to a non-numeric sort, the check is reported as
 skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on any sort.
 
-The integral-vs-fractional split is the one type-to-sort fact made in the Z3 translator
-rather than derived from the proof: the Isabelle `ty` has only `Int`/`Bool` (no fractional
-sort), so it cannot express it.
+The integral-vs-fractional split is part of the proof: the Isabelle `ty` carries both
+`TInt` and `TReal`, and `typeExprFullToTy` (`Semantics.thy`) assigns fractional names to
+`TReal`. `primitiveSortOf` in the Z3 translator is the hand-maintained mirror of that same
+name policy.
 
 ## Set theory
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -10366,7 +10366,9 @@ object SpecRestGenerated {
       case (enums, entities, NamedTypeF(n, uu)) =>
         n == "Bool" || n == "Boolean" match {
           case true => Some[ty](TBool())
-          case false => n == "Int" || (n == "DateTime" || n == "Date") match {
+          case false => n == "Int" ||
+              (n == "DateTime" ||
+                (n == "Date" || n == "Duration")) match {
               case true => Some[ty](TInt())
               case false => n == "Float" ||
                   (n == "Decimal" || n == "Money") match {

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -320,13 +320,13 @@ object Translator:
   // temporal names share Int/TInt (temporal values are epoch seconds),
   // fractional names map to Real/TReal, Bool/Boolean to Bool/TBool. String is
   // handled in sortForNamedType (native string sort / TStr, where
-  // String-refinement aliases get their own handling); opaque primitives
-  // (Duration, UUID) are absent on both sides and fall to uninterpreted.
+  // String-refinement aliases get their own handling); UUID is absent on both
+  // sides and falls to an uninterpreted sort (equality only).
   private def primitiveSortOf(name: String): Option[Z3Sort] = name match
-    case "Int" | "DateTime" | "Date"   => Some(Z3Sort.Int)
-    case "Float" | "Decimal" | "Money" => Some(Z3Sort.Real)
-    case "Bool" | "Boolean"            => Some(Z3Sort.Bool)
-    case _                             => None
+    case "Int" | "DateTime" | "Date" | "Duration" => Some(Z3Sort.Int)
+    case "Float" | "Decimal" | "Money"            => Some(Z3Sort.Real)
+    case "Bool" | "Boolean"                       => Some(Z3Sort.Bool)
+    case _                                        => None
 
   private def primitiveUnderlyingSort(t: type_alias_decl): Option[Z3Sort] =
     talType(t) match

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -36,6 +36,25 @@ class ConsistencyTest extends CatsEffectSuite:
     )
 
   test(
+    "ordering on Duration verifies via Z3 (Duration shares the Int sort, completing the #377 temporal lift)"
+  ):
+    val spec =
+      """service DurationDemo {
+        |  state {
+        |    timeouts: Map[Int, Duration]
+        |  }
+        |  invariant timeoutsNonNegative:
+        |    (the k in timeouts | timeouts[k] >= 0) >= 0
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("duration_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+      s"expected every check Sat (Duration ordering must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+    )
+
+  test(
     "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)"
   ):
     val spec =

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -255,7 +255,7 @@ fun typeExprFullToTy ::
   "typeExprFullToTy enums entities (NamedTypeF n _) =
      (if n = STR ''Bool'' \<or> n = STR ''Boolean'' then Some TBool
       else if n = STR ''Int'' \<or> n = STR ''DateTime''
-              \<or> n = STR ''Date'' then Some TInt
+              \<or> n = STR ''Date'' \<or> n = STR ''Duration'' then Some TInt
       else if n = STR ''Float'' \<or> n = STR ''Decimal''
               \<or> n = STR ''Money'' then Some TReal
       else if n = STR ''String'' then Some TStr


### PR DESCRIPTION
## What

`Duration` was the one temporal primitive that PR #377 left out. #377 modeled `DateTime` / `Date` as the Z3 `Int` sort (epoch seconds), so ordering and arithmetic on them verify directly — but `Duration` stayed an uninterpreted sort. Any invariant or refinement that ordered or did arithmetic on a `Duration` was skipped as a translator-coverage limitation (exit 2), never actually checked.

This models `Duration` as `Int` too (a span in seconds), completing the temporal-type lift.

## The change (one fact, both mirrors)

The spec-type → sort policy is the proof's `typeExprFullToTy` (`Semantics.thy`), extracted into `SpecRestGenerated.scala` and mirrored by the hand-written `primitiveSortOf` in the Z3 translator. Both now place `Duration` in the `TInt` / `Int` class:

- `proofs/isabelle/SpecRest/core/Semantics.thy` — `typeExprFullToTy` maps `Duration` to `TInt`.
- `modules/verify/src/main/scala/specrest/verify/z3/Translator.scala` — `primitiveSortOf` maps `Duration` to `Z3Sort.Int`.
- `modules/ir/.../generated/SpecRestGenerated.scala` — regenerated; the only diff is the new `Duration` disjunct.

`Duration` joins the **existing** `TInt` equivalence class, so there is no new `ty`, no new typing rule, and no new soundness case — the full `SpecRest_Soundness` build is zero-`sorry` green.

### Coherence fix

The documented helper `function days_until(deadline: DateTime, now: DateTime): Duration` subtracts two `DateTime`s. With `DateTime → Int` and `Duration` previously uninterpreted, the body (`Int - Int = Int`) and the declared `Duration` return type did not align. Now both are `Int`, so the example is type-coherent.

## Tests / checks

- `ConsistencyTest`: ordering on a `Duration` map value (`(the k in timeouts | timeouts[k] >= 0) >= 0`) now verifies (`Sat`) instead of skipping — mirrors the existing `the_demo` test, swapping the indexed value type to `Duration` and the inner op to an ordering.
- `SpecRest_Soundness` + `SpecRest_Codegen` build clean (zero `sorry`); the regenerated `SpecRestGenerated.scala` matches the extraction drift gate.
- `sbt scalafmtCheckAll` clean.

## Docs

`docs/content/docs/pipelines/verification.mdx` (Scalar types): added `Duration` to the `Int` row and prose, and corrected a stale claim that "the Isabelle `ty` has only `Int`/`Bool`" — `ty` has carried `TReal` since #377.

---

First of the limitations-catalog (#420 Part A) "realistic slice". String lexicographic ordering and map-indexing-via-arrays are larger, separate PRs (they need new typing rules / maps-as-arrays in the proof).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted `Duration` to the `Int` sort (seconds) in the proof and Z3 translator so ordering and arithmetic on durations verify instead of being skipped. Completes the temporal lift from #377; no new typing rules and the soundness build remains green.

- **New Features**
  - Map `Duration` to `TInt` in `typeExprFullToTy` (`Semantics.thy`) and to `Z3Sort.Int` in `primitiveSortOf`; regenerated `SpecRestGenerated.scala`.
  - Added a `ConsistencyTest` proving `Duration` ordering checks return `Sat`.
  - Docs: updated scalar types table to include `Duration` under `Int`, and clarified `ty` includes `TReal`.
  - Fixed type coherence for examples like `days_until(DateTime, DateTime): Duration` (now `Int - Int` aligns with `Duration`).

<sup>Written for commit e475245e9a3c8e5caed21d9bd02fb9ae3878d61b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `Duration` type in consistency verification checks.

* **Documentation**
  * Updated scalar types documentation to clarify how types are mapped for ordering, arithmetic, and equality operations in verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->