### PR TITLE
feat(verify): model #-cardinality on entity-field Sets (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1084,6 +1084,31 @@ object Translator:
           s"cardinality '#$targetName' requires a state relation; '$targetName' is not declared as one"
         )
 
+  // Cardinality of a set-valued operand (an entity-field `Set` or a local set binder):
+  // an uninterpreted `setCard : SetOf(elem) -> Int` with a one-off `forall s. setCard(s) >= 0`
+  // axiom. Z3's set theory has no native cardinality, so this is the same uninterpreted,
+  // functional (same set => same count) model used for state-relation cardinality; `#x` is
+  // vacuous under the reference semantics (`eval_un` has no cardinality case), so any
+  // non-negative interpretation is sound.
+  private def entitySetCardinality(ctx: TranslateCtx, setExpr: Z3Expr): Z3Expr =
+    inferSortOfZ3Expr(ctx, setExpr) match
+      case Some(Z3Sort.SetOf(elem)) =>
+        val funcName = s"setCard_${sortNameOf(elem)}"
+        if !ctx.funcs.contains(funcName) then
+          ctx.declareFunc(Z3FunctionDecl(funcName, List(Z3Sort.SetOf(elem)), Z3Sort.Int))
+          ctx.assertions += Z3Expr.Quantifier(
+            QKind.ForAll,
+            List(Z3Binding("setcard_s", Z3Sort.SetOf(elem))),
+            Z3Expr.Cmp(
+              CmpOp.Ge,
+              Z3Expr.App(funcName, List(Z3Expr.Var("setcard_s", Z3Sort.SetOf(elem)))),
+              Z3Expr.IntLit(BigInt(0))
+            )
+          )
+        Z3Expr.App(funcName, List(setExpr))
+      case _ =>
+        fail(ctx, "cardinality '#' on a non-relation operand requires a set-typed value")
+
   private def translateQuantifier(
       ctx: TranslateCtx,
       q: QuantifierF,
@@ -2313,7 +2338,13 @@ object Translator:
 
       case TInDom(rel, elem) =>
         encInDom(ctx, rel, elem, ctx.stateMode, env)
-      case TCardRel(rel) => cardinalityRefFor(ctx, rel, ctx.stateMode)
+      // `#x`: a state relation gets its cardinality constant; an `x` bound in `env`
+      // (an entity-field `Set`, e.g. `#items` inside an Order invariant, or a local
+      // set binder) is a set-valued operand and gets the uninterpreted setCard model.
+      case TCardRel(rel) =>
+        env.get(rel) match
+          case Some(setExpr) => entitySetCardinality(ctx, setExpr)
+          case None          => cardinalityRefFor(ctx, rel, ctx.stateMode)
 
       case TLetIn(name, value, body) =>
         val v      = encodeFromSmtTerm(ctx, value, env)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -431,6 +431,30 @@ class ConsistencyTest extends CatsEffectSuite:
         |    subtotal = sum(items, i => i.line_total)
         |}""".stripMargin,
       "sum(items, i => i.line_total) must verify: as an uninterpreted function keyed by collection and field, the invariant `subtotal = sum(items, _)` is preserved when items is unchanged (same collection => same sum)"
+    ),
+    (
+      "#contents on an entity-field Set verifies via Z3 (the ecommerce #items shape)",
+      "entity_set_card_demo",
+      """service EntitySetCardDemo {
+        |  entity Bag {
+        |    contents: Set[Int]
+        |    count: Int
+        |    invariant: #contents > 0 implies count > 0
+        |  }
+        |  state {
+        |    n: Int
+        |  }
+        |  operation Bump {
+        |    input: x: Int
+        |    requires:
+        |      true
+        |    ensures:
+        |      n' = pre(n) + x
+        |  }
+        |  invariant nonneg:
+        |    true
+        |}""".stripMargin,
+      "#contents on an entity-field Set (an Order's `#items` shape) must verify, not skip on 'cardinality requires a state relation' - it gets the uninterpreted setCard model"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

`#items` where `items` is an **entity-field `Set`** (e.g. the ecommerce Order invariant `#items > 0 implies total > 0`) previously failed the encoder with `cardinality '#items' requires a state relation`, aborting every check that carried that entity's invariants.

`#x` is already in the verified subset (`translate` produces `TCardRel x`, `Translate.thy`) and is **vacuous under the reference semantics** (`eval_un` has no cardinality case, so `eval (#x) = None`), so the encoder is free to model it soundly - the same situation as state-relation cardinality (#425).

## How

The `TCardRel` encoder case now checks whether the operand name is bound in the local `env` to a set-valued expression (an entity field under the `forall self. inv(self)` entity-invariant encoding, or a local set binder):

- **bound to a `Set`** -> uninterpreted `setCard_<elem> : SetOf(elem) -> Int` with a one-off `forall s. setCard(s) >= 0` axiom, applied to the set expression. Same set => same count (functional); non-negative.
- **otherwise** -> the existing state-relation cardinality path (unchanged).

Z3's set theory has no native cardinality, so this mirrors the uninterpreted-`Int` model already used for state relations - just parameterised by the set value (a function rather than a constant), because an entity-field set varies per entity instance.

The non-negativity axiom is a `forall` (not a per-use assertion) because `#items` is encoded *inside* `forall self. inv(self)`, so the set operand references the bound `self`; the universal binds its own `s` and covers every instantiation.

**Encoder-only**: no proof / `.thy` / regen change.

## Soundness

`#x` is vacuous-on-eval, so `direct_soundness` does not constrain it; any non-negative interpretation is sound. The model is the established uninterpreted-cardinality TCB extension (#425), now covering set-valued operands.

## Impact

- **ecommerce 0/89 -> 8/89** - the Order entity invariants now translate, unblocking 8 checks.
- New `entity_set_card_demo` verifies **4/4**.
- Remaining ecommerce translator skips are all `field access requires entity sort` (a separate construct, the next block); 57 checks stay outside-lower.

## Validation

- `sbt verify/test` - all green (ConsistencyTest 39 incl. the new demo).
- `sbt scalafmtCheckAll` - clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `#` cardinality on entity-field `Set` operands (e.g., `#items`) so entity invariants translate instead of skipping. This unblocks 8 ecommerce checks and the new demo verifies 4/4.

- New Features
  - When `#x` refers to a set bound in the local env, encode it as an uninterpreted `setCard_<elem>: SetOf(elem) -> Int` with a single `forall s. setCard(s) >= 0` axiom.
  - If not set-bound, keep the existing state-relation cardinality handling unchanged.

<sup>Written for commit 0cd2abfd435ed3f0a848fdaefc1aef09f39e6dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

