### PR TITLE
feat(verify): encode set difference (set - set) in the verified subset (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2239,6 +2239,25 @@ object Translator:
         "addition requires two numeric (Int or Real), two String, two Seq, or two Set operands"
       )
 
+  private def encSub(
+      ctx: TranslateCtx,
+      l: smt_term,
+      r: smt_term,
+      env: mutable.Map[String, Z3Expr]
+  ): Z3Expr =
+    val lz                        = encodeFromSmtTerm(ctx, l, env)
+    val rz                        = encodeFromSmtTerm(ctx, r, env)
+    def isNum(z: Z3Expr): Boolean = inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric)
+    // `set - set` is set difference (e.g. `items - {removed}`); both operands must share an element sort.
+    def sameSet(a: Z3Expr, b: Z3Expr): Boolean =
+      (inferSortOfZ3Expr(ctx, a), inferSortOfZ3Expr(ctx, b)) match
+        case (Some(Z3Sort.SetOf(ae)), Some(Z3Sort.SetOf(be))) => Z3Sort.eq(ae, be)
+        case _                                                => false
+    if isNum(lz) && isNum(rz) then Z3Expr.Arith(ArithOp.Sub, List(lz, rz))
+    else if sameSet(lz, rz) then Z3Expr.SetBinOp(SetOpKind.Diff, lz, rz)
+    else
+      fail(ctx, "subtraction requires two numeric (Int or Real) or two Set operands")
+
   private def encodeSetEmptyCmp(
       ctx: TranslateCtx,
       op: CmpOp,
@@ -2339,7 +2358,7 @@ object Translator:
       case TAdd(l, r) =>
         encAdd(ctx, l, r, env)
       case TSub(l, r) =>
-        Z3Expr.Arith(ArithOp.Sub, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
+        encSub(ctx, l, r, env)
       case TMul(l, r) =>
         Z3Expr.Arith(ArithOp.Mul, List(encNumeric(ctx, l, env), encNumeric(ctx, r, env)))
       case TDiv(l, r) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -608,6 +608,28 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`the it in pre(boxes)[bid].contents | it.id = target` - a definite description whose domain is a field-access set (not an identifier relation) - must verify, not skip: TheF over a non-identifier domain lowers to the new TTheSet node (the set-domain analogue of TTheRel)"
+    ),
+    (
+      "set difference via `-` verifies via Z3 (the ecommerce `items - {removed}` shape)",
+      "set_diff_demo",
+      """service SetDiffDemo {
+        |  entity It {
+        |    v: Int
+        |  }
+        |  state {
+        |    seen: Set[It]
+        |  }
+        |  operation Drop {
+        |    input: x: It
+        |    requires:
+        |      true
+        |    ensures:
+        |      seen' = pre(seen) - {x}
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`seen' = pre(seen) - {x}` - `-` on two Set operands - must verify as set difference, not skip on 'subtraction requires numeric' (the #441 set-union sibling)"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

`items - {removed}` - `-` on two `Set` operands - hit `ordering/arithmetic requires a numeric type (Int or Real)` because the `TSub` encoder only handled numerics. The new `encSub` recognizes two same-element-sort `Set`s and lowers them to `SetBinOp(Diff)`, the direct mirror of #441's `encAdd` Set+Set -> Union.

Vacuous-on-eval (`eval_arith`/`smtEval` `TSub` are both `None` for sets), so **encoder-only** (no proof change, no regen).

## Impact

ecommerce: clears the set-difference operand in RemoveLineItem's ensures (`pre(orders)[order_id].items - {removed}`). Those preservation checks advance one encoder layer further (the next gap is `field access requires entity sort`). Adds `set_diff_demo`; full ConsistencyTest + TranslatorPropTest green (48/48).

Stacked on #444. Part of #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encode set difference for `Set - Set` so expressions like `items - {removed}` verify by lowering to Z3 Diff. Part of Linear #420; this unblocks ecommerce RemoveLineItem ensures.

- **New Features**
  - `TSub` (via new `encSub`) now recognizes same-element-sort `Set - Set` and emits `SetBinOp(Diff)`; numeric subtraction is unchanged and the error text clarifies allowed operands.
  - Added `set_diff_demo` to confirm `seen' = pre(seen) - {x}` verifies.

<sup>Written for commit c14e9f5f5616d128d19b340d1ef6c2a3f0af7a28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

