### PR TITLE
feat(verify): model now() as an uninterpreted Int constant in the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -578,6 +578,7 @@ object SpecRestGenerated {
   final case class TStrLit(a: String)                              extends smt_term
   final case class TMatches(a: smt_term, b: String)                extends smt_term
   final case class TUStrPred(a: String, b: smt_term)               extends smt_term
+  final case class TUConst(a: String)                              extends smt_term
   final case class TSeqEmpty()                                     extends smt_term
   final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
   final case class TMapEmpty()                                     extends smt_term
@@ -1807,6 +1808,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
@@ -1856,6 +1858,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
@@ -2733,6 +2736,7 @@ object SpecRestGenerated {
           case Some(SSeq(_))              => None
           case Some(SMap(_))              => None
         }
+      case (m, env, TUConst(nm)) => Some[smt_val](SInt(BigInt(nm.hashCode)))
       case (m, env, TSeqEmpty()) => Some[smt_val](SSeq(Nil))
       case (m, env, TSeqCons(e, rest)) =>
         (smtEval(m, env, e), smtEval(m, env, rest)) match {
@@ -3260,6 +3264,7 @@ object SpecRestGenerated {
     case TStrLit(vi)           => Nil
     case TMatches(t, vj)       => smt_var_list(t)
     case TUStrPred(vk, t)      => smt_var_list(t)
+    case TUConst(vl)           => Nil
     case TSeqEmpty()           => Nil
     case TSeqCons(e, r)        => smt_var_list(e) ++ smt_var_list(r)
     case TMapEmpty()           => Nil
@@ -4608,6 +4613,8 @@ object SpecRestGenerated {
       case (Some(x), Some(y)) => Some[smt_term](f(x)(y))
     }
 
+  def is_builtin_const(nm: String): Boolean = nm == "now"
+
   def mpeKey(x0: map_entry): expr = x0 match {
     case MapEntryFull(x1, x2, x3) => x1
   }
@@ -5121,6 +5128,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
@@ -5170,6 +5178,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
@@ -5393,7 +5402,11 @@ object SpecRestGenerated {
         case (StringLitF(_, _), _)              => None
         case (BoolLitF(_, _), _)                => None
         case (NoneLitF(_), _)                   => None
-        case (IdentifierF(_, _), Nil)           => None
+        case (IdentifierF(nm, _), Nil) =>
+          is_builtin_const(nm) match {
+            case true  => Some[smt_term](TUConst(nm))
+            case false => None
+          }
         case (IdentifierF(nm, _), List(arg)) =>
           is_builtin_pred(nm) match {
             case true => map_option[smt_term, smt_term](

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2458,6 +2458,13 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Bool))
         Z3Expr.App(funcName, List(strZ))
+      // 0-arg reserved builtin (e.g. now()): an uninterpreted Int constant. The `${name}_0`
+      // name matches translateCall's argSortsMangled, so the in-subset and raw paths share it.
+      case TUConst(name) =>
+        val funcName = s"${name}_0"
+        if !ctx.funcs.contains(funcName) then
+          ctx.declareFunc(Z3FunctionDecl(funcName, Nil, Z3Sort.Int))
+        Z3Expr.App(funcName, Nil)
       case TSeqEmpty() =>
         fail(ctx, "empty sequence literal requires context to infer its element sort")
       case cons @ TSeqCons(_, _) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -169,6 +169,26 @@ class ConsistencyTest extends CatsEffectSuite:
         |    dbl(3) = 6 and isPos(dbl(1))
         |}""".stripMargin,
       "calls must inline + verify, not skip"
+    ),
+    (
+      "0-arg reserved builtin now() verifies via Z3 (uninterpreted Int constant)",
+      "now_demo",
+      """service NowDemo {
+        |  state {
+        |    log: Int -> lone Int
+        |  }
+        |  operation Stamp {
+        |    output: t: Int
+        |    requires:
+        |      true
+        |    ensures:
+        |      t = now()
+        |      log' = log
+        |  }
+        |  invariant cardNonNeg:
+        |    #log >= 0
+        |}""".stripMargin,
+      "now() must verify, not skip"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -114,13 +114,15 @@ code_printing
 | class_instance Int.int :: ord \<rightharpoonup> (Scala) -
 | class_instance Int.int :: equal \<rightharpoonup> (Scala) -
 
-text \<open>\<open>string_matches\<close> is abstract (see \<open>IR\<close>); the real regex semantics is Z3's
-  \<open>str.in_re\<close> in the hand-written translator. The extracted \<open>eval\<close>/\<open>smtEval\<close>
-  reference interpreters are not called by Scala consumers, so this serialisation
-  is a never-evaluated stub that only has to type-check.\<close>
+text \<open>\<open>string_matches\<close>, \<open>str_predicate\<close>, and \<open>builtin_const_val\<close> are abstract (see \<open>IR\<close>);
+  the real semantics is Z3's (regex \<open>str.in_re\<close>, an uninterpreted predicate / constant) in
+  the hand-written translator. The extracted \<open>eval\<close>/\<open>smtEval\<close> reference interpreters are not
+  called by Scala consumers, so these serialisations are never-evaluated stubs that only have
+  to type-check.\<close>
 code_printing
   constant string_matches \<rightharpoonup> (Scala) "((_) == (_))"
 | constant str_predicate \<rightharpoonup> (Scala) "((_) == (_))"
+| constant builtin_const_val \<rightharpoonup> (Scala) "(BigInt((_).hashCode))"
 
 export_code
     translate

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -95,6 +95,16 @@ text \<open>\<open>is_builtin_pred nm\<close> marks \<open>nm\<close> as a reser
 definition is_builtin_pred :: "String.literal \<Rightarrow> bool" where
   "is_builtin_pred nm \<longleftrightarrow> nm = STR ''isValidURI'' \<or> nm = STR ''isValidEmail''"
 
+text \<open>\<open>builtin_const_val name\<close> is the uninterpreted value of the reserved 0-argument
+  built-in \<open>name\<close> (e.g.\ \<open>now\<close>, the current timestamp). Like \<open>str_predicate\<close> it is
+  abstract: the trusted translator emits it as a Z3 uninterpreted constant, so soundness
+  stays parametric in the value and any realisation \<open>eval\<close>/\<open>smtEval\<close> share is sound by
+  construction - a proof for every interpretation soundly over-approximates the builtin.\<close>
+consts builtin_const_val :: "String.literal \<Rightarrow> int"
+
+definition is_builtin_const :: "String.literal \<Rightarrow> bool" where
+  "is_builtin_const nm \<longleftrightarrow> nm = STR ''now''"
+
 record schema_field_decl =
   fd_name :: "String.literal"
   fd_ty   :: "schema_type"

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -17,6 +17,7 @@ text \<open>\<open>eval\<close> is a reference semantics for the surface IR (\<o
 definition builtins_reserved ::
   "function_decl list \<Rightarrow> predicate_decl list \<Rightarrow> bool" where
   "builtins_reserved fs ps \<equiv> (\<forall>nm. is_builtin_pred nm \<longrightarrow> lookup_callee fs ps nm = None)
+                              \<and> (\<forall>nm. is_builtin_const nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> lookup_callee fs ps (STR ''dom'') = None
                               \<and> lookup_callee fs ps (STR ''range'') = None"
 
@@ -166,7 +167,10 @@ and eval_forall ::
                        else None)
                 | None \<Rightarrow>
                     (case args of
-                       [arg] \<Rightarrow>
+                       [] \<Rightarrow>
+                         (if is_builtin_const nm
+                            then Some (VInt (builtin_const_val nm)) else None)
+                     | [arg] \<Rightarrow>
                          (if is_builtin_pred nm
                             then (case eval fs ps fuel s st env arg of
                                     Some (VStr str) \<Rightarrow> Some (VBool (str_predicate nm str))
@@ -1331,18 +1335,27 @@ next
   show ?case
   proof (cases "lookup_callee fs ps nm")
     case None
-    obtain arg str where aeq: "args = [arg]" and bip: "is_builtin_pred nm"
-        and ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-        and w_eq: "w = VBool (str_predicate nm str)"
-      using "15.prems" fuel idc None
-      by (auto split: option.splits list.splits ir_value.splits if_splits)
-    have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
-      using "15.IH" fuel idc None aeq ea bip by (auto split: if_splits)
-    have inl: "inline_calls fs ps (CallF callee args sp)
-                 = CallF callee [inline_calls fs ps arg] sp"
-      using idc None aeq by (auto simp: lookup_callee_def split: option.splits)
-    show ?thesis using inl ea' w_eq fuel idc None aeq bip
-      by (simp split: option.splits ir_value.splits)
+    show ?thesis
+    proof (cases args)
+      case Nil
+      have inl: "inline_calls fs ps (CallF callee args sp) = CallF callee args sp"
+        using idc None Nil by (auto simp: lookup_callee_def split: option.splits)
+      show ?thesis using inl "15.prems" by simp
+    next
+      case (Cons arg rest)
+      obtain str where aeq: "args = [arg]" and bip: "is_builtin_pred nm"
+          and ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+          and w_eq: "w = VBool (str_predicate nm str)"
+        using "15.prems" fuel idc None Cons
+        by (cases rest) (auto split: option.splits ir_value.splits if_splits)
+      have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
+        using "15.IH" fuel idc None aeq ea bip by (auto split: if_splits)
+      have inl: "inline_calls fs ps (CallF callee args sp)
+                   = CallF callee [inline_calls fs ps arg] sp"
+        using idc None aeq by (auto simp: lookup_callee_def split: option.splits)
+      show ?thesis using inl ea' w_eq fuel idc None aeq bip
+        by (simp split: option.splits ir_value.splits)
+    qed
   next
     case (Some pb)
     obtain params body where lc: "lookup_callee fs ps nm = Some (params, body)"

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -65,6 +65,7 @@ datatype (plugins only: code size) smt_term =
   | TStrLit "String.literal"
   | TMatches "smt_term" "String.literal"
   | TUStrPred "String.literal" "smt_term"
+  | TUConst "String.literal"
   | TSeqEmpty
   | TSeqCons "smt_term" "smt_term"
   | TMapEmpty
@@ -117,6 +118,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TStrLit _)           = []"
 | "smt_var_list (TMatches t _)        = smt_var_list t"
 | "smt_var_list (TUStrPred _ t)       = smt_var_list t"
+| "smt_var_list (TUConst _)           = []"
 | "smt_var_list TSeqEmpty             = []"
 | "smt_var_list (TSeqCons e r)        = smt_var_list e @ smt_var_list r"
 | "smt_var_list TMapEmpty             = []"
@@ -514,6 +516,7 @@ where
      (case smtEval m env t of
         Some (SStr str) \<Rightarrow> Some (SBool (str_predicate name str))
       | _ \<Rightarrow> None)"
+| "smtEval m env (TUConst nm) = Some (SInt (builtin_const_val nm))"
 | "smtEval m env TSeqEmpty = Some (SSeq [])"
 | "smtEval m env (TSeqCons e rest) =
      (case (smtEval m env e, smtEval m env rest) of

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -130,6 +130,8 @@ where
           (if is_builtin_pred nm
              then map_option (\<lambda>a'. TUStrPred nm a') (translate enums arg)
              else None)
+      | (IdentifierF nm _, []) \<Rightarrow>
+          (if is_builtin_const nm then Some (TUConst nm) else None)
       | _ \<Rightarrow> None)"
 | "translate enums (ConstructorF name fas _) =
      translate_with_assigns enums fas (TEntityBase name)"

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -506,20 +506,34 @@ next
 next
   case (15 fs ps fuel s st env callee args sp v t)
   obtain fuel' where fuel: "fuel = Suc fuel'" using "15.prems"(1) by (cases fuel) auto
-  from "15.prems"(2) obtain nm sp1 arg argt where
-      ceq: "callee = IdentifierF nm sp1" and aeq: "args = [arg]" and bip: "is_builtin_pred nm"
-      and ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
-    by (cases callee; cases args) (auto split: if_splits list.splits option.splits)
-  have lc_none: "lookup_callee fs ps nm = None"
-    using "15.prems"(4) bip by (simp add: builtins_reserved_def)
-  from "15.prems"(1) fuel ceq aeq lc_none bip obtain str where
-      ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-      and veq: "v = VBool (str_predicate nm str)"
-    by (auto split: option.splits ir_value.splits if_splits)
-  have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
-    using "15.IH" fuel ceq aeq lc_none bip ea ta "15.prems"(3) "15.prems"(4)
-    by (auto split: if_splits)
-  show ?case using teq veq ev by simp
+  obtain nm sp1 where ceq: "callee = IdentifierF nm sp1"
+    using "15.prems"(2) by (cases callee) (auto split: list.splits if_splits option.splits)
+  show ?case
+  proof (cases args)
+    case Nil
+    have bic: "is_builtin_const nm" and teq: "t = TUConst nm"
+      using "15.prems"(2) ceq Nil by (auto split: if_splits)
+    have lc_none: "lookup_callee fs ps nm = None"
+      using "15.prems"(4) bic by (simp add: builtins_reserved_def)
+    have veq: "v = VInt (builtin_const_val nm)"
+      using "15.prems"(1) fuel ceq Nil lc_none bic by (auto split: option.splits)
+    show ?thesis using teq veq by simp
+  next
+    case (Cons arg rest)
+    obtain argt where aeq: "args = [arg]" and bip: "is_builtin_pred nm"
+        and ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
+      using "15.prems"(2) ceq Cons by (cases rest) (auto split: if_splits option.splits)
+    have lc_none: "lookup_callee fs ps nm = None"
+      using "15.prems"(4) bip by (simp add: builtins_reserved_def)
+    from "15.prems"(1) fuel ceq aeq lc_none bip obtain str where
+        ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+        and veq: "v = VBool (str_predicate nm str)"
+      by (auto split: option.splits ir_value.splits if_splits)
+    have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+      using "15.IH" fuel ceq aeq lc_none bip ea ta "15.prems"(3) "15.prems"(4)
+      by (auto split: if_splits)
+    show ?thesis using teq veq ev by simp
+  qed
 next
   case (17 fs ps fuel s st env es sp v t)
   from "17.prems"(1) obtain vs where efl: "eval_list fs ps fuel s st env es = Some vs"

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -214,6 +214,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TStrLit _)            = False"
 | "smt_uses_var x (TMatches t _)         = smt_uses_var x t"
 | "smt_uses_var x (TUStrPred _ t)        = smt_uses_var x t"
+| "smt_uses_var x (TUConst _)            = False"
 | "smt_uses_var x TSeqEmpty              = False"
 | "smt_uses_var x (TSeqCons e r)         = (smt_uses_var x e \<or> smt_uses_var x r)"
 | "smt_uses_var x TMapEmpty              = False"


### PR DESCRIPTION
## What

Reserved 0-argument built-ins (`now()`) now lower into the verified subset as **uninterpreted Int constants**, extending the existing `is_builtin_pred` / `str_predicate` precedent from string *predicates* to value-returning builtins. This is the first of the "external builtin" follow-ups under #420 (the verify-side `now()`/`hash()` direction).

## How

The mechanism mirrors `is_builtin_pred` exactly (so the soundness theorem stays parametric in the value, sound for every interpretation):

**Verified subset (Isabelle, zero-sorry):**
- IR: abstract `consts builtin_const_val :: String.literal => int` + `is_builtin_const` (currently `now`).
- Smt: a `TUConst` node; `smtEval (TUConst nm) = SInt (builtin_const_val nm)`.
- translate: `CallF (IdentifierF nm) []` -> `TUConst nm` when `is_builtin_const nm`.
- eval: the matching 0-arg builtin case, so `eval` and `smtEval` correspond **by construction** (DirectSound proven, not trusted-vacuous). `builtins_reserved` reserves the names. The `inline_calls` meaning-preservation lemma and DirectSound case 15 are restructured to split `args=[]` (builtin-const) from `args=[arg]` (builtin-pred).

**Encoder:** `TUConst nm` -> the uninterpreted Z3 constant `${nm}_0 : Int`, the same symbol `translateCall`'s raw fallback already declares, so in-subset and fallback paths share one constant.

## Impact

`auth_service`: **5 -> 7 passing** (64 -> 53 soundness skips: 11 checks lifted past the soundness gate; 2 verify, the other 9 now surface the *next* blocker, a non-numeric `+` in `RefreshToken` -- a follow-up). `ecommerce` stays blocked by entity-invariant lambdas (`sum(items, i => ...)`, a permanent `(P)` higher-order limitation).

## Testing

- New `ConsistencyTest` case (`now_demo`): a `now()`-using operation verifies (all checks Sat).
- Proof build (Core/Soundness/Codegen) zero-sorry; full `sbt test` green; no regression (url_shortener stays 21/21). No cli-runs golden uses `now()`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model 0-arg built-ins like now() as uninterpreted Int constants in the verified subset, encoded in Z3 as `${name}_0`, so they verify instead of being skipped. Addresses Linear #420 (verify-side built-ins) and lifts several checks past the soundness gate.

- **New Features**
  - Added `TUConst` and `is_builtin_const`/`builtin_const_val`; `translate` lowers `now()` to `TUConst`.
  - Z3 translator declares/uses `${name}_0 : Int` (shared with the raw fallback).
  - Updated proofs and reference interpreters; reserved names; zero-sorry maintained.
  - New `ConsistencyTest` for `now()`; impact: `auth_service` 5→7 passing; others unchanged.

<sup>Written for commit 2657ead82540ee4e9c05f9e89607a6205b9f3fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for zero-argument builtin constants in the verification system, enabling proper handling and validation of constant expressions like `now()` during consistency checks.

* **Tests**
  * Added test case validating that builtin constants are correctly verified by the SMT solver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->