### PR TITLE
refactor(proofs): move Semantics_Inlining to the Soundness session

### DIFF
--- a/proofs/isabelle/README.md
+++ b/proofs/isabelle/README.md
@@ -23,9 +23,9 @@ proofs/isabelle/
     ├── core/                SpecRest_IR: Names (string/var mechanics), IR (datatypes) +
     │                        analysis layer (IR_Helpers, IR_Recognizers, IR_Lint, IR_FreeVars, IR_Analysis)
     ├── semantics/           SpecRest_Semantics: Smt, Semantics(_Eval/_Typing),
-    │                        Semantics_Reference, Semantics_Inlining, Translate
+    │                        Semantics_Reference, Translate
     ├── soundness/           SpecRest_Soundness: Soundness_Framework, Preservation_*,
-    │                        DirectSound(_*), DirectTotality, DirectPreservation
+    │                        DirectSound(_*), DirectTotality, DirectPreservation, Semantics_Inlining
     └── codegen/             SpecRest_Codegen: schema/OpenAPI/Alloy/classify helpers +
                              Codegen.thy (export_code)
 ```

--- a/proofs/isabelle/SpecRest/ROOT
+++ b/proofs/isabelle/SpecRest/ROOT
@@ -19,7 +19,6 @@ session SpecRest_Semantics in semantics = SpecRest_IR +
     Semantics_Typing
     Semantics
     Semantics_Reference
-    Semantics_Inlining
     Translate
 
 session SpecRest_Soundness in soundness = SpecRest_Semantics +
@@ -33,6 +32,7 @@ session SpecRest_Soundness in soundness = SpecRest_Semantics +
     DirectSound
     DirectTotality
     DirectPreservation
+    Semantics_Inlining
 
 session SpecRest_Codegen in codegen = SpecRest_Semantics +
   options [document = false, threads = 0]

--- a/proofs/isabelle/SpecRest/soundness/Semantics_Inlining.thy
+++ b/proofs/isabelle/SpecRest/soundness/Semantics_Inlining.thy
@@ -1,5 +1,5 @@
 theory Semantics_Inlining
-  imports Semantics_Reference
+  imports SpecRest_Semantics.Semantics_Reference
 begin
 
 lemma eval_coincidence:


### PR DESCRIPTION
Outcome of digging deeper into the Semantics block. `Semantics_Inlining` contains **zero definitions** — it is purely the meaning-preservation proof `inline_calls_eval` ("inlining preserves the reference semantics"), and a **leaf** (nothing imports it). It was a *soundness theorem* misfiled in the `semantics/` definitions session. Relocated to `soundness/` alongside `DirectSound` / `DirectPreservation`, so `semantics/` is now purely definitions + their well-definedness.

## Why it's clean (and why the earlier session-split wasn't)
Its only dependency, `Semantics_Reference`, lives in `SpecRest_Semantics` — the **parent** of `SpecRest_Soundness` — so it builds on the parent heap with **no re-elaboration**:

| | baseline | after move |
|---|---|---|
| Soundness CPU | 102s | **119s** (just Inlining's own work) |
| Semantics wall | 111s | 109s |
| total | ~225s | ~neutral |

Contrast the rejected sibling-session split, where importing a *non-parent* session re-elaborated the SMT layer at **+260s/session**. The rule: moving a leaf *down* the parent chain reuses heaps; moving a shared dependency *sideways* re-elaborates it.

## Honest scope
This is an **architectural placement fix**, not a speedup — the build is ~neutral. The value is that the inlining-soundness proof now sits with the other soundness proofs, and `semantics/` no longer mixes a soundness theorem into the definitions layer.

- Full proof build green, zero `sorry`.
- **Zero proof churn** (leaf: only its own import qualifier + the ROOT theory lists changed).
- `SpecRestGenerated.scala` untouched (pure proof, not an `export_code` root).
- README structure synced.

Everything bigger I investigated (deleting the leaf, `value_has_ty` inductive↔executable collapse, dead `smt_term` ctors, lemma dedup) turned out load-bearing or inherent — this was the one genuine, safe improvement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `Semantics_Inlining` (inlining meaning-preservation proof) from `semantics/` to `soundness/` to keep soundness proofs together and leave `semantics/` definitions-only. Build impact is neutral; no proof changes.

- **Refactors**
  - Relocated `Semantics_Inlining.thy` into `soundness/` next to `DirectSound` and `DirectPreservation`.
  - Updated `SpecRest/ROOT` to remove from `SpecRest_Semantics` and add to `SpecRest_Soundness`.
  - Switched import to `SpecRest_Semantics.Semantics_Reference` to reuse the parent heap.
  - Synced the folder map in `README.md`.

<sup>Written for commit b1f0018da180b96e4e0b8ea1fb43c36a7aabf38c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the proof-track layout description to reflect the revised placement of the inlining theory.

* **Refactor**
  * Reorganized the Isabelle session setup so the inlining theory is grouped with soundness-related content instead of semantics.
  * Adjusted theory references to match the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->