### PR TITLE
feat(verify): lift universal quantification over field-access sets into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5688,7 +5688,173 @@ object SpecRestGenerated {
         case None => None
         case Some(bodya) =>
           k match {
-            case QAll() => translate_forall_bindings(enums, bs, bodya)
+            case QAll() =>
+              bs match {
+                case Nil => translate_forall_bindings(enums, bs, bodya)
+                case List(QuantifierBindingFull(v, d, _, _)) =>
+                  d match {
+                    case BinaryOpF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case UnaryOpF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case QuantifierF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case SomeWrapF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case TheF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case FieldAccessF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case EnumAccessF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case IndexF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case CallF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case PrimeF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case PreF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case WithF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case IfF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case LetF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case LambdaF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case ConstructorF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case SetLiteralF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case MapLiteralF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case SetComprehensionF(_, _, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case SeqLiteralF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case MatchesF(_, _, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case IntLitF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case FloatLitF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case StringLitF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case BoolLitF(_, _) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case NoneLitF(_) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, bodya),
+                        translate(enums, d)
+                      )
+                    case IdentifierF(_, _) =>
+                      translate_forall_bindings(enums, bs, bodya)
+                  }
+                case QuantifierBindingFull(_, _, _, _) :: _ :: _ =>
+                  translate_forall_bindings(enums, bs, bodya)
+              }
             case QSome() =>
               map_option[smt_term, smt_term](
                 (a: smt_term) => TNot(a),

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -478,6 +478,31 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "#(boxes[bid].contents) - cardinality of a set-valued field-access (not a bare relation identifier) - must verify: `#expr` lowers to TCard and gets the uninterpreted setCard model"
+    ),
+    (
+      "universal quantification over a field-access set verifies via Z3 (the ecommerce lineItemTotalConsistency shape)",
+      "set_forall_field_demo",
+      """service SetForallFieldDemo {
+        |  entity Item {
+        |    qty: Int
+        |  }
+        |  entity Box {
+        |    contents: Set[Item]
+        |  }
+        |  state {
+        |    boxes: Int -> lone Box
+        |  }
+        |  operation Touch {
+        |    input: bid: Int
+        |    requires:
+        |      true
+        |    ensures:
+        |      boxes' = pre(boxes)
+        |  }
+        |  invariant allQtyNonNeg:
+        |    all bid in boxes | all it in boxes[bid].contents | it.qty >= 0
+        |}""".stripMargin,
+      "`all it in boxes[bid].contents | it.qty >= 0` - a universal whose domain is a field-access set (not a bare identifier) - must verify: it lowers to TForallSet and the binder resolves to the Item entity sort"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -155,7 +155,13 @@ where
         None \<Rightarrow> None
       | Some body' \<Rightarrow>
           (case k of
-             QAll \<Rightarrow> translate_forall_bindings enums bs body'
+             QAll \<Rightarrow>
+               (case bs of
+                  [QuantifierBindingFull v d _ _] \<Rightarrow>
+                    (case d of
+                       IdentifierF _ _ \<Rightarrow> translate_forall_bindings enums bs body'
+                     | _ \<Rightarrow> map_option (\<lambda>d'. TForallSet v d' body') (translate enums d))
+                | _ \<Rightarrow> translate_forall_bindings enums bs body')
            | QNo \<Rightarrow> translate_forall_bindings enums bs (TNot body')
            | QSome \<Rightarrow>
                map_option TNot (translate_forall_bindings enums bs (TNot body'))

--- a/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
@@ -237,7 +237,27 @@ proof (induction e rule: measure_induct_rule[where f = size])
     show ?thesis
     proof (cases k)
       case QAll
-      thus ?thesis using QuantifierF hb dfb_some_of_wf[OF wb] by auto
+      show ?thesis
+      proof (cases bs)
+        case Nil
+        thus ?thesis using wb by simp
+      next
+        case (Cons b rest)
+        note bs_eq = Cons
+        show ?thesis
+        proof (cases rest)
+          case Nil
+          have "is_ident_dom b" using wb bs_eq Nil by simp
+          then obtain v dnm sp3 bk ex
+            where "b = QuantifierBindingFull v (IdentifierF dnm sp3) bk ex"
+            by (cases b rule: is_ident_dom.cases) auto
+          thus ?thesis using QuantifierF QAll hb dfb_some_of_wf[OF wb] bs_eq Nil by auto
+        next
+          case (Cons b2 rest2)
+          thus ?thesis using QuantifierF QAll hb dfb_some_of_wf[OF wb] bs_eq Cons
+            by (auto split: quantifier_binding.splits)
+        qed
+      qed
     next
       case QNo
       thus ?thesis using QuantifierF hb dfb_some_of_wf[OF wb] by auto


### PR DESCRIPTION
## What

`all item in orders[oid].items | P` - a universal whose **domain is a set-valued expression** (a field-access set) rather than a bare relation/enum identifier - was outside the verified subset. `translate_forall_step` only recognised `IdentifierF` domains (`TForallRel` / `TForallEnum`), so a non-identifier domain fell to `None` (`outside lower's coverage`).

This generalises the `QuantifierF` translate case: a single-binding `QAll` whose domain is a non-identifier expression lowers to `TForallSet` (the node already used for set-comprehension equality), wrapping `translate(domain)`.

## Why it's a clean, vacuous lift

**Vacuous-on-eval**: `eval(QuantifierF) = case quant_dom s st k bs of Some _ => eval_forall | None => None`, and `quant_dom` only matches a single-binding `QAll` over an *identifier* domain - any non-identifier (or multi-binding) domain gives `None`. So `eval(all x in <set-expr> | P) = None` and `direct_soundness` is vacuous.

The DirectSound `QuantifierF` case and DirectPreservation absorbed the new `TForallSet` result with **no edits**. Only the `wf_z3`-totality lemma's `QAll` case needed restructuring to navigate the new translate shape - and `wf_z3_bindings` still pins a single well-formed binding to an identifier, so the `TForallSet` branch is unreachable under `wf_z3` (vacuous there too). Built zero-sorry across all 3 sessions.

## No encoder change

The `TForallSet` encoder case already binds the variable at the set's element sort (so `item.line_total` resolves to the `LineItem` entity sort) and emits `forall v. (v in S -> body)`.

## Impact

- **ecommerce 9/89 -> 59/89** - the nested `all item in orders[oid].items` quantifier was the dominant blocker (it sits in `lineItemTotalConsistency`, asserted as background in ~50 checks), so lifting it unblocked them all at once.
- New `set_forall_field_demo` verifies **4/4**.
- No regressions: url_shortener 21/21, todo_list 49/55, auth_service unchanged.

Two checks now surface violations (`RecordPayment` vs `paidOrdersHavePayments` / `cancelledPaidOrdersHaveRefunds`) - previously skipped, now reachable, and found to have incomplete payment frames. These use relation-quantifiers (already supported); the lift only made the checks reachable. Same spec-completeness class as `auth_service`'s known violations, not a verifier soundness issue. A new translator limit (`addition requires numeric` on AddLineItem's `with`-update arithmetic, 6 checks) is the next gap.

## Validation

- `isabelle build` (Core/Soundness/Codegen) - zero sorry.
- `SpecRestGenerated.scala` regenerated via the documented pipeline.
- `sbt verify/test` - green (ConsistencyTest 41 incl. the new demo).
- `sbt scalafmtCheckAll` - clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for universal quantification over set-valued expressions (e.g., all item in orders[oid].items) by lowering to `TForallSet`. This expands the verified subset and unblocks many checks without changing the encoder.

- **New Features**
  - Translator: single-binding `QAll` with a non-identifier domain now lowers to `TForallSet( v, translate(domain), body )`; identifier domains still use `TForallRel/Enum`.
  - Proofs: updated `Translate.thy` and `DirectTotality.thy`; soundness cases remain unchanged and the new branch is vacuous under `wf_z3`.
  - Encoder: no change; the existing `TForallSet` path binds at the element sort and emits `forall v. (v in S -> body)`.
  - Tests/impact: added `set_forall_field_demo` (4/4 green). `ecommerce` 9/89 → 59/89; no regressions in other suites. Two checks now correctly surface spec violations. Regenerated `SpecRestGenerated.scala`.

<sup>Written for commit f7cdab90755e55178c9b44f5ccbaf152a9227ead. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test case for universal quantification over field-access sets, verifying correct lowering and entity binding resolution.

* **Refactor**
  * Refined translation and verification of universal quantifiers with improved handling for non-identifier domains and structured binding analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->