### PR TITLE
feat(proofs): lift the 1-arg builtin hash(x) into the verified subset as an uninterpreted String function (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -578,6 +578,7 @@ object SpecRestGenerated {
   final case class TStrLit(a: String)                              extends smt_term
   final case class TMatches(a: smt_term, b: String)                extends smt_term
   final case class TUStrPred(a: String, b: smt_term)               extends smt_term
+  final case class TUStrFunc(a: String, b: smt_term)               extends smt_term
   final case class TUConst(a: String)                              extends smt_term
   final case class TSeqEmpty()                                     extends smt_term
   final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
@@ -1808,6 +1809,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUStrFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -1858,6 +1860,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUStrFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -2736,6 +2739,22 @@ object SpecRestGenerated {
           case Some(SSeq(_))              => None
           case Some(SMap(_))              => None
         }
+      case (m, env, TUStrFunc(name, t)) =>
+        smtEval(m, env, t) match {
+          case None                       => None
+          case Some(SBool(_))             => None
+          case Some(SInt(_))              => None
+          case Some(SReal(_))             => None
+          case Some(SEnumElem(_, _))      => None
+          case Some(SEntityElem(_, _))    => None
+          case Some(SSet(_))              => None
+          case Some(SEntityWith(_, _, _)) => None
+          case Some(SNone())              => None
+          case Some(SSome(_))             => None
+          case Some(SStr(str))            => Some[smt_val](SStr(name + str))
+          case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
+        }
       case (m, env, TUConst(nm)) => Some[smt_val](SInt(BigInt(nm.hashCode)))
       case (m, env, TSeqEmpty()) => Some[smt_val](SSeq(Nil))
       case (m, env, TSeqCons(e, rest)) =>
@@ -3264,7 +3283,8 @@ object SpecRestGenerated {
     case TStrLit(vi)           => Nil
     case TMatches(t, vj)       => smt_var_list(t)
     case TUStrPred(vk, t)      => smt_var_list(t)
-    case TUConst(vl)           => Nil
+    case TUStrFunc(vl, t)      => smt_var_list(t)
+    case TUConst(vm)           => Nil
     case TSeqEmpty()           => Nil
     case TSeqCons(e, r)        => smt_var_list(e) ++ smt_var_list(r)
     case TMapEmpty()           => Nil
@@ -4038,6 +4058,8 @@ object SpecRestGenerated {
   def fkRefTable(x0: foreign_key_spec): String = x0 match {
     case ForeignKeySpec(uu, rt, uv, uw) => rt
   }
+
+  def is_builtin_func(nm: String): Boolean = nm == "hash"
 
   def is_builtin_pred(nm: String): Boolean =
     nm == "isValidURI" || nm == "isValidEmail"
@@ -5128,6 +5150,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUStrFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -5178,6 +5201,7 @@ object SpecRestGenerated {
     case TStrLit(v)             => None
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
+    case TUStrFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -5414,7 +5438,13 @@ object SpecRestGenerated {
                   TUStrPred(nm, a),
                 translate(enums, arg)
               )
-            case false => None
+            case false => is_builtin_func(nm) match {
+                case true => map_option[smt_term, smt_term](
+                    (a: smt_term) => TUStrFunc(nm, a),
+                    translate(enums, arg)
+                  )
+                case false => None
+              }
           }
         case (IdentifierF(_, _), _ :: _ :: _) => None
       }

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2543,6 +2543,15 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Bool))
         Z3Expr.App(funcName, List(strZ))
+      // 1-arg reserved builtin string function (e.g. hash(x)): an uninterpreted Str-valued function.
+      // Same name mangling as TUStrPred; determinism (same input -> same output) is the functionality.
+      case TUStrFunc(name, t) =>
+        val strZ     = encodeFromSmtTerm(ctx, t, env)
+        val s        = inferSortOfZ3Expr(ctx, strZ).getOrElse(Z3Sort.Str)
+        val funcName = s"${name}_${sortNameOf(s)}"
+        if !ctx.funcs.contains(funcName) then
+          ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Str))
+        Z3Expr.App(funcName, List(strZ))
       // 0-arg reserved builtin (e.g. now()): an uninterpreted Int constant. The `${name}_0`
       // name matches translateCall's argSortsMangled, so the in-subset and raw paths share it.
       case TUConst(name) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -290,6 +290,25 @@ class ConsistencyTest extends CatsEffectSuite:
         |    #recs >= 0
         |}""".stripMargin,
       "none in a with-update must verify (field Option sort gives the element sort), not skip"
+    ),
+    (
+      "1-arg builtin hash(x) verifies via Z3 as an uninterpreted String function (determinism preserved)",
+      "hash_demo",
+      """service HashDemo {
+        |  state {
+        |    a: String
+        |    b: String
+        |  }
+        |  operation Both {
+        |    input: pw: String
+        |    ensures:
+        |      a' = hash(pw)
+        |      b' = hash(pw)
+        |  }
+        |  invariant equalHashes:
+        |    a = b
+        |}""".stripMargin,
+      "hash(pw) must verify as a deterministic uninterpreted function (a' = b'), not skip"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -114,15 +114,16 @@ code_printing
 | class_instance Int.int :: ord \<rightharpoonup> (Scala) -
 | class_instance Int.int :: equal \<rightharpoonup> (Scala) -
 
-text \<open>\<open>string_matches\<close>, \<open>str_predicate\<close>, and \<open>builtin_const_val\<close> are abstract (see \<open>IR\<close>);
-  the real semantics is Z3's (regex \<open>str.in_re\<close>, an uninterpreted predicate / constant) in
-  the hand-written translator. The extracted \<open>eval\<close>/\<open>smtEval\<close> reference interpreters are not
-  called by Scala consumers, so these serialisations are never-evaluated stubs that only have
+text \<open>\<open>string_matches\<close>, \<open>str_predicate\<close>, \<open>builtin_const_val\<close>, and \<open>builtin_str_func\<close> are abstract
+  (see \<open>IR\<close>); the real semantics is Z3's (regex \<open>str.in_re\<close>, an uninterpreted predicate / constant /
+  function) in the hand-written translator. The extracted \<open>eval\<close>/\<open>smtEval\<close> reference interpreters are
+  not called by Scala consumers, so these serialisations are never-evaluated stubs that only have
   to type-check.\<close>
 code_printing
   constant string_matches \<rightharpoonup> (Scala) "((_) == (_))"
 | constant str_predicate \<rightharpoonup> (Scala) "((_) == (_))"
 | constant builtin_const_val \<rightharpoonup> (Scala) "(BigInt((_).hashCode))"
+| constant builtin_str_func \<rightharpoonup> (Scala) "((_) + (_))"
 
 export_code
     translate

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -105,6 +105,17 @@ consts builtin_const_val :: "String.literal \<Rightarrow> int"
 definition is_builtin_const :: "String.literal \<Rightarrow> bool" where
   "is_builtin_const nm \<longleftrightarrow> nm = STR ''now''"
 
+text \<open>\<open>builtin_str_func name s\<close> is the uninterpreted value of the reserved 1-argument
+  built-in string function \<open>name\<close> (e.g.\ \<open>hash\<close>) applied to string \<open>s\<close>. Like
+  \<open>str_predicate\<close> it is abstract - the trusted translator emits it as a Z3 uninterpreted
+  string function - so soundness stays parametric in the function and any realisation
+  \<open>eval\<close>/\<open>smtEval\<close> share is sound by construction. \<open>is_builtin_func nm\<close> gates lifting
+  \<open>CallF (IdentifierF nm) [arg]\<close> to \<open>UStrFunc\<close>: only reserved built-ins are lifted.\<close>
+consts builtin_str_func :: "String.literal \<Rightarrow> String.literal \<Rightarrow> String.literal"
+
+definition is_builtin_func :: "String.literal \<Rightarrow> bool" where
+  "is_builtin_func nm \<longleftrightarrow> nm = STR ''hash''"
+
 record schema_field_decl =
   fd_name :: "String.literal"
   fd_ty   :: "schema_type"

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -18,6 +18,7 @@ definition builtins_reserved ::
   "function_decl list \<Rightarrow> predicate_decl list \<Rightarrow> bool" where
   "builtins_reserved fs ps \<equiv> (\<forall>nm. is_builtin_pred nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> (\<forall>nm. is_builtin_const nm \<longrightarrow> lookup_callee fs ps nm = None)
+                              \<and> (\<forall>nm. is_builtin_func nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> lookup_callee fs ps (STR ''dom'') = None
                               \<and> lookup_callee fs ps (STR ''range'') = None"
 
@@ -175,6 +176,10 @@ and eval_forall ::
                             then (case eval fs ps fuel s st env arg of
                                     Some (VStr str) \<Rightarrow> Some (VBool (str_predicate nm str))
                                   | _ \<Rightarrow> None)
+                          else if is_builtin_func nm
+                            then (case eval fs ps fuel s st env arg of
+                                    Some (VStr str) \<Rightarrow> Some (VStr (builtin_str_func nm str))
+                                  | _ \<Rightarrow> None)
                             else None)
                      | _ \<Rightarrow> None))
            | _ \<Rightarrow> None))"
@@ -304,7 +309,7 @@ lemma eval_dom_CallF:
   assumes "lookup_callee fs ps (STR ''dom'') = None"
   shows "eval fs ps fuel s st env
            (CallF (IdentifierF (STR ''dom'') sp1) [IdentifierF rel sp2] sp) = None"
-  using assms by (simp add: is_builtin_pred_def split: nat.splits)
+  using assms by (simp add: is_builtin_pred_def is_builtin_func_def split: nat.splits)
 
 lemma quant_dom_qb_names:
   "quant_dom s st k bs = Some (var, dmv) \<Longrightarrow> qb_names bs = [var]"
@@ -545,7 +550,18 @@ next
                 by (auto split: option.splits ir_value.splits)
             next
               case False
-              thus ?thesis using Suc idc None ac Nil by simp
+              show ?thesis
+              proof (cases "is_builtin_func nm")
+                case True
+                have "eval fs ps fuel s st env a = eval fs ps fuel s st env2 a"
+                  using "15.IH" Suc idc None ac Nil agr \<open>\<not> is_builtin_pred nm\<close> True
+                  by (auto simp: env_lookup_def)
+                then show ?thesis using Suc idc None ac Nil \<open>\<not> is_builtin_pred nm\<close> True
+                  by (auto split: option.splits ir_value.splits)
+              next
+                case False
+                thus ?thesis using Suc idc None ac Nil \<open>\<not> is_builtin_pred nm\<close> by simp
+              qed
             qed
           next
             case (Cons b bs)
@@ -1343,18 +1359,37 @@ next
       show ?thesis using inl "15.prems" by simp
     next
       case (Cons arg rest)
-      obtain str where aeq: "args = [arg]" and bip: "is_builtin_pred nm"
-          and ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-          and w_eq: "w = VBool (str_predicate nm str)"
+      have aeq: "args = [arg]"
         using "15.prems" fuel idc None Cons
         by (cases rest) (auto split: option.splits ir_value.splits if_splits)
-      have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
-        using "15.IH" fuel idc None aeq ea bip by (auto split: if_splits)
       have inl: "inline_calls fs ps (CallF callee args sp)
                    = CallF callee [inline_calls fs ps arg] sp"
         using idc None aeq by (auto simp: lookup_callee_def split: option.splits)
-      show ?thesis using inl ea' w_eq fuel idc None aeq bip
-        by (simp split: option.splits ir_value.splits)
+      show ?thesis
+      proof (cases "is_builtin_pred nm")
+        case True
+        obtain str where ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+            and w_eq: "w = VBool (str_predicate nm str)"
+          using "15.prems" fuel idc None aeq True
+          by (auto split: option.splits ir_value.splits if_splits)
+        have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
+          using "15.IH" fuel idc None aeq ea True by (auto split: if_splits)
+        show ?thesis using inl ea' w_eq fuel idc None aeq True
+          by (simp split: option.splits ir_value.splits)
+      next
+        case False
+        have bif: "is_builtin_func nm"
+          using "15.prems" fuel idc None aeq False
+          by (auto split: option.splits ir_value.splits if_splits)
+        obtain str where ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+            and w_eq: "w = VStr (builtin_str_func nm str)"
+          using "15.prems" fuel idc None aeq False bif
+          by (auto split: option.splits ir_value.splits if_splits)
+        have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
+          using "15.IH" fuel idc None aeq ea False bif by (auto split: if_splits)
+        show ?thesis using inl ea' w_eq fuel idc None aeq False bif
+          by (simp split: option.splits ir_value.splits)
+      qed
     qed
   next
     case (Some pb)

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -65,6 +65,7 @@ datatype (plugins only: code size) smt_term =
   | TStrLit "String.literal"
   | TMatches "smt_term" "String.literal"
   | TUStrPred "String.literal" "smt_term"
+  | TUStrFunc "String.literal" "smt_term"
   | TUConst "String.literal"
   | TSeqEmpty
   | TSeqCons "smt_term" "smt_term"
@@ -118,6 +119,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TStrLit _)           = []"
 | "smt_var_list (TMatches t _)        = smt_var_list t"
 | "smt_var_list (TUStrPred _ t)       = smt_var_list t"
+| "smt_var_list (TUStrFunc _ t)       = smt_var_list t"
 | "smt_var_list (TUConst _)           = []"
 | "smt_var_list TSeqEmpty             = []"
 | "smt_var_list (TSeqCons e r)        = smt_var_list e @ smt_var_list r"
@@ -515,6 +517,10 @@ where
 | "smtEval m env (TUStrPred name t) =
      (case smtEval m env t of
         Some (SStr str) \<Rightarrow> Some (SBool (str_predicate name str))
+      | _ \<Rightarrow> None)"
+| "smtEval m env (TUStrFunc name t) =
+     (case smtEval m env t of
+        Some (SStr str) \<Rightarrow> Some (SStr (builtin_str_func name str))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TUConst nm) = Some (SInt (builtin_const_val nm))"
 | "smtEval m env TSeqEmpty = Some (SSeq [])"

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -129,6 +129,8 @@ where
         (IdentifierF nm _, [arg]) \<Rightarrow>
           (if is_builtin_pred nm
              then map_option (\<lambda>a'. TUStrPred nm a') (translate enums arg)
+           else if is_builtin_func nm
+             then map_option (\<lambda>a'. TUStrFunc nm a') (translate enums arg)
              else None)
       | (IdentifierF nm _, []) \<Rightarrow>
           (if is_builtin_const nm then Some (TUConst nm) else None)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -17,8 +17,10 @@ proof -
     using assms(1) by (simp add: builtins_reserved_def)
   have nb: "\<not> is_builtin_pred (STR ''range'')"
     by (simp add: is_builtin_pred_def)
+  have nf: "\<not> is_builtin_func (STR ''range'')"
+    by (simp add: is_builtin_func_def)
   show ?thesis
-    unfolding req by (cases fuel) (simp_all add: lk nb)
+    unfolding req by (cases fuel) (simp_all add: lk nb nf)
 qed
 
 lemma binop_noncomp_step:
@@ -520,19 +522,40 @@ next
     show ?thesis using teq veq by simp
   next
     case (Cons arg rest)
-    obtain argt where aeq: "args = [arg]" and bip: "is_builtin_pred nm"
-        and ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
+    have aeq: "args = [arg]"
       using "15.prems"(2) ceq Cons by (cases rest) (auto split: if_splits option.splits)
-    have lc_none: "lookup_callee fs ps nm = None"
-      using "15.prems"(4) bip by (simp add: builtins_reserved_def)
-    from "15.prems"(1) fuel ceq aeq lc_none bip obtain str where
-        ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-        and veq: "v = VBool (str_predicate nm str)"
-      by (auto split: option.splits ir_value.splits if_splits)
-    have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
-      using "15.IH" fuel ceq aeq lc_none bip ea ta "15.prems"(3) "15.prems"(4)
-      by (auto split: if_splits)
-    show ?thesis using teq veq ev by simp
+    show ?thesis
+    proof (cases "is_builtin_pred nm")
+      case True
+      obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
+        using "15.prems"(2) ceq aeq True by (auto split: if_splits option.splits)
+      have lc_none: "lookup_callee fs ps nm = None"
+        using "15.prems"(4) True by (simp add: builtins_reserved_def)
+      from "15.prems"(1) fuel ceq aeq lc_none True obtain str where
+          ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+          and veq: "v = VBool (str_predicate nm str)"
+        by (auto split: option.splits ir_value.splits if_splits)
+      have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+        using "15.IH" fuel ceq aeq lc_none True ea ta "15.prems"(3) "15.prems"(4)
+        by (auto split: if_splits)
+      show ?thesis using teq veq ev by simp
+    next
+      case False
+      have bif: "is_builtin_func nm"
+        using "15.prems"(2) ceq aeq False by (auto split: if_splits option.splits)
+      obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrFunc nm argt"
+        using "15.prems"(2) ceq aeq False bif by (auto split: if_splits option.splits)
+      have lc_none: "lookup_callee fs ps nm = None"
+        using "15.prems"(4) bif by (simp add: builtins_reserved_def)
+      from "15.prems"(1) fuel ceq aeq lc_none False bif obtain str where
+          ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+          and veq: "v = VStr (builtin_str_func nm str)"
+        by (auto split: option.splits ir_value.splits if_splits)
+      have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+        using "15.IH" fuel ceq aeq lc_none False bif ea ta "15.prems"(3) "15.prems"(4)
+        by (auto split: if_splits)
+      show ?thesis using teq veq ev by simp
+    qed
   qed
 next
   case (17 fs ps fuel s st env es sp v t)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -214,6 +214,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TStrLit _)            = False"
 | "smt_uses_var x (TMatches t _)         = smt_uses_var x t"
 | "smt_uses_var x (TUStrPred _ t)        = smt_uses_var x t"
+| "smt_uses_var x (TUStrFunc _ t)        = smt_uses_var x t"
 | "smt_uses_var x (TUConst _)            = False"
 | "smt_uses_var x TSeqEmpty              = False"
 | "smt_uses_var x (TSeqCons e r)         = (smt_uses_var x e \<or> smt_uses_var x r)"


### PR DESCRIPTION
## What

Lifts the 1-argument reserved builtin `hash(x)` into the verified subset as an **uninterpreted String function**, extending the #429 pattern (0-arg `now()`) to 1-arg string functions. Part of #420.

## How

`hash : String -> String` is modelled abstractly, mirroring `str_predicate`'s `String -> Bool` shape but `String -> String`:

- **IR.thy:** `consts builtin_str_func :: String.literal => String.literal => String.literal` + `is_builtin_func nm <-> nm = ''hash''`.
- **Smt.thy:** new `TUStrFunc` smt node; `smtEval`/`smt_var_list` arms.
- **Semantics_Reference.thy:** eval's `[arg]` branch + `builtins_reserved` gain an `is_builtin_func` case.
- **Translate.thy:** the verified gate lifts `CallF (IdentifierF nm) [arg]` to `TUStrFunc` when `is_builtin_func nm`.
- **Codegen.thy:** never-evaluated `code_printing` stub for the abstract constant.

Because `eval` and `smtEval` share the same abstract `builtin_str_func`, the soundness correspondence is **proven, not vacuous** (any interpretation is sound).

The four soundness/semantics proofs that case-split eval's CallF (`DirectSound` case 15, `eval_free_vars_cong`, `eval_inline_calls`, `range_eval_None`) were extended. The key subtlety: the new `is_builtin_func` recursive arg-IH is **guarded by `not is_builtin_pred and is_builtin_func`**, so both facts must be supplied to discharge it. **Zero-sorry across Core / Soundness / Codegen.**

`SpecRestGenerated.scala` regenerated via the standard pipeline. The Z3 encoder emits a `Str`-valued uninterpreted function for `TUStrFunc` (the determinism, same input -> same output, is the functionality).

## Impact

`auth_service`: **17 -> 19** passing. `hash(x)` was the sole out-of-subset clause for `LoginFailed`'s `requires` (`password_hash != hash(password)`) and `enabled` checks, which now verify. The remaining hash-using ops (Register, Login, ResetPassword) still need sequence-append (`seq + [elem]`) and entity-output construction before they flip -- groundwork laid here.

No regression: full `verify` suite **244/244**, `SmtLibGoldenTest` unchanged.

## Testing

New `ConsistencyTest` demo `hash_demo` (`a' = hash(pw)`, `b' = hash(pw)`, invariant `a = b`) -- verifies that `hash` is a deterministic uninterpreted function (`a' = b'`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the 1‑arg builtin `hash(x)` into the verified subset as an uninterpreted String function. This unlocks hash-based specs (auth_service passing ops 17 → 19) with no regressions.

- New Features
  - Added `TUStrFunc` SMT node and an `is_builtin_func` gate for `hash`.
  - Updated `Translate`, `eval`, `smtEval`, and soundness proofs; no new axioms.
  - Z3 encoder declares a Str-valued uninterpreted function; `eval`/SMT share `builtin_str_func`.
  - Reserved the builtin and added a Scala codegen stub; regenerated `SpecRestGenerated.scala`; new `hash_demo` test verifies determinism.

<sup>Written for commit 8028e59bc9924b762fcd754a0b16bc19238cdafd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for string-valued builtin functions (such as hash) in the verification framework.
  * Extended verification translation to recognize and properly evaluate 1-argument string-returning builtin functions.
  * Updated reference semantics and consistency checks to handle deterministic string operations.

* **Tests**
  * Added comprehensive test case verifying proper handling of string builtin functions in consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->