### PR TITLE
feat(verify): lift sum(coll, i => i.field) aggregates into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -584,6 +584,7 @@ object SpecRestGenerated {
   final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
   final case class TMapEmpty()                                     extends smt_term
   final case class TMapCons(a: smt_term, b: smt_term, c: smt_term) extends smt_term
+  final case class TSum(a: smt_term, b: String)                    extends smt_term
 
   sealed abstract class field_decl
   final case class FieldDeclFull(a: String, b: type_expr, c: Option[expr], d: Option[span_t])
@@ -1815,6 +1816,7 @@ object SpecRestGenerated {
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
     case TMapCons(v, va, vb)    => None
+    case TSum(v, va)            => None
   }
 
   def peelSmtRelationRef(x0: smt_term): Option[String] = x0 match {
@@ -1866,6 +1868,7 @@ object SpecRestGenerated {
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
     case TMapCons(v, va, vb)    => None
+    case TSum(v, va)            => None
   }
 
   def set_diff_smt_vals(l: List[smt_val], r: List[smt_val]): List[smt_val] =
@@ -2806,6 +2809,11 @@ object SpecRestGenerated {
           case (Some(kv), (Some(vv), Some(SMap(ps)))) =>
             Some[smt_val](SMap((kv, vv) :: ps))
         }
+      case (m, env, TSum(c, f)) =>
+        smtEval(m, env, c) match {
+          case None     => None
+          case Some(cv) => Some[smt_val](SInt(BigInt(cv.hashCode + f.hashCode)))
+        }
     }
 
   def binOpToTs(x0: bin_op): String = x0 match {
@@ -3302,6 +3310,7 @@ object SpecRestGenerated {
     case TMapEmpty()           => Nil
     case TMapCons(k, v, r) =>
       smt_var_list(k) ++ (smt_var_list(v) ++ smt_var_list(r))
+    case TSum(c, vn) => smt_var_list(c)
   }
 
   def isIntLit(x0: expr): Boolean = x0 match {
@@ -5168,6 +5177,7 @@ object SpecRestGenerated {
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
     case TMapCons(v, va, vb)    => None
+    case TSum(v, va)            => None
   }
 
   def peel_relation_ref_smt(x0: smt_term): Option[String] = x0 match {
@@ -5219,6 +5229,7 @@ object SpecRestGenerated {
     case TSeqCons(v, va)        => None
     case TMapEmpty()            => None
     case TMapCons(v, va, vb)    => None
+    case TSum(v, va)            => None
   }
 
   def translate_range_eq(setE: smt_term, rel: String): smt_term = {
@@ -5458,7 +5469,153 @@ object SpecRestGenerated {
                 case false => None
               }
           }
-        case (IdentifierF(_, _), _ :: _ :: _) => None
+        case (IdentifierF(_, _), _ :: BinaryOpF(_, _, _, _) :: _)                => None
+        case (IdentifierF(_, _), _ :: UnaryOpF(_, _, _) :: _)                    => None
+        case (IdentifierF(_, _), _ :: QuantifierF(_, _, _, _) :: _)              => None
+        case (IdentifierF(_, _), _ :: SomeWrapF(_, _) :: _)                      => None
+        case (IdentifierF(_, _), _ :: TheF(_, _, _, _) :: _)                     => None
+        case (IdentifierF(_, _), _ :: FieldAccessF(_, _, _) :: _)                => None
+        case (IdentifierF(_, _), _ :: EnumAccessF(_, _, _) :: _)                 => None
+        case (IdentifierF(_, _), _ :: IndexF(_, _, _) :: _)                      => None
+        case (IdentifierF(_, _), _ :: CallF(_, _, _) :: _)                       => None
+        case (IdentifierF(_, _), _ :: PrimeF(_, _) :: _)                         => None
+        case (IdentifierF(_, _), _ :: PreF(_, _) :: _)                           => None
+        case (IdentifierF(_, _), _ :: WithF(_, _, _) :: _)                       => None
+        case (IdentifierF(_, _), _ :: IfF(_, _, _, _) :: _)                      => None
+        case (IdentifierF(_, _), _ :: LetF(_, _, _, _) :: _)                     => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, BinaryOpF(_, _, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, UnaryOpF(_, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, QuantifierF(_, _, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, SomeWrapF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, TheF(_, _, _, _), _) :: _) =>
+          None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(BinaryOpF(_, _, _, _), _, _), _) ::
+              _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(UnaryOpF(_, _, _), _, _), _) :: _) =>
+          None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(QuantifierF(_, _, _, _), _, _), _) ::
+              _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SomeWrapF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(TheF(_, _, _, _), _, _), _) :: _) =>
+          None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(FieldAccessF(_, _, _), _, _), _) ::
+              _
+            ) => None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(EnumAccessF(_, _, _), _, _), _) :: _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IndexF(_, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(CallF(_, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(PrimeF(_, _), _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(PreF(_, _), _, _), _) :: _)   => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(WithF(_, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IfF(_, _, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(LetF(_, _, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(LambdaF(_, _, _), _, _), _) :: _) =>
+          None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(ConstructorF(_, _, _), _, _), _) ::
+              _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SetLiteralF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(MapLiteralF(_, _), _, _), _) :: _) =>
+          None
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(SetComprehensionF(_, _, _, _), _, _), _) ::
+              _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SeqLiteralF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(MatchesF(_, _, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IntLitF(_, _), _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(FloatLitF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(StringLitF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(BoolLitF(_, _), _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(NoneLitF(_), _, _), _) :: _) => None
+        case (
+              IdentifierF(nm, _),
+              List(arg, LambdaF(p, FieldAccessF(IdentifierF(q, _), field, _), _))
+            ) => nm == "sum" && p == q match {
+            case true => map_option[smt_term, smt_term](
+                (c: smt_term) =>
+                  TSum(c, field),
+                translate(enums, arg)
+              )
+            case false => None
+          }
+        case (
+              IdentifierF(_, _),
+              _ :: LambdaF(_, FieldAccessF(IdentifierF(_, _), _, _), _) ::
+              _ :: _
+            ) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, EnumAccessF(_, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, IndexF(_, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, CallF(_, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, PrimeF(_, _), _) :: _)   => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, PreF(_, _), _) :: _)     => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, WithF(_, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, IfF(_, _, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, LetF(_, _, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, LambdaF(_, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, ConstructorF(_, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, SetLiteralF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, MapLiteralF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, SetComprehensionF(_, _, _, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, SeqLiteralF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, MatchesF(_, _, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, IntLitF(_, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, FloatLitF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, StringLitF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, BoolLitF(_, _), _) :: _) => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, NoneLitF(_), _) :: _)    => None
+        case (IdentifierF(_, _), _ :: LambdaF(_, IdentifierF(_, _), _) :: _) =>
+          None
+        case (IdentifierF(_, _), _ :: ConstructorF(_, _, _) :: _)         => None
+        case (IdentifierF(_, _), _ :: SetLiteralF(_, _) :: _)             => None
+        case (IdentifierF(_, _), _ :: MapLiteralF(_, _) :: _)             => None
+        case (IdentifierF(_, _), _ :: SetComprehensionF(_, _, _, _) :: _) => None
+        case (IdentifierF(_, _), _ :: SeqLiteralF(_, _) :: _)             => None
+        case (IdentifierF(_, _), _ :: MatchesF(_, _, _) :: _)             => None
+        case (IdentifierF(_, _), _ :: IntLitF(_, _) :: _)                 => None
+        case (IdentifierF(_, _), _ :: FloatLitF(_, _) :: _)               => None
+        case (IdentifierF(_, _), _ :: StringLitF(_, _) :: _)              => None
+        case (IdentifierF(_, _), _ :: BoolLitF(_, _) :: _)                => None
+        case (IdentifierF(_, _), _ :: NoneLitF(_) :: _)                   => None
+        case (IdentifierF(_, _), _ :: IdentifierF(_, _) :: _)             => None
       }
     case (enums, ConstructorF(name, fas, vl)) =>
       translate_with_assigns(enums, fas, TEntityBase(name))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2616,6 +2616,20 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, Nil, Z3Sort.Int))
         Z3Expr.App(funcName, Nil)
+      // sum(coll, i => i.field): an uninterpreted Int-valued function keyed by the field name and
+      // the collection sort. Same collection => same sum (a functional dependency), so equality
+      // invariants like `subtotal = sum(items, _)` are preserved when the collection is unchanged.
+      // The sum's arithmetic value semantics is not modelled (no finite-sum theory in SMT).
+      case TSum(coll, field) =>
+        val collZ = encodeFromSmtTerm(ctx, coll, env)
+        inferSortOfZ3Expr(ctx, collZ) match
+          case Some(s) =>
+            val funcName = s"aggsum_${field}_${sortNameOf(s)}"
+            if !ctx.funcs.contains(funcName) then
+              ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Int))
+            Z3Expr.App(funcName, List(collZ))
+          case None =>
+            fail(ctx, s"cannot infer collection sort for sum aggregate over field $field")
       case TSeqEmpty() =>
         fail(ctx, "empty sequence literal requires context to infer its element sort")
       case cons @ TSeqCons(_, _) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -407,6 +407,30 @@ class ConsistencyTest extends CatsEffectSuite:
         |    #rel >= 0
         |}""".stripMargin,
       "ListTodos shape (range-membership `t in ran(rel)` + optional membership `tag_filter in t.tags`) must verify, not skip"
+    ),
+    (
+      "sum(coll, i => i.field) aggregate verifies via Z3 as an uninterpreted function (the ecommerce subtotal shape)",
+      "sum_demo",
+      """service SumDemo {
+        |  entity LineItem {
+        |    line_total: Int
+        |  }
+        |  state {
+        |    items: Set[LineItem]
+        |    subtotal: Int
+        |  }
+        |  operation Relabel {
+        |    input: x: Int
+        |    requires:
+        |      true
+        |    ensures:
+        |      items' = pre(items)
+        |      subtotal' = pre(subtotal)
+        |  }
+        |  invariant subtotalIsSum:
+        |    subtotal = sum(items, i => i.line_total)
+        |}""".stripMargin,
+      "sum(items, i => i.line_total) must verify: as an uninterpreted function keyed by collection and field, the invariant `subtotal = sum(items, _)` is preserved when items is unchanged (same collection => same sum)"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -114,16 +114,17 @@ code_printing
 | class_instance Int.int :: ord \<rightharpoonup> (Scala) -
 | class_instance Int.int :: equal \<rightharpoonup> (Scala) -
 
-text \<open>\<open>string_matches\<close>, \<open>str_predicate\<close>, \<open>builtin_const_val\<close>, and \<open>builtin_str_func\<close> are abstract
-  (see \<open>IR\<close>); the real semantics is Z3's (regex \<open>str.in_re\<close>, an uninterpreted predicate / constant /
-  function) in the hand-written translator. The extracted \<open>eval\<close>/\<open>smtEval\<close> reference interpreters are
-  not called by Scala consumers, so these serialisations are never-evaluated stubs that only have
-  to type-check.\<close>
+text \<open>\<open>string_matches\<close>, \<open>str_predicate\<close>, \<open>builtin_const_val\<close>, \<open>builtin_str_func\<close>, and \<open>agg_sum\<close> are
+  abstract (see \<open>IR\<close>); the real semantics is Z3's (regex \<open>str.in_re\<close>, an uninterpreted predicate /
+  constant / function, an uninterpreted sum keyed by collection and field) in the hand-written
+  translator. The extracted \<open>eval\<close>/\<open>smtEval\<close> reference interpreters are not called by Scala consumers,
+  so these serialisations are never-evaluated stubs that only have to type-check.\<close>
 code_printing
   constant string_matches \<rightharpoonup> (Scala) "((_) == (_))"
 | constant str_predicate \<rightharpoonup> (Scala) "((_) == (_))"
 | constant builtin_const_val \<rightharpoonup> (Scala) "(BigInt((_).hashCode))"
 | constant builtin_str_func \<rightharpoonup> (Scala) "((_) + (_))"
+| constant agg_sum \<rightharpoonup> (Scala) "(BigInt((_).hashCode + (_).hashCode))"
 
 export_code
     translate

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -21,7 +21,8 @@ definition builtins_reserved ::
                               \<and> (\<forall>nm. is_builtin_func nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> lookup_callee fs ps (STR ''dom'') = None
                               \<and> lookup_callee fs ps (STR ''range'') = None
-                              \<and> lookup_callee fs ps (STR ''ran'') = None"
+                              \<and> lookup_callee fs ps (STR ''ran'') = None
+                              \<and> lookup_callee fs ps (STR ''sum'') = None"
 
 fun quant_dom ::
   "schema \<Rightarrow> state \<Rightarrow> quant_kind \<Rightarrow> quantifier_binding list

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -71,6 +71,7 @@ datatype (plugins only: code size) smt_term =
   | TSeqCons "smt_term" "smt_term"
   | TMapEmpty
   | TMapCons "smt_term" "smt_term" "smt_term"
+  | TSum "smt_term" "String.literal"
 
 text \<open>\<open>smt_var_list\<close>: every variable name occurring anywhere in a term,
   binders included. Over-approximates the free variables, so a name not in
@@ -125,6 +126,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TSeqCons e r)        = smt_var_list e @ smt_var_list r"
 | "smt_var_list TMapEmpty             = []"
 | "smt_var_list (TMapCons k v r)      = smt_var_list k @ smt_var_list v @ smt_var_list r"
+| "smt_var_list (TSum c _)            = smt_var_list c"
 
 text \<open>\<open>fresh_var base avoid\<close>: the first of \<open>base\<close>, \<open>base_\<close>, \<open>base__\<close>, ...
   not in \<open>avoid\<close>. The candidates have strictly increasing lengths, so among
@@ -332,6 +334,14 @@ definition set_diff_smt_vals ::
   "smt_val list \<Rightarrow> smt_val list \<Rightarrow> smt_val list" where
   "set_diff_smt_vals l r \<equiv> dedupe_smt_vals (filter (\<lambda>v. \<not> contains_smt_val r v) l)"
 
+text \<open>\<open>agg_sum coll field\<close> is the uninterpreted value of \<open>sum(coll, i => i.field)\<close>: abstract, like
+  \<open>str_predicate\<close>, so the trusted translator emits it as a Z3 uninterpreted function of the
+  collection (same collection + field \<Rightarrow> same sum). It captures the functional dependency of the
+  aggregate on its collection, not the arithmetic of summation (finite sums are not expressible in
+  first-order SMT); the obligation is vacuous on the reference \<open>eval\<close> (a 2-arg \<open>CallF\<close> evaluates to
+  \<open>None\<close>), so any realisation is sound.\<close>
+consts agg_sum :: "smt_val \<Rightarrow> String.literal \<Rightarrow> int"
+
 function (sequential) smtEval :: "smt_model \<Rightarrow> smt_env \<Rightarrow> smt_term \<Rightarrow> smt_val option"
 and smtEval_forall_enum ::
   "smt_model \<Rightarrow> smt_env \<Rightarrow> String.literal \<Rightarrow> String.literal
@@ -534,6 +544,10 @@ where
      (case (smtEval m env k, smtEval m env v, smtEval m env rest) of
         (Some kv, Some vv, Some (SMap ps)) \<Rightarrow> Some (SMap ((kv, vv) # ps))
       | _ \<Rightarrow> None)"
+| "smtEval m env (TSum c f) =
+     (case smtEval m env c of
+        Some cv \<Rightarrow> Some (SInt (agg_sum cv f))
+      | None    \<Rightarrow> None)"
 
 | "smtEval_forall_enum m env var sort_name [] body = Some (SBool True)"
 | "smtEval_forall_enum m env var sort_name (mem # rest) body =

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -134,6 +134,10 @@ where
              else None)
       | (IdentifierF nm _, []) \<Rightarrow>
           (if is_builtin_const nm then Some (TUConst nm) else None)
+      | (IdentifierF nm _, [coll, LambdaF p (FieldAccessF (IdentifierF q _) field _) _]) \<Rightarrow>
+          (if nm = STR ''sum'' \<and> p = q
+             then map_option (\<lambda>c. TSum c field) (translate enums coll)
+             else None)
       | _ \<Rightarrow> None)"
 | "translate enums (ConstructorF name fas _) =
      translate_with_assigns enums fas (TEntityBase name)"

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -24,6 +24,18 @@ proof -
     unfolding req by (cases fuel) (simp_all add: lk nb nf)
 qed
 
+lemma sum_eval_None:
+  assumes res: "builtins_reserved fs ps"
+      and tr: "translate enums (CallF (IdentifierF nm sp1) (arg # a # list) sp) = Some t"
+  shows "eval fs ps fuel s st env (CallF (IdentifierF nm sp1) (arg # a # list) sp) = None"
+proof -
+  have nmsum: "nm = STR ''sum''"
+    using tr by (auto split: if_splits option.splits list.splits expr.splits)
+  have lk: "lookup_callee fs ps nm = None"
+    using res nmsum by (simp add: builtins_reserved_def)
+  show ?thesis by (cases fuel) (simp_all add: lk)
+qed
+
 lemma binop_noncomp_step:
   assumes deN: "dom_eq_domains fs ps st bop l r = None"
       and bcN: "beq_comp bop r = None"
@@ -523,39 +535,51 @@ next
     show ?thesis using teq veq by simp
   next
     case (Cons arg rest)
-    have aeq: "args = [arg]"
-      using "15.prems"(2) ceq Cons by (cases rest) (auto split: if_splits option.splits)
+    note args_eq = Cons
     show ?thesis
-    proof (cases "is_builtin_pred nm")
-      case True
-      obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
-        using "15.prems"(2) ceq aeq True by (auto split: if_splits option.splits)
-      have lc_none: "lookup_callee fs ps nm = None"
-        using "15.prems"(4) True by (simp add: builtins_reserved_def)
-      from "15.prems"(1) fuel ceq aeq lc_none True obtain str where
-          ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-          and veq: "v = VBool (str_predicate nm str)"
-        by (auto split: option.splits ir_value.splits if_splits)
-      have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
-        using "15.IH" fuel ceq aeq lc_none True ea ta "15.prems"(3) "15.prems"(4)
-        by (auto split: if_splits)
-      show ?thesis using teq veq ev by simp
+    proof (cases rest)
+      case Nil
+      have aeq: "args = [arg]" using args_eq Nil by simp
+      show ?thesis
+      proof (cases "is_builtin_pred nm")
+        case True
+        obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrPred nm argt"
+          using "15.prems"(2) ceq aeq True by (auto split: if_splits option.splits)
+        have lc_none: "lookup_callee fs ps nm = None"
+          using "15.prems"(4) True by (simp add: builtins_reserved_def)
+        from "15.prems"(1) fuel ceq aeq lc_none True obtain str where
+            ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+            and veq: "v = VBool (str_predicate nm str)"
+          by (auto split: option.splits ir_value.splits if_splits)
+        have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+          using "15.IH" fuel ceq aeq lc_none True ea ta "15.prems"(3) "15.prems"(4)
+          by (auto split: if_splits)
+        show ?thesis using teq veq ev by simp
+      next
+        case False
+        have bif: "is_builtin_func nm"
+          using "15.prems"(2) ceq aeq False by (auto split: if_splits option.splits)
+        obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrFunc nm argt"
+          using "15.prems"(2) ceq aeq False bif by (auto split: if_splits option.splits)
+        have lc_none: "lookup_callee fs ps nm = None"
+          using "15.prems"(4) bif by (simp add: builtins_reserved_def)
+        from "15.prems"(1) fuel ceq aeq lc_none False bif obtain str where
+            ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+            and veq: "v = VStr (builtin_str_func nm str)"
+          by (auto split: option.splits ir_value.splits if_splits)
+        have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+          using "15.IH" fuel ceq aeq lc_none False bif ea ta "15.prems"(3) "15.prems"(4)
+          by (auto split: if_splits)
+        show ?thesis using teq veq ev by simp
+      qed
     next
-      case False
-      have bif: "is_builtin_func nm"
-        using "15.prems"(2) ceq aeq False by (auto split: if_splits option.splits)
-      obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrFunc nm argt"
-        using "15.prems"(2) ceq aeq False bif by (auto split: if_splits option.splits)
-      have lc_none: "lookup_callee fs ps nm = None"
-        using "15.prems"(4) bif by (simp add: builtins_reserved_def)
-      from "15.prems"(1) fuel ceq aeq lc_none False bif obtain str where
-          ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-          and veq: "v = VStr (builtin_str_func nm str)"
-        by (auto split: option.splits ir_value.splits if_splits)
-      have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
-        using "15.IH" fuel ceq aeq lc_none False bif ea ta "15.prems"(3) "15.prems"(4)
-        by (auto split: if_splits)
-      show ?thesis using teq veq ev by simp
+      case (Cons b list)
+      have args2: "args = arg # b # list" using args_eq Cons by simp
+      have tr2: "translate enums (CallF (IdentifierF nm sp1) (arg # b # list) sp) = Some t"
+        using "15.prems"(2) ceq args2 by simp
+      have "eval fs ps fuel s st env (CallF (IdentifierF nm sp1) (arg # b # list) sp) = None"
+        by (rule sum_eval_None[OF "15.prems"(4) tr2])
+      then show ?thesis using "15.prems"(1) ceq args2 by simp
     qed
   qed
 next

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -220,6 +220,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TSeqCons e r)         = (smt_uses_var x e \<or> smt_uses_var x r)"
 | "smt_uses_var x TMapEmpty              = False"
 | "smt_uses_var x (TMapCons k v r)       = (smt_uses_var x k \<or> smt_uses_var x v \<or> smt_uses_var x r)"
+| "smt_uses_var x (TSum c _)             = smt_uses_var x c"
 
 lemma smtEval_drop_irrelevant:
   "\<not> smt_uses_var x t \<or> map_of pre x \<noteq> None


### PR DESCRIPTION
## What

Lifts field-projection `sum` aggregates (`sum(items, i => i.line_total)`) into the verified subset. Previously these hit a hard `expression kind 'Lambda' is not yet supported` translator error that aborted verification of any spec containing them.

The aggregate is modelled as an **uninterpreted Int-valued function keyed by the collection and the field name** - the weakest sound model (SMT has no finite-sum theory). Same collection means same sum (a functional dependency), so equality invariants like `subtotal = sum(items, _)` are preserved when the collection is unchanged.

## Proof (zero-sorry across all 3 sessions)

- **Smt.thy** - new `TSum smt_term String.literal` node and abstract `agg_sum :: smt_val => String.literal => int` constant; `smtEval` / `smt_var_list` / `smt_uses_var` arms.
- **Translate.thy** - a `CallF` recognizer desugars `sum(coll, i => i.field)` to `TSum (translate coll) field` (requires the lambda param to equal the field-access base, i.e. a pure `i => i.field` projection).
- **Semantics_Reference.thy** - `sum` joins `builtins_reserved`; `eval` of the 2-arg `CallF` is `None`, so the construct is **vacuous-on-eval**. `DirectSound` case 15 gains a 2-arg sub-case discharged via a new `sum_eval_None` lemma - the same soundness argument as #425 / #426 / #428.
- **Codegen.thy** - never-evaluated `agg_sum` serialisation stub.

## Encoder

`TSum` lowers to an uninterpreted `aggsum_<field>_<sort>(coll): Int` application (one new case in `encodeFromSmtTerm`, no new `Z3Expr` node - it reuses `App`, mirroring the `now()` / `hash(x)` uninterpreted-builtin precedent).

## Caveat (material)

The uninterpreted model verifies **functional** invariants (the sum is a function of its inputs - catches recompute / consistency mismatches) but **not** the arithmetic value semantics (`sum >= 0`, `sum + tax = total` with concrete values, or that appending an item increases the sum by that item's field). Modelling the finite-sum arithmetic is research-grade.

## Impact

- New `sum_demo` consistency test verifies **4/4** (the invariant `subtotal = sum(items, i => i.line_total)` is preserved across an operation that leaves `items` unchanged).
- The lift removes `ecommerce`'s `Lambda` hard-error. **`ecommerce` stays 0/89**, though: the now-dominant blocker is `#items` cardinality on an *entity-field* `Set` (32 checks; `#items` currently requires a state relation) plus other outside-lower constructs (57). Both are orthogonal to `sum` and are the next #420 blocks - the Lambda error was previously masking them.

## Validation

- `isabelle build SpecRest_Core SpecRest_Soundness SpecRest_Codegen` - zero sorry.
- `SpecRestGenerated.scala` regenerated via the documented pipeline.
- `sbt verify/test` - all green (ConsistencyTest 38 tests incl. `sum_demo`; SmtLib goldens unchanged).
- `sbt scalafmtCheckAll` - clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts field-projection sum aggregates like sum(items, i => i.line_total) into the verified subset by encoding them as an uninterpreted Int function keyed by collection and field. This removes the previous Lambda translator error and enables equality-style invariants (e.g., subtotal = sum(items, ...)) to verify.

- New Features
  - Translate sum(coll, i => i.field) to a new `TSum` term; encode as `aggsum_<field>_<sort>(coll): Int` (uninterpreted).
  - Mark `sum` as a reserved builtin; add `agg_sum` stub and update `smtEval`, `smt_var_list`, and var-usage.
  - Extend soundness with vacuous-on-eval handling and a `sum_eval_None` lemma.
  - Add `sum_demo` test; removes the ecommerce Lambda hard-error and unblocks part of #420 (remaining blockers are unrelated).
  - Scope: validates functional equality invariants only; numeric properties of sums are not modeled.

<sup>Written for commit f2f637e9b50524fc13ace218f87d9911ea9fa8e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended verification system to support aggregate sum operations in consistency checks. Users can now create and verify invariants that validate the sum of field values across collections against expected totals, such as verifying that an invoice's subtotal matches the sum of individual line items.

* **Tests**
  * Added test coverage for aggregate sum behavior in consistency checks, expanding verification capabilities for real-world aggregate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->