### PR TITLE
feat(verify): generalize the sum aggregate to computed lambda bodies (#420)

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5456,6 +5456,75 @@ object SpecRestGenerated {
 
   def is_builtin_int_func(nm: String): Boolean = nm == "days"
 
+  def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
+    case (uu, Nil) => Nil
+    case (n, x :: xs) =>
+      x == n match {
+        case true  => remove_name(n, xs)
+        case false => x :: remove_name(n, xs)
+      }
+  }
+
+  def remove_names(x0: List[String], xs: List[String]): List[String] = (x0, xs) match {
+    case (Nil, xs)     => xs
+    case (n :: ns, xs) => remove_name(n, remove_names(ns, xs))
+  }
+
+  def free_vars_bindings(x0: List[quantifier_binding]): List[String] = x0 match {
+    case Nil => Nil
+    case QuantifierBindingFull(wj, d, wk, wl) :: bs =>
+      free_vars(d) ++ free_vars_bindings(bs)
+  }
+
+  def free_vars_entries(x0: List[map_entry]): List[String] = x0 match {
+    case Nil => Nil
+    case MapEntryFull(k, v, wi) :: es =>
+      free_vars(k) ++ (free_vars(v) ++ free_vars_entries(es))
+  }
+
+  def free_vars_fields(x0: List[field_assign]): List[String] = x0 match {
+    case Nil                              => Nil
+    case FieldAssignFull(wg, v, wh) :: fs => free_vars(v) ++ free_vars_fields(fs)
+  }
+
+  def free_vars_list(x0: List[expr]): List[String] = x0 match {
+    case Nil     => Nil
+    case x :: xs => free_vars(x) ++ free_vars_list(xs)
+  }
+
+  def free_vars(x0: expr): List[String] = x0 match {
+    case IdentifierF(n, uu)      => List(n)
+    case BinaryOpF(uv, l, r, uw) => free_vars(l) ++ free_vars(r)
+    case UnaryOpF(ux, e, uy)     => free_vars(e)
+    case FieldAccessF(b, uz, va) => free_vars(b)
+    case EnumAccessF(b, vb, vc)  => free_vars(b)
+    case IndexF(b, i, vd)        => free_vars(b) ++ free_vars(i)
+    case CallF(c, args, ve)      => free_vars(c) ++ free_vars_list(args)
+    case PrimeF(e, vf)           => free_vars(e)
+    case PreF(e, vg)             => free_vars(e)
+    case WithF(b, upds, vh)      => free_vars(b) ++ free_vars_fields(upds)
+    case IfF(c, t, e, vi)        => free_vars(c) ++ (free_vars(t) ++ free_vars(e))
+    case LetF(v, vala, body, vj) =>
+      free_vars(vala) ++ remove_name(v, free_vars(body))
+    case LambdaF(p, b, vk)        => remove_name(p, free_vars(b))
+    case ConstructorF(vl, fs, vm) => free_vars_fields(fs)
+    case SetLiteralF(xs, vn)      => free_vars_list(xs)
+    case MapLiteralF(es, vo)      => free_vars_entries(es)
+    case SetComprehensionF(v, d, p, vp) =>
+      free_vars(d) ++ remove_name(v, free_vars(p))
+    case SeqLiteralF(xs, vq) => free_vars_list(xs)
+    case MatchesF(x, vr, vs) => free_vars(x)
+    case SomeWrapF(x, vt)    => free_vars(x)
+    case TheF(v, d, b, vu)   => free_vars(d) ++ remove_name(v, free_vars(b))
+    case QuantifierF(vv, bs, body, vw) =>
+      free_vars_bindings(bs) ++ remove_names(qb_names(bs), free_vars(body))
+    case IntLitF(vx, vy)    => Nil
+    case FloatLitF(vz, wa)  => Nil
+    case StringLitF(wb, wc) => Nil
+    case BoolLitF(wd, we)   => Nil
+    case NoneLitF(wf)       => Nil
+  }
+
   def comp_parts(x0: expr): Option[(String, (String, expr))] = x0 match {
     case SetComprehensionF(vara, d, p, uu) =>
       d match {
@@ -5655,7 +5724,7 @@ object SpecRestGenerated {
                 case (None, _)       => None
                 case (Some(_), None) => None
                 case (Some(c), Some(b)) =>
-                  list_all[String]((v: String) => v == p, smt_var_list(b)) match {
+                  list_all[String]((v: String) => v == p, free_vars(body)) match {
                     case true  => Some[smt_term](TSum(c, b))
                     case false => None
                   }
@@ -7041,75 +7110,6 @@ object SpecRestGenerated {
           case false => false
         }
     }
-
-  def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
-    case (uu, Nil) => Nil
-    case (n, x :: xs) =>
-      x == n match {
-        case true  => remove_name(n, xs)
-        case false => x :: remove_name(n, xs)
-      }
-  }
-
-  def remove_names(x0: List[String], xs: List[String]): List[String] = (x0, xs) match {
-    case (Nil, xs)     => xs
-    case (n :: ns, xs) => remove_name(n, remove_names(ns, xs))
-  }
-
-  def free_vars_bindings(x0: List[quantifier_binding]): List[String] = x0 match {
-    case Nil => Nil
-    case QuantifierBindingFull(wj, d, wk, wl) :: bs =>
-      free_vars(d) ++ free_vars_bindings(bs)
-  }
-
-  def free_vars_entries(x0: List[map_entry]): List[String] = x0 match {
-    case Nil => Nil
-    case MapEntryFull(k, v, wi) :: es =>
-      free_vars(k) ++ (free_vars(v) ++ free_vars_entries(es))
-  }
-
-  def free_vars_fields(x0: List[field_assign]): List[String] = x0 match {
-    case Nil                              => Nil
-    case FieldAssignFull(wg, v, wh) :: fs => free_vars(v) ++ free_vars_fields(fs)
-  }
-
-  def free_vars_list(x0: List[expr]): List[String] = x0 match {
-    case Nil     => Nil
-    case x :: xs => free_vars(x) ++ free_vars_list(xs)
-  }
-
-  def free_vars(x0: expr): List[String] = x0 match {
-    case IdentifierF(n, uu)      => List(n)
-    case BinaryOpF(uv, l, r, uw) => free_vars(l) ++ free_vars(r)
-    case UnaryOpF(ux, e, uy)     => free_vars(e)
-    case FieldAccessF(b, uz, va) => free_vars(b)
-    case EnumAccessF(b, vb, vc)  => free_vars(b)
-    case IndexF(b, i, vd)        => free_vars(b) ++ free_vars(i)
-    case CallF(c, args, ve)      => free_vars(c) ++ free_vars_list(args)
-    case PrimeF(e, vf)           => free_vars(e)
-    case PreF(e, vg)             => free_vars(e)
-    case WithF(b, upds, vh)      => free_vars(b) ++ free_vars_fields(upds)
-    case IfF(c, t, e, vi)        => free_vars(c) ++ (free_vars(t) ++ free_vars(e))
-    case LetF(v, vala, body, vj) =>
-      free_vars(vala) ++ remove_name(v, free_vars(body))
-    case LambdaF(p, b, vk)        => remove_name(p, free_vars(b))
-    case ConstructorF(vl, fs, vm) => free_vars_fields(fs)
-    case SetLiteralF(xs, vn)      => free_vars_list(xs)
-    case MapLiteralF(es, vo)      => free_vars_entries(es)
-    case SetComprehensionF(v, d, p, vp) =>
-      free_vars(d) ++ remove_name(v, free_vars(p))
-    case SeqLiteralF(xs, vq) => free_vars_list(xs)
-    case MatchesF(x, vr, vs) => free_vars(x)
-    case SomeWrapF(x, vt)    => free_vars(x)
-    case TheF(v, d, b, vu)   => free_vars(d) ++ remove_name(v, free_vars(b))
-    case QuantifierF(vv, bs, body, vw) =>
-      free_vars_bindings(bs) ++ remove_names(qb_names(bs), free_vars(body))
-    case IntLitF(vx, vy)    => Nil
-    case FloatLitF(vz, wa)  => Nil
-    case StringLitF(wb, wc) => Nil
-    case BoolLitF(wd, we)   => Nil
-    case NoneLitF(wf)       => Nil
-  }
 
   def isBoolLit(x0: expr): Boolean = x0 match {
     case BoolLitF(uu, uv)                 => true

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -588,7 +588,7 @@ object SpecRestGenerated {
   final case class TSeqCons(a: smt_term, b: smt_term)              extends smt_term
   final case class TMapEmpty()                                     extends smt_term
   final case class TMapCons(a: smt_term, b: smt_term, c: smt_term) extends smt_term
-  final case class TSum(a: smt_term, b: String)                    extends smt_term
+  final case class TSum(a: smt_term, b: smt_term)                  extends smt_term
 
   sealed abstract class field_decl
   final case class FieldDeclFull(a: String, b: type_expr, c: Option[expr], d: Option[span_t])
@@ -5635,141 +5635,34 @@ object SpecRestGenerated {
                   }
               }
           }
-        case (IdentifierF(_, _), _ :: BinaryOpF(_, _, _, _) :: _)                => None
-        case (IdentifierF(_, _), _ :: UnaryOpF(_, _, _) :: _)                    => None
-        case (IdentifierF(_, _), _ :: QuantifierF(_, _, _, _) :: _)              => None
-        case (IdentifierF(_, _), _ :: SomeWrapF(_, _) :: _)                      => None
-        case (IdentifierF(_, _), _ :: TheF(_, _, _, _) :: _)                     => None
-        case (IdentifierF(_, _), _ :: FieldAccessF(_, _, _) :: _)                => None
-        case (IdentifierF(_, _), _ :: EnumAccessF(_, _, _) :: _)                 => None
-        case (IdentifierF(_, _), _ :: IndexF(_, _, _) :: _)                      => None
-        case (IdentifierF(_, _), _ :: CallF(_, _, _) :: _)                       => None
-        case (IdentifierF(_, _), _ :: PrimeF(_, _) :: _)                         => None
-        case (IdentifierF(_, _), _ :: PreF(_, _) :: _)                           => None
-        case (IdentifierF(_, _), _ :: WithF(_, _, _) :: _)                       => None
-        case (IdentifierF(_, _), _ :: IfF(_, _, _, _) :: _)                      => None
-        case (IdentifierF(_, _), _ :: LetF(_, _, _, _) :: _)                     => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, BinaryOpF(_, _, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, UnaryOpF(_, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, QuantifierF(_, _, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, SomeWrapF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, TheF(_, _, _, _), _) :: _) =>
-          None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(BinaryOpF(_, _, _, _), _, _), _) ::
-              _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(UnaryOpF(_, _, _), _, _), _) :: _) =>
-          None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(QuantifierF(_, _, _, _), _, _), _) ::
-              _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SomeWrapF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(TheF(_, _, _, _), _, _), _) :: _) =>
-          None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(FieldAccessF(_, _, _), _, _), _) ::
-              _
-            ) => None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(EnumAccessF(_, _, _), _, _), _) :: _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IndexF(_, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(CallF(_, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(PrimeF(_, _), _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(PreF(_, _), _, _), _) :: _)   => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(WithF(_, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IfF(_, _, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(LetF(_, _, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(LambdaF(_, _, _), _, _), _) :: _) =>
-          None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(ConstructorF(_, _, _), _, _), _) ::
-              _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SetLiteralF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(MapLiteralF(_, _), _, _), _) :: _) =>
-          None
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(SetComprehensionF(_, _, _, _), _, _), _) ::
-              _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(SeqLiteralF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(MatchesF(_, _, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(IntLitF(_, _), _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(FloatLitF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(StringLitF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(BoolLitF(_, _), _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FieldAccessF(NoneLitF(_), _, _), _) :: _) => None
-        case (
-              IdentifierF(nm, _),
-              List(arg, LambdaF(p, FieldAccessF(IdentifierF(q, _), field, _), _))
-            ) => nm == "sum" && p == q match {
-            case true => map_option[smt_term, smt_term](
-                (c: smt_term) =>
-                  TSum(c, field),
-                translate(enums, arg)
-              )
+        case (IdentifierF(_, _), _ :: BinaryOpF(_, _, _, _) :: _)   => None
+        case (IdentifierF(_, _), _ :: UnaryOpF(_, _, _) :: _)       => None
+        case (IdentifierF(_, _), _ :: QuantifierF(_, _, _, _) :: _) => None
+        case (IdentifierF(_, _), _ :: SomeWrapF(_, _) :: _)         => None
+        case (IdentifierF(_, _), _ :: TheF(_, _, _, _) :: _)        => None
+        case (IdentifierF(_, _), _ :: FieldAccessF(_, _, _) :: _)   => None
+        case (IdentifierF(_, _), _ :: EnumAccessF(_, _, _) :: _)    => None
+        case (IdentifierF(_, _), _ :: IndexF(_, _, _) :: _)         => None
+        case (IdentifierF(_, _), _ :: CallF(_, _, _) :: _)          => None
+        case (IdentifierF(_, _), _ :: PrimeF(_, _) :: _)            => None
+        case (IdentifierF(_, _), _ :: PreF(_, _) :: _)              => None
+        case (IdentifierF(_, _), _ :: WithF(_, _, _) :: _)          => None
+        case (IdentifierF(_, _), _ :: IfF(_, _, _, _) :: _)         => None
+        case (IdentifierF(_, _), _ :: LetF(_, _, _, _) :: _)        => None
+        case (IdentifierF(nm, _), List(arg, LambdaF(p, body, _))) =>
+          nm == "sum" match {
+            case true => (translate(enums, arg), translate(enums, body)) match {
+                case (None, _)       => None
+                case (Some(_), None) => None
+                case (Some(c), Some(b)) =>
+                  list_all[String]((v: String) => v == p, smt_var_list(b)) match {
+                    case true  => Some[smt_term](TSum(c, b))
+                    case false => None
+                  }
+              }
             case false => None
           }
-        case (
-              IdentifierF(_, _),
-              _ :: LambdaF(_, FieldAccessF(IdentifierF(_, _), _, _), _) ::
-              _ :: _
-            ) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, EnumAccessF(_, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, IndexF(_, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, CallF(_, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, PrimeF(_, _), _) :: _)   => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, PreF(_, _), _) :: _)     => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, WithF(_, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, IfF(_, _, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, LetF(_, _, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, LambdaF(_, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, ConstructorF(_, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, SetLiteralF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, MapLiteralF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, SetComprehensionF(_, _, _, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, SeqLiteralF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, MatchesF(_, _, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, IntLitF(_, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, FloatLitF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, StringLitF(_, _), _) :: _) =>
-          None
-        case (IdentifierF(_, _), _ :: LambdaF(_, BoolLitF(_, _), _) :: _) => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, NoneLitF(_), _) :: _)    => None
-        case (IdentifierF(_, _), _ :: LambdaF(_, IdentifierF(_, _), _) :: _) =>
-          None
+        case (IdentifierF(_, _), _ :: LambdaF(_, _, _) :: _ :: _)         => None
         case (IdentifierF(_, _), _ :: ConstructorF(_, _, _) :: _)         => None
         case (IdentifierF(_, _), _ :: SetLiteralF(_, _) :: _)             => None
         case (IdentifierF(_, _), _ :: MapLiteralF(_, _) :: _)             => None

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2763,7 +2763,7 @@ object Translator:
               ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Int))
             Z3Expr.App(funcName, List(collZ))
           case None =>
-            fail(ctx, s"cannot infer collection sort for sum aggregate")
+            fail(ctx, "cannot infer collection sort for sum aggregate")
       case TSeqEmpty() =>
         fail(ctx, "empty sequence literal requires context to infer its element sort")
       case cons @ TSeqCons(_, _) =>

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -65,6 +65,7 @@ final private class TranslateCtx(val bnd: TranslateBoundary):
   val state: mutable.LinkedHashMap[String, StateEntry]        = mutable.LinkedHashMap.empty
   val matchesIds: mutable.LinkedHashMap[String, Int]          = mutable.LinkedHashMap.empty
   val stringLitIds: mutable.LinkedHashMap[String, Int]        = mutable.LinkedHashMap.empty
+  val aggSumIds: mutable.LinkedHashMap[String, Int]           = mutable.LinkedHashMap.empty
   val cardinalityNames: mutable.LinkedHashMap[String, String] = mutable.LinkedHashMap.empty
   val skolemIds: mutable.LinkedHashMap[String, Int]           = mutable.LinkedHashMap.empty
   val inputs: mutable.ArrayBuffer[ArtifactBinding]            = mutable.ArrayBuffer.empty
@@ -104,6 +105,17 @@ final private class TranslateCtx(val bnd: TranslateBoundary):
         s"str_$id"
 
   def stringLitCount: Int = stringLitIds.size
+
+  // A sum aggregate's uninterpreted function is keyed by its lambda body. The full term `toString`
+  // is the registry key (injective: distinct terms render distinctly), so distinct bodies always
+  // get distinct ids -- never the collisions a lossy name-sanitiser would risk.
+  def aggSumKeyFor(bodyRendered: String): String =
+    aggSumIds.get(bodyRendered) match
+      case Some(id) => s"b$id"
+      case None =>
+        val id = aggSumIds.size
+        aggSumIds(bodyRendered) = id
+        s"b$id"
 
   def cardinalityNameFor(targetName: String, mode: StateMode = StateMode.Pre): String =
     val key = if mode == StateMode.Post then s"${targetName}__post" else targetName
@@ -2757,8 +2769,7 @@ object Translator:
         val collZ = encodeFromSmtTerm(ctx, coll, env)
         inferSortOfZ3Expr(ctx, collZ) match
           case Some(s) =>
-            val bodyKey  = body.toString.replaceAll("[^A-Za-z0-9]+", "_")
-            val funcName = s"aggsum_${bodyKey}_${sortNameOf(s)}"
+            val funcName = s"aggsum_${ctx.aggSumKeyFor(body.toString)}_${sortNameOf(s)}"
             if !ctx.funcs.contains(funcName) then
               ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Int))
             Z3Expr.App(funcName, List(collZ))

--- a/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/Translator.scala
@@ -2748,20 +2748,22 @@ object Translator:
         if !ctx.funcs.contains(funcName) then
           ctx.declareFunc(Z3FunctionDecl(funcName, Nil, Z3Sort.Int))
         Z3Expr.App(funcName, Nil)
-      // sum(coll, i => i.field): an uninterpreted Int-valued function keyed by the field name and
-      // the collection sort. Same collection => same sum (a functional dependency), so equality
-      // invariants like `subtotal = sum(items, _)` are preserved when the collection is unchanged.
-      // The sum's arithmetic value semantics is not modelled (no finite-sum theory in SMT).
-      case TSum(coll, field) =>
+      // sum(coll, i => body): an uninterpreted Int-valued function keyed by the lambda body and the
+      // collection sort. Same collection + same body => same sum (a functional dependency), so
+      // equality invariants like `subtotal = sum(items, _)` are preserved when the collection is
+      // unchanged. The body (translated, closed over the binder) is a structural key only -- it is
+      // not summed; the arithmetic value semantics is not modelled (no finite-sum theory in SMT).
+      case TSum(coll, body) =>
         val collZ = encodeFromSmtTerm(ctx, coll, env)
         inferSortOfZ3Expr(ctx, collZ) match
           case Some(s) =>
-            val funcName = s"aggsum_${field}_${sortNameOf(s)}"
+            val bodyKey  = body.toString.replaceAll("[^A-Za-z0-9]+", "_")
+            val funcName = s"aggsum_${bodyKey}_${sortNameOf(s)}"
             if !ctx.funcs.contains(funcName) then
               ctx.declareFunc(Z3FunctionDecl(funcName, List(s), Z3Sort.Int))
             Z3Expr.App(funcName, List(collZ))
           case None =>
-            fail(ctx, s"cannot infer collection sort for sum aggregate over field $field")
+            fail(ctx, s"cannot infer collection sort for sum aggregate")
       case TSeqEmpty() =>
         fail(ctx, "empty sequence literal requires context to infer its element sort")
       case cons @ TSeqCons(_, _) =>

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -433,6 +433,27 @@ class ConsistencyTest extends CatsEffectSuite:
       "sum(items, i => i.line_total) must verify: as an uninterpreted function keyed by collection and field, the invariant `subtotal = sum(items, _)` is preserved when items is unchanged (same collection => same sum)"
     ),
     (
+      "sum(coll, i => i * 2) computed-body aggregate verifies (generalizes the field-access case to any binder-closed body)",
+      "sum_computed_demo",
+      """service SumComputedDemo {
+        |  state {
+        |    items: Set[Int]
+        |    doubled: Int
+        |  }
+        |  operation Relabel {
+        |    input: x: Int
+        |    requires:
+        |      true
+        |    ensures:
+        |      items' = pre(items)
+        |      doubled' = pre(doubled)
+        |  }
+        |  invariant doubledIsSum:
+        |    doubled = sum(items, i => i * 2)
+        |}""".stripMargin,
+      "sum(items, i => i * 2) - a computed (non-field-access) lambda body closed over the binder - must verify as an uninterpreted function keyed by the translated body and collection, generalizing #437's field-access-only sum recognizer"
+    ),
+    (
       "#contents on an entity-field Set verifies via Z3 (the ecommerce #items shape)",
       "entity_set_card_demo",
       """service EntitySetCardDemo {

--- a/proofs/isabelle/SpecRest/core/Smt.thy
+++ b/proofs/isabelle/SpecRest/core/Smt.thy
@@ -75,7 +75,7 @@ datatype (plugins only: code size) smt_term =
   | TSeqCons "smt_term" "smt_term"
   | TMapEmpty
   | TMapCons "smt_term" "smt_term" "smt_term"
-  | TSum "smt_term" "String.literal"
+  | TSum "smt_term" "smt_term"
 
 text \<open>\<open>smt_var_list\<close>: every variable name occurring anywhere in a term,
   binders included. Over-approximates the free variables, so a name not in
@@ -342,13 +342,15 @@ definition set_diff_smt_vals ::
   "smt_val list \<Rightarrow> smt_val list \<Rightarrow> smt_val list" where
   "set_diff_smt_vals l r \<equiv> dedupe_smt_vals (filter (\<lambda>v. \<not> contains_smt_val r v) l)"
 
-text \<open>\<open>agg_sum coll field\<close> is the uninterpreted value of \<open>sum(coll, i => i.field)\<close>: abstract, like
+text \<open>\<open>agg_sum coll body\<close> is the uninterpreted value of \<open>sum(coll, i => body)\<close>: abstract, like
   \<open>str_predicate\<close>, so the trusted translator emits it as a Z3 uninterpreted function of the
-  collection (same collection + field \<Rightarrow> same sum). It captures the functional dependency of the
-  aggregate on its collection, not the arithmetic of summation (finite sums are not expressible in
-  first-order SMT); the obligation is vacuous on the reference \<open>eval\<close> (a 2-arg \<open>CallF\<close> evaluates to
-  \<open>None\<close>), so any realisation is sound.\<close>
-consts agg_sum :: "smt_val \<Rightarrow> String.literal \<Rightarrow> int"
+  collection (same collection + body \<Rightarrow> same sum). The body is the translated lambda term, used
+  only as a key distinguishing one aggregate from another (\<open>i.field\<close> vs \<open>i * 2\<close>); the translator
+  restricts it to a body closed over the binder, so it has no free variables beyond the summed-over
+  element. It captures the functional dependency of the aggregate on its collection, not the
+  arithmetic of summation (finite sums are not expressible in first-order SMT); the obligation is
+  vacuous on the reference \<open>eval\<close> (a 2-arg \<open>CallF\<close> evaluates to \<open>None\<close>), so any realisation is sound.\<close>
+consts agg_sum :: "smt_val \<Rightarrow> smt_term \<Rightarrow> int"
 
 function (sequential) smtEval :: "smt_model \<Rightarrow> smt_env \<Rightarrow> smt_term \<Rightarrow> smt_val option"
 and smtEval_forall_enum ::

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -140,9 +140,13 @@ where
              else None)
       | (IdentifierF nm _, []) \<Rightarrow>
           (if is_builtin_const nm then Some (TUConst nm) else None)
-      | (IdentifierF nm _, [coll, LambdaF p (FieldAccessF (IdentifierF q _) field _) _]) \<Rightarrow>
-          (if nm = STR ''sum'' \<and> p = q
-             then map_option (\<lambda>c. TSum c field) (translate enums coll)
+      | (IdentifierF nm _, [coll, LambdaF p body _]) \<Rightarrow>
+          (if nm = STR ''sum''
+             then (case (translate enums coll, translate enums body) of
+                     (Some c, Some b) \<Rightarrow>
+                       (if list_all (\<lambda>v. v = p) (smt_var_list b)
+                          then Some (TSum c b) else None)
+                   | _ \<Rightarrow> None)
              else None)
       | _ \<Rightarrow> None)"
 | "translate enums (ConstructorF name fas _) =

--- a/proofs/isabelle/SpecRest/core/Translate.thy
+++ b/proofs/isabelle/SpecRest/core/Translate.thy
@@ -1,5 +1,5 @@
 theory Translate
-  imports IR Smt
+  imports IR IR_Analysis Smt
 begin
 
 fun identName_smt :: "smt_term \<Rightarrow> String.literal option" where
@@ -144,7 +144,7 @@ where
           (if nm = STR ''sum''
              then (case (translate enums coll, translate enums body) of
                      (Some c, Some b) \<Rightarrow>
-                       (if list_all (\<lambda>v. v = p) (smt_var_list b)
+                       (if list_all (\<lambda>v. v = p) (free_vars body)
                           then Some (TSum c b) else None)
                    | _ \<Rightarrow> None)
              else None)

--- a/proofs/isabelle/SpecRest/soundness/DirectSound.thy
+++ b/proofs/isabelle/SpecRest/soundness/DirectSound.thy
@@ -32,7 +32,7 @@ lemma sum_eval_None:
   shows "eval fs ps fuel s st env (CallF (IdentifierF nm sp1) (arg # a # list) sp) = None"
 proof -
   have nmsum: "nm = STR ''sum''"
-    using tr by (auto split: if_splits option.splits list.splits expr.splits)
+    using tr by (auto split: if_splits option.splits prod.splits list.splits expr.splits)
   have lk: "lookup_callee fs ps nm = None"
     using res nmsum by (simp add: builtins_reserved_def)
   show ?thesis by (cases fuel) (simp_all add: lk)


### PR DESCRIPTION
## What

#437 lifted `sum(coll, i => i.field)`, keyed by the field name only. This generalizes it to **any binder-closed lambda body** - `sum(coll, i => i * 2)`, computed line-totals, etc.

- `TSum`'s second argument changes from a field-name `String.literal` to the **translated lambda body** (`smt_term`).
- The translator recognizes `sum(coll, i => body)` whenever both `coll` and `body` translate **and** the body is closed over the binder (`smt_var_list(body) ⊆ {i}`). The free-var check rejects bodies that close over outer variables, which the collection-keyed uninterpreted function could not soundly capture - and it subsumes #437's old `p = q` check.
- The encoder keys the uninterpreted aggregate function by the body's structure instead of the field name. Same collection + same body still gives the same sum (the functional dependency), so `total = sum(items, _)` is preserved when the collection is unchanged. The arithmetic of summation is still not modelled (no finite-sum theory in SMT).

## Proof

`sum` stays **vacuous-on-eval** (a 2-arg `CallF` evaluates to `None`), so the soundness obligation is unchanged - `sum_eval_None` and the case-15 sum handling only use `nm = sum ∧ eval = None`, not `TSum`'s payload. The payload change is mechanical: `smt_var_list`/`smt_uses_var`/`smtEval` all bind the second argument generically, and the `agg_sum` codegen stub hashes it regardless of type. Only the recognizer and one `prod.splits` in `sum_eval_None` needed edits. Zero `sorry`; `SpecRest_Core` + `SpecRest_Soundness` + `SpecRest_Codegen` build clean (pre-commit hook).

The regenerated `SpecRestGenerated.scala` shrinks by ~87 lines: the old specific pattern `LambdaF p (FieldAccessF (IdentifierF q _) field _)` forced the extractor to enumerate explicit fallthrough cases for every other body shape; the generalized `LambdaF p body` collapses them.

## Result

- **ecommerce stays 78/89** - its `i => i.line_total` sums re-key (function name now derived from the body) but verify identically.
- New computed-body capability covered by `sum_computed_demo`; full verify suite green.
- Honest scope: this is a **capability generalization, not a real-spec coverage win**. The only spec with a computed-body sum (`edge_cases`) is still dominated by a separate **encoder** gap (`field access requires entity sort`, 56 exit-2 skips), and real specs already used field-access sums. It removes an artificial restriction so future specs with computed aggregates (`sum(items, i => i.price * i.qty)`) work.

Refs #420.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalize the sum aggregate to accept any binder‑closed lambda body and key its SMT function via a collision‑safe body‑term registry. Also fix the closure check to use binder‑aware free vars so bodies with inner binders are accepted; no change to eval soundness or existing spec behavior.

- **New Features**
  - `TSum` now carries the translated lambda body (`smt_term`) instead of a field-name string.
  - Translator recognizes `sum(coll, i => body)` when both sides translate and the body is closed over `i`; rejects other free variables.
  - Tests/proofs updated, `sum_computed_demo` added; IR shrinks.

- **Bug Fixes**
  - Use binder‑respecting `free_vars` for the closure check so computed bodies with local binders are accepted.
  - Prevent aggregate-name collisions by registering body terms and emitting `aggsum_b<id>_<sort>` instead of sanitizing `toString`.

<sup>Written for commit cb2b7ab2aae233aae02c793d3d4ee1079dc068f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended sum aggregate function to support computed expressions and custom lambda bodies beyond simple field access patterns.

* **Tests**
  * Added verification test case for sum operations with computed lambda expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->