### PR TITLE
feat(verify): support lexicographic ordering on String via str.<

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -559,21 +559,24 @@ mid-call abort details) are documented in
 
 Each spec primitive maps to a Z3 theory sort. Integral and temporal types share `Int`
 (`DateTime` / `Date` are epoch seconds and `Duration` is a second span, so ordering and
-arithmetic on them verify directly); fractional types use Z3 `Real`; everything else is an
-uninterpreted sort that supports equality only.
+arithmetic on them verify directly); fractional types use Z3 `Real`; `String` uses Z3's
+native string sort; `UUID`, entities, and enums are uninterpreted sorts that support
+equality only.
 
 | Spec type                              | Z3 sort                                    |
 | -------------------------------------- | ------------------------------------------ |
 | `Int`, `DateTime`, `Date`, `Duration`  | `Int`                                      |
 | `Float`, `Decimal`, `Money`            | `Real`                                     |
 | `Bool` / `Boolean`                     | `Bool`                                     |
-| `String`, `UUID`, entities, enums      | uninterpreted                              |
+| `String`                               | native string sort (`str.<`, regex)        |
+| `UUID`, entities, enums                | uninterpreted                              |
 | `Set[T]`                               | `(Set T)` (see [Set theory](#set-theory))  |
 
-Ordering (`<`, `<=`, `>`, `>=`) and arithmetic (`+`, `-`, `*`, `/`) require numeric operands
-(`Int` or `Real`); Z3 coerces `Int` to `Real` when the two are mixed (e.g. a `Money` field
-compared to an integer literal). Applied to a non-numeric sort, the check is reported as
-skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on any sort.
+Arithmetic (`+`, `-`, `*`, `/`) requires numeric operands (`Int` or `Real`); Z3 coerces
+`Int` to `Real` when the two are mixed (e.g. a `Money` field compared to an integer literal).
+Ordering (`<`, `<=`, `>`, `>=`) works on two numeric operands or two `String` operands
+(lexicographic, encoded as Z3 `str.<` / `str.<=`); a numeric/`String` mix or any other sort is
+reported as skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on any sort.
 
 The integral-vs-fractional split is part of the proof: the Isabelle `ty` carries both
 `TInt` and `TReal`, and `typeExprFullToTy` (`Semantics.thy`) assigns fractional names to

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2231,7 +2231,19 @@ object SpecRestGenerated {
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
-          case (Some(SStr(_)), _)                           => None
+          case (Some(SStr(_)), None)                        => None
+          case (Some(SStr(_)), Some(SBool(_)))              => None
+          case (Some(SStr(_)), Some(SInt(_)))               => None
+          case (Some(SStr(_)), Some(SReal(_)))              => None
+          case (Some(SStr(_)), Some(SEnumElem(_, _)))       => None
+          case (Some(SStr(_)), Some(SEntityElem(_, _)))     => None
+          case (Some(SStr(_)), Some(SSet(_)))               => None
+          case (Some(SStr(_)), Some(SEntityWith(_, _, _)))  => None
+          case (Some(SStr(_)), Some(SNone()))               => None
+          case (Some(SStr(_)), Some(SSome(_)))              => None
+          case (Some(SStr(a)), Some(SStr(b)))               => Some[smt_val](SBool(a < b))
+          case (Some(SStr(_)), Some(SSeq(_)))               => None
+          case (Some(SStr(_)), Some(SMap(_)))               => None
           case (Some(SSeq(_)), _)                           => None
           case (Some(SMap(_)), _)                           => None
         }

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -291,6 +291,7 @@ private object Backend:
     case Z3Expr.Implies(l, r, _) =>
       rctx.ctx.mkImplies(renderBool(rctx, l), renderBool(rctx, r))
     case Z3Expr.Cmp(op, l, r, _)           => renderCmp(rctx, op, l, r)
+    case Z3Expr.StrCmp(op, l, r, _)        => renderStrCmp(rctx, op, l, r)
     case Z3Expr.Arith(op, args, _)         => renderArith(rctx, op, args)
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
     case Z3Expr.EmptySet(elemSort, _) =>
@@ -398,6 +399,18 @@ private object Backend:
         case CmpOp.Gt => rctx.ctx.mkGt(l, r)
         case CmpOp.Ge => rctx.ctx.mkGe(l, r)
         case _        => backendFail(rctx, s"unreachable CmpOp: $op")
+
+  // Z3 exposes only str.</str.<=; > and >= are the swapped-operand forms.
+  private def renderStrCmp(rctx: RenderCtx, op: CmpOp, lhs: Z3Expr, rhs: Z3Expr): BoolExpr =
+    val l = renderExpr(rctx, lhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
+    val r = renderExpr(rctx, rhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
+    op match
+      case CmpOp.Lt  => rctx.ctx.MkStringLt(l, r)
+      case CmpOp.Le  => rctx.ctx.MkStringLe(l, r)
+      case CmpOp.Gt  => rctx.ctx.MkStringLt(r, l)
+      case CmpOp.Ge  => rctx.ctx.MkStringLe(r, l)
+      case CmpOp.Eq  => rctx.ctx.mkEq(l, r)
+      case CmpOp.Neq => rctx.ctx.mkNot(rctx.ctx.mkEq(l, r))
 
   private def renderArith(
       rctx: RenderCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -93,6 +93,14 @@ object SmtLib:
     case Z3Expr.Cmp(op, l, r, _) =>
       val token = if op == CmpOp.Neq then "distinct" else CmpOp.token(op)
       s"($token ${renderExpr(l)} ${renderExpr(r)})"
+    case Z3Expr.StrCmp(op, l, r, _) =>
+      op match
+        case CmpOp.Lt  => s"(str.< ${renderExpr(l)} ${renderExpr(r)})"
+        case CmpOp.Le  => s"(str.<= ${renderExpr(l)} ${renderExpr(r)})"
+        case CmpOp.Gt  => s"(str.< ${renderExpr(r)} ${renderExpr(l)})"
+        case CmpOp.Ge  => s"(str.<= ${renderExpr(r)} ${renderExpr(l)})"
+        case CmpOp.Eq  => s"(= ${renderExpr(l)} ${renderExpr(r)})"
+        case CmpOp.Neq => s"(distinct ${renderExpr(l)} ${renderExpr(r)})"
     case Z3Expr.Arith(op, args, _) =>
       s"(${ArithOp.token(op)} ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.Quantifier(q, bindings, body, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -888,6 +888,13 @@ object Translator:
         substituteVar(r, varName, replacement),
         sp
       )
+    case Z3Expr.StrCmp(op, l, r, sp) =>
+      Z3Expr.StrCmp(
+        op,
+        substituteVar(l, varName, replacement),
+        substituteVar(r, varName, replacement),
+        sp
+      )
     case Z3Expr.Arith(op, args, sp) =>
       Z3Expr.Arith(op, args.map(a => substituteVar(a, varName, replacement)), sp)
     case q @ Z3Expr.Quantifier(kind, bindings, body, sp) =>
@@ -1319,7 +1326,7 @@ object Translator:
     case Z3Expr.BoolLit(_, _)    => Some(Z3Sort.Bool)
     case Z3Expr.App(func, _, _)  => ctx.funcs.get(func).map(_.resultSort)
     case Z3Expr.And(_, _) | Z3Expr.Or(_, _) | Z3Expr.Not(_, _) | Z3Expr.Implies(_, _, _) |
-        Z3Expr.Cmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
+        Z3Expr.Cmp(_, _, _, _) | Z3Expr.StrCmp(_, _, _, _) | Z3Expr.Quantifier(_, _, _, _) =>
       Some(Z3Sort.Bool)
     case Z3Expr.Arith(_, args, _) =>
       val argSorts = args.map(inferSortOfZ3Expr(ctx, _))
@@ -1998,6 +2005,27 @@ object Translator:
       fail(ctx, "ordering/arithmetic requires a numeric type (Int or Real)")
     z
 
+  // Ordering: both operands numeric (Cmp, arithmetic <) or both String (StrCmp,
+  // str.</str.<=). A numeric/String mix is left to the skip path rather than
+  // handed to the solver ill-sorted.
+  private def encCmp(
+      ctx: TranslateCtx,
+      op: CmpOp,
+      l: smt_term,
+      r: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val lz = encodeFromSmtTerm(ctx, l, env)
+    val rz = encodeFromSmtTerm(ctx, r, env)
+    def isStr(z: Z3Expr): Boolean =
+      inferSortOfZ3Expr(ctx, z) match
+        case Some(Z3Sort.Str) => true
+        case _                => false
+    def isNum(z: Z3Expr): Boolean = inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric)
+    if isStr(lz) && isStr(rz) then Z3Expr.StrCmp(op, lz, rz)
+    else if isNum(lz) && isNum(rz) then Z3Expr.Cmp(op, lz, rz)
+    else fail(ctx, "ordering requires two numeric (Int or Real) operands or two String operands")
+
   private def encodeSetEmptyCmp(
       ctx: TranslateCtx,
       op: CmpOp,
@@ -2041,9 +2069,9 @@ object Translator:
       case TNot(TEq(l, r)) =>
         Z3Expr.Cmp(CmpOp.Neq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
       case TOr(TLt(a1, b1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
-        Z3Expr.Cmp(CmpOp.Le, encNumeric(ctx, a1, env), encNumeric(ctx, b1, env))
+        encCmp(ctx, CmpOp.Le, a1, b1, env)
       case TOr(TLt(b1, a1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
-        Z3Expr.Cmp(CmpOp.Ge, encNumeric(ctx, a2, env), encNumeric(ctx, b2, env))
+        encCmp(ctx, CmpOp.Ge, a2, b2, env)
 
       case TNot(t) => Z3Expr.Not(encodeFromSmtTerm(ctx, t, env))
       case TAnd(l, r) =>
@@ -2055,7 +2083,7 @@ object Translator:
       case TEq(l, r) =>
         Z3Expr.Cmp(CmpOp.Eq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
       case TLt(l, r) =>
-        Z3Expr.Cmp(CmpOp.Lt, encNumeric(ctx, l, env), encNumeric(ctx, r, env))
+        encCmp(ctx, CmpOp.Lt, l, r, env)
       case TNeg(t) =>
         Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), encNumeric(ctx, t, env)))
       case TAdd(l, r) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -88,6 +88,7 @@ enum Z3Expr derives CanEqual:
   case Not(arg: Z3Expr, span: Option[span_t] = None)
   case Implies(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case Cmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
+  case StrCmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case Arith(op: ArithOp, args: List[Z3Expr], span: Option[span_t] = None)
   case Quantifier(
       q: QKind,
@@ -123,6 +124,7 @@ enum Z3Expr derives CanEqual:
     case e: Not        => e.span
     case e: Implies    => e.span
     case e: Cmp        => e.span
+    case e: StrCmp     => e.span
     case e: Arith      => e.span
     case e: Quantifier => e.span
     case e: EmptySet   => e.span
@@ -151,6 +153,7 @@ enum Z3Expr derives CanEqual:
         case e: Not        => e.copy(span = s)
         case e: Implies    => e.copy(span = s)
         case e: Cmp        => e.copy(span = s)
+        case e: StrCmp     => e.copy(span = s)
         case e: Arith      => e.copy(span = s)
         case e: Quantifier => e.copy(span = s)
         case e: EmptySet   => e.copy(span = s)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -55,6 +55,25 @@ class ConsistencyTest extends CatsEffectSuite:
     )
 
   test(
+    "lexicographic ordering on String verifies via Z3 (T_Cmp_Str_Ord, str.< encoding)"
+  ):
+    val spec =
+      """service StringOrderDemo {
+        |  state {
+        |    names: Map[Int, String]
+        |  }
+        |  invariant namesBelowM:
+        |    (the k in names | names[k] < "m") >= 0
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("string_order_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+      s"expected every check Sat (String ordering must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+    )
+
+  test(
     "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)"
   ):
     val spec =

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -142,6 +142,13 @@ fun real_cmp :: "cmp_op \<Rightarrow> rat \<Rightarrow> rat \<Rightarrow> ir_val
 | "real_cmp GeOp a b = Some (VBool (a \<ge> b))"
 | "real_cmp _ _ _ = None"
 
+fun str_cmp :: "cmp_op \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> ir_value option" where
+  "str_cmp LtOp a b = Some (VBool (a < b))"
+| "str_cmp LeOp a b = Some (VBool (a \<le> b))"
+| "str_cmp GtOp a b = Some (VBool (a > b))"
+| "str_cmp GeOp a b = Some (VBool (a \<ge> b))"
+| "str_cmp _ _ _ = None"
+
 fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
   "eval_cmp op x y =
      (case x of
@@ -162,6 +169,10 @@ fun eval_cmp :: "cmp_op \<Rightarrow> ir_value option \<Rightarrow> ir_value opt
                          (case b of
                             VInt bi  \<Rightarrow> real_cmp op ar (of_int bi)
                           | VReal br \<Rightarrow> real_cmp op ar br
+                          | _        \<Rightarrow> None)
+                     | VStr sa \<Rightarrow>
+                         (case b of
+                            VStr sb \<Rightarrow> str_cmp op sa sb
                           | _        \<Rightarrow> None)
                      | _ \<Rightarrow> None))
            | _ \<Rightarrow> None)
@@ -196,10 +207,11 @@ lemma eval_cmp_some_imp_defined:
   "eval_cmp op x y = Some v \<Longrightarrow> (\<exists>a. x = Some a) \<and> (\<exists>b. y = Some b)"
   by (auto split: option.splits ir_value.splits cmp_op.splits)
 
-lemma eval_cmp_order_imp_numeric:
+lemma eval_cmp_order_imp_numeric_or_str:
   "op \<in> {LtOp, LeOp, GtOp, GeOp} \<Longrightarrow> eval_cmp op x y = Some v \<Longrightarrow>
-     ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
-     \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
+     (((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
+      \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b))))
+     \<or> ((\<exists>a. x = Some (VStr a)) \<and> (\<exists>b. y = Some (VStr b)))"
   by (auto split: option.splits ir_value.splits cmp_op.splits if_splits)
 
 text \<open>Category H Phase H1 — value types and value typing.
@@ -929,6 +941,11 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr \<Rightarrow> ty \<Rightarrow
        \<Longrightarrow> expr_has_ty \<Gamma> r t2
        \<Longrightarrow> numeric_ty t1
        \<Longrightarrow> numeric_ty t2
+       \<Longrightarrow> op \<in> {BLt, BLe, BGt, BGe}
+       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
+| T_Cmp_Str_Ord:
+    "expr_has_ty \<Gamma> l TStr
+       \<Longrightarrow> expr_has_ty \<Gamma> r TStr
        \<Longrightarrow> op \<in> {BLt, BLe, BGt, BGe}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) TBool"
 | T_Bool_Bin:

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -379,6 +379,7 @@ where
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SBool (a < b))
       | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SBool (of_int a < b))
       | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SBool (a < of_int b))
+      | (Some (SStr a), Some (SStr b)) \<Rightarrow> Some (SBool (a < b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TNeg t) =
      (case smtEval m env t of

--- a/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
@@ -174,6 +174,21 @@ next
     using ev T_Cmp_Ord.hyps(5) by (cases op) auto
   from eval_cmp_preservation[OF evc] show ?case .
 next
+  case (T_Cmp_Str_Ord \<Gamma> l r op sp)
+  have deN: "dom_eq_domains fs ps st op l r = None"
+    by (rule typed_dom_eq_domains_None[OF T_Cmp_Str_Ord.hyps(1)])
+  have bcN: "beq_comp op r = None"
+    by (rule typed_beq_comp_None[OF T_Cmp_Str_Ord.hyps(2)])
+  have ev: "eval_bin op (eval fs ps fuel sch st env l)
+              (eval fs ps fuel sch st env r) = Some v"
+    using T_Cmp_Str_Ord.prems(2) deN bcN by simp
+  have evc: "eval_cmp (case op of BLt \<Rightarrow> LtOp | BLe \<Rightarrow> LeOp
+                         | BGt \<Rightarrow> GtOp | BGe \<Rightarrow> GeOp)
+               (eval fs ps fuel sch st env l)
+               (eval fs ps fuel sch st env r) = Some v"
+    using ev T_Cmp_Str_Ord.hyps(3) by (cases op) auto
+  from eval_cmp_preservation[OF evc] show ?case .
+next
   case (T_Bool_Bin \<Gamma> l r op sp)
   have deN: "dom_eq_domains fs ps st op l r = None"
     by (rule typed_dom_eq_domains_None[OF T_Bool_Bin.hyps(1)])

--- a/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
@@ -33,6 +33,9 @@ next
   case (T_Cmp_Ord \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
+  case (T_Cmp_Str_Ord \<Gamma> l r op sp)
+  thus ?case by (cases op) auto
+next
   case (T_Bool_Bin \<Gamma> l r op sp)
   thus ?case by (cases op) auto
 next


### PR DESCRIPTION
## What

Lexicographic ordering on `String` (`<`, `<=`, `>`, `>=`) now verifies. Previously the Z3 translator rejected it as a translator-coverage limitation (`encNumeric`: "ordering/arithmetic requires a numeric type"), so any invariant or refinement comparing strings by order was skipped (exit 2) rather than checked. `String` was already the native Z3 string sort (equality and regex `Matches` worked); this adds the order relation end to end, proof first.

## Proof (sound, zero-`sorry`)

The reference semantics and typing now order strings via `String.literal`'s `linorder`:

- `Semantics.thy`: new `str_cmp` helper (mirrors `int_cmp`/`real_cmp`); `eval_cmp` gains a `VStr` arm; the partiality lemma is broadened (`eval_cmp_order_imp_numeric` -> `eval_cmp_order_imp_numeric_or_str`).
- `Semantics.thy`: new typing rule **`T_Cmp_Str_Ord`** (`l : TStr`, `r : TStr`, `op` an ordering op -> `TBool`). Additive - the numeric `T_Cmp_Ord` is untouched.
- `Smt.thy`: `smtEval (TLt …)` gains an `SStr` arm (same `<` on `String.literal`, so it agrees with `eval_cmp` by construction).
- `DirectPreservation.thy` + `Preservation_WellTyped.thy`: a `T_Cmp_Str_Ord` case (mirrors `T_Cmp_Ord`; the value-generic soundness helpers `TLt_sound` etc. already cover the string arm via `(cases a; cases b) auto`).

`translate` needed no change: it is structural (`BLt -> TLt`, `BLe/BGe -> TOr(TLt, TEq)`), so it already emits `TLt`/`TEq` for string operands. `SpecRest_Soundness` builds zero-`sorry`.

`SpecRestGenerated.scala` regenerated: the only diff is the `smtEval` `SStr` ordering arm (the partiality lemma, `str_cmp`, and `eval_cmp` are proof-only, not export roots).

## Encoder

- New `Z3Expr.StrCmp` node (`Types.scala`): the comparison's sort is decided once, at encode time, so both renderers stay dumb and correct.
- `Translator.scala`: `encCmp` encodes both operands and emits `StrCmp` when both are `String`, `Cmp` when both numeric, and **skips** a numeric/`String` mix (same clean-skip the old `encNumeric` gave, never an ill-sorted term).
- `Backend.scala`: `renderStrCmp` -> Z3 `MkStringLt` / `MkStringLe` (Z3 exposes only `<` / `<=`; `>` and `>=` are the swapped-operand forms).
- `SmtLib.scala`: `StrCmp` renders as `str.<` / `str.<=` so `--dump-smt` stays valid SMT-LIB.

## Tests / docs

- `ConsistencyTest`: lexicographic ordering on a `String` map value (`(the k in names | names[k] < "m") >= 0`) now verifies (`Sat`).
- `verification.mdx`: the ordering prose now covers two-`String` operands (`str.<` / `str.<=`), and the scalar table is corrected - `String` is the native string sort, not `uninterpreted` (a pre-existing mislabel; only `UUID`, entities, and enums are uninterpreted).

## Modeling note

`eval_cmp` and `smtEval` order strings with the same `String.literal` `<`, so they agree by construction; trusting that Z3's `str.<` realises that order is the same TCB assumption already made for `<` on `Int`/`Real`.

---

Second of the limitations-catalog (#420 Part A) slice (after Duration -> Int, #422). Map-indexing-via-arrays remains as a separate, larger PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds lexicographic ordering for `String` (`<`, `<=`, `>`, `>=`) in the verifier, encoded with Z3 `str.<`/`str.<=`, so string comparisons now verify instead of being skipped. Introduces `Z3Expr.StrCmp`, updates the backend/SMT-LIB emitters, extends typing and semantics proofs, and updates docs/tests.

- **New Features**
  - Encoder: `encCmp` emits `StrCmp` for two `String` operands; mixed numeric/`String` is cleanly skipped.
  - Backend/SMT-LIB: `StrCmp` renders to Z3 `MkStringLt`/`MkStringLe` and SMT-LIB `str.<`/`str.<=`; `>`/`>=` use swapped operands.
  - Proofs: adds `str_cmp`, a `VStr` arm in `eval_cmp`, typing rule `T_Cmp_Str_Ord`, and preservation cases; regenerated `smtEval` handles string ordering.
  - Docs/Tests: corrects type mapping (`String` is the native string sort) and documents string ordering; adds a consistency test with `names[k] < "m"`.

<sup>Written for commit 72ab69342906c9daa96c84ff6d12487b43117e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

