### PR TITLE
fix(parser): `implies`/`iff` bind looser than `and`/`or`

### DIFF
--- a/modules/parser/src/main/antlr4/Spec.g4
+++ b/modules/parser/src/main/antlr4/Spec.g4
@@ -271,14 +271,15 @@ expr
     | expr SUBSET expr                                          # subsetExpr
     | expr MATCHES REGEX_LIT                                    # matchesExpr
 
-    // ── Implication ──
-    | expr IMPLIES expr                                         # impliesExpr
-    | expr IFF expr                                             # iffExpr
-
-    // ── Logical (lowest precedence among binary ops) ──
+    // ── Logical negation / conjunction / disjunction ──
+    // (bind tighter than implication, per the usual `not > and > or > implies`)
     | NOT expr                                                  # notExpr
     | expr AND expr                                             # andExpr
     | expr OR expr                                              # orExpr
+
+    // ── Implication (lowest precedence among binary ops) ──
+    | expr IMPLIES expr                                         # impliesExpr
+    | expr IFF expr                                             # iffExpr
 
     // ── Primary (atoms — not left-recursive, no precedence) ──
     | LPAREN expr RPAREN                                        # parenExpr

--- a/modules/parser/src/test/scala/specrest/parser/PrecedenceTest.scala
+++ b/modules/parser/src/test/scala/specrest/parser/PrecedenceTest.scala
@@ -1,0 +1,45 @@
+package specrest.parser
+
+import munit.CatsEffectSuite
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.parser.testutil.SpecFixtures
+
+class PrecedenceTest extends CatsEffectSuite:
+
+  private def serviceWith(invariant: String): String =
+    s"""|service PrecDemo {
+        |  state {
+        |    count: Int
+        |  }
+        |  operation Noop {
+        |    ensures:
+        |      count' = count
+        |  }
+        |  invariant probe:
+        |    $invariant
+        |}
+        |""".stripMargin
+
+  private def probeBody(name: String, invariant: String) =
+    SpecFixtures.buildFromSource(name, serviceWith(invariant)).map: ir =>
+      invBody(svcInvariants(ir).head)
+
+  test("`and` binds tighter than `implies`: `a and b implies c` = `(a and b) implies c`"):
+    probeBody("and-implies", "count > 0 and count < 9 implies count > 5").map:
+      case BinaryOpF(BImplies(), BinaryOpF(BAnd(), _, _, _), _, _) => ()
+      case other                                                   => fail(s"expected Implies(And(_,_), _), got: $other")
+
+  test("`implies` binds looser on the right too: `a implies b and c` = `a implies (b and c)`"):
+    probeBody("implies-and", "count > 5 implies count > 0 and count < 9").map:
+      case BinaryOpF(BImplies(), _, BinaryOpF(BAnd(), _, _, _), _) => ()
+      case other                                                   => fail(s"expected Implies(_, And(_,_)), got: $other")
+
+  test("`or` binds tighter than `implies`: `a or b implies c` = `(a or b) implies c`"):
+    probeBody("or-implies", "count > 0 or count > 9 implies count > 5").map:
+      case BinaryOpF(BImplies(), BinaryOpF(BOr(), _, _, _), _, _) => ()
+      case other                                                  => fail(s"expected Implies(Or(_,_), _), got: $other")
+
+  test("`not` binds tighter than `and`: `not a and b` = `(not a) and b`"):
+    probeBody("not-and", "not count > 0 and count < 9").map:
+      case BinaryOpF(BAnd(), UnaryOpF(UNot(), _, _), _, _) => ()
+      case other                                           => fail(s"expected And(Not(_), _), got: $other")


### PR DESCRIPTION
Root-cause fix for the operator-precedence footgun flagged on #420 (surfaced by ecommerce's `cancelledPaidOrdersHaveRefunds` in #462).

## The bug

`Spec.g4`'s left-recursive `expr` rule listed `impliesExpr`/`iffExpr` **above** `andExpr`/`orExpr`. ANTLR4 ranks earlier alternatives higher, so `implies`/`iff` bound *tighter* than `and`/`or` — backwards from the standard `not > and > or > implies > iff`. Result: `a and b implies c` parsed as `a and (b implies c)`, silently mis-stating any invariant that mixed them (e.g. `... order_id = oid and status = CAPTURED implies (...)` demanded *every* payment belong to the order).

## The fix

Move the implication alternatives below the logical ones, giving `not > and > or > implies > iff`. A new `PrecedenceTest` locks it in:
- `a and b implies c` → `Implies(And(a,b), c)`
- `a implies b and c` → `Implies(a, And(b,c))`
- `a or b implies c` → `Implies(Or(a,b), c)`
- `not a and b` → `And(Not(a), b)`

## Zero current-spec impact

No fixture mixes unparenthesized `and`/`or` with `implies`/`iff` — they use parens (ecommerce's conditional inserts, the #462 invariants) or pure `comparison implies comparison` (auth/todo/edge_cases). So re-parsing every spec yields a **zero IR-golden diff**, confirmed by regenerating all 21 goldens. The fix only changes how *future* unparenthesized specs parse — toward the conventional meaning.

The explicit parens added to `cancelledPaidOrdersHaveRefunds` in #462 are now redundant but kept (explicit is clearer and decouples the spec from grammar precedence).

## Tests

Full suites green, no regressions: parser 52 (+4 PrecedenceTest), ir 43, verify 267, testgen 287, codegen 370, cli 71, lint 31, convention 114, profile 46, dafny 10, synth 112, arch 4. scalafmt/scalafix clean. Verify sanity: ecommerce 133/133, auth_service 99/99, todo_list 55/55 (unchanged — IR is byte-identical).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix parser precedence so `implies`/`iff` bind looser than `and`/`or`, matching standard logic. Prevents mis-parsing like `a and b implies c` and leaves existing specs unchanged.

- **Bug Fixes**
  - Reordered `expr` alternatives in `modules/parser/src/main/antlr4/Spec.g4` to enforce `not > and > or > implies > iff`.
  - Added `PrecedenceTest` to assert correct grouping for mixed logical/implication expressions.
  - No IR golden diffs; current fixtures remain the same.

<sup>Written for commit fb4eacbc550bd69c3943dc16edf12d395e8fff8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected operator precedence ordering in expression parsing to ensure boolean operations (`not`, `and`, `or`) evaluate before implication operations.

* **Tests**
  * Added comprehensive test coverage for operator precedence validation in parsed expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->