### PR TITLE
feat(proofs): lift sequence-append (seq + [elem]) into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -2325,7 +2325,19 @@ object SpecRestGenerated {
           case (Some(SStr(a)), Some(SStr(b)))               => Some[smt_val](SStr(a + b))
           case (Some(SStr(_)), Some(SSeq(_)))               => None
           case (Some(SStr(_)), Some(SMap(_)))               => None
-          case (Some(SSeq(_)), _)                           => None
+          case (Some(SSeq(_)), None)                        => None
+          case (Some(SSeq(_)), Some(SBool(_)))              => None
+          case (Some(SSeq(_)), Some(SInt(_)))               => None
+          case (Some(SSeq(_)), Some(SReal(_)))              => None
+          case (Some(SSeq(_)), Some(SEnumElem(_, _)))       => None
+          case (Some(SSeq(_)), Some(SEntityElem(_, _)))     => None
+          case (Some(SSeq(_)), Some(SSet(_)))               => None
+          case (Some(SSeq(_)), Some(SEntityWith(_, _, _)))  => None
+          case (Some(SSeq(_)), Some(SNone()))               => None
+          case (Some(SSeq(_)), Some(SSome(_)))              => None
+          case (Some(SSeq(_)), Some(SStr(_)))               => None
+          case (Some(SSeq(a)), Some(SSeq(b)))               => Some[smt_val](SSeq(a ++ b))
+          case (Some(SSeq(_)), Some(SMap(_)))               => None
           case (Some(SMap(_)), _)                           => None
         }
       case (m, env, TSub(l, r)) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -294,6 +294,7 @@ private object Backend:
     case Z3Expr.Cmp(op, l, r, _)           => renderCmp(rctx, op, l, r)
     case Z3Expr.StrCmp(op, l, r, _)        => renderStrCmp(rctx, op, l, r)
     case Z3Expr.StrConcat(l, r, _)         => renderStrConcat(rctx, l, r)
+    case Z3Expr.SeqConcat(l, r, _)         => renderSeqConcat(rctx, l, r)
     case Z3Expr.Arith(op, args, _)         => renderArith(rctx, op, args)
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
     case Z3Expr.EmptySet(elemSort, _) =>
@@ -421,6 +422,15 @@ private object Backend:
   ): Z3AstExpr[SeqSort[CharSort]] =
     val l = renderExpr(rctx, lhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
     val r = renderExpr(rctx, rhs).asInstanceOf[Z3AstExpr[SeqSort[CharSort]]]
+    rctx.ctx.mkConcat(l, r)
+
+  private def renderSeqConcat(
+      rctx: RenderCtx,
+      lhs: Z3Expr,
+      rhs: Z3Expr
+  ): SeqExpr[Sort] =
+    val l = renderExpr(rctx, lhs).asInstanceOf[SeqExpr[Sort]]
+    val r = renderExpr(rctx, rhs).asInstanceOf[SeqExpr[Sort]]
     rctx.ctx.mkConcat(l, r)
 
   private def renderArith(

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -103,6 +103,8 @@ object SmtLib:
         case CmpOp.Neq => s"(distinct ${renderExpr(l)} ${renderExpr(r)})"
     case Z3Expr.StrConcat(l, r, _) =>
       s"(str.++ ${renderExpr(l)} ${renderExpr(r)})"
+    case Z3Expr.SeqConcat(l, r, _) =>
+      s"(seq.++ ${renderExpr(l)} ${renderExpr(r)})"
     case Z3Expr.Arith(op, args, _) =>
       s"(${ArithOp.token(op)} ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.Quantifier(q, bindings, body, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -966,6 +966,12 @@ object Translator:
         substituteVar(r, varName, replacement),
         sp
       )
+    case Z3Expr.SeqConcat(l, r, sp) =>
+      Z3Expr.SeqConcat(
+        substituteVar(l, varName, replacement),
+        substituteVar(r, varName, replacement),
+        sp
+      )
     case Z3Expr.Arith(op, args, sp) =>
       Z3Expr.Arith(op, args.map(a => substituteVar(a, varName, replacement)), sp)
     case q @ Z3Expr.Quantifier(kind, bindings, body, sp) =>
@@ -1443,6 +1449,7 @@ object Translator:
     case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
     case Z3Expr.StrConcat(_, _, _)     => Some(Z3Sort.Str)
+    case Z3Expr.SeqConcat(l, _, _)     => inferSortOfZ3Expr(ctx, l)
     case Z3Expr.InRe(_, _, _)          => Some(Z3Sort.Bool)
     case Z3Expr.SeqLit(elemSort, _, _) => Some(Z3Sort.SeqOf(elemSort))
     case Z3Expr.MapLit(keySort, valueSort, _, _) =>
@@ -2181,9 +2188,15 @@ object Translator:
         case Some(Z3Sort.Str) => true
         case _                => false
     def isNum(z: Z3Expr): Boolean = inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric)
+    def isSeq(z: Z3Expr): Boolean =
+      inferSortOfZ3Expr(ctx, z) match
+        case Some(Z3Sort.SeqOf(_)) => true
+        case _                     => false
     if isStr(lz) && isStr(rz) then Z3Expr.StrConcat(lz, rz)
+    else if isSeq(lz) && isSeq(rz) then Z3Expr.SeqConcat(lz, rz)
     else if isNum(lz) && isNum(rz) then Z3Expr.Arith(ArithOp.Add, List(lz, rz))
-    else fail(ctx, "addition requires two numeric (Int or Real) operands or two String operands")
+    else
+      fail(ctx, "addition requires two numeric (Int or Real), two String, or two Seq operands")
 
   private def encodeSetEmptyCmp(
       ctx: TranslateCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
@@ -11,6 +11,7 @@ object Z3Trigger:
     case Z3Expr.Cmp(_, l, r, _)        => List(l, r)
     case Z3Expr.StrCmp(_, l, r, _)     => List(l, r)
     case Z3Expr.StrConcat(l, r, _)     => List(l, r)
+    case Z3Expr.SeqConcat(l, r, _)     => List(l, r)
     case Z3Expr.Arith(_, args, _)      => args
     case Z3Expr.Quantifier(_, _, b, _) => List(b)
     case Z3Expr.SetLit(_, ms, _)       => ms

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -90,6 +90,7 @@ enum Z3Expr derives CanEqual:
   case Cmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case StrCmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case StrConcat(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
+  case SeqConcat(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case Arith(op: ArithOp, args: List[Z3Expr], span: Option[span_t] = None)
   case Quantifier(
       q: QKind,
@@ -127,6 +128,7 @@ enum Z3Expr derives CanEqual:
     case e: Cmp        => e.span
     case e: StrCmp     => e.span
     case e: StrConcat  => e.span
+    case e: SeqConcat  => e.span
     case e: Arith      => e.span
     case e: Quantifier => e.span
     case e: EmptySet   => e.span
@@ -157,6 +159,7 @@ enum Z3Expr derives CanEqual:
         case e: Cmp        => e.copy(span = s)
         case e: StrCmp     => e.copy(span = s)
         case e: StrConcat  => e.copy(span = s)
+        case e: SeqConcat  => e.copy(span = s)
         case e: Arith      => e.copy(span = s)
         case e: Quantifier => e.copy(span = s)
         case e: EmptySet   => e.copy(span = s)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -309,6 +309,26 @@ class ConsistencyTest extends CatsEffectSuite:
         |    a = b
         |}""".stripMargin,
       "hash(pw) must verify as a deterministic uninterpreted function (a' = b'), not skip"
+    ),
+    (
+      "sequence-append (seq + [elem]) verifies via Z3 (BAdd on seqs -> seq.++, the auth login_attempts shape)",
+      "seq_append_demo",
+      """service SeqAppendDemo {
+        |  entity Ev {
+        |    tag: Int
+        |  }
+        |  state {
+        |    log: Seq[Ev]
+        |  }
+        |  operation Record {
+        |    input: t: Int
+        |    ensures:
+        |      log' = pre(log) + [Ev { tag = t }]
+        |  }
+        |  invariant trivial:
+        |    true
+        |}""".stripMargin,
+      "seq-append (log' = pre(log) + [Ev{...}]) must verify, not skip on 'addition requires numeric'"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/core/Semantics.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics.thy
@@ -110,6 +110,10 @@ fun str_arith :: "arith_op \<Rightarrow> String.literal \<Rightarrow> String.lit
   "str_arith AddOp a b = Some (VStr (a + b))"
 | "str_arith _ _ _ = None"
 
+fun seq_arith :: "arith_op \<Rightarrow> ir_value list \<Rightarrow> ir_value list \<Rightarrow> ir_value option" where
+  "seq_arith AddOp a b = Some (VSeq (a @ b))"
+| "seq_arith _ _ _ = None"
+
 fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value option \<Rightarrow> ir_value option" where
   "eval_arith op x y =
      (case x of
@@ -126,6 +130,10 @@ fun eval_arith :: "arith_op \<Rightarrow> ir_value option \<Rightarrow> ir_value
       | Some (VStr a) \<Rightarrow>
           (case y of
              Some (VStr b) \<Rightarrow> str_arith op a b
+           | _             \<Rightarrow> None)
+      | Some (VSeq a) \<Rightarrow>
+          (case y of
+             Some (VSeq b) \<Rightarrow> seq_arith op a b
            | _             \<Rightarrow> None)
       | _ \<Rightarrow> None)"
 
@@ -200,7 +208,8 @@ lemma eval_arith_some_imp_numeric_or_str:
   "eval_arith op x y = Some v \<Longrightarrow>
      (((\<exists>a. x = Some (VInt a)) \<or> (\<exists>a. x = Some (VReal a)))
       \<and> ((\<exists>b. y = Some (VInt b)) \<or> (\<exists>b. y = Some (VReal b))))
-     \<or> ((\<exists>a. x = Some (VStr a)) \<and> (\<exists>b. y = Some (VStr b)))"
+     \<or> ((\<exists>a. x = Some (VStr a)) \<and> (\<exists>b. y = Some (VStr b)))
+     \<or> ((\<exists>a. x = Some (VSeq a)) \<and> (\<exists>b. y = Some (VSeq b)))"
   by (auto split: option.splits ir_value.splits if_splits)
 
 lemma eval_arith_div_zero:
@@ -585,6 +594,16 @@ lemma eval_arith_str_preservation:
   by (cases op;
       auto split: option.splits ir_value.splits if_splits intro: vt_str)
 
+lemma eval_arith_seq_preservation:
+  assumes "eval_arith op x y = Some v"
+      and "\<And>a. x = Some a \<Longrightarrow> value_has_ty \<Gamma> a (TSeq t)"
+      and "\<And>b. y = Some b \<Longrightarrow> value_has_ty \<Gamma> b (TSeq t)"
+  shows "value_has_ty \<Gamma> v (TSeq t)"
+  using assms
+  by (cases op;
+      auto split: option.splits ir_value.splits if_splits
+           elim!: value_has_ty_seq_cases intro!: vt_seq)
+
 lemma eval_cmp_preservation:
   assumes "eval_cmp op x y = Some v"
   shows "value_has_ty \<Gamma> v TBool"
@@ -952,6 +971,10 @@ inductive expr_has_ty :: "tyctx \<Rightarrow> expr \<Rightarrow> ty \<Rightarrow
     "expr_has_ty \<Gamma> l TStr
        \<Longrightarrow> expr_has_ty \<Gamma> r TStr
        \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF BAdd l r sp) TStr"
+| T_Seq_Concat:
+    "expr_has_ty \<Gamma> l (TSeq t)
+       \<Longrightarrow> expr_has_ty \<Gamma> r (TSeq t)
+       \<Longrightarrow> expr_has_ty \<Gamma> (BinaryOpF BAdd l r sp) (TSeq t)"
 | T_Cmp_Eq:
     "expr_has_ty \<Gamma> l t1
        \<Longrightarrow> expr_has_ty \<Gamma> r t2

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -399,6 +399,7 @@ where
       | (Some (SInt a), Some (SReal b)) \<Rightarrow> Some (SReal (of_int a + b))
       | (Some (SReal a), Some (SInt b)) \<Rightarrow> Some (SReal (a + of_int b))
       | (Some (SStr a), Some (SStr b)) \<Rightarrow> Some (SStr (a + b))
+      | (Some (SSeq a), Some (SSeq b)) \<Rightarrow> Some (SSeq (a @ b))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TSub l r) =
      (case (smtEval m env l, smtEval m env r) of

--- a/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectPreservation.thy
@@ -165,6 +165,26 @@ next
     thus "value_has_ty \<Gamma> b TStr" using T_Str_Concat.IH(2)[OF T_Str_Concat.prems(1)] by blast
   qed
 next
+  case (T_Seq_Concat \<Gamma> l t r sp)
+  have deN: "dom_eq_domains fs ps st BAdd l r = None"
+    by (rule typed_dom_eq_domains_None[OF T_Seq_Concat.hyps(1)])
+  have bcN: "beq_comp BAdd r = None"
+    by (rule typed_beq_comp_None[OF T_Seq_Concat.hyps(2)])
+  have ev: "eval_bin BAdd (eval fs ps fuel sch st env l)
+              (eval fs ps fuel sch st env r) = Some v"
+    using T_Seq_Concat.prems(2) deN bcN by simp
+  have eva: "eval_arith AddOp (eval fs ps fuel sch st env l)
+               (eval fs ps fuel sch st env r) = Some v"
+    using ev by simp
+  show ?case
+  proof (rule eval_arith_seq_preservation[OF eva])
+    fix a assume "eval fs ps fuel sch st env l = Some a"
+    thus "value_has_ty \<Gamma> a (TSeq t)" using T_Seq_Concat.IH(1)[OF T_Seq_Concat.prems(1)] by blast
+  next
+    fix b assume "eval fs ps fuel sch st env r = Some b"
+    thus "value_has_ty \<Gamma> b (TSeq t)" using T_Seq_Concat.IH(2)[OF T_Seq_Concat.prems(1)] by blast
+  qed
+next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   have deN: "dom_eq_domains fs ps st op l r = None"
     by (rule typed_dom_eq_domains_None[OF T_Cmp_Eq.hyps(1)])

--- a/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
+++ b/proofs/isabelle/SpecRest/soundness/Preservation_WellTyped.thy
@@ -19,6 +19,9 @@ next
   case (T_Str_Concat \<Gamma> l r sp)
   thus ?case by auto
 next
+  case (T_Seq_Concat \<Gamma> l t r sp)
+  thus ?case by auto
+next
   case (T_Cmp_Eq \<Gamma> l t1 r t2 op sp)
   have rnc: "\<nexists>var dnm sp2 p sp3. r = SetComprehensionF var (IdentifierF dnm sp2) p sp3"
     using T_Cmp_Eq.hyps(2) by (auto dest: not_expr_has_ty_set_comp)


### PR DESCRIPTION
## What

Lifts sequence-append (`seq + [elem]`) into the verified subset, extending the #424 sort-dispatched `+` (String concat via `str.++`) to sequences. Part of #420.

## How

`+` on two `Seq[T]` operands now means append. No new smt node -- `+` already translates to `TAdd`; dispatch is by operand sort in `eval`/`smtEval`/encoder, exactly like String concat:

- **Semantics.thy:** `seq_arith` (AddOp -> `VSeq (a @ b)`); `eval_arith` gains a VSeq case; the `eval_arith_some_imp_numeric_or_str` characterisation lemma gains a seq disjunct; a `T_Seq_Concat` typing rule (`TSeq t`, `TSeq t` -> `TSeq t`).
- **Smt.thy:** `smtEval (TAdd ...)` gains `(SSeq a, SSeq b) -> SSeq (a @ b)`.
- **Soundness:** `eval_arith_seq_preservation` (the `@`-append-preserves-element-typing lemma) + `T_Seq_Concat` cases in `DirectPreservation` and `Preservation_WellTyped`. `DirectSound`'s BAdd case is sort-agnostic and needed no change. **Zero-sorry across Core / Soundness / Codegen.**

**Encoder:** a new `Z3Expr.SeqConcat` node renders to Z3 `seq.++` (`mkConcat`); `encAdd` dispatches two Seq-sorted operands to it (alongside numeric / String). Wired through `Backend`, `SmtLib`, `Triggers`, `substituteVar`, `inferSortOfZ3Expr` (the `-Werror` exhaustiveness checks flagged the two extra renderers). `SpecRestGenerated.scala` regenerated.

## Impact

`auth_service`: **19 -> 28**. All 9 `LoginFailed` preservation checks now verify -- `login_attempts' = pre(login_attempts) + [LoginAttempt{...}]` was their sole out-of-subset clause after the hash lift (#433). `Login` (which also appends to `login_attempts`) still needs entity-output construction before it flips.

No regression: full `verify` suite **245/245**, `SmtLibGoldenTest` unchanged.

## Testing

New `ConsistencyTest` demo `seq_append_demo` (`log' = pre(log) + [Ev{...}]`) -- verifies the BAdd-on-seqs -> `seq.++` path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts sequence append into the verified subset: `Seq[T] + Seq[T]` now appends and encodes to Z3 `seq.++`. This unblocks specs like `pre(seq) + [elem]`, raising `auth_service` verified checks from 19 to 28 with no regressions.

- **New Features**
  - `+` now dispatches on sequence operands (alongside numbers and strings).
  - Typing: `Seq[T] + Seq[T] -> Seq[T]`.
  - Encoder adds `Z3Expr.SeqConcat`; rendered as `seq.++` in `Backend` and `SmtLib`; triggers, substitution, and sort inference updated.
  - Evaluator and SMT eval handle seq append; new preservation lemma; soundness extended with `T_Seq_Concat`.
  - Added `seq_append_demo` test covering `pre(log) + [Ev{...}]`.

<sup>Written for commit e17d95593d7dae57d340e37da4d9eaf8bd548fe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

