### PR TITLE
refactor(proofs): centralize name/variable mechanics into Names.thy

### DIFF
--- a/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
+++ b/modules/ir/src/main/scala/specrest/ir/generated/SpecRestGenerated.scala
@@ -3233,6 +3233,20 @@ object SpecRestGenerated {
       }
   }
 
+  def string_in_list(y: String, x1: List[String]): Boolean = (y, x1) match {
+    case (y, Nil)     => false
+    case (y, x :: xs) => x == y || string_in_list(y, xs)
+  }
+
+  def fresh_in(n: nat, base: String, avoid: List[String]): String =
+    equal_nat(n, zero_nat) match {
+      case true => base
+      case false => string_in_list(base, avoid) match {
+          case true  => fresh_in(minus_nat(n, one_nat), base + "_", avoid)
+          case false => base
+        }
+    }
+
   def is_none[A](x0: Option[A]): Boolean = x0 match {
     case None    => true
     case Some(x) => false
@@ -3443,6 +3457,9 @@ object SpecRestGenerated {
         case Some(y) => y :: map_filter[A, B](f, xs)
       }
   }
+
+  def fresh_var(base: String, avoid: List[String]): String =
+    fresh_in(Suc(size_list[String](avoid)), base, avoid)
 
   def fkColumn(x0: foreign_key_spec): String = x0 match {
     case ForeignKeySpec(c, uu, uv, uw) => c
@@ -4252,11 +4269,6 @@ object SpecRestGenerated {
     case NoneLitF(v)                      => None
   }
 
-  def string_in_list(y: String, x1: List[String]): Boolean = (y, x1) match {
-    case (y, Nil)     => false
-    case (y, x :: xs) => x == y || string_in_list(y, xs)
-  }
-
   def typeStripSpans(x0: type_expr): type_expr = x0 match {
     case NamedTypeF(n, uu) => NamedTypeF(n, None)
     case SetTypeF(t, uv)   => SetTypeF(typeStripSpans(t), None)
@@ -4521,6 +4533,15 @@ object SpecRestGenerated {
     case IdentifierF(v, va)               => false
   }
 
+  def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
+    case (uu, Nil) => Nil
+    case (n, x :: xs) =>
+      x == n match {
+        case true  => remove_name(n, xs)
+        case false => x :: remove_name(n, xs)
+      }
+  }
+
   def columnName(x0: column_spec): String = x0 match {
     case ColumnSpec(n, uu, uv, uw) => n
   }
@@ -4559,6 +4580,11 @@ object SpecRestGenerated {
     case BUnion()     => false
     case BIntersect() => false
     case BDiff()      => false
+  }
+
+  def remove_names(x0: List[String], xs: List[String]): List[String] = (x0, xs) match {
+    case (Nil, xs)     => xs
+    case (n :: ns, xs) => remove_name(n, remove_names(ns, xs))
   }
 
   def isRedirectStatus(s: BigInt): Boolean =
@@ -4732,15 +4758,6 @@ object SpecRestGenerated {
     case BMul()       => None
     case BDiv()       => None
   }
-
-  def fresh_in(n: nat, base: String, avoid: List[String]): String =
-    equal_nat(n, zero_nat) match {
-      case true => base
-      case false => string_in_list(base, avoid) match {
-          case true  => fresh_in(minus_nat(n, one_nat), base + "_", avoid)
-          case false => base
-        }
-    }
 
   def emptyIntConstraint: int_constraint = IntConstraint(None, None, Nil)
 
@@ -5253,9 +5270,6 @@ object SpecRestGenerated {
     case TableSpec(uu, uv, uw, ux, uy, uz, ixs) => ixs
   }
 
-  def fresh_var(base: String, avoid: List[String]): String =
-    fresh_in(Suc(size_list[String](avoid)), base, avoid)
-
   def range_arg(x0: expr): Option[String] = x0 match {
     case CallF(IdentifierF(nm, uu), List(IdentifierF(rel, uv)), uw) =>
       nm == "range" || nm == "ran" match {
@@ -5675,20 +5689,6 @@ object SpecRestGenerated {
   def is_builtin_int_func(nm: String): Boolean =
     nm == "seconds" ||
       (nm == "minutes" || (nm == "hours" || (nm == "days" || nm == "weeks")))
-
-  def remove_name(uu: String, x1: List[String]): List[String] = (uu, x1) match {
-    case (uu, Nil) => Nil
-    case (n, x :: xs) =>
-      x == n match {
-        case true  => remove_name(n, xs)
-        case false => x :: remove_name(n, xs)
-      }
-  }
-
-  def remove_names(x0: List[String], xs: List[String]): List[String] = (x0, xs) match {
-    case (Nil, xs)     => xs
-    case (n :: ns, xs) => remove_name(n, remove_names(ns, xs))
-  }
 
   def free_vars_bindings(x0: List[quantifier_binding]): List[String] = x0 match {
     case Nil => Nil

--- a/proofs/isabelle/README.md
+++ b/proofs/isabelle/README.md
@@ -20,9 +20,9 @@ proofs/isabelle/
 ├── STATUS.md              proof-state ledger
 └── SpecRest/
     ├── ROOT                 session graph (IR → Semantics → Soundness, Codegen)
-    ├── core/                SpecRest_IR: IR (datatypes) + analysis layer
-    │                        (IR_Helpers, IR_Recognizers, IR_Lint, IR_FreeVars, IR_Analysis)
-    ├── semantics/           SpecRest_Semantics: Smt(_Fresh), Semantics(_Eval/_Typing),
+    ├── core/                SpecRest_IR: Names (string/var mechanics), IR (datatypes) +
+    │                        analysis layer (IR_Helpers, IR_Recognizers, IR_Lint, IR_FreeVars, IR_Analysis)
+    ├── semantics/           SpecRest_Semantics: Smt, Semantics(_Eval/_Typing),
     │                        Semantics_Reference, Semantics_Inlining, Translate
     ├── soundness/           SpecRest_Soundness: Soundness_Framework, Preservation_*,
     │                        DirectSound(_*), DirectTotality, DirectPreservation

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -3,6 +3,7 @@ chapter SpecRest
 session SpecRest_IR in core = HOL +
   options [document = false, threads = 0]
   theories
+    Names
     IR
     IR_Helpers
     IR_Recognizers
@@ -13,7 +14,6 @@ session SpecRest_IR in core = HOL +
 session SpecRest_Semantics in semantics = SpecRest_IR +
   options [document = false, threads = 0]
   theories
-    Smt_Fresh
     Smt
     Semantics_Eval
     Semantics_Typing

--- a/proofs/isabelle/SpecRest/core/IR.thy
+++ b/proofs/isabelle/SpecRest/core/IR.thy
@@ -1,5 +1,5 @@
 theory IR
-  imports Main "HOL.Rat"
+  imports Names "HOL.Rat"
 begin
 
 fun asciiToIntAcc :: "integer list \<Rightarrow> int \<Rightarrow> int option" where
@@ -346,18 +346,6 @@ datatype (plugins only: code size) service_ir =
                   (svcPredicates: "predicate_decl list") (svcConventions: "conventions_decl option")
                   (svcSecurity: "security_scheme_decl list") (svcSpan: option_span)
 
-text \<open>\<open>string_in_list\<close> is the monomorphic membership predicate over
-  \<open>String.literal list\<close>. Hoisted to the top of the file because using
-  \<open>list_ex (\<lambda>n. n = x) xs\<close> inside \<open>fun\<close> declarations triggers heavy
-  pattern-overlap analysis — see \<open>createPatternOf\<close> elaboration cost in
-  a baseline profile (~106 s for a single 8-line \<open>fun\<close>).\<close>
-
-primrec string_in_list :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> bool" where
-  "string_in_list y [] = False"
-| "string_in_list y (x # xs) = (x = y \<or> string_in_list y xs)"
-
-lemma string_in_list_iff: "string_in_list y xs = (y \<in> set xs)"
-  by (induction xs) auto
 
 fun identName :: "expr \<Rightarrow> String.literal option" where
   "identName (IdentifierF rel _) = Some rel"

--- a/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
+++ b/proofs/isabelle/SpecRest/core/IR_FreeVars.thy
@@ -2,23 +2,14 @@ theory IR_FreeVars
   imports IR
 begin
 
-text \<open>Phase 9\<gamma> (free-var helpers): monomorphic \<open>qb_names\<close>,
-  \<open>remove_name\<close>, \<open>remove_names\<close> avoid the polymorphic \<open>map\<close>/\<open>filter\<close>
-  HOFs that blow up Isabelle build wall-time when used inside large mutual
-  \<open>fun\<close> declarations.\<close>
+text \<open>Phase 9\<gamma> (free-var helpers): the monomorphic \<open>qb_names\<close> avoids the
+  polymorphic \<open>map\<close>/\<open>filter\<close> HOFs that blow up Isabelle build wall-time when
+  used inside large mutual \<open>fun\<close> declarations. The companion list-removal
+  primitives \<open>remove_name\<close> / \<open>remove_names\<close> live in \<open>Names\<close>.\<close>
 
 fun qb_names :: "quantifier_binding list \<Rightarrow> String.literal list" where
   "qb_names [] = []"
 | "qb_names (QuantifierBindingFull n _ _ _ # bs) = n # qb_names bs"
-
-fun remove_name :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
-  "remove_name _ [] = []"
-| "remove_name n (x # xs) =
-     (if x = n then remove_name n xs else x # remove_name n xs)"
-
-fun remove_names :: "String.literal list \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
-  "remove_names []       xs = xs"
-| "remove_names (n # ns) xs = remove_name n (remove_names ns xs)"
 
 text \<open>Phase 9\<gamma> (\<open>free_vars\<close>): collects the names of all free identifiers
   in an \<open>expr\<close>, respecting binders (\<open>LetF\<close>, \<open>LambdaF\<close>,

--- a/proofs/isabelle/SpecRest/core/Names.thy
+++ b/proofs/isabelle/SpecRest/core/Names.thy
@@ -1,6 +1,49 @@
-theory Smt_Fresh
-  imports SpecRest_IR.IR
+theory Names
+  imports Main
 begin
+
+text \<open>Variable / identifier mechanics over \<open>String.literal\<close>, used throughout the
+  IR and SMT layers: list membership, name removal, and fresh-name generation.
+  Centralised here (rather than scattered across IR / Smt) so the string-handling
+  primitives are one self-contained, datatype-independent module.\<close>
+
+text \<open>\<open>string_in_list\<close> is the monomorphic membership predicate over
+  \<open>String.literal list\<close>. Preferred over \<open>list_ex (\<lambda>n. n = x) xs\<close> inside \<open>fun\<close>
+  declarations, which triggers heavy pattern-overlap analysis — see
+  \<open>createPatternOf\<close> elaboration cost in a baseline profile (~106 s for a single
+  8-line \<open>fun\<close>).\<close>
+
+primrec string_in_list :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> bool" where
+  "string_in_list y [] = False"
+| "string_in_list y (x # xs) = (x = y \<or> string_in_list y xs)"
+
+lemma string_in_list_iff: "string_in_list y xs = (y \<in> set xs)"
+  by (induction xs) auto
+
+lemma string_in_list_append [simp]:
+  "string_in_list y (xs @ ys) = (string_in_list y xs \<or> string_in_list y ys)"
+  by (induction xs) auto
+
+text \<open>Monomorphic \<open>remove_name\<close> / \<open>remove_names\<close> avoid the polymorphic
+  \<open>map\<close>/\<open>filter\<close> HOFs that blow up Isabelle build wall-time when used inside
+  large mutual \<open>fun\<close> declarations.\<close>
+
+fun remove_name :: "String.literal \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
+  "remove_name _ [] = []"
+| "remove_name n (x # xs) =
+     (if x = n then remove_name n xs else x # remove_name n xs)"
+
+fun remove_names :: "String.literal list \<Rightarrow> String.literal list \<Rightarrow> String.literal list" where
+  "remove_names []       xs = xs"
+| "remove_names (n # ns) xs = remove_name n (remove_names ns xs)"
+
+lemma string_in_list_remove_name [simp]:
+  "string_in_list y (remove_name n xs) = (y \<noteq> n \<and> string_in_list y xs)"
+  by (induction xs) auto
+
+lemma string_in_list_remove_names [simp]:
+  "string_in_list y (remove_names ns xs) = (\<not> string_in_list y ns \<and> string_in_list y xs)"
+  by (induction ns) auto
 
 text \<open>\<open>fresh_var base avoid\<close>: the first of \<open>base\<close>, \<open>base_\<close>, \<open>base__\<close>, ...
   not in \<open>avoid\<close>. The candidates have strictly increasing lengths, so among

--- a/proofs/isabelle/SpecRest/semantics/Semantics_Reference.thy
+++ b/proofs/isabelle/SpecRest/semantics/Semantics_Reference.thy
@@ -293,18 +293,6 @@ termination
                      | Inr (Inr (Inr (fs, ps, fuel, s, st, env, var, dmv, body))) \<Rightarrow> Suc (length dmv))]")
      (auto dest: beq_comp_size)
 
-lemma string_in_list_append [simp]:
-  "string_in_list y (xs @ ys) = (string_in_list y xs \<or> string_in_list y ys)"
-  by (induction xs) auto
-
-lemma string_in_list_remove_name [simp]:
-  "string_in_list y (remove_name n xs) = (y \<noteq> n \<and> string_in_list y xs)"
-  by (induction xs) auto
-
-lemma string_in_list_remove_names [simp]:
-  "string_in_list y (remove_names ns xs) = (\<not> string_in_list y ns \<and> string_in_list y xs)"
-  by (induction ns) auto
-
 lemma eval_list_length:
   "eval_list fs ps fuel s st env es = Some vs \<Longrightarrow> length vs = length es"
   by (induction es arbitrary: vs) (auto split: option.splits)

--- a/proofs/isabelle/SpecRest/semantics/Smt.thy
+++ b/proofs/isabelle/SpecRest/semantics/Smt.thy
@@ -1,5 +1,5 @@
 theory Smt
-  imports SpecRest_IR.IR Smt_Fresh "HOL.Rat"
+  imports SpecRest_IR.IR "HOL.Rat"
 begin
 
 datatype (plugins only: code size) smt_sort =


### PR DESCRIPTION
The separation-of-concerns cleanup flagged across the proof-overhead investigation. The datatype-independent `String.literal` machinery was scattered across **three files in two sessions**:
- `string_in_list` (+`_iff`) in the **IR datatype theory** (a junk-drawer);
- `remove_name`/`remove_names` in `IR_FreeVars`;
- the entire `fresh_var` cluster in its own `Smt_Fresh.thy`;
- the `string_in_list_append`/`_remove_*` membership lemmas in `Semantics_Reference`.

Pulled them all into one base **`core/Names.thy`** (`imports Main` only), which `IR` now imports — so every layer gets the machinery through the normal import chain.

## What moved
| Into `Names.thy` | Stays put (datatype-dependent) |
|---|---|
| `string_in_list` / `_iff` / `_append` | `qb_names`, `free_vars`, `subst` (need `expr`) → `IR_FreeVars` |
| `remove_name` / `remove_names` / `string_in_list_remove_*` | `smt_var_list` (needs `smt_term`) → `Smt` |
| `fresh_in` / `fresh_var` / `underscored` + size/pigeonhole lemmas | |

`Smt_Fresh.thy` is deleted (folded in). `IR.thy` and `Smt.thy` no longer carry any string-handling defs.

## Why this is the cleanup, not churn
- The string/fresh/var primitives are now **one self-contained, documented module** instead of sprayed across the datatype theory + two layers — directly the "separation of concerns is broken" complaint.
- It de-junk-drawers `IR.thy` (the datatype theory stops holding string utilities) and makes future theory splits cleaner.

## Verification
- Full `isabelle build SpecRest_Soundness SpecRest_Codegen` green, zero `sorry`.
- **Zero proof churn** — the moved `[simp]` lemmas resolve through the import chain; no downstream proof edited.
- `SpecRestGenerated.scala` **sorted-identical** (the primitives just shift position in the emission order — 31 lines reordered, zero content change) and recompiles under `-Werror`.
- README structure block synced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes all string and variable-name utilities into core/Names.thy and updates imports so every layer gets them via the IR. No behavior change; builds and generated code are unchanged aside from minor reordering.

- **Refactors**
  - Added core/Names.thy with string_in_list (+iff/+append), remove_name/remove_names, and fresh_in/fresh_var (+size/pigeonhole lemmas).
  - Deleted Smt_Fresh.thy; IR now imports Names; Smt drops Smt_Fresh; membership lemmas moved out of Semantics_Reference; removed duplicates from IR and IR_FreeVars.
  - Full Isabelle build green with no proof edits; SpecRestGenerated.scala only reorders 31 lines; README and ROOT updated.

<sup>Written for commit f4db86511706562945c6a16645a965310c04c026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

