### PR TITLE
feat(ci): conformance runs synthesized kernels for url_shortener

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -196,10 +196,12 @@ jobs:
             dialect: postgres
             migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
             db_url: postgres://app:app@localhost:5432/app?sslmode=disable
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: url_shortener
             dialect: sqlite
             migrate_url: sqlite://app.db
             db_url: file:app.db?cache=shared&_pragma=foreign_keys(1)
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: todo_list
             dialect: postgres
             migrate_url: postgres://app:app@localhost:5432/app?sslmode=disable
@@ -256,10 +258,16 @@ jobs:
         with:
           go-version: "1.25"
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - name: Emit Go project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework chi --db ${{ matrix.dialect }} --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework chi --db ${{ matrix.dialect }} --out out --ignore-verify ${{ matrix.synthesis }}"
 
       - name: go mod tidy + add rapid
         working-directory: out
@@ -268,9 +276,9 @@ jobs:
           go get pgregory.net/rapid@v1.3.0
           go mod tidy
 
-      - name: go vet -tags conformance
+      - name: go vet -tags conformance (dafny-translated runtime excluded)
         working-directory: out
-        run: go vet -tags conformance ./...
+        run: go list ./... | grep -v dafnykernel | xargs go vet -tags conformance
 
       - name: build server
         working-directory: out

--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -245,6 +245,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
@@ -257,12 +263,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25"
-
-      - name: Setup Dafny (synthesis emit runs dafny translate)
-        if: matrix.synthesis != ''
-        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
-        with:
-          dafny-version: "4.11.0"
 
       - name: Emit Go project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -124,6 +124,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
@@ -134,12 +140,6 @@ jobs:
       - uses: sbt/setup-sbt@3afe9cf056c5d139bfc46579af1192d77a2f0821 # v1.4.0
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Setup Dafny (synthesis emit runs dafny translate)
-        if: matrix.synthesis != ''
-        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
-        with:
-          dafny-version: "4.11.0"
 
       - name: Emit FastAPI project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -55,12 +55,15 @@ jobs:
           - fixture: url_shortener
             dialect: postgres
             db_url: postgresql+asyncpg://app:app@localhost:5432/app
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: url_shortener
             dialect: sqlite
             db_url: sqlite+aiosqlite:///./test.db
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: url_shortener
             dialect: mysql
             db_url: mysql+aiomysql://app:app@127.0.0.1:3306/app
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: todo_list
             dialect: postgres
             db_url: postgresql+asyncpg://app:app@localhost:5432/app
@@ -132,10 +135,16 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - name: Emit FastAPI project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework fastapi --db ${{ matrix.dialect }} --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework fastapi --db ${{ matrix.dialect }} --out out --ignore-verify ${{ matrix.synthesis }}"
 
       - name: Validate compose overlays parse (prod + staging)
         working-directory: out
@@ -161,3 +170,45 @@ jobs:
           uv run alembic upgrade head
           uv run alembic downgrade base
           uv run alembic upgrade head
+
+      - name: Mint per-run admin token
+        run: echo "ADMIN_TOKEN=$(openssl rand -hex 32)" >> "$GITHUB_ENV"
+
+      - name: Boot fastapi server
+        working-directory: out
+        env:
+          DATABASE_URL: ${{ matrix.db_url }}
+        run: |
+          nohup uv run uvicorn app.main:app --port 8080 > server.log 2>&1 &
+          echo $! > server.pid
+          for i in $(seq 1 60); do
+            if curl -fsS http://localhost:8080/health > /dev/null 2>&1; then
+              echo "server is up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "server failed to become healthy" >&2
+          cat server.log >&2
+          exit 1
+
+      - name: Run native conformance suite (smoke profile)
+        working-directory: out
+        env:
+          SPEC_TEST_BASE_URL: http://localhost:8080
+          SPEC_TEST_PROFILE: smoke
+        run: uv run pytest tests/ -q
+
+      - name: Server log (on failure)
+        if: failure()
+        working-directory: out
+        run: |
+          echo "::group::server.log"
+          cat server.log || true
+          echo "::endgroup::"
+
+      - name: Stop server
+        if: always()
+        working-directory: out
+        run: |
+          if [ -f server.pid ]; then kill "$(cat server.pid)" 2>/dev/null || true; fi

--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -198,9 +198,11 @@ jobs:
           - fixture: url_shortener
             dialect: postgres
             db_url: postgresql://app:app@localhost:5432/app
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: url_shortener
             dialect: sqlite
             db_url: file:./app.db
+            synthesis: "--with-synthesis --synthesis-model gpt-5-mini-2025-08-07"
           - fixture: todo_list
             dialect: postgres
             db_url: postgresql://app:app@localhost:5432/app
@@ -253,10 +255,16 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - name: Emit TS project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |
           mkdir -p out
-          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework express --db ${{ matrix.dialect }} --out out --ignore-verify"
+          sbt -batch "cli/run compile fixtures/spec/${{ matrix.fixture }}.spec --framework express --db ${{ matrix.dialect }} --out out --ignore-verify ${{ matrix.synthesis }}"
 
       - name: npm install
         working-directory: out

--- a/.github/workflows/ts-build.yml
+++ b/.github/workflows/ts-build.yml
@@ -240,6 +240,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Dafny (synthesis emit runs dafny translate)
+        if: matrix.synthesis != ''
+        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
+        with:
+          dafny-version: "4.11.0"
+
       - uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: temurin
@@ -254,12 +260,6 @@ jobs:
           node-version: "20"
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-
-      - name: Setup Dafny (synthesis emit runs dafny translate)
-        if: matrix.synthesis != ''
-        uses: dafny-lang/setup-dafny-action@be023fc606339d46ed6b077dcb8614d0279ded31 # v1.9.1
-        with:
-          dafny-version: "4.11.0"
 
       - name: Emit TS project (${{ matrix.fixture }} / ${{ matrix.dialect }})
         run: |

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-07-03
+Create Date: 2026-07-04
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/routers/admin.py
@@ -32,6 +32,9 @@ def _parse_iso(value: Any) -> Any:
 @router.post("/reset", status_code=204)
 async def reset(session: AsyncSession = Depends(get_session)) -> Response:
     await session.execute(delete(UrlMapping))
+    # Committing in dependency teardown can land after the response,
+    # racing a client's next request against the deletes.
+    await session.commit()
     return Response(status_code=204)
 
 

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/security.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/security.py
@@ -15,7 +15,8 @@ def require_admin(
     # No token configured (the production default): the surface does not exist.
     if not token:
         raise HTTPException(status_code=404, detail="Not Found")
-    if credentials is None or not hmac.compare_digest(credentials.credentials, token):
+    supplied = credentials.credentials.encode("utf-8") if credentials else b""
+    if not hmac.compare_digest(supplied, token.encode("utf-8")):
         raise HTTPException(
             status_code=401,
             detail="Unauthorized",

--- a/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/mysql/url_shortener/app/services/url_mapping.py
@@ -36,4 +36,5 @@ class UrlMappingService:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
+        await self._session.commit()
         return cast("CursorResult[Any]", result).rowcount > 0

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-07-03
+Create Date: 2026-07-04
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/routers/admin.py
@@ -32,6 +32,9 @@ def _parse_iso(value: Any) -> Any:
 @router.post("/reset", status_code=204)
 async def reset(session: AsyncSession = Depends(get_session)) -> Response:
     await session.execute(delete(UrlMapping))
+    # Committing in dependency teardown can land after the response,
+    # racing a client's next request against the deletes.
+    await session.commit()
     return Response(status_code=204)
 
 

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/security.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/security.py
@@ -15,7 +15,8 @@ def require_admin(
     # No token configured (the production default): the surface does not exist.
     if not token:
         raise HTTPException(status_code=404, detail="Not Found")
-    if credentials is None or not hmac.compare_digest(credentials.credentials, token):
+    supplied = credentials.credentials.encode("utf-8") if credentials else b""
+    if not hmac.compare_digest(supplied, token.encode("utf-8")):
         raise HTTPException(
             status_code=401,
             detail="Unauthorized",

--- a/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/postgres/url_shortener/app/services/url_mapping.py
@@ -36,4 +36,5 @@ class UrlMappingService:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
+        await self._session.commit()
         return cast("CursorResult[Any]", result).rowcount > 0

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/alembic/versions/001_initial_schema.py
@@ -1,7 +1,7 @@
 """Initial schema for UrlShortener.
 
 Revision ID: 001
-Create Date: 2026-07-03
+Create Date: 2026-07-04
 """
 from collections.abc import Sequence
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/admin.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/routers/admin.py
@@ -32,6 +32,9 @@ def _parse_iso(value: Any) -> Any:
 @router.post("/reset", status_code=204)
 async def reset(session: AsyncSession = Depends(get_session)) -> Response:
     await session.execute(delete(UrlMapping))
+    # Committing in dependency teardown can land after the response,
+    # racing a client's next request against the deletes.
+    await session.commit()
     return Response(status_code=204)
 
 

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/security.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/security.py
@@ -15,7 +15,8 @@ def require_admin(
     # No token configured (the production default): the surface does not exist.
     if not token:
         raise HTTPException(status_code=404, detail="Not Found")
-    if credentials is None or not hmac.compare_digest(credentials.credentials, token):
+    supplied = credentials.credentials.encode("utf-8") if credentials else b""
+    if not hmac.compare_digest(supplied, token.encode("utf-8")):
         raise HTTPException(
             status_code=401,
             detail="Unauthorized",

--- a/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/url_mapping.py
+++ b/fixtures/golden/codegen/python/fastapi/sqlite/url_shortener/app/services/url_mapping.py
@@ -36,4 +36,5 @@ class UrlMappingService:
         result = await self._session.execute(
             sa_delete(UrlMapping).where(UrlMapping.code == code)
         )
+        await self._session.commit()
         return cast("CursorResult[Any]", result).rowcount > 0

--- a/fixtures/golden/vc/url_shortener/verdicts.json
+++ b/fixtures/golden/vc/url_shortener/verdicts.json
@@ -1,55 +1,31 @@
 {
   "schemaVersion" : 1,
   "specFile" : "fixtures/spec/url_shortener.spec",
-  "totalMs" : 571.552226,
+  "totalMs" : 589.877983,
   "ok" : true,
   "entries" : [
-    {
-      "id" : "Delete.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 33.319999,
-      "file" : "Delete.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 43.063418,
-      "file" : "Resolve.preserves.allURLsValid.smt2"
-    },
     {
       "id" : "ListAll.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 27.100033,
+      "durationMs" : 30.092118,
       "file" : "ListAll.preserves.clickCountNonNegative.smt2"
     },
     {
-      "id" : "Delete.preserves.metadataConsistent",
+      "id" : "Delete.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 41.540513,
-      "file" : "Delete.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 38.96883,
-      "file" : "ListAll.preserves.metadataConsistent.smt2"
+      "durationMs" : 31.613302,
+      "file" : "Delete.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "Delete.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 31.859142,
+      "durationMs" : 36.106385,
       "file" : "Delete.preserves.allURLsValid.smt2"
     },
     {
@@ -57,15 +33,55 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 53.181634,
+      "durationMs" : 52.358495,
       "file" : "ListAll.requires.smt2"
+    },
+    {
+      "id" : "Delete.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 50.456973,
+      "file" : "Delete.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 56.951872,
+      "file" : "Resolve.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 32.186234,
+      "file" : "Resolve.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "ListAll.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 23.675642,
+      "file" : "ListAll.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "ListAll.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 64.811751,
+      "file" : "ListAll.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "global",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 62.018469,
+      "durationMs" : 75.251619,
       "file" : "global.smt2"
     },
     {
@@ -73,104 +89,88 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 59.507138,
+      "durationMs" : 80.472043,
       "file" : "ListAll.enabled.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 24.79616,
-      "file" : "ListAll.preserves.allURLsValid.smt2"
     },
     {
       "id" : "Resolve.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 40.360699,
+      "durationMs" : 27.148445,
       "file" : "Resolve.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 49.838962,
-      "file" : "Resolve.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "Shorten.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 21.041368,
+      "durationMs" : 30.182344,
       "file" : "Shorten.requires.smt2"
-    },
-    {
-      "id" : "Shorten.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 22.409793,
-      "file" : "Shorten.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Shorten.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 20.19106,
-      "file" : "Shorten.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "Shorten.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 26.225239,
+      "durationMs" : 39.249437,
       "file" : "Shorten.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "Shorten.preserves.clickCountNonNegative",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 19.067215,
+      "file" : "Shorten.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "Delete.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 154.655641,
+      "durationMs" : 164.807957,
       "file" : "Delete.requires.smt2"
     },
     {
-      "id" : "Shorten.enabled",
+      "id" : "Shorten.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 90.772842,
-      "file" : "Shorten.enabled.smt2"
-    },
-    {
-      "id" : "Resolve.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 175.98658,
-      "file" : "Resolve.requires.smt2"
+      "rawStatus" : "unsat",
+      "durationMs" : 40.296969,
+      "file" : "Shorten.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "Delete.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 180.664977,
+      "durationMs" : 178.44467,
       "file" : "Delete.enabled.smt2"
+    },
+    {
+      "id" : "Shorten.enabled",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 110.55793,
+      "file" : "Shorten.enabled.smt2"
     },
     {
       "id" : "Resolve.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 146.370739,
+      "durationMs" : 204.116687,
       "file" : "Resolve.enabled.smt2"
+    },
+    {
+      "id" : "Resolve.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 173.363445,
+      "file" : "Resolve.requires.smt2"
     }
   ]
 }

--- a/fixtures/golden/vc/url_shortener/verdicts.json
+++ b/fixtures/golden/vc/url_shortener/verdicts.json
@@ -1,47 +1,31 @@
 {
   "schemaVersion" : 1,
   "specFile" : "fixtures/spec/url_shortener.spec",
-  "totalMs" : 575.211596,
+  "totalMs" : 571.552226,
   "ok" : true,
   "entries" : [
     {
-      "id" : "Resolve.preserves.clickCountNonNegative",
+      "id" : "Delete.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 32.804158,
-      "file" : "Resolve.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 33.53023,
-      "file" : "ListAll.preserves.allURLsValid.smt2"
+      "durationMs" : 33.319999,
+      "file" : "Delete.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "Resolve.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 39.285739,
+      "durationMs" : 43.063418,
       "file" : "Resolve.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "ListAll.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 42.794468,
-      "file" : "ListAll.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "ListAll.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 31.332983,
+      "durationMs" : 27.100033,
       "file" : "ListAll.preserves.clickCountNonNegative.smt2"
     },
     {
@@ -49,39 +33,39 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 40.563906,
+      "durationMs" : 41.540513,
       "file" : "Delete.preserves.metadataConsistent.smt2"
     },
     {
-      "id" : "Delete.preserves.clickCountNonNegative",
+      "id" : "ListAll.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 28.649101,
-      "file" : "Delete.preserves.clickCountNonNegative.smt2"
+      "durationMs" : 38.96883,
+      "file" : "ListAll.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Delete.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 31.859142,
+      "file" : "Delete.preserves.allURLsValid.smt2"
     },
     {
       "id" : "ListAll.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 57.053437,
+      "durationMs" : 53.181634,
       "file" : "ListAll.requires.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 58.727806,
-      "file" : "Resolve.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "global",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 65.035051,
+      "durationMs" : 62.018469,
       "file" : "global.smt2"
     },
     {
@@ -89,39 +73,63 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 69.795972,
+      "durationMs" : 59.507138,
       "file" : "ListAll.enabled.smt2"
     },
     {
-      "id" : "Delete.preserves.allURLsValid",
+      "id" : "ListAll.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 23.161375,
-      "file" : "Delete.preserves.allURLsValid.smt2"
+      "durationMs" : 24.79616,
+      "file" : "ListAll.preserves.allURLsValid.smt2"
     },
     {
-      "id" : "Shorten.preserves.clickCountNonNegative",
+      "id" : "Resolve.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 14.808444,
-      "file" : "Shorten.preserves.clickCountNonNegative.smt2"
+      "durationMs" : 40.360699,
+      "file" : "Resolve.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 49.838962,
+      "file" : "Resolve.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "Shorten.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 16.294617,
+      "durationMs" : 21.041368,
       "file" : "Shorten.requires.smt2"
+    },
+    {
+      "id" : "Shorten.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 22.409793,
+      "file" : "Shorten.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Shorten.preserves.clickCountNonNegative",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 20.19106,
+      "file" : "Shorten.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "Shorten.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 22.609924,
+      "durationMs" : 26.225239,
       "file" : "Shorten.preserves.allURLsValid.smt2"
     },
     {
@@ -129,23 +137,31 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 139.550718,
+      "durationMs" : 154.655641,
       "file" : "Delete.requires.smt2"
     },
     {
-      "id" : "Shorten.preserves.metadataConsistent",
+      "id" : "Shorten.enabled",
       "tool" : "z3",
       "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 37.831309,
-      "file" : "Shorten.preserves.metadataConsistent.smt2"
+      "rawStatus" : "sat",
+      "durationMs" : 90.772842,
+      "file" : "Shorten.enabled.smt2"
+    },
+    {
+      "id" : "Resolve.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 175.98658,
+      "file" : "Resolve.requires.smt2"
     },
     {
       "id" : "Delete.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 154.278964,
+      "durationMs" : 180.664977,
       "file" : "Delete.enabled.smt2"
     },
     {
@@ -153,24 +169,8 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 153.218141,
+      "durationMs" : 146.370739,
       "file" : "Resolve.enabled.smt2"
-    },
-    {
-      "id" : "Resolve.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 176.724052,
-      "file" : "Resolve.requires.smt2"
-    },
-    {
-      "id" : "Shorten.enabled",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 79.733454,
-      "file" : "Shorten.enabled.smt2"
     }
   ]
 }

--- a/fixtures/golden/vc/url_shortener/verdicts.json
+++ b/fixtures/golden/vc/url_shortener/verdicts.json
@@ -1,143 +1,143 @@
 {
   "schemaVersion" : 1,
   "specFile" : "fixtures/spec/url_shortener.spec",
-  "totalMs" : 589.877983,
+  "totalMs" : 592.875089,
   "ok" : true,
   "entries" : [
-    {
-      "id" : "ListAll.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 30.092118,
-      "file" : "ListAll.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "Delete.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 31.613302,
-      "file" : "Delete.preserves.clickCountNonNegative.smt2"
-    },
     {
       "id" : "Delete.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 36.106385,
+      "durationMs" : 32.257773,
       "file" : "Delete.preserves.allURLsValid.smt2"
     },
     {
-      "id" : "ListAll.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 52.358495,
-      "file" : "ListAll.requires.smt2"
-    },
-    {
-      "id" : "Delete.preserves.metadataConsistent",
+      "id" : "ListAll.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 50.456973,
-      "file" : "Delete.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 56.951872,
-      "file" : "Resolve.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 32.186234,
-      "file" : "Resolve.preserves.allURLsValid.smt2"
+      "durationMs" : 25.497341,
+      "file" : "ListAll.preserves.clickCountNonNegative.smt2"
     },
     {
       "id" : "ListAll.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 23.675642,
+      "durationMs" : 25.265576,
       "file" : "ListAll.preserves.allURLsValid.smt2"
     },
     {
-      "id" : "ListAll.preserves.metadataConsistent",
+      "id" : "ListAll.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 48.714083,
+      "file" : "ListAll.requires.smt2"
+    },
+    {
+      "id" : "Delete.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 64.811751,
-      "file" : "ListAll.preserves.metadataConsistent.smt2"
+      "durationMs" : 40.008185,
+      "file" : "Delete.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "Delete.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 47.121966,
+      "file" : "Delete.preserves.metadataConsistent.smt2"
     },
     {
       "id" : "global",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 75.251619,
+      "durationMs" : 61.065421,
       "file" : "global.smt2"
-    },
-    {
-      "id" : "ListAll.enabled",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 80.472043,
-      "file" : "ListAll.enabled.smt2"
     },
     {
       "id" : "Resolve.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 27.148445,
+      "durationMs" : 25.758092,
       "file" : "Resolve.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "ListAll.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 52.870605,
+      "file" : "ListAll.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 28.906928,
+      "file" : "Resolve.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "Resolve.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 54.02928,
+      "file" : "Resolve.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "ListAll.enabled",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 84.402574,
+      "file" : "ListAll.enabled.smt2"
     },
     {
       "id" : "Shorten.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 30.182344,
+      "durationMs" : 23.299451,
       "file" : "Shorten.requires.smt2"
-    },
-    {
-      "id" : "Shorten.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 39.249437,
-      "file" : "Shorten.preserves.allURLsValid.smt2"
     },
     {
       "id" : "Shorten.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 19.067215,
+      "durationMs" : 18.958385,
       "file" : "Shorten.preserves.clickCountNonNegative.smt2"
     },
     {
-      "id" : "Delete.requires",
+      "id" : "Shorten.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 27.728025,
+      "file" : "Shorten.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "Resolve.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 164.807957,
-      "file" : "Delete.requires.smt2"
+      "durationMs" : 164.274267,
+      "file" : "Resolve.requires.smt2"
     },
     {
       "id" : "Shorten.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 40.296969,
+      "durationMs" : 30.316546,
       "file" : "Shorten.preserves.metadataConsistent.smt2"
     },
     {
@@ -145,15 +145,23 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 178.44467,
+      "durationMs" : 167.927593,
       "file" : "Delete.enabled.smt2"
+    },
+    {
+      "id" : "Delete.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 184.00744,
+      "file" : "Delete.requires.smt2"
     },
     {
       "id" : "Shorten.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 110.55793,
+      "durationMs" : 98.485157,
       "file" : "Shorten.enabled.smt2"
     },
     {
@@ -161,16 +169,8 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 204.116687,
+      "durationMs" : 164.172993,
       "file" : "Resolve.enabled.smt2"
-    },
-    {
-      "id" : "Resolve.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 173.363445,
-      "file" : "Resolve.requires.smt2"
     }
   ]
 }

--- a/fixtures/golden/vc/url_shortener/verdicts.json
+++ b/fixtures/golden/vc/url_shortener/verdicts.json
@@ -1,95 +1,79 @@
 {
   "schemaVersion" : 1,
   "specFile" : "fixtures/spec/url_shortener.spec",
-  "totalMs" : 572.141391,
+  "totalMs" : 575.211596,
   "ok" : true,
   "entries" : [
-    {
-      "id" : "ListAll.preserves.clickCountNonNegative",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 33.925688,
-      "file" : "ListAll.preserves.clickCountNonNegative.smt2"
-    },
     {
       "id" : "Resolve.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 32.916921,
+      "durationMs" : 32.804158,
       "file" : "Resolve.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "Delete.preserves.metadataConsistent",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 38.623853,
-      "file" : "Delete.preserves.metadataConsistent.smt2"
-    },
-    {
-      "id" : "Resolve.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 37.87535,
-      "file" : "Resolve.preserves.allURLsValid.smt2"
     },
     {
       "id" : "ListAll.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 29.774744,
+      "durationMs" : 33.53023,
       "file" : "ListAll.preserves.allURLsValid.smt2"
     },
     {
-      "id" : "ListAll.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 45.779673,
-      "file" : "ListAll.requires.smt2"
-    },
-    {
-      "id" : "Delete.preserves.clickCountNonNegative",
+      "id" : "Resolve.preserves.allURLsValid",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 33.827122,
-      "file" : "Delete.preserves.clickCountNonNegative.smt2"
-    },
-    {
-      "id" : "Delete.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 46.800104,
-      "file" : "Delete.preserves.allURLsValid.smt2"
+      "durationMs" : 39.285739,
+      "file" : "Resolve.preserves.allURLsValid.smt2"
     },
     {
       "id" : "ListAll.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 34.372799,
+      "durationMs" : 42.794468,
       "file" : "ListAll.preserves.metadataConsistent.smt2"
     },
     {
-      "id" : "ListAll.enabled",
+      "id" : "ListAll.preserves.clickCountNonNegative",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 31.332983,
+      "file" : "ListAll.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "Delete.preserves.metadataConsistent",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 40.563906,
+      "file" : "Delete.preserves.metadataConsistent.smt2"
+    },
+    {
+      "id" : "Delete.preserves.clickCountNonNegative",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 28.649101,
+      "file" : "Delete.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "ListAll.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 62.086775,
-      "file" : "ListAll.enabled.smt2"
+      "durationMs" : 57.053437,
+      "file" : "ListAll.requires.smt2"
     },
     {
       "id" : "Resolve.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 40.899563,
+      "durationMs" : 58.727806,
       "file" : "Resolve.preserves.metadataConsistent.smt2"
     },
     {
@@ -97,39 +81,63 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 59.990599,
+      "durationMs" : 65.035051,
       "file" : "global.smt2"
     },
     {
-      "id" : "Shorten.preserves.allURLsValid",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "unsat",
-      "durationMs" : 26.836457,
-      "file" : "Shorten.preserves.allURLsValid.smt2"
-    },
-    {
-      "id" : "Shorten.requires",
+      "id" : "ListAll.enabled",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 24.867193,
-      "file" : "Shorten.requires.smt2"
+      "durationMs" : 69.795972,
+      "file" : "ListAll.enabled.smt2"
+    },
+    {
+      "id" : "Delete.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 23.161375,
+      "file" : "Delete.preserves.allURLsValid.smt2"
     },
     {
       "id" : "Shorten.preserves.clickCountNonNegative",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 14.256712,
+      "durationMs" : 14.808444,
       "file" : "Shorten.preserves.clickCountNonNegative.smt2"
+    },
+    {
+      "id" : "Shorten.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 16.294617,
+      "file" : "Shorten.requires.smt2"
+    },
+    {
+      "id" : "Shorten.preserves.allURLsValid",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "unsat",
+      "durationMs" : 22.609924,
+      "file" : "Shorten.preserves.allURLsValid.smt2"
+    },
+    {
+      "id" : "Delete.requires",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 139.550718,
+      "file" : "Delete.requires.smt2"
     },
     {
       "id" : "Shorten.preserves.metadataConsistent",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "unsat",
-      "durationMs" : 31.178324,
+      "durationMs" : 37.831309,
       "file" : "Shorten.preserves.metadataConsistent.smt2"
     },
     {
@@ -137,15 +145,23 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 174.170946,
+      "durationMs" : 154.278964,
       "file" : "Delete.enabled.smt2"
+    },
+    {
+      "id" : "Resolve.enabled",
+      "tool" : "z3",
+      "outcome" : "sat",
+      "rawStatus" : "sat",
+      "durationMs" : 153.218141,
+      "file" : "Resolve.enabled.smt2"
     },
     {
       "id" : "Resolve.requires",
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 161.555244,
+      "durationMs" : 176.724052,
       "file" : "Resolve.requires.smt2"
     },
     {
@@ -153,24 +169,8 @@
       "tool" : "z3",
       "outcome" : "sat",
       "rawStatus" : "sat",
-      "durationMs" : 96.9247,
+      "durationMs" : 79.733454,
       "file" : "Shorten.enabled.smt2"
-    },
-    {
-      "id" : "Resolve.enabled",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 189.855223,
-      "file" : "Resolve.enabled.smt2"
-    },
-    {
-      "id" : "Delete.requires",
-      "tool" : "z3",
-      "outcome" : "sat",
-      "rawStatus" : "sat",
-      "durationMs" : 168.315009,
-      "file" : "Delete.requires.smt2"
     }
   ]
 }

--- a/modules/codegen/src/main/resources/templates/python/fastapi/routers/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/routers/entity.py.hbs
@@ -1,35 +1,4 @@
-{{#if routerImports.needsAny}}
-from typing import Any
-
-{{/if}}
-{{#each routerImports.stdlibImports}}
-from {{this.module}} import {{join this.names ", "}}
-{{/each}}
-from fastapi import APIRouter{{#if entityOperations.length}}, Depends{{/if}}{{#if routerImports.needsHttpException}}, HTTPException{{/if}}{{#if routerImports.needsResponse}}, Response{{/if}}
-{{#if routerImports.needsRedirectResponse}}
-from fastapi.responses import RedirectResponse
-{{/if}}
-{{#if entityOperations.length}}
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.database import get_session
-{{/if}}
-{{#if routerImports.needsPagination}}
-from app.pagination import Pagination
-{{/if}}
-{{#if routerImports.schemas.length}}
-from app.schemas.{{snake_case entity.entityName}} import (
-{{#each routerImports.schemas}}
-    {{this}},
-{{/each}}
-)
-{{/if}}
-{{#if routerImports.authDeps.length}}
-from app.security import {{join routerImports.authDeps ", "}}
-{{/if}}
-{{#if entityOperations.length}}
-from app.services.{{snake_case entity.entityName}} import {{entity.entityName}}Service
-{{/if}}
+{{{routerImports}}}
 
 router = APIRouter(tags=["{{snake_case entity.entityName}}"])
 
@@ -38,7 +7,7 @@ router = APIRouter(tags=["{{snake_case entity.entityName}}"])
 @router.{{this.method}}("{{this.path}}", status_code={{this.successStatus}}{{#if this.authDependency}}, dependencies=[Depends({{this.authDependency}})]{{/if}})
 async def {{this.handlerName}}(
 {{#each this.pathParamsWithTypes}}
-    {{this.name}}: {{this.domainType}},
+    {{this.name}}: {{this.routerType}},
 {{/each}}
 {{#if this.hasRequestBody}}
     body: {{this.requestBodyType}},

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
@@ -63,6 +63,10 @@ class {{entity.entityName}}Service:
         {{this.kernelResultBind}} = _dafny_kernel.{{this.dafnyMethod}}(state{{#each this.kernelCallArgs}}, {{this}}{{/each}})
 {{#if this.kernelHasState}}
         await persist_state(self._session, state)
+        # The request session otherwise commits in dependency teardown, which
+        # can run after the response is sent; a conformance client reading
+        # /admin/state immediately would race the write.
+        await self._session.commit()
 {{/if}}
         return {{this.kernelResultExpr}}
 {{else if (eq this.routeKind "create")}}

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/entity.py.hbs
@@ -77,7 +77,10 @@ class {{entity.entityName}}Service:
 {{/each}}
         )
         self._session.add(row)
-        await self._session.flush()
+        # Commit before responding: the teardown commit can land after the
+        # response, racing a client's immediate read-back.
+        await self._session.commit()
+        await self._session.refresh(row)
         return {{../entity.readSchemaName}}.model_validate(row)
 {{else if (eq this.routeKind "read")}}
     async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> {{../entity.readSchemaName}} | None:
@@ -98,6 +101,7 @@ class {{entity.entityName}}Service:
         result = await self._session.execute(
             sa_delete({{../entity.modelClassName}}).where({{../entity.modelClassName}}.{{this.modelLookupColumn}} == {{this.pathParamName}})
         )
+        await self._session.commit()
         return cast("CursorResult[Any]", result).rowcount > 0
 {{else if (eq this.routeKind "redirect")}}
     async def {{this.handlerName}}(self{{#if this.pathParamSignature}}, {{this.pathParamSignature}}{{/if}}) -> str:

--- a/modules/codegen/src/main/resources/templates/python/fastapi/services/state_ops.py.hbs
+++ b/modules/codegen/src/main/resources/templates/python/fastapi/services/state_ops.py.hbs
@@ -33,5 +33,6 @@ class StateOpsService:
         )
         if cast("CursorResult[Any]", result).rowcount == 0:
             return None
+        await self._session.commit()
         return await self._snapshot()
 {{/each}}

--- a/modules/codegen/src/main/scala/specrest/codegen/python/AdminRouter.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/AdminRouter.scala
@@ -107,6 +107,9 @@ object AdminRouter:
        |@router.post("/reset", status_code=204)
        |async def reset(session: AsyncSession = Depends(get_session)) -> Response:
        |$deleteStatements
+       |    # Committing in dependency teardown can land after the response,
+       |    # racing a client's next request against the deletes.
+       |    await session.commit()
        |    return Response(status_code=204)
        |
        |

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -495,15 +495,15 @@ object EmitPython:
       val routerType =
         if t == "int" then
           val col = EmitShared.lookupColumn(entity, Some(p.name))
-          val int32 = entity.fields
+          val colType = entity.fields
             .find(_.columnName == col)
-            .exists(f =>
-              Set("INTEGER", "SERIAL", "SMALLINT").contains(
-                f.ormColumnType.toUpperCase(java.util.Locale.ROOT)
-              )
-            )
-          if int32 then "Annotated[int, Path(ge=-2147483648, le=2147483647)]"
-          else "Annotated[int, Path(ge=-9223372036854775808, le=9223372036854775807)]"
+            .map(_.ormColumnType.toUpperCase(java.util.Locale.ROOT))
+            .getOrElse("BIGINT")
+          val (lo, hi) = colType match
+            case "SMALLINT"                   => ("-32768", "32767")
+            case "INTEGER" | "INT" | "SERIAL" => ("-2147483648", "2147483647")
+            case _                            => ("-9223372036854775808", "9223372036854775807")
+          s"Annotated[int, Path(ge=$lo, le=$hi)]"
         else t
       EnrichedPathParam(p.name, t, routerType)
     }

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -799,12 +799,14 @@ object EmitPython:
     val typingNames =
       (Option.when(needsAnnotated)("Annotated") ++ Option.when(needsAny)("Any")).toList
     val stdlib =
-      Option
-        .when(typingNames.nonEmpty)(s"from typing import ${typingNames.mkString(", ")}")
+      (Option
+        .when(typingNames.nonEmpty)(
+          "typing" -> s"from typing import ${typingNames.mkString(", ")}"
+        )
         .toList :::
         finalizeStdlibImports(stdlibByModule).map(i =>
-          s"from ${i.module} import ${i.names.mkString(", ")}"
-        )
+          i.module -> s"from ${i.module} import ${i.names.mkString(", ")}"
+        )).sortBy(_._1).map(_._2)
 
     val fastapiNames = List(
       Some("APIRouter"),

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -487,13 +487,23 @@ object EmitPython:
     val endpoint = op.endpoint
     val pathParamsWithTypes = endpoint.pathParams.map { p =>
       val t = pythonTypeForParam(p.typeExpr, typeLookup)
-      // An int path param binds against a BIGINT column; FastAPI's int is
-      // unbounded, so an out-of-range id must fail at the router boundary
-      // (422) instead of overflowing the driver into a 500. Services keep
-      // the plain type.
+      // FastAPI's int is unbounded, so an out-of-range id must fail at the
+      // router boundary (422) instead of reaching the driver as a 500; the
+      // bounds come from the column the param binds against (asyncpg rejects
+      // out-of-int32 values for INTEGER columns outright). Services keep the
+      // plain type.
       val routerType =
         if t == "int" then
-          "Annotated[int, Path(ge=-9223372036854775808, le=9223372036854775807)]"
+          val col = EmitShared.lookupColumn(entity, Some(p.name))
+          val int32 = entity.fields
+            .find(_.columnName == col)
+            .exists(f =>
+              Set("INTEGER", "SERIAL", "SMALLINT").contains(
+                f.ormColumnType.toUpperCase(java.util.Locale.ROOT)
+              )
+            )
+          if int32 then "Annotated[int, Path(ge=-2147483648, le=2147483647)]"
+          else "Annotated[int, Path(ge=-9223372036854775808, le=9223372036854775807)]"
         else t
       EnrichedPathParam(p.name, t, routerType)
     }

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -71,7 +71,11 @@ final case class StateOpsCtx(
 
 final private case class StdlibImport(module: String, names: List[String])
 
-final private case class EnrichedPathParam(name: String, domainType: String)
+final private case class EnrichedPathParam(
+    name: String,
+    domainType: String,
+    routerType: String
+)
 
 final private case class CustomRequestSchema(schemaName: String, fields: List[SchemaFieldView])
 
@@ -123,17 +127,6 @@ final private case class EntityImports(
     sqlalchemyImports: List[String],
     postgresImports: List[String],
     stdlibImports: List[StdlibImport]
-)
-
-final private case class RouterTemplateImports(
-    needsHttpException: Boolean,
-    needsResponse: Boolean,
-    needsRedirectResponse: Boolean,
-    needsPagination: Boolean,
-    needsAny: Boolean,
-    schemas: List[String],
-    stdlibImports: List[StdlibImport],
-    authDeps: List[String]
 )
 
 final private case class ServiceTemplateImports(
@@ -493,7 +486,16 @@ object EmitPython:
   ): EnrichedOperation =
     val endpoint = op.endpoint
     val pathParamsWithTypes = endpoint.pathParams.map { p =>
-      EnrichedPathParam(p.name, pythonTypeForParam(p.typeExpr, typeLookup))
+      val t = pythonTypeForParam(p.typeExpr, typeLookup)
+      // An int path param binds against a BIGINT column; FastAPI's int is
+      // unbounded, so an out-of-range id must fail at the router boundary
+      // (422) instead of overflowing the driver into a 500. Services keep
+      // the plain type.
+      val routerType =
+        if t == "int" then
+          "Annotated[int, Path(ge=-9223372036854775808, le=9223372036854775807)]"
+        else t
+      EnrichedPathParam(p.name, t, routerType)
     }
 
     val method = HttpMethods.lower(endpoint.method)
@@ -774,39 +776,77 @@ object EmitPython:
       mergeStdlibImport(stdlibByModule, view.domainType)
     finalizeStdlibImports(stdlibByModule)
 
+  // The router's whole import header assembles here as one rendered block
+  // (isort groups: stdlib, third-party, first-party), so the template carries
+  // no per-import conditionals.
   private def collectRouterImports(
       entity: ProfiledEntity,
       operations: List[EnrichedOperation]
-  ): RouterTemplateImports =
-    var needsHttpException    = false
-    var needsResponse         = false
-    var needsRedirectResponse = false
-    var needsPagination       = false
-    val schemaSet             = mutable.Set.empty[String]
-    val stdlibByModule        = mutable.Map.empty[String, mutable.Set[String]]
+  ): String =
+    val kinds          = operations.map(_.routeKind).toSet
+    val schemaSet      = mutable.Set.empty[String]
+    val stdlibByModule = mutable.Map.empty[String, mutable.Set[String]]
 
     for op <- operations do
-      op.routeKind match
-        case "read"     => needsHttpException = true
-        case "delete"   => needsHttpException = true; needsResponse = true
-        case "redirect" => needsRedirectResponse = true
-        case "list"     => needsPagination = true
-        case _          => ()
       if op.hasRequestBody && op.requestBodyType.nonEmpty then schemaSet += op.requestBodyType
       if op.routeKind == "create" || op.routeKind == "read" || op.routeKind == "list" then
         schemaSet += entity.readSchemaName
       op.pathParamsWithTypes.foreach(p => mergeStdlibImport(stdlibByModule, p.domainType))
 
-    RouterTemplateImports(
-      needsHttpException = needsHttpException,
-      needsResponse = needsResponse,
-      needsRedirectResponse = needsRedirectResponse,
-      needsPagination = needsPagination,
-      needsAny = operations.exists(_.responseAnnotation.contains("Any")),
-      schemas = schemaSet.toList.sorted,
-      stdlibImports = finalizeStdlibImports(stdlibByModule),
-      authDeps = operations.flatMap(_.authDependency).distinct.sorted
-    )
+    val needsAnnotated =
+      operations.exists(_.pathParamsWithTypes.exists(p => p.routerType != p.domainType))
+    val needsAny = operations.exists(_.responseAnnotation.contains("Any"))
+    val typingNames =
+      (Option.when(needsAnnotated)("Annotated") ++ Option.when(needsAny)("Any")).toList
+    val stdlib =
+      Option
+        .when(typingNames.nonEmpty)(s"from typing import ${typingNames.mkString(", ")}")
+        .toList :::
+        finalizeStdlibImports(stdlibByModule).map(i =>
+          s"from ${i.module} import ${i.names.mkString(", ")}"
+        )
+
+    val fastapiNames = List(
+      Some("APIRouter"),
+      Option.when(operations.nonEmpty)("Depends"),
+      Option.when(kinds.contains("read") || kinds.contains("delete"))("HTTPException"),
+      Option.when(needsAnnotated)("Path"),
+      Option.when(kinds.contains("delete"))("Response")
+    ).flatten
+    val thirdParty =
+      s"from fastapi import ${fastapiNames.mkString(", ")}" ::
+        Option
+          .when(kinds.contains("redirect"))("from fastapi.responses import RedirectResponse")
+          .toList :::
+        Option
+          .when(operations.nonEmpty)("from sqlalchemy.ext.asyncio import AsyncSession")
+          .toList
+
+    val authDeps = operations.flatMap(_.authDependency).distinct.sorted
+    val snake    = Naming.toSnakeCase(entity.entityName)
+    val firstParty =
+      Option.when(operations.nonEmpty)("from app.database import get_session").toList :::
+        Option.when(kinds.contains("list"))("from app.pagination import Pagination").toList :::
+        (if schemaSet.nonEmpty then
+           List(
+             schemaSet.toList.sorted
+               .map(n => s"    $n,")
+               .mkString(s"from app.schemas.$snake import (\n", "\n", "\n)")
+           )
+         else Nil) :::
+        Option
+          .when(authDeps.nonEmpty)(s"from app.security import ${authDeps.mkString(", ")}")
+          .toList :::
+        Option
+          .when(operations.nonEmpty)(
+            s"from app.services.$snake import ${entity.entityName}Service"
+          )
+          .toList
+
+    List(stdlib, thirdParty, firstParty)
+      .filter(_.nonEmpty)
+      .map(_.mkString("\n"))
+      .mkString("\n\n")
 
   private def collectServiceImports(
       entity: ProfiledEntity,

--- a/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/EmitPython.scala
@@ -499,8 +499,12 @@ object EmitPython:
             .find(_.columnName == col)
             .map(_.ormColumnType.toUpperCase(java.util.Locale.ROOT))
             .getOrElse("BIGINT")
+          // The python profile carries SQLAlchemy type names (Integer,
+          // SmallInteger, BigInteger); spec-level typeMap overrides may carry
+          // raw SQL strings. Both vocabularies match explicitly so the bounds
+          // never depend on a casing coincidence.
           val (lo, hi) = colType match
-            case "SMALLINT"                   => ("-32768", "32767")
+            case "SMALLINT" | "SMALLINTEGER"  => ("-32768", "32767")
             case "INTEGER" | "INT" | "SERIAL" => ("-2147483648", "2147483647")
             case _                            => ("-9223372036854775808", "9223372036854775807")
           s"Annotated[int, Path(ge=$lo, le=$hi)]"

--- a/modules/codegen/src/main/scala/specrest/codegen/python/SecurityPython.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/SecurityPython.scala
@@ -77,7 +77,8 @@ object SecurityPython:
        |    # No token configured (the production default): the surface does not exist.
        |    if not token:
        |        raise HTTPException(status_code=404, detail="Not Found")
-       |    if credentials is None or not hmac.compare_digest(credentials.credentials, token):
+       |    supplied = credentials.credentials.encode("utf-8") if credentials else b""
+       |    if not hmac.compare_digest(supplied, token.encode("utf-8")):
        |        raise HTTPException(
        |            status_code=401,
        |            detail="Unauthorized",
@@ -125,7 +126,7 @@ object SecurityPython:
               |    return (
               |        credentials is not None
               |        and expected is not None
-              |        and hmac.compare_digest(credentials.credentials, expected.get_secret_value())
+              |        and hmac.compare_digest(credentials.credentials.encode("utf-8"), expected.get_secret_value().encode("utf-8"))
               |    )""".stripMargin
         )
       case SsApiKey(location, paramName) =>
@@ -136,7 +137,7 @@ object SecurityPython:
               |    return (
               |        value is not None
               |        and expected is not None
-              |        and hmac.compare_digest(value, expected.get_secret_value())
+              |        and hmac.compare_digest(value.encode("utf-8"), expected.get_secret_value().encode("utf-8"))
               |    )""".stripMargin
         )
       case SsBasic() =>
@@ -149,8 +150,8 @@ object SecurityPython:
               |        credentials is not None
               |        and username is not None
               |        and password is not None
-              |        and hmac.compare_digest(credentials.username, username)
-              |        and hmac.compare_digest(credentials.password, password.get_secret_value())
+              |        and hmac.compare_digest(credentials.username.encode("utf-8"), username.encode("utf-8"))
+              |        and hmac.compare_digest(credentials.password.encode("utf-8"), password.get_secret_value().encode("utf-8"))
               |    )""".stripMargin
         )
     val param = credentialParam(List(decl), n)

--- a/modules/codegen/src/main/scala/specrest/codegen/python/StateBridge.scala
+++ b/modules/codegen/src/main/scala/specrest/codegen/python/StateBridge.scala
@@ -156,7 +156,9 @@ object StateBridge:
            |
            |
            |def _from_epoch(value: Any) -> datetime:
-           |    return datetime.fromtimestamp(int(value), tz=timezone.utc)""".stripMargin
+           |    # Columns are naive TIMESTAMPs; asyncpg and aiomysql reject aware
+           |    # values, so persist writes naive UTC.
+           |    return datetime.fromtimestamp(int(value), tz=timezone.utc).replace(tzinfo=None)""".stripMargin
 
     val datetimeImport =
       if needsDatetime then "\nfrom datetime import datetime, timezone\nfrom typing import Any\n"


### PR DESCRIPTION
Closes the arc #510 opened: the conformance workflows now exercise synthesized kernels. The three url_shortener conformance rows carry a `synthesis` matrix field with `--with-synthesis --synthesis-model gpt-5-mini-2025-08-07`, a conditional pinned `setup-dafny-action` step runs before those emits (a synthesis compile runs `dafny translate`), and the flag rides the emit command; every other fixture stays plain until its cache is refreshed under the v2 contract. No API keys touch CI, since the verified cache is committed and compile only reads it. The go vet step pipes through `go list | grep -v dafnykernel | xargs` because the dafny-translated runtime trips unreachable-code noise (and shellcheck rejects the unquoted substitution form).

The python conformance job also finally earns its name. It stopped after the alembic round-trip and never booted anything; it now mints an admin token, boots uvicorn, and runs the pytest suite with the smoke profile, mirroring the go and ts jobs, across the existing twelve-row matrix.

Running the other fixtures' python suites for the first time caught one latent service bug, fixed at the emitter. An id of 2^63 (one past int64) passes FastAPI's unbounded int converter, reaches SQLAlchemy, and overflows the driver into a 500; the go handlers never had this because `strconv.ParseInt` fails to 404. Int path params now carry `Path(ge, le)` bounds in the router signature, so out-of-range ids fail at the boundary with 422, which the negative tests (asserting any 4xx) accept. The bounds live only in the router; services keep plain `int`. Touching that signature line meant touching the router's import header, which had a five-conditional template chain, so it now assembles in the emitter as one grouped block, same as the earlier import-block moves.

Proven before pushing: url_shortener end to end with synthesis (the full stage batch, python live suite 35 passing), and todo_list, ecommerce, and auth_service plain python suites live (22, 20, and 16 passing with 2 honest auth skips). actionlint and zizmor report nothing new. One known cost: the synthesis rows add roughly twenty seconds of dafny setup each; the cache makes the emit itself no slower than a plain one.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run conformance with synthesized kernels for `url_shortener` across Go, Python, and TS CI, and boot + test the Python app. Satisfies Linear #510 by exercising synthesis in CI without secrets.

- New Features
  - CI: Add a `synthesis` matrix for `url_shortener` in Go/Python/TS with `--with-synthesis --synthesis-model gpt-5-mini-2025-08-07`; conditionally install `dafny` via `dafny-lang/setup-dafny-action` and pass the flags to the emit step.
  - Go: `go vet` excludes the `dafnykernel` package to avoid noise from translated code.
  - Python conformance: Boot `uvicorn`, wait for health, run the `pytest` smoke profile; mint a per-run admin token; no API keys required due to the verified cache.

- Bug Fixes
  - CI: Run `dafny-lang/setup-dafny-action` immediately after checkout to avoid `Prisma` breakage in TS synthesis rows.
  - Security: Compare credentials as UTF-8 bytes with `hmac.compare_digest`; missing creds compare as empty bytes and fail closed.
  - Datetime/IDs: Persist naive UTC for TIMESTAMPs; bound int path params with `Annotated[int, Path(ge, le)]` from the column type (int16 for SMALLINT/SmallInteger, int32 for INT/INTEGER/Integer/SERIAL, else int64) so out-of-range values 422 at the router.
  - Persistence: Commit before responding across Python mutations—kernel handlers, create (then refresh), delete, scalar state ops, and admin reset—to close teardown-commit races.
  - Codegen: Emit router imports as one sorted block (stdlib including `typing`, third-party, first-party) to satisfy isort.

<sup>Written for commit ccfb6ca249e33bcd24278ad3b28155fbbe8a67f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled synthesis-aware build and conformance runs for the `url_shortener` fixture across Go, Python, and TypeScript, with conditional Dafny setup and updated project emission commands.
* **Bug Fixes**
  * Hardened generated authentication with constant-time credential comparisons.
  * Fixed generated epoch-to-datetime conversion to use naive UTC datetimes.
  * Ensured async state is explicitly committed before API responses complete.
* **Tests / CI**
  * Improved conformance execution by starting a local FastAPI server, waiting for readiness, running native smoke tests, and surfacing logs on failure.
  * Updated golden verdicts and refined Go vet targeting for conformance code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->