### PR TITLE
feat(verify): frame relation-assignments nested in let/and + chained relation-insert (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1513,7 +1513,7 @@ object Translator:
       )
     case LetF(x, v, body, _) =>
       val newEnv = env.clone()
-      newEnv(x) = translateExpr(ctx, v, env)
+      newEnv(x) = translateEnsuresClause(ctx, v, env)
       translateEnsuresClause(ctx, body, newEnv)
     case _ => translateExpr(ctx, expr, env)
 
@@ -1653,9 +1653,15 @@ object Translator:
     ))
     val lhsMap  = Z3Expr.App(mapFuncFor(lhs, lhsMode), List(keyVar))
     val baseMap = Z3Expr.App(mapFuncFor(base, baseMode), List(keyVar))
-    val perEntry = translated.map: (k, v) =>
+    // Last-write-wins: a chained / multi-entry insert with a repeated key keeps the LAST value.
+    // An entry's value applies only when keyVar matches no later entry's key; without this guard
+    // duplicate keys would assert two values for one key and the axiom would be UNSAT.
+    val perEntry = translated.zipWithIndex.map: (kv, i) =>
+      val (k, v) = kv
+      val laterNeqs =
+        translated.drop(i + 1).map((lk, _) => Z3Expr.Not(Z3Expr.Cmp(CmpOp.Eq, keyVar, lk)))
       Z3Expr.Implies(
-        Z3Expr.Cmp(CmpOp.Eq, keyVar, k),
+        Z3Expr.And(Z3Expr.Cmp(CmpOp.Eq, keyVar, k) :: laterNeqs),
         Z3Expr.Cmp(CmpOp.Eq, lhsMap, v)
       )
     val fallthrough = Z3Expr.Implies(

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1504,6 +1504,17 @@ object Translator:
   ): Z3Expr = expr match
     case BinaryOpF(BEq(), l, r, _) =>
       tryLowerRelationEquality(ctx, l, r, env).getOrElse(translateExpr(ctx, expr, env))
+    // Recurse through the conjunction/let structure so a relation-assignment nested inside a
+    // `let ... in (... and X' = rhs)` still gets its frame axiom (the dispatcher would otherwise
+    // only fire on a top-level `X' = rhs`, leaving the post-state relation under-constrained).
+    case BinaryOpF(BAnd(), a, b, _) =>
+      Z3Expr.And(
+        List(translateEnsuresClause(ctx, a, env), translateEnsuresClause(ctx, b, env))
+      )
+    case LetF(x, v, body, _) =>
+      val newEnv = env.clone()
+      newEnv(x) = translateExpr(ctx, v, env)
+      translateEnsuresClause(ctx, body, newEnv)
     case _ => translateExpr(ctx, expr, env)
 
   private def tryLowerRelationEquality(
@@ -1539,21 +1550,33 @@ object Translator:
       expr: expr,
       targetInfo: StateRelationInfo,
       env: mutable.Map[String, Z3Expr]
-  ): Option[RelationRhsLowering] = expr match
+  ): Option[RelationRhsLowering] =
+    collectInsertChain(ctx, expr).map: (base, entries) =>
+      (lhsInfo: StateRelationInfo, lhsMode: StateMode) =>
+        relationInsertionAxiom(
+          ctx,
+          lhsInfo,
+          lhsMode,
+          base._1,
+          base._2,
+          entries,
+          env,
+          targetInfo
+        )
+
+  // Flatten a chained insert `base + {k1->v1} + ... + {kn->vn}` (left-assoc `+`, each operand a
+  // MapLiteral) into the base relation plus all entries; relationInsertionAxiom emits the
+  // multi-entry frame as a single axiom. A single insert is the one-step base case.
+  private def collectInsertChain(
+      ctx: TranslateCtx,
+      expr: expr
+  ): Option[((StateRelationInfo, StateMode), List[KeyValueEntry])] = expr match
     case BinaryOpF(_: (BAdd | BUnion), left, right, _) =>
-      resolveStateRelationReference(ctx, left).flatMap: base =>
-        extractMapEntries(right).filter(_.nonEmpty).map: entries =>
-          (lhsInfo: StateRelationInfo, lhsMode: StateMode) =>
-            relationInsertionAxiom(
-              ctx,
-              lhsInfo,
-              lhsMode,
-              base._1,
-              base._2,
-              entries,
-              env,
-              targetInfo
-            )
+      extractMapEntries(right).filter(_.nonEmpty).flatMap: entries =>
+        resolveStateRelationReference(ctx, left) match
+          case Some(base) => Some((base, entries))
+          case None =>
+            collectInsertChain(ctx, left).map((base, acc) => (base, acc ++ entries))
     case _ => None
 
   private def tryLowerSingleMinusRhs(

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -189,6 +189,25 @@ class ConsistencyTest extends CatsEffectSuite:
         |    #log >= 0
         |}""".stripMargin,
       "now() must verify, not skip"
+    ),
+    (
+      "chained relation literal-insert verifies via Z3 (rel' = pre(rel) + {a->x} + {b->y})",
+      "chain_insert_demo",
+      """service ChainInsertDemo {
+        |  state {
+        |    store: Int -> lone Int
+        |  }
+        |  operation Put2 {
+        |    input:  a: Int, b: Int, va: Int, vb: Int
+        |    requires:
+        |      a != b
+        |    ensures:
+        |      store' = pre(store) + {a -> va} + {b -> vb}
+        |  }
+        |  invariant cardNonNeg:
+        |    #store >= 0
+        |}""".stripMargin,
+      "chained relation insert must verify, not skip"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -208,6 +208,25 @@ class ConsistencyTest extends CatsEffectSuite:
         |    #store >= 0
         |}""".stripMargin,
       "chained relation insert must verify, not skip"
+    ),
+    (
+      "chained insert with a repeated key is last-write-wins, not UNSAT",
+      "dup_key_insert_demo",
+      """service DupKeyDemo {
+        |  state {
+        |    store: Int -> lone Int
+        |  }
+        |  operation Put {
+        |    input:  a: Int, va: Int, vb: Int
+        |    requires:
+        |      va != vb
+        |    ensures:
+        |      store' = pre(store) + {a -> va} + {a -> vb}
+        |  }
+        |  invariant cardNonNeg:
+        |    #store >= 0
+        |}""".stripMargin,
+      "repeated-key chained insert must be last-write-wins (Sat), not UNSAT"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

Two encoder-only improvements extending relation-insert framing, unblocking auth_service's `RefreshToken`. Part of #420.

## How

- **collectInsertChain**: flattens a chained insert `pre(rel) + {k1->v1} + ... + {kn->vn}` (left-assoc `+`) into the base relation plus all entries. `relationInsertionAxiom` already emits the multi-entry frame, so this supplies the recognizer half (generalizing the single-insert #426).
- **translateEnsuresClause recursion**: now recurses through `and` and `let`, so a relation assignment nested in `let ... in (... and X' = rhs)` gets its frame axiom. Previously the dispatcher only fired on a top-level `X' = rhs`, leaving the post-state relation under-constrained when nested.

Both are **encoder-only** (no proof, no regen): these constructs already pass the trust gate (`translate` produces a vacuous-on-eval term), only the Z3 encoding was missing.

## Impact

`auth_service`: **7 -> 17 passing** (net failures 9 -> 8). RefreshToken's nested chained insert (`sessions' = pre(sessions) + {old->...} + {new->...}`) now encodes; Logout's `users' = users` frame is recovered. The remaining RefreshToken/Logout failures are **conservative** (under-constrained post-state from field-index updates `X'[k].f = v` and unmentioned-state framing) -- the sound direction (no false negatives), a follow-up, not a regression.

## Testing

- New `ConsistencyTest` case (`chain_insert_demo`): a chained insert verifies (all Sat).
- Full `sbt test` green; no regression (url_shortener stays 21/21, VerifyJsonTest passes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the Z3 encoder to frame relation assignments nested under `and`/`let` (including let values) and to handle chained relation inserts with last-write-wins for duplicate keys. Encoder-only; part of #420. Improves `auth_service` from 7 to 17 passing checks.

- **New Features**
  - Recurses through `and` and both `let` bodies and values so nested `X' = rhs` gets a frame axiom.
  - Flattens `pre(R) + {k->v} + ...` into a single multi-entry insert and enforces last-write-wins for repeated keys.

<sup>Written for commit a6b1a2cbf76add7212718cd95c59a4363e8654d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested constructs during verification to ensure proper frame synthesis.
  * Extended support for chained relation operations, enabling correct verification of sequential operations in more complex scenarios.

* **Tests**
  * Added test case validating verification of chained operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->