### PR TITLE
fix(todo_list): make nextIdFresh inductive so CreateTodo preserves it

### DIFF
--- a/fixtures/golden/dafny/todo_list.dfy
+++ b/fixtures/golden/dafny/todo_list.dfy
@@ -36,7 +36,7 @@ predicate ServiceStateInv(st: ServiceState)
 {
   (forall id :: (id in st.todos) ==> (id > 0))
   && (st.next_id > 0)
-  && (st.next_id !in st.todos)
+  && (forall id :: (id in st.todos) ==> (id < st.next_id))
   && (forall id :: (id in st.todos) ==> ((st.todos[id].status == DONE <==> st.todos[id].completed_at != None)))
 }
 

--- a/fixtures/golden/ir/todo_list.json
+++ b/fixtures/golden/ir/todo_list.json
@@ -4811,40 +4811,72 @@
       "kind" : "Invariant",
       "name" : "nextIdFresh",
       "expr" : {
-        "kind" : "BinaryOp",
-        "op" : "not_in",
-        "left" : {
-          "kind" : "Identifier",
-          "name" : "next_id",
-          "span" : {
-            "startLine" : 209,
-            "startCol" : 4,
-            "endLine" : 209,
-            "endCol" : 11
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "id",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "todos",
+              "span" : {
+                "startLine" : 209,
+                "startCol" : 14,
+                "endLine" : 209,
+                "endCol" : 19
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 209,
+              "startCol" : 8,
+              "endLine" : 209,
+              "endCol" : 19
+            }
           }
-        },
-        "right" : {
-          "kind" : "Identifier",
-          "name" : "todos",
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "<",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "id",
+            "span" : {
+              "startLine" : 209,
+              "startCol" : 22,
+              "endLine" : 209,
+              "endCol" : 24
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "next_id",
+            "span" : {
+              "startLine" : 209,
+              "startCol" : 27,
+              "endLine" : 209,
+              "endCol" : 34
+            }
+          },
           "span" : {
             "startLine" : 209,
-            "startCol" : 19,
+            "startCol" : 22,
             "endLine" : 209,
-            "endCol" : 24
+            "endCol" : 34
           }
         },
         "span" : {
           "startLine" : 209,
           "startCol" : 4,
           "endLine" : 209,
-          "endCol" : 24
+          "endCol" : 34
         }
       },
       "span" : {
         "startLine" : 208,
         "startCol" : 2,
         "endLine" : 209,
-        "endCol" : 24
+        "endCol" : 34
       }
     },
     {

--- a/fixtures/spec/todo_list.spec
+++ b/fixtures/spec/todo_list.spec
@@ -206,7 +206,7 @@ service TodoList {
     next_id > 0
 
   invariant nextIdFresh:
-    next_id not in todos
+    all id in todos | id < next_id
 
   invariant completedImpliesDone:
     all id in todos |


### PR DESCRIPTION
## Summary

`todo_list`'s `nextIdFresh` invariant was not inductive, so `CreateTodo` reported a (genuine, non-spurious) preservation violation — leaving the spec at 54/55.

```text
invariant nextIdFresh: next_id not in todos
```

This only constrains `next_id` itself, not `next_id + 1`. `CreateTodo` adds key `pre(next_id)` and sets `next_id' = pre(next_id) + 1`. When `pre(todos)` already contains `pre(next_id) + 1` — which the old invariant permits — the post-state has `next_id' in todos'`, violating `nextIdFresh`.

## Fix

Strengthen it to the inductive monotonic fresh-counter shape (the same form `auth_service`'s `nextUserIdFresh: all u in users | u < next_user_id` already uses):

```text
invariant nextIdFresh: all id in todos | id < next_id
```

This implies the old form (`all keys < next_id` ⇒ `next_id` is not a key) and is preserved by every operation. **todo_list now verifies 55/55.**

## Changes

- `fixtures/spec/todo_list.spec`: strengthen `nextIdFresh`.
- `fixtures/golden/ir/todo_list.json`, `fixtures/golden/dafny/todo_list.dfy`: regenerated (the invariant body changes shape, and is emitted into the Dafny skeleton).

## Validation

All affected module suites pass: parser, ir, verify, dafny, codegen, lint, convention, profile, testgen.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `todo_list` next-id freshness invariant inductive so `CreateTodo` preserves it. Switch to the monotonic counter form; the spec now verifies 55/55.

- **Bug Fixes**
  - Strengthened `nextIdFresh` to `all id in todos | id < next_id` (replacing `next_id not in todos`) to prevent post-state collisions after increment.
  - Regenerated `fixtures/golden/ir/todo_list.json` and `fixtures/golden/dafny/todo_list.dfy` to reflect the new invariant.

<sup>Written for commit 44381cb8530c4f5ebc4eea6a696a31e7bc0fbfab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened data consistency validation for todo ID tracking. The system now ensures all existing todo items have IDs strictly less than the next available ID, improving invariant checking robustness across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->