### PR TITLE
feat(synth): machine-verify few-shot examples in CI

### DIFF
--- a/.github/workflows/fewshot-verify.yml
+++ b/.github/workflows/fewshot-verify.yml
@@ -1,0 +1,35 @@
+name: fewshot-verify
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "modules/synth/src/main/resources/specrest/synth/few-shot/**"
+      - "scripts/verify_fewshot.sh"
+      - ".github/workflows/fewshot-verify.yml"
+  pull_request:
+    paths:
+      - "modules/synth/src/main/resources/specrest/synth/few-shot/**"
+      - "scripts/verify_fewshot.sh"
+      - ".github/workflows/fewshot-verify.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+      - name: Verify few-shot Dafny examples
+        run: scripts/verify_fewshot.sh

--- a/docs/content/docs/research/llm_verifier_synthesis/prompts.md
+++ b/docs/content/docs/research/llm_verifier_synthesis/prompts.md
@@ -47,9 +47,11 @@ request asked a different way. That escalation order lives on the
 ## Few-shot examples
 
 The examples are not retrieved by similarity. They are selected by the operation's kind,
-[`selectFor(operation_kind)`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/synth/src/main/scala/specrest/synth/FewShot.scala), from a five-file library kept as resources. A create draws the
+[`selectFor(operation_kind)`](https://github.com/HardMax71/spec_to_rest/blob/main/modules/synth/src/main/scala/specrest/synth/FewShot.scala), from a seven-file library kept as resources. A create draws the
 fresh-insert and counter examples, a delete draws map-remove, a filtered read draws the sequence-sum,
-and a transition draws the state-modify. Two of the files, verbatim:
+a batch mutation draws sequence-append and fresh-insert, and a transition draws guarded-transition
+and counter. Every file in the library is checked by `dafny verify` in CI, so a broken example
+cannot ship. Two of the files, verbatim:
 
 ```csharp
 // few-shot/map_insert_fresh.dfy

--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -186,7 +186,6 @@ Open follow-ups for the M6 synthesis pipeline. For the prose context, see
 | Concern | Tracked in |
 | ------- | ---------- |
 | Dafny `ServiceState` reconciliation with SQLAlchemy / Postgres (the kernel runs on fresh per-request state) | follow-up |
-| Few-shot examples machine-verified by `dafny verify` in CI | follow-up |
 | Counterexample formatting (Z3 model -> human-readable) | follow-up |
 | Cross-family escalation (Anthropic -> OpenAI) within one `--fallback` run | follow-up |
 | Automatic hint discovery, mining proof patterns from verified CEGIS runs instead of hand-curating `HintLibrary` | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |

--- a/docs/content/docs/synth/compile-and-fallback.mdx
+++ b/docs/content/docs/synth/compile-and-fallback.mdx
@@ -235,6 +235,6 @@ fixture.
 
 ## What's still deferred
 
-For the live synthesis follow-up backlog (ORM reconciliation, dafny-verified few-shots
-in CI, counterexample formatting, cross-family escalation), see
+For the live synthesis follow-up backlog (ORM reconciliation, counterexample formatting,
+and cross-family escalation), see
 [Roadmap, Synthesis follow-ups](/roadmap#synthesis-follow-ups).

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/guarded_transition.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/guarded_transition.dfy
@@ -1,0 +1,14 @@
+// A guarded state transition: advance status only from a permitted source state
+datatype Status = Draft | Placed | Shipped
+
+class Order {
+  var status: Status
+}
+
+method Place(o: Order)
+  modifies o
+  requires o.status == Draft
+  ensures o.status == Placed
+{
+  o.status := Placed;
+}

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/map_delete.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/map_delete.dfy
@@ -5,5 +5,5 @@ method Remove<K(==),V>(m: map<K,V>, k: K) returns (m': map<K,V>)
   ensures |m'| == |m| - 1
   ensures forall j :: j in m && j != k ==> j in m' && m'[j] == m[j]
 {
-  m' := map j | j in m && j != k :: m[j];
+  m' := m - {k};
 }

--- a/modules/synth/src/main/resources/specrest/synth/few-shot/seq_append.dfy
+++ b/modules/synth/src/main/resources/specrest/synth/few-shot/seq_append.dfy
@@ -1,0 +1,8 @@
+// Appending an element to the end of a sequence
+method Append<T>(s: seq<T>, x: T) returns (s': seq<T>)
+  ensures |s'| == |s| + 1
+  ensures s'[..|s|] == s
+  ensures s'[|s|] == x
+{
+  s' := s + [x];
+}

--- a/modules/synth/src/main/scala/specrest/synth/FewShot.scala
+++ b/modules/synth/src/main/scala/specrest/synth/FewShot.scala
@@ -10,14 +10,17 @@ object FewShot:
   private val resourceRoot = "/specrest/synth/few-shot"
 
   enum Snippet derives CanEqual:
-    case MapInsertFresh, MapUpdateExisting, MapDelete, SeqSum, StateModify
+    case MapInsertFresh, MapUpdateExisting, MapDelete, SeqSum, SeqAppend, StateModify,
+      GuardedTransition
 
   def fileName(s: Snippet): String = s match
     case Snippet.MapInsertFresh    => "map_insert_fresh.dfy"
     case Snippet.MapUpdateExisting => "map_update_existing.dfy"
     case Snippet.MapDelete         => "map_delete.dfy"
     case Snippet.SeqSum            => "seq_sum.dfy"
+    case Snippet.SeqAppend         => "seq_append.dfy"
     case Snippet.StateModify       => "state_modify.dfy"
+    case Snippet.GuardedTransition => "guarded_transition.dfy"
 
   def text(s: Snippet): String =
     val name     = fileName(s)
@@ -36,5 +39,5 @@ object FewShot:
     case _: CreateChild   => List(Snippet.MapInsertFresh)
     case _: FilteredRead  => List(Snippet.SeqSum)
     case _: SideEffect    => List(Snippet.StateModify, Snippet.SeqSum)
-    case _: BatchMutation => List(Snippet.SeqSum, Snippet.MapInsertFresh)
-    case _: Transition    => List(Snippet.StateModify)
+    case _: BatchMutation => List(Snippet.SeqAppend, Snippet.MapInsertFresh)
+    case _: Transition    => List(Snippet.GuardedTransition, Snippet.StateModify)

--- a/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FewShotTest.scala
@@ -25,6 +25,16 @@ class FewShotTest extends CatsEffectSuite:
       "Read operations get the map_update_existing example",
       Read(),
       List(FewShot.Snippet.MapUpdateExisting)
+    ),
+    (
+      "Transition operations get the guarded_transition example",
+      Transition(),
+      List(FewShot.Snippet.GuardedTransition, FewShot.Snippet.StateModify)
+    ),
+    (
+      "BatchMutation operations get the seq_append example",
+      BatchMutation(),
+      List(FewShot.Snippet.SeqAppend, FewShot.Snippet.MapInsertFresh)
     )
   ).foreach: (name, kind, expected) =>
     test(name):

--- a/scripts/verify_fewshot.sh
+++ b/scripts/verify_fewshot.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Verify every few-shot Dafny example shown to the synthesis LLM with `dafny verify`.
+# Usage: scripts/verify_fewshot.sh [dafny-bin]   (defaults to $DAFNY_BIN, else `dafny` on PATH)
+set -euo pipefail
+
+dafny_bin="${1:-${DAFNY_BIN:-dafny}}"
+dir="modules/synth/src/main/resources/specrest/synth/few-shot"
+
+shopt -s nullglob
+files=("$dir"/*.dfy)
+(( ${#files[@]} > 0 )) || { echo "no few-shot .dfy files under $dir" >&2; exit 1; }
+
+rc=0
+for f in "${files[@]}"; do
+  if out="$("$dafny_bin" verify "$f" 2>&1)"; then
+    echo "ok   $(basename "$f")"
+  else
+    echo "FAIL $(basename "$f")"
+    echo "$out"
+    rc=1
+  fi
+done
+exit "$rc"


### PR DESCRIPTION
Closes the "few-shot examples machine-verified by `dafny verify` in CI" synthesis follow-up, and fixes a bug it immediately surfaced.

**The bug.** The few-shot examples injected into the synthesis prompt were never verified, and `map_delete.dfy` did not verify: its map-comprehension body (`map j | j in m && j != k :: m[j]`) defeats Dafny's cardinality reasoning, so `ensures |m'| == |m| - 1` could not be proved. The LLM was being shown a non-verifying, non-idiomatic delete. Replaced the body with `m - {k}`, which verifies and is the pattern to teach.

**Two new examples**, both `dafny verify`-clean: `seq_append` (sequence growth, routed to `BatchMutation`) and `guarded_transition` (a status-machine transition, routed to `Transition`). Both wired into `FewShot.selectFor` with `FewShotTest` coverage.

**The CI guard.** `scripts/verify_fewshot.sh` runs `dafny verify` over every `.dfy` in the few-shot resource directory, auto-discovered so adding an example needs no script edit. The `fewshot-verify` workflow installs Dafny through `setup-dafny-action` and runs the script, path-filtered to the few-shot resources and the script itself. The CEGIS loop keeps using `MockDafnyVerifier`; this is a separate, narrow Dafny job for the example library only.

Ran locally against Dafny 4.11.0: all seven few-shot files verify, and `FewShotTest` passes. The 12 hint snippets stay unverified for now, since they are proof-pattern fragments rather than standalone programs and would need a harness (separate follow-up).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CI to machine-verify all few-shot Dafny examples, fixes the non-verifying map delete, adds two verified examples, and updates docs to reflect the now-verified seven-file library.

- **New Features**
  - Added `fewshot-verify` workflow using `dafny-lang/setup-dafny-action` (Dafny 4.11.0) to run `scripts/verify_fewshot.sh`, which auto-discovers and runs `dafny verify` on all few-shot `.dfy` files (path-filtered).
  - Added `seq_append.dfy` and `guarded_transition.dfy`; updated `FewShot.selectFor` to route `BatchMutation` to `SeqAppend` and `Transition` to `GuardedTransition`, with `FewShotTest` coverage.
  - Updated docs: prompts page now describes the seven-file library and CI verification; removed the "few-shot CI verification" follow-up from the roadmap and deferred list.

- **Bug Fixes**
  - Rewrote `map_delete.dfy` to use `m - {k}` instead of a map comprehension so the size postcondition verifies and matches idiomatic Dafny.

<sup>Written for commit b549a6dfb10d2f5bec6ca7783f77afcfb13f62e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader few-shot examples for sequence appends and guarded state transitions, improving the quality and coverage of synthesis guidance.
  * Expanded automated verification for few-shot examples in CI.

* **Bug Fixes**
  * Updated example selection so batch mutation and transition scenarios use the most relevant reference patterns.

* **Documentation**
  * Refreshed docs to reflect the larger few-shot library and revised example selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->