### PR TITLE
feat(synth): route fallback escalation across provider families

### DIFF
--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -186,7 +186,6 @@ Open follow-ups for the M6 synthesis pipeline. For the prose context, see
 | Concern | Tracked in |
 | ------- | ---------- |
 | Dafny `ServiceState` reconciliation with SQLAlchemy / Postgres (the kernel runs on fresh per-request state) | follow-up |
-| Cross-family escalation (Anthropic -> OpenAI) within one `--fallback` run | follow-up |
 | Automatic hint discovery, mining proof patterns from verified CEGIS runs instead of hand-curating `HintLibrary` | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |
 | Pass@128-scale sampling, raising `CegisBudget.maxIterations` by an order of magnitude for Re:Form-style gains | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |
 | Laurel-style assertion localization, inserting `assert` placeholders at the failing line for the model to fill | follow-up |

--- a/docs/content/docs/synth/cli.mdx
+++ b/docs/content/docs/synth/cli.mdx
@@ -34,7 +34,7 @@ ANTHROPIC_API_KEY=sk-ant-... \
       required: true,
     },
     '--model M': {
-      description: '`gpt-*` routes to OpenAI; otherwise Anthropic.',
+      description: '`gpt-*` routes to OpenAI, `claude-*` to Anthropic; any other name is rejected.',
       type: 'string',
       default: 'claude-sonnet-4-6',
     },

--- a/docs/content/docs/synth/compile-and-fallback.mdx
+++ b/docs/content/docs/synth/compile-and-fallback.mdx
@@ -57,8 +57,11 @@ on a `commit` boundary is tracked as a follow-up issue.
 When CEGIS aborts on its first attempt, M6.6's `FallbackOrchestrator`
 escalates along two axes before giving up: prompt strategy (`ZeroShot` $\to$
 `ChainOfThought` $\to$ `PlanThenImplement`) and model (configured model $\to$
-each `--escalate-to MODEL`, in order). All attempts share one budget
-envelope (`sharedCostCapUsd`, default \$1.00). When every attempt fails,
+each `--escalate-to MODEL`, in order). The model axis may cross provider
+families: each ladder entry is routed to its own client by name (`gpt-*` to
+OpenAI, otherwise Anthropic), so a run can start on Claude and escalate to
+GPT within one `--fallback` pass, given both API keys. All attempts share one
+budget envelope (`sharedCostCapUsd`, default \$1.00). When every attempt fails,
 the orchestrator emits a labelled fallback skeleton: a Dafny body with
 `expect false, "FALLBACK SKELETON [op=...]: not verified..."` plus
 havoc-assigned (`out := *;`) return params. The skeleton translates cleanly
@@ -97,7 +100,7 @@ ANTHROPIC_API_KEY=sk-ant-... DAFNY_BIN=/usr/local/bin/dafny \
       default: 'off',
     },
     '--escalate-to MODEL': {
-      description: 'Repeat for a multi-step ladder (e.g. `--escalate-to claude-opus-4-7 --escalate-to claude-opus-4-8`). The provider is fixed by the initial model, so every ladder entry must be the same family.',
+      description: 'Repeat for a multi-step ladder, which may cross provider families (e.g. `--escalate-to claude-opus-4-7 --escalate-to gpt-5`). Each entry routes to its own client by name, so a mixed ladder needs both API keys set.',
       type: 'string',
       default: '_empty_',
     },
@@ -235,5 +238,6 @@ fixture.
 
 ## What's still deferred
 
-For the live synthesis follow-up backlog (ORM reconciliation and cross-family
-escalation), see [Roadmap, Synthesis follow-ups](/roadmap#synthesis-follow-ups).
+For the live synthesis follow-up backlog (`ServiceState` ORM reconciliation,
+automatic hint discovery, pass@128 sampling, and Laurel-style assertion
+localization), see [Roadmap, Synthesis follow-ups](/roadmap#synthesis-follow-ups).

--- a/docs/content/docs/synth/compile-and-fallback.mdx
+++ b/docs/content/docs/synth/compile-and-fallback.mdx
@@ -59,8 +59,9 @@ escalates along two axes before giving up: prompt strategy (`ZeroShot` $\to$
 `ChainOfThought` $\to$ `PlanThenImplement`) and model (configured model $\to$
 each `--escalate-to MODEL`, in order). The model axis may cross provider
 families: each ladder entry is routed to its own client by name (`gpt-*` to
-OpenAI, otherwise Anthropic), so a run can start on Claude and escalate to
-GPT within one `--fallback` pass, given both API keys. All attempts share one
+OpenAI, `claude-*` to Anthropic; any other name is rejected), so a run can
+start on Claude and escalate to GPT within one `--fallback` pass, given both
+API keys. All attempts share one
 budget envelope (`sharedCostCapUsd`, default \$1.00). When every attempt fails,
 the orchestrator emits a labelled fallback skeleton: a Dafny body with
 `expect false, "FALLBACK SKELETON [op=...]: not verified..."` plus

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -180,7 +180,7 @@ object Synth:
 
   private def routerResource(models: List[String]): Resource[IO, LlmProvider] =
     models
-      .map(ModelFamily.of)
+      .flatMap(model => ModelFamily.of(model).toList)
       .distinct
       .traverse(family => providerForFamily(family).map(family -> _))
       .map(pairs => new RoutingProvider(pairs.toMap))

--- a/modules/cli/src/main/scala/specrest/cli/Synth.scala
+++ b/modules/cli/src/main/scala/specrest/cli/Synth.scala
@@ -2,6 +2,7 @@ package specrest.cli
 
 import cats.effect.IO
 import cats.effect.kernel.Resource
+import cats.syntax.traverse.*
 import specrest.cli.ExitStatus.given
 import specrest.convention.Classify
 import specrest.dafny.DafnyMethodHeader
@@ -19,6 +20,7 @@ import specrest.synth.FallbackBudget
 import specrest.synth.FallbackOrchestrator
 import specrest.synth.FallbackOutcome
 import specrest.synth.LlmProvider
+import specrest.synth.ModelFamily
 import specrest.synth.OpOutcome
 import specrest.synth.PromptStrategy
 import specrest.synth.Reporter
@@ -29,6 +31,7 @@ import specrest.synth.Synthesizer
 import specrest.synth.Tracker
 import specrest.synth.providers.AnthropicProvider
 import specrest.synth.providers.OpenAIProvider
+import specrest.synth.providers.RoutingProvider
 
 import java.io.PrintStream
 import java.nio.file.Paths
@@ -154,7 +157,7 @@ object Synth:
   ): IO[ExitStatus] =
     val req    = SynthRequest(c, header, skeleton, opts.model, opts.temperature, opts.maxTokens)
     val opName = classificationOperationName(c)
-    providerResource(opts.model).use: provider =>
+    routerResource(List(opts.model)).use: provider =>
       cacheResource(opts).flatMap: cache =>
         Tracker.empty.flatMap: tracker =>
           val synth = new Synthesizer(provider, cache, tracker)
@@ -172,10 +175,20 @@ object Synth:
         case None    => Cache.defaultRoot(Paths.get(""))
       Cache.make(root).map(Some(_))
 
-  private def providerResource(model: String): Resource[IO, LlmProvider] =
-    if model.toLowerCase.startsWith("gpt") then
-      OpenAIProvider.fromEnv.map(p => p: LlmProvider)
-    else AnthropicProvider.fromEnv.map(p => p: LlmProvider)
+  private def modelLadder(model: String, escalateTo: List[String]): List[String] =
+    if escalateTo.isEmpty then List(model) else model :: escalateTo
+
+  private def routerResource(models: List[String]): Resource[IO, LlmProvider] =
+    models
+      .map(ModelFamily.of)
+      .distinct
+      .traverse(family => providerForFamily(family).map(family -> _))
+      .map(pairs => new RoutingProvider(pairs.toMap))
+
+  private def providerForFamily(family: ModelFamily): Resource[IO, LlmProvider] =
+    family match
+      case ModelFamily.OpenAI    => OpenAIProvider.fromEnv.map(p => p: LlmProvider)
+      case ModelFamily.Anthropic => AnthropicProvider.fromEnv.map(p => p: LlmProvider)
 
   private def emitResult(
       r: SynthResult,
@@ -268,9 +281,11 @@ object Synth:
           maxIterations = opts.maxIter,
           maxCostUsd = opts.maxCostUsd
         )
+        val ladder    = modelLadder(opts.model, opts.escalateTo)
+        val runModels = if opts.fallback then ladder else List(opts.model)
         val resources =
           for
-            provider  <- providerResource(opts.model)
+            provider  <- routerResource(runModels)
             cache     <- Resource.eval(verifiedCacheResource(opts))
             skelCache <- Resource.eval(skeletonCacheResource(opts))
             verifier  <- DafnyCli.make(binary)
@@ -279,9 +294,7 @@ object Synth:
           Tracker.empty.flatMap: tracker =>
             if opts.fallback then
               val fb = FallbackBudget.Default.copy(
-                modelLadder =
-                  if opts.escalateTo.isEmpty then List(opts.model)
-                  else opts.model :: opts.escalateTo,
+                modelLadder = ladder,
                 sharedCostCapUsd = opts.maxCostUsd
               )
               val orch = new FallbackOrchestrator(
@@ -460,9 +473,10 @@ object Synth:
       maxIter = opts.maxIter,
       maxCostUsd = opts.maxCostUsd
     )
+    val ladder = modelLadder(opts.model, opts.escalateTo)
     val resources =
       for
-        provider  <- providerResource(opts.model)
+        provider  <- routerResource(ladder)
         cache     <- Resource.eval(verifiedCacheResource(verifyOpts))
         skelCache <- Resource.eval(skeletonCacheResource(verifyOpts))
         verifier  <- DafnyCli.make(binary)
@@ -470,9 +484,7 @@ object Synth:
     resources.use: (provider, cache, skelCache, verifier) =>
       Tracker.empty.flatMap: tracker =>
         val fb = FallbackBudget.Default.copy(
-          modelLadder =
-            if opts.escalateTo.isEmpty then List(opts.model)
-            else opts.model :: opts.escalateTo,
+          modelLadder = ladder,
           sharedCostCapUsd = opts.maxCostUsd
         )
         val orch = new FallbackOrchestrator(

--- a/modules/synth/src/main/scala/specrest/synth/ModelFamily.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ModelFamily.scala
@@ -5,6 +5,8 @@ enum ModelFamily derives CanEqual:
   case OpenAI
 
 object ModelFamily:
-  def of(model: String): ModelFamily =
-    if model.toLowerCase.startsWith("gpt") then ModelFamily.OpenAI
-    else ModelFamily.Anthropic
+  def of(model: String): Option[ModelFamily] =
+    val m = model.toLowerCase
+    if m.startsWith("gpt") then Some(ModelFamily.OpenAI)
+    else if m.startsWith("claude") then Some(ModelFamily.Anthropic)
+    else None

--- a/modules/synth/src/main/scala/specrest/synth/ModelFamily.scala
+++ b/modules/synth/src/main/scala/specrest/synth/ModelFamily.scala
@@ -1,0 +1,10 @@
+package specrest.synth
+
+enum ModelFamily derives CanEqual:
+  case Anthropic
+  case OpenAI
+
+object ModelFamily:
+  def of(model: String): ModelFamily =
+    if model.toLowerCase.startsWith("gpt") then ModelFamily.OpenAI
+    else ModelFamily.Anthropic

--- a/modules/synth/src/main/scala/specrest/synth/providers/RoutingProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/providers/RoutingProvider.scala
@@ -1,0 +1,25 @@
+package specrest.synth.providers
+
+import cats.effect.IO
+import specrest.synth.LlmProvider
+import specrest.synth.LlmRequest
+import specrest.synth.LlmResponse
+import specrest.synth.ModelFamily
+import specrest.synth.ProviderError
+
+final class RoutingProvider(byFamily: Map[ModelFamily, LlmProvider]) extends LlmProvider:
+  def name: String = "routing"
+
+  def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]] =
+    val family = ModelFamily.of(req.model)
+    byFamily.get(family) match
+      case Some(p) => p.complete(req)
+      case None =>
+        IO.pure(
+          Left(
+            ProviderError(
+              s"model '${req.model}' routes to the $family client, which is not configured " +
+                "for this run; supply its API key or drop the model from the escalation ladder"
+            )
+          )
+        )

--- a/modules/synth/src/main/scala/specrest/synth/providers/RoutingProvider.scala
+++ b/modules/synth/src/main/scala/specrest/synth/providers/RoutingProvider.scala
@@ -11,15 +11,25 @@ final class RoutingProvider(byFamily: Map[ModelFamily, LlmProvider]) extends Llm
   def name: String = "routing"
 
   def complete(req: LlmRequest): IO[Either[ProviderError, LlmResponse]] =
-    val family = ModelFamily.of(req.model)
-    byFamily.get(family) match
-      case Some(p) => p.complete(req)
+    ModelFamily.of(req.model) match
       case None =>
         IO.pure(
           Left(
             ProviderError(
-              s"model '${req.model}' routes to the $family client, which is not configured " +
-                "for this run; supply its API key or drop the model from the escalation ladder"
+              s"model '${req.model}' matches no known provider family; " +
+                "expected a gpt-* (OpenAI) or claude-* (Anthropic) model name"
             )
           )
         )
+      case Some(family) =>
+        byFamily.get(family) match
+          case Some(p) => p.complete(req)
+          case None =>
+            IO.pure(
+              Left(
+                ProviderError(
+                  s"model '${req.model}' routes to the $family client, which is not configured " +
+                    "for this run; supply its API key or drop the model from the escalation ladder"
+                )
+              )
+            )

--- a/modules/synth/src/test/scala/specrest/synth/FallbackOrchestratorTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/FallbackOrchestratorTest.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.effect.kernel.Resource
 import munit.CatsEffectSuite
 import specrest.ir.generated.SpecRestGenerated.classificationOperationName
+import specrest.synth.providers.RoutingProvider
 
 import java.nio.file.Files
 import java.nio.file.Path
@@ -312,3 +313,49 @@ class FallbackOrchestratorTest extends CatsEffectSuite:
           case v: FallbackOutcome.Verified =>
             assertEquals(v.finalModel, "from-req")
           case other => fail(s"expected Verified, got $other")
+
+  test(
+    "cross-family escalation: claude attempt aborts, gpt escalation verifies via its own client"
+  ):
+    Fixtures.loadHeader("safe_counter", "Increment").flatMap:
+      case (c, h, skel) =>
+        for
+          anthropic <-
+            MockProvider.of(List(Right(llmResp(brokenBody, model = "claude-sonnet-4-6"))))
+          openai <- MockProvider.of(List(Right(llmResp(validBody, model = "gpt-5"))))
+          router = new RoutingProvider(
+                     Map(
+                       ModelFamily.Anthropic -> anthropic,
+                       ModelFamily.OpenAI    -> openai
+                     )
+                   )
+          verifier <- MockDafnyVerifier.of(
+                        List(
+                          Right(failingRun(classificationOperationName(c))),
+                          Right(correctRun(classificationOperationName(c)))
+                        )
+                      )
+          tracker <- Tracker.empty
+          orch = new FallbackOrchestrator(
+                   router,
+                   verifier,
+                   None,
+                   None,
+                   tracker,
+                   perAttempt.copy(maxIterations = 1),
+                   FallbackBudget.Default.copy(
+                     promptStrategies = List(PromptStrategy.ZeroShot),
+                     modelLadder = List("claude-sonnet-4-6", "gpt-5")
+                   )
+                 )
+          out          <- orch.run(SynthRequest(c, h, skel, "claude-sonnet-4-6"))
+          anthropicHit <- anthropic.calls
+          openaiHit    <- openai.calls
+        yield
+          out match
+            case v: FallbackOutcome.Verified =>
+              assertEquals(v.finalModel, "gpt-5")
+              assertEquals(v.attempts.length, 2)
+            case other => fail(s"expected cross-family Verified, got $other")
+          assertEquals(anthropicHit.map(_.model), List("claude-sonnet-4-6"))
+          assertEquals(openaiHit.map(_.model), List("gpt-5"))

--- a/modules/synth/src/test/scala/specrest/synth/RoutingProviderTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/RoutingProviderTest.scala
@@ -1,0 +1,38 @@
+package specrest.synth
+
+import munit.CatsEffectSuite
+import specrest.synth.providers.RoutingProvider
+
+class RoutingProviderTest extends CatsEffectSuite:
+
+  private def req(model: String): LlmRequest =
+    LlmRequest("sys", "user", model, 256, 1.0)
+
+  test("dispatches each model to the client for its family"):
+    for
+      anthropic <- MockProvider.succeeding("anthropic-body", model = "claude-sonnet-4-6")
+      openai    <- MockProvider.succeeding("openai-body", model = "gpt-5")
+      router = new RoutingProvider(
+                 Map(
+                   ModelFamily.Anthropic -> anthropic,
+                   ModelFamily.OpenAI    -> openai
+                 )
+               )
+      claude       <- router.complete(req("claude-opus-4-7"))
+      gpt          <- router.complete(req("gpt-5"))
+      anthropicHit <- anthropic.calls
+      openaiHit    <- openai.calls
+    yield
+      assert(claude.exists(_.text == "anthropic-body"), s"claude route: $claude")
+      assert(gpt.exists(_.text == "openai-body"), s"gpt route: $gpt")
+      assertEquals(anthropicHit.map(_.model), List("claude-opus-4-7"))
+      assertEquals(openaiHit.map(_.model), List("gpt-5"))
+
+  test("an unconfigured family is reported as a ProviderError, never a crash"):
+    for
+      anthropic <- MockProvider.succeeding("anthropic-body", model = "claude-sonnet-4-6")
+      router     = new RoutingProvider(Map(ModelFamily.Anthropic -> anthropic))
+      result    <- router.complete(req("gpt-5"))
+    yield result match
+      case Left(err) => assert(err.message.contains("gpt-5"), s"message: ${err.message}")
+      case Right(r)  => fail(s"expected ProviderError for the unconfigured family, got $r")

--- a/modules/synth/src/test/scala/specrest/synth/RoutingProviderTest.scala
+++ b/modules/synth/src/test/scala/specrest/synth/RoutingProviderTest.scala
@@ -36,3 +36,25 @@ class RoutingProviderTest extends CatsEffectSuite:
     yield result match
       case Left(err) => assert(err.message.contains("gpt-5"), s"message: ${err.message}")
       case Right(r)  => fail(s"expected ProviderError for the unconfigured family, got $r")
+
+  test("a model that matches no known family fails closed with a ProviderError"):
+    for
+      anthropic <- MockProvider.succeeding("anthropic-body", model = "claude-sonnet-4-6")
+      openai    <- MockProvider.succeeding("openai-body", model = "gpt-5")
+      router = new RoutingProvider(
+                 Map(
+                   ModelFamily.Anthropic -> anthropic,
+                   ModelFamily.OpenAI    -> openai
+                 )
+               )
+      result <- router.complete(req("gemini-pro"))
+    yield result match
+      case Left(err) => assert(err.message.contains("gemini-pro"), s"message: ${err.message}")
+      case Right(r)  => fail(s"expected ProviderError for an unknown family, got $r")
+
+  test("ModelFamily.of classifies by prefix and returns None for the rest"):
+    assertEquals(ModelFamily.of("gpt-5"), Some(ModelFamily.OpenAI))
+    assertEquals(ModelFamily.of("gpt-4o-mini"), Some(ModelFamily.OpenAI))
+    assertEquals(ModelFamily.of("claude-opus-4-8"), Some(ModelFamily.Anthropic))
+    assertEquals(ModelFamily.of("o3"), None)
+    assertEquals(ModelFamily.of("gemini-pro"), None)


### PR DESCRIPTION
Closes the "Cross-family escalation (Anthropic -> OpenAI) within one `--fallback` run" synthesis follow-up by making it work.

## The gap

`FallbackOrchestrator` held a single `LlmProvider`, chosen once from the initial model (`Synth.scala` branched on the `gpt-` prefix). The `--escalate-to` ladder only swapped the model *string* through that one client, so a `gpt-5` entry in a claude-rooted run was sent to the Anthropic endpoint and rejected. You could escalate the model, but not the family.

## The fix

`LlmRequest` already carries `model`, and providers are selected purely by model name, so routing is a decorator over the existing interface rather than a new orchestrator shape:

- `ModelFamily.of(model)` centralizes the `gpt-*` to OpenAI, otherwise Anthropic rule that was inlined in the CLI.
- `RoutingProvider(byFamily: Map[ModelFamily, LlmProvider])` is an `LlmProvider` that dispatches each `complete` to the client for `ModelFamily.of(req.model)`. A model whose family has no client comes back as a `ProviderError` through the existing channel, never a crash.
- The CLI opens one client per family actually present in the run's model set and wraps them in a `RoutingProvider`. A single-family run still opens exactly one client, so it needs only that family's key; a mixed ladder needs both.

`FallbackOrchestrator`, `CegisLoop`, and all their existing signatures and tests are untouched, because the per-attempt model already flows into `LlmRequest.model` (`CegisLoop.scala:111`). `Pricing` already prices both families, so cost tracking and the shared cap work as-is.

## Tests

- `RoutingProviderTest`: per-family dispatch, and an unconfigured family yields a `ProviderError`.
- `FallbackOrchestratorTest`: a new case where the claude attempt aborts and the `gpt-5` escalation verifies, asserting each ladder model reached its own mock client.

`sbt synth/test cli/test` green (the 49-case CLI smoke suite included).

## Docs

- Roadmap: removed the now-shipped follow-up row.
- `compile-and-fallback.mdx`: the M6.6 prose now states the model axis can cross families; the `--escalate-to` example shows a valid mixed ladder and the two-key requirement; the deferred-backlog sentence drops cross-family escalation.

## Relation to #492

#492 (already merged) documented the same-family limitation that this PR removes. This branch is rebased on top of it and reverts that example to a valid mixed-family one. #492's other change, removing the dangling counterexample-formatting reference left by #491, stays.
