### PR TITLE
feat(verify): lift range-membership + optional-vs-base membership, flipping todo_list ListTodos (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5724,10 +5724,20 @@ object SpecRestGenerated {
                         case None =>
                           comp_parts(r) match {
                             case None =>
-                              map_option[smt_term, smt_term](
-                                (a: smt_term) => TSetMember(lt, a),
-                                translate(enums, r)
-                              )
+                              range_arg(r) match {
+                                case None =>
+                                  map_option[smt_term, smt_term](
+                                    (a: smt_term) => TSetMember(lt, a),
+                                    translate(enums, r)
+                                  )
+                                case Some(rel) =>
+                                  val k = fresh_var("k", rel :: smt_var_list(lt)): String;
+                                  Some[smt_term](TExistsRel(
+                                    k,
+                                    rel,
+                                    TEq(TIndexRel(TVar(rel), TVar(k)), lt)
+                                  ))
+                              }
                             case Some((vara, (dnm, p))) =>
                               map_option[smt_term, smt_term](
                                 (pt: smt_term) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2493,13 +2493,25 @@ object Translator:
             val rhs    = encodeFromSmtTerm(ctx, set, env)
             val rhSort = inferSortOfZ3Expr(ctx, rhs)
             (elemSort, rhSort) match
+              case (Some(Z3Sort.OptionOf(es)), Some(Z3Sort.SetOf(rs))) if Z3Sort.eq(es, rs) =>
+                // optional-vs-base membership (e.g. `tag_filter in t.tags`, tag_filter: Option[T]):
+                // `opt in S` iff some x in S has opt = some(x) (none is never a member).
+                val xName = ctx.freshSkolem("opt_in")
+                val xVar  = Z3Expr.Var(xName, rs)
+                Z3Expr.Quantifier(
+                  QKind.Exists,
+                  List(Z3Binding(xName, rs)),
+                  Z3Expr.And(List(
+                    Z3Expr.SetMember(xVar, rhs),
+                    Z3Expr.Cmp(CmpOp.Eq, elemZ, Z3Expr.OptSome(xVar))
+                  ))
+                )
               case (Some(es), Some(Z3Sort.SetOf(rs))) if !Z3Sort.eq(es, rs) =>
                 fail(
                   ctx,
                   s"membership operator 'in' requires the left-hand side sort to match the set's element sort; got $es against a set of $rs"
                 )
-              case _ => ()
-            Z3Expr.SetMember(elemZ, rhs)
+              case _ => Z3Expr.SetMember(elemZ, rhs)
       case TSetUnion(l, r)     => encodeSetBinOp(ctx, SetOpKind.Union, l, r, env)
       case TSetIntersect(l, r) => encodeSetBinOp(ctx, SetOpKind.Intersect, l, r, env)
       case TSetDiff(l, r)      => encodeSetBinOp(ctx, SetOpKind.Diff, l, r, env)

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2511,6 +2511,12 @@ object Translator:
                   ctx,
                   s"membership operator 'in' requires the left-hand side sort to match the set's element sort; got $es against a set of $rs"
                 )
+              case (_, Some(Z3Sort.SetOf(_))) => Z3Expr.SetMember(elemZ, rhs)
+              case (_, Some(other)) =>
+                fail(
+                  ctx,
+                  s"membership operator 'in' requires a set-typed right operand; got $other"
+                )
               case _ => Z3Expr.SetMember(elemZ, rhs)
       case TSetUnion(l, r)     => encodeSetBinOp(ctx, SetOpKind.Union, l, r, env)
       case TSetIntersect(l, r) => encodeSetBinOp(ctx, SetOpKind.Intersect, l, r, env)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -381,6 +381,32 @@ class ConsistencyTest extends CatsEffectSuite:
         |    ctr >= 0
         |}""".stripMargin,
       "universal-over-Seq (all t in xs | ...) must verify, not skip on 'field access requires entity sort'"
+    ),
+    (
+      "the ListTodos filter shape verifies: range-membership + optional-vs-base membership under all-in-Seq",
+      "list_filter_demo",
+      """service ListFilterDemo {
+        |  entity It {
+        |    tags: Set[String]
+        |  }
+        |  state {
+        |    rel: Int -> lone It
+        |  }
+        |  operation Filter {
+        |    input: tag_filter: Option[String]
+        |    output: results: Seq[It]
+        |    requires:
+        |      true
+        |    ensures:
+        |      all t in results |
+        |        t in ran(rel)
+        |        and (tag_filter = none or tag_filter in t.tags)
+        |      rel' = rel
+        |  }
+        |  invariant cardNonNeg:
+        |    #rel >= 0
+        |}""".stripMargin,
+      "ListTodos shape (range-membership `t in ran(rel)` + optional membership `tag_filter in t.tags`) must verify, not skip"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -231,8 +231,14 @@ where
                                           else TAnd (TInDom dnm (TVar var)) pt))
                                      (translate enums p)
                                | None \<Rightarrow>
-                                   map_option (\<lambda>rt. TSetMember lt rt)
-                                     (translate enums r))))))
+                                   (case range_arg r of
+                                      Some rel \<Rightarrow>
+                                        (let k = fresh_var (STR ''k'') (rel # smt_var_list lt)
+                                         in Some (TExistsRel k rel
+                                                    (TEq (TIndexRel (TVar rel) (TVar k)) lt)))
+                                    | None \<Rightarrow>
+                                        map_option (\<lambda>rt. TSetMember lt rt)
+                                          (translate enums r)))))))
       | BNotIn \<Rightarrow>
           (case translate enums l of
              None \<Rightarrow> None
@@ -360,7 +366,13 @@ lemma translate_BIn_noncomp:
                             (case identName r of
                                Some rel \<Rightarrow> Some (TInDom rel lt)
                              | None \<Rightarrow>
-                                 map_option (\<lambda>rt. TSetMember lt rt) (translate enums r)))))"
+                                 (case range_arg r of
+                                    Some rel \<Rightarrow>
+                                      (let k = fresh_var (STR ''k'') (rel # smt_var_list lt)
+                                       in Some (TExistsRel k rel
+                                                  (TEq (TIndexRel (TVar rel) (TVar k)) lt)))
+                                  | None \<Rightarrow>
+                                      map_option (\<lambda>rt. TSetMember lt rt) (translate enums r))))))"
   using comp_parts_None[OF assms] by (auto split: option.splits)
 
 end

--- a/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
@@ -418,7 +418,8 @@ proof (induction e rule: measure_induct_rule[where f = size])
           show ?thesis
             using hl hr translate_BIn_noncomp[OF nc]
             by (cases r2)
-               (auto simp: BinaryOpF BIn del: translate.simps split: option.splits)
+               (auto simp: BinaryOpF BIn Let_def del: translate.simps
+                     split: option.splits if_splits)
         qed
       qed
     next


### PR DESCRIPTION
## What

Completes the two remaining `todo_list` ListTodos body constructs (after #435's `ran` + universal-over-Seq), **flipping ListTodos: todo_list 45 -> 49**. Part of #420.

## How

**1. range-membership `t in ran(rel)` (proof, vacuous-on-eval).** The `translate` `BIn` case gains a `range_arg` recognizer that desugars `t in ran(rel)` to `exists k. rel[k] = t` -- `TExistsRel k rel (TEq (TIndexRel rel k) lt)` -- reusing existing smt nodes (`TExistsRel`/`TIndexRel`/`TEq`), so **no new node and no encoder change**. `translate_BIn_noncomp` characterises the range case in its RHS; DirectTotality handles it. Membership `eval` is uniformly `None` (`eval_bin BIn` is the catch-all), so DirectSound's BIn case stays vacuous. **Zero-sorry**; `SpecRestGenerated.scala` regenerated.

**2. optional-vs-base membership `opt in S` (encoder).** `tag_filter in t.tags` where `tag_filter: Option[T]`, `t.tags: Set[T]` now encodes as `exists x in S. opt = some(x)` (none is never a member), using existing `Quantifier`/`SetMember`/`Cmp`/`OptSome` nodes -- mirroring #431's optional-equality coercion for the membership case.

## Impact

`todo_list` ListTodos -- `all t in results | t in ran(todos) and (status_filter = none or t.status = status_filter) and ... and (tag_filter = none or tag_filter in t.tags)` -- now fully verifies. **todo_list 45 -> 49.** The remaining 6 skips are `CreateTodo` (the entity-output-construction *interaction*, emergent from full-spec complexity -- out of scope, documented in #420).

No regression: full `verify` suite **248/248**, `SmtLibGoldenTest` unchanged.

## Testing

New `ConsistencyTest` demo `list_filter_demo` -- the full ListTodos filter shape (range-membership + optional membership under universal-over-Seq).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds range membership and Option-vs-Set membership so the ListTodos filter verifies end to end. Completes #420’s ListTodos (todo_list 45 -> 49), keeps verify 248/248, and hardens `in` encoding to reject non-set RHS.

- **New Features**
  - Range membership `t in ran(rel)` desugars to `∃k. rel[k] = t` using existing SMT nodes; no new nodes or encoder changes.
  - Optional-vs-base membership `opt in S` encodes as `∃x ∈ S. opt = some(x)`; `none` is never a member.

- **Bug Fixes**
  - Reject known non-set RHS for `in` instead of emitting ill-sorted `SetMember`; now fails early with a clear translator error.

<sup>Written for commit 17c8ec075d77e2349305895cb7ef6fc33c008ae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved verification of set membership checks when working with optional elements.

* **Tests**
  * Added verification test cases for list filtering operations with optional filter conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->