### PR TITLE
feat(verify): resolve bare enum members + coerce base-vs-optional equality (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -733,6 +733,21 @@ object Translator:
         case _         => default
       (rel, mode)
 
+  // Comparing a base value with an optional (e.g. `todo.title = title` where `title: Option[String]`)
+  // lifts the base to `some(base)` so the comparison is Option[T] = Option[T], not a sort clash the
+  // solver rejects. Other operand pairs are left untouched.
+  private def coerceOptionalEquality(
+      ctx: TranslateCtx,
+      left: Z3Expr,
+      right: Z3Expr
+  ): (Z3Expr, Z3Expr) =
+    (inferSortOfZ3Expr(ctx, left), inferSortOfZ3Expr(ctx, right)) match
+      case (Some(Z3Sort.OptionOf(elem)), Some(rs)) if Z3Sort.eq(rs, elem) =>
+        (left, Z3Expr.OptSome(right))
+      case (Some(ls), Some(Z3Sort.OptionOf(elem))) if Z3Sort.eq(ls, elem) =>
+        (Z3Expr.OptSome(left), right)
+      case _ => (left, right)
+
   private def translateBinaryOp(
       ctx: TranslateCtx,
       op: bin_op,
@@ -763,7 +778,8 @@ object Translator:
       case BIff() =>
         Z3Expr.And(List(Z3Expr.Implies(left, right), Z3Expr.Implies(right, left)))
       case BEq() | BNeq() =>
-        Z3Expr.Cmp(if isEq then CmpOp.Eq else CmpOp.Neq, left, right)
+        val (l2, r2) = coerceOptionalEquality(ctx, left, right)
+        Z3Expr.Cmp(if isEq then CmpOp.Eq else CmpOp.Neq, l2, r2)
       case BLt() | BLe() | BGt() | BGe() =>
         requireNumericOperands(ctx, op, leftExpr, rightExpr, left, right, env)
         val cmp = op match
@@ -1326,10 +1342,24 @@ object Translator:
                   ctx.declareFunc(Z3FunctionDecl(funcName, Nil, entity.sort))
                 Z3Expr.App(funcName, Nil)
               case None =>
-                val funcName = s"id_$name"
-                if !ctx.funcs.contains(funcName) then
-                  ctx.declareFunc(Z3FunctionDecl(funcName, Nil, Z3Sort.Uninterp("Any")))
-                Z3Expr.App(funcName, Nil)
+                enumMemberConst(ctx, name).getOrElse:
+                  val funcName = s"id_$name"
+                  if !ctx.funcs.contains(funcName) then
+                    ctx.declareFunc(Z3FunctionDecl(funcName, Nil, Z3Sort.Uninterp("Any")))
+                  Z3Expr.App(funcName, Nil)
+
+  // A bare enum member (e.g. `DONE`, not `Status.DONE`) parses as an identifier; resolve it to the
+  // same constant translateEnumAccess emits so `status = DONE` is well-sorted, rather than comparing
+  // against an Uninterp("Any") placeholder (which makes the solver reject the query). Only resolves
+  // when exactly one enum declares the member (otherwise it stays an unresolved identifier).
+  private def enumMemberConst(ctx: TranslateCtx, name: String): Option[Z3Expr] =
+    ctx.enums.toList.filter((_, info) => info.members.contains(name)) match
+      case (enumName, info) :: Nil =>
+        val funcName = s"${enumName}_$name"
+        if !ctx.funcs.contains(funcName) then
+          ctx.declareFunc(Z3FunctionDecl(funcName, Nil, info.sort))
+        Some(Z3Expr.App(funcName, Nil))
+      case _ => None
 
   private def inferSort(
       ctx: TranslateCtx,
@@ -2111,6 +2141,20 @@ object Translator:
     else if isNum(lz) && isNum(rz) then Z3Expr.Cmp(op, lz, rz)
     else fail(ctx, "ordering requires two numeric (Int or Real) operands or two String operands")
 
+  // Equality/inequality of a verified TEq: coerce a base-vs-optional pair (e.g. `todo.title = title`
+  // where title is Option[String]) by lifting the base to some(base), so the solver sees
+  // Option[T] = Option[T] instead of an incompatible-sorts clash.
+  private def encEq(
+      ctx: TranslateCtx,
+      op: CmpOp,
+      l: smt_term,
+      r: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val (lz, rz) =
+      coerceOptionalEquality(ctx, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+    Z3Expr.Cmp(op, lz, rz)
+
   // Addition: both operands numeric (Arith Add) or both String (StrConcat, str.++);
   // a numeric/String mix is left to the skip path rather than handed to the solver
   // ill-sorted.
@@ -2210,8 +2254,7 @@ object Translator:
           ctx.declareFunc(Z3FunctionDecl(funcName, Nil, resultSort))
         Z3Expr.App(funcName, Nil)
 
-      case TNot(TEq(l, r)) =>
-        Z3Expr.Cmp(CmpOp.Neq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TNot(TEq(l, r)) => encEq(ctx, CmpOp.Neq, l, r, env)
       case TOr(TLt(a1, b1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
         encCmp(ctx, CmpOp.Le, a1, b1, env)
       case TOr(TLt(b1, a1), TEq(a2, b2)) if a1 == a2 && b1 == b2 =>
@@ -2224,8 +2267,7 @@ object Translator:
         Z3Expr.Or(List(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env)))
       case TImplies(l, r) =>
         Z3Expr.Implies(encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
-      case TEq(l, r) =>
-        Z3Expr.Cmp(CmpOp.Eq, encodeFromSmtTerm(ctx, l, env), encodeFromSmtTerm(ctx, r, env))
+      case TEq(l, r) => encEq(ctx, CmpOp.Eq, l, r, env)
       case TLt(l, r) =>
         encCmp(ctx, CmpOp.Lt, l, r, env)
       case TNeg(t) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1187,8 +1187,11 @@ object Translator:
     expr.a match
       case IdentifierF(name, _) =>
         val args = expr.b.map(a => translateExpr(ctx, a, env))
+        // Derive arg sorts from the translated terms, not a second inferSort pass on the source:
+        // the declared parameter sorts then match the applied arguments by construction (e.g. a bare
+        // enum member resolves to its enum sort here, where source inferSort would miss it and pick Any).
         val argSorts =
-          expr.b.map(a => inferSort(ctx, a, env, None).getOrElse(Z3Sort.Uninterp("Any")))
+          args.map(a => inferSortOfZ3Expr(ctx, a).getOrElse(Z3Sort.Uninterp("Any")))
         val resultSort = callReturnSort(name, ctx)
         val funcName   = s"${name}_${argSortsMangled(argSorts)}"
         if !ctx.funcs.contains(funcName) then

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1350,8 +1350,10 @@ object Translator:
 
   // A bare enum member (e.g. `DONE`, not `Status.DONE`) parses as an identifier; resolve it to the
   // same constant translateEnumAccess emits so `status = DONE` is well-sorted, rather than comparing
-  // against an Uninterp("Any") placeholder (which makes the solver reject the query). Only resolves
-  // when exactly one enum declares the member (otherwise it stays an unresolved identifier).
+  // against an Uninterp("Any") placeholder (which makes the solver reject the query). A unique match
+  // resolves; no match leaves it a free identifier; multiple matches are an ambiguity the bare syntax
+  // cannot resolve without type context, so we bail as a translator limit rather than fall through to
+  // the Any placeholder and recreate the sort clash.
   private def enumMemberConst(ctx: TranslateCtx, name: String): Option[Z3Expr] =
     ctx.enums.toList.filter((_, info) => info.members.contains(name)) match
       case (enumName, info) :: Nil =>
@@ -1359,7 +1361,12 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, Nil, info.sort))
         Some(Z3Expr.App(funcName, Nil))
-      case _ => None
+      case Nil => None
+      case matches =>
+        fail(
+          ctx,
+          s"bare enum member '$name' is ambiguous (declared by ${matches.map(_._1).mkString(", ")}); qualify it as 'Enum.$name'"
+        )
 
   private def inferSort(
       ctx: TranslateCtx,

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -268,6 +268,40 @@ class ConsistencyTest extends CatsEffectSuite:
         s"expected every check Sat ($reason); got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
       )
 
+  test("ambiguous bare enum member is a translator limit, not a solver crash"):
+    val spec =
+      """service AmbiguousEnumDemo {
+        |  enum Color {
+        |    RED,
+        |    GREEN
+        |  }
+        |  enum Signal {
+        |    RED,
+        |    AMBER
+        |  }
+        |  state {
+        |    c: Color
+        |  }
+        |  invariant pinned:
+        |    c = RED
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("ambiguous_enum_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val crashed =
+        report.checks.filter(_.diagnostic.exists(_.category == DiagnosticCategory.BackendError))
+      assert(
+        crashed.isEmpty,
+        s"ambiguous bare enum must not crash the solver; got: ${crashed.map(c => s"${c.id}->${c.diagnostic.map(_.message)}")}"
+      )
+      assert(
+        report.checks.exists(
+          _.diagnostic.exists(_.category == DiagnosticCategory.TranslatorLimitation)
+        ),
+        s"expected a TranslatorLimitation skip; got: ${report.checks.map(c => s"${c.id}->${c.status}/${c.diagnostic.map(_.category)}")}"
+      )
+
   test("unsat_invariants has contradictory_invariants diagnostic"):
     for
       ir     <- SpecFixtures.loadIR("unsat_invariants")

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -302,7 +302,9 @@ class ConsistencyTest extends CatsEffectSuite:
         s"expected a TranslatorLimitation skip; got: ${report.checks.map(c => s"${c.id}->${c.status}/${c.diagnostic.map(_.category)}")}"
       )
 
-  test("bare enum member as a call argument stays well-sorted (no solver crash)"):
+  test(
+    "bare enum member as a call argument is never mis-resolved (no crash, no false contradiction)"
+  ):
     val spec =
       """service CallEnumDemo {
         |  enum Status {
@@ -320,11 +322,17 @@ class ConsistencyTest extends CatsEffectSuite:
       ir     <- SpecFixtures.buildFromSource("call_enum_demo", spec)
       report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
     yield
-      val crashed =
-        report.checks.filter(_.diagnostic.exists(_.category == DiagnosticCategory.BackendError))
+      // isDone(DONE) inlines to the tautology DONE = DONE, which is outside the verified subset, so
+      // the check is soundness-skipped rather than Sat. Guard the real failure modes instead: a solver
+      // crash (BackendError) or a false contradiction (Unsat) from mis-sorting the bare enum argument.
+      assert(report.checks.nonEmpty, "expected at least one check")
+      val bad = report.checks.filter(c =>
+        c.status == CheckOutcome.Unsat ||
+          c.diagnostic.exists(_.category == DiagnosticCategory.BackendError)
+      )
       assert(
-        crashed.isEmpty,
-        s"bare enum member as a call argument must not crash the solver; got: ${crashed.map(c => s"${c.id}->${c.diagnostic.map(_.message)}")}"
+        bad.isEmpty,
+        s"bare enum call-arg must not crash or be mis-resolved to Unsat; got: ${report.checks.map(c => s"${c.id}->${c.status}")}"
       )
 
   test("unsat_invariants has contradictory_invariants diagnostic"):

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -227,6 +227,36 @@ class ConsistencyTest extends CatsEffectSuite:
         |    #store >= 0
         |}""".stripMargin,
       "repeated-key chained insert must be last-write-wins (Sat), not UNSAT"
+    ),
+    (
+      "bare enum member resolves to the enum sort (c = RED, not c = Uninterp(Any))",
+      "bare_enum_demo",
+      """service EnumDemo {
+        |  enum Color {
+        |    RED,
+        |    GREEN,
+        |    BLUE
+        |  }
+        |  state {
+        |    c: Color
+        |  }
+        |  invariant pinned:
+        |    c = RED implies c != GREEN
+        |}""".stripMargin,
+      "bare enum member must verify, not crash on Sorts Color/Any"
+    ),
+    (
+      "base-vs-optional comparison verifies (chosen = fallback where chosen: Option[Int])",
+      "optional_eq_demo",
+      """service OptDemo {
+        |  state {
+        |    chosen: Option[Int]
+        |    fallback: Int
+        |  }
+        |  invariant chosenOrFallback:
+        |    chosen = none or chosen = fallback
+        |}""".stripMargin,
+      "base-vs-optional equality must verify, not crash on incompatible sorts"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -302,6 +302,31 @@ class ConsistencyTest extends CatsEffectSuite:
         s"expected a TranslatorLimitation skip; got: ${report.checks.map(c => s"${c.id}->${c.status}/${c.diagnostic.map(_.category)}")}"
       )
 
+  test("bare enum member as a call argument stays well-sorted (no solver crash)"):
+    val spec =
+      """service CallEnumDemo {
+        |  enum Status {
+        |    DONE,
+        |    TODO
+        |  }
+        |  predicate isDone(s: Status) = s = DONE
+        |  state {
+        |    cur: Status
+        |  }
+        |  invariant pinned:
+        |    isDone(DONE)
+        |}""".stripMargin
+    for
+      ir     <- SpecFixtures.buildFromSource("call_enum_demo", spec)
+      report <- Consistency.runConsistencyChecks(ir, VerificationConfig.Default)
+    yield
+      val crashed =
+        report.checks.filter(_.diagnostic.exists(_.category == DiagnosticCategory.BackendError))
+      assert(
+        crashed.isEmpty,
+        s"bare enum member as a call argument must not crash the solver; got: ${crashed.map(c => s"${c.id}->${c.diagnostic.map(_.message)}")}"
+      )
+
   test("unsat_invariants has contradictory_invariants diagnostic"):
     for
       ir     <- SpecFixtures.loadIR("unsat_invariants")


### PR DESCRIPTION
## What

Two encoder-only fixes that take `todo_list` from a **solver crash** (0/55, exit 3 backend-error) to **41/55 passing**. Part of #420.

## How

- **Bare enum members** — `resolveIdentifier` now resolves a bare enum member (`DONE`, written without the `Status.` qualifier) to the same constant `translateEnumAccess` emits, instead of falling through to an `Uninterp("Any")` placeholder. Previously `status = DONE` compared the enum sort against `Any`, which the solver rejected: *"Sorts Status and Any are incompatible"*. Resolves only when exactly one enum declares the member.
- **Base-vs-optional equality** — comparing a base value with an optional (`todo.title = title` where `title: Option[String]`) now lifts the base to `some(base)` (`coerceOptionalEquality`), so the solver sees `Option[T] = Option[T]` rather than an incompatible-sorts clash. Applied on the verified `TEq` path (`encEq`) and the raw `translateBinaryOp` path.

Both are **encoder-only** (no proof, no regen): these are sort-inference / coercion gaps, not subset-coverage changes.

## Impact

`todo_list`: **0/55 (crashed, exit 3) -> 41/55 passing** (the remaining 14 are graceful translator-limit skips, no crash). No regression: full `sbt test` green; `auth_service` unchanged at 17 passing; url_shortener stays 21/21.

## Testing

New `ConsistencyTest` cases: `bare_enum_demo` (`c = RED implies c != GREEN`) and `optional_eq_demo` (`chosen = none or chosen = fallback`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix encoder to resolve bare enum members, coerce base-vs-optional equality, and bail on ambiguous members to remove sort clashes and prevent solver crashes. Also align call-arg sorts with translated args to avoid `Any`/enum mismatches, and strengthen the bare-enum call-arg test to catch mis-resolution; `todo_list` moves from crash (0/55) to 41/55 passing; full test suite green.

- **Bug Fixes**
  - Bare enum members: resolve a unique bare member (e.g., DONE) to its enum constant, not `Uninterp("Any")`, so `status = DONE` is well-sorted.
  - Base vs optional equality: when comparing `T` with `Option[T]`, lift the base to `some(base)`; applied in verified `TEq` and `translateBinaryOp`.
  - Ambiguous bare enum members: fail with a translator-limit skip instead of emitting `Any` and crashing.

- **Refactors**
  - Call arguments: derive parameter sorts from translated args, not a second source-side infer, preventing `Any`/enum declaration mismatches; regression test strengthened to assert no crash and no false Unsat for bare-enum call args.

<sup>Written for commit 06b9b975f849ec3a0ca68da4ad798d56bdddc599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of equality comparisons involving optional values to prevent unintended verification failures.
  * Enhanced enum member resolution with more informative error diagnostics when ambiguous declarations are detected.

* **Tests**
  * Expanded verification test coverage for enum member resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->