### PR TITLE
fix(testgen): point Go/TS pending-skip messages at the real tracking issue

### DIFF
--- a/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoBehavioral.scala
@@ -30,7 +30,7 @@ object GoBehavioral:
                   operName(opDecl),
                   "behavioral_go_pending",
                   "negative/invariant/temporal/transition behavioral tests are not " +
-                    "yet emitted by the Go backend (#176); these remain covered by " +
+                    "yet emitted by the Go backend (#420); these remain covered by " +
                     "the Python oracle suite"
                 )
               )

--- a/modules/testgen/src/main/scala/specrest/testgen/GoStateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoStateful.scala
@@ -54,7 +54,7 @@ object GoStateful:
         "<stateful>",
         "stateful_go_pending",
         "bundle id-flow, transitions and temporals are not yet modelled by the " +
-          "Go stateful backend (#176); covered by the Python oracle suite"
+          "Go stateful backend (#420); covered by the Python oracle suite"
       )
 
     val file =

--- a/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsBehavioral.scala
@@ -30,7 +30,7 @@ object TsBehavioral:
                   operName(opDecl),
                   "behavioral_ts_pending",
                   "negative/invariant/temporal/transition behavioral tests are not " +
-                    "yet emitted by the TypeScript backend (#174); these remain " +
+                    "yet emitted by the TypeScript backend (#420); these remain " +
                     "covered by the Python oracle suite"
                 )
               )

--- a/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsStateful.scala
@@ -53,7 +53,7 @@ object TsStateful:
         "<stateful>",
         "stateful_ts_pending",
         "bundle id-flow, transitions and temporals are not yet modelled by the " +
-          "TypeScript stateful backend (#174); covered by the Python oracle suite"
+          "TypeScript stateful backend (#420); covered by the Python oracle suite"
       )
 
     val file =


### PR DESCRIPTION
## What

The native Go/TS testgen backends emit only positive-`ensures` behavioral tests and skip the rest, recording a skip in every generated project's `tests/_testgen_skips.json`. Four of those skip messages cited **wrong issue numbers**:

- `GoBehavioral` / `GoStateful` cited **#176** — actually "proof governance for M_G.1" (merged, unrelated).
- `TsBehavioral` / `TsStateful` cited **#174** — actually "M_G.3 roadmap reprioritize" (closed, unrelated).

A user following the cited issue from a generated project lands on an unrelated global-proof issue.

## Fix

- Repoint all four messages at the limitations catalog (**#420**), which is the correct umbrella and the single open tracking issue.
- Add the gap to **#420 section D** (it wasn't catalogued): native Go/TS behavioral backends emit only positive-`ensures`; negative/invariant/temporal/transition tests and the stateful id-flow/transition/temporal machine are skipped (`behavioral_{go,ts}_pending` / `stateful_{go,ts}_pending`). The full categories run in the **Python** suite, which is the byte-identical differential oracle the Go/TS conformance runs against, so correctness is covered; the gap is native-test parity for standalone `go test` / `vitest` (bounded value).

## Safe

- Tests assert on the skip **kind** (`behavioral_go_pending`, etc.), not the message text or issue number; `BackendTest` (45) still passes.
- No golden/fixture file contains these message strings.
- Message-string-only change; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed wrong issue links in Go/TS testgen pending-skip messages to point to #420 (limitations catalog). This directs users from generated projects to the correct tracking issue.

- **Bug Fixes**
  - Updated messages in `GoBehavioral`, `GoStateful`, `TsBehavioral`, and `TsStateful` from #176/#174 to #420.
  - Message-only change; no behavior changes and existing tests remain valid.

<sup>Written for commit 0df0ccfe57949f8f4ad2df9e3dce55828458b599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

