### PR TITLE
feat(verify): lift the (definite description) over set domains into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -562,6 +562,7 @@ object SpecRestGenerated {
   final case class TTheRel(a: String, b: String, c: smt_term)      extends smt_term
   final case class TEntityBase(a: String)                          extends smt_term
   final case class TForallSet(a: String, b: smt_term, c: smt_term) extends smt_term
+  final case class TTheSet(a: String, b: smt_term, c: smt_term)    extends smt_term
   final case class TIndexRel(a: smt_term, b: smt_term)             extends smt_term
   final case class TFieldAccess(a: smt_term, b: String)            extends smt_term
   final case class TSetEmpty()                                     extends smt_term
@@ -1795,6 +1796,7 @@ object SpecRestGenerated {
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
+    case TTheSet(v, va, vb)     => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -1850,6 +1852,7 @@ object SpecRestGenerated {
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
+    case TTheSet(v, va, vb)     => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -2571,6 +2574,31 @@ object SpecRestGenerated {
           case Some(SEnumElem(_, _))      => None
           case Some(SEntityElem(_, _))    => None
           case Some(SSet(elems))          => smtEval_forall_rel(m, env, vara, elems, body)
+          case Some(SEntityWith(_, _, _)) => None
+          case Some(SNone())              => None
+          case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
+        }
+      case (m, env, TTheSet(vara, setT, body)) =>
+        smtEval(m, env, setT) match {
+          case None                    => None
+          case Some(SBool(_))          => None
+          case Some(SInt(_))           => None
+          case Some(SReal(_))          => None
+          case Some(SEnumElem(_, _))   => None
+          case Some(SEntityElem(_, _)) => None
+          case Some(SSet(elems)) =>
+            smtEval_the_rel(m, env, vara, elems, body) match {
+              case None      => None
+              case Some(Nil) => None
+              case Some(x :: rest) =>
+                list_all[smt_val]((y: smt_val) => equal_smt_vala(y, x), rest) match {
+                  case true  => Some[smt_val](x)
+                  case false => None
+                }
+            }
           case Some(SEntityWith(_, _, _)) => None
           case Some(SNone())              => None
           case Some(SSome(_))             => None
@@ -3307,6 +3335,7 @@ object SpecRestGenerated {
     case TTheRel(v, ve, b)     => v :: smt_var_list(b)
     case TEntityBase(vf)       => Nil
     case TForallSet(v, d, b)   => v :: smt_var_list(d) ++ smt_var_list(b)
+    case TTheSet(v, d, b)      => v :: smt_var_list(d) ++ smt_var_list(b)
     case TIndexRel(b, k)       => smt_var_list(b) ++ smt_var_list(k)
     case TFieldAccess(b, vg)   => smt_var_list(b)
     case TSetEmpty()           => Nil
@@ -5230,6 +5259,7 @@ object SpecRestGenerated {
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
+    case TTheSet(v, va, vb)     => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -5285,6 +5315,7 @@ object SpecRestGenerated {
     case TTheRel(v, va, vb)     => None
     case TEntityBase(v)         => None
     case TForallSet(v, va, vb)  => None
+    case TTheSet(v, va, vb)     => None
     case TIndexRel(v, va)       => None
     case TFieldAccess(v, va)    => None
     case TSetEmpty()            => None
@@ -5699,32 +5730,162 @@ object SpecRestGenerated {
     case (vm, SetComprehensionF(vn, vo, vp, vq)) => None
     case (enums, TheF(vara, dm, body, vr)) =>
       dm match {
-        case BinaryOpF(_, _, _, _)         => None
-        case UnaryOpF(_, _, _)             => None
-        case QuantifierF(_, _, _, _)       => None
-        case SomeWrapF(_, _)               => None
-        case TheF(_, _, _, _)              => None
-        case FieldAccessF(_, _, _)         => None
-        case EnumAccessF(_, _, _)          => None
-        case IndexF(_, _, _)               => None
-        case CallF(_, _, _)                => None
-        case PrimeF(_, _)                  => None
-        case PreF(_, _)                    => None
-        case WithF(_, _, _)                => None
-        case IfF(_, _, _, _)               => None
-        case LetF(_, _, _, _)              => None
-        case LambdaF(_, _, _)              => None
-        case ConstructorF(_, _, _)         => None
-        case SetLiteralF(_, _)             => None
-        case MapLiteralF(_, _)             => None
-        case SetComprehensionF(_, _, _, _) => None
-        case SeqLiteralF(_, _)             => None
-        case MatchesF(_, _, _)             => None
-        case IntLitF(_, _)                 => None
-        case FloatLitF(_, _)               => None
-        case StringLitF(_, _)              => None
-        case BoolLitF(_, _)                => None
-        case NoneLitF(_)                   => None
+        case BinaryOpF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case UnaryOpF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case QuantifierF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case SomeWrapF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case TheF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case FieldAccessF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case EnumAccessF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case IndexF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case CallF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case PrimeF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case PreF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case WithF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case IfF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case LetF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case LambdaF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case ConstructorF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case SetLiteralF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case MapLiteralF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case SetComprehensionF(_, _, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case SeqLiteralF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case MatchesF(_, _, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case IntLitF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case FloatLitF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case StringLitF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case BoolLitF(_, _) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
+        case NoneLitF(_) =>
+          map2_opt(
+            (a: smt_term) => (b: smt_term) => TTheSet(vara, a, b),
+            translate(enums, dm),
+            translate(enums, body)
+          )
         case IdentifierF(rel, _) =>
           string_in_list(rel, enums) match {
             case true => None

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2439,6 +2439,38 @@ object Translator:
           Z3Expr.Implies(Z3Expr.SetMember(binderVar, setZ), inner)
         )
 
+      case TTheSet(varName, setT, body) =>
+        val setZ = encodeFromSmtTerm(ctx, setT, env)
+        val elemSort = inferSortOfZ3Expr(ctx, setZ) match
+          case Some(Z3Sort.SetOf(e)) => e
+          case _ =>
+            fail(ctx, "definite description `the` requires a set-sorted domain")
+        // a Skolem constant denotes "the unique element" only at quantifier-free position;
+        // under a binder it would need a Skolem function of the bound vars (mirrors TTheRel)
+        if env.values.exists { case _: Z3Expr.Var => true; case _ => false } then
+          fail(ctx, "definite description `the` is not supported under a quantifier")
+        val skolemName = ctx.freshSkolem(s"the_set_$varName")
+        ctx.declareFunc(Z3FunctionDecl(skolemName, Nil, elemSort))
+        val c    = Z3Expr.App(skolemName, Nil)
+        val envC = env.clone()
+        envC(varName) = c
+        val bodyC = encodeFromSmtTerm(ctx, body, envC)
+        ctx.assertions += Z3Expr.And(List(Z3Expr.SetMember(c, setZ), bodyC))
+        val wName = ctx.freshSkolem(s"the_set_witness_$varName")
+        val w     = Z3Expr.Var(wName, elemSort)
+        val envW  = env.clone()
+        envW(varName) = w
+        val bodyW = encodeFromSmtTerm(ctx, body, envW)
+        ctx.assertions += Z3Expr.Quantifier(
+          QKind.ForAll,
+          List(Z3Binding(wName, elemSort)),
+          Z3Expr.Implies(
+            Z3Expr.And(List(Z3Expr.SetMember(w, setZ), bodyW)),
+            Z3Expr.Cmp(CmpOp.Eq, w, c)
+          )
+        )
+        c
+
       case TTheRel(varName, rel, body) =>
         ctx.state.get(rel) match
           case Some(_: StateRelationInfo)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -580,6 +580,34 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`some it in boxes[bid].contents | it.id = target` - an existential whose domain is a field-access set (not an identifier) - must verify, not skip: QSome over a non-identifier domain lowers to TNot(TForallSet ...), mirroring #440's QAll path"
+    ),
+    (
+      "definite description over a field-access set verifies via Z3 (the ecommerce `the i in pre(orders)[oid].items` shape)",
+      "the_set_demo",
+      """service TheSetDemo {
+        |  entity Item {
+        |    id: Int
+        |  }
+        |  entity Box {
+        |    contents: Set[Item]
+        |  }
+        |  state {
+        |    boxes: Int -> lone Box
+        |    last_id: Int
+        |  }
+        |  operation Pick {
+        |    input: bid: Int, target: Int
+        |    requires:
+        |      bid in boxes
+        |      some it in boxes[bid].contents | it.id = target
+        |    ensures:
+        |      last_id' = (the it in pre(boxes)[bid].contents | it.id = target).id
+        |      boxes' = pre(boxes)
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`the it in pre(boxes)[bid].contents | it.id = target` - a definite description whose domain is a field-access set (not an identifier relation) - must verify, not skip: TheF over a non-identifier domain lowers to the new TTheSet node (the set-domain analogue of TTheRel)"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/TrustTest.scala
@@ -78,9 +78,9 @@ class TrustTest extends CatsEffectSuite:
       TrustLevel.Sound
     ),
     (
-      "BestEffort: TheF over a non-identifier domain",
-      TheF("s", BinaryOpF(BAdd(), i(1), i(2), None), lit(true), None),
-      TrustLevel.BestEffort
+      "Sound: TheF over a non-identifier (set-valued) domain lowers to TTheSet",
+      TheF("s", FieldAccessF(id("box"), "contents", None), lit(true), None),
+      TrustLevel.Sound
     ),
     (
       "Sound: IfF lowers to the Ite verified-subset ctor",

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -49,6 +49,7 @@ datatype (plugins only: code size) smt_term =
   | TTheRel "String.literal" "String.literal" "smt_term"
   | TEntityBase "String.literal"
   | TForallSet "String.literal" "smt_term" "smt_term"
+  | TTheSet "String.literal" "smt_term" "smt_term"
   | TIndexRel "smt_term" "smt_term"
   | TFieldAccess "smt_term" "String.literal"
   | TSetEmpty
@@ -105,6 +106,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TTheRel v _ b)       = v # smt_var_list b"
 | "smt_var_list (TEntityBase _)       = []"
 | "smt_var_list (TForallSet v d b)    = v # smt_var_list d @ smt_var_list b"
+| "smt_var_list (TTheSet v d b)       = v # smt_var_list d @ smt_var_list b"
 | "smt_var_list (TIndexRel b k)       = smt_var_list b @ smt_var_list k"
 | "smt_var_list (TFieldAccess b _)    = smt_var_list b"
 | "smt_var_list TSetEmpty             = []"
@@ -483,6 +485,13 @@ where
 | "smtEval m env (TForallSet var setT body) =
      (case smtEval m env setT of
         Some (SSet elems) \<Rightarrow> smtEval_forall_rel m env var elems body
+      | _ \<Rightarrow> None)"
+| "smtEval m env (TTheSet var setT body) =
+     (case smtEval m env setT of
+        Some (SSet elems) \<Rightarrow>
+          (case smtEval_the_rel m env var elems body of
+             Some (x # rest) \<Rightarrow> (if list_all (\<lambda>y. y = x) rest then Some x else None)
+           | _               \<Rightarrow> None)
       | _ \<Rightarrow> None)"
 | "smtEval m env (TIndexRel base key) =
      (case (peelSmtRelationRef base, smtEval m env key) of

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -149,7 +149,7 @@ where
         IdentifierF rel _ \<Rightarrow>
           (if string_in_list rel enums then None
            else map_option (\<lambda>b. TTheRel var rel b) (translate enums body))
-      | _ \<Rightarrow> None)"
+      | _ \<Rightarrow> map2_opt (TTheSet var) (translate enums dm) (translate enums body))"
 | "translate enums (MatchesF e pat _) =
      map_option (\<lambda>e'. TMatches e' pat) (translate enums e)"
 | "translate enums (QuantifierF k bs body _) =

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -666,7 +666,7 @@ next
     have uniq': "list_all (\<lambda>y. y = value_to_smt x) (map value_to_smt rest)"
       using uniq by (induction rest) auto
     show ?thesis using teq srd etr uniq' v_eq by simp
-  qed (use "24.prems"(2) in simp_all)
+  qed (use "24.prems"(1) in simp_all)
 next
   case (25 fs ps fuel s st env k bs body sp v t)
   note wf = "25.prems"(3)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -198,6 +198,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TTheRel y _ b)        = (y \<noteq> x \<and> smt_uses_var x b)"
 | "smt_uses_var x (TEntityBase _)        = False"
 | "smt_uses_var x (TForallSet y setT b)  = (smt_uses_var x setT \<or> (y \<noteq> x \<and> smt_uses_var x b))"
+| "smt_uses_var x (TTheSet y setT b)     = (smt_uses_var x setT \<or> (y \<noteq> x \<and> smt_uses_var x b))"
 | "smt_uses_var x (TIndexRel b k)        = (smt_uses_var x b \<or> smt_uses_var x k)"
 | "smt_uses_var x (TFieldAccess b _)     = smt_uses_var x b"
 | "smt_uses_var x TSetEmpty              = False"
@@ -369,6 +370,35 @@ next
       have hb: "smtEval m (((y, v) # pre) @ (x, xv) # post) b
               = smtEval m (((y, v) # pre) @ post) b"
         using TForallSet.prems by (intro TForallSet.IH(2)) auto
+      show ?case
+      proof (cases "smtEval m ((y, v) # pre @ post) b")
+        case None
+        thus ?thesis using hb by simp
+      next
+        case (Some bv)
+        show ?thesis using hb Some Cons.IH by (cases bv) simp_all
+      qed
+    qed
+  qed
+  thus ?case using hs by (simp split: option.splits smt_val.splits)
+next
+  case (TTheSet y setT b)
+  have hs: "smtEval m (pre @ (x, xv) # post) setT = smtEval m (pre @ post) setT"
+    using TTheSet.prems by (auto intro: TTheSet.IH(1))
+  have "\<And>d. smtEval_the_rel m (pre @ (x, xv) # post) y d b
+          = smtEval_the_rel m (pre @ post) y d b"
+  proof -
+    fix d
+    show "smtEval_the_rel m (pre @ (x, xv) # post) y d b
+            = smtEval_the_rel m (pre @ post) y d b"
+    proof (induction d)
+      case Nil
+      show ?case by simp
+    next
+      case (Cons v rest)
+      have hb: "smtEval m (((y, v) # pre) @ (x, xv) # post) b
+              = smtEval m (((y, v) # pre) @ post) b"
+        using TTheSet.prems by (intro TTheSet.IH(2)) auto
       show ?case
       proof (cases "smtEval m ((y, v) # pre @ post) b")
         case None


### PR DESCRIPTION
## What

Lifts the definite description over a **non-identifier (field-access set) domain** - `the i in pre(orders)[oid].items | P` - into the verified subset, via a new `TTheSet` node, the set-domain analogue of `TTheRel`.

`translate` emits `map2_opt (TTheSet var) (translate dm) (translate body)`; `smtEval` reuses `smtEval_the_rel` over the set's elements (unique-element extraction, like `TTheRel`). The encoder mirrors `TTheRel`: a Skolem element asserted to be in the set and satisfy the body, plus a uniqueness constraint.

## Why it's sound (vacuous-on-eval)

`eval` of `TheF` over a non-identifier domain is `None` (the reference semantics only resolves identifier-relation domains), so DirectSound case 24 discharges the new `TTheSet` outputs through its `eval = None` premise. `wf_z3 (TheF) = False`, so DirectTotality is untouched. The `smt_term` env-weakening lemma gains a `TTheSet` case mirroring `TForallSet`'s (`setT` via IH(1), `smtEval_the_rel` per element via IH(2)). 3-session zero-sorry build green; the new-node ripple (datatype + smtEval + smt_var_list + smt_uses_var + encoder) is complete.

## Impact

ecommerce: RemoveLineItem's 6 preservation checks were skipped *outside lower's coverage* (exit 4) on `let removed = (the i in pre(orders)[order_id].items | i.id = item_id)`. They now **translate into the verified subset**, advancing the frontier from "outside the verified fragment" to "in-subset, encoder-incomplete" (exit 2). They surface one remaining encoder gap - **set difference via `-`** (`items - {removed}`), the direct sibling of #441's set-union-via-`+` - addressed in the follow-up. Adds `the_set_demo` (verifies); full ConsistencyTest + TranslatorPropTest green (47/47).

Stacked on #443. Part of #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifts `the` over set domains into the verified subset via `TTheSet`, so shapes like `the i in pre(orders)[oid].items | P` now translate and verify. Ecommerce RemoveLineItem checks move into the subset; set difference `-` remains. Part of #420.

- **New Features**
  - Lower `TheF` over non-identifier (set) domains to `TTheSet` via `map2_opt`; `smtEval` uses `smtEval_the_rel` to pick the unique element.
  - Z3 encoder mirrors `TTheRel`: Skolem element in the set that satisfies the body, plus a uniqueness constraint; rejects use under quantifiers and non-set domains.
  - Proofs and tests: add `TTheSet` cases in Isabelle (`Smt.thy`, `Translate.thy`, `DirectSound*.thy`), new `the_set_demo`; ecommerce checks go from “skip” to “encode” (exit 4 → 2).

- **Bug Fixes**
  - Trust classifier marks `TheF` over set-valued (non-identifier) domains as Sound; updated `TrustTest`.

<sup>Written for commit 884aea6eaa8abff173133ef56548636bd2650975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

