### PR TITLE
fix(auth_service): hoist Logout's the so its session-update frames

### DIFF
--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -5564,209 +5564,179 @@
       ],
       "ensures" : [
         {
-          "kind" : "Let",
-          "variable" : "s",
-          "value" : {
-            "kind" : "The",
-            "variable" : "s",
-            "domain" : {
-              "kind" : "Identifier",
-              "name" : "sessions",
-              "span" : {
-                "startLine" : 204,
-                "startCol" : 24,
-                "endLine" : 204,
-                "endCol" : 32
-              }
-            },
-            "body" : {
-              "kind" : "BinaryOp",
-              "op" : "=",
-              "left" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Index",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "sessions",
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Index",
+              "base" : {
+                "kind" : "Prime",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "sessions",
+                  "span" : {
+                    "startLine" : 204,
+                    "startCol" : 6,
+                    "endLine" : 204,
+                    "endCol" : 14
+                  }
+                },
+                "span" : {
+                  "startLine" : 204,
+                  "startCol" : 6,
+                  "endLine" : 204,
+                  "endCol" : 15
+                }
+              },
+              "index" : {
+                "kind" : "The",
+                "variable" : "s",
+                "domain" : {
+                  "kind" : "Identifier",
+                  "name" : "sessions",
+                  "span" : {
+                    "startLine" : 204,
+                    "startCol" : 26,
+                    "endLine" : 204,
+                    "endCol" : 34
+                  }
+                },
+                "body" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "FieldAccess",
+                    "base" : {
+                      "kind" : "Index",
+                      "base" : {
+                        "kind" : "Identifier",
+                        "name" : "sessions",
+                        "span" : {
+                          "startLine" : 205,
+                          "startCol" : 8,
+                          "endLine" : 205,
+                          "endCol" : 16
+                        }
+                      },
+                      "index" : {
+                        "kind" : "Identifier",
+                        "name" : "s",
+                        "span" : {
+                          "startLine" : 205,
+                          "startCol" : 17,
+                          "endLine" : 205,
+                          "endCol" : 18
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 205,
+                        "startCol" : 8,
+                        "endLine" : 205,
+                        "endCol" : 19
+                      }
+                    },
+                    "field" : "access_token",
                     "span" : {
                       "startLine" : 205,
                       "startCol" : 8,
                       "endLine" : 205,
-                      "endCol" : 16
+                      "endCol" : 32
                     }
                   },
-                  "index" : {
+                  "right" : {
                     "kind" : "Identifier",
-                    "name" : "s",
+                    "name" : "access_token",
                     "span" : {
                       "startLine" : 205,
-                      "startCol" : 17,
+                      "startCol" : 35,
                       "endLine" : 205,
-                      "endCol" : 18
+                      "endCol" : 47
                     }
                   },
                   "span" : {
                     "startLine" : 205,
                     "startCol" : 8,
                     "endLine" : 205,
-                    "endCol" : 19
+                    "endCol" : 47
                   }
                 },
-                "field" : "access_token",
                 "span" : {
-                  "startLine" : 205,
-                  "startCol" : 8,
-                  "endLine" : 205,
-                  "endCol" : 32
-                }
-              },
-              "right" : {
-                "kind" : "Identifier",
-                "name" : "access_token",
-                "span" : {
-                  "startLine" : 205,
-                  "startCol" : 35,
+                  "startLine" : 204,
+                  "startCol" : 17,
                   "endLine" : 205,
                   "endCol" : 47
                 }
               },
               "span" : {
-                "startLine" : 205,
-                "startCol" : 8,
+                "startLine" : 204,
+                "startCol" : 6,
                 "endLine" : 205,
-                "endCol" : 47
+                "endCol" : 49
               }
             },
+            "field" : "is_revoked",
             "span" : {
               "startLine" : 204,
-              "startCol" : 15,
+              "startCol" : 6,
               "endLine" : 205,
-              "endCol" : 47
+              "endCol" : 60
             }
           },
-          "body" : {
-            "kind" : "BinaryOp",
-            "op" : "and",
-            "left" : {
-              "kind" : "BinaryOp",
-              "op" : "=",
-              "left" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Index",
-                  "base" : {
-                    "kind" : "Prime",
-                    "expr" : {
-                      "kind" : "Identifier",
-                      "name" : "sessions",
-                      "span" : {
-                        "startLine" : 206,
-                        "startCol" : 8,
-                        "endLine" : 206,
-                        "endCol" : 16
-                      }
-                    },
-                    "span" : {
-                      "startLine" : 206,
-                      "startCol" : 8,
-                      "endLine" : 206,
-                      "endCol" : 17
-                    }
-                  },
-                  "index" : {
-                    "kind" : "Identifier",
-                    "name" : "s",
-                    "span" : {
-                      "startLine" : 206,
-                      "startCol" : 18,
-                      "endLine" : 206,
-                      "endCol" : 19
-                    }
-                  },
-                  "span" : {
-                    "startLine" : 206,
-                    "startCol" : 8,
-                    "endLine" : 206,
-                    "endCol" : 20
-                  }
-                },
-                "field" : "is_revoked",
-                "span" : {
-                  "startLine" : 206,
-                  "startCol" : 8,
-                  "endLine" : 206,
-                  "endCol" : 31
-                }
-              },
-              "right" : {
-                "kind" : "BoolLit",
-                "value" : true,
-                "span" : {
-                  "startLine" : 206,
-                  "startCol" : 34,
-                  "endLine" : 206,
-                  "endCol" : 38
-                }
-              },
-              "span" : {
-                "startLine" : 206,
-                "startCol" : 8,
-                "endLine" : 206,
-                "endCol" : 38
-              }
-            },
-            "right" : {
-              "kind" : "BinaryOp",
-              "op" : "=",
-              "left" : {
-                "kind" : "Prime",
-                "expr" : {
-                  "kind" : "Identifier",
-                  "name" : "users",
-                  "span" : {
-                    "startLine" : 207,
-                    "startCol" : 12,
-                    "endLine" : 207,
-                    "endCol" : 17
-                  }
-                },
-                "span" : {
-                  "startLine" : 207,
-                  "startCol" : 12,
-                  "endLine" : 207,
-                  "endCol" : 18
-                }
-              },
-              "right" : {
-                "kind" : "Identifier",
-                "name" : "users",
-                "span" : {
-                  "startLine" : 207,
-                  "startCol" : 21,
-                  "endLine" : 207,
-                  "endCol" : 26
-                }
-              },
-              "span" : {
-                "startLine" : 207,
-                "startCol" : 12,
-                "endLine" : 207,
-                "endCol" : 26
-              }
-            },
+          "right" : {
+            "kind" : "BoolLit",
+            "value" : true,
             "span" : {
-              "startLine" : 206,
-              "startCol" : 8,
-              "endLine" : 207,
-              "endCol" : 26
+              "startLine" : 205,
+              "startCol" : 63,
+              "endLine" : 205,
+              "endCol" : 67
             }
           },
           "span" : {
             "startLine" : 204,
             "startCol" : 6,
-            "endLine" : 207,
-            "endCol" : 26
+            "endLine" : 205,
+            "endCol" : 67
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "Prime",
+            "expr" : {
+              "kind" : "Identifier",
+              "name" : "users",
+              "span" : {
+                "startLine" : 206,
+                "startCol" : 6,
+                "endLine" : 206,
+                "endCol" : 11
+              }
+            },
+            "span" : {
+              "startLine" : 206,
+              "startCol" : 6,
+              "endLine" : 206,
+              "endCol" : 12
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "users",
+            "span" : {
+              "startLine" : 206,
+              "startCol" : 15,
+              "endLine" : 206,
+              "endCol" : 20
+            }
+          },
+          "span" : {
+            "startLine" : 206,
+            "startCol" : 6,
+            "endLine" : 206,
+            "endCol" : 20
           }
         }
       ],
@@ -5776,7 +5746,7 @@
       "span" : {
         "startLine" : 194,
         "startCol" : 2,
-        "endLine" : 208,
+        "endLine" : 207,
         "endCol" : 3
       }
     }
@@ -5797,17 +5767,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 221,
+                "startLine" : 220,
                 "startCol" : 14,
-                "endLine" : 221,
+                "endLine" : 220,
                 "endCol" : 19
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 221,
+              "startLine" : 220,
               "startCol" : 8,
-              "endLine" : 221,
+              "endLine" : 220,
               "endCol" : 19
             }
           },
@@ -5817,17 +5787,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 221,
+                "startLine" : 220,
                 "startCol" : 27,
-                "endLine" : 221,
+                "endLine" : 220,
                 "endCol" : 32
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 221,
+              "startLine" : 220,
               "startCol" : 21,
-              "endLine" : 221,
+              "endLine" : 220,
               "endCol" : 32
             }
           }
@@ -5842,9 +5812,9 @@
               "kind" : "Identifier",
               "name" : "u1",
               "span" : {
-                "startLine" : 222,
+                "startLine" : 221,
                 "startCol" : 6,
-                "endLine" : 222,
+                "endLine" : 221,
                 "endCol" : 8
               }
             },
@@ -5852,16 +5822,16 @@
               "kind" : "Identifier",
               "name" : "u2",
               "span" : {
-                "startLine" : 222,
+                "startLine" : 221,
                 "startCol" : 12,
-                "endLine" : 222,
+                "endLine" : 221,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 222,
+              "startLine" : 221,
               "startCol" : 6,
-              "endLine" : 222,
+              "endLine" : 221,
               "endCol" : 14
             }
           },
@@ -5876,9 +5846,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 222,
+                    "startLine" : 221,
                     "startCol" : 23,
-                    "endLine" : 222,
+                    "endLine" : 221,
                     "endCol" : 28
                   }
                 },
@@ -5886,24 +5856,24 @@
                   "kind" : "Identifier",
                   "name" : "u1",
                   "span" : {
-                    "startLine" : 222,
+                    "startLine" : 221,
                     "startCol" : 29,
-                    "endLine" : 222,
+                    "endLine" : 221,
                     "endCol" : 31
                   }
                 },
                 "span" : {
-                  "startLine" : 222,
+                  "startLine" : 221,
                   "startCol" : 23,
-                  "endLine" : 222,
+                  "endLine" : 221,
                   "endCol" : 32
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 222,
+                "startLine" : 221,
                 "startCol" : 23,
-                "endLine" : 222,
+                "endLine" : 221,
                 "endCol" : 38
               }
             },
@@ -5915,9 +5885,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 222,
+                    "startLine" : 221,
                     "startCol" : 42,
-                    "endLine" : 222,
+                    "endLine" : 221,
                     "endCol" : 47
                   }
                 },
@@ -5925,52 +5895,52 @@
                   "kind" : "Identifier",
                   "name" : "u2",
                   "span" : {
-                    "startLine" : 222,
+                    "startLine" : 221,
                     "startCol" : 48,
-                    "endLine" : 222,
+                    "endLine" : 221,
                     "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 222,
+                  "startLine" : 221,
                   "startCol" : 42,
-                  "endLine" : 222,
+                  "endLine" : 221,
                   "endCol" : 51
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 222,
+                "startLine" : 221,
                 "startCol" : 42,
-                "endLine" : 222,
+                "endLine" : 221,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 222,
+              "startLine" : 221,
               "startCol" : 23,
-              "endLine" : 222,
+              "endLine" : 221,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 222,
+            "startLine" : 221,
             "startCol" : 6,
-            "endLine" : 222,
+            "endLine" : 221,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 221,
+          "startLine" : 220,
           "startCol" : 4,
-          "endLine" : 222,
+          "endLine" : 221,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 220,
+        "startLine" : 219,
         "startCol" : 2,
-        "endLine" : 222,
+        "endLine" : 221,
         "endCol" : 57
       }
     },
@@ -5987,17 +5957,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 225,
+                "startLine" : 224,
                 "startCol" : 17,
-                "endLine" : 225,
+                "endLine" : 224,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 225,
+              "startLine" : 224,
               "startCol" : 8,
-              "endLine" : 225,
+              "endLine" : 224,
               "endCol" : 30
             }
           }
@@ -6019,9 +5989,9 @@
                     "kind" : "Identifier",
                     "name" : "user_by_email",
                     "span" : {
-                      "startLine" : 226,
+                      "startLine" : 225,
                       "startCol" : 6,
-                      "endLine" : 226,
+                      "endLine" : 225,
                       "endCol" : 19
                     }
                   },
@@ -6029,24 +5999,24 @@
                     "kind" : "Identifier",
                     "name" : "email",
                     "span" : {
-                      "startLine" : 226,
+                      "startLine" : 225,
                       "startCol" : 20,
-                      "endLine" : 226,
+                      "endLine" : 225,
                       "endCol" : 25
                     }
                   },
                   "span" : {
-                    "startLine" : 226,
+                    "startLine" : 225,
                     "startCol" : 6,
-                    "endLine" : 226,
+                    "endLine" : 225,
                     "endCol" : 26
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 226,
+                  "startLine" : 225,
                   "startCol" : 6,
-                  "endLine" : 226,
+                  "endLine" : 225,
                   "endCol" : 29
                 }
               },
@@ -6054,16 +6024,16 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 226,
+                  "startLine" : 225,
                   "startCol" : 33,
-                  "endLine" : 226,
+                  "endLine" : 225,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 226,
+                "startLine" : 225,
                 "startCol" : 6,
-                "endLine" : 226,
+                "endLine" : 225,
                 "endCol" : 38
               }
             },
@@ -6076,9 +6046,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 227,
+                    "startLine" : 226,
                     "startCol" : 10,
-                    "endLine" : 227,
+                    "endLine" : 226,
                     "endCol" : 15
                   }
                 },
@@ -6090,9 +6060,9 @@
                       "kind" : "Identifier",
                       "name" : "user_by_email",
                       "span" : {
-                        "startLine" : 227,
+                        "startLine" : 226,
                         "startCol" : 16,
-                        "endLine" : 227,
+                        "endLine" : 226,
                         "endCol" : 29
                       }
                     },
@@ -6100,31 +6070,31 @@
                       "kind" : "Identifier",
                       "name" : "email",
                       "span" : {
-                        "startLine" : 227,
+                        "startLine" : 226,
                         "startCol" : 30,
-                        "endLine" : 227,
+                        "endLine" : 226,
                         "endCol" : 35
                       }
                     },
                     "span" : {
-                      "startLine" : 227,
+                      "startLine" : 226,
                       "startCol" : 16,
-                      "endLine" : 227,
+                      "endLine" : 226,
                       "endCol" : 36
                     }
                   },
                   "field" : "id",
                   "span" : {
-                    "startLine" : 227,
+                    "startLine" : 226,
                     "startCol" : 16,
-                    "endLine" : 227,
+                    "endLine" : 226,
                     "endCol" : 39
                   }
                 },
                 "span" : {
-                  "startLine" : 227,
+                  "startLine" : 226,
                   "startCol" : 10,
-                  "endLine" : 227,
+                  "endLine" : 226,
                   "endCol" : 40
                 }
               },
@@ -6134,9 +6104,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 227,
+                    "startLine" : 226,
                     "startCol" : 43,
-                    "endLine" : 227,
+                    "endLine" : 226,
                     "endCol" : 56
                   }
                 },
@@ -6144,30 +6114,30 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 227,
+                    "startLine" : 226,
                     "startCol" : 57,
-                    "endLine" : 227,
+                    "endLine" : 226,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 227,
+                  "startLine" : 226,
                   "startCol" : 43,
-                  "endLine" : 227,
+                  "endLine" : 226,
                   "endCol" : 63
                 }
               },
               "span" : {
-                "startLine" : 227,
+                "startLine" : 226,
                 "startCol" : 10,
-                "endLine" : 227,
+                "endLine" : 226,
                 "endCol" : 63
               }
             },
             "span" : {
-              "startLine" : 226,
+              "startLine" : 225,
               "startCol" : 6,
-              "endLine" : 227,
+              "endLine" : 226,
               "endCol" : 63
             }
           },
@@ -6182,9 +6152,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 227,
                     "startCol" : 10,
-                    "endLine" : 228,
+                    "endLine" : 227,
                     "endCol" : 23
                   }
                 },
@@ -6192,24 +6162,24 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 228,
+                    "startLine" : 227,
                     "startCol" : 24,
-                    "endLine" : 228,
+                    "endLine" : 227,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 228,
+                  "startLine" : 227,
                   "startCol" : 10,
-                  "endLine" : 228,
+                  "endLine" : 227,
                   "endCol" : 30
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 227,
                 "startCol" : 10,
-                "endLine" : 228,
+                "endLine" : 227,
                 "endCol" : 36
               }
             },
@@ -6217,37 +6187,37 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 228,
+                "startLine" : 227,
                 "startCol" : 39,
-                "endLine" : 228,
+                "endLine" : 227,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 228,
+              "startLine" : 227,
               "startCol" : 10,
-              "endLine" : 228,
+              "endLine" : 227,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 226,
+            "startLine" : 225,
             "startCol" : 6,
-            "endLine" : 228,
+            "endLine" : 227,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 225,
+          "startLine" : 224,
           "startCol" : 4,
-          "endLine" : 228,
+          "endLine" : 227,
           "endCol" : 44
         }
       },
       "span" : {
-        "startLine" : 224,
+        "startLine" : 223,
         "startCol" : 2,
-        "endLine" : 228,
+        "endLine" : 227,
         "endCol" : 44
       }
     },
@@ -6264,17 +6234,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 231,
+                "startLine" : 230,
                 "startCol" : 13,
-                "endLine" : 231,
+                "endLine" : 230,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 231,
+              "startLine" : 230,
               "startCol" : 8,
-              "endLine" : 231,
+              "endLine" : 230,
               "endCol" : 18
             }
           }
@@ -6296,9 +6266,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 232,
+                      "startLine" : 231,
                       "startCol" : 6,
-                      "endLine" : 232,
+                      "endLine" : 231,
                       "endCol" : 11
                     }
                   },
@@ -6306,24 +6276,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 232,
+                      "startLine" : 231,
                       "startCol" : 12,
-                      "endLine" : 232,
+                      "endLine" : 231,
                       "endCol" : 13
                     }
                   },
                   "span" : {
-                    "startLine" : 232,
+                    "startLine" : 231,
                     "startCol" : 6,
-                    "endLine" : 232,
+                    "endLine" : 231,
                     "endCol" : 14
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 232,
+                  "startLine" : 231,
                   "startCol" : 6,
-                  "endLine" : 232,
+                  "endLine" : 231,
                   "endCol" : 17
                 }
               },
@@ -6331,16 +6301,16 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 232,
+                  "startLine" : 231,
                   "startCol" : 20,
-                  "endLine" : 232,
+                  "endLine" : 231,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 232,
+                "startLine" : 231,
                 "startCol" : 6,
-                "endLine" : 232,
+                "endLine" : 231,
                 "endCol" : 21
               }
             },
@@ -6355,9 +6325,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 233,
+                      "startLine" : 232,
                       "startCol" : 10,
-                      "endLine" : 233,
+                      "endLine" : 232,
                       "endCol" : 15
                     }
                   },
@@ -6365,24 +6335,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 233,
+                      "startLine" : 232,
                       "startCol" : 16,
-                      "endLine" : 233,
+                      "endLine" : 232,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 233,
+                    "startLine" : 232,
                     "startCol" : 10,
-                    "endLine" : 233,
+                    "endLine" : 232,
                     "endCol" : 18
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 233,
+                  "startLine" : 232,
                   "startCol" : 10,
-                  "endLine" : 233,
+                  "endLine" : 232,
                   "endCol" : 24
                 }
               },
@@ -6390,23 +6360,23 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 233,
+                  "startLine" : 232,
                   "startCol" : 28,
-                  "endLine" : 233,
+                  "endLine" : 232,
                   "endCol" : 41
                 }
               },
               "span" : {
-                "startLine" : 233,
+                "startLine" : 232,
                 "startCol" : 10,
-                "endLine" : 233,
+                "endLine" : 232,
                 "endCol" : 41
               }
             },
             "span" : {
-              "startLine" : 232,
+              "startLine" : 231,
               "startCol" : 6,
-              "endLine" : 233,
+              "endLine" : 232,
               "endCol" : 41
             }
           },
@@ -6419,9 +6389,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 234,
+                  "startLine" : 233,
                   "startCol" : 10,
-                  "endLine" : 234,
+                  "endLine" : 233,
                   "endCol" : 23
                 }
               },
@@ -6433,9 +6403,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 234,
+                      "startLine" : 233,
                       "startCol" : 24,
-                      "endLine" : 234,
+                      "endLine" : 233,
                       "endCol" : 29
                     }
                   },
@@ -6443,31 +6413,31 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 234,
+                      "startLine" : 233,
                       "startCol" : 30,
-                      "endLine" : 234,
+                      "endLine" : 233,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 234,
+                    "startLine" : 233,
                     "startCol" : 24,
-                    "endLine" : 234,
+                    "endLine" : 233,
                     "endCol" : 32
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 234,
+                  "startLine" : 233,
                   "startCol" : 24,
-                  "endLine" : 234,
+                  "endLine" : 233,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 234,
+                "startLine" : 233,
                 "startCol" : 10,
-                "endLine" : 234,
+                "endLine" : 233,
                 "endCol" : 39
               }
             },
@@ -6477,9 +6447,9 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 234,
+                  "startLine" : 233,
                   "startCol" : 42,
-                  "endLine" : 234,
+                  "endLine" : 233,
                   "endCol" : 47
                 }
               },
@@ -6487,44 +6457,44 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 234,
+                  "startLine" : 233,
                   "startCol" : 48,
-                  "endLine" : 234,
+                  "endLine" : 233,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 234,
+                "startLine" : 233,
                 "startCol" : 42,
-                "endLine" : 234,
+                "endLine" : 233,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 234,
+              "startLine" : 233,
               "startCol" : 10,
-              "endLine" : 234,
+              "endLine" : 233,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 232,
+            "startLine" : 231,
             "startCol" : 6,
-            "endLine" : 234,
+            "endLine" : 233,
             "endCol" : 50
           }
         },
         "span" : {
-          "startLine" : 231,
+          "startLine" : 230,
           "startCol" : 4,
-          "endLine" : 234,
+          "endLine" : 233,
           "endCol" : 50
         }
       },
       "span" : {
-        "startLine" : 230,
+        "startLine" : 229,
         "startCol" : 2,
-        "endLine" : 234,
+        "endLine" : 233,
         "endCol" : 50
       }
     },
@@ -6541,17 +6511,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 237,
+                "startLine" : 236,
                 "startCol" : 13,
-                "endLine" : 237,
+                "endLine" : 236,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 237,
+              "startLine" : 236,
               "startCol" : 8,
-              "endLine" : 237,
+              "endLine" : 236,
               "endCol" : 21
             }
           }
@@ -6567,9 +6537,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 238,
+                  "startLine" : 237,
                   "startCol" : 6,
-                  "endLine" : 238,
+                  "endLine" : 237,
                   "endCol" : 14
                 }
               },
@@ -6577,24 +6547,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 238,
+                  "startLine" : 237,
                   "startCol" : 15,
-                  "endLine" : 238,
+                  "endLine" : 237,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 238,
+                "startLine" : 237,
                 "startCol" : 6,
-                "endLine" : 238,
+                "endLine" : 237,
                 "endCol" : 17
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 238,
+              "startLine" : 237,
               "startCol" : 6,
-              "endLine" : 238,
+              "endLine" : 237,
               "endCol" : 25
             }
           },
@@ -6602,30 +6572,30 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 238,
+              "startLine" : 237,
               "startCol" : 29,
-              "endLine" : 238,
+              "endLine" : 237,
               "endCol" : 34
             }
           },
           "span" : {
-            "startLine" : 238,
+            "startLine" : 237,
             "startCol" : 6,
-            "endLine" : 238,
+            "endLine" : 237,
             "endCol" : 34
           }
         },
         "span" : {
-          "startLine" : 237,
+          "startLine" : 236,
           "startCol" : 4,
-          "endLine" : 238,
+          "endLine" : 237,
           "endCol" : 34
         }
       },
       "span" : {
-        "startLine" : 236,
+        "startLine" : 235,
         "startCol" : 2,
-        "endLine" : 238,
+        "endLine" : 237,
         "endCol" : 34
       }
     },
@@ -6642,17 +6612,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 241,
+                "startLine" : 240,
                 "startCol" : 13,
-                "endLine" : 241,
+                "endLine" : 240,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 241,
+              "startLine" : 240,
               "startCol" : 8,
-              "endLine" : 241,
+              "endLine" : 240,
               "endCol" : 21
             }
           }
@@ -6668,9 +6638,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 241,
+                  "startLine" : 240,
                   "startCol" : 24,
-                  "endLine" : 241,
+                  "endLine" : 240,
                   "endCol" : 32
                 }
               },
@@ -6678,24 +6648,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 241,
+                  "startLine" : 240,
                   "startCol" : 33,
-                  "endLine" : 241,
+                  "endLine" : 240,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 241,
+                "startLine" : 240,
                 "startCol" : 24,
-                "endLine" : 241,
+                "endLine" : 240,
                 "endCol" : 35
               }
             },
             "field" : "id",
             "span" : {
-              "startLine" : 241,
+              "startLine" : 240,
               "startCol" : 24,
-              "endLine" : 241,
+              "endLine" : 240,
               "endCol" : 38
             }
           },
@@ -6703,30 +6673,30 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 241,
+              "startLine" : 240,
               "startCol" : 41,
-              "endLine" : 241,
+              "endLine" : 240,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 241,
+            "startLine" : 240,
             "startCol" : 24,
-            "endLine" : 241,
+            "endLine" : 240,
             "endCol" : 42
           }
         },
         "span" : {
-          "startLine" : 241,
+          "startLine" : 240,
           "startCol" : 4,
-          "endLine" : 241,
+          "endLine" : 240,
           "endCol" : 42
         }
       },
       "span" : {
-        "startLine" : 240,
+        "startLine" : 239,
         "startCol" : 2,
-        "endLine" : 241,
+        "endLine" : 240,
         "endCol" : 42
       }
     },
@@ -6743,17 +6713,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 244,
+                "startLine" : 243,
                 "startCol" : 13,
-                "endLine" : 244,
+                "endLine" : 243,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 244,
+              "startLine" : 243,
               "startCol" : 8,
-              "endLine" : 244,
+              "endLine" : 243,
               "endCol" : 18
             }
           }
@@ -6765,9 +6735,9 @@
             "kind" : "Identifier",
             "name" : "u",
             "span" : {
-              "startLine" : 244,
+              "startLine" : 243,
               "startCol" : 21,
-              "endLine" : 244,
+              "endLine" : 243,
               "endCol" : 22
             }
           },
@@ -6775,30 +6745,30 @@
             "kind" : "Identifier",
             "name" : "next_user_id",
             "span" : {
-              "startLine" : 244,
+              "startLine" : 243,
               "startCol" : 25,
-              "endLine" : 244,
+              "endLine" : 243,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 244,
+            "startLine" : 243,
             "startCol" : 21,
-            "endLine" : 244,
+            "endLine" : 243,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 244,
+          "startLine" : 243,
           "startCol" : 4,
-          "endLine" : 244,
+          "endLine" : 243,
           "endCol" : 37
         }
       },
       "span" : {
-        "startLine" : 243,
+        "startLine" : 242,
         "startCol" : 2,
-        "endLine" : 244,
+        "endLine" : 243,
         "endCol" : 37
       }
     },
@@ -6815,17 +6785,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 246,
                 "startCol" : 13,
-                "endLine" : 247,
+                "endLine" : 246,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 247,
+              "startLine" : 246,
               "startCol" : 8,
-              "endLine" : 247,
+              "endLine" : 246,
               "endCol" : 21
             }
           }
@@ -6837,9 +6807,9 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 247,
+              "startLine" : 246,
               "startCol" : 24,
-              "endLine" : 247,
+              "endLine" : 246,
               "endCol" : 25
             }
           },
@@ -6847,30 +6817,30 @@
             "kind" : "Identifier",
             "name" : "next_session_id",
             "span" : {
-              "startLine" : 247,
+              "startLine" : 246,
               "startCol" : 28,
-              "endLine" : 247,
+              "endLine" : 246,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 247,
+            "startLine" : 246,
             "startCol" : 24,
-            "endLine" : 247,
+            "endLine" : 246,
             "endCol" : 43
           }
         },
         "span" : {
-          "startLine" : 247,
+          "startLine" : 246,
           "startCol" : 4,
-          "endLine" : 247,
+          "endLine" : 246,
           "endCol" : 43
         }
       },
       "span" : {
-        "startLine" : 246,
+        "startLine" : 245,
         "startCol" : 2,
-        "endLine" : 247,
+        "endLine" : 246,
         "endCol" : 43
       }
     },
@@ -6887,17 +6857,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 256,
+                "startLine" : 255,
                 "startCol" : 14,
-                "endLine" : 256,
+                "endLine" : 255,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 256,
+              "startLine" : 255,
               "startCol" : 8,
-              "endLine" : 256,
+              "endLine" : 255,
               "endCol" : 22
             }
           },
@@ -6907,17 +6877,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 256,
+                "startLine" : 255,
                 "startCol" : 30,
-                "endLine" : 256,
+                "endLine" : 255,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 256,
+              "startLine" : 255,
               "startCol" : 24,
-              "endLine" : 256,
+              "endLine" : 255,
               "endCol" : 38
             }
           }
@@ -6932,9 +6902,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 257,
+                "startLine" : 256,
                 "startCol" : 6,
-                "endLine" : 257,
+                "endLine" : 256,
                 "endCol" : 8
               }
             },
@@ -6942,16 +6912,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 257,
+                "startLine" : 256,
                 "startCol" : 12,
-                "endLine" : 257,
+                "endLine" : 256,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 257,
+              "startLine" : 256,
               "startCol" : 6,
-              "endLine" : 257,
+              "endLine" : 256,
               "endCol" : 14
             }
           },
@@ -6966,9 +6936,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 258,
+                    "startLine" : 257,
                     "startCol" : 8,
-                    "endLine" : 258,
+                    "endLine" : 257,
                     "endCol" : 16
                   }
                 },
@@ -6976,24 +6946,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 258,
+                    "startLine" : 257,
                     "startCol" : 17,
-                    "endLine" : 258,
+                    "endLine" : 257,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 258,
+                  "startLine" : 257,
                   "startCol" : 8,
-                  "endLine" : 258,
+                  "endLine" : 257,
                   "endCol" : 20
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 258,
+                "startLine" : 257,
                 "startCol" : 8,
-                "endLine" : 258,
+                "endLine" : 257,
                 "endCol" : 33
               }
             },
@@ -7005,9 +6975,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 258,
+                    "startLine" : 257,
                     "startCol" : 37,
-                    "endLine" : 258,
+                    "endLine" : 257,
                     "endCol" : 45
                   }
                 },
@@ -7015,52 +6985,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 258,
+                    "startLine" : 257,
                     "startCol" : 46,
-                    "endLine" : 258,
+                    "endLine" : 257,
                     "endCol" : 48
                   }
                 },
                 "span" : {
-                  "startLine" : 258,
+                  "startLine" : 257,
                   "startCol" : 37,
-                  "endLine" : 258,
+                  "endLine" : 257,
                   "endCol" : 49
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 258,
+                "startLine" : 257,
                 "startCol" : 37,
-                "endLine" : 258,
+                "endLine" : 257,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 258,
+              "startLine" : 257,
               "startCol" : 8,
-              "endLine" : 258,
+              "endLine" : 257,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 257,
+            "startLine" : 256,
             "startCol" : 6,
-            "endLine" : 258,
+            "endLine" : 257,
             "endCol" : 62
           }
         },
         "span" : {
-          "startLine" : 256,
+          "startLine" : 255,
           "startCol" : 4,
-          "endLine" : 258,
+          "endLine" : 257,
           "endCol" : 62
         }
       },
       "span" : {
-        "startLine" : 255,
+        "startLine" : 254,
         "startCol" : 2,
-        "endLine" : 258,
+        "endLine" : 257,
         "endCol" : 62
       }
     },
@@ -7077,17 +7047,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 261,
+                "startLine" : 260,
                 "startCol" : 14,
-                "endLine" : 261,
+                "endLine" : 260,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 261,
+              "startLine" : 260,
               "startCol" : 8,
-              "endLine" : 261,
+              "endLine" : 260,
               "endCol" : 22
             }
           },
@@ -7097,17 +7067,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 261,
+                "startLine" : 260,
                 "startCol" : 30,
-                "endLine" : 261,
+                "endLine" : 260,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 261,
+              "startLine" : 260,
               "startCol" : 24,
-              "endLine" : 261,
+              "endLine" : 260,
               "endCol" : 38
             }
           }
@@ -7122,9 +7092,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 262,
+                "startLine" : 261,
                 "startCol" : 6,
-                "endLine" : 262,
+                "endLine" : 261,
                 "endCol" : 8
               }
             },
@@ -7132,16 +7102,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 262,
+                "startLine" : 261,
                 "startCol" : 12,
-                "endLine" : 262,
+                "endLine" : 261,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 262,
+              "startLine" : 261,
               "startCol" : 6,
-              "endLine" : 262,
+              "endLine" : 261,
               "endCol" : 14
             }
           },
@@ -7156,9 +7126,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 262,
                     "startCol" : 8,
-                    "endLine" : 263,
+                    "endLine" : 262,
                     "endCol" : 16
                   }
                 },
@@ -7166,24 +7136,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 262,
                     "startCol" : 17,
-                    "endLine" : 263,
+                    "endLine" : 262,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 262,
                   "startCol" : 8,
-                  "endLine" : 263,
+                  "endLine" : 262,
                   "endCol" : 20
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 263,
+                "startLine" : 262,
                 "startCol" : 8,
-                "endLine" : 263,
+                "endLine" : 262,
                 "endCol" : 34
               }
             },
@@ -7195,9 +7165,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 262,
                     "startCol" : 38,
-                    "endLine" : 263,
+                    "endLine" : 262,
                     "endCol" : 46
                   }
                 },
@@ -7205,52 +7175,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 263,
+                    "startLine" : 262,
                     "startCol" : 47,
-                    "endLine" : 263,
+                    "endLine" : 262,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 262,
                   "startCol" : 38,
-                  "endLine" : 263,
+                  "endLine" : 262,
                   "endCol" : 50
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 263,
+                "startLine" : 262,
                 "startCol" : 38,
-                "endLine" : 263,
+                "endLine" : 262,
                 "endCol" : 64
               }
             },
             "span" : {
-              "startLine" : 263,
+              "startLine" : 262,
               "startCol" : 8,
-              "endLine" : 263,
+              "endLine" : 262,
               "endCol" : 64
             }
           },
           "span" : {
-            "startLine" : 262,
+            "startLine" : 261,
             "startCol" : 6,
-            "endLine" : 263,
+            "endLine" : 262,
             "endCol" : 64
           }
         },
         "span" : {
-          "startLine" : 261,
+          "startLine" : 260,
           "startCol" : 4,
-          "endLine" : 263,
+          "endLine" : 262,
           "endCol" : 64
         }
       },
       "span" : {
-        "startLine" : 260,
+        "startLine" : 259,
         "startCol" : 2,
-        "endLine" : 263,
+        "endLine" : 262,
         "endCol" : 64
       }
     }
@@ -7271,16 +7241,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 212,
+              "startLine" : 211,
               "startCol" : 39,
-              "endLine" : 212,
+              "endLine" : 211,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 212,
+            "startLine" : 211,
             "startCol" : 32,
-            "endLine" : 212,
+            "endLine" : 211,
             "endCol" : 44
           }
         }
@@ -7289,9 +7259,9 @@
         "kind" : "NamedType",
         "name" : "Int",
         "span" : {
-          "startLine" : 212,
+          "startLine" : 211,
           "startCol" : 47,
-          "endLine" : 212,
+          "endLine" : 211,
           "endCol" : 50
         }
       },
@@ -7305,9 +7275,9 @@
             "kind" : "Identifier",
             "name" : "login_attempts",
             "span" : {
-              "startLine" : 213,
+              "startLine" : 212,
               "startCol" : 12,
-              "endLine" : 213,
+              "endLine" : 212,
               "endCol" : 26
             }
           },
@@ -7326,17 +7296,17 @@
                     "kind" : "Identifier",
                     "name" : "a",
                     "span" : {
-                      "startLine" : 214,
+                      "startLine" : 213,
                       "startCol" : 7,
-                      "endLine" : 214,
+                      "endLine" : 213,
                       "endCol" : 8
                     }
                   },
                   "field" : "email",
                   "span" : {
-                    "startLine" : 214,
+                    "startLine" : 213,
                     "startCol" : 7,
-                    "endLine" : 214,
+                    "endLine" : 213,
                     "endCol" : 14
                   }
                 },
@@ -7344,16 +7314,16 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 214,
+                    "startLine" : 213,
                     "startCol" : 17,
-                    "endLine" : 214,
+                    "endLine" : 213,
                     "endCol" : 22
                   }
                 },
                 "span" : {
-                  "startLine" : 214,
+                  "startLine" : 213,
                   "startCol" : 7,
-                  "endLine" : 214,
+                  "endLine" : 213,
                   "endCol" : 22
                 }
               },
@@ -7366,17 +7336,17 @@
                     "kind" : "Identifier",
                     "name" : "a",
                     "span" : {
-                      "startLine" : 215,
+                      "startLine" : 214,
                       "startCol" : 11,
-                      "endLine" : 215,
+                      "endLine" : 214,
                       "endCol" : 12
                     }
                   },
                   "field" : "success",
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 214,
                     "startCol" : 11,
-                    "endLine" : 215,
+                    "endLine" : 214,
                     "endCol" : 20
                   }
                 },
@@ -7384,23 +7354,23 @@
                   "kind" : "BoolLit",
                   "value" : false,
                   "span" : {
-                    "startLine" : 215,
+                    "startLine" : 214,
                     "startCol" : 23,
-                    "endLine" : 215,
+                    "endLine" : 214,
                     "endCol" : 28
                   }
                 },
                 "span" : {
-                  "startLine" : 215,
+                  "startLine" : 214,
                   "startCol" : 11,
-                  "endLine" : 215,
+                  "endLine" : 214,
                   "endCol" : 28
                 }
               },
               "span" : {
-                "startLine" : 214,
+                "startLine" : 213,
                 "startCol" : 7,
-                "endLine" : 215,
+                "endLine" : 214,
                 "endCol" : 28
               }
             },
@@ -7413,17 +7383,17 @@
                   "kind" : "Identifier",
                   "name" : "a",
                   "span" : {
-                    "startLine" : 216,
+                    "startLine" : 215,
                     "startCol" : 11,
-                    "endLine" : 216,
+                    "endLine" : 215,
                     "endCol" : 12
                   }
                 },
                 "field" : "timestamp",
                 "span" : {
-                  "startLine" : 216,
+                  "startLine" : 215,
                   "startCol" : 11,
-                  "endLine" : 216,
+                  "endLine" : 215,
                   "endCol" : 22
                 }
               },
@@ -7436,18 +7406,18 @@
                     "kind" : "Identifier",
                     "name" : "now",
                     "span" : {
-                      "startLine" : 216,
+                      "startLine" : 215,
                       "startCol" : 25,
-                      "endLine" : 216,
+                      "endLine" : 215,
                       "endCol" : 28
                     }
                   },
                   "args" : [
                   ],
                   "span" : {
-                    "startLine" : 216,
+                    "startLine" : 215,
                     "startCol" : 25,
-                    "endLine" : 216,
+                    "endLine" : 215,
                     "endCol" : 30
                   }
                 },
@@ -7457,9 +7427,9 @@
                     "kind" : "Identifier",
                     "name" : "minutes",
                     "span" : {
-                      "startLine" : 216,
+                      "startLine" : 215,
                       "startCol" : 33,
-                      "endLine" : 216,
+                      "endLine" : 215,
                       "endCol" : 40
                     }
                   },
@@ -7468,59 +7438,59 @@
                       "kind" : "IntLit",
                       "value" : 15,
                       "span" : {
-                        "startLine" : 216,
+                        "startLine" : 215,
                         "startCol" : 41,
-                        "endLine" : 216,
+                        "endLine" : 215,
                         "endCol" : 43
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 216,
+                    "startLine" : 215,
                     "startCol" : 33,
-                    "endLine" : 216,
+                    "endLine" : 215,
                     "endCol" : 44
                   }
                 },
                 "span" : {
-                  "startLine" : 216,
+                  "startLine" : 215,
                   "startCol" : 25,
-                  "endLine" : 216,
+                  "endLine" : 215,
                   "endCol" : 44
                 }
               },
               "span" : {
-                "startLine" : 216,
+                "startLine" : 215,
                 "startCol" : 11,
-                "endLine" : 216,
+                "endLine" : 215,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 214,
+              "startLine" : 213,
               "startCol" : 7,
-              "endLine" : 216,
+              "endLine" : 215,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 213,
+            "startLine" : 212,
             "startCol" : 5,
-            "endLine" : 216,
+            "endLine" : 215,
             "endCol" : 46
           }
         },
         "span" : {
-          "startLine" : 213,
+          "startLine" : 212,
           "startCol" : 4,
-          "endLine" : 216,
+          "endLine" : 215,
           "endCol" : 46
         }
       },
       "span" : {
-        "startLine" : 212,
+        "startLine" : 211,
         "startCol" : 2,
-        "endLine" : 216,
+        "endLine" : 215,
         "endCol" : 46
       }
     }
@@ -7644,9 +7614,9 @@
           "value" : "/auth/register"
         },
         "span" : {
-          "startLine" : 273,
+          "startLine" : 272,
           "startCol" : 4,
-          "endLine" : 273,
+          "endLine" : 272,
           "endCol" : 41
         }
       },
@@ -7660,9 +7630,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 274,
+          "startLine" : 273,
           "startCol" : 4,
-          "endLine" : 274,
+          "endLine" : 273,
           "endCol" : 38
         }
       },
@@ -7676,9 +7646,9 @@
           "value" : "/auth/login"
         },
         "span" : {
-          "startLine" : 276,
+          "startLine" : 275,
           "startCol" : 4,
-          "endLine" : 276,
+          "endLine" : 275,
           "endCol" : 35
         }
       },
@@ -7692,9 +7662,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 277,
+          "startLine" : 276,
           "startCol" : 4,
-          "endLine" : 277,
+          "endLine" : 276,
           "endCol" : 30
         }
       },
@@ -7708,9 +7678,9 @@
           "value" : 200
         },
         "span" : {
-          "startLine" : 278,
+          "startLine" : 277,
           "startCol" : 4,
-          "endLine" : 278,
+          "endLine" : 277,
           "endCol" : 35
         }
       },
@@ -7724,9 +7694,9 @@
           "value" : "/auth/refresh"
         },
         "span" : {
-          "startLine" : 280,
+          "startLine" : 279,
           "startCol" : 4,
-          "endLine" : 280,
+          "endLine" : 279,
           "endCol" : 44
         }
       },
@@ -7740,9 +7710,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 281,
+          "startLine" : 280,
           "startCol" : 4,
-          "endLine" : 281,
+          "endLine" : 280,
           "endCol" : 37
         }
       },
@@ -7756,9 +7726,9 @@
           "value" : "/auth/password-reset"
         },
         "span" : {
-          "startLine" : 283,
+          "startLine" : 282,
           "startCol" : 4,
-          "endLine" : 283,
+          "endLine" : 282,
           "endCol" : 59
         }
       },
@@ -7772,9 +7742,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 284,
+          "startLine" : 283,
           "startCol" : 4,
-          "endLine" : 284,
+          "endLine" : 283,
           "endCol" : 45
         }
       },
@@ -7788,9 +7758,9 @@
           "value" : "/auth/password-reset/confirm"
         },
         "span" : {
-          "startLine" : 286,
+          "startLine" : 285,
           "startCol" : 4,
-          "endLine" : 286,
+          "endLine" : 285,
           "endCol" : 60
         }
       },
@@ -7804,9 +7774,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 287,
+          "startLine" : 286,
           "startCol" : 4,
-          "endLine" : 287,
+          "endLine" : 286,
           "endCol" : 38
         }
       },
@@ -7820,9 +7790,9 @@
           "value" : "/auth/logout"
         },
         "span" : {
-          "startLine" : 289,
+          "startLine" : 288,
           "startCol" : 4,
-          "endLine" : 289,
+          "endLine" : 288,
           "endCol" : 37
         }
       },
@@ -7836,9 +7806,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 290,
+          "startLine" : 289,
           "startCol" : 4,
-          "endLine" : 290,
+          "endLine" : 289,
           "endCol" : 31
         }
       },
@@ -7852,17 +7822,17 @@
           "value" : 204
         },
         "span" : {
-          "startLine" : 291,
+          "startLine" : 290,
           "startCol" : 4,
-          "endLine" : 291,
+          "endLine" : 290,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 272,
+      "startLine" : 271,
       "startCol" : 2,
-      "endLine" : 292,
+      "endLine" : 291,
       "endCol" : 3
     }
   },
@@ -7898,7 +7868,7 @@
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 293,
+    "endLine" : 292,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/auth_service.spec
+++ b/fixtures/spec/auth_service.spec
@@ -201,10 +201,9 @@ service AuthService {
         and sessions[s].is_revoked = false
 
     ensures:
-      let s = (the s in sessions |
-        sessions[s].access_token = access_token) in
-        sessions'[s].is_revoked = true
-        and users' = users
+      sessions'[(the s in sessions |
+        sessions[s].access_token = access_token)].is_revoked = true
+      users' = users
   }
 
   // --- Helper Functions ---

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -90,9 +90,9 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ("edge_cases", 29, 0, "plain is an Int scalar backed by service_state since #407"),
     (
       "auth_service",
-      43,
+      44,
       4,
-      "4 unbacked scalar-state; total 43 after adding userKeyMatchesId, sessionKeyMatchesId, nextUserIdFresh, nextSessionIdFresh, post-state membership clauses to make the Dafny kernel hand-verifiable (all 7 ops verified with bodies, see #149)"
+      "4 unbacked scalar-state; total 44 since Logout's `let s = (the ..) in (sessions'[s].. and users'=users)` was hoisted to two top-level ensures clauses (`sessions'[(the ..)].is_revoked` + `users'=users`) so the partial-relation frame synthesizes and Logout's 5 spurious uniqueness/freshness violations clear"
     )
   ).foreach: (name, expectedTotal, expectedSkipped, why) =>
     test(s"$name: $expectedTotal clauses, $expectedSkipped skips ($why)"):


### PR DESCRIPTION
## Summary

Fixes 5 spurious verification failures on `auth_service.Logout` by hoisting its `the` out of the `let` so the session update gets framed (**auth_service 23 → 18 failures**).

## The bug

Logout's ensures was:

```text
let s = (the s in sessions | sessions[s].access_token = access_token) in
  sessions'[s].is_revoked = true
  and users' = users
```

The frame synthesizer (`analyzeStateMention`) only classifies **top-level** state updates. The `sessions'[s]..` update is buried inside the `let`, so it's never recognized -> the post-state `sessions` relation is left under-constrained -> the solver freely mutates session tokens/keys and reports 5 spurious violations: `accessTokensUnique`, `refreshTokensUnique`, `sessionKeyMatchesId`, `sessionBelongsToUser`, `nextSessionIdFresh`.

## The fix

Hoist the `the` into the index so the update is a top-level clause that gets the normal partial-relation frame (other fields/keys preserved):

```text
sessions'[(the s in sessions | sessions[s].access_token = access_token)].is_revoked = true
users' = users
```

Semantically identical; now `analyzeStateMention` classifies it as a field update and frames it. All 5 Logout violations clear.

## What remains (Z3-hard, deferred)

The other 18 failures are **not** framing gaps:
- `ResetPassword` / `RequestPasswordReset` / `RefreshToken` — framing their session/user updates makes the quantified uniqueness/consistency invariants (`accessTokensUnique`, `emailIndexConsistent`, `userKeyMatchesId`) exceed the 30s solver budget. Confirmed by experiment: hoisting ResetPassword too pushes the run from 5.5s to 31s with real timeouts. These need E-matching triggers.
- `Login`'s 11 skips are the separate Seq-comprehension-cardinality (`#{ a in login_attempts | .. }`) dead-end, outside the verified subset.

## Validation

All affected suites pass: parser, ir, testgen, verify, convention, codegen, lint, dafny, profile, cli. Regenerated `ir/auth_service.json`; updated `SkipRateProbeTest` (auth total 43 -> 44; the Logout hoist splits one clause into two).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 5 spurious verification failures in `auth_service.Logout` by hoisting the quantified selector so the session update is top-level and gets framed. auth_service failures drop from 23 to 18.

- **Bug Fixes**
  - Rewrote Logout ensures to update `sessions'[(the s in sessions | sessions[s].access_token = access_token)].is_revoked = true` at top level; kept `users' = users`.
  - Frame synthesizer now classifies the field update; uniqueness/freshness checks stop failing: accessTokensUnique, refreshTokensUnique, sessionKeyMatchesId, sessionBelongsToUser, nextSessionIdFresh.
  - Regenerated `fixtures/golden/ir/auth_service.json` and updated `fixtures/spec/auth_service.spec`.
  - Adjusted `SkipRateProbeTest` total clauses 43 → 44 (split ensures into two clauses).

<sup>Written for commit 72af2e5e04ad49ad9877339929a500b613ce6620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the clarity of the authentication service's logout operation specification through restructuring.
  * Updated test fixtures to align with specification changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->