### PR TITLE
feat(verify): conditional relation-insert in ensures frames

### DIFF
--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -5793,29 +5793,38 @@
                 "endCol" : 13
               }
             },
-            "field" : "order_id",
+            "field" : "id",
             "span" : {
               "startLine" : 226,
               "startCol" : 6,
               "endLine" : 226,
-              "endCol" : 22
+              "endCol" : 16
             }
           },
           "right" : {
-            "kind" : "Identifier",
-            "name" : "order_id",
+            "kind" : "Pre",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_payment_id",
+              "span" : {
+                "startLine" : 226,
+                "startCol" : 23,
+                "endLine" : 226,
+                "endCol" : 38
+              }
+            },
             "span" : {
               "startLine" : 226,
-              "startCol" : 25,
+              "startCol" : 19,
               "endLine" : 226,
-              "endCol" : 33
+              "endCol" : 39
             }
           },
           "span" : {
             "startLine" : 226,
             "startCol" : 6,
             "endLine" : 226,
-            "endCol" : 33
+            "endCol" : 39
           }
         },
         {
@@ -5833,29 +5842,29 @@
                 "endCol" : 13
               }
             },
-            "field" : "amount",
+            "field" : "order_id",
             "span" : {
               "startLine" : 227,
               "startCol" : 6,
               "endLine" : 227,
-              "endCol" : 20
+              "endCol" : 22
             }
           },
           "right" : {
             "kind" : "Identifier",
-            "name" : "amount",
+            "name" : "order_id",
             "span" : {
               "startLine" : 227,
-              "startCol" : 23,
+              "startCol" : 25,
               "endLine" : 227,
-              "endCol" : 29
+              "endCol" : 33
             }
           },
           "span" : {
             "startLine" : 227,
             "startCol" : 6,
             "endLine" : 227,
-            "endCol" : 29
+            "endCol" : 33
           }
         },
         {
@@ -5873,7 +5882,7 @@
                 "endCol" : 13
               }
             },
-            "field" : "status",
+            "field" : "amount",
             "span" : {
               "startLine" : 228,
               "startCol" : 6,
@@ -5883,18 +5892,58 @@
           },
           "right" : {
             "kind" : "Identifier",
-            "name" : "CAPTURED",
+            "name" : "amount",
             "span" : {
               "startLine" : 228,
               "startCol" : 23,
               "endLine" : 228,
-              "endCol" : 31
+              "endCol" : 29
             }
           },
           "span" : {
             "startLine" : 228,
             "startCol" : 6,
             "endLine" : 228,
+            "endCol" : 29
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Identifier",
+              "name" : "payment",
+              "span" : {
+                "startLine" : 229,
+                "startCol" : 6,
+                "endLine" : 229,
+                "endCol" : 13
+              }
+            },
+            "field" : "status",
+            "span" : {
+              "startLine" : 229,
+              "startCol" : 6,
+              "endLine" : 229,
+              "endCol" : 20
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "CAPTURED",
+            "span" : {
+              "startLine" : 229,
+              "startCol" : 23,
+              "endLine" : 229,
+              "endCol" : 31
+            }
+          },
+          "span" : {
+            "startLine" : 229,
+            "startCol" : 6,
+            "endLine" : 229,
             "endCol" : 31
           }
         },
@@ -5911,16 +5960,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 229,
+                    "startLine" : 230,
                     "startCol" : 6,
-                    "endLine" : 229,
+                    "endLine" : 230,
                     "endCol" : 12
                   }
                 },
                 "span" : {
-                  "startLine" : 229,
+                  "startLine" : 230,
                   "startCol" : 6,
-                  "endLine" : 229,
+                  "endLine" : 230,
                   "endCol" : 13
                 }
               },
@@ -5928,24 +5977,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 229,
+                  "startLine" : 230,
                   "startCol" : 14,
-                  "endLine" : 229,
+                  "endLine" : 230,
                   "endCol" : 22
                 }
               },
               "span" : {
-                "startLine" : 229,
+                "startLine" : 230,
                 "startCol" : 6,
-                "endLine" : 229,
+                "endLine" : 230,
                 "endCol" : 23
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 229,
+              "startLine" : 230,
               "startCol" : 6,
-              "endLine" : 229,
+              "endLine" : 230,
               "endCol" : 30
             }
           },
@@ -5953,16 +6002,16 @@
             "kind" : "Identifier",
             "name" : "PAID",
             "span" : {
-              "startLine" : 229,
+              "startLine" : 230,
               "startCol" : 33,
-              "endLine" : 229,
+              "endLine" : 230,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 229,
+            "startLine" : 230,
             "startCol" : 6,
-            "endLine" : 229,
+            "endLine" : 230,
             "endCol" : 37
           }
         },
@@ -5975,16 +6024,16 @@
               "kind" : "Identifier",
               "name" : "payments",
               "span" : {
-                "startLine" : 230,
+                "startLine" : 231,
                 "startCol" : 6,
-                "endLine" : 230,
+                "endLine" : 231,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 230,
+              "startLine" : 231,
               "startCol" : 6,
-              "endLine" : 230,
+              "endLine" : 231,
               "endCol" : 15
             }
           },
@@ -5997,16 +6046,16 @@
                 "kind" : "Identifier",
                 "name" : "payments",
                 "span" : {
-                  "startLine" : 230,
+                  "startLine" : 231,
                   "startCol" : 22,
-                  "endLine" : 230,
+                  "endLine" : 231,
                   "endCol" : 30
                 }
               },
               "span" : {
-                "startLine" : 230,
+                "startLine" : 231,
                 "startCol" : 18,
-                "endLine" : 230,
+                "endLine" : 231,
                 "endCol" : 31
               }
             },
@@ -6020,17 +6069,17 @@
                       "kind" : "Identifier",
                       "name" : "payment",
                       "span" : {
-                        "startLine" : 230,
+                        "startLine" : 231,
                         "startCol" : 35,
-                        "endLine" : 230,
+                        "endLine" : 231,
                         "endCol" : 42
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 230,
+                      "startLine" : 231,
                       "startCol" : 35,
-                      "endLine" : 230,
+                      "endLine" : 231,
                       "endCol" : 45
                     }
                   },
@@ -6038,38 +6087,38 @@
                     "kind" : "Identifier",
                     "name" : "payment",
                     "span" : {
-                      "startLine" : 230,
+                      "startLine" : 231,
                       "startCol" : 49,
-                      "endLine" : 230,
+                      "endLine" : 231,
                       "endCol" : 56
                     }
                   },
                   "span" : {
-                    "startLine" : 230,
+                    "startLine" : 231,
                     "startCol" : 35,
-                    "endLine" : 230,
+                    "endLine" : 231,
                     "endCol" : 45
                   }
                 }
               ],
               "span" : {
-                "startLine" : 230,
+                "startLine" : 231,
                 "startCol" : 34,
-                "endLine" : 230,
+                "endLine" : 231,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 230,
+              "startLine" : 231,
               "startCol" : 18,
-              "endLine" : 230,
+              "endLine" : 231,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 230,
+            "startLine" : 231,
             "startCol" : 6,
-            "endLine" : 230,
+            "endLine" : 231,
             "endCol" : 57
           }
         },
@@ -6082,16 +6131,16 @@
               "kind" : "Identifier",
               "name" : "next_payment_id",
               "span" : {
-                "startLine" : 231,
+                "startLine" : 232,
                 "startCol" : 6,
-                "endLine" : 231,
+                "endLine" : 232,
                 "endCol" : 21
               }
             },
             "span" : {
-              "startLine" : 231,
+              "startLine" : 232,
               "startCol" : 6,
-              "endLine" : 231,
+              "endLine" : 232,
               "endCol" : 22
             }
           },
@@ -6104,16 +6153,16 @@
                 "kind" : "Identifier",
                 "name" : "next_payment_id",
                 "span" : {
-                  "startLine" : 231,
+                  "startLine" : 232,
                   "startCol" : 29,
-                  "endLine" : 231,
+                  "endLine" : 232,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 231,
+                "startLine" : 232,
                 "startCol" : 25,
-                "endLine" : 231,
+                "endLine" : 232,
                 "endCol" : 45
               }
             },
@@ -6121,23 +6170,23 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 231,
+                "startLine" : 232,
                 "startCol" : 48,
-                "endLine" : 231,
+                "endLine" : 232,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 231,
+              "startLine" : 232,
               "startCol" : 25,
-              "endLine" : 231,
+              "endLine" : 232,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 231,
+            "startLine" : 232,
             "startCol" : 6,
-            "endLine" : 231,
+            "endLine" : 232,
             "endCol" : 49
           }
         }
@@ -6145,7 +6194,7 @@
       "span" : {
         "startLine" : 216,
         "startCol" : 2,
-        "endLine" : 232,
+        "endLine" : 233,
         "endCol" : 3
       }
     },
@@ -6160,16 +6209,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 235,
+              "startLine" : 236,
               "startCol" : 22,
-              "endLine" : 235,
+              "endLine" : 236,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 235,
+            "startLine" : 236,
             "startCol" : 12,
-            "endLine" : 235,
+            "endLine" : 236,
             "endCol" : 29
           }
         }
@@ -6182,16 +6231,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 236,
+              "startLine" : 237,
               "startCol" : 19,
-              "endLine" : 236,
+              "endLine" : 237,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 236,
+            "startLine" : 237,
             "startCol" : 12,
-            "endLine" : 236,
+            "endLine" : 237,
             "endCol" : 24
           }
         }
@@ -6204,9 +6253,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 239,
+              "startLine" : 240,
               "startCol" : 6,
-              "endLine" : 239,
+              "endLine" : 240,
               "endCol" : 14
             }
           },
@@ -6214,16 +6263,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 239,
+              "startLine" : 240,
               "startCol" : 18,
-              "endLine" : 239,
+              "endLine" : 240,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 239,
+            "startLine" : 240,
             "startCol" : 6,
-            "endLine" : 239,
+            "endLine" : 240,
             "endCol" : 24
           }
         },
@@ -6238,9 +6287,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 240,
+                  "startLine" : 241,
                   "startCol" : 6,
-                  "endLine" : 240,
+                  "endLine" : 241,
                   "endCol" : 12
                 }
               },
@@ -6248,24 +6297,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 240,
+                  "startLine" : 241,
                   "startCol" : 13,
-                  "endLine" : 240,
+                  "endLine" : 241,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 240,
+                "startLine" : 241,
                 "startCol" : 6,
-                "endLine" : 240,
+                "endLine" : 241,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 240,
+              "startLine" : 241,
               "startCol" : 6,
-              "endLine" : 240,
+              "endLine" : 241,
               "endCol" : 29
             }
           },
@@ -6273,16 +6322,16 @@
             "kind" : "Identifier",
             "name" : "PAID",
             "span" : {
-              "startLine" : 240,
+              "startLine" : 241,
               "startCol" : 32,
-              "endLine" : 240,
+              "endLine" : 241,
               "endCol" : 36
             }
           },
           "span" : {
-            "startLine" : 240,
+            "startLine" : 241,
             "startCol" : 6,
-            "endLine" : 240,
+            "endLine" : 241,
             "endCol" : 36
           }
         }
@@ -6295,9 +6344,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 243,
+              "startLine" : 244,
               "startCol" : 6,
-              "endLine" : 243,
+              "endLine" : 244,
               "endCol" : 11
             }
           },
@@ -6311,16 +6360,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 243,
+                    "startLine" : 244,
                     "startCol" : 18,
-                    "endLine" : 243,
+                    "endLine" : 244,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 243,
+                  "startLine" : 244,
                   "startCol" : 14,
-                  "endLine" : 243,
+                  "endLine" : 244,
                   "endCol" : 25
                 }
               },
@@ -6328,16 +6377,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 243,
+                  "startLine" : 244,
                   "startCol" : 26,
-                  "endLine" : 243,
+                  "endLine" : 244,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 243,
+                "startLine" : 244,
                 "startCol" : 14,
-                "endLine" : 243,
+                "endLine" : 244,
                 "endCol" : 35
               }
             },
@@ -6348,16 +6397,16 @@
                   "kind" : "Identifier",
                   "name" : "SHIPPED",
                   "span" : {
-                    "startLine" : 244,
+                    "startLine" : 245,
                     "startCol" : 17,
-                    "endLine" : 244,
+                    "endLine" : 245,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 244,
+                  "startLine" : 245,
                   "startCol" : 8,
-                  "endLine" : 244,
+                  "endLine" : 245,
                   "endCol" : 24
                 }
               },
@@ -6371,47 +6420,47 @@
                       "kind" : "Identifier",
                       "name" : "now",
                       "span" : {
-                        "startLine" : 245,
+                        "startLine" : 246,
                         "startCol" : 26,
-                        "endLine" : 245,
+                        "endLine" : 246,
                         "endCol" : 29
                       }
                     },
                     "args" : [
                     ],
                     "span" : {
-                      "startLine" : 245,
+                      "startLine" : 246,
                       "startCol" : 26,
-                      "endLine" : 245,
+                      "endLine" : 246,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 245,
+                    "startLine" : 246,
                     "startCol" : 21,
-                    "endLine" : 245,
+                    "endLine" : 246,
                     "endCol" : 32
                   }
                 },
                 "span" : {
-                  "startLine" : 245,
+                  "startLine" : 246,
                   "startCol" : 8,
-                  "endLine" : 245,
+                  "endLine" : 246,
                   "endCol" : 32
                 }
               }
             ],
             "span" : {
-              "startLine" : 243,
+              "startLine" : 244,
               "startCol" : 14,
-              "endLine" : 246,
+              "endLine" : 247,
               "endCol" : 7
             }
           },
           "span" : {
-            "startLine" : 243,
+            "startLine" : 244,
             "startCol" : 6,
-            "endLine" : 246,
+            "endLine" : 247,
             "endCol" : 7
           }
         },
@@ -6424,16 +6473,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 248,
                 "startCol" : 6,
-                "endLine" : 247,
+                "endLine" : 248,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 247,
+              "startLine" : 248,
               "startCol" : 6,
-              "endLine" : 247,
+              "endLine" : 248,
               "endCol" : 13
             }
           },
@@ -6446,16 +6495,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 247,
+                  "startLine" : 248,
                   "startCol" : 20,
-                  "endLine" : 247,
+                  "endLine" : 248,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 247,
+                "startLine" : 248,
                 "startCol" : 16,
-                "endLine" : 247,
+                "endLine" : 248,
                 "endCol" : 27
               }
             },
@@ -6467,9 +6516,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 247,
+                      "startLine" : 248,
                       "startCol" : 31,
-                      "endLine" : 247,
+                      "endLine" : 248,
                       "endCol" : 39
                     }
                   },
@@ -6477,38 +6526,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 247,
+                      "startLine" : 248,
                       "startCol" : 43,
-                      "endLine" : 247,
+                      "endLine" : 248,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 247,
+                    "startLine" : 248,
                     "startCol" : 31,
-                    "endLine" : 247,
+                    "endLine" : 248,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 247,
+                "startLine" : 248,
                 "startCol" : 30,
-                "endLine" : 247,
+                "endLine" : 248,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 247,
+              "startLine" : 248,
               "startCol" : 16,
-              "endLine" : 247,
+              "endLine" : 248,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 247,
+            "startLine" : 248,
             "startCol" : 6,
-            "endLine" : 247,
+            "endLine" : 248,
             "endCol" : 49
           }
         },
@@ -6524,25 +6573,25 @@
                   "kind" : "Identifier",
                   "name" : "order",
                   "span" : {
-                    "startLine" : 248,
+                    "startLine" : 249,
                     "startCol" : 18,
-                    "endLine" : 248,
+                    "endLine" : 249,
                     "endCol" : 23
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 248,
+                  "startLine" : 249,
                   "startCol" : 18,
-                  "endLine" : 248,
+                  "endLine" : 249,
                   "endCol" : 29
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 248,
+                "startLine" : 249,
                 "startCol" : 10,
-                "endLine" : 248,
+                "endLine" : 249,
                 "endCol" : 29
               }
             }
@@ -6560,16 +6609,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 249,
+                      "startLine" : 250,
                       "startCol" : 8,
-                      "endLine" : 249,
+                      "endLine" : 250,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 250,
                     "startCol" : 8,
-                    "endLine" : 249,
+                    "endLine" : 250,
                     "endCol" : 18
                   }
                 },
@@ -6579,32 +6628,32 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 249,
+                      "startLine" : 250,
                       "startCol" : 19,
-                      "endLine" : 249,
+                      "endLine" : 250,
                       "endCol" : 23
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 249,
+                    "startLine" : 250,
                     "startCol" : 19,
-                    "endLine" : 249,
+                    "endLine" : 250,
                     "endCol" : 35
                   }
                 },
                 "span" : {
-                  "startLine" : 249,
+                  "startLine" : 250,
                   "startCol" : 8,
-                  "endLine" : 249,
+                  "endLine" : 250,
                   "endCol" : 36
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 249,
+                "startLine" : 250,
                 "startCol" : 8,
-                "endLine" : 249,
+                "endLine" : 250,
                 "endCol" : 45
               }
             },
@@ -6621,16 +6670,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 250,
+                        "startLine" : 251,
                         "startCol" : 14,
-                        "endLine" : 250,
+                        "endLine" : 251,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 250,
+                      "startLine" : 251,
                       "startCol" : 10,
-                      "endLine" : 250,
+                      "endLine" : 251,
                       "endCol" : 24
                     }
                   },
@@ -6640,32 +6689,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 250,
+                        "startLine" : 251,
                         "startCol" : 25,
-                        "endLine" : 250,
+                        "endLine" : 251,
                         "endCol" : 29
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 250,
+                      "startLine" : 251,
                       "startCol" : 25,
-                      "endLine" : 250,
+                      "endLine" : 251,
                       "endCol" : 41
                     }
                   },
                   "span" : {
-                    "startLine" : 250,
+                    "startLine" : 251,
                     "startCol" : 10,
-                    "endLine" : 250,
+                    "endLine" : 251,
                     "endCol" : 42
                   }
                 },
                 "field" : "reserved",
                 "span" : {
-                  "startLine" : 250,
+                  "startLine" : 251,
                   "startCol" : 10,
-                  "endLine" : 250,
+                  "endLine" : 251,
                   "endCol" : 51
                 }
               },
@@ -6675,46 +6724,46 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 250,
+                    "startLine" : 251,
                     "startCol" : 54,
-                    "endLine" : 250,
+                    "endLine" : 251,
                     "endCol" : 58
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 250,
+                  "startLine" : 251,
                   "startCol" : 54,
-                  "endLine" : 250,
+                  "endLine" : 251,
                   "endCol" : 67
                 }
               },
               "span" : {
-                "startLine" : 250,
+                "startLine" : 251,
                 "startCol" : 10,
-                "endLine" : 250,
+                "endLine" : 251,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 249,
+              "startLine" : 250,
               "startCol" : 8,
-              "endLine" : 250,
+              "endLine" : 251,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 248,
+            "startLine" : 249,
             "startCol" : 6,
-            "endLine" : 250,
+            "endLine" : 251,
             "endCol" : 67
           }
         }
       ],
       "span" : {
-        "startLine" : 234,
+        "startLine" : 235,
         "startCol" : 2,
-        "endLine" : 251,
+        "endLine" : 252,
         "endCol" : 3
       }
     },
@@ -6729,16 +6778,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 254,
+              "startLine" : 255,
               "startCol" : 22,
-              "endLine" : 254,
+              "endLine" : 255,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 254,
+            "startLine" : 255,
             "startCol" : 12,
-            "endLine" : 254,
+            "endLine" : 255,
             "endCol" : 29
           }
         }
@@ -6751,16 +6800,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 255,
+              "startLine" : 256,
               "startCol" : 19,
-              "endLine" : 255,
+              "endLine" : 256,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 255,
+            "startLine" : 256,
             "startCol" : 12,
-            "endLine" : 255,
+            "endLine" : 256,
             "endCol" : 24
           }
         }
@@ -6773,9 +6822,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 258,
+              "startLine" : 259,
               "startCol" : 6,
-              "endLine" : 258,
+              "endLine" : 259,
               "endCol" : 14
             }
           },
@@ -6783,16 +6832,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 258,
+              "startLine" : 259,
               "startCol" : 18,
-              "endLine" : 258,
+              "endLine" : 259,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 258,
+            "startLine" : 259,
             "startCol" : 6,
-            "endLine" : 258,
+            "endLine" : 259,
             "endCol" : 24
           }
         },
@@ -6807,9 +6856,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 259,
+                  "startLine" : 260,
                   "startCol" : 6,
-                  "endLine" : 259,
+                  "endLine" : 260,
                   "endCol" : 12
                 }
               },
@@ -6817,24 +6866,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 259,
+                  "startLine" : 260,
                   "startCol" : 13,
-                  "endLine" : 259,
+                  "endLine" : 260,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 259,
+                "startLine" : 260,
                 "startCol" : 6,
-                "endLine" : 259,
+                "endLine" : 260,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 259,
+              "startLine" : 260,
               "startCol" : 6,
-              "endLine" : 259,
+              "endLine" : 260,
               "endCol" : 29
             }
           },
@@ -6842,16 +6891,16 @@
             "kind" : "Identifier",
             "name" : "SHIPPED",
             "span" : {
-              "startLine" : 259,
+              "startLine" : 260,
               "startCol" : 32,
-              "endLine" : 259,
+              "endLine" : 260,
               "endCol" : 39
             }
           },
           "span" : {
-            "startLine" : 259,
+            "startLine" : 260,
             "startCol" : 6,
-            "endLine" : 259,
+            "endLine" : 260,
             "endCol" : 39
           }
         }
@@ -6864,9 +6913,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 262,
+              "startLine" : 263,
               "startCol" : 6,
-              "endLine" : 262,
+              "endLine" : 263,
               "endCol" : 11
             }
           },
@@ -6880,16 +6929,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 262,
+                    "startLine" : 263,
                     "startCol" : 18,
-                    "endLine" : 262,
+                    "endLine" : 263,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 262,
+                  "startLine" : 263,
                   "startCol" : 14,
-                  "endLine" : 262,
+                  "endLine" : 263,
                   "endCol" : 25
                 }
               },
@@ -6897,16 +6946,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 262,
+                  "startLine" : 263,
                   "startCol" : 26,
-                  "endLine" : 262,
+                  "endLine" : 263,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 262,
+                "startLine" : 263,
                 "startCol" : 14,
-                "endLine" : 262,
+                "endLine" : 263,
                 "endCol" : 35
               }
             },
@@ -6917,16 +6966,16 @@
                   "kind" : "Identifier",
                   "name" : "DELIVERED",
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 264,
                     "startCol" : 17,
-                    "endLine" : 263,
+                    "endLine" : 264,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 264,
                   "startCol" : 8,
-                  "endLine" : 263,
+                  "endLine" : 264,
                   "endCol" : 26
                 }
               },
@@ -6940,47 +6989,47 @@
                       "kind" : "Identifier",
                       "name" : "now",
                       "span" : {
-                        "startLine" : 264,
+                        "startLine" : 265,
                         "startCol" : 28,
-                        "endLine" : 264,
+                        "endLine" : 265,
                         "endCol" : 31
                       }
                     },
                     "args" : [
                     ],
                     "span" : {
-                      "startLine" : 264,
+                      "startLine" : 265,
                       "startCol" : 28,
-                      "endLine" : 264,
+                      "endLine" : 265,
                       "endCol" : 33
                     }
                   },
                   "span" : {
-                    "startLine" : 264,
+                    "startLine" : 265,
                     "startCol" : 23,
-                    "endLine" : 264,
+                    "endLine" : 265,
                     "endCol" : 34
                   }
                 },
                 "span" : {
-                  "startLine" : 264,
+                  "startLine" : 265,
                   "startCol" : 8,
-                  "endLine" : 264,
+                  "endLine" : 265,
                   "endCol" : 34
                 }
               }
             ],
             "span" : {
-              "startLine" : 262,
+              "startLine" : 263,
               "startCol" : 14,
-              "endLine" : 265,
+              "endLine" : 266,
               "endCol" : 7
             }
           },
           "span" : {
-            "startLine" : 262,
+            "startLine" : 263,
             "startCol" : 6,
-            "endLine" : 265,
+            "endLine" : 266,
             "endCol" : 7
           }
         },
@@ -6993,16 +7042,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 266,
+                "startLine" : 267,
                 "startCol" : 6,
-                "endLine" : 266,
+                "endLine" : 267,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 266,
+              "startLine" : 267,
               "startCol" : 6,
-              "endLine" : 266,
+              "endLine" : 267,
               "endCol" : 13
             }
           },
@@ -7015,16 +7064,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 266,
+                  "startLine" : 267,
                   "startCol" : 20,
-                  "endLine" : 266,
+                  "endLine" : 267,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 266,
+                "startLine" : 267,
                 "startCol" : 16,
-                "endLine" : 266,
+                "endLine" : 267,
                 "endCol" : 27
               }
             },
@@ -7036,9 +7085,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 266,
+                      "startLine" : 267,
                       "startCol" : 31,
-                      "endLine" : 266,
+                      "endLine" : 267,
                       "endCol" : 39
                     }
                   },
@@ -7046,46 +7095,46 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 266,
+                      "startLine" : 267,
                       "startCol" : 43,
-                      "endLine" : 266,
+                      "endLine" : 267,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 266,
+                    "startLine" : 267,
                     "startCol" : 31,
-                    "endLine" : 266,
+                    "endLine" : 267,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 266,
+                "startLine" : 267,
                 "startCol" : 30,
-                "endLine" : 266,
+                "endLine" : 267,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 266,
+              "startLine" : 267,
               "startCol" : 16,
-              "endLine" : 266,
+              "endLine" : 267,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 266,
+            "startLine" : 267,
             "startCol" : 6,
-            "endLine" : 266,
+            "endLine" : 267,
             "endCol" : 49
           }
         }
       ],
       "span" : {
-        "startLine" : 253,
+        "startLine" : 254,
         "startCol" : 2,
-        "endLine" : 267,
+        "endLine" : 268,
         "endCol" : 3
       }
     },
@@ -7100,16 +7149,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 270,
+              "startLine" : 271,
               "startCol" : 22,
-              "endLine" : 270,
+              "endLine" : 271,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 270,
+            "startLine" : 271,
             "startCol" : 12,
-            "endLine" : 270,
+            "endLine" : 271,
             "endCol" : 29
           }
         }
@@ -7122,16 +7171,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 271,
+              "startLine" : 272,
               "startCol" : 19,
-              "endLine" : 271,
+              "endLine" : 272,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 271,
+            "startLine" : 272,
             "startCol" : 12,
-            "endLine" : 271,
+            "endLine" : 272,
             "endCol" : 24
           }
         }
@@ -7144,9 +7193,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 274,
+              "startLine" : 275,
               "startCol" : 6,
-              "endLine" : 274,
+              "endLine" : 275,
               "endCol" : 14
             }
           },
@@ -7154,16 +7203,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 274,
+              "startLine" : 275,
               "startCol" : 18,
-              "endLine" : 274,
+              "endLine" : 275,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 274,
+            "startLine" : 275,
             "startCol" : 6,
-            "endLine" : 274,
+            "endLine" : 275,
             "endCol" : 24
           }
         },
@@ -7178,9 +7227,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 276,
                   "startCol" : 6,
-                  "endLine" : 275,
+                  "endLine" : 276,
                   "endCol" : 12
                 }
               },
@@ -7188,24 +7237,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 276,
                   "startCol" : 13,
-                  "endLine" : 275,
+                  "endLine" : 276,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 275,
+                "startLine" : 276,
                 "startCol" : 6,
-                "endLine" : 275,
+                "endLine" : 276,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 275,
+              "startLine" : 276,
               "startCol" : 6,
-              "endLine" : 275,
+              "endLine" : 276,
               "endCol" : 29
             }
           },
@@ -7216,9 +7265,9 @@
                 "kind" : "Identifier",
                 "name" : "DRAFT",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 276,
                   "startCol" : 34,
-                  "endLine" : 275,
+                  "endLine" : 276,
                   "endCol" : 39
                 }
               },
@@ -7226,9 +7275,9 @@
                 "kind" : "Identifier",
                 "name" : "PLACED",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 276,
                   "startCol" : 41,
-                  "endLine" : 275,
+                  "endLine" : 276,
                   "endCol" : 47
                 }
               },
@@ -7236,24 +7285,24 @@
                 "kind" : "Identifier",
                 "name" : "PAID",
                 "span" : {
-                  "startLine" : 275,
+                  "startLine" : 276,
                   "startCol" : 49,
-                  "endLine" : 275,
+                  "endLine" : 276,
                   "endCol" : 53
                 }
               }
             ],
             "span" : {
-              "startLine" : 275,
+              "startLine" : 276,
               "startCol" : 33,
-              "endLine" : 275,
+              "endLine" : 276,
               "endCol" : 54
             }
           },
           "span" : {
-            "startLine" : 275,
+            "startLine" : 276,
             "startCol" : 6,
-            "endLine" : 275,
+            "endLine" : 276,
             "endCol" : 54
           }
         }
@@ -7266,9 +7315,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 278,
+              "startLine" : 279,
               "startCol" : 6,
-              "endLine" : 278,
+              "endLine" : 279,
               "endCol" : 11
             }
           },
@@ -7282,16 +7331,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 278,
+                    "startLine" : 279,
                     "startCol" : 18,
-                    "endLine" : 278,
+                    "endLine" : 279,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 278,
+                  "startLine" : 279,
                   "startCol" : 14,
-                  "endLine" : 278,
+                  "endLine" : 279,
                   "endCol" : 25
                 }
               },
@@ -7299,16 +7348,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 278,
+                  "startLine" : 279,
                   "startCol" : 26,
-                  "endLine" : 278,
+                  "endLine" : 279,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 278,
+                "startLine" : 279,
                 "startCol" : 14,
-                "endLine" : 278,
+                "endLine" : 279,
                 "endCol" : 35
               }
             },
@@ -7319,31 +7368,31 @@
                   "kind" : "Identifier",
                   "name" : "CANCELLED",
                   "span" : {
-                    "startLine" : 278,
+                    "startLine" : 279,
                     "startCol" : 52,
-                    "endLine" : 278,
+                    "endLine" : 279,
                     "endCol" : 61
                   }
                 },
                 "span" : {
-                  "startLine" : 278,
+                  "startLine" : 279,
                   "startCol" : 43,
-                  "endLine" : 278,
+                  "endLine" : 279,
                   "endCol" : 61
                 }
               }
             ],
             "span" : {
-              "startLine" : 278,
+              "startLine" : 279,
               "startCol" : 14,
-              "endLine" : 278,
+              "endLine" : 279,
               "endCol" : 63
             }
           },
           "span" : {
-            "startLine" : 278,
+            "startLine" : 279,
             "startCol" : 6,
-            "endLine" : 278,
+            "endLine" : 279,
             "endCol" : 63
           }
         },
@@ -7356,16 +7405,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 279,
+                "startLine" : 280,
                 "startCol" : 6,
-                "endLine" : 279,
+                "endLine" : 280,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 279,
+              "startLine" : 280,
               "startCol" : 6,
-              "endLine" : 279,
+              "endLine" : 280,
               "endCol" : 13
             }
           },
@@ -7378,16 +7427,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 279,
+                  "startLine" : 280,
                   "startCol" : 20,
-                  "endLine" : 279,
+                  "endLine" : 280,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 279,
+                "startLine" : 280,
                 "startCol" : 16,
-                "endLine" : 279,
+                "endLine" : 280,
                 "endCol" : 27
               }
             },
@@ -7399,9 +7448,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 279,
+                      "startLine" : 280,
                       "startCol" : 31,
-                      "endLine" : 279,
+                      "endLine" : 280,
                       "endCol" : 39
                     }
                   },
@@ -7409,38 +7458,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 279,
+                      "startLine" : 280,
                       "startCol" : 43,
-                      "endLine" : 279,
+                      "endLine" : 280,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 279,
+                    "startLine" : 280,
                     "startCol" : 31,
-                    "endLine" : 279,
+                    "endLine" : 280,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 279,
+                "startLine" : 280,
                 "startCol" : 30,
-                "endLine" : 279,
+                "endLine" : 280,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 279,
+              "startLine" : 280,
               "startCol" : 16,
-              "endLine" : 279,
+              "endLine" : 280,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 279,
+            "startLine" : 280,
             "startCol" : 6,
-            "endLine" : 279,
+            "endLine" : 280,
             "endCol" : 49
           }
         },
@@ -7460,16 +7509,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 280,
+                        "startLine" : 281,
                         "startCol" : 22,
-                        "endLine" : 280,
+                        "endLine" : 281,
                         "endCol" : 28
                       }
                     },
                     "span" : {
-                      "startLine" : 280,
+                      "startLine" : 281,
                       "startCol" : 18,
-                      "endLine" : 280,
+                      "endLine" : 281,
                       "endCol" : 29
                     }
                   },
@@ -7477,32 +7526,32 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 280,
+                      "startLine" : 281,
                       "startCol" : 30,
-                      "endLine" : 280,
+                      "endLine" : 281,
                       "endCol" : 38
                     }
                   },
                   "span" : {
-                    "startLine" : 280,
+                    "startLine" : 281,
                     "startCol" : 18,
-                    "endLine" : 280,
+                    "endLine" : 281,
                     "endCol" : 39
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 280,
+                  "startLine" : 281,
                   "startCol" : 18,
-                  "endLine" : 280,
+                  "endLine" : 281,
                   "endCol" : 45
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 280,
+                "startLine" : 281,
                 "startCol" : 10,
-                "endLine" : 280,
+                "endLine" : 281,
                 "endCol" : 45
               }
             }
@@ -7523,16 +7572,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 281,
+                        "startLine" : 282,
                         "startCol" : 8,
-                        "endLine" : 281,
+                        "endLine" : 282,
                         "endCol" : 17
                       }
                     },
                     "span" : {
-                      "startLine" : 281,
+                      "startLine" : 282,
                       "startCol" : 8,
-                      "endLine" : 281,
+                      "endLine" : 282,
                       "endCol" : 18
                     }
                   },
@@ -7542,32 +7591,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 281,
+                        "startLine" : 282,
                         "startCol" : 19,
-                        "endLine" : 281,
+                        "endLine" : 282,
                         "endCol" : 23
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 281,
+                      "startLine" : 282,
                       "startCol" : 19,
-                      "endLine" : 281,
+                      "endLine" : 282,
                       "endCol" : 35
                     }
                   },
                   "span" : {
-                    "startLine" : 281,
+                    "startLine" : 282,
                     "startCol" : 8,
-                    "endLine" : 281,
+                    "endLine" : 282,
                     "endCol" : 36
                   }
                 },
                 "field" : "available",
                 "span" : {
-                  "startLine" : 281,
+                  "startLine" : 282,
                   "startCol" : 8,
-                  "endLine" : 281,
+                  "endLine" : 282,
                   "endCol" : 46
                 }
               },
@@ -7584,16 +7633,16 @@
                         "kind" : "Identifier",
                         "name" : "inventory",
                         "span" : {
-                          "startLine" : 282,
+                          "startLine" : 283,
                           "startCol" : 14,
-                          "endLine" : 282,
+                          "endLine" : 283,
                           "endCol" : 23
                         }
                       },
                       "span" : {
-                        "startLine" : 282,
+                        "startLine" : 283,
                         "startCol" : 10,
-                        "endLine" : 282,
+                        "endLine" : 283,
                         "endCol" : 24
                       }
                     },
@@ -7603,32 +7652,32 @@
                         "kind" : "Identifier",
                         "name" : "item",
                         "span" : {
-                          "startLine" : 282,
+                          "startLine" : 283,
                           "startCol" : 25,
-                          "endLine" : 282,
+                          "endLine" : 283,
                           "endCol" : 29
                         }
                       },
                       "field" : "product_sku",
                       "span" : {
-                        "startLine" : 282,
+                        "startLine" : 283,
                         "startCol" : 25,
-                        "endLine" : 282,
+                        "endLine" : 283,
                         "endCol" : 41
                       }
                     },
                     "span" : {
-                      "startLine" : 282,
+                      "startLine" : 283,
                       "startCol" : 10,
-                      "endLine" : 282,
+                      "endLine" : 283,
                       "endCol" : 42
                     }
                   },
                   "field" : "available",
                   "span" : {
-                    "startLine" : 282,
+                    "startLine" : 283,
                     "startCol" : 10,
-                    "endLine" : 282,
+                    "endLine" : 283,
                     "endCol" : 52
                   }
                 },
@@ -7638,31 +7687,31 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 282,
+                      "startLine" : 283,
                       "startCol" : 55,
-                      "endLine" : 282,
+                      "endLine" : 283,
                       "endCol" : 59
                     }
                   },
                   "field" : "quantity",
                   "span" : {
-                    "startLine" : 282,
+                    "startLine" : 283,
                     "startCol" : 55,
-                    "endLine" : 282,
+                    "endLine" : 283,
                     "endCol" : 68
                   }
                 },
                 "span" : {
-                  "startLine" : 282,
+                  "startLine" : 283,
                   "startCol" : 10,
-                  "endLine" : 282,
+                  "endLine" : 283,
                   "endCol" : 68
                 }
               },
               "span" : {
-                "startLine" : 281,
+                "startLine" : 282,
                 "startCol" : 8,
-                "endLine" : 282,
+                "endLine" : 283,
                 "endCol" : 68
               }
             },
@@ -7679,16 +7728,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 283,
+                        "startLine" : 284,
                         "startCol" : 12,
-                        "endLine" : 283,
+                        "endLine" : 284,
                         "endCol" : 21
                       }
                     },
                     "span" : {
-                      "startLine" : 283,
+                      "startLine" : 284,
                       "startCol" : 12,
-                      "endLine" : 283,
+                      "endLine" : 284,
                       "endCol" : 22
                     }
                   },
@@ -7698,32 +7747,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 283,
+                        "startLine" : 284,
                         "startCol" : 23,
-                        "endLine" : 283,
+                        "endLine" : 284,
                         "endCol" : 27
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 283,
+                      "startLine" : 284,
                       "startCol" : 23,
-                      "endLine" : 283,
+                      "endLine" : 284,
                       "endCol" : 39
                     }
                   },
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 284,
                     "startCol" : 12,
-                    "endLine" : 283,
+                    "endLine" : 284,
                     "endCol" : 40
                   }
                 },
                 "field" : "reserved",
                 "span" : {
-                  "startLine" : 283,
+                  "startLine" : 284,
                   "startCol" : 12,
-                  "endLine" : 283,
+                  "endLine" : 284,
                   "endCol" : 49
                 }
               },
@@ -7740,16 +7789,16 @@
                         "kind" : "Identifier",
                         "name" : "inventory",
                         "span" : {
-                          "startLine" : 284,
+                          "startLine" : 285,
                           "startCol" : 14,
-                          "endLine" : 284,
+                          "endLine" : 285,
                           "endCol" : 23
                         }
                       },
                       "span" : {
-                        "startLine" : 284,
+                        "startLine" : 285,
                         "startCol" : 10,
-                        "endLine" : 284,
+                        "endLine" : 285,
                         "endCol" : 24
                       }
                     },
@@ -7759,32 +7808,32 @@
                         "kind" : "Identifier",
                         "name" : "item",
                         "span" : {
-                          "startLine" : 284,
+                          "startLine" : 285,
                           "startCol" : 25,
-                          "endLine" : 284,
+                          "endLine" : 285,
                           "endCol" : 29
                         }
                       },
                       "field" : "product_sku",
                       "span" : {
-                        "startLine" : 284,
+                        "startLine" : 285,
                         "startCol" : 25,
-                        "endLine" : 284,
+                        "endLine" : 285,
                         "endCol" : 41
                       }
                     },
                     "span" : {
-                      "startLine" : 284,
+                      "startLine" : 285,
                       "startCol" : 10,
-                      "endLine" : 284,
+                      "endLine" : 285,
                       "endCol" : 42
                     }
                   },
                   "field" : "reserved",
                   "span" : {
-                    "startLine" : 284,
+                    "startLine" : 285,
                     "startCol" : 10,
-                    "endLine" : 284,
+                    "endLine" : 285,
                     "endCol" : 51
                   }
                 },
@@ -7794,45 +7843,45 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 284,
+                      "startLine" : 285,
                       "startCol" : 54,
-                      "endLine" : 284,
+                      "endLine" : 285,
                       "endCol" : 58
                     }
                   },
                   "field" : "quantity",
                   "span" : {
-                    "startLine" : 284,
+                    "startLine" : 285,
                     "startCol" : 54,
-                    "endLine" : 284,
+                    "endLine" : 285,
                     "endCol" : 67
                   }
                 },
                 "span" : {
-                  "startLine" : 284,
+                  "startLine" : 285,
                   "startCol" : 10,
-                  "endLine" : 284,
+                  "endLine" : 285,
                   "endCol" : 67
                 }
               },
               "span" : {
-                "startLine" : 283,
+                "startLine" : 284,
                 "startCol" : 12,
-                "endLine" : 284,
+                "endLine" : 285,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 281,
+              "startLine" : 282,
               "startCol" : 8,
-              "endLine" : 284,
+              "endLine" : 285,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 280,
+            "startLine" : 281,
             "startCol" : 6,
-            "endLine" : 284,
+            "endLine" : 285,
             "endCol" : 67
           }
         },
@@ -7847,305 +7896,601 @@
               "base" : {
                 "kind" : "Index",
                 "base" : {
-                  "kind" : "Identifier",
-                  "name" : "orders",
+                  "kind" : "Pre",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "orders",
+                    "span" : {
+                      "startLine" : 286,
+                      "startCol" : 10,
+                      "endLine" : 286,
+                      "endCol" : 16
+                    }
+                  },
                   "span" : {
-                    "startLine" : 285,
+                    "startLine" : 286,
                     "startCol" : 6,
-                    "endLine" : 285,
-                    "endCol" : 12
+                    "endLine" : 286,
+                    "endCol" : 17
                   }
                 },
                 "index" : {
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 285,
-                    "startCol" : 13,
-                    "endLine" : 285,
-                    "endCol" : 21
+                    "startLine" : 286,
+                    "startCol" : 18,
+                    "endLine" : 286,
+                    "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 285,
+                  "startLine" : 286,
                   "startCol" : 6,
-                  "endLine" : 285,
-                  "endCol" : 22
+                  "endLine" : 286,
+                  "endCol" : 27
                 }
               },
               "field" : "status",
               "span" : {
-                "startLine" : 285,
+                "startLine" : 286,
                 "startCol" : 6,
-                "endLine" : 285,
-                "endCol" : 29
+                "endLine" : 286,
+                "endCol" : 34
               }
             },
             "right" : {
               "kind" : "Identifier",
               "name" : "PAID",
               "span" : {
-                "startLine" : 285,
-                "startCol" : 32,
-                "endLine" : 285,
-                "endCol" : 36
+                "startLine" : 286,
+                "startCol" : 37,
+                "endLine" : 286,
+                "endCol" : 41
               }
             },
             "span" : {
-              "startLine" : 285,
+              "startLine" : 286,
               "startCol" : 6,
-              "endLine" : 285,
-              "endCol" : 36
+              "endLine" : 286,
+              "endCol" : 41
             }
           },
           "right" : {
-            "kind" : "Quantifier",
-            "quantifier" : "some",
-            "bindings" : [
-              {
-                "variable" : "p",
-                "domain" : {
-                  "kind" : "Prime",
+            "kind" : "BinaryOp",
+            "op" : "and",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "=",
+              "left" : {
+                "kind" : "Prime",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "payments",
+                  "span" : {
+                    "startLine" : 287,
+                    "startCol" : 8,
+                    "endLine" : 287,
+                    "endCol" : 16
+                  }
+                },
+                "span" : {
+                  "startLine" : 287,
+                  "startCol" : 8,
+                  "endLine" : 287,
+                  "endCol" : 17
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "+",
+                "left" : {
+                  "kind" : "Pre",
                   "expr" : {
                     "kind" : "Identifier",
                     "name" : "payments",
                     "span" : {
-                      "startLine" : 286,
-                      "startCol" : 18,
-                      "endLine" : 286,
-                      "endCol" : 26
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 286,
-                    "startCol" : 18,
-                    "endLine" : 286,
-                    "endCol" : 27
-                  }
-                },
-                "bindingKind" : "in",
-                "span" : {
-                  "startLine" : 286,
-                  "startCol" : 13,
-                  "endLine" : 286,
-                  "endCol" : 27
-                }
-              }
-            ],
-            "body" : {
-              "kind" : "BinaryOp",
-              "op" : "and",
-              "left" : {
-                "kind" : "BinaryOp",
-                "op" : "and",
-                "left" : {
-                  "kind" : "BinaryOp",
-                  "op" : "not_in",
-                  "left" : {
-                    "kind" : "Identifier",
-                    "name" : "p",
-                    "span" : {
                       "startLine" : 287,
-                      "startCol" : 10,
-                      "endLine" : 287,
-                      "endCol" : 11
-                    }
-                  },
-                  "right" : {
-                    "kind" : "Pre",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "payments",
-                      "span" : {
-                        "startLine" : 287,
-                        "startCol" : 23,
-                        "endLine" : 287,
-                        "endCol" : 31
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 287,
-                      "startCol" : 19,
+                      "startCol" : 24,
                       "endLine" : 287,
                       "endCol" : 32
                     }
                   },
                   "span" : {
                     "startLine" : 287,
-                    "startCol" : 10,
+                    "startCol" : 20,
                     "endLine" : 287,
-                    "endCol" : 32
-                  }
-                },
-                "right" : {
-                  "kind" : "BinaryOp",
-                  "op" : "=",
-                  "left" : {
-                    "kind" : "FieldAccess",
-                    "base" : {
-                      "kind" : "Index",
-                      "base" : {
-                        "kind" : "Prime",
-                        "expr" : {
-                          "kind" : "Identifier",
-                          "name" : "payments",
-                          "span" : {
-                            "startLine" : 288,
-                            "startCol" : 14,
-                            "endLine" : 288,
-                            "endCol" : 22
-                          }
-                        },
-                        "span" : {
-                          "startLine" : 288,
-                          "startCol" : 14,
-                          "endLine" : 288,
-                          "endCol" : 23
-                        }
-                      },
-                      "index" : {
-                        "kind" : "Identifier",
-                        "name" : "p",
-                        "span" : {
-                          "startLine" : 288,
-                          "startCol" : 24,
-                          "endLine" : 288,
-                          "endCol" : 25
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 288,
-                        "startCol" : 14,
-                        "endLine" : 288,
-                        "endCol" : 26
-                      }
-                    },
-                    "field" : "order_id",
-                    "span" : {
-                      "startLine" : 288,
-                      "startCol" : 14,
-                      "endLine" : 288,
-                      "endCol" : 35
-                    }
-                  },
-                  "right" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 288,
-                      "startCol" : 38,
-                      "endLine" : 288,
-                      "endCol" : 46
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 288,
-                    "startCol" : 14,
-                    "endLine" : 288,
-                    "endCol" : 46
-                  }
-                },
-                "span" : {
-                  "startLine" : 287,
-                  "startCol" : 10,
-                  "endLine" : 288,
-                  "endCol" : 46
-                }
-              },
-              "right" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Index",
-                    "base" : {
-                      "kind" : "Prime",
-                      "expr" : {
-                        "kind" : "Identifier",
-                        "name" : "payments",
-                        "span" : {
-                          "startLine" : 289,
-                          "startCol" : 14,
-                          "endLine" : 289,
-                          "endCol" : 22
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 289,
-                        "startCol" : 14,
-                        "endLine" : 289,
-                        "endCol" : 23
-                      }
-                    },
-                    "index" : {
-                      "kind" : "Identifier",
-                      "name" : "p",
-                      "span" : {
-                        "startLine" : 289,
-                        "startCol" : 24,
-                        "endLine" : 289,
-                        "endCol" : 25
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 289,
-                      "startCol" : 14,
-                      "endLine" : 289,
-                      "endCol" : 26
-                    }
-                  },
-                  "field" : "status",
-                  "span" : {
-                    "startLine" : 289,
-                    "startCol" : 14,
-                    "endLine" : 289,
                     "endCol" : 33
                   }
                 },
                 "right" : {
-                  "kind" : "Identifier",
-                  "name" : "REFUNDED",
+                  "kind" : "MapLiteral",
+                  "entries" : [
+                    {
+                      "key" : {
+                        "kind" : "Pre",
+                        "expr" : {
+                          "kind" : "Identifier",
+                          "name" : "next_payment_id",
+                          "span" : {
+                            "startLine" : 287,
+                            "startCol" : 41,
+                            "endLine" : 287,
+                            "endCol" : 56
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 287,
+                          "startCol" : 37,
+                          "endLine" : 287,
+                          "endCol" : 57
+                        }
+                      },
+                      "value" : {
+                        "kind" : "Constructor",
+                        "typeName" : "Payment",
+                        "fields" : [
+                          {
+                            "name" : "id",
+                            "value" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "next_payment_id",
+                                "span" : {
+                                  "startLine" : 288,
+                                  "startCol" : 19,
+                                  "endLine" : 288,
+                                  "endCol" : 34
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 288,
+                                "startCol" : 15,
+                                "endLine" : 288,
+                                "endCol" : 35
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 288,
+                              "startCol" : 10,
+                              "endLine" : 288,
+                              "endCol" : 35
+                            }
+                          },
+                          {
+                            "name" : "order_id",
+                            "value" : {
+                              "kind" : "Identifier",
+                              "name" : "order_id",
+                              "span" : {
+                                "startLine" : 289,
+                                "startCol" : 21,
+                                "endLine" : 289,
+                                "endCol" : 29
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 289,
+                              "startCol" : 10,
+                              "endLine" : 289,
+                              "endCol" : 29
+                            }
+                          },
+                          {
+                            "name" : "amount",
+                            "value" : {
+                              "kind" : "FieldAccess",
+                              "base" : {
+                                "kind" : "Index",
+                                "base" : {
+                                  "kind" : "Pre",
+                                  "expr" : {
+                                    "kind" : "Identifier",
+                                    "name" : "orders",
+                                    "span" : {
+                                      "startLine" : 290,
+                                      "startCol" : 23,
+                                      "endLine" : 290,
+                                      "endCol" : 29
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 290,
+                                    "startCol" : 19,
+                                    "endLine" : 290,
+                                    "endCol" : 30
+                                  }
+                                },
+                                "index" : {
+                                  "kind" : "Identifier",
+                                  "name" : "order_id",
+                                  "span" : {
+                                    "startLine" : 290,
+                                    "startCol" : 31,
+                                    "endLine" : 290,
+                                    "endCol" : 39
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 290,
+                                  "startCol" : 19,
+                                  "endLine" : 290,
+                                  "endCol" : 40
+                                }
+                              },
+                              "field" : "total",
+                              "span" : {
+                                "startLine" : 290,
+                                "startCol" : 19,
+                                "endLine" : 290,
+                                "endCol" : 46
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 290,
+                              "startCol" : 10,
+                              "endLine" : 290,
+                              "endCol" : 46
+                            }
+                          },
+                          {
+                            "name" : "status",
+                            "value" : {
+                              "kind" : "Identifier",
+                              "name" : "REFUNDED",
+                              "span" : {
+                                "startLine" : 291,
+                                "startCol" : 19,
+                                "endLine" : 291,
+                                "endCol" : 27
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 291,
+                              "startCol" : 10,
+                              "endLine" : 291,
+                              "endCol" : 27
+                            }
+                          },
+                          {
+                            "name" : "created_at",
+                            "value" : {
+                              "kind" : "Call",
+                              "callee" : {
+                                "kind" : "Identifier",
+                                "name" : "now",
+                                "span" : {
+                                  "startLine" : 292,
+                                  "startCol" : 23,
+                                  "endLine" : 292,
+                                  "endCol" : 26
+                                }
+                              },
+                              "args" : [
+                              ],
+                              "span" : {
+                                "startLine" : 292,
+                                "startCol" : 23,
+                                "endLine" : 292,
+                                "endCol" : 28
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 292,
+                              "startCol" : 10,
+                              "endLine" : 292,
+                              "endCol" : 28
+                            }
+                          }
+                        ],
+                        "span" : {
+                          "startLine" : 287,
+                          "startCol" : 61,
+                          "endLine" : 293,
+                          "endCol" : 9
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 287,
+                        "startCol" : 37,
+                        "endLine" : 287,
+                        "endCol" : 57
+                      }
+                    }
+                  ],
                   "span" : {
-                    "startLine" : 289,
+                    "startLine" : 287,
                     "startCol" : 36,
-                    "endLine" : 289,
-                    "endCol" : 44
+                    "endLine" : 293,
+                    "endCol" : 10
                   }
                 },
                 "span" : {
-                  "startLine" : 289,
-                  "startCol" : 14,
-                  "endLine" : 289,
-                  "endCol" : 44
+                  "startLine" : 287,
+                  "startCol" : 20,
+                  "endLine" : 293,
+                  "endCol" : 10
                 }
               },
               "span" : {
                 "startLine" : 287,
-                "startCol" : 10,
-                "endLine" : 289,
-                "endCol" : 44
+                "startCol" : 8,
+                "endLine" : 293,
+                "endCol" : 10
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "=",
+              "left" : {
+                "kind" : "Prime",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "next_payment_id",
+                  "span" : {
+                    "startLine" : 294,
+                    "startCol" : 12,
+                    "endLine" : 294,
+                    "endCol" : 27
+                  }
+                },
+                "span" : {
+                  "startLine" : 294,
+                  "startCol" : 12,
+                  "endLine" : 294,
+                  "endCol" : 28
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "+",
+                "left" : {
+                  "kind" : "Pre",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "next_payment_id",
+                    "span" : {
+                      "startLine" : 294,
+                      "startCol" : 35,
+                      "endLine" : 294,
+                      "endCol" : 50
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 294,
+                    "startCol" : 31,
+                    "endLine" : 294,
+                    "endCol" : 51
+                  }
+                },
+                "right" : {
+                  "kind" : "IntLit",
+                  "value" : 1,
+                  "span" : {
+                    "startLine" : 294,
+                    "startCol" : 54,
+                    "endLine" : 294,
+                    "endCol" : 55
+                  }
+                },
+                "span" : {
+                  "startLine" : 294,
+                  "startCol" : 31,
+                  "endLine" : 294,
+                  "endCol" : 55
+                }
+              },
+              "span" : {
+                "startLine" : 294,
+                "startCol" : 12,
+                "endLine" : 294,
+                "endCol" : 55
               }
             },
             "span" : {
-              "startLine" : 286,
+              "startLine" : 287,
               "startCol" : 8,
-              "endLine" : 289,
-              "endCol" : 44
+              "endLine" : 294,
+              "endCol" : 55
             }
           },
           "span" : {
-            "startLine" : 285,
+            "startLine" : 286,
             "startCol" : 6,
-            "endLine" : 289,
-            "endCol" : 44
+            "endLine" : 294,
+            "endCol" : 56
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "implies",
+          "left" : {
+            "kind" : "BinaryOp",
+            "op" : "!=",
+            "left" : {
+              "kind" : "FieldAccess",
+              "base" : {
+                "kind" : "Index",
+                "base" : {
+                  "kind" : "Pre",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "orders",
+                    "span" : {
+                      "startLine" : 295,
+                      "startCol" : 10,
+                      "endLine" : 295,
+                      "endCol" : 16
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 295,
+                    "startCol" : 6,
+                    "endLine" : 295,
+                    "endCol" : 17
+                  }
+                },
+                "index" : {
+                  "kind" : "Identifier",
+                  "name" : "order_id",
+                  "span" : {
+                    "startLine" : 295,
+                    "startCol" : 18,
+                    "endLine" : 295,
+                    "endCol" : 26
+                  }
+                },
+                "span" : {
+                  "startLine" : 295,
+                  "startCol" : 6,
+                  "endLine" : 295,
+                  "endCol" : 27
+                }
+              },
+              "field" : "status",
+              "span" : {
+                "startLine" : 295,
+                "startCol" : 6,
+                "endLine" : 295,
+                "endCol" : 34
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "PAID",
+              "span" : {
+                "startLine" : 295,
+                "startCol" : 38,
+                "endLine" : 295,
+                "endCol" : 42
+              }
+            },
+            "span" : {
+              "startLine" : 295,
+              "startCol" : 6,
+              "endLine" : 295,
+              "endCol" : 42
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "and",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "=",
+              "left" : {
+                "kind" : "Prime",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "payments",
+                  "span" : {
+                    "startLine" : 296,
+                    "startCol" : 8,
+                    "endLine" : 296,
+                    "endCol" : 16
+                  }
+                },
+                "span" : {
+                  "startLine" : 296,
+                  "startCol" : 8,
+                  "endLine" : 296,
+                  "endCol" : 17
+                }
+              },
+              "right" : {
+                "kind" : "Pre",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "payments",
+                  "span" : {
+                    "startLine" : 296,
+                    "startCol" : 24,
+                    "endLine" : 296,
+                    "endCol" : 32
+                  }
+                },
+                "span" : {
+                  "startLine" : 296,
+                  "startCol" : 20,
+                  "endLine" : 296,
+                  "endCol" : 33
+                }
+              },
+              "span" : {
+                "startLine" : 296,
+                "startCol" : 8,
+                "endLine" : 296,
+                "endCol" : 33
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "=",
+              "left" : {
+                "kind" : "Prime",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "next_payment_id",
+                  "span" : {
+                    "startLine" : 297,
+                    "startCol" : 12,
+                    "endLine" : 297,
+                    "endCol" : 27
+                  }
+                },
+                "span" : {
+                  "startLine" : 297,
+                  "startCol" : 12,
+                  "endLine" : 297,
+                  "endCol" : 28
+                }
+              },
+              "right" : {
+                "kind" : "Pre",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "next_payment_id",
+                  "span" : {
+                    "startLine" : 297,
+                    "startCol" : 35,
+                    "endLine" : 297,
+                    "endCol" : 50
+                  }
+                },
+                "span" : {
+                  "startLine" : 297,
+                  "startCol" : 31,
+                  "endLine" : 297,
+                  "endCol" : 51
+                }
+              },
+              "span" : {
+                "startLine" : 297,
+                "startCol" : 12,
+                "endLine" : 297,
+                "endCol" : 51
+              }
+            },
+            "span" : {
+              "startLine" : 296,
+              "startCol" : 8,
+              "endLine" : 297,
+              "endCol" : 51
+            }
+          },
+          "span" : {
+            "startLine" : 295,
+            "startCol" : 6,
+            "endLine" : 297,
+            "endCol" : 52
           }
         }
       ],
       "span" : {
-        "startLine" : 269,
+        "startLine" : 270,
         "startCol" : 2,
-        "endLine" : 290,
+        "endLine" : 298,
         "endCol" : 3
       }
     },
@@ -8160,16 +8505,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 293,
+              "startLine" : 301,
               "startCol" : 22,
-              "endLine" : 293,
+              "endLine" : 301,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 293,
+            "startLine" : 301,
             "startCol" : 12,
-            "endLine" : 293,
+            "endLine" : 301,
             "endCol" : 29
           }
         }
@@ -8182,16 +8527,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 294,
+              "startLine" : 302,
               "startCol" : 19,
-              "endLine" : 294,
+              "endLine" : 302,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 294,
+            "startLine" : 302,
             "startCol" : 12,
-            "endLine" : 294,
+            "endLine" : 302,
             "endCol" : 24
           }
         }
@@ -8204,9 +8549,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 297,
+              "startLine" : 305,
               "startCol" : 6,
-              "endLine" : 297,
+              "endLine" : 305,
               "endCol" : 14
             }
           },
@@ -8214,16 +8559,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 297,
+              "startLine" : 305,
               "startCol" : 18,
-              "endLine" : 297,
+              "endLine" : 305,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 297,
+            "startLine" : 305,
             "startCol" : 6,
-            "endLine" : 297,
+            "endLine" : 305,
             "endCol" : 24
           }
         },
@@ -8238,9 +8583,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 298,
+                  "startLine" : 306,
                   "startCol" : 6,
-                  "endLine" : 298,
+                  "endLine" : 306,
                   "endCol" : 12
                 }
               },
@@ -8248,24 +8593,24 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 298,
+                  "startLine" : 306,
                   "startCol" : 13,
-                  "endLine" : 298,
+                  "endLine" : 306,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 298,
+                "startLine" : 306,
                 "startCol" : 6,
-                "endLine" : 298,
+                "endLine" : 306,
                 "endCol" : 22
               }
             },
             "field" : "status",
             "span" : {
-              "startLine" : 298,
+              "startLine" : 306,
               "startCol" : 6,
-              "endLine" : 298,
+              "endLine" : 306,
               "endCol" : 29
             }
           },
@@ -8273,16 +8618,16 @@
             "kind" : "Identifier",
             "name" : "DELIVERED",
             "span" : {
-              "startLine" : 298,
+              "startLine" : 306,
               "startCol" : 32,
-              "endLine" : 298,
+              "endLine" : 306,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 298,
+            "startLine" : 306,
             "startCol" : 6,
-            "endLine" : 298,
+            "endLine" : 306,
             "endCol" : 41
           }
         },
@@ -8297,9 +8642,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 299,
+                  "startLine" : 307,
                   "startCol" : 6,
-                  "endLine" : 299,
+                  "endLine" : 307,
                   "endCol" : 12
                 }
               },
@@ -8307,40 +8652,40 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 299,
+                  "startLine" : 307,
                   "startCol" : 13,
-                  "endLine" : 299,
+                  "endLine" : 307,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 299,
+                "startLine" : 307,
                 "startCol" : 6,
-                "endLine" : 299,
+                "endLine" : 307,
                 "endCol" : 22
               }
             },
             "field" : "delivered_at",
             "span" : {
-              "startLine" : 299,
+              "startLine" : 307,
               "startCol" : 6,
-              "endLine" : 299,
+              "endLine" : 307,
               "endCol" : 35
             }
           },
           "right" : {
             "kind" : "NoneLit",
             "span" : {
-              "startLine" : 299,
+              "startLine" : 307,
               "startCol" : 39,
-              "endLine" : 299,
+              "endLine" : 307,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 299,
+            "startLine" : 307,
             "startCol" : 6,
-            "endLine" : 299,
+            "endLine" : 307,
             "endCol" : 43
           }
         },
@@ -8356,18 +8701,18 @@
                 "kind" : "Identifier",
                 "name" : "now",
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 308,
                   "startCol" : 6,
-                  "endLine" : 300,
+                  "endLine" : 308,
                   "endCol" : 9
                 }
               },
               "args" : [
               ],
               "span" : {
-                "startLine" : 300,
+                "startLine" : 308,
                 "startCol" : 6,
-                "endLine" : 300,
+                "endLine" : 308,
                 "endCol" : 11
               }
             },
@@ -8379,9 +8724,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 300,
+                    "startLine" : 308,
                     "startCol" : 14,
-                    "endLine" : 300,
+                    "endLine" : 308,
                     "endCol" : 20
                   }
                 },
@@ -8389,31 +8734,31 @@
                   "kind" : "Identifier",
                   "name" : "order_id",
                   "span" : {
-                    "startLine" : 300,
+                    "startLine" : 308,
                     "startCol" : 21,
-                    "endLine" : 300,
+                    "endLine" : 308,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 308,
                   "startCol" : 14,
-                  "endLine" : 300,
+                  "endLine" : 308,
                   "endCol" : 30
                 }
               },
               "field" : "delivered_at",
               "span" : {
-                "startLine" : 300,
+                "startLine" : 308,
                 "startCol" : 14,
-                "endLine" : 300,
+                "endLine" : 308,
                 "endCol" : 43
               }
             },
             "span" : {
-              "startLine" : 300,
+              "startLine" : 308,
               "startCol" : 6,
-              "endLine" : 300,
+              "endLine" : 308,
               "endCol" : 43
             }
           },
@@ -8423,9 +8768,9 @@
               "kind" : "Identifier",
               "name" : "days",
               "span" : {
-                "startLine" : 300,
+                "startLine" : 308,
                 "startCol" : 47,
-                "endLine" : 300,
+                "endLine" : 308,
                 "endCol" : 51
               }
             },
@@ -8434,24 +8779,24 @@
                 "kind" : "IntLit",
                 "value" : 30,
                 "span" : {
-                  "startLine" : 300,
+                  "startLine" : 308,
                   "startCol" : 52,
-                  "endLine" : 300,
+                  "endLine" : 308,
                   "endCol" : 54
                 }
               }
             ],
             "span" : {
-              "startLine" : 300,
+              "startLine" : 308,
               "startCol" : 47,
-              "endLine" : 300,
+              "endLine" : 308,
               "endCol" : 55
             }
           },
           "span" : {
-            "startLine" : 300,
+            "startLine" : 308,
             "startCol" : 6,
-            "endLine" : 300,
+            "endLine" : 308,
             "endCol" : 55
           }
         }
@@ -8464,9 +8809,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 303,
+              "startLine" : 311,
               "startCol" : 6,
-              "endLine" : 303,
+              "endLine" : 311,
               "endCol" : 11
             }
           },
@@ -8480,16 +8825,16 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 303,
+                    "startLine" : 311,
                     "startCol" : 18,
-                    "endLine" : 303,
+                    "endLine" : 311,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 303,
+                  "startLine" : 311,
                   "startCol" : 14,
-                  "endLine" : 303,
+                  "endLine" : 311,
                   "endCol" : 25
                 }
               },
@@ -8497,16 +8842,16 @@
                 "kind" : "Identifier",
                 "name" : "order_id",
                 "span" : {
-                  "startLine" : 303,
+                  "startLine" : 311,
                   "startCol" : 26,
-                  "endLine" : 303,
+                  "endLine" : 311,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 303,
+                "startLine" : 311,
                 "startCol" : 14,
-                "endLine" : 303,
+                "endLine" : 311,
                 "endCol" : 35
               }
             },
@@ -8517,31 +8862,31 @@
                   "kind" : "Identifier",
                   "name" : "RETURNED",
                   "span" : {
-                    "startLine" : 303,
+                    "startLine" : 311,
                     "startCol" : 52,
-                    "endLine" : 303,
+                    "endLine" : 311,
                     "endCol" : 60
                   }
                 },
                 "span" : {
-                  "startLine" : 303,
+                  "startLine" : 311,
                   "startCol" : 43,
-                  "endLine" : 303,
+                  "endLine" : 311,
                   "endCol" : 60
                 }
               }
             ],
             "span" : {
-              "startLine" : 303,
+              "startLine" : 311,
               "startCol" : 14,
-              "endLine" : 303,
+              "endLine" : 311,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 303,
+            "startLine" : 311,
             "startCol" : 6,
-            "endLine" : 303,
+            "endLine" : 311,
             "endCol" : 62
           }
         },
@@ -8554,16 +8899,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 304,
+                "startLine" : 312,
                 "startCol" : 6,
-                "endLine" : 304,
+                "endLine" : 312,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 304,
+              "startLine" : 312,
               "startCol" : 6,
-              "endLine" : 304,
+              "endLine" : 312,
               "endCol" : 13
             }
           },
@@ -8576,16 +8921,16 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 304,
+                  "startLine" : 312,
                   "startCol" : 20,
-                  "endLine" : 304,
+                  "endLine" : 312,
                   "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 304,
+                "startLine" : 312,
                 "startCol" : 16,
-                "endLine" : 304,
+                "endLine" : 312,
                 "endCol" : 27
               }
             },
@@ -8597,9 +8942,9 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 304,
+                      "startLine" : 312,
                       "startCol" : 31,
-                      "endLine" : 304,
+                      "endLine" : 312,
                       "endCol" : 39
                     }
                   },
@@ -8607,38 +8952,38 @@
                     "kind" : "Identifier",
                     "name" : "order",
                     "span" : {
-                      "startLine" : 304,
+                      "startLine" : 312,
                       "startCol" : 43,
-                      "endLine" : 304,
+                      "endLine" : 312,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 304,
+                    "startLine" : 312,
                     "startCol" : 31,
-                    "endLine" : 304,
+                    "endLine" : 312,
                     "endCol" : 39
                   }
                 }
               ],
               "span" : {
-                "startLine" : 304,
+                "startLine" : 312,
                 "startCol" : 30,
-                "endLine" : 304,
+                "endLine" : 312,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 304,
+              "startLine" : 312,
               "startCol" : 16,
-              "endLine" : 304,
+              "endLine" : 312,
               "endCol" : 49
             }
           },
           "span" : {
-            "startLine" : 304,
+            "startLine" : 312,
             "startCol" : 6,
-            "endLine" : 304,
+            "endLine" : 312,
             "endCol" : 49
           }
         },
@@ -8658,16 +9003,16 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 305,
+                        "startLine" : 313,
                         "startCol" : 22,
-                        "endLine" : 305,
+                        "endLine" : 313,
                         "endCol" : 28
                       }
                     },
                     "span" : {
-                      "startLine" : 305,
+                      "startLine" : 313,
                       "startCol" : 18,
-                      "endLine" : 305,
+                      "endLine" : 313,
                       "endCol" : 29
                     }
                   },
@@ -8675,32 +9020,32 @@
                     "kind" : "Identifier",
                     "name" : "order_id",
                     "span" : {
-                      "startLine" : 305,
+                      "startLine" : 313,
                       "startCol" : 30,
-                      "endLine" : 305,
+                      "endLine" : 313,
                       "endCol" : 38
                     }
                   },
                   "span" : {
-                    "startLine" : 305,
+                    "startLine" : 313,
                     "startCol" : 18,
-                    "endLine" : 305,
+                    "endLine" : 313,
                     "endCol" : 39
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 305,
+                  "startLine" : 313,
                   "startCol" : 18,
-                  "endLine" : 305,
+                  "endLine" : 313,
                   "endCol" : 45
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 305,
+                "startLine" : 313,
                 "startCol" : 10,
-                "endLine" : 305,
+                "endLine" : 313,
                 "endCol" : 45
               }
             }
@@ -8718,16 +9063,16 @@
                     "kind" : "Identifier",
                     "name" : "inventory",
                     "span" : {
-                      "startLine" : 306,
+                      "startLine" : 314,
                       "startCol" : 8,
-                      "endLine" : 306,
+                      "endLine" : 314,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 306,
+                    "startLine" : 314,
                     "startCol" : 8,
-                    "endLine" : 306,
+                    "endLine" : 314,
                     "endCol" : 18
                   }
                 },
@@ -8737,32 +9082,32 @@
                     "kind" : "Identifier",
                     "name" : "item",
                     "span" : {
-                      "startLine" : 306,
+                      "startLine" : 314,
                       "startCol" : 19,
-                      "endLine" : 306,
+                      "endLine" : 314,
                       "endCol" : 23
                     }
                   },
                   "field" : "product_sku",
                   "span" : {
-                    "startLine" : 306,
+                    "startLine" : 314,
                     "startCol" : 19,
-                    "endLine" : 306,
+                    "endLine" : 314,
                     "endCol" : 35
                   }
                 },
                 "span" : {
-                  "startLine" : 306,
+                  "startLine" : 314,
                   "startCol" : 8,
-                  "endLine" : 306,
+                  "endLine" : 314,
                   "endCol" : 36
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 306,
+                "startLine" : 314,
                 "startCol" : 8,
-                "endLine" : 306,
+                "endLine" : 314,
                 "endCol" : 46
               }
             },
@@ -8779,16 +9124,16 @@
                       "kind" : "Identifier",
                       "name" : "inventory",
                       "span" : {
-                        "startLine" : 307,
+                        "startLine" : 315,
                         "startCol" : 14,
-                        "endLine" : 307,
+                        "endLine" : 315,
                         "endCol" : 23
                       }
                     },
                     "span" : {
-                      "startLine" : 307,
+                      "startLine" : 315,
                       "startCol" : 10,
-                      "endLine" : 307,
+                      "endLine" : 315,
                       "endCol" : 24
                     }
                   },
@@ -8798,32 +9143,32 @@
                       "kind" : "Identifier",
                       "name" : "item",
                       "span" : {
-                        "startLine" : 307,
+                        "startLine" : 315,
                         "startCol" : 25,
-                        "endLine" : 307,
+                        "endLine" : 315,
                         "endCol" : 29
                       }
                     },
                     "field" : "product_sku",
                     "span" : {
-                      "startLine" : 307,
+                      "startLine" : 315,
                       "startCol" : 25,
-                      "endLine" : 307,
+                      "endLine" : 315,
                       "endCol" : 41
                     }
                   },
                   "span" : {
-                    "startLine" : 307,
+                    "startLine" : 315,
                     "startCol" : 10,
-                    "endLine" : 307,
+                    "endLine" : 315,
                     "endCol" : 42
                   }
                 },
                 "field" : "available",
                 "span" : {
-                  "startLine" : 307,
+                  "startLine" : 315,
                   "startCol" : 10,
-                  "endLine" : 307,
+                  "endLine" : 315,
                   "endCol" : 52
                 }
               },
@@ -8833,398 +9178,375 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 307,
+                    "startLine" : 315,
                     "startCol" : 55,
-                    "endLine" : 307,
+                    "endLine" : 315,
                     "endCol" : 59
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 307,
+                  "startLine" : 315,
                   "startCol" : 55,
-                  "endLine" : 307,
+                  "endLine" : 315,
                   "endCol" : 68
                 }
               },
               "span" : {
-                "startLine" : 307,
+                "startLine" : 315,
                 "startCol" : 10,
-                "endLine" : 307,
+                "endLine" : 315,
                 "endCol" : 68
               }
             },
             "span" : {
-              "startLine" : 306,
+              "startLine" : 314,
               "startCol" : 8,
-              "endLine" : 307,
+              "endLine" : 315,
               "endCol" : 68
             }
           },
           "span" : {
-            "startLine" : 305,
+            "startLine" : 313,
             "startCol" : 6,
-            "endLine" : 307,
+            "endLine" : 315,
             "endCol" : 68
           }
         },
         {
-          "kind" : "Quantifier",
-          "quantifier" : "some",
-          "bindings" : [
-            {
-              "variable" : "p",
-              "domain" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "payments",
-                  "span" : {
-                    "startLine" : 308,
-                    "startCol" : 16,
-                    "endLine" : 308,
-                    "endCol" : 24
-                  }
-                },
-                "span" : {
-                  "startLine" : 308,
-                  "startCol" : 16,
-                  "endLine" : 308,
-                  "endCol" : 25
-                }
-              },
-              "bindingKind" : "in",
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "payments",
               "span" : {
-                "startLine" : 308,
-                "startCol" : 11,
-                "endLine" : 308,
-                "endCol" : 25
-              }
-            }
-          ],
-          "body" : {
-            "kind" : "BinaryOp",
-            "op" : "and",
-            "left" : {
-              "kind" : "BinaryOp",
-              "op" : "and",
-              "left" : {
-                "kind" : "BinaryOp",
-                "op" : "and",
-                "left" : {
-                  "kind" : "BinaryOp",
-                  "op" : "not_in",
-                  "left" : {
-                    "kind" : "Identifier",
-                    "name" : "p",
-                    "span" : {
-                      "startLine" : 309,
-                      "startCol" : 8,
-                      "endLine" : 309,
-                      "endCol" : 9
-                    }
-                  },
-                  "right" : {
-                    "kind" : "Pre",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "payments",
-                      "span" : {
-                        "startLine" : 309,
-                        "startCol" : 21,
-                        "endLine" : 309,
-                        "endCol" : 29
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 309,
-                      "startCol" : 17,
-                      "endLine" : 309,
-                      "endCol" : 30
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 309,
-                    "startCol" : 8,
-                    "endLine" : 309,
-                    "endCol" : 30
-                  }
-                },
-                "right" : {
-                  "kind" : "BinaryOp",
-                  "op" : "=",
-                  "left" : {
-                    "kind" : "FieldAccess",
-                    "base" : {
-                      "kind" : "Index",
-                      "base" : {
-                        "kind" : "Prime",
-                        "expr" : {
-                          "kind" : "Identifier",
-                          "name" : "payments",
-                          "span" : {
-                            "startLine" : 310,
-                            "startCol" : 12,
-                            "endLine" : 310,
-                            "endCol" : 20
-                          }
-                        },
-                        "span" : {
-                          "startLine" : 310,
-                          "startCol" : 12,
-                          "endLine" : 310,
-                          "endCol" : 21
-                        }
-                      },
-                      "index" : {
-                        "kind" : "Identifier",
-                        "name" : "p",
-                        "span" : {
-                          "startLine" : 310,
-                          "startCol" : 22,
-                          "endLine" : 310,
-                          "endCol" : 23
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 310,
-                        "startCol" : 12,
-                        "endLine" : 310,
-                        "endCol" : 24
-                      }
-                    },
-                    "field" : "order_id",
-                    "span" : {
-                      "startLine" : 310,
-                      "startCol" : 12,
-                      "endLine" : 310,
-                      "endCol" : 33
-                    }
-                  },
-                  "right" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 310,
-                      "startCol" : 36,
-                      "endLine" : 310,
-                      "endCol" : 44
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 310,
-                    "startCol" : 12,
-                    "endLine" : 310,
-                    "endCol" : 44
-                  }
-                },
-                "span" : {
-                  "startLine" : 309,
-                  "startCol" : 8,
-                  "endLine" : 310,
-                  "endCol" : 44
-                }
-              },
-              "right" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Index",
-                    "base" : {
-                      "kind" : "Prime",
-                      "expr" : {
-                        "kind" : "Identifier",
-                        "name" : "payments",
-                        "span" : {
-                          "startLine" : 311,
-                          "startCol" : 12,
-                          "endLine" : 311,
-                          "endCol" : 20
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 311,
-                        "startCol" : 12,
-                        "endLine" : 311,
-                        "endCol" : 21
-                      }
-                    },
-                    "index" : {
-                      "kind" : "Identifier",
-                      "name" : "p",
-                      "span" : {
-                        "startLine" : 311,
-                        "startCol" : 22,
-                        "endLine" : 311,
-                        "endCol" : 23
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 311,
-                      "startCol" : 12,
-                      "endLine" : 311,
-                      "endCol" : 24
-                    }
-                  },
-                  "field" : "status",
-                  "span" : {
-                    "startLine" : 311,
-                    "startCol" : 12,
-                    "endLine" : 311,
-                    "endCol" : 31
-                  }
-                },
-                "right" : {
-                  "kind" : "Identifier",
-                  "name" : "REFUNDED",
-                  "span" : {
-                    "startLine" : 311,
-                    "startCol" : 34,
-                    "endLine" : 311,
-                    "endCol" : 42
-                  }
-                },
-                "span" : {
-                  "startLine" : 311,
-                  "startCol" : 12,
-                  "endLine" : 311,
-                  "endCol" : 42
-                }
-              },
-              "span" : {
-                "startLine" : 309,
-                "startCol" : 8,
-                "endLine" : 311,
-                "endCol" : 42
-              }
-            },
-            "right" : {
-              "kind" : "BinaryOp",
-              "op" : "=",
-              "left" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Index",
-                  "base" : {
-                    "kind" : "Prime",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "payments",
-                      "span" : {
-                        "startLine" : 312,
-                        "startCol" : 12,
-                        "endLine" : 312,
-                        "endCol" : 20
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 312,
-                      "startCol" : 12,
-                      "endLine" : 312,
-                      "endCol" : 21
-                    }
-                  },
-                  "index" : {
-                    "kind" : "Identifier",
-                    "name" : "p",
-                    "span" : {
-                      "startLine" : 312,
-                      "startCol" : 22,
-                      "endLine" : 312,
-                      "endCol" : 23
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 312,
-                    "startCol" : 12,
-                    "endLine" : 312,
-                    "endCol" : 24
-                  }
-                },
-                "field" : "amount",
-                "span" : {
-                  "startLine" : 312,
-                  "startCol" : 12,
-                  "endLine" : 312,
-                  "endCol" : 31
-                }
-              },
-              "right" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Index",
-                  "base" : {
-                    "kind" : "Pre",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "orders",
-                      "span" : {
-                        "startLine" : 312,
-                        "startCol" : 38,
-                        "endLine" : 312,
-                        "endCol" : 44
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 312,
-                      "startCol" : 34,
-                      "endLine" : 312,
-                      "endCol" : 45
-                    }
-                  },
-                  "index" : {
-                    "kind" : "Identifier",
-                    "name" : "order_id",
-                    "span" : {
-                      "startLine" : 312,
-                      "startCol" : 46,
-                      "endLine" : 312,
-                      "endCol" : 54
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 312,
-                    "startCol" : 34,
-                    "endLine" : 312,
-                    "endCol" : 55
-                  }
-                },
-                "field" : "total",
-                "span" : {
-                  "startLine" : 312,
-                  "startCol" : 34,
-                  "endLine" : 312,
-                  "endCol" : 61
-                }
-              },
-              "span" : {
-                "startLine" : 312,
-                "startCol" : 12,
-                "endLine" : 312,
-                "endCol" : 61
+                "startLine" : 316,
+                "startCol" : 6,
+                "endLine" : 316,
+                "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 309,
-              "startCol" : 8,
-              "endLine" : 312,
-              "endCol" : 61
+              "startLine" : 316,
+              "startCol" : 6,
+              "endLine" : 316,
+              "endCol" : 15
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "payments",
+                "span" : {
+                  "startLine" : 316,
+                  "startCol" : 22,
+                  "endLine" : 316,
+                  "endCol" : 30
+                }
+              },
+              "span" : {
+                "startLine" : 316,
+                "startCol" : 18,
+                "endLine" : 316,
+                "endCol" : 31
+              }
+            },
+            "right" : {
+              "kind" : "MapLiteral",
+              "entries" : [
+                {
+                  "key" : {
+                    "kind" : "Pre",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "next_payment_id",
+                      "span" : {
+                        "startLine" : 316,
+                        "startCol" : 39,
+                        "endLine" : 316,
+                        "endCol" : 54
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 316,
+                      "startCol" : 35,
+                      "endLine" : 316,
+                      "endCol" : 55
+                    }
+                  },
+                  "value" : {
+                    "kind" : "Constructor",
+                    "typeName" : "Payment",
+                    "fields" : [
+                      {
+                        "name" : "id",
+                        "value" : {
+                          "kind" : "Pre",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "next_payment_id",
+                            "span" : {
+                              "startLine" : 317,
+                              "startCol" : 17,
+                              "endLine" : 317,
+                              "endCol" : 32
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 317,
+                            "startCol" : 13,
+                            "endLine" : 317,
+                            "endCol" : 33
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 317,
+                          "startCol" : 8,
+                          "endLine" : 317,
+                          "endCol" : 33
+                        }
+                      },
+                      {
+                        "name" : "order_id",
+                        "value" : {
+                          "kind" : "Identifier",
+                          "name" : "order_id",
+                          "span" : {
+                            "startLine" : 318,
+                            "startCol" : 19,
+                            "endLine" : 318,
+                            "endCol" : 27
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 318,
+                          "startCol" : 8,
+                          "endLine" : 318,
+                          "endCol" : 27
+                        }
+                      },
+                      {
+                        "name" : "amount",
+                        "value" : {
+                          "kind" : "FieldAccess",
+                          "base" : {
+                            "kind" : "Index",
+                            "base" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "orders",
+                                "span" : {
+                                  "startLine" : 319,
+                                  "startCol" : 21,
+                                  "endLine" : 319,
+                                  "endCol" : 27
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 319,
+                                "startCol" : 17,
+                                "endLine" : 319,
+                                "endCol" : 28
+                              }
+                            },
+                            "index" : {
+                              "kind" : "Identifier",
+                              "name" : "order_id",
+                              "span" : {
+                                "startLine" : 319,
+                                "startCol" : 29,
+                                "endLine" : 319,
+                                "endCol" : 37
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 319,
+                              "startCol" : 17,
+                              "endLine" : 319,
+                              "endCol" : 38
+                            }
+                          },
+                          "field" : "total",
+                          "span" : {
+                            "startLine" : 319,
+                            "startCol" : 17,
+                            "endLine" : 319,
+                            "endCol" : 44
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 319,
+                          "startCol" : 8,
+                          "endLine" : 319,
+                          "endCol" : 44
+                        }
+                      },
+                      {
+                        "name" : "status",
+                        "value" : {
+                          "kind" : "Identifier",
+                          "name" : "REFUNDED",
+                          "span" : {
+                            "startLine" : 320,
+                            "startCol" : 17,
+                            "endLine" : 320,
+                            "endCol" : 25
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 320,
+                          "startCol" : 8,
+                          "endLine" : 320,
+                          "endCol" : 25
+                        }
+                      },
+                      {
+                        "name" : "created_at",
+                        "value" : {
+                          "kind" : "Call",
+                          "callee" : {
+                            "kind" : "Identifier",
+                            "name" : "now",
+                            "span" : {
+                              "startLine" : 321,
+                              "startCol" : 21,
+                              "endLine" : 321,
+                              "endCol" : 24
+                            }
+                          },
+                          "args" : [
+                          ],
+                          "span" : {
+                            "startLine" : 321,
+                            "startCol" : 21,
+                            "endLine" : 321,
+                            "endCol" : 26
+                          }
+                        },
+                        "span" : {
+                          "startLine" : 321,
+                          "startCol" : 8,
+                          "endLine" : 321,
+                          "endCol" : 26
+                        }
+                      }
+                    ],
+                    "span" : {
+                      "startLine" : 316,
+                      "startCol" : 59,
+                      "endLine" : 322,
+                      "endCol" : 7
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 316,
+                    "startCol" : 35,
+                    "endLine" : 316,
+                    "endCol" : 55
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 316,
+                "startCol" : 34,
+                "endLine" : 322,
+                "endCol" : 8
+              }
+            },
+            "span" : {
+              "startLine" : 316,
+              "startCol" : 18,
+              "endLine" : 322,
+              "endCol" : 8
             }
           },
           "span" : {
-            "startLine" : 308,
+            "startLine" : 316,
             "startCol" : 6,
-            "endLine" : 312,
-            "endCol" : 61
+            "endLine" : 322,
+            "endCol" : 8
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "next_payment_id",
+              "span" : {
+                "startLine" : 323,
+                "startCol" : 6,
+                "endLine" : 323,
+                "endCol" : 21
+              }
+            },
+            "span" : {
+              "startLine" : 323,
+              "startCol" : 6,
+              "endLine" : 323,
+              "endCol" : 22
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : "+",
+            "left" : {
+              "kind" : "Pre",
+              "expr" : {
+                "kind" : "Identifier",
+                "name" : "next_payment_id",
+                "span" : {
+                  "startLine" : 323,
+                  "startCol" : 29,
+                  "endLine" : 323,
+                  "endCol" : 44
+                }
+              },
+              "span" : {
+                "startLine" : 323,
+                "startCol" : 25,
+                "endLine" : 323,
+                "endCol" : 45
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 1,
+              "span" : {
+                "startLine" : 323,
+                "startCol" : 48,
+                "endLine" : 323,
+                "endCol" : 49
+              }
+            },
+            "span" : {
+              "startLine" : 323,
+              "startCol" : 25,
+              "endLine" : 323,
+              "endCol" : 49
+            }
+          },
+          "span" : {
+            "startLine" : 323,
+            "startCol" : 6,
+            "endLine" : 323,
+            "endCol" : 49
           }
         }
       ],
       "span" : {
-        "startLine" : 292,
+        "startLine" : 300,
         "startCol" : 2,
-        "endLine" : 313,
+        "endLine" : 324,
         "endCol" : 3
       }
     },
@@ -9239,16 +9561,16 @@
             "kind" : "NamedType",
             "name" : "OrderId",
             "span" : {
-              "startLine" : 316,
+              "startLine" : 327,
               "startCol" : 22,
-              "endLine" : 316,
+              "endLine" : 327,
               "endCol" : 29
             }
           },
           "span" : {
-            "startLine" : 316,
+            "startLine" : 327,
             "startCol" : 12,
-            "endLine" : 316,
+            "endLine" : 327,
             "endCol" : 29
           }
         }
@@ -9261,16 +9583,16 @@
             "kind" : "NamedType",
             "name" : "Order",
             "span" : {
-              "startLine" : 317,
+              "startLine" : 328,
               "startCol" : 19,
-              "endLine" : 317,
+              "endLine" : 328,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 317,
+            "startLine" : 328,
             "startCol" : 12,
-            "endLine" : 317,
+            "endLine" : 328,
             "endCol" : 24
           }
         }
@@ -9283,9 +9605,9 @@
             "kind" : "Identifier",
             "name" : "order_id",
             "span" : {
-              "startLine" : 320,
+              "startLine" : 331,
               "startCol" : 6,
-              "endLine" : 320,
+              "endLine" : 331,
               "endCol" : 14
             }
           },
@@ -9293,16 +9615,16 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 320,
+              "startLine" : 331,
               "startCol" : 18,
-              "endLine" : 320,
+              "endLine" : 331,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 320,
+            "startLine" : 331,
             "startCol" : 6,
-            "endLine" : 320,
+            "endLine" : 331,
             "endCol" : 24
           }
         }
@@ -9315,9 +9637,9 @@
             "kind" : "Identifier",
             "name" : "order",
             "span" : {
-              "startLine" : 323,
+              "startLine" : 334,
               "startCol" : 6,
-              "endLine" : 323,
+              "endLine" : 334,
               "endCol" : 11
             }
           },
@@ -9327,9 +9649,9 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 323,
+                "startLine" : 334,
                 "startCol" : 14,
-                "endLine" : 323,
+                "endLine" : 334,
                 "endCol" : 20
               }
             },
@@ -9337,23 +9659,23 @@
               "kind" : "Identifier",
               "name" : "order_id",
               "span" : {
-                "startLine" : 323,
+                "startLine" : 334,
                 "startCol" : 21,
-                "endLine" : 323,
+                "endLine" : 334,
                 "endCol" : 29
               }
             },
             "span" : {
-              "startLine" : 323,
+              "startLine" : 334,
               "startCol" : 14,
-              "endLine" : 323,
+              "endLine" : 334,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 323,
+            "startLine" : 334,
             "startCol" : 6,
-            "endLine" : 323,
+            "endLine" : 334,
             "endCol" : 30
           }
         },
@@ -9366,16 +9688,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 324,
+                "startLine" : 335,
                 "startCol" : 6,
-                "endLine" : 324,
+                "endLine" : 335,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 324,
+              "startLine" : 335,
               "startCol" : 6,
-              "endLine" : 324,
+              "endLine" : 335,
               "endCol" : 13
             }
           },
@@ -9383,24 +9705,24 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 324,
+              "startLine" : 335,
               "startCol" : 16,
-              "endLine" : 324,
+              "endLine" : 335,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 324,
+            "startLine" : 335,
             "startCol" : 6,
-            "endLine" : 324,
+            "endLine" : 335,
             "endCol" : 22
           }
         }
       ],
       "span" : {
-        "startLine" : 315,
+        "startLine" : 326,
         "startCol" : 2,
-        "endLine" : 325,
+        "endLine" : 336,
         "endCol" : 3
       }
     },
@@ -9417,23 +9739,23 @@
               "kind" : "NamedType",
               "name" : "CustomerId",
               "span" : {
-                "startLine" : 328,
+                "startLine" : 339,
                 "startCol" : 32,
-                "endLine" : 328,
+                "endLine" : 339,
                 "endCol" : 42
               }
             },
             "span" : {
-              "startLine" : 328,
+              "startLine" : 339,
               "startCol" : 25,
-              "endLine" : 328,
+              "endLine" : 339,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 328,
+            "startLine" : 339,
             "startCol" : 12,
-            "endLine" : 328,
+            "endLine" : 339,
             "endCol" : 43
           }
         },
@@ -9446,23 +9768,23 @@
               "kind" : "NamedType",
               "name" : "OrderStatus",
               "span" : {
-                "startLine" : 329,
+                "startLine" : 340,
                 "startCol" : 34,
-                "endLine" : 329,
+                "endLine" : 340,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 329,
+              "startLine" : 340,
               "startCol" : 27,
-              "endLine" : 329,
+              "endLine" : 340,
               "endCol" : 46
             }
           },
           "span" : {
-            "startLine" : 329,
+            "startLine" : 340,
             "startCol" : 12,
-            "endLine" : 329,
+            "endLine" : 340,
             "endCol" : 46
           }
         }
@@ -9477,23 +9799,23 @@
               "kind" : "NamedType",
               "name" : "Order",
               "span" : {
-                "startLine" : 330,
+                "startLine" : 341,
                 "startCol" : 25,
-                "endLine" : 330,
+                "endLine" : 341,
                 "endCol" : 30
               }
             },
             "span" : {
-              "startLine" : 330,
+              "startLine" : 341,
               "startCol" : 21,
-              "endLine" : 330,
+              "endLine" : 341,
               "endCol" : 31
             }
           },
           "span" : {
-            "startLine" : 330,
+            "startLine" : 341,
             "startCol" : 12,
-            "endLine" : 330,
+            "endLine" : 341,
             "endCol" : 31
           }
         }
@@ -9503,9 +9825,9 @@
           "kind" : "BoolLit",
           "value" : true,
           "span" : {
-            "startLine" : 333,
+            "startLine" : 344,
             "startCol" : 6,
-            "endLine" : 333,
+            "endLine" : 344,
             "endCol" : 10
           }
         }
@@ -9521,17 +9843,17 @@
                 "kind" : "Identifier",
                 "name" : "results",
                 "span" : {
-                  "startLine" : 336,
+                  "startLine" : 347,
                   "startCol" : 15,
-                  "endLine" : 336,
+                  "endLine" : 347,
                   "endCol" : 22
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 336,
+                "startLine" : 347,
                 "startCol" : 10,
-                "endLine" : 336,
+                "endLine" : 347,
                 "endCol" : 22
               }
             }
@@ -9549,9 +9871,9 @@
                   "kind" : "Identifier",
                   "name" : "o",
                   "span" : {
-                    "startLine" : 337,
+                    "startLine" : 348,
                     "startCol" : 8,
-                    "endLine" : 337,
+                    "endLine" : 348,
                     "endCol" : 9
                   }
                 },
@@ -9561,9 +9883,9 @@
                     "kind" : "Identifier",
                     "name" : "ran",
                     "span" : {
-                      "startLine" : 337,
+                      "startLine" : 348,
                       "startCol" : 13,
-                      "endLine" : 337,
+                      "endLine" : 348,
                       "endCol" : 16
                     }
                   },
@@ -9572,24 +9894,24 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 337,
+                        "startLine" : 348,
                         "startCol" : 17,
-                        "endLine" : 337,
+                        "endLine" : 348,
                         "endCol" : 23
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 337,
+                    "startLine" : 348,
                     "startCol" : 13,
-                    "endLine" : 337,
+                    "endLine" : 348,
                     "endCol" : 24
                   }
                 },
                 "span" : {
-                  "startLine" : 337,
+                  "startLine" : 348,
                   "startCol" : 8,
-                  "endLine" : 337,
+                  "endLine" : 348,
                   "endCol" : 24
                 }
               },
@@ -9603,25 +9925,25 @@
                     "kind" : "Identifier",
                     "name" : "customer_id",
                     "span" : {
-                      "startLine" : 338,
+                      "startLine" : 349,
                       "startCol" : 13,
-                      "endLine" : 338,
+                      "endLine" : 349,
                       "endCol" : 24
                     }
                   },
                   "right" : {
                     "kind" : "NoneLit",
                     "span" : {
-                      "startLine" : 338,
+                      "startLine" : 349,
                       "startCol" : 27,
-                      "endLine" : 338,
+                      "endLine" : 349,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 338,
+                    "startLine" : 349,
                     "startCol" : 13,
-                    "endLine" : 338,
+                    "endLine" : 349,
                     "endCol" : 31
                   }
                 },
@@ -9634,17 +9956,17 @@
                       "kind" : "Identifier",
                       "name" : "o",
                       "span" : {
-                        "startLine" : 338,
+                        "startLine" : 349,
                         "startCol" : 35,
-                        "endLine" : 338,
+                        "endLine" : 349,
                         "endCol" : 36
                       }
                     },
                     "field" : "customer_id",
                     "span" : {
-                      "startLine" : 338,
+                      "startLine" : 349,
                       "startCol" : 35,
-                      "endLine" : 338,
+                      "endLine" : 349,
                       "endCol" : 48
                     }
                   },
@@ -9652,30 +9974,30 @@
                     "kind" : "Identifier",
                     "name" : "customer_id",
                     "span" : {
-                      "startLine" : 338,
+                      "startLine" : 349,
                       "startCol" : 51,
-                      "endLine" : 338,
+                      "endLine" : 349,
                       "endCol" : 62
                     }
                   },
                   "span" : {
-                    "startLine" : 338,
+                    "startLine" : 349,
                     "startCol" : 35,
-                    "endLine" : 338,
+                    "endLine" : 349,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 338,
+                  "startLine" : 349,
                   "startCol" : 13,
-                  "endLine" : 338,
+                  "endLine" : 349,
                   "endCol" : 62
                 }
               },
               "span" : {
-                "startLine" : 337,
+                "startLine" : 348,
                 "startCol" : 8,
-                "endLine" : 338,
+                "endLine" : 349,
                 "endCol" : 63
               }
             },
@@ -9689,25 +10011,25 @@
                   "kind" : "Identifier",
                   "name" : "status_filter",
                   "span" : {
-                    "startLine" : 339,
+                    "startLine" : 350,
                     "startCol" : 13,
-                    "endLine" : 339,
+                    "endLine" : 350,
                     "endCol" : 26
                   }
                 },
                 "right" : {
                   "kind" : "NoneLit",
                   "span" : {
-                    "startLine" : 339,
+                    "startLine" : 350,
                     "startCol" : 29,
-                    "endLine" : 339,
+                    "endLine" : 350,
                     "endCol" : 33
                   }
                 },
                 "span" : {
-                  "startLine" : 339,
+                  "startLine" : 350,
                   "startCol" : 13,
-                  "endLine" : 339,
+                  "endLine" : 350,
                   "endCol" : 33
                 }
               },
@@ -9720,17 +10042,17 @@
                     "kind" : "Identifier",
                     "name" : "o",
                     "span" : {
-                      "startLine" : 339,
+                      "startLine" : 350,
                       "startCol" : 37,
-                      "endLine" : 339,
+                      "endLine" : 350,
                       "endCol" : 38
                     }
                   },
                   "field" : "status",
                   "span" : {
-                    "startLine" : 339,
+                    "startLine" : 350,
                     "startCol" : 37,
-                    "endLine" : 339,
+                    "endLine" : 350,
                     "endCol" : 45
                   }
                 },
@@ -9738,37 +10060,37 @@
                   "kind" : "Identifier",
                   "name" : "status_filter",
                   "span" : {
-                    "startLine" : 339,
+                    "startLine" : 350,
                     "startCol" : 48,
-                    "endLine" : 339,
+                    "endLine" : 350,
                     "endCol" : 61
                   }
                 },
                 "span" : {
-                  "startLine" : 339,
+                  "startLine" : 350,
                   "startCol" : 37,
-                  "endLine" : 339,
+                  "endLine" : 350,
                   "endCol" : 61
                 }
               },
               "span" : {
-                "startLine" : 339,
+                "startLine" : 350,
                 "startCol" : 13,
-                "endLine" : 339,
+                "endLine" : 350,
                 "endCol" : 61
               }
             },
             "span" : {
-              "startLine" : 337,
+              "startLine" : 348,
               "startCol" : 8,
-              "endLine" : 339,
+              "endLine" : 350,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 336,
+            "startLine" : 347,
             "startCol" : 6,
-            "endLine" : 339,
+            "endLine" : 350,
             "endCol" : 62
           }
         },
@@ -9781,16 +10103,16 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 340,
+                "startLine" : 351,
                 "startCol" : 6,
-                "endLine" : 340,
+                "endLine" : 351,
                 "endCol" : 12
               }
             },
             "span" : {
-              "startLine" : 340,
+              "startLine" : 351,
               "startCol" : 6,
-              "endLine" : 340,
+              "endLine" : 351,
               "endCol" : 13
             }
           },
@@ -9798,24 +10120,24 @@
             "kind" : "Identifier",
             "name" : "orders",
             "span" : {
-              "startLine" : 340,
+              "startLine" : 351,
               "startCol" : 16,
-              "endLine" : 340,
+              "endLine" : 351,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 340,
+            "startLine" : 351,
             "startCol" : 6,
-            "endLine" : 340,
+            "endLine" : 351,
             "endCol" : 22
           }
         }
       ],
       "span" : {
-        "startLine" : 327,
+        "startLine" : 338,
         "startCol" : 2,
-        "endLine" : 341,
+        "endLine" : 352,
         "endCol" : 3
       }
     }
@@ -10044,17 +10366,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 346,
+                "startLine" : 357,
                 "startCol" : 15,
-                "endLine" : 346,
+                "endLine" : 357,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 346,
+              "startLine" : 357,
               "startCol" : 8,
-              "endLine" : 346,
+              "endLine" : 357,
               "endCol" : 21
             }
           }
@@ -10070,9 +10392,9 @@
                 "kind" : "Identifier",
                 "name" : "orders",
                 "span" : {
-                  "startLine" : 347,
+                  "startLine" : 358,
                   "startCol" : 6,
-                  "endLine" : 347,
+                  "endLine" : 358,
                   "endCol" : 12
                 }
               },
@@ -10080,24 +10402,24 @@
                 "kind" : "Identifier",
                 "name" : "oid",
                 "span" : {
-                  "startLine" : 347,
+                  "startLine" : 358,
                   "startCol" : 13,
-                  "endLine" : 347,
+                  "endLine" : 358,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 347,
+                "startLine" : 358,
                 "startCol" : 6,
-                "endLine" : 347,
+                "endLine" : 358,
                 "endCol" : 17
               }
             },
             "field" : "total",
             "span" : {
-              "startLine" : 347,
+              "startLine" : 358,
               "startCol" : 6,
-              "endLine" : 347,
+              "endLine" : 358,
               "endCol" : 23
             }
           },
@@ -10110,9 +10432,9 @@
                 "kind" : "Identifier",
                 "name" : "sum",
                 "span" : {
-                  "startLine" : 348,
+                  "startLine" : 359,
                   "startCol" : 8,
-                  "endLine" : 348,
+                  "endLine" : 359,
                   "endCol" : 11
                 }
               },
@@ -10125,9 +10447,9 @@
                       "kind" : "Identifier",
                       "name" : "orders",
                       "span" : {
-                        "startLine" : 348,
+                        "startLine" : 359,
                         "startCol" : 12,
-                        "endLine" : 348,
+                        "endLine" : 359,
                         "endCol" : 18
                       }
                     },
@@ -10135,24 +10457,24 @@
                       "kind" : "Identifier",
                       "name" : "oid",
                       "span" : {
-                        "startLine" : 348,
+                        "startLine" : 359,
                         "startCol" : 19,
-                        "endLine" : 348,
+                        "endLine" : 359,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 348,
+                      "startLine" : 359,
                       "startCol" : 12,
-                      "endLine" : 348,
+                      "endLine" : 359,
                       "endCol" : 23
                     }
                   },
                   "field" : "items",
                   "span" : {
-                    "startLine" : 348,
+                    "startLine" : 359,
                     "startCol" : 12,
-                    "endLine" : 348,
+                    "endLine" : 359,
                     "endCol" : 29
                   }
                 },
@@ -10165,32 +10487,32 @@
                       "kind" : "Identifier",
                       "name" : "i",
                       "span" : {
-                        "startLine" : 348,
+                        "startLine" : 359,
                         "startCol" : 36,
-                        "endLine" : 348,
+                        "endLine" : 359,
                         "endCol" : 37
                       }
                     },
                     "field" : "line_total",
                     "span" : {
-                      "startLine" : 348,
+                      "startLine" : 359,
                       "startCol" : 36,
-                      "endLine" : 348,
+                      "endLine" : 359,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 348,
+                    "startLine" : 359,
                     "startCol" : 31,
-                    "endLine" : 348,
+                    "endLine" : 359,
                     "endCol" : 48
                   }
                 }
               ],
               "span" : {
-                "startLine" : 348,
+                "startLine" : 359,
                 "startCol" : 8,
-                "endLine" : 348,
+                "endLine" : 359,
                 "endCol" : 49
               }
             },
@@ -10202,9 +10524,9 @@
                   "kind" : "Identifier",
                   "name" : "orders",
                   "span" : {
-                    "startLine" : 348,
+                    "startLine" : 359,
                     "startCol" : 52,
-                    "endLine" : 348,
+                    "endLine" : 359,
                     "endCol" : 58
                   }
                 },
@@ -10212,52 +10534,52 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 348,
+                    "startLine" : 359,
                     "startCol" : 59,
-                    "endLine" : 348,
+                    "endLine" : 359,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 348,
+                  "startLine" : 359,
                   "startCol" : 52,
-                  "endLine" : 348,
+                  "endLine" : 359,
                   "endCol" : 63
                 }
               },
               "field" : "tax",
               "span" : {
-                "startLine" : 348,
+                "startLine" : 359,
                 "startCol" : 52,
-                "endLine" : 348,
+                "endLine" : 359,
                 "endCol" : 67
               }
             },
             "span" : {
-              "startLine" : 348,
+              "startLine" : 359,
               "startCol" : 8,
-              "endLine" : 348,
+              "endLine" : 359,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 347,
+            "startLine" : 358,
             "startCol" : 6,
-            "endLine" : 348,
+            "endLine" : 359,
             "endCol" : 67
           }
         },
         "span" : {
-          "startLine" : 346,
+          "startLine" : 357,
           "startCol" : 4,
-          "endLine" : 348,
+          "endLine" : 359,
           "endCol" : 67
         }
       },
       "span" : {
-        "startLine" : 345,
+        "startLine" : 356,
         "startCol" : 2,
-        "endLine" : 348,
+        "endLine" : 359,
         "endCol" : 67
       }
     },
@@ -10274,17 +10596,17 @@
               "kind" : "Identifier",
               "name" : "orders",
               "span" : {
-                "startLine" : 351,
+                "startLine" : 362,
                 "startCol" : 15,
-                "endLine" : 351,
+                "endLine" : 362,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 351,
+              "startLine" : 362,
               "startCol" : 8,
-              "endLine" : 351,
+              "endLine" : 362,
               "endCol" : 21
             }
           }
@@ -10303,9 +10625,9 @@
                     "kind" : "Identifier",
                     "name" : "orders",
                     "span" : {
-                      "startLine" : 352,
+                      "startLine" : 363,
                       "startCol" : 18,
-                      "endLine" : 352,
+                      "endLine" : 363,
                       "endCol" : 24
                     }
                   },
@@ -10313,32 +10635,32 @@
                     "kind" : "Identifier",
                     "name" : "oid",
                     "span" : {
-                      "startLine" : 352,
+                      "startLine" : 363,
                       "startCol" : 25,
-                      "endLine" : 352,
+                      "endLine" : 363,
                       "endCol" : 28
                     }
                   },
                   "span" : {
-                    "startLine" : 352,
+                    "startLine" : 363,
                     "startCol" : 18,
-                    "endLine" : 352,
+                    "endLine" : 363,
                     "endCol" : 29
                   }
                 },
                 "field" : "items",
                 "span" : {
-                  "startLine" : 352,
+                  "startLine" : 363,
                   "startCol" : 18,
-                  "endLine" : 352,
+                  "endLine" : 363,
                   "endCol" : 35
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 352,
+                "startLine" : 363,
                 "startCol" : 10,
-                "endLine" : 352,
+                "endLine" : 363,
                 "endCol" : 35
               }
             }
@@ -10352,17 +10674,17 @@
                 "kind" : "Identifier",
                 "name" : "item",
                 "span" : {
-                  "startLine" : 353,
+                  "startLine" : 364,
                   "startCol" : 8,
-                  "endLine" : 353,
+                  "endLine" : 364,
                   "endCol" : 12
                 }
               },
               "field" : "line_total",
               "span" : {
-                "startLine" : 353,
+                "startLine" : 364,
                 "startCol" : 8,
-                "endLine" : 353,
+                "endLine" : 364,
                 "endCol" : 23
               }
             },
@@ -10375,17 +10697,17 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 353,
+                    "startLine" : 364,
                     "startCol" : 26,
-                    "endLine" : 353,
+                    "endLine" : 364,
                     "endCol" : 30
                   }
                 },
                 "field" : "unit_price",
                 "span" : {
-                  "startLine" : 353,
+                  "startLine" : 364,
                   "startCol" : 26,
-                  "endLine" : 353,
+                  "endLine" : 364,
                   "endCol" : 41
                 }
               },
@@ -10395,52 +10717,52 @@
                   "kind" : "Identifier",
                   "name" : "item",
                   "span" : {
-                    "startLine" : 353,
+                    "startLine" : 364,
                     "startCol" : 44,
-                    "endLine" : 353,
+                    "endLine" : 364,
                     "endCol" : 48
                   }
                 },
                 "field" : "quantity",
                 "span" : {
-                  "startLine" : 353,
+                  "startLine" : 364,
                   "startCol" : 44,
-                  "endLine" : 353,
+                  "endLine" : 364,
                   "endCol" : 57
                 }
               },
               "span" : {
-                "startLine" : 353,
+                "startLine" : 364,
                 "startCol" : 26,
-                "endLine" : 353,
+                "endLine" : 364,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 353,
+              "startLine" : 364,
               "startCol" : 8,
-              "endLine" : 353,
+              "endLine" : 364,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 352,
+            "startLine" : 363,
             "startCol" : 6,
-            "endLine" : 353,
+            "endLine" : 364,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 351,
+          "startLine" : 362,
           "startCol" : 4,
-          "endLine" : 353,
+          "endLine" : 364,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 350,
+        "startLine" : 361,
         "startCol" : 2,
-        "endLine" : 353,
+        "endLine" : 364,
         "endCol" : 57
       }
     },
@@ -10457,17 +10779,17 @@
               "kind" : "Identifier",
               "name" : "inventory",
               "span" : {
-                "startLine" : 356,
+                "startLine" : 367,
                 "startCol" : 15,
-                "endLine" : 356,
+                "endLine" : 367,
                 "endCol" : 24
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 356,
+              "startLine" : 367,
               "startCol" : 8,
-              "endLine" : 356,
+              "endLine" : 367,
               "endCol" : 24
             }
           }
@@ -10486,9 +10808,9 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 357,
+                    "startLine" : 368,
                     "startCol" : 6,
-                    "endLine" : 357,
+                    "endLine" : 368,
                     "endCol" : 15
                   }
                 },
@@ -10496,24 +10818,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 357,
+                    "startLine" : 368,
                     "startCol" : 16,
-                    "endLine" : 357,
+                    "endLine" : 368,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 357,
+                  "startLine" : 368,
                   "startCol" : 6,
-                  "endLine" : 357,
+                  "endLine" : 368,
                   "endCol" : 20
                 }
               },
               "field" : "available",
               "span" : {
-                "startLine" : 357,
+                "startLine" : 368,
                 "startCol" : 6,
-                "endLine" : 357,
+                "endLine" : 368,
                 "endCol" : 30
               }
             },
@@ -10521,16 +10843,16 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 357,
+                "startLine" : 368,
                 "startCol" : 34,
-                "endLine" : 357,
+                "endLine" : 368,
                 "endCol" : 35
               }
             },
             "span" : {
-              "startLine" : 357,
+              "startLine" : 368,
               "startCol" : 6,
-              "endLine" : 357,
+              "endLine" : 368,
               "endCol" : 35
             }
           },
@@ -10545,9 +10867,9 @@
                   "kind" : "Identifier",
                   "name" : "inventory",
                   "span" : {
-                    "startLine" : 358,
+                    "startLine" : 369,
                     "startCol" : 10,
-                    "endLine" : 358,
+                    "endLine" : 369,
                     "endCol" : 19
                   }
                 },
@@ -10555,24 +10877,24 @@
                   "kind" : "Identifier",
                   "name" : "sku",
                   "span" : {
-                    "startLine" : 358,
+                    "startLine" : 369,
                     "startCol" : 20,
-                    "endLine" : 358,
+                    "endLine" : 369,
                     "endCol" : 23
                   }
                 },
                 "span" : {
-                  "startLine" : 358,
+                  "startLine" : 369,
                   "startCol" : 10,
-                  "endLine" : 358,
+                  "endLine" : 369,
                   "endCol" : 24
                 }
               },
               "field" : "reserved",
               "span" : {
-                "startLine" : 358,
+                "startLine" : 369,
                 "startCol" : 10,
-                "endLine" : 358,
+                "endLine" : 369,
                 "endCol" : 33
               }
             },
@@ -10580,546 +10902,43 @@
               "kind" : "IntLit",
               "value" : 0,
               "span" : {
-                "startLine" : 358,
+                "startLine" : 369,
                 "startCol" : 37,
-                "endLine" : 358,
+                "endLine" : 369,
                 "endCol" : 38
               }
             },
             "span" : {
-              "startLine" : 358,
+              "startLine" : 369,
               "startCol" : 10,
-              "endLine" : 358,
+              "endLine" : 369,
               "endCol" : 38
             }
           },
           "span" : {
-            "startLine" : 357,
+            "startLine" : 368,
             "startCol" : 6,
-            "endLine" : 358,
+            "endLine" : 369,
             "endCol" : 38
           }
         },
         "span" : {
-          "startLine" : 356,
+          "startLine" : 367,
           "startCol" : 4,
-          "endLine" : 358,
+          "endLine" : 369,
           "endCol" : 38
         }
       },
       "span" : {
-        "startLine" : 355,
+        "startLine" : 366,
         "startCol" : 2,
-        "endLine" : 358,
+        "endLine" : 369,
         "endCol" : 38
       }
     },
     {
       "kind" : "Invariant",
       "name" : "placedOrdersHaveItems",
-      "expr" : {
-        "kind" : "Quantifier",
-        "quantifier" : "all",
-        "bindings" : [
-          {
-            "variable" : "oid",
-            "domain" : {
-              "kind" : "Identifier",
-              "name" : "orders",
-              "span" : {
-                "startLine" : 361,
-                "startCol" : 15,
-                "endLine" : 361,
-                "endCol" : 21
-              }
-            },
-            "bindingKind" : "in",
-            "span" : {
-              "startLine" : 361,
-              "startCol" : 8,
-              "endLine" : 361,
-              "endCol" : 21
-            }
-          }
-        ],
-        "body" : {
-          "kind" : "BinaryOp",
-          "op" : "implies",
-          "left" : {
-            "kind" : "BinaryOp",
-            "op" : "not_in",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Identifier",
-                  "name" : "orders",
-                  "span" : {
-                    "startLine" : 362,
-                    "startCol" : 6,
-                    "endLine" : 362,
-                    "endCol" : 12
-                  }
-                },
-                "index" : {
-                  "kind" : "Identifier",
-                  "name" : "oid",
-                  "span" : {
-                    "startLine" : 362,
-                    "startCol" : 13,
-                    "endLine" : 362,
-                    "endCol" : 16
-                  }
-                },
-                "span" : {
-                  "startLine" : 362,
-                  "startCol" : 6,
-                  "endLine" : 362,
-                  "endCol" : 17
-                }
-              },
-              "field" : "status",
-              "span" : {
-                "startLine" : 362,
-                "startCol" : 6,
-                "endLine" : 362,
-                "endCol" : 24
-              }
-            },
-            "right" : {
-              "kind" : "SetLiteral",
-              "elements" : [
-                {
-                  "kind" : "Identifier",
-                  "name" : "DRAFT",
-                  "span" : {
-                    "startLine" : 362,
-                    "startCol" : 33,
-                    "endLine" : 362,
-                    "endCol" : 38
-                  }
-                },
-                {
-                  "kind" : "Identifier",
-                  "name" : "CANCELLED",
-                  "span" : {
-                    "startLine" : 362,
-                    "startCol" : 40,
-                    "endLine" : 362,
-                    "endCol" : 49
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 362,
-                "startCol" : 32,
-                "endLine" : 362,
-                "endCol" : 50
-              }
-            },
-            "span" : {
-              "startLine" : 362,
-              "startCol" : 6,
-              "endLine" : 362,
-              "endCol" : 50
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : ">",
-            "left" : {
-              "kind" : "UnaryOp",
-              "op" : "cardinality",
-              "operand" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Index",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "orders",
-                    "span" : {
-                      "startLine" : 362,
-                      "startCol" : 60,
-                      "endLine" : 362,
-                      "endCol" : 66
-                    }
-                  },
-                  "index" : {
-                    "kind" : "Identifier",
-                    "name" : "oid",
-                    "span" : {
-                      "startLine" : 362,
-                      "startCol" : 67,
-                      "endLine" : 362,
-                      "endCol" : 70
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 362,
-                    "startCol" : 60,
-                    "endLine" : 362,
-                    "endCol" : 71
-                  }
-                },
-                "field" : "items",
-                "span" : {
-                  "startLine" : 362,
-                  "startCol" : 60,
-                  "endLine" : 362,
-                  "endCol" : 77
-                }
-              },
-              "span" : {
-                "startLine" : 362,
-                "startCol" : 59,
-                "endLine" : 362,
-                "endCol" : 77
-              }
-            },
-            "right" : {
-              "kind" : "IntLit",
-              "value" : 0,
-              "span" : {
-                "startLine" : 362,
-                "startCol" : 80,
-                "endLine" : 362,
-                "endCol" : 81
-              }
-            },
-            "span" : {
-              "startLine" : 362,
-              "startCol" : 59,
-              "endLine" : 362,
-              "endCol" : 81
-            }
-          },
-          "span" : {
-            "startLine" : 362,
-            "startCol" : 6,
-            "endLine" : 362,
-            "endCol" : 81
-          }
-        },
-        "span" : {
-          "startLine" : 361,
-          "startCol" : 4,
-          "endLine" : 362,
-          "endCol" : 81
-        }
-      },
-      "span" : {
-        "startLine" : 360,
-        "startCol" : 2,
-        "endLine" : 362,
-        "endCol" : 81
-      }
-    },
-    {
-      "kind" : "Invariant",
-      "name" : "paidOrdersHavePayments",
-      "expr" : {
-        "kind" : "Quantifier",
-        "quantifier" : "all",
-        "bindings" : [
-          {
-            "variable" : "oid",
-            "domain" : {
-              "kind" : "Identifier",
-              "name" : "orders",
-              "span" : {
-                "startLine" : 365,
-                "startCol" : 15,
-                "endLine" : 365,
-                "endCol" : 21
-              }
-            },
-            "bindingKind" : "in",
-            "span" : {
-              "startLine" : 365,
-              "startCol" : 8,
-              "endLine" : 365,
-              "endCol" : 21
-            }
-          }
-        ],
-        "body" : {
-          "kind" : "BinaryOp",
-          "op" : "implies",
-          "left" : {
-            "kind" : "BinaryOp",
-            "op" : "in",
-            "left" : {
-              "kind" : "FieldAccess",
-              "base" : {
-                "kind" : "Index",
-                "base" : {
-                  "kind" : "Identifier",
-                  "name" : "orders",
-                  "span" : {
-                    "startLine" : 366,
-                    "startCol" : 6,
-                    "endLine" : 366,
-                    "endCol" : 12
-                  }
-                },
-                "index" : {
-                  "kind" : "Identifier",
-                  "name" : "oid",
-                  "span" : {
-                    "startLine" : 366,
-                    "startCol" : 13,
-                    "endLine" : 366,
-                    "endCol" : 16
-                  }
-                },
-                "span" : {
-                  "startLine" : 366,
-                  "startCol" : 6,
-                  "endLine" : 366,
-                  "endCol" : 17
-                }
-              },
-              "field" : "status",
-              "span" : {
-                "startLine" : 366,
-                "startCol" : 6,
-                "endLine" : 366,
-                "endCol" : 24
-              }
-            },
-            "right" : {
-              "kind" : "SetLiteral",
-              "elements" : [
-                {
-                  "kind" : "Identifier",
-                  "name" : "PAID",
-                  "span" : {
-                    "startLine" : 366,
-                    "startCol" : 29,
-                    "endLine" : 366,
-                    "endCol" : 33
-                  }
-                },
-                {
-                  "kind" : "Identifier",
-                  "name" : "SHIPPED",
-                  "span" : {
-                    "startLine" : 366,
-                    "startCol" : 35,
-                    "endLine" : 366,
-                    "endCol" : 42
-                  }
-                },
-                {
-                  "kind" : "Identifier",
-                  "name" : "DELIVERED",
-                  "span" : {
-                    "startLine" : 366,
-                    "startCol" : 44,
-                    "endLine" : 366,
-                    "endCol" : 53
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 366,
-                "startCol" : 28,
-                "endLine" : 366,
-                "endCol" : 54
-              }
-            },
-            "span" : {
-              "startLine" : 366,
-              "startCol" : 6,
-              "endLine" : 366,
-              "endCol" : 54
-            }
-          },
-          "right" : {
-            "kind" : "Quantifier",
-            "quantifier" : "some",
-            "bindings" : [
-              {
-                "variable" : "pid",
-                "domain" : {
-                  "kind" : "Identifier",
-                  "name" : "payments",
-                  "span" : {
-                    "startLine" : 367,
-                    "startCol" : 20,
-                    "endLine" : 367,
-                    "endCol" : 28
-                  }
-                },
-                "bindingKind" : "in",
-                "span" : {
-                  "startLine" : 367,
-                  "startCol" : 13,
-                  "endLine" : 367,
-                  "endCol" : 28
-                }
-              }
-            ],
-            "body" : {
-              "kind" : "BinaryOp",
-              "op" : "and",
-              "left" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Index",
-                    "base" : {
-                      "kind" : "Identifier",
-                      "name" : "payments",
-                      "span" : {
-                        "startLine" : 368,
-                        "startCol" : 10,
-                        "endLine" : 368,
-                        "endCol" : 18
-                      }
-                    },
-                    "index" : {
-                      "kind" : "Identifier",
-                      "name" : "pid",
-                      "span" : {
-                        "startLine" : 368,
-                        "startCol" : 19,
-                        "endLine" : 368,
-                        "endCol" : 22
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 368,
-                      "startCol" : 10,
-                      "endLine" : 368,
-                      "endCol" : 23
-                    }
-                  },
-                  "field" : "order_id",
-                  "span" : {
-                    "startLine" : 368,
-                    "startCol" : 10,
-                    "endLine" : 368,
-                    "endCol" : 32
-                  }
-                },
-                "right" : {
-                  "kind" : "Identifier",
-                  "name" : "oid",
-                  "span" : {
-                    "startLine" : 368,
-                    "startCol" : 35,
-                    "endLine" : 368,
-                    "endCol" : 38
-                  }
-                },
-                "span" : {
-                  "startLine" : 368,
-                  "startCol" : 10,
-                  "endLine" : 368,
-                  "endCol" : 38
-                }
-              },
-              "right" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Index",
-                    "base" : {
-                      "kind" : "Identifier",
-                      "name" : "payments",
-                      "span" : {
-                        "startLine" : 369,
-                        "startCol" : 14,
-                        "endLine" : 369,
-                        "endCol" : 22
-                      }
-                    },
-                    "index" : {
-                      "kind" : "Identifier",
-                      "name" : "pid",
-                      "span" : {
-                        "startLine" : 369,
-                        "startCol" : 23,
-                        "endLine" : 369,
-                        "endCol" : 26
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 369,
-                      "startCol" : 14,
-                      "endLine" : 369,
-                      "endCol" : 27
-                    }
-                  },
-                  "field" : "status",
-                  "span" : {
-                    "startLine" : 369,
-                    "startCol" : 14,
-                    "endLine" : 369,
-                    "endCol" : 34
-                  }
-                },
-                "right" : {
-                  "kind" : "Identifier",
-                  "name" : "CAPTURED",
-                  "span" : {
-                    "startLine" : 369,
-                    "startCol" : 37,
-                    "endLine" : 369,
-                    "endCol" : 45
-                  }
-                },
-                "span" : {
-                  "startLine" : 369,
-                  "startCol" : 14,
-                  "endLine" : 369,
-                  "endCol" : 45
-                }
-              },
-              "span" : {
-                "startLine" : 368,
-                "startCol" : 10,
-                "endLine" : 369,
-                "endCol" : 45
-              }
-            },
-            "span" : {
-              "startLine" : 367,
-              "startCol" : 8,
-              "endLine" : 369,
-              "endCol" : 45
-            }
-          },
-          "span" : {
-            "startLine" : 366,
-            "startCol" : 6,
-            "endLine" : 369,
-            "endCol" : 45
-          }
-        },
-        "span" : {
-          "startLine" : 365,
-          "startCol" : 4,
-          "endLine" : 369,
-          "endCol" : 45
-        }
-      },
-      "span" : {
-        "startLine" : 364,
-        "startCol" : 2,
-        "endLine" : 369,
-        "endCol" : 45
-      }
-    },
-    {
-      "kind" : "Invariant",
-      "name" : "cancelledPaidOrdersHaveRefunds",
       "expr" : {
         "kind" : "Quantifier",
         "quantifier" : "all",
@@ -11150,7 +10969,7 @@
           "op" : "implies",
           "left" : {
             "kind" : "BinaryOp",
-            "op" : "=",
+            "op" : "not_in",
             "left" : {
               "kind" : "FieldAccess",
               "base" : {
@@ -11191,25 +11010,257 @@
               }
             },
             "right" : {
-              "kind" : "Identifier",
-              "name" : "CANCELLED",
+              "kind" : "SetLiteral",
+              "elements" : [
+                {
+                  "kind" : "Identifier",
+                  "name" : "DRAFT",
+                  "span" : {
+                    "startLine" : 373,
+                    "startCol" : 33,
+                    "endLine" : 373,
+                    "endCol" : 38
+                  }
+                },
+                {
+                  "kind" : "Identifier",
+                  "name" : "CANCELLED",
+                  "span" : {
+                    "startLine" : 373,
+                    "startCol" : 40,
+                    "endLine" : 373,
+                    "endCol" : 49
+                  }
+                }
+              ],
               "span" : {
                 "startLine" : 373,
-                "startCol" : 27,
+                "startCol" : 32,
                 "endLine" : 373,
-                "endCol" : 36
+                "endCol" : 50
               }
             },
             "span" : {
               "startLine" : 373,
               "startCol" : 6,
               "endLine" : 373,
-              "endCol" : 36
+              "endCol" : 50
+            }
+          },
+          "right" : {
+            "kind" : "BinaryOp",
+            "op" : ">",
+            "left" : {
+              "kind" : "UnaryOp",
+              "op" : "cardinality",
+              "operand" : {
+                "kind" : "FieldAccess",
+                "base" : {
+                  "kind" : "Index",
+                  "base" : {
+                    "kind" : "Identifier",
+                    "name" : "orders",
+                    "span" : {
+                      "startLine" : 373,
+                      "startCol" : 60,
+                      "endLine" : 373,
+                      "endCol" : 66
+                    }
+                  },
+                  "index" : {
+                    "kind" : "Identifier",
+                    "name" : "oid",
+                    "span" : {
+                      "startLine" : 373,
+                      "startCol" : 67,
+                      "endLine" : 373,
+                      "endCol" : 70
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 373,
+                    "startCol" : 60,
+                    "endLine" : 373,
+                    "endCol" : 71
+                  }
+                },
+                "field" : "items",
+                "span" : {
+                  "startLine" : 373,
+                  "startCol" : 60,
+                  "endLine" : 373,
+                  "endCol" : 77
+                }
+              },
+              "span" : {
+                "startLine" : 373,
+                "startCol" : 59,
+                "endLine" : 373,
+                "endCol" : 77
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 0,
+              "span" : {
+                "startLine" : 373,
+                "startCol" : 80,
+                "endLine" : 373,
+                "endCol" : 81
+              }
+            },
+            "span" : {
+              "startLine" : 373,
+              "startCol" : 59,
+              "endLine" : 373,
+              "endCol" : 81
+            }
+          },
+          "span" : {
+            "startLine" : 373,
+            "startCol" : 6,
+            "endLine" : 373,
+            "endCol" : 81
+          }
+        },
+        "span" : {
+          "startLine" : 372,
+          "startCol" : 4,
+          "endLine" : 373,
+          "endCol" : 81
+        }
+      },
+      "span" : {
+        "startLine" : 371,
+        "startCol" : 2,
+        "endLine" : 373,
+        "endCol" : 81
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "paidOrdersHavePayments",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "oid",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "orders",
+              "span" : {
+                "startLine" : 376,
+                "startCol" : 15,
+                "endLine" : 376,
+                "endCol" : 21
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 376,
+              "startCol" : 8,
+              "endLine" : 376,
+              "endCol" : 21
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "implies",
+          "left" : {
+            "kind" : "BinaryOp",
+            "op" : "in",
+            "left" : {
+              "kind" : "FieldAccess",
+              "base" : {
+                "kind" : "Index",
+                "base" : {
+                  "kind" : "Identifier",
+                  "name" : "orders",
+                  "span" : {
+                    "startLine" : 377,
+                    "startCol" : 6,
+                    "endLine" : 377,
+                    "endCol" : 12
+                  }
+                },
+                "index" : {
+                  "kind" : "Identifier",
+                  "name" : "oid",
+                  "span" : {
+                    "startLine" : 377,
+                    "startCol" : 13,
+                    "endLine" : 377,
+                    "endCol" : 16
+                  }
+                },
+                "span" : {
+                  "startLine" : 377,
+                  "startCol" : 6,
+                  "endLine" : 377,
+                  "endCol" : 17
+                }
+              },
+              "field" : "status",
+              "span" : {
+                "startLine" : 377,
+                "startCol" : 6,
+                "endLine" : 377,
+                "endCol" : 24
+              }
+            },
+            "right" : {
+              "kind" : "SetLiteral",
+              "elements" : [
+                {
+                  "kind" : "Identifier",
+                  "name" : "PAID",
+                  "span" : {
+                    "startLine" : 377,
+                    "startCol" : 29,
+                    "endLine" : 377,
+                    "endCol" : 33
+                  }
+                },
+                {
+                  "kind" : "Identifier",
+                  "name" : "SHIPPED",
+                  "span" : {
+                    "startLine" : 377,
+                    "startCol" : 35,
+                    "endLine" : 377,
+                    "endCol" : 42
+                  }
+                },
+                {
+                  "kind" : "Identifier",
+                  "name" : "DELIVERED",
+                  "span" : {
+                    "startLine" : 377,
+                    "startCol" : 44,
+                    "endLine" : 377,
+                    "endCol" : 53
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 377,
+                "startCol" : 28,
+                "endLine" : 377,
+                "endCol" : 54
+              }
+            },
+            "span" : {
+              "startLine" : 377,
+              "startCol" : 6,
+              "endLine" : 377,
+              "endCol" : 54
             }
           },
           "right" : {
             "kind" : "Quantifier",
-            "quantifier" : "all",
+            "quantifier" : "some",
             "bindings" : [
               {
                 "variable" : "pid",
@@ -11217,17 +11268,17 @@
                   "kind" : "Identifier",
                   "name" : "payments",
                   "span" : {
-                    "startLine" : 374,
+                    "startLine" : 378,
                     "startCol" : 20,
-                    "endLine" : 374,
+                    "endLine" : 378,
                     "endCol" : 28
                   }
                 },
                 "bindingKind" : "in",
                 "span" : {
-                  "startLine" : 374,
+                  "startLine" : 378,
                   "startCol" : 13,
-                  "endLine" : 374,
+                  "endLine" : 378,
                   "endCol" : 28
                 }
               }
@@ -11246,9 +11297,9 @@
                       "kind" : "Identifier",
                       "name" : "payments",
                       "span" : {
-                        "startLine" : 375,
+                        "startLine" : 379,
                         "startCol" : 10,
-                        "endLine" : 375,
+                        "endLine" : 379,
                         "endCol" : 18
                       }
                     },
@@ -11256,24 +11307,24 @@
                       "kind" : "Identifier",
                       "name" : "pid",
                       "span" : {
-                        "startLine" : 375,
+                        "startLine" : 379,
                         "startCol" : 19,
-                        "endLine" : 375,
+                        "endLine" : 379,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 375,
+                      "startLine" : 379,
                       "startCol" : 10,
-                      "endLine" : 375,
+                      "endLine" : 379,
                       "endCol" : 23
                     }
                   },
                   "field" : "order_id",
                   "span" : {
-                    "startLine" : 375,
+                    "startLine" : 379,
                     "startCol" : 10,
-                    "endLine" : 375,
+                    "endLine" : 379,
                     "endCol" : 32
                   }
                 },
@@ -11281,16 +11332,287 @@
                   "kind" : "Identifier",
                   "name" : "oid",
                   "span" : {
-                    "startLine" : 375,
+                    "startLine" : 379,
                     "startCol" : 35,
-                    "endLine" : 375,
+                    "endLine" : 379,
                     "endCol" : 38
                   }
                 },
                 "span" : {
-                  "startLine" : 375,
+                  "startLine" : 379,
                   "startCol" : 10,
-                  "endLine" : 375,
+                  "endLine" : 379,
+                  "endCol" : 38
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "FieldAccess",
+                  "base" : {
+                    "kind" : "Index",
+                    "base" : {
+                      "kind" : "Identifier",
+                      "name" : "payments",
+                      "span" : {
+                        "startLine" : 380,
+                        "startCol" : 14,
+                        "endLine" : 380,
+                        "endCol" : 22
+                      }
+                    },
+                    "index" : {
+                      "kind" : "Identifier",
+                      "name" : "pid",
+                      "span" : {
+                        "startLine" : 380,
+                        "startCol" : 23,
+                        "endLine" : 380,
+                        "endCol" : 26
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 380,
+                      "startCol" : 14,
+                      "endLine" : 380,
+                      "endCol" : 27
+                    }
+                  },
+                  "field" : "status",
+                  "span" : {
+                    "startLine" : 380,
+                    "startCol" : 14,
+                    "endLine" : 380,
+                    "endCol" : 34
+                  }
+                },
+                "right" : {
+                  "kind" : "Identifier",
+                  "name" : "CAPTURED",
+                  "span" : {
+                    "startLine" : 380,
+                    "startCol" : 37,
+                    "endLine" : 380,
+                    "endCol" : 45
+                  }
+                },
+                "span" : {
+                  "startLine" : 380,
+                  "startCol" : 14,
+                  "endLine" : 380,
+                  "endCol" : 45
+                }
+              },
+              "span" : {
+                "startLine" : 379,
+                "startCol" : 10,
+                "endLine" : 380,
+                "endCol" : 45
+              }
+            },
+            "span" : {
+              "startLine" : 378,
+              "startCol" : 8,
+              "endLine" : 380,
+              "endCol" : 45
+            }
+          },
+          "span" : {
+            "startLine" : 377,
+            "startCol" : 6,
+            "endLine" : 380,
+            "endCol" : 45
+          }
+        },
+        "span" : {
+          "startLine" : 376,
+          "startCol" : 4,
+          "endLine" : 380,
+          "endCol" : 45
+        }
+      },
+      "span" : {
+        "startLine" : 375,
+        "startCol" : 2,
+        "endLine" : 380,
+        "endCol" : 45
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "cancelledPaidOrdersHaveRefunds",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "oid",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "orders",
+              "span" : {
+                "startLine" : 383,
+                "startCol" : 15,
+                "endLine" : 383,
+                "endCol" : 21
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 383,
+              "startCol" : 8,
+              "endLine" : 383,
+              "endCol" : 21
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "implies",
+          "left" : {
+            "kind" : "BinaryOp",
+            "op" : "=",
+            "left" : {
+              "kind" : "FieldAccess",
+              "base" : {
+                "kind" : "Index",
+                "base" : {
+                  "kind" : "Identifier",
+                  "name" : "orders",
+                  "span" : {
+                    "startLine" : 384,
+                    "startCol" : 6,
+                    "endLine" : 384,
+                    "endCol" : 12
+                  }
+                },
+                "index" : {
+                  "kind" : "Identifier",
+                  "name" : "oid",
+                  "span" : {
+                    "startLine" : 384,
+                    "startCol" : 13,
+                    "endLine" : 384,
+                    "endCol" : 16
+                  }
+                },
+                "span" : {
+                  "startLine" : 384,
+                  "startCol" : 6,
+                  "endLine" : 384,
+                  "endCol" : 17
+                }
+              },
+              "field" : "status",
+              "span" : {
+                "startLine" : 384,
+                "startCol" : 6,
+                "endLine" : 384,
+                "endCol" : 24
+              }
+            },
+            "right" : {
+              "kind" : "Identifier",
+              "name" : "CANCELLED",
+              "span" : {
+                "startLine" : 384,
+                "startCol" : 27,
+                "endLine" : 384,
+                "endCol" : 36
+              }
+            },
+            "span" : {
+              "startLine" : 384,
+              "startCol" : 6,
+              "endLine" : 384,
+              "endCol" : 36
+            }
+          },
+          "right" : {
+            "kind" : "Quantifier",
+            "quantifier" : "all",
+            "bindings" : [
+              {
+                "variable" : "pid",
+                "domain" : {
+                  "kind" : "Identifier",
+                  "name" : "payments",
+                  "span" : {
+                    "startLine" : 385,
+                    "startCol" : 20,
+                    "endLine" : 385,
+                    "endCol" : 28
+                  }
+                },
+                "bindingKind" : "in",
+                "span" : {
+                  "startLine" : 385,
+                  "startCol" : 13,
+                  "endLine" : 385,
+                  "endCol" : 28
+                }
+              }
+            ],
+            "body" : {
+              "kind" : "BinaryOp",
+              "op" : "and",
+              "left" : {
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "FieldAccess",
+                  "base" : {
+                    "kind" : "Index",
+                    "base" : {
+                      "kind" : "Identifier",
+                      "name" : "payments",
+                      "span" : {
+                        "startLine" : 386,
+                        "startCol" : 10,
+                        "endLine" : 386,
+                        "endCol" : 18
+                      }
+                    },
+                    "index" : {
+                      "kind" : "Identifier",
+                      "name" : "pid",
+                      "span" : {
+                        "startLine" : 386,
+                        "startCol" : 19,
+                        "endLine" : 386,
+                        "endCol" : 22
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 386,
+                      "startCol" : 10,
+                      "endLine" : 386,
+                      "endCol" : 23
+                    }
+                  },
+                  "field" : "order_id",
+                  "span" : {
+                    "startLine" : 386,
+                    "startCol" : 10,
+                    "endLine" : 386,
+                    "endCol" : 32
+                  }
+                },
+                "right" : {
+                  "kind" : "Identifier",
+                  "name" : "oid",
+                  "span" : {
+                    "startLine" : 386,
+                    "startCol" : 35,
+                    "endLine" : 386,
+                    "endCol" : 38
+                  }
+                },
+                "span" : {
+                  "startLine" : 386,
+                  "startCol" : 10,
+                  "endLine" : 386,
                   "endCol" : 38
                 }
               },
@@ -11308,9 +11630,9 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 386,
                           "startCol" : 43,
-                          "endLine" : 375,
+                          "endLine" : 386,
                           "endCol" : 51
                         }
                       },
@@ -11318,24 +11640,24 @@
                         "kind" : "Identifier",
                         "name" : "pid",
                         "span" : {
-                          "startLine" : 375,
+                          "startLine" : 386,
                           "startCol" : 52,
-                          "endLine" : 375,
+                          "endLine" : 386,
                           "endCol" : 55
                         }
                       },
                       "span" : {
-                        "startLine" : 375,
+                        "startLine" : 386,
                         "startCol" : 43,
-                        "endLine" : 375,
+                        "endLine" : 386,
                         "endCol" : 56
                       }
                     },
                     "field" : "status",
                     "span" : {
-                      "startLine" : 375,
+                      "startLine" : 386,
                       "startCol" : 43,
-                      "endLine" : 375,
+                      "endLine" : 386,
                       "endCol" : 63
                     }
                   },
@@ -11343,16 +11665,16 @@
                     "kind" : "Identifier",
                     "name" : "CAPTURED",
                     "span" : {
-                      "startLine" : 375,
+                      "startLine" : 386,
                       "startCol" : 66,
-                      "endLine" : 375,
+                      "endLine" : 386,
                       "endCol" : 74
                     }
                   },
                   "span" : {
-                    "startLine" : 375,
+                    "startLine" : 386,
                     "startCol" : 43,
-                    "endLine" : 375,
+                    "endLine" : 386,
                     "endCol" : 74
                   }
                 },
@@ -11366,17 +11688,17 @@
                         "kind" : "Identifier",
                         "name" : "payments",
                         "span" : {
-                          "startLine" : 377,
+                          "startLine" : 388,
                           "startCol" : 22,
-                          "endLine" : 377,
+                          "endLine" : 388,
                           "endCol" : 30
                         }
                       },
                       "bindingKind" : "in",
                       "span" : {
-                        "startLine" : 377,
+                        "startLine" : 388,
                         "startCol" : 15,
-                        "endLine" : 377,
+                        "endLine" : 388,
                         "endCol" : 30
                       }
                     }
@@ -11395,9 +11717,9 @@
                             "kind" : "Identifier",
                             "name" : "payments",
                             "span" : {
-                              "startLine" : 378,
+                              "startLine" : 389,
                               "startCol" : 12,
-                              "endLine" : 378,
+                              "endLine" : 389,
                               "endCol" : 20
                             }
                           },
@@ -11405,24 +11727,24 @@
                             "kind" : "Identifier",
                             "name" : "rid",
                             "span" : {
-                              "startLine" : 378,
+                              "startLine" : 389,
                               "startCol" : 21,
-                              "endLine" : 378,
+                              "endLine" : 389,
                               "endCol" : 24
                             }
                           },
                           "span" : {
-                            "startLine" : 378,
+                            "startLine" : 389,
                             "startCol" : 12,
-                            "endLine" : 378,
+                            "endLine" : 389,
                             "endCol" : 25
                           }
                         },
                         "field" : "order_id",
                         "span" : {
-                          "startLine" : 378,
+                          "startLine" : 389,
                           "startCol" : 12,
-                          "endLine" : 378,
+                          "endLine" : 389,
                           "endCol" : 34
                         }
                       },
@@ -11430,16 +11752,16 @@
                         "kind" : "Identifier",
                         "name" : "oid",
                         "span" : {
-                          "startLine" : 378,
+                          "startLine" : 389,
                           "startCol" : 37,
-                          "endLine" : 378,
+                          "endLine" : 389,
                           "endCol" : 40
                         }
                       },
                       "span" : {
-                        "startLine" : 378,
+                        "startLine" : 389,
                         "startCol" : 12,
-                        "endLine" : 378,
+                        "endLine" : 389,
                         "endCol" : 40
                       }
                     },
@@ -11454,9 +11776,9 @@
                             "kind" : "Identifier",
                             "name" : "payments",
                             "span" : {
-                              "startLine" : 378,
+                              "startLine" : 389,
                               "startCol" : 45,
-                              "endLine" : 378,
+                              "endLine" : 389,
                               "endCol" : 53
                             }
                           },
@@ -11464,24 +11786,24 @@
                             "kind" : "Identifier",
                             "name" : "rid",
                             "span" : {
-                              "startLine" : 378,
+                              "startLine" : 389,
                               "startCol" : 54,
-                              "endLine" : 378,
+                              "endLine" : 389,
                               "endCol" : 57
                             }
                           },
                           "span" : {
-                            "startLine" : 378,
+                            "startLine" : 389,
                             "startCol" : 45,
-                            "endLine" : 378,
+                            "endLine" : 389,
                             "endCol" : 58
                           }
                         },
                         "field" : "status",
                         "span" : {
-                          "startLine" : 378,
+                          "startLine" : 389,
                           "startCol" : 45,
-                          "endLine" : 378,
+                          "endLine" : 389,
                           "endCol" : 65
                         }
                       },
@@ -11489,73 +11811,145 @@
                         "kind" : "Identifier",
                         "name" : "REFUNDED",
                         "span" : {
-                          "startLine" : 378,
+                          "startLine" : 389,
                           "startCol" : 68,
-                          "endLine" : 378,
+                          "endLine" : 389,
                           "endCol" : 76
                         }
                       },
                       "span" : {
-                        "startLine" : 378,
+                        "startLine" : 389,
                         "startCol" : 45,
-                        "endLine" : 378,
+                        "endLine" : 389,
                         "endCol" : 76
                       }
                     },
                     "span" : {
-                      "startLine" : 378,
+                      "startLine" : 389,
                       "startCol" : 12,
-                      "endLine" : 378,
+                      "endLine" : 389,
                       "endCol" : 76
                     }
                   },
                   "span" : {
-                    "startLine" : 377,
+                    "startLine" : 388,
                     "startCol" : 10,
-                    "endLine" : 378,
+                    "endLine" : 389,
                     "endCol" : 76
                   }
                 },
                 "span" : {
-                  "startLine" : 375,
+                  "startLine" : 386,
                   "startCol" : 43,
-                  "endLine" : 378,
+                  "endLine" : 389,
                   "endCol" : 76
                 }
               },
               "span" : {
-                "startLine" : 375,
+                "startLine" : 386,
                 "startCol" : 10,
-                "endLine" : 378,
+                "endLine" : 389,
                 "endCol" : 76
               }
             },
             "span" : {
-              "startLine" : 374,
+              "startLine" : 385,
               "startCol" : 9,
-              "endLine" : 378,
+              "endLine" : 389,
               "endCol" : 76
             }
           },
           "span" : {
-            "startLine" : 373,
+            "startLine" : 384,
             "startCol" : 6,
-            "endLine" : 378,
+            "endLine" : 389,
             "endCol" : 77
           }
         },
         "span" : {
-          "startLine" : 372,
+          "startLine" : 383,
           "startCol" : 4,
-          "endLine" : 378,
+          "endLine" : 389,
           "endCol" : 77
         }
       },
       "span" : {
-        "startLine" : 371,
+        "startLine" : 382,
         "startCol" : 2,
-        "endLine" : 378,
+        "endLine" : 389,
         "endCol" : 77
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "paymentIdFresh",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "pid",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "payments",
+              "span" : {
+                "startLine" : 392,
+                "startCol" : 15,
+                "endLine" : 392,
+                "endCol" : 23
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 392,
+              "startCol" : 8,
+              "endLine" : 392,
+              "endCol" : 23
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "<",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "pid",
+            "span" : {
+              "startLine" : 392,
+              "startCol" : 26,
+              "endLine" : 392,
+              "endCol" : 29
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "next_payment_id",
+            "span" : {
+              "startLine" : 392,
+              "startCol" : 32,
+              "endLine" : 392,
+              "endCol" : 47
+            }
+          },
+          "span" : {
+            "startLine" : 392,
+            "startCol" : 26,
+            "endLine" : 392,
+            "endCol" : 47
+          }
+        },
+        "span" : {
+          "startLine" : 392,
+          "startCol" : 4,
+          "endLine" : 392,
+          "endCol" : 47
+        }
+      },
+      "span" : {
+        "startLine" : 391,
+        "startCol" : 2,
+        "endLine" : 392,
+        "endCol" : 47
       }
     }
   ],
@@ -11684,9 +12078,9 @@
           "value" : "/orders"
         },
         "span" : {
-          "startLine" : 383,
+          "startLine" : 397,
           "startCol" : 4,
-          "endLine" : 383,
+          "endLine" : 397,
           "endCol" : 42
         }
       },
@@ -11700,9 +12094,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 384,
+          "startLine" : 398,
           "startCol" : 4,
-          "endLine" : 384,
+          "endLine" : 398,
           "endCol" : 46
         }
       },
@@ -11716,9 +12110,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 386,
+          "startLine" : 400,
           "startCol" : 4,
-          "endLine" : 386,
+          "endLine" : 400,
           "endCol" : 36
         }
       },
@@ -11732,9 +12126,9 @@
           "value" : "/orders/{order_id}/items"
         },
         "span" : {
-          "startLine" : 387,
+          "startLine" : 401,
           "startCol" : 4,
-          "endLine" : 387,
+          "endLine" : 401,
           "endCol" : 54
         }
       },
@@ -11748,9 +12142,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 388,
+          "startLine" : 402,
           "startCol" : 4,
-          "endLine" : 388,
+          "endLine" : 402,
           "endCol" : 41
         }
       },
@@ -11764,9 +12158,9 @@
           "value" : "DELETE"
         },
         "span" : {
-          "startLine" : 390,
+          "startLine" : 404,
           "startCol" : 4,
-          "endLine" : 390,
+          "endLine" : 404,
           "endCol" : 41
         }
       },
@@ -11780,9 +12174,9 @@
           "value" : "/orders/{order_id}/items/{item_id}"
         },
         "span" : {
-          "startLine" : 391,
+          "startLine" : 405,
           "startCol" : 4,
-          "endLine" : 391,
+          "endLine" : 405,
           "endCol" : 67
         }
       },
@@ -11796,9 +12190,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 393,
+          "startLine" : 407,
           "startCol" : 4,
-          "endLine" : 393,
+          "endLine" : 407,
           "endCol" : 35
         }
       },
@@ -11812,9 +12206,9 @@
           "value" : "/orders/{order_id}/place"
         },
         "span" : {
-          "startLine" : 394,
+          "startLine" : 408,
           "startCol" : 4,
-          "endLine" : 394,
+          "endLine" : 408,
           "endCol" : 53
         }
       },
@@ -11828,9 +12222,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 396,
+          "startLine" : 410,
           "startCol" : 4,
-          "endLine" : 396,
+          "endLine" : 410,
           "endCol" : 38
         }
       },
@@ -11844,9 +12238,9 @@
           "value" : "/orders/{order_id}/payments"
         },
         "span" : {
-          "startLine" : 397,
+          "startLine" : 411,
           "startCol" : 4,
-          "endLine" : 397,
+          "endLine" : 411,
           "endCol" : 59
         }
       },
@@ -11860,9 +12254,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 398,
+          "startLine" : 412,
           "startCol" : 4,
-          "endLine" : 398,
+          "endLine" : 412,
           "endCol" : 43
         }
       },
@@ -11876,9 +12270,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 400,
+          "startLine" : 414,
           "startCol" : 4,
-          "endLine" : 400,
+          "endLine" : 414,
           "endCol" : 34
         }
       },
@@ -11892,9 +12286,9 @@
           "value" : "/orders/{order_id}/ship"
         },
         "span" : {
-          "startLine" : 401,
+          "startLine" : 415,
           "startCol" : 4,
-          "endLine" : 401,
+          "endLine" : 415,
           "endCol" : 51
         }
       },
@@ -11908,9 +12302,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 403,
+          "startLine" : 417,
           "startCol" : 4,
-          "endLine" : 403,
+          "endLine" : 417,
           "endCol" : 40
         }
       },
@@ -11924,9 +12318,9 @@
           "value" : "/orders/{order_id}/deliver"
         },
         "span" : {
-          "startLine" : 404,
+          "startLine" : 418,
           "startCol" : 4,
-          "endLine" : 404,
+          "endLine" : 418,
           "endCol" : 60
         }
       },
@@ -11940,9 +12334,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 406,
+          "startLine" : 420,
           "startCol" : 4,
-          "endLine" : 406,
+          "endLine" : 420,
           "endCol" : 36
         }
       },
@@ -11956,9 +12350,9 @@
           "value" : "/orders/{order_id}/cancel"
         },
         "span" : {
-          "startLine" : 407,
+          "startLine" : 421,
           "startCol" : 4,
-          "endLine" : 407,
+          "endLine" : 421,
           "endCol" : 55
         }
       },
@@ -11972,9 +12366,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 409,
+          "startLine" : 423,
           "startCol" : 4,
-          "endLine" : 409,
+          "endLine" : 423,
           "endCol" : 38
         }
       },
@@ -11988,9 +12382,9 @@
           "value" : "/orders/{order_id}/return"
         },
         "span" : {
-          "startLine" : 410,
+          "startLine" : 424,
           "startCol" : 4,
-          "endLine" : 410,
+          "endLine" : 424,
           "endCol" : 57
         }
       },
@@ -12004,9 +12398,9 @@
           "value" : "/orders/{order_id}"
         },
         "span" : {
-          "startLine" : 412,
+          "startLine" : 426,
           "startCol" : 4,
-          "endLine" : 412,
+          "endLine" : 426,
           "endCol" : 45
         }
       },
@@ -12020,9 +12414,9 @@
           "value" : "/orders"
         },
         "span" : {
-          "startLine" : 413,
+          "startLine" : 427,
           "startCol" : 4,
-          "endLine" : 413,
+          "endLine" : 427,
           "endCol" : 36
         }
       },
@@ -12036,24 +12430,24 @@
           "value" : "active = true"
         },
         "span" : {
-          "startLine" : 415,
+          "startLine" : 429,
           "startCol" : 4,
-          "endLine" : 415,
+          "endLine" : 429,
           "endCol" : 52
         }
       }
     ],
     "span" : {
-      "startLine" : 382,
+      "startLine" : 396,
       "startCol" : 2,
-      "endLine" : 416,
+      "endLine" : 430,
       "endCol" : 3
     }
   },
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 417,
+    "endLine" : 431,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/ecommerce.spec
+++ b/fixtures/spec/ecommerce.spec
@@ -223,6 +223,7 @@ service OrderService {
       amount = orders[order_id].total
 
     ensures:
+      payment.id = pre(next_payment_id)
       payment.order_id = order_id
       payment.amount = amount
       payment.status = CAPTURED
@@ -282,11 +283,18 @@ service OrderService {
           pre(inventory)[item.product_sku].available + item.quantity
         and inventory'[item.product_sku].reserved =
           pre(inventory)[item.product_sku].reserved - item.quantity
-      orders[order_id].status = PAID implies
-        some p in payments' |
-          p not in pre(payments)
-          and payments'[p].order_id = order_id
-          and payments'[p].status = REFUNDED
+      pre(orders)[order_id].status = PAID implies (
+        payments' = pre(payments) + {pre(next_payment_id) -> Payment {
+          id = pre(next_payment_id),
+          order_id = order_id,
+          amount = pre(orders)[order_id].total,
+          status = REFUNDED,
+          created_at = now()
+        }}
+        and next_payment_id' = pre(next_payment_id) + 1)
+      pre(orders)[order_id].status != PAID implies (
+        payments' = pre(payments)
+        and next_payment_id' = pre(next_payment_id))
   }
 
   operation ProcessReturn {
@@ -305,11 +313,14 @@ service OrderService {
       all item in pre(orders)[order_id].items |
         inventory'[item.product_sku].available =
           pre(inventory)[item.product_sku].available + item.quantity
-      some p in payments' |
-        p not in pre(payments)
-        and payments'[p].order_id = order_id
-        and payments'[p].status = REFUNDED
-        and payments'[p].amount = pre(orders)[order_id].total
+      payments' = pre(payments) + {pre(next_payment_id) -> Payment {
+        id = pre(next_payment_id),
+        order_id = order_id,
+        amount = pre(orders)[order_id].total,
+        status = REFUNDED,
+        created_at = now()
+      }}
+      next_payment_id' = pre(next_payment_id) + 1
   }
 
   operation GetOrder {
@@ -376,6 +387,9 @@ service OrderService {
           implies
           some rid in payments |
             payments[rid].order_id = oid and payments[rid].status = REFUNDED)
+
+  invariant paymentIdFresh:
+    all pid in payments | pid < next_payment_id
 
   // --- Conventions ---
 

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -83,9 +83,9 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ),
     (
       "ecommerce",
-      70,
-      2,
-      "2 non-Int scalar ensures (next_order_id unbacked); the prior 2 `removed` skips are gone now that a `let` scopes its whole ensures block"
+      74,
+      8,
+      "8 unbacked-scalar ensures (next_order_id + next_payment_id): the payment-frame completion (RecordPayment fresh id, ProcessReturn/CancelOrder deterministic refund inserts that bump next_payment_id) adds next_payment_id ensures, which the test-admin /state endpoint can't project black-box - same class as the next_order_id skips"
     ),
     ("edge_cases", 29, 0, "plain is an Int scalar backed by service_state since #407"),
     (

--- a/modules/verify/src/main/scala/specrest/verify/z3/RelationFrames.scala
+++ b/modules/verify/src/main/scala/specrest/verify/z3/RelationFrames.scala
@@ -29,6 +29,12 @@ private[z3] trait RelationFrames:
       val newEnv = env.clone()
       newEnv(x) = translateEnsuresClause(ctx, v, env)
       translateEnsuresClause(ctx, body, newEnv)
+    // A conditional effect `cond implies (... X' = rhs ...)` must keep recursing into the body so
+    // the relation-assignment still routes through the frame path; otherwise the nested `pre(X) +
+    // {..}` reaches the generic translator as a bare `+` and is rejected as numeric addition. For a
+    // body with no relation-assignment this yields the same `Implies(cond, body)` as before.
+    case BinaryOpF(BImplies(), cond, body, _) =>
+      Z3Expr.Implies(translateCheckedExpr(ctx, cond, env), translateEnsuresClause(ctx, body, env))
     case _ => translateCheckedExpr(ctx, expr, env)
 
   private[z3] def tryLowerRelationEquality(

--- a/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
+++ b/modules/verify/src/test/scala/specrest/verify/ConsistencyTest.scala
@@ -722,6 +722,42 @@ class ConsistencyTest extends CatsEffectSuite:
         |    true
         |}""".stripMargin,
       "`len(pw) >= 8` and `len(users[k].name) > 0` - the 1-arg `len(s)` String->Int builtin lowers to an uninterpreted Int function (mirroring now()/hash/days; functional dependency preserved, native str.len avoided so exact-length constraints don't blow up the string solver), so the length constraints must verify, not skip; this is the auth_service Register/ResetPassword and todo_list shape"
+    ),
+    (
+      "conditional relation-insert verifies via Z3 (the ecommerce CancelOrder `status = PAID implies payments' = pre(payments) + {..}` shape)",
+      "cond_insert_demo",
+      """service CondInsertDemo {
+        |  enum PayStatus {
+        |    PENDING,
+        |    REFUNDED
+        |  }
+        |  entity Payment {
+        |    id: Int
+        |    status: PayStatus
+        |  }
+        |  state {
+        |    payments: Int -> lone Payment
+        |    next_id: Int
+        |  }
+        |  operation MaybeRefund {
+        |    input: doRefund: Bool
+        |    requires:
+        |      true
+        |    ensures:
+        |      doRefund implies (
+        |        payments' = pre(payments) + {pre(next_id) -> Payment {
+        |          id = pre(next_id),
+        |          status = REFUNDED
+        |        }}
+        |        and next_id' = pre(next_id) + 1)
+        |      doRefund = false implies (
+        |        payments' = pre(payments)
+        |        and next_id' = pre(next_id))
+        |  }
+        |  invariant idFresh:
+        |    all pid in payments | pid < next_id
+        |}""".stripMargin,
+      "a relation-insert nested in `cond implies (payments' = pre(payments) + {..} and ..)` must route through the frame path (guarded by the condition), not reach the generic translator as a bare numeric `+`; both branches frame payments'/next_id' so idFresh is preserved - this is the ecommerce CancelOrder conditional-refund shape"
     )
   ).foreach: (name, fixture, spec, reason) =>
     test(name):


### PR DESCRIPTION
## Summary

Adds **conditional relation-insert** support to the Z3 frame synthesis, and uses it to complete most of ecommerce's payment frames (**5 → 2 failures**).

### The feature

`translateEnsuresClause` already recurses through `and`/`let` so a relation assignment `X' = pre(X) + {k -> v}` routes through the frame path (`tryLowerRelationEquality` → `relationInsertionAxiom`). It did **not** recurse through `implies`, so a conditional effect like `cond implies (X' = pre(X) + {..})` fell to the generic translator, where the nested `+` was rejected as *"addition requires two numeric operands"* (translator-limit on every check of the operation).

The fix is one `BImplies` case that guards the recursively-built frame axiom by the condition:

```scala
case BinaryOpF(BImplies(), cond, body, _) =>
  Z3Expr.Implies(translateCheckedExpr(ctx, cond, env), translateEnsuresClause(ctx, body, env))
```

For an `implies` body with no relation assignment this produces the same `Implies(cond, body)` as before, so existing implies-ensures are unchanged (verified: full verify suite green). New focused `ConsistencyTest` fixture `cond_insert_demo` guards the capability.

### ecommerce payment frames (5 → 2)

- **RecordPayment** — its ensures never bound `payment.id`, letting the solver pick a colliding id that overwrites another order's CAPTURED payment. Now binds `payment.id = pre(next_payment_id)` + adds a `paymentIdFresh: all pid in payments | pid < next_payment_id` invariant.
- **ProcessReturn** — replaced the under-framing `some p in payments' | p not in pre(payments) and …` refund idiom (which leaves existing payments unconstrained) with a deterministic `payments' = pre(payments) + {pre(next_payment_id) -> Payment {…}}` insert.
- **CancelOrder** — same, but its refund is *conditional* (`status = PAID`), which is exactly what the new conditional-insert support enables.

### Known follow-up (the 2 remaining)

`RecordPayment`/`CancelOrder` still trip `cancelledPaidOrdersHaveRefunds`. This needs an intricate order/payment-lifecycle invariant to be inductive: the current invariants permit a PLACED order holding a CAPTURED payment (only RecordPayment makes captures and it sets PAID, but no *invariant* enforces that), and the invariant's nested `some rid` existential is hard for Z3 to instantiate. Deferred — it's a circular-with-cancellation invariant-design problem, not a framing gap.

## Validation

All affected suites pass: verify (incl. new fixture), parser, ir, testgen, codegen, lint, convention, profile, dafny, cli. Regenerated `ir/ecommerce.json`; updated the `SkipRateProbeTest` ecommerce expectation (70/2 → 74/8; the new skips are `next_payment_id` ensures, same unbacked-scalar class as `next_order_id`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds conditional relation-insert support to ensures frame translation so guarded inserts verify. Applies it to ecommerce payment flows with deterministic inserts and a fresh-id invariant, reducing verify failures from 5 to 2.

- **New Features**
  - `translateEnsuresClause` now recurses into `implies`, producing guarded frame axioms so `X' = pre(X) + {..}` inside conditions is handled.
  - Added `cond_insert_demo` consistency test to cover the conditional-insert shape.
  - Ecommerce: RecordPayment binds `payment.id = pre(next_payment_id)` and adds `paymentIdFresh`; ProcessReturn and CancelOrder switch to deterministic refund inserts (CancelOrder guarded by `PAID`) and bump `next_payment_id'`.
  - Updated `ecommerce.spec`, regenerated `ir/ecommerce.json`, and adjusted `SkipRateProbeTest` expectations (skip count increases due to new `next_payment_id` ensures).

<sup>Written for commit 3d41f861b2bbb40be4bca4aa697c883facc34a74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

