### PR TITLE
feat(verify): infer the none-literal element sort from the with-update field type (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2486,7 +2486,11 @@ object Translator:
                 val skolemName = ctx.freshSkolem(s"with_$name")
                 ctx.declareFunc(Z3FunctionDecl(skolemName, Nil, Z3Sort.Uninterp(name)))
                 val skolemRef = Z3Expr.App(skolemName, Nil)
-                val v         = encodeFromSmtTerm(ctx, value, env)
+                // A bare `none` carries no element sort; in a record-update the target field's
+                // declared sort supplies it (e.g. `completed_at = none`, completed_at: Option[DateTime]).
+                val v = (value, entity.fields.get(fld).map(_._1)) match
+                  case (TNone(), Some(Z3Sort.OptionOf(elem))) => Z3Expr.OptNone(elem)
+                  case _                                      => encodeFromSmtTerm(ctx, value, env)
                 for (fname, (_, funcName)) <- entity.fields do
                   if fname == fld then
                     ctx.assertions += Z3Expr.Cmp(

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -257,6 +257,39 @@ class ConsistencyTest extends CatsEffectSuite:
         |    chosen = none or chosen = fallback
         |}""".stripMargin,
       "base-vs-optional equality must verify, not crash on incompatible sorts"
+    ),
+    (
+      "none in a with-record-update verifies (the target field's Option sort supplies the element sort)",
+      "with_none_demo",
+      """service WithNoneDemo {
+        |  enum Status {
+        |    OPEN,
+        |    CLOSED
+        |  }
+        |  entity Rec {
+        |    id: Int
+        |    status: Status
+        |    done_at: Option[Int]
+        |  }
+        |  state {
+        |    recs: Int -> lone Rec
+        |  }
+        |  operation Reopen {
+        |    input: id: Int
+        |    output: r: Rec
+        |    requires:
+        |      id in recs
+        |    ensures:
+        |      r = pre(recs)[id] with {
+        |        status = OPEN,
+        |        done_at = none
+        |      }
+        |      recs' = pre(recs) + {id -> r}
+        |  }
+        |  invariant cardNonNeg:
+        |    #recs >= 0
+        |}""".stripMargin,
+      "none in a with-update must verify (field Option sort gives the element sort), not skip"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

A bare `none` literal in a `with`-record-update field assignment now infers its element sort from the target field's declared `Option[T]` type, instead of failing the encoder. Part of #420.

## Why

`todo_list`'s `Reopen` op writes:

```text
ensures:
  todo = pre(todos)[id] with {
    status = IN_PROGRESS,
    completed_at = none      // completed_at: Option[DateTime]
  }
```

The `with`-update encoded the new field value with no sort context, so a bare `none` hit `'none' literal requires an optional-typed context` (translator-limit, exit 2) and the 4 `Reopen` preservation checks were skipped.

## How

In the `TWithRec` encoder case, when the new value is a bare `none` and the target field's declared sort is `Option[T]`, encode it as `OptNone(T)` using that field sort, mirroring how `encodeNoneEq` reads the operand sort on the comparison path. Encoder-only (no proof, no regen).

## Impact

`todo_list`: **41/55 -> 45/55** (the 4 `Reopen` preservation skips now verify). The remaining 10 skips are the soundness/outside-lower frontier (CreateTodo/ListTodos entity-output construction, `all t in seq`, `ran()`), out of scope here. No regression: full `verify` suite **243/243**, `SmtLibGoldenTest` unchanged.

## Testing

New `ConsistencyTest` demo `with_none_demo` (mirrors the `Reopen` `with { ..., done_at = none }` pattern; must verify Sat).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bare `none` in a `with { field = ... }` record update now infers its element sort from the field’s `Option[T]`, fixing the encoder error and allowing these updates to verify. Addresses #420.

- **Bug Fixes**
  - In the `TWithRec` encoder, when the new value is `none` and the field type is `Option[T]`, emit `OptNone(T)`; otherwise use the existing path.
  - Added `with_none_demo` in `ConsistencyTest` to cover `done_at = none`.
  - No suite regressions; `todo_list` improves from 41/55 to 45/55.

<sup>Written for commit da529554c9907aa0b72b2a86944b2774fad0a94b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

