### PR TITLE
docs(synth): fix stale escalation example and dangling follow-up link

### DIFF
--- a/docs/content/docs/synth/compile-and-fallback.mdx
+++ b/docs/content/docs/synth/compile-and-fallback.mdx
@@ -97,7 +97,7 @@ ANTHROPIC_API_KEY=sk-ant-... DAFNY_BIN=/usr/local/bin/dafny \
       default: 'off',
     },
     '--escalate-to MODEL': {
-      description: 'Repeat for a multi-step ladder (e.g. `--escalate-to opus --escalate-to gpt-5`).',
+      description: 'Repeat for a multi-step ladder (e.g. `--escalate-to claude-opus-4-7 --escalate-to claude-opus-4-8`). The provider is fixed by the initial model, so every ladder entry must be the same family.',
       type: 'string',
       default: '_empty_',
     },
@@ -235,6 +235,5 @@ fixture.
 
 ## What's still deferred
 
-For the live synthesis follow-up backlog (ORM reconciliation, counterexample formatting,
-and cross-family escalation), see
-[Roadmap, Synthesis follow-ups](/roadmap#synthesis-follow-ups).
+For the live synthesis follow-up backlog (ORM reconciliation and cross-family
+escalation), see [Roadmap, Synthesis follow-ups](/roadmap#synthesis-follow-ups).


### PR DESCRIPTION
Two fixes in `docs/content/docs/synth/compile-and-fallback.mdx`, both found while verifying the "Cross-family escalation (Anthropic -> OpenAI)" roadmap follow-up against the code.

## Mixed-family `--escalate-to` example was wrong

The `--escalate-to` row showed `--escalate-to opus --escalate-to gpt-5`, a claude-then-gpt ladder. That cannot work. `Synth.scala` `providerResource(model)` picks the provider once from the initial model (gpt prefix routes to `OpenAIProvider`, otherwise `AnthropicProvider`) and hands that single instance to the `FallbackOrchestrator`. Every ladder entry runs through it, with only the model string swapped, so a `gpt-5` step in a claude-rooted run ships `model=gpt-5` to the Anthropic endpoint and is rejected. The example now uses a same-family ladder and states the constraint, which matches the cross-family-escalation follow-up still being open.

## Dangling counterexample-formatting reference

The "What's still deferred" sentence still listed counterexample formatting alongside ORM reconciliation and cross-family escalation. That roadmap row was removed in #491 (it was a duplicate of the shipped verification-ledger entry), so the reference dangled. Dropped it.

Docs-only; the Site workflow builds the docs in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the `--escalate-to` example in the synth fallback docs to use a same-family ladder and clarified that the provider is fixed by the initial model (all ladder entries must be the same family). Removed the stale “counterexample formatting” reference from the deferred backlog.

<sup>Written for commit d91c7f3bfefc5d10738ba07a6221cedf7bd430d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

