### PR TITLE
fix(testgen): send query parameters in the native Go/TS conformance suites

### DIFF
--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_client.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_client.go
@@ -12,8 +12,10 @@ package tests
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"testing"
 )
@@ -85,6 +87,24 @@ func httpDo(method, path string, body any) clientResponse {
 	defer func() { _ = resp.Body.Close() }()
 	buf, _ := io.ReadAll(resp.Body)
 	return clientResponse{status: resp.StatusCode, body: buf}
+}
+
+// withQuery appends the alternating key/value pairs as an encoded query
+// string. A nil value is an absent optional parameter and is skipped, so the
+// call reaches the server without that key at all.
+func withQuery(p string, kv ...any) string {
+	q := url.Values{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		k, ok := kv[i].(string)
+		if !ok || kv[i+1] == nil {
+			continue
+		}
+		q.Set(k, fmt.Sprintf("%v", kv[i+1]))
+	}
+	if len(q) == 0 {
+		return p
+	}
+	return p + "?" + q.Encode()
 }
 
 type httpClient struct{}

--- a/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
+++ b/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
@@ -17,6 +17,20 @@ function asArray(x: Anything): Anything[] {
   return [];
 }
 
+// Appends the params as an encoded query string. A null/undefined value is
+// an absent optional parameter and is skipped, so the call reaches the
+// server without that key at all.
+export function withQuery(path: string, params: Record<string, unknown>): string {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== null && v !== undefined) {
+      q.set(k, String(v));
+    }
+  }
+  const s = q.toString();
+  return s === "" ? path : `${path}?${s}`;
+}
+
 export function _len(x: Anything): number {
   if (x instanceof Set || x instanceof Map) return x.size;
   if (Array.isArray(x) || typeof x === "string") return (x as { length: number }).length;

--- a/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/NativeSuites.scala
@@ -219,12 +219,18 @@ private[testgen] object GoRender:
             "%v"
         )
         s"fmt.Sprintf(${GoLit.str(tmpl)}, ${names.map(ref).mkString(", ")})"
+    val target =
+      if ep.queryParams.isEmpty then pathExpr
+      else
+        val pairs =
+          ep.queryParams.map(p => s"${GoLit.str(p.name)}, ${ref(p.name)}").mkString(", ")
+        s"withQuery($pathExpr, $pairs)"
     val bodyExpr =
       if ep.bodyParams.isEmpty then ""
       else
         val pairs = ep.bodyParams.map(p => s"${GoLit.str(p.name)}: ${ref(p.name)}").mkString(", ")
         s", map[string]any{$pairs}"
-    s"client.$method($pathExpr$bodyExpr)"
+    s"client.$method($target$bodyExpr)"
 
   def module(bodies: String): String =
     val stdlib     = (if bodies.contains("fmt.") then List("\t\"fmt\"") else Nil) :+ "\t\"testing\""
@@ -262,12 +268,18 @@ private[testgen] object TsRender:
           m => scala.util.matching.Regex.quoteReplacement(s"$${${ref(m.group(1))}}")
         )
         s"`$raw`"
+    val target =
+      if ep.queryParams.isEmpty then pathExpr
+      else
+        val pairs =
+          ep.queryParams.map(p => s"${TsLit.str(p.name)}: ${ref(p.name)}").mkString(", ")
+        s"withQuery($pathExpr, { $pairs })"
     val bodyExpr =
       if ep.bodyParams.isEmpty then ""
       else
         val pairs = ep.bodyParams.map(p => s"${TsLit.str(p.name)}: ${ref(p.name)}").mkString(", ")
         s", { $pairs }"
-    s"client.$method($pathExpr$bodyExpr)"
+    s"client.$method($target$bodyExpr)"
 
   def runtimeImport(scanText: String): Option[String] =
     val used = TestFormat.TsRuntimeHelpers.filter(h => scanText.contains(s"$h("))

--- a/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
@@ -20,7 +20,18 @@ private[testgen] object TestFormat:
 
   // Names must match the exports of testgen-templates/typescript/express/tests/_runtime.ts.
   val TsRuntimeHelpers: List[String] =
-    List("_diff", "_eq", "_in", "_inter", "_len", "_powerset", "_sha256Hex", "_subset", "_union")
+    List(
+      "_diff",
+      "_eq",
+      "_in",
+      "_inter",
+      "_len",
+      "_powerset",
+      "_sha256Hex",
+      "_subset",
+      "_union",
+      "withQuery"
+    )
 
   def inputArbs(
       pop: ProfiledOperation,

--- a/modules/testgen/src/main/scala/specrest/testgen/TsStructural.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsStructural.scala
@@ -68,6 +68,7 @@ object TsStructural:
     sb.append("import { test } from \"vitest\";\n")
     sb.append("import fc from \"fast-check\";\n")
     sb.append("import { client } from \"./_client.js\";\n")
+    TsRender.runtimeImport(bodies).foreach(sb.append)
     TsRender.strategiesImport(ir, bodies).foreach(sb.append)
     sb.append("\n")
     sb.append(TsRender.NumRunsPreamble)

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -520,6 +520,26 @@ class BackendTest extends CatsEffectSuite:
       assert(preds.contains("package tests"), preds.take(200))
       assert(preds.contains("func isValidURI("), preds)
 
+  test("native structural suites send query parameters through withQuery"):
+    loadIR("fixtures/spec/todo_list.spec").map: ir =>
+      val profiled = SynthFixture.profiled(ir)
+      val go = GoStructural
+        .emitFor(profiled)
+        .tests
+        .find(_.name == "Test_structural_list_todos")
+        .getOrElse(fail("missing Test_structural_list_todos"))
+      assert(go.body.contains("client.get(withQuery("), go.body)
+      assert(go.body.contains("\"status_filter\", status_filter"), go.body)
+      assert(go.body.contains("\"tag_filter\", tag_filter"), go.body)
+      val tsOut = TsStructural.emitFor(profiled)
+      val ts = tsOut.tests
+        .find(_.name == "test_structural_list_todos")
+        .getOrElse(fail("missing test_structural_list_todos"))
+      assert(ts.body.contains("client.get(withQuery("), ts.body)
+      assert(ts.body.contains("\"status_filter\": status_filter"), ts.body)
+      val mod = TsStructural.renderModule(ir, tsOut.tests)
+      assert(mod.contains("import { withQuery } from \"./_runtime.js\";"), mod.take(700))
+
   test("GoBehavioral emits go test + rapid for the positive-ensures path"):
     loadIR("fixtures/spec/edge_cases.spec").map: ir =>
       val out = GoBehavioral.emitFor(SynthFixture.profiled(ir))


### PR DESCRIPTION
Closes the coverage gap the #503 dedup made visible (and CodeRabbit flagged there): `TestFormat.inputArbs` draws generator values for path, body, and query parameters, and the Python oracle sends all three (`params={...}`), but the native Go/TS request builders sent only path and body. Any GET operation's non-path inputs become query parameters (Path.scala), so query-driven behavior on those targets was tested against calls that silently dropped the very inputs the properties quantified over.

The fix is one helper per static harness client plus the send in the shared renderers:

- `conf_client.go` gains `withQuery(p string, kv ...any) string` (url.Values encoding) and `_runtime.ts` gains `withQuery(path, params)` (URLSearchParams). A nil/null value is an absent optional parameter and the pair is skipped, so the request omits the key entirely.
- `GoRender.requestCall`/`TsRender.requestCall` wrap the path expression in `withQuery(...)` when the endpoint has query parameters; the existing name-reference hook applies, so the stateful dispatchers pass `step.`-prefixed values like they do for body fields.
- `withQuery` joins `TestFormat.TsRuntimeHelpers` so the import scans pick it up, and the TS structural renderer now runs the runtime-import scan (it previously imported no runtime helpers because its bodies could not reference any; they can now).

Two deliberate semantics notes. Absent optionals are omitted rather than sent as empty strings; httpx serializes Python `None` as `""`, which an enum-typed optional filter would reject with a 422, so omission is the server-correct encoding and the one place the native suites intentionally differ from the oracle's httpx artifact. And `url.Values`/`URLSearchParams` form-encode spaces as `+` where httpx percent-encodes; servers decode both identically.

Operations with query parameters are synthesis-backed (FilteredRead and friends), so plain emits and today's CI conformance jobs skip them as fail-loud stubs; the change materializes in `--with-synthesis` emits and is pinned byte-for-byte by a new BackendTest case (todo_list's ListTodos via SynthFixture) asserting the emitted Go and TS calls and the new structural import.

Verified beyond the suite (all green): `go vet -tags conformance` over an emitted todo_list project including a scratch file with the exact generated call shape, nil optional included; strict `tsc` over `_runtime.ts`/`_client.ts`; an offline vitest run of `withQuery` asserting encoding and optional-skipping ("/todos?a=1&b=x+y", `{}` passthrough, `false` serialized). The only gofmt finding on the emitted suite is a pre-existing long-line wrap in the invariant rendering, untouched here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the native Go and TypeScript conformance suites to send query parameters generated by the tests. This aligns them with the Python `httpx` oracle and restores coverage for query-driven behavior.

- **Bug Fixes**
  - Go: added withQuery(...) in `conf_client.go` (uses url.Values); skips nil to omit optional keys.
  - TypeScript: added withQuery(path, params) in `_runtime.ts` (uses URLSearchParams); skips null/undefined.
  - Renderers: wrap the path with withQuery(...) when an endpoint has query params (GoRender/TsRender).
  - TypeScript structural: now scans and imports runtime helpers; added withQuery to the helper list.
  - Tests: new BackendTest pins the generated Go/TS calls and the structural import.
  - Semantics: absent optionals are omitted (differs from `httpx` empty-string behavior); standard form encoding is used.

<sup>Written for commit af3e789a412ae25d21dbf4f70a12d74e9b7d3164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

