### PR TITLE
docs: mark ServiceState reconciliation shipped in the roadmap

### DIFF
--- a/docs/content/docs/roadmap.mdx
+++ b/docs/content/docs/roadmap.mdx
@@ -186,7 +186,7 @@ Open follow-ups for the M6 synthesis pipeline. For the prose context, see
 
 | Concern | Tracked in |
 | ------- | ---------- |
-| Dafny `ServiceState` reconciliation with SQLAlchemy / Postgres (the kernel runs on fresh per-request state) | follow-up |
+| Dafny `ServiceState` reconciliation (the kernel used to run on fresh per-request state) | shipped for all three targets in [#511](https://github.com/HardMax71/spec_to_rest/pull/511), [#512](https://github.com/HardMax71/spec_to_rest/pull/512), [#513](https://github.com/HardMax71/spec_to_rest/pull/513); CI runs the synthesized url_shortener conformance suites since [#514](https://github.com/HardMax71/spec_to_rest/pull/514). Kernel handlers hydrate state from the database, check the compiled `Requires` twins, and persist mutations in one transaction. Remaining gaps live in [#510](https://github.com/HardMax71/spec_to_rest/issues/510): nullable fields in the go/ts bridges, enum and collection marshalling, query-param kernel ops, keyed hydration. |
 | Automatic hint discovery, mining proof patterns from verified CEGIS runs instead of hand-curating `HintLibrary` | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |
 | Pass@128-scale sampling, raising `CegisBudget.maxIterations` by an order of magnitude for Re:Form-style gains | follow-up, deferred in [the compositional synthesis findings](/research/compositional_synthesis_findings) |
 | Laurel-style assertion localization, inserting `assert` placeholders at the failing line for the model to fill | follow-up |


### PR DESCRIPTION
The synthesis follow-up table still listed the reconciliation as open. It shipped across #511, #512, and #513, CI exercises it since #514, and #510 is closed with the remaining gaps documented there. One row updated, nothing else touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the roadmap to mark Dafny ServiceState reconciliation as shipped across all three targets, and note CI now runs the synthesized url_shortener conformance suites. The row links to the shipping PRs (#511–#513), CI coverage (#514), and the remaining gaps in #510.

<sup>Written for commit 9eb3fc29254eca15cbcd3ea35901b4ecdfeb25f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/HardMax71/spec_to_rest/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

