### PR TITLE
feat(verify): lift existential/negative quantifiers over set domains into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5910,16 +5910,50 @@ object SpecRestGenerated {
                   translate_forall_bindings(enums, bs, bodya)
               }
             case QSome() =>
-              map_option[smt_term, smt_term](
-                (a: smt_term) => TNot(a),
-                translate_forall_bindings(enums, bs, TNot(bodya))
-              )
-            case QNo() => translate_forall_bindings(enums, bs, TNot(bodya))
+              translate_forall_bindings(enums, bs, TNot(bodya)) match {
+                case None =>
+                  bs match {
+                    case Nil => None
+                    case List(QuantifierBindingFull(v, d, _, _)) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TNot(TForallSet(v, da, TNot(bodya))),
+                        translate(enums, d)
+                      )
+                    case QuantifierBindingFull(_, _, _, _) :: _ :: _ => None
+                  }
+                case Some(t) => Some[smt_term](TNot(t))
+              }
+            case QNo() =>
+              translate_forall_bindings(enums, bs, TNot(bodya)) match {
+                case None =>
+                  bs match {
+                    case Nil => None
+                    case List(QuantifierBindingFull(v, d, _, _)) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TForallSet(v, da, TNot(bodya)),
+                        translate(enums, d)
+                      )
+                    case QuantifierBindingFull(_, _, _, _) :: _ :: _ => None
+                  }
+                case Some(a) => Some[smt_term](a)
+              }
             case QExists() =>
-              map_option[smt_term, smt_term](
-                (a: smt_term) => TNot(a),
-                translate_forall_bindings(enums, bs, TNot(bodya))
-              )
+              translate_forall_bindings(enums, bs, TNot(bodya)) match {
+                case None =>
+                  bs match {
+                    case Nil => None
+                    case List(QuantifierBindingFull(v, d, _, _)) =>
+                      map_option[smt_term, smt_term](
+                        (da: smt_term) =>
+                          TNot(TForallSet(v, da, TNot(bodya))),
+                        translate(enums, d)
+                      )
+                    case QuantifierBindingFull(_, _, _, _) :: _ :: _ => None
+                  }
+                case Some(t) => Some[smt_term](TNot(t))
+              }
           }
       }
     case (enums, UnaryOpF(op, e, vu)) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -554,6 +554,32 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`some p in payments' | p not in pre(payments) and payments'[p].status = REFUNDED` - an existential whose domain is a primed state relation - must verify, not skip: it lowers to TNot(TPrime(TForallRel ...)) and the encoder composes the post-state domain via stateMode"
+    ),
+    (
+      "existential over a field-access set verifies via Z3 (the ecommerce `some i in orders[oid].items` shape)",
+      "set_exists_demo",
+      """service SetExistsDemo {
+        |  entity Item {
+        |    id: Int
+        |  }
+        |  entity Box {
+        |    contents: Set[Item]
+        |  }
+        |  state {
+        |    boxes: Int -> lone Box
+        |  }
+        |  operation Find {
+        |    input: bid: Int, target: Int
+        |    requires:
+        |      bid in boxes
+        |      some it in boxes[bid].contents | it.id = target
+        |    ensures:
+        |      boxes' = pre(boxes)
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`some it in boxes[bid].contents | it.id = target` - an existential whose domain is a field-access set (not an identifier) - must verify, not skip: QSome over a non-identifier domain lowers to TNot(TForallSet ...), mirroring #440's QAll path"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -164,11 +164,23 @@ where
                        IdentifierF _ _ \<Rightarrow> translate_forall_bindings enums bs body'
                      | _ \<Rightarrow> map_option (\<lambda>d'. TForallSet v d' body') (translate enums d))
                 | _ \<Rightarrow> translate_forall_bindings enums bs body')
-           | QNo \<Rightarrow> translate_forall_bindings enums bs (TNot body')
-           | QSome \<Rightarrow>
-               map_option TNot (translate_forall_bindings enums bs (TNot body'))
-           | QExists \<Rightarrow>
-               map_option TNot (translate_forall_bindings enums bs (TNot body'))))"
+           | QNo \<Rightarrow>
+               (case translate_forall_bindings enums bs (TNot body') of
+                  Some t \<Rightarrow> Some t
+                | None \<Rightarrow>
+                    (case bs of
+                       [QuantifierBindingFull v d _ _] \<Rightarrow>
+                         map_option (\<lambda>d'. TForallSet v d' (TNot body')) (translate enums d)
+                     | _ \<Rightarrow> None))
+           | _ \<Rightarrow>
+               \<comment> \<open>QSome and QExists: both existential, \<open>\<exists>x. P \<equiv> \<not>(\<forall>x. \<not>P)\<close>\<close>
+               (case translate_forall_bindings enums bs (TNot body') of
+                  Some t \<Rightarrow> Some (TNot t)
+                | None \<Rightarrow>
+                    (case bs of
+                       [QuantifierBindingFull v d _ _] \<Rightarrow>
+                         map_option (\<lambda>d'. TNot (TForallSet v d' (TNot body'))) (translate enums d)
+                     | _ \<Rightarrow> None))))"
 | "translate enums (UnaryOpF op e _) =
      (case op of
         UNot \<Rightarrow> map_option TNot (translate enums e)

--- a/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectTotality.thy
@@ -260,13 +260,19 @@ proof (induction e rule: measure_induct_rule[where f = size])
       qed
     next
       case QNo
-      thus ?thesis using QuantifierF hb dfb_some_of_wf[OF wb] by auto
+      obtain r where "translate_forall_bindings enums bs (TNot bt) = Some r"
+        using dfb_some_of_wf[OF wb] by blast
+      thus ?thesis using QuantifierF QNo hb by auto
     next
       case QSome
-      thus ?thesis using QuantifierF hb dfb_some_of_wf[OF wb] by auto
+      obtain r where "translate_forall_bindings enums bs (TNot bt) = Some r"
+        using dfb_some_of_wf[OF wb] by blast
+      thus ?thesis using QuantifierF QSome hb by auto
     next
       case QExists
-      thus ?thesis using QuantifierF hb dfb_some_of_wf[OF wb] by auto
+      obtain r where "translate_forall_bindings enums bs (TNot bt) = Some r"
+        using dfb_some_of_wf[OF wb] by blast
+      thus ?thesis using QuantifierF QExists hb by auto
     qed
   next
     case (ConstructorF name fas sp2)


### PR DESCRIPTION
## What

Extends #440's `QAll -> TForallSet` set-domain handling to the other quantifier kinds - `QSome` / `QNo` / `QExists` over a non-identifier (field-access set) domain (`some i in orders[oid].items | P`).

The dispatch is now a uniform "try relational first, fall back to set": try `translate_forall_bindings` (which handles identifier, enum, and - via #442 - primed/pre-relation domains); on `None`, fall back to `TForallSet` over the translated set domain. So `some i in S | P` becomes `TNot(TForallSet v S' (TNot body'))`. **No new SMT node, no encoder change** (reuses #440's `TForallSet` encoder).

## Why it's sound (vacuous-on-eval)

`quant_dom` returns `None` for any `QSome`/`QNo`/`QExists` (it matches only `QAll` over an identifier domain), so `eval` is `None` and DirectSound discharges via its existing `quant_dom = None` branch. Only the DirectTotality `QNo`/`QSome`/`QExists` cases change: they `obtain` the `translate_forall_bindings` witness for the concrete `TNot`-body, making the unreachable set-fallback branch provably dead. 3-session zero-sorry build green.

## Impact

ecommerce: RemoveLineItem's `requires` + `enabled` were skipped on `some i in orders[order_id].items | i.id = item_id`; both now decidable and verify. ecommerce **69 -> 71**. Adds `set_exists_demo`; full ConsistencyTest + TranslatorPropTest green (46/46).

Stacked on #442 (primed/pre-relation quantifiers) - base will retarget to `main` once #442 merges. Part of #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables verification of existential and negative quantifiers over set domains by lowering them to `TForallSet`, so cases like `some i in orders[oid].items | P` are checked instead of skipped. Addresses #420 and increases ecommerce verified checks from 69 to 71.

- **New Features**
  - Uniform lowering: try `translate_forall_bindings` (identifier/enum/primed domains); if it returns `None` and there is exactly one binding, fall back to `TForallSet` over the translated set.
  - Supports `QSome`/`QNo`/`QExists` via De Morgan: `some/exists -> TNot(TForallSet ...)`, `no -> TForallSet ...`; uses `TNot(t)` when the relational path succeeds.
  - Reuses existing encoder; no new SMT nodes. Proofs updated to obtain the `translate_forall_bindings` witness for the `TNot` body. Adds `set_exists_demo`; ecommerce RemoveLineItem now verifies.

<sup>Written for commit d2b49f3ce2423c2c58243f1d9d7e2070f13535ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of existential quantification patterns over field-access sets in verification checks to ensure correct validation results.

* **Tests**
  * Added consistency test case for quantified field-access specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->