### PR TITLE
perf(proofs): prune BNF plugins on codegen datatypes (Codegen session ~20% faster)

### DIFF
--- a/proofs/isabelle/SPEEDUP.md
+++ b/proofs/isabelle/SPEEDUP.md
@@ -130,6 +130,21 @@ isabelle export -d proofs/isabelle/SpecRest -O ... -x 'SpecRest_Codegen.Codegen:
 diff -u modules/ir/.../SpecRestGenerated.scala $exported  →  DRIFT OK
 ```
 
+### Tier 2.1 follow-up — codegen datatypes (2026-06-25) — **`SpecRest_Codegen` −11 s (~20 %)**
+
+Tier 2.1 pruned the `IR` / `Semantics` / `Smt` datatypes but never reached the `SpecRest_Codegen`
+session — all **53** codegen datatypes still derived the full plugin set. Extended
+`(plugins only: code size)` to every one. Codegen uses no `quickcheck` / `nitpick` /
+`lift_definition` / `transfer_rule` and no local-datatype `map_/set_/rel_` BNF combinators
+(verified), so the skipped derivations are genuinely unused.
+
+| Metric                     | Before | After | Δ             |
+| -------------------------- | ------ | ----- | ------------- |
+| `SpecRest_Codegen` session | 51 s   | 40 s  | −11 s (~20 %) |
+
+`SpecRestGenerated.scala` byte-identical (the `code` plugin is kept, so code equations are
+unchanged).
+
 ### Tier 2.2 — `primrec` audit (2026-05-13) — **negligible (in noise)**
 
 Converted six list-recursive helpers from `fun` to `primrec`:

--- a/proofs/isabelle/SpecRest/codegen/AlloyBuildSigs.thy
+++ b/proofs/isabelle/SpecRest/codegen/AlloyBuildSigs.thy
@@ -17,12 +17,12 @@ text \<open>Lifted Alloy signature builder. Mirrors
   unsupported (\<open>alloyFieldTypeOf\<close> returned \<open>None\<close>); the Scala
   caller \<open>failAlloy\<close>'s with the matching diagnostic.\<close>
 
-datatype alloy_field = AlloyFieldLifted
+datatype (plugins only: code size) alloy_field = AlloyFieldLifted
   "String.literal"                  \<comment> \<open>field name\<close>
   alloy_field_multiplicity          \<comment> \<open>multiplicity tag\<close>
   "String.literal"                  \<comment> \<open>element sig name\<close>
 
-datatype alloy_sig = AlloySigLifted
+datatype (plugins only: code size) alloy_sig = AlloySigLifted
   "String.literal"                  \<comment> \<open>sig name\<close>
   bool                              \<comment> \<open>abstract\<close>
   bool                              \<comment> \<open>isOne\<close>

--- a/proofs/isabelle/SpecRest/codegen/AlloyTypes.thy
+++ b/proofs/isabelle/SpecRest/codegen/AlloyTypes.thy
@@ -16,7 +16,7 @@ text \<open>Type-to-sig mapping kernel for the Alloy translator. Lifts the pure
   caller turns \<open>None\<close> into a \<open>boundary/break\<close> \<open>failAlloy\<close>
   diagnostic with the unsupported shape's class name.\<close>
 
-datatype alloy_field_multiplicity =
+datatype (plugins only: code size) alloy_field_multiplicity =
     AfmOne
   | AfmLone
   | AfmSome
@@ -133,7 +133,7 @@ text \<open>\<open>renderBinaryOp\<close>'s structural decision: each spec binar
   \<^item> \<open>AbsPrefixCall tok\<close>: \<open>tok[$l, $r]\<close> — Alloy's prefix-call form
     used for the arithmetic builtins \<open>plus\<close>/\<open>minus\<close>/\<open>mul\<close>/\<open>div\<close>.\<close>
 
-datatype alloy_binop_shape =
+datatype (plugins only: code size) alloy_binop_shape =
     AbsLogical "String.literal"
   | AbsInfix "String.literal"
   | AbsPrefixCall "String.literal"
@@ -164,7 +164,7 @@ text \<open>\<open>renderExpr\<close>'s unary-operator dispatch. \<open>UPower\<
   prefix is unsupported (it requires higher-order Alloy reasoning); the
   binder-domain form is handled separately in \<open>buildBinding\<close>.\<close>
 
-datatype alloy_unop_shape =
+datatype (plugins only: code size) alloy_unop_shape =
     AusNot           \<comment> \<open>\<open>not (X)\<close>\<close>
   | AusCardinality   \<comment> \<open>\<open>#(X)\<close>\<close>
   | AusMinusZero     \<comment> \<open>\<open>minus[0, X]\<close>\<close>
@@ -182,7 +182,7 @@ text \<open>\<open>IdentifierF\<close> resolution classifier. Mirrors the four-w
   then falls through unprefixed. The Scala caller emits the prefix
   (\<open>currentStateSig.\<close> or \<open>Inputs.\<close>) for the field cases.\<close>
 
-datatype alloy_identifier_kind =
+datatype (plugins only: code size) alloy_identifier_kind =
     AikBoundVar
   | AikStateField
   | AikInputField
@@ -205,7 +205,7 @@ text \<open>Quantifier-keyword classifier. \<open>QExists\<close> shares the \<o
   keyword with \<open>QSome\<close> (the spec language distinguishes them; Alloy
   collapses both onto the same surface keyword).\<close>
 
-datatype alloy_quantifier_class =
+datatype (plugins only: code size) alloy_quantifier_class =
     AqAll
   | AqSome
   | AqExists
@@ -283,7 +283,7 @@ text \<open>\<open>buildBinding\<close>'s \<open>IdentifierF\<close>-case resolu
     containment fact.
   \<^item> \<open>AbirPlain\<close>: \<open>$name\<close> is unresolved. Emit \<open>$name\<close> as-is.\<close>
 
-datatype alloy_binding_identifier_resolution =
+datatype (plugins only: code size) alloy_binding_identifier_resolution =
     AbirEntity "String.literal"
   | AbirEnum "String.literal"
   | AbirStateOrInput

--- a/proofs/isabelle/SpecRest/codegen/Classify.thy
+++ b/proofs/isabelle/SpecRest/codegen/Classify.thy
@@ -11,9 +11,9 @@ text \<open>Operation-classification ADTs and decision logic lifted from
   \<open>SynthesisStrategy\<close>, \<open>OperationClassification\<close>) are retired;
   consumers use these extracted forms directly.\<close>
 
-datatype synthesis_strategy = DirectEmit | LlmSynthesis
+datatype (plugins only: code size) synthesis_strategy = DirectEmit | LlmSynthesis
 
-datatype analysis_signals = AnalysisSignals
+datatype (plugins only: code size) analysis_signals = AnalysisSignals
   "String.literal list"     \<comment> \<open>mutatedRelations\<close>
   "String.literal list"     \<comment> \<open>preservedRelations\<close>
   bool                      \<comment> \<open>createsNewKey\<close>
@@ -49,7 +49,7 @@ where
   "setTargetEntityFieldCount v (AnalysisSignals m p c d _ w f t h) =
      AnalysisSignals m p c d v w f t h"
 
-datatype operation_classification = OperationClassification
+datatype (plugins only: code size) operation_classification = OperationClassification
   String.literal             \<comment> \<open>operationName\<close>
   operation_kind             \<comment> \<open>kind\<close>
   http_method                \<comment> \<open>method\<close>
@@ -73,7 +73,7 @@ primrec classificationStrategy :: "operation_classification \<Rightarrow> synthe
 primrec classificationSignals :: "operation_classification \<Rightarrow> analysis_signals" where
   "classificationSignals (OperationClassification _ _ _ _ _ _ sg) = sg"
 
-datatype classification_result = ClassificationResult
+datatype (plugins only: code size) classification_result = ClassificationResult
   operation_kind
   http_method
   String.literal             \<comment> \<open>matchedRule\<close>
@@ -182,7 +182,7 @@ text \<open>Scalar direct-emit recognisers (issue #407). A scalar-update ensures
   the emitted SQL cannot drift. Guards are the requires atoms an emitter
   can fold into the atomic UPDATE's WHERE clause.\<close>
 
-datatype scalar_rhs =
+datatype (plugins only: code size) scalar_rhs =
     SrLit int
   | SrSelf
   | SrAdd scalar_rhs scalar_rhs
@@ -229,9 +229,9 @@ where
       | _ \<Rightarrow> None)"
 | "scalarUpdateOf _ _ = None"
 
-datatype scalar_cmp = ScGt | ScGe | ScLt | ScLe | ScEq | ScNeq
+datatype (plugins only: code size) scalar_cmp = ScGt | ScGe | ScLt | ScLe | ScEq | ScNeq
 
-datatype scalar_guard =
+datatype (plugins only: code size) scalar_guard =
     SgTrue
   | SgCmp String.literal scalar_cmp int
 

--- a/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
+++ b/proofs/isabelle/SpecRest/codegen/DafnyTransform.thy
@@ -191,9 +191,9 @@ text \<open>Lift of \<open>convention.dafny.Generator.classifyExterns\<close>'s 
   info constructor is \<open>ExInfo\<close> (not \<open>ExternInfo\<close>) so it doesn't clash with the Scala
   \<open>ExternInfo\<close> case class the adapter targets.\<close>
 
-datatype extern_kind = EkPredicate | EkIntFunction
-datatype extern_info = ExInfo extern_kind int
-datatype extern_item = EiExtern String.literal int extern_kind | EiPattern String.literal
+datatype (plugins only: code size) extern_kind = EkPredicate | EkIntFunction
+datatype (plugins only: code size) extern_info = ExInfo extern_kind int
+datatype (plugins only: code size) extern_item = EiExtern String.literal int extern_kind | EiPattern String.literal
 
 definition knownBuiltinNames :: "String.literal list" where
   "knownBuiltinNames = [STR ''len'', STR ''dom'', STR ''ran'']"

--- a/proofs/isabelle/SpecRest/codegen/DialectSchema.thy
+++ b/proofs/isabelle/SpecRest/codegen/DialectSchema.thy
@@ -8,7 +8,7 @@ text \<open>Canonical SQL column type discriminator + per-dialect rendering.
   regex to extract \<open>VARCHAR(n)\<close> / \<open>NUMERIC(p, s)\<close> parameters); the ADT
   and the dialect-specific renderers move here.\<close>
 
-datatype canonical_type =
+datatype (plugins only: code size) canonical_type =
     CtText
   | CtVarchar int
   | CtInt4
@@ -41,7 +41,7 @@ text \<open>SQLAlchemy type rendering per Postgres / Sqlite / MySQL.
   and uses \<open>importModule\<close> to inject \<open>from postgresql import JSONB\<close>
   style imports.\<close>
 
-datatype sa_type = SaType "String.literal" "String.literal option"
+datatype (plugins only: code size) sa_type = SaType "String.literal" "String.literal option"
 
 fun saTypeExpr :: "sa_type \<Rightarrow> String.literal" where
   "saTypeExpr (SaType e _) = e"
@@ -187,7 +187,7 @@ text \<open>Dialect capability matrix: which target-dialect features (partial
   shortcuts (e.g. SQLite drops a CHECK on a serial PK because MySQL
   error 3818 would reject it elsewhere; Postgres keeps it).\<close>
 
-datatype dialect_caps = DialectCaps
+datatype (plugins only: code size) dialect_caps = DialectCaps
   bool  \<comment> \<open>supportsPartialIndex\<close>
   bool  \<comment> \<open>supportsCheckConstraint\<close>
   bool  \<comment> \<open>supportsCheckOnAutoIncrement\<close>

--- a/proofs/isabelle/SpecRest/codegen/Methods.thy
+++ b/proofs/isabelle/SpecRest/codegen/Methods.thy
@@ -8,9 +8,9 @@ text \<open>HTTP method and operation-kind enums lifted from
   rule out collisions (\<open>DELETE\<close> vs \<open>Delete\<close>), and none of these
   names clash with existing extracted constructors.\<close>
 
-datatype http_method = GET | POST | PUT | PATCH | DELETE
+datatype (plugins only: code size) http_method = GET | POST | PUT | PATCH | DELETE
 
-datatype operation_kind =
+datatype (plugins only: code size) operation_kind =
     Create | Read | Replace | PartialUpdate | Delete
   | CreateChild | FilteredRead | SideEffect | BatchMutation | Transition
 

--- a/proofs/isabelle/SpecRest/codegen/MigrationOps.thy
+++ b/proofs/isabelle/SpecRest/codegen/MigrationOps.thy
@@ -7,7 +7,7 @@ text \<open>Schema-migration operation ADT. Constructor names match the desired 
   via \<open>code_identifier\<close> in \<open>Codegen\<close>. The Scala layer drops its
   hand-written enum and uses these constructors directly.\<close>
 
-datatype migration_op =
+datatype (plugins only: code size) migration_op =
     CreateTable table_spec
   | DropTable table_spec
   | AddColumn String.literal column_spec

--- a/proofs/isabelle/SpecRest/codegen/OpenApiConstraints.thy
+++ b/proofs/isabelle/SpecRest/codegen/OpenApiConstraints.thy
@@ -17,7 +17,7 @@ text \<open>Constraint-bounds walker for OpenAPI schema emission. Lifts
   to preserve the user's input form exactly. Length bounds remain
   \<open>int\<close> because lengths can't be fractional.\<close>
 
-datatype decimal_lit = DecimalLit int int
+datatype (plugins only: code size) decimal_lit = DecimalLit int int
   \<comment> \<open>\<open>DecimalLit m e\<close> represents \<open>m * 10\<^sup>e\<close>.
        Examples: "3.14" \<rightharpoonup> DecimalLit 314 (-2), "5" \<rightharpoonup> DecimalLit 5 0,
                  "0.5" \<rightharpoonup> DecimalLit 5 (-1)\<close>
@@ -102,7 +102,7 @@ definition parseDecimalLit :: "String.literal \<Rightarrow> decimal_lit option" 
 text \<open>Bounds record. Length bounds stay \<open>int option\<close> (lengths can't be
   fractional); numeric bounds are \<open>decimal_lit option\<close>.\<close>
 
-datatype openapi_bounds = OpenApiBounds
+datatype (plugins only: code size) openapi_bounds = OpenApiBounds
   "int option"               \<comment> \<open>min_length (inclusive)\<close>
   "int option"               \<comment> \<open>max_length (inclusive)\<close>
   "decimal_lit option"       \<comment> \<open>minimum (inclusive)\<close>

--- a/proofs/isabelle/SpecRest/codegen/OpenApiSchema.thy
+++ b/proofs/isabelle/SpecRest/codegen/OpenApiSchema.thy
@@ -23,7 +23,7 @@ text \<open>Lifted core of the OpenAPI \<open>SchemaObject\<close> datatype and 
   (\<open>additionalProperties\<close> may hold either a nested schema or a bool),
   so they are declared in a single \<open>datatype\<close> block.\<close>
 
-datatype schema_object = SchemaObject
+datatype (plugins only: code size) schema_object = SchemaObject
   "String.literal list option"            \<comment> \<open>type (one or more JSON-schema type tags, ordered)\<close>
   "String.literal option"                 \<comment> \<open>format\<close>
   "int option"                            \<comment> \<open>minLength\<close>
@@ -112,7 +112,7 @@ text \<open>Lift of \<open>OpenApi.Schema.makeNullable\<close> as a *decision cl
   \<^item> \<open>NdAppendNull\<close>: \<open>type\<close> is set and doesn't yet contain \<open>"null"\<close>
     — append \<open>"null"\<close> to the type list.\<close>
 
-datatype nullable_decision = NdNoop | NdWrapAnyOfNull | NdAppendNull
+datatype (plugins only: code size) nullable_decision = NdNoop | NdWrapAnyOfNull | NdAppendNull
 
 definition decideNullable ::
   "String.literal option \<Rightarrow> String.literal list option \<Rightarrow> nullable_decision"

--- a/proofs/isabelle/SpecRest/codegen/RouteKind.thy
+++ b/proofs/isabelle/SpecRest/codegen/RouteKind.thy
@@ -9,7 +9,7 @@ text \<open>Route-kind classification for the codegen + testgen route emitters.
   Constructor names carry an \<open>Rk\<close> prefix so the extracted \<open>RkList\<close> does
   not shadow \<open>scala.collection.immutable.List\<close>.\<close>
 
-datatype route_kind = RkCreate | RkRead | RkList | RkDelete | RkRedirect | RkOther
+datatype (plugins only: code size) route_kind = RkCreate | RkRead | RkList | RkDelete | RkRedirect | RkOther
 
 definition isRedirectStatus :: "int \<Rightarrow> bool" where
   "isRedirectStatus s = (s = 301 \<or> s = 302 \<or> s = 303 \<or> s = 307 \<or> s = 308)"

--- a/proofs/isabelle/SpecRest/codegen/Schema.thy
+++ b/proofs/isabelle/SpecRest/codegen/Schema.thy
@@ -8,25 +8,25 @@ text \<open>Schema model mirroring \<open>specrest.convention.{ColumnSpec, Forei
   case classes via wildcard imports; a follow-up that retires the hand-written
   types will drop the suffix.\<close>
 
-datatype column_spec = ColumnSpec
+datatype (plugins only: code size) column_spec = ColumnSpec
   String.literal              \<comment> \<open>name\<close>
   String.literal              \<comment> \<open>sql_type\<close>
   bool                        \<comment> \<open>nullable\<close>
   "String.literal option"     \<comment> \<open>default_value\<close>
 
-datatype foreign_key_spec = ForeignKeySpec
+datatype (plugins only: code size) foreign_key_spec = ForeignKeySpec
   String.literal              \<comment> \<open>column\<close>
   String.literal              \<comment> \<open>ref_table\<close>
   String.literal              \<comment> \<open>ref_column\<close>
   String.literal              \<comment> \<open>on_delete\<close>
 
-datatype index_spec = IndexSpec
+datatype (plugins only: code size) index_spec = IndexSpec
   String.literal              \<comment> \<open>name\<close>
   "String.literal list"       \<comment> \<open>columns\<close>
   bool                        \<comment> \<open>unique\<close>
   "String.literal option"     \<comment> \<open>filter_clause\<close>
 
-datatype table_spec = TableSpec
+datatype (plugins only: code size) table_spec = TableSpec
   String.literal              \<comment> \<open>name\<close>
   String.literal              \<comment> \<open>entity_name\<close>
   "column_spec list"          \<comment> \<open>columns\<close>
@@ -35,9 +35,9 @@ datatype table_spec = TableSpec
   "String.literal list"       \<comment> \<open>checks\<close>
   "index_spec list"           \<comment> \<open>indexes\<close>
 
-datatype trigger_aggregate = SumAgg | CountAgg | MinAgg | MaxAgg
+datatype (plugins only: code size) trigger_aggregate = SumAgg | CountAgg | MinAgg | MaxAgg
 
-datatype trigger_spec = TriggerSpec
+datatype (plugins only: code size) trigger_spec = TriggerSpec
   String.literal              \<comment> \<open>name\<close>
   String.literal              \<comment> \<open>function_name\<close>
   String.literal              \<comment> \<open>target_table\<close>
@@ -47,7 +47,7 @@ datatype trigger_spec = TriggerSpec
   trigger_aggregate           \<comment> \<open>aggregate\<close>
   "String.literal option"     \<comment> \<open>source_column\<close>
 
-datatype database_schema = DatabaseSchema
+datatype (plugins only: code size) database_schema = DatabaseSchema
   "table_spec list"           \<comment> \<open>tables\<close>
   "trigger_spec list"         \<comment> \<open>triggers\<close>
 

--- a/proofs/isabelle/SpecRest/codegen/SchemaDerive.thy
+++ b/proofs/isabelle/SpecRest/codegen/SchemaDerive.thy
@@ -12,7 +12,7 @@ text \<open>Pure utility lifts from \<open>specrest.convention.Schema\<close>. T
   \<open>flattenAnd\<close>/\<open>flattenEnsuresExpr\<close>) so the extracted Scala can be called
   directly from hand-written code without a wrapper-rename indirection.\<close>
 
-datatype detected_aggregate = DetectedAggregate
+datatype (plugins only: code size) detected_aggregate = DetectedAggregate
   String.literal             \<comment> \<open>target_field\<close>
   String.literal             \<comment> \<open>collection_field\<close>
   trigger_aggregate          \<comment> \<open>aggregate\<close>
@@ -56,7 +56,7 @@ text \<open>Aggregate-call decoding: a verified-subset SUM/COUNT/MIN/MAX over a
   record (Isabelle tuples extract as right-nested in Scala, which makes them
   awkward to destructure; a datatype lifts cleanly to a flat case class).\<close>
 
-datatype aggregate_call = AggregateCall
+datatype (plugins only: code size) aggregate_call = AggregateCall
   String.literal             \<comment> \<open>collection_field\<close>
   trigger_aggregate          \<comment> \<open>aggregate\<close>
   "String.literal option"    \<comment> \<open>source_projection\<close>
@@ -129,7 +129,7 @@ text \<open>Column-kind classification for the deriveSchema field walker. Lifts 
   Alias-cycle protection: the same fuel-bounded visited-set pattern as
   \<open>aliasRefinements\<close> / \<open>findEnumValuesInType\<close> in \<open>SchemaTraversal\<close>.\<close>
 
-datatype column_kind =
+datatype (plugins only: code size) column_kind =
     CkPrim "String.literal"        \<comment> \<open>sql type from primitiveTypeToSql\<close>
   | CkEnum "String.literal list"   \<comment> \<open>enum value list (used to build IN-list CHECK)\<close>
   | CkEntityRef "String.literal"   \<comment> \<open>target entity name (Scala builds FK + _id suffix)\<close>
@@ -138,7 +138,7 @@ datatype column_kind =
   | CkRelation                     \<comment> \<open>RelationTypeF → BIGINT\<close>
   | CkUnknown                      \<comment> \<open>unresolved NamedTypeF → TEXT fallback\<close>
 
-datatype classified_column = ClassifiedColumn column_kind bool
+datatype (plugins only: code size) classified_column = ClassifiedColumn column_kind bool
   \<comment> \<open>kind + nullable flag (true iff the type expression had an outer OptionTypeF
       anywhere in the alias chain)\<close>
 
@@ -210,7 +210,7 @@ text \<open>Aggregate-trigger validation: the pure validity-check kernel of
   \<^enum> if the aggregate carries a source-projection name, the child entity has
     a field with that name\<close>
 
-datatype trigger_candidate = TriggerCandidate
+datatype (plugins only: code size) trigger_candidate = TriggerCandidate
   String.literal             \<comment> \<open>parent_table\<close>
   String.literal             \<comment> \<open>target_field (Scala turns into column name)\<close>
   String.literal             \<comment> \<open>child_table\<close>
@@ -329,7 +329,7 @@ text \<open>Invariant-atom classifier for entity \<open>CHECK\<close> constraint
   Scala dispatches on the typed class and emits the SQL string from
   the components (escape, format, interpolate).\<close>
 
-datatype invariant_check_class =
+datatype (plugins only: code size) invariant_check_class =
     IcSkip
   | IcInClause "String.literal" "expr list"
   | IcCompare "String.literal" bin_op expr
@@ -374,7 +374,7 @@ text \<open>Column-CHECK atom classifier for \<open>Schema.applyAtom\<close>. Mi
     on the RHS for length/value comparisons.
   \<^item> \<open>CcSkip\<close>: \<open>RaPredCall\<close>, or an unrecognised shape.\<close>
 
-datatype column_check_class =
+datatype (plugins only: code size) column_check_class =
     CcSkip
   | CcRegexMatch "String.literal"               \<comment> \<open>regex pattern\<close>
   | CcLenCompare bin_op int                \<comment> \<open>op, n\<close>

--- a/proofs/isabelle/SpecRest/codegen/SchemaTraversal.thy
+++ b/proofs/isabelle/SpecRest/codegen/SchemaTraversal.thy
@@ -87,7 +87,7 @@ text \<open>OpenAPI primitive type table — lifted from
   primitive maps to an OpenAPI \<open>type\<close> list and an optional \<open>format\<close>
   string. The Scala caller wraps this into \<open>SchemaObject\<close>.\<close>
 
-datatype openapi_primitive_def = OpenApiPrimDef
+datatype (plugins only: code size) openapi_primitive_def = OpenApiPrimDef
   "String.literal list"      \<comment> \<open>type list, e.g. ["string"] or ["integer"]\<close>
   "String.literal option"    \<comment> \<open>format, e.g. Some "date-time"\<close>
 
@@ -121,7 +121,7 @@ text \<open>OpenAPI named-type classifier — mirrors \<open>classifyColumnType\
   (array \<open>items\<close>, object \<open>additionalProperties\<close>, etc.) in Scala where it
   builds the recursive \<open>SchemaObject\<close>.\<close>
 
-datatype openapi_named_kind =
+datatype (plugins only: code size) openapi_named_kind =
     OntPrimitive openapi_primitive_def
   | OntEnum "String.literal list"
   | OntEntityRef String.literal

--- a/proofs/isabelle/SpecRest/codegen/Strategies.thy
+++ b/proofs/isabelle/SpecRest/codegen/Strategies.thy
@@ -9,12 +9,12 @@ text \<open>Constraint-walker primitives for the testgen strategy derivation.
   stay in Scala. The Scala layer composes these walkers with its IR-aware
   postprocessing.\<close>
 
-datatype int_constraint = IntConstraint
+datatype (plugins only: code size) int_constraint = IntConstraint
   "int option"               \<comment> \<open>min_value (inclusive)\<close>
   "int option"               \<comment> \<open>max_value (inclusive)\<close>
   "String.literal list"      \<comment> \<open>extra_filters\<close>
 
-datatype string_constraint = StringConstraint
+datatype (plugins only: code size) string_constraint = StringConstraint
   "int option"               \<comment> \<open>min_size (inclusive)\<close>
   "int option"               \<comment> \<open>max_size (inclusive)\<close>
   "String.literal list"      \<comment> \<open>regexes\<close>

--- a/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
+++ b/proofs/isabelle/SpecRest/codegen/TargetExpr.thy
@@ -20,7 +20,7 @@ text \<open>Language-neutral decision kernels shared by the per-target expressio
   \<open>ident_ctx\<close> is a positional datatype (not a \<open>record\<close>) so it extracts cleanly via
   \<open>Code_Target_Scala\<close>, mirroring the \<open>schema_object\<close> convention.\<close>
 
-datatype ident_ctx = IdentCtx
+datatype (plugins only: code size) ident_ctx = IdentCtx
   "String.literal list"   \<comment> \<open>reserved words (per target language)\<close>
   "String.literal list"   \<comment> \<open>bound variables in scope\<close>
   "String.literal option" \<comment> \<open>the bare-body output name, if any\<close>
@@ -31,7 +31,7 @@ datatype ident_ctx = IdentCtx
   "String.literal list"   \<comment> \<open>enum type names\<close>
   "String.literal list"   \<comment> \<open>all enum member values (flattened)\<close>
 
-datatype ident_class =
+datatype (plugins only: code size) ident_class =
     IcReserved
   | IcBound
   | IcBareBody
@@ -73,7 +73,7 @@ fun lookupArity :: "(String.literal \<times> int) list \<Rightarrow> String.lite
 | "lookupArity ((nm, ar) # rest) fname =
      (if nm = fname then Some ar else lookupArity rest fname)"
 
-datatype user_call_class = UcUnknown | UcWrongArity int | UcOk
+datatype (plugins only: code size) user_call_class = UcUnknown | UcWrongArity int | UcOk
 
 definition classifyUserCall ::
   "(String.literal \<times> int) list \<Rightarrow> (String.literal \<times> int) list

--- a/proofs/isabelle/SpecRest/codegen/ValidateConventions.thy
+++ b/proofs/isabelle/SpecRest/codegen/ValidateConventions.thy
@@ -165,7 +165,7 @@ text \<open>IR-context validation for individual convention rules. Two
 
   Mirrors the legacy \<open>Validate.validateIrContext\<close> branch logic.\<close>
 
-datatype convention_ir_diagnostic =
+datatype (plugins only: code size) convention_ir_diagnostic =
     PartialIndexFieldMissing "String.literal" "String.literal"
       \<comment> \<open>target entity name, qualifier field name\<close>
   | TestStrategyFieldMissing "String.literal" "String.literal" "String.literal"

--- a/proofs/isabelle/SpecRest/codegen/VerifierDispatch.thy
+++ b/proofs/isabelle/SpecRest/codegen/VerifierDispatch.thy
@@ -19,9 +19,9 @@ text \<open>Verifier-dispatch and trust classification. Lifts the pure
   wrappers (global, requires, enabled, preservation, temporal) so the
   Scala caller becomes a thin delegation.\<close>
 
-datatype verifier_tool = VtZ3 | VtAlloy
+datatype (plugins only: code size) verifier_tool = VtZ3 | VtAlloy
 
-datatype trust_level = TlSound | TlBestEffort
+datatype (plugins only: code size) trust_level = TlSound | TlBestEffort
 
 text \<open>\<open>foldVerifier\<close>: any formula needs Alloy \<Longrightarrow> bundle goes Alloy.\<close>
 


### PR DESCRIPTION
SPEEDUP.md's plugin-prune (Tier 2.1) added `(plugins only: code size)` to every datatype in `IR`/`Semantics`/`Smt` (~22s saved) but **never reached the `SpecRest_Codegen` session** — all **53** codegen datatypes still derived the full `quickcheck`/`nitpick`/`transfer`/`lifting` plugin set. None of those are used anywhere in codegen (verified), so pruning skips the unused BNF derivations.

## Measured
- `SpecRest_Codegen` session: **51s → 40s (~−11s, ~20%)** — runs on every pre-commit hook + CI job.
- `SpecRestGenerated.scala`: **byte-identical** (the `code` plugin is kept, so extraction is unchanged — no regen).
- Full proof build green, zero `sorry`.

## Safety
Mechanical edit (`datatype X` → `datatype (plugins only: code size) X`, 53 of them). Verified codegen uses no `quickcheck`/`nitpick`/`lift_definition`/`transfer_rule` and no local-datatype BNF `map_`/`set_`/`rel_` combinators, so the dropped derivations are genuinely unused. This just extends the existing, documented optimization to the one session it had missed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes unused BNF plugins on all codegen datatypes to skip `quickcheck`/`nitpick`/`transfer`/`lifting` derivations. `SpecRest_Codegen` drops from 51s to 40s (~20%) with byte-identical Scala output and no proof changes.

- **Refactors**
  - Switched 53 codegen datatypes to `datatype (plugins only: code size) X`, keeping the `code` plugin.
  - Verified codegen does not use dropped plugins or BNF combinators; documented in `SPEEDUP.md`.
  - No regeneration needed; full proof build stays green.

<sup>Written for commit 17513073b4cc1f7b0a26bf4d9b174e21360b1eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

