### PR TITLE
feat: reconcile kernel ServiceState with the database (ts)

### DIFF
--- a/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/mysql/url_shortener/src/schemas/urlMapping.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-  code: z.string(),
-  url: z.string(),
+  code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
   createdAt: z.coerce.date(),
   clickCount: z.number(),
 });
@@ -10,7 +10,7 @@ export const UrlMappingCreateSchema = z.object({
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
 export const ShortenRequestSchema = z.object({
-  url: z.string(),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;

--- a/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/postgres/url_shortener/src/schemas/urlMapping.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-  code: z.string(),
-  url: z.string(),
+  code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
   createdAt: z.coerce.date(),
   clickCount: z.number(),
 });
@@ -10,7 +10,7 @@ export const UrlMappingCreateSchema = z.object({
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
 export const ShortenRequestSchema = z.object({
-  url: z.string(),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;

--- a/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
+++ b/fixtures/golden/codegen/ts/express/sqlite/url_shortener/src/schemas/urlMapping.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const UrlMappingCreateSchema = z.object({
-  code: z.string(),
-  url: z.string(),
+  code: z.string().min(6).regex(/^(?:^[a-zA-Z0-9]+$)$/),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
   createdAt: z.coerce.date(),
   clickCount: z.number(),
 });
@@ -10,7 +10,7 @@ export const UrlMappingCreateSchema = z.object({
 export type UrlMappingCreate = z.infer<typeof UrlMappingCreateSchema>;
 
 export const ShortenRequestSchema = z.object({
-  url: z.string(),
+  url: z.string().min(1).regex(/^(?:^https?:\/\/[^\s\x00-\x1f\x7f]+)$/),
 });
 
 export type ShortenRequest = z.infer<typeof ShortenRequestSchema>;

--- a/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/dafnyKernel/adapter.ts.hbs
@@ -16,6 +16,15 @@ export const companion = kernel._module.__default as Record<
 
 export const makeState = (): unknown => new kernel._module.ServiceState();
 
+// The generated state bridge builds relation maps and entity values through
+// these; everything else goes through the typed converters below.
+export const dafnyModule = kernel._module as Record<
+  string,
+  { [ctor: string]: (...args: unknown[]) => unknown }
+>;
+
+export const emptyDafnyMap = (): unknown => kernel._dafny.Map.Empty;
+
 export const stringToDafny = (s: string): unknown =>
   kernel._dafny.Seq.UnicodeFromString(s);
 

--- a/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
+++ b/modules/codegen/src/main/resources/templates/ts/express/src/services/entity.ts.hbs
@@ -1,13 +1,6 @@
 import { prisma } from '../prisma.js';
 {{#if entity.usesKernel}}
-import {
-  companion,
-  intFromDafny,
-  intToDafny,
-  makeState,
-  stringFromDafny,
-  stringToDafny,
-} from '../dafnyKernel/adapter.js';
+{{{entity.kernelImports}}}
 {{/if}}
 import type {
   {{entity.entity.modelClassName}},

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/EmitTs.scala
@@ -22,6 +22,7 @@ import specrest.codegen.migration.SchemaDiff
 import specrest.codegen.migration.SchemaSnapshot
 import specrest.codegen.migration.SqlRenderer
 import specrest.codegen.openapi.OpenApi
+import specrest.convention.StringRefinements
 import specrest.ir.HttpMethods
 import specrest.ir.Naming
 import specrest.ir.generated.SpecRestGenerated.*
@@ -103,6 +104,7 @@ final private case class TsEntityCtx(
     needsResultCast: Boolean,
     hasListRoute: Boolean,
     usesKernel: Boolean,
+    kernelImports: String,
     customSchemas: List[TsCustomSchema]
 )
 
@@ -155,6 +157,13 @@ object EmitTs:
     val service     = ctx.service
 
     val typeLookup = EmitShared.aliasResolvedDomainLookup(profiled)
+    val bridgePlan = StateBridgeTs.plan(profiled)
+    val kernelCtx = TsKernelCtx(
+      stateReady = irStateFields(profiled.ir).isEmpty || bridgePlan.isRight,
+      hasState = bridgePlan.toOption.exists(_.hasState),
+      hasInv = irStateFields(profiled.ir).nonEmpty,
+      ir = profiled.ir
+    )
 
     val triggerMaintainedByTable: Map[String, Set[String]] =
       schemaTriggers(profiled.schema)
@@ -170,11 +179,12 @@ object EmitTs:
     val entities = profiled.entities.map: entity =>
       val entityOps = profiled.operations
         .filter(_.targetEntity.contains(entity.entityName))
-        .map(op => enrichOperation(op, entity, typeLookup, db.nativeAttrs))
+        .map(op => enrichOperation(op, entity, typeLookup, db.nativeAttrs, kernelCtx))
         .sortWith((a, b) => EmitShared.byPathSpecificity(a.path, b.path))
       val maintained = triggerMaintainedByTable.getOrElse(entity.tableName, Set.empty)
       buildEntityCtx(
         packageName,
+        profiled,
         entity,
         entityOps,
         maintained,
@@ -291,6 +301,8 @@ object EmitTs:
 
     emitPrismaMigrations(profiled, opts, templates, engine, projectCtx.db, files)
 
+    if entities.exists(_.usesKernel) && kernelCtx.hasState then
+      files += EmittedFile("src/services/stateBridge.ts", StateBridgeTs.emit(profiled))
     opts.dafnyKernel.foreach: kernel =>
       val pkg = kernel.packagePath.stripSuffix("/")
       DafnyKernel.rewriteJsKernel(kernel.files).toList.sortBy(_._1).foreach: (rel, content) =>
@@ -559,6 +571,7 @@ object EmitTs:
 
   private def buildEntityCtx(
       packageName: String,
+      profiled: ProfiledService,
       entity: ProfiledEntity,
       operations: List[TsOperation],
       triggerMaintainedColumns: Set[String],
@@ -574,7 +587,7 @@ object EmitTs:
     val entityPluralKebab = Naming.toKebabCase(entityPlural)
 
     def mkField(f: ProfiledField): TsFieldView =
-      val base = toTsField(f, nativeAttrs)
+      val base = toTsField(f, nativeAttrs, EmitShared.entityFieldRefinement(profiled, entity, f))
       if triggerMaintainedColumns.contains(f.columnName)
         && NumericPrismaTypes.contains(base.prismaType)
       then
@@ -654,10 +667,35 @@ object EmitTs:
       needsResultCast = needsResultCast,
       hasListRoute = operations.exists(_.routeKind == "list"),
       usesKernel = operations.exists(_.routeThroughKernel),
+      kernelImports = {
+        val fns = operations.filter(_.routeThroughKernel).map(_.kernelServiceFn).mkString("\n")
+        val adapterNames = List(
+          "companion",
+          "intFromDafny",
+          "intToDafny",
+          "makeState",
+          "stringFromDafny",
+          "stringToDafny"
+        ).filter(n => fns.contains(n + "(") || fns.contains(n + "."))
+        val lines = List.newBuilder[String]
+        if fns.contains("HttpError(") then
+          lines += "import { HttpError } from '../middleware/error.js';"
+        if adapterNames.nonEmpty then
+          lines += adapterNames
+            .map(n => s"  $n,")
+            .mkString("import {\n", "\n", "\n} from '../dafnyKernel/adapter.js';")
+        if fns.contains("hydrateState(") then
+          lines += "import { hydrateState, persistState } from './stateBridge.js';"
+        lines.result().mkString("\n")
+      },
       customSchemas = customSchemas
     )
 
-  private def toTsField(f: ProfiledField, nativeAttrs: Boolean): TsFieldView =
+  private def toTsField(
+      f: ProfiledField,
+      nativeAttrs: Boolean,
+      reduced: StringRefinements.Reduced = StringRefinements.Reduced(None, None, Nil)
+  ): TsFieldView =
     val tsName = toCamelCase(f.fieldName)
     val attrs  = prismaAttrs(f, tsName, nativeAttrs)
     TsFieldView(
@@ -667,7 +705,7 @@ object EmitTs:
       domainType = f.domainType,
       prismaType = prismaTypeFor(f.ormColumnType),
       prismaAttrs = attrs,
-      zodSchema = zodSchemaFor(f),
+      zodSchema = zodSchemaFor(f, reduced),
       nullable = f.nullable,
       isPrimaryKey = false
     )
@@ -709,8 +747,21 @@ object EmitTs:
   private def nativePrismaAttr(sqlColumnType: String): String =
     PrismaSqlTypes.get(sqlColumnType.toUpperCase(Locale.ROOT)).map(_.dbAttr).getOrElse("")
 
-  private def zodSchemaFor(f: ProfiledField): String =
-    val base = baseZod(f.domainType)
+  // Request schemas carry the spec's string refinements as zod constraints,
+  // the same reduction the python and go boundaries enforce; the JS regex
+  // literal escapes its slashes.
+  private def zodSchemaFor(f: ProfiledField, reduced: StringRefinements.Reduced): String =
+    val base0 = baseZod(f.domainType)
+    val base =
+      if f.domainType == "string" && !reduced.isEmpty then
+        val minS = reduced.minLen.map(n => s".min($n)").getOrElse("")
+        val maxS = reduced.maxLen.map(n => s".max($n)").getOrElse("")
+        val reS = StringRefinements
+          .combinedPattern(reduced.patterns)
+          .map(p => s".regex(/${p.replace("/", "\\/")}/)")
+          .getOrElse("")
+        s"$base0$minS$maxS$reS"
+      else base0
     if f.nullable then s"$base.nullable()" else base
 
   private def baseZod(domainType: String): String =
@@ -732,11 +783,19 @@ object EmitTs:
   private def toPascalCase(name: String): String =
     Naming.toPascalCase(name, Naming.PascalStrategy.Plain)
 
+  final private case class TsKernelCtx(
+      stateReady: Boolean,
+      hasState: Boolean,
+      hasInv: Boolean,
+      ir: ServiceIRFull
+  )
+
   private def enrichOperation(
       op: ProfiledOperation,
       entity: ProfiledEntity,
       typeLookup: Map[String, String],
-      nativeAttrs: Boolean
+      nativeAttrs: Boolean,
+      kernelCtx: TsKernelCtx
   ): TsOperation =
     val endpoint = op.endpoint
     // The synthesized PK is BIGSERIAL -> Prisma `BigInt`, so a path param that resolves to the
@@ -787,7 +846,14 @@ object EmitTs:
           case None =>
             (entity.createSchemaName, List.empty[TsFieldView])
           case Some(name) =>
-            (name, OperationContext.customRequestBodyFields(op).map(toTsField(_, nativeAttrs)))
+            val byName = endpoint.bodyParams.map(p => p.name -> p.typeExpr).toMap
+            val views = OperationContext.customRequestBodyFields(op).map { f =>
+              val reduced = byName.get(f.fieldName) match
+                case Some(t) => StringRefinements.reduceField(t, None, kernelCtx.ir)
+                case None    => StringRefinements.Reduced(None, None, Nil)
+              toTsField(f, nativeAttrs, reduced)
+            }
+            (name, views)
 
     val readSchemaName = entity.readSchemaName
     val pathArgsCsv    = pathParams.map(_.tsName).mkString(", ")
@@ -874,7 +940,8 @@ object EmitTs:
         EmitShared.routeKindName(routeKind),
         hasRequestBody,
         requestBodyType,
-        typeLookup
+        typeLookup,
+        kernelCtx
       )
 
     TsOperation(
@@ -933,10 +1000,12 @@ object EmitTs:
       routeKind: String,
       hasRequestBody: Boolean,
       requestBodyType: String,
-      typeLookup: Map[String, String]
+      typeLookup: Map[String, String],
+      kernelCtx: TsKernelCtx
   ): Option[(String, String)] =
     val endpoint = op.endpoint
-    op.dafnyMethod.filter(_ => endpoint.queryParams.isEmpty).flatMap: dafnyName =>
+    val eligible = endpoint.queryParams.isEmpty && kernelCtx.stateReady
+    op.dafnyMethod.filter(_ => eligible).flatMap: dafnyName =>
       val inputs =
         endpoint.pathParams.map(p =>
           toCamelCase(p.name) -> tsTypeForParam(p.typeExpr, typeLookup)
@@ -986,9 +1055,39 @@ object EmitTs:
                   s"  return { ${retFields.mkString(", ")} };"
                 )
               )
+        val guardStatus = routeKind match
+          case "read" | "redirect" | "delete" => 404
+          case _                              => 409
+        val guardDetail = if guardStatus == 404 then "not found" else "precondition failed"
+        val invCheck =
+          if kernelCtx.hasInv then
+            List(
+              "  if (!(companion.ServiceStateInv(state) as boolean)) {",
+              "    throw new HttpError(500, 'service state invariant violated');",
+              "  }"
+            )
+          else Nil
+        val guardCheck = List(
+          s"  if (!(companion.Requires$dafnyName($callArgs) as boolean)) {",
+          s"    throw new HttpError($guardStatus, '$guardDetail');",
+          "  }"
+        )
         val header = s"export const $handlerName = async ($sig): Promise<$returnType> => {"
         val fn =
-          (header :: "  const state = makeState();" :: bodyLines ::: List("};")).mkString("\n")
+          if kernelCtx.hasState then
+            val steps =
+              "const state = await hydrateState(tx);" ::
+                (invCheck ::: guardCheck).map(_.stripPrefix("  ")) :::
+                bodyLines.dropRight(1).map(_.stripPrefix("  ")) :::
+                "await persistState(tx, state);" ::
+                bodyLines.last.stripPrefix("  ") :: Nil
+            (header ::
+              "  return prisma.$transaction(async (tx) => {" ::
+              steps.map("    " + _) :::
+              List("  });", "};")).mkString("\n")
+          else
+            (header :: "  const state = makeState();" ::
+              invCheck ::: guardCheck ::: bodyLines ::: List("};")).mkString("\n")
         val routeArgs =
           (endpoint.pathParams.map(p => toCamelCase(p.name)) ++ Option.when(hasRequestBody)("body"))
             .mkString(", ")

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -115,14 +115,15 @@ object StateBridgeTs:
       persist ++= "    }\n"
       persist ++= "  }\n"
     if planned.scalars.nonEmpty then
-      persist ++= "  const scalarRow = await tx.serviceState.findUnique({ where: { id: 1 } });\n"
-      persist ++= "  if (scalarRow) {\n"
-      persist ++= "    await tx.serviceState.update({\n"
-      persist ++= "      where: { id: 1 },\n"
-      persist ++= "      data: {\n"
+      persist ++= "  const scalarData = {\n"
       for sc <- planned.scalars do
-        persist ++= s"        ${camel(sc.columnName)}: intFromDafny(st['${dafnyName(sc.stateField)}']),\n"
-      persist ++= "      },\n    });\n  }\n"
+        persist ++= s"    ${camel(sc.columnName)}: intFromDafny(st['${dafnyName(sc.stateField)}']),\n"
+      persist ++= "  };\n"
+      persist ++= "  await tx.serviceState.upsert({\n"
+      persist ++= "    where: { id: 1 },\n"
+      persist ++= "    update: scalarData,\n"
+      persist ++= "    create: { id: 1, ...scalarData },\n"
+      persist ++= "  });\n"
 
     s"""import type { Prisma } from '@prisma/client';
        |

--- a/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/ts/StateBridgeTs.scala
@@ -1,0 +1,152 @@
+package specrest.codegen.ts
+
+import specrest.codegen.StatePlan
+import specrest.ir.Naming
+import specrest.profile.ProfiledField
+import specrest.profile.ProfiledService
+
+// Generates src/services/stateBridge.ts: hydrate a Dafny ServiceState from the
+// database and persist its mutations back, both against Prisma's transaction
+// client so kernel service functions run them inside one $transaction. The
+// Dafny JS backend doubles underscores in identifiers (dtor_created__at,
+// base__url) and exposes datatype fields as dtor_ properties.
+object StateBridgeTs:
+
+  private val ScalarTsTypes = Set("string", "number", "boolean", "Date")
+
+  // Nullable fields would need Option constructors on the Dafny side; the
+  // gate keeps them out until a spec actually needs them in ts.
+  def plan(profiled: ProfiledService): Either[String, StatePlan.Plan] =
+    StatePlan.analyze(
+      profiled,
+      fieldSupported = f => ScalarTsTypes.contains(f.domainType) && !f.nullable,
+      keySupported = k => Set("string", "number").contains(k.domainType) && !k.nullable
+    )
+
+  private def camel(name: String): String =
+    Naming.toCamelCase(name, Naming.CamelStrategy.Plain)
+
+  private def dafnyName(specName: String): String = specName.replace("_", "__")
+
+  private def toDafnyExpr(f: ProfiledField, rowRef: String): String =
+    val access = s"$rowRef.${camel(f.fieldName)}"
+    f.domainType match
+      case "string" => s"stringToDafny($access)"
+      case "number" => s"intToDafny($access)"
+      case "Date"   => s"intToDafny(Math.floor($access.getTime() / 1000))"
+      case _        => access
+
+  private def fromDafnyExpr(f: ProfiledField, valueRef: String): String =
+    val access = s"$valueRef['dtor_${dafnyName(f.fieldName)}']"
+    f.domainType match
+      case "string" => s"stringFromDafny($access)"
+      case "number" => s"intFromDafny($access)"
+      case "Date"   => s"new Date(intFromDafny($access) * 1000)"
+      case _        => s"($access as boolean)"
+
+  private def keyToDafny(key: ProfiledField, rowRef: String): String =
+    key.domainType match
+      case "string" => s"stringToDafny($rowRef.${camel(key.fieldName)})"
+      case _        => s"intToDafny($rowRef.${camel(key.fieldName)})"
+
+  private def keyFromDafny(key: ProfiledField): String =
+    key.domainType match
+      case "string" => "stringFromDafny(k)"
+      case _        => "intFromDafny(k)"
+
+  def emit(profiled: ProfiledService): String =
+    val planned = plan(profiled) match
+      case Right(p) => p
+      case Left(_)  => StatePlan.Plan(Nil, Nil)
+
+    val entities = planned.relations.map(_.entity).distinctBy(_.entityName)
+
+    val hydrate = new StringBuilder
+    for e <- entities do
+      hydrate ++= s"  const ${camel(e.entityName)}Rows = await tx.${camel(e.entityName)}.findMany();\n"
+    for r <- planned.relations do
+      val rows    = s"${camel(r.entity.entityName)}Rows"
+      val builder = s"${camel(r.stateField)}Map"
+      hydrate ++= s"  let $builder = emptyDafnyMap() as DafnyMap;\n"
+      hydrate ++= s"  for (const r of $rows) {\n"
+      val value = r.valueField match
+        case Some(vf) => toDafnyExpr(vf, "r")
+        case None =>
+          val args = r.entity.fields.map(f => s"      ${toDafnyExpr(f, "r")},").mkString("\n")
+          s"dafnyModule['${r.entity.entityName}'].create_${r.entity.entityName}(\n$args\n    )"
+      hydrate ++= s"    $builder = $builder.update(${keyToDafny(r.keyField, "r")}, $value);\n"
+      hydrate ++= "  }\n"
+      hydrate ++= s"  st['${dafnyName(r.stateField)}'] = $builder;\n"
+    if planned.scalars.nonEmpty then
+      hydrate ++= "  const scalarRow = await tx.serviceState.findUnique({ where: { id: 1 } });\n"
+      hydrate ++= "  if (scalarRow) {\n"
+      for sc <- planned.scalars do
+        hydrate ++= s"    st['${dafnyName(sc.stateField)}'] = intToDafny(scalarRow.${camel(sc.columnName)});\n"
+      hydrate ++= "  }\n"
+
+    val persist = new StringBuilder
+    for r <- planned.entityRowRelations do
+      val e      = r.entity
+      val client = camel(e.entityName)
+      persist ++= s"  const ${client}Rows = await tx.$client.findMany();\n"
+      persist ++= s"  const ${client}Existing = new Map(${client}Rows.map((r) => [r.${camel(r.keyField.fieldName)}, r]));\n"
+      persist ++= s"  const seen = new Set<${r.keyField.domainType}>();\n"
+      persist ++= s"  for (const [k, v] of st['${dafnyName(r.stateField)}'] as Iterable<[unknown, unknown]>) {\n"
+      persist ++= s"    const key = ${keyFromDafny(r.keyField)};\n"
+      persist ++= "    const value = v as Record<string, unknown>;\n"
+      persist ++= "    seen.add(key);\n"
+      val nonKey = e.fields.filter(_.fieldName != r.keyField.fieldName)
+      persist ++= "    const data = {\n"
+      for f <- nonKey do
+        persist ++= s"      ${camel(f.fieldName)}: ${fromDafnyExpr(f, "value")},\n"
+      persist ++= "    };\n"
+      persist ++= s"    const row = ${client}Existing.get(key);\n"
+      persist ++= "    if (row) {\n"
+      persist ++= s"      await tx.$client.update({ where: { id: row.id }, data });\n"
+      persist ++= "    } else {\n"
+      persist ++= s"      await tx.$client.create({\n"
+      persist ++= s"        data: { ${camel(r.keyField.fieldName)}: ${fromDafnyExpr(r.keyField, "value")}, ...data },\n"
+      persist ++= "      });\n"
+      persist ++= "    }\n"
+      persist ++= "  }\n"
+      persist ++= s"  for (const [key, row] of ${client}Existing) {\n"
+      persist ++= "    if (!seen.has(key)) {\n"
+      persist ++= s"      await tx.$client.delete({ where: { id: row.id } });\n"
+      persist ++= "    }\n"
+      persist ++= "  }\n"
+    if planned.scalars.nonEmpty then
+      persist ++= "  const scalarRow = await tx.serviceState.findUnique({ where: { id: 1 } });\n"
+      persist ++= "  if (scalarRow) {\n"
+      persist ++= "    await tx.serviceState.update({\n"
+      persist ++= "      where: { id: 1 },\n"
+      persist ++= "      data: {\n"
+      for sc <- planned.scalars do
+        persist ++= s"        ${camel(sc.columnName)}: intFromDafny(st['${dafnyName(sc.stateField)}']),\n"
+      persist ++= "      },\n    });\n  }\n"
+
+    s"""import type { Prisma } from '@prisma/client';
+       |
+       |import {
+       |  dafnyModule,
+       |  emptyDafnyMap,
+       |  intFromDafny,
+       |  intToDafny,
+       |  makeState,
+       |  stringFromDafny,
+       |  stringToDafny,
+       |} from '../dafnyKernel/adapter.js';
+       |
+       |type DafnyMap = { update(k: unknown, v: unknown): DafnyMap } & Iterable<[unknown, unknown]>;
+       |
+       |export const hydrateState = async (tx: Prisma.TransactionClient): Promise<unknown> => {
+       |  const st = makeState() as Record<string, unknown>;
+       |${hydrate.toString}  return st;
+       |};
+       |
+       |export const persistState = async (
+       |  tx: Prisma.TransactionClient,
+       |  state: unknown,
+       |): Promise<void> => {
+       |  const st = state as Record<string, unknown>;
+       |${persist.toString}};
+       |""".stripMargin

--- a/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
+++ b/modules/testgen/src/main/resources/testgen-templates/typescript/express/tests/_runtime.ts
@@ -9,6 +9,20 @@ import { createHash } from "node:crypto";
 
 type Anything = unknown;
 
+// Spec quantifiers over a relation range over its domain: `all c in store`
+// binds keys, and the body indexes store[c]. Plain objects are the JSON shape
+// relations arrive in from /admin/state; everything else quantifies over its
+// elements. Array.from on a plain object would yield [] and make every
+// quantified invariant vacuously true.
+export function quantDomain(x: Anything): Anything[] {
+  if (x instanceof Map) return Array.from(x.keys());
+  if (x instanceof Set || Array.isArray(x) || typeof x === "string") {
+    return Array.from(x as Iterable<Anything>);
+  }
+  if (x && typeof x === "object") return Object.keys(x as object).sort();
+  return [];
+}
+
 function asArray(x: Anything): Anything[] {
   if (x instanceof Set || x instanceof Map) return Array.from(x.values());
   if (Array.isArray(x)) return x;

--- a/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TestFormat.scala
@@ -21,6 +21,7 @@ private[testgen] object TestFormat:
   // Names must match the exports of testgen-templates/typescript/express/tests/_runtime.ts.
   val TsRuntimeHelpers: List[String] =
     List(
+      "quantDomain",
       "_diff",
       "_eq",
       "_in",

--- a/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
+++ b/modules/testgen/src/main/scala/specrest/testgen/TsExprBackend.scala
@@ -141,13 +141,13 @@ object TsExprBackend extends ExprBackendBase:
       case _      => "some"
     val nested = bound.foldRight(body): (pair, acc) =>
       val (v, d) = pair
-      s"Array.from($d).$method(($v) => ($acc))"
+      s"quantDomain($d).$method(($v) => ($acc))"
     kind match
       case QNo() => s"(!($nested))"
       case _     => nested
 
   def theExpr(v: String, dom: String, body: String): String =
-    s"(Array.from($dom).find(($v) => ($body)) ?? null)"
+    s"(quantDomain($dom).find(($v) => ($body)) ?? null)"
 
   def lambdaExpr(param: String, body: String): String = s"(($param) => ($body))"
 

--- a/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
+++ b/modules/testgen/src/test/scala/specrest/testgen/BackendTest.scala
@@ -152,7 +152,7 @@ class BackendTest extends CatsEffectSuite:
     assert(pyText(q, c).startsWith("all("), pyText(q, c))
     assertEquals(
       tsText(q, c),
-      "Array.from(post_state[\"s\"]).every((e) => (true))".replace("post_state", "postState")
+      "quantDomain(post_state[\"s\"]).every((e) => (true))".replace("post_state", "postState")
     )
 
   test("unbacked-state skip is shared scoping logic — both backends skip"):


### PR DESCRIPTION
Stage 3 of #510, closing the reconciliation ports: ts-express with Prisma gets the same five steps the python (#511) and go (#512) targets got, and the exit criterion holds again. A synthesized url_shortener boots and passes its full ts conformance suite live (11 passed, 1 honest skip for the unbacked base_url assertion).

Kernel service functions wrap one `prisma.$transaction`: hydrate a `ServiceState` from the transaction client, check `ServiceStateInv`, check the op's compiled `Requires` twin, call the verified method, persist before returning. Guard failures throw the project's existing `HttpError` (404 or 409 by route kind, 500 for a broken invariant), which the error middleware already maps; nothing new in the middleware layer. Redirect kernel ops were already shaped right in ts (the route consumes a bare string), so only the service internals changed.

`StateBridgeTs` generates `src/services/stateBridge.ts` on the shared `StatePlan` analysis from #512. Hydration folds rows through the immutable `Map.Empty.update` into `create_<Entity>` constructors; persist walks the post-state pairs, updates by primary key with the key column immutable (the #512 review lesson, applied here from the start), creates missing rows, prunes departed keys, and updates the `serviceState` singleton for scalar fields. The JS backend's quirks live in the bridge emitter only: `dtor_` property accessors, doubled underscores (`base__url`), epoch seconds for `Date` fields. Nullable fields stay gated out pending Dafny-side Option construction, same as go.

Boundary enforcement lands in the natural ts place: the zod schemas the routes already parse with. Refined string fields get `.min`, `.max`, and `.regex` from the shared `StringRefinements` reduction (JS regex takes the lookahead combiner directly, unlike RE2), so garbage fails at 422 before any state is touched. The services template's kernel import block now assembles in the emitter as one rendered value, per the no-template-flags rule.

The pre-existing oracle bug this stage surfaced is the ts edition of #512's quantifier-domain fix, in its worst form: `Array.from` on a plain object yields an empty array, so every quantified invariant over a relation in ts suites has been vacuously true since the ts oracle existed. Quantifier and definite-description lowering now route through a `quantDomain` runtime helper (keys for plain objects and Maps, elements for sets, arrays, and strings).

With all three targets reconciled, the CI `--with-synthesis` wiring this arc exists for is unblocked. The scope I'd propose there: synthesis on url_shortener across all three conformance workflows (the one spec with a complete v2-verified cache), other fixtures staying plain until their caches are refreshed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the kernel `ServiceState` with the database for the TS `express` target using Prisma, running hydrate → checks → call → persist inside one `prisma.$transaction`. Adds zod string refinements at request boundaries, fixes the TS test oracle quantifier domain, and ensures scalar state persists via Prisma upsert.

- **New Features**
  - Generate `src/services/stateBridge.ts` to hydrate and persist `ServiceState` via the `@prisma/client` transaction client.
  - Run kernel handlers in a single `prisma.$transaction`; enforce `ServiceStateInv` and `Requires*`; throw `HttpError` (404/409) on guard failures, 500 on invariant failure.
  - Persist state with key-stable updates (update by PK, create missing, prune removed); scalars go through the `serviceState` singleton.
  - Apply spec `StringRefinements` to `zod` request schemas (min, max, regex).

- **Bug Fixes**
  - Fix TS test oracle quantifiers by introducing `quantDomain`, so relations quantify over their keys instead of `Array.from({})` returning an empty array.
  - Ensure scalar state persists by using Prisma `upsert` for the `serviceState` singleton.

<sup>Written for commit acc14e26eeef57597794b25d4ef650ee28b32985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

