### PR TITLE
feat: reconcile kernel ServiceState with the database (go)

### DIFF
--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/handlers/url_mappings.go
@@ -24,6 +24,10 @@ func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	if err := body.Validate(); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -28,13 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var urlMappingValidationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !validationPattern1.MatchString(b.URL) {
+	if !urlMappingValidationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/uptrace/bun"
 )
@@ -23,4 +26,35 @@ type UrlMappingCreate struct {
 }
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
+}
+
+var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
+var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b UrlMappingCreate) Validate() error {
+	if utf8.RuneCountInString(b.Code) < 6 {
+		return fmt.Errorf("code: shorter than minimum length 6")
+	}
+	if !urlMappingCreateCodePattern.MatchString(b.Code) {
+		return fmt.Errorf("code: does not match the required pattern")
+	}
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !urlMappingCreateURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
+}
+
+var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b ShortenRequest) Validate() error {
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !shortenRequestURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
 }

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/models/url_mapping.go
@@ -28,32 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
-var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
-
-func (b UrlMappingCreate) Validate() error {
-	if utf8.RuneCountInString(b.Code) < 6 {
-		return fmt.Errorf("code: shorter than minimum length 6")
-	}
-	if !urlMappingCreateCodePattern.MatchString(b.Code) {
-		return fmt.Errorf("code: does not match the required pattern")
-	}
-	if utf8.RuneCountInString(b.URL) < 1 {
-		return fmt.Errorf("url: shorter than minimum length 1")
-	}
-	if !urlMappingCreateURLPattern.MatchString(b.URL) {
-		return fmt.Errorf("url: does not match the required pattern")
-	}
-	return nil
-}
-
-var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !shortenRequestURLPattern.MatchString(b.URL) {
+	if !validationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/common.go
+++ b/fixtures/golden/codegen/go/chi/mysql/url_shortener/internal/services/common.go
@@ -3,3 +3,7 @@ package services
 import "errors"
 
 var ErrNotFound = errors.New("not found")
+
+var ErrKernelPrecondition = errors.New("kernel precondition failed")
+
+var ErrKernelStateInvariant = errors.New("service state invariant violated")

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/handlers/url_mappings.go
@@ -24,6 +24,10 @@ func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	if err := body.Validate(); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
@@ -28,13 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var urlMappingValidationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !validationPattern1.MatchString(b.URL) {
+	if !urlMappingValidationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/uptrace/bun"
 )
@@ -23,4 +26,35 @@ type UrlMappingCreate struct {
 }
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
+}
+
+var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
+var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b UrlMappingCreate) Validate() error {
+	if utf8.RuneCountInString(b.Code) < 6 {
+		return fmt.Errorf("code: shorter than minimum length 6")
+	}
+	if !urlMappingCreateCodePattern.MatchString(b.Code) {
+		return fmt.Errorf("code: does not match the required pattern")
+	}
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !urlMappingCreateURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
+}
+
+var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b ShortenRequest) Validate() error {
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !shortenRequestURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
 }

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/models/url_mapping.go
@@ -28,32 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
-var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
-
-func (b UrlMappingCreate) Validate() error {
-	if utf8.RuneCountInString(b.Code) < 6 {
-		return fmt.Errorf("code: shorter than minimum length 6")
-	}
-	if !urlMappingCreateCodePattern.MatchString(b.Code) {
-		return fmt.Errorf("code: does not match the required pattern")
-	}
-	if utf8.RuneCountInString(b.URL) < 1 {
-		return fmt.Errorf("url: shorter than minimum length 1")
-	}
-	if !urlMappingCreateURLPattern.MatchString(b.URL) {
-		return fmt.Errorf("url: does not match the required pattern")
-	}
-	return nil
-}
-
-var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !shortenRequestURLPattern.MatchString(b.URL) {
+	if !validationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/common.go
+++ b/fixtures/golden/codegen/go/chi/postgres/url_shortener/internal/services/common.go
@@ -3,3 +3,7 @@ package services
 import "errors"
 
 var ErrNotFound = errors.New("not found")
+
+var ErrKernelPrecondition = errors.New("kernel precondition failed")
+
+var ErrKernelStateInvariant = errors.New("service state invariant violated")

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/handlers/url_mappings.go
@@ -24,6 +24,10 @@ func (h *UrlMappingHandler) Shorten(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
+	if err := body.Validate(); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
 	if err := h.svc.Shorten(r.Context(), body); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -28,13 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var urlMappingValidationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !validationPattern1.MatchString(b.URL) {
+	if !urlMappingValidationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/uptrace/bun"
 )
@@ -23,4 +26,35 @@ type UrlMappingCreate struct {
 }
 type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
+}
+
+var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
+var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b UrlMappingCreate) Validate() error {
+	if utf8.RuneCountInString(b.Code) < 6 {
+		return fmt.Errorf("code: shorter than minimum length 6")
+	}
+	if !urlMappingCreateCodePattern.MatchString(b.Code) {
+		return fmt.Errorf("code: does not match the required pattern")
+	}
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !urlMappingCreateURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
+}
+
+var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+
+func (b ShortenRequest) Validate() error {
+	if utf8.RuneCountInString(b.URL) < 1 {
+		return fmt.Errorf("url: shorter than minimum length 1")
+	}
+	if !shortenRequestURLPattern.MatchString(b.URL) {
+		return fmt.Errorf("url: does not match the required pattern")
+	}
+	return nil
 }

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/models/url_mapping.go
@@ -28,32 +28,13 @@ type ShortenRequest struct {
 	URL string `json:"url" validate:"required"`
 }
 
-var urlMappingCreateCodePattern = regexp.MustCompile(`^(?:^[a-zA-Z0-9]+$)$`)
-var urlMappingCreateURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
-
-func (b UrlMappingCreate) Validate() error {
-	if utf8.RuneCountInString(b.Code) < 6 {
-		return fmt.Errorf("code: shorter than minimum length 6")
-	}
-	if !urlMappingCreateCodePattern.MatchString(b.Code) {
-		return fmt.Errorf("code: does not match the required pattern")
-	}
-	if utf8.RuneCountInString(b.URL) < 1 {
-		return fmt.Errorf("url: shorter than minimum length 1")
-	}
-	if !urlMappingCreateURLPattern.MatchString(b.URL) {
-		return fmt.Errorf("url: does not match the required pattern")
-	}
-	return nil
-}
-
-var shortenRequestURLPattern = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
+var validationPattern1 = regexp.MustCompile(`^(?:^https?://[^\s\x00-\x1f\x7f]+)$`)
 
 func (b ShortenRequest) Validate() error {
 	if utf8.RuneCountInString(b.URL) < 1 {
 		return fmt.Errorf("url: shorter than minimum length 1")
 	}
-	if !shortenRequestURLPattern.MatchString(b.URL) {
+	if !validationPattern1.MatchString(b.URL) {
 		return fmt.Errorf("url: does not match the required pattern")
 	}
 	return nil

--- a/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/common.go
+++ b/fixtures/golden/codegen/go/chi/sqlite/url_shortener/internal/services/common.go
@@ -3,3 +3,7 @@ package services
 import "errors"
 
 var ErrNotFound = errors.New("not found")
+
+var ErrKernelPrecondition = errors.New("kernel precondition failed")
+
+var ErrKernelStateInvariant = errors.New("service state invariant violated")

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/schemas/url_mapping.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class UrlMappingCreate(BaseModel):
     code: str = Field(min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime
     click_count: int
 
@@ -22,10 +22,10 @@ class UrlMappingRead(BaseModel):
 
 class UrlMappingUpdate(BaseModel):
     code: str | None = Field(default=None, min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime | None = None
     click_count: int | None = None
 
 
 class ShortenRequest(BaseModel):
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/schemas/url_mapping.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class UrlMappingCreate(BaseModel):
     code: str = Field(min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime
     click_count: int
 
@@ -22,10 +22,10 @@ class UrlMappingRead(BaseModel):
 
 class UrlMappingUpdate(BaseModel):
     code: str | None = Field(default=None, min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime | None = None
     click_count: int | None = None
 
 
 class ShortenRequest(BaseModel):
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/schemas/url_mapping.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class UrlMappingCreate(BaseModel):
     code: str = Field(min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime
     click_count: int
 
@@ -22,10 +22,10 @@ class UrlMappingRead(BaseModel):
 
 class UrlMappingUpdate(BaseModel):
     code: str | None = Field(default=None, min_length=6, pattern=r"^(?:^[a-zA-Z0-9]+$)$")
-    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str | None = Field(default=None, min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")
     created_at: datetime | None = None
     click_count: int | None = None
 
 
 class ShortenRequest(BaseModel):
-    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s]+)$")
+    url: str = Field(min_length=1, pattern=r"^(?:^https?://[^\s\x00-\x1f\x7f]+)$")

--- a/fixtures/golden/ir/auth_service.json
+++ b/fixtures/golden/ir/auth_service.json
@@ -9317,19 +9317,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/broken_decrement.json
+++ b/fixtures/golden/ir/broken_decrement.json
@@ -217,19 +217,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/broken_url_shortener.json
+++ b/fixtures/golden/ir/broken_url_shortener.json
@@ -578,19 +578,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/contradictory_powerset.json
+++ b/fixtures/golden/ir/contradictory_powerset.json
@@ -268,19 +268,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/convention_errors.json
+++ b/fixtures/golden/ir/convention_errors.json
@@ -374,19 +374,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/dead_op.json
+++ b/fixtures/golden/ir/dead_op.json
@@ -234,19 +234,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/ecommerce.json
+++ b/fixtures/golden/ir/ecommerce.json
@@ -12462,19 +12462,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/edge_cases.json
+++ b/fixtures/golden/ir/edge_cases.json
@@ -3315,19 +3315,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/powerset_demo.json
+++ b/fixtures/golden/ir/powerset_demo.json
@@ -227,19 +227,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/powerset_ops.json
+++ b/fixtures/golden/ir/powerset_ops.json
@@ -406,19 +406,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/safe_counter.json
+++ b/fixtures/golden/ir/safe_counter.json
@@ -324,19 +324,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/secret_create.json
+++ b/fixtures/golden/ir/secret_create.json
@@ -1150,19 +1150,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/set_comp_demo.json
+++ b/fixtures/golden/ir/set_comp_demo.json
@@ -226,19 +226,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/set_ops.json
+++ b/fixtures/golden/ir/set_ops.json
@@ -1701,19 +1701,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/strict_strategies_negative.json
+++ b/fixtures/golden/ir/strict_strategies_negative.json
@@ -268,19 +268,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/strict_strategies_positive.json
+++ b/fixtures/golden/ir/strict_strategies_positive.json
@@ -268,19 +268,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/temporal_demo.json
+++ b/fixtures/golden/ir/temporal_demo.json
@@ -348,19 +348,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/todo_list.json
+++ b/fixtures/golden/ir/todo_list.json
@@ -5093,19 +5093,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/unreachable_op.json
+++ b/fixtures/golden/ir/unreachable_op.json
@@ -178,19 +178,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/unsat_invariants.json
+++ b/fixtures/golden/ir/unsat_invariants.json
@@ -220,19 +220,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/ir/url_shortener.json
+++ b/fixtures/golden/ir/url_shortener.json
@@ -2089,19 +2089,19 @@
             "endCol" : 37
           }
         },
-        "pattern" : "^https?://[^\\s]+",
+        "pattern" : "^https?://[^\\s\\x00-\\x1f\\x7f]+",
         "span" : {
           "startLine" : 3,
           "startCol" : 36,
           "endLine" : 3,
-          "endCol" : 66
+          "endCol" : 79
         }
       },
       "span" : {
         "startLine" : 3,
         "startCol" : 2,
         "endLine" : 3,
-        "endCol" : 66
+        "endCol" : 79
       }
     },
     {

--- a/fixtures/golden/vc/url_shortener/verdicts.json
+++ b/fixtures/golden/vc/url_shortener/verdicts.json
@@ -1,119 +1,127 @@
 {
   "schemaVersion" : 1,
   "specFile" : "fixtures/spec/url_shortener.spec",
-  "totalMs" : 619.448733,
+  "totalMs" : 572.141391,
   "ok" : true,
   "entries" : [
-    {
-      "id" : "Delete.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 35.958648,
-      "file" : "Delete.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 33.433902,
-      "file" : "ListAll.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "Delete.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 36.751815,
-      "file" : "Delete.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "ListAll.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 52.722235,
-      "file" : "ListAll.requires.smt2"
-    },
     {
       "id" : "ListAll.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 42.600836,
+      "durationMs" : 33.925688,
       "file" : "ListAll.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 41.681839,
-      "file" : "ListAll.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 38.611169,
-      "file" : "Resolve.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "Delete.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 40.028198,
-      "file" : "Delete.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 49.750073,
-      "file" : "Resolve.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "ListAll.enabled",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 66.222642,
-      "file" : "ListAll.enabled.smt2"
-    },
-    {
-      "id" : "global",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 69.084633,
-      "file" : "global.smt2"
     },
     {
       "id" : "Resolve.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 34.492997,
+      "durationMs" : 32.916921,
       "file" : "Resolve.preserves.clickCountNonNegative.smt2"
     },
     {
-      "id" : "Delete.enabled",
+      "id" : "Delete.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 38.623853,
+      "file" : "Delete.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 37.87535,
+      "file" : "Resolve.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "ListAll.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 29.774744,
+      "file" : "ListAll.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "ListAll.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 141.97449,
-      "file" : "Delete.enabled.smt2"
+      "durationMs" : 45.779673,
+      "file" : "ListAll.requires.smt2"
+    },
+    {
+      "id" : "Delete.preserves.clickCountNonNegative",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 33.827122,
+      "file" : "Delete.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "Delete.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 46.800104,
+      "file" : "Delete.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "ListAll.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 34.372799,
+      "file" : "ListAll.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "ListAll.enabled",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 62.086775,
+      "file" : "ListAll.enabled.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 40.899563,
+      "file" : "Resolve.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "global",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 59.990599,
+      "file" : "global.smt2"
+    },
+    {
+      "id" : "Shorten.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 26.836457,
+      "file" : "Shorten.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "Shorten.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 24.867193,
+      "file" : "Shorten.requires.smt2"
     },
     {
       "id" : "Shorten.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 22.399118,
+      "durationMs" : 14.256712,
       "file" : "Shorten.preserves.clickCountNonNegative.smt2"
     },
     {
@@ -121,47 +129,23 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 36.463584,
+      "durationMs" : 31.178324,
       "file" : "Shorten.preserves.metadataConsistent.smt2"
     },
     {
-      "id" : "Shorten.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 29.412035,
-      "file" : "Shorten.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "Delete.requires",
+      "id" : "Delete.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 160.415543,
-      "file" : "Delete.requires.smt2"
-    },
-    {
-      "id" : "Shorten.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 18.211394,
-      "file" : "Shorten.requires.smt2"
-    },
-    {
-      "id" : "Resolve.enabled",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 163.156882,
-      "file" : "Resolve.enabled.smt2"
+      "durationMs" : 174.170946,
+      "file" : "Delete.enabled.smt2"
     },
     {
       "id" : "Resolve.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 150.625418,
+      "durationMs" : 161.555244,
       "file" : "Resolve.requires.smt2"
     },
     {
@@ -169,8 +153,24 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 78.758536,
+      "durationMs" : 96.9247,
       "file" : "Shorten.enabled.smt2"
+    },
+    {
+      "id" : "Resolve.enabled",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 189.855223,
+      "file" : "Resolve.enabled.smt2"
+    },
+    {
+      "id" : "Delete.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 168.315009,
+      "file" : "Delete.requires.smt2"
     }
   ]
 }

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/handlers/entity.go.hbs
@@ -24,13 +24,22 @@ func (h *{{../entity.entity.modelClassName}}Handler) {{handlerName}}(w http.Resp
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
-{{/if}}{{#if routeThroughKernel}}	result, err := h.svc.{{serviceMethod}}(r.Context(){{#if kernelHandlerArgs}}, {{kernelHandlerArgs}}{{/if}})
+{{#if bodyValidates}}	if err := body.Validate(); err != nil {
+		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+{{/if}}{{/if}}{{#if routeThroughKernel}}	result, err := h.svc.{{serviceMethod}}(r.Context(){{#if kernelHandlerArgs}}, {{kernelHandlerArgs}}{{/if}})
 	if err != nil {
+		if errors.Is(err, services.ErrKernelPrecondition) {
+			writeError(w, {{kernelGuardStatus}}, "{{kernelGuardDetail}}")
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
-	writeJSON(w, {{successStatus}}, result)
-{{else}}{{#if (eq routeKind "create")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
+{{#if kernelRedirect}}	http.Redirect(w, r, result, {{successStatus}})
+{{else}}	writeJSON(w, {{successStatus}}, result)
+{{/if}}{{else}}{{#if (eq routeKind "create")}}	result, err := h.svc.{{serviceMethod}}(r.Context(), {{serviceCallArgs}})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
@@ -1,15 +1,6 @@
 package models
 
-import (
-{{#if entity.needsFmt}}	"fmt"
-{{/if}}{{#if entity.needsRegexp}}	"regexp"
-{{/if}}{{#if entity.needsTime}}	"time"
-{{/if}}{{#if entity.needsUtf8}}	"unicode/utf8"
-
-{{/if}}{{#if entity.needsUuid}}	"github.com/google/uuid"
-{{/if}}{{#if entity.needsDecimal}}	"github.com/shopspring/decimal"
-{{/if}}	"github.com/uptrace/bun"
-)
+{{{entity.modelImports}}}
 
 type {{entity.entity.modelClassName}} struct {
 {{#each entity.modelStructLines}}	{{{this}}}

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/models/entity.go.hbs
@@ -1,7 +1,10 @@
 package models
 
 import (
-{{#if entity.needsTime}}	"time"
+{{#if entity.needsFmt}}	"fmt"
+{{/if}}{{#if entity.needsRegexp}}	"regexp"
+{{/if}}{{#if entity.needsTime}}	"time"
+{{/if}}{{#if entity.needsUtf8}}	"unicode/utf8"
 
 {{/if}}{{#if entity.needsUuid}}	"github.com/google/uuid"
 {{/if}}{{#if entity.needsDecimal}}	"github.com/shopspring/decimal"
@@ -19,4 +22,6 @@ type {{entity.entity.createSchemaName}} struct {
 type {{this.name}} struct {
 {{#each this.structLines}}	{{{this}}}
 {{/each}}{{! }}}
-{{/each}}
+{{/each}}{{#if entity.validationBlock}}
+{{{entity.validationBlock}}}
+{{/if}}

--- a/modules/codegen/src/main/resources/templates/go/chi/internal/services/common.go.hbs
+++ b/modules/codegen/src/main/resources/templates/go/chi/internal/services/common.go.hbs
@@ -3,3 +3,7 @@ package services
 import "errors"
 
 var ErrNotFound = errors.New("not found")
+
+var ErrKernelPrecondition = errors.New("kernel precondition failed")
+
+var ErrKernelStateInvariant = errors.New("service state invariant violated")

--- a/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/EmitShared.scala
@@ -6,6 +6,22 @@ import specrest.profile.ProfiledService
 
 private[codegen] object EmitShared:
 
+  // A field's boundary-enforceable string refinement: the entity declaration's
+  // alias type plus its inline where clause, reduced by StringRefinements.
+  def entityFieldRefinement(
+      profiled: specrest.profile.ProfiledService,
+      entity: specrest.profile.ProfiledEntity,
+      f: specrest.profile.ProfiledField
+  ): specrest.convention.StringRefinements.Reduced =
+    import specrest.ir.generated.SpecRestGenerated.*
+    svcEntities(profiled.ir)
+      .find(d => entName(d) == entity.entityName)
+      .flatMap(d => entFields(d).find(fd => fldName(fd) == f.fieldName))
+      .map(fd =>
+        specrest.convention.StringRefinements.reduceField(fldType(fd), fldDefault(fd), profiled.ir)
+      )
+      .getOrElse(specrest.convention.StringRefinements.Reduced(None, None, Nil))
+
   def routeKindName(rk: route_kind): String = rk match
     case _: RkCreate   => "create"
     case _: RkRead     => "read"

--- a/modules/codegen/src/main/scala/specrest/codegen/StatePlan.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/StatePlan.scala
@@ -1,0 +1,86 @@
+package specrest.codegen
+
+import specrest.ir.generated.SpecRestGenerated.*
+import specrest.profile.ProfiledEntity
+import specrest.profile.ProfiledField
+import specrest.profile.ProfiledService
+
+// Target-neutral analysis of whether a spec's state round-trips through a
+// generated bridge: which relations hydrate from which tables, which scalars
+// ride the service_state singleton, and the first reason it cannot. The type
+// predicates are the only target-specific part (python and go spell their
+// domain types differently), so emitters inject them.
+object StatePlan:
+
+  final case class RelationPlan(
+      stateField: String,
+      entity: ProfiledEntity,
+      keyField: ProfiledField,
+      valueField: Option[ProfiledField]
+  ):
+    def isEntityRow: Boolean = valueField.isEmpty
+
+  final case class ScalarPlan(stateField: String, columnName: String)
+
+  final case class Plan(
+      relations: List[RelationPlan],
+      scalars: List[ScalarPlan]
+  ):
+    def entityRowRelations: List[RelationPlan] =
+      relations.filter(_.isEntityRow).distinctBy(_.entity.entityName)
+    def hasState: Boolean = relations.nonEmpty || scalars.nonEmpty
+
+  def analyze(
+      profiled: ProfiledService,
+      fieldSupported: ProfiledField => Boolean,
+      keySupported: ProfiledField => Boolean
+  ): Either[String, Plan] =
+    val ir        = profiled.ir
+    val byName    = profiled.entities.map(e => e.entityName -> e).toMap
+    val relations = List.newBuilder[RelationPlan]
+    val scalars   = List.newBuilder[ScalarPlan]
+    val problems  = List.newBuilder[String]
+
+    for sf <- irStateFields(ir) do
+      val name = stfName(sf)
+      AdminModel.projectionFor(sf, ir) match
+        case None => () // unbacked: hydrates to the target's zero value, like /admin/state's null
+        case Some(p) =>
+          p.valueShape match
+            case AdminModel.ProjectionValue.ScalarStateColumn(col) =>
+              scalars += ScalarPlan(name, col)
+            case shape =>
+              byName.get(p.entityName) match
+                case None =>
+                  problems += s"state field '$name' projects onto unknown entity '${p.entityName}'"
+                case Some(entity) =>
+                  entity.fields.find(_.fieldName == p.keyFieldName) match
+                    case None =>
+                      problems += s"state field '$name': key field '${p.keyFieldName}' not on '${p.entityName}'"
+                    case Some(key) =>
+                      val unsupported = entity.fields.filterNot(fieldSupported)
+                      if unsupported.nonEmpty then
+                        problems += s"state field '$name': entity '${p.entityName}' has field types the bridge cannot marshal (${unsupported.map(_.domainType).distinct.mkString(", ")})"
+                      else if !keySupported(key) then
+                        problems += s"state field '$name': key '${p.keyFieldName}' must be a non-optional scalar"
+                      else
+                        val valueField = shape match
+                          case AdminModel.ProjectionValue.PrimitiveField(vf) =>
+                            entity.fields.find(_.fieldName == vf)
+                          case _ => None
+                        shape match
+                          case AdminModel.ProjectionValue.PrimitiveField(vf)
+                              if valueField.isEmpty =>
+                            problems += s"state field '$name': value field '$vf' not on '${p.entityName}'"
+                          case _ =>
+                            relations += RelationPlan(name, entity, key, valueField)
+
+    val built       = Plan(relations.result(), scalars.result())
+    val persistable = built.entityRowRelations.map(_.entity.entityName).toSet
+    for r <- built.relations if !r.isEntityRow do
+      if !persistable.contains(r.entity.entityName) then
+        problems += s"state field '${r.stateField}' projects a single column of '${r.entity.entityName}', which no entity-valued state field covers; mutations could not be written back"
+
+    problems.result() match
+      case first :: _ => Left(first)
+      case Nil        => Right(built)

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -69,7 +69,7 @@ final private case class GoOperation(
     requestBodyType: String,
     customRequestSchemaName: Option[String],
     customRequestFields: List[GoFieldView],
-    customValidation: Option[GoValidation.StructValidation],
+    customRules: List[GoValidation.FieldRule],
     bodyValidates: Boolean,
     responseType: String,
     serviceMethod: String,
@@ -593,18 +593,23 @@ object EmitGo:
         GoCustomSchema(name, op.customRequestFields, schemaStructLines(op.customRequestFields))
       )
 
-    val createValidation =
-      GoValidation.forStruct(
-        entity.createSchemaName,
-        entity.fields
-          .filterNot(_.fieldName == "id")
-          .map(f =>
-            GoValidation.FieldRule(f, EmitShared.entityFieldRefinement(profiled, entity, f))
-          )
-      )
-    val customValidations = operations.flatMap(_.customValidation).distinctBy(_.structName)
-    val allValidations    = createValidation.toList ++ customValidations
-    val validatedNames    = allValidations.map(_.structName).toSet
+    // Validators emit only for request types some handler actually decodes;
+    // an unused create schema would otherwise carry dead validation code.
+    val usedBodyTypes = operations.filter(_.hasRequestBody).map(_.requestBodyType).toSet
+    val createRules = entity.fields
+      .filterNot(_.fieldName == "id")
+      .map(f => GoValidation.FieldRule(f, EmitShared.entityFieldRefinement(profiled, entity, f)))
+    val structRules =
+      (Option
+        .when(usedBodyTypes.contains(entity.createSchemaName))(
+          entity.createSchemaName -> createRules
+        )
+        .toList :::
+        operations
+          .filter(o => o.customRequestSchemaName.isDefined && o.customRules.nonEmpty)
+          .map(o => o.requestBodyType -> o.customRules)).distinctBy(_._1)
+    val fileValidations = GoValidation.forStructs(structRules)
+    val validatedNames  = fileValidations.structs.map(_.structName).toSet
     val opsWithValidation = operations.map: o =>
       o.copy(bodyValidates = o.hasRequestBody && validatedNames.contains(o.requestBodyType))
 
@@ -633,18 +638,15 @@ object EmitGo:
       usesKernel = usesKernel,
       usesModels = usesModels,
       customSchemas = customSchemas,
-      validationBlock = allValidations
-        .map(v =>
-          (v.patternVars.mkString("\n") :: v.funcText :: Nil)
-            .filter(_.nonEmpty)
-            .mkString("\n\n")
-        )
-        .mkString("\n\n") match
-        case ""    => ""
-        case block => "\n" + block,
-      needsRegexp = allValidations.exists(_.patternVars.nonEmpty),
-      needsFmt = allValidations.nonEmpty,
-      needsUtf8 = allValidations.exists(_.needsUtf8),
+      validationBlock =
+        if fileValidations.isEmpty then ""
+        else
+          "\n" + (fileValidations.patternVars.mkString("\n") ::
+            fileValidations.structs.map(_.funcText)).filter(_.nonEmpty).mkString("\n\n")
+      ,
+      needsRegexp = fileValidations.needsRegexp,
+      needsFmt = !fileValidations.isEmpty,
+      needsUtf8 = fileValidations.needsUtf8,
       modelStructLines = padCells(
         List(
           "bun.BaseModel",
@@ -738,12 +740,12 @@ object EmitGo:
     val hasRequestBody          = ctx.hasRequestBody
     val routeKind               = ctx.routeKind
 
-    val (requestBodyType, customRequestFields, customValidation) =
-      if !hasRequestBody then ("", List.empty[GoFieldView], None)
+    val (requestBodyType, customRequestFields, customRules) =
+      if !hasRequestBody then ("", List.empty[GoFieldView], List.empty[GoValidation.FieldRule])
       else
         customRequestSchemaName match
           case None =>
-            (entity.createSchemaName, List.empty[GoFieldView], None)
+            (entity.createSchemaName, List.empty[GoFieldView], List.empty[GoValidation.FieldRule])
           case Some(name) =>
             val fields = OperationContext.customRequestBodyFields(op)
             val byName = endpoint.bodyParams.map(p => p.name -> p.typeExpr).toMap
@@ -753,7 +755,7 @@ object EmitGo:
                 case None    => StringRefinements.Reduced(None, None, Nil)
               GoValidation.FieldRule(f, reduced)
             }
-            (name, fields.map(toGoField), GoValidation.forStruct(name, rules))
+            (name, fields.map(toGoField), rules)
 
     val pathParamCallArgs  = pathParams.map(_.goName).mkString(", ")
     val pathParamSignature = pathParams.map(p => s"${p.goName} ${p.domainType}").mkString(", ")
@@ -848,7 +850,7 @@ object EmitGo:
       requestBodyType = requestBodyType,
       customRequestSchemaName = customRequestSchemaName,
       customRequestFields = customRequestFields,
-      customValidation = customValidation,
+      customRules = customRules,
       bodyValidates = false,
       responseType = responseType,
       serviceMethod = serviceMethodName,

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -116,7 +116,6 @@ final private case class GoEntityCtx(
     customSchemas: List[GoCustomSchema],
     validationBlock: String,
     modelImports: String,
-    hasStdlibImports: Boolean,
     modelStructLines: List[String],
     createStructLines: List[String],
     handlerImports: String
@@ -657,8 +656,6 @@ object EmitGo:
         val groups = List(stdlib, third).filter(_.nonEmpty)
         groups.map(_.map("\t" + _).mkString("\n")).mkString("import (\n", "\n\n", "\n)")
       },
-      hasStdlibImports = !fileValidations.isEmpty || fileValidations.needsRegexp ||
-        fileValidations.needsUtf8 || needsTime,
       modelStructLines = padCells(
         List(
           "bun.BaseModel",

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -22,6 +22,7 @@ import specrest.codegen.migration.SchemaDiff
 import specrest.codegen.migration.SchemaSnapshot
 import specrest.codegen.migration.SqlRenderer
 import specrest.codegen.openapi.OpenApi
+import specrest.convention.StringRefinements
 import specrest.ir.HttpMethods
 import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.*
@@ -68,6 +69,8 @@ final private case class GoOperation(
     requestBodyType: String,
     customRequestSchemaName: Option[String],
     customRequestFields: List[GoFieldView],
+    customValidation: Option[GoValidation.StructValidation],
+    bodyValidates: Boolean,
     responseType: String,
     serviceMethod: String,
     serviceCallArgs: String,
@@ -77,6 +80,9 @@ final private case class GoOperation(
     dafnyMethod: Option[String],
     routeThroughKernel: Boolean,
     kernelServiceMethod: String,
+    kernelGuardStatus: Int,
+    kernelGuardDetail: String,
+    kernelRedirect: Boolean,
     kernelHandlerArgs: String,
     lookupColumn: String,
     createAssigns: List[String],
@@ -108,6 +114,10 @@ final private case class GoEntityCtx(
     usesKernel: Boolean,
     usesModels: Boolean,
     customSchemas: List[GoCustomSchema],
+    validationBlock: String,
+    needsRegexp: Boolean,
+    needsFmt: Boolean,
+    needsUtf8: Boolean,
     modelStructLines: List[String],
     createStructLines: List[String],
     handlerImports: String
@@ -166,13 +176,20 @@ object EmitGo:
     val service   = ctx.service
 
     val typeLookup = EmitShared.aliasResolvedDomainLookup(profiled)
+    val bridgePlan = StateBridgeGo.plan(profiled)
+    val kernelCtx = GoKernelCtx(
+      stateReady = irStateFields(profiled.ir).isEmpty || bridgePlan.isRight,
+      hasState = bridgePlan.toOption.exists(_.hasState),
+      hasInv = irStateFields(profiled.ir).nonEmpty,
+      ir = profiled.ir
+    )
 
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
         .filter(_.targetEntity.contains(entity.entityName))
-        .map(op => enrichOperation(op, entity, typeLookup))
+        .map(op => enrichOperation(op, entity, typeLookup, kernelCtx))
         .sortWith((a, b) => EmitShared.byPathSpecificity(a.path, b.path))
-      buildEntityCtx(module, entity, entityOps)
+      buildEntityCtx(module, profiled, entity, entityOps)
 
     val needsTime    = entities.exists(_.needsTime)
     val needsUuid    = entities.exists(_.needsUuid)
@@ -196,6 +213,13 @@ object EmitGo:
 
     val files        = List.newBuilder[EmittedFile]
     val projectScope = mergeProfile(ctx, projectCtx)
+
+    val kernelRouted = entities.exists(_.operations.exists(_.routeThroughKernel))
+    if kernelRouted && kernelCtx.hasState then
+      files += EmittedFile(
+        "internal/services/state_bridge.go",
+        StateBridgeGo.emit(profiled, module)
+      )
 
     val projectFiles: List[(String, String)] = List(
       "go.mod"                        -> templates.goMod,
@@ -497,6 +521,7 @@ object EmitGo:
 
   private def buildEntityCtx(
       module: String,
+      profiled: ProfiledService,
       entity: ProfiledEntity,
       operations: List[GoOperation]
   ): GoEntityCtx =
@@ -547,9 +572,13 @@ object EmitGo:
       if o.routeThroughKernel then "kernel" else o.routeKind
     val usesNotFound = operations.exists: o =>
       effectiveKind(o) == "read" || effectiveKind(o) == "redirect"
-    val usesErrors    = usesNotFound || operations.exists(effectiveKind(_) == "other")
-    val usesSqlNoRows = operations.exists(effectiveKind(_) == "read")
-    val usesKernel    = operations.exists(_.routeThroughKernel)
+    // Kernel handlers errors.Is the precondition sentinel, so the handler
+    // file needs the errors import even when no route-kind body does; the
+    // services file must not (its sentinels live in common.go).
+    val handlerUsesErrors = usesNotFound || operations.exists(_.routeThroughKernel)
+    val usesErrors        = usesNotFound || operations.exists(effectiveKind(_) == "other")
+    val usesSqlNoRows     = operations.exists(effectiveKind(_) == "read")
+    val usesKernel        = operations.exists(_.routeThroughKernel)
     // The `models` import is referenced by every CRUD route-kind body (entity model query/return)
     // and by any op carrying a request body. A kernel-routed scalar op without a body, or an
     // `other` stub without a body, never names a models type — so gating on hasOperations alone
@@ -564,6 +593,21 @@ object EmitGo:
         GoCustomSchema(name, op.customRequestFields, schemaStructLines(op.customRequestFields))
       )
 
+    val createValidation =
+      GoValidation.forStruct(
+        entity.createSchemaName,
+        entity.fields
+          .filterNot(_.fieldName == "id")
+          .map(f =>
+            GoValidation.FieldRule(f, EmitShared.entityFieldRefinement(profiled, entity, f))
+          )
+      )
+    val customValidations = operations.flatMap(_.customValidation).distinctBy(_.structName)
+    val allValidations    = createValidation.toList ++ customValidations
+    val validatedNames    = allValidations.map(_.structName).toSet
+    val opsWithValidation = operations.map: o =>
+      o.copy(bodyValidates = o.hasRequestBody && validatedNames.contains(o.requestBodyType))
+
     GoEntityCtx(
       module = module,
       entity = entity,
@@ -574,7 +618,7 @@ object EmitGo:
       primaryKey = primaryKey,
       fields = allFields,
       nonIdFields = nonIdFields,
-      operations = operations,
+      operations = opsWithValidation,
       needsTime = needsTime,
       needsUuid = needsUuid,
       needsDecimal = needsDecimal,
@@ -589,6 +633,18 @@ object EmitGo:
       usesKernel = usesKernel,
       usesModels = usesModels,
       customSchemas = customSchemas,
+      validationBlock = allValidations
+        .map(v =>
+          (v.patternVars.mkString("\n") :: v.funcText :: Nil)
+            .filter(_.nonEmpty)
+            .mkString("\n\n")
+        )
+        .mkString("\n\n") match
+        case ""    => ""
+        case block => "\n" + block,
+      needsRegexp = allValidations.exists(_.patternVars.nonEmpty),
+      needsFmt = allValidations.nonEmpty,
+      needsUtf8 = allValidations.exists(_.needsUtf8),
       modelStructLines = padCells(
         List(
           "bun.BaseModel",
@@ -601,7 +657,7 @@ object EmitGo:
       handlerImports = {
         val stdlib = List(
           Option.when(usesRequestBody)("\"encoding/json\""),
-          Option.when(usesNotFound)("\"errors\""),
+          Option.when(handlerUsesErrors)("\"errors\""),
           Option.when(operations.nonEmpty)("\"net/http\""),
           Option.when(operations.exists(_.pathParams.exists(_.isInt)))("\"strconv\"")
         ).flatten
@@ -651,10 +707,18 @@ object EmitGo:
   private def toPascalCase(name: String): String =
     Naming.toPascalCase(name, Naming.PascalStrategy.Go)
 
+  final private case class GoKernelCtx(
+      stateReady: Boolean,
+      hasState: Boolean,
+      hasInv: Boolean,
+      ir: ServiceIRFull
+  )
+
   private def enrichOperation(
       op: ProfiledOperation,
       entity: ProfiledEntity,
-      typeLookup: Map[String, String]
+      typeLookup: Map[String, String],
+      kernelCtx: GoKernelCtx
   ): GoOperation =
     val endpoint = op.endpoint
     val pathParams = endpoint.pathParams.map: p =>
@@ -674,14 +738,22 @@ object EmitGo:
     val hasRequestBody          = ctx.hasRequestBody
     val routeKind               = ctx.routeKind
 
-    val (requestBodyType, customRequestFields) =
-      if !hasRequestBody then ("", List.empty[GoFieldView])
+    val (requestBodyType, customRequestFields, customValidation) =
+      if !hasRequestBody then ("", List.empty[GoFieldView], None)
       else
         customRequestSchemaName match
           case None =>
-            (entity.createSchemaName, List.empty[GoFieldView])
+            (entity.createSchemaName, List.empty[GoFieldView], None)
           case Some(name) =>
-            (name, OperationContext.customRequestBodyFields(op).map(toGoField))
+            val fields = OperationContext.customRequestBodyFields(op)
+            val byName = endpoint.bodyParams.map(p => p.name -> p.typeExpr).toMap
+            val rules = fields.map { f =>
+              val reduced = byName.get(f.fieldName) match
+                case Some(t) => StringRefinements.reduceField(t, None, kernelCtx.ir)
+                case None    => StringRefinements.Reduced(None, None, Nil)
+              GoValidation.FieldRule(f, reduced)
+            }
+            (name, fields.map(toGoField), GoValidation.forStruct(name, rules))
 
     val pathParamCallArgs  = pathParams.map(_.goName).mkString(", ")
     val pathParamSignature = pathParams.map(p => s"${p.goName} ${p.domainType}").mkString(", ")
@@ -743,6 +815,12 @@ object EmitGo:
             .mkString(", ")
           ("", Option.empty[String], "error", op.operationName, call, args.mkString(", "))
 
+    val isRedirectKind = routeKind match
+      case _: RkRedirect => true
+      case _             => false
+    val kernelGuardStatus = routeKind match
+      case _: RkRead | _: RkRedirect | _: RkDelete => 404
+      case _                                       => 409
     val kernelMethod =
       goKernelServiceMethod(
         op,
@@ -750,7 +828,8 @@ object EmitGo:
         serviceMethodName,
         hasRequestBody,
         requestBodyType,
-        typeLookup
+        typeLookup,
+        kernelCtx
       )
     val kernelHandlerArgs =
       (endpoint.pathParams.map(p => toCamelCase(p.name)) ++
@@ -769,6 +848,8 @@ object EmitGo:
       requestBodyType = requestBodyType,
       customRequestSchemaName = customRequestSchemaName,
       customRequestFields = customRequestFields,
+      customValidation = customValidation,
+      bodyValidates = false,
       responseType = responseType,
       serviceMethod = serviceMethodName,
       serviceCallArgs = serviceCallArgs,
@@ -778,6 +859,9 @@ object EmitGo:
       dafnyMethod = op.dafnyMethod,
       routeThroughKernel = kernelMethod.isDefined,
       kernelServiceMethod = kernelMethod.getOrElse(""),
+      kernelGuardStatus = kernelGuardStatus,
+      kernelGuardDetail = if kernelGuardStatus == 404 then "not found" else "precondition failed",
+      kernelRedirect = isRedirectKind,
       kernelHandlerArgs = kernelHandlerArgs,
       lookupColumn = lookupCol,
       createAssigns = createAssigns,
@@ -933,66 +1017,132 @@ object EmitGo:
     "bool"   -> ("", "")
   )
 
-  // Render a service method that routes the operation through its verified Dafny kernel method,
-  // marshalling scalar inputs and outputs across the Go/Dafny boundary. Returns None (the caller
-  // falls back to the route-kind stub) unless the op is kernel-bound and every input/output is a
-  // supported scalar; query-param inputs and collection/datatype results are deferred follow-ups.
+  // Render a service method that routes the operation through its verified Dafny kernel method.
+  // With bridgeable state the whole call runs in one transaction: hydrate the ServiceState from
+  // the database, check the compiled contract twins (invariant failure and precondition failure
+  // map to sentinels the handler translates), call the verified method, persist the mutation.
+  // Returns None (the caller falls back to the route-kind stub) unless the op is kernel-bound,
+  // every input/output is a supported scalar, and the spec's state round-trips through the
+  // bridge; query-param inputs and collection/datatype results remain deferred follow-ups.
   private def goKernelServiceMethod(
       op: ProfiledOperation,
       entity: ProfiledEntity,
       serviceMethod: String,
       hasRequestBody: Boolean,
       requestBodyType: String,
-      typeLookup: Map[String, String]
+      typeLookup: Map[String, String],
+      kernelCtx: GoKernelCtx
   ): Option[String] =
     val endpoint = op.endpoint
-    op.dafnyMethod.filter(_ => endpoint.queryParams.isEmpty).flatMap: dafnyName =>
-      val inputSources =
-        endpoint.pathParams.map(p =>
-          toCamelCase(p.name) -> goTypeForParam(p.typeExpr, typeLookup)
-        ) ++
-          endpoint.bodyParams.map(p =>
-            s"body.${toPascalCase(p.name)}" -> goTypeForParam(p.typeExpr, typeLookup)
-          )
-      val convertedArgs = inputSources.map: (access, goType) =>
-        goKernelScalarConv.get(goType).map: (toDafny, _) =>
-          if toDafny.isEmpty then access else s"$toDafny($access)"
-      val outputs = op.responseFields
-      val outputsOk =
-        outputs.nonEmpty && outputs.forall(f => goKernelScalarConv.contains(f.domainType))
-      Option.when(convertedArgs.forall(_.isDefined) && outputsOk):
-        val callArgs = ("state" :: convertedArgs.flatten).mkString(", ")
-        val call     = s"dafnykernel.Companion_Default___.$dafnyName($callArgs)"
-        val sigParts =
+    op.dafnyMethod
+      .filter(_ => endpoint.queryParams.isEmpty && kernelCtx.stateReady)
+      .flatMap: dafnyName =>
+        val inputSources =
           endpoint.pathParams.map(p =>
-            s"${toCamelCase(p.name)} ${goTypeForParam(p.typeExpr, typeLookup)}"
-          ) ++ Option.when(hasRequestBody)(s"body models.$requestBodyType")
-        val sig = if sigParts.isEmpty then "" else sigParts.mkString(", ", ", ", "")
-        def fromDafny(f: ProfiledField, v: String): String =
-          val conv = goKernelScalarConv(f.domainType)._2
-          if conv.isEmpty then v else s"$conv($v)"
-        val (returnType, resultLines) =
-          outputs match
-            case single :: Nil =>
-              val v = "out" + toPascalCase(single.fieldName)
-              (
-                s"(${single.domainType}, error)",
-                List(s"\t$v := $call", s"\treturn ${fromDafny(single, v)}, nil")
+            toCamelCase(p.name) -> goTypeForParam(p.typeExpr, typeLookup)
+          ) ++
+            endpoint.bodyParams.map(p =>
+              s"body.${toPascalCase(p.name)}" -> goTypeForParam(p.typeExpr, typeLookup)
+            )
+        val convertedArgs = inputSources.map: (access, goType) =>
+          goKernelScalarConv.get(goType).map: (toDafny, _) =>
+            if toDafny.isEmpty then access else s"$toDafny($access)"
+        val outputs = op.responseFields
+        val outputsOk =
+          outputs.nonEmpty && outputs.forall(f => goKernelScalarConv.contains(f.domainType))
+        Option.when(convertedArgs.forall(_.isDefined) && outputsOk):
+          val args     = convertedArgs.flatten
+          val callArgs = ("state" :: args).mkString(", ")
+          val call     = s"dafnykernel.Companion_Default___.$dafnyName($callArgs)"
+          val guard    = s"dafnykernel.Companion_Default___.Requires$dafnyName($callArgs)"
+          val sigParts =
+            endpoint.pathParams.map(p =>
+              s"${toCamelCase(p.name)} ${goTypeForParam(p.typeExpr, typeLookup)}"
+            ) ++ Option.when(hasRequestBody)(s"body models.$requestBodyType")
+          val sig = if sigParts.isEmpty then "" else sigParts.mkString(", ", ", ", "")
+          def fromDafny(f: ProfiledField, v: String): String =
+            val conv = goKernelScalarConv(f.domainType)._2
+            if conv.isEmpty then v else s"$conv($v)"
+          def zeroOf(goType: String): String = goType match
+            case "string" => "\"\""
+            case "int64"  => "0"
+            case "bool"   => "false"
+            case _        => "nil"
+          val (returnType, zero, resultAssign) =
+            outputs match
+              case single :: Nil =>
+                val v = "out" + toPascalCase(single.fieldName)
+                (
+                  s"(${single.domainType}, error)",
+                  zeroOf(single.domainType),
+                  List(
+                    s"\t\t$v := $call",
+                    s"\t\tresult = ${fromDafny(single, v)}"
+                  )
+                )
+              case many =>
+                val vars      = many.map(f => "out" + toPascalCase(f.fieldName))
+                val keyTokens = many.map(f => s"\"${f.columnName}\":")
+                val keyWidth  = keyTokens.map(_.length).max
+                val entries = many.zip(vars).zip(keyTokens).map: (fv, key) =>
+                  s"\t\t\t${key.padTo(keyWidth, ' ')} ${fromDafny(fv._1, fv._2)},"
+                (
+                  "(map[string]any, error)",
+                  "nil",
+                  (s"\t\t${vars.mkString(", ")} := $call" :: "\t\tresult = map[string]any{" :: entries) :::
+                    List("\t\t}")
+                )
+          val resultDecl = returnType match
+            case "(map[string]any, error)" => "\tvar result map[string]any"
+            case other                     => s"\tvar result ${outputs.head.domainType}"
+          val invCheck =
+            if kernelCtx.hasInv then
+              List(
+                "\t\tif !dafnykernel.Companion_Default___.ServiceStateInv(state) {",
+                "\t\t\treturn ErrKernelStateInvariant",
+                "\t\t}"
               )
-            case many =>
-              val vars      = many.map(f => "out" + toPascalCase(f.fieldName))
-              val keyTokens = many.map(f => s"\"${f.columnName}\":")
-              val keyWidth  = keyTokens.map(_.length).max
-              val entries = many.zip(vars).zip(keyTokens).map: (fv, key) =>
-                s"\t\t${key.padTo(keyWidth, ' ')} ${fromDafny(fv._1, fv._2)},"
-              (
-                "(map[string]any, error)",
-                (s"\t${vars.mkString(", ")} := $call" :: "\treturn map[string]any{" :: entries) :::
-                  List("\t}, nil")
-              )
-        val header =
-          s"func (s *${entity.modelClassName}Service) $serviceMethod(ctx context.Context$sig) $returnType {"
-        (header :: "\tstate := dafnykernel.MakeState()" :: resultLines ::: List("}")).mkString("\n")
+            else Nil
+          val guardCheck = List(
+            s"\t\tif !$guard {",
+            "\t\t\treturn ErrKernelPrecondition",
+            "\t\t}"
+          )
+          val header =
+            s"func (s *${entity.modelClassName}Service) $serviceMethod(ctx context.Context$sig) $returnType {"
+          val body =
+            if kernelCtx.hasState then
+              (header :: resultDecl ::
+                "\tif err := s.db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {" ::
+                "\t\tstate, err := hydrateState(ctx, tx)" ::
+                "\t\tif err != nil {" :: "\t\t\treturn err" :: "\t\t}" ::
+                (invCheck ::: guardCheck ::: resultAssign :::
+                  List(
+                    "\t\tif err := persistState(ctx, tx, state); err != nil {",
+                    "\t\t\treturn err",
+                    "\t\t}",
+                    "\t\treturn nil",
+                    "\t}); err != nil {",
+                    s"\t\treturn $zero, err",
+                    "\t}",
+                    "\treturn result, nil",
+                    "}"
+                  ))): List[String]
+            else
+              (header :: resultDecl ::
+                "\tstate := dafnykernel.MakeState()" ::
+                "\terr := func() error {" ::
+                (invCheck ::: guardCheck ::: resultAssign :::
+                  List(
+                    "\t\treturn nil",
+                    "\t}()",
+                    "\tif err != nil {",
+                    s"\t\treturn $zero, err",
+                    "\t}",
+                    "\treturn result, nil",
+                    "}"
+                  ))): List[String]
+          body.mkString("\n")
 
   private def toCamelCase(name: String): String =
     Naming.toCamelCase(name, Naming.CamelStrategy.Plain)

--- a/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/EmitGo.scala
@@ -115,9 +115,8 @@ final private case class GoEntityCtx(
     usesModels: Boolean,
     customSchemas: List[GoCustomSchema],
     validationBlock: String,
-    needsRegexp: Boolean,
-    needsFmt: Boolean,
-    needsUtf8: Boolean,
+    modelImports: String,
+    hasStdlibImports: Boolean,
     modelStructLines: List[String],
     createStructLines: List[String],
     handlerImports: String
@@ -608,7 +607,7 @@ object EmitGo:
         operations
           .filter(o => o.customRequestSchemaName.isDefined && o.customRules.nonEmpty)
           .map(o => o.requestBodyType -> o.customRules)).distinctBy(_._1)
-    val fileValidations = GoValidation.forStructs(structRules)
+    val fileValidations = GoValidation.forStructs(entity.entityName, structRules)
     val validatedNames  = fileValidations.structs.map(_.structName).toSet
     val opsWithValidation = operations.map: o =>
       o.copy(bodyValidates = o.hasRequestBody && validatedNames.contains(o.requestBodyType))
@@ -644,9 +643,22 @@ object EmitGo:
           "\n" + (fileValidations.patternVars.mkString("\n") ::
             fileValidations.structs.map(_.funcText)).filter(_.nonEmpty).mkString("\n\n")
       ,
-      needsRegexp = fileValidations.needsRegexp,
-      needsFmt = !fileValidations.isEmpty,
-      needsUtf8 = fileValidations.needsUtf8,
+      modelImports = {
+        val stdlib = List(
+          Option.when(!fileValidations.isEmpty)("\"fmt\""),
+          Option.when(fileValidations.needsRegexp)("\"regexp\""),
+          Option.when(needsTime)("\"time\""),
+          Option.when(fileValidations.needsUtf8)("\"unicode/utf8\"")
+        ).flatten
+        val third =
+          Option.when(needsUuid)("\"github.com/google/uuid\"").toList :::
+            Option.when(needsDecimal)("\"github.com/shopspring/decimal\"").toList :::
+            List("\"github.com/uptrace/bun\"")
+        val groups = List(stdlib, third).filter(_.nonEmpty)
+        groups.map(_.map("\t" + _).mkString("\n")).mkString("import (\n", "\n\n", "\n)")
+      },
+      hasStdlibImports = !fileValidations.isEmpty || fileValidations.needsRegexp ||
+        fileValidations.needsUtf8 || needsTime,
       modelStructLines = padCells(
         List(
           "bun.BaseModel",

--- a/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
@@ -14,48 +14,57 @@ object GoValidation:
 
   final case class StructValidation(
       structName: String,
-      patternVars: List[String],
       funcText: String,
       needsUtf8: Boolean
   )
 
+  final case class FileValidations(
+      patternVars: List[String],
+      structs: List[StructValidation]
+  ):
+    def needsUtf8: Boolean   = structs.exists(_.needsUtf8)
+    def needsRegexp: Boolean = patternVars.nonEmpty
+    def isEmpty: Boolean     = structs.isEmpty
+
   private def pascal(name: String): String =
     Naming.toPascalCase(name, Naming.PascalStrategy.Go)
 
-  private def patternVar(structName: String, fieldName: String, idx: Int): String =
-    val suffix = if idx == 0 then "" else (idx + 1).toString
-    Naming.toCamelCase(structName, Naming.CamelStrategy.Plain) + pascal(fieldName) +
-      s"Pattern$suffix"
-
-  def forStruct(structName: String, rules: List[FieldRule]): Option[StructValidation] =
-    val active = rules.filter(r => !r.reduced.isEmpty && r.field.domainType == "string")
-    Option.when(active.nonEmpty):
-      val patternVars = List.newBuilder[String]
-      val body        = new StringBuilder
-      val needsUtf8 =
-        active.exists(r => r.reduced.minLen.isDefined || r.reduced.maxLen.isDefined)
-      for r <- active do
-        val goField = pascal(r.field.fieldName)
-        val access  = if r.field.nullable then s"*b.$goField" else s"b.$goField"
-        val checks  = new StringBuilder
-        r.reduced.minLen.foreach { n =>
-          checks ++= s"\tif utf8.RuneCountInString($access) < $n {\n"
-          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: shorter than minimum length $n\")\n\t}\n"
-        }
-        r.reduced.maxLen.foreach { n =>
-          checks ++= s"\tif utf8.RuneCountInString($access) > $n {\n"
-          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: longer than maximum length $n\")\n\t}\n"
-        }
-        r.reduced.patterns.zipWithIndex.foreach { (p, i) =>
-          val v = patternVar(structName, r.field.fieldName, i)
-          patternVars += s"var $v = regexp.MustCompile(`${StringRefinements.fullMatch(p)}`)"
-          checks ++= s"\tif !$v.MatchString($access) {\n"
-          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: does not match the required pattern\")\n\t}\n"
-        }
-        if r.field.nullable then
-          val indented = checks.toString.linesIterator.map("\t" + _).mkString("\n")
-          body ++= s"\tif b.$goField != nil {\n$indented\n\t}\n"
-        else body ++= checks.toString
-      val func =
-        s"func (b $structName) Validate() error {\n${body.toString}\treturn nil\n}"
-      StructValidation(structName, patternVars.result(), func, needsUtf8)
+  // One compiled var per distinct pattern text, shared across structs and
+  // fields, so identical refinements cannot drift apart when edited.
+  def forStructs(structs: List[(String, List[FieldRule])]): FileValidations =
+    val pool = scala.collection.mutable.LinkedHashMap.empty[String, String]
+    def poolVar(anchored: String): String =
+      pool.getOrElseUpdate(anchored, s"validationPattern${pool.size + 1}")
+    val validations = structs.flatMap { (structName, rules) =>
+      val active = rules.filter(r => !r.reduced.isEmpty && r.field.domainType == "string")
+      Option.when(active.nonEmpty):
+        val body = new StringBuilder
+        val needsUtf8 =
+          active.exists(r => r.reduced.minLen.isDefined || r.reduced.maxLen.isDefined)
+        for r <- active do
+          val goField = pascal(r.field.fieldName)
+          val access  = if r.field.nullable then s"*b.$goField" else s"b.$goField"
+          val checks  = new StringBuilder
+          r.reduced.minLen.foreach { n =>
+            checks ++= s"\tif utf8.RuneCountInString($access) < $n {\n"
+            checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: shorter than minimum length $n\")\n\t}\n"
+          }
+          r.reduced.maxLen.foreach { n =>
+            checks ++= s"\tif utf8.RuneCountInString($access) > $n {\n"
+            checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: longer than maximum length $n\")\n\t}\n"
+          }
+          r.reduced.patterns.foreach { p =>
+            val v = poolVar(StringRefinements.fullMatch(p))
+            checks ++= s"\tif !$v.MatchString($access) {\n"
+            checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: does not match the required pattern\")\n\t}\n"
+          }
+          if r.field.nullable then
+            val indented = checks.toString.linesIterator.map("\t" + _).mkString("\n")
+            body ++= s"\tif b.$goField != nil {\n$indented\n\t}\n"
+          else body ++= checks.toString
+        val func =
+          s"func (b $structName) Validate() error {\n${body.toString}\treturn nil\n}"
+        StructValidation(structName, func, needsUtf8)
+    }
+    val vars = pool.toList.map((pat, name) => s"var $name = regexp.MustCompile(`$pat`)")
+    FileValidations(vars, validations)

--- a/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
@@ -30,11 +30,16 @@ object GoValidation:
     Naming.toPascalCase(name, Naming.PascalStrategy.Go)
 
   // One compiled var per distinct pattern text, shared across structs and
-  // fields, so identical refinements cannot drift apart when edited.
-  def forStructs(structs: List[(String, List[FieldRule])]): FileValidations =
+  // fields, so identical refinements cannot drift apart when edited. The
+  // prefix must be unique per file: every entity's models file shares the one
+  // go package, so bare names would collide across entities.
+  def forStructs(prefix: String, structs: List[(String, List[FieldRule])]): FileValidations =
     val pool = scala.collection.mutable.LinkedHashMap.empty[String, String]
     def poolVar(anchored: String): String =
-      pool.getOrElseUpdate(anchored, s"validationPattern${pool.size + 1}")
+      pool.getOrElseUpdate(
+        anchored,
+        s"${Naming.toCamelCase(prefix, Naming.CamelStrategy.Plain)}ValidationPattern${pool.size + 1}"
+      )
     val validations = structs.flatMap { (structName, rules) =>
       val active = rules.filter(r => !r.reduced.isEmpty && r.field.domainType == "string")
       Option.when(active.nonEmpty):

--- a/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/GoValidation.scala
@@ -1,0 +1,61 @@
+package specrest.codegen.go
+
+import specrest.convention.StringRefinements
+import specrest.ir.Naming
+import specrest.profile.ProfiledField
+
+// Emits Validate() methods on request models from the spec's string
+// refinements, the same reduction the python schemas and the test oracle use.
+// Length bounds count runes (spec len is characters, go len is bytes), and
+// each pattern anchors and checks separately because RE2 has no lookaheads.
+object GoValidation:
+
+  final case class FieldRule(field: ProfiledField, reduced: StringRefinements.Reduced)
+
+  final case class StructValidation(
+      structName: String,
+      patternVars: List[String],
+      funcText: String,
+      needsUtf8: Boolean
+  )
+
+  private def pascal(name: String): String =
+    Naming.toPascalCase(name, Naming.PascalStrategy.Go)
+
+  private def patternVar(structName: String, fieldName: String, idx: Int): String =
+    val suffix = if idx == 0 then "" else (idx + 1).toString
+    Naming.toCamelCase(structName, Naming.CamelStrategy.Plain) + pascal(fieldName) +
+      s"Pattern$suffix"
+
+  def forStruct(structName: String, rules: List[FieldRule]): Option[StructValidation] =
+    val active = rules.filter(r => !r.reduced.isEmpty && r.field.domainType == "string")
+    Option.when(active.nonEmpty):
+      val patternVars = List.newBuilder[String]
+      val body        = new StringBuilder
+      val needsUtf8 =
+        active.exists(r => r.reduced.minLen.isDefined || r.reduced.maxLen.isDefined)
+      for r <- active do
+        val goField = pascal(r.field.fieldName)
+        val access  = if r.field.nullable then s"*b.$goField" else s"b.$goField"
+        val checks  = new StringBuilder
+        r.reduced.minLen.foreach { n =>
+          checks ++= s"\tif utf8.RuneCountInString($access) < $n {\n"
+          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: shorter than minimum length $n\")\n\t}\n"
+        }
+        r.reduced.maxLen.foreach { n =>
+          checks ++= s"\tif utf8.RuneCountInString($access) > $n {\n"
+          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: longer than maximum length $n\")\n\t}\n"
+        }
+        r.reduced.patterns.zipWithIndex.foreach { (p, i) =>
+          val v = patternVar(structName, r.field.fieldName, i)
+          patternVars += s"var $v = regexp.MustCompile(`${StringRefinements.fullMatch(p)}`)"
+          checks ++= s"\tif !$v.MatchString($access) {\n"
+          checks ++= s"\t\treturn fmt.Errorf(\"${r.field.fieldName}: does not match the required pattern\")\n\t}\n"
+        }
+        if r.field.nullable then
+          val indented = checks.toString.linesIterator.map("\t" + _).mkString("\n")
+          body ++= s"\tif b.$goField != nil {\n$indented\n\t}\n"
+        else body ++= checks.toString
+      val func =
+        s"func (b $structName) Validate() error {\n${body.toString}\treturn nil\n}"
+      StructValidation(structName, patternVars.result(), func, needsUtf8)

--- a/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
@@ -66,6 +66,9 @@ object StateBridgeGo:
     val entities   = planned.relations.map(_.entity).distinctBy(_.entityName)
     val needsTime  = entities.exists(_.fields.exists(_.domainType == "time.Time"))
     val timeImport = if needsTime then "\n\t\"time\"" else ""
+    val scalarImports =
+      if planned.scalars.isEmpty then ""
+      else "\n\t\"database/sql\"\n\t\"errors\""
 
     val hydrate = new StringBuilder
     for e <- entities do
@@ -108,12 +111,16 @@ object StateBridgeGo:
       persist ++= s"\t\tvalue := (*pair.IndexInt(1)).(dafnykernel.${e.entityName})\n"
       persist ++= "\t\tseen[key] = true\n"
       persist ++= s"\t\trow, exists := $existing[key]\n"
-      for f <- e.fields do
+      // The key column stays immutable on updates (the row was fetched by it,
+      // and rewriting it from the Dafny value could desync row identity from
+      // the map key); inserts set it from the value like every other field.
+      for f <- e.fields if f.fieldName != r.keyField.fieldName do
         persist ++= s"\t\trow.${pascal(f.fieldName)} = ${fromDafnyExpr(f, "value")}\n"
       persist ++= "\t\tif exists {\n"
       persist ++= "\t\t\tif _, err := db.NewUpdate().Model(&row).WherePK().Exec(ctx); err != nil {\n"
       persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
       persist ++= "\t\t} else {\n"
+      persist ++= s"\t\t\trow.${pascal(r.keyField.fieldName)} = ${fromDafnyExpr(r.keyField, "value")}\n"
       persist ++= "\t\t\tif _, err := db.NewInsert().Model(&row).Exec(ctx); err != nil {\n"
       persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
       persist ++= "\t\t}\n"
@@ -136,7 +143,10 @@ object StateBridgeGo:
     val scalarHydrate = new StringBuilder
     if planned.scalars.nonEmpty then
       scalarHydrate ++= "\tscalarRow := new(models.ServiceState)\n"
-      scalarHydrate ++= "\tif err := db.NewSelect().Model(scalarRow).Where(\"id = 1\").Limit(1).Scan(ctx); err == nil {\n"
+      scalarHydrate ++= "\tif err := db.NewSelect().Model(scalarRow).Where(\"id = 1\").Limit(1).Scan(ctx); err != nil {\n"
+      scalarHydrate ++= "\t\tif !errors.Is(err, sql.ErrNoRows) {\n"
+      scalarHydrate ++= "\t\t\treturn nil, err\n\t\t}\n"
+      scalarHydrate ++= "\t} else {\n"
       for sc <- planned.scalars do
         scalarHydrate ++= s"\t\tst.${stateFieldName(sc.stateField)} = dafnykernel.IntToDafny(scalarRow.${pascal(sc.columnName)})\n"
       scalarHydrate ++= "\t}\n"
@@ -144,7 +154,7 @@ object StateBridgeGo:
     s"""package services
        |
        |import (
-       |\t"context"$timeImport
+       |\t"context"$scalarImports$timeImport
        |
        |\t"github.com/uptrace/bun"
        |

--- a/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/go/StateBridgeGo.scala
@@ -1,0 +1,164 @@
+package specrest.codegen.go
+
+import specrest.codegen.StatePlan
+import specrest.ir.Naming
+import specrest.profile.ProfiledEntity
+import specrest.profile.ProfiledField
+import specrest.profile.ProfiledService
+
+// Generates internal/services/state_bridge.go: hydrate a Dafny ServiceState
+// from the database and persist its mutations back, both against bun.IDB so
+// the kernel service methods can run them inside one RunInTx transaction.
+// Dafny's Go backend doubles underscores in identifiers (Dtor_created__at)
+// and returns tuple elements behind pointers; both quirks live here only.
+object StateBridgeGo:
+
+  private val ScalarGoTypes = Set("string", "int64", "bool", "time.Time")
+
+  // Nullable fields would need Option constructors on the Dafny side; the
+  // gate keeps them out until a spec actually needs them in go.
+  def plan(profiled: ProfiledService): Either[String, StatePlan.Plan] =
+    StatePlan.analyze(
+      profiled,
+      fieldSupported = f => ScalarGoTypes.contains(f.domainType) && !f.nullable,
+      keySupported = k => Set("string", "int64").contains(k.domainType) && !k.nullable
+    )
+
+  private def pascal(name: String): String =
+    Naming.toPascalCase(name, Naming.PascalStrategy.Go)
+
+  private def dafnyName(specName: String): String = specName.replace("_", "__")
+
+  // Dafny's Go backend exports a state field by capitalizing its first rune
+  // and keeping the doubled underscores: base_url becomes Base__url.
+  private def stateFieldName(specName: String): String =
+    val d = dafnyName(specName)
+    d.head.toUpper.toString + d.tail
+
+  private def rowsVar(e: ProfiledEntity): String =
+    Naming.toCamelCase(e.entityName, Naming.CamelStrategy.Plain) + "Rows"
+
+  private def toDafnyExpr(f: ProfiledField, rowRef: String): String =
+    val access = s"$rowRef.${pascal(f.fieldName)}"
+    f.domainType match
+      case "string"    => s"dafnykernel.StringToDafny($access)"
+      case "int64"     => s"dafnykernel.IntToDafny($access)"
+      case "time.Time" => s"dafnykernel.IntToDafny($access.Unix())"
+      case _           => access
+  private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
+    val access = s"$valueRef.Dtor_${dafnyName(f.fieldName)}()"
+    f.domainType match
+      case "string"    => s"dafnykernel.StringFromDafny($access)"
+      case "int64"     => s"dafnykernel.IntFromDafny($access)"
+      case "time.Time" => s"time.Unix(dafnykernel.IntFromDafny($access), 0).UTC()"
+      case _           => access
+
+  private def keyToDafny(key: ProfiledField, rowRef: String): String =
+    key.domainType match
+      case "string" => s"dafnykernel.StringToDafny($rowRef.${pascal(key.fieldName)})"
+      case _        => s"dafnykernel.IntToDafny($rowRef.${pascal(key.fieldName)})"
+
+  def emit(profiled: ProfiledService, module: String): String =
+    val planned = plan(profiled) match
+      case Right(p) => p
+      case Left(_)  => StatePlan.Plan(Nil, Nil)
+
+    val entities   = planned.relations.map(_.entity).distinctBy(_.entityName)
+    val needsTime  = entities.exists(_.fields.exists(_.domainType == "time.Time"))
+    val timeImport = if needsTime then "\n\t\"time\"" else ""
+
+    val hydrate = new StringBuilder
+    for e <- entities do
+      hydrate ++= s"\t${rowsVar(e)} := make([]models.${e.modelClassName}, 0)\n"
+      hydrate ++= s"\tif err := db.NewSelect().Model(&${rowsVar(e)}).Scan(ctx); err != nil {\n"
+      hydrate ++= "\t\treturn nil, err\n\t}\n"
+    for r <- planned.relations do
+      val builder = Naming.toCamelCase(r.stateField, Naming.CamelStrategy.Plain) + "Builder"
+      hydrate ++= s"\t$builder := _dafny.NewMapBuilder()\n"
+      hydrate ++= s"\tfor _, r := range ${rowsVar(r.entity)} {\n"
+      val value = r.valueField match
+        case Some(vf) => toDafnyExpr(vf, "r")
+        case None =>
+          val args = r.entity.fields.map(f => s"\t\t\t${toDafnyExpr(f, "r")},").mkString("\n")
+          s"dafnykernel.Companion_${r.entity.entityName}_.Create_${r.entity.entityName}_(\n$args\n\t\t)"
+      hydrate ++= s"\t\t$builder.Add(${keyToDafny(r.keyField, "r")}, $value)\n"
+      hydrate ++= "\t}\n"
+      hydrate ++= s"\tst.${stateFieldName(r.stateField)} = $builder.ToMap()\n"
+
+    val persist = new StringBuilder
+    for r <- planned.entityRowRelations do
+      val e        = r.entity
+      val rows     = rowsVar(e)
+      val keyGo    = pascal(r.keyField.fieldName)
+      val existing = Naming.toCamelCase(e.entityName, Naming.CamelStrategy.Plain) + "Existing"
+      val keyType  = r.keyField.domainType
+      persist ++= s"\t$rows := make([]models.${e.modelClassName}, 0)\n"
+      persist ++= s"\tif err := db.NewSelect().Model(&$rows).Scan(ctx); err != nil {\n"
+      persist ++= "\t\treturn err\n\t}\n"
+      persist ++= s"\t$existing := make(map[$keyType]models.${e.modelClassName}, len($rows))\n"
+      persist ++= s"\tfor _, r := range $rows {\n\t\t$existing[r.$keyGo] = r\n\t}\n"
+      persist ++= s"\tseen := make(map[$keyType]bool)\n"
+      persist ++= s"\tit := st.${stateFieldName(r.stateField)}.Items().Iterator()\n"
+      persist ++= "\tfor tu, ok := it(); ok; tu, ok = it() {\n"
+      persist ++= "\t\tpair := tu.(_dafny.Tuple)\n"
+      val keyExpr = keyType match
+        case "string" => "dafnykernel.StringFromDafny((*pair.IndexInt(0)).(_dafny.Sequence))"
+        case _        => "dafnykernel.IntFromDafny((*pair.IndexInt(0)).(_dafny.Int))"
+      persist ++= s"\t\tkey := $keyExpr\n"
+      persist ++= s"\t\tvalue := (*pair.IndexInt(1)).(dafnykernel.${e.entityName})\n"
+      persist ++= "\t\tseen[key] = true\n"
+      persist ++= s"\t\trow, exists := $existing[key]\n"
+      for f <- e.fields do
+        persist ++= s"\t\trow.${pascal(f.fieldName)} = ${fromDafnyExpr(f, "value")}\n"
+      persist ++= "\t\tif exists {\n"
+      persist ++= "\t\t\tif _, err := db.NewUpdate().Model(&row).WherePK().Exec(ctx); err != nil {\n"
+      persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
+      persist ++= "\t\t} else {\n"
+      persist ++= "\t\t\tif _, err := db.NewInsert().Model(&row).Exec(ctx); err != nil {\n"
+      persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
+      persist ++= "\t\t}\n"
+      persist ++= "\t}\n"
+      persist ++= s"\tfor key := range $existing {\n"
+      persist ++= "\t\tif !seen[key] {\n"
+      persist ++= s"\t\t\trow := $existing[key]\n"
+      persist ++= "\t\t\tif _, err := db.NewDelete().Model(&row).WherePK().Exec(ctx); err != nil {\n"
+      persist ++= "\t\t\t\treturn err\n\t\t\t}\n"
+      persist ++= "\t\t}\n\t}\n"
+    if planned.scalars.nonEmpty then
+      persist ++= "\tscalarRow := new(models.ServiceState)\n"
+      persist ++= "\terr := db.NewSelect().Model(scalarRow).Where(\"id = 1\").Limit(1).Scan(ctx)\n"
+      persist ++= "\tif err != nil {\n\t\treturn err\n\t}\n"
+      for sc <- planned.scalars do
+        persist ++= s"\tscalarRow.${pascal(sc.columnName)} = dafnykernel.IntFromDafny(st.${stateFieldName(sc.stateField)})\n"
+      persist ++= "\tif _, err := db.NewUpdate().Model(scalarRow).WherePK().Exec(ctx); err != nil {\n"
+      persist ++= "\t\treturn err\n\t}\n"
+
+    val scalarHydrate = new StringBuilder
+    if planned.scalars.nonEmpty then
+      scalarHydrate ++= "\tscalarRow := new(models.ServiceState)\n"
+      scalarHydrate ++= "\tif err := db.NewSelect().Model(scalarRow).Where(\"id = 1\").Limit(1).Scan(ctx); err == nil {\n"
+      for sc <- planned.scalars do
+        scalarHydrate ++= s"\t\tst.${stateFieldName(sc.stateField)} = dafnykernel.IntToDafny(scalarRow.${pascal(sc.columnName)})\n"
+      scalarHydrate ++= "\t}\n"
+
+    s"""package services
+       |
+       |import (
+       |\t"context"$timeImport
+       |
+       |\t"github.com/uptrace/bun"
+       |
+       |\tdafnykernel "$module/internal/dafnykernel"
+       |\t_dafny "$module/internal/dafnykernel/dafny"
+       |\t"$module/internal/models"
+       |)
+       |
+       |func hydrateState(ctx context.Context, db bun.IDB) (*dafnykernel.ServiceState, error) {
+       |\tst := dafnykernel.MakeState()
+       |${hydrate.toString}${scalarHydrate.toString}\treturn st, nil
+       |}
+       |
+       |func persistState(ctx context.Context, db bun.IDB, st *dafnykernel.ServiceState) error {
+       |${persist.toString}\treturn nil
+       |}
+       |""".stripMargin

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -242,7 +242,9 @@ object EmitPython:
       val readFieldsRaw =
         nonIdFields.filterNot(f => SensitiveFields.isSensitive(f.columnName))
       val nonIdFieldViews =
-        nonIdFields.map(f => schemaInputField(f, entityFieldRefinement(profiled, entity, f)))
+        nonIdFields.map(f =>
+          schemaInputField(f, EmitShared.entityFieldRefinement(profiled, entity, f))
+        )
       val readFieldViews       = readFieldsRaw.map(schemaReadField)
       val customRequestSchemas = entityOps.flatMap(_.customRequestSchema)
       val schemaStdlib         = collectSchemaStdlibImports(entity, customRequestSchemas)
@@ -447,17 +449,6 @@ object EmitPython:
       if args.isEmpty then " = None"
       else s" = Field(default=None, ${args.mkString(", ")})"
     SchemaFieldView(f.columnName, ptype, f.domainType, f.nullable, fieldSuffix, updateSuffix)
-
-  private def entityFieldRefinement(
-      profiled: ProfiledService,
-      entity: ProfiledEntity,
-      f: ProfiledField
-  ): StringRefinements.Reduced =
-    svcEntities(profiled.ir)
-      .find(d => entName(d) == entity.entityName)
-      .flatMap(d => entFields(d).find(fd => fldName(fd) == f.fieldName))
-      .map(fd => StringRefinements.reduceField(fldType(fd), fldDefault(fd), profiled.ir))
-      .getOrElse(StringRefinements.Reduced(None, None, Nil))
 
   private def schemaReadField(f: ProfiledField): SchemaFieldView =
     SchemaFieldView(f.columnName, f.validationType, f.domainType, f.nullable, "", "")

--- a/modules/codegen/src/main/scala/specrest/codegen/python/StateBridge.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/StateBridge.scala
@@ -1,8 +1,6 @@
 package specrest.codegen.python
 
-import specrest.codegen.AdminModel
 import specrest.ir.Naming
-import specrest.ir.generated.SpecRestGenerated.*
 import specrest.profile.ProfiledEntity
 import specrest.profile.ProfiledField
 import specrest.profile.ProfiledService
@@ -16,86 +14,21 @@ object StateBridge:
 
   private val ScalarPyTypes = Set("str", "int", "bool", "datetime")
 
-  final private case class RelationPlan(
-      stateField: String,
-      entity: ProfiledEntity,
-      keyField: ProfiledField,
-      valueField: Option[ProfiledField]
-  ):
-    def isEntityRow: Boolean = valueField.isEmpty
-
-  final private case class ScalarPlan(stateField: String, columnName: String)
-
-  final case class Plan private[StateBridge] (
-      private[StateBridge] val relations: List[RelationPlan],
-      private[StateBridge] val scalars: List[ScalarPlan]
-  ):
-    private[StateBridge] def entityRowRelations: List[RelationPlan] =
-      relations.filter(_.isEntityRow).distinctBy(_.entity.entityName)
+  export specrest.codegen.StatePlan.Plan
 
   def dafnyName(specName: String): String = specName.replace("_", "__")
 
   private def baseType(domainType: String): String =
     domainType.replaceAll("\\s*\\|\\s*None$", "").trim
 
-  private def fieldSupported(f: ProfiledField): Boolean =
-    ScalarPyTypes.contains(baseType(f.domainType))
-
-  // None when the spec's state cannot round-trip through the bridge; the
-  // reason keeps the eligibility decision explainable in logs and tests.
   def plan(profiled: ProfiledService): Either[String, Plan] =
-    val ir        = profiled.ir
-    val byName    = profiled.entities.map(e => e.entityName -> e).toMap
-    val relations = List.newBuilder[RelationPlan]
-    val scalars   = List.newBuilder[ScalarPlan]
-    val problems  = List.newBuilder[String]
+    specrest.codegen.StatePlan.analyze(
+      profiled,
+      fieldSupported = f => ScalarPyTypes.contains(baseType(f.domainType)),
+      keySupported = k => Set("str", "int").contains(baseType(k.domainType)) && !k.nullable
+    )
 
-    for sf <- irStateFields(ir) do
-      val name = stfName(sf)
-      AdminModel.projectionFor(sf, ir) match
-        case None => () // unbacked: hydrates to the Dafny zero value, like /admin/state's null
-        case Some(p) =>
-          p.valueShape match
-            case AdminModel.ProjectionValue.ScalarStateColumn(col) =>
-              scalars += ScalarPlan(name, col)
-            case shape =>
-              byName.get(p.entityName) match
-                case None =>
-                  problems += s"state field '$name' projects onto unknown entity '${p.entityName}'"
-                case Some(entity) =>
-                  entity.fields.find(_.fieldName == p.keyFieldName) match
-                    case None =>
-                      problems += s"state field '$name': key field '${p.keyFieldName}' not on '${p.entityName}'"
-                    case Some(key) =>
-                      val unsupported = entity.fields.filterNot(fieldSupported)
-                      if unsupported.nonEmpty then
-                        problems += s"state field '$name': entity '${p.entityName}' has field types the bridge cannot marshal (${unsupported.map(_.domainType).distinct.mkString(", ")})"
-                      else if !Set("str", "int").contains(baseType(key.domainType)) || key.nullable
-                      then
-                        problems += s"state field '$name': key '${p.keyFieldName}' must be a non-optional str or int"
-                      else
-                        val valueField = shape match
-                          case AdminModel.ProjectionValue.PrimitiveField(vf) =>
-                            entity.fields.find(_.fieldName == vf)
-                          case _ => None
-                        shape match
-                          case AdminModel.ProjectionValue.PrimitiveField(vf)
-                              if valueField.isEmpty =>
-                            problems += s"state field '$name': value field '$vf' not on '${p.entityName}'"
-                          case _ =>
-                            relations += RelationPlan(name, entity, key, valueField)
-
-    val built       = Plan(relations.result(), scalars.result())
-    val persistable = built.entityRowRelations.map(_.entity.entityName).toSet
-    for r <- built.relations if !r.isEntityRow do
-      if !persistable.contains(r.entity.entityName) then
-        problems += s"state field '${r.stateField}' projects a single column of '${r.entity.entityName}', which no entity-valued state field covers; mutations could not be written back"
-
-    problems.result() match
-      case first :: _ => Left(first)
-      case Nil        => Right(built)
-
-  def hasState(plan: Plan): Boolean = plan.relations.nonEmpty || plan.scalars.nonEmpty
+  def hasState(plan: Plan): Boolean = plan.hasState
 
   private def toDafnyFieldExpr(f: ProfiledField, rowRef: String): String =
     val access = s"$rowRef.${f.columnName}"
@@ -132,7 +65,7 @@ object StateBridge:
   def emit(profiled: ProfiledService): String =
     val planned = plan(profiled) match
       case Right(p) => p
-      case Left(_)  => Plan(Nil, Nil)
+      case Left(_)  => specrest.codegen.StatePlan.Plan(Nil, Nil)
 
     val entityImports = planned.relations
       .map(_.entity)

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -233,6 +233,19 @@ class EmitTest extends CatsEffectSuite:
         s"resolve kernel call should pass the converted code — got:\n$service"
       )
 
+  test("go validators use package-unique pattern names across entities"):
+    SpecFixtures.loadIR("auth_service").map: ir =>
+      val profiled = Annotate.buildProfiledService(ir, "go-chi-sqlite")
+      val files    = Emit.emitProject(profiled)
+      val declared = files
+        .filter(f => f.path.startsWith("internal/models/"))
+        .flatMap(_.content.linesIterator.filter(_.startsWith("var ")).map(_.split(" ")(1)))
+      assertEquals(
+        declared.diff(declared.distinct),
+        List.empty[String],
+        s"duplicate package-level var names across model files: $declared"
+      )
+
   test("Go kernel-routed service marshals scalar in/out via the dafnykernel adapter"):
     SpecFixtures.loadIR("url_shortener").map: ir =>
       val profiledBase = Annotate.buildProfiledService(ir, "go-chi-postgres")

--- a/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
+++ b/modules/codegen/src/test/scala/specrest/codegen/EmitTest.scala
@@ -251,12 +251,27 @@ class EmitTest extends CatsEffectSuite:
       val byPath = files.map(f => f.path -> f.content).toMap
       val service =
         byPath.getOrElse("internal/services/url_mapping.go", fail("no go service emitted"))
-      // Shorten: body op with a two-value (code, short_url) return -> map[string]any.
+      // Shorten: body op with a two-value (code, short_url) return -> map[string]any,
+      // hydrated, guarded, and persisted inside one transaction.
       assert(
         service.contains(
           "outCode, outShortURL := dafnykernel.Companion_Default___.Shorten(state, dafnykernel.StringToDafny(body.URL))"
         ),
         s"Shorten should marshal body.URL and capture both outputs — got:\n$service"
+      )
+      assert(
+        service.contains("state, err := hydrateState(ctx, tx)"),
+        s"kernel ops must hydrate state inside the transaction — got:\n$service"
+      )
+      assert(
+        service.contains(
+          "dafnykernel.Companion_Default___.RequiresShorten(state, dafnykernel.StringToDafny(body.URL))"
+        ),
+        s"kernel ops must check the compiled requires twin — got:\n$service"
+      )
+      assert(
+        service.contains("persistState(ctx, tx, state)"),
+        s"kernel ops must persist the mutated state — got:\n$service"
       )
       assert(
         service.contains("\"code\":") && service.contains(

--- a/modules/parser/src/main/resources/specrest/parser/preamble.spec
+++ b/modules/parser/src/main/resources/specrest/parser/preamble.spec
@@ -1,6 +1,6 @@
 service Preamble {
 
-  predicate isValidURI(s: String) = s matches /^https?:\/\/[^\s]+/
+  predicate isValidURI(s: String) = s matches /^https?:\/\/[^\s\x00-\x1f\x7f]+/
 
   predicate isValidEmail(s: String) = s matches /^[^@\s]+@[^@\s]+\.[^@\s]+$/
 

--- a/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
+++ b/modules/testgen/src/main/resources/testgen-templates/go/chi/tests/conf_runtime.go
@@ -83,6 +83,25 @@ func _slice(x any) []any {
 	}
 }
 
+// Spec quantifiers over a relation range over its domain: `all c in store`
+// binds keys, and the body indexes store[c]. _slice keeps value semantics for
+// comprehension-style consumers; quantifier lowering routes through this.
+func _quantDomain(x any) []any {
+	if m, ok := x.(map[string]any); ok {
+		keys := make([]string, 0, len(m))
+		for k := range m {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		out := make([]any, 0, len(keys))
+		for _, k := range keys {
+			out = append(out, k)
+		}
+		return out
+	}
+	return _slice(x)
+}
+
 func _dedupe(xs []any) []any {
 	out := make([]any, 0, len(xs))
 	for _, x := range xs {

--- a/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/GoExprBackend.scala
@@ -178,13 +178,13 @@ object GoExprBackend extends ExprBackendBase:
       case _      => "_any"
     val nested = bound.foldRight(s"_truthy($body)"): (pair, acc) =>
       val (v, d) = pair
-      s"$helper($d, func($v any) bool { return $acc })"
+      s"$helper(_quantDomain($d), func($v any) bool { return $acc })"
     kind match
       case QNo() => s"(!($nested))"
       case _     => nested
 
   def theExpr(v: String, dom: String, body: String): String =
-    s"_find($dom, func($v any) bool { return _truthy($body) })"
+    s"_find(_quantDomain($dom), func($v any) bool { return _truthy($body) })"
 
   def lambdaExpr(param: String, body: String): String =
     s"func($param any) any { return $body }"


### PR DESCRIPTION
Stage 2 of #510: the reconciliation shape from #511, ported to go-chi. The exit criterion holds here too. A synthesized url_shortener boots and passes its full go conformance suite (behavioral, structural, stateful), where before this branch every state-touching kernel op ran on fresh memory and the suites were red.

Kernel service methods now run five steps inside one `bun.RunInTx`: hydrate a `ServiceState` from the database, check `ServiceStateInv`, check the op's compiled `Requires` twin, call the verified method, persist the mutation. Guard failures return sentinels (`ErrKernelPrecondition`, `ErrKernelStateInvariant` in the services package, next to the existing `ErrNotFound`) and handlers map them: 404 or 409 by route kind, 500 for a broken invariant. Redirect-kind kernel ops write a real Location header instead of serializing the URL as JSON, which the old kernel branch would have done since it flattened every kernel op to one handler shape.

The bridge itself is `internal/services/state_bridge.go`, generated by `StateBridgeGo` against `bun.IDB` so it runs on the transaction. Hydration selects each backing table once and builds the Dafny maps through `MapBuilder` and the datatype companions; persist walks the post-state map, upserts by key column so autoincrement ids survive, prunes rows whose key left the domain, and updates the `service_state` singleton for scalar fields. The plan analysis behind it (which relations map to which tables, and the first reason a spec cannot round-trip) moved from the python emitter into a target-neutral `StatePlan`; python delegates with its own type predicates and its emitted output is unchanged, byte for byte. Nullable fields are gated out of the go plan for now since they need Option constructors on the Dafny side; the fallback is the same fail-loud stub as every other ineligibility.

Boundary enforcement comes along, as it had to: the go structural suite finds the same holes the python one found in #511. Request models get generated `Validate()` methods from the shared `StringRefinements` reduction, handlers answer 422 on violation. Two go-specific choices: lengths count runes, not bytes, because spec `len` is characters; and each pattern is anchored and checked separately because RE2 has no lookaheads to conjoin them with.

Live testing surfaced two pre-existing bugs beyond the port, both fixed here at their roots. First, the go test oracle's `_slice` yields map values, so `all c in store | isValidURI(store[c])` bound values as `c` and indexed the store with them: nil every time. One invariant failed on perfectly valid state and another has been passing vacuously for as long as go suites have existed, latent only because CI's go conformance never had a live state-writing op. Quantifier and definite-description lowering now route through `_quantDomain` (keys for maps, pass-through for sets and sequences); comprehension consumers keep value semantics. Second, rapid drew `http://\x00`, spec-valid but impossible to store faithfully: the go sqlite driver mangles NUL and postgres text rejects it outright. `isValidURI` now excludes control characters, which costs verification nothing since the predicate is uninterpreted in VCs, and URLs never contain them anyway.

Known limits, stated rather than hidden: the emitted stateful test file is not gofmt-clean (the long-closure formatting item already on the backlog; my local gate checks app packages only, matching what CI checks), and stage 3 (ts/express plus Prisma) follows the same recipe next. After that, the CI `--with-synthesis` wiring this whole arc exists for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transactional kernel-state reconciliation for Go codegen and tightens input validation. Also makes validator pattern variables package‑unique and moves Go model imports into the emitter for clean, grouped imports.

- **New Features**
  - Generate `internal/services/state_bridge.go` from `StateBridgeGo` against `bun.IDB` to hydrate/persist kernel `ServiceState` (map‑builder hydration, key‑stable upsert + prune, singleton scalars).
  - Kernel service methods run inside one `bun.RunInTx`: hydrate state, check `ServiceStateInv`, check compiled `Requires`, call the verified method, persist. Guard failures surface as `ErrKernelPrecondition` or `ErrKernelStateInvariant`; handlers map to 404/409 or 500. Redirect ops set a real Location header.
  - Generate `Validate()` on Go request models from shared string refinements via `GoValidation` (rune‑counted lengths; each `RE2` pattern anchored and checked separately). Handlers return 422 on violation.
  - Introduce target‑neutral `StatePlan` for bridge planning; Go uses it directly, Python delegates without changing emitted output.

- **Bug Fixes**
  - Bridge persistence keeps key columns immutable on updates and sets them only on inserts; scalar hydration treats only `sql.ErrNoRows` as the zero case and surfaces other DB errors.
  - Validators emit only for request types handlers decode; identical regex patterns are pooled with package‑unique names to avoid cross‑file collisions.
  - Go model import blocks are assembled in the emitter to produce one grouped list (stdlib, blank line, third‑party), keeping formatting and avoiding duplication.
  - Go test harness quantifiers now range over relation domains via `_quantDomain`; `isValidURI` excludes control chars and URL patterns in Go/Python are aligned with backends to avoid round‑trip failures.
  - Remove unused `hasStdlibImports` generator flag.

<sup>Written for commit 3ae0f273da7ec7abb141f6fab3a50d8897c9d5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request inputs are now validated more strictly, including minimum-length checks and requiring `http://` or `https://` URLs.
  * Generated endpoints return `422 Unprocessable Entity` with the validation error message when input is invalid.
  * For kernel-routed operations, error handling can now surface kernel guard status/details, and redirects are returned when configured.

* **Bug Fixes**
  * Invalid requests are rejected before any processing continues.
  * URL validation was tightened across generated Go and Python schemas to reject control characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->