### PR TITLE
feat(verify): type-directed range projection for value-sorted set comprehensions (#420)

### DIFF
--- a/docs/lib/cli-runs/d18afafac3c8e803.json
+++ b/docs/lib/cli-runs/d18afafac3c8e803.json
@@ -3,8 +3,8 @@
   "spec": "url_shortener",
   "command": "verify",
   "flags": "",
-  "exitCode": 2,
+  "exitCode": 0,
   "stdout": "\n",
-  "stderr": "⚠ <spec>: 18/21 checks passed; 3 skipped (3 translator coverage) (<elapsed>)\n⚠ \n⚠ <spec>:74:2: warning: translator limitation on check 'ListAll.preserves.allURLsValid': membership operator 'in' requires the left-hand side sort to match the set's element sort; got Str against a set of Uninterp(UrlMapping)\n\n  hint: This spec uses a construct the verifier cannot yet translate. File an issue or narrow the invariant so the unsupported construct does not appear on the verification path.\n⚠ \n⚠ <spec>:74:2: warning: translator limitation on check 'ListAll.preserves.metadataConsistent': membership operator 'in' requires the left-hand side sort to match the set's element sort; got Str against a set of Uninterp(UrlMapping)\n\n  hint: This spec uses a construct the verifier cannot yet translate. File an issue or narrow the invariant so the unsupported construct does not appear on the verification path.\n⚠ \n⚠ <spec>:74:2: warning: translator limitation on check 'ListAll.preserves.clickCountNonNegative': membership operator 'in' requires the left-hand side sort to match the set's element sort; got Str against a set of Uninterp(UrlMapping)\n\n  hint: This spec uses a construct the verifier cannot yet translate. File an issue or narrow the invariant so the unsupported construct does not appear on the verification path.\n⚠ <spec>: exit 2 (translator-limit): verification or synthesis hit a translation limit (an unsupported construct, or an unparseable or rejected generated artifact); the affected verify check is skipped, not failed\nexit codes: 0 ok | 1 violations | 2 translator-limit | 3 backend-error | 4 trust-limit\n",
+  "stderr": "✔ <spec>: 21/21 consistency checks passed (<elapsed>)\n",
   "specText": null
 }

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -557,6 +557,7 @@ object SpecRestGenerated {
   final case class TLetIn(a: String, b: smt_term, c: smt_term)     extends smt_term
   final case class TForallEnum(a: String, b: String, c: smt_term)  extends smt_term
   final case class TForallRel(a: String, b: String, c: smt_term)   extends smt_term
+  final case class TExistsRel(a: String, b: String, c: smt_term)   extends smt_term
   final case class TTheRel(a: String, b: String, c: smt_term)      extends smt_term
   final case class TEntityBase(a: String)                          extends smt_term
   final case class TForallSet(a: String, b: smt_term, c: smt_term) extends smt_term
@@ -1785,6 +1786,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TExistsRel(v, va, vb)  => None
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
@@ -1835,6 +1837,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TExistsRel(v, va, vb)  => None
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
@@ -2492,6 +2495,16 @@ object SpecRestGenerated {
         smt_model_lookup_rel(m, rel_name) match {
           case None    => None
           case Some(d) => smtEval_forall_rel(m, env, vara, d, body)
+        }
+      case (m, env, TExistsRel(vara, rel_name, body)) =>
+        smt_model_lookup_rel(m, rel_name) match {
+          case None => None
+          case Some(d) =>
+            smtEval_the_rel(m, env, vara, d, body) match {
+              case None => None
+              case Some(matches) =>
+                Some[smt_val](SBool(!nulla[smt_val](matches)))
+            }
         }
       case (m, env, TTheRel(vara, rel_name, body)) =>
         smt_model_lookup_rel(m, rel_name) match {
@@ -3226,11 +3239,12 @@ object SpecRestGenerated {
     case TLetIn(v, a, b)       => v :: smt_var_list(a) ++ smt_var_list(b)
     case TForallEnum(v, vb, b) => v :: smt_var_list(b)
     case TForallRel(v, vc, b)  => v :: smt_var_list(b)
-    case TTheRel(v, vd, b)     => v :: smt_var_list(b)
-    case TEntityBase(ve)       => Nil
+    case TExistsRel(v, vd, b)  => v :: smt_var_list(b)
+    case TTheRel(v, ve, b)     => v :: smt_var_list(b)
+    case TEntityBase(vf)       => Nil
     case TForallSet(v, d, b)   => v :: smt_var_list(d) ++ smt_var_list(b)
     case TIndexRel(b, k)       => smt_var_list(b) ++ smt_var_list(k)
-    case TFieldAccess(b, vf)   => smt_var_list(b)
+    case TFieldAccess(b, vg)   => smt_var_list(b)
     case TSetEmpty()           => Nil
     case TSetInsert(e, s)      => smt_var_list(e) ++ smt_var_list(s)
     case TSetMember(e, s)      => smt_var_list(e) ++ smt_var_list(s)
@@ -3239,13 +3253,13 @@ object SpecRestGenerated {
     case TSetDiff(l, r)        => smt_var_list(l) ++ smt_var_list(r)
     case TPrime(t)             => smt_var_list(t)
     case TPre(t)               => smt_var_list(t)
-    case TWithRec(b, vg, v)    => smt_var_list(b) ++ smt_var_list(v)
+    case TWithRec(b, vh, v)    => smt_var_list(b) ++ smt_var_list(v)
     case TIte(c, a, b)         => smt_var_list(c) ++ (smt_var_list(a) ++ smt_var_list(b))
     case TNone()               => Nil
     case TSome(t)              => smt_var_list(t)
-    case TStrLit(vh)           => Nil
-    case TMatches(t, vi)       => smt_var_list(t)
-    case TUStrPred(vj, t)      => smt_var_list(t)
+    case TStrLit(vi)           => Nil
+    case TMatches(t, vj)       => smt_var_list(t)
+    case TUStrPred(vk, t)      => smt_var_list(t)
     case TSeqEmpty()           => Nil
     case TSeqCons(e, r)        => smt_var_list(e) ++ smt_var_list(r)
     case TMapEmpty()           => Nil
@@ -4884,6 +4898,94 @@ object SpecRestGenerated {
     case TableSpec(uu, uv, uw, ux, uy, uz, ixs) => ixs
   }
 
+  def range_arg(x0: expr): Option[String] = x0 match {
+    case CallF(IdentifierF(nm, uu), List(IdentifierF(rel, uv)), uw) =>
+      nm == "range" match {
+        case true  => Some[String](rel)
+        case false => None
+      }
+    case BinaryOpF(v, va, vb, vc)                              => None
+    case UnaryOpF(v, va, vb)                                   => None
+    case QuantifierF(v, va, vb, vc)                            => None
+    case SomeWrapF(v, va)                                      => None
+    case TheF(v, va, vb, vc)                                   => None
+    case FieldAccessF(v, va, vb)                               => None
+    case EnumAccessF(v, va, vb)                                => None
+    case IndexF(v, va, vb)                                     => None
+    case CallF(BinaryOpF(vc, vd, ve, vf), va, vb)              => None
+    case CallF(UnaryOpF(vc, vd, ve), va, vb)                   => None
+    case CallF(QuantifierF(vc, vd, ve, vf), va, vb)            => None
+    case CallF(SomeWrapF(vc, vd), va, vb)                      => None
+    case CallF(TheF(vc, vd, ve, vf), va, vb)                   => None
+    case CallF(FieldAccessF(vc, vd, ve), va, vb)               => None
+    case CallF(EnumAccessF(vc, vd, ve), va, vb)                => None
+    case CallF(IndexF(vc, vd, ve), va, vb)                     => None
+    case CallF(CallF(vc, vd, ve), va, vb)                      => None
+    case CallF(PrimeF(vc, vd), va, vb)                         => None
+    case CallF(PreF(vc, vd), va, vb)                           => None
+    case CallF(WithF(vc, vd, ve), va, vb)                      => None
+    case CallF(IfF(vc, vd, ve, vf), va, vb)                    => None
+    case CallF(LetF(vc, vd, ve, vf), va, vb)                   => None
+    case CallF(LambdaF(vc, vd, ve), va, vb)                    => None
+    case CallF(ConstructorF(vc, vd, ve), va, vb)               => None
+    case CallF(SetLiteralF(vc, vd), va, vb)                    => None
+    case CallF(MapLiteralF(vc, vd), va, vb)                    => None
+    case CallF(SetComprehensionF(vc, vd, ve, vf), va, vb)      => None
+    case CallF(SeqLiteralF(vc, vd), va, vb)                    => None
+    case CallF(MatchesF(vc, vd, ve), va, vb)                   => None
+    case CallF(IntLitF(vc, vd), va, vb)                        => None
+    case CallF(FloatLitF(vc, vd), va, vb)                      => None
+    case CallF(StringLitF(vc, vd), va, vb)                     => None
+    case CallF(BoolLitF(vc, vd), va, vb)                       => None
+    case CallF(NoneLitF(vc), va, vb)                           => None
+    case CallF(v, Nil, vb)                                     => None
+    case CallF(v, BinaryOpF(ve, vf, vg, vh) :: vd, vb)         => None
+    case CallF(v, UnaryOpF(ve, vf, vg) :: vd, vb)              => None
+    case CallF(v, QuantifierF(ve, vf, vg, vh) :: vd, vb)       => None
+    case CallF(v, SomeWrapF(ve, vf) :: vd, vb)                 => None
+    case CallF(v, TheF(ve, vf, vg, vh) :: vd, vb)              => None
+    case CallF(v, FieldAccessF(ve, vf, vg) :: vd, vb)          => None
+    case CallF(v, EnumAccessF(ve, vf, vg) :: vd, vb)           => None
+    case CallF(v, IndexF(ve, vf, vg) :: vd, vb)                => None
+    case CallF(v, CallF(ve, vf, vg) :: vd, vb)                 => None
+    case CallF(v, PrimeF(ve, vf) :: vd, vb)                    => None
+    case CallF(v, PreF(ve, vf) :: vd, vb)                      => None
+    case CallF(v, WithF(ve, vf, vg) :: vd, vb)                 => None
+    case CallF(v, IfF(ve, vf, vg, vh) :: vd, vb)               => None
+    case CallF(v, LetF(ve, vf, vg, vh) :: vd, vb)              => None
+    case CallF(v, LambdaF(ve, vf, vg) :: vd, vb)               => None
+    case CallF(v, ConstructorF(ve, vf, vg) :: vd, vb)          => None
+    case CallF(v, SetLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, MapLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, SetComprehensionF(ve, vf, vg, vh) :: vd, vb) => None
+    case CallF(v, SeqLiteralF(ve, vf) :: vd, vb)               => None
+    case CallF(v, MatchesF(ve, vf, vg) :: vd, vb)              => None
+    case CallF(v, IntLitF(ve, vf) :: vd, vb)                   => None
+    case CallF(v, FloatLitF(ve, vf) :: vd, vb)                 => None
+    case CallF(v, StringLitF(ve, vf) :: vd, vb)                => None
+    case CallF(v, BoolLitF(ve, vf) :: vd, vb)                  => None
+    case CallF(v, NoneLitF(ve) :: vd, vb)                      => None
+    case CallF(v, vc :: ve :: vf, vb)                          => None
+    case PrimeF(v, va)                                         => None
+    case PreF(v, va)                                           => None
+    case WithF(v, va, vb)                                      => None
+    case IfF(v, va, vb, vc)                                    => None
+    case LetF(v, va, vb, vc)                                   => None
+    case LambdaF(v, va, vb)                                    => None
+    case ConstructorF(v, va, vb)                               => None
+    case SetLiteralF(v, va)                                    => None
+    case MapLiteralF(v, va)                                    => None
+    case SetComprehensionF(v, va, vb, vc)                      => None
+    case SeqLiteralF(v, va)                                    => None
+    case MatchesF(v, va, vb)                                   => None
+    case IntLitF(v, va)                                        => None
+    case FloatLitF(v, va)                                      => None
+    case StringLitF(v, va)                                     => None
+    case BoolLitF(v, va)                                       => None
+    case NoneLitF(v)                                           => None
+    case IdentifierF(v, va)                                    => None
+  }
+
   def translate_forall_step(
       enums: List[String],
       x1: quantifier_binding,
@@ -4998,6 +5100,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TExistsRel(v, va, vb)  => None
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
@@ -5048,6 +5151,7 @@ object SpecRestGenerated {
     case TLetIn(v, va, vb)      => None
     case TForallEnum(v, va, vb) => None
     case TForallRel(v, va, vb)  => None
+    case TExistsRel(v, va, vb)  => None
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
@@ -5070,6 +5174,16 @@ object SpecRestGenerated {
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
     case TMapCons(v, va, vb)    => None
+  }
+
+  def translate_range_eq(setE: smt_term, rel: String): smt_term = {
+    val k    = fresh_var("k", smt_var_list(setE)): String
+    val vv   = fresh_var("v", k :: smt_var_list(setE)): String
+    val valK = TIndexRel(TVar(rel), TVar(k)): smt_term;
+    TAnd(
+      TForallRel(k, rel, TSetMember(valK, setE)),
+      TForallSet(vv, setE, TExistsRel(k, rel, TEq(valK, TVar(vv))))
+    )
   }
 
   def prime_rel_name(x0: expr): Option[String] = x0 match {
@@ -5477,22 +5591,31 @@ object SpecRestGenerated {
             case None =>
               rel_insert_parts(BEq(), l, r) match {
                 case None =>
-                  comp_parts(r) match {
+                  range_arg(r) match {
                     case None =>
-                      map2_opt(
-                        (a: smt_term) =>
-                          (b: smt_term) =>
-                            TEq(a, b),
-                        translate(enums, l),
-                        translate(enums, r)
-                      )
-                    case Some((vara, (dnm, p))) =>
-                      map2_opt(
-                        (a: smt_term) =>
-                          (b: smt_term) =>
-                            translate_set_comp_eq(enums, vara, dnm, a, b),
-                        translate(enums, l),
-                        translate(enums, p)
+                      comp_parts(r) match {
+                        case None =>
+                          map2_opt(
+                            (a: smt_term) =>
+                              (b: smt_term) =>
+                                TEq(a, b),
+                            translate(enums, l),
+                            translate(enums, r)
+                          )
+                        case Some((vara, (dnm, p))) =>
+                          map2_opt(
+                            (a: smt_term) =>
+                              (b: smt_term) =>
+                                translate_set_comp_eq(enums, vara, dnm, a, b),
+                            translate(enums, l),
+                            translate(enums, p)
+                          )
+                      }
+                    case Some(rel) =>
+                      map_option[smt_term, smt_term](
+                        (lt: smt_term) =>
+                          translate_range_eq(lt, rel),
+                        translate(enums, l)
                       )
                   }
                 case Some((rel, (kn, vn))) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -640,17 +640,18 @@ object Translator:
   private def rewriteRangeComprehension(ctx: TranslateCtx, e: expr): expr = e match
     case BinaryOpF(BEq(), l, SetComprehensionF(_, IdentifierF(rel, spRel), pred, spSc), spEq)
         if isTrueLit(pred) && isValueProjection(ctx, l, rel) =>
-      BinaryOpF(
-        BEq(),
-        l,
-        CallF(IdentifierF("range", spRel), List(IdentifierF(rel, spRel)), spSc),
-        spEq
-      )
+      BinaryOpF(BEq(), l, rangeOf(rel, spRel, spSc), spEq)
+    case BinaryOpF(BEq(), SetComprehensionF(_, IdentifierF(rel, spRel), pred, spSc), r, spEq)
+        if isTrueLit(pred) && isValueProjection(ctx, r, rel) =>
+      BinaryOpF(BEq(), r, rangeOf(rel, spRel, spSc), spEq)
     case BinaryOpF(op, l, r, sp) if isBoolConnective(op) =>
       BinaryOpF(op, rewriteRangeComprehension(ctx, l), rewriteRangeComprehension(ctx, r), sp)
     case UnaryOpF(op, x, sp) =>
       UnaryOpF(op, rewriteRangeComprehension(ctx, x), sp)
     case other => other
+
+  private def rangeOf(rel: String, spRel: Option[span_t], spSc: Option[span_t]): expr =
+    CallF(IdentifierF("range", spRel), List(IdentifierF(rel, spRel)), spSc)
 
   private def isTrueLit(e: expr): Boolean = e match
     case BoolLitF(true, _) => true

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -629,10 +629,57 @@ object Translator:
 
   def translateExpr(ctx: TranslateCtx, expr: expr, env: mutable.Map[String, Z3Expr]): Z3Expr =
     val enums = ctx.enums.keys.toList
-    val out = SpecRestGenerated.translate(enums, expr) match
+    val out = SpecRestGenerated.translate(enums, rewriteRangeComprehension(ctx, expr)) match
       case Some(smtTerm) => encodeFromSmtTerm(ctx, smtTerm, env)
       case None          => translateExprRaw(ctx, expr, env)
     out.withSpan(expr.spanOpt)
+
+  // `translate` is untyped: it projects `{ x in rel | true }` onto rel's keys (domain). When the
+  // receiver is sorted by rel's value type the intended projection is the range (values); decide
+  // that here, where the receiver's sort is known, by rewriting to the verified `range(rel)` form.
+  private def rewriteRangeComprehension(ctx: TranslateCtx, e: expr): expr = e match
+    case BinaryOpF(BEq(), l, SetComprehensionF(_, IdentifierF(rel, spRel), pred, spSc), spEq)
+        if isTrueLit(pred) && isValueProjection(ctx, l, rel) =>
+      BinaryOpF(
+        BEq(),
+        l,
+        CallF(IdentifierF("range", spRel), List(IdentifierF(rel, spRel)), spSc),
+        spEq
+      )
+    case BinaryOpF(op, l, r, sp) if isBoolConnective(op) =>
+      BinaryOpF(op, rewriteRangeComprehension(ctx, l), rewriteRangeComprehension(ctx, r), sp)
+    case UnaryOpF(op, x, sp) =>
+      UnaryOpF(op, rewriteRangeComprehension(ctx, x), sp)
+    case other => other
+
+  private def isTrueLit(e: expr): Boolean = e match
+    case BoolLitF(true, _) => true
+    case _                 => false
+
+  private def isBoolConnective(op: bin_op): Boolean = op match
+    case BAnd() | BOr() | BImplies() | BIff() => true
+    case _                                    => false
+
+  private def isValueProjection(ctx: TranslateCtx, receiver: expr, rel: String): Boolean =
+    (relKeyValueSorts(ctx, rel), receiverSetElemSort(ctx, receiver)) match
+      case (Some((keySort, valueSort)), Some(elemSort)) =>
+        elemSort == valueSort && valueSort != keySort
+      case _ => false
+
+  private def relKeyValueSorts(ctx: TranslateCtx, rel: String): Option[(Z3Sort, Z3Sort)] =
+    ctx.state.get(rel).collect { case r: StateRelationInfo => (r.keySort, r.valueSort) }
+
+  private def receiverSetElemSort(ctx: TranslateCtx, e: expr): Option[Z3Sort] = e match
+    case IdentifierF(name, _) =>
+      ctx.state
+        .get(name)
+        .collect { case c: StateConstInfo => c.sort }
+        .orElse(ctx.outputs.find(_.name == name).map(_.sort))
+        .orElse(ctx.inputs.find(_.name == name).map(_.sort))
+        .collect { case Z3Sort.SetOf(elem) => elem }
+    case PrimeF(inner, _) => receiverSetElemSort(ctx, inner)
+    case PreF(inner, _)   => receiverSetElemSort(ctx, inner)
+    case _                => None
 
   private def translateExprRaw(
       ctx: TranslateCtx,
@@ -2191,6 +2238,20 @@ object Translator:
           case None    => inner
         Z3Expr.Quantifier(
           QKind.ForAll,
+          List(Z3Binding(varName, sort)),
+          guarded
+        )
+
+      case TExistsRel(varName, rel, body) =>
+        val (sort, guard) = quantifierDomainFor(ctx, rel, varName)
+        val newEnv        = env.clone()
+        newEnv(varName) = Z3Expr.Var(varName, sort)
+        val inner = encodeFromSmtTerm(ctx, body, newEnv)
+        val guarded = guard match
+          case Some(g) => Z3Expr.And(List(g, inner))
+          case None    => inner
+        Z3Expr.Quantifier(
+          QKind.Exists,
           List(Z3Binding(varName, sort)),
           guarded
         )

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -171,6 +171,36 @@ class ConsistencyTest extends CatsEffectSuite:
     )
 
   test(
+    "value-projection comprehension verifies via Z3 (entries = { m in rel | true } projects to rel's range)"
+  ):
+    val spec =
+      """service RangeCompDemo {
+        |  entity Item {
+        |    size: Int
+        |  }
+        |  state {
+        |    rel: Int -> lone Item
+        |  }
+        |  operation ListAll {
+        |    output: entries: Set[Item]
+        |    requires:
+        |      true
+        |    ensures:
+        |      entries = { m in rel | true }
+        |      rel' = rel
+        |  }
+        |  invariant cardNonNeg:
+        |    #rel >= 0
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("range_comp_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield assert(
+      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+      s"expected every check Sat (value-projection comprehension must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+    )
+
+  test(
     "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)"
   ):
     val spec =

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -16,86 +16,59 @@ class ConsistencyTest extends CatsEffectSuite:
         ).map(_.id)}"
     )
 
-  test(
-    "definite description (the v in rel | P) verifies via Z3 (TheF lifted to the verified subset)"
-  ):
-    val spec =
+  // Each verified-subset lift: a focused spec whose every check must verify (Sat), not skip.
+  List(
+    (
+      "definite description (the v in rel | P) verifies via Z3 (TheF lifted to the verified subset)",
+      "the_demo",
       """service TheDemo {
         |  state {
         |    scores: Map[Int, Int]
         |  }
         |  invariant pivotNonNegative:
         |    (the k in scores | scores[k] = 100) >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("the_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (the must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "ordering on Duration verifies via Z3 (Duration shares the Int sort, completing the #377 temporal lift)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "the must verify, not skip"
+    ),
+    (
+      "ordering on Duration verifies via Z3 (Duration shares the Int sort, completing the #377 temporal lift)",
+      "duration_demo",
       """service DurationDemo {
         |  state {
         |    timeouts: Map[Int, Duration]
         |  }
         |  invariant timeoutsNonNegative:
         |    (the k in timeouts | timeouts[k] >= 0) >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("duration_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (Duration ordering must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "lexicographic ordering on String verifies via Z3 (T_Cmp_Str_Ord, str.< encoding)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "Duration ordering must verify, not skip"
+    ),
+    (
+      "lexicographic ordering on String verifies via Z3 (T_Cmp_Str_Ord, str.< encoding)",
+      "string_order_demo",
       """service StringOrderDemo {
         |  state {
         |    names: Map[Int, String]
         |  }
         |  invariant namesBelowM:
         |    (the k in names | names[k] < "m") >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("string_order_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (String ordering must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "string concatenation verifies via Z3 (T_Str_Concat, str.++ encoding)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "String ordering must verify, not skip"
+    ),
+    (
+      "string concatenation verifies via Z3 (T_Str_Concat, str.++ encoding)",
+      "string_concat_demo",
       """service StringConcatDemo {
         |  state {
         |    names: Map[Int, String]
         |  }
         |  invariant concatMatches:
         |    (the k in names | "a" + names[k] = "ab") >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("string_concat_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (String concat must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "cardinality on primed/pre-state relations verifies via Z3 (#rel' / #pre(rel) translate)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "String concat must verify, not skip"
+    ),
+    (
+      "cardinality on primed/pre-state relations verifies via Z3 (#rel' / #pre(rel) translate)",
+      "card_demo",
       """service CardDemo {
         |  state {
         |    items: Int -> lone Int
@@ -106,19 +79,12 @@ class ConsistencyTest extends CatsEffectSuite:
         |  }
         |  invariant cardNonNeg:
         |    #items >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("card_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (cardinality on primed/pre must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "relation literal-insert verifies via Z3 (rel' = pre(rel) + {k -> v} desugars to rel'[k] = v)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "cardinality on primed/pre must verify, not skip"
+    ),
+    (
+      "relation literal-insert verifies via Z3 (rel' = pre(rel) + {k -> v} desugars to rel'[k] = v)",
+      "insert_demo",
       """service InsertDemo {
         |  state {
         |    store: Int -> lone Int
@@ -133,19 +99,12 @@ class ConsistencyTest extends CatsEffectSuite:
         |  }
         |  invariant cardNonNeg:
         |    #store >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("insert_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (relation insert must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "String-refinement alias relations verify on the native String sort (E-matching triggers keep them tractable)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "relation insert must verify, not skip"
+    ),
+    (
+      "String-refinement alias relations verify on the native String sort (E-matching triggers keep them tractable)",
+      "string_alias_demo",
       """service StringAliasDemo {
         |  type Code = String where len(value) >= 3 and len(value) <= 8
         |  state {
@@ -161,19 +120,12 @@ class ConsistencyTest extends CatsEffectSuite:
         |  }
         |  invariant cardNonNeg:
         |    #store >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("string_alias_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (String-refinement alias on relations must verify on the String sort, not time out); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "value-projection comprehension verifies via Z3 (entries = { m in rel | true } projects to rel's range)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "String-refinement alias on relations must verify on the String sort, not time out"
+    ),
+    (
+      "value-projection comprehension verifies via Z3 (entries = { m in rel | true } projects to rel's range)",
+      "range_comp_demo",
       """service RangeCompDemo {
         |  entity Item {
         |    size: Int
@@ -191,19 +143,12 @@ class ConsistencyTest extends CatsEffectSuite:
         |  }
         |  invariant cardNonNeg:
         |    #rel >= 0
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("range_comp_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (value-projection comprehension must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test(
-    "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)"
-  ):
-    val spec =
+        |}""".stripMargin,
+      "value-projection comprehension must verify, not skip"
+    ),
+    (
+      "entity construction (Entity{...}) verifies via Z3 (ConstructorF lifted to the verified subset)",
+      "constructor_demo",
       """service ConstructorDemo {
         |  entity Point {
         |    x: Int
@@ -211,30 +156,29 @@ class ConsistencyTest extends CatsEffectSuite:
         |  }
         |  invariant ctorFieldRoundtrips:
         |    (Point { x = 5, y = 7 }).x = 5
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("constructor_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (Entity{...} must verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
-    )
-
-  test("function/predicate calls inline + verify via Z3 (CallF lifted to the verified subset)"):
-    val spec =
+        |}""".stripMargin,
+      "Entity{...} must verify, not skip"
+    ),
+    (
+      "function/predicate calls inline + verify via Z3 (CallF lifted to the verified subset)",
+      "call_demo",
       """service CallDemo {
         |  function dbl(n: Int): Int = n + n
         |  predicate isPos(n: Int) = n > 0
         |  invariant callsInline:
         |    dbl(3) = 6 and isPos(dbl(1))
-        |}""".stripMargin
-    for
-      ir     <- SpecFixtures.buildFromSource("call_demo", spec)
-      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
-    yield assert(
-      report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
-      s"expected every check Sat (calls must inline + verify, not skip); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+        |}""".stripMargin,
+      "calls must inline + verify, not skip"
     )
+  ).foreach: (name, fixture, spec, reason) =>
+    test(name):
+      for
+        ir     <- SpecFixtures.buildFromSource(fixture, spec)
+        report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+      yield assert(
+        report.checks.nonEmpty && report.checks.forall(_.status == CheckOutcome.Sat),
+        s"expected every check Sat ($reason); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
+      )
 
   test("unsat_invariants has contradictory_invariants diagnostic"):
     for

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -17,7 +17,8 @@ text \<open>\<open>eval\<close> is a reference semantics for the surface IR (\<o
 definition builtins_reserved ::
   "function_decl list \<Rightarrow> predicate_decl list \<Rightarrow> bool" where
   "builtins_reserved fs ps \<equiv> (\<forall>nm. is_builtin_pred nm \<longrightarrow> lookup_callee fs ps nm = None)
-                              \<and> lookup_callee fs ps (STR ''dom'') = None"
+                              \<and> lookup_callee fs ps (STR ''dom'') = None
+                              \<and> lookup_callee fs ps (STR ''range'') = None"
 
 fun quant_dom ::
   "schema \<Rightarrow> state \<Rightarrow> quant_kind \<Rightarrow> quantifier_binding list

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -44,6 +44,7 @@ datatype (plugins only: code size) smt_term =
   | TLetIn "String.literal" "smt_term" "smt_term"
   | TForallEnum "String.literal" "String.literal" "smt_term"
   | TForallRel "String.literal" "String.literal" "smt_term"
+  | TExistsRel "String.literal" "String.literal" "smt_term"
   | TTheRel "String.literal" "String.literal" "smt_term"
   | TEntityBase "String.literal"
   | TForallSet "String.literal" "smt_term" "smt_term"
@@ -95,6 +96,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TLetIn v a b)        = v # smt_var_list a @ smt_var_list b"
 | "smt_var_list (TForallEnum v _ b)   = v # smt_var_list b"
 | "smt_var_list (TForallRel v _ b)    = v # smt_var_list b"
+| "smt_var_list (TExistsRel v _ b)    = v # smt_var_list b"
 | "smt_var_list (TTheRel v _ b)       = v # smt_var_list b"
 | "smt_var_list (TEntityBase _)       = []"
 | "smt_var_list (TForallSet v d b)    = v # smt_var_list d @ smt_var_list b"
@@ -442,6 +444,13 @@ where
      (case smt_model_lookup_rel m rel_name of
         Some d \<Rightarrow> smtEval_forall_rel m env var d body
       | None   \<Rightarrow> None)"
+| "smtEval m env (TExistsRel var rel_name body) =
+     (case smt_model_lookup_rel m rel_name of
+        Some d \<Rightarrow>
+          (case smtEval_the_rel m env var d body of
+             Some matches \<Rightarrow> Some (SBool (matches \<noteq> []))
+           | None         \<Rightarrow> None)
+      | None \<Rightarrow> None)"
 | "smtEval m env (TTheRel var rel_name body) =
      (case smt_model_lookup_rel m rel_name of
         Some d \<Rightarrow>

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -85,6 +85,19 @@ definition translate_beq_dom_or_none :: "expr \<Rightarrow> expr \<Rightarrow> s
      (case (dom_arg l, dom_arg r) of
         (Some x, Some y) \<Rightarrow> Some (translate_dom_eq x y) | _ \<Rightarrow> None)"
 
+fun range_arg :: "expr \<Rightarrow> String.literal option" where
+  "range_arg (CallF (IdentifierF nm _) [IdentifierF rel _] _) =
+     (if nm = STR ''range'' then Some rel else None)"
+| "range_arg _ = None"
+
+definition translate_range_eq :: "smt_term \<Rightarrow> String.literal \<Rightarrow> smt_term" where
+  "translate_range_eq setE rel =
+     (let k    = fresh_var (STR ''k'') (smt_var_list setE);
+          vv   = fresh_var (STR ''v'') (k # smt_var_list setE);
+          valK = TIndexRel (TVar rel) (TVar k)
+      in TAnd (TForallRel k rel (TSetMember valK setE))
+              (TForallSet vv setE (TExistsRel k rel (TEq valK (TVar vv)))))"
+
 fun prime_rel_name :: "expr \<Rightarrow> String.literal option" where
   "prime_rel_name (PrimeF e _) = identName e"
 | "prime_rel_name _ = None"
@@ -167,11 +180,15 @@ where
                   Some (rel, kn, vn) \<Rightarrow>
                     Some (TEq (TIndexRel (TPrime (TVar rel)) (TVar kn)) (TVar vn))
                 | None \<Rightarrow>
+                  (case range_arg r of
+                     Some rel \<Rightarrow>
+                       map_option (\<lambda>lt. translate_range_eq lt rel) (translate enums l)
+                   | None \<Rightarrow>
                   (case comp_parts r of
                      Some (var, dnm, p) \<Rightarrow>
                        map2_opt (translate_set_comp_eq enums var dnm)
                          (translate enums l) (translate enums p)
-                   | None \<Rightarrow> map2_opt TEq (translate enums l) (translate enums r))))
+                   | None \<Rightarrow> map2_opt TEq (translate enums l) (translate enums r)))))
       | BNeq \<Rightarrow>
           map2_opt (\<lambda>lt rt. TNot (TEq lt rt)) (translate enums l) (translate enums r)
       | BLt \<Rightarrow> map2_opt TLt (translate enums l) (translate enums r)
@@ -315,12 +332,13 @@ lemma translate_BEq_noncomp:
   assumes "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
       and "dom_arg l = None \<or> dom_arg r = None"
       and "rel_insert_parts BEq l r = None"
+      and "range_arg r = None"
   shows "translate enums (BinaryOpF BEq l r sp)
            = map2_opt TEq (translate enums l) (translate enums r)"
 proof -
   have dn: "translate_beq_dom_or_none l r = None"
     using assms(2) by (auto simp: translate_beq_dom_or_none_def split: option.splits)
-  show ?thesis using dn comp_parts_None[OF assms(1)] assms(3) by simp
+  show ?thesis using dn comp_parts_None[OF assms(1)] assms(3) assms(4) by simp
 qed
 
 lemma translate_BIn_noncomp:

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -5,6 +5,22 @@ theory DirectSound
 begin
 section \<open>Direct soundness: eval agrees with smtEval of translate\<close>
 
+lemma range_eval_None:
+  assumes "builtins_reserved fs ps"
+      and "range_arg r = Some rel"
+  shows "eval fs ps fuel s st env r = None"
+proof -
+  from assms(2) obtain sp1 sp2 sp3
+    where req: "r = CallF (IdentifierF (STR ''range'') sp1) [IdentifierF rel sp2] sp3"
+    by (cases r rule: range_arg.cases) (auto split: if_splits)
+  have lk: "lookup_callee fs ps (STR ''range'') = None"
+    using assms(1) by (simp add: builtins_reserved_def)
+  have nb: "\<not> is_builtin_pred (STR ''range'')"
+    by (simp add: is_builtin_pred_def)
+  show ?thesis
+    unfolding req by (cases fuel) (simp_all add: lk nb)
+qed
+
 lemma binop_noncomp_step:
   assumes deN: "dom_eq_domains fs ps st bop l r = None"
       and bcN: "beq_comp bop r = None"
@@ -81,7 +97,14 @@ next
     hence "eval fs ps fuel s st env l = None" using eval_dom_CallF[OF lcdom] by simp
     thus False using efl by simp
   qed
-  from tt[unfolded BEq translate_BEq_noncomp[OF rnc dnone riN[unfolded BEq]]] obtain lt rt
+  have raN: "range_arg r = None"
+  proof (rule ccontr)
+    assume "range_arg r \<noteq> None"
+    then obtain rel where ra: "range_arg r = Some rel" by (cases "range_arg r") auto
+    have "eval fs ps fuel s st env r = None" using range_eval_None[OF br ra] .
+    thus False using efr by simp
+  qed
+  from tt[unfolded BEq translate_BEq_noncomp[OF rnc dnone riN[unfolded BEq] raN]] obtain lt rt
       where tl: "translate enums l = Some lt"
         and tr: "translate enums r = Some rt"
         and teq: "t = TEq lt rt"

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -193,6 +193,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TLetIn y v b)         = (smt_uses_var x v \<or> (y \<noteq> x \<and> smt_uses_var x b))"
 | "smt_uses_var x (TForallEnum y _ b)    = (y \<noteq> x \<and> smt_uses_var x b)"
 | "smt_uses_var x (TForallRel y _ b)     = (y \<noteq> x \<and> smt_uses_var x b)"
+| "smt_uses_var x (TExistsRel y _ b)     = (y \<noteq> x \<and> smt_uses_var x b)"
 | "smt_uses_var x (TTheRel y _ b)        = (y \<noteq> x \<and> smt_uses_var x b)"
 | "smt_uses_var x (TEntityBase _)        = False"
 | "smt_uses_var x (TForallSet y setT b)  = (smt_uses_var x setT \<or> (y \<noteq> x \<and> smt_uses_var x b))"
@@ -308,6 +309,33 @@ next
       have hb: "smtEval m (((y, v) # pre) @ (x, xv) # post) b
               = smtEval m (((y, v) # pre) @ post) b"
         using TTheRel.prems by (intro TTheRel.IH) auto
+      show ?case
+      proof (cases "smtEval m ((y, v) # pre @ post) b")
+        case None
+        thus ?thesis using hb by simp
+      next
+        case (Some bv)
+        show ?thesis using hb Some Cons.IH by (cases bv) simp_all
+      qed
+    qed
+  qed
+  thus ?case by (simp split: option.splits)
+next
+  case (TExistsRel y rel b)
+  have "\<And>d. smtEval_the_rel m (pre @ (x, xv) # post) y d b
+          = smtEval_the_rel m (pre @ post) y d b"
+  proof -
+    fix d
+    show "smtEval_the_rel m (pre @ (x, xv) # post) y d b
+            = smtEval_the_rel m (pre @ post) y d b"
+    proof (induction d)
+      case Nil
+      show ?case by simp
+    next
+      case (Cons v rest)
+      have hb: "smtEval m (((y, v) # pre) @ (x, xv) # post) b
+              = smtEval m (((y, v) # pre) @ post) b"
+        using TExistsRel.prems by (intro TExistsRel.IH) auto
       show ?case
       proof (cases "smtEval m ((y, v) # pre @ post) b")
         case None

--- a/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
@@ -366,8 +366,18 @@ proof (induction e rule: measure_induct_rule[where f = size])
             show ?thesis using BinaryOpF BEq tbn ri by simp
           next
             case None
-            then show ?thesis
-              using BinaryOpF BEq translate_BEq_noncomp[OF nc dnone None] hl hr by auto
+            note riNone = this
+            show ?thesis
+            proof (cases "range_arg r2")
+              case (Some rel)
+              have tbn: "translate_beq_dom_or_none l2 r2 = None"
+                using dnone by (auto simp: translate_beq_dom_or_none_def split: option.splits)
+              show ?thesis using BinaryOpF BEq tbn riNone Some hl by simp
+            next
+              case None
+              show ?thesis
+                using BinaryOpF BEq translate_BEq_noncomp[OF nc dnone riNone None] hl hr by auto
+            qed
           qed
         qed
       qed


### PR DESCRIPTION
## What

A set comprehension `{ x in rel | true }` whose receiver is a `Set` of the relation's **value** type now verifies by projecting to the relation's **range** (values) instead of its domain (keys). This takes `url_shortener` from **18/21 to 21/21**, resolving `ListAll`'s three preservation checks (`allURLsValid`, `metadataConsistent`, `clickCountNonNegative`), which previously skipped with:

> translator limitation: membership operator 'in' requires the left-hand side sort to match the set's element sort; got Str against a set of Uninterp(UrlMapping)

Part of #420 (full catalog of pipeline limitations).

## How

The projection is **type-directed**: a `Set[V]` receiver wants the relation's values (range); a `Set[K]` receiver wants its keys (domain, the existing behavior). The untyped verified `translate` cannot make that distinction, so the decision lives in the encoder, which has the sorts.

**Verified subset (Isabelle, zero-sorry):**
- `translate` accepts `X = range(rel)` via `translate_range_eq`, an image/set-equality term built from `TForallRel` / `TForallSet` / `TExistsRel` (the new existential reuses `smtEval_the_rel`, so no new mutual function and no termination-measure change).
- `range` is reserved (`builtins_reserved`), so `eval (range(rel)) = None` and DirectSound's `BEq` sub-case is **vacuous**. The range encoding is trusted frame synthesis, the same vacuous-on-eval trust boundary as #425 / #426. `DirectTotality` gains the corresponding range case; `DirectSound` derives the `range_arg r = None` fact locally from `eval r = Some vr`.

**Encoder (trusted):**
- `rewriteRangeComprehension` rewrites `X = { m in rel | true }` to `X = range(rel)` when `X`'s element sort equals `rel`'s value sort (and differs from its key sort), recursing through boolean connectives. Receiver sorts resolve from `ctx.state` / `ctx.outputs` / `ctx.inputs`. Key-sorted (domain) comprehensions are left unchanged.

## Testing

- New `ConsistencyTest` case (inline `RangeCompDemo`): a value-projection comprehension verifies (every check `Sat`).
- `url_shortener`: 21/21 (621ms, no MBQI timeout).
- **No regression** (verified against the `main` baseline): `edge_cases` 9/67 and `auth_service` (9 pre-existing failures) are byte-identical before and after; the pre-pass does not fire on either (no `X = {comp}` value-projection shape), and the regen is additive.
- Full `verify/test` green; proof build (Core/Soundness/Codegen) green zero-sorry; `docs/lib/cli-runs` golden regenerated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables type-directed range projection for value-sorted set comprehensions by rewriting `X = { m in rel | true }` or `{ m in rel | true } = X` to `X = range(rel)` when `X` is a set of the relation’s value type. This removes the previous translator limitation and makes `url_shortener` 21/21 green.

- **New Features**
  - Encoder: adds a type-aware rewrite that replaces value-projection `{ m in rel | true }` with `range(rel)` when the set’s element sort matches the relation’s value sort (and differs from its key sort); supports both equality orders; recurses through boolean connectives.
  - Verified subset: adds `TExistsRel` and `translate_range_eq`; reserves `range` so `eval(range(rel)) = None`; updates soundness and totality proofs; Z3 encoder now handles `TExistsRel`.
  - Tests: adds a value-projection consistency case; `url_shortener` now 21/21; golden `docs/lib/cli-runs` updated.

- **Refactors**
  - Consolidates verified-subset lift tests into a parameterized table to reduce duplication.

<sup>Written for commit 73cb24a241ccb69abf589dd94a4f1147aeed6120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved translator limitations preventing verification checks from completing; consistency checks now pass successfully.

* **New Features**
  * Added support for existential quantification over relations in specifications.
  * Enhanced handling of range comprehensions when working with relation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->