### PR TITLE
feat(verify): recognize the ran builtin + universal quantification over Seq (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4941,7 +4941,7 @@ object SpecRestGenerated {
 
   def range_arg(x0: expr): Option[String] = x0 match {
     case CallF(IdentifierF(nm, uu), List(IdentifierF(rel, uv)), uw) =>
-      nm == "range" match {
+      nm == "range" || nm == "ran" match {
         case true  => Some[String](rel)
         case false => None
       }

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -295,6 +295,7 @@ private object Backend:
     case Z3Expr.StrCmp(op, l, r, _)        => renderStrCmp(rctx, op, l, r)
     case Z3Expr.StrConcat(l, r, _)         => renderStrConcat(rctx, l, r)
     case Z3Expr.SeqConcat(l, r, _)         => renderSeqConcat(rctx, l, r)
+    case Z3Expr.SeqContains(s, e, _)       => renderSeqContains(rctx, s, e)
     case Z3Expr.Arith(op, args, _)         => renderArith(rctx, op, args)
     case q @ Z3Expr.Quantifier(_, _, _, _) => renderQuantifier(rctx, q)
     case Z3Expr.EmptySet(elemSort, _) =>
@@ -432,6 +433,16 @@ private object Backend:
     val l = renderExpr(rctx, lhs).asInstanceOf[SeqExpr[Sort]]
     val r = renderExpr(rctx, rhs).asInstanceOf[SeqExpr[Sort]]
     rctx.ctx.mkConcat(l, r)
+
+  private def renderSeqContains(
+      rctx: RenderCtx,
+      seq: Z3Expr,
+      elem: Z3Expr
+  ): BoolExpr =
+    val s = renderExpr(rctx, seq).asInstanceOf[SeqExpr[Sort]]
+    val unit = rctx.ctx.mkUnit(renderExpr(rctx, elem).asInstanceOf[Z3AstExpr[Sort]])
+      .asInstanceOf[SeqExpr[Sort]]
+    rctx.ctx.mkContains(s, unit)
 
   private def renderArith(
       rctx: RenderCtx,

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -105,6 +105,8 @@ object SmtLib:
       s"(str.++ ${renderExpr(l)} ${renderExpr(r)})"
     case Z3Expr.SeqConcat(l, r, _) =>
       s"(seq.++ ${renderExpr(l)} ${renderExpr(r)})"
+    case Z3Expr.SeqContains(s, e, _) =>
+      s"(seq.contains ${renderExpr(s)} (seq.unit ${renderExpr(e)}))"
     case Z3Expr.Arith(op, args, _) =>
       s"(${ArithOp.token(op)} ${args.map(renderExpr).mkString(" ")})"
     case Z3Expr.Quantifier(q, bindings, body, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -972,6 +972,12 @@ object Translator:
         substituteVar(r, varName, replacement),
         sp
       )
+    case Z3Expr.SeqContains(s, e, sp) =>
+      Z3Expr.SeqContains(
+        substituteVar(s, varName, replacement),
+        substituteVar(e, varName, replacement),
+        sp
+      )
     case Z3Expr.Arith(op, args, sp) =>
       Z3Expr.Arith(op, args.map(a => substituteVar(a, varName, replacement)), sp)
     case q @ Z3Expr.Quantifier(kind, bindings, body, sp) =>
@@ -1450,6 +1456,7 @@ object Translator:
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
     case Z3Expr.StrConcat(_, _, _)     => Some(Z3Sort.Str)
     case Z3Expr.SeqConcat(l, _, _)     => inferSortOfZ3Expr(ctx, l)
+    case Z3Expr.SeqContains(_, _, _)   => Some(Z3Sort.Bool)
     case Z3Expr.InRe(_, _, _)          => Some(Z3Sort.Bool)
     case Z3Expr.SeqLit(elemSort, _, _) => Some(Z3Sort.SeqOf(elemSort))
     case Z3Expr.MapLit(keySort, valueSort, _, _) =>
@@ -2324,18 +2331,34 @@ object Translator:
           encodeFromSmtTerm(ctx, body, newEnv)
         )
       case TForallRel(varName, rel, body) =>
-        val (sort, guard) = quantifierDomainFor(ctx, rel, varName)
-        val newEnv        = env.clone()
-        newEnv(varName) = Z3Expr.Var(varName, sort)
-        val inner = encodeFromSmtTerm(ctx, body, newEnv)
-        val guarded = guard match
-          case Some(g) => Z3Expr.Implies(g, inner)
-          case None    => inner
-        Z3Expr.Quantifier(
-          QKind.ForAll,
-          List(Z3Binding(varName, sort)),
-          guarded
-        )
+        // `translate` emits TForallRel for any identifier domain. When the domain is actually a
+        // Seq-sorted value (e.g. an operation output Seq[T]) rather than a state relation, quantify
+        // over the sequence's elements. eval is vacuous on a non-relation domain, so the seq
+        // interpretation is trusted frame synthesis (like the #428 range projection).
+        env.get(rel).flatMap(z => inferSortOfZ3Expr(ctx, z)) match
+          case Some(Z3Sort.SeqOf(elem)) =>
+            val seqZ   = env(rel)
+            val newEnv = env.clone()
+            newEnv(varName) = Z3Expr.Var(varName, elem)
+            val inner = encodeFromSmtTerm(ctx, body, newEnv)
+            Z3Expr.Quantifier(
+              QKind.ForAll,
+              List(Z3Binding(varName, elem)),
+              Z3Expr.Implies(Z3Expr.SeqContains(seqZ, Z3Expr.Var(varName, elem)), inner)
+            )
+          case _ =>
+            val (sort, guard) = quantifierDomainFor(ctx, rel, varName)
+            val newEnv        = env.clone()
+            newEnv(varName) = Z3Expr.Var(varName, sort)
+            val inner = encodeFromSmtTerm(ctx, body, newEnv)
+            val guarded = guard match
+              case Some(g) => Z3Expr.Implies(g, inner)
+              case None    => inner
+            Z3Expr.Quantifier(
+              QKind.ForAll,
+              List(Z3Binding(varName, sort)),
+              guarded
+            )
 
       case TExistsRel(varName, rel, body) =>
         val (sort, guard) = quantifierDomainFor(ctx, rel, varName)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2337,14 +2337,17 @@ object Translator:
         // interpretation is trusted frame synthesis (like the #428 range projection).
         env.get(rel).flatMap(z => inferSortOfZ3Expr(ctx, z)) match
           case Some(Z3Sort.SeqOf(elem)) =>
-            val seqZ   = env(rel)
-            val newEnv = env.clone()
-            newEnv(varName) = Z3Expr.Var(varName, elem)
+            val seqZ = env(rel)
+            // fresh binder so an outer identifier of the same name inside `seqZ` is not captured
+            val freshName = ctx.freshSkolem(s"forall_seq_$varName")
+            val binderVar = Z3Expr.Var(freshName, elem)
+            val newEnv    = env.clone()
+            newEnv(varName) = binderVar
             val inner = encodeFromSmtTerm(ctx, body, newEnv)
             Z3Expr.Quantifier(
               QKind.ForAll,
-              List(Z3Binding(varName, elem)),
-              Z3Expr.Implies(Z3Expr.SeqContains(seqZ, Z3Expr.Var(varName, elem)), inner)
+              List(Z3Binding(freshName, elem)),
+              Z3Expr.Implies(Z3Expr.SeqContains(seqZ, binderVar), inner)
             )
           case _ =>
             val (sort, guard) = quantifierDomainFor(ctx, rel, varName)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
@@ -12,6 +12,7 @@ object Z3Trigger:
     case Z3Expr.StrCmp(_, l, r, _)     => List(l, r)
     case Z3Expr.StrConcat(l, r, _)     => List(l, r)
     case Z3Expr.SeqConcat(l, r, _)     => List(l, r)
+    case Z3Expr.SeqContains(s, e, _)   => List(s, e)
     case Z3Expr.Arith(_, args, _)      => args
     case Z3Expr.Quantifier(_, _, b, _) => List(b)
     case Z3Expr.SetLit(_, ms, _)       => ms

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -91,6 +91,7 @@ enum Z3Expr derives CanEqual:
   case StrCmp(op: CmpOp, lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case StrConcat(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
   case SeqConcat(lhs: Z3Expr, rhs: Z3Expr, span: Option[span_t] = None)
+  case SeqContains(seq: Z3Expr, elem: Z3Expr, span: Option[span_t] = None)
   case Arith(op: ArithOp, args: List[Z3Expr], span: Option[span_t] = None)
   case Quantifier(
       q: QKind,
@@ -116,63 +117,65 @@ enum Z3Expr derives CanEqual:
   )
 
   def spanOpt: Option[span_t] = this match
-    case e: Var        => e.span
-    case e: App        => e.span
-    case e: IntLit     => e.span
-    case e: RealLit    => e.span
-    case e: BoolLit    => e.span
-    case e: And        => e.span
-    case e: Or         => e.span
-    case e: Not        => e.span
-    case e: Implies    => e.span
-    case e: Cmp        => e.span
-    case e: StrCmp     => e.span
-    case e: StrConcat  => e.span
-    case e: SeqConcat  => e.span
-    case e: Arith      => e.span
-    case e: Quantifier => e.span
-    case e: EmptySet   => e.span
-    case e: SetLit     => e.span
-    case e: SetMember  => e.span
-    case e: SetBinOp   => e.span
-    case e: Ite        => e.span
-    case e: OptNone    => e.span
-    case e: OptSome    => e.span
-    case e: StrLit     => e.span
-    case e: InRe       => e.span
-    case e: SeqLit     => e.span
-    case e: MapLit     => e.span
+    case e: Var         => e.span
+    case e: App         => e.span
+    case e: IntLit      => e.span
+    case e: RealLit     => e.span
+    case e: BoolLit     => e.span
+    case e: And         => e.span
+    case e: Or          => e.span
+    case e: Not         => e.span
+    case e: Implies     => e.span
+    case e: Cmp         => e.span
+    case e: StrCmp      => e.span
+    case e: StrConcat   => e.span
+    case e: SeqConcat   => e.span
+    case e: SeqContains => e.span
+    case e: Arith       => e.span
+    case e: Quantifier  => e.span
+    case e: EmptySet    => e.span
+    case e: SetLit      => e.span
+    case e: SetMember   => e.span
+    case e: SetBinOp    => e.span
+    case e: Ite         => e.span
+    case e: OptNone     => e.span
+    case e: OptSome     => e.span
+    case e: StrLit      => e.span
+    case e: InRe        => e.span
+    case e: SeqLit      => e.span
+    case e: MapLit      => e.span
 
   def withSpan(s: Option[span_t]): Z3Expr =
     if s.isEmpty then this
     else
       this match
-        case e: Var        => e.copy(span = s)
-        case e: App        => e.copy(span = s)
-        case e: IntLit     => e.copy(span = s)
-        case e: RealLit    => e.copy(span = s)
-        case e: BoolLit    => e.copy(span = s)
-        case e: And        => e.copy(span = s)
-        case e: Or         => e.copy(span = s)
-        case e: Not        => e.copy(span = s)
-        case e: Implies    => e.copy(span = s)
-        case e: Cmp        => e.copy(span = s)
-        case e: StrCmp     => e.copy(span = s)
-        case e: StrConcat  => e.copy(span = s)
-        case e: SeqConcat  => e.copy(span = s)
-        case e: Arith      => e.copy(span = s)
-        case e: Quantifier => e.copy(span = s)
-        case e: EmptySet   => e.copy(span = s)
-        case e: SetLit     => e.copy(span = s)
-        case e: SetMember  => e.copy(span = s)
-        case e: SetBinOp   => e.copy(span = s)
-        case e: Ite        => e.copy(span = s)
-        case e: OptNone    => e.copy(span = s)
-        case e: OptSome    => e.copy(span = s)
-        case e: StrLit     => e.copy(span = s)
-        case e: InRe       => e.copy(span = s)
-        case e: SeqLit     => e.copy(span = s)
-        case e: MapLit     => e.copy(span = s)
+        case e: Var         => e.copy(span = s)
+        case e: App         => e.copy(span = s)
+        case e: IntLit      => e.copy(span = s)
+        case e: RealLit     => e.copy(span = s)
+        case e: BoolLit     => e.copy(span = s)
+        case e: And         => e.copy(span = s)
+        case e: Or          => e.copy(span = s)
+        case e: Not         => e.copy(span = s)
+        case e: Implies     => e.copy(span = s)
+        case e: Cmp         => e.copy(span = s)
+        case e: StrCmp      => e.copy(span = s)
+        case e: StrConcat   => e.copy(span = s)
+        case e: SeqConcat   => e.copy(span = s)
+        case e: SeqContains => e.copy(span = s)
+        case e: Arith       => e.copy(span = s)
+        case e: Quantifier  => e.copy(span = s)
+        case e: EmptySet    => e.copy(span = s)
+        case e: SetLit      => e.copy(span = s)
+        case e: SetMember   => e.copy(span = s)
+        case e: SetBinOp    => e.copy(span = s)
+        case e: Ite         => e.copy(span = s)
+        case e: OptNone     => e.copy(span = s)
+        case e: OptSome     => e.copy(span = s)
+        case e: StrLit      => e.copy(span = s)
+        case e: InRe        => e.copy(span = s)
+        case e: SeqLit      => e.copy(span = s)
+        case e: MapLit      => e.copy(span = s)
 
 enum Z3Regex derives CanEqual:
   case Str(s: String)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -329,6 +329,58 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "seq-append (log' = pre(log) + [Ev{...}]) must verify, not skip on 'addition requires numeric'"
+    ),
+    (
+      "ran(rel) verifies via Z3 (the user-facing value-set builtin reuses #428's range projection)",
+      "ran_demo",
+      """service RanDemo {
+        |  entity It {
+        |    v: Int
+        |  }
+        |  state {
+        |    rel: Int -> lone It
+        |  }
+        |  operation Values {
+        |    output: xs: Set[It]
+        |    requires:
+        |      true
+        |    ensures:
+        |      xs = ran(rel)
+        |      rel' = rel
+        |  }
+        |  invariant cardNonNeg:
+        |    #rel >= 0
+        |}""".stripMargin,
+      "ran(rel) must verify (reuses #428 range projection), not skip as an unrecognized builtin"
+    ),
+    (
+      "universal quantification over a Seq output verifies via Z3 (all t in xs | P, the ListTodos shape)",
+      "seq_forall_demo",
+      """service SeqForallDemo {
+        |  enum St { A, B }
+        |  entity It {
+        |    st: St
+        |    tags: Set[String]
+        |  }
+        |  state {
+        |    ctr: Int
+        |  }
+        |  operation Emit {
+        |    input: sf: Option[St], tf: String
+        |    output: xs: Seq[It]
+        |    requires:
+        |      true
+        |    ensures:
+        |      all t in xs |
+        |        t.st = A
+        |        and (sf = none or t.st = sf)
+        |        and tf in t.tags
+        |      ctr' = pre(ctr)
+        |  }
+        |  invariant nonneg:
+        |    ctr >= 0
+        |}""".stripMargin,
+      "universal-over-Seq (all t in xs | ...) must verify, not skip on 'field access requires entity sort'"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -20,7 +20,8 @@ definition builtins_reserved ::
                               \<and> (\<forall>nm. is_builtin_const nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> (\<forall>nm. is_builtin_func nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> lookup_callee fs ps (STR ''dom'') = None
-                              \<and> lookup_callee fs ps (STR ''range'') = None"
+                              \<and> lookup_callee fs ps (STR ''range'') = None
+                              \<and> lookup_callee fs ps (STR ''ran'') = None"
 
 fun quant_dom ::
   "schema \<Rightarrow> state \<Rightarrow> quant_kind \<Rightarrow> quantifier_binding list

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -87,7 +87,7 @@ definition translate_beq_dom_or_none :: "expr \<Rightarrow> expr \<Rightarrow> s
 
 fun range_arg :: "expr \<Rightarrow> String.literal option" where
   "range_arg (CallF (IdentifierF nm _) [IdentifierF rel _] _) =
-     (if nm = STR ''range'' then Some rel else None)"
+     (if nm = STR ''range'' \<or> nm = STR ''ran'' then Some rel else None)"
 | "range_arg _ = None"
 
 definition translate_range_eq :: "smt_term \<Rightarrow> String.literal \<Rightarrow> smt_term" where

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -10,15 +10,16 @@ lemma range_eval_None:
       and "range_arg r = Some rel"
   shows "eval fs ps fuel s st env r = None"
 proof -
-  from assms(2) obtain sp1 sp2 sp3
-    where req: "r = CallF (IdentifierF (STR ''range'') sp1) [IdentifierF rel sp2] sp3"
+  from assms(2) obtain nm sp1 sp2 sp3
+    where req: "r = CallF (IdentifierF nm sp1) [IdentifierF rel sp2] sp3"
+      and nmv: "nm = STR ''range'' \<or> nm = STR ''ran''"
     by (cases r rule: range_arg.cases) (auto split: if_splits)
-  have lk: "lookup_callee fs ps (STR ''range'') = None"
-    using assms(1) by (simp add: builtins_reserved_def)
-  have nb: "\<not> is_builtin_pred (STR ''range'')"
-    by (simp add: is_builtin_pred_def)
-  have nf: "\<not> is_builtin_func (STR ''range'')"
-    by (simp add: is_builtin_func_def)
+  have lk: "lookup_callee fs ps nm = None"
+    using assms(1) nmv by (auto simp: builtins_reserved_def)
+  have nb: "\<not> is_builtin_pred nm"
+    using nmv by (auto simp: is_builtin_pred_def)
+  have nf: "\<not> is_builtin_func nm"
+    using nmv by (auto simp: is_builtin_func_def)
   show ?thesis
     unfolding req by (cases fuel) (simp_all add: lk nb nf)
 qed


### PR DESCRIPTION
## What

Two related verified-subset extensions toward `todo_list` ListTodos, both vacuous-on-eval (trusted encoder, like #428's range projection). Part of #420.

## How

**1. `ran(rel)` builtin recognition (proof, reuses #428).** The user-facing value-set builtin `ran` is now recognized as the *same* projection #428 synthesizes internally as `range(rel)`. `range_arg` accepts `ran` (Translate.thy), `builtins_reserved` reserves it, `range_eval_None` generalizes to both names. No new machinery -- `ran(rel)` reuses the verified range projection (`translate_range_eq`) and the encoder unchanged. Zero-sorry; `SpecRestGenerated.scala` regenerated.

**2. Universal quantification over a `Seq` value (encoder-only).** `all t in xs | P` where `xs` is a Seq-sorted output. `translate` already emits `TForallRel` for any identifier domain (vacuous-on-eval on a non-relation domain), so this is encoder-only: a new `Z3Expr.SeqContains` node (Z3 `seq.contains`) and a Seq-domain branch in the `TForallRel` encoder case that binds the var over the sequence's elements (`forall t. seq.contains(xs, unit(t)) => P(t)`). Wired through Backend, SmtLib, Triggers, `substituteVar`, `inferSortOfZ3Expr`.

## Impact

**Groundwork: 0 real-spec checks flip yet.** ListTodos needs ONE more construct -- **range-membership `t in ran(rel)`** (the bound var in a relation's range) -- before it flips 45 -> 49. I confirmed the other body pieces all work under univ-over-Seq (Option-`none` comparison, enum equality, set-membership). range-membership follows the #425/#426 binop-recognizer pattern (`translate_BIn_noncomp` + a `raN` discharge mirroring `riN`) and is a clean follow-up.

No regression: full `verify` suite **247/247**, `SmtLibGoldenTest` unchanged.

## Testing

New `ConsistencyTest` demos: `ran_demo` (`xs = ran(rel)`) and `seq_forall_demo` (`all t in xs | t.st = A and (sf = none or t.st = sf) and tf in t.tags` -- univ-over-Seq with Option/enum/set body).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the `ran(rel)` builtin and universal quantification over `Seq`, plus a fix to avoid variable capture in that quantifier, advancing ListTodos in #420. No behavior change on eval; tests stay green.

- **New Features**
  - Recognize `ran(rel)` as an alias of `range(rel)` using the existing verified projection; reserved as a builtin and proof rules generalized.
  - Encode `all t in xs | P` when `xs: Seq[T]` as `forall t. seq.contains(xs, seq.unit(t)) => P(t)` by adding `Z3Expr.SeqContains` and wiring through `Backend`, `SmtLib`, `Triggers`, substitution, and sort inference.

- **Bug Fixes**
  - Use a fresh binder for `Seq`-domain `forall` to prevent variable capture and map the original var name to it.

<sup>Written for commit 618a845661bfa7e579970d86cef84441d43d593f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sequence containment verification support for more expressive constraint checking
  * Enhanced universal quantification capabilities to work directly with sequence values

* **Improvements**
  * Extended range operation support to recognize both `range` and `ran` built-in functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->