### PR TITLE
feat(verify): lift the days(n) builtin into the verified subset (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -581,6 +581,7 @@ object SpecRestGenerated {
   final case class TMatches(a: smt_term, b: String)                extends smt_term
   final case class TUStrPred(a: String, b: smt_term)               extends smt_term
   final case class TUStrFunc(a: String, b: smt_term)               extends smt_term
+  final case class TUIntFunc(a: String, b: smt_term)               extends smt_term
   final case class TUConst(a: String)                              extends smt_term
   final case class TSeqEmpty()                                     extends smt_term
   final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
@@ -1815,6 +1816,7 @@ object SpecRestGenerated {
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
     case TUStrFunc(v, va)       => None
+    case TUIntFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -1869,6 +1871,7 @@ object SpecRestGenerated {
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
     case TUStrFunc(v, va)       => None
+    case TUIntFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -2818,6 +2821,22 @@ object SpecRestGenerated {
           case Some(SSeq(_))              => None
           case Some(SMap(_))              => None
         }
+      case (m, env, TUIntFunc(name, t)) =>
+        smtEval(m, env, t) match {
+          case None                       => None
+          case Some(SBool(_))             => None
+          case Some(SInt(n))              => Some[smt_val](SInt(BigInt(name.hashCode) + n))
+          case Some(SReal(_))             => None
+          case Some(SEnumElem(_, _))      => None
+          case Some(SEntityElem(_, _))    => None
+          case Some(SSet(_))              => None
+          case Some(SEntityWith(_, _, _)) => None
+          case Some(SNone())              => None
+          case Some(SSome(_))             => None
+          case Some(SStr(_))              => None
+          case Some(SSeq(_))              => None
+          case Some(SMap(_))              => None
+        }
       case (m, env, TUConst(nm)) => Some[smt_val](SInt(BigInt(nm.hashCode)))
       case (m, env, TSeqEmpty()) => Some[smt_val](SSeq(Nil))
       case (m, env, TSeqCons(e, rest)) =>
@@ -3354,13 +3373,14 @@ object SpecRestGenerated {
     case TMatches(t, vj)       => smt_var_list(t)
     case TUStrPred(vk, t)      => smt_var_list(t)
     case TUStrFunc(vl, t)      => smt_var_list(t)
-    case TUConst(vm)           => Nil
+    case TUIntFunc(vm, t)      => smt_var_list(t)
+    case TUConst(vn)           => Nil
     case TSeqEmpty()           => Nil
     case TSeqCons(e, r)        => smt_var_list(e) ++ smt_var_list(r)
     case TMapEmpty()           => Nil
     case TMapCons(k, v, r) =>
       smt_var_list(k) ++ (smt_var_list(v) ++ smt_var_list(r))
-    case TSum(c, vn) => smt_var_list(c)
+    case TSum(c, vo) => smt_var_list(c)
   }
 
   def isIntLit(x0: expr): Boolean = x0 match {
@@ -5278,6 +5298,7 @@ object SpecRestGenerated {
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
     case TUStrFunc(v, va)       => None
+    case TUIntFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -5332,6 +5353,7 @@ object SpecRestGenerated {
     case TMatches(v, va)        => None
     case TUStrPred(v, va)       => None
     case TUStrFunc(v, va)       => None
+    case TUIntFunc(v, va)       => None
     case TUConst(v)             => None
     case TSeqEmpty()            => None
     case TSeqCons(v, va)        => None
@@ -5409,6 +5431,8 @@ object SpecRestGenerated {
     case NoneLitF(v)                      => None
     case IdentifierF(v, va)               => None
   }
+
+  def is_builtin_int_func(nm: String): Boolean = nm == "days"
 
   def comp_parts(x0: expr): Option[(String, (String, expr))] = x0 match {
     case SetComprehensionF(vara, d, p, uu) =>
@@ -5574,7 +5598,13 @@ object SpecRestGenerated {
                     (a: smt_term) => TUStrFunc(nm, a),
                     translate(enums, arg)
                   )
-                case false => None
+                case false => is_builtin_int_func(nm) match {
+                    case true => map_option[smt_term, smt_term](
+                        (a: smt_term) => TUIntFunc(nm, a),
+                        translate(enums, arg)
+                      )
+                    case false => None
+                  }
               }
           }
         case (IdentifierF(_, _), _ :: BinaryOpF(_, _, _, _) :: _)                => None

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2720,6 +2720,15 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Str))
         Z3Expr.App(funcName, List(strZ))
+      // 1-arg reserved builtin int function (e.g. days(n)): an uninterpreted Int-valued function.
+      // Same name mangling as TUStrFunc; determinism (same input -> same output) is the functionality.
+      case TUIntFunc(name, t) =>
+        val argZ     = encodeFromSmtTerm(ctx, t, env)
+        val s        = inferSortOfZ3Expr(ctx, argZ).getOrElse(Z3Sort.Int)
+        val funcName = s"${name}_${sortNameOf(s)}"
+        if !ctx.funcs.contains(funcName) then
+          ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Int))
+        Z3Expr.App(funcName, List(argZ))
       // 0-arg reserved builtin (e.g. now()): an uninterpreted Int constant. The `${name}_0`
       // name matches translateCall's argSortsMangled, so the in-subset and raw paths share it.
       case TUConst(name) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -654,6 +654,30 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`now() - recs[k].ts` where ts: Option[DateTime] - an Option[Numeric] operand in arithmetic - must verify: the encoder unwraps it via OptGet (DateTime is already the Int sort; the blocker was the Option wrapper), the dual of #431's optional-vs-base equality coercion"
+    ),
+    (
+      "days(n) builtin verifies via Z3 (the ecommerce ProcessReturn `now() - delivered_at <= days(30)` shape)",
+      "days_demo",
+      """service DaysDemo {
+        |  entity Rec {
+        |    ts: Option[DateTime]
+        |  }
+        |  state {
+        |    recs: Int -> lone Rec
+        |  }
+        |  operation Check {
+        |    input: k: Int
+        |    requires:
+        |      k in recs
+        |      recs[k].ts != none
+        |      now() - recs[k].ts <= days(30)
+        |    ensures:
+        |      recs' = pre(recs)
+        |  }
+        |  invariant t:
+        |    true
+        |}""".stripMargin,
+      "`now() - recs[k].ts <= days(30)` - the 1-arg `days(n)` Int->Int builtin (uninterpreted, mirroring now()/hash) plus the optional-arithmetic coercion - must verify, not skip; this is exactly the ecommerce ProcessReturn.requires shape"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):

--- a/proofs/isabelle/SpecRest/codegen/Codegen.thy
+++ b/proofs/isabelle/SpecRest/codegen/Codegen.thy
@@ -124,6 +124,7 @@ code_printing
 | constant str_predicate \<rightharpoonup> (Scala) "((_) == (_))"
 | constant builtin_const_val \<rightharpoonup> (Scala) "(BigInt((_).hashCode))"
 | constant builtin_str_func \<rightharpoonup> (Scala) "((_) + (_))"
+| constant builtin_int_func \<rightharpoonup> (Scala) "(BigInt((_).hashCode) + (_))"
 | constant agg_sum \<rightharpoonup> (Scala) "(BigInt((_).hashCode + (_).hashCode))"
 
 export_code

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -116,6 +116,16 @@ consts builtin_str_func :: "String.literal \<Rightarrow> String.literal \<Righta
 definition is_builtin_func :: "String.literal \<Rightarrow> bool" where
   "is_builtin_func nm \<longleftrightarrow> nm = STR ''hash''"
 
+text \<open>\<open>builtin_int_func name n\<close> is the uninterpreted value of a reserved 1-argument
+  built-in \<open>int \<Rightarrow> int\<close> function \<open>name\<close> (e.g.\ \<open>days\<close>, a duration in epoch seconds)
+  applied to \<open>n\<close>. The integer analogue of \<open>builtin_str_func\<close>: abstract, so soundness
+  stays parametric in the realisation. \<open>is_builtin_int_func nm\<close> gates lifting
+  \<open>CallF (IdentifierF nm) [arg]\<close> to \<open>UIntFunc\<close>.\<close>
+consts builtin_int_func :: "String.literal \<Rightarrow> int \<Rightarrow> int"
+
+definition is_builtin_int_func :: "String.literal \<Rightarrow> bool" where
+  "is_builtin_int_func nm \<longleftrightarrow> nm = STR ''days''"
+
 record schema_field_decl =
   fd_name :: "String.literal"
   fd_ty   :: "schema_type"

--- a/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/core/Semantics_Reference.thy
@@ -19,6 +19,7 @@ definition builtins_reserved ::
   "builtins_reserved fs ps \<equiv> (\<forall>nm. is_builtin_pred nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> (\<forall>nm. is_builtin_const nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> (\<forall>nm. is_builtin_func nm \<longrightarrow> lookup_callee fs ps nm = None)
+                              \<and> (\<forall>nm. is_builtin_int_func nm \<longrightarrow> lookup_callee fs ps nm = None)
                               \<and> lookup_callee fs ps (STR ''dom'') = None
                               \<and> lookup_callee fs ps (STR ''range'') = None
                               \<and> lookup_callee fs ps (STR ''ran'') = None
@@ -182,6 +183,10 @@ and eval_forall ::
                             then (case eval fs ps fuel s st env arg of
                                     Some (VStr str) \<Rightarrow> Some (VStr (builtin_str_func nm str))
                                   | _ \<Rightarrow> None)
+                          else if is_builtin_int_func nm
+                            then (case eval fs ps fuel s st env arg of
+                                    Some (VInt n) \<Rightarrow> Some (VInt (builtin_int_func nm n))
+                                  | _ \<Rightarrow> None)
                             else None)
                      | _ \<Rightarrow> None))
            | _ \<Rightarrow> None))"
@@ -311,7 +316,8 @@ lemma eval_dom_CallF:
   assumes "lookup_callee fs ps (STR ''dom'') = None"
   shows "eval fs ps fuel s st env
            (CallF (IdentifierF (STR ''dom'') sp1) [IdentifierF rel sp2] sp) = None"
-  using assms by (simp add: is_builtin_pred_def is_builtin_func_def split: nat.splits)
+  using assms
+  by (simp add: is_builtin_pred_def is_builtin_func_def is_builtin_int_func_def split: nat.splits)
 
 lemma quant_dom_qb_names:
   "quant_dom s st k bs = Some (var, dmv) \<Longrightarrow> qb_names bs = [var]"
@@ -562,7 +568,19 @@ next
                   by (auto split: option.splits ir_value.splits)
               next
                 case False
-                thus ?thesis using Suc idc None ac Nil \<open>\<not> is_builtin_pred nm\<close> by simp
+                show ?thesis
+                proof (cases "is_builtin_int_func nm")
+                  case True
+                  have "eval fs ps fuel s st env a = eval fs ps fuel s st env2 a"
+                    using "15.IH" Suc idc None ac Nil agr \<open>\<not> is_builtin_pred nm\<close> \<open>\<not> is_builtin_func nm\<close> True
+                    by (auto simp: env_lookup_def)
+                  then show ?thesis using Suc idc None ac Nil \<open>\<not> is_builtin_pred nm\<close> \<open>\<not> is_builtin_func nm\<close> True
+                    by (auto split: option.splits ir_value.splits)
+                next
+                  case False
+                  thus ?thesis
+                    using Suc idc None ac Nil \<open>\<not> is_builtin_pred nm\<close> \<open>\<not> is_builtin_func nm\<close> by simp
+                qed
               qed
             qed
           next
@@ -1380,17 +1398,34 @@ next
           by (simp split: option.splits ir_value.splits)
       next
         case False
-        have bif: "is_builtin_func nm"
-          using "15.prems" fuel idc None aeq False
-          by (auto split: option.splits ir_value.splits if_splits)
-        obtain str where ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-            and w_eq: "w = VStr (builtin_str_func nm str)"
-          using "15.prems" fuel idc None aeq False bif
-          by (auto split: option.splits ir_value.splits if_splits)
-        have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
-          using "15.IH" fuel idc None aeq ea False bif by (auto split: if_splits)
-        show ?thesis using inl ea' w_eq fuel idc None aeq False bif
-          by (simp split: option.splits ir_value.splits)
+        note npred = False
+        show ?thesis
+        proof (cases "is_builtin_func nm")
+          case True
+          note bif = True
+          obtain str where ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+              and w_eq: "w = VStr (builtin_str_func nm str)"
+            using "15.prems" fuel idc None aeq npred bif
+            by (auto split: option.splits ir_value.splits if_splits)
+          have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VStr str)"
+            using "15.IH" fuel idc None aeq ea npred bif by (auto split: if_splits)
+          show ?thesis using inl ea' w_eq fuel idc None aeq npred bif
+            by (simp split: option.splits ir_value.splits)
+        next
+          case False
+          note nfunc = False
+          have bif: "is_builtin_int_func nm"
+            using "15.prems" fuel idc None aeq npred nfunc
+            by (auto split: option.splits ir_value.splits if_splits)
+          obtain n where ea: "eval fs ps fuel s st env arg = Some (VInt n)"
+              and w_eq: "w = VInt (builtin_int_func nm n)"
+            using "15.prems" fuel idc None aeq npred nfunc bif
+            by (auto split: option.splits ir_value.splits if_splits)
+          have ea': "eval fs ps fuel s st env (inline_calls fs ps arg) = Some (VInt n)"
+            using "15.IH" fuel idc None aeq ea npred nfunc bif by (auto split: if_splits)
+          show ?thesis using inl ea' w_eq fuel idc None aeq npred nfunc bif
+            by (simp split: option.splits ir_value.splits)
+        qed
       qed
     qed
   next

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -68,6 +68,7 @@ datatype (plugins only: code size) smt_term =
   | TMatches "smt_term" "String.literal"
   | TUStrPred "String.literal" "smt_term"
   | TUStrFunc "String.literal" "smt_term"
+  | TUIntFunc "String.literal" "smt_term"
   | TUConst "String.literal"
   | TSeqEmpty
   | TSeqCons "smt_term" "smt_term"
@@ -125,6 +126,7 @@ fun smt_var_list :: "smt_term \<Rightarrow> String.literal list" where
 | "smt_var_list (TMatches t _)        = smt_var_list t"
 | "smt_var_list (TUStrPred _ t)       = smt_var_list t"
 | "smt_var_list (TUStrFunc _ t)       = smt_var_list t"
+| "smt_var_list (TUIntFunc _ t)       = smt_var_list t"
 | "smt_var_list (TUConst _)           = []"
 | "smt_var_list TSeqEmpty             = []"
 | "smt_var_list (TSeqCons e r)        = smt_var_list e @ smt_var_list r"
@@ -547,6 +549,10 @@ where
 | "smtEval m env (TUStrFunc name t) =
      (case smtEval m env t of
         Some (SStr str) \<Rightarrow> Some (SStr (builtin_str_func name str))
+      | _ \<Rightarrow> None)"
+| "smtEval m env (TUIntFunc name t) =
+     (case smtEval m env t of
+        Some (SInt n) \<Rightarrow> Some (SInt (builtin_int_func name n))
       | _ \<Rightarrow> None)"
 | "smtEval m env (TUConst nm) = Some (SInt (builtin_const_val nm))"
 | "smtEval m env TSeqEmpty = Some (SSeq [])"

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -133,6 +133,8 @@ where
              then map_option (\<lambda>a'. TUStrPred nm a') (translate enums arg)
            else if is_builtin_func nm
              then map_option (\<lambda>a'. TUStrFunc nm a') (translate enums arg)
+           else if is_builtin_int_func nm
+             then map_option (\<lambda>a'. TUIntFunc nm a') (translate enums arg)
              else None)
       | (IdentifierF nm _, []) \<Rightarrow>
           (if is_builtin_const nm then Some (TUConst nm) else None)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -20,8 +20,10 @@ proof -
     using nmv by (auto simp: is_builtin_pred_def)
   have nf: "\<not> is_builtin_func nm"
     using nmv by (auto simp: is_builtin_func_def)
+  have ni: "\<not> is_builtin_int_func nm"
+    using nmv by (auto simp: is_builtin_int_func_def)
   show ?thesis
-    unfolding req by (cases fuel) (simp_all add: lk nb nf)
+    unfolding req by (cases fuel) (simp_all add: lk nb nf ni)
 qed
 
 lemma sum_eval_None:
@@ -557,20 +559,41 @@ next
         show ?thesis using teq veq ev by simp
       next
         case False
-        have bif: "is_builtin_func nm"
-          using "15.prems"(2) ceq aeq False by (auto split: if_splits option.splits)
-        obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrFunc nm argt"
-          using "15.prems"(2) ceq aeq False bif by (auto split: if_splits option.splits)
-        have lc_none: "lookup_callee fs ps nm = None"
-          using "15.prems"(4) bif by (simp add: builtins_reserved_def)
-        from "15.prems"(1) fuel ceq aeq lc_none False bif obtain str where
-            ea: "eval fs ps fuel s st env arg = Some (VStr str)"
-            and veq: "v = VStr (builtin_str_func nm str)"
-          by (auto split: option.splits ir_value.splits if_splits)
-        have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
-          using "15.IH" fuel ceq aeq lc_none False bif ea ta "15.prems"(3) "15.prems"(4)
-          by (auto split: if_splits)
-        show ?thesis using teq veq ev by simp
+        note npred = False
+        show ?thesis
+        proof (cases "is_builtin_func nm")
+          case True
+          note bif = True
+          obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUStrFunc nm argt"
+            using "15.prems"(2) ceq aeq npred bif by (auto split: if_splits option.splits)
+          have lc_none: "lookup_callee fs ps nm = None"
+            using "15.prems"(4) bif by (simp add: builtins_reserved_def)
+          from "15.prems"(1) fuel ceq aeq lc_none npred bif obtain str where
+              ea: "eval fs ps fuel s st env arg = Some (VStr str)"
+              and veq: "v = VStr (builtin_str_func nm str)"
+            by (auto split: option.splits ir_value.splits if_splits)
+          have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SStr str)"
+            using "15.IH" fuel ceq aeq lc_none npred bif ea ta "15.prems"(3) "15.prems"(4)
+            by (auto split: if_splits)
+          show ?thesis using teq veq ev by simp
+        next
+          case False
+          note nfunc = False
+          have bif: "is_builtin_int_func nm"
+            using "15.prems"(2) ceq aeq npred nfunc by (auto split: if_splits option.splits)
+          obtain argt where ta: "translate enums arg = Some argt" and teq: "t = TUIntFunc nm argt"
+            using "15.prems"(2) ceq aeq npred nfunc bif by (auto split: if_splits option.splits)
+          have lc_none: "lookup_callee fs ps nm = None"
+            using "15.prems"(4) bif by (simp add: builtins_reserved_def)
+          from "15.prems"(1) fuel ceq aeq lc_none npred nfunc bif obtain n where
+              ea: "eval fs ps fuel s st env arg = Some (VInt n)"
+              and veq: "v = VInt (builtin_int_func nm n)"
+            by (auto split: option.splits ir_value.splits if_splits)
+          have ev: "smtEval (correlate_model s st) (correlate_env env) argt = Some (SInt n)"
+            using "15.IH" fuel ceq aeq lc_none npred nfunc bif ea ta "15.prems"(3) "15.prems"(4)
+            by (auto split: if_splits)
+          show ?thesis using teq veq ev by simp
+        qed
       qed
     next
       case (Cons b list)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound_Smt.thy
@@ -217,6 +217,7 @@ fun smt_uses_var :: "String.literal \<Rightarrow> smt_term \<Rightarrow> bool" w
 | "smt_uses_var x (TMatches t _)         = smt_uses_var x t"
 | "smt_uses_var x (TUStrPred _ t)        = smt_uses_var x t"
 | "smt_uses_var x (TUStrFunc _ t)        = smt_uses_var x t"
+| "smt_uses_var x (TUIntFunc _ t)        = smt_uses_var x t"
 | "smt_uses_var x (TUConst _)            = False"
 | "smt_uses_var x TSeqEmpty              = False"
 | "smt_uses_var x (TSeqCons e r)         = (smt_uses_var x e \<or> smt_uses_var x r)"


### PR DESCRIPTION
## What

Lifts the 1-arg `days(n)` `Int -> Int` reserved builtin (n days in epoch seconds) into the verified subset, via a new `TUIntFunc` node - the integer analogue of #433's `hash`/`TUStrFunc`.

- Abstract `builtin_int_func :: String.literal => int => int` + `is_builtin_int_func` (`= "days"`), added to `builtins_reserved`.
- `eval` / `smtEval` / `translate` gain the int-func branch; `TUIntFunc` extracts + encodes as an uninterpreted `days_Int : Int -> Int`.
- **Proven-corresponding** (not vacuous), like `now()` (#429) / `hash` (#433): DirectSound case-15 splits `not is_builtin_pred -> cases is_builtin_func -> TUIntFunc` sub-case (`VInt n` / `builtin_int_func nm n`). The four eval-CallF dispatch lemmas (`eval_dom_CallF`, `range_eval_None`, env-agnosticism, `inline_calls` preservation) gained the int-func case in their pred/func splits. 3-session zero-sorry build green.

## Impact

Stacked on #446 (optional-arithmetic coercion), which ProcessReturn also needs. Together, ecommerce **ProcessReturn**'s `now() - orders[order_id].delivered_at <= days(30)` translates + encodes:

- ecommerce **71 -> 78**: ProcessReturn's `requires` + `enabled` + 5/6 preservation checks verify.
- The 6th (`ProcessReturn.preserves.paidOrdersHavePayments`) is a genuine spec-completeness violation (incomplete payment frame, same class as RecordPayment / CancelOrder).

`days` was already in `Builtins.scala` (codegen); this adds the verified-subset side. Adds `days_demo`; full verify suite green (263). Part of #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lifted the 1‑arg `days(n)` Int -> Int builtin into the verified subset via `TUIntFunc`, so `now() - delivered_at <= days(30)` verifies and encodes to an uninterpreted `days_Int : Int -> Int`. Addresses #420 and builds on optional‑arithmetic from #446.

- **New Features**
  - Added `builtin_int_func`/`is_builtin_int_func` (recognizes `"days"`) and extended `builtins_reserved`.
  - Translate `days(arg)` to `TUIntFunc`; Z3 declares a sort‑mangled `days_Int` uninterpreted function.
  - Updated `eval`, `smtEval`, translate/var‑walk, and soundness proofs for int funcs; added `days_demo`.
  - Ecommerce ProcessReturn shape (`now() - delivered_at <= days(30)`) now verifies (requires/enabled + 5/6 preservation).

<sup>Written for commit c8eb2372b6107a790acd18c041a14b84b596d48c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

