### PR TITLE
docs(roadmap): drop duplicate counterexample-formatting follow-up row

### DIFF
--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -186,7 +186,6 @@ Open follow-ups for the M6 synthesis pipeline. For the prose context, see
 | Concern | Tracked in |
 | ------- | ---------- |
 | Dafny `ServiceState` reconciliation with SQLAlchemy / Postgres (the kernel runs on fresh per-request state) | follow-up |
-| Counterexample formatting (Z3 model -> human-readable) | follow-up |
 | Cross-family escalation (Anthropic -> OpenAI) within one `--fallback` run | follow-up |
 | Automatic hint discovery, mining proof patterns from verified CEGIS runs instead of hand-curating `HintLibrary` | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |
 | Pass@128-scale sampling, raising `CegisBudget.maxIterations` by an order of magnitude for Re:Form-style gains | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |


### PR DESCRIPTION
## What

Removes one stale row from the **Synthesis follow-ups** table in `roadmap.mdx`:

```text
| Counterexample formatting (Z3 model -> human-readable) | follow-up |
```

## Why

The roadmap listed the same capability twice, with conflicting status:

- Verification capabilities ledger (line 144): `Counterexample-driven diagnostics (spans, entity/state decoding) | shipped`
- Synthesis follow-ups (line 189): `Counterexample formatting (Z3 model -> human-readable) | follow-up`

Counterexample formatting is shipped. Running `verify` on a counterexample-producing spec decodes the Z3 model directly into readable output: entities with `UrlMapping#N` labels and decoded fields, pre-state and post-state relations side by side, the chosen inputs, and the numbered "Why this violates the invariant" narration. The code is `modules/verify/src/main/scala/specrest/verify/z3/CounterExample.scala` (`decode(model: Model, ...)` walks the sort universes, builds the `#N` labels, maps raw `!val!` elements through `rawToLabel`, decodes the relation sides and inputs), with the prose layer in `Narration.scala` (#89).

The row was also misfiled. Counterexample decoding is a verification-engine feature; synthesis runs `dafny verify`, which produces no Z3 model, so it never belonged under synthesis follow-ups. Unlike the M5.11/M5.12 cleanup there is no milestone to move it to, since the capability is already recorded as shipped in the ledger, so deletion is the whole fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate "Counterexample formatting (Z3 model -> human-readable)" follow-up row from `roadmap.mdx`. This capability is already shipped in the verification ledger, so deleting it resolves the conflicting status and removes a misfiled synthesis item.

<sup>Written for commit 68c8b42b0ad0a61037c7ab29880910d3da2041dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

