### PR TITLE
fix(proofs): exclude callee names from free_vars; recognize mirrored refinement atoms

### DIFF
--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -100,7 +100,7 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
     assertEquals(res.minimum, Some(dec(42, 0)))
     assertEquals(res.maximum, Some(dec(42, 0)))
 
-  // -- Mirrored atoms (n <op> value): decomposeAtom flips the operator -----
+  // -- Mirrored comparison atoms (n <op> value) --------------------------
 
   List[(String, bin_op, Int, openapi_bounds => Option[decimal_lit], decimal_lit)](
     ("n < value  = value > n  -> exclusive min", BLt(), 10, _.exclusiveMinimum, dec(10, 0)),

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -100,6 +100,25 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
     assertEquals(res.minimum, Some(dec(42, 0)))
     assertEquals(res.maximum, Some(dec(42, 0)))
 
+  // -- Mirrored atoms (n <op> value): decomposeAtom flips the operator -----
+
+  List[(String, bin_op, Int, openapi_bounds => Option[decimal_lit], decimal_lit)](
+    ("n < value  = value > n  -> exclusive min", BLt(), 10, _.exclusiveMinimum, dec(10, 0)),
+    ("n <= value = value >= n -> inclusive min", BLe(), 10, _.minimum, dec(10, 0)),
+    ("n > value  = value < n  -> exclusive max", BGt(), 100, _.exclusiveMaximum, dec(100, 0)),
+    ("n >= value = value <= n -> inclusive max", BGe(), 100, _.maximum, dec(100, 0))
+  ).foreach: (name, op, n, field, expected) =>
+    test(s"Mirrored RaValueCmp: $name"):
+      assertEquals(field(walk(binOp(op, intL(n), valueRef))), Some(expected))
+
+  test("Mirrored RaValueCmp BEq pins both inclusive bounds"):
+    val res = walk(binOp(BEq(), intL(42), valueRef))
+    assertEquals(res.minimum, Some(dec(42, 0)))
+    assertEquals(res.maximum, Some(dec(42, 0)))
+
+  test("Mirrored RaLenCmp: n < len(value) = len(value) > n -> minLength n+1"):
+    assertEquals(walk(binOp(BLt(), intL(3), lenOfValue)).minLength, Some(i(4)))
+
   // -- RaLenCmp (Int path) ------------------------------------------------
 
   List[(String, bin_op, Int, openapi_bounds => Option[BigInt], Int)](

--- a/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/openapi/OpenApiConstraintsTest.scala
@@ -116,8 +116,14 @@ class OpenApiConstraintsTest extends CatsEffectSuite:
     assertEquals(res.minimum, Some(dec(42, 0)))
     assertEquals(res.maximum, Some(dec(42, 0)))
 
-  test("Mirrored RaLenCmp: n < len(value) = len(value) > n -> minLength n+1"):
-    assertEquals(walk(binOp(BLt(), intL(3), lenOfValue)).minLength, Some(i(4)))
+  List[(String, bin_op, Int, openapi_bounds => Option[BigInt], Int)](
+    ("n < len  = len > n  -> minLength n+1", BLt(), 3, _.minLength, 4),
+    ("n <= len = len >= n -> minLength n", BLe(), 3, _.minLength, 3),
+    ("n > len  = len < n  -> maxLength n-1", BGt(), 10, _.maxLength, 9),
+    ("n >= len = len <= n -> maxLength n", BGe(), 10, _.maxLength, 10)
+  ).foreach: (name, op, n, field, expected) =>
+    test(s"Mirrored RaLenCmp: $name"):
+      assertEquals(field(walk(binOp(op, intL(n), lenOfValue))), Some(i(expected)))
 
   // -- RaLenCmp (Int path) ------------------------------------------------
 

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4813,34 +4813,78 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => false
   }
 
+  def intLitVal(x0: expr): Option[BigInt] = x0 match {
+    case IntLitF(n, uu)                   => Some[BigInt](n)
+    case BinaryOpF(v, va, vb, vc)         => None
+    case UnaryOpF(v, va, vb)              => None
+    case QuantifierF(v, va, vb, vc)       => None
+    case SomeWrapF(v, va)                 => None
+    case TheF(v, va, vb, vc)              => None
+    case FieldAccessF(v, va, vb)          => None
+    case EnumAccessF(v, va, vb)           => None
+    case IndexF(v, va, vb)                => None
+    case CallF(v, va, vb)                 => None
+    case PrimeF(v, va)                    => None
+    case PreF(v, va)                      => None
+    case WithF(v, va, vb)                 => None
+    case IfF(v, va, vb, vc)               => None
+    case LetF(v, va, vb, vc)              => None
+    case LambdaF(v, va, vb)               => None
+    case ConstructorF(v, va, vb)          => None
+    case SetLiteralF(v, va)               => None
+    case MapLiteralF(v, va)               => None
+    case SetComprehensionF(v, va, vb, vc) => None
+    case SeqLiteralF(v, va)               => None
+    case MatchesF(v, va, vb)              => None
+    case FloatLitF(v, va)                 => None
+    case StringLitF(v, va)                => None
+    case BoolLitF(v, va)                  => None
+    case NoneLitF(v)                      => None
+    case IdentifierF(v, va)               => None
+  }
+
   def decomposeAtom(e: expr): refinement_atom =
     e match {
       case BinaryOpF(op, l, rhs, _) =>
         !isRefinementCmp(op) match {
           case true => RaUnknown(e)
-          case false => rhs match {
-              case BinaryOpF(_, _, _, _)         => RaUnknown(e)
-              case UnaryOpF(_, _, _)             => RaUnknown(e)
-              case QuantifierF(_, _, _, _)       => RaUnknown(e)
-              case SomeWrapF(_, _)               => RaUnknown(e)
-              case TheF(_, _, _, _)              => RaUnknown(e)
-              case FieldAccessF(_, _, _)         => RaUnknown(e)
-              case EnumAccessF(_, _, _)          => RaUnknown(e)
-              case IndexF(_, _, _)               => RaUnknown(e)
-              case CallF(_, _, _)                => RaUnknown(e)
-              case PrimeF(_, _)                  => RaUnknown(e)
-              case PreF(_, _)                    => RaUnknown(e)
-              case WithF(_, _, _)                => RaUnknown(e)
-              case IfF(_, _, _, _)               => RaUnknown(e)
-              case LetF(_, _, _, _)              => RaUnknown(e)
-              case LambdaF(_, _, _)              => RaUnknown(e)
-              case ConstructorF(_, _, _)         => RaUnknown(e)
-              case SetLiteralF(_, _)             => RaUnknown(e)
-              case MapLiteralF(_, _)             => RaUnknown(e)
-              case SetComprehensionF(_, _, _, _) => RaUnknown(e)
-              case SeqLiteralF(_, _)             => RaUnknown(e)
-              case MatchesF(_, _, _)             => RaUnknown(e)
-              case IntLitF(n, _) =>
+          case false => intLitVal(rhs) match {
+              case None =>
+                intLitVal(l) match {
+                  case None => RaUnknown(e)
+                  case Some(n) =>
+                    val opa =
+                      (op match {
+                        case BAnd()       => op
+                        case BOr()        => op
+                        case BImplies()   => op
+                        case BIff()       => op
+                        case BEq()        => op
+                        case BNeq()       => op
+                        case BLt()        => BGt()
+                        case BGt()        => BLt()
+                        case BLe()        => BGe()
+                        case BGe()        => BLe()
+                        case BIn()        => op
+                        case BNotIn()     => op
+                        case BSubset()    => op
+                        case BUnion()     => op
+                        case BIntersect() => op
+                        case BDiff()      => op
+                        case BAdd()       => op
+                        case BSub()       => op
+                        case BMul()       => op
+                        case BDiv()       => op
+                      }): bin_op;
+                    isLenOfValue(rhs) match {
+                      case true => RaLenCmp(opa, n)
+                      case false => isValueRef(rhs) match {
+                          case true  => RaValueCmp(opa, n)
+                          case false => RaUnknown(e)
+                        }
+                    }
+                }
+              case Some(n) =>
                 isLenOfValue(l) match {
                   case true => RaLenCmp(op, n)
                   case false => isValueRef(l) match {
@@ -4848,11 +4892,6 @@ object SpecRestGenerated {
                       case false => RaUnknown(e)
                     }
                 }
-              case FloatLitF(_, _)   => RaUnknown(e)
-              case StringLitF(_, _)  => RaUnknown(e)
-              case BoolLitF(_, _)    => RaUnknown(e)
-              case NoneLitF(_)       => RaUnknown(e)
-              case IdentifierF(_, _) => RaUnknown(e)
             }
         }
       case UnaryOpF(_, _, _)       => RaUnknown(e)
@@ -5632,11 +5671,16 @@ object SpecRestGenerated {
     case FieldAccessF(b, uz, va) => free_vars(b)
     case EnumAccessF(b, vb, vc)  => free_vars(b)
     case IndexF(b, i, vd)        => free_vars(b) ++ free_vars(i)
-    case CallF(c, args, ve)      => free_vars(c) ++ free_vars_list(args)
-    case PrimeF(e, vf)           => free_vars(e)
-    case PreF(e, vg)             => free_vars(e)
-    case WithF(b, upds, vh)      => free_vars(b) ++ free_vars_fields(upds)
-    case IfF(c, t, e, vi)        => free_vars(c) ++ (free_vars(t) ++ free_vars(e))
+    case CallF(c, args, ve) =>
+      (identName(c) match {
+        case None    => free_vars(c)
+        case Some(_) => Nil
+      }) ++
+        free_vars_list(args)
+    case PrimeF(e, vf)      => free_vars(e)
+    case PreF(e, vg)        => free_vars(e)
+    case WithF(b, upds, vh) => free_vars(b) ++ free_vars_fields(upds)
+    case IfF(c, t, e, vi)   => free_vars(c) ++ (free_vars(t) ++ free_vars(e))
     case LetF(v, vala, body, vj) =>
       free_vars(vala) ++ remove_name(v, free_vars(body))
     case LambdaF(p, b, vk)        => remove_name(p, free_vars(b))

--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -4272,7 +4272,14 @@ object SpecRestGenerated {
     case (x, r, EnumAccessF(b, m, sp))  => EnumAccessF(subst(x, r, b), m, sp)
     case (x, r, IndexF(b, i, sp))       => IndexF(subst(x, r, b), subst(x, r, i), sp)
     case (x, r, CallF(c, args, sp)) =>
-      CallF(subst(x, r, c), subst_list(x, r, args), sp)
+      CallF(
+        identName(c) match {
+          case None    => subst(x, r, c)
+          case Some(_) => c
+        },
+        subst_list(x, r, args),
+        sp
+      )
     case (x, r, PrimeF(e, sp)) => PrimeF(subst(x, r, e), sp)
     case (x, r, PreF(e, sp))   => PreF(subst(x, r, e), sp)
     case (x, r, WithF(b, upds, sp)) =>

--- a/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
+++ b/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
@@ -37,7 +37,8 @@ where
 | "free_vars (FieldAccessF b _ _)        = free_vars b"
 | "free_vars (EnumAccessF b _ _)         = free_vars b"
 | "free_vars (IndexF b i _)              = free_vars b @ free_vars i"
-| "free_vars (CallF c args _)            = free_vars c @ free_vars_list args"
+| "free_vars (CallF c args _)            =
+     (case identName c of Some _ \<Rightarrow> [] | None \<Rightarrow> free_vars c) @ free_vars_list args"
 | "free_vars (PrimeF e _)                = free_vars e"
 | "free_vars (PreF e _)                  = free_vars e"
 | "free_vars (WithF b upds _)            = free_vars b @ free_vars_fields upds"

--- a/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
+++ b/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
@@ -103,7 +103,8 @@ where
 | "subst x r (FieldAccessF b f sp)           = FieldAccessF (subst x r b) f sp"
 | "subst x r (EnumAccessF b m sp)            = EnumAccessF (subst x r b) m sp"
 | "subst x r (IndexF b i sp)                 = IndexF (subst x r b) (subst x r i) sp"
-| "subst x r (CallF c args sp)               = CallF (subst x r c) (subst_list x r args) sp"
+| "subst x r (CallF c args sp)               =
+     CallF (case identName c of Some _ \<Rightarrow> c | None \<Rightarrow> subst x r c) (subst_list x r args) sp"
 | "subst x r (PrimeF e sp)                   = PrimeF (subst x r e) sp"
 | "subst x r (PreF e sp)                     = PreF (subst x r e) sp"
 | "subst x r (WithF b upds sp)               = WithF (subst x r b) (subst_fields x r upds) sp"

--- a/proofs/isabelle/SpecRest/core/IR_Recognizers.thy
+++ b/proofs/isabelle/SpecRest/core/IR_Recognizers.thy
@@ -67,6 +67,10 @@ fun isRefinementCmp :: "bin_op \<Rightarrow> bool" where
 | "isRefinementCmp BNeq = True"
 | "isRefinementCmp _    = False"
 
+fun intLitVal :: "expr \<Rightarrow> int option" where
+  "intLitVal (IntLitF n _) = Some n"
+| "intLitVal _             = None"
+
 definition decomposeAtom :: "expr \<Rightarrow> refinement_atom" where
   "decomposeAtom e \<equiv>
      (case e of
@@ -77,12 +81,24 @@ definition decomposeAtom :: "expr \<Rightarrow> refinement_atom" where
            | _ \<Rightarrow> RaUnknown e)
       | BinaryOpF op l rhs sp \<Rightarrow>
           (if \<not> isRefinementCmp op then RaUnknown e
-           else (case rhs of
-                   IntLitF n _ \<Rightarrow>
+           else (case intLitVal rhs of
+                   Some n \<Rightarrow>
                      (if isLenOfValue l then RaLenCmp op n
                       else if isValueRef l then RaValueCmp op n
                       else RaUnknown e)
-                 | _ \<Rightarrow> RaUnknown e))
+                 | None \<Rightarrow>
+                     \<comment> \<open>mirrored shape \<open>n op value\<close>: flip the operator so the atom is
+                        still stated as \<open>value op' n\<close> (rangeOf does the same flip).
+                        Matching on \<open>intLitVal _ :: int option\<close> keeps extraction off the
+                        wide \<open>expr\<close> case (no constructor cross-product).\<close>
+                     (case intLitVal l of
+                        Some n \<Rightarrow>
+                          (let op' = (case op of BLt \<Rightarrow> BGt | BGt \<Rightarrow> BLt
+                                               | BLe \<Rightarrow> BGe | BGe \<Rightarrow> BLe | _ \<Rightarrow> op) in
+                             if isLenOfValue rhs then RaLenCmp op' n
+                             else if isValueRef rhs then RaValueCmp op' n
+                             else RaUnknown e)
+                      | None \<Rightarrow> RaUnknown e)))
       | CallF f args sp \<Rightarrow>
           (case (f, args) of
              (IdentifierF p _, [arg]) \<Rightarrow>

--- a/proofs/isabelle/SpecRest/semantics/Semantics_Inlining.thy
+++ b/proofs/isabelle/SpecRest/semantics/Semantics_Inlining.thy
@@ -170,7 +170,7 @@ next
 next
   case (15 fs ps fuel s st env callee args sp env2)
   have agr: "\<forall>y. string_in_list y (free_vars_list args) \<longrightarrow> env_lookup env y = env_lookup env2 y"
-    using "15.prems" by (auto simp: env_lookup_def)
+    using "15.prems" by (cases callee) (auto simp: env_lookup_def)
   show ?case
   proof (cases fuel)
     case 0


### PR DESCRIPTION
Closes the two genuine latent gaps the #472 review surfaced (CodeRabbit, both Major). Both are pre-existing behaviour in the verified subset — not regressions — fixed here with proofs re-discharged and the extraction regenerated.

## 1. `free_vars` counted callee names as free variables
`free_vars (CallF (IdentifierF nm _) args)` included `nm`, so a sum-lambda body like `p => len(p)` was wrongly rejected by the verified `translate` guard `list_all (\v. v = p) (free_vars body)` (the builtin callee `len` showed up as a free var).

**Fix:** drop the callee when it is a bare identifier, via `identName` (an `option`-match — keeps extraction off the wide `expr` case):
```isabelle
free_vars (CallF c args _) =
  (case identName c of Some _ ⇒ [] | None ⇒ free_vars c) @ free_vars_list args
```
`eval_coincidence`'s CallF case re-proved. Soundness-safe: shrinking `free_vars` only *strengthens* the coincidence lemma, and it holds because `eval` reads the callee from the function/predicate decls, never from `env`.

## 2. `decomposeAtom` ignored mirrored comparison atoms
It recognized `value <op> IntLit` and `len(value) <op> IntLit` but not the mirrored `IntLit <op> value` (e.g. `3 < value`) — inconsistent with `rangeOf`, which already flips via `mirrorBinOp`. So a mirrored refinement produced no OpenAPI/SQL/Hypothesis constraint.

**Fix:** recognize both forms, flipping the operator so the atom stays `value op' n`. Added `intLitVal :: expr ⇒ int option` and matched on the `option` (2 constructors) rather than nesting `expr` cases — the tuple/`expr` form blew the code generator up into a constructor cross-product (~2.2k lines); the option form keeps the extraction compact.

## Not changed (Block A #3)
`eval` not modelling `LambdaF` is **correct**, not a gap: `ir_value` is a first-order value domain with no closure value, so a bare lambda has no value → `LambdaF → None`. Only the stale comment was wrong (fixed in #472). Modelling it would mean adding a closure type to `ir_value` — unwarranted.

## Verification
- `isabelle build SpecRest_Soundness SpecRest_Codegen` green, zero `sorry`/`oops`.
- `SpecRestGenerated.scala` regenerated; `sbt ir/compile` clean.
- `codegen/test` 376 passed, `verify/test` 267 passed — no drift (no shipped spec uses the newly-recognized patterns; the changes are additive).
- Added mirrored-comparison regression tests to `OpenApiConstraintsTest` (decomposeAtom has no proof guard; `free_vars` is guarded by `eval_coincidence`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop counting bare callee names as free vars, recognize mirrored comparison atoms in `decomposeAtom`, and align `subst` to leave identifier callees untouched. This fixes false free-var rejections, restores the `free_vars`/`subst` contract, and keeps OpenAPI/SQL constraints consistent.

- **Bug Fixes**
  - `free_vars`: drop a bare-identifier callee in `CallF` via `identName`. Proofs re-discharged; extraction regenerated.
  - `decomposeAtom`: handle `IntLit <op> value` and `IntLit <op> len(value)` by flipping the operator and returning `RaValueCmp`/`RaLenCmp`. Added `intLitVal`; regression tests added and parameterized across all flipped ops.
  - `subst`: guard `CallF`’s callee with `identName` so identifier callees are not rewritten, restoring the `x ∉ free_vars e ⇒ subst x r e = e` property. Codegen updated.

<sup>Written for commit 620398cd845be8f0ecaadc28ef0bbf5f42bc67d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI constraint handling now recognizes mirrored comparison forms, so bounds are derived correctly whether the literal appears on the left or right side.
  * Length-based comparisons now map more accurately to the expected minimum and maximum constraints.

* **Bug Fixes**
  * Improved free-variable handling for function calls by avoiding false free-variable entries for recognized call names.
  * Added coverage for mirrored comparison cases to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->