### PR TITLE
feat(verify): support string concatenation via str.++

### DIFF
--- a/docs/content/docs/pipelines/verification.mdx
+++ b/docs/content/docs/pipelines/verification.mdx
@@ -572,11 +572,13 @@ equality only.
 | `UUID`, entities, enums                | uninterpreted                              |
 | `Set[T]`                               | `(Set T)` (see [Set theory](#set-theory))  |
 
-Arithmetic (`+`, `-`, `*`, `/`) requires numeric operands (`Int` or `Real`); Z3 coerces
-`Int` to `Real` when the two are mixed (e.g. a `Money` field compared to an integer literal).
-Ordering (`<`, `<=`, `>`, `>=`) works on two numeric operands or two `String` operands
-(lexicographic, encoded as Z3 `str.<` / `str.<=`); a numeric/`String` mix or any other sort is
-reported as skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on any sort.
+Arithmetic `-`, `*`, `/` requires numeric operands (`Int` or `Real`); `+` is numeric addition
+on two numeric operands or string concatenation on two `String` operands (Z3 `str.++`). Z3
+coerces `Int` to `Real` when numeric operands are mixed (e.g. a `Money` field compared to an
+integer literal). Ordering (`<`, `<=`, `>`, `>=`) works on two numeric operands or two `String`
+operands (lexicographic, encoded as Z3 `str.<` / `str.<=`); a numeric/`String` mix or any other
+sort is reported as skipped (translator coverage), never crashed. Equality (`=`, `!=`) works on
+any sort.
 
 The integral-vs-fractional split is part of the proof: the Isabelle `ty` carries both
 `TInt` and `TReal`, and `typeExprFullToTy` (`Semantics.thy`) assigns fractional names to

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2303,7 +2303,19 @@ object SpecRestGenerated {
           case (Some(SEntityWith(_, _, _)), _)              => None
           case (Some(SNone()), _)                           => None
           case (Some(SSome(_)), _)                          => None
-          case (Some(SStr(_)), _)                           => None
+          case (Some(SStr(_)), None)                        => None
+          case (Some(SStr(_)), Some(SBool(_)))              => None
+          case (Some(SStr(_)), Some(SInt(_)))               => None
+          case (Some(SStr(_)), Some(SReal(_)))              => None
+          case (Some(SStr(_)), Some(SEnumElem(_, _)))       => None
+          case (Some(SStr(_)), Some(SEntityElem(_, _)))     => None
+          case (Some(SStr(_)), Some(SSet(_)))               => None
+          case (Some(SStr(_)), Some(SEntityWith(_, _, _)))  => None
+          case (Some(SStr(_)), Some(SNone()))               => None
+          case (Some(SStr(_)), Some(SSome(_)))              => None
+          case (Some(SStr(a)), Some(SStr(b)))               => Some[smt_val](SStr(a + b))
+          case (Some(SStr(_)), Some(SSeq(_)))               => None
+          case (Some(SStr(_)), Some(SMap(_)))               => None
           case (Some(SSeq(_)), _)                           => None
           case (Some(SMap(_)), _)                           => None
         }

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -292,6 +292,7 @@ private object Backend:
       rctx.ctx.mkImplies(renderBool(rctx, l), renderBool(rctx, r))
     case Z3Expr.Cmp(op, l, r, _)           => renderCmp(rctx, op, l, r)
     case Z3Expr.StrCmp(op, l, r, _)        => renderStrCmp(rctx, op, l, r)
+    case Z3Expr.StrConcat(l, r, _)         => renderStrConcat(rctx, l, r)
     case Z3Expr.Arith(op, args, _)         => renderArith(rctx, op, args)
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
     case Z3Expr.EmptySet(elemSort, _) =>
@@ -411,6 +412,15 @@ private object Backend:
       case CmpOp.Ge  => rctx.ctx.MkStringLe(r, l)
       case CmpOp.Eq  => rctx.ctx.mkEq(l, r)
       case CmpOp.Neq => rctx.ctx.mkNot(rctx.ctx.mkEq(l, r))
+
+  private def renderStrConcat(
+      rctx: RenderCtx,
+      lhs: Z3Expr,
+      rhs: Z3Expr
+  ): Z3AstExpr[SeqSort[CharSort]] =
+    val l = renderExpr(rctx, lhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
+    val r = renderExpr(rctx, rhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
+    rctx.ctx.mkConcat(l, r)
 
   private def renderArith(
       rctx: RenderCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -101,6 +101,8 @@ object SmtLib:
         case CmpOp.Ge  => s"(str.<= ${renderExpr(r)} ${renderExpr(l)})"
         case CmpOp.Eq  => s"(= ${renderExpr(l)} ${renderExpr(r)})"
         case CmpOp.Neq => s"(distinct ${renderExpr(l)} ${renderExpr(r)})"
+    case Z3Expr.StrConcat(l, r, _) =>
+      s"(str.++ ${renderExpr(l)} ${renderExpr(r)})"
     case Z3Expr.Arith(op, args, _) =>
       s"(${ArithOp.token(op)} ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.Quantifier(q, bindings, body, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -895,6 +895,12 @@ object Translator:
         substituteVar(r, varName, replacement),
         sp
       )
+    case Z3Expr.StrConcat(l, r, sp) =>
+      Z3Expr.StrConcat(
+        substituteVar(l, varName, replacement),
+        substituteVar(r, varName, replacement),
+        sp
+      )
     case Z3Expr.Arith(op, args, sp) =>
       Z3Expr.Arith(op, args.map(a => substituteVar(a, varName, replacement)), sp)
     case q @ Z3Expr.Quantifier(kind, bindings, body, sp) =>
@@ -1347,6 +1353,7 @@ object Translator:
     case Z3Expr.OptNone(elemSort, _)   => Some(Z3Sort.OptionOf(elemSort))
     case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
+    case Z3Expr.StrConcat(_, _, _)     => Some(Z3Sort.Str)
     case Z3Expr.InRe(_, _, _)          => Some(Z3Sort.Bool)
     case Z3Expr.SeqLit(elemSort, _, _) => Some(Z3Sort.SeqOf(elemSort))
     case Z3Expr.MapLit(keySort, valueSort, _, _) =>
@@ -2026,6 +2033,26 @@ object Translator:
     else if isNum(lz) && isNum(rz) then Z3Expr.Cmp(op, lz, rz)
     else fail(ctx, "ordering requires two numeric (Int or Real) operands or two String operands")
 
+  // Addition: both operands numeric (Arith Add) or both String (StrConcat, str.++);
+  // a numeric/String mix is left to the skip path rather than handed to the solver
+  // ill-sorted.
+  private def encAdd(
+      ctx: TranslateCtx,
+      l: smt_term,
+      r: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val lz = encodeFromSmtTerm(ctx, l, env)
+    val rz = encodeFromSmtTerm(ctx, r, env)
+    def isStr(z: Z3Expr): Boolean =
+      inferSortOfZ3Expr(ctx, z) match
+        case Some(Z3Sort.Str) => true
+        case _                => false
+    def isNum(z: Z3Expr): Boolean = inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric)
+    if isStr(lz) && isStr(rz) then Z3Expr.StrConcat(lz, rz)
+    else if isNum(lz) && isNum(rz) then Z3Expr.Arith(ArithOp.Add, List(lz, rz))
+    else fail(ctx, "addition requires two numeric (Int or Real) operands or two String operands")
+
   private def encodeSetEmptyCmp(
       ctx: TranslateCtx,
       op: CmpOp,
@@ -2087,7 +2114,7 @@ object Translator:
       case TNeg(t) =>
         Z3Expr.Arith(ArithOp.Sub, List(Z3Expr.IntLit(BigInt(0)), encNumeric(ctx, t, env)))
       case TAdd(l, r) =>
-        Z3Expr.Arith(ArithOp.Add, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
+        encAdd(ctx, l, r, env)
       case TSub(l, r) =>
         Z3Expr.Arith(ArithOp.Sub, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
       case TMul(l, r) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -89,6 +89,7 @@ enum Z3Expr derives CanEqual:
   case Implies(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case Cmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case StrCmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
+  case StrConcat(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case Arith(op: ArithOp, args: List[Z3Expr], span: Option[span_t] = None)
   case Quantifier(
       q: QKind,
@@ -125,6 +126,7 @@ enum Z3Expr derives CanEqual:
     case e: Implies    => e.span
     case e: Cmp        => e.span
     case e: StrCmp     => e.span
+    case e: StrConcat  => e.span
     case e: Arith      => e.span
     case e: Quantifier => e.span
     case e: EmptySet   => e.span
@@ -154,6 +156,7 @@ enum Z3Expr derives CanEqual:
         case e: Implies    => e.copy(span = s)
         case e: Cmp        => e.copy(span = s)
         case e: StrCmp     => e.copy(span = s)
+        case e: StrConcat  => e.copy(span = s)
         case e: Arith      => e.copy(span = s)
         case e: Quantifier => e.copy(span = s)
         case e: EmptySet   => e.copy(span = s)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -74,6 +74,25 @@ class ConsistencyTest extends CatsEffectSuite:
     )
 
   test(
+    "string concatenation verifies via Z3 (T_Str_Concat, str.++ encoding)"
+  ):
+    val spec =
+      """service StringConcatDemo {
+        |  state {
+        |    names: Map[Int, String]
+        |  }
+        |  invariant concatMatches:
+        |    (the k in names | "a" + names[k] = "ab") >= 0
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("string_concat_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+      s"expected every check Sat (String concat must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+    )
+
+  test(
     "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)"
   ):
     val spec =

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -106,6 +106,10 @@ fun real_arith :: "arith_op \<Rightarrow> rat \<Rightarrow> rat \<Rightarrow> ir
 | "real_arith MulOp a b = Some (VReal (a * b))"
 | "real_arith DivOp a b = (if b = 0 then None else Some (VReal (a / b)))"
 
+fun str_arith :: "arith_op \<Rightarrow> String.literal \<Rightarrow> String.literal \<Rightarrow> ir_value option" where
+  "str_arith AddOp a b = Some (VStr (a + b))"
+| "str_arith _ _ _ = None"
+
 fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
   "eval_arith op x y =
      (case x of
@@ -119,6 +123,10 @@ fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value
              Some (VInt b)  \<Rightarrow> real_arith op a (of_int b)
            | Some (VReal b) \<Rightarrow> real_arith op a b
            | _              \<Rightarrow> None)
+      | Some (VStr a) \<Rightarrow>
+          (case y of
+             Some (VStr b) \<Rightarrow> str_arith op a b
+           | _             \<Rightarrow> None)
       | _ \<Rightarrow> None)"
 
 definition ir_val_eq :: "ir_value \<Rightarrow> ir_value \<Rightarrow> bool" where
@@ -188,10 +196,11 @@ text \<open>Category H — first proven bricks of the spec front-half (the
   it is *false* here because \<open>eval\<close>'s \<open>Ident\<close> arm legitimately resolves
   from \<open>state\<close>, not only \<open>env\<close>.\<close>
 
-lemma eval_arith_some_imp_numeric:
+lemma eval_arith_some_imp_numeric_or_str:
   "eval_arith op x y = Some v \<Longrightarrow>
-     ((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
-     \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b)))"
+     (((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
+      \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b))))
+     \<or> ((\<exists>a. x = Some (VStr a)) \<and> (\<exists>b. y = Some (VStr b)))"
   by (auto split: option.splits ir_value.splits if_splits)
 
 lemma eval_arith_div_zero:
@@ -567,6 +576,15 @@ lemma eval_arith_preservation:
       auto split: option.splits ir_value.splits if_splits
            simp: numeric_ty_def numeric_join_def intro: vt_int vt_real)
 
+lemma eval_arith_str_preservation:
+  assumes "eval_arith op x y = Some v"
+      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a TStr"
+      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b TStr"
+  shows "value_has_ty \<Gamma> v TStr"
+  using assms
+  by (cases op;
+      auto split: option.splits ir_value.splits if_splits intro: vt_str)
+
 lemma eval_cmp_preservation:
   assumes "eval_cmp op x y = Some v"
   shows "value_has_ty \<Gamma> v TBool"
@@ -930,6 +948,10 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr \<Rightarrow> ty \<Rightarrow
        \<Longrightarrow> numeric_ty t2
        \<Longrightarrow> op \<in> {BAdd, BSub, BMul, BDiv}
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF op l r sp) (numeric_join t1 t2)"
+| T_Str_Concat:
+    "expr_has_ty \<Gamma> l TStr
+       \<Longrightarrow> expr_has_ty \<Gamma> r TStr
+       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF BAdd l r sp) TStr"
 | T_Cmp_Eq:
     "expr_has_ty \<Gamma> l t1
        \<Longrightarrow> expr_has_ty \<Gamma> r t2

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -392,6 +392,7 @@ where
       | (Some (SReal a), Some (SReal b)) \<Rightarrow> Some (SReal (a + b))
       | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SReal (of_int a + b))
       | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SReal (a + of_int b))
+      | (Some (SStr a), Some (SStr b)) \<Rightarrow> Some (SStr (a + b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TSub l r) =
      (case (smtEval m env l, smtEval m env r) of

--- a/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
@@ -145,6 +145,26 @@ next
     thus "value_has_ty \<Gamma> b t2" using T_Arith.IH(2)[OF T_Arith.prems(1)] by blast
   qed
 next
+  case (T_Str_Concat \<Gamma> l r sp)
+  have deN: "dom_eq_domains fs ps st BAdd l r = None"
+    by (rule typed_dom_eq_domains_None[OF T_Str_Concat.hyps(1)])
+  have bcN: "beq_comp BAdd r = None"
+    by (rule typed_beq_comp_None[OF T_Str_Concat.hyps(2)])
+  have ev: "eval_bin BAdd (eval fs ps fuel sch st env l)
+              (eval fs ps fuel sch st env r) = Some v"
+    using T_Str_Concat.prems(2) deN bcN by simp
+  have eva: "eval_arith AddOp (eval fs ps fuel sch st env l)
+               (eval fs ps fuel sch st env r) = Some v"
+    using ev by simp
+  show ?case
+  proof (rule eval_arith_str_preservation[OF eva])
+    fix a assume "eval fs ps fuel sch st env l = Some a"
+    thus "value_has_ty \<Gamma> a TStr" using T_Str_Concat.IH(1)[OF T_Str_Concat.prems(1)] by blast
+  next
+    fix b assume "eval fs ps fuel sch st env r = Some b"
+    thus "value_has_ty \<Gamma> b TStr" using T_Str_Concat.IH(2)[OF T_Str_Concat.prems(1)] by blast
+  qed
+next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   have deN: "dom_eq_domains fs ps st op l r = None"
     by (rule typed_dom_eq_domains_None[OF T_Cmp_Eq.hyps(1)])

--- a/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
@@ -16,6 +16,9 @@ proof (induction rule: expr_has_ty.induct)
   case (T_Arith \<Gamma> l t1 r t2 op sp)
   thus ?case by (cases op) auto
 next
+  case (T_Str_Concat \<Gamma> l r sp)
+  thus ?case by auto
+next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   have rnc: "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
     using T_Cmp_Eq.hyps(2) by (auto dest: not_expr_has_ty_set_comp)


### PR DESCRIPTION
## What

String concatenation (`+` on `String` → Z3 `str.++`) now verifies. Previously `+` required numeric operands (`encNumeric`: "ordering/arithmetic requires a numeric type"), so any `ensures` / invariant / refinement building a string was skipped. This adds it end to end, proof first — the direct sibling of String ordering (#423).

## Proof (zero-`sorry`)

- `Semantics.thy`: `str_arith` helper (`AddOp` → `VStr` append via `String.literal`'s `+`); `eval_arith` gains a `VStr` arm; the partiality lemma is broadened (`eval_arith_some_imp_numeric` → `_or_str`); new `eval_arith_str_preservation` (yields `TStr`, analogous to `eval_cmp_preservation`); additive typing rule **`T_Str_Concat`** (`l : TStr`, `r : TStr` → `BinaryOpF BAdd l r : TStr`). The numeric `T_Arith` is untouched.
- `Smt.thy`: `smtEval (TAdd …)` gains an `SStr` arm (same `+` on `String.literal`, so it agrees with `eval_arith` by construction).
- `DirectPreservation.thy` + `Preservation_WellTyped.thy`: `T_Str_Concat` cases. `translate` is structural (`BAdd → TAdd`), so no translate change; `DirectSound`'s `BAdd` case is value-generic (`TAdd_sound`) and absorbs the string arm. `SpecRest_Soundness` builds zero-`sorry`.
- `SpecRestGenerated.scala` regenerated: the only diff is the `smtEval` `TAdd` `SStr` arm.

## Encoder

- New `Z3Expr.StrConcat` node (sort decided at encode time, both renderers stay dumb — same pattern as #423's `StrCmp`).
- `Translator.scala`: `encAdd` emits `StrConcat` for two `String` operands, `Arith(Add)` for two numeric, and **skips** a numeric/`String` mix (never an ill-sorted term).
- `Backend.scala`: `renderStrConcat` → Z3 `mkConcat`. `SmtLib.scala`: `str.++`.

## Tests / docs

- `ConsistencyTest`: `(the k in names | "a" + names[k] = "ab") >= 0` now verifies (`Sat`).
- `verification.mdx`: `+` is documented as numeric addition on two numeric operands or string concatenation on two `String` operands (`str.++`).

## Modeling note

`eval_arith` and `smtEval` concatenate with the same `String.literal` `+`, so they agree by construction; trusting Z3's `str.++` to realise it is the same TCB assumption already made for `+` on `Int`/`Real`.

---

Third of the limitations-catalog (#420 Part A) slice — Duration→Int (#422), String ordering (#423), String concatenation. It does **not** by itself unblock url_shortener's `Shorten` (which also needs relation literal-insert and cardinality deltas); those relation-update constructs are a separate, harder track.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end support for string concatenation using `+` on `String`, encoded as Z3 `str.++`, so string-building ensures/invariants now verify. Updates semantics, Z3 encoding, tests, and docs.

- **New Features**
  - Verifier adds `StrConcat`; Backend renders via Z3 `mkConcat`; SMT-LIB prints `str.++`.
  - Translator `encAdd`: emits `StrConcat` for two `String`s, numeric `Add` for two numbers; mixed `String`/numeric is skipped (never ill-sorted).
  - Proofs: new `T_Str_Concat` typing rule; `eval_arith` and `smtEval` concatenate via the same `String.literal` `+`; preservation proven with `eval_arith_str_preservation`.
  - Regenerated `SpecRestGenerated.scala` with `TAdd` string arm.
  - Consistency test added; docs clarify `+` as numeric addition or string concatenation.

<sup>Written for commit af74483b63517dc05244a2a3c3b7a580361c5675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string concatenation support via the `+` operator for string operands, alongside existing numeric addition behavior.
  * Verification system can now check invariants involving string operations.

* **Documentation**
  * Updated operator documentation to clarify `+` behavior for strings versus numeric types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->