### PR TITLE
fix(parser): a let-binding scopes the rest of its requires/ensures block

### DIFF
--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -3874,38 +3874,38 @@
                     }
                   },
                   "span" : {
-                    "startLine" : 156,
-                    "startCol" : 6,
-                    "endLine" : 168,
-                    "endCol" : 9
+                    "startLine" : 170,
+                    "startCol" : 8,
+                    "endLine" : 173,
+                    "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 156,
-                  "startCol" : 6,
-                  "endLine" : 168,
-                  "endCol" : 9
+                  "startLine" : 169,
+                  "startCol" : 8,
+                  "endLine" : 173,
+                  "endCol" : 50
                 }
               },
               "span" : {
-                "startLine" : 156,
-                "startCol" : 6,
-                "endLine" : 168,
-                "endCol" : 9
+                "startLine" : 163,
+                "startCol" : 8,
+                "endLine" : 173,
+                "endCol" : 50
               }
             },
             "span" : {
               "startLine" : 156,
               "startCol" : 6,
-              "endLine" : 168,
-              "endCol" : 9
+              "endLine" : 173,
+              "endCol" : 50
             }
           },
           "span" : {
             "startLine" : 155,
             "startCol" : 6,
-            "endLine" : 168,
-            "endCol" : 9
+            "endLine" : 173,
+            "endCol" : 50
           }
         }
       ],
@@ -5085,31 +5085,31 @@
                   }
                 },
                 "span" : {
-                  "startLine" : 186,
-                  "startCol" : 6,
-                  "endLine" : 193,
-                  "endCol" : 9
+                  "startLine" : 195,
+                  "startCol" : 8,
+                  "endLine" : 198,
+                  "endCol" : 74
                 }
               },
               "span" : {
-                "startLine" : 186,
-                "startCol" : 6,
-                "endLine" : 193,
-                "endCol" : 9
+                "startLine" : 194,
+                "startCol" : 8,
+                "endLine" : 198,
+                "endCol" : 74
               }
             },
             "span" : {
-              "startLine" : 186,
-              "startCol" : 6,
-              "endLine" : 193,
-              "endCol" : 9
+              "startLine" : 188,
+              "startCol" : 8,
+              "endLine" : 198,
+              "endCol" : 74
             }
           },
           "span" : {
             "startLine" : 186,
             "startCol" : 6,
-            "endLine" : 193,
-            "endCol" : 9
+            "endLine" : 198,
+            "endCol" : 74
           }
         }
       ],

--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -3128,239 +3128,64 @@
             },
             "body" : {
               "kind" : "BinaryOp",
-              "op" : "=",
+              "op" : "and",
               "left" : {
-                "kind" : "Identifier",
-                "name" : "order",
-                "span" : {
-                  "startLine" : 163,
-                  "startCol" : 8,
-                  "endLine" : 163,
-                  "endCol" : 13
-                }
-              },
-              "right" : {
-                "kind" : "With",
-                "base" : {
-                  "kind" : "Index",
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "Identifier",
+                  "name" : "order",
+                  "span" : {
+                    "startLine" : 163,
+                    "startCol" : 8,
+                    "endLine" : 163,
+                    "endCol" : 13
+                  }
+                },
+                "right" : {
+                  "kind" : "With",
                   "base" : {
-                    "kind" : "Pre",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "orders",
+                    "kind" : "Index",
+                    "base" : {
+                      "kind" : "Pre",
+                      "expr" : {
+                        "kind" : "Identifier",
+                        "name" : "orders",
+                        "span" : {
+                          "startLine" : 163,
+                          "startCol" : 20,
+                          "endLine" : 163,
+                          "endCol" : 26
+                        }
+                      },
                       "span" : {
                         "startLine" : 163,
-                        "startCol" : 20,
+                        "startCol" : 16,
                         "endLine" : 163,
-                        "endCol" : 26
+                        "endCol" : 27
+                      }
+                    },
+                    "index" : {
+                      "kind" : "Identifier",
+                      "name" : "order_id",
+                      "span" : {
+                        "startLine" : 163,
+                        "startCol" : 28,
+                        "endLine" : 163,
+                        "endCol" : 36
                       }
                     },
                     "span" : {
                       "startLine" : 163,
                       "startCol" : 16,
                       "endLine" : 163,
-                      "endCol" : 27
+                      "endCol" : 37
                     }
                   },
-                  "index" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 163,
-                      "startCol" : 28,
-                      "endLine" : 163,
-                      "endCol" : 36
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 163,
-                    "startCol" : 16,
-                    "endLine" : 163,
-                    "endCol" : 37
-                  }
-                },
-                "updates" : [
-                  {
-                    "name" : "items",
-                    "value" : {
-                      "kind" : "BinaryOp",
-                      "op" : "+",
-                      "left" : {
-                        "kind" : "FieldAccess",
-                        "base" : {
-                          "kind" : "Index",
-                          "base" : {
-                            "kind" : "Pre",
-                            "expr" : {
-                              "kind" : "Identifier",
-                              "name" : "orders",
-                              "span" : {
-                                "startLine" : 164,
-                                "startCol" : 22,
-                                "endLine" : 164,
-                                "endCol" : 28
-                              }
-                            },
-                            "span" : {
-                              "startLine" : 164,
-                              "startCol" : 18,
-                              "endLine" : 164,
-                              "endCol" : 29
-                            }
-                          },
-                          "index" : {
-                            "kind" : "Identifier",
-                            "name" : "order_id",
-                            "span" : {
-                              "startLine" : 164,
-                              "startCol" : 30,
-                              "endLine" : 164,
-                              "endCol" : 38
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 164,
-                            "startCol" : 18,
-                            "endLine" : 164,
-                            "endCol" : 39
-                          }
-                        },
-                        "field" : "items",
-                        "span" : {
-                          "startLine" : 164,
-                          "startCol" : 18,
-                          "endLine" : 164,
-                          "endCol" : 45
-                        }
-                      },
-                      "right" : {
-                        "kind" : "SetLiteral",
-                        "elements" : [
-                          {
-                            "kind" : "Identifier",
-                            "name" : "item",
-                            "span" : {
-                              "startLine" : 164,
-                              "startCol" : 49,
-                              "endLine" : 164,
-                              "endCol" : 53
-                            }
-                          }
-                        ],
-                        "span" : {
-                          "startLine" : 164,
-                          "startCol" : 48,
-                          "endLine" : 164,
-                          "endCol" : 54
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 164,
-                        "startCol" : 18,
-                        "endLine" : 164,
-                        "endCol" : 54
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 164,
-                      "startCol" : 10,
-                      "endLine" : 164,
-                      "endCol" : 54
-                    }
-                  },
-                  {
-                    "name" : "subtotal",
-                    "value" : {
-                      "kind" : "BinaryOp",
-                      "op" : "+",
-                      "left" : {
-                        "kind" : "FieldAccess",
-                        "base" : {
-                          "kind" : "Index",
-                          "base" : {
-                            "kind" : "Pre",
-                            "expr" : {
-                              "kind" : "Identifier",
-                              "name" : "orders",
-                              "span" : {
-                                "startLine" : 165,
-                                "startCol" : 25,
-                                "endLine" : 165,
-                                "endCol" : 31
-                              }
-                            },
-                            "span" : {
-                              "startLine" : 165,
-                              "startCol" : 21,
-                              "endLine" : 165,
-                              "endCol" : 32
-                            }
-                          },
-                          "index" : {
-                            "kind" : "Identifier",
-                            "name" : "order_id",
-                            "span" : {
-                              "startLine" : 165,
-                              "startCol" : 33,
-                              "endLine" : 165,
-                              "endCol" : 41
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 165,
-                            "startCol" : 21,
-                            "endLine" : 165,
-                            "endCol" : 42
-                          }
-                        },
-                        "field" : "subtotal",
-                        "span" : {
-                          "startLine" : 165,
-                          "startCol" : 21,
-                          "endLine" : 165,
-                          "endCol" : 51
-                        }
-                      },
-                      "right" : {
-                        "kind" : "FieldAccess",
-                        "base" : {
-                          "kind" : "Identifier",
-                          "name" : "item",
-                          "span" : {
-                            "startLine" : 165,
-                            "startCol" : 54,
-                            "endLine" : 165,
-                            "endCol" : 58
-                          }
-                        },
-                        "field" : "line_total",
-                        "span" : {
-                          "startLine" : 165,
-                          "startCol" : 54,
-                          "endLine" : 165,
-                          "endCol" : 69
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 165,
-                        "startCol" : 21,
-                        "endLine" : 165,
-                        "endCol" : 69
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 165,
-                      "startCol" : 10,
-                      "endLine" : 165,
-                      "endCol" : 69
-                    }
-                  },
-                  {
-                    "name" : "total",
-                    "value" : {
-                      "kind" : "BinaryOp",
-                      "op" : "+",
-                      "left" : {
+                  "updates" : [
+                    {
+                      "name" : "items",
+                      "value" : {
                         "kind" : "BinaryOp",
                         "op" : "+",
                         "left" : {
@@ -3373,16 +3198,16 @@
                                 "kind" : "Identifier",
                                 "name" : "orders",
                                 "span" : {
-                                  "startLine" : 166,
+                                  "startLine" : 164,
                                   "startCol" : 22,
-                                  "endLine" : 166,
+                                  "endLine" : 164,
                                   "endCol" : 28
                                 }
                               },
                               "span" : {
-                                "startLine" : 166,
+                                "startLine" : 164,
                                 "startCol" : 18,
-                                "endLine" : 166,
+                                "endLine" : 164,
                                 "endCol" : 29
                               }
                             },
@@ -3390,25 +3215,113 @@
                               "kind" : "Identifier",
                               "name" : "order_id",
                               "span" : {
-                                "startLine" : 166,
+                                "startLine" : 164,
                                 "startCol" : 30,
-                                "endLine" : 166,
+                                "endLine" : 164,
                                 "endCol" : 38
                               }
                             },
                             "span" : {
-                              "startLine" : 166,
+                              "startLine" : 164,
                               "startCol" : 18,
-                              "endLine" : 166,
+                              "endLine" : 164,
                               "endCol" : 39
+                            }
+                          },
+                          "field" : "items",
+                          "span" : {
+                            "startLine" : 164,
+                            "startCol" : 18,
+                            "endLine" : 164,
+                            "endCol" : 45
+                          }
+                        },
+                        "right" : {
+                          "kind" : "SetLiteral",
+                          "elements" : [
+                            {
+                              "kind" : "Identifier",
+                              "name" : "item",
+                              "span" : {
+                                "startLine" : 164,
+                                "startCol" : 49,
+                                "endLine" : 164,
+                                "endCol" : 53
+                              }
+                            }
+                          ],
+                          "span" : {
+                            "startLine" : 164,
+                            "startCol" : 48,
+                            "endLine" : 164,
+                            "endCol" : 54
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 164,
+                          "startCol" : 18,
+                          "endLine" : 164,
+                          "endCol" : 54
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 164,
+                        "startCol" : 10,
+                        "endLine" : 164,
+                        "endCol" : 54
+                      }
+                    },
+                    {
+                      "name" : "subtotal",
+                      "value" : {
+                        "kind" : "BinaryOp",
+                        "op" : "+",
+                        "left" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Index",
+                            "base" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "orders",
+                                "span" : {
+                                  "startLine" : 165,
+                                  "startCol" : 25,
+                                  "endLine" : 165,
+                                  "endCol" : 31
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 165,
+                                "startCol" : 21,
+                                "endLine" : 165,
+                                "endCol" : 32
+                              }
+                            },
+                            "index" : {
+                              "kind" : "Identifier",
+                              "name" : "order_id",
+                              "span" : {
+                                "startLine" : 165,
+                                "startCol" : 33,
+                                "endLine" : 165,
+                                "endCol" : 41
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 165,
+                              "startCol" : 21,
+                              "endLine" : 165,
+                              "endCol" : 42
                             }
                           },
                           "field" : "subtotal",
                           "span" : {
-                            "startLine" : 166,
-                            "startCol" : 18,
-                            "endLine" : 166,
-                            "endCol" : 48
+                            "startLine" : 165,
+                            "startCol" : 21,
+                            "endLine" : 165,
+                            "endCol" : 51
                           }
                         },
                         "right" : {
@@ -3417,28 +3330,352 @@
                             "kind" : "Identifier",
                             "name" : "item",
                             "span" : {
-                              "startLine" : 166,
-                              "startCol" : 51,
-                              "endLine" : 166,
-                              "endCol" : 55
+                              "startLine" : 165,
+                              "startCol" : 54,
+                              "endLine" : 165,
+                              "endCol" : 58
                             }
                           },
                           "field" : "line_total",
                           "span" : {
+                            "startLine" : 165,
+                            "startCol" : 54,
+                            "endLine" : 165,
+                            "endCol" : 69
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 165,
+                          "startCol" : 21,
+                          "endLine" : 165,
+                          "endCol" : 69
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 165,
+                        "startCol" : 10,
+                        "endLine" : 165,
+                        "endCol" : 69
+                      }
+                    },
+                    {
+                      "name" : "total",
+                      "value" : {
+                        "kind" : "BinaryOp",
+                        "op" : "+",
+                        "left" : {
+                          "kind" : "BinaryOp",
+                          "op" : "+",
+                          "left" : {
+                            "kind" : "FieldAccess",
+                            "base" : {
+                              "kind" : "Index",
+                              "base" : {
+                                "kind" : "Pre",
+                                "expr" : {
+                                  "kind" : "Identifier",
+                                  "name" : "orders",
+                                  "span" : {
+                                    "startLine" : 166,
+                                    "startCol" : 22,
+                                    "endLine" : 166,
+                                    "endCol" : 28
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 166,
+                                  "startCol" : 18,
+                                  "endLine" : 166,
+                                  "endCol" : 29
+                                }
+                              },
+                              "index" : {
+                                "kind" : "Identifier",
+                                "name" : "order_id",
+                                "span" : {
+                                  "startLine" : 166,
+                                  "startCol" : 30,
+                                  "endLine" : 166,
+                                  "endCol" : 38
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 166,
+                                "startCol" : 18,
+                                "endLine" : 166,
+                                "endCol" : 39
+                              }
+                            },
+                            "field" : "subtotal",
+                            "span" : {
+                              "startLine" : 166,
+                              "startCol" : 18,
+                              "endLine" : 166,
+                              "endCol" : 48
+                            }
+                          },
+                          "right" : {
+                            "kind" : "FieldAccess",
+                            "base" : {
+                              "kind" : "Identifier",
+                              "name" : "item",
+                              "span" : {
+                                "startLine" : 166,
+                                "startCol" : 51,
+                                "endLine" : 166,
+                                "endCol" : 55
+                              }
+                            },
+                            "field" : "line_total",
+                            "span" : {
+                              "startLine" : 166,
+                              "startCol" : 51,
+                              "endLine" : 166,
+                              "endCol" : 66
+                            }
+                          },
+                          "span" : {
                             "startLine" : 166,
-                            "startCol" : 51,
+                            "startCol" : 18,
                             "endLine" : 166,
                             "endCol" : 66
+                          }
+                        },
+                        "right" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Index",
+                            "base" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "orders",
+                                "span" : {
+                                  "startLine" : 167,
+                                  "startCol" : 24,
+                                  "endLine" : 167,
+                                  "endCol" : 30
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 167,
+                                "startCol" : 20,
+                                "endLine" : 167,
+                                "endCol" : 31
+                              }
+                            },
+                            "index" : {
+                              "kind" : "Identifier",
+                              "name" : "order_id",
+                              "span" : {
+                                "startLine" : 167,
+                                "startCol" : 32,
+                                "endLine" : 167,
+                                "endCol" : 40
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 167,
+                              "startCol" : 20,
+                              "endLine" : 167,
+                              "endCol" : 41
+                            }
+                          },
+                          "field" : "tax",
+                          "span" : {
+                            "startLine" : 167,
+                            "startCol" : 20,
+                            "endLine" : 167,
+                            "endCol" : 45
                           }
                         },
                         "span" : {
                           "startLine" : 166,
                           "startCol" : 18,
-                          "endLine" : 166,
-                          "endCol" : 66
+                          "endLine" : 167,
+                          "endCol" : 45
                         }
                       },
-                      "right" : {
+                      "span" : {
+                        "startLine" : 166,
+                        "startCol" : 10,
+                        "endLine" : 167,
+                        "endCol" : 45
+                      }
+                    }
+                  ],
+                  "span" : {
+                    "startLine" : 163,
+                    "startCol" : 16,
+                    "endLine" : 168,
+                    "endCol" : 9
+                  }
+                },
+                "span" : {
+                  "startLine" : 163,
+                  "startCol" : 8,
+                  "endLine" : 168,
+                  "endCol" : 9
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "and",
+                "left" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "Prime",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "orders",
+                      "span" : {
+                        "startLine" : 169,
+                        "startCol" : 8,
+                        "endLine" : 169,
+                        "endCol" : 14
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 169,
+                      "startCol" : 8,
+                      "endLine" : 169,
+                      "endCol" : 15
+                    }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "+",
+                    "left" : {
+                      "kind" : "Pre",
+                      "expr" : {
+                        "kind" : "Identifier",
+                        "name" : "orders",
+                        "span" : {
+                          "startLine" : 169,
+                          "startCol" : 22,
+                          "endLine" : 169,
+                          "endCol" : 28
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 169,
+                        "startCol" : 18,
+                        "endLine" : 169,
+                        "endCol" : 29
+                      }
+                    },
+                    "right" : {
+                      "kind" : "MapLiteral",
+                      "entries" : [
+                        {
+                          "key" : {
+                            "kind" : "Identifier",
+                            "name" : "order_id",
+                            "span" : {
+                              "startLine" : 169,
+                              "startCol" : 33,
+                              "endLine" : 169,
+                              "endCol" : 41
+                            }
+                          },
+                          "value" : {
+                            "kind" : "Identifier",
+                            "name" : "order",
+                            "span" : {
+                              "startLine" : 169,
+                              "startCol" : 45,
+                              "endLine" : 169,
+                              "endCol" : 50
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 169,
+                            "startCol" : 33,
+                            "endLine" : 169,
+                            "endCol" : 41
+                          }
+                        }
+                      ],
+                      "span" : {
+                        "startLine" : 169,
+                        "startCol" : 32,
+                        "endLine" : 169,
+                        "endCol" : 51
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 169,
+                      "startCol" : 18,
+                      "endLine" : 169,
+                      "endCol" : 51
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 169,
+                    "startCol" : 8,
+                    "endLine" : 169,
+                    "endCol" : 51
+                  }
+                },
+                "right" : {
+                  "kind" : "BinaryOp",
+                  "op" : "and",
+                  "left" : {
+                    "kind" : "BinaryOp",
+                    "op" : "=",
+                    "left" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Index",
+                        "base" : {
+                          "kind" : "Prime",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "inventory",
+                            "span" : {
+                              "startLine" : 170,
+                              "startCol" : 8,
+                              "endLine" : 170,
+                              "endCol" : 17
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 170,
+                            "startCol" : 8,
+                            "endLine" : 170,
+                            "endCol" : 18
+                          }
+                        },
+                        "index" : {
+                          "kind" : "Identifier",
+                          "name" : "sku",
+                          "span" : {
+                            "startLine" : 170,
+                            "startCol" : 19,
+                            "endLine" : 170,
+                            "endCol" : 22
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 170,
+                          "startCol" : 8,
+                          "endLine" : 170,
+                          "endCol" : 23
+                        }
+                      },
+                      "field" : "reserved",
+                      "span" : {
+                        "startLine" : 170,
+                        "startCol" : 8,
+                        "endLine" : 170,
+                        "endCol" : 32
+                      }
+                    },
+                    "right" : {
+                      "kind" : "BinaryOp",
+                      "op" : "+",
+                      "left" : {
                         "kind" : "FieldAccess",
                         "base" : {
                           "kind" : "Index",
@@ -3446,71 +3683,213 @@
                             "kind" : "Pre",
                             "expr" : {
                               "kind" : "Identifier",
-                              "name" : "orders",
+                              "name" : "inventory",
                               "span" : {
-                                "startLine" : 167,
-                                "startCol" : 24,
-                                "endLine" : 167,
-                                "endCol" : 30
+                                "startLine" : 171,
+                                "startCol" : 14,
+                                "endLine" : 171,
+                                "endCol" : 23
                               }
                             },
                             "span" : {
-                              "startLine" : 167,
-                              "startCol" : 20,
-                              "endLine" : 167,
-                              "endCol" : 31
+                              "startLine" : 171,
+                              "startCol" : 10,
+                              "endLine" : 171,
+                              "endCol" : 24
                             }
                           },
                           "index" : {
                             "kind" : "Identifier",
-                            "name" : "order_id",
+                            "name" : "sku",
                             "span" : {
-                              "startLine" : 167,
-                              "startCol" : 32,
-                              "endLine" : 167,
-                              "endCol" : 40
+                              "startLine" : 171,
+                              "startCol" : 25,
+                              "endLine" : 171,
+                              "endCol" : 28
                             }
                           },
                           "span" : {
-                            "startLine" : 167,
-                            "startCol" : 20,
-                            "endLine" : 167,
-                            "endCol" : 41
+                            "startLine" : 171,
+                            "startCol" : 10,
+                            "endLine" : 171,
+                            "endCol" : 29
                           }
                         },
-                        "field" : "tax",
+                        "field" : "reserved",
                         "span" : {
-                          "startLine" : 167,
-                          "startCol" : 20,
-                          "endLine" : 167,
-                          "endCol" : 45
+                          "startLine" : 171,
+                          "startCol" : 10,
+                          "endLine" : 171,
+                          "endCol" : 38
+                        }
+                      },
+                      "right" : {
+                        "kind" : "Identifier",
+                        "name" : "quantity",
+                        "span" : {
+                          "startLine" : 171,
+                          "startCol" : 41,
+                          "endLine" : 171,
+                          "endCol" : 49
                         }
                       },
                       "span" : {
-                        "startLine" : 166,
-                        "startCol" : 18,
-                        "endLine" : 167,
-                        "endCol" : 45
+                        "startLine" : 171,
+                        "startCol" : 10,
+                        "endLine" : 171,
+                        "endCol" : 49
                       }
                     },
                     "span" : {
-                      "startLine" : 166,
-                      "startCol" : 10,
-                      "endLine" : 167,
-                      "endCol" : 45
+                      "startLine" : 170,
+                      "startCol" : 8,
+                      "endLine" : 171,
+                      "endCol" : 49
                     }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "=",
+                    "left" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Index",
+                        "base" : {
+                          "kind" : "Prime",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "inventory",
+                            "span" : {
+                              "startLine" : 172,
+                              "startCol" : 8,
+                              "endLine" : 172,
+                              "endCol" : 17
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 172,
+                            "startCol" : 8,
+                            "endLine" : 172,
+                            "endCol" : 18
+                          }
+                        },
+                        "index" : {
+                          "kind" : "Identifier",
+                          "name" : "sku",
+                          "span" : {
+                            "startLine" : 172,
+                            "startCol" : 19,
+                            "endLine" : 172,
+                            "endCol" : 22
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 172,
+                          "startCol" : 8,
+                          "endLine" : 172,
+                          "endCol" : 23
+                        }
+                      },
+                      "field" : "available",
+                      "span" : {
+                        "startLine" : 172,
+                        "startCol" : 8,
+                        "endLine" : 172,
+                        "endCol" : 33
+                      }
+                    },
+                    "right" : {
+                      "kind" : "BinaryOp",
+                      "op" : "-",
+                      "left" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Index",
+                          "base" : {
+                            "kind" : "Pre",
+                            "expr" : {
+                              "kind" : "Identifier",
+                              "name" : "inventory",
+                              "span" : {
+                                "startLine" : 173,
+                                "startCol" : 14,
+                                "endLine" : 173,
+                                "endCol" : 23
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 173,
+                              "startCol" : 10,
+                              "endLine" : 173,
+                              "endCol" : 24
+                            }
+                          },
+                          "index" : {
+                            "kind" : "Identifier",
+                            "name" : "sku",
+                            "span" : {
+                              "startLine" : 173,
+                              "startCol" : 25,
+                              "endLine" : 173,
+                              "endCol" : 28
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 173,
+                            "startCol" : 10,
+                            "endLine" : 173,
+                            "endCol" : 29
+                          }
+                        },
+                        "field" : "available",
+                        "span" : {
+                          "startLine" : 173,
+                          "startCol" : 10,
+                          "endLine" : 173,
+                          "endCol" : 39
+                        }
+                      },
+                      "right" : {
+                        "kind" : "Identifier",
+                        "name" : "quantity",
+                        "span" : {
+                          "startLine" : 173,
+                          "startCol" : 42,
+                          "endLine" : 173,
+                          "endCol" : 50
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 173,
+                        "startCol" : 10,
+                        "endLine" : 173,
+                        "endCol" : 50
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 172,
+                      "startCol" : 8,
+                      "endLine" : 173,
+                      "endCol" : 50
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 156,
+                    "startCol" : 6,
+                    "endLine" : 168,
+                    "endCol" : 9
                   }
-                ],
+                },
                 "span" : {
-                  "startLine" : 163,
-                  "startCol" : 16,
+                  "startLine" : 156,
+                  "startCol" : 6,
                   "endLine" : 168,
                   "endCol" : 9
                 }
               },
               "span" : {
-                "startLine" : 163,
-                "startCol" : 8,
+                "startLine" : 156,
+                "startCol" : 6,
                 "endLine" : 168,
                 "endCol" : 9
               }
@@ -3527,355 +3906,6 @@
             "startCol" : 6,
             "endLine" : 168,
             "endCol" : 9
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Prime",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "orders",
-              "span" : {
-                "startLine" : 169,
-                "startCol" : 8,
-                "endLine" : 169,
-                "endCol" : 14
-              }
-            },
-            "span" : {
-              "startLine" : 169,
-              "startCol" : 8,
-              "endLine" : 169,
-              "endCol" : 15
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "+",
-            "left" : {
-              "kind" : "Pre",
-              "expr" : {
-                "kind" : "Identifier",
-                "name" : "orders",
-                "span" : {
-                  "startLine" : 169,
-                  "startCol" : 22,
-                  "endLine" : 169,
-                  "endCol" : 28
-                }
-              },
-              "span" : {
-                "startLine" : 169,
-                "startCol" : 18,
-                "endLine" : 169,
-                "endCol" : 29
-              }
-            },
-            "right" : {
-              "kind" : "MapLiteral",
-              "entries" : [
-                {
-                  "key" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 169,
-                      "startCol" : 33,
-                      "endLine" : 169,
-                      "endCol" : 41
-                    }
-                  },
-                  "value" : {
-                    "kind" : "Identifier",
-                    "name" : "order",
-                    "span" : {
-                      "startLine" : 169,
-                      "startCol" : 45,
-                      "endLine" : 169,
-                      "endCol" : 50
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 169,
-                    "startCol" : 33,
-                    "endLine" : 169,
-                    "endCol" : 41
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 169,
-                "startCol" : 32,
-                "endLine" : 169,
-                "endCol" : 51
-              }
-            },
-            "span" : {
-              "startLine" : 169,
-              "startCol" : 18,
-              "endLine" : 169,
-              "endCol" : 51
-            }
-          },
-          "span" : {
-            "startLine" : 169,
-            "startCol" : 8,
-            "endLine" : 169,
-            "endCol" : 51
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Index",
-              "base" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "inventory",
-                  "span" : {
-                    "startLine" : 170,
-                    "startCol" : 8,
-                    "endLine" : 170,
-                    "endCol" : 17
-                  }
-                },
-                "span" : {
-                  "startLine" : 170,
-                  "startCol" : 8,
-                  "endLine" : 170,
-                  "endCol" : 18
-                }
-              },
-              "index" : {
-                "kind" : "Identifier",
-                "name" : "sku",
-                "span" : {
-                  "startLine" : 170,
-                  "startCol" : 19,
-                  "endLine" : 170,
-                  "endCol" : 22
-                }
-              },
-              "span" : {
-                "startLine" : 170,
-                "startCol" : 8,
-                "endLine" : 170,
-                "endCol" : 23
-              }
-            },
-            "field" : "reserved",
-            "span" : {
-              "startLine" : 170,
-              "startCol" : 8,
-              "endLine" : 170,
-              "endCol" : 32
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "+",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Pre",
-                  "expr" : {
-                    "kind" : "Identifier",
-                    "name" : "inventory",
-                    "span" : {
-                      "startLine" : 171,
-                      "startCol" : 14,
-                      "endLine" : 171,
-                      "endCol" : 23
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 171,
-                    "startCol" : 10,
-                    "endLine" : 171,
-                    "endCol" : 24
-                  }
-                },
-                "index" : {
-                  "kind" : "Identifier",
-                  "name" : "sku",
-                  "span" : {
-                    "startLine" : 171,
-                    "startCol" : 25,
-                    "endLine" : 171,
-                    "endCol" : 28
-                  }
-                },
-                "span" : {
-                  "startLine" : 171,
-                  "startCol" : 10,
-                  "endLine" : 171,
-                  "endCol" : 29
-                }
-              },
-              "field" : "reserved",
-              "span" : {
-                "startLine" : 171,
-                "startCol" : 10,
-                "endLine" : 171,
-                "endCol" : 38
-              }
-            },
-            "right" : {
-              "kind" : "Identifier",
-              "name" : "quantity",
-              "span" : {
-                "startLine" : 171,
-                "startCol" : 41,
-                "endLine" : 171,
-                "endCol" : 49
-              }
-            },
-            "span" : {
-              "startLine" : 171,
-              "startCol" : 10,
-              "endLine" : 171,
-              "endCol" : 49
-            }
-          },
-          "span" : {
-            "startLine" : 170,
-            "startCol" : 8,
-            "endLine" : 171,
-            "endCol" : 49
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Index",
-              "base" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "inventory",
-                  "span" : {
-                    "startLine" : 172,
-                    "startCol" : 8,
-                    "endLine" : 172,
-                    "endCol" : 17
-                  }
-                },
-                "span" : {
-                  "startLine" : 172,
-                  "startCol" : 8,
-                  "endLine" : 172,
-                  "endCol" : 18
-                }
-              },
-              "index" : {
-                "kind" : "Identifier",
-                "name" : "sku",
-                "span" : {
-                  "startLine" : 172,
-                  "startCol" : 19,
-                  "endLine" : 172,
-                  "endCol" : 22
-                }
-              },
-              "span" : {
-                "startLine" : 172,
-                "startCol" : 8,
-                "endLine" : 172,
-                "endCol" : 23
-              }
-            },
-            "field" : "available",
-            "span" : {
-              "startLine" : 172,
-              "startCol" : 8,
-              "endLine" : 172,
-              "endCol" : 33
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "-",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Pre",
-                  "expr" : {
-                    "kind" : "Identifier",
-                    "name" : "inventory",
-                    "span" : {
-                      "startLine" : 173,
-                      "startCol" : 14,
-                      "endLine" : 173,
-                      "endCol" : 23
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 173,
-                    "startCol" : 10,
-                    "endLine" : 173,
-                    "endCol" : 24
-                  }
-                },
-                "index" : {
-                  "kind" : "Identifier",
-                  "name" : "sku",
-                  "span" : {
-                    "startLine" : 173,
-                    "startCol" : 25,
-                    "endLine" : 173,
-                    "endCol" : 28
-                  }
-                },
-                "span" : {
-                  "startLine" : 173,
-                  "startCol" : 10,
-                  "endLine" : 173,
-                  "endCol" : 29
-                }
-              },
-              "field" : "available",
-              "span" : {
-                "startLine" : 173,
-                "startCol" : 10,
-                "endLine" : 173,
-                "endCol" : 39
-              }
-            },
-            "right" : {
-              "kind" : "Identifier",
-              "name" : "quantity",
-              "span" : {
-                "startLine" : 173,
-                "startCol" : 42,
-                "endLine" : 173,
-                "endCol" : 50
-              }
-            },
-            "span" : {
-              "startLine" : 173,
-              "startCol" : 10,
-              "endLine" : 173,
-              "endCol" : 50
-            }
-          },
-          "span" : {
-            "startLine" : 172,
-            "startCol" : 8,
-            "endLine" : 173,
-            "endCol" : 50
           }
         }
       ],
@@ -4249,310 +4279,67 @@
           },
           "body" : {
             "kind" : "BinaryOp",
-            "op" : "=",
+            "op" : "and",
             "left" : {
-              "kind" : "Identifier",
-              "name" : "order",
-              "span" : {
-                "startLine" : 188,
-                "startCol" : 8,
-                "endLine" : 188,
-                "endCol" : 13
-              }
-            },
-            "right" : {
-              "kind" : "With",
-              "base" : {
-                "kind" : "Index",
+              "kind" : "BinaryOp",
+              "op" : "=",
+              "left" : {
+                "kind" : "Identifier",
+                "name" : "order",
+                "span" : {
+                  "startLine" : 188,
+                  "startCol" : 8,
+                  "endLine" : 188,
+                  "endCol" : 13
+                }
+              },
+              "right" : {
+                "kind" : "With",
                 "base" : {
-                  "kind" : "Pre",
-                  "expr" : {
-                    "kind" : "Identifier",
-                    "name" : "orders",
+                  "kind" : "Index",
+                  "base" : {
+                    "kind" : "Pre",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "orders",
+                      "span" : {
+                        "startLine" : 188,
+                        "startCol" : 20,
+                        "endLine" : 188,
+                        "endCol" : 26
+                      }
+                    },
                     "span" : {
                       "startLine" : 188,
-                      "startCol" : 20,
+                      "startCol" : 16,
                       "endLine" : 188,
-                      "endCol" : 26
+                      "endCol" : 27
+                    }
+                  },
+                  "index" : {
+                    "kind" : "Identifier",
+                    "name" : "order_id",
+                    "span" : {
+                      "startLine" : 188,
+                      "startCol" : 28,
+                      "endLine" : 188,
+                      "endCol" : 36
                     }
                   },
                   "span" : {
                     "startLine" : 188,
                     "startCol" : 16,
                     "endLine" : 188,
-                    "endCol" : 27
+                    "endCol" : 37
                   }
                 },
-                "index" : {
-                  "kind" : "Identifier",
-                  "name" : "order_id",
-                  "span" : {
-                    "startLine" : 188,
-                    "startCol" : 28,
-                    "endLine" : 188,
-                    "endCol" : 36
-                  }
-                },
-                "span" : {
-                  "startLine" : 188,
-                  "startCol" : 16,
-                  "endLine" : 188,
-                  "endCol" : 37
-                }
-              },
-              "updates" : [
-                {
-                  "name" : "items",
-                  "value" : {
-                    "kind" : "BinaryOp",
-                    "op" : "-",
-                    "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Index",
-                        "base" : {
-                          "kind" : "Pre",
-                          "expr" : {
-                            "kind" : "Identifier",
-                            "name" : "orders",
-                            "span" : {
-                              "startLine" : 189,
-                              "startCol" : 22,
-                              "endLine" : 189,
-                              "endCol" : 28
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 189,
-                            "startCol" : 18,
-                            "endLine" : 189,
-                            "endCol" : 29
-                          }
-                        },
-                        "index" : {
-                          "kind" : "Identifier",
-                          "name" : "order_id",
-                          "span" : {
-                            "startLine" : 189,
-                            "startCol" : 30,
-                            "endLine" : 189,
-                            "endCol" : 38
-                          }
-                        },
-                        "span" : {
-                          "startLine" : 189,
-                          "startCol" : 18,
-                          "endLine" : 189,
-                          "endCol" : 39
-                        }
-                      },
-                      "field" : "items",
-                      "span" : {
-                        "startLine" : 189,
-                        "startCol" : 18,
-                        "endLine" : 189,
-                        "endCol" : 45
-                      }
-                    },
-                    "right" : {
-                      "kind" : "SetLiteral",
-                      "elements" : [
-                        {
-                          "kind" : "Identifier",
-                          "name" : "removed",
-                          "span" : {
-                            "startLine" : 189,
-                            "startCol" : 49,
-                            "endLine" : 189,
-                            "endCol" : 56
-                          }
-                        }
-                      ],
-                      "span" : {
-                        "startLine" : 189,
-                        "startCol" : 48,
-                        "endLine" : 189,
-                        "endCol" : 57
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 189,
-                      "startCol" : 18,
-                      "endLine" : 189,
-                      "endCol" : 57
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 189,
-                    "startCol" : 10,
-                    "endLine" : 189,
-                    "endCol" : 57
-                  }
-                },
-                {
-                  "name" : "subtotal",
-                  "value" : {
-                    "kind" : "BinaryOp",
-                    "op" : "-",
-                    "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Index",
-                        "base" : {
-                          "kind" : "Pre",
-                          "expr" : {
-                            "kind" : "Identifier",
-                            "name" : "orders",
-                            "span" : {
-                              "startLine" : 190,
-                              "startCol" : 25,
-                              "endLine" : 190,
-                              "endCol" : 31
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 190,
-                            "startCol" : 21,
-                            "endLine" : 190,
-                            "endCol" : 32
-                          }
-                        },
-                        "index" : {
-                          "kind" : "Identifier",
-                          "name" : "order_id",
-                          "span" : {
-                            "startLine" : 190,
-                            "startCol" : 33,
-                            "endLine" : 190,
-                            "endCol" : 41
-                          }
-                        },
-                        "span" : {
-                          "startLine" : 190,
-                          "startCol" : 21,
-                          "endLine" : 190,
-                          "endCol" : 42
-                        }
-                      },
-                      "field" : "subtotal",
-                      "span" : {
-                        "startLine" : 190,
-                        "startCol" : 21,
-                        "endLine" : 190,
-                        "endCol" : 51
-                      }
-                    },
-                    "right" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Identifier",
-                        "name" : "removed",
-                        "span" : {
-                          "startLine" : 190,
-                          "startCol" : 54,
-                          "endLine" : 190,
-                          "endCol" : 61
-                        }
-                      },
-                      "field" : "line_total",
-                      "span" : {
-                        "startLine" : 190,
-                        "startCol" : 54,
-                        "endLine" : 190,
-                        "endCol" : 72
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 190,
-                      "startCol" : 21,
-                      "endLine" : 190,
-                      "endCol" : 72
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 190,
-                    "startCol" : 10,
-                    "endLine" : 190,
-                    "endCol" : 72
-                  }
-                },
-                {
-                  "name" : "total",
-                  "value" : {
-                    "kind" : "BinaryOp",
-                    "op" : "-",
-                    "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Index",
-                        "base" : {
-                          "kind" : "Pre",
-                          "expr" : {
-                            "kind" : "Identifier",
-                            "name" : "orders",
-                            "span" : {
-                              "startLine" : 191,
-                              "startCol" : 22,
-                              "endLine" : 191,
-                              "endCol" : 28
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 191,
-                            "startCol" : 18,
-                            "endLine" : 191,
-                            "endCol" : 29
-                          }
-                        },
-                        "index" : {
-                          "kind" : "Identifier",
-                          "name" : "order_id",
-                          "span" : {
-                            "startLine" : 191,
-                            "startCol" : 30,
-                            "endLine" : 191,
-                            "endCol" : 38
-                          }
-                        },
-                        "span" : {
-                          "startLine" : 191,
-                          "startCol" : 18,
-                          "endLine" : 191,
-                          "endCol" : 39
-                        }
-                      },
-                      "field" : "subtotal",
-                      "span" : {
-                        "startLine" : 191,
-                        "startCol" : 18,
-                        "endLine" : 191,
-                        "endCol" : 48
-                      }
-                    },
-                    "right" : {
+                "updates" : [
+                  {
+                    "name" : "items",
+                    "value" : {
                       "kind" : "BinaryOp",
-                      "op" : "+",
+                      "op" : "-",
                       "left" : {
-                        "kind" : "FieldAccess",
-                        "base" : {
-                          "kind" : "Identifier",
-                          "name" : "removed",
-                          "span" : {
-                            "startLine" : 191,
-                            "startCol" : 51,
-                            "endLine" : 191,
-                            "endCol" : 58
-                          }
-                        },
-                        "field" : "line_total",
-                        "span" : {
-                          "startLine" : 191,
-                          "startCol" : 51,
-                          "endLine" : 191,
-                          "endCol" : 69
-                        }
-                      },
-                      "right" : {
                         "kind" : "FieldAccess",
                         "base" : {
                           "kind" : "Index",
@@ -4562,76 +4349,758 @@
                               "kind" : "Identifier",
                               "name" : "orders",
                               "span" : {
-                                "startLine" : 192,
-                                "startCol" : 24,
-                                "endLine" : 192,
-                                "endCol" : 30
+                                "startLine" : 189,
+                                "startCol" : 22,
+                                "endLine" : 189,
+                                "endCol" : 28
                               }
                             },
                             "span" : {
-                              "startLine" : 192,
-                              "startCol" : 20,
-                              "endLine" : 192,
-                              "endCol" : 31
+                              "startLine" : 189,
+                              "startCol" : 18,
+                              "endLine" : 189,
+                              "endCol" : 29
                             }
                           },
                           "index" : {
                             "kind" : "Identifier",
                             "name" : "order_id",
                             "span" : {
-                              "startLine" : 192,
-                              "startCol" : 32,
-                              "endLine" : 192,
-                              "endCol" : 40
+                              "startLine" : 189,
+                              "startCol" : 30,
+                              "endLine" : 189,
+                              "endCol" : 38
                             }
                           },
+                          "span" : {
+                            "startLine" : 189,
+                            "startCol" : 18,
+                            "endLine" : 189,
+                            "endCol" : 39
+                          }
+                        },
+                        "field" : "items",
+                        "span" : {
+                          "startLine" : 189,
+                          "startCol" : 18,
+                          "endLine" : 189,
+                          "endCol" : 45
+                        }
+                      },
+                      "right" : {
+                        "kind" : "SetLiteral",
+                        "elements" : [
+                          {
+                            "kind" : "Identifier",
+                            "name" : "removed",
+                            "span" : {
+                              "startLine" : 189,
+                              "startCol" : 49,
+                              "endLine" : 189,
+                              "endCol" : 56
+                            }
+                          }
+                        ],
+                        "span" : {
+                          "startLine" : 189,
+                          "startCol" : 48,
+                          "endLine" : 189,
+                          "endCol" : 57
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 189,
+                        "startCol" : 18,
+                        "endLine" : 189,
+                        "endCol" : 57
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 189,
+                      "startCol" : 10,
+                      "endLine" : 189,
+                      "endCol" : 57
+                    }
+                  },
+                  {
+                    "name" : "subtotal",
+                    "value" : {
+                      "kind" : "BinaryOp",
+                      "op" : "-",
+                      "left" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Index",
+                          "base" : {
+                            "kind" : "Pre",
+                            "expr" : {
+                              "kind" : "Identifier",
+                              "name" : "orders",
+                              "span" : {
+                                "startLine" : 190,
+                                "startCol" : 25,
+                                "endLine" : 190,
+                                "endCol" : 31
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 190,
+                              "startCol" : 21,
+                              "endLine" : 190,
+                              "endCol" : 32
+                            }
+                          },
+                          "index" : {
+                            "kind" : "Identifier",
+                            "name" : "order_id",
+                            "span" : {
+                              "startLine" : 190,
+                              "startCol" : 33,
+                              "endLine" : 190,
+                              "endCol" : 41
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 190,
+                            "startCol" : 21,
+                            "endLine" : 190,
+                            "endCol" : 42
+                          }
+                        },
+                        "field" : "subtotal",
+                        "span" : {
+                          "startLine" : 190,
+                          "startCol" : 21,
+                          "endLine" : 190,
+                          "endCol" : 51
+                        }
+                      },
+                      "right" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Identifier",
+                          "name" : "removed",
+                          "span" : {
+                            "startLine" : 190,
+                            "startCol" : 54,
+                            "endLine" : 190,
+                            "endCol" : 61
+                          }
+                        },
+                        "field" : "line_total",
+                        "span" : {
+                          "startLine" : 190,
+                          "startCol" : 54,
+                          "endLine" : 190,
+                          "endCol" : 72
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 190,
+                        "startCol" : 21,
+                        "endLine" : 190,
+                        "endCol" : 72
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 190,
+                      "startCol" : 10,
+                      "endLine" : 190,
+                      "endCol" : 72
+                    }
+                  },
+                  {
+                    "name" : "total",
+                    "value" : {
+                      "kind" : "BinaryOp",
+                      "op" : "-",
+                      "left" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Index",
+                          "base" : {
+                            "kind" : "Pre",
+                            "expr" : {
+                              "kind" : "Identifier",
+                              "name" : "orders",
+                              "span" : {
+                                "startLine" : 191,
+                                "startCol" : 22,
+                                "endLine" : 191,
+                                "endCol" : 28
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 191,
+                              "startCol" : 18,
+                              "endLine" : 191,
+                              "endCol" : 29
+                            }
+                          },
+                          "index" : {
+                            "kind" : "Identifier",
+                            "name" : "order_id",
+                            "span" : {
+                              "startLine" : 191,
+                              "startCol" : 30,
+                              "endLine" : 191,
+                              "endCol" : 38
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 191,
+                            "startCol" : 18,
+                            "endLine" : 191,
+                            "endCol" : 39
+                          }
+                        },
+                        "field" : "subtotal",
+                        "span" : {
+                          "startLine" : 191,
+                          "startCol" : 18,
+                          "endLine" : 191,
+                          "endCol" : 48
+                        }
+                      },
+                      "right" : {
+                        "kind" : "BinaryOp",
+                        "op" : "+",
+                        "left" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Identifier",
+                            "name" : "removed",
+                            "span" : {
+                              "startLine" : 191,
+                              "startCol" : 51,
+                              "endLine" : 191,
+                              "endCol" : 58
+                            }
+                          },
+                          "field" : "line_total",
+                          "span" : {
+                            "startLine" : 191,
+                            "startCol" : 51,
+                            "endLine" : 191,
+                            "endCol" : 69
+                          }
+                        },
+                        "right" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Index",
+                            "base" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "orders",
+                                "span" : {
+                                  "startLine" : 192,
+                                  "startCol" : 24,
+                                  "endLine" : 192,
+                                  "endCol" : 30
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 192,
+                                "startCol" : 20,
+                                "endLine" : 192,
+                                "endCol" : 31
+                              }
+                            },
+                            "index" : {
+                              "kind" : "Identifier",
+                              "name" : "order_id",
+                              "span" : {
+                                "startLine" : 192,
+                                "startCol" : 32,
+                                "endLine" : 192,
+                                "endCol" : 40
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 192,
+                              "startCol" : 20,
+                              "endLine" : 192,
+                              "endCol" : 41
+                            }
+                          },
+                          "field" : "tax",
                           "span" : {
                             "startLine" : 192,
                             "startCol" : 20,
                             "endLine" : 192,
-                            "endCol" : 41
+                            "endCol" : 45
                           }
                         },
-                        "field" : "tax",
                         "span" : {
-                          "startLine" : 192,
-                          "startCol" : 20,
+                          "startLine" : 191,
+                          "startCol" : 51,
                           "endLine" : 192,
                           "endCol" : 45
                         }
                       },
                       "span" : {
                         "startLine" : 191,
-                        "startCol" : 51,
+                        "startCol" : 18,
                         "endLine" : 192,
                         "endCol" : 45
                       }
                     },
                     "span" : {
                       "startLine" : 191,
-                      "startCol" : 18,
+                      "startCol" : 10,
                       "endLine" : 192,
                       "endCol" : 45
                     }
-                  },
-                  "span" : {
-                    "startLine" : 191,
-                    "startCol" : 10,
-                    "endLine" : 192,
-                    "endCol" : 45
                   }
+                ],
+                "span" : {
+                  "startLine" : 188,
+                  "startCol" : 16,
+                  "endLine" : 193,
+                  "endCol" : 9
                 }
-              ],
+              },
               "span" : {
                 "startLine" : 188,
-                "startCol" : 16,
+                "startCol" : 8,
+                "endLine" : 193,
+                "endCol" : 9
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "and",
+              "left" : {
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "Prime",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "orders",
+                    "span" : {
+                      "startLine" : 194,
+                      "startCol" : 8,
+                      "endLine" : 194,
+                      "endCol" : 14
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 194,
+                    "startCol" : 8,
+                    "endLine" : 194,
+                    "endCol" : 15
+                  }
+                },
+                "right" : {
+                  "kind" : "BinaryOp",
+                  "op" : "+",
+                  "left" : {
+                    "kind" : "Pre",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "orders",
+                      "span" : {
+                        "startLine" : 194,
+                        "startCol" : 22,
+                        "endLine" : 194,
+                        "endCol" : 28
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 194,
+                      "startCol" : 18,
+                      "endLine" : 194,
+                      "endCol" : 29
+                    }
+                  },
+                  "right" : {
+                    "kind" : "MapLiteral",
+                    "entries" : [
+                      {
+                        "key" : {
+                          "kind" : "Identifier",
+                          "name" : "order_id",
+                          "span" : {
+                            "startLine" : 194,
+                            "startCol" : 33,
+                            "endLine" : 194,
+                            "endCol" : 41
+                          }
+                        },
+                        "value" : {
+                          "kind" : "Identifier",
+                          "name" : "order",
+                          "span" : {
+                            "startLine" : 194,
+                            "startCol" : 45,
+                            "endLine" : 194,
+                            "endCol" : 50
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 194,
+                          "startCol" : 33,
+                          "endLine" : 194,
+                          "endCol" : 41
+                        }
+                      }
+                    ],
+                    "span" : {
+                      "startLine" : 194,
+                      "startCol" : 32,
+                      "endLine" : 194,
+                      "endCol" : 51
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 194,
+                    "startCol" : 18,
+                    "endLine" : 194,
+                    "endCol" : 51
+                  }
+                },
+                "span" : {
+                  "startLine" : 194,
+                  "startCol" : 8,
+                  "endLine" : 194,
+                  "endCol" : 51
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "and",
+                "left" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "FieldAccess",
+                    "base" : {
+                      "kind" : "Index",
+                      "base" : {
+                        "kind" : "Prime",
+                        "expr" : {
+                          "kind" : "Identifier",
+                          "name" : "inventory",
+                          "span" : {
+                            "startLine" : 195,
+                            "startCol" : 8,
+                            "endLine" : 195,
+                            "endCol" : 17
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 195,
+                          "startCol" : 8,
+                          "endLine" : 195,
+                          "endCol" : 18
+                        }
+                      },
+                      "index" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Identifier",
+                          "name" : "removed",
+                          "span" : {
+                            "startLine" : 195,
+                            "startCol" : 19,
+                            "endLine" : 195,
+                            "endCol" : 26
+                          }
+                        },
+                        "field" : "product_sku",
+                        "span" : {
+                          "startLine" : 195,
+                          "startCol" : 19,
+                          "endLine" : 195,
+                          "endCol" : 38
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 195,
+                        "startCol" : 8,
+                        "endLine" : 195,
+                        "endCol" : 39
+                      }
+                    },
+                    "field" : "reserved",
+                    "span" : {
+                      "startLine" : 195,
+                      "startCol" : 8,
+                      "endLine" : 195,
+                      "endCol" : 48
+                    }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "-",
+                    "left" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Index",
+                        "base" : {
+                          "kind" : "Pre",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "inventory",
+                            "span" : {
+                              "startLine" : 196,
+                              "startCol" : 14,
+                              "endLine" : 196,
+                              "endCol" : 23
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 196,
+                            "startCol" : 10,
+                            "endLine" : 196,
+                            "endCol" : 24
+                          }
+                        },
+                        "index" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Identifier",
+                            "name" : "removed",
+                            "span" : {
+                              "startLine" : 196,
+                              "startCol" : 25,
+                              "endLine" : 196,
+                              "endCol" : 32
+                            }
+                          },
+                          "field" : "product_sku",
+                          "span" : {
+                            "startLine" : 196,
+                            "startCol" : 25,
+                            "endLine" : 196,
+                            "endCol" : 44
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 196,
+                          "startCol" : 10,
+                          "endLine" : 196,
+                          "endCol" : 45
+                        }
+                      },
+                      "field" : "reserved",
+                      "span" : {
+                        "startLine" : 196,
+                        "startCol" : 10,
+                        "endLine" : 196,
+                        "endCol" : 54
+                      }
+                    },
+                    "right" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Identifier",
+                        "name" : "removed",
+                        "span" : {
+                          "startLine" : 196,
+                          "startCol" : 57,
+                          "endLine" : 196,
+                          "endCol" : 64
+                        }
+                      },
+                      "field" : "quantity",
+                      "span" : {
+                        "startLine" : 196,
+                        "startCol" : 57,
+                        "endLine" : 196,
+                        "endCol" : 73
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 196,
+                      "startCol" : 10,
+                      "endLine" : 196,
+                      "endCol" : 73
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 195,
+                    "startCol" : 8,
+                    "endLine" : 196,
+                    "endCol" : 73
+                  }
+                },
+                "right" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "FieldAccess",
+                    "base" : {
+                      "kind" : "Index",
+                      "base" : {
+                        "kind" : "Prime",
+                        "expr" : {
+                          "kind" : "Identifier",
+                          "name" : "inventory",
+                          "span" : {
+                            "startLine" : 197,
+                            "startCol" : 8,
+                            "endLine" : 197,
+                            "endCol" : 17
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 197,
+                          "startCol" : 8,
+                          "endLine" : 197,
+                          "endCol" : 18
+                        }
+                      },
+                      "index" : {
+                        "kind" : "FieldAccess",
+                        "base" : {
+                          "kind" : "Identifier",
+                          "name" : "removed",
+                          "span" : {
+                            "startLine" : 197,
+                            "startCol" : 19,
+                            "endLine" : 197,
+                            "endCol" : 26
+                          }
+                        },
+                        "field" : "product_sku",
+                        "span" : {
+                          "startLine" : 197,
+                          "startCol" : 19,
+                          "endLine" : 197,
+                          "endCol" : 38
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 197,
+                        "startCol" : 8,
+                        "endLine" : 197,
+                        "endCol" : 39
+                      }
+                    },
+                    "field" : "available",
+                    "span" : {
+                      "startLine" : 197,
+                      "startCol" : 8,
+                      "endLine" : 197,
+                      "endCol" : 49
+                    }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "+",
+                    "left" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Index",
+                        "base" : {
+                          "kind" : "Pre",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "inventory",
+                            "span" : {
+                              "startLine" : 198,
+                              "startCol" : 14,
+                              "endLine" : 198,
+                              "endCol" : 23
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 198,
+                            "startCol" : 10,
+                            "endLine" : 198,
+                            "endCol" : 24
+                          }
+                        },
+                        "index" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Identifier",
+                            "name" : "removed",
+                            "span" : {
+                              "startLine" : 198,
+                              "startCol" : 25,
+                              "endLine" : 198,
+                              "endCol" : 32
+                            }
+                          },
+                          "field" : "product_sku",
+                          "span" : {
+                            "startLine" : 198,
+                            "startCol" : 25,
+                            "endLine" : 198,
+                            "endCol" : 44
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 198,
+                          "startCol" : 10,
+                          "endLine" : 198,
+                          "endCol" : 45
+                        }
+                      },
+                      "field" : "available",
+                      "span" : {
+                        "startLine" : 198,
+                        "startCol" : 10,
+                        "endLine" : 198,
+                        "endCol" : 55
+                      }
+                    },
+                    "right" : {
+                      "kind" : "FieldAccess",
+                      "base" : {
+                        "kind" : "Identifier",
+                        "name" : "removed",
+                        "span" : {
+                          "startLine" : 198,
+                          "startCol" : 58,
+                          "endLine" : 198,
+                          "endCol" : 65
+                        }
+                      },
+                      "field" : "quantity",
+                      "span" : {
+                        "startLine" : 198,
+                        "startCol" : 58,
+                        "endLine" : 198,
+                        "endCol" : 74
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 198,
+                      "startCol" : 10,
+                      "endLine" : 198,
+                      "endCol" : 74
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 197,
+                    "startCol" : 8,
+                    "endLine" : 198,
+                    "endCol" : 74
+                  }
+                },
+                "span" : {
+                  "startLine" : 186,
+                  "startCol" : 6,
+                  "endLine" : 193,
+                  "endCol" : 9
+                }
+              },
+              "span" : {
+                "startLine" : 186,
+                "startCol" : 6,
                 "endLine" : 193,
                 "endCol" : 9
               }
             },
             "span" : {
-              "startLine" : 188,
-              "startCol" : 8,
+              "startLine" : 186,
+              "startCol" : 6,
               "endLine" : 193,
               "endCol" : 9
             }
@@ -4641,415 +5110,6 @@
             "startCol" : 6,
             "endLine" : 193,
             "endCol" : 9
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Prime",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "orders",
-              "span" : {
-                "startLine" : 194,
-                "startCol" : 8,
-                "endLine" : 194,
-                "endCol" : 14
-              }
-            },
-            "span" : {
-              "startLine" : 194,
-              "startCol" : 8,
-              "endLine" : 194,
-              "endCol" : 15
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "+",
-            "left" : {
-              "kind" : "Pre",
-              "expr" : {
-                "kind" : "Identifier",
-                "name" : "orders",
-                "span" : {
-                  "startLine" : 194,
-                  "startCol" : 22,
-                  "endLine" : 194,
-                  "endCol" : 28
-                }
-              },
-              "span" : {
-                "startLine" : 194,
-                "startCol" : 18,
-                "endLine" : 194,
-                "endCol" : 29
-              }
-            },
-            "right" : {
-              "kind" : "MapLiteral",
-              "entries" : [
-                {
-                  "key" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 194,
-                      "startCol" : 33,
-                      "endLine" : 194,
-                      "endCol" : 41
-                    }
-                  },
-                  "value" : {
-                    "kind" : "Identifier",
-                    "name" : "order",
-                    "span" : {
-                      "startLine" : 194,
-                      "startCol" : 45,
-                      "endLine" : 194,
-                      "endCol" : 50
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 194,
-                    "startCol" : 33,
-                    "endLine" : 194,
-                    "endCol" : 41
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 194,
-                "startCol" : 32,
-                "endLine" : 194,
-                "endCol" : 51
-              }
-            },
-            "span" : {
-              "startLine" : 194,
-              "startCol" : 18,
-              "endLine" : 194,
-              "endCol" : 51
-            }
-          },
-          "span" : {
-            "startLine" : 194,
-            "startCol" : 8,
-            "endLine" : 194,
-            "endCol" : 51
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Index",
-              "base" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "inventory",
-                  "span" : {
-                    "startLine" : 195,
-                    "startCol" : 8,
-                    "endLine" : 195,
-                    "endCol" : 17
-                  }
-                },
-                "span" : {
-                  "startLine" : 195,
-                  "startCol" : 8,
-                  "endLine" : 195,
-                  "endCol" : 18
-                }
-              },
-              "index" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Identifier",
-                  "name" : "removed",
-                  "span" : {
-                    "startLine" : 195,
-                    "startCol" : 19,
-                    "endLine" : 195,
-                    "endCol" : 26
-                  }
-                },
-                "field" : "product_sku",
-                "span" : {
-                  "startLine" : 195,
-                  "startCol" : 19,
-                  "endLine" : 195,
-                  "endCol" : 38
-                }
-              },
-              "span" : {
-                "startLine" : 195,
-                "startCol" : 8,
-                "endLine" : 195,
-                "endCol" : 39
-              }
-            },
-            "field" : "reserved",
-            "span" : {
-              "startLine" : 195,
-              "startCol" : 8,
-              "endLine" : 195,
-              "endCol" : 48
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "-",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Pre",
-                  "expr" : {
-                    "kind" : "Identifier",
-                    "name" : "inventory",
-                    "span" : {
-                      "startLine" : 196,
-                      "startCol" : 14,
-                      "endLine" : 196,
-                      "endCol" : 23
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 196,
-                    "startCol" : 10,
-                    "endLine" : 196,
-                    "endCol" : 24
-                  }
-                },
-                "index" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "removed",
-                    "span" : {
-                      "startLine" : 196,
-                      "startCol" : 25,
-                      "endLine" : 196,
-                      "endCol" : 32
-                    }
-                  },
-                  "field" : "product_sku",
-                  "span" : {
-                    "startLine" : 196,
-                    "startCol" : 25,
-                    "endLine" : 196,
-                    "endCol" : 44
-                  }
-                },
-                "span" : {
-                  "startLine" : 196,
-                  "startCol" : 10,
-                  "endLine" : 196,
-                  "endCol" : 45
-                }
-              },
-              "field" : "reserved",
-              "span" : {
-                "startLine" : 196,
-                "startCol" : 10,
-                "endLine" : 196,
-                "endCol" : 54
-              }
-            },
-            "right" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Identifier",
-                "name" : "removed",
-                "span" : {
-                  "startLine" : 196,
-                  "startCol" : 57,
-                  "endLine" : 196,
-                  "endCol" : 64
-                }
-              },
-              "field" : "quantity",
-              "span" : {
-                "startLine" : 196,
-                "startCol" : 57,
-                "endLine" : 196,
-                "endCol" : 73
-              }
-            },
-            "span" : {
-              "startLine" : 196,
-              "startCol" : 10,
-              "endLine" : 196,
-              "endCol" : 73
-            }
-          },
-          "span" : {
-            "startLine" : 195,
-            "startCol" : 8,
-            "endLine" : 196,
-            "endCol" : 73
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Index",
-              "base" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "inventory",
-                  "span" : {
-                    "startLine" : 197,
-                    "startCol" : 8,
-                    "endLine" : 197,
-                    "endCol" : 17
-                  }
-                },
-                "span" : {
-                  "startLine" : 197,
-                  "startCol" : 8,
-                  "endLine" : 197,
-                  "endCol" : 18
-                }
-              },
-              "index" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Identifier",
-                  "name" : "removed",
-                  "span" : {
-                    "startLine" : 197,
-                    "startCol" : 19,
-                    "endLine" : 197,
-                    "endCol" : 26
-                  }
-                },
-                "field" : "product_sku",
-                "span" : {
-                  "startLine" : 197,
-                  "startCol" : 19,
-                  "endLine" : 197,
-                  "endCol" : 38
-                }
-              },
-              "span" : {
-                "startLine" : 197,
-                "startCol" : 8,
-                "endLine" : 197,
-                "endCol" : 39
-              }
-            },
-            "field" : "available",
-            "span" : {
-              "startLine" : 197,
-              "startCol" : 8,
-              "endLine" : 197,
-              "endCol" : 49
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "+",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Pre",
-                  "expr" : {
-                    "kind" : "Identifier",
-                    "name" : "inventory",
-                    "span" : {
-                      "startLine" : 198,
-                      "startCol" : 14,
-                      "endLine" : 198,
-                      "endCol" : 23
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 198,
-                    "startCol" : 10,
-                    "endLine" : 198,
-                    "endCol" : 24
-                  }
-                },
-                "index" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "removed",
-                    "span" : {
-                      "startLine" : 198,
-                      "startCol" : 25,
-                      "endLine" : 198,
-                      "endCol" : 32
-                    }
-                  },
-                  "field" : "product_sku",
-                  "span" : {
-                    "startLine" : 198,
-                    "startCol" : 25,
-                    "endLine" : 198,
-                    "endCol" : 44
-                  }
-                },
-                "span" : {
-                  "startLine" : 198,
-                  "startCol" : 10,
-                  "endLine" : 198,
-                  "endCol" : 45
-                }
-              },
-              "field" : "available",
-              "span" : {
-                "startLine" : 198,
-                "startCol" : 10,
-                "endLine" : 198,
-                "endCol" : 55
-              }
-            },
-            "right" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Identifier",
-                "name" : "removed",
-                "span" : {
-                  "startLine" : 198,
-                  "startCol" : 58,
-                  "endLine" : 198,
-                  "endCol" : 65
-                }
-              },
-              "field" : "quantity",
-              "span" : {
-                "startLine" : 198,
-                "startCol" : 58,
-                "endLine" : 198,
-                "endCol" : 74
-              }
-            },
-            "span" : {
-              "startLine" : 198,
-              "startCol" : 10,
-              "endLine" : 198,
-              "endCol" : 74
-            }
-          },
-          "span" : {
-            "startLine" : 197,
-            "startCol" : 8,
-            "endLine" : 198,
-            "endCol" : 74
           }
         }
       ],

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -277,9 +277,21 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
     case c :: rest => c :: scopeLetsOverBlock(rest)
 
   private def extendLetBody(lf: LetF, extra: List[expr]): LetF = lf match
-    case LetF(x, v, inner: LetF, d) => LetF(x, v, extendLetBody(inner, extra), d)
+    case LetF(x, v, inner: LetF, d) =>
+      val extended = extendLetBody(inner, extra)
+      LetF(x, v, extended, coverSpan(d, spanOf(extended)))
     case LetF(x, v, body, d) =>
-      LetF(x, v, (body :: extra).reduceRight((a, b) => BinaryOpF(BAnd(), a, b, d)), d)
+      val folded = (body :: extra).reduceRight: (a, b) =>
+        BinaryOpF(BAnd(), a, b, coverSpan(spanOf(a), spanOf(b)))
+      LetF(x, v, folded, coverSpan(d, spanOf(folded)))
+
+  // The span from `first`'s start to `last`'s end. Synthetic `let`/`and` nodes must cover the
+  // clauses they now fold in (which start after the original body), else a parent's span ends
+  // before its children and source-mapped diagnostics point at an incomplete range.
+  private def coverSpan(first: Option[span_t], last: Option[span_t]): Option[span_t] =
+    (first, last) match
+      case (Some(SpanT(sl, sc, _, _)), Some(SpanT(_, _, el, ec))) => Some(SpanT(sl, sc, el, ec))
+      case (f, l)                                                 => f.orElse(l)
 
   private def buildParam(ctx: ParamContext): BuildResult[ParamDeclFull] =
     buildTypeExpr(ctx.typeExpr).map(t => ParamDeclFull(ctx.lowerIdent.getText, t, sp(ctx)))

--- a/modules/parser/src/main/scala/specrest/parser/Builder.scala
+++ b/modules/parser/src/main/scala/specrest/parser/Builder.scala
@@ -254,17 +254,32 @@ final private class IRBuilder extends SpecBaseVisitor[BuildResult[expr]]:
           else if clause.requiresClause ne null then
             clause.requiresClause.expr.asScala.toList
               .traverseB(expr)
-              .map(es => (ins, outs, reqs ++ es, ens, auth))
+              .map(es => (ins, outs, reqs ++ scopeLetsOverBlock(es), ens, auth))
           else if clause.ensuresClause ne null then
             clause.ensuresClause.expr.asScala.toList
               .traverseB(expr)
-              .map(es => (ins, outs, reqs, ens ++ es, auth))
+              .map(es => (ins, outs, reqs, ens ++ scopeLetsOverBlock(es), auth))
           else if clause.requiresAuthClause ne null then
             val names = clause.requiresAuthClause.lowerIdent.asScala.toList.map(_.getText)
             Right((ins, outs, reqs, ens, Some(auth.getOrElse(Nil) ++ names)))
           else Right((ins, outs, reqs, ens, auth))
     collected.map: (ins, outs, reqs, ens, auth) =>
       OperationDeclFull(name, ins, outs, reqs, ens, auth, sp(ctx))
+
+  // A `let x = v in ...` written above newline-separated clauses reads, by its indentation, as
+  // binding `x` over the whole block. The grammar (`letExpr : LET id EQ expr IN expr`) scopes the
+  // let body to a single clause, so any later clause sees `x` as a free identifier. Fold the
+  // following clauses into the let's innermost body so the binding spans the block as written.
+  private def scopeLetsOverBlock(clauses: List[expr]): List[expr] = clauses match
+    case Nil => Nil
+    case (lf: LetF) :: rest if rest.nonEmpty =>
+      List(extendLetBody(lf, scopeLetsOverBlock(rest)))
+    case c :: rest => c :: scopeLetsOverBlock(rest)
+
+  private def extendLetBody(lf: LetF, extra: List[expr]): LetF = lf match
+    case LetF(x, v, inner: LetF, d) => LetF(x, v, extendLetBody(inner, extra), d)
+    case LetF(x, v, body, d) =>
+      LetF(x, v, (body :: extra).reduceRight((a, b) => BinaryOpF(BAnd(), a, b, d)), d)
 
   private def buildParam(ctx: ParamContext): BuildResult[ParamDeclFull] =
     buildTypeExpr(ctx.typeExpr).map(t => ParamDeclFull(ctx.lowerIdent.getText, t, sp(ctx)))

--- a/modules/parser/src/test/scala/specrest/parser/LetScopeTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/LetScopeTest.scala
@@ -1,0 +1,78 @@
+package specrest.parser
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.parser.testutil.SpecFixtures
+
+class LetScopeTest extends CatsEffectSuite:
+
+  private def service(op: String): String =
+    s"""|service Demo {
+        |  state {
+        |    count: Int
+        |  }
+        |
+        |$op
+        |}
+        |""".stripMargin
+
+  private def ensuresOf(ir: service_ir): List[expr] =
+    operEnsures(svcOperations(ir).head)
+
+  test("let scopes the newline-separated clauses that follow it in an ensures block"):
+    val src = service(
+      """|  operation Bump {
+         |    ensures:
+         |      let c = count in
+         |        count' = c + 1
+         |        count' > c
+         |  }
+         |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("let-block", src).map: ir =>
+      ensuresOf(ir) match
+        case List(LetF("c", _, BinaryOpF(BAnd(), _, _, _), _)) => ()
+        case other                                             => fail(s"expected a single let folding both clauses, got: $other")
+
+  test("clauses before the let stay siblings; the let only absorbs what follows"):
+    val src = service(
+      """|  operation Bump {
+         |    ensures:
+         |      count' >= 0
+         |      let c = count in
+         |        count' = c + 1
+         |        count' > c
+         |  }
+         |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("let-mid", src).map: ir =>
+      ensuresOf(ir) match
+        case List(_, LetF("c", _, BinaryOpF(BAnd(), _, _, _), _)) => ()
+        case other                                                => fail(s"expected [clause, let(c1 and c2)], got: $other")
+
+  test("an `and`-connected let (single clause) is left unchanged"):
+    val src = service(
+      """|  operation Bump {
+         |    ensures:
+         |      let c = count in
+         |        count' = c + 1 and count' > c
+         |  }
+         |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("let-and", src).map: ir =>
+      ensuresOf(ir) match
+        case List(LetF("c", _, BinaryOpF(BAnd(), _, _, _), _)) => ()
+        case other                                             => fail(s"expected a single unchanged let, got: $other")
+
+  test("a let with no following clauses is unchanged (no spurious folding)"):
+    val src = service(
+      """|  operation Bump {
+         |    ensures:
+         |      let c = count in count' = c + 1
+         |  }
+         |""".stripMargin
+    )
+    SpecFixtures.buildFromSource("let-solo", src).map: ir =>
+      ensuresOf(ir) match
+        case List(LetF("c", _, BinaryOpF(BEq(), _, _, _), _)) => ()
+        case other                                            => fail(s"expected a single let with a bare body, got: $other")

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -83,9 +83,9 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ),
     (
       "ecommerce",
-      76,
-      4,
-      "2 `removed` parser scope leak + 2 non-Int scalar ensures; Int scalars backed since #407"
+      70,
+      2,
+      "2 non-Int scalar ensures (next_order_id unbacked); the prior 2 `removed` skips are gone now that a `let` scopes its whole ensures block"
     ),
     ("edge_cases", 29, 0, "plain is an Int scalar backed by service_state since #407"),
     (


### PR DESCRIPTION
## Summary

A `let x = v in ...` written above newline-separated clauses in a `requires`/`ensures` block reads, by its indentation, as binding `x` over the whole block. But the grammar (`letExpr : LET id EQ expr IN expr`) scopes the let body to a **single** clause, so any later clause saw `x` as a free identifier — which `resolveIdentifier` silently resolved to an uninterpreted `Uninterp("Any")` constant. The symptom was a misleading translator error rather than an out-of-scope diagnostic.

This folds the clauses that follow a `let` into the let's innermost body, so the binding spans the block as written (matching how `and`-connected blocks like `auth_service.Login` already behave).

## Impact

- **ecommerce `RemoveLineItem`**: 6 verification checks were skipped with `field access requires entity sort`. The cause was `removed` (bound by `let removed = (the i in ...) in`) being out of scope in the later `inventory'[removed.product_sku]...` clauses. They now verify — ecommerce goes from `5 failures, 6 skipped` to `5 failures, 0 skipped` (the 5 remaining are pre-existing payment-frame spec-completeness violations, unrelated).
- **testgen**: the two previously-skipped `removed` clauses now translate (the `let` binds `removed` over them).

## How it was diagnosed

Hand-rewriting `RemoveLineItem.ensures` with `and` connectives (instead of newline-separated clauses) makes all 6 checks pass; placing the `inventory` clause first after `in` also passes. Both isolate the scope of the `let` body to its first clause.

## Changes

- `modules/parser/.../Builder.scala`: `scopeLetsOverBlock` / `extendLetBody` fold, applied to both `requires` and `ensures` clause lists.
- `modules/parser/.../LetScopeTest.scala` (new): asserts a `let` folds the following clauses, that clauses before it stay siblings, and that single / `and`-connected lets are unchanged.
- `modules/testgen/.../SkipRateProbeTest.scala`: ecommerce expectation updated (`76, 4` → `70, 2`); the prior entry literally documented the "`removed` parser scope leak" this fixes.
- `fixtures/golden/ir/ecommerce.json`: regenerated (only IR golden affected; `RemoveLineItem`/`AddLineItem` ensures re-nest — semantically unchanged for the latter since its siblings don't use the bound vars).

## Validation

All affected module suites pass: parser, ir, verify, convention, codegen, lint, testgen, profile, cli, dafny, synth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `let` scoping so a `let x = ... in` above newline-separated `requires`/`ensures` clauses binds over the whole block, and updates spans so diagnostics cover the full folded block. This removes out-of-scope errors and unblocks ecommerce verification and testgen skips.

- **Bug Fixes**
  - Parser: fold following clauses into the `let` body in both `requires` and `ensures`, and set full source spans on synthetic `let`/`and` nodes so errors highlight the whole block.
  - Removes the free-identifier leak that led to "field access requires entity sort"; ecommerce `RemoveLineItem` now verifies, and the affected clauses translate instead of being skipped.
  - Tests/fixtures: added `LetScopeTest`; updated `modules/testgen/.../SkipRateProbeTest.scala` to `70, 2`; regenerated `fixtures/golden/ir/ecommerce.json`.

<sup>Written for commit 2b5b5d196624f70b75282525d04e1e377b7bcd13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved handling of variable bindings in specification logic expressions for more accurate evaluation across multiple clauses.

* **Tests**
  * Added new test suite validating correct scoping behavior.
  * Updated test expectations to reflect improved parsing behavior.

* **Chores**
  * Updated test fixture data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->