### PR TITLE
feat(auth_service): verifiable login rate-limiting — auth_service now fully verifies

### DIFF
--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -773,6 +773,113 @@
         "endLine" : 56,
         "endCol" : 3
       }
+    },
+    {
+      "kind" : "Entity",
+      "name" : "FailedLogin",
+      "extends_" : null,
+      "fields" : [
+        {
+          "kind" : "Field",
+          "name" : "email",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Email",
+            "span" : {
+              "startLine" : 59,
+              "startCol" : 11,
+              "endLine" : 59,
+              "endCol" : 16
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 59,
+            "startCol" : 4,
+            "endLine" : 59,
+            "endCol" : 16
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "count",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Int",
+            "span" : {
+              "startLine" : 60,
+              "startCol" : 11,
+              "endLine" : 60,
+              "endCol" : 14
+            }
+          },
+          "constraint" : {
+            "kind" : "BinaryOp",
+            "op" : ">",
+            "left" : {
+              "kind" : "Identifier",
+              "name" : "value",
+              "span" : {
+                "startLine" : 60,
+                "startCol" : 21,
+                "endLine" : 60,
+                "endCol" : 26
+              }
+            },
+            "right" : {
+              "kind" : "IntLit",
+              "value" : 0,
+              "span" : {
+                "startLine" : 60,
+                "startCol" : 29,
+                "endLine" : 60,
+                "endCol" : 30
+              }
+            },
+            "span" : {
+              "startLine" : 60,
+              "startCol" : 21,
+              "endLine" : 60,
+              "endCol" : 30
+            }
+          },
+          "span" : {
+            "startLine" : 60,
+            "startCol" : 4,
+            "endLine" : 60,
+            "endCol" : 30
+          }
+        },
+        {
+          "kind" : "Field",
+          "name" : "window_start",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "DateTime",
+            "span" : {
+              "startLine" : 61,
+              "startCol" : 18,
+              "endLine" : 61,
+              "endCol" : 26
+            }
+          },
+          "constraint" : null,
+          "span" : {
+            "startLine" : 61,
+            "startCol" : 4,
+            "endLine" : 61,
+            "endCol" : 26
+          }
+        }
+      ],
+      "invariants" : [
+      ],
+      "span" : {
+        "startLine" : 58,
+        "startCol" : 2,
+        "endLine" : 62,
+        "endCol" : 3
+      }
     }
   ],
   "enums" : [
@@ -1038,9 +1145,9 @@
             "kind" : "NamedType",
             "name" : "UserId",
             "span" : {
-              "startLine" : 61,
+              "startLine" : 67,
               "startCol" : 11,
-              "endLine" : 61,
+              "endLine" : 67,
               "endCol" : 17
             }
           },
@@ -1049,23 +1156,23 @@
             "kind" : "NamedType",
             "name" : "User",
             "span" : {
-              "startLine" : 61,
+              "startLine" : 67,
               "startCol" : 26,
-              "endLine" : 61,
+              "endLine" : 67,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 61,
+            "startLine" : 67,
             "startCol" : 11,
-            "endLine" : 61,
+            "endLine" : 67,
             "endCol" : 30
           }
         },
         "span" : {
-          "startLine" : 61,
+          "startLine" : 67,
           "startCol" : 4,
-          "endLine" : 61,
+          "endLine" : 67,
           "endCol" : 30
         }
       },
@@ -1078,9 +1185,9 @@
             "kind" : "NamedType",
             "name" : "Int",
             "span" : {
-              "startLine" : 62,
+              "startLine" : 68,
               "startCol" : 14,
-              "endLine" : 62,
+              "endLine" : 68,
               "endCol" : 17
             }
           },
@@ -1089,23 +1196,23 @@
             "kind" : "NamedType",
             "name" : "Session",
             "span" : {
-              "startLine" : 62,
+              "startLine" : 68,
               "startCol" : 26,
-              "endLine" : 62,
+              "endLine" : 68,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 62,
+            "startLine" : 68,
             "startCol" : 14,
-            "endLine" : 62,
+            "endLine" : 68,
             "endCol" : 33
           }
         },
         "span" : {
-          "startLine" : 62,
+          "startLine" : 68,
           "startCol" : 4,
-          "endLine" : 62,
+          "endLine" : 68,
           "endCol" : 33
         }
       },
@@ -1118,23 +1225,23 @@
             "kind" : "NamedType",
             "name" : "LoginAttempt",
             "span" : {
-              "startLine" : 63,
+              "startLine" : 69,
               "startCol" : 24,
-              "endLine" : 63,
+              "endLine" : 69,
               "endCol" : 36
             }
           },
           "span" : {
-            "startLine" : 63,
+            "startLine" : 69,
             "startCol" : 20,
-            "endLine" : 63,
+            "endLine" : 69,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 63,
+          "startLine" : 69,
           "startCol" : 4,
-          "endLine" : 63,
+          "endLine" : 69,
           "endCol" : 37
         }
       },
@@ -1147,9 +1254,9 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 64,
+              "startLine" : 70,
               "startCol" : 19,
-              "endLine" : 64,
+              "endLine" : 70,
               "endCol" : 24
             }
           },
@@ -1158,23 +1265,23 @@
             "kind" : "NamedType",
             "name" : "User",
             "span" : {
-              "startLine" : 64,
+              "startLine" : 70,
               "startCol" : 33,
-              "endLine" : 64,
+              "endLine" : 70,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 64,
+            "startLine" : 70,
             "startCol" : 19,
-            "endLine" : 64,
+            "endLine" : 70,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 64,
+          "startLine" : 70,
           "startCol" : 4,
-          "endLine" : 64,
+          "endLine" : 70,
           "endCol" : 37
         }
       },
@@ -1187,9 +1294,9 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 65,
+              "startLine" : 71,
               "startCol" : 18,
-              "endLine" : 65,
+              "endLine" : 71,
               "endCol" : 23
             }
           },
@@ -1198,24 +1305,64 @@
             "kind" : "NamedType",
             "name" : "ResetToken",
             "span" : {
-              "startLine" : 65,
+              "startLine" : 71,
               "startCol" : 32,
-              "endLine" : 65,
+              "endLine" : 71,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 65,
+            "startLine" : 71,
             "startCol" : 18,
-            "endLine" : 65,
+            "endLine" : 71,
             "endCol" : 42
           }
         },
         "span" : {
-          "startLine" : 65,
+          "startLine" : 71,
           "startCol" : 4,
-          "endLine" : 65,
+          "endLine" : 71,
           "endCol" : 42
+        }
+      },
+      {
+        "kind" : "StateField",
+        "name" : "failed_logins",
+        "typeExpr" : {
+          "kind" : "RelationType",
+          "fromType" : {
+            "kind" : "NamedType",
+            "name" : "Email",
+            "span" : {
+              "startLine" : 72,
+              "startCol" : 19,
+              "endLine" : 72,
+              "endCol" : 24
+            }
+          },
+          "multiplicity" : "lone",
+          "toType" : {
+            "kind" : "NamedType",
+            "name" : "FailedLogin",
+            "span" : {
+              "startLine" : 72,
+              "startCol" : 33,
+              "endLine" : 72,
+              "endCol" : 44
+            }
+          },
+          "span" : {
+            "startLine" : 72,
+            "startCol" : 19,
+            "endLine" : 72,
+            "endCol" : 44
+          }
+        },
+        "span" : {
+          "startLine" : 72,
+          "startCol" : 4,
+          "endLine" : 72,
+          "endCol" : 44
         }
       },
       {
@@ -1225,16 +1372,16 @@
           "kind" : "NamedType",
           "name" : "UserId",
           "span" : {
-            "startLine" : 66,
+            "startLine" : 73,
             "startCol" : 18,
-            "endLine" : 66,
+            "endLine" : 73,
             "endCol" : 24
           }
         },
         "span" : {
-          "startLine" : 66,
+          "startLine" : 73,
           "startCol" : 4,
-          "endLine" : 66,
+          "endLine" : 73,
           "endCol" : 24
         }
       },
@@ -1245,24 +1392,24 @@
           "kind" : "NamedType",
           "name" : "Int",
           "span" : {
-            "startLine" : 67,
+            "startLine" : 74,
             "startCol" : 21,
-            "endLine" : 67,
+            "endLine" : 74,
             "endCol" : 24
           }
         },
         "span" : {
-          "startLine" : 67,
+          "startLine" : 74,
           "startCol" : 4,
-          "endLine" : 67,
+          "endLine" : 74,
           "endCol" : 24
         }
       }
     ],
     "span" : {
-      "startLine" : 60,
+      "startLine" : 66,
       "startCol" : 2,
-      "endLine" : 68,
+      "endLine" : 75,
       "endCol" : 3
     }
   },
@@ -1278,16 +1425,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 80,
+              "startLine" : 87,
               "startCol" : 19,
-              "endLine" : 80,
+              "endLine" : 87,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 80,
+            "startLine" : 87,
             "startCol" : 12,
-            "endLine" : 80,
+            "endLine" : 87,
             "endCol" : 24
           }
         },
@@ -1298,16 +1445,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 80,
+              "startLine" : 87,
               "startCol" : 36,
-              "endLine" : 80,
+              "endLine" : 87,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 80,
+            "startLine" : 87,
             "startCol" : 26,
-            "endLine" : 80,
+            "endLine" : 87,
             "endCol" : 42
           }
         },
@@ -1318,16 +1465,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 81,
+              "startLine" : 88,
               "startCol" : 26,
-              "endLine" : 81,
+              "endLine" : 88,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 81,
+            "startLine" : 88,
             "startCol" : 12,
-            "endLine" : 81,
+            "endLine" : 88,
             "endCol" : 32
           }
         }
@@ -1340,16 +1487,16 @@
             "kind" : "NamedType",
             "name" : "User",
             "span" : {
-              "startLine" : 82,
+              "startLine" : 89,
               "startCol" : 18,
-              "endLine" : 82,
+              "endLine" : 89,
               "endCol" : 22
             }
           },
           "span" : {
-            "startLine" : 82,
+            "startLine" : 89,
             "startCol" : 12,
-            "endLine" : 82,
+            "endLine" : 89,
             "endCol" : 22
           }
         }
@@ -1362,9 +1509,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 85,
+              "startLine" : 92,
               "startCol" : 6,
-              "endLine" : 85,
+              "endLine" : 92,
               "endCol" : 11
             }
           },
@@ -1372,16 +1519,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 85,
+              "startLine" : 92,
               "startCol" : 19,
-              "endLine" : 85,
+              "endLine" : 92,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 85,
+            "startLine" : 92,
             "startCol" : 6,
-            "endLine" : 85,
+            "endLine" : 92,
             "endCol" : 32
           }
         },
@@ -1394,9 +1541,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 86,
+                "startLine" : 93,
                 "startCol" : 6,
-                "endLine" : 86,
+                "endLine" : 93,
                 "endCol" : 9
               }
             },
@@ -1405,17 +1552,17 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 86,
+                  "startLine" : 93,
                   "startCol" : 10,
-                  "endLine" : 86,
+                  "endLine" : 93,
                   "endCol" : 18
                 }
               }
             ],
             "span" : {
-              "startLine" : 86,
+              "startLine" : 93,
               "startCol" : 6,
-              "endLine" : 86,
+              "endLine" : 93,
               "endCol" : 19
             }
           },
@@ -1423,16 +1570,16 @@
             "kind" : "IntLit",
             "value" : 8,
             "span" : {
-              "startLine" : 86,
+              "startLine" : 93,
               "startCol" : 23,
-              "endLine" : 86,
+              "endLine" : 93,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 86,
+            "startLine" : 93,
             "startCol" : 6,
-            "endLine" : 86,
+            "endLine" : 93,
             "endCol" : 24
           }
         },
@@ -1445,9 +1592,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 87,
+                "startLine" : 94,
                 "startCol" : 6,
-                "endLine" : 87,
+                "endLine" : 94,
                 "endCol" : 9
               }
             },
@@ -1456,17 +1603,17 @@
                 "kind" : "Identifier",
                 "name" : "display_name",
                 "span" : {
-                  "startLine" : 87,
+                  "startLine" : 94,
                   "startCol" : 10,
-                  "endLine" : 87,
+                  "endLine" : 94,
                   "endCol" : 22
                 }
               }
             ],
             "span" : {
-              "startLine" : 87,
+              "startLine" : 94,
               "startCol" : 6,
-              "endLine" : 87,
+              "endLine" : 94,
               "endCol" : 23
             }
           },
@@ -1474,16 +1621,16 @@
             "kind" : "IntLit",
             "value" : 1,
             "span" : {
-              "startLine" : 87,
+              "startLine" : 94,
               "startCol" : 27,
-              "endLine" : 87,
+              "endLine" : 94,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 87,
+            "startLine" : 94,
             "startCol" : 6,
-            "endLine" : 87,
+            "endLine" : 94,
             "endCol" : 28
           }
         }
@@ -1498,17 +1645,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 90,
+                "startLine" : 97,
                 "startCol" : 6,
-                "endLine" : 90,
+                "endLine" : 97,
                 "endCol" : 10
               }
             },
             "field" : "id",
             "span" : {
-              "startLine" : 90,
+              "startLine" : 97,
               "startCol" : 6,
-              "endLine" : 90,
+              "endLine" : 97,
               "endCol" : 13
             }
           },
@@ -1518,23 +1665,23 @@
               "kind" : "Identifier",
               "name" : "next_user_id",
               "span" : {
-                "startLine" : 90,
+                "startLine" : 97,
                 "startCol" : 20,
-                "endLine" : 90,
+                "endLine" : 97,
                 "endCol" : 32
               }
             },
             "span" : {
-              "startLine" : 90,
+              "startLine" : 97,
               "startCol" : 16,
-              "endLine" : 90,
+              "endLine" : 97,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 90,
+            "startLine" : 97,
             "startCol" : 6,
-            "endLine" : 90,
+            "endLine" : 97,
             "endCol" : 33
           }
         },
@@ -1547,17 +1694,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 91,
+                "startLine" : 98,
                 "startCol" : 6,
-                "endLine" : 91,
+                "endLine" : 98,
                 "endCol" : 10
               }
             },
             "field" : "email",
             "span" : {
-              "startLine" : 91,
+              "startLine" : 98,
               "startCol" : 6,
-              "endLine" : 91,
+              "endLine" : 98,
               "endCol" : 16
             }
           },
@@ -1565,16 +1712,16 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 91,
+              "startLine" : 98,
               "startCol" : 19,
-              "endLine" : 91,
+              "endLine" : 98,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 91,
+            "startLine" : 98,
             "startCol" : 6,
-            "endLine" : 91,
+            "endLine" : 98,
             "endCol" : 24
           }
         },
@@ -1587,17 +1734,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 92,
+                "startLine" : 99,
                 "startCol" : 6,
-                "endLine" : 92,
+                "endLine" : 99,
                 "endCol" : 10
               }
             },
             "field" : "password_hash",
             "span" : {
-              "startLine" : 92,
+              "startLine" : 99,
               "startCol" : 6,
-              "endLine" : 92,
+              "endLine" : 99,
               "endCol" : 24
             }
           },
@@ -1607,9 +1754,9 @@
               "kind" : "Identifier",
               "name" : "hash",
               "span" : {
-                "startLine" : 92,
+                "startLine" : 99,
                 "startCol" : 27,
-                "endLine" : 92,
+                "endLine" : 99,
                 "endCol" : 31
               }
             },
@@ -1618,24 +1765,24 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 92,
+                  "startLine" : 99,
                   "startCol" : 32,
-                  "endLine" : 92,
+                  "endLine" : 99,
                   "endCol" : 40
                 }
               }
             ],
             "span" : {
-              "startLine" : 92,
+              "startLine" : 99,
               "startCol" : 27,
-              "endLine" : 92,
+              "endLine" : 99,
               "endCol" : 41
             }
           },
           "span" : {
-            "startLine" : 92,
+            "startLine" : 99,
             "startCol" : 6,
-            "endLine" : 92,
+            "endLine" : 99,
             "endCol" : 41
           }
         },
@@ -1648,17 +1795,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 93,
+                "startLine" : 100,
                 "startCol" : 6,
-                "endLine" : 93,
+                "endLine" : 100,
                 "endCol" : 10
               }
             },
             "field" : "display_name",
             "span" : {
-              "startLine" : 93,
+              "startLine" : 100,
               "startCol" : 6,
-              "endLine" : 93,
+              "endLine" : 100,
               "endCol" : 23
             }
           },
@@ -1666,16 +1813,16 @@
             "kind" : "Identifier",
             "name" : "display_name",
             "span" : {
-              "startLine" : 93,
+              "startLine" : 100,
               "startCol" : 26,
-              "endLine" : 93,
+              "endLine" : 100,
               "endCol" : 38
             }
           },
           "span" : {
-            "startLine" : 93,
+            "startLine" : 100,
             "startCol" : 6,
-            "endLine" : 93,
+            "endLine" : 100,
             "endCol" : 38
           }
         },
@@ -1688,17 +1835,17 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 94,
+                "startLine" : 101,
                 "startCol" : 6,
-                "endLine" : 94,
+                "endLine" : 101,
                 "endCol" : 10
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 94,
+              "startLine" : 101,
               "startCol" : 6,
-              "endLine" : 94,
+              "endLine" : 101,
               "endCol" : 20
             }
           },
@@ -1706,16 +1853,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 94,
+              "startLine" : 101,
               "startCol" : 23,
-              "endLine" : 94,
+              "endLine" : 101,
               "endCol" : 27
             }
           },
           "span" : {
-            "startLine" : 94,
+            "startLine" : 101,
             "startCol" : 6,
-            "endLine" : 94,
+            "endLine" : 101,
             "endCol" : 27
           }
         },
@@ -1728,33 +1875,33 @@
               "kind" : "Identifier",
               "name" : "user",
               "span" : {
-                "startLine" : 95,
+                "startLine" : 102,
                 "startCol" : 6,
-                "endLine" : 95,
+                "endLine" : 102,
                 "endCol" : 10
               }
             },
             "field" : "last_login",
             "span" : {
-              "startLine" : 95,
+              "startLine" : 102,
               "startCol" : 6,
-              "endLine" : 95,
+              "endLine" : 102,
               "endCol" : 21
             }
           },
           "right" : {
             "kind" : "NoneLit",
             "span" : {
-              "startLine" : 95,
+              "startLine" : 102,
               "startCol" : 24,
-              "endLine" : 95,
+              "endLine" : 102,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 95,
+            "startLine" : 102,
             "startCol" : 6,
-            "endLine" : 95,
+            "endLine" : 102,
             "endCol" : 28
           }
         },
@@ -1767,16 +1914,16 @@
               "kind" : "Identifier",
               "name" : "next_user_id",
               "span" : {
-                "startLine" : 96,
+                "startLine" : 103,
                 "startCol" : 6,
-                "endLine" : 96,
+                "endLine" : 103,
                 "endCol" : 18
               }
             },
             "span" : {
-              "startLine" : 96,
+              "startLine" : 103,
               "startCol" : 6,
-              "endLine" : 96,
+              "endLine" : 103,
               "endCol" : 19
             }
           },
@@ -1789,16 +1936,16 @@
                 "kind" : "Identifier",
                 "name" : "next_user_id",
                 "span" : {
-                  "startLine" : 96,
+                  "startLine" : 103,
                   "startCol" : 26,
-                  "endLine" : 96,
+                  "endLine" : 103,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 96,
+                "startLine" : 103,
                 "startCol" : 22,
-                "endLine" : 96,
+                "endLine" : 103,
                 "endCol" : 39
               }
             },
@@ -1806,23 +1953,23 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 96,
+                "startLine" : 103,
                 "startCol" : 42,
-                "endLine" : 96,
+                "endLine" : 103,
                 "endCol" : 43
               }
             },
             "span" : {
-              "startLine" : 96,
+              "startLine" : 103,
               "startCol" : 22,
-              "endLine" : 96,
+              "endLine" : 103,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 96,
+            "startLine" : 103,
             "startCol" : 6,
-            "endLine" : 96,
+            "endLine" : 103,
             "endCol" : 43
           }
         },
@@ -1835,16 +1982,16 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 97,
+                "startLine" : 104,
                 "startCol" : 6,
-                "endLine" : 97,
+                "endLine" : 104,
                 "endCol" : 11
               }
             },
             "span" : {
-              "startLine" : 97,
+              "startLine" : 104,
               "startCol" : 6,
-              "endLine" : 97,
+              "endLine" : 104,
               "endCol" : 12
             }
           },
@@ -1857,16 +2004,16 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 97,
+                  "startLine" : 104,
                   "startCol" : 19,
-                  "endLine" : 97,
+                  "endLine" : 104,
                   "endCol" : 24
                 }
               },
               "span" : {
-                "startLine" : 97,
+                "startLine" : 104,
                 "startCol" : 15,
-                "endLine" : 97,
+                "endLine" : 104,
                 "endCol" : 25
               }
             },
@@ -1880,17 +2027,17 @@
                       "kind" : "Identifier",
                       "name" : "user",
                       "span" : {
-                        "startLine" : 97,
+                        "startLine" : 104,
                         "startCol" : 29,
-                        "endLine" : 97,
+                        "endLine" : 104,
                         "endCol" : 33
                       }
                     },
                     "field" : "id",
                     "span" : {
-                      "startLine" : 97,
+                      "startLine" : 104,
                       "startCol" : 29,
-                      "endLine" : 97,
+                      "endLine" : 104,
                       "endCol" : 36
                     }
                   },
@@ -1898,38 +2045,38 @@
                     "kind" : "Identifier",
                     "name" : "user",
                     "span" : {
-                      "startLine" : 97,
+                      "startLine" : 104,
                       "startCol" : 40,
-                      "endLine" : 97,
+                      "endLine" : 104,
                       "endCol" : 44
                     }
                   },
                   "span" : {
-                    "startLine" : 97,
+                    "startLine" : 104,
                     "startCol" : 29,
-                    "endLine" : 97,
+                    "endLine" : 104,
                     "endCol" : 36
                   }
                 }
               ],
               "span" : {
-                "startLine" : 97,
+                "startLine" : 104,
                 "startCol" : 28,
-                "endLine" : 97,
+                "endLine" : 104,
                 "endCol" : 45
               }
             },
             "span" : {
-              "startLine" : 97,
+              "startLine" : 104,
               "startCol" : 15,
-              "endLine" : 97,
+              "endLine" : 104,
               "endCol" : 45
             }
           },
           "span" : {
-            "startLine" : 97,
+            "startLine" : 104,
             "startCol" : 6,
-            "endLine" : 97,
+            "endLine" : 104,
             "endCol" : 45
           }
         },
@@ -1942,16 +2089,16 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 98,
+                "startLine" : 105,
                 "startCol" : 6,
-                "endLine" : 98,
+                "endLine" : 105,
                 "endCol" : 19
               }
             },
             "span" : {
-              "startLine" : 98,
+              "startLine" : 105,
               "startCol" : 6,
-              "endLine" : 98,
+              "endLine" : 105,
               "endCol" : 20
             }
           },
@@ -1964,16 +2111,16 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 98,
+                  "startLine" : 105,
                   "startCol" : 27,
-                  "endLine" : 98,
+                  "endLine" : 105,
                   "endCol" : 40
                 }
               },
               "span" : {
-                "startLine" : 98,
+                "startLine" : 105,
                 "startCol" : 23,
-                "endLine" : 98,
+                "endLine" : 105,
                 "endCol" : 41
               }
             },
@@ -1985,9 +2132,9 @@
                     "kind" : "Identifier",
                     "name" : "email",
                     "span" : {
-                      "startLine" : 98,
+                      "startLine" : 105,
                       "startCol" : 45,
-                      "endLine" : 98,
+                      "endLine" : 105,
                       "endCol" : 50
                     }
                   },
@@ -1995,38 +2142,38 @@
                     "kind" : "Identifier",
                     "name" : "user",
                     "span" : {
-                      "startLine" : 98,
+                      "startLine" : 105,
                       "startCol" : 54,
-                      "endLine" : 98,
+                      "endLine" : 105,
                       "endCol" : 58
                     }
                   },
                   "span" : {
-                    "startLine" : 98,
+                    "startLine" : 105,
                     "startCol" : 45,
-                    "endLine" : 98,
+                    "endLine" : 105,
                     "endCol" : 50
                   }
                 }
               ],
               "span" : {
-                "startLine" : 98,
+                "startLine" : 105,
                 "startCol" : 44,
-                "endLine" : 98,
+                "endLine" : 105,
                 "endCol" : 59
               }
             },
             "span" : {
-              "startLine" : 98,
+              "startLine" : 105,
               "startCol" : 23,
-              "endLine" : 98,
+              "endLine" : 105,
               "endCol" : 59
             }
           },
           "span" : {
-            "startLine" : 98,
+            "startLine" : 105,
             "startCol" : 6,
-            "endLine" : 98,
+            "endLine" : 105,
             "endCol" : 59
           }
         },
@@ -2042,23 +2189,23 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 99,
+                  "startLine" : 106,
                   "startCol" : 7,
-                  "endLine" : 99,
+                  "endLine" : 106,
                   "endCol" : 12
                 }
               },
               "span" : {
-                "startLine" : 99,
+                "startLine" : 106,
                 "startCol" : 7,
-                "endLine" : 99,
+                "endLine" : 106,
                 "endCol" : 13
               }
             },
             "span" : {
-              "startLine" : 99,
+              "startLine" : 106,
               "startCol" : 6,
-              "endLine" : 99,
+              "endLine" : 106,
               "endCol" : 13
             }
           },
@@ -2074,23 +2221,23 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 99,
+                    "startLine" : 106,
                     "startCol" : 21,
-                    "endLine" : 99,
+                    "endLine" : 106,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 99,
+                  "startLine" : 106,
                   "startCol" : 17,
-                  "endLine" : 99,
+                  "endLine" : 106,
                   "endCol" : 27
                 }
               },
               "span" : {
-                "startLine" : 99,
+                "startLine" : 106,
                 "startCol" : 16,
-                "endLine" : 99,
+                "endLine" : 106,
                 "endCol" : 27
               }
             },
@@ -2098,31 +2245,31 @@
               "kind" : "IntLit",
               "value" : 1,
               "span" : {
-                "startLine" : 99,
+                "startLine" : 106,
                 "startCol" : 30,
-                "endLine" : 99,
+                "endLine" : 106,
                 "endCol" : 31
               }
             },
             "span" : {
-              "startLine" : 99,
+              "startLine" : 106,
               "startCol" : 16,
-              "endLine" : 99,
+              "endLine" : 106,
               "endCol" : 31
             }
           },
           "span" : {
-            "startLine" : 99,
+            "startLine" : 106,
             "startCol" : 6,
-            "endLine" : 99,
+            "endLine" : 106,
             "endCol" : 31
           }
         }
       ],
       "span" : {
-        "startLine" : 79,
+        "startLine" : 86,
         "startCol" : 2,
-        "endLine" : 100,
+        "endLine" : 107,
         "endCol" : 3
       }
     },
@@ -2137,16 +2284,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 103,
+              "startLine" : 110,
               "startCol" : 19,
-              "endLine" : 103,
+              "endLine" : 110,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 103,
+            "startLine" : 110,
             "startCol" : 12,
-            "endLine" : 103,
+            "endLine" : 110,
             "endCol" : 24
           }
         },
@@ -2157,16 +2304,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 103,
+              "startLine" : 110,
               "startCol" : 36,
-              "endLine" : 103,
+              "endLine" : 110,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 103,
+            "startLine" : 110,
             "startCol" : 26,
-            "endLine" : 103,
+            "endLine" : 110,
             "endCol" : 42
           }
         }
@@ -2179,16 +2326,16 @@
             "kind" : "NamedType",
             "name" : "Session",
             "span" : {
-              "startLine" : 104,
+              "startLine" : 111,
               "startCol" : 21,
-              "endLine" : 104,
+              "endLine" : 111,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 104,
+            "startLine" : 111,
             "startCol" : 12,
-            "endLine" : 104,
+            "endLine" : 111,
             "endCol" : 28
           }
         }
@@ -2201,9 +2348,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 107,
+              "startLine" : 114,
               "startCol" : 6,
-              "endLine" : 107,
+              "endLine" : 114,
               "endCol" : 11
             }
           },
@@ -2211,16 +2358,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 107,
+              "startLine" : 114,
               "startCol" : 15,
-              "endLine" : 107,
+              "endLine" : 114,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 107,
+            "startLine" : 114,
             "startCol" : 6,
-            "endLine" : 107,
+            "endLine" : 114,
             "endCol" : 28
           }
         },
@@ -2235,9 +2382,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 108,
+                  "startLine" : 115,
                   "startCol" : 6,
-                  "endLine" : 108,
+                  "endLine" : 115,
                   "endCol" : 19
                 }
               },
@@ -2245,24 +2392,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 108,
+                  "startLine" : 115,
                   "startCol" : 20,
-                  "endLine" : 108,
+                  "endLine" : 115,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 108,
+                "startLine" : 115,
                 "startCol" : 6,
-                "endLine" : 108,
+                "endLine" : 115,
                 "endCol" : 26
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 108,
+              "startLine" : 115,
               "startCol" : 6,
-              "endLine" : 108,
+              "endLine" : 115,
               "endCol" : 36
             }
           },
@@ -2270,16 +2417,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 108,
+              "startLine" : 115,
               "startCol" : 39,
-              "endLine" : 108,
+              "endLine" : 115,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 108,
+            "startLine" : 115,
             "startCol" : 6,
-            "endLine" : 108,
+            "endLine" : 115,
             "endCol" : 43
           }
         },
@@ -2294,9 +2441,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 109,
+                  "startLine" : 116,
                   "startCol" : 6,
-                  "endLine" : 109,
+                  "endLine" : 116,
                   "endCol" : 19
                 }
               },
@@ -2304,24 +2451,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 109,
+                  "startLine" : 116,
                   "startCol" : 20,
-                  "endLine" : 109,
+                  "endLine" : 116,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 109,
+                "startLine" : 116,
                 "startCol" : 6,
-                "endLine" : 109,
+                "endLine" : 116,
                 "endCol" : 26
               }
             },
             "field" : "password_hash",
             "span" : {
-              "startLine" : 109,
+              "startLine" : 116,
               "startCol" : 6,
-              "endLine" : 109,
+              "endLine" : 116,
               "endCol" : 40
             }
           },
@@ -2331,9 +2478,9 @@
               "kind" : "Identifier",
               "name" : "hash",
               "span" : {
-                "startLine" : 109,
+                "startLine" : 116,
                 "startCol" : 43,
-                "endLine" : 109,
+                "endLine" : 116,
                 "endCol" : 47
               }
             },
@@ -2342,76 +2489,245 @@
                 "kind" : "Identifier",
                 "name" : "password",
                 "span" : {
-                  "startLine" : 109,
+                  "startLine" : 116,
                   "startCol" : 48,
-                  "endLine" : 109,
+                  "endLine" : 116,
                   "endCol" : 56
                 }
               }
             ],
             "span" : {
-              "startLine" : 109,
+              "startLine" : 116,
               "startCol" : 43,
-              "endLine" : 109,
+              "endLine" : 116,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 109,
+            "startLine" : 116,
             "startCol" : 6,
-            "endLine" : 109,
+            "endLine" : 116,
             "endCol" : 57
           }
         },
         {
           "kind" : "BinaryOp",
-          "op" : "<",
+          "op" : "or",
           "left" : {
-            "kind" : "Call",
-            "callee" : {
-              "kind" : "Identifier",
-              "name" : "recentFailedAttempts",
-              "span" : {
-                "startLine" : 110,
-                "startCol" : 6,
-                "endLine" : 110,
-                "endCol" : 26
-              }
-            },
-            "args" : [
-              {
+            "kind" : "BinaryOp",
+            "op" : "or",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "not_in",
+              "left" : {
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 110,
-                  "startCol" : 27,
-                  "endLine" : 110,
+                  "startLine" : 120,
+                  "startCol" : 6,
+                  "endLine" : 120,
+                  "endCol" : 11
+                }
+              },
+              "right" : {
+                "kind" : "Identifier",
+                "name" : "failed_logins",
+                "span" : {
+                  "startLine" : 120,
+                  "startCol" : 19,
+                  "endLine" : 120,
                   "endCol" : 32
                 }
+              },
+              "span" : {
+                "startLine" : 120,
+                "startCol" : 6,
+                "endLine" : 120,
+                "endCol" : 32
               }
-            ],
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "<",
+              "left" : {
+                "kind" : "FieldAccess",
+                "base" : {
+                  "kind" : "Index",
+                  "base" : {
+                    "kind" : "Identifier",
+                    "name" : "failed_logins",
+                    "span" : {
+                      "startLine" : 121,
+                      "startCol" : 11,
+                      "endLine" : 121,
+                      "endCol" : 24
+                    }
+                  },
+                  "index" : {
+                    "kind" : "Identifier",
+                    "name" : "email",
+                    "span" : {
+                      "startLine" : 121,
+                      "startCol" : 25,
+                      "endLine" : 121,
+                      "endCol" : 30
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 121,
+                    "startCol" : 11,
+                    "endLine" : 121,
+                    "endCol" : 31
+                  }
+                },
+                "field" : "count",
+                "span" : {
+                  "startLine" : 121,
+                  "startCol" : 11,
+                  "endLine" : 121,
+                  "endCol" : 37
+                }
+              },
+              "right" : {
+                "kind" : "IntLit",
+                "value" : 5,
+                "span" : {
+                  "startLine" : 121,
+                  "startCol" : 40,
+                  "endLine" : 121,
+                  "endCol" : 41
+                }
+              },
+              "span" : {
+                "startLine" : 121,
+                "startCol" : 11,
+                "endLine" : 121,
+                "endCol" : 41
+              }
+            },
             "span" : {
-              "startLine" : 110,
+              "startLine" : 120,
               "startCol" : 6,
-              "endLine" : 110,
-              "endCol" : 33
+              "endLine" : 121,
+              "endCol" : 41
             }
           },
           "right" : {
-            "kind" : "IntLit",
-            "value" : 5,
+            "kind" : "BinaryOp",
+            "op" : ">",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "-",
+              "left" : {
+                "kind" : "Call",
+                "callee" : {
+                  "kind" : "Identifier",
+                  "name" : "now",
+                  "span" : {
+                    "startLine" : 122,
+                    "startCol" : 11,
+                    "endLine" : 122,
+                    "endCol" : 14
+                  }
+                },
+                "args" : [
+                ],
+                "span" : {
+                  "startLine" : 122,
+                  "startCol" : 11,
+                  "endLine" : 122,
+                  "endCol" : 16
+                }
+              },
+              "right" : {
+                "kind" : "FieldAccess",
+                "base" : {
+                  "kind" : "Index",
+                  "base" : {
+                    "kind" : "Identifier",
+                    "name" : "failed_logins",
+                    "span" : {
+                      "startLine" : 122,
+                      "startCol" : 19,
+                      "endLine" : 122,
+                      "endCol" : 32
+                    }
+                  },
+                  "index" : {
+                    "kind" : "Identifier",
+                    "name" : "email",
+                    "span" : {
+                      "startLine" : 122,
+                      "startCol" : 33,
+                      "endLine" : 122,
+                      "endCol" : 38
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 122,
+                    "startCol" : 19,
+                    "endLine" : 122,
+                    "endCol" : 39
+                  }
+                },
+                "field" : "window_start",
+                "span" : {
+                  "startLine" : 122,
+                  "startCol" : 19,
+                  "endLine" : 122,
+                  "endCol" : 52
+                }
+              },
+              "span" : {
+                "startLine" : 122,
+                "startCol" : 11,
+                "endLine" : 122,
+                "endCol" : 52
+              }
+            },
+            "right" : {
+              "kind" : "Call",
+              "callee" : {
+                "kind" : "Identifier",
+                "name" : "minutes",
+                "span" : {
+                  "startLine" : 122,
+                  "startCol" : 55,
+                  "endLine" : 122,
+                  "endCol" : 62
+                }
+              },
+              "args" : [
+                {
+                  "kind" : "IntLit",
+                  "value" : 15,
+                  "span" : {
+                    "startLine" : 122,
+                    "startCol" : 63,
+                    "endLine" : 122,
+                    "endCol" : 65
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 122,
+                "startCol" : 55,
+                "endLine" : 122,
+                "endCol" : 66
+              }
+            },
             "span" : {
-              "startLine" : 110,
-              "startCol" : 36,
-              "endLine" : 110,
-              "endCol" : 37
+              "startLine" : 122,
+              "startCol" : 11,
+              "endLine" : 122,
+              "endCol" : 66
             }
           },
           "span" : {
-            "startLine" : 110,
+            "startLine" : 120,
             "startCol" : 6,
-            "endLine" : 110,
-            "endCol" : 37
+            "endLine" : 122,
+            "endCol" : 66
           }
         }
       ],
@@ -2425,9 +2741,9 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 113,
+                "startLine" : 125,
                 "startCol" : 17,
-                "endLine" : 113,
+                "endLine" : 125,
                 "endCol" : 30
               }
             },
@@ -2435,23 +2751,83 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 113,
+                "startLine" : 125,
                 "startCol" : 31,
-                "endLine" : 113,
+                "endLine" : 125,
                 "endCol" : 36
               }
             },
             "span" : {
-              "startLine" : 113,
+              "startLine" : 125,
               "startCol" : 17,
-              "endLine" : 113,
+              "endLine" : 125,
               "endCol" : 37
             }
           },
           "body" : {
-            "kind" : "BinaryOp",
-            "op" : "and",
-            "left" : {
+            "kind" : "Let",
+            "variable" : "updated",
+            "value" : {
+              "kind" : "With",
+              "base" : {
+                "kind" : "Identifier",
+                "name" : "user",
+                "span" : {
+                  "startLine" : 128,
+                  "startCol" : 22,
+                  "endLine" : 128,
+                  "endCol" : 26
+                }
+              },
+              "updates" : [
+                {
+                  "name" : "last_login",
+                  "value" : {
+                    "kind" : "SomeWrap",
+                    "expr" : {
+                      "kind" : "Call",
+                      "callee" : {
+                        "kind" : "Identifier",
+                        "name" : "now",
+                        "span" : {
+                          "startLine" : 128,
+                          "startCol" : 52,
+                          "endLine" : 128,
+                          "endCol" : 55
+                        }
+                      },
+                      "args" : [
+                      ],
+                      "span" : {
+                        "startLine" : 128,
+                        "startCol" : 52,
+                        "endLine" : 128,
+                        "endCol" : 57
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 128,
+                      "startCol" : 47,
+                      "endLine" : 128,
+                      "endCol" : 58
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 128,
+                    "startCol" : 34,
+                    "endLine" : 128,
+                    "endCol" : 58
+                  }
+                }
+              ],
+              "span" : {
+                "startLine" : 128,
+                "startCol" : 22,
+                "endLine" : 128,
+                "endCol" : 60
+              }
+            },
+            "body" : {
               "kind" : "BinaryOp",
               "op" : "and",
               "left" : {
@@ -2468,214 +2844,1876 @@
                       "op" : "and",
                       "left" : {
                         "kind" : "BinaryOp",
-                        "op" : "=",
+                        "op" : "and",
                         "left" : {
-                          "kind" : "FieldAccess",
-                          "base" : {
-                            "kind" : "Identifier",
-                            "name" : "session",
+                          "kind" : "BinaryOp",
+                          "op" : "and",
+                          "left" : {
+                            "kind" : "BinaryOp",
+                            "op" : "and",
+                            "left" : {
+                              "kind" : "BinaryOp",
+                              "op" : "and",
+                              "left" : {
+                                "kind" : "BinaryOp",
+                                "op" : "and",
+                                "left" : {
+                                  "kind" : "BinaryOp",
+                                  "op" : "and",
+                                  "left" : {
+                                    "kind" : "BinaryOp",
+                                    "op" : "and",
+                                    "left" : {
+                                      "kind" : "BinaryOp",
+                                      "op" : "=",
+                                      "left" : {
+                                        "kind" : "FieldAccess",
+                                        "base" : {
+                                          "kind" : "Identifier",
+                                          "name" : "session",
+                                          "span" : {
+                                            "startLine" : 129,
+                                            "startCol" : 10,
+                                            "endLine" : 129,
+                                            "endCol" : 17
+                                          }
+                                        },
+                                        "field" : "id",
+                                        "span" : {
+                                          "startLine" : 129,
+                                          "startCol" : 10,
+                                          "endLine" : 129,
+                                          "endCol" : 20
+                                        }
+                                      },
+                                      "right" : {
+                                        "kind" : "Pre",
+                                        "expr" : {
+                                          "kind" : "Identifier",
+                                          "name" : "next_session_id",
+                                          "span" : {
+                                            "startLine" : 129,
+                                            "startCol" : 27,
+                                            "endLine" : 129,
+                                            "endCol" : 42
+                                          }
+                                        },
+                                        "span" : {
+                                          "startLine" : 129,
+                                          "startCol" : 23,
+                                          "endLine" : 129,
+                                          "endCol" : 43
+                                        }
+                                      },
+                                      "span" : {
+                                        "startLine" : 129,
+                                        "startCol" : 10,
+                                        "endLine" : 129,
+                                        "endCol" : 43
+                                      }
+                                    },
+                                    "right" : {
+                                      "kind" : "BinaryOp",
+                                      "op" : "=",
+                                      "left" : {
+                                        "kind" : "FieldAccess",
+                                        "base" : {
+                                          "kind" : "Identifier",
+                                          "name" : "session",
+                                          "span" : {
+                                            "startLine" : 130,
+                                            "startCol" : 14,
+                                            "endLine" : 130,
+                                            "endCol" : 21
+                                          }
+                                        },
+                                        "field" : "user_id",
+                                        "span" : {
+                                          "startLine" : 130,
+                                          "startCol" : 14,
+                                          "endLine" : 130,
+                                          "endCol" : 29
+                                        }
+                                      },
+                                      "right" : {
+                                        "kind" : "FieldAccess",
+                                        "base" : {
+                                          "kind" : "Identifier",
+                                          "name" : "user",
+                                          "span" : {
+                                            "startLine" : 130,
+                                            "startCol" : 32,
+                                            "endLine" : 130,
+                                            "endCol" : 36
+                                          }
+                                        },
+                                        "field" : "id",
+                                        "span" : {
+                                          "startLine" : 130,
+                                          "startCol" : 32,
+                                          "endLine" : 130,
+                                          "endCol" : 39
+                                        }
+                                      },
+                                      "span" : {
+                                        "startLine" : 130,
+                                        "startCol" : 14,
+                                        "endLine" : 130,
+                                        "endCol" : 39
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 129,
+                                      "startCol" : 10,
+                                      "endLine" : 130,
+                                      "endCol" : 39
+                                    }
+                                  },
+                                  "right" : {
+                                    "kind" : "BinaryOp",
+                                    "op" : "=",
+                                    "left" : {
+                                      "kind" : "FieldAccess",
+                                      "base" : {
+                                        "kind" : "Identifier",
+                                        "name" : "session",
+                                        "span" : {
+                                          "startLine" : 131,
+                                          "startCol" : 14,
+                                          "endLine" : 131,
+                                          "endCol" : 21
+                                        }
+                                      },
+                                      "field" : "is_revoked",
+                                      "span" : {
+                                        "startLine" : 131,
+                                        "startCol" : 14,
+                                        "endLine" : 131,
+                                        "endCol" : 32
+                                      }
+                                    },
+                                    "right" : {
+                                      "kind" : "BoolLit",
+                                      "value" : false,
+                                      "span" : {
+                                        "startLine" : 131,
+                                        "startCol" : 35,
+                                        "endLine" : 131,
+                                        "endCol" : 40
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 131,
+                                      "startCol" : 14,
+                                      "endLine" : 131,
+                                      "endCol" : 40
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 129,
+                                    "startCol" : 10,
+                                    "endLine" : 131,
+                                    "endCol" : 40
+                                  }
+                                },
+                                "right" : {
+                                  "kind" : "BinaryOp",
+                                  "op" : ">",
+                                  "left" : {
+                                    "kind" : "FieldAccess",
+                                    "base" : {
+                                      "kind" : "Identifier",
+                                      "name" : "session",
+                                      "span" : {
+                                        "startLine" : 132,
+                                        "startCol" : 14,
+                                        "endLine" : 132,
+                                        "endCol" : 21
+                                      }
+                                    },
+                                    "field" : "access_expires_at",
+                                    "span" : {
+                                      "startLine" : 132,
+                                      "startCol" : 14,
+                                      "endLine" : 132,
+                                      "endCol" : 39
+                                    }
+                                  },
+                                  "right" : {
+                                    "kind" : "Call",
+                                    "callee" : {
+                                      "kind" : "Identifier",
+                                      "name" : "now",
+                                      "span" : {
+                                        "startLine" : 132,
+                                        "startCol" : 42,
+                                        "endLine" : 132,
+                                        "endCol" : 45
+                                      }
+                                    },
+                                    "args" : [
+                                    ],
+                                    "span" : {
+                                      "startLine" : 132,
+                                      "startCol" : 42,
+                                      "endLine" : 132,
+                                      "endCol" : 47
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 132,
+                                    "startCol" : 14,
+                                    "endLine" : 132,
+                                    "endCol" : 47
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 129,
+                                  "startCol" : 10,
+                                  "endLine" : 132,
+                                  "endCol" : 47
+                                }
+                              },
+                              "right" : {
+                                "kind" : "BinaryOp",
+                                "op" : ">",
+                                "left" : {
+                                  "kind" : "FieldAccess",
+                                  "base" : {
+                                    "kind" : "Identifier",
+                                    "name" : "session",
+                                    "span" : {
+                                      "startLine" : 133,
+                                      "startCol" : 14,
+                                      "endLine" : 133,
+                                      "endCol" : 21
+                                    }
+                                  },
+                                  "field" : "refresh_expires_at",
+                                  "span" : {
+                                    "startLine" : 133,
+                                    "startCol" : 14,
+                                    "endLine" : 133,
+                                    "endCol" : 40
+                                  }
+                                },
+                                "right" : {
+                                  "kind" : "FieldAccess",
+                                  "base" : {
+                                    "kind" : "Identifier",
+                                    "name" : "session",
+                                    "span" : {
+                                      "startLine" : 133,
+                                      "startCol" : 43,
+                                      "endLine" : 133,
+                                      "endCol" : 50
+                                    }
+                                  },
+                                  "field" : "access_expires_at",
+                                  "span" : {
+                                    "startLine" : 133,
+                                    "startCol" : 43,
+                                    "endLine" : 133,
+                                    "endCol" : 68
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 133,
+                                  "startCol" : 14,
+                                  "endLine" : 133,
+                                  "endCol" : 68
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 129,
+                                "startCol" : 10,
+                                "endLine" : 133,
+                                "endCol" : 68
+                              }
+                            },
+                            "right" : {
+                              "kind" : "Quantifier",
+                              "quantifier" : "all",
+                              "bindings" : [
+                                {
+                                  "variable" : "s",
+                                  "domain" : {
+                                    "kind" : "Pre",
+                                    "expr" : {
+                                      "kind" : "Identifier",
+                                      "name" : "sessions",
+                                      "span" : {
+                                        "startLine" : 135,
+                                        "startCol" : 28,
+                                        "endLine" : 135,
+                                        "endCol" : 36
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 135,
+                                      "startCol" : 24,
+                                      "endLine" : 135,
+                                      "endCol" : 37
+                                    }
+                                  },
+                                  "bindingKind" : "in",
+                                  "span" : {
+                                    "startLine" : 135,
+                                    "startCol" : 19,
+                                    "endLine" : 135,
+                                    "endCol" : 37
+                                  }
+                                }
+                              ],
+                              "body" : {
+                                "kind" : "BinaryOp",
+                                "op" : "!=",
+                                "left" : {
+                                  "kind" : "FieldAccess",
+                                  "base" : {
+                                    "kind" : "Identifier",
+                                    "name" : "session",
+                                    "span" : {
+                                      "startLine" : 136,
+                                      "startCol" : 16,
+                                      "endLine" : 136,
+                                      "endCol" : 23
+                                    }
+                                  },
+                                  "field" : "access_token",
+                                  "span" : {
+                                    "startLine" : 136,
+                                    "startCol" : 16,
+                                    "endLine" : 136,
+                                    "endCol" : 36
+                                  }
+                                },
+                                "right" : {
+                                  "kind" : "FieldAccess",
+                                  "base" : {
+                                    "kind" : "Index",
+                                    "base" : {
+                                      "kind" : "Pre",
+                                      "expr" : {
+                                        "kind" : "Identifier",
+                                        "name" : "sessions",
+                                        "span" : {
+                                          "startLine" : 136,
+                                          "startCol" : 44,
+                                          "endLine" : 136,
+                                          "endCol" : 52
+                                        }
+                                      },
+                                      "span" : {
+                                        "startLine" : 136,
+                                        "startCol" : 40,
+                                        "endLine" : 136,
+                                        "endCol" : 53
+                                      }
+                                    },
+                                    "index" : {
+                                      "kind" : "Identifier",
+                                      "name" : "s",
+                                      "span" : {
+                                        "startLine" : 136,
+                                        "startCol" : 54,
+                                        "endLine" : 136,
+                                        "endCol" : 55
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 136,
+                                      "startCol" : 40,
+                                      "endLine" : 136,
+                                      "endCol" : 56
+                                    }
+                                  },
+                                  "field" : "access_token",
+                                  "span" : {
+                                    "startLine" : 136,
+                                    "startCol" : 40,
+                                    "endLine" : 136,
+                                    "endCol" : 69
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 136,
+                                  "startCol" : 16,
+                                  "endLine" : 136,
+                                  "endCol" : 69
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 135,
+                                "startCol" : 15,
+                                "endLine" : 136,
+                                "endCol" : 69
+                              }
+                            },
                             "span" : {
-                              "startLine" : 114,
-                              "startCol" : 8,
-                              "endLine" : 114,
-                              "endCol" : 15
+                              "startLine" : 129,
+                              "startCol" : 10,
+                              "endLine" : 136,
+                              "endCol" : 70
                             }
                           },
-                          "field" : "user_id",
+                          "right" : {
+                            "kind" : "Quantifier",
+                            "quantifier" : "all",
+                            "bindings" : [
+                              {
+                                "variable" : "s",
+                                "domain" : {
+                                  "kind" : "Pre",
+                                  "expr" : {
+                                    "kind" : "Identifier",
+                                    "name" : "sessions",
+                                    "span" : {
+                                      "startLine" : 137,
+                                      "startCol" : 28,
+                                      "endLine" : 137,
+                                      "endCol" : 36
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 137,
+                                    "startCol" : 24,
+                                    "endLine" : 137,
+                                    "endCol" : 37
+                                  }
+                                },
+                                "bindingKind" : "in",
+                                "span" : {
+                                  "startLine" : 137,
+                                  "startCol" : 19,
+                                  "endLine" : 137,
+                                  "endCol" : 37
+                                }
+                              }
+                            ],
+                            "body" : {
+                              "kind" : "BinaryOp",
+                              "op" : "!=",
+                              "left" : {
+                                "kind" : "FieldAccess",
+                                "base" : {
+                                  "kind" : "Identifier",
+                                  "name" : "session",
+                                  "span" : {
+                                    "startLine" : 138,
+                                    "startCol" : 16,
+                                    "endLine" : 138,
+                                    "endCol" : 23
+                                  }
+                                },
+                                "field" : "refresh_token",
+                                "span" : {
+                                  "startLine" : 138,
+                                  "startCol" : 16,
+                                  "endLine" : 138,
+                                  "endCol" : 37
+                                }
+                              },
+                              "right" : {
+                                "kind" : "FieldAccess",
+                                "base" : {
+                                  "kind" : "Index",
+                                  "base" : {
+                                    "kind" : "Pre",
+                                    "expr" : {
+                                      "kind" : "Identifier",
+                                      "name" : "sessions",
+                                      "span" : {
+                                        "startLine" : 138,
+                                        "startCol" : 45,
+                                        "endLine" : 138,
+                                        "endCol" : 53
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 138,
+                                      "startCol" : 41,
+                                      "endLine" : 138,
+                                      "endCol" : 54
+                                    }
+                                  },
+                                  "index" : {
+                                    "kind" : "Identifier",
+                                    "name" : "s",
+                                    "span" : {
+                                      "startLine" : 138,
+                                      "startCol" : 55,
+                                      "endLine" : 138,
+                                      "endCol" : 56
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 138,
+                                    "startCol" : 41,
+                                    "endLine" : 138,
+                                    "endCol" : 57
+                                  }
+                                },
+                                "field" : "refresh_token",
+                                "span" : {
+                                  "startLine" : 138,
+                                  "startCol" : 41,
+                                  "endLine" : 138,
+                                  "endCol" : 71
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 138,
+                                "startCol" : 16,
+                                "endLine" : 138,
+                                "endCol" : 71
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 137,
+                              "startCol" : 15,
+                              "endLine" : 138,
+                              "endCol" : 71
+                            }
+                          },
                           "span" : {
-                            "startLine" : 114,
-                            "startCol" : 8,
-                            "endLine" : 114,
-                            "endCol" : 23
+                            "startLine" : 129,
+                            "startCol" : 10,
+                            "endLine" : 138,
+                            "endCol" : 72
                           }
                         },
                         "right" : {
-                          "kind" : "FieldAccess",
-                          "base" : {
-                            "kind" : "Identifier",
-                            "name" : "user",
+                          "kind" : "BinaryOp",
+                          "op" : "=",
+                          "left" : {
+                            "kind" : "Prime",
+                            "expr" : {
+                              "kind" : "Identifier",
+                              "name" : "next_session_id",
+                              "span" : {
+                                "startLine" : 139,
+                                "startCol" : 14,
+                                "endLine" : 139,
+                                "endCol" : 29
+                              }
+                            },
                             "span" : {
-                              "startLine" : 114,
-                              "startCol" : 26,
-                              "endLine" : 114,
+                              "startLine" : 139,
+                              "startCol" : 14,
+                              "endLine" : 139,
                               "endCol" : 30
                             }
                           },
-                          "field" : "id",
+                          "right" : {
+                            "kind" : "BinaryOp",
+                            "op" : "+",
+                            "left" : {
+                              "kind" : "Pre",
+                              "expr" : {
+                                "kind" : "Identifier",
+                                "name" : "next_session_id",
+                                "span" : {
+                                  "startLine" : 139,
+                                  "startCol" : 37,
+                                  "endLine" : 139,
+                                  "endCol" : 52
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 139,
+                                "startCol" : 33,
+                                "endLine" : 139,
+                                "endCol" : 53
+                              }
+                            },
+                            "right" : {
+                              "kind" : "IntLit",
+                              "value" : 1,
+                              "span" : {
+                                "startLine" : 139,
+                                "startCol" : 56,
+                                "endLine" : 139,
+                                "endCol" : 57
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 139,
+                              "startCol" : 33,
+                              "endLine" : 139,
+                              "endCol" : 57
+                            }
+                          },
                           "span" : {
-                            "startLine" : 114,
-                            "startCol" : 26,
-                            "endLine" : 114,
-                            "endCol" : 33
+                            "startLine" : 139,
+                            "startCol" : 14,
+                            "endLine" : 139,
+                            "endCol" : 57
                           }
                         },
                         "span" : {
-                          "startLine" : 114,
-                          "startCol" : 8,
-                          "endLine" : 114,
-                          "endCol" : 33
+                          "startLine" : 129,
+                          "startCol" : 10,
+                          "endLine" : 139,
+                          "endCol" : 57
                         }
                       },
                       "right" : {
                         "kind" : "BinaryOp",
                         "op" : "=",
                         "left" : {
-                          "kind" : "FieldAccess",
-                          "base" : {
+                          "kind" : "Prime",
+                          "expr" : {
                             "kind" : "Identifier",
-                            "name" : "session",
+                            "name" : "sessions",
                             "span" : {
-                              "startLine" : 115,
-                              "startCol" : 12,
-                              "endLine" : 115,
-                              "endCol" : 19
+                              "startLine" : 140,
+                              "startCol" : 14,
+                              "endLine" : 140,
+                              "endCol" : 22
                             }
                           },
-                          "field" : "is_revoked",
                           "span" : {
-                            "startLine" : 115,
-                            "startCol" : 12,
-                            "endLine" : 115,
-                            "endCol" : 30
+                            "startLine" : 140,
+                            "startCol" : 14,
+                            "endLine" : 140,
+                            "endCol" : 23
                           }
                         },
                         "right" : {
-                          "kind" : "BoolLit",
-                          "value" : false,
+                          "kind" : "BinaryOp",
+                          "op" : "+",
+                          "left" : {
+                            "kind" : "Pre",
+                            "expr" : {
+                              "kind" : "Identifier",
+                              "name" : "sessions",
+                              "span" : {
+                                "startLine" : 140,
+                                "startCol" : 30,
+                                "endLine" : 140,
+                                "endCol" : 38
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 140,
+                              "startCol" : 26,
+                              "endLine" : 140,
+                              "endCol" : 39
+                            }
+                          },
+                          "right" : {
+                            "kind" : "MapLiteral",
+                            "entries" : [
+                              {
+                                "key" : {
+                                  "kind" : "FieldAccess",
+                                  "base" : {
+                                    "kind" : "Identifier",
+                                    "name" : "session",
+                                    "span" : {
+                                      "startLine" : 140,
+                                      "startCol" : 43,
+                                      "endLine" : 140,
+                                      "endCol" : 50
+                                    }
+                                  },
+                                  "field" : "id",
+                                  "span" : {
+                                    "startLine" : 140,
+                                    "startCol" : 43,
+                                    "endLine" : 140,
+                                    "endCol" : 53
+                                  }
+                                },
+                                "value" : {
+                                  "kind" : "Identifier",
+                                  "name" : "session",
+                                  "span" : {
+                                    "startLine" : 140,
+                                    "startCol" : 57,
+                                    "endLine" : 140,
+                                    "endCol" : 64
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 140,
+                                  "startCol" : 43,
+                                  "endLine" : 140,
+                                  "endCol" : 53
+                                }
+                              }
+                            ],
+                            "span" : {
+                              "startLine" : 140,
+                              "startCol" : 42,
+                              "endLine" : 140,
+                              "endCol" : 65
+                            }
+                          },
                           "span" : {
-                            "startLine" : 115,
-                            "startCol" : 33,
-                            "endLine" : 115,
-                            "endCol" : 38
+                            "startLine" : 140,
+                            "startCol" : 26,
+                            "endLine" : 140,
+                            "endCol" : 65
                           }
                         },
                         "span" : {
-                          "startLine" : 115,
-                          "startCol" : 12,
-                          "endLine" : 115,
-                          "endCol" : 38
+                          "startLine" : 140,
+                          "startCol" : 14,
+                          "endLine" : 140,
+                          "endCol" : 65
                         }
                       },
                       "span" : {
-                        "startLine" : 114,
-                        "startCol" : 8,
-                        "endLine" : 115,
-                        "endCol" : 38
+                        "startLine" : 129,
+                        "startCol" : 10,
+                        "endLine" : 140,
+                        "endCol" : 65
                       }
                     },
                     "right" : {
                       "kind" : "BinaryOp",
-                      "op" : ">",
+                      "op" : "=",
                       "left" : {
-                        "kind" : "FieldAccess",
-                        "base" : {
+                        "kind" : "Prime",
+                        "expr" : {
                           "kind" : "Identifier",
-                          "name" : "session",
+                          "name" : "users",
                           "span" : {
-                            "startLine" : 116,
-                            "startCol" : 12,
-                            "endLine" : 116,
+                            "startLine" : 141,
+                            "startCol" : 14,
+                            "endLine" : 141,
                             "endCol" : 19
                           }
                         },
-                        "field" : "access_expires_at",
                         "span" : {
-                          "startLine" : 116,
-                          "startCol" : 12,
-                          "endLine" : 116,
-                          "endCol" : 37
+                          "startLine" : 141,
+                          "startCol" : 14,
+                          "endLine" : 141,
+                          "endCol" : 20
                         }
                       },
                       "right" : {
-                        "kind" : "Call",
-                        "callee" : {
-                          "kind" : "Identifier",
-                          "name" : "now",
+                        "kind" : "BinaryOp",
+                        "op" : "+",
+                        "left" : {
+                          "kind" : "Pre",
+                          "expr" : {
+                            "kind" : "Identifier",
+                            "name" : "users",
+                            "span" : {
+                              "startLine" : 141,
+                              "startCol" : 27,
+                              "endLine" : 141,
+                              "endCol" : 32
+                            }
+                          },
                           "span" : {
-                            "startLine" : 116,
-                            "startCol" : 40,
-                            "endLine" : 116,
-                            "endCol" : 43
+                            "startLine" : 141,
+                            "startCol" : 23,
+                            "endLine" : 141,
+                            "endCol" : 33
                           }
                         },
-                        "args" : [
-                        ],
+                        "right" : {
+                          "kind" : "MapLiteral",
+                          "entries" : [
+                            {
+                              "key" : {
+                                "kind" : "FieldAccess",
+                                "base" : {
+                                  "kind" : "Identifier",
+                                  "name" : "user",
+                                  "span" : {
+                                    "startLine" : 141,
+                                    "startCol" : 37,
+                                    "endLine" : 141,
+                                    "endCol" : 41
+                                  }
+                                },
+                                "field" : "id",
+                                "span" : {
+                                  "startLine" : 141,
+                                  "startCol" : 37,
+                                  "endLine" : 141,
+                                  "endCol" : 44
+                                }
+                              },
+                              "value" : {
+                                "kind" : "Identifier",
+                                "name" : "updated",
+                                "span" : {
+                                  "startLine" : 141,
+                                  "startCol" : 48,
+                                  "endLine" : 141,
+                                  "endCol" : 55
+                                }
+                              },
+                              "span" : {
+                                "startLine" : 141,
+                                "startCol" : 37,
+                                "endLine" : 141,
+                                "endCol" : 44
+                              }
+                            }
+                          ],
+                          "span" : {
+                            "startLine" : 141,
+                            "startCol" : 36,
+                            "endLine" : 141,
+                            "endCol" : 56
+                          }
+                        },
                         "span" : {
-                          "startLine" : 116,
-                          "startCol" : 40,
-                          "endLine" : 116,
-                          "endCol" : 45
+                          "startLine" : 141,
+                          "startCol" : 23,
+                          "endLine" : 141,
+                          "endCol" : 56
                         }
                       },
                       "span" : {
-                        "startLine" : 116,
-                        "startCol" : 12,
-                        "endLine" : 116,
-                        "endCol" : 45
+                        "startLine" : 141,
+                        "startCol" : 14,
+                        "endLine" : 141,
+                        "endCol" : 56
                       }
                     },
                     "span" : {
-                      "startLine" : 114,
-                      "startCol" : 8,
-                      "endLine" : 116,
-                      "endCol" : 45
+                      "startLine" : 129,
+                      "startCol" : 10,
+                      "endLine" : 141,
+                      "endCol" : 56
                     }
                   },
                   "right" : {
                     "kind" : "BinaryOp",
-                    "op" : ">",
+                    "op" : "=",
                     "left" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
+                      "kind" : "Prime",
+                      "expr" : {
                         "kind" : "Identifier",
-                        "name" : "session",
+                        "name" : "user_by_email",
                         "span" : {
-                          "startLine" : 117,
-                          "startCol" : 12,
-                          "endLine" : 117,
-                          "endCol" : 19
+                          "startLine" : 142,
+                          "startCol" : 14,
+                          "endLine" : 142,
+                          "endCol" : 27
                         }
                       },
-                      "field" : "refresh_expires_at",
                       "span" : {
-                        "startLine" : 117,
-                        "startCol" : 12,
-                        "endLine" : 117,
-                        "endCol" : 38
+                        "startLine" : 142,
+                        "startCol" : 14,
+                        "endLine" : 142,
+                        "endCol" : 28
                       }
                     },
                     "right" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Identifier",
-                        "name" : "session",
+                      "kind" : "BinaryOp",
+                      "op" : "+",
+                      "left" : {
+                        "kind" : "Pre",
+                        "expr" : {
+                          "kind" : "Identifier",
+                          "name" : "user_by_email",
+                          "span" : {
+                            "startLine" : 142,
+                            "startCol" : 35,
+                            "endLine" : 142,
+                            "endCol" : 48
+                          }
+                        },
                         "span" : {
-                          "startLine" : 117,
-                          "startCol" : 41,
-                          "endLine" : 117,
-                          "endCol" : 48
+                          "startLine" : 142,
+                          "startCol" : 31,
+                          "endLine" : 142,
+                          "endCol" : 49
                         }
                       },
-                      "field" : "access_expires_at",
+                      "right" : {
+                        "kind" : "MapLiteral",
+                        "entries" : [
+                          {
+                            "key" : {
+                              "kind" : "Identifier",
+                              "name" : "email",
+                              "span" : {
+                                "startLine" : 142,
+                                "startCol" : 53,
+                                "endLine" : 142,
+                                "endCol" : 58
+                              }
+                            },
+                            "value" : {
+                              "kind" : "Identifier",
+                              "name" : "updated",
+                              "span" : {
+                                "startLine" : 142,
+                                "startCol" : 62,
+                                "endLine" : 142,
+                                "endCol" : 69
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 142,
+                              "startCol" : 53,
+                              "endLine" : 142,
+                              "endCol" : 58
+                            }
+                          }
+                        ],
+                        "span" : {
+                          "startLine" : 142,
+                          "startCol" : 52,
+                          "endLine" : 142,
+                          "endCol" : 70
+                        }
+                      },
                       "span" : {
-                        "startLine" : 117,
-                        "startCol" : 41,
-                        "endLine" : 117,
-                        "endCol" : 66
+                        "startLine" : 142,
+                        "startCol" : 31,
+                        "endLine" : 142,
+                        "endCol" : 70
                       }
                     },
                     "span" : {
-                      "startLine" : 117,
-                      "startCol" : 12,
-                      "endLine" : 117,
-                      "endCol" : 66
+                      "startLine" : 142,
+                      "startCol" : 14,
+                      "endLine" : 142,
+                      "endCol" : 70
                     }
                   },
                   "span" : {
-                    "startLine" : 114,
+                    "startLine" : 129,
+                    "startCol" : 10,
+                    "endLine" : 142,
+                    "endCol" : 70
+                  }
+                },
+                "right" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "Prime",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "failed_logins",
+                      "span" : {
+                        "startLine" : 144,
+                        "startCol" : 14,
+                        "endLine" : 144,
+                        "endCol" : 27
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 144,
+                      "startCol" : 14,
+                      "endLine" : 144,
+                      "endCol" : 28
+                    }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "-",
+                    "left" : {
+                      "kind" : "Pre",
+                      "expr" : {
+                        "kind" : "Identifier",
+                        "name" : "failed_logins",
+                        "span" : {
+                          "startLine" : 144,
+                          "startCol" : 35,
+                          "endLine" : 144,
+                          "endCol" : 48
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 144,
+                        "startCol" : 31,
+                        "endLine" : 144,
+                        "endCol" : 49
+                      }
+                    },
+                    "right" : {
+                      "kind" : "SetLiteral",
+                      "elements" : [
+                        {
+                          "kind" : "Identifier",
+                          "name" : "email",
+                          "span" : {
+                            "startLine" : 144,
+                            "startCol" : 53,
+                            "endLine" : 144,
+                            "endCol" : 58
+                          }
+                        }
+                      ],
+                      "span" : {
+                        "startLine" : 144,
+                        "startCol" : 52,
+                        "endLine" : 144,
+                        "endCol" : 59
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 144,
+                      "startCol" : 31,
+                      "endLine" : 144,
+                      "endCol" : 59
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 144,
+                    "startCol" : 14,
+                    "endLine" : 144,
+                    "endCol" : 59
+                  }
+                },
+                "span" : {
+                  "startLine" : 129,
+                  "startCol" : 10,
+                  "endLine" : 144,
+                  "endCol" : 59
+                }
+              },
+              "right" : {
+                "kind" : "BinaryOp",
+                "op" : "=",
+                "left" : {
+                  "kind" : "Prime",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "login_attempts",
+                    "span" : {
+                      "startLine" : 145,
+                      "startCol" : 14,
+                      "endLine" : 145,
+                      "endCol" : 28
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 145,
+                    "startCol" : 14,
+                    "endLine" : 145,
+                    "endCol" : 29
+                  }
+                },
+                "right" : {
+                  "kind" : "BinaryOp",
+                  "op" : "+",
+                  "left" : {
+                    "kind" : "Pre",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "login_attempts",
+                      "span" : {
+                        "startLine" : 145,
+                        "startCol" : 36,
+                        "endLine" : 145,
+                        "endCol" : 50
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 145,
+                      "startCol" : 32,
+                      "endLine" : 145,
+                      "endCol" : 51
+                    }
+                  },
+                  "right" : {
+                    "kind" : "SeqLiteral",
+                    "elements" : [
+                      {
+                        "kind" : "Constructor",
+                        "typeName" : "LoginAttempt",
+                        "fields" : [
+                          {
+                            "name" : "email",
+                            "value" : {
+                              "kind" : "Identifier",
+                              "name" : "email",
+                              "span" : {
+                                "startLine" : 146,
+                                "startCol" : 41,
+                                "endLine" : 146,
+                                "endCol" : 46
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 146,
+                              "startCol" : 33,
+                              "endLine" : 146,
+                              "endCol" : 46
+                            }
+                          },
+                          {
+                            "name" : "timestamp",
+                            "value" : {
+                              "kind" : "Call",
+                              "callee" : {
+                                "kind" : "Identifier",
+                                "name" : "now",
+                                "span" : {
+                                  "startLine" : 147,
+                                  "startCol" : 45,
+                                  "endLine" : 147,
+                                  "endCol" : 48
+                                }
+                              },
+                              "args" : [
+                              ],
+                              "span" : {
+                                "startLine" : 147,
+                                "startCol" : 45,
+                                "endLine" : 147,
+                                "endCol" : 50
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 147,
+                              "startCol" : 33,
+                              "endLine" : 147,
+                              "endCol" : 50
+                            }
+                          },
+                          {
+                            "name" : "success",
+                            "value" : {
+                              "kind" : "BoolLit",
+                              "value" : true,
+                              "span" : {
+                                "startLine" : 148,
+                                "startCol" : 43,
+                                "endLine" : 148,
+                                "endCol" : 47
+                              }
+                            },
+                            "span" : {
+                              "startLine" : 148,
+                              "startCol" : 33,
+                              "endLine" : 148,
+                              "endCol" : 47
+                            }
+                          }
+                        ],
+                        "span" : {
+                          "startLine" : 146,
+                          "startCol" : 18,
+                          "endLine" : 148,
+                          "endCol" : 49
+                        }
+                      }
+                    ],
+                    "span" : {
+                      "startLine" : 146,
+                      "startCol" : 17,
+                      "endLine" : 148,
+                      "endCol" : 50
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 145,
+                    "startCol" : 32,
+                    "endLine" : 148,
+                    "endCol" : 50
+                  }
+                },
+                "span" : {
+                  "startLine" : 145,
+                  "startCol" : 14,
+                  "endLine" : 148,
+                  "endCol" : 50
+                }
+              },
+              "span" : {
+                "startLine" : 129,
+                "startCol" : 10,
+                "endLine" : 148,
+                "endCol" : 50
+              }
+            },
+            "span" : {
+              "startLine" : 128,
+              "startCol" : 8,
+              "endLine" : 148,
+              "endCol" : 50
+            }
+          },
+          "span" : {
+            "startLine" : 125,
+            "startCol" : 6,
+            "endLine" : 148,
+            "endCol" : 50
+          }
+        }
+      ],
+      "span" : {
+        "startLine" : 109,
+        "startCol" : 2,
+        "endLine" : 149,
+        "endCol" : 3
+      }
+    },
+    {
+      "kind" : "Operation",
+      "name" : "LoginFailed",
+      "inputs" : [
+        {
+          "kind" : "Param",
+          "name" : "email",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "Email",
+            "span" : {
+              "startLine" : 152,
+              "startCol" : 18,
+              "endLine" : 152,
+              "endCol" : 23
+            }
+          },
+          "span" : {
+            "startLine" : 152,
+            "startCol" : 11,
+            "endLine" : 152,
+            "endCol" : 23
+          }
+        },
+        {
+          "kind" : "Param",
+          "name" : "password",
+          "typeExpr" : {
+            "kind" : "NamedType",
+            "name" : "String",
+            "span" : {
+              "startLine" : 152,
+              "startCol" : 35,
+              "endLine" : 152,
+              "endCol" : 41
+            }
+          },
+          "span" : {
+            "startLine" : 152,
+            "startCol" : 25,
+            "endLine" : 152,
+            "endCol" : 41
+          }
+        }
+      ],
+      "outputs" : [
+      ],
+      "requires" : [
+        {
+          "kind" : "BinaryOp",
+          "op" : "in",
+          "left" : {
+            "kind" : "Identifier",
+            "name" : "email",
+            "span" : {
+              "startLine" : 155,
+              "startCol" : 6,
+              "endLine" : 155,
+              "endCol" : 11
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "user_by_email",
+            "span" : {
+              "startLine" : 155,
+              "startCol" : 15,
+              "endLine" : 155,
+              "endCol" : 28
+            }
+          },
+          "span" : {
+            "startLine" : 155,
+            "startCol" : 6,
+            "endLine" : 155,
+            "endCol" : 28
+          }
+        },
+        {
+          "kind" : "BinaryOp",
+          "op" : "!=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Index",
+              "base" : {
+                "kind" : "Identifier",
+                "name" : "user_by_email",
+                "span" : {
+                  "startLine" : 156,
+                  "startCol" : 6,
+                  "endLine" : 156,
+                  "endCol" : 19
+                }
+              },
+              "index" : {
+                "kind" : "Identifier",
+                "name" : "email",
+                "span" : {
+                  "startLine" : 156,
+                  "startCol" : 20,
+                  "endLine" : 156,
+                  "endCol" : 25
+                }
+              },
+              "span" : {
+                "startLine" : 156,
+                "startCol" : 6,
+                "endLine" : 156,
+                "endCol" : 26
+              }
+            },
+            "field" : "password_hash",
+            "span" : {
+              "startLine" : 156,
+              "startCol" : 6,
+              "endLine" : 156,
+              "endCol" : 40
+            }
+          },
+          "right" : {
+            "kind" : "Call",
+            "callee" : {
+              "kind" : "Identifier",
+              "name" : "hash",
+              "span" : {
+                "startLine" : 156,
+                "startCol" : 44,
+                "endLine" : 156,
+                "endCol" : 48
+              }
+            },
+            "args" : [
+              {
+                "kind" : "Identifier",
+                "name" : "password",
+                "span" : {
+                  "startLine" : 156,
+                  "startCol" : 49,
+                  "endLine" : 156,
+                  "endCol" : 57
+                }
+              }
+            ],
+            "span" : {
+              "startLine" : 156,
+              "startCol" : 44,
+              "endLine" : 156,
+              "endCol" : 58
+            }
+          },
+          "span" : {
+            "startLine" : 156,
+            "startCol" : 6,
+            "endLine" : 156,
+            "endCol" : 58
+          }
+        }
+      ],
+      "ensures" : [
+        {
+          "kind" : "Let",
+          "variable" : "active",
+          "value" : {
+            "kind" : "BinaryOp",
+            "op" : "and",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "in",
+              "left" : {
+                "kind" : "Identifier",
+                "name" : "email",
+                "span" : {
+                  "startLine" : 163,
+                  "startCol" : 19,
+                  "endLine" : 163,
+                  "endCol" : 24
+                }
+              },
+              "right" : {
+                "kind" : "Pre",
+                "expr" : {
+                  "kind" : "Identifier",
+                  "name" : "failed_logins",
+                  "span" : {
+                    "startLine" : 163,
+                    "startCol" : 32,
+                    "endLine" : 163,
+                    "endCol" : 45
+                  }
+                },
+                "span" : {
+                  "startLine" : 163,
+                  "startCol" : 28,
+                  "endLine" : 163,
+                  "endCol" : 46
+                }
+              },
+              "span" : {
+                "startLine" : 163,
+                "startCol" : 19,
+                "endLine" : 163,
+                "endCol" : 46
+              }
+            },
+            "right" : {
+              "kind" : "BinaryOp",
+              "op" : "<=",
+              "left" : {
+                "kind" : "BinaryOp",
+                "op" : "-",
+                "left" : {
+                  "kind" : "Call",
+                  "callee" : {
+                    "kind" : "Identifier",
+                    "name" : "now",
+                    "span" : {
+                      "startLine" : 164,
+                      "startCol" : 12,
+                      "endLine" : 164,
+                      "endCol" : 15
+                    }
+                  },
+                  "args" : [
+                  ],
+                  "span" : {
+                    "startLine" : 164,
+                    "startCol" : 12,
+                    "endLine" : 164,
+                    "endCol" : 17
+                  }
+                },
+                "right" : {
+                  "kind" : "FieldAccess",
+                  "base" : {
+                    "kind" : "Index",
+                    "base" : {
+                      "kind" : "Pre",
+                      "expr" : {
+                        "kind" : "Identifier",
+                        "name" : "failed_logins",
+                        "span" : {
+                          "startLine" : 164,
+                          "startCol" : 24,
+                          "endLine" : 164,
+                          "endCol" : 37
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 164,
+                        "startCol" : 20,
+                        "endLine" : 164,
+                        "endCol" : 38
+                      }
+                    },
+                    "index" : {
+                      "kind" : "Identifier",
+                      "name" : "email",
+                      "span" : {
+                        "startLine" : 164,
+                        "startCol" : 39,
+                        "endLine" : 164,
+                        "endCol" : 44
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 164,
+                      "startCol" : 20,
+                      "endLine" : 164,
+                      "endCol" : 45
+                    }
+                  },
+                  "field" : "window_start",
+                  "span" : {
+                    "startLine" : 164,
+                    "startCol" : 20,
+                    "endLine" : 164,
+                    "endCol" : 58
+                  }
+                },
+                "span" : {
+                  "startLine" : 164,
+                  "startCol" : 12,
+                  "endLine" : 164,
+                  "endCol" : 58
+                }
+              },
+              "right" : {
+                "kind" : "Call",
+                "callee" : {
+                  "kind" : "Identifier",
+                  "name" : "minutes",
+                  "span" : {
+                    "startLine" : 164,
+                    "startCol" : 62,
+                    "endLine" : 164,
+                    "endCol" : 69
+                  }
+                },
+                "args" : [
+                  {
+                    "kind" : "IntLit",
+                    "value" : 15,
+                    "span" : {
+                      "startLine" : 164,
+                      "startCol" : 70,
+                      "endLine" : 164,
+                      "endCol" : 72
+                    }
+                  }
+                ],
+                "span" : {
+                  "startLine" : 164,
+                  "startCol" : 62,
+                  "endLine" : 164,
+                  "endCol" : 73
+                }
+              },
+              "span" : {
+                "startLine" : 164,
+                "startCol" : 12,
+                "endLine" : 164,
+                "endCol" : 73
+              }
+            },
+            "span" : {
+              "startLine" : 163,
+              "startCol" : 19,
+              "endLine" : 164,
+              "endCol" : 73
+            }
+          },
+          "body" : {
+            "kind" : "BinaryOp",
+            "op" : "and",
+            "left" : {
+              "kind" : "BinaryOp",
+              "op" : "and",
+              "left" : {
+                "kind" : "BinaryOp",
+                "op" : "and",
+                "left" : {
+                  "kind" : "BinaryOp",
+                  "op" : "=",
+                  "left" : {
+                    "kind" : "Prime",
+                    "expr" : {
+                      "kind" : "Identifier",
+                      "name" : "failed_logins",
+                      "span" : {
+                        "startLine" : 165,
+                        "startCol" : 8,
+                        "endLine" : 165,
+                        "endCol" : 21
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 165,
+                      "startCol" : 8,
+                      "endLine" : 165,
+                      "endCol" : 22
+                    }
+                  },
+                  "right" : {
+                    "kind" : "BinaryOp",
+                    "op" : "+",
+                    "left" : {
+                      "kind" : "Pre",
+                      "expr" : {
+                        "kind" : "Identifier",
+                        "name" : "failed_logins",
+                        "span" : {
+                          "startLine" : 165,
+                          "startCol" : 29,
+                          "endLine" : 165,
+                          "endCol" : 42
+                        }
+                      },
+                      "span" : {
+                        "startLine" : 165,
+                        "startCol" : 25,
+                        "endLine" : 165,
+                        "endCol" : 43
+                      }
+                    },
+                    "right" : {
+                      "kind" : "MapLiteral",
+                      "entries" : [
+                        {
+                          "key" : {
+                            "kind" : "Identifier",
+                            "name" : "email",
+                            "span" : {
+                              "startLine" : 165,
+                              "startCol" : 47,
+                              "endLine" : 165,
+                              "endCol" : 52
+                            }
+                          },
+                          "value" : {
+                            "kind" : "Constructor",
+                            "typeName" : "FailedLogin",
+                            "fields" : [
+                              {
+                                "name" : "email",
+                                "value" : {
+                                  "kind" : "Identifier",
+                                  "name" : "email",
+                                  "span" : {
+                                    "startLine" : 166,
+                                    "startCol" : 18,
+                                    "endLine" : 166,
+                                    "endCol" : 23
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 166,
+                                  "startCol" : 10,
+                                  "endLine" : 166,
+                                  "endCol" : 23
+                                }
+                              },
+                              {
+                                "name" : "count",
+                                "value" : {
+                                  "kind" : "BinaryOp",
+                                  "op" : "+",
+                                  "left" : {
+                                    "kind" : "If",
+                                    "condition" : {
+                                      "kind" : "Identifier",
+                                      "name" : "active",
+                                      "span" : {
+                                        "startLine" : 167,
+                                        "startCol" : 22,
+                                        "endLine" : 167,
+                                        "endCol" : 28
+                                      }
+                                    },
+                                    "then" : {
+                                      "kind" : "FieldAccess",
+                                      "base" : {
+                                        "kind" : "Index",
+                                        "base" : {
+                                          "kind" : "Pre",
+                                          "expr" : {
+                                            "kind" : "Identifier",
+                                            "name" : "failed_logins",
+                                            "span" : {
+                                              "startLine" : 167,
+                                              "startCol" : 38,
+                                              "endLine" : 167,
+                                              "endCol" : 51
+                                            }
+                                          },
+                                          "span" : {
+                                            "startLine" : 167,
+                                            "startCol" : 34,
+                                            "endLine" : 167,
+                                            "endCol" : 52
+                                          }
+                                        },
+                                        "index" : {
+                                          "kind" : "Identifier",
+                                          "name" : "email",
+                                          "span" : {
+                                            "startLine" : 167,
+                                            "startCol" : 53,
+                                            "endLine" : 167,
+                                            "endCol" : 58
+                                          }
+                                        },
+                                        "span" : {
+                                          "startLine" : 167,
+                                          "startCol" : 34,
+                                          "endLine" : 167,
+                                          "endCol" : 59
+                                        }
+                                      },
+                                      "field" : "count",
+                                      "span" : {
+                                        "startLine" : 167,
+                                        "startCol" : 34,
+                                        "endLine" : 167,
+                                        "endCol" : 65
+                                      }
+                                    },
+                                    "else_" : {
+                                      "kind" : "IntLit",
+                                      "value" : 0,
+                                      "span" : {
+                                        "startLine" : 167,
+                                        "startCol" : 71,
+                                        "endLine" : 167,
+                                        "endCol" : 72
+                                      }
+                                    },
+                                    "span" : {
+                                      "startLine" : 167,
+                                      "startCol" : 19,
+                                      "endLine" : 167,
+                                      "endCol" : 72
+                                    }
+                                  },
+                                  "right" : {
+                                    "kind" : "IntLit",
+                                    "value" : 1,
+                                    "span" : {
+                                      "startLine" : 167,
+                                      "startCol" : 76,
+                                      "endLine" : 167,
+                                      "endCol" : 77
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 167,
+                                    "startCol" : 18,
+                                    "endLine" : 167,
+                                    "endCol" : 77
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 167,
+                                  "startCol" : 10,
+                                  "endLine" : 167,
+                                  "endCol" : 77
+                                }
+                              },
+                              {
+                                "name" : "window_start",
+                                "value" : {
+                                  "kind" : "If",
+                                  "condition" : {
+                                    "kind" : "Identifier",
+                                    "name" : "active",
+                                    "span" : {
+                                      "startLine" : 168,
+                                      "startCol" : 28,
+                                      "endLine" : 168,
+                                      "endCol" : 34
+                                    }
+                                  },
+                                  "then" : {
+                                    "kind" : "FieldAccess",
+                                    "base" : {
+                                      "kind" : "Index",
+                                      "base" : {
+                                        "kind" : "Pre",
+                                        "expr" : {
+                                          "kind" : "Identifier",
+                                          "name" : "failed_logins",
+                                          "span" : {
+                                            "startLine" : 168,
+                                            "startCol" : 44,
+                                            "endLine" : 168,
+                                            "endCol" : 57
+                                          }
+                                        },
+                                        "span" : {
+                                          "startLine" : 168,
+                                          "startCol" : 40,
+                                          "endLine" : 168,
+                                          "endCol" : 58
+                                        }
+                                      },
+                                      "index" : {
+                                        "kind" : "Identifier",
+                                        "name" : "email",
+                                        "span" : {
+                                          "startLine" : 168,
+                                          "startCol" : 59,
+                                          "endLine" : 168,
+                                          "endCol" : 64
+                                        }
+                                      },
+                                      "span" : {
+                                        "startLine" : 168,
+                                        "startCol" : 40,
+                                        "endLine" : 168,
+                                        "endCol" : 65
+                                      }
+                                    },
+                                    "field" : "window_start",
+                                    "span" : {
+                                      "startLine" : 168,
+                                      "startCol" : 40,
+                                      "endLine" : 168,
+                                      "endCol" : 78
+                                    }
+                                  },
+                                  "else_" : {
+                                    "kind" : "Call",
+                                    "callee" : {
+                                      "kind" : "Identifier",
+                                      "name" : "now",
+                                      "span" : {
+                                        "startLine" : 169,
+                                        "startCol" : 30,
+                                        "endLine" : 169,
+                                        "endCol" : 33
+                                      }
+                                    },
+                                    "args" : [
+                                    ],
+                                    "span" : {
+                                      "startLine" : 169,
+                                      "startCol" : 30,
+                                      "endLine" : 169,
+                                      "endCol" : 35
+                                    }
+                                  },
+                                  "span" : {
+                                    "startLine" : 168,
+                                    "startCol" : 25,
+                                    "endLine" : 169,
+                                    "endCol" : 35
+                                  }
+                                },
+                                "span" : {
+                                  "startLine" : 168,
+                                  "startCol" : 10,
+                                  "endLine" : 169,
+                                  "endCol" : 35
+                                }
+                              }
+                            ],
+                            "span" : {
+                              "startLine" : 165,
+                              "startCol" : 56,
+                              "endLine" : 170,
+                              "endCol" : 9
+                            }
+                          },
+                          "span" : {
+                            "startLine" : 165,
+                            "startCol" : 47,
+                            "endLine" : 165,
+                            "endCol" : 52
+                          }
+                        }
+                      ],
+                      "span" : {
+                        "startLine" : 165,
+                        "startCol" : 46,
+                        "endLine" : 170,
+                        "endCol" : 10
+                      }
+                    },
+                    "span" : {
+                      "startLine" : 165,
+                      "startCol" : 25,
+                      "endLine" : 170,
+                      "endCol" : 10
+                    }
+                  },
+                  "span" : {
+                    "startLine" : 165,
                     "startCol" : 8,
-                    "endLine" : 117,
-                    "endCol" : 66
+                    "endLine" : 170,
+                    "endCol" : 10
                   }
                 },
                 "right" : {
@@ -2687,214 +4725,87 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 118,
+                        "startLine" : 171,
                         "startCol" : 12,
-                        "endLine" : 118,
+                        "endLine" : 171,
                         "endCol" : 20
                       }
                     },
                     "span" : {
-                      "startLine" : 118,
+                      "startLine" : 171,
                       "startCol" : 12,
-                      "endLine" : 118,
+                      "endLine" : 171,
                       "endCol" : 21
                     }
                   },
                   "right" : {
-                    "kind" : "BinaryOp",
-                    "op" : "+",
-                    "left" : {
-                      "kind" : "Pre",
-                      "expr" : {
-                        "kind" : "Identifier",
-                        "name" : "sessions",
-                        "span" : {
-                          "startLine" : 118,
-                          "startCol" : 28,
-                          "endLine" : 118,
-                          "endCol" : 36
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 118,
-                        "startCol" : 24,
-                        "endLine" : 118,
-                        "endCol" : 37
-                      }
-                    },
-                    "right" : {
-                      "kind" : "MapLiteral",
-                      "entries" : [
-                        {
-                          "key" : {
-                            "kind" : "FieldAccess",
-                            "base" : {
-                              "kind" : "Identifier",
-                              "name" : "session",
-                              "span" : {
-                                "startLine" : 118,
-                                "startCol" : 41,
-                                "endLine" : 118,
-                                "endCol" : 48
-                              }
-                            },
-                            "field" : "id",
-                            "span" : {
-                              "startLine" : 118,
-                              "startCol" : 41,
-                              "endLine" : 118,
-                              "endCol" : 51
-                            }
-                          },
-                          "value" : {
-                            "kind" : "Identifier",
-                            "name" : "session",
-                            "span" : {
-                              "startLine" : 118,
-                              "startCol" : 55,
-                              "endLine" : 118,
-                              "endCol" : 62
-                            }
-                          },
-                          "span" : {
-                            "startLine" : 118,
-                            "startCol" : 41,
-                            "endLine" : 118,
-                            "endCol" : 51
-                          }
-                        }
-                      ],
-                      "span" : {
-                        "startLine" : 118,
-                        "startCol" : 40,
-                        "endLine" : 118,
-                        "endCol" : 63
-                      }
-                    },
+                    "kind" : "Identifier",
+                    "name" : "sessions",
                     "span" : {
-                      "startLine" : 118,
+                      "startLine" : 171,
                       "startCol" : 24,
-                      "endLine" : 118,
-                      "endCol" : 63
+                      "endLine" : 171,
+                      "endCol" : 32
                     }
                   },
                   "span" : {
-                    "startLine" : 118,
+                    "startLine" : 171,
                     "startCol" : 12,
-                    "endLine" : 118,
-                    "endCol" : 63
+                    "endLine" : 171,
+                    "endCol" : 32
                   }
                 },
                 "span" : {
-                  "startLine" : 114,
+                  "startLine" : 165,
                   "startCol" : 8,
-                  "endLine" : 118,
-                  "endCol" : 63
+                  "endLine" : 171,
+                  "endCol" : 32
                 }
               },
               "right" : {
                 "kind" : "BinaryOp",
                 "op" : "=",
                 "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Index",
-                    "base" : {
-                      "kind" : "Prime",
-                      "expr" : {
-                        "kind" : "Identifier",
-                        "name" : "users",
-                        "span" : {
-                          "startLine" : 119,
-                          "startCol" : 12,
-                          "endLine" : 119,
-                          "endCol" : 17
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 119,
-                        "startCol" : 12,
-                        "endLine" : 119,
-                        "endCol" : 18
-                      }
-                    },
-                    "index" : {
-                      "kind" : "FieldAccess",
-                      "base" : {
-                        "kind" : "Identifier",
-                        "name" : "user",
-                        "span" : {
-                          "startLine" : 119,
-                          "startCol" : 19,
-                          "endLine" : 119,
-                          "endCol" : 23
-                        }
-                      },
-                      "field" : "id",
-                      "span" : {
-                        "startLine" : 119,
-                        "startCol" : 19,
-                        "endLine" : 119,
-                        "endCol" : 26
-                      }
-                    },
+                  "kind" : "Prime",
+                  "expr" : {
+                    "kind" : "Identifier",
+                    "name" : "users",
                     "span" : {
-                      "startLine" : 119,
+                      "startLine" : 172,
                       "startCol" : 12,
-                      "endLine" : 119,
-                      "endCol" : 27
+                      "endLine" : 172,
+                      "endCol" : 17
                     }
                   },
-                  "field" : "last_login",
                   "span" : {
-                    "startLine" : 119,
+                    "startLine" : 172,
                     "startCol" : 12,
-                    "endLine" : 119,
-                    "endCol" : 38
+                    "endLine" : 172,
+                    "endCol" : 18
                   }
                 },
                 "right" : {
-                  "kind" : "SomeWrap",
-                  "expr" : {
-                    "kind" : "Call",
-                    "callee" : {
-                      "kind" : "Identifier",
-                      "name" : "now",
-                      "span" : {
-                        "startLine" : 119,
-                        "startCol" : 46,
-                        "endLine" : 119,
-                        "endCol" : 49
-                      }
-                    },
-                    "args" : [
-                    ],
-                    "span" : {
-                      "startLine" : 119,
-                      "startCol" : 46,
-                      "endLine" : 119,
-                      "endCol" : 51
-                    }
-                  },
+                  "kind" : "Identifier",
+                  "name" : "users",
                   "span" : {
-                    "startLine" : 119,
-                    "startCol" : 41,
-                    "endLine" : 119,
-                    "endCol" : 52
+                    "startLine" : 172,
+                    "startCol" : 21,
+                    "endLine" : 172,
+                    "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 119,
+                  "startLine" : 172,
                   "startCol" : 12,
-                  "endLine" : 119,
-                  "endCol" : 52
+                  "endLine" : 172,
+                  "endCol" : 26
                 }
               },
               "span" : {
-                "startLine" : 114,
+                "startLine" : 165,
                 "startCol" : 8,
-                "endLine" : 119,
-                "endCol" : 52
+                "endLine" : 172,
+                "endCol" : 26
               }
             },
             "right" : {
@@ -2906,16 +4817,16 @@
                   "kind" : "Identifier",
                   "name" : "login_attempts",
                   "span" : {
-                    "startLine" : 120,
+                    "startLine" : 173,
                     "startCol" : 12,
-                    "endLine" : 120,
+                    "endLine" : 173,
                     "endCol" : 26
                   }
                 },
                 "span" : {
-                  "startLine" : 120,
+                  "startLine" : 173,
                   "startCol" : 12,
-                  "endLine" : 120,
+                  "endLine" : 173,
                   "endCol" : 27
                 }
               },
@@ -2928,16 +4839,16 @@
                     "kind" : "Identifier",
                     "name" : "login_attempts",
                     "span" : {
-                      "startLine" : 120,
+                      "startLine" : 173,
                       "startCol" : 34,
-                      "endLine" : 120,
+                      "endLine" : 173,
                       "endCol" : 48
                     }
                   },
                   "span" : {
-                    "startLine" : 120,
+                    "startLine" : 173,
                     "startCol" : 30,
-                    "endLine" : 120,
+                    "endLine" : 173,
                     "endCol" : 49
                   }
                 },
@@ -2954,17 +4865,17 @@
                             "kind" : "Identifier",
                             "name" : "email",
                             "span" : {
-                              "startLine" : 121,
-                              "startCol" : 39,
-                              "endLine" : 121,
-                              "endCol" : 44
+                              "startLine" : 174,
+                              "startCol" : 36,
+                              "endLine" : 174,
+                              "endCol" : 41
                             }
                           },
                           "span" : {
-                            "startLine" : 121,
-                            "startCol" : 31,
-                            "endLine" : 121,
-                            "endCol" : 44
+                            "startLine" : 174,
+                            "startCol" : 28,
+                            "endLine" : 174,
+                            "endCol" : 41
                           }
                         },
                         {
@@ -2975,491 +4886,96 @@
                               "kind" : "Identifier",
                               "name" : "now",
                               "span" : {
-                                "startLine" : 122,
-                                "startCol" : 43,
-                                "endLine" : 122,
-                                "endCol" : 46
+                                "startLine" : 175,
+                                "startCol" : 40,
+                                "endLine" : 175,
+                                "endCol" : 43
                               }
                             },
                             "args" : [
                             ],
                             "span" : {
-                              "startLine" : 122,
-                              "startCol" : 43,
-                              "endLine" : 122,
-                              "endCol" : 48
+                              "startLine" : 175,
+                              "startCol" : 40,
+                              "endLine" : 175,
+                              "endCol" : 45
                             }
                           },
                           "span" : {
-                            "startLine" : 122,
-                            "startCol" : 31,
-                            "endLine" : 122,
-                            "endCol" : 48
+                            "startLine" : 175,
+                            "startCol" : 28,
+                            "endLine" : 175,
+                            "endCol" : 45
                           }
                         },
                         {
                           "name" : "success",
                           "value" : {
                             "kind" : "BoolLit",
-                            "value" : true,
+                            "value" : false,
                             "span" : {
-                              "startLine" : 123,
-                              "startCol" : 41,
-                              "endLine" : 123,
-                              "endCol" : 45
+                              "startLine" : 176,
+                              "startCol" : 38,
+                              "endLine" : 176,
+                              "endCol" : 43
                             }
                           },
                           "span" : {
-                            "startLine" : 123,
-                            "startCol" : 31,
-                            "endLine" : 123,
-                            "endCol" : 45
+                            "startLine" : 176,
+                            "startCol" : 28,
+                            "endLine" : 176,
+                            "endCol" : 43
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 121,
-                        "startCol" : 16,
-                        "endLine" : 123,
-                        "endCol" : 47
+                        "startLine" : 174,
+                        "startCol" : 13,
+                        "endLine" : 176,
+                        "endCol" : 45
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 121,
-                    "startCol" : 15,
-                    "endLine" : 123,
-                    "endCol" : 48
+                    "startLine" : 174,
+                    "startCol" : 12,
+                    "endLine" : 176,
+                    "endCol" : 46
                   }
                 },
                 "span" : {
-                  "startLine" : 120,
+                  "startLine" : 173,
                   "startCol" : 30,
-                  "endLine" : 123,
-                  "endCol" : 48
+                  "endLine" : 176,
+                  "endCol" : 46
                 }
               },
               "span" : {
-                "startLine" : 120,
+                "startLine" : 173,
                 "startCol" : 12,
-                "endLine" : 123,
-                "endCol" : 48
+                "endLine" : 176,
+                "endCol" : 46
               }
             },
             "span" : {
-              "startLine" : 114,
+              "startLine" : 165,
               "startCol" : 8,
-              "endLine" : 123,
-              "endCol" : 48
+              "endLine" : 176,
+              "endCol" : 46
             }
           },
           "span" : {
-            "startLine" : 113,
+            "startLine" : 163,
             "startCol" : 6,
-            "endLine" : 123,
-            "endCol" : 48
+            "endLine" : 176,
+            "endCol" : 46
           }
         }
       ],
       "span" : {
-        "startLine" : 102,
+        "startLine" : 151,
         "startCol" : 2,
-        "endLine" : 124,
-        "endCol" : 3
-      }
-    },
-    {
-      "kind" : "Operation",
-      "name" : "LoginFailed",
-      "inputs" : [
-        {
-          "kind" : "Param",
-          "name" : "email",
-          "typeExpr" : {
-            "kind" : "NamedType",
-            "name" : "Email",
-            "span" : {
-              "startLine" : 127,
-              "startCol" : 18,
-              "endLine" : 127,
-              "endCol" : 23
-            }
-          },
-          "span" : {
-            "startLine" : 127,
-            "startCol" : 11,
-            "endLine" : 127,
-            "endCol" : 23
-          }
-        },
-        {
-          "kind" : "Param",
-          "name" : "password",
-          "typeExpr" : {
-            "kind" : "NamedType",
-            "name" : "String",
-            "span" : {
-              "startLine" : 127,
-              "startCol" : 35,
-              "endLine" : 127,
-              "endCol" : 41
-            }
-          },
-          "span" : {
-            "startLine" : 127,
-            "startCol" : 25,
-            "endLine" : 127,
-            "endCol" : 41
-          }
-        }
-      ],
-      "outputs" : [
-      ],
-      "requires" : [
-        {
-          "kind" : "BinaryOp",
-          "op" : "in",
-          "left" : {
-            "kind" : "Identifier",
-            "name" : "email",
-            "span" : {
-              "startLine" : 130,
-              "startCol" : 6,
-              "endLine" : 130,
-              "endCol" : 11
-            }
-          },
-          "right" : {
-            "kind" : "Identifier",
-            "name" : "user_by_email",
-            "span" : {
-              "startLine" : 130,
-              "startCol" : 15,
-              "endLine" : 130,
-              "endCol" : 28
-            }
-          },
-          "span" : {
-            "startLine" : 130,
-            "startCol" : 6,
-            "endLine" : 130,
-            "endCol" : 28
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "!=",
-          "left" : {
-            "kind" : "FieldAccess",
-            "base" : {
-              "kind" : "Index",
-              "base" : {
-                "kind" : "Identifier",
-                "name" : "user_by_email",
-                "span" : {
-                  "startLine" : 131,
-                  "startCol" : 6,
-                  "endLine" : 131,
-                  "endCol" : 19
-                }
-              },
-              "index" : {
-                "kind" : "Identifier",
-                "name" : "email",
-                "span" : {
-                  "startLine" : 131,
-                  "startCol" : 20,
-                  "endLine" : 131,
-                  "endCol" : 25
-                }
-              },
-              "span" : {
-                "startLine" : 131,
-                "startCol" : 6,
-                "endLine" : 131,
-                "endCol" : 26
-              }
-            },
-            "field" : "password_hash",
-            "span" : {
-              "startLine" : 131,
-              "startCol" : 6,
-              "endLine" : 131,
-              "endCol" : 40
-            }
-          },
-          "right" : {
-            "kind" : "Call",
-            "callee" : {
-              "kind" : "Identifier",
-              "name" : "hash",
-              "span" : {
-                "startLine" : 131,
-                "startCol" : 44,
-                "endLine" : 131,
-                "endCol" : 48
-              }
-            },
-            "args" : [
-              {
-                "kind" : "Identifier",
-                "name" : "password",
-                "span" : {
-                  "startLine" : 131,
-                  "startCol" : 49,
-                  "endLine" : 131,
-                  "endCol" : 57
-                }
-              }
-            ],
-            "span" : {
-              "startLine" : 131,
-              "startCol" : 44,
-              "endLine" : 131,
-              "endCol" : 58
-            }
-          },
-          "span" : {
-            "startLine" : 131,
-            "startCol" : 6,
-            "endLine" : 131,
-            "endCol" : 58
-          }
-        }
-      ],
-      "ensures" : [
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Prime",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "sessions",
-              "span" : {
-                "startLine" : 134,
-                "startCol" : 6,
-                "endLine" : 134,
-                "endCol" : 14
-              }
-            },
-            "span" : {
-              "startLine" : 134,
-              "startCol" : 6,
-              "endLine" : 134,
-              "endCol" : 15
-            }
-          },
-          "right" : {
-            "kind" : "Identifier",
-            "name" : "sessions",
-            "span" : {
-              "startLine" : 134,
-              "startCol" : 18,
-              "endLine" : 134,
-              "endCol" : 26
-            }
-          },
-          "span" : {
-            "startLine" : 134,
-            "startCol" : 6,
-            "endLine" : 134,
-            "endCol" : 26
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Prime",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "users",
-              "span" : {
-                "startLine" : 135,
-                "startCol" : 6,
-                "endLine" : 135,
-                "endCol" : 11
-              }
-            },
-            "span" : {
-              "startLine" : 135,
-              "startCol" : 6,
-              "endLine" : 135,
-              "endCol" : 12
-            }
-          },
-          "right" : {
-            "kind" : "Identifier",
-            "name" : "users",
-            "span" : {
-              "startLine" : 135,
-              "startCol" : 15,
-              "endLine" : 135,
-              "endCol" : 20
-            }
-          },
-          "span" : {
-            "startLine" : 135,
-            "startCol" : 6,
-            "endLine" : 135,
-            "endCol" : 20
-          }
-        },
-        {
-          "kind" : "BinaryOp",
-          "op" : "=",
-          "left" : {
-            "kind" : "Prime",
-            "expr" : {
-              "kind" : "Identifier",
-              "name" : "login_attempts",
-              "span" : {
-                "startLine" : 136,
-                "startCol" : 6,
-                "endLine" : 136,
-                "endCol" : 20
-              }
-            },
-            "span" : {
-              "startLine" : 136,
-              "startCol" : 6,
-              "endLine" : 136,
-              "endCol" : 21
-            }
-          },
-          "right" : {
-            "kind" : "BinaryOp",
-            "op" : "+",
-            "left" : {
-              "kind" : "Pre",
-              "expr" : {
-                "kind" : "Identifier",
-                "name" : "login_attempts",
-                "span" : {
-                  "startLine" : 136,
-                  "startCol" : 28,
-                  "endLine" : 136,
-                  "endCol" : 42
-                }
-              },
-              "span" : {
-                "startLine" : 136,
-                "startCol" : 24,
-                "endLine" : 136,
-                "endCol" : 43
-              }
-            },
-            "right" : {
-              "kind" : "SeqLiteral",
-              "elements" : [
-                {
-                  "kind" : "Constructor",
-                  "typeName" : "LoginAttempt",
-                  "fields" : [
-                    {
-                      "name" : "email",
-                      "value" : {
-                        "kind" : "Identifier",
-                        "name" : "email",
-                        "span" : {
-                          "startLine" : 137,
-                          "startCol" : 34,
-                          "endLine" : 137,
-                          "endCol" : 39
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 137,
-                        "startCol" : 26,
-                        "endLine" : 137,
-                        "endCol" : 39
-                      }
-                    },
-                    {
-                      "name" : "timestamp",
-                      "value" : {
-                        "kind" : "Call",
-                        "callee" : {
-                          "kind" : "Identifier",
-                          "name" : "now",
-                          "span" : {
-                            "startLine" : 138,
-                            "startCol" : 38,
-                            "endLine" : 138,
-                            "endCol" : 41
-                          }
-                        },
-                        "args" : [
-                        ],
-                        "span" : {
-                          "startLine" : 138,
-                          "startCol" : 38,
-                          "endLine" : 138,
-                          "endCol" : 43
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 138,
-                        "startCol" : 26,
-                        "endLine" : 138,
-                        "endCol" : 43
-                      }
-                    },
-                    {
-                      "name" : "success",
-                      "value" : {
-                        "kind" : "BoolLit",
-                        "value" : false,
-                        "span" : {
-                          "startLine" : 139,
-                          "startCol" : 36,
-                          "endLine" : 139,
-                          "endCol" : 41
-                        }
-                      },
-                      "span" : {
-                        "startLine" : 139,
-                        "startCol" : 26,
-                        "endLine" : 139,
-                        "endCol" : 41
-                      }
-                    }
-                  ],
-                  "span" : {
-                    "startLine" : 137,
-                    "startCol" : 11,
-                    "endLine" : 139,
-                    "endCol" : 43
-                  }
-                }
-              ],
-              "span" : {
-                "startLine" : 137,
-                "startCol" : 10,
-                "endLine" : 139,
-                "endCol" : 44
-              }
-            },
-            "span" : {
-              "startLine" : 136,
-              "startCol" : 24,
-              "endLine" : 139,
-              "endCol" : 44
-            }
-          },
-          "span" : {
-            "startLine" : 136,
-            "startCol" : 6,
-            "endLine" : 139,
-            "endCol" : 44
-          }
-        }
-      ],
-      "span" : {
-        "startLine" : 126,
-        "startCol" : 2,
-        "endLine" : 140,
+        "endLine" : 177,
         "endCol" : 3
       }
     },
@@ -3474,16 +4990,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 143,
+              "startLine" : 180,
               "startCol" : 27,
-              "endLine" : 143,
+              "endLine" : 180,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 143,
+            "startLine" : 180,
             "startCol" : 12,
-            "endLine" : 143,
+            "endLine" : 180,
             "endCol" : 32
           }
         }
@@ -3496,16 +5012,16 @@
             "kind" : "NamedType",
             "name" : "Session",
             "span" : {
-              "startLine" : 144,
+              "startLine" : 181,
               "startCol" : 25,
-              "endLine" : 144,
+              "endLine" : 181,
               "endCol" : 32
             }
           },
           "span" : {
-            "startLine" : 144,
+            "startLine" : 181,
             "startCol" : 12,
-            "endLine" : 144,
+            "endLine" : 181,
             "endCol" : 32
           }
         }
@@ -3521,17 +5037,17 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 148,
+                  "startLine" : 185,
                   "startCol" : 16,
-                  "endLine" : 148,
+                  "endLine" : 185,
                   "endCol" : 24
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 148,
+                "startLine" : 185,
                 "startCol" : 11,
-                "endLine" : 148,
+                "endLine" : 185,
                 "endCol" : 24
               }
             }
@@ -3553,9 +5069,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 149,
+                        "startLine" : 186,
                         "startCol" : 8,
-                        "endLine" : 149,
+                        "endLine" : 186,
                         "endCol" : 16
                       }
                     },
@@ -3563,24 +5079,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 149,
+                        "startLine" : 186,
                         "startCol" : 17,
-                        "endLine" : 149,
+                        "endLine" : 186,
                         "endCol" : 18
                       }
                     },
                     "span" : {
-                      "startLine" : 149,
+                      "startLine" : 186,
                       "startCol" : 8,
-                      "endLine" : 149,
+                      "endLine" : 186,
                       "endCol" : 19
                     }
                   },
                   "field" : "refresh_token",
                   "span" : {
-                    "startLine" : 149,
+                    "startLine" : 186,
                     "startCol" : 8,
-                    "endLine" : 149,
+                    "endLine" : 186,
                     "endCol" : 33
                   }
                 },
@@ -3588,16 +5104,16 @@
                   "kind" : "Identifier",
                   "name" : "refresh_token",
                   "span" : {
-                    "startLine" : 149,
+                    "startLine" : 186,
                     "startCol" : 36,
-                    "endLine" : 149,
+                    "endLine" : 186,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 149,
+                  "startLine" : 186,
                   "startCol" : 8,
-                  "endLine" : 149,
+                  "endLine" : 186,
                   "endCol" : 49
                 }
               },
@@ -3612,9 +5128,9 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 150,
+                        "startLine" : 187,
                         "startCol" : 12,
-                        "endLine" : 150,
+                        "endLine" : 187,
                         "endCol" : 20
                       }
                     },
@@ -3622,24 +5138,24 @@
                       "kind" : "Identifier",
                       "name" : "s",
                       "span" : {
-                        "startLine" : 150,
+                        "startLine" : 187,
                         "startCol" : 21,
-                        "endLine" : 150,
+                        "endLine" : 187,
                         "endCol" : 22
                       }
                     },
                     "span" : {
-                      "startLine" : 150,
+                      "startLine" : 187,
                       "startCol" : 12,
-                      "endLine" : 150,
+                      "endLine" : 187,
                       "endCol" : 23
                     }
                   },
                   "field" : "is_revoked",
                   "span" : {
-                    "startLine" : 150,
+                    "startLine" : 187,
                     "startCol" : 12,
-                    "endLine" : 150,
+                    "endLine" : 187,
                     "endCol" : 34
                   }
                 },
@@ -3647,23 +5163,23 @@
                   "kind" : "BoolLit",
                   "value" : false,
                   "span" : {
-                    "startLine" : 150,
+                    "startLine" : 187,
                     "startCol" : 37,
-                    "endLine" : 150,
+                    "endLine" : 187,
                     "endCol" : 42
                   }
                 },
                 "span" : {
-                  "startLine" : 150,
+                  "startLine" : 187,
                   "startCol" : 12,
-                  "endLine" : 150,
+                  "endLine" : 187,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 149,
+                "startLine" : 186,
                 "startCol" : 8,
-                "endLine" : 150,
+                "endLine" : 187,
                 "endCol" : 42
               }
             },
@@ -3678,9 +5194,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 151,
+                      "startLine" : 188,
                       "startCol" : 12,
-                      "endLine" : 151,
+                      "endLine" : 188,
                       "endCol" : 20
                     }
                   },
@@ -3688,24 +5204,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 151,
+                      "startLine" : 188,
                       "startCol" : 21,
-                      "endLine" : 151,
+                      "endLine" : 188,
                       "endCol" : 22
                     }
                   },
                   "span" : {
-                    "startLine" : 151,
+                    "startLine" : 188,
                     "startCol" : 12,
-                    "endLine" : 151,
+                    "endLine" : 188,
                     "endCol" : 23
                   }
                 },
                 "field" : "refresh_expires_at",
                 "span" : {
-                  "startLine" : 151,
+                  "startLine" : 188,
                   "startCol" : 12,
-                  "endLine" : 151,
+                  "endLine" : 188,
                   "endCol" : 42
                 }
               },
@@ -3715,39 +5231,39 @@
                   "kind" : "Identifier",
                   "name" : "now",
                   "span" : {
-                    "startLine" : 151,
+                    "startLine" : 188,
                     "startCol" : 45,
-                    "endLine" : 151,
+                    "endLine" : 188,
                     "endCol" : 48
                   }
                 },
                 "args" : [
                 ],
                 "span" : {
-                  "startLine" : 151,
+                  "startLine" : 188,
                   "startCol" : 45,
-                  "endLine" : 151,
+                  "endLine" : 188,
                   "endCol" : 50
                 }
               },
               "span" : {
-                "startLine" : 151,
+                "startLine" : 188,
                 "startCol" : 12,
-                "endLine" : 151,
+                "endLine" : 188,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 149,
+              "startLine" : 186,
               "startCol" : 8,
-              "endLine" : 151,
+              "endLine" : 188,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 148,
+            "startLine" : 185,
             "startCol" : 6,
-            "endLine" : 151,
+            "endLine" : 188,
             "endCol" : 50
           }
         }
@@ -3763,9 +5279,9 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 154,
+                "startLine" : 191,
                 "startCol" : 34,
-                "endLine" : 154,
+                "endLine" : 191,
                 "endCol" : 42
               }
             },
@@ -3780,9 +5296,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 155,
+                      "startLine" : 192,
                       "startCol" : 8,
-                      "endLine" : 155,
+                      "endLine" : 192,
                       "endCol" : 16
                     }
                   },
@@ -3790,24 +5306,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 155,
+                      "startLine" : 192,
                       "startCol" : 17,
-                      "endLine" : 155,
+                      "endLine" : 192,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 155,
+                    "startLine" : 192,
                     "startCol" : 8,
-                    "endLine" : 155,
+                    "endLine" : 192,
                     "endCol" : 19
                   }
                 },
                 "field" : "refresh_token",
                 "span" : {
-                  "startLine" : 155,
+                  "startLine" : 192,
                   "startCol" : 8,
-                  "endLine" : 155,
+                  "endLine" : 192,
                   "endCol" : 33
                 }
               },
@@ -3815,23 +5331,23 @@
                 "kind" : "Identifier",
                 "name" : "refresh_token",
                 "span" : {
-                  "startLine" : 155,
+                  "startLine" : 192,
                   "startCol" : 36,
-                  "endLine" : 155,
+                  "endLine" : 192,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 155,
+                "startLine" : 192,
                 "startCol" : 8,
-                "endLine" : 155,
+                "endLine" : 192,
                 "endCol" : 49
               }
             },
             "span" : {
-              "startLine" : 154,
+              "startLine" : 191,
               "startCol" : 25,
-              "endLine" : 155,
+              "endLine" : 192,
               "endCol" : 49
             }
           },
@@ -3865,17 +5381,17 @@
                               "kind" : "Identifier",
                               "name" : "new_session",
                               "span" : {
-                                "startLine" : 156,
+                                "startLine" : 193,
                                 "startCol" : 8,
-                                "endLine" : 156,
+                                "endLine" : 193,
                                 "endCol" : 19
                               }
                             },
                             "field" : "id",
                             "span" : {
-                              "startLine" : 156,
+                              "startLine" : 193,
                               "startCol" : 8,
-                              "endLine" : 156,
+                              "endLine" : 193,
                               "endCol" : 22
                             }
                           },
@@ -3885,23 +5401,23 @@
                               "kind" : "Identifier",
                               "name" : "next_session_id",
                               "span" : {
-                                "startLine" : 156,
+                                "startLine" : 193,
                                 "startCol" : 29,
-                                "endLine" : 156,
+                                "endLine" : 193,
                                 "endCol" : 44
                               }
                             },
                             "span" : {
-                              "startLine" : 156,
+                              "startLine" : 193,
                               "startCol" : 25,
-                              "endLine" : 156,
+                              "endLine" : 193,
                               "endCol" : 45
                             }
                           },
                           "span" : {
-                            "startLine" : 156,
+                            "startLine" : 193,
                             "startCol" : 8,
-                            "endLine" : 156,
+                            "endLine" : 193,
                             "endCol" : 45
                           }
                         },
@@ -3914,17 +5430,17 @@
                               "kind" : "Identifier",
                               "name" : "new_session",
                               "span" : {
-                                "startLine" : 157,
+                                "startLine" : 194,
                                 "startCol" : 12,
-                                "endLine" : 157,
+                                "endLine" : 194,
                                 "endCol" : 23
                               }
                             },
                             "field" : "user_id",
                             "span" : {
-                              "startLine" : 157,
+                              "startLine" : 194,
                               "startCol" : 12,
-                              "endLine" : 157,
+                              "endLine" : 194,
                               "endCol" : 31
                             }
                           },
@@ -3938,16 +5454,16 @@
                                   "kind" : "Identifier",
                                   "name" : "sessions",
                                   "span" : {
-                                    "startLine" : 157,
+                                    "startLine" : 194,
                                     "startCol" : 38,
-                                    "endLine" : 157,
+                                    "endLine" : 194,
                                     "endCol" : 46
                                   }
                                 },
                                 "span" : {
-                                  "startLine" : 157,
+                                  "startLine" : 194,
                                   "startCol" : 34,
-                                  "endLine" : 157,
+                                  "endLine" : 194,
                                   "endCol" : 47
                                 }
                               },
@@ -3955,38 +5471,38 @@
                                 "kind" : "Identifier",
                                 "name" : "old_session",
                                 "span" : {
-                                  "startLine" : 157,
+                                  "startLine" : 194,
                                   "startCol" : 48,
-                                  "endLine" : 157,
+                                  "endLine" : 194,
                                   "endCol" : 59
                                 }
                               },
                               "span" : {
-                                "startLine" : 157,
+                                "startLine" : 194,
                                 "startCol" : 34,
-                                "endLine" : 157,
+                                "endLine" : 194,
                                 "endCol" : 60
                               }
                             },
                             "field" : "user_id",
                             "span" : {
-                              "startLine" : 157,
+                              "startLine" : 194,
                               "startCol" : 34,
-                              "endLine" : 157,
+                              "endLine" : 194,
                               "endCol" : 68
                             }
                           },
                           "span" : {
-                            "startLine" : 157,
+                            "startLine" : 194,
                             "startCol" : 12,
-                            "endLine" : 157,
+                            "endLine" : 194,
                             "endCol" : 68
                           }
                         },
                         "span" : {
-                          "startLine" : 156,
+                          "startLine" : 193,
                           "startCol" : 8,
-                          "endLine" : 157,
+                          "endLine" : 194,
                           "endCol" : 68
                         }
                       },
@@ -3999,17 +5515,17 @@
                             "kind" : "Identifier",
                             "name" : "new_session",
                             "span" : {
-                              "startLine" : 158,
+                              "startLine" : 195,
                               "startCol" : 12,
-                              "endLine" : 158,
+                              "endLine" : 195,
                               "endCol" : 23
                             }
                           },
                           "field" : "is_revoked",
                           "span" : {
-                            "startLine" : 158,
+                            "startLine" : 195,
                             "startCol" : 12,
-                            "endLine" : 158,
+                            "endLine" : 195,
                             "endCol" : 34
                           }
                         },
@@ -4017,23 +5533,23 @@
                           "kind" : "BoolLit",
                           "value" : false,
                           "span" : {
-                            "startLine" : 158,
+                            "startLine" : 195,
                             "startCol" : 37,
-                            "endLine" : 158,
+                            "endLine" : 195,
                             "endCol" : 42
                           }
                         },
                         "span" : {
-                          "startLine" : 158,
+                          "startLine" : 195,
                           "startCol" : 12,
-                          "endLine" : 158,
+                          "endLine" : 195,
                           "endCol" : 42
                         }
                       },
                       "span" : {
-                        "startLine" : 156,
+                        "startLine" : 193,
                         "startCol" : 8,
-                        "endLine" : 158,
+                        "endLine" : 195,
                         "endCol" : 42
                       }
                     },
@@ -4046,17 +5562,17 @@
                           "kind" : "Identifier",
                           "name" : "new_session",
                           "span" : {
-                            "startLine" : 159,
+                            "startLine" : 196,
                             "startCol" : 12,
-                            "endLine" : 159,
+                            "endLine" : 196,
                             "endCol" : 23
                           }
                         },
                         "field" : "access_expires_at",
                         "span" : {
-                          "startLine" : 159,
+                          "startLine" : 196,
                           "startCol" : 12,
-                          "endLine" : 159,
+                          "endLine" : 196,
                           "endCol" : 41
                         }
                       },
@@ -4066,32 +5582,32 @@
                           "kind" : "Identifier",
                           "name" : "now",
                           "span" : {
-                            "startLine" : 159,
+                            "startLine" : 196,
                             "startCol" : 44,
-                            "endLine" : 159,
+                            "endLine" : 196,
                             "endCol" : 47
                           }
                         },
                         "args" : [
                         ],
                         "span" : {
-                          "startLine" : 159,
+                          "startLine" : 196,
                           "startCol" : 44,
-                          "endLine" : 159,
+                          "endLine" : 196,
                           "endCol" : 49
                         }
                       },
                       "span" : {
-                        "startLine" : 159,
+                        "startLine" : 196,
                         "startCol" : 12,
-                        "endLine" : 159,
+                        "endLine" : 196,
                         "endCol" : 49
                       }
                     },
                     "span" : {
-                      "startLine" : 156,
+                      "startLine" : 193,
                       "startCol" : 8,
-                      "endLine" : 159,
+                      "endLine" : 196,
                       "endCol" : 49
                     }
                   },
@@ -4107,24 +5623,24 @@
                             "kind" : "Identifier",
                             "name" : "sessions",
                             "span" : {
-                              "startLine" : 160,
+                              "startLine" : 197,
                               "startCol" : 26,
-                              "endLine" : 160,
+                              "endLine" : 197,
                               "endCol" : 34
                             }
                           },
                           "span" : {
-                            "startLine" : 160,
+                            "startLine" : 197,
                             "startCol" : 22,
-                            "endLine" : 160,
+                            "endLine" : 197,
                             "endCol" : 35
                           }
                         },
                         "bindingKind" : "in",
                         "span" : {
-                          "startLine" : 160,
+                          "startLine" : 197,
                           "startCol" : 17,
-                          "endLine" : 160,
+                          "endLine" : 197,
                           "endCol" : 35
                         }
                       }
@@ -4138,17 +5654,17 @@
                           "kind" : "Identifier",
                           "name" : "new_session",
                           "span" : {
-                            "startLine" : 161,
+                            "startLine" : 198,
                             "startCol" : 14,
-                            "endLine" : 161,
+                            "endLine" : 198,
                             "endCol" : 25
                           }
                         },
                         "field" : "access_token",
                         "span" : {
-                          "startLine" : 161,
+                          "startLine" : 198,
                           "startCol" : 14,
-                          "endLine" : 161,
+                          "endLine" : 198,
                           "endCol" : 38
                         }
                       },
@@ -4162,16 +5678,16 @@
                               "kind" : "Identifier",
                               "name" : "sessions",
                               "span" : {
-                                "startLine" : 161,
+                                "startLine" : 198,
                                 "startCol" : 46,
-                                "endLine" : 161,
+                                "endLine" : 198,
                                 "endCol" : 54
                               }
                             },
                             "span" : {
-                              "startLine" : 161,
+                              "startLine" : 198,
                               "startCol" : 42,
-                              "endLine" : 161,
+                              "endLine" : 198,
                               "endCol" : 55
                             }
                           },
@@ -4179,45 +5695,45 @@
                             "kind" : "Identifier",
                             "name" : "s",
                             "span" : {
-                              "startLine" : 161,
+                              "startLine" : 198,
                               "startCol" : 56,
-                              "endLine" : 161,
+                              "endLine" : 198,
                               "endCol" : 57
                             }
                           },
                           "span" : {
-                            "startLine" : 161,
+                            "startLine" : 198,
                             "startCol" : 42,
-                            "endLine" : 161,
+                            "endLine" : 198,
                             "endCol" : 58
                           }
                         },
                         "field" : "access_token",
                         "span" : {
-                          "startLine" : 161,
+                          "startLine" : 198,
                           "startCol" : 42,
-                          "endLine" : 161,
+                          "endLine" : 198,
                           "endCol" : 71
                         }
                       },
                       "span" : {
-                        "startLine" : 161,
+                        "startLine" : 198,
                         "startCol" : 14,
-                        "endLine" : 161,
+                        "endLine" : 198,
                         "endCol" : 71
                       }
                     },
                     "span" : {
-                      "startLine" : 160,
+                      "startLine" : 197,
                       "startCol" : 13,
-                      "endLine" : 161,
+                      "endLine" : 198,
                       "endCol" : 71
                     }
                   },
                   "span" : {
-                    "startLine" : 156,
+                    "startLine" : 193,
                     "startCol" : 8,
-                    "endLine" : 161,
+                    "endLine" : 198,
                     "endCol" : 72
                   }
                 },
@@ -4233,24 +5749,24 @@
                           "kind" : "Identifier",
                           "name" : "sessions",
                           "span" : {
-                            "startLine" : 162,
+                            "startLine" : 199,
                             "startCol" : 26,
-                            "endLine" : 162,
+                            "endLine" : 199,
                             "endCol" : 34
                           }
                         },
                         "span" : {
-                          "startLine" : 162,
+                          "startLine" : 199,
                           "startCol" : 22,
-                          "endLine" : 162,
+                          "endLine" : 199,
                           "endCol" : 35
                         }
                       },
                       "bindingKind" : "in",
                       "span" : {
-                        "startLine" : 162,
+                        "startLine" : 199,
                         "startCol" : 17,
-                        "endLine" : 162,
+                        "endLine" : 199,
                         "endCol" : 35
                       }
                     }
@@ -4264,17 +5780,17 @@
                         "kind" : "Identifier",
                         "name" : "new_session",
                         "span" : {
-                          "startLine" : 163,
+                          "startLine" : 200,
                           "startCol" : 14,
-                          "endLine" : 163,
+                          "endLine" : 200,
                           "endCol" : 25
                         }
                       },
                       "field" : "refresh_token",
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 200,
                         "startCol" : 14,
-                        "endLine" : 163,
+                        "endLine" : 200,
                         "endCol" : 39
                       }
                     },
@@ -4288,16 +5804,16 @@
                             "kind" : "Identifier",
                             "name" : "sessions",
                             "span" : {
-                              "startLine" : 163,
+                              "startLine" : 200,
                               "startCol" : 47,
-                              "endLine" : 163,
+                              "endLine" : 200,
                               "endCol" : 55
                             }
                           },
                           "span" : {
-                            "startLine" : 163,
+                            "startLine" : 200,
                             "startCol" : 43,
-                            "endLine" : 163,
+                            "endLine" : 200,
                             "endCol" : 56
                           }
                         },
@@ -4305,45 +5821,45 @@
                           "kind" : "Identifier",
                           "name" : "s",
                           "span" : {
-                            "startLine" : 163,
+                            "startLine" : 200,
                             "startCol" : 57,
-                            "endLine" : 163,
+                            "endLine" : 200,
                             "endCol" : 58
                           }
                         },
                         "span" : {
-                          "startLine" : 163,
+                          "startLine" : 200,
                           "startCol" : 43,
-                          "endLine" : 163,
+                          "endLine" : 200,
                           "endCol" : 59
                         }
                       },
                       "field" : "refresh_token",
                       "span" : {
-                        "startLine" : 163,
+                        "startLine" : 200,
                         "startCol" : 43,
-                        "endLine" : 163,
+                        "endLine" : 200,
                         "endCol" : 73
                       }
                     },
                     "span" : {
-                      "startLine" : 163,
+                      "startLine" : 200,
                       "startCol" : 14,
-                      "endLine" : 163,
+                      "endLine" : 200,
                       "endCol" : 73
                     }
                   },
                   "span" : {
-                    "startLine" : 162,
+                    "startLine" : 199,
                     "startCol" : 13,
-                    "endLine" : 163,
+                    "endLine" : 200,
                     "endCol" : 73
                   }
                 },
                 "span" : {
-                  "startLine" : 156,
+                  "startLine" : 193,
                   "startCol" : 8,
-                  "endLine" : 163,
+                  "endLine" : 200,
                   "endCol" : 74
                 }
               },
@@ -4356,16 +5872,16 @@
                     "kind" : "Identifier",
                     "name" : "next_session_id",
                     "span" : {
-                      "startLine" : 164,
+                      "startLine" : 201,
                       "startCol" : 12,
-                      "endLine" : 164,
+                      "endLine" : 201,
                       "endCol" : 27
                     }
                   },
                   "span" : {
-                    "startLine" : 164,
+                    "startLine" : 201,
                     "startCol" : 12,
-                    "endLine" : 164,
+                    "endLine" : 201,
                     "endCol" : 28
                   }
                 },
@@ -4378,16 +5894,16 @@
                       "kind" : "Identifier",
                       "name" : "next_session_id",
                       "span" : {
-                        "startLine" : 164,
+                        "startLine" : 201,
                         "startCol" : 35,
-                        "endLine" : 164,
+                        "endLine" : 201,
                         "endCol" : 50
                       }
                     },
                     "span" : {
-                      "startLine" : 164,
+                      "startLine" : 201,
                       "startCol" : 31,
-                      "endLine" : 164,
+                      "endLine" : 201,
                       "endCol" : 51
                     }
                   },
@@ -4395,30 +5911,30 @@
                     "kind" : "IntLit",
                     "value" : 1,
                     "span" : {
-                      "startLine" : 164,
+                      "startLine" : 201,
                       "startCol" : 54,
-                      "endLine" : 164,
+                      "endLine" : 201,
                       "endCol" : 55
                     }
                   },
                   "span" : {
-                    "startLine" : 164,
+                    "startLine" : 201,
                     "startCol" : 31,
-                    "endLine" : 164,
+                    "endLine" : 201,
                     "endCol" : 55
                   }
                 },
                 "span" : {
-                  "startLine" : 164,
+                  "startLine" : 201,
                   "startCol" : 12,
-                  "endLine" : 164,
+                  "endLine" : 201,
                   "endCol" : 55
                 }
               },
               "span" : {
-                "startLine" : 156,
+                "startLine" : 193,
                 "startCol" : 8,
-                "endLine" : 164,
+                "endLine" : 201,
                 "endCol" : 55
               }
             },
@@ -4431,16 +5947,16 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 165,
+                    "startLine" : 202,
                     "startCol" : 12,
-                    "endLine" : 165,
+                    "endLine" : 202,
                     "endCol" : 20
                   }
                 },
                 "span" : {
-                  "startLine" : 165,
+                  "startLine" : 202,
                   "startCol" : 12,
-                  "endLine" : 165,
+                  "endLine" : 202,
                   "endCol" : 21
                 }
               },
@@ -4456,16 +5972,16 @@
                       "kind" : "Identifier",
                       "name" : "sessions",
                       "span" : {
-                        "startLine" : 165,
+                        "startLine" : 202,
                         "startCol" : 28,
-                        "endLine" : 165,
+                        "endLine" : 202,
                         "endCol" : 36
                       }
                     },
                     "span" : {
-                      "startLine" : 165,
+                      "startLine" : 202,
                       "startCol" : 24,
-                      "endLine" : 165,
+                      "endLine" : 202,
                       "endCol" : 37
                     }
                   },
@@ -4477,9 +5993,9 @@
                           "kind" : "Identifier",
                           "name" : "old_session",
                           "span" : {
-                            "startLine" : 166,
+                            "startLine" : 203,
                             "startCol" : 16,
-                            "endLine" : 166,
+                            "endLine" : 203,
                             "endCol" : 27
                           }
                         },
@@ -4493,16 +6009,16 @@
                                 "kind" : "Identifier",
                                 "name" : "sessions",
                                 "span" : {
-                                  "startLine" : 166,
+                                  "startLine" : 203,
                                   "startCol" : 35,
-                                  "endLine" : 166,
+                                  "endLine" : 203,
                                   "endCol" : 43
                                 }
                               },
                               "span" : {
-                                "startLine" : 166,
+                                "startLine" : 203,
                                 "startCol" : 31,
-                                "endLine" : 166,
+                                "endLine" : 203,
                                 "endCol" : 44
                               }
                             },
@@ -4510,16 +6026,16 @@
                               "kind" : "Identifier",
                               "name" : "old_session",
                               "span" : {
-                                "startLine" : 166,
+                                "startLine" : 203,
                                 "startCol" : 45,
-                                "endLine" : 166,
+                                "endLine" : 203,
                                 "endCol" : 56
                               }
                             },
                             "span" : {
-                              "startLine" : 166,
+                              "startLine" : 203,
                               "startCol" : 31,
-                              "endLine" : 166,
+                              "endLine" : 203,
                               "endCol" : 57
                             }
                           },
@@ -4530,46 +6046,46 @@
                                 "kind" : "BoolLit",
                                 "value" : true,
                                 "span" : {
-                                  "startLine" : 167,
+                                  "startLine" : 204,
                                   "startCol" : 38,
-                                  "endLine" : 167,
+                                  "endLine" : 204,
                                   "endCol" : 42
                                 }
                               },
                               "span" : {
-                                "startLine" : 167,
+                                "startLine" : 204,
                                 "startCol" : 25,
-                                "endLine" : 167,
+                                "endLine" : 204,
                                 "endCol" : 42
                               }
                             }
                           ],
                           "span" : {
-                            "startLine" : 166,
+                            "startLine" : 203,
                             "startCol" : 31,
-                            "endLine" : 167,
+                            "endLine" : 204,
                             "endCol" : 44
                           }
                         },
                         "span" : {
-                          "startLine" : 166,
+                          "startLine" : 203,
                           "startCol" : 16,
-                          "endLine" : 166,
+                          "endLine" : 203,
                           "endCol" : 27
                         }
                       }
                     ],
                     "span" : {
-                      "startLine" : 166,
+                      "startLine" : 203,
                       "startCol" : 15,
-                      "endLine" : 167,
+                      "endLine" : 204,
                       "endCol" : 45
                     }
                   },
                   "span" : {
-                    "startLine" : 165,
+                    "startLine" : 202,
                     "startCol" : 24,
-                    "endLine" : 167,
+                    "endLine" : 204,
                     "endCol" : 45
                   }
                 },
@@ -4583,17 +6099,17 @@
                           "kind" : "Identifier",
                           "name" : "new_session",
                           "span" : {
-                            "startLine" : 168,
+                            "startLine" : 205,
                             "startCol" : 16,
-                            "endLine" : 168,
+                            "endLine" : 205,
                             "endCol" : 27
                           }
                         },
                         "field" : "id",
                         "span" : {
-                          "startLine" : 168,
+                          "startLine" : 205,
                           "startCol" : 16,
-                          "endLine" : 168,
+                          "endLine" : 205,
                           "endCol" : 30
                         }
                       },
@@ -4601,52 +6117,52 @@
                         "kind" : "Identifier",
                         "name" : "new_session",
                         "span" : {
-                          "startLine" : 168,
+                          "startLine" : 205,
                           "startCol" : 34,
-                          "endLine" : 168,
+                          "endLine" : 205,
                           "endCol" : 45
                         }
                       },
                       "span" : {
-                        "startLine" : 168,
+                        "startLine" : 205,
                         "startCol" : 16,
-                        "endLine" : 168,
+                        "endLine" : 205,
                         "endCol" : 30
                       }
                     }
                   ],
                   "span" : {
-                    "startLine" : 168,
+                    "startLine" : 205,
                     "startCol" : 15,
-                    "endLine" : 168,
+                    "endLine" : 205,
                     "endCol" : 46
                   }
                 },
                 "span" : {
-                  "startLine" : 165,
+                  "startLine" : 202,
                   "startCol" : 24,
-                  "endLine" : 168,
+                  "endLine" : 205,
                   "endCol" : 46
                 }
               },
               "span" : {
-                "startLine" : 165,
+                "startLine" : 202,
                 "startCol" : 12,
-                "endLine" : 168,
+                "endLine" : 205,
                 "endCol" : 46
               }
             },
             "span" : {
-              "startLine" : 156,
+              "startLine" : 193,
               "startCol" : 8,
-              "endLine" : 168,
+              "endLine" : 205,
               "endCol" : 46
             }
           },
           "span" : {
-            "startLine" : 154,
+            "startLine" : 191,
             "startCol" : 6,
-            "endLine" : 168,
+            "endLine" : 205,
             "endCol" : 46
           }
         }
@@ -4656,9 +6172,9 @@
         "api_key"
       ],
       "span" : {
-        "startLine" : 142,
+        "startLine" : 179,
         "startCol" : 2,
-        "endLine" : 169,
+        "endLine" : 206,
         "endCol" : 3
       }
     },
@@ -4673,16 +6189,16 @@
             "kind" : "NamedType",
             "name" : "Email",
             "span" : {
-              "startLine" : 172,
+              "startLine" : 209,
               "startCol" : 19,
-              "endLine" : 172,
+              "endLine" : 209,
               "endCol" : 24
             }
           },
           "span" : {
-            "startLine" : 172,
+            "startLine" : 209,
             "startCol" : 12,
-            "endLine" : 172,
+            "endLine" : 209,
             "endCol" : 24
           }
         }
@@ -4695,16 +6211,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 173,
+              "startLine" : 210,
               "startCol" : 25,
-              "endLine" : 173,
+              "endLine" : 210,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 173,
+            "startLine" : 210,
             "startCol" : 12,
-            "endLine" : 173,
+            "endLine" : 210,
             "endCol" : 30
           }
         }
@@ -4717,9 +6233,9 @@
             "kind" : "Identifier",
             "name" : "email",
             "span" : {
-              "startLine" : 176,
+              "startLine" : 213,
               "startCol" : 6,
-              "endLine" : 176,
+              "endLine" : 213,
               "endCol" : 11
             }
           },
@@ -4727,16 +6243,16 @@
             "kind" : "Identifier",
             "name" : "user_by_email",
             "span" : {
-              "startLine" : 176,
+              "startLine" : 213,
               "startCol" : 15,
-              "endLine" : 176,
+              "endLine" : 213,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 176,
+            "startLine" : 213,
             "startCol" : 6,
-            "endLine" : 176,
+            "endLine" : 213,
             "endCol" : 28
           }
         },
@@ -4751,9 +6267,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 177,
+                  "startLine" : 214,
                   "startCol" : 6,
-                  "endLine" : 177,
+                  "endLine" : 214,
                   "endCol" : 19
                 }
               },
@@ -4761,24 +6277,24 @@
                 "kind" : "Identifier",
                 "name" : "email",
                 "span" : {
-                  "startLine" : 177,
+                  "startLine" : 214,
                   "startCol" : 20,
-                  "endLine" : 177,
+                  "endLine" : 214,
                   "endCol" : 25
                 }
               },
               "span" : {
-                "startLine" : 177,
+                "startLine" : 214,
                 "startCol" : 6,
-                "endLine" : 177,
+                "endLine" : 214,
                 "endCol" : 26
               }
             },
             "field" : "is_active",
             "span" : {
-              "startLine" : 177,
+              "startLine" : 214,
               "startCol" : 6,
-              "endLine" : 177,
+              "endLine" : 214,
               "endCol" : 36
             }
           },
@@ -4786,16 +6302,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 177,
+              "startLine" : 214,
               "startCol" : 39,
-              "endLine" : 177,
+              "endLine" : 214,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 177,
+            "startLine" : 214,
             "startCol" : 6,
-            "endLine" : 177,
+            "endLine" : 214,
             "endCol" : 43
           }
         }
@@ -4810,16 +6326,16 @@
               "kind" : "Identifier",
               "name" : "reset_tokens",
               "span" : {
-                "startLine" : 184,
+                "startLine" : 221,
                 "startCol" : 6,
-                "endLine" : 184,
+                "endLine" : 221,
                 "endCol" : 18
               }
             },
             "span" : {
-              "startLine" : 184,
+              "startLine" : 221,
               "startCol" : 6,
-              "endLine" : 184,
+              "endLine" : 221,
               "endCol" : 19
             }
           },
@@ -4832,16 +6348,16 @@
                 "kind" : "Identifier",
                 "name" : "reset_tokens",
                 "span" : {
-                  "startLine" : 184,
+                  "startLine" : 221,
                   "startCol" : 26,
-                  "endLine" : 184,
+                  "endLine" : 221,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 184,
+                "startLine" : 221,
                 "startCol" : 22,
-                "endLine" : 184,
+                "endLine" : 221,
                 "endCol" : 39
               }
             },
@@ -4853,9 +6369,9 @@
                     "kind" : "Identifier",
                     "name" : "reset_token",
                     "span" : {
-                      "startLine" : 184,
+                      "startLine" : 221,
                       "startCol" : 43,
-                      "endLine" : 184,
+                      "endLine" : 221,
                       "endCol" : 54
                     }
                   },
@@ -4869,16 +6385,16 @@
                           "kind" : "Identifier",
                           "name" : "reset_token",
                           "span" : {
-                            "startLine" : 185,
+                            "startLine" : 222,
                             "startCol" : 16,
-                            "endLine" : 185,
+                            "endLine" : 222,
                             "endCol" : 27
                           }
                         },
                         "span" : {
-                          "startLine" : 185,
+                          "startLine" : 222,
                           "startCol" : 8,
-                          "endLine" : 185,
+                          "endLine" : 222,
                           "endCol" : 27
                         }
                       },
@@ -4892,9 +6408,9 @@
                               "kind" : "Identifier",
                               "name" : "user_by_email",
                               "span" : {
-                                "startLine" : 186,
+                                "startLine" : 223,
                                 "startCol" : 18,
-                                "endLine" : 186,
+                                "endLine" : 223,
                                 "endCol" : 31
                               }
                             },
@@ -4902,76 +6418,76 @@
                               "kind" : "Identifier",
                               "name" : "email",
                               "span" : {
-                                "startLine" : 186,
+                                "startLine" : 223,
                                 "startCol" : 32,
-                                "endLine" : 186,
+                                "endLine" : 223,
                                 "endCol" : 37
                               }
                             },
                             "span" : {
-                              "startLine" : 186,
+                              "startLine" : 223,
                               "startCol" : 18,
-                              "endLine" : 186,
+                              "endLine" : 223,
                               "endCol" : 38
                             }
                           },
                           "field" : "id",
                           "span" : {
-                            "startLine" : 186,
+                            "startLine" : 223,
                             "startCol" : 18,
-                            "endLine" : 186,
+                            "endLine" : 223,
                             "endCol" : 41
                           }
                         },
                         "span" : {
-                          "startLine" : 186,
+                          "startLine" : 223,
                           "startCol" : 8,
-                          "endLine" : 186,
+                          "endLine" : 223,
                           "endCol" : 41
                         }
                       }
                     ],
                     "span" : {
-                      "startLine" : 184,
+                      "startLine" : 221,
                       "startCol" : 58,
-                      "endLine" : 187,
+                      "endLine" : 224,
                       "endCol" : 7
                     }
                   },
                   "span" : {
-                    "startLine" : 184,
+                    "startLine" : 221,
                     "startCol" : 43,
-                    "endLine" : 184,
+                    "endLine" : 221,
                     "endCol" : 54
                   }
                 }
               ],
               "span" : {
-                "startLine" : 184,
+                "startLine" : 221,
                 "startCol" : 42,
-                "endLine" : 187,
+                "endLine" : 224,
                 "endCol" : 8
               }
             },
             "span" : {
-              "startLine" : 184,
+              "startLine" : 221,
               "startCol" : 22,
-              "endLine" : 187,
+              "endLine" : 224,
               "endCol" : 8
             }
           },
           "span" : {
-            "startLine" : 184,
+            "startLine" : 221,
             "startCol" : 6,
-            "endLine" : 187,
+            "endLine" : 224,
             "endCol" : 8
           }
         }
       ],
       "span" : {
-        "startLine" : 171,
+        "startLine" : 208,
         "startCol" : 2,
-        "endLine" : 188,
+        "endLine" : 225,
         "endCol" : 3
       }
     },
@@ -4986,16 +6502,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 191,
+              "startLine" : 228,
               "startCol" : 25,
-              "endLine" : 191,
+              "endLine" : 228,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 191,
+            "startLine" : 228,
             "startCol" : 12,
-            "endLine" : 191,
+            "endLine" : 228,
             "endCol" : 30
           }
         },
@@ -5006,16 +6522,16 @@
             "kind" : "NamedType",
             "name" : "String",
             "span" : {
-              "startLine" : 191,
+              "startLine" : 228,
               "startCol" : 46,
-              "endLine" : 191,
+              "endLine" : 228,
               "endCol" : 52
             }
           },
           "span" : {
-            "startLine" : 191,
+            "startLine" : 228,
             "startCol" : 32,
-            "endLine" : 191,
+            "endLine" : 228,
             "endCol" : 52
           }
         }
@@ -5030,9 +6546,9 @@
             "kind" : "Identifier",
             "name" : "reset_token",
             "span" : {
-              "startLine" : 194,
+              "startLine" : 231,
               "startCol" : 6,
-              "endLine" : 194,
+              "endLine" : 231,
               "endCol" : 17
             }
           },
@@ -5040,16 +6556,16 @@
             "kind" : "Identifier",
             "name" : "reset_tokens",
             "span" : {
-              "startLine" : 194,
+              "startLine" : 231,
               "startCol" : 21,
-              "endLine" : 194,
+              "endLine" : 231,
               "endCol" : 33
             }
           },
           "span" : {
-            "startLine" : 194,
+            "startLine" : 231,
             "startCol" : 6,
-            "endLine" : 194,
+            "endLine" : 231,
             "endCol" : 33
           }
         },
@@ -5062,9 +6578,9 @@
               "kind" : "Identifier",
               "name" : "len",
               "span" : {
-                "startLine" : 195,
+                "startLine" : 232,
                 "startCol" : 6,
-                "endLine" : 195,
+                "endLine" : 232,
                 "endCol" : 9
               }
             },
@@ -5073,17 +6589,17 @@
                 "kind" : "Identifier",
                 "name" : "new_password",
                 "span" : {
-                  "startLine" : 195,
+                  "startLine" : 232,
                   "startCol" : 10,
-                  "endLine" : 195,
+                  "endLine" : 232,
                   "endCol" : 22
                 }
               }
             ],
             "span" : {
-              "startLine" : 195,
+              "startLine" : 232,
               "startCol" : 6,
-              "endLine" : 195,
+              "endLine" : 232,
               "endCol" : 23
             }
           },
@@ -5091,16 +6607,16 @@
             "kind" : "IntLit",
             "value" : 8,
             "span" : {
-              "startLine" : 195,
+              "startLine" : 232,
               "startCol" : 27,
-              "endLine" : 195,
+              "endLine" : 232,
               "endCol" : 28
             }
           },
           "span" : {
-            "startLine" : 195,
+            "startLine" : 232,
             "startCol" : 6,
-            "endLine" : 195,
+            "endLine" : 232,
             "endCol" : 28
           }
         }
@@ -5119,16 +6635,16 @@
                   "kind" : "Identifier",
                   "name" : "reset_tokens",
                   "span" : {
-                    "startLine" : 201,
+                    "startLine" : 238,
                     "startCol" : 24,
-                    "endLine" : 201,
+                    "endLine" : 238,
                     "endCol" : 36
                   }
                 },
                 "span" : {
-                  "startLine" : 201,
+                  "startLine" : 238,
                   "startCol" : 20,
-                  "endLine" : 201,
+                  "endLine" : 238,
                   "endCol" : 37
                 }
               },
@@ -5136,24 +6652,24 @@
                 "kind" : "Identifier",
                 "name" : "reset_token",
                 "span" : {
-                  "startLine" : 201,
+                  "startLine" : 238,
                   "startCol" : 38,
-                  "endLine" : 201,
+                  "endLine" : 238,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 201,
+                "startLine" : 238,
                 "startCol" : 20,
-                "endLine" : 201,
+                "endLine" : 238,
                 "endCol" : 50
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 201,
+              "startLine" : 238,
               "startCol" : 20,
-              "endLine" : 201,
+              "endLine" : 238,
               "endCol" : 58
             }
           },
@@ -5170,16 +6686,16 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 202,
+                      "startLine" : 239,
                       "startCol" : 26,
-                      "endLine" : 202,
+                      "endLine" : 239,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 202,
+                    "startLine" : 239,
                     "startCol" : 22,
-                    "endLine" : 202,
+                    "endLine" : 239,
                     "endCol" : 32
                   }
                 },
@@ -5187,16 +6703,16 @@
                   "kind" : "Identifier",
                   "name" : "user_id",
                   "span" : {
-                    "startLine" : 202,
+                    "startLine" : 239,
                     "startCol" : 33,
-                    "endLine" : 202,
+                    "endLine" : 239,
                     "endCol" : 40
                   }
                 },
                 "span" : {
-                  "startLine" : 202,
+                  "startLine" : 239,
                   "startCol" : 22,
-                  "endLine" : 202,
+                  "endLine" : 239,
                   "endCol" : 41
                 }
               },
@@ -5209,9 +6725,9 @@
                       "kind" : "Identifier",
                       "name" : "hash",
                       "span" : {
-                        "startLine" : 203,
+                        "startLine" : 240,
                         "startCol" : 26,
-                        "endLine" : 203,
+                        "endLine" : 240,
                         "endCol" : 30
                       }
                     },
@@ -5220,32 +6736,32 @@
                         "kind" : "Identifier",
                         "name" : "new_password",
                         "span" : {
-                          "startLine" : 203,
+                          "startLine" : 240,
                           "startCol" : 31,
-                          "endLine" : 203,
+                          "endLine" : 240,
                           "endCol" : 43
                         }
                       }
                     ],
                     "span" : {
-                      "startLine" : 203,
+                      "startLine" : 240,
                       "startCol" : 26,
-                      "endLine" : 203,
+                      "endLine" : 240,
                       "endCol" : 44
                     }
                   },
                   "span" : {
-                    "startLine" : 203,
+                    "startLine" : 240,
                     "startCol" : 10,
-                    "endLine" : 203,
+                    "endLine" : 240,
                     "endCol" : 44
                   }
                 }
               ],
               "span" : {
-                "startLine" : 202,
+                "startLine" : 239,
                 "startCol" : 22,
-                "endLine" : 204,
+                "endLine" : 241,
                 "endCol" : 9
               }
             },
@@ -5264,16 +6780,16 @@
                       "kind" : "Identifier",
                       "name" : "users",
                       "span" : {
-                        "startLine" : 205,
+                        "startLine" : 242,
                         "startCol" : 10,
-                        "endLine" : 205,
+                        "endLine" : 242,
                         "endCol" : 15
                       }
                     },
                     "span" : {
-                      "startLine" : 205,
+                      "startLine" : 242,
                       "startCol" : 10,
-                      "endLine" : 205,
+                      "endLine" : 242,
                       "endCol" : 16
                     }
                   },
@@ -5286,16 +6802,16 @@
                         "kind" : "Identifier",
                         "name" : "users",
                         "span" : {
-                          "startLine" : 205,
+                          "startLine" : 242,
                           "startCol" : 23,
-                          "endLine" : 205,
+                          "endLine" : 242,
                           "endCol" : 28
                         }
                       },
                       "span" : {
-                        "startLine" : 205,
+                        "startLine" : 242,
                         "startCol" : 19,
-                        "endLine" : 205,
+                        "endLine" : 242,
                         "endCol" : 29
                       }
                     },
@@ -5307,9 +6823,9 @@
                             "kind" : "Identifier",
                             "name" : "user_id",
                             "span" : {
-                              "startLine" : 205,
+                              "startLine" : 242,
                               "startCol" : 33,
-                              "endLine" : 205,
+                              "endLine" : 242,
                               "endCol" : 40
                             }
                           },
@@ -5317,38 +6833,38 @@
                             "kind" : "Identifier",
                             "name" : "updated",
                             "span" : {
-                              "startLine" : 205,
+                              "startLine" : 242,
                               "startCol" : 44,
-                              "endLine" : 205,
+                              "endLine" : 242,
                               "endCol" : 51
                             }
                           },
                           "span" : {
-                            "startLine" : 205,
+                            "startLine" : 242,
                             "startCol" : 33,
-                            "endLine" : 205,
+                            "endLine" : 242,
                             "endCol" : 40
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 205,
+                        "startLine" : 242,
                         "startCol" : 32,
-                        "endLine" : 205,
+                        "endLine" : 242,
                         "endCol" : 52
                       }
                     },
                     "span" : {
-                      "startLine" : 205,
+                      "startLine" : 242,
                       "startCol" : 19,
-                      "endLine" : 205,
+                      "endLine" : 242,
                       "endCol" : 52
                     }
                   },
                   "span" : {
-                    "startLine" : 205,
+                    "startLine" : 242,
                     "startCol" : 10,
-                    "endLine" : 205,
+                    "endLine" : 242,
                     "endCol" : 52
                   }
                 },
@@ -5361,16 +6877,16 @@
                       "kind" : "Identifier",
                       "name" : "user_by_email",
                       "span" : {
-                        "startLine" : 206,
+                        "startLine" : 243,
                         "startCol" : 14,
-                        "endLine" : 206,
+                        "endLine" : 243,
                         "endCol" : 27
                       }
                     },
                     "span" : {
-                      "startLine" : 206,
+                      "startLine" : 243,
                       "startCol" : 14,
-                      "endLine" : 206,
+                      "endLine" : 243,
                       "endCol" : 28
                     }
                   },
@@ -5383,16 +6899,16 @@
                         "kind" : "Identifier",
                         "name" : "user_by_email",
                         "span" : {
-                          "startLine" : 207,
+                          "startLine" : 244,
                           "startCol" : 16,
-                          "endLine" : 207,
+                          "endLine" : 244,
                           "endCol" : 29
                         }
                       },
                       "span" : {
-                        "startLine" : 207,
+                        "startLine" : 244,
                         "startCol" : 12,
-                        "endLine" : 207,
+                        "endLine" : 244,
                         "endCol" : 30
                       }
                     },
@@ -5410,16 +6926,16 @@
                                   "kind" : "Identifier",
                                   "name" : "users",
                                   "span" : {
-                                    "startLine" : 207,
+                                    "startLine" : 244,
                                     "startCol" : 38,
-                                    "endLine" : 207,
+                                    "endLine" : 244,
                                     "endCol" : 43
                                   }
                                 },
                                 "span" : {
-                                  "startLine" : 207,
+                                  "startLine" : 244,
                                   "startCol" : 34,
-                                  "endLine" : 207,
+                                  "endLine" : 244,
                                   "endCol" : 44
                                 }
                               },
@@ -5427,24 +6943,24 @@
                                 "kind" : "Identifier",
                                 "name" : "user_id",
                                 "span" : {
-                                  "startLine" : 207,
+                                  "startLine" : 244,
                                   "startCol" : 45,
-                                  "endLine" : 207,
+                                  "endLine" : 244,
                                   "endCol" : 52
                                 }
                               },
                               "span" : {
-                                "startLine" : 207,
+                                "startLine" : 244,
                                 "startCol" : 34,
-                                "endLine" : 207,
+                                "endLine" : 244,
                                 "endCol" : 53
                               }
                             },
                             "field" : "email",
                             "span" : {
-                              "startLine" : 207,
+                              "startLine" : 244,
                               "startCol" : 34,
-                              "endLine" : 207,
+                              "endLine" : 244,
                               "endCol" : 59
                             }
                           },
@@ -5452,45 +6968,45 @@
                             "kind" : "Identifier",
                             "name" : "updated",
                             "span" : {
-                              "startLine" : 207,
+                              "startLine" : 244,
                               "startCol" : 63,
-                              "endLine" : 207,
+                              "endLine" : 244,
                               "endCol" : 70
                             }
                           },
                           "span" : {
-                            "startLine" : 207,
+                            "startLine" : 244,
                             "startCol" : 34,
-                            "endLine" : 207,
+                            "endLine" : 244,
                             "endCol" : 59
                           }
                         }
                       ],
                       "span" : {
-                        "startLine" : 207,
+                        "startLine" : 244,
                         "startCol" : 33,
-                        "endLine" : 207,
+                        "endLine" : 244,
                         "endCol" : 71
                       }
                     },
                     "span" : {
-                      "startLine" : 207,
+                      "startLine" : 244,
                       "startCol" : 12,
-                      "endLine" : 207,
+                      "endLine" : 244,
                       "endCol" : 71
                     }
                   },
                   "span" : {
-                    "startLine" : 206,
+                    "startLine" : 243,
                     "startCol" : 14,
-                    "endLine" : 207,
+                    "endLine" : 244,
                     "endCol" : 71
                   }
                 },
                 "span" : {
-                  "startLine" : 205,
+                  "startLine" : 242,
                   "startCol" : 10,
-                  "endLine" : 207,
+                  "endLine" : 244,
                   "endCol" : 71
                 }
               },
@@ -5503,16 +7019,16 @@
                     "kind" : "Identifier",
                     "name" : "reset_tokens",
                     "span" : {
-                      "startLine" : 211,
+                      "startLine" : 248,
                       "startCol" : 14,
-                      "endLine" : 211,
+                      "endLine" : 248,
                       "endCol" : 26
                     }
                   },
                   "span" : {
-                    "startLine" : 211,
+                    "startLine" : 248,
                     "startCol" : 14,
-                    "endLine" : 211,
+                    "endLine" : 248,
                     "endCol" : 27
                   }
                 },
@@ -5525,16 +7041,16 @@
                       "kind" : "Identifier",
                       "name" : "reset_tokens",
                       "span" : {
-                        "startLine" : 211,
+                        "startLine" : 248,
                         "startCol" : 34,
-                        "endLine" : 211,
+                        "endLine" : 248,
                         "endCol" : 46
                       }
                     },
                     "span" : {
-                      "startLine" : 211,
+                      "startLine" : 248,
                       "startCol" : 30,
-                      "endLine" : 211,
+                      "endLine" : 248,
                       "endCol" : 47
                     }
                   },
@@ -5545,60 +7061,60 @@
                         "kind" : "Identifier",
                         "name" : "reset_token",
                         "span" : {
-                          "startLine" : 211,
+                          "startLine" : 248,
                           "startCol" : 51,
-                          "endLine" : 211,
+                          "endLine" : 248,
                           "endCol" : 62
                         }
                       }
                     ],
                     "span" : {
-                      "startLine" : 211,
+                      "startLine" : 248,
                       "startCol" : 50,
-                      "endLine" : 211,
+                      "endLine" : 248,
                       "endCol" : 63
                     }
                   },
                   "span" : {
-                    "startLine" : 211,
+                    "startLine" : 248,
                     "startCol" : 30,
-                    "endLine" : 211,
+                    "endLine" : 248,
                     "endCol" : 63
                   }
                 },
                 "span" : {
-                  "startLine" : 211,
+                  "startLine" : 248,
                   "startCol" : 14,
-                  "endLine" : 211,
+                  "endLine" : 248,
                   "endCol" : 63
                 }
               },
               "span" : {
-                "startLine" : 205,
+                "startLine" : 242,
                 "startCol" : 10,
-                "endLine" : 211,
+                "endLine" : 248,
                 "endCol" : 63
               }
             },
             "span" : {
-              "startLine" : 202,
+              "startLine" : 239,
               "startCol" : 8,
-              "endLine" : 211,
+              "endLine" : 248,
               "endCol" : 63
             }
           },
           "span" : {
-            "startLine" : 201,
+            "startLine" : 238,
             "startCol" : 6,
-            "endLine" : 211,
+            "endLine" : 248,
             "endCol" : 63
           }
         }
       ],
       "span" : {
-        "startLine" : 190,
+        "startLine" : 227,
         "startCol" : 2,
-        "endLine" : 212,
+        "endLine" : 249,
         "endCol" : 3
       }
     },
@@ -5613,16 +7129,16 @@
             "kind" : "NamedType",
             "name" : "Token",
             "span" : {
-              "startLine" : 215,
+              "startLine" : 252,
               "startCol" : 25,
-              "endLine" : 215,
+              "endLine" : 252,
               "endCol" : 30
             }
           },
           "span" : {
-            "startLine" : 215,
+            "startLine" : 252,
             "startCol" : 11,
-            "endLine" : 215,
+            "endLine" : 252,
             "endCol" : 30
           }
         }
@@ -5640,17 +7156,17 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 219,
+                  "startLine" : 256,
                   "startCol" : 16,
-                  "endLine" : 219,
+                  "endLine" : 256,
                   "endCol" : 24
                 }
               },
               "bindingKind" : "in",
               "span" : {
-                "startLine" : 219,
+                "startLine" : 256,
                 "startCol" : 11,
-                "endLine" : 219,
+                "endLine" : 256,
                 "endCol" : 24
               }
             }
@@ -5669,9 +7185,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 220,
+                      "startLine" : 257,
                       "startCol" : 8,
-                      "endLine" : 220,
+                      "endLine" : 257,
                       "endCol" : 16
                     }
                   },
@@ -5679,24 +7195,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 220,
+                      "startLine" : 257,
                       "startCol" : 17,
-                      "endLine" : 220,
+                      "endLine" : 257,
                       "endCol" : 18
                     }
                   },
                   "span" : {
-                    "startLine" : 220,
+                    "startLine" : 257,
                     "startCol" : 8,
-                    "endLine" : 220,
+                    "endLine" : 257,
                     "endCol" : 19
                   }
                 },
                 "field" : "access_token",
                 "span" : {
-                  "startLine" : 220,
+                  "startLine" : 257,
                   "startCol" : 8,
-                  "endLine" : 220,
+                  "endLine" : 257,
                   "endCol" : 32
                 }
               },
@@ -5704,16 +7220,16 @@
                 "kind" : "Identifier",
                 "name" : "access_token",
                 "span" : {
-                  "startLine" : 220,
+                  "startLine" : 257,
                   "startCol" : 35,
-                  "endLine" : 220,
+                  "endLine" : 257,
                   "endCol" : 47
                 }
               },
               "span" : {
-                "startLine" : 220,
+                "startLine" : 257,
                 "startCol" : 8,
-                "endLine" : 220,
+                "endLine" : 257,
                 "endCol" : 47
               }
             },
@@ -5728,9 +7244,9 @@
                     "kind" : "Identifier",
                     "name" : "sessions",
                     "span" : {
-                      "startLine" : 221,
+                      "startLine" : 258,
                       "startCol" : 12,
-                      "endLine" : 221,
+                      "endLine" : 258,
                       "endCol" : 20
                     }
                   },
@@ -5738,24 +7254,24 @@
                     "kind" : "Identifier",
                     "name" : "s",
                     "span" : {
-                      "startLine" : 221,
+                      "startLine" : 258,
                       "startCol" : 21,
-                      "endLine" : 221,
+                      "endLine" : 258,
                       "endCol" : 22
                     }
                   },
                   "span" : {
-                    "startLine" : 221,
+                    "startLine" : 258,
                     "startCol" : 12,
-                    "endLine" : 221,
+                    "endLine" : 258,
                     "endCol" : 23
                   }
                 },
                 "field" : "is_revoked",
                 "span" : {
-                  "startLine" : 221,
+                  "startLine" : 258,
                   "startCol" : 12,
-                  "endLine" : 221,
+                  "endLine" : 258,
                   "endCol" : 34
                 }
               },
@@ -5763,30 +7279,30 @@
                 "kind" : "BoolLit",
                 "value" : false,
                 "span" : {
-                  "startLine" : 221,
+                  "startLine" : 258,
                   "startCol" : 37,
-                  "endLine" : 221,
+                  "endLine" : 258,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 221,
+                "startLine" : 258,
                 "startCol" : 12,
-                "endLine" : 221,
+                "endLine" : 258,
                 "endCol" : 42
               }
             },
             "span" : {
-              "startLine" : 220,
+              "startLine" : 257,
               "startCol" : 8,
-              "endLine" : 221,
+              "endLine" : 258,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 219,
+            "startLine" : 256,
             "startCol" : 6,
-            "endLine" : 221,
+            "endLine" : 258,
             "endCol" : 42
           }
         }
@@ -5805,16 +7321,16 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 224,
+                    "startLine" : 261,
                     "startCol" : 6,
-                    "endLine" : 224,
+                    "endLine" : 261,
                     "endCol" : 14
                   }
                 },
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 261,
                   "startCol" : 6,
-                  "endLine" : 224,
+                  "endLine" : 261,
                   "endCol" : 15
                 }
               },
@@ -5825,9 +7341,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 224,
+                    "startLine" : 261,
                     "startCol" : 26,
-                    "endLine" : 224,
+                    "endLine" : 261,
                     "endCol" : 34
                   }
                 },
@@ -5842,9 +7358,9 @@
                         "kind" : "Identifier",
                         "name" : "sessions",
                         "span" : {
-                          "startLine" : 225,
+                          "startLine" : 262,
                           "startCol" : 8,
-                          "endLine" : 225,
+                          "endLine" : 262,
                           "endCol" : 16
                         }
                       },
@@ -5852,24 +7368,24 @@
                         "kind" : "Identifier",
                         "name" : "s",
                         "span" : {
-                          "startLine" : 225,
+                          "startLine" : 262,
                           "startCol" : 17,
-                          "endLine" : 225,
+                          "endLine" : 262,
                           "endCol" : 18
                         }
                       },
                       "span" : {
-                        "startLine" : 225,
+                        "startLine" : 262,
                         "startCol" : 8,
-                        "endLine" : 225,
+                        "endLine" : 262,
                         "endCol" : 19
                       }
                     },
                     "field" : "access_token",
                     "span" : {
-                      "startLine" : 225,
+                      "startLine" : 262,
                       "startCol" : 8,
-                      "endLine" : 225,
+                      "endLine" : 262,
                       "endCol" : 32
                     }
                   },
@@ -5877,38 +7393,38 @@
                     "kind" : "Identifier",
                     "name" : "access_token",
                     "span" : {
-                      "startLine" : 225,
+                      "startLine" : 262,
                       "startCol" : 35,
-                      "endLine" : 225,
+                      "endLine" : 262,
                       "endCol" : 47
                     }
                   },
                   "span" : {
-                    "startLine" : 225,
+                    "startLine" : 262,
                     "startCol" : 8,
-                    "endLine" : 225,
+                    "endLine" : 262,
                     "endCol" : 47
                   }
                 },
                 "span" : {
-                  "startLine" : 224,
+                  "startLine" : 261,
                   "startCol" : 17,
-                  "endLine" : 225,
+                  "endLine" : 262,
                   "endCol" : 47
                 }
               },
               "span" : {
-                "startLine" : 224,
+                "startLine" : 261,
                 "startCol" : 6,
-                "endLine" : 225,
+                "endLine" : 262,
                 "endCol" : 49
               }
             },
             "field" : "is_revoked",
             "span" : {
-              "startLine" : 224,
+              "startLine" : 261,
               "startCol" : 6,
-              "endLine" : 225,
+              "endLine" : 262,
               "endCol" : 60
             }
           },
@@ -5916,16 +7432,16 @@
             "kind" : "BoolLit",
             "value" : true,
             "span" : {
-              "startLine" : 225,
+              "startLine" : 262,
               "startCol" : 63,
-              "endLine" : 225,
+              "endLine" : 262,
               "endCol" : 67
             }
           },
           "span" : {
-            "startLine" : 224,
+            "startLine" : 261,
             "startCol" : 6,
-            "endLine" : 225,
+            "endLine" : 262,
             "endCol" : 67
           }
         },
@@ -5938,16 +7454,16 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 226,
+                "startLine" : 263,
                 "startCol" : 6,
-                "endLine" : 226,
+                "endLine" : 263,
                 "endCol" : 11
               }
             },
             "span" : {
-              "startLine" : 226,
+              "startLine" : 263,
               "startCol" : 6,
-              "endLine" : 226,
+              "endLine" : 263,
               "endCol" : 12
             }
           },
@@ -5955,16 +7471,16 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 226,
+              "startLine" : 263,
               "startCol" : 15,
-              "endLine" : 226,
+              "endLine" : 263,
               "endCol" : 20
             }
           },
           "span" : {
-            "startLine" : 226,
+            "startLine" : 263,
             "startCol" : 6,
-            "endLine" : 226,
+            "endLine" : 263,
             "endCol" : 20
           }
         }
@@ -5973,9 +7489,9 @@
         "bearer"
       ],
       "span" : {
-        "startLine" : 214,
+        "startLine" : 251,
         "startCol" : 2,
-        "endLine" : 227,
+        "endLine" : 264,
         "endCol" : 3
       }
     }
@@ -5996,17 +7512,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 240,
+                "startLine" : 270,
                 "startCol" : 14,
-                "endLine" : 240,
+                "endLine" : 270,
                 "endCol" : 19
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 240,
+              "startLine" : 270,
               "startCol" : 8,
-              "endLine" : 240,
+              "endLine" : 270,
               "endCol" : 19
             }
           },
@@ -6016,17 +7532,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 240,
+                "startLine" : 270,
                 "startCol" : 27,
-                "endLine" : 240,
+                "endLine" : 270,
                 "endCol" : 32
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 240,
+              "startLine" : 270,
               "startCol" : 21,
-              "endLine" : 240,
+              "endLine" : 270,
               "endCol" : 32
             }
           }
@@ -6041,9 +7557,9 @@
               "kind" : "Identifier",
               "name" : "u1",
               "span" : {
-                "startLine" : 241,
+                "startLine" : 271,
                 "startCol" : 6,
-                "endLine" : 241,
+                "endLine" : 271,
                 "endCol" : 8
               }
             },
@@ -6051,16 +7567,16 @@
               "kind" : "Identifier",
               "name" : "u2",
               "span" : {
-                "startLine" : 241,
+                "startLine" : 271,
                 "startCol" : 12,
-                "endLine" : 241,
+                "endLine" : 271,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 241,
+              "startLine" : 271,
               "startCol" : 6,
-              "endLine" : 241,
+              "endLine" : 271,
               "endCol" : 14
             }
           },
@@ -6075,9 +7591,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 241,
+                    "startLine" : 271,
                     "startCol" : 23,
-                    "endLine" : 241,
+                    "endLine" : 271,
                     "endCol" : 28
                   }
                 },
@@ -6085,24 +7601,24 @@
                   "kind" : "Identifier",
                   "name" : "u1",
                   "span" : {
-                    "startLine" : 241,
+                    "startLine" : 271,
                     "startCol" : 29,
-                    "endLine" : 241,
+                    "endLine" : 271,
                     "endCol" : 31
                   }
                 },
                 "span" : {
-                  "startLine" : 241,
+                  "startLine" : 271,
                   "startCol" : 23,
-                  "endLine" : 241,
+                  "endLine" : 271,
                   "endCol" : 32
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 241,
+                "startLine" : 271,
                 "startCol" : 23,
-                "endLine" : 241,
+                "endLine" : 271,
                 "endCol" : 38
               }
             },
@@ -6114,9 +7630,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 241,
+                    "startLine" : 271,
                     "startCol" : 42,
-                    "endLine" : 241,
+                    "endLine" : 271,
                     "endCol" : 47
                   }
                 },
@@ -6124,52 +7640,52 @@
                   "kind" : "Identifier",
                   "name" : "u2",
                   "span" : {
-                    "startLine" : 241,
+                    "startLine" : 271,
                     "startCol" : 48,
-                    "endLine" : 241,
+                    "endLine" : 271,
                     "endCol" : 50
                   }
                 },
                 "span" : {
-                  "startLine" : 241,
+                  "startLine" : 271,
                   "startCol" : 42,
-                  "endLine" : 241,
+                  "endLine" : 271,
                   "endCol" : 51
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 241,
+                "startLine" : 271,
                 "startCol" : 42,
-                "endLine" : 241,
+                "endLine" : 271,
                 "endCol" : 57
               }
             },
             "span" : {
-              "startLine" : 241,
+              "startLine" : 271,
               "startCol" : 23,
-              "endLine" : 241,
+              "endLine" : 271,
               "endCol" : 57
             }
           },
           "span" : {
-            "startLine" : 241,
+            "startLine" : 271,
             "startCol" : 6,
-            "endLine" : 241,
+            "endLine" : 271,
             "endCol" : 57
           }
         },
         "span" : {
-          "startLine" : 240,
+          "startLine" : 270,
           "startCol" : 4,
-          "endLine" : 241,
+          "endLine" : 271,
           "endCol" : 57
         }
       },
       "span" : {
-        "startLine" : 239,
+        "startLine" : 269,
         "startCol" : 2,
-        "endLine" : 241,
+        "endLine" : 271,
         "endCol" : 57
       }
     },
@@ -6186,17 +7702,17 @@
               "kind" : "Identifier",
               "name" : "user_by_email",
               "span" : {
-                "startLine" : 244,
+                "startLine" : 274,
                 "startCol" : 17,
-                "endLine" : 244,
+                "endLine" : 274,
                 "endCol" : 30
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 244,
+              "startLine" : 274,
               "startCol" : 8,
-              "endLine" : 244,
+              "endLine" : 274,
               "endCol" : 30
             }
           }
@@ -6218,9 +7734,9 @@
                     "kind" : "Identifier",
                     "name" : "user_by_email",
                     "span" : {
-                      "startLine" : 245,
+                      "startLine" : 275,
                       "startCol" : 6,
-                      "endLine" : 245,
+                      "endLine" : 275,
                       "endCol" : 19
                     }
                   },
@@ -6228,24 +7744,24 @@
                     "kind" : "Identifier",
                     "name" : "email",
                     "span" : {
-                      "startLine" : 245,
+                      "startLine" : 275,
                       "startCol" : 20,
-                      "endLine" : 245,
+                      "endLine" : 275,
                       "endCol" : 25
                     }
                   },
                   "span" : {
-                    "startLine" : 245,
+                    "startLine" : 275,
                     "startCol" : 6,
-                    "endLine" : 245,
+                    "endLine" : 275,
                     "endCol" : 26
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 245,
+                  "startLine" : 275,
                   "startCol" : 6,
-                  "endLine" : 245,
+                  "endLine" : 275,
                   "endCol" : 29
                 }
               },
@@ -6253,16 +7769,16 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 245,
+                  "startLine" : 275,
                   "startCol" : 33,
-                  "endLine" : 245,
+                  "endLine" : 275,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 245,
+                "startLine" : 275,
                 "startCol" : 6,
-                "endLine" : 245,
+                "endLine" : 275,
                 "endCol" : 38
               }
             },
@@ -6275,9 +7791,9 @@
                   "kind" : "Identifier",
                   "name" : "users",
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 276,
                     "startCol" : 10,
-                    "endLine" : 246,
+                    "endLine" : 276,
                     "endCol" : 15
                   }
                 },
@@ -6289,9 +7805,9 @@
                       "kind" : "Identifier",
                       "name" : "user_by_email",
                       "span" : {
-                        "startLine" : 246,
+                        "startLine" : 276,
                         "startCol" : 16,
-                        "endLine" : 246,
+                        "endLine" : 276,
                         "endCol" : 29
                       }
                     },
@@ -6299,31 +7815,31 @@
                       "kind" : "Identifier",
                       "name" : "email",
                       "span" : {
-                        "startLine" : 246,
+                        "startLine" : 276,
                         "startCol" : 30,
-                        "endLine" : 246,
+                        "endLine" : 276,
                         "endCol" : 35
                       }
                     },
                     "span" : {
-                      "startLine" : 246,
+                      "startLine" : 276,
                       "startCol" : 16,
-                      "endLine" : 246,
+                      "endLine" : 276,
                       "endCol" : 36
                     }
                   },
                   "field" : "id",
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 276,
                     "startCol" : 16,
-                    "endLine" : 246,
+                    "endLine" : 276,
                     "endCol" : 39
                   }
                 },
                 "span" : {
-                  "startLine" : 246,
+                  "startLine" : 276,
                   "startCol" : 10,
-                  "endLine" : 246,
+                  "endLine" : 276,
                   "endCol" : 40
                 }
               },
@@ -6333,9 +7849,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 276,
                     "startCol" : 43,
-                    "endLine" : 246,
+                    "endLine" : 276,
                     "endCol" : 56
                   }
                 },
@@ -6343,30 +7859,30 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 246,
+                    "startLine" : 276,
                     "startCol" : 57,
-                    "endLine" : 246,
+                    "endLine" : 276,
                     "endCol" : 62
                   }
                 },
                 "span" : {
-                  "startLine" : 246,
+                  "startLine" : 276,
                   "startCol" : 43,
-                  "endLine" : 246,
+                  "endLine" : 276,
                   "endCol" : 63
                 }
               },
               "span" : {
-                "startLine" : 246,
+                "startLine" : 276,
                 "startCol" : 10,
-                "endLine" : 246,
+                "endLine" : 276,
                 "endCol" : 63
               }
             },
             "span" : {
-              "startLine" : 245,
+              "startLine" : 275,
               "startCol" : 6,
-              "endLine" : 246,
+              "endLine" : 276,
               "endCol" : 63
             }
           },
@@ -6381,9 +7897,9 @@
                   "kind" : "Identifier",
                   "name" : "user_by_email",
                   "span" : {
-                    "startLine" : 247,
+                    "startLine" : 277,
                     "startCol" : 10,
-                    "endLine" : 247,
+                    "endLine" : 277,
                     "endCol" : 23
                   }
                 },
@@ -6391,24 +7907,24 @@
                   "kind" : "Identifier",
                   "name" : "email",
                   "span" : {
-                    "startLine" : 247,
+                    "startLine" : 277,
                     "startCol" : 24,
-                    "endLine" : 247,
+                    "endLine" : 277,
                     "endCol" : 29
                   }
                 },
                 "span" : {
-                  "startLine" : 247,
+                  "startLine" : 277,
                   "startCol" : 10,
-                  "endLine" : 247,
+                  "endLine" : 277,
                   "endCol" : 30
                 }
               },
               "field" : "email",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 277,
                 "startCol" : 10,
-                "endLine" : 247,
+                "endLine" : 277,
                 "endCol" : 36
               }
             },
@@ -6416,37 +7932,37 @@
               "kind" : "Identifier",
               "name" : "email",
               "span" : {
-                "startLine" : 247,
+                "startLine" : 277,
                 "startCol" : 39,
-                "endLine" : 247,
+                "endLine" : 277,
                 "endCol" : 44
               }
             },
             "span" : {
-              "startLine" : 247,
+              "startLine" : 277,
               "startCol" : 10,
-              "endLine" : 247,
+              "endLine" : 277,
               "endCol" : 44
             }
           },
           "span" : {
-            "startLine" : 245,
+            "startLine" : 275,
             "startCol" : 6,
-            "endLine" : 247,
+            "endLine" : 277,
             "endCol" : 44
           }
         },
         "span" : {
-          "startLine" : 244,
+          "startLine" : 274,
           "startCol" : 4,
-          "endLine" : 247,
+          "endLine" : 277,
           "endCol" : 44
         }
       },
       "span" : {
-        "startLine" : 243,
+        "startLine" : 273,
         "startCol" : 2,
-        "endLine" : 247,
+        "endLine" : 277,
         "endCol" : 44
       }
     },
@@ -6463,17 +7979,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 250,
+                "startLine" : 280,
                 "startCol" : 13,
-                "endLine" : 250,
+                "endLine" : 280,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 250,
+              "startLine" : 280,
               "startCol" : 8,
-              "endLine" : 250,
+              "endLine" : 280,
               "endCol" : 18
             }
           }
@@ -6495,9 +8011,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 251,
+                      "startLine" : 281,
                       "startCol" : 6,
-                      "endLine" : 251,
+                      "endLine" : 281,
                       "endCol" : 11
                     }
                   },
@@ -6505,24 +8021,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 251,
+                      "startLine" : 281,
                       "startCol" : 12,
-                      "endLine" : 251,
+                      "endLine" : 281,
                       "endCol" : 13
                     }
                   },
                   "span" : {
-                    "startLine" : 251,
+                    "startLine" : 281,
                     "startCol" : 6,
-                    "endLine" : 251,
+                    "endLine" : 281,
                     "endCol" : 14
                   }
                 },
                 "field" : "id",
                 "span" : {
-                  "startLine" : 251,
+                  "startLine" : 281,
                   "startCol" : 6,
-                  "endLine" : 251,
+                  "endLine" : 281,
                   "endCol" : 17
                 }
               },
@@ -6530,16 +8046,16 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 251,
+                  "startLine" : 281,
                   "startCol" : 20,
-                  "endLine" : 251,
+                  "endLine" : 281,
                   "endCol" : 21
                 }
               },
               "span" : {
-                "startLine" : 251,
+                "startLine" : 281,
                 "startCol" : 6,
-                "endLine" : 251,
+                "endLine" : 281,
                 "endCol" : 21
               }
             },
@@ -6554,9 +8070,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 252,
+                      "startLine" : 282,
                       "startCol" : 10,
-                      "endLine" : 252,
+                      "endLine" : 282,
                       "endCol" : 15
                     }
                   },
@@ -6564,24 +8080,24 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 252,
+                      "startLine" : 282,
                       "startCol" : 16,
-                      "endLine" : 252,
+                      "endLine" : 282,
                       "endCol" : 17
                     }
                   },
                   "span" : {
-                    "startLine" : 252,
+                    "startLine" : 282,
                     "startCol" : 10,
-                    "endLine" : 252,
+                    "endLine" : 282,
                     "endCol" : 18
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 252,
+                  "startLine" : 282,
                   "startCol" : 10,
-                  "endLine" : 252,
+                  "endLine" : 282,
                   "endCol" : 24
                 }
               },
@@ -6589,23 +8105,23 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 252,
+                  "startLine" : 282,
                   "startCol" : 28,
-                  "endLine" : 252,
+                  "endLine" : 282,
                   "endCol" : 41
                 }
               },
               "span" : {
-                "startLine" : 252,
+                "startLine" : 282,
                 "startCol" : 10,
-                "endLine" : 252,
+                "endLine" : 282,
                 "endCol" : 41
               }
             },
             "span" : {
-              "startLine" : 251,
+              "startLine" : 281,
               "startCol" : 6,
-              "endLine" : 252,
+              "endLine" : 282,
               "endCol" : 41
             }
           },
@@ -6618,9 +8134,9 @@
                 "kind" : "Identifier",
                 "name" : "user_by_email",
                 "span" : {
-                  "startLine" : 253,
+                  "startLine" : 283,
                   "startCol" : 10,
-                  "endLine" : 253,
+                  "endLine" : 283,
                   "endCol" : 23
                 }
               },
@@ -6632,9 +8148,9 @@
                     "kind" : "Identifier",
                     "name" : "users",
                     "span" : {
-                      "startLine" : 253,
+                      "startLine" : 283,
                       "startCol" : 24,
-                      "endLine" : 253,
+                      "endLine" : 283,
                       "endCol" : 29
                     }
                   },
@@ -6642,31 +8158,31 @@
                     "kind" : "Identifier",
                     "name" : "u",
                     "span" : {
-                      "startLine" : 253,
+                      "startLine" : 283,
                       "startCol" : 30,
-                      "endLine" : 253,
+                      "endLine" : 283,
                       "endCol" : 31
                     }
                   },
                   "span" : {
-                    "startLine" : 253,
+                    "startLine" : 283,
                     "startCol" : 24,
-                    "endLine" : 253,
+                    "endLine" : 283,
                     "endCol" : 32
                   }
                 },
                 "field" : "email",
                 "span" : {
-                  "startLine" : 253,
+                  "startLine" : 283,
                   "startCol" : 24,
-                  "endLine" : 253,
+                  "endLine" : 283,
                   "endCol" : 38
                 }
               },
               "span" : {
-                "startLine" : 253,
+                "startLine" : 283,
                 "startCol" : 10,
-                "endLine" : 253,
+                "endLine" : 283,
                 "endCol" : 39
               }
             },
@@ -6676,9 +8192,9 @@
                 "kind" : "Identifier",
                 "name" : "users",
                 "span" : {
-                  "startLine" : 253,
+                  "startLine" : 283,
                   "startCol" : 42,
-                  "endLine" : 253,
+                  "endLine" : 283,
                   "endCol" : 47
                 }
               },
@@ -6686,44 +8202,44 @@
                 "kind" : "Identifier",
                 "name" : "u",
                 "span" : {
-                  "startLine" : 253,
+                  "startLine" : 283,
                   "startCol" : 48,
-                  "endLine" : 253,
+                  "endLine" : 283,
                   "endCol" : 49
                 }
               },
               "span" : {
-                "startLine" : 253,
+                "startLine" : 283,
                 "startCol" : 42,
-                "endLine" : 253,
+                "endLine" : 283,
                 "endCol" : 50
               }
             },
             "span" : {
-              "startLine" : 253,
+              "startLine" : 283,
               "startCol" : 10,
-              "endLine" : 253,
+              "endLine" : 283,
               "endCol" : 50
             }
           },
           "span" : {
-            "startLine" : 251,
+            "startLine" : 281,
             "startCol" : 6,
-            "endLine" : 253,
+            "endLine" : 283,
             "endCol" : 50
           }
         },
         "span" : {
-          "startLine" : 250,
+          "startLine" : 280,
           "startCol" : 4,
-          "endLine" : 253,
+          "endLine" : 283,
           "endCol" : 50
         }
       },
       "span" : {
-        "startLine" : 249,
+        "startLine" : 279,
         "startCol" : 2,
-        "endLine" : 253,
+        "endLine" : 283,
         "endCol" : 50
       }
     },
@@ -6740,17 +8256,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 256,
+                "startLine" : 286,
                 "startCol" : 13,
-                "endLine" : 256,
+                "endLine" : 286,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 256,
+              "startLine" : 286,
               "startCol" : 8,
-              "endLine" : 256,
+              "endLine" : 286,
               "endCol" : 21
             }
           }
@@ -6766,9 +8282,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 257,
+                  "startLine" : 287,
                   "startCol" : 6,
-                  "endLine" : 257,
+                  "endLine" : 287,
                   "endCol" : 14
                 }
               },
@@ -6776,24 +8292,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 257,
+                  "startLine" : 287,
                   "startCol" : 15,
-                  "endLine" : 257,
+                  "endLine" : 287,
                   "endCol" : 16
                 }
               },
               "span" : {
-                "startLine" : 257,
+                "startLine" : 287,
                 "startCol" : 6,
-                "endLine" : 257,
+                "endLine" : 287,
                 "endCol" : 17
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 257,
+              "startLine" : 287,
               "startCol" : 6,
-              "endLine" : 257,
+              "endLine" : 287,
               "endCol" : 25
             }
           },
@@ -6801,30 +8317,30 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 257,
+              "startLine" : 287,
               "startCol" : 29,
-              "endLine" : 257,
+              "endLine" : 287,
               "endCol" : 34
             }
           },
           "span" : {
-            "startLine" : 257,
+            "startLine" : 287,
             "startCol" : 6,
-            "endLine" : 257,
+            "endLine" : 287,
             "endCol" : 34
           }
         },
         "span" : {
-          "startLine" : 256,
+          "startLine" : 286,
           "startCol" : 4,
-          "endLine" : 257,
+          "endLine" : 287,
           "endCol" : 34
         }
       },
       "span" : {
-        "startLine" : 255,
+        "startLine" : 285,
         "startCol" : 2,
-        "endLine" : 257,
+        "endLine" : 287,
         "endCol" : 34
       }
     },
@@ -6841,17 +8357,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 260,
+                "startLine" : 290,
                 "startCol" : 13,
-                "endLine" : 260,
+                "endLine" : 290,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 260,
+              "startLine" : 290,
               "startCol" : 8,
-              "endLine" : 260,
+              "endLine" : 290,
               "endCol" : 21
             }
           }
@@ -6867,9 +8383,9 @@
                 "kind" : "Identifier",
                 "name" : "sessions",
                 "span" : {
-                  "startLine" : 260,
+                  "startLine" : 290,
                   "startCol" : 24,
-                  "endLine" : 260,
+                  "endLine" : 290,
                   "endCol" : 32
                 }
               },
@@ -6877,24 +8393,24 @@
                 "kind" : "Identifier",
                 "name" : "s",
                 "span" : {
-                  "startLine" : 260,
+                  "startLine" : 290,
                   "startCol" : 33,
-                  "endLine" : 260,
+                  "endLine" : 290,
                   "endCol" : 34
                 }
               },
               "span" : {
-                "startLine" : 260,
+                "startLine" : 290,
                 "startCol" : 24,
-                "endLine" : 260,
+                "endLine" : 290,
                 "endCol" : 35
               }
             },
             "field" : "id",
             "span" : {
-              "startLine" : 260,
+              "startLine" : 290,
               "startCol" : 24,
-              "endLine" : 260,
+              "endLine" : 290,
               "endCol" : 38
             }
           },
@@ -6902,30 +8418,30 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 260,
+              "startLine" : 290,
               "startCol" : 41,
-              "endLine" : 260,
+              "endLine" : 290,
               "endCol" : 42
             }
           },
           "span" : {
-            "startLine" : 260,
+            "startLine" : 290,
             "startCol" : 24,
-            "endLine" : 260,
+            "endLine" : 290,
             "endCol" : 42
           }
         },
         "span" : {
-          "startLine" : 260,
+          "startLine" : 290,
           "startCol" : 4,
-          "endLine" : 260,
+          "endLine" : 290,
           "endCol" : 42
         }
       },
       "span" : {
-        "startLine" : 259,
+        "startLine" : 289,
         "startCol" : 2,
-        "endLine" : 260,
+        "endLine" : 290,
         "endCol" : 42
       }
     },
@@ -6942,17 +8458,17 @@
               "kind" : "Identifier",
               "name" : "reset_tokens",
               "span" : {
-                "startLine" : 263,
+                "startLine" : 293,
                 "startCol" : 13,
-                "endLine" : 263,
+                "endLine" : 293,
                 "endCol" : 25
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 263,
+              "startLine" : 293,
               "startCol" : 8,
-              "endLine" : 263,
+              "endLine" : 293,
               "endCol" : 25
             }
           }
@@ -6968,9 +8484,9 @@
                 "kind" : "Identifier",
                 "name" : "reset_tokens",
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 293,
                   "startCol" : 28,
-                  "endLine" : 263,
+                  "endLine" : 293,
                   "endCol" : 40
                 }
               },
@@ -6978,24 +8494,24 @@
                 "kind" : "Identifier",
                 "name" : "t",
                 "span" : {
-                  "startLine" : 263,
+                  "startLine" : 293,
                   "startCol" : 41,
-                  "endLine" : 263,
+                  "endLine" : 293,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 263,
+                "startLine" : 293,
                 "startCol" : 28,
-                "endLine" : 263,
+                "endLine" : 293,
                 "endCol" : 43
               }
             },
             "field" : "token",
             "span" : {
-              "startLine" : 263,
+              "startLine" : 293,
               "startCol" : 28,
-              "endLine" : 263,
+              "endLine" : 293,
               "endCol" : 49
             }
           },
@@ -7003,30 +8519,30 @@
             "kind" : "Identifier",
             "name" : "t",
             "span" : {
-              "startLine" : 263,
+              "startLine" : 293,
               "startCol" : 52,
-              "endLine" : 263,
+              "endLine" : 293,
               "endCol" : 53
             }
           },
           "span" : {
-            "startLine" : 263,
+            "startLine" : 293,
             "startCol" : 28,
-            "endLine" : 263,
+            "endLine" : 293,
             "endCol" : 53
           }
         },
         "span" : {
-          "startLine" : 263,
+          "startLine" : 293,
           "startCol" : 4,
-          "endLine" : 263,
+          "endLine" : 293,
           "endCol" : 53
         }
       },
       "span" : {
-        "startLine" : 262,
+        "startLine" : 292,
         "startCol" : 2,
-        "endLine" : 263,
+        "endLine" : 293,
         "endCol" : 53
       }
     },
@@ -7043,17 +8559,17 @@
               "kind" : "Identifier",
               "name" : "reset_tokens",
               "span" : {
-                "startLine" : 266,
+                "startLine" : 296,
                 "startCol" : 13,
-                "endLine" : 266,
+                "endLine" : 296,
                 "endCol" : 25
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 266,
+              "startLine" : 296,
               "startCol" : 8,
-              "endLine" : 266,
+              "endLine" : 296,
               "endCol" : 25
             }
           }
@@ -7069,9 +8585,9 @@
                 "kind" : "Identifier",
                 "name" : "reset_tokens",
                 "span" : {
-                  "startLine" : 266,
+                  "startLine" : 296,
                   "startCol" : 28,
-                  "endLine" : 266,
+                  "endLine" : 296,
                   "endCol" : 40
                 }
               },
@@ -7079,24 +8595,24 @@
                 "kind" : "Identifier",
                 "name" : "t",
                 "span" : {
-                  "startLine" : 266,
+                  "startLine" : 296,
                   "startCol" : 41,
-                  "endLine" : 266,
+                  "endLine" : 296,
                   "endCol" : 42
                 }
               },
               "span" : {
-                "startLine" : 266,
+                "startLine" : 296,
                 "startCol" : 28,
-                "endLine" : 266,
+                "endLine" : 296,
                 "endCol" : 43
               }
             },
             "field" : "user_id",
             "span" : {
-              "startLine" : 266,
+              "startLine" : 296,
               "startCol" : 28,
-              "endLine" : 266,
+              "endLine" : 296,
               "endCol" : 51
             }
           },
@@ -7104,31 +8620,132 @@
             "kind" : "Identifier",
             "name" : "users",
             "span" : {
-              "startLine" : 266,
+              "startLine" : 296,
               "startCol" : 55,
-              "endLine" : 266,
+              "endLine" : 296,
               "endCol" : 60
             }
           },
           "span" : {
-            "startLine" : 266,
+            "startLine" : 296,
             "startCol" : 28,
-            "endLine" : 266,
+            "endLine" : 296,
             "endCol" : 60
           }
         },
         "span" : {
-          "startLine" : 266,
+          "startLine" : 296,
           "startCol" : 4,
-          "endLine" : 266,
+          "endLine" : 296,
           "endCol" : 60
         }
       },
       "span" : {
-        "startLine" : 265,
+        "startLine" : 295,
         "startCol" : 2,
-        "endLine" : 266,
+        "endLine" : 296,
         "endCol" : 60
+      }
+    },
+    {
+      "kind" : "Invariant",
+      "name" : "failedLoginKeyMatches",
+      "expr" : {
+        "kind" : "Quantifier",
+        "quantifier" : "all",
+        "bindings" : [
+          {
+            "variable" : "e",
+            "domain" : {
+              "kind" : "Identifier",
+              "name" : "failed_logins",
+              "span" : {
+                "startLine" : 299,
+                "startCol" : 13,
+                "endLine" : 299,
+                "endCol" : 26
+              }
+            },
+            "bindingKind" : "in",
+            "span" : {
+              "startLine" : 299,
+              "startCol" : 8,
+              "endLine" : 299,
+              "endCol" : 26
+            }
+          }
+        ],
+        "body" : {
+          "kind" : "BinaryOp",
+          "op" : "=",
+          "left" : {
+            "kind" : "FieldAccess",
+            "base" : {
+              "kind" : "Index",
+              "base" : {
+                "kind" : "Identifier",
+                "name" : "failed_logins",
+                "span" : {
+                  "startLine" : 299,
+                  "startCol" : 29,
+                  "endLine" : 299,
+                  "endCol" : 42
+                }
+              },
+              "index" : {
+                "kind" : "Identifier",
+                "name" : "e",
+                "span" : {
+                  "startLine" : 299,
+                  "startCol" : 43,
+                  "endLine" : 299,
+                  "endCol" : 44
+                }
+              },
+              "span" : {
+                "startLine" : 299,
+                "startCol" : 29,
+                "endLine" : 299,
+                "endCol" : 45
+              }
+            },
+            "field" : "email",
+            "span" : {
+              "startLine" : 299,
+              "startCol" : 29,
+              "endLine" : 299,
+              "endCol" : 51
+            }
+          },
+          "right" : {
+            "kind" : "Identifier",
+            "name" : "e",
+            "span" : {
+              "startLine" : 299,
+              "startCol" : 54,
+              "endLine" : 299,
+              "endCol" : 55
+            }
+          },
+          "span" : {
+            "startLine" : 299,
+            "startCol" : 29,
+            "endLine" : 299,
+            "endCol" : 55
+          }
+        },
+        "span" : {
+          "startLine" : 299,
+          "startCol" : 4,
+          "endLine" : 299,
+          "endCol" : 55
+        }
+      },
+      "span" : {
+        "startLine" : 298,
+        "startCol" : 2,
+        "endLine" : 299,
+        "endCol" : 55
       }
     },
     {
@@ -7144,17 +8761,17 @@
               "kind" : "Identifier",
               "name" : "users",
               "span" : {
-                "startLine" : 269,
+                "startLine" : 302,
                 "startCol" : 13,
-                "endLine" : 269,
+                "endLine" : 302,
                 "endCol" : 18
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 269,
+              "startLine" : 302,
               "startCol" : 8,
-              "endLine" : 269,
+              "endLine" : 302,
               "endCol" : 18
             }
           }
@@ -7166,9 +8783,9 @@
             "kind" : "Identifier",
             "name" : "u",
             "span" : {
-              "startLine" : 269,
+              "startLine" : 302,
               "startCol" : 21,
-              "endLine" : 269,
+              "endLine" : 302,
               "endCol" : 22
             }
           },
@@ -7176,30 +8793,30 @@
             "kind" : "Identifier",
             "name" : "next_user_id",
             "span" : {
-              "startLine" : 269,
+              "startLine" : 302,
               "startCol" : 25,
-              "endLine" : 269,
+              "endLine" : 302,
               "endCol" : 37
             }
           },
           "span" : {
-            "startLine" : 269,
+            "startLine" : 302,
             "startCol" : 21,
-            "endLine" : 269,
+            "endLine" : 302,
             "endCol" : 37
           }
         },
         "span" : {
-          "startLine" : 269,
+          "startLine" : 302,
           "startCol" : 4,
-          "endLine" : 269,
+          "endLine" : 302,
           "endCol" : 37
         }
       },
       "span" : {
-        "startLine" : 268,
+        "startLine" : 301,
         "startCol" : 2,
-        "endLine" : 269,
+        "endLine" : 302,
         "endCol" : 37
       }
     },
@@ -7216,17 +8833,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 272,
+                "startLine" : 305,
                 "startCol" : 13,
-                "endLine" : 272,
+                "endLine" : 305,
                 "endCol" : 21
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 272,
+              "startLine" : 305,
               "startCol" : 8,
-              "endLine" : 272,
+              "endLine" : 305,
               "endCol" : 21
             }
           }
@@ -7238,9 +8855,9 @@
             "kind" : "Identifier",
             "name" : "s",
             "span" : {
-              "startLine" : 272,
+              "startLine" : 305,
               "startCol" : 24,
-              "endLine" : 272,
+              "endLine" : 305,
               "endCol" : 25
             }
           },
@@ -7248,30 +8865,30 @@
             "kind" : "Identifier",
             "name" : "next_session_id",
             "span" : {
-              "startLine" : 272,
+              "startLine" : 305,
               "startCol" : 28,
-              "endLine" : 272,
+              "endLine" : 305,
               "endCol" : 43
             }
           },
           "span" : {
-            "startLine" : 272,
+            "startLine" : 305,
             "startCol" : 24,
-            "endLine" : 272,
+            "endLine" : 305,
             "endCol" : 43
           }
         },
         "span" : {
-          "startLine" : 272,
+          "startLine" : 305,
           "startCol" : 4,
-          "endLine" : 272,
+          "endLine" : 305,
           "endCol" : 43
         }
       },
       "span" : {
-        "startLine" : 271,
+        "startLine" : 304,
         "startCol" : 2,
-        "endLine" : 272,
+        "endLine" : 305,
         "endCol" : 43
       }
     },
@@ -7288,17 +8905,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 281,
+                "startLine" : 314,
                 "startCol" : 14,
-                "endLine" : 281,
+                "endLine" : 314,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 281,
+              "startLine" : 314,
               "startCol" : 8,
-              "endLine" : 281,
+              "endLine" : 314,
               "endCol" : 22
             }
           },
@@ -7308,17 +8925,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 281,
+                "startLine" : 314,
                 "startCol" : 30,
-                "endLine" : 281,
+                "endLine" : 314,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 281,
+              "startLine" : 314,
               "startCol" : 24,
-              "endLine" : 281,
+              "endLine" : 314,
               "endCol" : 38
             }
           }
@@ -7333,9 +8950,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 282,
+                "startLine" : 315,
                 "startCol" : 6,
-                "endLine" : 282,
+                "endLine" : 315,
                 "endCol" : 8
               }
             },
@@ -7343,16 +8960,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 282,
+                "startLine" : 315,
                 "startCol" : 12,
-                "endLine" : 282,
+                "endLine" : 315,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 282,
+              "startLine" : 315,
               "startCol" : 6,
-              "endLine" : 282,
+              "endLine" : 315,
               "endCol" : 14
             }
           },
@@ -7367,9 +8984,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 316,
                     "startCol" : 8,
-                    "endLine" : 283,
+                    "endLine" : 316,
                     "endCol" : 16
                   }
                 },
@@ -7377,24 +8994,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 316,
                     "startCol" : 17,
-                    "endLine" : 283,
+                    "endLine" : 316,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 283,
+                  "startLine" : 316,
                   "startCol" : 8,
-                  "endLine" : 283,
+                  "endLine" : 316,
                   "endCol" : 20
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 283,
+                "startLine" : 316,
                 "startCol" : 8,
-                "endLine" : 283,
+                "endLine" : 316,
                 "endCol" : 33
               }
             },
@@ -7406,9 +9023,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 316,
                     "startCol" : 37,
-                    "endLine" : 283,
+                    "endLine" : 316,
                     "endCol" : 45
                   }
                 },
@@ -7416,52 +9033,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 283,
+                    "startLine" : 316,
                     "startCol" : 46,
-                    "endLine" : 283,
+                    "endLine" : 316,
                     "endCol" : 48
                   }
                 },
                 "span" : {
-                  "startLine" : 283,
+                  "startLine" : 316,
                   "startCol" : 37,
-                  "endLine" : 283,
+                  "endLine" : 316,
                   "endCol" : 49
                 }
               },
               "field" : "access_token",
               "span" : {
-                "startLine" : 283,
+                "startLine" : 316,
                 "startCol" : 37,
-                "endLine" : 283,
+                "endLine" : 316,
                 "endCol" : 62
               }
             },
             "span" : {
-              "startLine" : 283,
+              "startLine" : 316,
               "startCol" : 8,
-              "endLine" : 283,
+              "endLine" : 316,
               "endCol" : 62
             }
           },
           "span" : {
-            "startLine" : 282,
+            "startLine" : 315,
             "startCol" : 6,
-            "endLine" : 283,
+            "endLine" : 316,
             "endCol" : 62
           }
         },
         "span" : {
-          "startLine" : 281,
+          "startLine" : 314,
           "startCol" : 4,
-          "endLine" : 283,
+          "endLine" : 316,
           "endCol" : 62
         }
       },
       "span" : {
-        "startLine" : 280,
+        "startLine" : 313,
         "startCol" : 2,
-        "endLine" : 283,
+        "endLine" : 316,
         "endCol" : 62
       }
     },
@@ -7478,17 +9095,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 286,
+                "startLine" : 319,
                 "startCol" : 14,
-                "endLine" : 286,
+                "endLine" : 319,
                 "endCol" : 22
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 286,
+              "startLine" : 319,
               "startCol" : 8,
-              "endLine" : 286,
+              "endLine" : 319,
               "endCol" : 22
             }
           },
@@ -7498,17 +9115,17 @@
               "kind" : "Identifier",
               "name" : "sessions",
               "span" : {
-                "startLine" : 286,
+                "startLine" : 319,
                 "startCol" : 30,
-                "endLine" : 286,
+                "endLine" : 319,
                 "endCol" : 38
               }
             },
             "bindingKind" : "in",
             "span" : {
-              "startLine" : 286,
+              "startLine" : 319,
               "startCol" : 24,
-              "endLine" : 286,
+              "endLine" : 319,
               "endCol" : 38
             }
           }
@@ -7523,9 +9140,9 @@
               "kind" : "Identifier",
               "name" : "s1",
               "span" : {
-                "startLine" : 287,
+                "startLine" : 320,
                 "startCol" : 6,
-                "endLine" : 287,
+                "endLine" : 320,
                 "endCol" : 8
               }
             },
@@ -7533,16 +9150,16 @@
               "kind" : "Identifier",
               "name" : "s2",
               "span" : {
-                "startLine" : 287,
+                "startLine" : 320,
                 "startCol" : 12,
-                "endLine" : 287,
+                "endLine" : 320,
                 "endCol" : 14
               }
             },
             "span" : {
-              "startLine" : 287,
+              "startLine" : 320,
               "startCol" : 6,
-              "endLine" : 287,
+              "endLine" : 320,
               "endCol" : 14
             }
           },
@@ -7557,9 +9174,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 288,
+                    "startLine" : 321,
                     "startCol" : 8,
-                    "endLine" : 288,
+                    "endLine" : 321,
                     "endCol" : 16
                   }
                 },
@@ -7567,24 +9184,24 @@
                   "kind" : "Identifier",
                   "name" : "s1",
                   "span" : {
-                    "startLine" : 288,
+                    "startLine" : 321,
                     "startCol" : 17,
-                    "endLine" : 288,
+                    "endLine" : 321,
                     "endCol" : 19
                   }
                 },
                 "span" : {
-                  "startLine" : 288,
+                  "startLine" : 321,
                   "startCol" : 8,
-                  "endLine" : 288,
+                  "endLine" : 321,
                   "endCol" : 20
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 288,
+                "startLine" : 321,
                 "startCol" : 8,
-                "endLine" : 288,
+                "endLine" : 321,
                 "endCol" : 34
               }
             },
@@ -7596,9 +9213,9 @@
                   "kind" : "Identifier",
                   "name" : "sessions",
                   "span" : {
-                    "startLine" : 288,
+                    "startLine" : 321,
                     "startCol" : 38,
-                    "endLine" : 288,
+                    "endLine" : 321,
                     "endCol" : 46
                   }
                 },
@@ -7606,52 +9223,52 @@
                   "kind" : "Identifier",
                   "name" : "s2",
                   "span" : {
-                    "startLine" : 288,
+                    "startLine" : 321,
                     "startCol" : 47,
-                    "endLine" : 288,
+                    "endLine" : 321,
                     "endCol" : 49
                   }
                 },
                 "span" : {
-                  "startLine" : 288,
+                  "startLine" : 321,
                   "startCol" : 38,
-                  "endLine" : 288,
+                  "endLine" : 321,
                   "endCol" : 50
                 }
               },
               "field" : "refresh_token",
               "span" : {
-                "startLine" : 288,
+                "startLine" : 321,
                 "startCol" : 38,
-                "endLine" : 288,
+                "endLine" : 321,
                 "endCol" : 64
               }
             },
             "span" : {
-              "startLine" : 288,
+              "startLine" : 321,
               "startCol" : 8,
-              "endLine" : 288,
+              "endLine" : 321,
               "endCol" : 64
             }
           },
           "span" : {
-            "startLine" : 287,
+            "startLine" : 320,
             "startCol" : 6,
-            "endLine" : 288,
+            "endLine" : 321,
             "endCol" : 64
           }
         },
         "span" : {
-          "startLine" : 286,
+          "startLine" : 319,
           "startCol" : 4,
-          "endLine" : 288,
+          "endLine" : 321,
           "endCol" : 64
         }
       },
       "span" : {
-        "startLine" : 285,
+        "startLine" : 318,
         "startCol" : 2,
-        "endLine" : 288,
+        "endLine" : 321,
         "endCol" : 64
       }
     }
@@ -7661,270 +9278,6 @@
   "facts" : [
   ],
   "functions" : [
-    {
-      "kind" : "Function",
-      "name" : "recentFailedAttempts",
-      "params" : [
-        {
-          "kind" : "Param",
-          "name" : "email",
-          "typeExpr" : {
-            "kind" : "NamedType",
-            "name" : "Email",
-            "span" : {
-              "startLine" : 231,
-              "startCol" : 39,
-              "endLine" : 231,
-              "endCol" : 44
-            }
-          },
-          "span" : {
-            "startLine" : 231,
-            "startCol" : 32,
-            "endLine" : 231,
-            "endCol" : 44
-          }
-        }
-      ],
-      "returnType" : {
-        "kind" : "NamedType",
-        "name" : "Int",
-        "span" : {
-          "startLine" : 231,
-          "startCol" : 47,
-          "endLine" : 231,
-          "endCol" : 50
-        }
-      },
-      "body" : {
-        "kind" : "UnaryOp",
-        "op" : "cardinality",
-        "operand" : {
-          "kind" : "SetComprehension",
-          "variable" : "a",
-          "domain" : {
-            "kind" : "Identifier",
-            "name" : "login_attempts",
-            "span" : {
-              "startLine" : 232,
-              "startCol" : 12,
-              "endLine" : 232,
-              "endCol" : 26
-            }
-          },
-          "predicate" : {
-            "kind" : "BinaryOp",
-            "op" : "and",
-            "left" : {
-              "kind" : "BinaryOp",
-              "op" : "and",
-              "left" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "a",
-                    "span" : {
-                      "startLine" : 233,
-                      "startCol" : 7,
-                      "endLine" : 233,
-                      "endCol" : 8
-                    }
-                  },
-                  "field" : "email",
-                  "span" : {
-                    "startLine" : 233,
-                    "startCol" : 7,
-                    "endLine" : 233,
-                    "endCol" : 14
-                  }
-                },
-                "right" : {
-                  "kind" : "Identifier",
-                  "name" : "email",
-                  "span" : {
-                    "startLine" : 233,
-                    "startCol" : 17,
-                    "endLine" : 233,
-                    "endCol" : 22
-                  }
-                },
-                "span" : {
-                  "startLine" : 233,
-                  "startCol" : 7,
-                  "endLine" : 233,
-                  "endCol" : 22
-                }
-              },
-              "right" : {
-                "kind" : "BinaryOp",
-                "op" : "=",
-                "left" : {
-                  "kind" : "FieldAccess",
-                  "base" : {
-                    "kind" : "Identifier",
-                    "name" : "a",
-                    "span" : {
-                      "startLine" : 234,
-                      "startCol" : 11,
-                      "endLine" : 234,
-                      "endCol" : 12
-                    }
-                  },
-                  "field" : "success",
-                  "span" : {
-                    "startLine" : 234,
-                    "startCol" : 11,
-                    "endLine" : 234,
-                    "endCol" : 20
-                  }
-                },
-                "right" : {
-                  "kind" : "BoolLit",
-                  "value" : false,
-                  "span" : {
-                    "startLine" : 234,
-                    "startCol" : 23,
-                    "endLine" : 234,
-                    "endCol" : 28
-                  }
-                },
-                "span" : {
-                  "startLine" : 234,
-                  "startCol" : 11,
-                  "endLine" : 234,
-                  "endCol" : 28
-                }
-              },
-              "span" : {
-                "startLine" : 233,
-                "startCol" : 7,
-                "endLine" : 234,
-                "endCol" : 28
-              }
-            },
-            "right" : {
-              "kind" : "BinaryOp",
-              "op" : ">",
-              "left" : {
-                "kind" : "FieldAccess",
-                "base" : {
-                  "kind" : "Identifier",
-                  "name" : "a",
-                  "span" : {
-                    "startLine" : 235,
-                    "startCol" : 11,
-                    "endLine" : 235,
-                    "endCol" : 12
-                  }
-                },
-                "field" : "timestamp",
-                "span" : {
-                  "startLine" : 235,
-                  "startCol" : 11,
-                  "endLine" : 235,
-                  "endCol" : 22
-                }
-              },
-              "right" : {
-                "kind" : "BinaryOp",
-                "op" : "-",
-                "left" : {
-                  "kind" : "Call",
-                  "callee" : {
-                    "kind" : "Identifier",
-                    "name" : "now",
-                    "span" : {
-                      "startLine" : 235,
-                      "startCol" : 25,
-                      "endLine" : 235,
-                      "endCol" : 28
-                    }
-                  },
-                  "args" : [
-                  ],
-                  "span" : {
-                    "startLine" : 235,
-                    "startCol" : 25,
-                    "endLine" : 235,
-                    "endCol" : 30
-                  }
-                },
-                "right" : {
-                  "kind" : "Call",
-                  "callee" : {
-                    "kind" : "Identifier",
-                    "name" : "minutes",
-                    "span" : {
-                      "startLine" : 235,
-                      "startCol" : 33,
-                      "endLine" : 235,
-                      "endCol" : 40
-                    }
-                  },
-                  "args" : [
-                    {
-                      "kind" : "IntLit",
-                      "value" : 15,
-                      "span" : {
-                        "startLine" : 235,
-                        "startCol" : 41,
-                        "endLine" : 235,
-                        "endCol" : 43
-                      }
-                    }
-                  ],
-                  "span" : {
-                    "startLine" : 235,
-                    "startCol" : 33,
-                    "endLine" : 235,
-                    "endCol" : 44
-                  }
-                },
-                "span" : {
-                  "startLine" : 235,
-                  "startCol" : 25,
-                  "endLine" : 235,
-                  "endCol" : 44
-                }
-              },
-              "span" : {
-                "startLine" : 235,
-                "startCol" : 11,
-                "endLine" : 235,
-                "endCol" : 44
-              }
-            },
-            "span" : {
-              "startLine" : 233,
-              "startCol" : 7,
-              "endLine" : 235,
-              "endCol" : 44
-            }
-          },
-          "span" : {
-            "startLine" : 232,
-            "startCol" : 5,
-            "endLine" : 235,
-            "endCol" : 46
-          }
-        },
-        "span" : {
-          "startLine" : 232,
-          "startCol" : 4,
-          "endLine" : 235,
-          "endCol" : 46
-        }
-      },
-      "span" : {
-        "startLine" : 231,
-        "startCol" : 2,
-        "endLine" : 235,
-        "endCol" : 46
-      }
-    }
   ],
   "predicates" : [
     {
@@ -8045,9 +9398,9 @@
           "value" : "/auth/register"
         },
         "span" : {
-          "startLine" : 298,
+          "startLine" : 331,
           "startCol" : 4,
-          "endLine" : 298,
+          "endLine" : 331,
           "endCol" : 41
         }
       },
@@ -8061,9 +9414,9 @@
           "value" : 201
         },
         "span" : {
-          "startLine" : 299,
+          "startLine" : 332,
           "startCol" : 4,
-          "endLine" : 299,
+          "endLine" : 332,
           "endCol" : 38
         }
       },
@@ -8077,9 +9430,9 @@
           "value" : "/auth/login"
         },
         "span" : {
-          "startLine" : 301,
+          "startLine" : 334,
           "startCol" : 4,
-          "endLine" : 301,
+          "endLine" : 334,
           "endCol" : 35
         }
       },
@@ -8093,9 +9446,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 302,
+          "startLine" : 335,
           "startCol" : 4,
-          "endLine" : 302,
+          "endLine" : 335,
           "endCol" : 30
         }
       },
@@ -8109,9 +9462,9 @@
           "value" : 200
         },
         "span" : {
-          "startLine" : 303,
+          "startLine" : 336,
           "startCol" : 4,
-          "endLine" : 303,
+          "endLine" : 336,
           "endCol" : 35
         }
       },
@@ -8125,9 +9478,9 @@
           "value" : "/auth/refresh"
         },
         "span" : {
-          "startLine" : 305,
+          "startLine" : 338,
           "startCol" : 4,
-          "endLine" : 305,
+          "endLine" : 338,
           "endCol" : 44
         }
       },
@@ -8141,9 +9494,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 306,
+          "startLine" : 339,
           "startCol" : 4,
-          "endLine" : 306,
+          "endLine" : 339,
           "endCol" : 37
         }
       },
@@ -8157,9 +9510,9 @@
           "value" : "/auth/password-reset"
         },
         "span" : {
-          "startLine" : 308,
+          "startLine" : 341,
           "startCol" : 4,
-          "endLine" : 308,
+          "endLine" : 341,
           "endCol" : 59
         }
       },
@@ -8173,9 +9526,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 309,
+          "startLine" : 342,
           "startCol" : 4,
-          "endLine" : 309,
+          "endLine" : 342,
           "endCol" : 45
         }
       },
@@ -8189,9 +9542,9 @@
           "value" : "/auth/password-reset/confirm"
         },
         "span" : {
-          "startLine" : 311,
+          "startLine" : 344,
           "startCol" : 4,
-          "endLine" : 311,
+          "endLine" : 344,
           "endCol" : 60
         }
       },
@@ -8205,9 +9558,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 312,
+          "startLine" : 345,
           "startCol" : 4,
-          "endLine" : 312,
+          "endLine" : 345,
           "endCol" : 38
         }
       },
@@ -8221,9 +9574,9 @@
           "value" : "/auth/logout"
         },
         "span" : {
-          "startLine" : 314,
+          "startLine" : 347,
           "startCol" : 4,
-          "endLine" : 314,
+          "endLine" : 347,
           "endCol" : 37
         }
       },
@@ -8237,9 +9590,9 @@
           "value" : "POST"
         },
         "span" : {
-          "startLine" : 315,
+          "startLine" : 348,
           "startCol" : 4,
-          "endLine" : 315,
+          "endLine" : 348,
           "endCol" : 31
         }
       },
@@ -8253,17 +9606,17 @@
           "value" : 204
         },
         "span" : {
-          "startLine" : 316,
+          "startLine" : 349,
           "startCol" : 4,
-          "endLine" : 316,
+          "endLine" : 349,
           "endCol" : 36
         }
       }
     ],
     "span" : {
-      "startLine" : 297,
+      "startLine" : 330,
       "startCol" : 2,
-      "endLine" : 317,
+      "endLine" : 350,
       "endCol" : 3
     }
   },
@@ -8275,9 +9628,9 @@
       },
       "name" : "bearer",
       "span" : {
-        "startLine" : 73,
+        "startLine" : 80,
         "startCol" : 4,
-        "endLine" : 73,
+        "endLine" : 80,
         "endCol" : 40
       }
     },
@@ -8289,9 +9642,9 @@
       },
       "name" : "api_key",
       "span" : {
-        "startLine" : 74,
+        "startLine" : 81,
         "startCol" : 4,
-        "endLine" : 74,
+        "endLine" : 81,
         "endCol" : 40
       }
     }
@@ -8299,7 +9652,7 @@
   "span" : {
     "startLine" : 1,
     "startCol" : 0,
-    "endLine" : 318,
+    "endLine" : 351,
     "endCol" : 1
   }
 }

--- a/fixtures/spec/auth_service.spec
+++ b/fixtures/spec/auth_service.spec
@@ -55,6 +55,12 @@ service AuthService {
     user_id: UserId
   }
 
+  entity FailedLogin {
+    email: Email
+    count: Int where value > 0
+    window_start: DateTime
+  }
+
   // --- State ---
 
   state {
@@ -63,6 +69,7 @@ service AuthService {
     login_attempts: Seq[LoginAttempt]
     user_by_email: Email -> lone User
     reset_tokens: Token -> lone ResetToken
+    failed_logins: Email -> lone FailedLogin
     next_user_id: UserId
     next_session_id: Int
   }
@@ -107,20 +114,38 @@ service AuthService {
       email in user_by_email
       user_by_email[email].is_active = true
       user_by_email[email].password_hash = hash(password)
-      recentFailedAttempts(email) < 5
+      // Rate limit: at most 5 failures inside a 15-minute window. A window that
+      // started over 15 minutes ago has lapsed, so it no longer blocks (this is
+      // what prevents a permanent lockout).
+      email not in failed_logins
+        or failed_logins[email].count < 5
+        or now() - failed_logins[email].window_start > minutes(15)
 
     ensures:
       let user = user_by_email[email] in
-        session.user_id = user.id
-        and session.is_revoked = false
-        and session.access_expires_at > now()
-        and session.refresh_expires_at > session.access_expires_at
-        and sessions' = pre(sessions) + {session.id -> session}
-        and users'[user.id].last_login = some(now())
-        and login_attempts' = pre(login_attempts)
-             + [LoginAttempt { email = email,
-                               timestamp = now(),
-                               success = true }]
+        // Stamp last_login on one updated record and write it to both stores so
+        // the cross-store value-equality invariants hold (see ResetPassword).
+        let updated = user with { last_login = some(now()) } in
+          session.id = pre(next_session_id)
+          and session.user_id = user.id
+          and session.is_revoked = false
+          and session.access_expires_at > now()
+          and session.refresh_expires_at > session.access_expires_at
+          // Fresh session id and tokens (see RefreshToken).
+          and (all s in pre(sessions) |
+                session.access_token != pre(sessions)[s].access_token)
+          and (all s in pre(sessions) |
+                session.refresh_token != pre(sessions)[s].refresh_token)
+          and next_session_id' = pre(next_session_id) + 1
+          and sessions' = pre(sessions) + {session.id -> session}
+          and users' = pre(users) + {user.id -> updated}
+          and user_by_email' = pre(user_by_email) + {email -> updated}
+          // A successful login clears the failure counter.
+          and failed_logins' = pre(failed_logins) - {email}
+          and login_attempts' = pre(login_attempts)
+               + [LoginAttempt { email = email,
+                                 timestamp = now(),
+                                 success = true }]
   }
 
   operation LoginFailed {
@@ -131,12 +156,24 @@ service AuthService {
       user_by_email[email].password_hash != hash(password)
 
     ensures:
-      sessions' = sessions
-      users' = users
-      login_attempts' = pre(login_attempts)
-        + [LoginAttempt { email = email,
-                          timestamp = now(),
-                          success = false }]
+      // Bump the failure counter. A single insert handles all three cases via
+      // `if`: no prior record or a lapsed window starts a fresh window at count
+      // 1, an active window increments in place. Computing the values inline
+      // (rather than branching the state update) keeps the relation framed.
+      let active = email in pre(failed_logins)
+        and now() - pre(failed_logins)[email].window_start <= minutes(15) in
+        failed_logins' = pre(failed_logins) + {email -> FailedLogin {
+          email = email,
+          count = (if active then pre(failed_logins)[email].count else 0) + 1,
+          window_start = if active then pre(failed_logins)[email].window_start
+                         else now()
+        }}
+        and sessions' = sessions
+        and users' = users
+        and login_attempts' = pre(login_attempts)
+          + [LoginAttempt { email = email,
+                            timestamp = now(),
+                            success = false }]
   }
 
   operation RefreshToken {
@@ -226,13 +263,6 @@ service AuthService {
       users' = users
   }
 
-  // --- Helper Functions ---
-
-  function recentFailedAttempts(email: Email): Int =
-    #{ a in login_attempts |
-       a.email = email
-       and a.success = false
-       and a.timestamp > now() - minutes(15) }
 
   // --- Global Invariants ---
 
@@ -264,6 +294,9 @@ service AuthService {
 
   invariant resetTokenBelongsToUser:
     all t in reset_tokens | reset_tokens[t].user_id in users
+
+  invariant failedLoginKeyMatches:
+    all e in failed_logins | failed_logins[e].email = e
 
   invariant nextUserIdFresh:
     all u in users | u < next_user_id

--- a/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
+++ b/modules/cli/src/test/scala/specrest/cli/VerifyJsonTest.scala
@@ -136,25 +136,49 @@ class VerifyJsonTest extends CatsEffectSuite:
         assert(nonEmpty.nonEmpty, s"expected at least one non-empty suggestion; got: $out")
 
   test("best-effort checks always skip with soundness_limitation (default behavior)"):
-    // auth_service uses pre(rel)[k] / TheF — neither lowers under v2; those checks skip.
+    // A Seq-comprehension cardinality is outside lower's coverage, so its checks
+    // are skipped as best-effort soundness limitations. Use a self-contained spec
+    // rather than a real fixture — fixtures get lifted into the subset over time
+    // (e.g. auth_service is now fully verified), which would silently gut this test.
+    val spec =
+      """service SoundnessSkipDemo {
+        |  entity Item { tag: String where len(value) >= 1 }
+        |  state { items: Seq[Item] }
+        |  operation Tally {
+        |    input: needle: String
+        |    requires:
+        |      #{ i in items | i.tag = needle } < 5
+        |    ensures:
+        |      items' = items
+        |  }
+        |  invariant ok:
+        |    true
+        |}""".stripMargin
     val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)
-    captureStdout(ps => Verify.run("fixtures/spec/auth_service.spec", opts, log, ps))
-      .map: (_, out) =>
-        val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
-        val checks = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
-        val soundnessSkipped = checks.filter: c =>
-          val status   = c.hcursor.downField("status").as[String].toOption
-          val category = c.hcursor.downField("diagnostic").downField("category").as[String].toOption
-          status.contains("skipped") && category.contains("soundness_limitation")
-        assert(
-          soundnessSkipped.nonEmpty,
-          s"expected at least one soundness_limitation skip; checks=$checks"
-        )
-        soundnessSkipped.foreach: c =>
-          assertEquals(
-            c.hcursor.downField("trust").as[String].toOption,
-            Some("best-effort")
+    IO.blocking {
+      val tmp = Files.createTempFile("soundness_skip", ".spec")
+      Files.writeString(tmp, spec)
+      tmp
+    }.flatMap: tmp =>
+      captureStdout(ps => Verify.run(tmp.toString, opts, log, ps))
+        .guarantee(IO.blocking(Files.deleteIfExists(tmp)).void)
+        .map: (_, out) =>
+          val parsed = parser.parse(out).toOption.getOrElse(fail(s"invalid JSON: $out"))
+          val checks = parsed.hcursor.downField("checks").values.getOrElse(Vector.empty).toList
+          val soundnessSkipped = checks.filter: c =>
+            val status = c.hcursor.downField("status").as[String].toOption
+            val category =
+              c.hcursor.downField("diagnostic").downField("category").as[String].toOption
+            status.contains("skipped") && category.contains("soundness_limitation")
+          assert(
+            soundnessSkipped.nonEmpty,
+            s"expected at least one soundness_limitation skip; checks=$checks"
           )
+          soundnessSkipped.foreach: c =>
+            assertEquals(
+              c.hcursor.downField("trust").as[String].toOption,
+              Some("best-effort")
+            )
 
   test("safe_counter still passes (every check lowers; routes via extracted)"):
     val opts = VerifyOptions(30_000L, dumpSmt = false, dumpSmtOut = None, json = true)

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -5454,7 +5454,9 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => None
   }
 
-  def is_builtin_int_func(nm: String): Boolean = nm == "days"
+  def is_builtin_int_func(nm: String): Boolean =
+    nm == "seconds" ||
+      (nm == "minutes" || (nm == "hours" || (nm == "days" || nm == "weeks")))
 
   def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
     case (uu, Nil) => Nil

--- a/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/SkipRateProbeTest.scala
@@ -90,9 +90,9 @@ class SkipRateProbeTest extends CatsEffectSuite:
     ("edge_cases", 29, 0, "plain is an Int scalar backed by service_state since #407"),
     (
       "auth_service",
-      45,
+      44,
       5,
-      "45 (was 44): password-reset tokens moved into their own `reset_tokens: Token -> lone ResetToken` relation, so RequestPasswordReset/ResetPassword now lower as backed-relation updates (no longer skipped) while the two new reset-token consistency invariants add to the count. The 5 skips are all unbacked non-entity state the test-admin /state endpoint projects as null: next_user_id (Register x2), login_attempts (Login, LoginFailed), next_session_id (RefreshToken)"
+      "44 (was 45): rate-limiting moved off the `login_attempts` Seq comprehension onto a `failed_logins: Email -> lone FailedLogin` relation, so Login now lowers fully (fresh-session + value-level user update like RefreshToken/ResetPassword) and LoginFailed's three top-level ensures fold into one let-scoped block; net -1 after adding the failedLoginKeyMatches invariant. The 5 skips are unbacked non-entity state the test-admin /state endpoint projects as null: next_user_id (Register x2), next_session_id (Login bump, RefreshToken), login_attempts (LoginFailed append)"
     )
   ).foreach: (name, expectedTotal, expectedSkipped, why) =>
     test(s"$name: $expectedTotal clauses, $expectedSkipped skips ($why)"):

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -117,14 +117,17 @@ definition is_builtin_func :: "String.literal \<Rightarrow> bool" where
   "is_builtin_func nm \<longleftrightarrow> nm = STR ''hash''"
 
 text \<open>\<open>builtin_int_func name n\<close> is the uninterpreted value of a reserved 1-argument
-  built-in \<open>int \<Rightarrow> int\<close> function \<open>name\<close> (e.g.\ \<open>days\<close>, a duration in epoch seconds)
+  built-in \<open>int \<Rightarrow> int\<close> function \<open>name\<close> (the duration constructors \<open>seconds\<close>,
+  \<open>minutes\<close>, \<open>hours\<close>, \<open>days\<close>, \<open>weeks\<close>, each a duration in epoch seconds)
   applied to \<open>n\<close>. The integer analogue of \<open>builtin_str_func\<close>: abstract, so soundness
   stays parametric in the realisation. \<open>is_builtin_int_func nm\<close> gates lifting
   \<open>CallF (IdentifierF nm) [arg]\<close> to \<open>UIntFunc\<close>.\<close>
 consts builtin_int_func :: "String.literal \<Rightarrow> int \<Rightarrow> int"
 
 definition is_builtin_int_func :: "String.literal \<Rightarrow> bool" where
-  "is_builtin_int_func nm \<longleftrightarrow> nm = STR ''days''"
+  "is_builtin_int_func nm \<longleftrightarrow> nm = STR ''seconds'' \<or> nm = STR ''minutes''
+                              \<or> nm = STR ''hours'' \<or> nm = STR ''days''
+                              \<or> nm = STR ''weeks''"
 
 text \<open>\<open>str_length s\<close> is the length of string \<open>s\<close>, the meaning of the reserved
   builtin \<open>len(s)\<close>. Abstract here (like \<open>builtin_str_func\<close>); the codegen serialisation


### PR DESCRIPTION
With this, **auth_service verifies 99/99 — zero skips, zero failures.** The last gap (the Login rate-limit, which had been trust-limited since it was written) is closed.

## The gap

Login's rate limit was `recentFailedAttempts(email) < 5`, defined as the cardinality of a filtered comprehension over the `login_attempts` Seq:
```
#{ a in login_attempts | a.email = email and a.success = false
                         and a.timestamp > now() - minutes(15) }
```
Seq-comprehension cardinality is outside the verified subset, so **all 13 Login checks were skipped** (trust-limit). Lifting that construct is deep and — more importantly — would be lifting a hard construct to preserve a model that doesn't need it. So instead, this redesigns the rate-limit onto a relation (the #460 lesson: a construct that fights verification usually signals a data-model problem).

## Two changes

**1. Lift the duration builtins (verifier).** `is_builtin_int_func` covered only `days`; extend it to `seconds`/`minutes`/`hours`/`days`/`weeks`. `TUIntFunc` is already name-generic across translate, `smtEval`, the encoder, and codegen, so this is a one-line predicate change, re-proved by mirroring the existing `days` cases. DirectSound/DirectTotality build green, zero sorry; the generated Scala diff is 3 lines.

**2. Move rate-limiting off the audit-log Seq onto a relation (spec).**
```
entity FailedLogin { email: Email, count: Int where value > 0, window_start: DateTime }
state { … failed_logins: Email -> lone FailedLogin … }
```
- **Login.requires:** `email not in failed_logins or failed_logins[email].count < 5 or now() - failed_logins[email].window_start > minutes(15)`. The lapse clause prevents a permanent lockout (a window older than 15 min no longer blocks).
- **LoginFailed:** bumps the counter with a *single* insert whose `count`/`window_start` are computed with `if` — a fresh or lapsed window starts at 1, an active window increments in place (computing the values inline keeps the relation framed; no conditional state update).
- **Login (success):** clears the counter (`failed_logins' = pre(failed_logins) - {email}`).

Surfacing Login also exposed the session-creation and user-update gaps it shared with RefreshToken (#459) and ResetPassword (#458) — previously hidden behind the skip. Fixed identically: Login now pins `session.id = pre(next_session_id)` with fresh tokens and a counter bump, and stamps `last_login` via one updated record written to **both** `users` and `user_by_email` (cross-store value-equality).

The `login_attempts` Seq remains as a pure audit log (Login/LoginFailed still append; that Seq-append already lowers).

## Result

**auth_service: 99/99 checks pass.** No regressions: ecommerce 2 (unchanged — `days(30)` still lowers), url_shortener 21/21, todo_list 55/55, set_ops 29/29. Codegen emits a clean `failed_logins` table (email, `count > 0` check, window_start).

## Tests

Full suites green: verify 267, testgen 287, cli 71, codegen 370, lint 31, profile 46, convention 114, dafny 10, ir/parser. Regenerated SpecRestGenerated.scala (predicate) + ir/auth_service.json; `SkipRateProbeTest` auth 45→44.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made login rate limiting verifiable by moving it to a `failed_logins` relation and extending duration builtins; `auth_service` now fully verifies (99/99, 0 skips). Also fixed a CLI test by making it self-contained.

- **Refactors**
  - Tracked failures via `FailedLogin` and `failed_logins: Email -> lone FailedLogin` with a 15‑minute window; Login clears the counter, and LoginFailed increments via a single insert with inline `if`.
  - Ensured Login creates a fresh session (unique tokens, `session.id = pre(next_session_id)`, bump `next_session_id`) and sets `last_login` on one updated user written to both `users` and `user_by_email`; added `failedLoginKeyMatches` invariant.
  - Lifted duration builtins to support `seconds`/`minutes`/`hours`/`days`/`weeks` (Isabelle and codegen updated).

- **Bug Fixes**
  - Updated the “best‑effort checks always skip” CLI test to use an inline spec (no longer depends on `auth_service`, which now has zero skips).

<sup>Written for commit 1c405f5a83f78d474e130c6da2196dd78ecab244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for additional duration units in specs: seconds, minutes, hours, and weeks (previously only days).

* **Improvements**
  * Upgraded authentication rate-limiting to more accurately track repeated login failures within a rolling time window, and to reset failure tracking after a successful login.

* **Tests**
  * Updated internal verification and rate-limit expectations to match the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->