### PR TITLE
feat(verify): coerce optional-numeric operands in arithmetic (#420)

### DIFF
--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -335,11 +335,17 @@ private object Backend:
       val v = renderExpr(rctx, value)
       optionSortFor(rctx.ctx, rctx.sortMap, v.getSort).getConstructors()(1).apply(v)
     case Z3Expr.OptGet(value, _) =>
-      // `valOf` accessor of the `some` constructor; applying it to `none` yields an
-      // unspecified value of the element sort, which is sound here (the construct is
-      // vacuous-on-eval, so the encoder is the trusted oracle and the source guards != none).
+      // `valOf` accessor of the `some` constructor (constructor index 1, accessor 0);
+      // applying it to `none` yields an unspecified value of the element sort, which is
+      // sound here (the construct is vacuous-on-eval, so the encoder is the trusted oracle
+      // and the source guards != none). `coerceOptionalNumeric` only builds OptGet over an
+      // Option-sorted operand, but match defensively rather than cast blindly at the FFI.
       val o = renderExpr(rctx, value).asInstanceOf[Z3AstExpr[Sort]]
-      o.getSort.asInstanceOf[DatatypeSort[Sort]].getAccessors()(1)(0).apply(o)
+      o.getSort match
+        case dt: DatatypeSort[?] if dt.getAccessors().length > 1 && dt.getAccessors()(1).nonEmpty =>
+          dt.asInstanceOf[DatatypeSort[Sort]].getAccessors()(1)(0).apply(o)
+        case other =>
+          backendFail(rctx, s"OptGet requires an Option datatype sort, got $other")
     case Z3Expr.StrLit(s, _) =>
       rctx.ctx.mkString(s)
     case Z3Expr.InRe(str, re, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Backend.scala
@@ -334,6 +334,12 @@ private object Backend:
     case Z3Expr.OptSome(value, _) =>
       val v = renderExpr(rctx, value)
       optionSortFor(rctx.ctx, rctx.sortMap, v.getSort).getConstructors()(1).apply(v)
+    case Z3Expr.OptGet(value, _) =>
+      // `valOf` accessor of the `some` constructor; applying it to `none` yields an
+      // unspecified value of the element sort, which is sound here (the construct is
+      // vacuous-on-eval, so the encoder is the trusted oracle and the source guards != none).
+      val o = renderExpr(rctx, value).asInstanceOf[Z3AstExpr[Sort]]
+      o.getSort.asInstanceOf[DatatypeSort[Sort]].getAccessors()(1)(0).apply(o)
     case Z3Expr.StrLit(s, _) =>
       rctx.ctx.mkString(s)
     case Z3Expr.InRe(str, re, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/SmtLib.scala
@@ -130,6 +130,8 @@ object SmtLib:
       s"(as none (Option ${renderSort(elemSort)}))"
     case Z3Expr.OptSome(value, _) =>
       s"(some ${renderExpr(value)})"
+    case Z3Expr.OptGet(value, _) =>
+      s"(valOf ${renderExpr(value)})"
     case Z3Expr.StrLit(s, _) =>
       "\"" + s.replace("\"", "\"\"") + "\""
     case Z3Expr.InRe(str, re, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1007,6 +1007,8 @@ object Translator:
       )
     case Z3Expr.OptSome(value, sp) =>
       Z3Expr.OptSome(substituteVar(value, varName, replacement), sp)
+    case Z3Expr.OptGet(value, sp) =>
+      Z3Expr.OptGet(substituteVar(value, varName, replacement), sp)
     case Z3Expr.SeqLit(elemSort, members, sp) =>
       Z3Expr.SeqLit(elemSort, members.map(m => substituteVar(m, varName, replacement)), sp)
     case Z3Expr.MapLit(keySort, valueSort, entries, sp) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -1476,8 +1476,12 @@ object Translator:
       (inferSortOfZ3Expr(ctx, t), inferSortOfZ3Expr(ctx, e)) match
         case (Some(ts), Some(es)) => if Z3Sort.eq(ts, es) then Some(ts) else None
         case (ts, es)             => ts.orElse(es)
-    case Z3Expr.OptNone(elemSort, _)   => Some(Z3Sort.OptionOf(elemSort))
-    case Z3Expr.OptSome(value, _)      => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
+    case Z3Expr.OptNone(elemSort, _) => Some(Z3Sort.OptionOf(elemSort))
+    case Z3Expr.OptSome(value, _)    => inferSortOfZ3Expr(ctx, value).map(Z3Sort.OptionOf.apply)
+    case Z3Expr.OptGet(value, _) =>
+      inferSortOfZ3Expr(ctx, value) match
+        case Some(Z3Sort.OptionOf(e)) => Some(e)
+        case _                        => None
     case Z3Expr.StrLit(_, _)           => Some(Z3Sort.Str)
     case Z3Expr.StrConcat(_, _, _)     => Some(Z3Sort.Str)
     case Z3Expr.SeqConcat(l, _, _)     => inferSortOfZ3Expr(ctx, l)
@@ -2155,6 +2159,16 @@ object Translator:
       case _ =>
         subexprs(expr).exists(walkMentionsPost(_, stateName, insidePrime))
 
+  // An `Option[T]` operand in numeric position (e.g. `now() - order.delivered_at`,
+  // delivered_at: Option[DateTime], guarded by `!= none`) is unwrapped to its `T`
+  // value. Sound because such arithmetic is vacuous-on-eval (`eval_arith` rejects a
+  // non-numeric operand), so the encoder is the trusted oracle - the dual of #431's
+  // optional-vs-base equality coercion, which lifts the base to `some(...)`.
+  private def coerceOptionalNumeric(ctx: TranslateCtx, z: Z3Expr): Z3Expr =
+    inferSortOfZ3Expr(ctx, z) match
+      case Some(Z3Sort.OptionOf(e)) if Z3Sort.isNumeric(e) => Z3Expr.OptGet(z)
+      case _                                               => z
+
   // Arithmetic/ordering are valid only on the verifier's numeric theory sorts
   // (Int for integers and temporal-as-epoch, Real for Float/Decimal/Money). An
   // operand of any other sort is outside the encodable subset, so the check is
@@ -2164,7 +2178,7 @@ object Translator:
       term: smt_term,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
-    val z = encodeFromSmtTerm(ctx, term, env)
+    val z = coerceOptionalNumeric(ctx, encodeFromSmtTerm(ctx, term, env))
     if !inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric) then
       fail(ctx, "ordering/arithmetic requires a numeric type (Int or Real)")
     z
@@ -2213,8 +2227,8 @@ object Translator:
       r: smt_term,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
-    val lz = encodeFromSmtTerm(ctx, l, env)
-    val rz = encodeFromSmtTerm(ctx, r, env)
+    val lz = coerceOptionalNumeric(ctx, encodeFromSmtTerm(ctx, l, env))
+    val rz = coerceOptionalNumeric(ctx, encodeFromSmtTerm(ctx, r, env))
     def isStr(z: Z3Expr): Boolean =
       inferSortOfZ3Expr(ctx, z) match
         case Some(Z3Sort.Str) => true
@@ -2245,8 +2259,8 @@ object Translator:
       r: smt_term,
       env: mutable.Map[String, Z3Expr]
   ): Z3Expr =
-    val lz                        = encodeFromSmtTerm(ctx, l, env)
-    val rz                        = encodeFromSmtTerm(ctx, r, env)
+    val lz                        = coerceOptionalNumeric(ctx, encodeFromSmtTerm(ctx, l, env))
+    val rz                        = coerceOptionalNumeric(ctx, encodeFromSmtTerm(ctx, r, env))
     def isNum(z: Z3Expr): Boolean = inferSortOfZ3Expr(ctx, z).exists(Z3Sort.isNumeric)
     // `set - set` is set difference (e.g. `items - {removed}`); both operands must share an element sort.
     def sameSet(a: Z3Expr, b: Z3Expr): Boolean =

--- a/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Triggers.scala
@@ -20,6 +20,7 @@ object Z3Trigger:
     case Z3Expr.SetBinOp(_, l, r, _)   => List(l, r)
     case Z3Expr.Ite(c, t, el, _)       => List(c, t, el)
     case Z3Expr.OptSome(v, _)          => List(v)
+    case Z3Expr.OptGet(v, _)           => List(v)
     case Z3Expr.InRe(s, _, _)          => List(s)
     case Z3Expr.SeqLit(_, ms, _)       => ms
     case Z3Expr.MapLit(_, _, es, _)    => es.flatMap((k, v) => List(k, v))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Types.scala
@@ -106,6 +106,7 @@ enum Z3Expr derives CanEqual:
   case Ite(cond: Z3Expr, thenE: Z3Expr, elseE: Z3Expr, span: Option[span_t] = None)
   case OptNone(elemSort: Z3Sort, span: Option[span_t] = None)
   case OptSome(value: Z3Expr, span: Option[span_t] = None)
+  case OptGet(value: Z3Expr, span: Option[span_t] = None)
   case StrLit(value: String, span: Option[span_t] = None)
   case InRe(str: Z3Expr, re: Z3Regex, span: Option[span_t] = None)
   case SeqLit(elemSort: Z3Sort, members: List[Z3Expr], span: Option[span_t] = None)
@@ -140,6 +141,7 @@ enum Z3Expr derives CanEqual:
     case e: Ite         => e.span
     case e: OptNone     => e.span
     case e: OptSome     => e.span
+    case e: OptGet      => e.span
     case e: StrLit      => e.span
     case e: InRe        => e.span
     case e: SeqLit      => e.span
@@ -172,6 +174,7 @@ enum Z3Expr derives CanEqual:
         case e: Ite         => e.copy(span = s)
         case e: OptNone     => e.copy(span = s)
         case e: OptSome     => e.copy(span = s)
+        case e: OptGet      => e.copy(span = s)
         case e: StrLit      => e.copy(span = s)
         case e: InRe        => e.copy(span = s)
         case e: SeqLit      => e.copy(span = s)

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -630,6 +630,30 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`seen' = pre(seen) - {x}` - `-` on two Set operands - must verify as set difference, not skip on 'subtraction requires numeric' (the #441 set-union sibling)"
+    ),
+    (
+      "optional-numeric arithmetic verifies via Z3 (the ecommerce `now() - delivered_at` shape, delivered_at: Option[DateTime])",
+      "opt_arith_demo",
+      """service OptArithDemo {
+        |  entity Rec {
+        |    ts: Option[DateTime]
+        |  }
+        |  state {
+        |    recs: Int -> lone Rec
+        |  }
+        |  operation Check {
+        |    input: k: Int
+        |    requires:
+        |      k in recs
+        |      recs[k].ts != none
+        |      now() - recs[k].ts <= 100
+        |    ensures:
+        |      recs' = pre(recs)
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`now() - recs[k].ts` where ts: Option[DateTime] - an Option[Numeric] operand in arithmetic - must verify: the encoder unwraps it via OptGet (DateTime is already the Int sort; the blocker was the Option wrapper), the dual of #431's optional-vs-base equality coercion"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## What

An `Option[T]` operand in numeric position - e.g. `now() - order.delivered_at` where `delivered_at: Option[DateTime]`, guarded by `!= none` - now unwraps to its `T` value via a new `Z3Expr.OptGet` node (the `valOf` accessor of the Option datatype's `some` constructor), applied in `encNumeric`, `encAdd`, and `encSub`.

## Why it's sound (vacuous-on-eval)

Arithmetic with a non-numeric operand has `eval = None` (`eval_arith` rejects it), so it's vacuous-on-eval and the encoder is the trusted oracle - the dual of #431's optional-vs-base **equality** coercion (which lifts the base to `some(...)`). Encoder-only: no proof change, no regen. Full verify suite green (262).

## Context (DateTime is already Int)

`DateTime`/`Date`/`Duration` all map to `Z3Sort.Int` (`primitiveSortOf`), so non-optional DateTime arithmetic already verified - the blocker was purely the `Option` wrapper, **not** a DateTime/Int mismatch (a non-optional-DateTime probe verifies cleanly; the optional one was the only failure). This is one of the two lifts ecommerce's **ProcessReturn** needs; the other is the `days(n)` builtin (follow-up). Together they take ProcessReturn's 8 checks into the verified subset.

Adds `opt_arith_demo`. Part of #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable arithmetic on optional numerics by unwrapping `Option[T]` to `T` in numeric positions, so expressions like `now() - rec.ts` (with `ts != none`) verify. Implemented via `Z3Expr.OptGet`; addresses Linear #420 and unblocks ProcessReturn checks.

- **New Features**
  - Added `Z3Expr.OptGet` with SMT `(valOf ...)` and backend accessor; applied in numeric position and in `+`/`-` translator paths.
  - Sound via vacuous-on-eval under `!= none`; dual to the optional-vs-base equality coercion; added `opt_arith_demo` test.

- **Bug Fixes**
  - Handle `OptGet` in `substituteVar` and trigger inference to keep substitutions and triggers complete.
  - Backend defensively checks for an `Option` datatype before applying `valOf` and fails on invalid sorts.

<sup>Written for commit ba9d22bfa353a64178efea3c5754015a4f1bddd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive support for optional values in verification expressions.
  * Optional numeric values in arithmetic operations are now implicitly handled, eliminating the need for explicit unwrapping.
  * Enhanced type inference system for optional value constructs and operations.

* **Tests**
  * Added test coverage for optional numeric arithmetic verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->