### PR TITLE
feat(verify): encode set union (set + set) in the verified subset (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2224,11 +2224,20 @@ object Translator:
       inferSortOfZ3Expr(ctx, z) match
         case Some(Z3Sort.SeqOf(_)) => true
         case _                     => false
+    // `set + set` is set union (e.g. `items + {item}`); both operands must share an element sort.
+    def sameSet(a: Z3Expr, b: Z3Expr): Boolean =
+      (inferSortOfZ3Expr(ctx, a), inferSortOfZ3Expr(ctx, b)) match
+        case (Some(Z3Sort.SetOf(ae)), Some(Z3Sort.SetOf(be))) => Z3Sort.eq(ae, be)
+        case _                                                => false
     if isStr(lz) && isStr(rz) then Z3Expr.StrConcat(lz, rz)
     else if isSeq(lz) && isSeq(rz) then Z3Expr.SeqConcat(lz, rz)
     else if isNum(lz) && isNum(rz) then Z3Expr.Arith(ArithOp.Add, List(lz, rz))
+    else if sameSet(lz, rz) then Z3Expr.SetBinOp(SetOpKind.Union, lz, rz)
     else
-      fail(ctx, "addition requires two numeric (Int or Real), two String, or two Seq operands")
+      fail(
+        ctx,
+        "addition requires two numeric (Int or Real), two String, two Seq, or two Set operands"
+      )
 
   private def encodeSetEmptyCmp(
       ctx: TranslateCtx,

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -503,6 +503,28 @@ class ConsistencyTest extends CatsEffectSuite:
         |    all bid in boxes | all it in boxes[bid].contents | it.qty >= 0
         |}""".stripMargin,
       "`all it in boxes[bid].contents | it.qty >= 0` - a universal whose domain is a field-access set (not a bare identifier) - must verify: it lowers to TForallSet and the binder resolves to the Item entity sort"
+    ),
+    (
+      "set union via `+` verifies via Z3 (the ecommerce `items + {item}` shape)",
+      "set_union_demo",
+      """service SetUnionDemo {
+        |  entity It {
+        |    v: Int
+        |  }
+        |  state {
+        |    seen: Set[It]
+        |  }
+        |  operation Add {
+        |    input: x: It
+        |    requires:
+        |      true
+        |    ensures:
+        |      seen' = pre(seen) + {x}
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`seen' = pre(seen) + {x}` - `+` on two Set operands - must verify as set union, not skip on 'addition requires numeric'"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

`items + {item}` - `+` on two `Set` operands (e.g. AddLineItem's `items = pre(orders)[order_id].items + {item}`) - failed the encoder with `addition requires two numeric/String/Seq operands`. `encAdd` handled Str (concat), Seq (concat), and Num (add), but not two `Set`s.

`+` on sets is **set union**, and it is vacuous under the reference semantics: `eval_arith` on `AddOp` is `None` for non-numeric/string/seq operands, and `smtEval`'s `TAdd` has no `Set` case - both return `None`. So the encoder is free to synthesize it soundly. Two `Set` operands sharing an element sort now lower to a `SetBinOp(Union)`.

**Pure encoder change** - no proof / `.thy` / regen.

## Impact

- **ecommerce 59/89 -> 65/89** - the 6 `AddLineItem.preserves.*` translator skips clear. ecommerce now has **zero translator-coverage skips**: every construct inside the verified subset encodes. The remaining 24 unverified checks are 22 outside-lower (soundness) + 2 `RecordPayment` spec-completeness violations.
- New `set_union_demo` verifies **4/4**.
- No regressions: url_shortener 21/21, todo_list 49/55, auth_service unchanged.

## Validation

- `sbt verify/test` - green (ConsistencyTest 42 incl. the new demo).
- `sbt scalafmtCheckAll` - clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode `Set + Set` as set union in the verifier so expressions like `items + {item}` compile and verify. This removes a translator skip and improves ecommerce coverage with no regressions.

- **New Features**
  - `+` on two sets lowers to `SetBinOp(Union)` when element sorts match.
  - Error message now mentions Set when addition operands are invalid.
  - Added `set_union_demo` to `ConsistencyTest` (passes 4/4).
  - Ecommerce: 59/89 → 65/89; clears 6 `AddLineItem.preserves.*` translator skips; no regressions (`url_shortener` 21/21, `todo_list` 49/55, `auth_service` unchanged).

<sup>Written for commit 3bac865f166adf206c285b0781affaff3dd9df2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

